### PR TITLE
Eng 6335 valgrind

### DIFF
--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -279,6 +279,7 @@ public class LocalCluster implements VoltServerConfig {
      * Called after a constructor but before startup.
      */
     public void overrideAnyRequestForValgrind() {
+        Assume.assumeTrue (templateCmdLine.m_backend != BackendTarget.NATIVE_EE_VALGRIND_IPC);
         if (templateCmdLine.m_backend == BackendTarget.NATIVE_EE_VALGRIND_IPC) {
             m_target = BackendTarget.NATIVE_EE_JNI;
             templateCmdLine.m_backend = BackendTarget.NATIVE_EE_JNI;

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -40,6 +40,8 @@ import org.voltdb.utils.CommandLine;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltFile;
 
+import org.junit.Assume;
+
 /**
  * Implementation of a VoltServerConfig for a multi-process
  * cluster. All cluster processes run locally (keep this in
@@ -1237,6 +1239,12 @@ public class LocalCluster implements VoltServerConfig {
 
     @Override
     public boolean isValgrind() {
+        Assume.assumeTrue( templateCmdLine.m_backend != BackendTarget.NATIVE_EE_VALGRIND_IPC);
+        return templateCmdLine.m_backend == BackendTarget.NATIVE_EE_VALGRIND_IPC;
+    }
+
+    @Override
+    public boolean isValgrindNoExit() {
         return templateCmdLine.m_backend == BackendTarget.NATIVE_EE_VALGRIND_IPC;
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/LocalSingleProcessServer.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalSingleProcessServer.java
@@ -34,6 +34,8 @@ import org.voltdb.StartAction;
 import org.voltdb.VoltDB.Configuration;
 import org.voltdb.compiler.VoltProjectBuilder;
 
+import org.junit.Assume;
+
 /**
  * Implementation of a VoltServerConfig for the simplest case:
  * the single-process VoltServer that's so easy to use.
@@ -214,8 +216,15 @@ public abstract class LocalSingleProcessServer implements VoltServerConfig {
 
     @Override
     public boolean isValgrind() {
+        Assume.assumeTrue( m_target != BackendTarget.NATIVE_EE_VALGRIND_IPC);
         return m_target == BackendTarget.NATIVE_EE_VALGRIND_IPC;
     }
+
+    @Override
+    public boolean isValgrindNoExit() {
+        return m_target == BackendTarget.NATIVE_EE_VALGRIND_IPC;
+    }
+
     @Override
     public void startUp() {
         startUp(true);

--- a/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Random;
 
 import junit.framework.TestCase;
+import org.junit.Assume;
 
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
@@ -117,6 +118,14 @@ public class RegressionSuite extends TestCase {
      * @return Is the underlying instance of VoltDB running Valgrind with the IPC client?
      */
     public boolean isValgrind() {
+        Assume.assumeTrue( ! m_config.isValgrind());
+        return m_config.isValgrind();
+    }
+
+    /**
+     * @return Is the underlying instance of VoltDB running Valgrind with the IPC client?
+     */
+    public boolean isValgrindNoExit() {
         return m_config.isValgrind();
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/VoltServerConfig.java
+++ b/tests/frontend/org/voltdb/regressionsuites/VoltServerConfig.java
@@ -95,8 +95,14 @@ public interface VoltServerConfig {
 
     /**
      * @return Is the underlying instance of VoltDB running IPC with Valgrind?
+     * Will fail assumption of so
      */
     public boolean isValgrind();
+
+    /**
+     * @return Is the underlying instance of VoltDB running IPC with Valgrind?
+     */
+    public boolean isValgrindNoExit();
 
     boolean compileWithPartitionDetection(VoltProjectBuilder builder,
             String snapshotPath,


### PR DESCRIPTION
DO NOT MERGE.
Finds the tests that previously PASS under valgrind, but don't really run valgrind.  2 patterns are recognized and will now FAIL due to a junit Assume failure.
* isValgrind() now exits when it is set. This is often used just before a return, but  the few tests that use this call to change something in the test (such as a constant or sleep) now call isValgrindNoExit().
* overrideAnyRequestForValgrind() now exits when it is set.