### PR TITLE
ENG-7442.  Remove limit in VoltDB on snapshotpriority.

### DIFF
--- a/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
+++ b/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
@@ -199,7 +199,6 @@
   <xs:simpleType name="snapshotPriorityType">
     <xs:restriction base="xs:int">
       <xs:minInclusive value="0"/>
-      <xs:maxInclusive value="10"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
ENG-7442. Remove the max value for snapshot priority. 
See matching pro pull request for making this possible in VEM.
Do not merge until pro tests pass on branch.