### PR TITLE
Trigger disappears after truncate table

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1875,7 +1875,7 @@ void VoltDBEngine::executeTask(TaskType taskType, const char* taskParams) {
 }
 
 int VoltDBEngine::executePurgeFragment(PersistentTable* table) {
-    ExecutorVector *pev = table->getPurgeExecutorVector();
+    boost::shared_ptr<ExecutorVector> pev = table->getPurgeExecutorVector();
 
     // Push a new frame onto the stack for this executor vector
     // to report its tuples modified.  We don't want to actually

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -305,6 +305,14 @@ void PersistentTable::truncateTable(VoltDBEngine* engine) {
         assert(targetEmptyTable);
         new MaterializedViewMetadata(emptyTable, targetEmptyTable, originalView->getMaterializedViewInfo());
     }
+
+    // If there is a purge fragment on the old table, pass it on to the new one
+    if (hasPurgeFragment()) {
+        assert(! emptyTable->hasPurgeFragment());
+        boost::shared_ptr<ExecutorVector> evPtr = getPurgeExecutorVector();
+        emptyTable->swapPurgeExecutorVector(evPtr);
+    }
+
     engine->rebuildTableCollections();
 
     UndoQuantum *uq = ExecutorContext::currentUndoQuantum();

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -444,9 +444,9 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     /**
      * Returns the purge executor vector for this table
      */
-    ExecutorVector* getPurgeExecutorVector() {
+    boost::shared_ptr<ExecutorVector> getPurgeExecutorVector() {
         assert(hasPurgeFragment());
-        return m_purgeExecutorVector.get();
+        return m_purgeExecutorVector;
     }
 
   private:

--- a/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
@@ -508,60 +508,70 @@ public class TestSQLFeaturesNewSuite extends RegressionSuite {
 
         Client client = getClient();
 
-        // The table EVENTS is capped at 5 rows/partition.  Inserts that
-        // would cause the constraint to fail trigger a delete of
-        // the oldest row.
+        // The following test runs twice and does a truncate table
+        // in between, to ensure that the trigger will still work.
+        for (int j = 0; j < 2; ++j) {
 
-        VoltTable vt;
-        for (int i = 0; i < 50; ++i) {
-            String uuid = UUID.randomUUID().toString();
+            // The table EVENTS is capped at 5 rows/partition.  Inserts that
+            // would cause the constraint to fail trigger a delete of
+            // the oldest row.
+            VoltTable vt;
+            for (int i = 0; i < 50; ++i) {
+                String uuid = UUID.randomUUID().toString();
+                vt = client.callProcedure("@AdHoc",
+                        "INSERT INTO events_capped VALUES ('" + uuid + "', NOW, " + i + ")")
+                        .getResults()[0];
+
+                // Note: this should be *one*, even if insert triggered a delete
+                validateTableOfScalarLongs(vt, new long[] {1});
+            }
+
+            // Check the contents
+
+            if (numPartitions > 1) {
+                // For multi-partition tables, it's possible that just one partition
+                // got all the rows, or that rows were evenly distributed (all partitions full).
+                final long minRows = partitionRowLimit;
+                final long maxRows = partitionRowLimit * numPartitions;
+                vt = client.callProcedure("@AdHoc",
+                        "select count(*) from events_capped")
+                        .getResults()[0];
+                long numRows = vt.asScalarLong();
+                assertTrue ("Too many rows in target table: ", numRows <= maxRows);
+                assertTrue ("Too few rows in target table: ", numRows >= minRows);
+
+                // Get all rows in descending order, skipping the 5 most recent rows
+                // (we check the 5 most recent below)
+                vt = client.callProcedure("@AdHoc",
+                        "SELECT info FROM events_capped "
+                                + "ORDER BY when_occurred desc, info desc "
+                                + "LIMIT 50 OFFSET 5")
+                                .getResults()[0];
+                long prevValue = 50;
+                while (vt.advanceRow()) {
+                    long curValue = vt.getLong(0);
+
+                    // row numbers may not be adjacent, depending on how UUID hashed,
+                    // but there should be no duplicates
+                    assertTrue(curValue < prevValue);
+                    prevValue = curValue;
+
+                    // not sure what else we could assert here?
+                }
+            }
+
+            // Should have all of the most recent 5 rows.
             vt = client.callProcedure("@AdHoc",
-                    "INSERT INTO events_capped VALUES ('" + uuid + "', NOW, " + i + ")")
+                    "select info from events_capped order by when_occurred desc, info desc limit 5")
                     .getResults()[0];
+            validateTableOfScalarLongs(vt, new long[] {49, 48, 47, 46, 45});
 
-            // Note: this should be *one*, even if insert triggered a delete
-            validateTableOfScalarLongs(vt, new long[] {1});
-        }
-
-        // Check the contents
-
-        if (numPartitions > 1) {
-            // For multi-partition tables, it's possible that just one partition
-            // got all the rows, or that rows were evenly distributed (all partitions full).
-            final long minRows = partitionRowLimit;
-            final long maxRows = partitionRowLimit * numPartitions;
-            vt = client.callProcedure("@AdHoc",
-                    "select count(*) from events_capped")
-                    .getResults()[0];
-            long numRows = vt.asScalarLong();
-            assertTrue ("Too many rows in target table: ", numRows <= maxRows);
-            assertTrue ("Too few rows in target table: ", numRows >= minRows);
-
-            // Get all rows in descending order, skipping the 5 most recent rows
-            // (we check the 5 most recent below)
-            vt = client.callProcedure("@AdHoc",
-                    "SELECT info FROM events_capped "
-                    + "ORDER BY when_occurred desc, info desc "
-                    + "LIMIT 50 OFFSET 5")
-                    .getResults()[0];
-            long prevValue = 50;
-            while (vt.advanceRow()) {
-                long curValue = vt.getLong(0);
-
-                // row numbers may not be adjacent, depending on how UUID hashed,
-                // but there should be no duplicates
-                assertTrue(curValue < prevValue);
-                prevValue = curValue;
-
-                // not sure what else we could assert here?
+            if (j == 0) {
+                // Do a truncate table and run the test again,
+                // to ensure that the delete trigger still works.
+                client.callProcedure("@AdHoc", "delete from events_capped");
             }
         }
-
-        // Should have all of the most recent 5 rows.
-        vt = client.callProcedure("@AdHoc",
-                "select info from events_capped order by when_occurred desc, info desc limit 5")
-                .getResults()[0];
-        validateTableOfScalarLongs(vt, new long[] {49, 48, 47, 46, 45});
     }
 
     /**


### PR DESCRIPTION
I noticed that if I do "delete from t" where t has a row limit trigger, then the trigger will disappear afterwards.  It turns out that the persistent table object gets created anew for truncate table, and it needs to get the executor vector for the row limit trigger as well.
