### PR TITLE
Fix ENG-7466, extraneous quotes, by removing toString() call.

### DIFF
--- a/examples/json-sessions/client/jsonsessions/JSONClient.java
+++ b/examples/json-sessions/client/jsonsessions/JSONClient.java
@@ -156,7 +156,7 @@ public class JSONClient {
             } else {
                 site = new BlogSession("writer", "reader");
             }
-            site.props.put("last-login", new Long(System.currentTimeMillis()).toString());
+            site.props.put("last-login", new Long(System.currentTimeMillis()));
             // Return the generated login
             return new LoginRecord(username, "pwd", gson.toJson(site));
         }


### PR DESCRIPTION
This is a trivial, one-line bug, in the json-sessions example, which I noticed while writing the new, updated JSON blog(s): the special user sessions named 'voltdb' and 'voltdb2' were being created with extraneous double-quotes around the last-login value, unlike all the other, randomly generated user sessions, so I removed the .toString() call (which was used for those two user sessions, but not elsewhere), which fixes it.