### PR TITLE
Fix issues with row limit trigger and truncate table

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1875,7 +1875,7 @@ void VoltDBEngine::executeTask(TaskType taskType, const char* taskParams) {
 }
 
 int VoltDBEngine::executePurgeFragment(PersistentTable* table) {
-    ExecutorVector *pev = table->getPurgeExecutorVector();
+    boost::shared_ptr<ExecutorVector> pev = table->getPurgeExecutorVector();
 
     // Push a new frame onto the stack for this executor vector
     // to report its tuples modified.  We don't want to actually

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -125,7 +125,7 @@ bool InsertExecutor::p_init(AbstractPlanNode* abstractNode,
     return true;
 }
 
-bool InsertExecutor::executePurgeFragmentIfNeeded(PersistentTable* table) {
+bool InsertExecutor::executePurgeFragmentIfNeeded(PersistentTable** ptrToTable) {
     InsertPlanNode *insertPlanNode = static_cast<InsertPlanNode*>(getPlanNode());
     if (insertPlanNode->isMultiRowInsert()) {
         // Multi-row inserts triggering a purge is not supported yet.
@@ -134,6 +134,7 @@ bool InsertExecutor::executePurgeFragmentIfNeeded(PersistentTable* table) {
         return true;
     }
 
+    PersistentTable* table = *ptrToTable;
     int tupleLimit = table->tupleLimit();
     int numTuples = table->visibleTupleCount();
 
@@ -151,6 +152,13 @@ bool InsertExecutor::executePurgeFragmentIfNeeded(PersistentTable* table) {
                        tupleLimit);
             return false;
         }
+
+        // If the purge fragment did a truncate table, then the old
+        // table is still around for undo purposes, but there is now a
+        // new empty table we can insert into.  Update the caller's table
+        // pointer to use it.
+        TableCatalogDelegate* tcd = m_engine->getTableDelegate(table->name());
+        *ptrToTable = tcd->getPersistentTable();
     }
 
     return true;
@@ -249,8 +257,12 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
             // try to put the tuple into the target table
 
             if (m_hasPurgeFragment) {
-                if (!executePurgeFragmentIfNeeded(persistentTable))
+                if (!executePurgeFragmentIfNeeded(&persistentTable))
                     return false;
+                // purge fragment might have truncated the table, and
+                // refreshed the persistent table pointer.  Make sure to
+                // use it when doing the insert below.
+                targetTable = persistentTable;
             }
 
             if (!targetTable->insertTuple(templateTuple)) {
@@ -270,7 +282,7 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
                 // try to put the tuple into the target table
 
                 if (m_hasPurgeFragment) {
-                    if (!executePurgeFragmentIfNeeded(persistentTable))
+                    if (!executePurgeFragmentIfNeeded(&persistentTable))
                         return false;
                 }
 

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -157,8 +157,10 @@ bool InsertExecutor::executePurgeFragmentIfNeeded(PersistentTable** ptrToTable) 
         // table is still around for undo purposes, but there is now a
         // new empty table we can insert into.  Update the caller's table
         // pointer to use it.
-        TableCatalogDelegate* tcd = m_engine->getTableDelegate(table->name());
-        *ptrToTable = tcd->getPersistentTable();
+        //
+        // The plan node will go through the table catalog delegate to get
+        // the correct instance of PersistentTable.
+        *ptrToTable = static_cast<PersistentTable*>(m_node->getTargetTable());
     }
 
     return true;

--- a/src/ee/executors/insertexecutor.h
+++ b/src/ee/executors/insertexecutor.h
@@ -97,8 +97,14 @@ public:
         /** If the table is at or over its tuple limit, this method
          * executes the purge fragment for the table.  Returns true if
          * nothing went wrong (regardless of whether the purge
-         * fragment was executed) and false otherwise. */
-        bool executePurgeFragmentIfNeeded(PersistentTable* table);
+         * fragment was executed) and false otherwise.
+         *
+         * The purge fragment might perform a truncate table,
+         * in which case the persistent table object we're inserting
+         * into might change.  Passing a pointer-to-pointer allows
+         * the callee to update the persistent table pointer.
+         */
+        bool executePurgeFragmentIfNeeded(PersistentTable** table);
 
         /** A tuple with the target table's schema that is populated
          * with default values for each field. */

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -305,6 +305,14 @@ void PersistentTable::truncateTable(VoltDBEngine* engine) {
         assert(targetEmptyTable);
         new MaterializedViewMetadata(emptyTable, targetEmptyTable, originalView->getMaterializedViewInfo());
     }
+
+    // If there is a purge fragment on the old table, pass it on to the new one
+    if (hasPurgeFragment()) {
+        assert(! emptyTable->hasPurgeFragment());
+        boost::shared_ptr<ExecutorVector> evPtr = getPurgeExecutorVector();
+        emptyTable->swapPurgeExecutorVector(evPtr);
+    }
+
     engine->rebuildTableCollections();
 
     UndoQuantum *uq = ExecutorContext::currentUndoQuantum();

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -444,9 +444,9 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     /**
      * Returns the purge executor vector for this table
      */
-    ExecutorVector* getPurgeExecutorVector() {
+    boost::shared_ptr<ExecutorVector> getPurgeExecutorVector() {
         assert(hasPurgeFragment());
-        return m_purgeExecutorVector.get();
+        return m_purgeExecutorVector;
     }
 
   private:

--- a/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
@@ -574,6 +574,19 @@ public class TestSQLFeaturesNewSuite extends RegressionSuite {
         }
     }
 
+    public void testLimitRowsWithTruncate() throws IOException, ProcCallException {
+        if (isHSQL())
+            return;
+
+        Client client = getClient();
+
+        for (int i = 0; i < 13; ++i) {
+            VoltTable vt = client.callProcedure("CAPPED_TRUNCATE.insert", i)
+                    .getResults()[0];
+            validateTableOfScalarLongs(vt, new long[] {1});
+        }
+    }
+
     /**
      * Build a list of the tests that will be run when TestTPCCSuite gets run by JUnit.
      * Use helper classes that are part of the RegressionSuite framework.

--- a/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
@@ -508,60 +508,70 @@ public class TestSQLFeaturesNewSuite extends RegressionSuite {
 
         Client client = getClient();
 
-        // The table EVENTS is capped at 5 rows/partition.  Inserts that
-        // would cause the constraint to fail trigger a delete of
-        // the oldest row.
+        // The following test runs twice and does a truncate table
+        // in between, to ensure that the trigger will still work.
+        for (int j = 0; j < 2; ++j) {
 
-        VoltTable vt;
-        for (int i = 0; i < 50; ++i) {
-            String uuid = UUID.randomUUID().toString();
+            // The table EVENTS is capped at 5 rows/partition.  Inserts that
+            // would cause the constraint to fail trigger a delete of
+            // the oldest row.
+            VoltTable vt;
+            for (int i = 0; i < 50; ++i) {
+                String uuid = UUID.randomUUID().toString();
+                vt = client.callProcedure("@AdHoc",
+                        "INSERT INTO events_capped VALUES ('" + uuid + "', NOW, " + i + ")")
+                        .getResults()[0];
+
+                // Note: this should be *one*, even if insert triggered a delete
+                validateTableOfScalarLongs(vt, new long[] {1});
+            }
+
+            // Check the contents
+
+            if (numPartitions > 1) {
+                // For multi-partition tables, it's possible that just one partition
+                // got all the rows, or that rows were evenly distributed (all partitions full).
+                final long minRows = partitionRowLimit;
+                final long maxRows = partitionRowLimit * numPartitions;
+                vt = client.callProcedure("@AdHoc",
+                        "select count(*) from events_capped")
+                        .getResults()[0];
+                long numRows = vt.asScalarLong();
+                assertTrue ("Too many rows in target table: ", numRows <= maxRows);
+                assertTrue ("Too few rows in target table: ", numRows >= minRows);
+
+                // Get all rows in descending order, skipping the 5 most recent rows
+                // (we check the 5 most recent below)
+                vt = client.callProcedure("@AdHoc",
+                        "SELECT info FROM events_capped "
+                                + "ORDER BY when_occurred desc, info desc "
+                                + "LIMIT 50 OFFSET 5")
+                                .getResults()[0];
+                long prevValue = 50;
+                while (vt.advanceRow()) {
+                    long curValue = vt.getLong(0);
+
+                    // row numbers may not be adjacent, depending on how UUID hashed,
+                    // but there should be no duplicates
+                    assertTrue(curValue < prevValue);
+                    prevValue = curValue;
+
+                    // not sure what else we could assert here?
+                }
+            }
+
+            // Should have all of the most recent 5 rows.
             vt = client.callProcedure("@AdHoc",
-                    "INSERT INTO events_capped VALUES ('" + uuid + "', NOW, " + i + ")")
+                    "select info from events_capped order by when_occurred desc, info desc limit 5")
                     .getResults()[0];
+            validateTableOfScalarLongs(vt, new long[] {49, 48, 47, 46, 45});
 
-            // Note: this should be *one*, even if insert triggered a delete
-            validateTableOfScalarLongs(vt, new long[] {1});
-        }
-
-        // Check the contents
-
-        if (numPartitions > 1) {
-            // For multi-partition tables, it's possible that just one partition
-            // got all the rows, or that rows were evenly distributed (all partitions full).
-            final long minRows = partitionRowLimit;
-            final long maxRows = partitionRowLimit * numPartitions;
-            vt = client.callProcedure("@AdHoc",
-                    "select count(*) from events_capped")
-                    .getResults()[0];
-            long numRows = vt.asScalarLong();
-            assertTrue ("Too many rows in target table: ", numRows <= maxRows);
-            assertTrue ("Too few rows in target table: ", numRows >= minRows);
-
-            // Get all rows in descending order, skipping the 5 most recent rows
-            // (we check the 5 most recent below)
-            vt = client.callProcedure("@AdHoc",
-                    "SELECT info FROM events_capped "
-                    + "ORDER BY when_occurred desc, info desc "
-                    + "LIMIT 50 OFFSET 5")
-                    .getResults()[0];
-            long prevValue = 50;
-            while (vt.advanceRow()) {
-                long curValue = vt.getLong(0);
-
-                // row numbers may not be adjacent, depending on how UUID hashed,
-                // but there should be no duplicates
-                assertTrue(curValue < prevValue);
-                prevValue = curValue;
-
-                // not sure what else we could assert here?
+            if (j == 0) {
+                // Do a truncate table and run the test again,
+                // to ensure that the delete trigger still works.
+                client.callProcedure("@AdHoc", "delete from events_capped");
             }
         }
-
-        // Should have all of the most recent 5 rows.
-        vt = client.callProcedure("@AdHoc",
-                "select info from events_capped order by when_occurred desc, info desc limit 5")
-                .getResults()[0];
-        validateTableOfScalarLongs(vt, new long[] {49, 48, 47, 46, 45});
     }
 
     /**

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/sqlfeatures-new-ddl.sql
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/sqlfeatures-new-ddl.sql
@@ -64,6 +64,12 @@ PARTITION TABLE events_capped ON COLUMN event_id;
 CREATE UNIQUE INDEX events_capped_when_id
        ON events_capped (when_occurred, event_id);
 
+CREATE TABLE capped_truncate (
+  i integer,
+  CONSTRAINT limit_5_truncate LIMIT PARTITION ROWS 5
+  EXECUTE (DELETE FROM capped_truncate)
+);
+
 
 CREATE TABLE RTABLE (
     ID INTEGER DEFAULT 0 NOT NULL,


### PR DESCRIPTION
When writing the example app I found a few issues that had to do with truncating a table:
* When truncating a table, the row limit trigger for a table would disappear.  It needs to be propagated to the new PersistentTable object that gets created.
* When the row limit trigger itself does a truncate table, then the insert executor's pointer to the PersistentTable being modified needs to be updated; otherwise we're just attempting to insert into the old, full table.
