### PR TITLE
Execute row limit trigger for INSERT and UPSERT INTO ... SELECT

### DIFF
--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -126,14 +126,6 @@ bool InsertExecutor::p_init(AbstractPlanNode* abstractNode,
 }
 
 bool InsertExecutor::executePurgeFragmentIfNeeded(PersistentTable** ptrToTable) {
-    InsertPlanNode *insertPlanNode = static_cast<InsertPlanNode*>(getPlanNode());
-    if (insertPlanNode->isMultiRowInsert()) {
-        // Multi-row inserts triggering a purge is not supported yet.
-        // This should not be difficult to support, just need to
-        // remove this check and add testing.
-        return true;
-    }
-
     PersistentTable* table = *ptrToTable;
     int tupleLimit = table->tupleLimit();
     int numTuples = table->visibleTupleCount();

--- a/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
@@ -221,7 +221,6 @@ public class ParsedInsertStmt extends AbstractParsedStmt {
      * when row limit is met
      */
     public boolean targetTableHasLimitRowsTrigger() {
-        // TODO Auto-generated method stub
         assert(m_tableList.size() == 1);
         CatalogMap<Statement> stmtMap = m_tableList.get(0).getTuplelimitdeletestmt();
         if (stmtMap != null && stmtMap.size() > 0)

--- a/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
@@ -24,8 +24,10 @@ import java.util.Map.Entry;
 
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.voltdb.VoltType;
+import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.Database;
+import org.voltdb.catalog.Statement;
 import org.voltdb.catalog.Table;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.ConstantValueExpression;
@@ -221,6 +223,9 @@ public class ParsedInsertStmt extends AbstractParsedStmt {
     public boolean targetTableHasLimitRowsTrigger() {
         // TODO Auto-generated method stub
         assert(m_tableList.size() == 1);
-        return m_tableList.get(0).getTuplelimitdeletestmt().size() != 0;
+        CatalogMap<Statement> stmtMap = m_tableList.get(0).getTuplelimitdeletestmt();
+        if (stmtMap != null && stmtMap.size() > 0)
+            return true;
+        return false;
     }
 }

--- a/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
@@ -213,4 +213,14 @@ public class ParsedInsertStmt extends AbstractParsedStmt {
         assert(getSubselectStmt() != null);
         return getSubselectStmt().isOrderDeterministicInSpiteOfUnorderedSubqueries();
     }
+
+    /**
+     * Returns true if the table being inserted into has a trigger executed
+     * when row limit is met
+     */
+    public boolean targetTableHasLimitRowsTrigger() {
+        // TODO Auto-generated method stub
+        assert(m_tableList.size() == 1);
+        return m_tableList.get(0).getTuplelimitdeletestmt().size() != 0;
+    }
 }

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -365,7 +365,7 @@ public class PlanAssembler {
             else if (targetHasLimitRowsTrigger) {
                 throw new PlanningErrorException(
                         "Order of rows produced by SELECT statement in INSERT INTO ... SELECT is "
-                        + "non-deterministic.  Since the table being insert into has a row limit "
+                        + "non-deterministic.  Since the table being inserted into has a row limit "
                         + "trigger, the SELECT output must be ordered.  Add an ORDER BY clause "
                         + "to address this issue."
                         );


### PR DESCRIPTION
This was pretty straightforward, except that it occurred to me that we get non-deterministic behavior when doing multi-row inserts into a table with a row limit trigger. So I added checks to guard against that.