### PR TITLE
Add regular expressions to VMC for LIMIT PARTITION ROWS

### DIFF
--- a/src/frontend/org/voltdb/dbmonitor/js/voltdb.queryrender.js
+++ b/src/frontend/org/voltdb/dbmonitor/js/voltdb.queryrender.js
@@ -89,12 +89,16 @@
                 /(\s*(?:create\s+procedure\s+)(?:(?!create\s+(?:view|procedure))[\s\S])*\s+as\s+)((?:(?:\s\()*select)|insert|update|upsert|delete|truncate)\s+/gim,
             //   ($1----------------------------------------------------------------------------)($2------------------------------------------------------)
 
-	    // LIMIT PARTITION ROWS <n> EXECUTE (DELETE ...)
-	    // There are three keywords that may start statements to escape:
-	    //	 partition, execute, and delete
-	    MatchLimitPartition = /(\s*limit\s+)(partition)/gim,
-	    MatchRowcountExecute = /(\s*rows\s+\d+\s+)(execute)/gim,
-	    MatchExecuteDelete = /(\s*execute\s*\(\s*)(delete)/gim,
+            // LIMIT PARTITION ROWS <n> EXECUTE (DELETE ...)
+            // There are three keywords that may start statements to escape:
+            //
+            //   partition, execute, and delete
+            //
+            // They require escaping when they are immediately preceded by
+            // "limit", "rows <n>", and "execute(", respectively.
+            MatchLimitPartition = /(\s*limit\s+)(partition)/gim,
+            MatchRowcountExecute = /(\s*rows\s+\d+\s+)(execute)/gim,
+            MatchExecuteDelete = /(\s*execute\s*\(\s*)(delete)/gim,
 
             MatchCompoundKeywordDisguise = /#NON_BREAKING_SUFFIX_KEYWORD#/g,
             GenerateDisguisedCompoundKeywords = ' $1 #NON_BREAKING_SUFFIX_KEYWORD#$2 ';
@@ -162,9 +166,9 @@
             src = src.replace(MatchCreateView, GenerateDisguisedCompoundKeywords);
             src = src.replace(MatchCreateSingleQueryProcedure, GenerateDisguisedCompoundKeywords);
 
-	    src = src.replace(MatchLimitPartition, GenerateDisguisedCompoundKeywords);
-	    src = src.replace(MatchRowcountExecute, GenerateDisguisedCompoundKeywords);
-	    src = src.replace(MatchExecuteDelete, GenerateDisguisedCompoundKeywords);
+            src = src.replace(MatchLimitPartition, GenerateDisguisedCompoundKeywords);
+            src = src.replace(MatchRowcountExecute, GenerateDisguisedCompoundKeywords);
+            src = src.replace(MatchExecuteDelete, GenerateDisguisedCompoundKeywords);
 
             if (!src.match("^explain")) {
                 // Start a new statement before each remaining statement keyword.

--- a/src/frontend/org/voltdb/dbmonitor/js/voltdb.queryrender.js
+++ b/src/frontend/org/voltdb/dbmonitor/js/voltdb.queryrender.js
@@ -88,6 +88,14 @@
             MatchCreateSingleQueryProcedure =
                 /(\s*(?:create\s+procedure\s+)(?:(?!create\s+(?:view|procedure))[\s\S])*\s+as\s+)((?:(?:\s\()*select)|insert|update|upsert|delete|truncate)\s+/gim,
             //   ($1----------------------------------------------------------------------------)($2------------------------------------------------------)
+
+	    // LIMIT PARTITION ROWS <n> EXECUTE (DELETE ...)
+	    // There are three keywords that may start statements to escape:
+	    //	 partition, execute, and delete
+	    MatchLimitPartition = /(\s*limit\s+)(partition)/gim,
+	    MatchRowcountExecute = /(\s*rows\s+\d+\s+)(execute)/gim,
+	    MatchExecuteDelete = /(\s*execute\s*\(\s*)(delete)/gim,
+
             MatchCompoundKeywordDisguise = /#NON_BREAKING_SUFFIX_KEYWORD#/g,
             GenerateDisguisedCompoundKeywords = ' $1 #NON_BREAKING_SUFFIX_KEYWORD#$2 ';
 
@@ -153,6 +161,10 @@
             src = src.replace(MatchNonBreakingCompoundKeywords, GenerateDisguisedCompoundKeywords);
             src = src.replace(MatchCreateView, GenerateDisguisedCompoundKeywords);
             src = src.replace(MatchCreateSingleQueryProcedure, GenerateDisguisedCompoundKeywords);
+
+	    src = src.replace(MatchLimitPartition, GenerateDisguisedCompoundKeywords);
+	    src = src.replace(MatchRowcountExecute, GenerateDisguisedCompoundKeywords);
+	    src = src.replace(MatchExecuteDelete, GenerateDisguisedCompoundKeywords);
 
             if (!src.match("^explain")) {
                 // Start a new statement before each remaining statement keyword.
@@ -259,7 +271,7 @@
 
         $("#runBTn").attr('disabled', 'disabled');
         $("#runBTn").addClass("graphOpacity");
-        
+
         var statements = CommandParser.parseUserInput(source);
         var start = (new Date()).getTime();
         var connectionQueue = connection.getQueue();


### PR DESCRIPTION
In particular, we don't want to start new commands for keywords
PARTITON, EXECUTE and DELETE when they appear in a limit rows
constraint.

I tested this manually, I'll create a separate ticket for the GEB testing bit.