### PR TITLE
Include a call to ensure inserts have plans for @LoadXXXTable calls in replay modes

### DIFF
--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -156,6 +156,14 @@ public class FragmentTask extends TransactionTask
                 m_txnState.setBeginUndoToken(siteConnection.getLatestUndoToken());
             }
         }
+
+        // Ensure default procs loaded here
+        String procName = m_fragmentMsg.getProcedureName();
+        if (procName != null) {
+            // this will ensure proc is loaded
+            siteConnection.getProcedureRunner(procName);
+        }
+
         // ignore response.
         processFragmentTask(siteConnection);
         completeFragment();
@@ -182,6 +190,7 @@ public class FragmentTask extends TransactionTask
             // this will ensure proc is loaded
             siteConnection.getProcedureRunner(procName);
         }
+
         // @LoadMultipartitionTable also uses a default proc plan for insert into
         // replicated tables, so it needed to be awkwardly teased out here.
         if (procName.startsWith("@LoadMultipartitionTable")) {


### PR DESCRIPTION
Fix a bug introduced by not-compiling default procs until they are called.