### PR TITLE
Remove erroneous assertion from EE

### DIFF
--- a/src/ee/executors/nestloopindexexecutor.cpp
+++ b/src/ee/executors/nestloopindexexecutor.cpp
@@ -312,10 +312,6 @@ bool NestLoopIndexExecutor::p_execute(const NValueArray &params)
                     if ((localLookupType != INDEX_LOOKUP_TYPE_EQ) &&
                         (ctr == (activeNumOfSearchKeys - 1))) {
 
-                        // sanity check that there is at least one EQ column
-                        // or else the join wouldn't work, right?
-                        assert(activeNumOfSearchKeys > 1);
-
                         if (e.getInternalFlags() & SQLException::TYPE_OVERFLOW) {
                             if ((localLookupType == INDEX_LOOKUP_TYPE_GT) ||
                                 (localLookupType == INDEX_LOOKUP_TYPE_GTE)) {
@@ -357,8 +353,8 @@ bool NestLoopIndexExecutor::p_execute(const NValueArray &params)
                         keyException = true;
                     }
                     break;
-                }
-            }
+                } // End catch block for under- or overflow when setting index key
+            } // End for each active search key
             VOLT_TRACE("Searching %s", index_values.debug("").c_str());
 
             // if a search value didn't fit into the targeted index key, skip this key

--- a/src/ee/plannodes/abstractjoinnode.cpp
+++ b/src/ee/plannodes/abstractjoinnode.cpp
@@ -83,7 +83,7 @@ void AbstractJoinPlanNode::getOutputColumnExpressions(
 std::string AbstractJoinPlanNode::debugInfo(const std::string& spacer) const
 {
     std::ostringstream buffer;
-    buffer << spacer << "JoinType[" << m_joinType << "]\n";
+    buffer << spacer << "JoinType[" << joinToString(m_joinType) << "]\n";
     if (m_preJoinPredicate != NULL)
     {
         buffer << spacer << "Pre-Join Predicate\n";

--- a/src/ee/plannodes/indexscannode.cpp
+++ b/src/ee/plannodes/indexscannode.cpp
@@ -60,8 +60,10 @@ std::string IndexScanPlanNode::debugInfo(const std::string &spacer) const
     std::ostringstream buffer;
     buffer << AbstractScanPlanNode::debugInfo(spacer);
     buffer << spacer << "TargetIndexName[" << m_target_index_name << "]\n";
-    buffer << spacer << "IndexLookupType[" << m_lookup_type << "]\n";
-    buffer << spacer << "SortDirection[" << m_sort_direction << "]\n";
+    buffer << spacer << "IndexLookupType["
+           << indexLookupToString(m_lookup_type) << "]\n";
+    buffer << spacer << "SortDirection["
+           << sortDirectionToString(m_sort_direction) << "]\n";
 
     buffer << spacer << "SearchKey Expressions:\n";
     for (int ctr = 0, cnt = (int)m_searchkey_expressions.size(); ctr < cnt; ctr++) {

--- a/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
@@ -1840,6 +1840,23 @@ public class TestFixedSQLSuite extends RegressionSuite {
                 new long[][] {{1}});
     }
 
+    public void testInnerJoinWithOverflow() throws Exception {
+        // In this bug, ENG-7349, we would fail an erroneous assertion
+        // in the EE that we must have more than one active index key when
+        // joining with a multi-component index.
+
+        Client client = getClient();
+
+        VoltTable vt = client.callProcedure("SM_IDX_TBL.insert", 1, 1, 1000)
+                .getResults()[0];
+        validateTableOfScalarLongs(vt, new long[] {1});
+
+        validateTableOfLongs(client,
+                "select * "
+                + "from sm_idx_tbl as t1 inner join sm_idx_tbl as t2 "
+                + "on t1.ti1 = t2.bi",
+                new long[][] {});
+    }
 
     //
     // JUnit / RegressionSuite boilerplate

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/fixed-sql-ddl.sql
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/fixed-sql-ddl.sql
@@ -254,3 +254,14 @@ FROM transaction
 GROUP BY acc_no, vendor_id;
 -- End tables for ENG-7041   --
 -- ************************* --
+
+-- ************************* --
+-- Table for ENG-7349        --
+create table sm_idx_tbl(
+       ti1 tinyint,
+       ti2 tinyint,
+       bi bigint
+);
+create index sm_idx on sm_idx_tbl(ti1, ti2);
+-- End table for ENG-7349    --
+-- ************************* --


### PR DESCRIPTION
This was causing a failed assertion when running sqlcoverage.  When searching for a value in an index that is larger than the index's component types (e.g., I have a bigint 1000 that I'm searching for in a tinyint index), then an assertion in the EE requires more than one component in the index to be specified.  Now, that I understand the code a bit better, I don't think there's any reason this needs to be the case, so I just removed the assertion.