### PR TITLE
ENG-7573: Introduce catalog hash down into CorePlan.  Goes nowhere

### DIFF
--- a/src/frontend/org/voltdb/CatalogContext.java
+++ b/src/frontend/org/voltdb/CatalogContext.java
@@ -61,6 +61,7 @@ public class CatalogContext {
     public final CatalogMap<Table> tables;
     public final AuthSystem authSystem;
     public final int catalogVersion;
+    private final byte[] catalogHash;
     private final long catalogCRC;
     private final byte[] deploymentBytes;
     public final byte[] deploymentHash;
@@ -79,7 +80,6 @@ public class CatalogContext {
     public final PlannerTool m_ptool;
 
     // PRIVATE
-    //private final String m_path;
     private final InMemoryJarfile m_jarfile;
 
     // Some people may be interested in the JAXB rather than the raw deployment bytes.
@@ -91,34 +91,34 @@ public class CatalogContext {
             Catalog catalog,
             byte[] catalogBytes,
             byte[] deploymentBytes,
-            int version,
-            long prevCRC) {
+            int version)
+    {
         m_transactionId = transactionId;
         m_uniqueId = uniqueId;
         // check the heck out of the given params in this immutable class
         assert(catalog != null);
-        if (catalog == null)
+        if (catalog == null) {
             throw new RuntimeException("Can't create CatalogContext with null catalog.");
+        }
 
         assert(deploymentBytes != null);
-        if (deploymentBytes == null)
+        if (deploymentBytes == null) {
             throw new RuntimeException("Can't create CatalogContext with null deployment bytes.");
+        }
 
-        //m_path = pathToCatalogJar;
-        long tempCRC = 0;
+        assert(catalogBytes != null);
         if (catalogBytes != null) {
             try {
                 m_jarfile = new InMemoryJarfile(catalogBytes);
-                tempCRC = m_jarfile.getCRC();
+                catalogCRC = m_jarfile.getCRC();
             }
             catch (Exception e) {
                 throw new RuntimeException(e);
             }
-            catalogCRC = tempCRC;
+            this.catalogHash = CatalogUtil.makeCatalogOrDeploymentHash(catalogBytes);
         }
         else {
-            m_jarfile = null;
-            catalogCRC = prevCRC;
+            throw new RuntimeException("Can't create CatalogContext with null catalog bytes.");
         }
 
         this.catalog = catalog;
@@ -135,7 +135,7 @@ public class CatalogContext {
         m_defaultProcs = new DefaultProcedureManager(database);
 
         m_jdbc = new JdbcDatabaseMetaDataGenerator(catalog, m_defaultProcs, m_jarfile);
-        m_ptool = new PlannerTool(cluster, database, version);
+        m_ptool = new PlannerTool(cluster, database, catalogHash);
         catalogVersion = version;
 
         if (procedures != null) {
@@ -182,8 +182,7 @@ public class CatalogContext {
                     newCatalog,
                     bytes,
                     depbytes,
-                    catalogVersion + incValue,
-                    catalogCRC);
+                    catalogVersion + incValue);
         return retval;
     }
 
@@ -345,13 +344,6 @@ public class CatalogContext {
 
     public byte[] getCatalogHash()
     {
-        byte[] catalogHash = null;
-        try {
-            // IZZY: memoize the catalog hash in the catalog context sometime, maybe
-            catalogHash = CatalogUtil.makeCatalogOrDeploymentHash(getCatalogJarBytes());
-        } catch (IOException ioe) {
-            // Should never happen
-        }
         return catalogHash;
     }
 }

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -2191,7 +2191,8 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
 
                         // assume all stmts have the same catalog version
                         if ((plannedStmtBatch.getPlannedStatementCount() > 0) &&
-                            (plannedStmtBatch.getPlannedStatement(0).core.catalogVersion != m_catalogContext.get().catalogVersion)) {
+                            (!plannedStmtBatch.getPlannedStatement(0).core.wasPlannedAgainstHash(m_catalogContext.get().getCatalogHash())))
+                        {
 
                             /* The adhoc planner learns of catalog updates after the EE and the
                                rest of the system. If the adhoc sql was planned against an

--- a/src/frontend/org/voltdb/Inits.java
+++ b/src/frontend/org/voltdb/Inits.java
@@ -388,7 +388,7 @@ public class Inits {
                         catalogJarBytes,
                         // Our starter catalog has set the deployment stuff, just yoink it out for now
                         m_rvdb.m_catalogContext.getDeploymentBytes(),
-                        catalogStuff.version, -1);
+                        catalogStuff.version);
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("Error agreeing on starting catalog version", true, e);
             }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1447,10 +1447,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback
                             TxnEgo.makeZero(MpInitiator.MP_INIT_PID).getTxnId(), //txnid
                             0, //timestamp
                             catalog,
-                            null,
+                            new byte[] {},
                             deploymentBytes,
-                            0,
-                            -1);
+                            0);
 
             return deployment.getCluster().getHostcount();
         } catch (Exception e) {
@@ -1967,7 +1966,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback
                 m_latencyStats = null;
                 m_latencyHistogramStats = null;
 
-                AdHocCompilerCache.clearVersionCache();
+                AdHocCompilerCache.clearHashCache();
                 org.voltdb.iv2.InitiatorMailbox.m_allInitiatorMailboxes.clear();
 
                 // probably unnecessary

--- a/src/frontend/org/voltdb/compiler/AdHocCompilerCache.java
+++ b/src/frontend/org/voltdb/compiler/AdHocCompilerCache.java
@@ -27,6 +27,7 @@ import java.util.TimerTask;
 
 import org.voltdb.common.Constants;
 import org.voltdb.planner.BoundPlan;
+import org.voltdb.utils.Encoder;
 
 import com.google_voltpatches.common.cache.Cache;
 import com.google_voltpatches.common.cache.CacheBuilder;
@@ -50,23 +51,24 @@ public class AdHocCompilerCache implements Serializable {
     // STATIC CODE TO MANAGE CACHE LIFETIMES / GLOBALNESS
     //////////////////////////////////////////////////////////////////////////
 
-    // weak values should remove the object when the catalog version is no longer needed
-    private static Cache<Integer, AdHocCompilerCache> m_catalogVersionMatch =
+    // weak values should remove the object when the catalog hash is no longer needed
+    private static Cache<String, AdHocCompilerCache> m_catalogHashMatch =
             CacheBuilder.newBuilder().weakValues().build();
 
-    public static void clearVersionCache() {
-        m_catalogVersionMatch.invalidateAll();
+    public static void clearHashCache() {
+        m_catalogHashMatch.invalidateAll();
     }
 
     /**
-     * Get the global cache for a given version of the catalog. Note that there can be only
-     * one cache per catalogVersion at a time.
+     * Get the global cache for a given hash of the catalog. Note that there can be only
+     * one cache per catalogHash at a time.
      */
-    public synchronized static AdHocCompilerCache getCacheForCatalogVersion(int catalogVersion) {
-        AdHocCompilerCache cache = m_catalogVersionMatch.getIfPresent(catalogVersion);
+    public synchronized static AdHocCompilerCache getCacheForCatalogHash(byte[] catalogHash) {
+        String hashString = Encoder.hexEncode(catalogHash);
+        AdHocCompilerCache cache = m_catalogHashMatch.getIfPresent(hashString);
         if (cache == null) {
             cache = new AdHocCompilerCache();
-            m_catalogVersionMatch.put(catalogVersion, cache);
+            m_catalogHashMatch.put(hashString, cache);
         }
         return cache;
     }

--- a/src/frontend/org/voltdb/compiler/AdHocPlannedStmtBatch.java
+++ b/src/frontend/org/voltdb/compiler/AdHocPlannedStmtBatch.java
@@ -110,7 +110,8 @@ public class AdHocPlannedStmtBatch extends AsyncCompilerResult implements Clonea
 
     public static AdHocPlannedStmtBatch mockStatementBatch(long replySiteId, String sql,
             Object[] extractedValues, VoltType[] paramTypes,
-            Object[] userParams, int partitionParamIndex) {
+            Object[] userParams, int partitionParamIndex, byte[] catalogHash)
+    {
         // Mock up a dummy completion handler to satisfy the dummy work request.
         AsyncCompilerWorkCompletionHandler dummyHandler = new AsyncCompilerWorkCompletionHandler() {
 
@@ -133,7 +134,7 @@ public class AdHocPlannedStmtBatch extends AsyncCompilerResult implements Clonea
                 false,
                 true,
                 paramTypes,
-                0);
+                catalogHash);
         AdHocPlannedStatement s = new AdHocPlannedStatement(sql.getBytes(Constants.UTF8ENCODING),
                 core,
                 extractedValues == null ? ParameterSet.emptyParameterSet() :

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -50,20 +50,21 @@ public class PlannerTool {
     final Database m_database;
     final Cluster m_cluster;
     final HSQLInterface m_hsql;
-    final int m_catalogVersion;
+    final byte[] m_catalogHash;
     final AdHocCompilerCache m_cache;
     static PlannerStatsCollector m_plannerStats;
 
     public static final int AD_HOC_JOINED_TABLE_LIMIT = 5;
 
-    public PlannerTool(final Cluster cluster, final Database database, int catalogVersion) {
+    public PlannerTool(final Cluster cluster, final Database database, byte[] catalogHash)
+    {
         assert(cluster != null);
         assert(database != null);
 
         m_database = database;
         m_cluster = cluster;
-        m_catalogVersion = catalogVersion;
-        m_cache = AdHocCompilerCache.getCacheForCatalogVersion(catalogVersion);
+        m_catalogHash = catalogHash;
+        m_cache = AdHocCompilerCache.getCacheForCatalogHash(catalogHash);
 
         // LOAD HSQL
         m_hsql = HSQLInterface.loadHsqldb();
@@ -229,7 +230,7 @@ public class PlannerTool {
             //////////////////////
             // OUTPUT THE RESULT
             //////////////////////
-            CorePlan core = new CorePlan(plan, m_catalogVersion);
+            CorePlan core = new CorePlan(plan, m_catalogHash);
             AdHocPlannedStatement ahps = new AdHocPlannedStatement(plan, core);
 
             if (partitioning.isInferred()) {

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -150,7 +150,9 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
 
         @Override
         public byte[] getCatalogHash() {
-            throw new RuntimeException("Not needed for RO MP Site, shouldn't be here.");
+            // AdHoc invocations need to be able to check the hash of the current catalog
+            // against the hash of the catalog they were planned against.
+            return m_context.getCatalogHash();
         }
 
         @Override

--- a/src/frontend/org/voltdb/planner/CorePlan.java
+++ b/src/frontend/org/voltdb/planner/CorePlan.java
@@ -54,8 +54,8 @@ public class CorePlan {
     /** Does the statement write? */
     public final boolean readOnly;
 
-    /** Which version of the catalog is this plan good for? */
-    public final int catalogVersion;
+    /** What SHA-1 hash of the catalog is this plan good for? */
+    private final byte[] catalogHash;
 
     /** What are the types of the paramters this plan accepts? */
     public final VoltType[] parameterTypes;
@@ -72,9 +72,9 @@ public class CorePlan {
      * Constructor from QueryPlanner output.
      *
      * @param plan The output from the QueryPlanner.
-     * @param catalogVersion The version of the catalog this plan was generated against.
+     * @param catalogHash  The sha-1 hash of the catalog this plan was generated against.
      */
-    public CorePlan(CompiledPlan plan, int catalogVersion) {
+    public CorePlan(CompiledPlan plan, byte[] catalogHash) {
         aggregatorFragment = CompiledPlan.bytesForPlan(plan.rootPlanGraph);
         collectorFragment = CompiledPlan.bytesForPlan(plan.subPlanGraph);
 
@@ -98,7 +98,7 @@ public class CorePlan {
         }
 
         isReplicatedTableDML = plan.replicatedTableDML;
-        this.catalogVersion = catalogVersion;
+        this.catalogHash = catalogHash;
         parameterTypes = plan.parameterTypes();
         readOnly = plan.getReadOnly();
     }
@@ -111,7 +111,7 @@ public class CorePlan {
      * @param isReplicatedTableDML      replication flag
      * @param isReadOnly                does it write
      * @param paramTypes                parameter type array
-     * @param catalogVersion            catalog version
+     * @param catalogHash               SHA-1 hash of catalog
      */
     public CorePlan(byte[] aggregatorFragment,
                     byte[] collectorFragment,
@@ -120,7 +120,8 @@ public class CorePlan {
                     boolean isReplicatedTableDML,
                     boolean isReadOnly,
                     VoltType[] paramTypes,
-                    int catalogVersion) {
+                    byte[] catalogHash)
+    {
         this.aggregatorFragment = aggregatorFragment;
         this.collectorFragment = collectorFragment;
         this.aggregatorHash = aggregatorHash;
@@ -128,7 +129,7 @@ public class CorePlan {
         this.isReplicatedTableDML = isReplicatedTableDML;
         this.readOnly = isReadOnly;
         this.parameterTypes = paramTypes;
-        this.catalogVersion = catalogVersion;
+        this.catalogHash = catalogHash;
     }
 
     @Override
@@ -153,8 +154,8 @@ public class CorePlan {
         else {
             size += 4;
         }
-        size += 3; // booleans
-        size += 4; // catalog version
+        size += 2; // booleans
+        size += 20;  // catalog hash SHA-1 is 20b
 
         size += 2; // params count
         size += parameterTypes.length;
@@ -180,8 +181,8 @@ public class CorePlan {
         buf.put((byte) (isReplicatedTableDML ? 1 : 0));
         buf.put((byte) (readOnly ? 1 : 0));
 
-        // catalog version
-        buf.putInt(catalogVersion);
+        // catalog hash
+        buf.put(catalogHash);
 
         // param types
         buf.putShort((short) parameterTypes.length);
@@ -210,8 +211,9 @@ public class CorePlan {
         boolean isReplicatedTableDML = buf.get() == 1;
         boolean isReadOnly = buf.get() == 1;
 
-        // catalog version
-        int catalogVersion = buf.getInt();
+        // catalog hash
+        byte[] catalogHash = new byte[20];  // Catalog sha-1 hash is 20b
+        buf.get(catalogHash);
 
         // param types
         short paramCount = buf.getShort();
@@ -228,7 +230,7 @@ public class CorePlan {
                 isReplicatedTableDML,
                 isReadOnly,
                 paramTypes,
-                catalogVersion);
+                catalogHash);
     }
 
     /* (non-Javadoc)
@@ -258,7 +260,7 @@ public class CorePlan {
         if (readOnly != other.readOnly) {
             return false;
         }
-        if (catalogVersion != other.catalogVersion) {
+        if (!Arrays.equals(catalogHash, other.catalogHash)) {
             return false;
         }
         if (partitioningParamIndex != other.partitioningParamIndex) {
@@ -291,11 +293,13 @@ public class CorePlan {
     }
 
     public VoltType getPartitioningParamType() {
-        // TODO Auto-generated method stub
         if (partitioningParamIndex < 0 || partitioningParamIndex >= parameterTypes.length) {
             return VoltType.NULL;
         }
         return parameterTypes[partitioningParamIndex];
     }
 
+    public boolean wasPlannedAgainstHash(byte[] catalogHash) {
+        return Arrays.equals(catalogHash, this.catalogHash);
+    }
 }

--- a/src/frontend/org/voltdb/sysprocs/AdHocBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocBase.java
@@ -89,10 +89,8 @@ public abstract class AdHocBase extends VoltSystemProcedure {
             return new VoltTable[]{};
         }
 
-        int currentCatalogVersion = ctx.getCatalogVersion();
-
         for (AdHocPlannedStatement statement : statements) {
-            if (currentCatalogVersion != statement.core.catalogVersion) {
+            if (!statement.core.wasPlannedAgainstHash(ctx.getCatalogHash())) {
                 String msg = String.format("AdHoc transaction %d wasn't planned " +
                         "against the current catalog version. Statement: %s",
                         getVoltPrivateRealTransactionIdDontUseMe(),

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -254,7 +254,7 @@ public class MockVoltDB implements VoltDBInterface
     public CatalogContext getCatalogContext()
     {
         long now = System.currentTimeMillis();
-        m_context = new CatalogContext( now, now, m_catalog, null, new byte[] {}, 0, 0) {
+        m_context = new CatalogContext( now, now, m_catalog, new byte[] {}, new byte[] {}, 0) {
             @Override
             public long getCatalogCRC() {
                 return 13;

--- a/tests/frontend/org/voltdb/TestClientInterface.java
+++ b/tests/frontend/org/voltdb/TestClientInterface.java
@@ -222,7 +222,7 @@ public class TestClientInterface {
         String deploymentPath = builder.getPathToDeployment();
         CatalogUtil.compileDeployment(catalog, deploymentPath, false);
 
-        m_context = new CatalogContext(0, 0, catalog, bytes, new byte[] {}, 0, 0);
+        m_context = new CatalogContext(0, 0, catalog, bytes, new byte[] {}, 0);
         TheHashinator.initialize(TheHashinator.getConfiguredHashinatorClass(), TheHashinator.getConfigureBytes(3));
     }
 
@@ -351,7 +351,8 @@ public class TestClientInterface {
         VoltType[] paramTypes =  new VoltType[]{VoltType.INTEGER};
         AdHocPlannedStmtBatch plannedStmtBatch =
                 AdHocPlannedStmtBatch.mockStatementBatch(3, query, extractedValues, paramTypes,
-                                                         new Object[]{3}, partitionParamIndex);
+                                                         new Object[]{3}, partitionParamIndex,
+                                                         m_context.getCatalogHash());
         m_ci.processFinishedCompilerWork(plannedStmtBatch).run();
 
         ArgumentCaptor<Long> destinationCaptor =
@@ -393,7 +394,8 @@ public class TestClientInterface {
         Object[] extractedValues =  new Object[0];
         VoltType[] paramTypes =  new VoltType[0];
         AdHocPlannedStmtBatch plannedStmtBatch =
-            AdHocPlannedStmtBatch.mockStatementBatch(3, query, extractedValues, paramTypes, null, -1);
+            AdHocPlannedStmtBatch.mockStatementBatch(3, query, extractedValues, paramTypes, null, -1,
+                    m_context.getCatalogHash());
         m_ci.processFinishedCompilerWork(plannedStmtBatch).run();
 
         ArgumentCaptor<Long> destinationCaptor =

--- a/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
@@ -50,8 +50,8 @@ public class TestAdHocPlans extends AdHocQueryTester {
         String serializedCatalog = CatalogUtil.getSerializedCatalogStringFromJar(CatalogUtil.loadAndUpgradeCatalogFromJar(bytes).getFirst());
         Catalog catalog = new Catalog();
         catalog.execute(serializedCatalog);
-        CatalogContext context = new CatalogContext(0, 0, catalog, bytes, new byte[] {}, 0, 0);
-        m_pt = new PlannerTool(context.cluster, context.database, 0);
+        CatalogContext context = new CatalogContext(0, 0, catalog, bytes, new byte[] {}, 0);
+        m_pt = new PlannerTool(context.cluster, context.database, context.getCatalogHash());
     }
 
     @Override

--- a/tests/frontend/org/voltdb/planner/TestPlannerTool.java
+++ b/tests/frontend/org/voltdb/planner/TestPlannerTool.java
@@ -60,9 +60,9 @@ public class TestPlannerTool extends TestCase {
         String serializedCatalog = CatalogUtil.getSerializedCatalogStringFromJar(CatalogUtil.loadAndUpgradeCatalogFromJar(bytes).getFirst());
         Catalog catalog = new Catalog();
         catalog.execute(serializedCatalog);
-        CatalogContext context = new CatalogContext(0, 0, catalog, bytes, new byte[] {}, 0, 0);
+        CatalogContext context = new CatalogContext(0, 0, catalog, bytes, new byte[] {}, 0);
 
-        m_pt = new PlannerTool(context.cluster, context.database, 0);
+        m_pt = new PlannerTool(context.cluster, context.database, context.getCatalogHash());
 
         AdHocPlannedStatement result = null;
         result = m_pt.planSqlForTest("select * from warehouse;");
@@ -155,9 +155,9 @@ public class TestPlannerTool extends TestCase {
         assertNotNull(serializedCatalog);
         Catalog c = new Catalog();
         c.execute(serializedCatalog);
-        CatalogContext context = new CatalogContext(0, 0, c, bytes, new byte[] {}, 0, 0);
+        CatalogContext context = new CatalogContext(0, 0, c, bytes, new byte[] {}, 0);
 
-        m_pt = new PlannerTool(context.cluster, context.database, 0);
+        m_pt = new PlannerTool(context.cluster, context.database, context.getCatalogHash());
 
         // Bad DDL would kill the planner before it starts and this query
         // would return a Stream Closed error


### PR DESCRIPTION
does nothing.
- Swap out usage of CorePlan.catalogVersion to check plan matching for
  usage of CorePlan.catalogHash.
-- Add convenience method wasPlannedAgainstHash to CorePlan
- Remove catalogVersion from CorePlan
- Clean up CatalogContext after making catalog bytes
  non-nullity a requirement.
- Switch AdHocCompilerCache to use hash rather than version
  number to track different catalogs.  Eliminate catalogVersion where
  appropriate.