### PR TITLE
Do bounds-checking when getting SQL text for long running query

### DIFF
--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -412,12 +412,37 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
                         m_currMemoryInBytes,
                         m_peakMemoryInBytes);
 
-        // ENG-7610: array of SQL texts seems to get out of sync with the current
-        // batch index, so we need to do bounds checking here.
         if (m_sqlTexts != null
                 && m_currentBatchIndex >= 0
                 && m_currentBatchIndex < m_sqlTexts.length) {
             msg += "  Executing SQL statement is \"" + m_sqlTexts[m_currentBatchIndex] + "\".";
+        }
+        else if (m_sqlTexts == null) {
+            // Can this happen?
+            msg += "  SQL statement text is not available.";
+        }
+        else {
+            // For some reason, the current index in the batch isn't a valid
+            // index into the m_sqlTexts array.  We don't expect this to happen,
+            // but let's dump something useful if it does.  (See ENG-7610)
+            StringBuffer sb = new StringBuffer();
+            sb.append("  Unable to report specific SQL statement text for batch index "
+                    + m_currentBatchIndex + ".  ");
+            sb.append("It MAY be one of these " + m_sqlTexts.length + " items: ");
+            for (int i = 0; i < m_sqlTexts.length; ++i) {
+                if (m_sqlTexts[i] != null) {
+                    sb.append("\"" + m_sqlTexts[i] + "\"");
+                }
+                else {
+                    sb.append("[null]");
+                }
+
+                if (i != m_sqlTexts.length - 1) {
+                    sb.append(", ");
+                }
+            }
+
+            msg += sb.toString();
         }
 
         return msg;

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -411,7 +411,12 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
                         CoreUtils.hsIdToString(m_siteId),
                         m_currMemoryInBytes,
                         m_peakMemoryInBytes);
-        if (m_sqlTexts != null) {
+
+        // ENG-7610: array of SQL texts seems to get out of sync with the current
+        // batch index, so we need to do bounds checking here.
+        if (m_sqlTexts != null
+                && m_currentBatchIndex >= 0
+                && m_currentBatchIndex < m_sqlTexts.length) {
             msg += "  Executing SQL statement is \"" + m_sqlTexts[m_currentBatchIndex] + "\".";
         }
 


### PR DESCRIPTION
This was causing an array out of bounds exception when the EE was
calling back into Java, and the EE was crashing.

This isn't a complete fix, as I still don't understand why m_sqlTexts did not have text for the fragment, but it least avoids taking down the EE.