### PR TITLE
ENG-7619.  Remove version check logic used by rabbit-mq builder code.

### DIFF
--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -78,20 +78,6 @@ def buildPro():
 ################################################
 
 def buildRabbitMQExport(version):
-    # Only compile the RabbitMQ connector if version is >= 4.5
-    parts = version.split(".")
-    skip = True
-    try:
-        if len(parts) >= 2 and \
-           int(parts[0]) >= 4 and \
-           int(parts[1][0]) >= 5:
-            skip = False
-    except Exception as e:
-        pass
-
-    if skip:
-        return
-
     with cd(builddir + "/export-rabbitmq"):
         run("pwd")
         run("git status")


### PR DESCRIPTION
It was checking for V4.5 or greater (and doing it wrong), but it isn't
needed at all. build_kits.py can be used to build another branch or tag,
but is not used that way by Jenkins or any other processes.