### PR TITLE
Backport fix for ENG-7610 (long-running-query crash) to 4.9.

### DIFF
--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -333,7 +333,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         TIME_OUT_MILLIS = newLatency;
     }
 
-    public long fragmentProgressUpdate(int batchIndex,
+    public long fragmentProgressUpdate(int indexFromFragmentTask,
             String planNodeName,
             String lastAccessedTable,
             long lastAccessedTableSize,
@@ -354,7 +354,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         long latency = currentTime - m_startTime;
 
         if (m_readOnly && TIME_OUT_MILLIS > 0 && latency > TIME_OUT_MILLIS) {
-            String msg = getLongRunningQueriesMessage(latency, planNodeName, true);
+            String msg = getLongRunningQueriesMessage(indexFromFragmentTask, latency, planNodeName, true);
             log.info(msg);
 
             // timing out the long running queries
@@ -379,7 +379,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             // future callbacks per log entry, ideally so that one callback arrives just in time to log.
             return LONG_OP_THRESHOLD;
         }
-        String msg = getLongRunningQueriesMessage(latency, planNodeName, false);
+        String msg = getLongRunningQueriesMessage(indexFromFragmentTask, latency, planNodeName, false);
         log.info(msg);
 
         m_logDuration = (m_logDuration < 30000) ? (2 * m_logDuration) : 30000;
@@ -390,7 +390,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         return LONG_OP_THRESHOLD;
     }
 
-    private String getLongRunningQueriesMessage(long latency, String planNodeName, boolean timeout) {
+    private String getLongRunningQueriesMessage(int indexFromFragmentTask,
+            long latency, String planNodeName, boolean timeout) {
         String status = timeout ? "timed out at" : "taking a long time to execute -- at least";
         String msg = String.format(
                 "Procedure %s is %s " +
@@ -410,8 +411,38 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
                         CoreUtils.hsIdToString(m_siteId),
                         m_currMemoryInBytes,
                         m_peakMemoryInBytes);
-        if (m_sqlTexts != null) {
-            msg += "  Executing SQL statement is \"" + m_sqlTexts[m_currentBatchIndex] + "\".";
+
+        if (m_sqlTexts != null
+                && indexFromFragmentTask >= 0
+                && indexFromFragmentTask < m_sqlTexts.length) {
+            msg += "  Executing SQL statement is \"" + m_sqlTexts[indexFromFragmentTask] + "\".";
+        }
+        else if (m_sqlTexts == null) {
+            // Can this happen?
+            msg += "  SQL statement text is not available.";
+        }
+        else {
+            // For some reason, the current index in the fragment task message isn't a valid
+            // index into the m_sqlTexts array.  We don't expect this to happen,
+            // but let's dump something useful if it does.  (See ENG-7610)
+            StringBuffer sb = new StringBuffer();
+            sb.append("  Unable to report specific SQL statement text for "
+                    + "fragment task message index " + indexFromFragmentTask + ".  ");
+            sb.append("It MAY be one of these " + m_sqlTexts.length + " items: ");
+            for (int i = 0; i < m_sqlTexts.length; ++i) {
+                if (m_sqlTexts[i] != null) {
+                    sb.append("\"" + m_sqlTexts[i] + "\"");
+                }
+                else {
+                    sb.append("[null]");
+                }
+
+                if (i != m_sqlTexts.length - 1) {
+                    sb.append(", ");
+                }
+            }
+
+            msg += sb.toString();
         }
 
         return msg;

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/FragmentUpdateTestProcedure.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/FragmentUpdateTestProcedure.java
@@ -59,6 +59,11 @@ import org.voltdb.VoltTable;
         singlePartition = false
     )
 public class FragmentUpdateTestProcedure extends VoltProcedure {
+
+    // Note: all of these SQL statements are accessed via reflection in the test:
+    //   TestFragmentProgressUpdate
+    // So please don't remove them or change their names.
+
     public final SQLStmt warehouse_select = new SQLStmt("SELECT * FROM WAREHOUSE;");
     public final SQLStmt warehouse_del_half = new SQLStmt("DELETE FROM WAREHOUSE WHERE W_ID > 5000;");
     public final SQLStmt warehouse_join = new SQLStmt("SELECT W1.W_TAX + W1.W_YTD FROM WAREHOUSE W1, WAREHOUSE W2"
@@ -70,6 +75,9 @@ public class FragmentUpdateTestProcedure extends VoltProcedure {
 
     // Not meaningful, but should take long.
     public final SQLStmt item_big_del = new SQLStmt("DELETE FROM ITEM WHERE I_NAME <> 'NULL_NULL';");
+
+    // Just a quick query
+    public final SQLStmt quick_query = new SQLStmt("SELECT W_ID FROM WAREHOUSE LIMIT 1");
 
     public VoltTable[] run() {
         voltQueueSQL(warehouse_select);

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -26,6 +26,9 @@ package org.voltdb.jni;
 import static org.mockito.Matchers.contains;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+
 import junit.framework.TestCase;
 
 import org.mockito.Mockito;
@@ -50,22 +53,22 @@ import org.voltdb.utils.Encoder;
 
 public class TestFragmentProgressUpdate extends TestCase {
 
-    private long READ_ONLY_TOKEN = Long.MAX_VALUE;
-    private long WRITE_TOKEN = 0;
+    private final long READ_ONLY_TOKEN = Long.MAX_VALUE;
+    private final long WRITE_TOKEN = 0;
 
     public void testFragmentProgressUpdate() throws Exception {
         m_ee.loadCatalog( 0, m_catalog.serialize());
 
-        m_tableSize = 5001;
+        int tableSize = 5001;
         m_longOpthreshold = 10000;
         m_warehousedata.clearRowData();
 
-        for (int i = 0; i < m_tableSize; ++i) {
+        for (int i = 0; i < tableSize; ++i) {
             m_warehousedata.addRow(i, "name" + i, "st1", "st2", "city", "ST", "zip", 0, 0);
         }
 
         m_ee.loadTable(WAREHOUSE_TABLEID, m_warehousedata, 0, 0, 0, false, false, WRITE_TOKEN);
-        assertEquals(m_tableSize, m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
+        assertEquals(tableSize, m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
         System.out.println("Rows loaded to table "+m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
 
         Statement selectStmt = m_testProc.getStatements().getIgnoreCase("warehouse_select");
@@ -106,16 +109,16 @@ public class TestFragmentProgressUpdate extends TestCase {
     public void testTwoUpdates() throws Exception {
         m_ee.loadCatalog( 0, m_catalog.serialize());
 
-        m_tableSize = 10000;
+        int tableSize = 10000;
         m_longOpthreshold = 10000;
         m_warehousedata.clearRowData();
 
-        for (int i = 0; i < m_tableSize; ++i) {
+        for (int i = 0; i < tableSize; ++i) {
             m_warehousedata.addRow(i, "name" + i, "st1", "st2", "city", "ST", "zip", 0, 0);
         }
 
         m_ee.loadTable(WAREHOUSE_TABLEID, m_warehousedata, 0, 0, 0, false, false, Long.MAX_VALUE);
-        assertEquals(m_tableSize, m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
+        assertEquals(tableSize, m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
         System.out.println("Rows loaded to table "+m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
 
         Statement selectStmt = m_testProc.getStatements().getIgnoreCase("warehouse_select");
@@ -211,16 +214,16 @@ public class TestFragmentProgressUpdate extends TestCase {
     public void testPeakLargerThanCurr() throws Exception {
         m_ee.loadCatalog( 0, m_catalog.serialize());
 
-        m_tableSize = 20000;
+        int tableSize = 20000;
         m_longOpthreshold = 10000;
         m_warehousedata.clearRowData();
 
-        for (int i = 0; i < m_tableSize; ++i) {
+        for (int i = 0; i < tableSize; ++i) {
             m_warehousedata.addRow(i, "name" + i, "st1", "st2", "city", "ST", "zip", 0, 0);
         }
 
         m_ee.loadTable(WAREHOUSE_TABLEID, m_warehousedata, 0, 0, 0, false, false, WRITE_TOKEN);
-        assertEquals(m_tableSize, m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
+        assertEquals(tableSize, m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
         System.out.println("Rows loaded to table "+m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
 
         Statement selectStmt = m_testProc.getStatements().getIgnoreCase("warehouse_join");
@@ -262,38 +265,154 @@ public class TestFragmentProgressUpdate extends TestCase {
         // Set the log duration to be very short, to ensure that a message will be logged.
         m_ee.setInitialLogDurationForTest(1);
 
-        verifyLongRunningQueries(50, 0, "item_crazy_join", true);
+        verifyLongRunningQueries(50, 0, "item_crazy_join", 5, true, SqlTextExpectation.SQL_STATEMENT);
     }
 
-    private void verifyLongRunningQueries(int scale, int timeout, String query, boolean readOnly) {
-        m_tableSize = scale;
+    @SuppressWarnings("deprecation")
+    public void testProgressUpdateLogNoSqlStmt() throws Exception {
+        // Set the log duration to be very short, to ensure that a message will be logged.
+        m_ee.setInitialLogDurationForTest(1);
+
+        verifyLongRunningQueries(50, 0, "item_crazy_join", 5, true, SqlTextExpectation.NO_STATEMENT);
+    }
+
+    @SuppressWarnings("deprecation")
+    public void testProgressUpdateLogSqlStmtList() throws Exception {
+        // Set the log duration to be very short, to ensure that a message will be logged.
+        m_ee.setInitialLogDurationForTest(1);
+
+        verifyLongRunningQueries(50, 0, "item_crazy_join", 5, true, SqlTextExpectation.STATEMENT_LIST);
+    }
+
+    @SuppressWarnings("deprecation")
+    public void testProgressUpdateLogSqlStmtRW() throws Exception {
+        // Set the log duration to be very short, to ensure that a message will be logged.
+        m_ee.setInitialLogDurationForTest(1);
+
+        verifyLongRunningQueries(50, 0, "item_crazy_join", 5, false, SqlTextExpectation.SQL_STATEMENT);
+    }
+
+    @SuppressWarnings("deprecation")
+    public void testProgressUpdateLogNoSqlStmtRW() throws Exception {
+        // Set the log duration to be very short, to ensure that a message will be logged.
+        m_ee.setInitialLogDurationForTest(1);
+
+        verifyLongRunningQueries(50, 0, "item_crazy_join", 5, false, SqlTextExpectation.NO_STATEMENT);
+    }
+
+    @SuppressWarnings("deprecation")
+    public void testProgressUpdateLogSqlStmtListRW() throws Exception {
+        // Set the log duration to be very short, to ensure that a message will be logged.
+        m_ee.setInitialLogDurationForTest(1);
+
+        verifyLongRunningQueries(50, 0, "item_crazy_join", 5, false, SqlTextExpectation.STATEMENT_LIST);
+    }
+
+    private enum SqlTextExpectation {
+            SQL_STATEMENT,
+            NO_STATEMENT,
+            STATEMENT_LIST
+    }
+
+    /**
+     * A simple class that encapsulates the fragment ID and text for
+     * a SQL statement, given the name of SQLStmt object.
+     *
+     * Will also put the plan fragment into the ActivePlanRepository.
+     */
+    private class FragIdAndText {
+        private final String sqlText;
+        private final long fragId;
+
+        @SuppressWarnings("deprecation")
+        FragIdAndText(String stmtName) {
+            Statement stmt = m_testProc.getStatements().getIgnoreCase(stmtName);
+            PlanFragment frag = null;
+            for (PlanFragment f : stmt.getFragments()) {
+                frag = f;
+            }
+
+            fragId = CatalogUtil.getUniqueIdForFragment(frag);
+            sqlText = stmt.getSqltext();
+
+            ActivePlanRepository.addFragmentForTest(
+                    fragId,
+                    Encoder.decodeBase64AndDecompressToBytes(frag.getPlannodetree()),
+                    sqlText);
+        }
+
+        long id() { return fragId; }
+        String text() { return sqlText; }
+    }
+
+    /**
+     * Build a set of inputs for the EE to execute a group of
+     * fragments.  Uses the sizes of arrays to determine how many
+     * fragments to run.  The first fragments will be quick, and
+     * should not trigger a log message; the last one is specified by
+     * its SQL statement name.
+     * @param lastStmtName   Stmt whose fragment should be executed last
+     * @param fragIds        Fragment IDs, populated by this method
+     * @param paramSets      Param sets, populated by this method
+     * @param sqlTexts       Statement text for fragments, populated by this method
+     */
+    private void createExecutionEngineInputs(
+            String lastStmtName,
+            long[] fragIds,
+            ParameterSet[] paramSets,
+            String[] sqlTexts) {
+
+        ActivePlanRepository.clear();
+
+        int numQuickFrags = fragIds.length - 1;
+        FragIdAndText quickFragIdAndText = new FragIdAndText("quick_query");
+        for (int i = 0; i < numQuickFrags; ++i) {
+            fragIds[i] = quickFragIdAndText.id();
+            paramSets[i] = ParameterSet.emptyParameterSet();
+            sqlTexts[i] = quickFragIdAndText.text();
+        }
+
+        FragIdAndText lastFragIdAndText = new FragIdAndText(lastStmtName);
+        fragIds[numQuickFrags] = lastFragIdAndText.id();
+        paramSets[numQuickFrags] = ParameterSet.emptyParameterSet();
+        sqlTexts[numQuickFrags] = lastFragIdAndText.text();
+    }
+
+    /**
+     * This method inserts a bunch of rows into table Items,
+     * and executes a set of fragments in the EE.
+     * @param numRowsToInsert     how many rows to insert into Items
+     * @param timeout             number of ms to wait before canceling RO fragments
+     * @param stmtName            SQL stmt name for last fragment to execute
+     * @param numFragsToExecute   Total number of frags to execute
+     *                            (if greater than 1, will prepend quick-running fragments)
+     * @param readOnly            Identify the set of fragments as read-only (may timeout)
+     * @param sqlTextExpectation  Behavior to expect when verify SQL text in log message
+     */
+    @SuppressWarnings("deprecation")
+    private void verifyLongRunningQueries(
+            int numRowsToInsert,
+            int timeout,
+            String stmtName,
+            int numFragsToExecute,
+            boolean readOnly,
+            SqlTextExpectation sqlTextExpectation) {
 
         m_ee.loadCatalog( 0, m_catalog.serialize());
 
         m_itemData.clearRowData();
-        for (int i = 0; i < m_tableSize; ++i) {
+        for (int i = 0; i < numRowsToInsert; ++i) {
             m_itemData.addRow(i, i + 50, "item" + i, (double)i / 2, "data" + i);
         }
 
         m_ee.loadTable(ITEM_TABLEID, m_itemData, 0, 0, 0, false, false, WRITE_TOKEN);
-        assertEquals(m_tableSize, m_ee.serializeTable(ITEM_TABLEID).getRowCount());
+        assertEquals(numRowsToInsert, m_ee.serializeTable(ITEM_TABLEID).getRowCount());
         System.out.println("Rows loaded to table " + m_ee.serializeTable(ITEM_TABLEID).getRowCount());
 
-        Statement queryStmt = m_testProc.getStatements().getIgnoreCase(query);
-        String sqlText = queryStmt.getSqltext();
-
-        PlanFragment frag = null;
-        for (PlanFragment f : queryStmt.getFragments()) {
-            frag = f;
-        }
-
-        // populate plan cache
-        ActivePlanRepository.clear();
-        ActivePlanRepository.addFragmentForTest(
-                CatalogUtil.getUniqueIdForFragment(frag),
-                Encoder.decodeBase64AndDecompressToBytes(frag.getPlannodetree()),
-                sqlText);
-        ParameterSet params = ParameterSet.emptyParameterSet();
+        long[] fragIds = new long[numFragsToExecute];
+        ParameterSet[] paramSets = new ParameterSet[numFragsToExecute];
+        String[] sqlTexts = new String[numFragsToExecute];
+        createExecutionEngineInputs(stmtName, fragIds, paramSets, sqlTexts);
 
         // Replace the normal logger with a mocked one, so we can verify the message
         VoltLogger mockedLogger = Mockito.mock(VoltLogger.class);
@@ -302,12 +421,35 @@ public class TestFragmentProgressUpdate extends TestCase {
         m_ee.setTimeoutLatency(timeout);
 
         try {
+
+            // NOTE: callers of this method specify something other than SQL_STATEMENT
+            // in order to prove that we don't crash if the sqlTexts array passed to
+            // (Java class) ExecutionEngine is malformed.
+            //
+            // This issue was related to ENG-7610, which took down the EE.  It has since
+            // been fixed, so (we hope) nothing like this will happen in the wild.
+            switch (sqlTextExpectation) {
+            case SQL_STATEMENT:
+                // leave sqlTexts AS-IS
+                break;
+            case NO_STATEMENT:
+                sqlTexts = null;
+                break;
+            case STATEMENT_LIST:
+                // Leave off the last item, which is the one that needs to be
+                // reported.
+                sqlTexts = Arrays.copyOfRange(sqlTexts, 0, numFragsToExecute - 1);
+                break;
+            default:
+                fail("Invalid value for sqlTextExpectation");
+            }
+
             m_ee.executePlanFragments(
-                    1,
-                    new long[] { CatalogUtil.getUniqueIdForFragment(frag) },
+                    numFragsToExecute,
+                    fragIds,
                     null,
-                    new ParameterSet[] { params },
-                    new String[] { sqlText },
+                    paramSets,
+                    sqlTexts,
                     3, 3, 2, 42,
                     readOnly ? READ_ONLY_TOKEN : WRITE_TOKEN);
             if (readOnly && timeout > 0) {
@@ -321,8 +463,42 @@ public class TestFragmentProgressUpdate extends TestCase {
             assertEquals(msg, ex.getMessage());
         }
 
-        verify(mockedLogger, atLeastOnce()).info(contains(
-            String.format("Executing SQL statement is \"%s\".", sqlText)));
+        String expectedSqlTextMsg = null;
+        switch (sqlTextExpectation) {
+        case SQL_STATEMENT:
+            String sqlText = sqlTexts[numFragsToExecute - 1];
+            expectedSqlTextMsg = String.format("Executing SQL statement is \"%s\".", sqlText);
+            break;
+        case NO_STATEMENT:
+            expectedSqlTextMsg = "SQL statement text is not available.";
+            break;
+        case STATEMENT_LIST:
+            expectedSqlTextMsg = "Unable to report specific SQL statement text "
+                    + "for fragment task message index " + (numFragsToExecute - 1) + ".  "
+                    + "It MAY be one of these " + (numFragsToExecute - 1) + " items: "
+                    + "\"SELECT W_ID FROM WAREHOUSE LIMIT 1;\", ";
+            break;
+        default:
+            fail("Invalid value for sqlTextExpectation");
+        }
+
+        verify(mockedLogger, atLeastOnce()).info(contains(expectedSqlTextMsg));
+    }
+
+    /**
+     * A simpler version of verifyLongRunningQueries that executes just one
+     * fragment and assumes the SQL text will be correctly displayed.
+     * @param numRowsToInsert     how many rows to insert into Items
+     * @param timeout             number of ms to wait before canceling RO fragments
+     * @param stmtName            SQL stmt name for last fragment to execute
+     * @param readOnly            Identify the set of fragments as read-only (may timeout)
+     */
+    private void verifyLongRunningQueries(
+            int numRowsToInsert,
+            int timeout,
+            String stmtName,
+            boolean readOnly) {
+        verifyLongRunningQueries(numRowsToInsert, timeout, stmtName, 1, readOnly, SqlTextExpectation.SQL_STATEMENT);
     }
 
     public void testTimingoutQueries() throws Exception {
@@ -356,9 +532,6 @@ public class TestFragmentProgressUpdate extends TestCase {
     }
 
     private ExecutionEngine m_ee;
-    private static final int CLUSTER_ID = 2;
-    private static final long NODE_ID = 1;
-    private int m_tableSize;
     private int m_longOpthreshold;
     private VoltTable m_warehousedata;
     private VoltTable m_itemData;
@@ -369,6 +542,9 @@ public class TestFragmentProgressUpdate extends TestCase {
 
     @Override
     protected void setUp() throws Exception {
+        final int CLUSTER_ID = 2;
+        final long NODE_ID = 1;
+
         super.setUp();
         VoltDB.instance().readBuildInfo("Test");
         m_warehousedata = new VoltTable(


### PR DESCRIPTION
Merged the following commits from version 5.0:
  2bf2748 Do bounds-checking when getting SQL text for long running query
  e0de4a6 Log a more detailed message when failing to get SQL text for log
  2978313 Use correct index when getting SQL text for logging
  0c43ad5 Make changes based on review feedback