### PR TITLE
ENG-7593: Return an error to the client if @AdHoc has no actionable

### DIFF
--- a/src/frontend/org/voltdb/compiler/AsyncCompilerAgent.java
+++ b/src/frontend/org/voltdb/compiler/AsyncCompilerAgent.java
@@ -114,14 +114,12 @@ public class AsyncCompilerAgent {
         if (wrapper.payload instanceof AdHocPlannerWork) {
             final AdHocPlannerWork w = (AdHocPlannerWork)(wrapper.payload);
             // do initial naive scan of statements for DDL, forbid mixed DDL and (DML|DQL)
-            // This is not currently robust to comment, multi-line statments,
-            // multiple statements on a line, etc.
             Boolean hasDDL = null;
             // conflictTables tracks dropped tables before removing the ones that don't have CREATEs.
             SortedSet<String> conflictTables = new TreeSet<String>();
             Set<String> createdTables = new HashSet<String>();
             for (String stmt : w.sqlStatements) {
-                if (SQLLexer.isComment(stmt)) {
+                if (SQLLexer.isComment(stmt) || stmt.trim().isEmpty()) {
                     continue;
                 }
                 String ddlToken = SQLLexer.extractDDLToken(stmt);

--- a/src/frontend/org/voltdb/compiler/AsyncCompilerAgent.java
+++ b/src/frontend/org/voltdb/compiler/AsyncCompilerAgent.java
@@ -162,7 +162,16 @@ public class AsyncCompilerAgent {
                     }
                 }
             }
-            if (!hasDDL) {
+            if (hasDDL == null) {
+                // we saw neither DDL or DQL/DML.  Make sure that we get a
+                // response back to the client
+                AsyncCompilerResult errResult =
+                    AsyncCompilerResult.makeErrorResult(w,
+                            "Failed to plan, no SQL statement provided.");
+                w.completionHandler.onCompletion(errResult);
+                return;
+            }
+            else if (!hasDDL) {
                 final AsyncCompilerResult result = compileAdHocPlan(w);
                 w.completionHandler.onCompletion(result);
             }

--- a/tests/frontend/org/voltdb/TestAdhocWithOnlyComment.java
+++ b/tests/frontend/org/voltdb/TestAdhocWithOnlyComment.java
@@ -1,0 +1,78 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb;
+
+import org.voltdb.VoltDB.Configuration;
+import org.voltdb.client.ProcCallException;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.utils.MiscUtils;
+
+public class TestAdhocWithOnlyComment extends AdhocDDLTestBase {
+
+    public void testAdhocWithOnlyComment() throws Exception
+    {
+        String pathToCatalog = Configuration.getPathToCatalogForTest("adhocddl.jar");
+        String pathToDeployment = Configuration.getPathToCatalogForTest("adhocddl.xml");
+
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        builder.addLiteralSchema("--dont care");
+        builder.setUseDDLSchema(true);
+        boolean success = builder.compile(pathToCatalog, 2, 1, 0);
+        assertTrue("Schema compilation failed", success);
+        MiscUtils.copyFile(builder.getPathToDeployment(), pathToDeployment);
+
+        VoltDB.Configuration config = new VoltDB.Configuration();
+        config.m_pathToCatalog = pathToCatalog;
+        config.m_pathToDeployment = pathToDeployment;
+
+        try {
+            startSystem(config);
+
+            boolean threw = false;
+            try {
+                m_client.callProcedure("@AdHoc",
+                        "-- this used to hang the server");
+            }
+            catch (ProcCallException pce) {
+                pce.printStackTrace();
+                threw = true;
+            }
+            assertTrue("Adhoc with no statements should return an error", threw);
+
+            threw = false;
+            try {
+                m_client.callProcedure("@AdHoc",
+                        "/* this used to hang the server\n too, probably, test it! */");
+            }
+            catch (ProcCallException pce) {
+                pce.printStackTrace();
+                threw = true;
+            }
+            assertTrue("Adhoc with no statements should return an error", threw);
+        }
+        finally {
+            teardownSystem();
+        }
+    }
+}


### PR DESCRIPTION
statements rather than returning nothing and hanging the client.