### PR TITLE
ENG-7673. Fix uniquedevices and voter demos so they work in docker

### DIFF
--- a/examples/uniquedevices/run.sh
+++ b/examples/uniquedevices/run.sh
@@ -110,7 +110,7 @@ function background_server_andload() {
     sleeptime=0
     until ../../bin/sqlcmd  --query=' exec @SystemInformation, OVERVIEW;' > /dev/null 2>&1
     do
-        sleeptime=$((sleeptime + 1))
+        sleeptime=$((sleeptime + 2))
         sleep 2
         echo " ... Waiting for VoltDB to start"
         if [[ $sleeptime -gt 30 ]]

--- a/examples/uniquedevices/run.sh
+++ b/examples/uniquedevices/run.sh
@@ -104,11 +104,22 @@ function init() {
     sqlcmd < ddl.sql
 }
 
-function nohup_server() {
-    jars-ifneeded
+function background_server_andload() {
     # run the server
-    nohup $VOLTDB create -d deployment.xml -l $LICENSE -H $HOST > nohup.log 2>&1 &
-    sqlcmd < ddl.sql
+    voltdb create -B -d deployment.xml -l $LICENSE -H $HOST > nohup.log 2>&1 &
+    sleeptime=0
+    until ../../bin/sqlcmd  --query=' exec @SystemInformation, OVERVIEW;' > /dev/null 2>&1
+    do
+        sleeptime=$((sleeptime + 1))
+        sleep 2
+        echo " ... Waiting for VoltDB to start"
+        if [[ $sleeptime -gt 30 ]]
+        then
+            echo "Exiting.  VoltDB did not startup within 30 seconds" 1>&2; exit 1;
+        fi
+    done
+    # load the schema
+    init
 }
 
 # run the voltdb server locally

--- a/examples/uniquedevices/run.sh
+++ b/examples/uniquedevices/run.sh
@@ -104,28 +104,25 @@ function init() {
     sqlcmd < ddl.sql
 }
 
-function background_server_andload() {
-    # run the server
-    voltdb create -B -d deployment.xml -l $LICENSE -H $HOST > nohup.log 2>&1 &
-    sleeptime=0
-    until ../../bin/sqlcmd  --query=' exec @SystemInformation, OVERVIEW;' > /dev/null 2>&1
+# wait for backgrounded server to start up
+function wait_for_startup() {
+    until sqlcmd  --query=' exec @SystemInformation, OVERVIEW;' > /dev/null 2>&1
     do
-        sleeptime=$((sleeptime + 2))
         sleep 2
         echo " ... Waiting for VoltDB to start"
-        if [[ $sleeptime -gt 30 ]]
+        if [[ $SECONDS -gt 60 ]]
         then
-            echo "Exiting.  VoltDB did not startup within 30 seconds" 1>&2; exit 1;
+            echo "Exiting.  VoltDB did not startup within 60 seconds" 1>&2; exit 1;
         fi
     done
-    # load the schema
-    init
 }
 
-# run the voltdb server locally
-function rejoin() {
-    # run the server
-    voltdb rejoin -H $HOST -d deployment.xml -l $LICENSE
+# startup server in background and load schema
+function background_server_andload() {
+    # run the server in the background
+    voltdb create -B -d deployment.xml -l $LICENSE -H $HOST > nohup.log 2>&1 &
+    wait_for_startup
+    init
 }
 
 # run the client that drives the example
@@ -146,8 +143,26 @@ function client-help() {
     java -classpath $CLIENTCLASSPATH uniquedevices.UniqueDevicesClient --help
 }
 
+# The following two demo functions are used by the Docker package. Don't remove.
+# compile the jars for procs and client code
+function demo-compile() {
+    jars
+}
+
+function demo() {
+    echo "starting server in background..."
+    background_server_andload
+    echo "starting client..."
+    client
+
+    echo
+    echo When you are done with the demo database, \
+        remember to use \"voltadmin shutdown\" to stop \
+        the server process.
+}
+
 function help() {
-    echo "Usage: ./run.sh {clean|server|init|client|async-benchmark|aysnc-benchmark-help|...}"
+    echo "Usage: ./run.sh {clean|server|init|demo|client|async-benchmark|aysnc-benchmark-help|...}"
     echo "       {...|sync-benchmark|sync-benchmark-help|jdbc-benchmark|jdbc-benchmark-help}"
 }
 

--- a/examples/voter/run.sh
+++ b/examples/voter/run.sh
@@ -109,12 +109,6 @@ function background_server_andload() {
     init
 }
 
-# run the voltdb server locally
-function rejoin() {
-    # run the server
-    voltdb rejoin -H $HOST -d deployment.xml -l $LICENSE
-}
-
 # run the client that drives the example
 function client() {
     async-benchmark


### PR DESCRIPTION
The run.sh target that started the server in the background (nohup_server) was not working.  It was trying to load the ddl before the server was up.  
- Renamed function from nohup_server to background_server_andload - it no longer uses nohup, and does more than run the server
- Stopped using nohup - using voltdb to background it instead (-B)
- Added a wait loop before loading the ddl - it times out after 30 seconds.

While in there, I also removed rejoin. It is not part of any demo and is useless on a single server. 