### PR TITLE
ENG-7223 wildcard class drop

### DIFF
--- a/src/frontend/org/voltdb/compiler/ClassMatcher.java
+++ b/src/frontend/org/voltdb/compiler/ClassMatcher.java
@@ -67,8 +67,10 @@ public class ClassMatcher {
             classNamePattern = classNamePattern.substring(0, indexOfDollarSign);
         }
 
-        String regExPreppedName = preppedName.replace("**", "[\\w.\\$]+");
-        regExPreppedName = regExPreppedName.replace("*",  "[\\w\\$]+");
+        // Substitution order is critical.
+        String regExPreppedName = preppedName.replace(".", "[.]");
+        regExPreppedName = regExPreppedName.replace("**", "[\\w.\\$]+");
+        regExPreppedName = regExPreppedName.replace("*",  "[\\w\\$]*");
 
         String regex = "^" + // (line start)
                        regExPreppedName +

--- a/src/frontend/org/voltdb/compiler/ClassMatcher.java
+++ b/src/frontend/org/voltdb/compiler/ClassMatcher.java
@@ -68,9 +68,14 @@ public class ClassMatcher {
         }
 
         // Substitution order is critical.
+        // Keep track of whether or not this is a wildcard expression.
+        // '.' is specifically not a wildcard.
         String regExPreppedName = preppedName.replace(".", "[.]");
-        regExPreppedName = regExPreppedName.replace("**", "[\\w.\\$]+");
-        regExPreppedName = regExPreppedName.replace("*",  "[\\w\\$]*");
+        boolean isWildcard = regExPreppedName.contains("*");
+        if (isWildcard) {
+            regExPreppedName = regExPreppedName.replace("**", "[\\w.\\$]+");
+            regExPreppedName = regExPreppedName.replace("*",  "[\\w\\$]*");
+        }
 
         String regex = "^" + // (line start)
                        regExPreppedName +
@@ -92,11 +97,11 @@ public class ClassMatcher {
             return ClassNameMatchStatus.MATCH_FOUND;
         }
         else {
-            if (preppedName.compareTo(regExPreppedName) == 0) {
-                return ClassNameMatchStatus.NO_EXACT_MATCH;
+            if (isWildcard) {
+                return ClassNameMatchStatus.NO_WILDCARD_MATCH;
             }
             else {
-                return ClassNameMatchStatus.NO_WILDCARD_MATCH;
+                return ClassNameMatchStatus.NO_EXACT_MATCH;
             }
         }
 

--- a/tests/frontend/org/voltdb/compiler/TestClassMatcher.java
+++ b/tests/frontend/org/voltdb/compiler/TestClassMatcher.java
@@ -27,6 +27,8 @@ import java.util.Set;
 
 import junit.framework.TestCase;
 
+import org.apache.commons.lang.StringUtils;
+
 public class TestClassMatcher extends TestCase {
     static String testClasses = "org.voltdb.utils.BinaryDeque\n" +
                                 "org.voltdb.utils.BinaryDeque$BinaryDequeTruncator\n" +
@@ -76,6 +78,31 @@ public class TestClassMatcher extends TestCase {
         cm = new ClassMatcher();
         cm.m_classList = testClasses;
         cm.addPattern("*.voltdb.*CLibrary");
+        matchedClasses = cm.getMatchedClassList();
+        out = matchedClasses.toArray(new String[matchedClasses.size()]);
+        assertEquals(0, out.length);
+    }
+
+    public void testEng7223() {
+        String[] classes = {
+            "voter.ContestantWinningStates",
+            "voter.ContestantWinningStates$OrderByVotesDesc",
+            "voter.ContestantWinningStates$Result"
+        };
+
+        // Should match the outer class, not the nested ones.
+        ClassMatcher cm = new ClassMatcher();
+        cm.m_classList = StringUtils.join(classes, '\n');
+        cm.addPattern("**.*Cont*");
+        Set<String> matchedClasses = cm.getMatchedClassList();
+        String[] out = matchedClasses.toArray(new String[matchedClasses.size()]);
+        assertEquals(1, out.length);
+        assertTrue(strContains(out, "voter.ContestantWinningStates"));
+
+        // Make sure '.' is literal, and not treated as a regex "match any character".
+        cm = new ClassMatcher();
+        cm.m_classList = StringUtils.join(classes, '\n');
+        cm.addPattern("**.*Cont.*");
         matchedClasses = cm.getMatchedClassList();
         out = matchedClasses.toArray(new String[matchedClasses.size()]);
         assertEquals(0, out.length);

--- a/tests/frontend/org/voltdb/compiler/TestClassMatcher.java
+++ b/tests/frontend/org/voltdb/compiler/TestClassMatcher.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import junit.framework.TestCase;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class TestClassMatcher extends TestCase {
     static String testClasses = "org.voltdb.utils.BinaryDeque\n" +


### PR DESCRIPTION
Improved the regex generator in ClassMatcher so that '*' allows an empty string and '.' is forced to be literal in the regex.