### PR TITLE
Delay replicated cluster policy check for Adhocs until after the planner...

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -2096,6 +2096,14 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
             error.flattenToBuffer(buffer).flip();
             c.writeStream().enqueue(buffer);
         }
+        else
+        if ((error = m_invocationValidator.shouldAccept(task.procName, plannedStmtBatch.work.user, task,
+                SystemProcedureCatalog.listing.get(task.procName).asCatalogProcedure())) != null) {
+            ByteBuffer buffer = ByteBuffer.allocate(error.getSerializedSize() + 4);
+            buffer.putInt(buffer.capacity() - 4);
+            error.flattenToBuffer(buffer).flip();
+            c.writeStream().enqueue(buffer);
+        }
         else {
             /*
              * Round trip the invocation to initialize it for command logging

--- a/src/frontend/org/voltdb/ReplicaInvocationAcceptancePolicy.java
+++ b/src/frontend/org/voltdb/ReplicaInvocationAcceptancePolicy.java
@@ -41,14 +41,10 @@ public class ReplicaInvocationAcceptancePolicy extends InvocationValidationPolic
                 return null;
             }
 
-            // hackish way to check if an adhoc query is read-only
-            //??? What keeps @AdHoc from invoking a read/write mixed batch that starts with a 'select'?
-            //??? Or what would prevent these writes from getting missed here?
-            if (invocation.procName.equals("@AdHoc") || invocation.procName.equals("@AdHocSpForTest")) {
-                String sql = (String) invocation.getParams().toArray()[0];
-                String initial = sql.trim().substring(0, 1);
-                // Match "SELECT ... , "select ..." and the likes of "(select ... ) union ... "
-                isReadOnly = "sS(".contains(initial);
+            // This path is only executed before the AdHoc statement is run through the planner. After the
+            // Planner, the client interface will figure out what kind of statement this is.
+            if (invocation.procName.equals("@AdHoc")) {
+                return null;
             }
 
             if (isReadOnly) {

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -133,8 +133,8 @@ public class SystemProcedureCatalog {
         // special-case replica acceptability by DR version
         boolean useDRV2 = Boolean.getBoolean("USE_DR_V2");
         ImmutableMap.Builder<String, Config> builder = ImmutableMap.builder();
-        builder.put("@AdHoc_RW_MP",             new Config("org.voltdb.sysprocs.AdHoc_RW_MP",              false, false, false, 0, VoltType.INVALID,   false, false, false, true, true));
-        builder.put("@AdHoc_RW_SP",             new Config("org.voltdb.sysprocs.AdHoc_RW_SP",              true,  false, false, 0, VoltType.VARBINARY, false, false, false, true, true));
+        builder.put("@AdHoc_RW_MP",             new Config("org.voltdb.sysprocs.AdHoc_RW_MP",              false, false, false, 0, VoltType.INVALID,   false, false, false, !useDRV2, true));
+        builder.put("@AdHoc_RW_SP",             new Config("org.voltdb.sysprocs.AdHoc_RW_SP",              true,  false, false, 0, VoltType.VARBINARY, false, false, false, !useDRV2, true));
         builder.put("@AdHoc_RO_MP",             new Config("org.voltdb.sysprocs.AdHoc_RO_MP",              false, true,  false, 0, VoltType.INVALID,   false, false, false, true, false));
         builder.put("@AdHoc_RO_SP",             new Config("org.voltdb.sysprocs.AdHoc_RO_SP",              true,  true,  false, 0, VoltType.VARBINARY, false, false, false, true, false));
         builder.put("@Pause",                   new Config("org.voltdb.sysprocs.Pause",                    false, false, true,  0, VoltType.INVALID,   false, false, true,  true, false));

--- a/src/frontend/org/voltdb/compiler/AsyncCompilerAgent.java
+++ b/src/frontend/org/voltdb/compiler/AsyncCompilerAgent.java
@@ -142,22 +142,13 @@ public class AsyncCompilerAgent {
             }
             else {
                 // We have adhoc DDL.  Is it okay to run it?
-                // Is it forbidden by the replication role and configured schema change method?
-                // master and UAC method chosen:
-                if (!w.onReplica && !w.useAdhocDDL) {
+                // Is it configured schema change method?
+                // UAC method chosen:
+                if (!w.useAdhocDDL) {
                     AsyncCompilerResult errResult =
                         AsyncCompilerResult.makeErrorResult(w,
                                 "Cluster is configured to use @UpdateApplicationCatalog " +
                                 "to change application schema.  AdHoc DDL is forbidden.");
-                    w.completionHandler.onCompletion(errResult);
-                    return;
-                }
-                // Any adhoc DDL on the replica is forbidden (master changes appear as UAC
-                else if (w.onReplica) {
-                    AsyncCompilerResult errResult =
-                        AsyncCompilerResult.makeErrorResult(w,
-                                "AdHoc DDL is forbidden on a DR replica cluster. " +
-                                "Apply schema changes to the master and they will propogate to replicas.");
                     w.completionHandler.onCompletion(errResult);
                     return;
                 }

--- a/src/frontend/org/voltdb/compiler/AsyncCompilerWork.java
+++ b/src/frontend/org/voltdb/compiler/AsyncCompilerWork.java
@@ -41,6 +41,7 @@ public class AsyncCompilerWork implements Serializable {
     final public ProcedureInvocationType invocationType;
     public final long originalTxnId;
     public final long originalUniqueId;
+    // We don't use onReplica with DRv2 but we will almost certainly need this in the future
     final boolean onReplica;
     final boolean useAdhocDDL;
     public final AuthSystem.AuthUser user;


### PR DESCRIPTION
....

Fix rejoin test that fails because DRId was not associated with the same partition.