### PR TITLE
ENG-7496 Replace python process with server

### DIFF
--- a/lib/python/voltcli/environment.py
+++ b/lib/python/voltcli/environment.py
@@ -101,7 +101,9 @@ if not [opt for opt in java_opts if opt.startswith('-Xmx')]:
 
 # Set common options now.
 java_opts.append('-server')
-java_opts.append('-Djava.awt.headless=true -Dsun.net.inetaddr.ttl=300 -Dsun.net.inetaddr.negative.ttl=3600')
+java_opts.append('-Djava.awt.headless=true')
+java_opts.append('-Dsun.net.inetaddr.ttl=300')
+java_opts.append('-Dsun.net.inetaddr.negative.ttl=3600')
 java_opts.append('-XX:+HeapDumpOnOutOfMemoryError')
 java_opts.append('-XX:HeapDumpPath=/tmp')
 java_opts.append('-XX:+UseParNewGC')

--- a/lib/python/voltcli/utility.py
+++ b/lib/python/voltcli/utility.py
@@ -425,26 +425,93 @@ def format_volt_tables(table_list, caption_list = None, headings = True):
     return '\n\n'.join(output)
 
 #===============================================================================
+def quote_shell_arg(arg):
+#===============================================================================
+    """
+    Return an argument with quotes added as needed.
+    """
+    sarg = str(arg)
+    if len(sarg) == 0 or len(sarg.split()) > 1:
+        return '"%s"' % sarg
+    return sarg
+
+#===============================================================================
+def unquote_shell_arg(arg):
+#===============================================================================
+    """
+    Return an argument with quotes removed if present.
+    """
+    sarg = str(arg)
+    if len(sarg) == 0:
+        return sarg
+    quote_char = sarg[-1]
+    if quote_char not in ('"', "'"):
+        return sarg
+    # Deal with a starting quote that might not be at the beginning
+    if sarg[0] == quote_char:
+        return sarg[1:-1]
+    pos = sarg.find(quote_char)
+    if pos == len(sarg) - 1:
+        # No first quote, don't know what else to do but return as is
+        return sarg
+    return sarg[:pos] + sarg[pos+1:-1]
+
+#===============================================================================
+def quote_shell_args(*args_in):
+#===============================================================================
+    """
+    Return a list of arguments that are quoted as needed.
+    """
+    return [quote_shell_arg(arg) for arg in args_in]
+
+#===============================================================================
+def unquote_shell_args(*args_in):
+#===============================================================================
+    """
+    Return a list of arguments with quotes removed when present.
+    """
+    return [unquote_shell_arg(arg) for arg in args_in]
+
+#===============================================================================
+def join_shell_cmd(cmd, *args):
+#===============================================================================
+    """
+    Join shell command and arguments into one string.
+    Add quotes as appropriate.
+    """
+    return ' '.join(quote_shell_args(*args))
+
+#===============================================================================
 def run_cmd(cmd, *args):
 #===============================================================================
     """
     Run external program without capturing or suppressing output and check return code.
     """
-    fullcmd = cmd
-    for arg in args:
-        sarg = str(arg)
-        if len(sarg) == 0 or len(sarg.split()) > 1:
-            fullcmd += ' "%s"' % sarg
-        else:
-            fullcmd += ' %s' % sarg
+    fullcmd = join_shell_cmd(cmd, *args)
     if Global.dryrun_enabled:
-        sys.stdout.write('%s\n' % fullcmd)
+        sys.stdout.write('Run: %s\n' % fullcmd)
     else:
         if Global.verbose_enabled:
             verbose_info('Run: %s' % fullcmd)
         retcode = os.system(fullcmd)
         if retcode != 0:
             abort(return_code=retcode)
+
+#===============================================================================
+def exec_cmd(cmd, *args):
+#===============================================================================
+    """
+    Run external program by replacing the current (Python) process.
+    """
+    display_cmd = join_shell_cmd(cmd, *args)
+    if Global.dryrun_enabled:
+        sys.stdout.write('Exec: %s\n' % display_cmd)
+    else:
+        if Global.verbose_enabled:
+            verbose_info('Exec: %s' % display_cmd)
+        # Need to strip out quotes because the shell won't be doing it for us.
+        cmd_and_args = unquote_shell_args(cmd, *args)
+        os.execvp(cmd, cmd_and_args)
 
 #===============================================================================
 def pipe_cmd(*args):

--- a/lib/python/voltcli/verbs.py
+++ b/lib/python/voltcli/verbs.py
@@ -512,6 +512,9 @@ class ServerBundle(JavaBundle):
             runner.setup_daemon_kwargs(kwargs, name=self.daemon_name,
                                                description=daemon_description,
                                                output=self.daemon_output)
+        else:
+            # Replace the Python process.
+            kwargs['exec'] = True
         self.run_java(verb, runner, *final_args, **kwargs)
 
     def stop(self, verb, runner):


### PR DESCRIPTION
Mainly had to deal with quoted arguments because exec doesn't filter them the way the shell does. We were improperly combining multiple arguments in quotes and also unnecessarily quoting paths. This solution won't handle all possible shell quoting, but is good enough for running volt.