### PR TITLE
ENG-7796: Correctly reset DR buffers on txn rollback.

### DIFF
--- a/src/ee/common/StreamBlock.h
+++ b/src/ee/common/StreamBlock.h
@@ -162,6 +162,8 @@ namespace voltdb
                                     "\n m_uso(%jd), m_offset(%jd), mark(%jd)\n",
                                     (intmax_t)m_uso, (intmax_t)m_offset, (intmax_t)mark);
             }
+
+            recordLastBeginTxnOffset();
         }
 
         void recordLastBeginTxnOffset() {

--- a/src/ee/storage/TupleStreamBase.cpp
+++ b/src/ee/storage/TupleStreamBase.cpp
@@ -251,8 +251,8 @@ void TupleStreamBase::rollbackTo(size_t mark)
             extendBufferChain(m_defaultCapacity);
         }
         m_currBlock->recordCompletedTxnForDR(m_committedSequenceNumber, m_committedUniqueId);
-        m_openSequenceNumber = m_committedSequenceNumber;
     }
+    m_openSequenceNumber = m_committedSequenceNumber;
 }
 
 /*


### PR DESCRIPTION
Reset m_lastDRBeginTxnOffset and m_openSequenceNumber on transaction
rollback.