### PR TITLE
ENG-7797: Propagate EE exception to @ApplyBinaryLog.

### DIFF
--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1300,7 +1300,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
-    public void applyBinaryLog(byte log[]) {
+    public void applyBinaryLog(byte log[]) throws EEException {
         ByteBuffer paramBuffer = m_ee.getParamBufferForExecuteTask(4 + log.length);
         paramBuffer.putInt(log.length);
         paramBuffer.put(log);

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -671,7 +671,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * @param task
      * @return
      */
-    public abstract byte[] executeTask(TaskType taskType, ByteBuffer task);
+    public abstract byte[] executeTask(TaskType taskType, ByteBuffer task) throws EEException;
 
     public abstract ByteBuffer getParamBufferForExecuteTask(int requiredCapacity);
 
@@ -923,8 +923,9 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * This is a generic entry point into the EE that doesn't need to be updated in the IPC
      * client every time you add a new task
      * @param pointer
+     * @return error code
      */
-    protected native void nativeExecuteTask(long pointer);
+    protected native int nativeExecuteTask(long pointer);
 
     /**
      * Perform an export poll or ack action. Poll data will be returned via the usual

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -618,20 +618,19 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     }
 
     @Override
-    public byte[] executeTask(TaskType taskType, ByteBuffer task) {
-
-        byte retval[] = null;
+    public byte[] executeTask(TaskType taskType, ByteBuffer task) throws EEException {
         try {
             psetBuffer.putLong(0, taskType.taskId);
 
             //Clear is destructive, do it before the native call
             deserializer.clear();
-            nativeExecuteTask(pointer);
+            final int errorCode = nativeExecuteTask(pointer);
+            checkErrorCode(errorCode);
             return (byte[])deserializer.readArray(byte.class);
         } catch (IOException e) {
             Throwables.propagate(e);
         }
-        return retval;
+        return null;
     }
 
     @Override


### PR DESCRIPTION
In case an error occurred when applying the binary log, the exception
will be propagated to the procedure and handled there.