### PR TITLE
Fix IPC build compilation failure.

### DIFF
--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -1371,8 +1371,6 @@ void VoltDBIPC::executeTask(struct ipc_command *cmd) {
         writeOrDie(m_fd, (unsigned char*)resultsBuffer, responseLength);
     } catch (const FatalException& e) {
         crashVoltDB(e);
-    } catch (const SerializableEEException &e) {
-        crashVoltDB(e);
     }
 }
 


### PR DESCRIPTION
Following the pattern of not catching SerializableEEException. The IPC
process will probably exit when it hits the exception.