### PR TITLE
ENG-7880: Fix unsafe use of temp tuple in the EE.

### DIFF
--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -67,7 +67,7 @@ void BinaryLogSink::apply(const char *taskParams, boost::unordered_map<int64_t, 
 
             PersistentTable *table = tableIter->second;
 
-            TableTuple tempTuple = table->tempTuple();
+            TableTuple tempTuple = table->tempTupleWithZeroedBits();
 
             ReferenceSerializeInputLE rowInput(rowData,  rowLength);
             tempTuple.deserializeFromDR(rowInput, pool);

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -145,6 +145,7 @@ class Table {
 
     TableTuple& tempTuple() {
         assert (m_tempTuple.m_data);
+        ::memset(m_tempTuple.address(), 0, m_tempTuple.tupleLength());
         return m_tempTuple;
     }
 

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -145,6 +145,11 @@ class Table {
 
     TableTuple& tempTuple() {
         assert (m_tempTuple.m_data);
+        return m_tempTuple;
+    }
+
+    TableTuple& tempTupleWithZeroedBits() {
+        assert (m_tempTuple.m_data);
         ::memset(m_tempTuple.address(), 0, m_tempTuple.tupleLength());
         return m_tempTuple;
     }

--- a/tests/ee/storage/persistent_table_log_test.cpp
+++ b/tests/ee/storage/persistent_table_log_test.cpp
@@ -427,19 +427,19 @@ TEST_F(PersistentTableLogTest, LookupTupleUsingTempTupleTest) {
     m_table->insertTuple(nullTuple);
     delete[] nullTuple.address();
 
-    TableTuple tempTuple = m_table->tempTuple();
+    TableTuple tempTuple = m_table->tempTupleWithZeroedBits();
     tempTuple.setNValue(0, ValueFactory::getBigIntValue(1));
     tempTuple.setNValue(1, ValueFactory::getStringValue("a long string"));
     TableTuple result = m_table->lookupTupleForUndo(tempTuple);
     ASSERT_FALSE(result.isNullTuple());
 
-    tempTuple = m_table->tempTuple();
+    tempTuple = m_table->tempTupleWithZeroedBits();
     tempTuple.setNValue(0, ValueFactory::getBigIntValue(2));
     tempTuple.setNValue(1, ValueFactory::getStringValue("a"));
     result = m_table->lookupTupleForUndo(tempTuple);
     ASSERT_FALSE(result.isNullTuple());
 
-    tempTuple = m_table->tempTuple();
+    tempTuple = m_table->tempTupleWithZeroedBits();
     tempTuple.setNValue(0, ValueFactory::getBigIntValue(3));
     tempTuple.setNValue(1, ValueFactory::getNullStringValue());
     result = m_table->lookupTupleForUndo(tempTuple);


### PR DESCRIPTION
Reset all the bits of temp tuple before use, or it may have unexpected
consequences for inline VARCHAR columns during byte comparison.