### PR TITLE
ENG-7880: Fix unsafe use of temp tuple in the EE.

### DIFF
--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -1492,6 +1492,10 @@ class NValue {
      * inline object in the provided storage area
      */
     void inlineCopyObject(void *storage, int32_t maxLength, bool isInBytes) const {
+        // Always reset all the bits regardless of the actual length of the value
+        // 1 additional byte for the length prefix
+        ::memset(storage, 0, maxLength + 1);
+
         if (isNull()) {
             /*
              * The 7th bit of the length preceding value
@@ -2801,6 +2805,9 @@ template <TupleSerializationFormat F, Endianess E> inline void NValue::deseriali
         const int8_t lengthLength = getAppropriateObjectLengthLength(length);
         // the NULL SQL string is a NULL C pointer
         if (isInlined) {
+            // Always reset the bits regardless of how long the actual value is.
+            ::memset(storage, 0, lengthLength + maxLength);
+
             setObjectLengthToLocation(length, storage);
             if (length == OBJECTLENGTH_NULL) {
                 break;

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -1492,11 +1492,11 @@ class NValue {
      * inline object in the provided storage area
      */
     void inlineCopyObject(void *storage, int32_t maxLength, bool isInBytes) const {
-        // Always reset all the bits regardless of the actual length of the value
-        // 1 additional byte for the length prefix
-        ::memset(storage, 0, maxLength + 1);
-
         if (isNull()) {
+            // Always reset all the bits regardless of the actual length of the value
+            // 1 additional byte for the length prefix
+            ::memset(storage, 0, maxLength + 1);
+
             /*
              * The 7th bit of the length preceding value
              * is used to indicate that the object is null.
@@ -1507,6 +1507,10 @@ class NValue {
             const int32_t objLength = getObjectLength_withoutNull();
             const char* ptr = reinterpret_cast<const char*>(getObjectValue_withoutNull());
             checkTooNarrowVarcharAndVarbinary(m_valueType, ptr, objLength, maxLength, isInBytes);
+
+            // Always reset all the bits regardless of the actual length of the value
+            // 1 additional byte for the length prefix
+            ::memset(storage, 0, maxLength + 1);
 
             if (m_sourceInlined)
             {


### PR DESCRIPTION
Reset all the bits when setting an inline VARCHAR or VARBINARY, or it
may have unexpected consequences when used in an uncleared tuple during
byte comparison.