### PR TITLE
ENG-7886 Fix regression in sqlcmd LOAD CLASSES

### DIFF
--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -755,24 +755,32 @@ public class SQLCommand
             // LOAD CLASS <jar>?
             String loadPath = SQLParser.parseLoadClasses(statement);
             if (loadPath != null) {
-                printResponse(m_client.callProcedure("@UpdateClasses", loadPath, null));
+                File jarfile = new File(loadPath);
+                printDdlResponse(m_client.updateClasses(jarfile, null));
+                loadStoredProcedures(Procedures, Classlist);
+                return;
             }
 
             // REMOVE CLASS <class-selector>?
             String classSelector = SQLParser.parseRemoveClasses(statement);
             if (classSelector != null) {
-                printResponse(m_client.callProcedure("@UpdateClasses", null, classSelector));
+                printDdlResponse(m_client.updateClasses(null, classSelector));
+                loadStoredProcedures(Procedures, Classlist);
+                return;
             }
 
-            // All other commands get forwarded to @AdHoc
+            // DDL statements get forwarded to @AdHoc,
+            // but get special post-processing.
             if (SQLParser.queryIsDDL(statement)) {
                 // if the query is DDL, reload the stored procedures.
                 printDdlResponse(m_client.callProcedure("@AdHoc", statement));
                 loadStoredProcedures(Procedures, Classlist);
+                return;
             }
-            else {
-                printResponse(m_client.callProcedure("@AdHoc", statement));
-            }
+
+            // All other commands get forwarded to @AdHoc
+            printResponse(m_client.callProcedure("@AdHoc", statement));
+
         } catch (Exception exc) {
             stopOrContinue(exc);
         }


### PR DESCRIPTION
My recent fix to bypass the translation of LOAD/REMOVE commands 
into exec @UpdateClasses commands and rewrite them directly as 
m_client.callProcedure("@UpdateClasses" calls missed the fact that these 
particular exec calls never actually become m_client.callProcedure("@UpdateClasses"
calls at all -- they are special cased to become direct m_client.updateClasses calls.