### PR TITLE
ENG-7880: Fix unsafe use of temp tuple in the EE.

### DIFF
--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -1493,6 +1493,10 @@ class NValue {
      */
     void inlineCopyObject(void *storage, int32_t maxLength, bool isInBytes) const {
         if (isNull()) {
+            // Always reset all the bits regardless of the actual length of the value
+            // 1 additional byte for the length prefix
+            ::memset(storage, 0, maxLength + 1);
+
             /*
              * The 7th bit of the length preceding value
              * is used to indicate that the object is null.
@@ -1503,6 +1507,10 @@ class NValue {
             const int32_t objLength = getObjectLength_withoutNull();
             const char* ptr = reinterpret_cast<const char*>(getObjectValue_withoutNull());
             checkTooNarrowVarcharAndVarbinary(m_valueType, ptr, objLength, maxLength, isInBytes);
+
+            // Always reset all the bits regardless of the actual length of the value
+            // 1 additional byte for the length prefix
+            ::memset(storage, 0, maxLength + 1);
 
             if (m_sourceInlined)
             {
@@ -2801,6 +2809,9 @@ template <TupleSerializationFormat F, Endianess E> inline void NValue::deseriali
         const int8_t lengthLength = getAppropriateObjectLengthLength(length);
         // the NULL SQL string is a NULL C pointer
         if (isInlined) {
+            // Always reset the bits regardless of how long the actual value is.
+            ::memset(storage, 0, lengthLength + maxLength);
+
             setObjectLengthToLocation(length, storage);
             if (length == OBJECTLENGTH_NULL) {
                 break;

--- a/tests/ee/storage/persistent_table_log_test.cpp
+++ b/tests/ee/storage/persistent_table_log_test.cpp
@@ -96,6 +96,19 @@ public:
         m_primaryKeyIndexColumns.push_back(6);
         m_primaryKeyIndexColumns.push_back(7);
 
+        // Narrower table with no uninlined column
+        m_narrowColumnNames.push_back("1");
+        m_narrowColumnNames.push_back("2");
+
+        m_narrowTableSchemaTypes.push_back(voltdb::VALUE_TYPE_BIGINT);
+        m_narrowTableSchemaTypes.push_back(voltdb::VALUE_TYPE_VARCHAR);
+
+        m_narrowTableSchemaColumnSizes.push_back(NValue::getTupleStorageSize(voltdb::VALUE_TYPE_BIGINT));
+        m_narrowTableSchemaColumnSizes.push_back(15);
+
+        m_narrowTableSchemaAllowNull.push_back(false);
+        m_narrowTableSchemaAllowNull.push_back(true);
+
         m_engine->setUndoToken(INT64_MIN + 1);
     }
 
@@ -126,6 +139,14 @@ public:
         m_table->setPrimaryKeyIndex(pkeyIndex);
     }
 
+    void initNarrowTable() {
+        m_tableSchema = TupleSchema::createTupleSchemaForTest(m_narrowTableSchemaTypes,
+                                                              m_narrowTableSchemaColumnSizes,
+                                                              m_narrowTableSchemaAllowNull);
+        m_table = dynamic_cast<PersistentTable*>(
+            TableFactory::getPersistentTable(0, "Foo", m_tableSchema, m_narrowColumnNames, signature, &drStream, false, 0));
+    }
+
     VoltDBEngine *m_engine;
     TupleSchema *m_tableSchema;
     PersistentTable *m_table;
@@ -135,6 +156,12 @@ public:
     std::vector<int32_t> m_tableSchemaColumnSizes;
     std::vector<bool> m_tableSchemaAllowNull;
     std::vector<int> m_primaryKeyIndexColumns;
+
+    std::vector<std::string> m_narrowColumnNames;
+    std::vector<ValueType> m_narrowTableSchemaTypes;
+    std::vector<int32_t> m_narrowTableSchemaColumnSizes;
+    std::vector<bool> m_narrowTableSchemaAllowNull;
+
     char signature[20];
 };
 
@@ -366,6 +393,65 @@ TEST_F(PersistentTableLogTest, LookupTupleForUndoNoPKTest) {
     voltdb::TableTuple tuple(m_tableSchema);
     tableutil::getRandomTuple(m_table, tuple);
     ASSERT_EQ(m_table->lookupTupleForUndo(tuple).address(), tuple.address());
+}
+
+TEST_F(PersistentTableLogTest, LookupTupleUsingTempTupleTest) {
+    initNarrowTable();
+
+    // Create three tuple with a variable length VARCHAR column, then call
+    // lookupTupleForUndo() to look each tuple up from wide to narrower column.
+    // It will use the memcmp() code path for the comparison, which should all
+    // succeed because there is no uninlined stuff.
+
+    NValue wideStr = ValueFactory::getStringValue("a long string");
+    NValue narrowStr = ValueFactory::getStringValue("a");
+    NValue nullStr = ValueFactory::getNullStringValue();
+
+    TableTuple wideTuple(m_tableSchema);
+    wideTuple.move(new char[wideTuple.tupleLength()]);
+    ::memset(wideTuple.address(), 0, wideTuple.tupleLength());
+    wideTuple.setNValue(0, ValueFactory::getBigIntValue(1));
+    wideTuple.setNValue(1, wideStr);
+    m_table->insertTuple(wideTuple);
+    delete[] wideTuple.address();
+
+    TableTuple narrowTuple(m_tableSchema);
+    narrowTuple.move(new char[narrowTuple.tupleLength()]);
+    ::memset(narrowTuple.address(), 0, narrowTuple.tupleLength());
+    narrowTuple.setNValue(0, ValueFactory::getBigIntValue(2));
+    narrowTuple.setNValue(1, narrowStr);
+    m_table->insertTuple(narrowTuple);
+    delete[] narrowTuple.address();
+
+    TableTuple nullTuple(m_tableSchema);
+    nullTuple.move(new char[nullTuple.tupleLength()]);
+    ::memset(nullTuple.address(), 0, nullTuple.tupleLength());
+    nullTuple.setNValue(0, ValueFactory::getBigIntValue(3));
+    nullTuple.setNValue(1, nullStr);
+    m_table->insertTuple(nullTuple);
+    delete[] nullTuple.address();
+
+    TableTuple tempTuple = m_table->tempTuple();
+    tempTuple.setNValue(0, ValueFactory::getBigIntValue(1));
+    tempTuple.setNValue(1, wideStr);
+    TableTuple result = m_table->lookupTupleForUndo(tempTuple);
+    ASSERT_FALSE(result.isNullTuple());
+
+    tempTuple = m_table->tempTuple();
+    tempTuple.setNValue(0, ValueFactory::getBigIntValue(2));
+    tempTuple.setNValue(1, narrowStr);
+    result = m_table->lookupTupleForUndo(tempTuple);
+    ASSERT_FALSE(result.isNullTuple());
+
+    tempTuple = m_table->tempTuple();
+    tempTuple.setNValue(0, ValueFactory::getBigIntValue(3));
+    tempTuple.setNValue(1, nullStr);
+    result = m_table->lookupTupleForUndo(tempTuple);
+    ASSERT_FALSE(result.isNullTuple());
+
+    wideStr.free();
+    narrowStr.free();
+    nullStr.free();
 }
 
 int main() {


### PR DESCRIPTION
Reset all the bits when setting an inline VARCHAR or VARBINARY, or it
may have unexpected consequences when used in an uncleared tuple during
byte comparison.