### PR TITLE
one-line fix for sqlcmd save history

### DIFF
--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -221,7 +221,7 @@ public class SQLCommand
 
                 // EXIT command - exit immediately
                 if (SQLParser.isExitCommand(line)) {
-                    System.exit(m_exitCode);
+                    return;
                 }
 
                 // RECALL command


### PR DESCRIPTION
Interactive sqlcmd was normally exiting via System.exit, bypassing the finally block that saved history between sessions. 