### PR TITLE
ENG-7917 refresh sqlcmd metadata cache after a batch

### DIFF
--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -119,6 +119,7 @@ public class SQLCommand
             // Assert the current DDL AdHoc batch call behavior
             assert(response.getResults().length == 1);
             System.out.println("Batch command succeeded.");
+            loadStoredProcedures(Procedures, Classlist);
         }
         catch (ProcCallException ex) {
             String fixedMessage = patchErrorMessageWithFile(batchFileName, ex.getMessage());

--- a/tests/sqlcmd/baselines/batching/file_inlinebatch_simple.outbaseline
+++ b/tests/sqlcmd/baselines/batching/file_inlinebatch_simple.outbaseline
@@ -1,4 +1,7 @@
 
+drop procedure p if exists;
+Command succeeded.
+
 drop table t if exists;
 Command succeeded.
 
@@ -9,8 +12,17 @@ FILE -inlinebatch EOF
 
 partition table t on column i;
 create index tidx on t(i);
+create procedure p as
+    select * from t;
+
 
 Batch command succeeded.
+
+exec p;
+I 
+--
+
+(Returned 0 rows in #.##s)
 
 explain select * from t;
 EXECUTION_PLAN                 
@@ -22,3 +34,9 @@ RETURN RESULTS TO STORED PROCEDURE
 
 
 (Returned 1 rows in #.##s)
+
+drop procedure p;
+Command succeeded.
+
+drop table t;
+Command succeeded.

--- a/tests/sqlcmd/baselines/batching/file_inlinebatch_simple_via_file.outbaseline
+++ b/tests/sqlcmd/baselines/batching/file_inlinebatch_simple_via_file.outbaseline
@@ -1,6 +1,9 @@
 
 FILE scripts/batching/file_inlinebatch_simple.in
 
+drop procedure p if exists;
+Command succeeded.
+
 drop table t if exists;
 Command succeeded.
 
@@ -11,8 +14,17 @@ FILE -inlinebatch EOF
 
 partition table t on column i;
 create index tidx on t(i);
+create procedure p as
+    select * from t;
+
 
 Batch command succeeded.
+
+exec p;
+I 
+--
+
+(Returned 0 rows in #.##s)
 
 explain select * from t;
 EXECUTION_PLAN                 
@@ -24,3 +36,9 @@ RETURN RESULTS TO STORED PROCEDURE
 
 
 (Returned 1 rows in #.##s)
+
+drop procedure p;
+Command succeeded.
+
+drop table t;
+Command succeeded.

--- a/tests/sqlcmd/scripts/batching/file_inlinebatch_simple.in
+++ b/tests/sqlcmd/scripts/batching/file_inlinebatch_simple.in
@@ -1,9 +1,18 @@
+drop procedure p if exists;
 drop table t if exists;
 create table t (i integer not null);
 
 file -inlinebatch EOF
 partition table t on column i;
 create index tidx on t(i);
+create procedure p as
+    select * from t;
+
 EOF
 
+exec p;
+
 explain select * from t;
+
+drop procedure p;
+drop table t;


### PR DESCRIPTION
Tested by extending a sqlcmdtest script
 -- also added db schema cleanup steps to the test script.