### PR TITLE
ENG-7849: Rollback BEGIN TXN entry in the binary log.

### DIFF
--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -72,8 +72,8 @@ public:
 
     size_t computeOffsets(TableTuple &tuple,size_t *rowHeaderSz);
 
-    void beginTransaction(int64_t sequenceNumber, int64_t uniqueId);
-    void endTransaction(int64_t sequenceNumber, int64_t uniqueId);
+    size_t beginTransaction(int64_t sequenceNumber, int64_t uniqueId);
+    size_t endTransaction(int64_t sequenceNumber, int64_t uniqueId);
 
     bool checkOpenTransaction(StreamBlock *sb, size_t minLength, size_t& blockSize, size_t& uso, bool continueTxn);
 

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -74,13 +74,13 @@ public:
     void pushPendingBlocks();
     void discardBlock(StreamBlock *sb);
 
-    virtual void beginTransaction(int64_t sequenceNumber, int64_t uniqueId) {}
-    virtual void endTransaction(int64_t sequenceNumber, int64_t uniqueId) {}
+    virtual size_t beginTransaction(int64_t sequenceNumber, int64_t uniqueId) { return m_uso; }
+    virtual size_t endTransaction(int64_t sequenceNumber, int64_t uniqueId) { return m_uso; }
 
     virtual bool checkOpenTransaction(StreamBlock *sb, size_t minLength, size_t& blockSize, size_t& uso, bool continueTxn) { return false; }
 
-    /** Send committed data to the top end */
-    void commit(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t txnId, int64_t uniqueId, bool sync, bool flush);
+    /** Send committed data to the top end. Returns the USO before the BEGIN TXN entry is written, or 0 if not written. */
+    size_t commit(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t txnId, int64_t uniqueId, bool sync, bool flush);
 
     /** timestamp of most recent flush() */
     int64_t m_lastFlush;

--- a/tests/ee/storage/DRTupleStream_test.cpp
+++ b/tests/ee/storage/DRTupleStream_test.cpp
@@ -52,7 +52,6 @@ const int COLUMN_COUNT = 5;
 // total: 67
 const int MAGIC_TUPLE_SIZE = 39;
 const int MAGIC_TRANSACTION_SIZE = 36;
-const int MAGIC_BEGIN_SIZE = 22;
 const int MAGIC_TUPLE_PLUS_TRANSACTION_SIZE = MAGIC_TUPLE_SIZE + MAGIC_TRANSACTION_SIZE;
 // 1k buffer
 const int BUFFER_SIZE = 950;
@@ -548,7 +547,7 @@ TEST_F(DRTupleStreamTest, RollbackMiddleTuple)
     boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
     m_topend.blocks.pop_front();
     EXPECT_EQ(results->uso(), 0);
-    EXPECT_EQ(results->offset(), (MAGIC_TUPLE_PLUS_TRANSACTION_SIZE * 10) + MAGIC_BEGIN_SIZE);
+    EXPECT_EQ(results->offset(), MAGIC_TUPLE_PLUS_TRANSACTION_SIZE * 10);
 }
 
 /**


### PR DESCRIPTION
It was possible that when a transaction rolls back, it doesn't roll back
the BEGIN TXN entry, leaving it orphaned in the binary log. This causes
problems like inconsistent unique IDs for the same sequence number
downstream.

Returning the correct start USO for the undo actions to correctly
rollback all entries generated by a transaction.