### PR TITLE
ENG-7918: Reverse the order of releasing the undo actions.

### DIFF
--- a/src/ee/common/UndoQuantum.h
+++ b/src/ee/common/UndoQuantum.h
@@ -105,10 +105,15 @@ protected:
      * "delete" here only really calls their virtual destructors (important!)
      * but their no-op delete operator leaves them to be purged in one go with the data pool.
      * Also call own destructor to ensure that the vector is released.
+     *
+     * The order of releasing should be FIFO order, which is the reverse of what
+     * undo does. Think about the case where you insert and delete a bunch of
+     * tuples in a table, then does a truncate. You do not want to delete that
+     * table before all the inserts and deletes are released.
      */
     inline Pool* release() {
-        for (std::vector<UndoAction*>::reverse_iterator i = m_undoActions.rbegin();
-             i != m_undoActions.rend(); ++i) {
+        for (std::vector<UndoAction*>::iterator i = m_undoActions.begin();
+             i != m_undoActions.end(); ++i) {
             UndoAction* goner = *i;
             goner->release();
             delete goner;

--- a/tests/ee/common/undolog_test.cpp
+++ b/tests/ee/common/undolog_test.cpp
@@ -95,7 +95,7 @@ public:
     }
 
     /*
-     * Confirm all actions were undone in the correct order.
+     * Confirm all actions were undone in FILO order.
      */
     void confirmUndoneActionHistoryOrder(std::vector<MockUndoActionHistory*> histories, int &expectedStartingIndex) {
         for (std::vector<MockUndoActionHistory*>::reverse_iterator i = histories.rbegin();
@@ -110,11 +110,11 @@ public:
     }
 
     /*
-     * Confirm all actions were released in the correct order
+     * Confirm all actions were released in FIFO order.
      */
     void confirmReleaseActionHistoryOrder(std::vector<MockUndoActionHistory*> histories, int &expectedStartingIndex) {
-        for (std::vector<MockUndoActionHistory*>::reverse_iterator i = histories.rbegin();
-             i != histories.rend();
+        for (std::vector<MockUndoActionHistory*>::iterator i = histories.begin();
+             i != histories.end();
              i++) {
             const MockUndoActionHistory *history = *i;
             ASSERT_TRUE(history->m_released);


### PR DESCRIPTION
Undo actions should be released in FIFO order, which is the reverse of
what undo does. Think about the case where you insert and delete a bunch
of tuples in a table, then does a truncate. You do not want to delete
that table before all the inserts and deletes are released.