### PR TITLE
Tweaks to prevent unwarranted throws/crashes.

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1802,7 +1802,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
                 while ((b = (byte) buildstringStream.read()) != -1) {
                     sb.append((char)b);
                 }
-                sb.append("\n");
                 String parts[] = sb.toString().split(" ", 2);
                 if (parts.length == 2) {
                     parts[0] = parts[0].trim();

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1794,42 +1794,40 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
 
     public static String[] extractBuildInfo(VoltLogger logger) {
         StringBuilder sb = new StringBuilder(64);
-        String buildString = "VoltDB";
-        String versionString = m_defaultVersionString;
-        byte b = -1;
         try {
             InputStream buildstringStream =
                 ClassLoader.getSystemResourceAsStream("buildstring.txt");
-            if (buildstringStream == null) {
-                throw new RuntimeException("Unreadable or missing buildstring.txt file.");
-            }
-            while ((b = (byte) buildstringStream.read()) != -1) {
-                sb.append((char)b);
-            }
-            sb.append("\n");
-            String parts[] = sb.toString().split(" ", 2);
-            if (parts.length != 2) {
-                throw new RuntimeException("Invalid buildstring.txt file.");
-            }
-            versionString = parts[0].trim();
-            buildString = parts[1].trim();
-        } catch (Exception ignored) {
-            try {
-                InputStream buildstringStream = new FileInputStream("version.txt");
-                try {
-                    while ((b = (byte) buildstringStream.read()) != -1) {
-                        sb.append((char)b);
-                    }
-                    versionString = sb.toString().trim();
-                } finally {
-                    buildstringStream.close();
+            if (buildstringStream != null) {
+                byte b;
+                while ((b = (byte) buildstringStream.read()) != -1) {
+                    sb.append((char)b);
+                }
+                sb.append("\n");
+                String parts[] = sb.toString().split(" ", 2);
+                if (parts.length == 2) {
+                    parts[0] = parts[0].trim();
+                    parts[1] = parts[1].trim();
+                    return parts;
                 }
             }
-            catch (Exception ignored2) {
-                logger.l7dlog(Level.ERROR, LogKeys.org_voltdb_VoltDB_FailedToRetrieveBuildString.name(), null);
+        } catch (Exception ignored) {
+        }
+        try {
+            InputStream versionstringStream = new FileInputStream("version.txt");
+            try {
+                byte b;
+                while ((b = (byte) versionstringStream.read()) != -1) {
+                    sb.append((char)b);
+                }
+                return new String[] { sb.toString().trim(), "VoltDB" };
+            } finally {
+                versionstringStream.close();
             }
         }
-        return new String[] { versionString, buildString };
+        catch (Exception ignored2) {
+            logger.l7dlog(Level.ERROR, LogKeys.org_voltdb_VoltDB_FailedToRetrieveBuildString.name(), null);
+            return new String[] { m_defaultVersionString, "VoltDB" };
+        }
     }
 
     @Override

--- a/src/frontend/org/voltdb/RestoreAgent.java
+++ b/src/frontend/org/voltdb/RestoreAgent.java
@@ -614,13 +614,27 @@ SnapshotCompletionInterest, Promotable
             // if the cluster instance IDs in the snapshot and command log don't match, just move along
             if (m_replayAgent.getInstanceId() != null && info != null &&
                 !m_replayAgent.getInstanceId().equals(info.instanceId)) {
+                // Exceptions are not well tolerated here, so don't throw over something
+                // as trivial as error message formatting.
+                String agentIdString;
+                String infoIdString;
+                try {
+                    agentIdString = m_replayAgent.getInstanceId().serializeToJSONObject().toString();
+                } catch (JSONException e1) {
+                    agentIdString = "<failed to serialize id>";
+                }
+                try {
+                    infoIdString = info.instanceId.serializeToJSONObject().toString();
+                } catch (JSONException e1) {
+                    infoIdString = "<failed to serialize id>";
+                }
                 m_snapshotErrLogStr.append("\nRejected snapshot ")
-                                .append(info.nonce)
-                                .append(" due to mismatching instance IDs.")
-                                .append(" Command log ID: ")
-                                .append(m_replayAgent.getInstanceId().serializeToJSONObject().toString())
-                                .append(" Snapshot ID: ")
-                                .append(info.instanceId.serializeToJSONObject().toString());
+                .append(info.nonce)
+                .append(" due to mismatching instance IDs.")
+                .append(" Command log ID: ")
+                .append(agentIdString)
+                .append(" Snapshot ID: ")
+                .append(infoIdString);
                 continue;
             }
             if (info != null) {


### PR DESCRIPTION
In extractBuildInfo, use early return and fall-through instead of a RuntimeException throw+catch to implement normal flow control.

In "RestoreAgent.generatePlans", just fudge an error message in the unlikely (maybe impossible) event of a JSON exception during its formatting. This is preferable to leaking the exception to the caller. The caller is set up to call crashGlobalVoltDB on any exception.