### PR TITLE
Support hexadecimal literals in sqlcmd's EXEC syntax

### DIFF
--- a/src/frontend/org/voltdb/parser/SQLParser.java
+++ b/src/frontend/org/voltdb/parser/SQLParser.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -347,6 +348,8 @@ public class SQLParser extends SQLPatternFactory
             "[^']*" +      // arbitrary string content
             "'",           // end of string OR start of escaped quote
             Pattern.MULTILINE);
+
+    private static final Pattern SingleQuotedHexLiteral = Pattern.compile("[Xx]'([0-9A-Fa-f]*)'", Pattern.MULTILINE);
 
     // Define a common pattern to sweep up a mix of semicolons and space and
     // meaningless garbage at the end of the simpler sqlcmd directives.
@@ -1374,6 +1377,44 @@ public class SQLParser extends SQLPatternFactory
             return paramType;
         }
 
+        /**
+         * Given a parameter string, if it's of the form x'0123456789ABCDEF',
+         * return a string containing just the digits.
+         */
+        private static String getDigitsFromHexLiteral(String paramString) {
+            Matcher matcher = SingleQuotedHexLiteral.matcher(paramString);
+            if (matcher.matches()) {
+                return matcher.group(1);
+            }
+            return null;
+        }
+
+        /**
+         * Given a string of hex digits, produce a long value, assuming
+         * a 2's complement representation.
+         */
+        private long hexDigitsToLong(String hexDigits) throws NumberFormatException {
+            // The method
+            //   Long.parseLong(<digits>, <radix>);
+            // Doesn't quite do what we want---it expects a '-' to
+            // indicate negative values, and doesn't want the sign bit set
+            // in the hex digits.
+
+            // BigInteger.longValue() will truncate to the lowest 64 bits,
+            // so we need to exlicitly check if there's too many digits.
+            if (hexDigits.length() > 16) {
+                throw new SQLParser.Exception("Too many hexadecimal digits for BIGINT value");
+            }
+
+            if (hexDigits.length() == 0) {
+                throw new SQLParser.Exception("Zero hexadecimal digits is invalid for BIGINT value");
+            }
+
+
+            long val = new BigInteger(hexDigits, 16).longValue();
+            return val;
+        }
+
         public Object[] getParameterObjects() throws SQLParser.Exception
         {
             Object[] objectParams = new Object[this.params.size()];
@@ -1411,7 +1452,16 @@ public class SQLParser extends SQLPatternFactory
                             objParam = Integer.parseInt(param);
                         }
                         else if (paramType.equals("bigint")) {
-                            objParam = Long.parseLong(param);
+                            // Could be literal of the form x'0007'
+                            // or just a simple decimal literal
+                            String hexDigits = getDigitsFromHexLiteral(param);
+                            if (hexDigits != null) {
+                                objParam = hexDigitsToLong(hexDigits);
+                            }
+                            else {
+                                // It's a decimal literal
+                                objParam = Long.parseLong(param);
+                            }
                         }
                         else if (paramType.equals("float")) {
                             objParam = Double.parseDouble(param);
@@ -1426,10 +1476,17 @@ public class SQLParser extends SQLPatternFactory
                             objParam = parseDate(param);
                         }
                         else if (paramType.equals("varbinary") || paramType.equals("tinyint_array")) {
-                            String val = Unquote.matcher(param).replaceAll("");
-                            objParam = Encoder.hexDecode(val);
+                            // A VARBINARY literal may or may not be
+                            // prefixed with an X.
+                            String hexDigits = getDigitsFromHexLiteral(param);
+                            if (hexDigits == null) {
+                                hexDigits = Unquote.matcher(param).replaceAll("");
+                            }
+                            objParam = Encoder.hexDecode(hexDigits);
                             // Make sure we have an even number of characters, otherwise it is an invalid byte string
-                            if (param.length() % 2 == 1) {
+                            if (hexDigits.length() % 2 == 1) {
+                                // This seems to be dead code:
+                                // Encoder will throw an exception before we get here.
                                 throw new SQLParser.Exception(
                                         "Invalid varbinary value (%s) (param %d) : "
                                         + "must have an even number of hex characters to be valid.",
@@ -1453,6 +1510,14 @@ public class SQLParser extends SQLPatternFactory
         // No public constructor.
         ExecuteCallResults()
         {}
+
+        @Override
+        public String toString() {
+            return "ExecuteCallResults { "
+                            + "procedure: " + procedure + ", "
+                            + "params: " + params + ", "
+                            + "paramTypes: " + paramTypes + " }";
+        }
     }
 
     /**
@@ -1472,6 +1537,7 @@ public class SQLParser extends SQLPatternFactory
 
     /**
      * Parse EXECUTE procedure call for testing without looking up parameter types.
+     * Used for testing.
      * @param statement   statement to parse
      * @param procedures  maps procedures to parameter signature maps
      * @return            results object or NULL if statement wasn't recognized

--- a/tests/frontend/org/voltdb/parser/TestSQLParser.java
+++ b/tests/frontend/org/voltdb/parser/TestSQLParser.java
@@ -23,6 +23,11 @@
 
 package org.voltdb.parser;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,6 +37,7 @@ import org.junit.Test;
 import org.voltdb.parser.SQLParser.ExecuteCallResults;
 import org.voltdb.parser.SQLParser.FileOption;
 import org.voltdb.parser.SQLParser.ParseRecallResults;
+import org.voltdb.utils.Encoder;
 
 import com.google_voltpatches.common.base.Joiner;
 
@@ -544,4 +550,135 @@ public class TestSQLParser extends TestCase {
                 expected, parsedString);
     }
 
+    // Add an entry to the procedures map for a function with the given
+    // signature
+    private void addToProcsMap(Map<String, Map<Integer, List<String>>> procs, String procName, String... paramTypes) {
+        Map<Integer, List<String>> signatures = new HashMap<>();
+        List<String> paramTypesList = new ArrayList<>();
+
+        for (String paramType : paramTypes) {
+            paramTypesList.add(paramType);
+        }
+
+        signatures.put(paramTypesList.size(), paramTypesList);
+
+        procs.put(procName, signatures);
+    }
+
+    private void assertParamsParseAs(
+            Map<String, Map<Integer, List<String>>> procs,
+            Object[] expectedParams,
+            String execCommand) {
+        ExecuteCallResults results = SQLParser.parseExecuteCall(execCommand, procs);
+        Object[] actualParams = results.getParameterObjects();
+
+        int numActualParams = actualParams.length;
+        assertEquals("SQLParser produced wrong number of parameters",
+                expectedParams.length, numActualParams);
+
+        for (int i = 0; i < numActualParams; ++i) {
+            if (expectedParams[i] instanceof byte[]) {
+                // byte[] doesn't override equals and just compares references.
+                // Need to use Arrays.equals instead here.
+                assertTrue(actualParams[i] instanceof byte[]);
+
+                byte[] expectedByteArray = (byte[])expectedParams[i];
+                byte[] actualByteArray = (byte[])actualParams[i];
+
+                assertTrue(Arrays.equals(expectedByteArray, actualByteArray));
+            }
+            else {
+                assertEquals(expectedParams[i], actualParams[i]);
+            }
+        }
+    }
+
+    private static void assertParamParsingFails(
+            Map<String, Map<Integer, List<String>>> procs,
+            String expectedMessage,
+            String execCommand) {
+
+        try {
+            ExecuteCallResults results = SQLParser.parseExecuteCall(execCommand, procs);
+            results.getParameterObjects();
+        }
+        catch (Exception exc) {
+            assertTrue("Expected parsing to fail with message '"
+                    + expectedMessage + "', but instead it failed with '"
+                    + exc.getMessage() + "'.",
+                    exc.getMessage().contains(expectedMessage));
+            return;
+        }
+
+        fail("Expected parsing to fail with message '"
+                + expectedMessage + "', but it didn't fail.");
+    }
+
+    @Test
+    public void testExecHexLiteralParamsVarbinary() {
+
+        Map<String, Map<Integer, List<String>>> procs = new HashMap<>();
+        addToProcsMap(procs, "myProc_vb", "varbinary");
+
+        // 0-length hex string is okay.
+        assertParamsParseAs(procs,
+                new Object[] {new byte[] {}},
+                "exec myProc_vb x''");
+        assertParamsParseAs(procs,
+                new Object[] {new byte[] {}},
+                "exec myProc_vb ''");
+
+        assertParamsParseAs(procs,
+                new byte[][] {{(byte) 255}},
+                "exec myProc_vb x'ff'");
+        assertParamsParseAs(procs,
+                new byte[][] {{(byte) 255}},
+                "exec myProc_vb 'ff'");
+
+        assertParamsParseAs(procs,
+                new Object[] {Encoder.hexDecode("deadbeef")},
+                "exec myProc_vb x'deadbeef'");
+        assertParamsParseAs(procs,
+                new Object[] {Encoder.hexDecode("deadbeef")},
+                "exec myProc_vb 'deadbeef'");
+
+        // number of hex digits must be even in varbinary context.
+        assertParamParsingFails(procs, "String is not properly hex-encoded.",
+                "exec myProc_vb x'a'");
+        assertParamParsingFails(procs, "String is not properly hex-encoded.",
+                "exec myProc_vb x'abc'");
+    }
+
+    @Test
+    public void testExecHexLiteralParamsBigint() {
+
+        Map<String, Map<Integer, List<String>>> procs = new HashMap<>();
+        addToProcsMap(procs, "myProc_bi", "bigint");
+
+        assertParamsParseAs(procs,
+                new Object[] {Long.parseLong("deadbeef", 16)},
+                "exec myProc_bi x'deadbeef'");
+
+        assertParamsParseAs(procs,
+                new Long[] {-1L},
+                "exec myProc_bi x'ffffffffffffffff'");
+
+        assertParamsParseAs(procs,
+                new Long[] {-16L},
+                "exec myProc_bi x'fffffffffffffff0'");
+
+        // a minus sign isn't allowed to indicate negative values.
+        assertParamParsingFails(procs,
+                "Expected a long numeric value, got 'x'-10''",
+                "exec myProc_bi x'-10'");
+
+        assertParamParsingFails(procs,
+                "Zero hexadecimal digits is invalid for BIGINT value",
+                "exec myProc_bi x''");
+
+        assertParamParsingFails(procs,
+                "Too many hexadecimal digits for BIGINT value",
+                "exec myProc_bi x'ffffffffffffffff0'");
+
+    }
 }


### PR DESCRIPTION
What's missing from here?
- No VMC support (yet)
- No sqlcmdtest tests (I tested manually)