### PR TITLE
ENG-8062 Workaround for making rolling upgrade work

### DIFF
--- a/build-client.xml
+++ b/build-client.xml
@@ -154,10 +154,19 @@ JAR BUILDING
 ***************************************
 -->
 
-<target name="buildinfo">
+<target name="getversion">
   <loadfile property='dist.version' srcFile='version.txt'>
       <filterchain><striplinebreaks/></filterchain>
   </loadfile>
+</target>
+
+<!-- Use buildstring from passed parameterm but set version from version.txt -->
+<target name="override_buildstring" depends="getversion">
+  <echo message = "${buildstring}" file="buildstring.txt"/>
+  <echo message = "Version set from commandline property: ${buildstring}"/>
+</target>
+
+<target name="buildinfo" unless="buildstring" depends="override_buildstring, getversion">
   <exec dir="." executable="tools/getgitinfo.py">
       <arg line='${dist.version}' />
   </exec>

--- a/build.xml
+++ b/build.xml
@@ -44,7 +44,6 @@
 <!-- allow env.VOLTBUILD to override "build" property -->
 <envdefault prop="build" var="VOLTBUILD" default="release" />
 <envdefault prop="jmemcheck" var="JMEMCHECK" default="memcheck" />
-
 <!-- allow env.VOLTPRO to override "voltpro" property -->
 <condition property="voltpro" value="${env.VOLTPRO}">
     <isset property="env.VOLTPRO"/>
@@ -781,10 +780,19 @@ JAR BUILDING
 ***************************************
 -->
 
-<target name="buildinfo">
+<target name="getversion">
   <loadfile property='dist.version' srcFile='version.txt'>
       <filterchain><striplinebreaks/></filterchain>
   </loadfile>
+</target>
+
+<!-- Use buildstring from passed parameterm but set version from version.txt -->
+<target name="override_buildstring" depends="getversion">
+  <echo message = "${buildstring}" file="buildstring.txt"/>
+  <echo message = "Version set from commandline property: ${buildstring}"/>
+</target>
+
+<target name="buildinfo" unless="buildstring" depends="override_buildstring, getversion">
   <exec dir="." executable="tools/getgitinfo.py">
       <arg line='${dist.version}' />
   </exec>

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -60,7 +60,7 @@ def buildCommunity():
         run("pwd")
         run("git status")
         run("git describe --dirty")
-        run("ant -Djmemcheck=NO_MEMCHECK clean default dist")
+        run("ant %s -Djmemcheck=NO_MEMCHECK clean default dist" % build_args)
 
 ################################################
 # BUILD THE ENTERPRISE VERSION
@@ -71,7 +71,7 @@ def buildPro():
         run("pwd")
         run("git status")
         run("git describe --dirty")
-        run("VOLTCORE=../voltdb ant -f mmt.xml -Djmemcheck=NO_MEMCHECK -Dallowreplication=true -Dlicensedays=%d clean dist.pro" % defaultlicensedays)
+        run("VOLTCORE=../voltdb ant -f mmt.xml -Djmemcheck=NO_MEMCHECK -Dallowreplication=true -Dlicensedays=%d %s clean dist.pro" % (defaultlicensedays, build_args))
 
 ################################################
 # BUILD THE RABBITMQ EXPORT CONNECTOR
@@ -233,6 +233,11 @@ if len(sys.argv) == 3:
     rbmqExportTreeish = sys.argv[2]
     if voltdbTreeish != proTreeish:
         oneOff = True     #force oneoff when not same tag/branch
+
+try:
+    build_args = os.environ['VOLTDB_BUILD_ARGS']
+except:
+    build_args=""
 
 print "Building with pro: %s and voltdb: %s" % (proTreeish, voltdbTreeish)
 


### PR DESCRIPTION
DO NOT MERGE. I want to squash these.
Rolling upgrade should only require a regex on the hotfix patch to allow a match against the running version.  Unfortunately, there is a later check during rejoin against the entire buildstring (loaded from buildstring.txt in the voltdb .jar)  which contains git --describe output. This branch allows the build to take a -Dbuildstring="..." arg that will write buildstring.txt instead of creating it from the version and git sha.