### PR TITLE
Support x-quoted literals for VARBINARY, but not integers (yet)

### DIFF
--- a/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
@@ -21,7 +21,6 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
-import org.voltdb.parser.SQLParser;
 import org.voltdb.planner.PlanningErrorException;
 import org.voltdb.types.ExpressionType;
 import org.voltdb.types.TimestampType;
@@ -303,7 +302,8 @@ public class ConstantValueExpression extends AbstractValueExpression {
             }
         }
 
-        if ((neededType == VoltType.FLOAT) || (neededType == VoltType.DECIMAL)) {
+        if ((neededType == VoltType.FLOAT || neededType == VoltType.DECIMAL)
+                && getValueType() != VoltType.VARBINARY) {
             if (m_valueType == null ||
                     (m_valueType != VoltType.NUMERIC && ! m_valueType.isExactNumeric())) {
                 try {
@@ -319,20 +319,10 @@ public class ConstantValueExpression extends AbstractValueExpression {
             return;
         }
 
-        if (neededType.isInteger()) {
+        if (neededType.isInteger() && getValueType() != VoltType.VARBINARY) {
             long value = 0;
             try {
-                String hexDigits = SQLParser.getDigitsFromHexLiteral(getValue());
-                if (hexDigits != null) {
-                    value = SQLParser.hexDigitsToLong(hexDigits);
-                }
-                else {
-                    value = Long.parseLong(getValue());
-                }
-            }
-            catch (SQLParser.Exception spe) {
-                // Caught in the catch block below.
-                throw new NumberFormatException();
+                value = Long.parseLong(getValue());
             } catch (NumberFormatException nfe) {
                 throw new PlanningErrorException("Value (" + getValue() +
                                                  ") has an invalid format for a constant " +

--- a/src/frontend/org/voltdb/parser/SQLParser.java
+++ b/src/frontend/org/voltdb/parser/SQLParser.java
@@ -1479,7 +1479,12 @@ public class SQLParser extends SQLPatternFactory
                             objParam = parseDate(param);
                         }
                         else if (paramType.equals("varbinary") || paramType.equals("tinyint_array")) {
-                            String hexDigits = Unquote.matcher(param).replaceAll("");
+                            // A VARBINARY literal may or may not be
+                            // prefixed with an X.
+                            String hexDigits = getDigitsFromHexLiteral(param);
+                            if (hexDigits == null) {
+                                hexDigits = Unquote.matcher(param).replaceAll("");
+                            }
                             // The following call with throw an exception if we
                             // have an odd number of hex digits.
                             objParam = Encoder.hexDecode(hexDigits);

--- a/src/frontend/org/voltdb/utils/Encoder.java
+++ b/src/frontend/org/voltdb/utils/Encoder.java
@@ -75,16 +75,21 @@ public class Encoder {
      * @return The binary byte array value for the string (half length).
      */
     public static byte[] hexDecode(String hexString) {
-        if ((hexString.length() % 2) != 0)
-            throw new RuntimeException("String is not properly hex-encoded.");
+        byte[] retval = null;
+        try {
+            if ((hexString.length() % 2) != 0)
+                throw new IllegalArgumentException();
 
-        hexString = hexString.toUpperCase();
-        byte[] retval = new byte[hexString.length() / 2];
-        for (int i = 0; i < retval.length; i++) {
-            int value = Integer.parseInt(hexString.substring(2 * i, 2 * i + 2), 16);
-            if ((value < 0) || (value > 255))
-                throw new RuntimeException("String is not properly hex-encoded.");
-            retval[i] = (byte) value;
+            retval = new byte[hexString.length() / 2];
+            for (int i = 0; i < retval.length; i++) {
+                int value = Integer.parseInt(hexString.substring(2 * i, 2 * i + 2), 16);
+                retval[i] = (byte) value;
+            }
+        }
+        catch (IllegalArgumentException exc) {
+            // parseInt can throw a NumberFormatException, which is a subclass of
+            // IllegalArgumentException, so both kinds of failure come here.
+            throw new RuntimeException("String is not properly hex-encoded");
         }
         return retval;
     }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Scanner.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Scanner.java
@@ -32,9 +32,6 @@
 package org.hsqldb_voltpatches;
 
 import java.math.BigDecimal;
-// A VoltDB Extension to use x'....' literals as BIGINTs
-import java.math.BigInteger;
-// End of VoltDB extension
 import java.util.Locale;
 
 import org.hsqldb_voltpatches.lib.ArrayUtil;
@@ -1563,9 +1560,6 @@ public class Scanner {
                         ((BinaryData) token.tokenValue).length(null));
                     token.tokenType = Tokens.X_VALUE;
 
-                    // A VoltDB extension to make x'abcd' literals look like integers
-                    voltForceHexLiteralToBigint();
-                    // End of VoltDB extension
                     return;
                 }
                 break;
@@ -2458,33 +2452,4 @@ public class Scanner {
                 throw Error.runtimeError(ErrorCode.U_S0500, "Scanner");
         }
     }
-    // A VoltDB extension to make x'abcd' literals look like integers
-    /**
-     * Assuming we just parsed a x'....' literal, update the current token
-     * to be a BIGINT instead of VARBINARY
-     */
-    private void voltForceHexLiteralToBigint() {
-        token.dataType = Type.SQL_BIGINT;
-        byte[] data = ((BinaryData)(token.tokenValue)).getBytes();
-        if (data.length == 0 || data.length > 8) {
-            // Too short or too long.
-            token.tokenType   = Tokens.X_MALFORMED_NUMERIC;
-            token.isMalformed = true;
-        }
-        else {
-            // pad with leading zeros, to avoid sign-extension.
-            byte[] dataWithLeadingZeros = new byte[8];
-            int lenDiff = 8 - data.length;
-            for (int i = 0; i < 8; ++i) {
-                byte b = 0;
-                if (i - lenDiff >= 0) {
-                    b = data[i - lenDiff];
-                }
-                dataWithLeadingZeros[i] = b;
-            }
-            BigInteger bi = new BigInteger(dataWithLeadingZeros);
-            token.tokenValue = ValuePool.getLong(bi.longValue());
-        }
-    }
-    // End of VoltDB extension
 }

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompilerErrorMsgs.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompilerErrorMsgs.java
@@ -209,16 +209,28 @@ public class TestVoltCompilerErrorMsgs extends TestCase {
 
     public void testHexLiterals() throws Exception {
 
-        // 0 digits is no good.
-        ddlErrorTest("malformed numeric constant",
+        // x-quoted literals with hexadecimal digits currently not
+        // allowed to represent integers.
+
+        ddlErrorTest("invalid format for a constant bigint value",
                 "create procedure insHex as insert into blah (ival) values (x'');");
 
-        // An odd number of digits is not accepted (VARBINARY legacy)
+        // This *would* work if we accepted hex literals as ints,
+        // but we don't.
+        ddlErrorTest("invalid format for a constant bigint value",
+                "create procedure insHex as insert into blah (ival) values (x'FF');");
+
+        // This *would* work if we accepted hex literals as ints,
+        // but we don't.  This would be a decimal 128.
+        ddlErrorTest("invalid format for a constant bigint value",
+                "create procedure insHex as insert into blah (ival) values (x'10');");
+
+        // The HSQL parser complains about an odd number of digits,
+        // so the error message is different here.
         ddlErrorTest("malformed binary string",
                 "create procedure insHex as insert into blah (ival) values (x'0123456789abcdef0');");
 
-        // More than 16 digits is also not accepted (won't fit into BIGINT)
-        ddlErrorTest("malformed numeric constant",
+        ddlErrorTest("invalid format for a constant bigint value",
                 "create procedure insHex as insert into blah (ival) values (x'0123456789abcdef01');");
 
     }

--- a/tests/frontend/org/voltdb/parser/TestSQLParser.java
+++ b/tests/frontend/org/voltdb/parser/TestSQLParser.java
@@ -615,6 +615,41 @@ public class TestSQLParser extends TestCase {
     }
 
     @Test
+    public void testExecHexLiteralParamsVarbinary() {
+
+        Map<String, Map<Integer, List<String>>> procs = new HashMap<>();
+        addToProcsMap(procs, "myProc_vb", "varbinary");
+
+        // 0-length hex string is okay.
+        assertParamsParseAs(procs,
+                new Object[] {new byte[] {}},
+                "exec myProc_vb x''");
+        assertParamsParseAs(procs,
+                new Object[] {new byte[] {}},
+                "exec myProc_vb ''");
+
+        assertParamsParseAs(procs,
+                new byte[][] {{(byte) 255}},
+                "exec myProc_vb x'ff'");
+        assertParamsParseAs(procs,
+                new byte[][] {{(byte) 255}},
+                "exec myProc_vb 'ff'");
+
+        assertParamsParseAs(procs,
+                new Object[] {Encoder.hexDecode("deadbeef")},
+                "exec myProc_vb x'deadbeef'");
+        assertParamsParseAs(procs,
+                new Object[] {Encoder.hexDecode("deadbeef")},
+                "exec myProc_vb 'deadbeef'");
+
+        // number of hex digits must be even in varbinary context.
+        assertParamParsingFails(procs, "String is not properly hex-encoded.",
+                "exec myProc_vb x'a'");
+        assertParamParsingFails(procs, "String is not properly hex-encoded.",
+                "exec myProc_vb x'abc'");
+    }
+
+    @Test
     public void testExecHexLiteralParamsBigint() {
 
         Map<String, Map<Integer, List<String>>> procs = new HashMap<>();

--- a/tests/frontend/org/voltdb/regressionsuites/TestHexLiteralsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestHexLiteralsSuite.java
@@ -23,19 +23,24 @@
 
 package org.voltdb.regressionsuites;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
 import org.junit.Test;
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.client.Client;
+import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
 
-/**
- * Actual regression tests for SQL that I found that was broken and
- * have fixed.  Didn't like any of the other potential homes that already
- * existed for this for one reason or another.
- */
-
 public class TestHexLiteralsSuite extends RegressionSuite {
+
+    /*
+     * Make sure that x-quoted literals (indicating a sequence of bytes
+     * denoted by hexadecimal digits) are not interpreted as integers,
+     * but that they *do* work as VARBINARY literals.
+     */
 
     static private long[] interestingValues = new long[] {
             Long.MIN_VALUE,
@@ -50,72 +55,61 @@ public class TestHexLiteralsSuite extends RegressionSuite {
         };
 
     private static String longToHexLiteral(long val) {
-        return "X'" + makeEvenDigits(val) + "'";
+        return "X'" + makeSixteenDigits(val) + "'";
     }
 
-    private static String makeEvenDigits(long val) {
+    private static String makeSixteenDigits(long val) {
         String valAsHex = Long.toHexString(val).toUpperCase();
-        if ((valAsHex.length() % 2) == 1) {
-            valAsHex = "0" + valAsHex;
+        if (valAsHex.length() < 16) {
+            int numZerosNeeded = 16 - valAsHex.length();
+            StringBuffer sb = new StringBuffer();
+            for (int i = 0; i < numZerosNeeded; ++i) {
+                sb.append('0');
+            }
+            sb.append(valAsHex);
+            valAsHex = sb.toString();
         }
 
         return valAsHex;
     }
 
     @Test
-    public void testHexLiteralsAsParams() throws Exception {
+    public void testHexLiteralsAsVarbinaryParams() throws Exception {
         Client client = getClient();
 
         for (int i = 0; i < interestingValues.length; ++i) {
             long val = interestingValues[i];
-            client.callProcedure("T.Insert", i, longToHexLiteral(val));
+            client.callProcedure("InsertVarbinary", i, longToHexLiteral(val));
             // Verify that the right constant was inserted
-            VoltTable vt = client.callProcedure("@AdHoc", "select bi from t where pk = ?", i)
+            VoltTable vt = client.callProcedure("@AdHoc", "select vb from t where pk = ?", i)
                     .getResults()[0];
-            validateRowOfLongs(vt, new long[] {val});
+            assertTrue(vt.advanceRow());
+            assertTrue(Arrays.equals(longToBytes(val), vt.getVarbinary(0)));
         }
 
-        // 0 digits is not a valid value
-        verifyProcFails(client, "Unable to convert string x'' to long value for target parameter",
-                "T.Insert", 21, "x''");
+        // Mixed case literals are okay.
+        ClientResponse cr = client.callProcedure("InsertVarbinary", 20, "X'AaBbCcDdEeFf'");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
 
-        // Too many digits (more than 16) won't fit into a BIGINT.
-        verifyProcFails(client, "Unable to convert string x'FFFFffffFFFFffffF' to long value for target parameter",
-                "T.Insert", 21, "x'FFFFffffFFFFffffF'");
+        // Must be an even number of digits
+        verifyProcFails(client, "String is not properly hex-encoded",
+                "InsertVarbinary", 21, "x'F'");
+
+        verifyProcFails(client, "String is not properly hex-encoded",
+                "InsertVarbinary", 21, "x'XYZZY'");
+
+        // Too many digits for type
+        verifyProcFails(client, "The size 9 of the value exceeds the size of the VARBINARY\\(8\\) column",
+                "InsertVarbinary", 21, "x'FfffFfffFfffFfffFf'");
     }
 
-    @Test
-    public void testProcsWithEmbeddedHexLiteralsSelect() throws Exception {
-        Client client = getClient();
-
-        // Insert one row, so calls below produce just one row.
-        client.callProcedure("T.Insert", 0, 0);
-
-        // For each interesting value,
-        // invoke a corresponding procedure that does XOR against that value.
-        // Make sure that the literal in the procedure was interpreted correctly.
-
-        for (long val : interestingValues) {
-            VoltTable result = client.callProcedure("HEX_LITERAL_PROC_" + makeEvenDigits(val),
-                    0xF0F0F0F0F0F0F0F0L)
-                    .getResults()[0];
-            assertTrue(result.advanceRow());
-            String actual = result.getString(0);
-            long expectedNum = val ^ 0xF0F0F0F0F0F0F0F0L;
-            if (expectedNum != Long.MIN_VALUE && val != Long.MIN_VALUE) {
-                String expected = Long.toHexString(expectedNum).toUpperCase();
-                assertEquals(expected, actual);
-            }
-            else {
-                // Input or output to bit op was null value
-                // So output of HEX will be null.
-                assertEquals(null, actual);
-            }
-        }
+    private static byte[] longToBytes(long x) {
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        buffer.putLong(x);
+        return buffer.array();
     }
-
     @Test
-    public void testProcsWithEmbeddedHexLiteralsWhere() throws Exception {
+    public void testProcsWithEmbeddedVarbinaryLiterals() throws Exception {
         Client client = getClient();
 
         // Insert all the interesting values in the table,
@@ -123,21 +117,27 @@ public class TestHexLiteralsSuite extends RegressionSuite {
         // embedded in the where clause
 
         for (int i = 0; i < interestingValues.length; ++i) {
-            client.callProcedure("T.Insert", i, interestingValues[i]);
+            client.callProcedure("InsertVarbinary", i, longToBytes(interestingValues[i]));
         }
+
+        VoltTable vvt = client.callProcedure("@AdHoc", "select * from t").getResults()[0];
+        System.out.println(vvt);
 
         for (int i = 0; i < interestingValues.length; ++i) {
             long val = interestingValues[i];
-            String procName = "HEX_LITERAL_PROC_WHERE_" + makeEvenDigits(interestingValues[i]);
+            String digits = makeSixteenDigits(val);
+            String procName = "XQUOTE_VARBINARY_PROC_" + digits;
             VoltTable vt = client.callProcedure(procName).getResults()[0];
-            if (val != Long.MIN_VALUE) {
-                assertTrue(vt.advanceRow());
-                assertEquals(i, vt.getLong(0));
-            }
-            else {
-                assertFalse(vt.advanceRow());
-            }
+            validateRowOfLongs(vt, new long[] {i});
         }
+    }
+
+    @Test
+    public void testIntegerHexLiteralsFail() throws IOException {
+        Client client = getClient();
+
+        verifyProcFails(client, "Unable to convert string X'15' to long value for target parameter",
+                "InsertBigint", 0, "X'15'");
     }
 
     //
@@ -159,22 +159,22 @@ public class TestHexLiteralsSuite extends RegressionSuite {
         String literalSchema =
                 "CREATE TABLE T (\n"
                 + "  PK INTEGER NOT NULL PRIMARY KEY,\n"
-                + "  BI BIGINT\n"
+                + "  BI BIGINT,"
+                + "  VB VARBINARY(8)\n"
                 + ");\n"
                 ;
+
+        literalSchema += "CREATE PROCEDURE InsertVarbinary AS "
+                + "INSERT INTO T (PK, VB) VALUES (?, ?);";
+
+        literalSchema += "CREATE PROCEDURE InsertBigint AS "
+                + "INSERT INTO T (PK, BI) VALUES (?, ?);";
 
         // Create a bunch of procedures with various embedded literals
         // in the select list
         for (long val : interestingValues) {
-            literalSchema += "CREATE PROCEDURE HEX_LITERAL_PROC_" + makeEvenDigits(val) + " AS\n"
-                    + "  SELECT HEX(BITXOR(X'" + makeEvenDigits(val) + "', ?)) FROM T;\n";
-        }
-
-        // Create a bunch of procedures with various embedded literals
-        // in the where clause
-        for (long val : interestingValues) {
-            literalSchema += "CREATE PROCEDURE HEX_LITERAL_PROC_WHERE_" + makeEvenDigits(val) + " AS\n"
-                    + "  SELECT PK FROM T WHERE BI = X'" + makeEvenDigits(val) + "';\n";
+            literalSchema += "CREATE PROCEDURE XQUOTE_VARBINARY_PROC_" + makeSixteenDigits(val) + " AS\n"
+                    + "  SELECT PK FROM T WHERE VB = " + longToHexLiteral(val) + ";\n";
         }
 
         try {


### PR DESCRIPTION
This brings us back to where we were before release 5.2EA1, but more formally supports x-quoted literals for VARBINARY types (which is standard SQL), and adds testing for same.

Supporting x-quoted literals in integer contexts is to follow (ticket ENG-8046).

