### PR TITLE
Support hexadecimal literals as integers

### DIFF
--- a/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
@@ -21,6 +21,7 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
+import org.voltdb.parser.SQLParser;
 import org.voltdb.planner.PlanningErrorException;
 import org.voltdb.types.ExpressionType;
 import org.voltdb.types.TimestampType;
@@ -211,6 +212,26 @@ public class ConstantValueExpression extends AbstractValueExpression {
         return null;
     }
 
+    /**
+     * This method will alter the type of this constant expression based on the context
+     * in which it appears.  For example, each constant in the value list of an INSERT
+     * statement will be refined to the type of the column in the table being inserted into.
+     *
+     * Here is a summary of the rules used to convert types here:
+     * - VARCHAR literals may be reinterpreted as (depending on the type needed):
+     *   - VARBINARY (string is required to have an even number of hex digits)
+     *   - TIMESTAMP (string must have timestamp format)
+     *   - Some numeric type (any of the four integer types, DECIMAL or FLOAT)
+     *
+     * In addition, if this object is a VARBINARY constant (e.g., X'00abcd') and we need
+     * an integer constant, (any of TINYINT, SMALLINT, INTEGER or BIGINT),
+     * we interpret the hex digits as a 64-bit signed integer.  If there are fewer than 16 hex digits,
+     * the most significant bits are assumed to be zeros.  So for example, X'FF' appearing where we want a
+     * TINYINT would be out-of-range, since it's 255 and not -1.
+     *
+     * There is corresponding code for handling integer hex literals in ParameterConverter for parameters,
+     * and in HSQL's ExpressionValue class.
+     */
     @Override
     public void refineValueType(VoltType neededType, int neededSize)
     {
@@ -319,11 +340,17 @@ public class ConstantValueExpression extends AbstractValueExpression {
             return;
         }
 
-        if (neededType.isInteger() && getValueType() != VoltType.VARBINARY) {
+        if (neededType.isInteger()) {
             long value = 0;
             try {
-                value = Long.parseLong(getValue());
-            } catch (NumberFormatException nfe) {
+                if (getValueType() == VoltType.VARBINARY) {
+                    value = SQLParser.hexDigitsToLong(getValue());
+                    setValue(Long.toString(value));
+                }
+                else {
+                    value = Long.parseLong(getValue());
+                }
+            } catch (SQLParser.Exception | NumberFormatException exc) {
                 throw new PlanningErrorException("Value (" + getValue() +
                                                  ") has an invalid format for a constant " +
                                                  neededType.toSQLString() + " value");

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionArithmetic.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionArithmetic.java
@@ -451,10 +451,7 @@ public class ExpressionArithmetic extends Expression {
 
         for (int i = 0; i < nodes.length; ++i) {
             Expression e = nodes[i];
-            if (e.opType == OpTypes.VALUE && e.dataType.isBinaryType()) {
-                ExpressionValue exprVal = (ExpressionValue)e;
-                exprVal.mutateToBigintType(this, i);
-            }
+            ExpressionValue.voltMutateToBigintType(e, this, i);
         }
     }
     // End VoltDB extension

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionArithmetic.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionArithmetic.java
@@ -262,7 +262,9 @@ public class ExpressionArithmetic extends Expression {
                 if (nodes[LEFT].isParam || nodes[LEFT].dataType == null) {
                     throw Error.error(ErrorCode.X_42567);
                 }
-
+                // A VoltDB extension to use X'..' as a numeric literal
+                voltConvertBinaryLiteralOperandsToBigint();
+                // End VoltDB extension
                 dataType = nodes[LEFT].dataType;
 
                 if (!dataType.isNumberType()) {
@@ -310,7 +312,9 @@ public class ExpressionArithmetic extends Expression {
         if (nodes[LEFT].isParam && nodes[RIGHT].isParam) {
             throw Error.error(ErrorCode.X_42567);
         }
-
+        // A VoltDB extension to use X'..' as a numeric literal
+        voltConvertBinaryLiteralOperandsToBigint();
+        // End VoltDB extension
         if (nodes[LEFT].isParam) {
             nodes[LEFT].dataType = nodes[RIGHT].dataType;
         } else if (nodes[RIGHT].isParam) {
@@ -438,4 +442,20 @@ public class ExpressionArithmetic extends Expression {
                 throw Error.runtimeError(ErrorCode.U_S0500, "Expression");
         }
     }
+    // A VoltDB extension to use X'..' as a numeric value
+    private void voltConvertBinaryLiteralOperandsToBigint() {
+        // Strange that CONCAT is an arithmetic operator.
+        // You could imagine using it for VARBINARY, so
+        // definitely don't convert its operands to BIGINT!
+        assert(opType != OpTypes.CONCAT);
+
+        for (int i = 0; i < nodes.length; ++i) {
+            Expression e = nodes[i];
+            if (e.opType == OpTypes.VALUE && e.dataType.isBinaryType()) {
+                ExpressionValue exprVal = (ExpressionValue)e;
+                exprVal.mutateToBigintType(this, i);
+            }
+        }
+    }
+    // End VoltDB extension
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLogical.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLogical.java
@@ -660,7 +660,7 @@ public class ExpressionLogical extends Expression {
 
                     // compatibility for scalars only
                 // A VoltDB extension to support X'..' as numeric literals
-                } else if (convertBinaryIntegerLiteral(session, nodes[LEFT],
+                } else if (voltConvertBinaryIntegerLiteral(session, nodes[LEFT],
                             nodes[RIGHT])) {
                     // End VoltDB extension
                 } else {
@@ -1708,24 +1708,21 @@ public class ExpressionLogical extends Expression {
      * If one child is an integer, and the other is a VARBINARY literal, try to convert the
      * literal to an integer.
      */
-    private boolean convertBinaryIntegerLiteral(Session session, Expression lhs, Expression rhs) {
+    private boolean voltConvertBinaryIntegerLiteral(Session session, Expression lhs, Expression rhs) {
         Expression nonIntegralExpr;
+        int whichChild;
         if (lhs.dataType.isIntegralType()) {
             nonIntegralExpr = rhs;
+            whichChild = RIGHT;
         }
         else if (rhs.dataType.isIntegralType()) {
             nonIntegralExpr = lhs;
+            whichChild = LEFT;
         } else {
             return false;
         }
 
-        if (nonIntegralExpr.opType == OpTypes.VALUE && nonIntegralExpr.dataType.isBinaryType()) {
-            int whichChild = (nonIntegralExpr == rhs) ? RIGHT : LEFT;
-            ExpressionValue exprVal = (ExpressionValue)nonIntegralExpr;
-            return exprVal.mutateToBigintType(this, whichChild);
-        }
-
-        return false;
+        return ExpressionValue.voltMutateToBigintType(nonIntegralExpr, this, whichChild);
     }
     // End VoltDB extension
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQL.java
@@ -2372,7 +2372,7 @@ public class FunctionSQL extends Expression {
             node.dataType = Type.SQL_BIGINT;
         }
         else if (node.dataType.isBinaryType() && node.opType == OpTypes.VALUE) {
-            boolean success = ((ExpressionValue)node).mutateToBigintType(this, nodeIdx);
+            boolean success = ExpressionValue.voltMutateToBigintType(node, this, nodeIdx);
             if (! success) {
                 throw Error.error(ErrorCode.X_42561);
             }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQL.java
@@ -43,6 +43,9 @@ import org.hsqldb_voltpatches.types.DateTimeType;
 import org.hsqldb_voltpatches.types.NumberType;
 import org.hsqldb_voltpatches.types.Type;
 
+// A VoltDB extension to allow use of X'..' as numeric literals
+import java.math.BigInteger;
+// End VoltDB extension
 /**
  * Implementation of SQL standard function calls
  *
@@ -2347,17 +2350,35 @@ public class FunctionSQL extends Expression {
         dataType = Type.SQL_BIGINT;
     }
 
-    protected void voltResolveToBigintType(int i) {
-        if (nodes[i].dataType == null) {
-            nodes[i].dataType = Type.SQL_BIGINT;
+    protected void voltResolveToBigintType(int nodeIdx) {
+        Expression node = nodes[nodeIdx];
+
+        if (node.dataType == null) {
+            node.dataType = Type.SQL_BIGINT;
+            return;
         }
-        else if (nodes[i].dataType.typeCode != Types.SQL_BIGINT) {
-            if (! nodes[i].dataType.isIntegralType() || nodes[i].valueData == null) {
+
+        if (node.dataType.typeCode == Types.SQL_BIGINT) {
+            return;
+        }
+
+        if (node.valueData == null) {
+            throw Error.error(ErrorCode.X_42561);
+        }
+
+        if (node.dataType.isIntegralType()) {
+            // Only constants are checked here for long type range limits
+            NumberType.checkValueIsInLongLimits(node.valueData);
+            node.dataType = Type.SQL_BIGINT;
+        }
+        else if (node.dataType.isBinaryType() && node.opType == OpTypes.VALUE) {
+            boolean success = ((ExpressionValue)node).mutateToBigintType(this, nodeIdx);
+            if (! success) {
                 throw Error.error(ErrorCode.X_42561);
             }
-            // Only constants are checked here for long type range limits
-            NumberType.checkValueIsInLongLimits(nodes[i].valueData);
-            nodes[i].dataType = Type.SQL_BIGINT;
+        }
+        else {
+            throw Error.error(ErrorCode.X_42561);
         }
     }
 

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserBase.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserBase.java
@@ -787,4 +787,9 @@ public class ParserBase {
         }
     }
     /**********************************************************************/
+    // A VoltDB extension to make it easier to see SQL statement being parsed in the debugger
+    public String toString() {
+        return "A subclass of ParserBase parsing <<" + scanner.sqlString + ">>";
+    }
+    // End of VoltDB extension
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/types/NumberType.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/types/NumberType.java
@@ -728,6 +728,11 @@ public final class NumberType extends Type {
             case Types.SQL_DECIMAL :
                 break;
 
+                // A VoltDB extension to use X'..' as default values for integers
+            case Types.SQL_VARBINARY:
+                a = ValuePool.getLong(((BinaryData)a).toLong());
+                break;
+                // End VoltDB extension
             default :
                 throw Error.error(ErrorCode.X_42561);
         }

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompilerErrorMsgs.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompilerErrorMsgs.java
@@ -252,5 +252,36 @@ public class TestVoltCompilerErrorMsgs extends TestCase {
         ddlErrorTest("invalid format for a constant decimal value",
                 "create procedure insHex as insert into blah (decval) values (x'80');");
 
+        // In arithmetic or logical expressions, we catch malformed (for BIGINT) x-literals
+        // in HSQL.
+
+        ddlErrorTest("malformed numeric constant",
+                "create procedure selHex as select 30 + X'' from blah;");
+
+        // (too many hex digits)
+        ddlErrorTest("malformed numeric constant",
+                "create procedure selHex as select tinyval from blah where X'0000000000000000FF' < tinyval;");
+    }
+
+    public void testHexLiteralDefaultValues() throws Exception {
+        ddlErrorTest("malformed numeric constant",
+                "create table t (bi bigint default X'');");
+
+        ddlErrorTest("malformed numeric constant",
+                "create table t (bi bigint default X'FFFF0000FFFF0000FF');");
+
+        ddlErrorTest("numeric value out of range",
+                "create table t (ti tinyint default X'80');");
+
+        ddlErrorTest("numeric value out of range",
+                "create table t (ti tinyint default X'FF');");
+
+        // This does not fail, but it seems like it should fail with an
+        // out of range error.  -128 is reserved for the TINYINT null value
+        // This is ENG-8148.
+        ddlNonErrorTest("create table t (ti tinyint default -X'80');");
+
+        ddlErrorTest("numeric value out of range",
+                "create table t (ti tinyint default -X'81');");
     }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -3298,7 +3298,11 @@ public class TestFunctionsSuite extends RegressionSuite {
     }
 
     private static String longToHexLiteral(long val) {
-        return "x'" + Long.toHexString(val) + "'";
+        String hexDigits = Long.toHexString(val);
+        if (hexDigits.length() % 2 == 1) {
+            hexDigits = "0" + hexDigits;
+        }
+        return "x'" + hexDigits + "'";
     }
 
     private void validateBitwiseAndOrXor(VoltTable vt, long bignum, long in) {
@@ -3319,9 +3323,9 @@ public class TestFunctionsSuite extends RegressionSuite {
         validateBitwiseAndOrXor(vt, bignum, in);
 
         // Try again using x'...' syntax
-        // Doesn't work yet, just verify it fails.
         String hexIn = longToHexLiteral(in);
-        verifyProcFails(client, "Unable to convert string", "BITWISE_AND_OR_XOR", hexIn, hexIn, hexIn, pk);
+        vt = client.callProcedure("BITWISE_AND_OR_XOR", hexIn, hexIn, hexIn, pk).getResults()[0];
+        validateBitwiseAndOrXor(vt, bignum, in);
     }
 
     public void testBitwiseFunction_AND_OR_XOR() throws IOException, ProcCallException {


### PR DESCRIPTION
This changeset supports using hexadecimal literals (`X'00ABCD'`) to express integers in SQL.

This required some changes to HSQL to convert VARBINARY literals into BIGINTs based on context.  This is done for arithmetic (+, -, *, /) and logical (<. >, =, etc) expressions, and the new bitwise functions.

I decided *not* to support hexadecimal literals for the other, non-bitwise functions, since it seems really unlikely that a user would ever type something like `SQRT(X'0100')`.  The way HSQL handles the non-VoltDB specific functions this would require changes for each function.  I can file a ticket to support these other functions, if we feel there's a need for it.

