### PR TITLE
Fix nonsensical parameter passing to TableFactory::getPersistentTable() in c++ unit tests.

### DIFF
--- a/tests/ee/indexes/index_test.cpp
+++ b/tests/ee/indexes/index_test.cpp
@@ -181,8 +181,7 @@ public:
         m_engine->updateHashinator(HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
         table = dynamic_cast<PersistentTable*>(
             TableFactory::getPersistentTable(database_id, "test_wide_table",
-                                             schema, columnNames, signature, &drStream, false,
-                                             -1, false, false));
+                                             schema, columnNames, signature));
 
         TableIndex *pkeyIndex = TableIndexFactory::TableIndexFactory::getInstance(pkeyScheme);
         assert(pkeyIndex);
@@ -316,7 +315,7 @@ public:
         int partitionCount = 1;
         m_engine->initialize(0, 0, 0, 0, "", false, DEFAULT_TEMP_TABLE_MEMORY);
         m_engine->updateHashinator(HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
-        table = dynamic_cast<PersistentTable*>(TableFactory::getPersistentTable(database_id, (const string)"test_table", schema, columnNames, signature, &drStream, false));
+        table = dynamic_cast<PersistentTable*>(TableFactory::getPersistentTable(database_id, (const string)"test_table", schema, columnNames, signature));
 
         TableIndex *pkeyIndex = TableIndexFactory::TableIndexFactory::getInstance(pkeyScheme);
         assert(pkeyIndex);
@@ -390,7 +389,6 @@ protected:
     char* m_exceptionBuffer;
     VoltDBEngine* m_engine;
     ThreadLocalPool m_pool;
-    MockDRTupleStream drStream;
     char signature[20];
 };
 

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -155,7 +155,7 @@ public:
 
 
         m_table = dynamic_cast<voltdb::PersistentTable*>(
-                voltdb::TableFactory::getPersistentTable(m_tableId, "Foo", m_tableSchema, m_columnNames, signature, &drStream));
+                voltdb::TableFactory::getPersistentTable(m_tableId, "Foo", m_tableSchema, m_columnNames, signature));
 
         TableIndex *pkeyIndex = TableIndexFactory::TableIndexFactory::getInstance(indexScheme);
         assert(pkeyIndex);
@@ -276,7 +276,6 @@ public:
     int64_t m_undoToken;
 
     CatalogId m_tableId;
-    MockDRTupleStream drStream;
     char signature[20];
 };
 

--- a/tests/ee/storage/PersistentTableMemStatsTest.cpp
+++ b/tests/ee/storage/PersistentTableMemStatsTest.cpp
@@ -91,7 +91,7 @@ public:
         vector<TableIndexScheme> indexes;
 
         m_table = dynamic_cast<PersistentTable*>(
-            TableFactory::getPersistentTable(0, "Foo", m_tableSchema, m_columnNames, signature, &drStream, false, 0));
+            TableFactory::getPersistentTable(0, "Foo", m_tableSchema, m_columnNames, signature));
 
         TableIndex *pkeyIndex = TableIndexFactory::TableIndexFactory::getInstance(indexScheme);
         assert(pkeyIndex);
@@ -109,7 +109,6 @@ public:
     VoltDBEngine *m_engine;
     TupleSchema *m_tableSchema;
     PersistentTable *m_table;
-    MockDRTupleStream drStream;
     vector<string> m_columnNames;
     vector<ValueType> m_tableSchemaTypes;
     vector<int32_t> m_tableSchemaColumnSizes;

--- a/tests/ee/storage/constraint_test.cpp
+++ b/tests/ee/storage/constraint_test.cpp
@@ -92,7 +92,6 @@ protected:
     voltdb::Table* table;
     voltdb::CatalogId database_id;
     voltdb::VoltDBEngine m_engine;
-    voltdb::MockDRTupleStream drStream;
     char signature[20];
 
     char *m_exceptionBuffer;
@@ -117,7 +116,7 @@ protected:
         if (pkey != NULL) {
             pkey->tupleSchema = schema;
         }
-        table = TableFactory::getPersistentTable(this->database_id, "test_table", schema, columnNames, signature, &drStream, false);
+        table = TableFactory::getPersistentTable(this->database_id, "test_table", schema, columnNames, signature);
         if (pkey) {
             TableIndex *pkeyIndex = TableIndexFactory::TableIndexFactory::getInstance(*pkey);
             assert(pkeyIndex);

--- a/tests/ee/storage/persistent_table_log_test.cpp
+++ b/tests/ee/storage/persistent_table_log_test.cpp
@@ -122,7 +122,7 @@ public:
                                                               m_tableSchemaColumnSizes,
                                                               m_tableSchemaAllowNull);
         m_table = dynamic_cast<PersistentTable*>(
-            TableFactory::getPersistentTable(0, "Foo", m_tableSchema, m_columnNames, signature, &drStream, false, 0));
+            TableFactory::getPersistentTable(0, "Foo", m_tableSchema, m_columnNames, signature));
 
         if ( ! withPK ) {
             return;
@@ -144,13 +144,12 @@ public:
                                                               m_narrowTableSchemaColumnSizes,
                                                               m_narrowTableSchemaAllowNull);
         m_table = dynamic_cast<PersistentTable*>(
-            TableFactory::getPersistentTable(0, "Foo", m_tableSchema, m_narrowColumnNames, signature, &drStream, false, 0));
+            TableFactory::getPersistentTable(0, "Foo", m_tableSchema, m_narrowColumnNames, signature));
     }
 
     VoltDBEngine *m_engine;
     TupleSchema *m_tableSchema;
     PersistentTable *m_table;
-    MockDRTupleStream drStream;
     std::vector<std::string> m_columnNames;
     std::vector<ValueType> m_tableSchemaTypes;
     std::vector<int32_t> m_tableSchemaColumnSizes;

--- a/tests/ee/storage/table_test.cpp
+++ b/tests/ee/storage/table_test.cpp
@@ -122,7 +122,7 @@ protected:
         }
         TupleSchema *schema = TupleSchema::createTupleSchemaForTest(columnTypes, columnLengths, columnAllowNull);
         if (xact) {
-            persistent_table = TableFactory::getPersistentTable(database_id, "test_table", schema, columnNames, signature, &drStream, false);
+            persistent_table = TableFactory::getPersistentTable(database_id, "test_table", schema, columnNames, signature);
             m_table = persistent_table;
         } else {
             temp_table = TableFactory::getTempTable(database_id, "test_temp_table", schema, columnNames, &limits);
@@ -135,7 +135,6 @@ protected:
     Table* temp_table;
     Table* persistent_table;
     TempTableLimits limits;
-    MockDRTupleStream drStream;
     char signature[20];
 };
 


### PR DESCRIPTION
Found by @BillWhite . Sad that we didn't pick this up earlier.