### PR TITLE
Improve display of DELETE statement for row limit triggers in VMC

### DIFF
--- a/src/frontend/org/voltdb/compilereport/ReportMaker.java
+++ b/src/frontend/org/voltdb/compilereport/ReportMaker.java
@@ -253,6 +253,9 @@ public class ReportMaker {
         sb.append("<td>");
         if (table.getTuplelimit() != Integer.MAX_VALUE) {
             tag(sb, "info", String.valueOf(table.getTuplelimit()));
+            if (CatalogUtil.getLimitPartitionRowsDeleteStmt(table) != null) {
+                sb.append("<small>enforced by DELETE statement</small>");
+            }
         } else {
             tag(sb, null, "No-limit");
         }

--- a/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
+++ b/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
@@ -287,7 +287,7 @@ public abstract class CatalogSchemaTools {
                     // StatementCompiler appends the semicolon, we don't want it here.
                     deleteStmt = deleteStmt.substring(0, deleteStmt.length() - 1);
                 }
-                table_sb.append(" EXECUTE (" + deleteStmt + ")");
+                table_sb.append("\n" + spacer + spacer + "EXECUTE (" + deleteStmt + ")");
             }
         }
 

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -5086,7 +5086,9 @@ public class ParserDDL extends ParserRoutine {
             // LIMIT PARTITION ROWS 10 EXECUTE (DELETE FROM tbl WHERE b = 1)
             //
             readThis(Tokens.OPENBRACKET);
-            int position = getPosition();
+
+            startRecording();
+
             int numOpenBrackets = 1;
             while (numOpenBrackets > 0) {
                 switch(token.tokenType) {
@@ -5111,8 +5113,10 @@ public class ParserDDL extends ParserRoutine {
                 }
             }
 
+            Token[] stmtTokens = getRecordedStatement();
+
             // This captures the DELETE statement exactly, including embedded whitespace, etc.
-            c.rowsLimitDeleteStmt = getLastPart(position);
+            c.rowsLimitDeleteStmt = Token.getSQL(stmtTokens);
             readThis(Tokens.CLOSEBRACKET);
         }
     }

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -2505,6 +2505,11 @@ public class TestVoltCompiler extends TestCase {
                     stmt = stmt.substring(0, stmt.length() - 1);
                 }
 
+                // Remove spaces from both strings so we compare whitespace insensitively
+                // Capturing the DELETE statement in HSQL does not preserve whitespace.
+                expectedStmt = stmt.replace(" ", "");
+                stmt = stmt.replace(" ", "");
+
                 assertEquals("Did not find the LIMIT DELETE statement that we expected",
                         expectedStmt, stmt);
             }


### PR DESCRIPTION
Some minor changes to the catalog report for row limit delete statements.  I also change how we capture the statement in HSQL so that whitespace is condensed, similar to what we do with views.