### PR TITLE
HSQL Style tweaks from subquery code review.

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ErrorCode.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ErrorCode.java
@@ -608,11 +608,11 @@ public interface ErrorCode {
     int X_46102 = 6012;                                   // invalid JAR name in path
     int X_46103 = 6013;                                   // unresolved class name
 
-    /************************* Volt DB Extensions *************************/
+    // A VoltDB extension to implement subquery syntax limitations
     int X_47000 = 7000;                                   // invalid WHERE expression
     int X_47001 = 7001;                                   // subquery WHERE expression with parent aggregates
-    /**********************************************************************/
 
+    // End of VoltDB extension
     // Unknown Error: Catch-All - xxxx
     int X_99000 = 6500;                                   // Unknown Error: Catch-All
     int X_99099 = 6501;                                   // Error converting vendor code to SQL state code

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
@@ -579,12 +579,12 @@ public class Expression {
     boolean isComposedOf(OrderedHashSet expressions,
                          OrderedIntHashSet excludeSet) {
 
-        /************************* Volt DB Extensions *************************/
+        // BEGIN Cherry-picked code change from hsqldb-2.3.2
         if (opType == OpTypes.VALUE || opType == OpTypes.DYNAMIC_PARAM
                 || opType == OpTypes.PARAMETER || opType == OpTypes.VARIABLE) {
             return true;
         }
-        /**********************************************************************/
+        // END Cherry-picked code change from hsqldb-2.3.2
 
         if (excludeSet.contains(opType)) {
             return true;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
@@ -239,8 +239,7 @@ public class ExpressionColumn extends Expression {
 
     void collectObjectNames(Set set) {
 
-        /************************* Volt DB Extensions *************************/
-        // Implementation is taken from the HSQL 2.3.0
+        // BEGIN Cherry-picked code change from hsqldb-2.3.2
         switch (opType) {
 
             case OpTypes.SEQUENCE :
@@ -270,7 +269,22 @@ public class ExpressionColumn extends Expression {
 
                 return;
         }
-        /**********************************************************************/
+        /* Disable 13 lines
+        if (opType == OpTypes.SEQUENCE) {
+            HsqlName name = ((NumberSequence) valueData).getName();
+
+            set.add(name);
+
+            return;
+        }
+
+        set.add(column.getName());
+
+        if (column.getName().parent != null) {
+            set.add(column.getName().parent);
+        }
+        ... disabled 13 lines */
+        // END Cherry-picked code change from hsqldb-2.3.2
     }
 
     String getColumnName() {

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLogical.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLogical.java
@@ -634,20 +634,24 @@ public class ExpressionLogical extends Expression {
 
         if (nodes[LEFT].opType == OpTypes.ROW
                 || nodes[RIGHT].opType == OpTypes.ROW) {
-
-            /************************* Volt DB Extensions *************************/
-            // To allow row subqueries (C1, C2) = (SELECT C1, C2 FROM ...)
-            if (nodes[LEFT].opType == OpTypes.ROW && nodes[RIGHT].opType == OpTypes.TABLE_SUBQUERY) {
+            // A VoltDB extension to allow row subqueries (C1, C2) = (SELECT C1, C2 FROM ...)
+            if (nodes[RIGHT].opType == OpTypes.TABLE_SUBQUERY) {
                 assert(nodes[RIGHT].subQuery != null);
                 if (nodes[LEFT].nodes.length != nodes[RIGHT].subQuery.getTable().columnCount) {
                     throw Error.error(ErrorCode.X_42564);
                 }
-            } else if (nodes[LEFT].opType == OpTypes.TABLE_SUBQUERY && nodes[RIGHT].opType == OpTypes.ROW) {
+            } else if (nodes[LEFT].opType == OpTypes.TABLE_SUBQUERY) {
                 assert(nodes[LEFT].subQuery != null);
                 if (nodes[LEFT].subQuery.getTable().columnCount != nodes[RIGHT].nodes.length) {
                     throw Error.error(ErrorCode.X_42564);
                 }
             } else if (nodes[LEFT].nodes.length != nodes[RIGHT].nodes.length) {
+            /* Disable 3 lines ...
+            if (nodes[LEFT].opType != OpTypes.ROW
+                    || nodes[RIGHT].opType != OpTypes.ROW
+                    || nodes[LEFT].nodes.length != nodes[RIGHT].nodes.length) {
+            ... disabled 3 lines. */
+            // End of VoltDB extension
                 throw Error.error(ErrorCode.X_42564);
             }
 

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLInterface.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLInterface.java
@@ -406,7 +406,7 @@ public class HSQLInterface {
     /**
      * Take an equality-test expression that represents in-list
      * and munge it into the simpler thing we want to output
-     * to the ParsedExrpession classes.
+     * to the AbstractParsedStmt for its AbstractExpression classes.
      */
     private void inFixup(VoltXMLElement inElement) {
         // make this an in expression

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDQL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDQL.java
@@ -1817,13 +1817,25 @@ public class ParserDQL extends ParserBase {
                             return null;
                         }
 
-                        /************************* Volt DB Extensions *************************/
-                        if (sq.queryExpression.isSingleColumn()) {
-                            return new Expression(OpTypes.SCALAR_SUBQUERY, sq);
+                        // A VoltDB extension to adapt to the hsqldb 2.3.2 change for fuller subquery support.
+                        SubQuery td = sq;
+                        // End of VoltDB extension
+                        // BEGIN Cherry-picked code change from hsqldb-2.3.2
+                        if (td.queryExpression.isSingleColumn()) {
+                            e = new Expression(OpTypes.SCALAR_SUBQUERY, td);
                         } else {
-                            return new Expression(OpTypes.ROW_SUBQUERY, sq);
+                            e = new Expression(OpTypes.ROW_SUBQUERY, td);
                         }
-                        /**********************************************************************/
+
+                        return e;
+                        /* Disable 5 lines ...
+                        if (!sq.queryExpression.isSingleColumn()) {
+                            throw Error.error(ErrorCode.W_01000);
+                        }
+
+                        return new Expression(OpTypes.SCALAR_SUBQUERY, sq);
+                        ... disabled 5 lines. */
+                        // END Cherry-picked code change from hsqldb-2.3.2
 
                     default :
                         rewind(position);

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
@@ -1153,10 +1153,6 @@ final class RangeVariable {
 
     /************************* Volt DB Extensions *************************/
 
-    private Expression subqueryExpression;
-
-    void setSubqueryExpression(Expression sqe) { subqueryExpression = sqe; }
-
     /**
      * VoltDB added method to get a non-catalog-dependent
      * representation of this HSQLDB object.

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariableResolver.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariableResolver.java
@@ -317,11 +317,11 @@ public class RangeVariableResolver {
         int idx2  = rangeVarSet.getIndex(e2.getRangeVariable());
         int index = idx1 > idx2 ? idx1
                                 : idx2;
-        /************************* Volt DB Extensions *************************/
+        // BEGIN Cherry-picked code change from hsqldb-2.3.2
         if (idx1 == -1 || idx2 == -1) {
             return;
         }
-        /**********************************************************************/
+        // END Cherry-picked code change from hsqldb-2.3.2
 
         array[index].add(new ExpressionLogical(e1, e2));
     }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/TableDerived.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/TableDerived.java
@@ -48,7 +48,7 @@ public class TableDerived extends Table {
 
     QueryExpression queryExpression;
     View            view;
-
+    
     /*************** VOLTDB *********************/
     Expression      dataExpression;
 


### PR DESCRIPTION
These are just stylistic tweaks of Mike's work.
There were a few cases of minor whitespace-only or dead-code only changes from the original HSQL code that I backed out.
I cleaned the structured comments to more clearly mark disabled lines, new VoltDB patches, and cherry-picks from future hsql -- Mike made wise use of future code to patch current bugs, so the amount of new VoltDB code in this part of his changes turned out to be pretty minimal. We'll be glad of that soon when we upgrade. It may even help with some of the "known problems" I've already detected in the upgrade merge.
In a few places, I streamlined out some redundancy, but I don't think that I found any need to change the code's effective behavior.