### PR TITLE
basic-select.sql: added two basic query (sqlcoverage) patterns, to test

### DIFF
--- a/tests/scripts/examples/sql_coverage/basic-select.sql
+++ b/tests/scripts/examples/sql_coverage/basic-select.sql
@@ -99,3 +99,7 @@ SELECT * FROM @fromtables LHS INNER JOIN @fromtables B20RHS ON LHS._variable[@co
 SELECT * FROM @fromtables A WHERE EXISTS ( SELECT * FROM @fromtables B WHERE B._variable[@columntype] _cmp A._variable[@columntype] )
 SELECT * FROM @fromtables A WHERE _variable[@columntype] IN ( SELECT _variable[@columntype] FROM @fromtables B )
 SELECT * FROM @fromtables A WHERE _variable[@comparabletype] _cmp @comparableconstant AND EXISTS ( SELECT * FROM @fromtables B WHERE B._variable[@columntype] _cmp A._variable[@columntype] )
+
+--- test scalar subqueries (ENG-7959)
+SELECT *, (SELECT COUNT(*) FROM @fromtables WHERE _variable[@comparabletype] _cmp B24._variable[@comparabletype]) FROM @fromtables AS B24
+SELECT * FROM @fromtables AS B25 WHERE _variable[numeric] _cmp (SELECT COUNT(*) FROM @fromtables)


### PR DESCRIPTION
the simplest scalar subqueries. (Note: more scalar subquery patterns
will be added to a separate file, advanced-scalar-subquery.sql.)