### PR TITLE
Guard the argument to REPEAT(str,count) to prevent memory explosion.

### DIFF
--- a/src/ee/common/ThreadLocalPool.cpp
+++ b/src/ee/common/ThreadLocalPool.cpp
@@ -21,12 +21,12 @@
 #include <iostream>
 #include "common/SQLException.h"
 
+namespace voltdb {
 // This needs to be >= the VoltType.MAX_VALUE_LENGTH defined in java, currently 1048576.
 // The rationale for making it any larger would be to allow calculating wider "temp" values
 // for use in situations where they are not being stored as column values.
-static const int POOLED_MAX_VALUE_LENGTH = 1048576;
+const int ThreadLocalPool::POOLED_MAX_VALUE_LENGTH = 1048576;
 
-namespace voltdb {
 /**
  * Thread local key for storing thread specific memory pools
  */

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -45,6 +45,8 @@ public:
     ThreadLocalPool();
     ~ThreadLocalPool();
 
+    static const int POOLED_MAX_VALUE_LENGTH;
+
     /**
      * Return the nearest power-of-two-plus-or-minus buffer size that
      * will be allocated for an object of the given length

--- a/src/ee/expressions/stringfunctions.h
+++ b/src/ee/expressions/stringfunctions.h
@@ -139,7 +139,7 @@ template<> inline NValue NValue::call<FUNC_REPEAT>(const std::vector<NValue>& ar
     const int32_t valueUTF8Length = strValue.getObjectLength_withoutNull();
     if ((count * valueUTF8Length) > ThreadLocalPool::POOLED_MAX_VALUE_LENGTH) {
         char msg[1024];
-        snprintf(msg, sizeof(msg), "data exception: string too long (%d > %d)",
+        snprintf(msg, sizeof(msg), "REPEAT function call would create a string of size %d which is larger than the maximum size %d",
                  count * valueUTF8Length, ThreadLocalPool::POOLED_MAX_VALUE_LENGTH);
         throw SQLException(SQLException::data_exception_string_data_length_mismatch,
                            msg);

--- a/src/ee/expressions/stringfunctions.h
+++ b/src/ee/expressions/stringfunctions.h
@@ -137,6 +137,13 @@ template<> inline NValue NValue::call<FUNC_REPEAT>(const std::vector<NValue>& ar
     }
 
     const int32_t valueUTF8Length = strValue.getObjectLength_withoutNull();
+    if ((count * valueUTF8Length) > ThreadLocalPool::POOLED_MAX_VALUE_LENGTH) {
+        char msg[1024];
+        snprintf(msg, sizeof(msg), "data exception: string too long (%d > %d)",
+                 count * valueUTF8Length, ThreadLocalPool::POOLED_MAX_VALUE_LENGTH);
+        throw SQLException(SQLException::data_exception_string_data_length_mismatch,
+                           msg);
+    }
     char *repeatChars = reinterpret_cast<char*>(strValue.getObjectValue_withoutNull());
 
     std::string repeatStr;

--- a/tests/ee/expressions/function_test.cpp
+++ b/tests/ee/expressions/function_test.cpp
@@ -152,6 +152,8 @@ int FunctionTest::testUnary(int operation, INPUT_TYPE input, OUTPUT_TYPE output,
                   << ", expected: \"" << (expect_null ? "<NULL>" : expected.debug()) << "\""
                   << ", comp:     " << std::dec << cmpout << "\n";
     }
+    delete bin_exp;
+    expected.free();
     return cmpout;
 }
 /**
@@ -170,7 +172,7 @@ int FunctionTest::testBinary(int operation, LEFT_INPUT_TYPE linput, RIGHT_INPUT_
     argument->push_back(rhsexp);
 
     NValue expected = getSomeValue(output);
-    AbstractExpression* bin_exp = ExpressionUtil::functionFactory(operation, argument);
+    AbstractExpression *bin_exp = ExpressionUtil::functionFactory(operation, argument);
     int cmpout;
     NValue answer;
     try {
@@ -181,17 +183,19 @@ int FunctionTest::testBinary(int operation, LEFT_INPUT_TYPE linput, RIGHT_INPUT_
         } else {
             cmpout = answer.compare(expected);
         }
-        if (staticVerboseFlag) {
-            std::cout << std::hex << "input: test(" << linput << ", " << rinput << ")"
-                      << ", answer: \"" << answer.debug() << "\""
-                      << ", expected: \"" << (expect_null ? "<NULL>" : expected.debug()) << "\""
-                      << ", comp:     " << std::dec << cmpout << "\n";
-        }
     } catch (SQLException &ex) {
         expected.free();
         delete bin_exp;
         throw;
     }
+    if (staticVerboseFlag) {
+        std::cout << std::hex << "input: test(" << linput << ", " << rinput << ")"
+                  << ", answer: \"" << answer.debug() << "\""
+                  << ", expected: \"" << (expect_null ? "<NULL>" : expected.debug()) << "\""
+                  << ", comp:     " << std::dec << cmpout << "\n";
+    }
+    expected.free();
+    delete bin_exp;
     return cmpout;
 }
 

--- a/tests/ee/expressions/function_test.cpp
+++ b/tests/ee/expressions/function_test.cpp
@@ -61,6 +61,7 @@
 #include "common/ValuePeeker.hpp"
 #include "common/PlannerDomValue.h"
 #include "common/NValue.hpp"
+#include "common/SQLException.h"
 #include "expressions/expressions.h"
 #include "expressions/expressionutil.h"
 #include "expressions/functionexpression.h"
@@ -84,10 +85,23 @@ struct FunctionTest : public Test {
                                   0,
                                   (DRTupleStream *)0,
                                   (DRTupleStream *)0) {}
+        /**
+         * A template for calling unary function call expressions.  For any C++
+         * type T, define the function "NValue getSomeValue(T val)" to
+         * convert the T value to an NValue below.
+         */
         template <typename INPUT_TYPE, typename OUTPUT_TYPE>
         int testUnary(int operation, INPUT_TYPE input, OUTPUT_TYPE output, bool expect_null = false);
-        int testBinary(int operation, int64_t left_input, int64_t right_input, int64_t output, bool expect_null = false);
-        static const size_t BIGINT_SIZE = int(sizeof(int64_t) * CHAR_BIT);
+
+        /**
+         * A template for calling binary function call expressions.  For any C++
+         * type T, define the function "NValue getSomeValue(T val)" to
+         * convert the T value to an NValue below.
+         */
+        template <typename LEFT_INPUT_TYPE, typename RIGHT_INPUT_TYPE, typename OUTPUT_TYPE>
+        int testBinary(int operation, LEFT_INPUT_TYPE left_input, RIGHT_INPUT_TYPE right_input, OUTPUT_TYPE output, bool expect_null = false);
+
+        static const int64_t BIGINT_SIZE = int64_t(sizeof(int64_t) * CHAR_BIT);
 private:
         Pool            m_pool;
         ExecutorContext m_executorContext;
@@ -104,7 +118,11 @@ static NValue getSomeValue(const int64_t val)
 }
 
 /**
- * Test a unary expression.
+ * Test a unary function call expression.
+ * @returns: -1 if the result of the function evaluation is less than the expected result.
+ *            0 if the result of the function evaluation is as expected.
+ *            1 if the result of the function evaluation is greater than the expected result.
+ * Note that this function may throw an exception from the call to AbstractExpression::eval().
  */
 template <typename INPUT_TYPE, typename OUTPUT_TYPE>
 int FunctionTest::testUnary(int operation, INPUT_TYPE input, OUTPUT_TYPE output, bool expect_null) {
@@ -131,15 +149,22 @@ int FunctionTest::testUnary(int operation, INPUT_TYPE input, OUTPUT_TYPE output,
     expected.free();
     return cmpout;
 }
-
-int FunctionTest::testBinary(int operation, int64_t linput, int64_t rinput, int64_t output, bool expect_null) {
+/**
+ * Test a binary function call expression.
+ * @returns: -1 if the result of the function evaluation is less than the expected result.
+ *            0 if the result of the function evaluation is as expected.
+ *            1 if the result of the function evaluation is greater than the expected result.
+ * Note that this function may throw an exception from the call to AbstractExpression::eval().
+ */
+template <typename LEFT_INPUT_TYPE, typename RIGHT_INPUT_TYPE, typename OUTPUT_TYPE>
+int FunctionTest::testBinary(int operation, LEFT_INPUT_TYPE linput, RIGHT_INPUT_TYPE rinput, OUTPUT_TYPE output, bool expect_null) {
     std::vector<AbstractExpression *> *argument = new std::vector<AbstractExpression *>();
-    ConstantValueExpression *lhsexp = new ConstantValueExpression(ValueFactory::getBigIntValue(linput));
-    ConstantValueExpression *rhsexp = new ConstantValueExpression(ValueFactory::getBigIntValue(rinput));
+    ConstantValueExpression *lhsexp = new ConstantValueExpression(getSomeValue(linput));
+    ConstantValueExpression *rhsexp = new ConstantValueExpression(getSomeValue(rinput));
     argument->push_back(lhsexp);
     argument->push_back(rhsexp);
 
-    NValue expected = ValueFactory::getBigIntValue(output);
+    NValue expected = getSomeValue(output);
     AbstractExpression* bin_exp = ExpressionUtil::functionFactory(operation, argument);
     NValue answer = bin_exp->eval();
     int cmpout;
@@ -161,45 +186,45 @@ int FunctionTest::testBinary(int operation, int64_t linput, int64_t rinput, int6
 }
 
 TEST_F(FunctionTest, BinTest) {
-        ASSERT_EQ(testUnary(FUNC_VOLT_BIN,
-                            0xffULL,
-                            "11111111"),
-                  0);
-        ASSERT_EQ(testUnary(FUNC_VOLT_BIN,
-                            0x0ULL,
-                            "0"),
-                  0);
-        ASSERT_EQ(testUnary(FUNC_VOLT_BIN, 0x8000000000000000, "", true), 0);
+    ASSERT_EQ(testUnary(FUNC_VOLT_BIN,
+                        0xffLL,
+                        "11111111"),
+              0);
+    ASSERT_EQ(testUnary(FUNC_VOLT_BIN,
+                        0x0LL,
+                        "0"),
+              0);
+    ASSERT_EQ(testUnary(FUNC_VOLT_BIN, int64_t(0x8000000000000000), "", true), 0);
 
-        // Walking ones.
-        std::string expected("1");
-        std::string expectedz("1111111111111111111111111111111111111111111111111111111111111111");
-        for (int idx = 0; idx < (BIGINT_SIZE-1); idx += 1) {
-                int64_t input = 1ULL << idx;
-                ASSERT_EQ(testUnary(FUNC_VOLT_BIN,
-                                    input,
-                                    expected),
-                          0);
-                expected = expected + "0";
-                expectedz[(BIGINT_SIZE-1) - idx] = '0';
-                ASSERT_EQ(testUnary(FUNC_VOLT_BIN,
-                                    ~input,
-                                    expectedz),
-                          0);
-                expectedz[(BIGINT_SIZE-1) - idx] = '1';
-        }
+    // Walking ones.
+    std::string expected("1");
+    std::string expectedz("1111111111111111111111111111111111111111111111111111111111111111");
+    for (int idx = 0; idx < (BIGINT_SIZE-1); idx += 1) {
+            int64_t input = 1ULL << idx;
+            ASSERT_EQ(testUnary(FUNC_VOLT_BIN,
+                                input,
+                                expected),
+                      0);
+            expected = expected + "0";
+            expectedz[(BIGINT_SIZE-1) - idx] = '0';
+            ASSERT_EQ(testUnary(FUNC_VOLT_BIN,
+                                ~input,
+                                expectedz),
+                      0);
+            expectedz[(BIGINT_SIZE-1) - idx] = '1';
+    }
 }
 
 TEST_F(FunctionTest, HexTest) {
         ASSERT_EQ(testUnary(FUNC_VOLT_HEX,
-                            0xffULL,
+                            0xffLL,
                             "FF"),
                   0);
         ASSERT_EQ(testUnary(FUNC_VOLT_HEX,
-                            0x0ULL,
+                            0x0LL,
                             "0"),
                   0);
-        ASSERT_EQ(testUnary(FUNC_VOLT_HEX, 0x8000000000000000LL,"", true),
+        ASSERT_EQ(testUnary(FUNC_VOLT_HEX, int64_t(0x8000000000000000),"", true),
                     0);
         // Walking ones.
         // Apparently it's unrecommended to reuse std::stringstream,
@@ -310,6 +335,22 @@ TEST_F(FunctionTest, BitNotTest) {
     }
 }
 
+TEST_F(FunctionTest, RepeatTooBig) {
+    bool sawexception = false;
+    try {
+        ASSERT_EQ(testBinary(FUNC_REPEAT, "amanaplanacanalpanama", int64_t(1), "amanaplanacanalpanama", false), 0);
+    } catch (voltdb::SQLException &ex) {
+        sawexception = true;
+    }
+    ASSERT_FALSE(sawexception);
+    sawexception = false;
+    try {
+        ASSERT_EQ(testBinary(FUNC_REPEAT, "amanaplanacanalpanama", 1000000, "", false), 1);
+    } catch (voltdb::SQLException &ex) {
+        sawexception = true;
+    }
+    ASSERT_TRUE(sawexception);
+}
 
 int main() {
      return TestSuite::globalInstance()->runAll();

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
@@ -608,17 +608,6 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
                 "Could not convert to number");
     }
 
-    public void testRepeat() throws Exception {
-        System.out.println("STARTING Repeat Test");
-        Client client = getClient();
-
-        // ENG-7015 If the result of the REPEAT function would be too large we throw an exception.
-        ClientResponse cr;
-        cr = client.callProcedure("R3.insert", 1, 1, 1, 1, 1, 1.1, "2013-07-18 02:00:00.123457", "IBM", 1);
-        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
-        verifyStmtFails(client, "select REPEAT('foo', 1000000) from R3 where id = 1;", "VOLTDB ERROR: SQL ERROR\\s*REPEAT function call would create a string of size \\d+ which is larger than the maximum size \\d+");
-    }
-
     public void testSINCE_EPOCH() throws Exception {
         System.out.println("STARTING SINCE_EPOCH");
         Client client = getClient();

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
@@ -608,6 +608,17 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
                 "Could not convert to number");
     }
 
+    public void testRepeat() throws Exception {
+        System.out.println("STARTING Repeat Test");
+        Client client = getClient();
+
+        // ENG-7015 If the result of the REPEAT function would be too large we throw an exception.
+        ClientResponse cr;
+        cr = client.callProcedure("R3.insert", 1, 1, 1, 1, 1, 1.1, "2013-07-18 02:00:00.123457", "IBM", 1);
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+        verifyStmtFails(client, "select REPEAT('foo', 1000000) from R3 where id = 1;", "VOLTDB ERROR: SQL ERROR\\s*REPEAT function call would create a string of size \\d+ which is larger than the maximum size \\d+");
+    }
+    
     public void testSINCE_EPOCH() throws Exception {
         System.out.println("STARTING SINCE_EPOCH");
         Client client = getClient();

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
@@ -618,7 +618,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
         verifyStmtFails(client, "select REPEAT('foo', 1000000) from R3 where id = 1;", "VOLTDB ERROR: SQL ERROR\\s*REPEAT function call would create a string of size \\d+ which is larger than the maximum size \\d+");
     }
-    
+
     public void testSINCE_EPOCH() throws Exception {
         System.out.println("STARTING SINCE_EPOCH");
         Client client = getClient();

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -2435,6 +2435,17 @@ public class TestFunctionsSuite extends RegressionSuite {
         assertEquals(1, result.getRowCount());
         assertTrue(result.advanceRow());
         assertEquals("foofoofoo", result.getString(1));
+
+        boolean sawException = false;
+        try {
+            cr = client.callProcedure("REPEAT", 1000000, 1);
+            assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+            result = cr.getResults()[0];
+            assertTrue("Exception expected here.", false);
+        } catch (ProcCallException ex) {
+            sawException = true;
+        }
+        assertTrue("SQLException expected for oversize REPEAT function", sawException);
     }
 
     public void testReplace() throws NoConnectionsException, IOException, ProcCallException {

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -2435,6 +2435,11 @@ public class TestFunctionsSuite extends RegressionSuite {
         assertEquals(1, result.getRowCount());
         assertTrue(result.advanceRow());
         assertEquals("foofoofoo", result.getString(1));
+        if (!isHSQL()) {
+            verifyProcFails(client,
+                            "VOLTDB ERROR: SQL ERROR\\s*REPEAT function call would create a string of size \\d+ which is larger than the maximum size \\d+",
+                            "REPEAT", 10000000, 1);
+        }
     }
 
     public void testReplace() throws NoConnectionsException, IOException, ProcCallException {

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -2435,17 +2435,6 @@ public class TestFunctionsSuite extends RegressionSuite {
         assertEquals(1, result.getRowCount());
         assertTrue(result.advanceRow());
         assertEquals("foofoofoo", result.getString(1));
-
-        boolean sawException = false;
-        try {
-            cr = client.callProcedure("REPEAT", 1000000, 1);
-            assertEquals(ClientResponse.SUCCESS, cr.getStatus());
-            result = cr.getResults()[0];
-            assertTrue("Exception expected here.", false);
-        } catch (ProcCallException ex) {
-            sawException = true;
-        }
-        assertTrue("SQLException expected for oversize REPEAT function", sawException);
     }
 
     public void testReplace() throws NoConnectionsException, IOException, ProcCallException {


### PR DESCRIPTION
1. I had to move the const int POOLED_MAX_VALUE_LENGTH into the ThreadLocalPool.  It's still static, but it's now class static and not file static.
2. I wrote a small check in the existing C++ code.
3. I wrote a C++ unit test for this.  This required making the binary test function more generic.
3. I wrote a small test in the existing Java code.

