### PR TITLE
Address valgrind issue and minor changes

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -667,7 +667,6 @@ int VoltDBEngine::executePlanFragment(int64_t planfragmentId,
     }
 
     int64_t tuplesModified = m_tuplesModifiedStack.top();
-    m_tuplesModifiedStack.pop();
     resetExecutionMetadata();
 
     // assume this is sendless dml
@@ -700,6 +699,12 @@ int VoltDBEngine::executePlanFragment(int64_t planfragmentId,
 }
 
 void VoltDBEngine::resetExecutionMetadata() {
+
+    if (m_tuplesModifiedStack.size() != 0) {
+        m_tuplesModifiedStack.pop();
+    }
+    assert (m_tuplesModifiedStack.size() == 0);
+
     // set this back to -1 for error handling
     m_currentInputDepId = -1;
     if (m_currExecutorVec == NULL) {

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -298,17 +298,9 @@ private:
 
 ExecutorVector::~ExecutorVector()
 {
-    // We could avoid having call delete here if we stored an instance in the
-    // map, rather than a pointer to it?
-    //
-    // Also, why do we need to call erase here?
-    std::map<int, std::vector<AbstractExecutor*>* >::iterator it = m_subplanExecListMap.begin();
-    while (it != m_subplanExecListMap.end()) {
-        std::vector<AbstractExecutor*>* executorList = it->second;
-        // Note: we need to increment the iterator here
-        // to avoid invalidating it.
-        m_subplanExecListMap.erase(it++);
-        delete executorList;
+    typedef  std::map<int, std::vector<AbstractExecutor*>*>::value_type MapEntry;
+    BOOST_FOREACH(MapEntry &entry, m_subplanExecListMap) {
+        delete entry.second;
     }
 }
 

--- a/src/ee/expressions/subqueryexpression.cpp
+++ b/src/ee/expressions/subqueryexpression.cpp
@@ -50,14 +50,12 @@ SubqueryExpression::SubqueryExpression(
 
 SubqueryExpression::~SubqueryExpression()
 {
-    // This is curious: m_tveParams is a shared_ptr to
-    // a std::vector, but we're deleting values from it here.
-    //
-    // This suggests that we're the sole owner of this vector.
-    // Why not just use a scoped_ptr or non-pointer member vector?
     if (m_tveParams.get() != NULL) {
+        // When we support C++11, we should store unique_ptrs
+        // in this vector so cleanup happens automatically.
         size_t i = m_tveParams->size();
         while (i--) {
+
             delete (*m_tveParams)[i];
         }
     }

--- a/src/ee/expressions/subqueryexpression.h
+++ b/src/ee/expressions/subqueryexpression.h
@@ -20,7 +20,7 @@
 
 #include "expressions/abstractexpression.h"
 
-#include <boost/shared_ptr.hpp>
+#include <boost/scoped_ptr.hpp>
 
 #include <vector>
 
@@ -60,7 +60,7 @@ class SubqueryExpression : public AbstractExpression {
     std::vector<int> m_otherParamIdxs;
 
     // The list of the corresponding TVE for each parameter index
-    boost::shared_ptr<const std::vector<AbstractExpression*> > m_tveParams;
+    boost::scoped_ptr<const std::vector<AbstractExpression*> > m_tveParams;
 };
 
 }

--- a/src/ee/plannodes/plannodefragment.cpp
+++ b/src/ee/plannodes/plannodefragment.cpp
@@ -46,6 +46,9 @@
 #include <stdexcept>
 #include <sstream>
 #include <memory>
+
+#include <boost/foreach.hpp>
+
 #include "common/FatalException.hpp"
 #include "plannodefragment.h"
 #include "catalog/catalog.h"
@@ -89,17 +92,9 @@ void PlanNodeFragment::constructTree(AbstractPlanNode* node)
 
 PlanNodeFragment::~PlanNodeFragment()
 {
-    // The need to delete this could be avoided just by storing
-    // an actual instance (instead of a pointer) in the map?
-    //
-    // Also, why is the call to erase needed below?
-    PlanNodeMapIterator mapIt = m_stmtExecutionListMap.begin();
-    while (mapIt != m_stmtExecutionListMap.end()) {
-        std::vector<AbstractPlanNode*>* execList = mapIt->second;
-        // Note: we need to increment the iterator to avoid
-        // invalidating it in the call to erase.
-        m_stmtExecutionListMap.erase(mapIt++);
-        delete execList;
+    typedef  std::map<int, std::vector<AbstractPlanNode*>* >::value_type MapEntry;
+    BOOST_FOREACH(MapEntry& entry, m_stmtExecutionListMap) {
+        delete entry.second;
     }
 
     std::map<CatalogId, AbstractPlanNode*>::iterator it = m_idToNodeMap.begin();

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -1010,26 +1010,6 @@ public class TestSubQueriesSuite extends RegressionSuite {
 
     }
 
-    public void notestENG8196_minimumn_unit_test_case() throws Exception {
-        Client client = getClient();
-        loadData(false);
-        VoltTable vt;
-
-        try {
-            vt = client.callProcedure("@AdHoc",
-                    "select R1.ID, R1.DEPT, (SELECT ID FROM R2) FROM R1 where R1.ID > 3 order by R1.ID desc;").getResults()[0];
-        } catch (ProcCallException ex) {
-            String errMsg = (isHSQL()) ? "cardinality violation" :
-                "More than one row returned by a scalar/row subquery";
-            assertTrue(ex.getMessage().contains(errMsg));
-        }
-
-        // Any questions after the run time exception for sub-query will trigger memory leak.
-        // It should be related to the clean up in the global scope sub-query context.
-        vt = client.callProcedure("@AdHoc", "select * from R1;").getResults()[0];
-        assertTrue(vt.advanceRow());
-    }
-
     // Test scalar subqueries
     public void testSelectScalarSubSelects() throws Exception
     {
@@ -1054,16 +1034,14 @@ public class TestSubQueriesSuite extends RegressionSuite {
                 "select R1.DEPT, (SELECT ID FROM R2 where R2.ID = 1) FROM R1 where R1.DEPT = 2;").getResults()[0];
         validateTableOfLongs(vt, new long[][] {  {2, 1}, {2, 1} });
 
-
-        // Turn the next commented query on when ENG8196 is fixed.
-//        try {
-//            vt = client.callProcedure("@AdHoc",
-//                    "select R1.ID, R1.DEPT, (SELECT ID FROM R2) FROM R1 where R1.ID > 3 order by R1.ID desc;").getResults()[0];
-//        } catch (ProcCallException ex) {
-//            String errMsg = (isHSQL()) ? "cardinality violation" :
-//                "More than one row returned by a scalar/row subquery";
-//            assertTrue(ex.getMessage().contains(errMsg));
-//        }
+        try {
+            vt = client.callProcedure("@AdHoc",
+                    "select R1.ID, R1.DEPT, (SELECT ID FROM R2) FROM R1 where R1.ID > 3 order by R1.ID desc;").getResults()[0];
+        } catch (ProcCallException ex) {
+            String errMsg = (isHSQL()) ? "cardinality violation" :
+                "More than one row returned by a scalar/row subquery";
+            assertTrue(ex.getMessage().contains(errMsg));
+        }
 
         // ENG-8145
         subTestScalarSubqueryWithOrderByOrGroupBy();
@@ -1080,7 +1058,7 @@ public class TestSubQueriesSuite extends RegressionSuite {
         int len = 100;
 
         if (isValgrind()) {
-            // valgrind is to slow with 100 rows, use a small number
+            // valgrind is too slow with 100 rows, use a small number
             len = 10;
         }
 


### PR DESCRIPTION
The first commit addresses the valgrind issue.

I added back in `std::` prefixes in VoltDBEngine.cpp.  I made this its own commit, since it makes it difficult to see the other changes.

I convinced myself that calls to `erase` that were in a couple destructors are not needed, so I removed them.

I also updated TestSubQueriesSuite now that valgrind is passing there.