### PR TITLE
SqlQueriesTestBase.ensureOnSqlQueryPage(): added a try/catch for a

### DIFF
--- a/tests/geb/vmc/src/tests/SqlQueriesTestBase.groovy
+++ b/tests/geb/vmc/src/tests/SqlQueriesTestBase.groovy
@@ -23,6 +23,8 @@
 
 package vmcTest.tests
 
+import geb.waiting.WaitTimeoutException
+
 import vmcTest.pages.SqlQueryPage
 import vmcTest.pages.VoltDBManagementCenterPage.ColumnHeaderCase
 
@@ -43,7 +45,23 @@ class SqlQueriesTestBase extends TestBase {
 
     def ensureOnSqlQueryPage() {
         ensureOnVoltDBManagementCenterPage()
-        page.openSqlQueryPage()
+        try {
+            debugPrint 'Attempting to open SqlQueryPage, at: ' + sdf.format(new Date())
+            page.openSqlQueryPage()
+            debugPrint 'Succeeded:  opened SqlQueryPage, at: ' + sdf.format(new Date())
+        } catch (WaitTimeoutException e) {
+            // If a WaitTimeoutException is encountered, make a second attempt
+            String message = '\nCaught a WaitTimeoutException attempting to open SqlQueryPage ' +
+                             '[in SqlQueriesTestBase.ensureOnSqlQueryPage()]'
+            System.err.println message + ':'
+            e.printStackTrace()
+            println message + '; see Standard error for details.'
+            println 'Will refresh page and try again...    (' + sdf.format(new Date()) + ')'
+            driver.navigate().refresh()
+            ensureOnVoltDBManagementCenterPage()
+            page.openSqlQueryPage()
+            println '... second open attempt succeeded, at: ' + sdf.format(new Date())
+        }
     }
     
     /**


### PR DESCRIPTION
WaitTimeoutException, and give it a second chance to open the
SqlQueryPage, since this is the spot where we most often see sporadic
test failures.