### PR TITLE
Avoid wrong answers when using subqueries within other expressions

### DIFF
--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -233,6 +233,15 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
     }
 
     /**
+     * Update the argument at specified index
+     * @param index   the index of the item to replace
+     * @param arg     the new argument to insert into the list
+     */
+    public void setArgAtIndex(int index, AbstractExpression arg) {
+        m_args.set(index, arg);
+    }
+
+    /**
      * @return The type of this expression's value.
      */
     public VoltType getValueType() {

--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -493,7 +493,7 @@ public abstract class ExpressionUtil {
         return scalarExpr;
     }
 
-    private static boolean isScalarSubqueryContext(AbstractExpression parentExpr) {
+    private static boolean subqueryRequiresScalarValueExpressionFromContext(AbstractExpression parentExpr) {
         if (parentExpr == null) {
             // No context: we are a top-level expression.  E.g, an item on the
             // select list.  In this case, assume the expression must be scalar.
@@ -503,6 +503,11 @@ public abstract class ExpressionUtil {
         // Exists and comparison operators can handle non-scalar subqueries.
         if (parentExpr.getExpressionType() == ExpressionType.OPERATOR_EXISTS
                 || parentExpr instanceof ComparisonExpression) {
+            return false;
+        }
+
+        // There is already a ScalarValueExpression above the subquery.
+        if (parentExpr instanceof ScalarValueExpression) {
             return false;
         }
 
@@ -524,7 +529,7 @@ public abstract class ExpressionUtil {
         }
 
         if (expr instanceof SelectSubqueryExpression
-                && isScalarSubqueryContext(parentExpr)) {
+                && subqueryRequiresScalarValueExpressionFromContext(parentExpr)) {
             expr = addScalarValueExpression((SelectSubqueryExpression)expr);
         }
         return expr;

--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -493,6 +493,18 @@ public abstract class ExpressionUtil {
             }
         }
 
+        // Let's not forget the args, which may also contain subqueries.
+        List<AbstractExpression> args = expr.getArgs();
+        if (args != null) {
+            for (int i = 0; i < args.size(); ++i) {
+                AbstractExpression arg = args.get(i);
+                AbstractExpression newArg = wrapScalarSubqueriesHelper(expr, arg);
+                if (newArg != arg) {
+                    expr.setArgAtIndex(i, newArg);
+                }
+            }
+        }
+
         if (expr instanceof SelectSubqueryExpression
                 && subqueryRequiresScalarValueExpressionFromContext(parentExpr)) {
             expr = addScalarValueExpression((SelectSubqueryExpression)expr);

--- a/src/frontend/org/voltdb/expressions/InComparisonExpression.java
+++ b/src/frontend/org/voltdb/expressions/InComparisonExpression.java
@@ -32,10 +32,10 @@ public class InComparisonExpression extends ComparisonExpression {
     public void validate() throws Exception {
         super.validate();
         //
-        // We need at least one value defined
+        // Args list is not used by IN.
         //
-        if (m_args.isEmpty()) {
-            throw new Exception("ERROR: There were no values defined for '" + this + "'");
+        if (m_args != null) {
+            throw new Exception("ERROR: Args list was not null for '" + this + "'");
         }
         //
         // We always need both a left node and a right node

--- a/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
@@ -17,6 +17,7 @@
 
 package org.voltdb.expressions;
 
+import org.voltdb.planner.parseinfo.StmtSubqueryScan;
 import org.voltdb.types.ExpressionType;
 
 /**
@@ -43,6 +44,11 @@ public class ScalarValueExpression extends AbstractValueExpression {
     public String explain(String impliedTableName) {
         assert(m_left != null);
         return m_left.explain(impliedTableName);
+    }
+
+    public StmtSubqueryScan getSubqueryScan() {
+        SelectSubqueryExpression subqExpr = (SelectSubqueryExpression)m_left;
+        return subqExpr.getSubqueryScan();
     }
 
 }

--- a/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
@@ -46,6 +46,11 @@ public class ScalarValueExpression extends AbstractValueExpression {
         return m_left.explain(impliedTableName);
     }
 
+    /**
+     * Currently ScalarValueExpressions can only have a subquery as children.  Return
+     * the StmtSubqueryScan object for our child.
+     * @return StmtSubqueryScan object for subquery
+     */
     public StmtSubqueryScan getSubqueryScan() {
         SelectSubqueryExpression subqExpr = (SelectSubqueryExpression)m_left;
         return subqExpr.getSubqueryScan();

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -285,6 +285,10 @@ public abstract class AbstractParsedStmt {
     // so, the methods COULD be relocated to class AbstractExpression or ExpressionUtil.
     public AbstractExpression parseExpressionTree(VoltXMLElement root) {
         AbstractExpression expr = parseExpressionTreeHelper(root);
+
+        // If there were any subquery expressions appearing in a scalar context,
+        // we must wrap them in ScalarValueExpressions to avoid wrong answers.
+        // See ENG-8226.
         expr = ExpressionUtil.wrapScalarSubqueries(expr);
         return expr;
     }

--- a/src/frontend/org/voltdb/planner/SubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SubPlanAssembler.java
@@ -1418,7 +1418,7 @@ public abstract class SubPlanAssembler {
         scanNode.setEndExpression(ExpressionUtil.combine(path.endExprs));
         scanNode.setPredicate(ExpressionUtil.combine(path.otherExprs));
         // The initial expression is needed to control a (short?) forward scan to adjust the start of a reverse
-        // iteration after So initially settle for starting at "greater than a prefix key".
+        // iteration after it had to initially settle for starting at "greater than a prefix key".
         scanNode.setInitialExpression(ExpressionUtil.combine(path.initialExpr));
         scanNode.setSkipNullPredicate();
         scanNode.setEliminatedPostFilters(path.eliminatedPostExprs);

--- a/src/frontend/org/voltdb/planner/SubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SubPlanAssembler.java
@@ -1409,7 +1409,6 @@ public abstract class SubPlanAssembler {
 
                 // DEAD CODE with the guards on index: ENG-8203
                 assert(false);
-                expr2 = ExpressionUtil.addScalarValueExpression((AbstractSubqueryExpression)expr2);
             }
             scanNode.addSearchKeyExpression(expr2);
         }
@@ -1419,7 +1418,7 @@ public abstract class SubPlanAssembler {
         scanNode.setEndExpression(ExpressionUtil.combine(path.endExprs));
         scanNode.setPredicate(ExpressionUtil.combine(path.otherExprs));
         // The initial expression is needed to control a (short?) forward scan to adjust the start of a reverse
-        // iteration after it had to initially settle for starting at "greater than a prefix key".
+        // iteration after So initially settle for starting at "greater than a prefix key".
         scanNode.setInitialExpression(ExpressionUtil.combine(path.initialExpr));
         scanNode.setSkipNullPredicate();
         scanNode.setEliminatedPostFilters(path.eliminatedPostExprs);

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -451,7 +451,7 @@ public class TestSubQueriesSuite extends RegressionSuite {
             sql = "select dept from " + tb +
                     " group by dept " +
                     " having max(wage) in (select wage from R1) order by dept desc";
-            /* enable for debug */ vt = client.callProcedure("@Explain", sql).getResults()[0];
+            //* enable for debug */ vt = client.callProcedure("@Explain", sql).getResults()[0];
             //* enable for debug */ System.out.println(vt);
             //TODO: Whatever @Explain is testung here should be covered in a planner test instead.
             assertFalse(vt.toString().toLowerCase().contains("subquery: null"));

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -1410,8 +1410,15 @@ public class TestSubQueriesSuite extends RegressionSuite {
 
       client.callProcedure("R1.insert", 1, 300,  1 , "2013-06-18 02:00:00.123457");
 
+      // These test cases exercise the fix for ENG-8226, in which a missing ScalarValueExpression
+      // caused the result of a subquery to be seen as the subquery ID, rather than the contents
+      // of subquery's result table.
+
       validateTableOfScalarLongs(client, "select (select max(wage) from r1) from r1", new long[] {300});
       validateTableOfScalarLongs(client, "select (select max(wage) from r1) + 0 from r1", new long[] {300});
+
+      validateTableOfScalarLongs(client, "select wage from r1 where wage = (select max(wage) from r1)", new long[] {300});
+      validateTableOfScalarLongs(client, "select wage from r1 where wage = (select max(wage) - 30 from r1) + 30", new long[] {300});
   }
 
     static public junit.framework.Test suite()

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -1409,16 +1409,27 @@ public class TestSubQueriesSuite extends RegressionSuite {
       Client client = getClient();
 
       client.callProcedure("R1.insert", 1, 300,  1 , "2013-06-18 02:00:00.123457");
+      client.callProcedure("R1.insert", 2, 200,  1 , "2013-06-18 02:00:00.123457");
 
       // These test cases exercise the fix for ENG-8226, in which a missing ScalarValueExpression
       // caused the result of a subquery to be seen as the subquery ID, rather than the contents
       // of subquery's result table.
 
-      validateTableOfScalarLongs(client, "select (select max(wage) from r1) from r1", new long[] {300});
-      validateTableOfScalarLongs(client, "select (select max(wage) from r1) + 0 from r1", new long[] {300});
+      validateTableOfScalarLongs(client, "select (select max(wage) from r1) from r1",
+              new long[] {300, 300});
+      validateTableOfScalarLongs(client, "select (select max(wage) from r1) + 0 as subq from r1",
+              new long[] {300, 300});
 
       validateTableOfScalarLongs(client, "select wage from r1 where wage = (select max(wage) from r1)", new long[] {300});
       validateTableOfScalarLongs(client, "select wage from r1 where wage = (select max(wage) - 30 from r1) + 30", new long[] {300});
+
+      // The IN operator takes a VectorExpression on its RHS, which uses the "args" field.
+      // Make sure that we can handle subqueries in there too.
+      validateTableOfScalarLongs(client,
+              "select wage from r1 "
+              + "where wage in (7, 8, (select max(wage) from r1), 9, 10, 200) "
+              + "order by wage",
+              new long[] {200, 300});
   }
 
     static public junit.framework.Test suite()

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -1405,6 +1405,15 @@ public class TestSubQueriesSuite extends RegressionSuite {
       verifyStmtFails(client, "select (select max(30 / wage) from r1) from r1;", expectedMsg);
   }
 
+  public void testSubqueriesWithArithmetic() throws Exception {
+      Client client = getClient();
+
+      client.callProcedure("R1.insert", 1, 300,  1 , "2013-06-18 02:00:00.123457");
+
+      validateTableOfScalarLongs(client, "select (select max(wage) from r1) from r1", new long[] {300});
+      validateTableOfScalarLongs(client, "select (select max(wage) from r1) + 0 from r1", new long[] {300});
+  }
+
     static public junit.framework.Test suite()
     {
         VoltServerConfig config = null;


### PR DESCRIPTION
These changes add a post-pass over parsed expression trees to wrap scalar subqueries in an instance of ScalarValueExpression where needed.  I also pushed the check for single-column schema in to the code that creates the ScalarValueExpression node.

Another approach might be to always create the ScalarValueExpression over subqueries, and then remove the SVE node if its parent is a comparison operator or an EXISTS operator.  We still wouldn't avoid the overhead of a post-pass though: we would need to check that the subquery children of SVE nodes have only one column after parsing is complete.