### PR TITLE
Improve output from AbstractExpression.toString()

### DIFF
--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -270,35 +270,41 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         m_inBytes = inBytes;
     }
 
-    private static final String INDENT = "  | ";
-    private void toStringHelper(String linePrefix, StringBuilder sb) {
-        sb.append(linePrefix + this.getClass().getSimpleName() + "[" + getExpressionType().toString() + "]"
-                + " : " + m_valueType.toSQLString() + "\n");
-
-        if (getLeft() != null) {
-            sb.append(linePrefix + "Left:\n");
-            getLeft().toStringHelper(linePrefix + INDENT, sb);
-        }
-
-        if (getRight() != null) {
-            sb.append(linePrefix + "Right:\n");
-            getRight().toStringHelper(linePrefix + INDENT, sb);
-        }
-
-        List<AbstractExpression> args = getArgs();
-        if (args != null) {
-            sb.append(linePrefix + "Args:\n");
-            for (AbstractExpression arg : args) {
-                arg.toStringHelper(linePrefix + INDENT, sb);
-            }
-        }
-    }
-
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         toStringHelper("", sb);
         return sb.toString();
+    }
+
+    private static final String INDENT = "  | ";
+
+    private void toStringHelper(String linePrefix, StringBuilder sb) {
+        String header = this.getClass().getSimpleName() + "[" + getExpressionType().toString() + "] : ";
+        if (m_valueType != null) {
+            header += m_valueType.toSQLString();
+        }
+        else {
+            header += "[null type]";
+        }
+        sb.append(linePrefix + header + "\n");
+
+        if (m_left != null) {
+            sb.append(linePrefix + "Left:\n");
+            m_left.toStringHelper(linePrefix + INDENT, sb);
+        }
+
+        if (m_right != null) {
+            sb.append(linePrefix + "Right:\n");
+            m_right.toStringHelper(linePrefix + INDENT, sb);
+        }
+
+        if (m_args != null) {
+            sb.append(linePrefix + "Args:\n");
+            for (AbstractExpression arg : m_args) {
+                arg.toStringHelper(linePrefix + INDENT, sb);
+            }
+        }
     }
 
     @Override

--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -270,9 +270,35 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         m_inBytes = inBytes;
     }
 
+    private static final String INDENT = "  | ";
+    private void toStringHelper(String linePrefix, StringBuilder sb) {
+        sb.append(linePrefix + this.getClass().getSimpleName() + "[" + getExpressionType().toString() + "]"
+                + " : " + m_valueType.toSQLString() + "\n");
+
+        if (getLeft() != null) {
+            sb.append(linePrefix + "Left:\n");
+            getLeft().toStringHelper(linePrefix + INDENT, sb);
+        }
+
+        if (getRight() != null) {
+            sb.append(linePrefix + "Right:\n");
+            getRight().toStringHelper(linePrefix + INDENT, sb);
+        }
+
+        List<AbstractExpression> args = getArgs();
+        if (args != null) {
+            sb.append(linePrefix + "Args:\n");
+            for (AbstractExpression arg : args) {
+                arg.toStringHelper(linePrefix + INDENT, sb);
+            }
+        }
+    }
+
     @Override
     public String toString() {
-        return "Expression: " + toJSONString();
+        StringBuilder sb = new StringBuilder();
+        toStringHelper("", sb);
+        return sb.toString();
     }
 
     @Override


### PR DESCRIPTION
Old implementation just used toJsonString which was hard on the eyes.

The new output for `bi in (2, 3, 5)` looks like this in Eclipse:
```
InComparisonExpression[COMPARE_IN] : bigint
Left:
  | TupleValueExpression[VALUE_TUPLE] : bigint
Right:
  | VectorValueExpression[VALUE_VECTOR] : null
  | Args:
  |   | ParameterValueExpression[VALUE_PARAMETER] : integer
  |   | ParameterValueExpression[VALUE_PARAMETER] : integer
  |   | ParameterValueExpression[VALUE_PARAMETER] : integer
```
Still lots of possible improvements (could show values for constants and column names for TVEs), but this is a start.

Is there some reason this hasn't been done before?