### PR TITLE
Squash commit the fix for group by scalar value subquery, add more tests

### DIFF
--- a/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
@@ -133,9 +133,7 @@ public abstract class AbstractSubqueryExpression extends AbstractExpression {
     public int hashCode() {
         // defer to the superclass, which factors in other attributes
         int result = super.hashCode();
-        if (m_subqueryNode != null) {
-            result += m_subqueryNode.hashCode();
-        }
+        result += m_subqueryId;
         return result;
     }
 

--- a/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
@@ -37,7 +37,9 @@ public class ScalarValueExpression extends AbstractValueExpression {
     @Override
     public boolean equals(Object obj) {
         assert(m_left != null);
-        return m_left.equals(obj);
+        if (obj instanceof ScalarValueExpression == false) return false;
+        ScalarValueExpression expr = (ScalarValueExpression) obj;
+        return m_left.equals(expr.getLeft());
     }
 
     @Override

--- a/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
@@ -41,6 +41,11 @@ public class ScalarValueExpression extends AbstractValueExpression {
     }
 
     @Override
+    public int hashCode() {
+        return m_left.hashCode();
+    }
+
+    @Override
     public String explain(String impliedTableName) {
         assert(m_left != null);
         return m_left.explain(impliedTableName);

--- a/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
@@ -169,16 +169,6 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
     }
 
     @Override
-    public int hashCode() {
-        // defer to the superclass, which factors in other attributes
-        int result = super.hashCode();
-        if (m_subquery != null) {
-            result += m_subquery.hashCode();
-        }
-        return result;
-    }
-
-    @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
         // Output the correlated parameter ids that this subquery or its descendants

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -1454,8 +1454,8 @@ public abstract class AbstractParsedStmt {
     /*
      *  Extract all subexpressions of a given expression class from this statement
      */
-    public List<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        List<AbstractExpression> exprs = new ArrayList<AbstractExpression>();
+    public Set<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
+        HashSet<AbstractExpression> exprs = new HashSet<AbstractExpression>();
         if (m_joinTree != null) {
             AbstractExpression treeExpr = m_joinTree.getAllFilters();
             if (treeExpr != null) {
@@ -1478,7 +1478,7 @@ public abstract class AbstractParsedStmt {
             return true;
         }
         // Verify expression subqueries
-        List<AbstractExpression> subqueryExprs = findAllSubexpressionsOfClass(
+        Set<AbstractExpression> subqueryExprs = findAllSubexpressionsOfClass(
                 SelectSubqueryExpression.class);
         return !subqueryExprs.isEmpty();
     }

--- a/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
@@ -21,13 +21,12 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.voltdb.VoltType;
-import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.Database;
-import org.voltdb.catalog.Statement;
 import org.voltdb.catalog.Table;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.ConstantValueExpression;
@@ -225,8 +224,8 @@ public class ParsedInsertStmt extends AbstractParsedStmt {
     }
 
     @Override
-    public List<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        List<AbstractExpression> exprs = super.findAllSubexpressionsOfClass(aeClass);
+    public Set<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
+        Set<AbstractExpression> exprs = super.findAllSubexpressionsOfClass(aeClass);
 
         for (AbstractExpression expr : m_columns.values()) {
             if (expr != null) {

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -70,7 +70,11 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
     private NodeSchema m_distinctProjectSchema = null;
 
     // It may has the consistent element order as the displayColumns
+    // This list contains the core information for aggregation.
+    // It collects aggregate expression, group by expression from display columns,
+    // group by columns, having, order by columns.
     public ArrayList<ParsedColInfo> m_aggResultColumns = new ArrayList<ParsedColInfo>();
+    // It represents the group by expression and replace TVE if it's complex group by.
     public Map<String, AbstractExpression> m_groupByExpressions = null;
 
     private ArrayList<ParsedColInfo> m_avgPushdownDisplayColumns = null;
@@ -473,6 +477,12 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
      */
     private void insertAggExpressionsToAggResultColumns (List<AbstractExpression> aggColumns, ParsedColInfo cookedCol) {
         for (AbstractExpression expr: aggColumns) {
+            assert(expr instanceof AggregateExpression);
+            if (! expr.findAllSubexpressionsOfClass(SelectSubqueryExpression.class).isEmpty()) {
+                throw new PlanningErrorException(
+                        "SQL Aggregate with subquery expression is not allowed.");
+            }
+
             ParsedColInfo col = new ParsedColInfo();
             col.expression = (AbstractExpression) expr.clone();
             assert(col.expression instanceof AggregateExpression);
@@ -1845,9 +1855,17 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         return exprs;
     }
 
+    /**
+     * This functions tries to find all expression from the statement. For complex group by or complex aggregate,
+     * we have a special function ParsedSelectStmt::placeTVEsinColumns() to replace the expression with TVE for
+     * the convenience of projection node after group by node.
+     *
+     * So use the original expression from the XML of hsqldb, other than the processed information. See ENG-8263.
+     * m_having and m_projectSchema seem to have the same issue in ENG-8263.
+     */
     @Override
-    public List<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        List<AbstractExpression> exprs = super.findAllSubexpressionsOfClass(aeClass);
+    public Set<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
+        Set<AbstractExpression> exprs = super.findAllSubexpressionsOfClass(aeClass);
         if (m_having != null) {
             exprs.addAll(m_having.findAllSubexpressionsOfClass(aeClass));
         }
@@ -1861,6 +1879,14 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
                 if (col.getExpression() != null) {
                     exprs.addAll(col.getExpression().findAllSubexpressionsOfClass(aeClass));
                 }
+            }
+        }
+
+        // m_having, m_groupByExpressions, m_projectSchema may contain the aggregation or group by expression that have
+        // been replaced with TVEs already. So check out the repository of the original expression in m_aggResultColumns.
+        for (ParsedColInfo col: m_aggResultColumns) {
+            if (col.expression != null) {
+                exprs.addAll(col.expression.findAllSubexpressionsOfClass(aeClass));
             }
         }
         return exprs;

--- a/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
@@ -18,7 +18,9 @@
 package org.voltdb.planner;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.voltdb.catalog.Database;
@@ -164,8 +166,8 @@ public class ParsedUnionStmt extends AbstractParsedStmt {
     }
 
     @Override
-    public List<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        List<AbstractExpression> exprs = new ArrayList<AbstractExpression>();
+    public Set<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
+        Set<AbstractExpression> exprs = new HashSet<AbstractExpression>();
         for (AbstractParsedStmt childStmt : m_children) {
             exprs.addAll(childStmt.findAllSubexpressionsOfClass(aeClass));
         }

--- a/src/frontend/org/voltdb/planner/ParsedUpdateStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedUpdateStmt.java
@@ -18,7 +18,7 @@
 package org.voltdb.planner;
 
 import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.Set;
 
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.voltdb.catalog.Column;
@@ -76,8 +76,8 @@ public class ParsedUpdateStmt extends AbstractParsedStmt {
     }
 
     @Override
-    public List<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        List<AbstractExpression> exprs = super.findAllSubexpressionsOfClass(aeClass);
+    public Set<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
+        Set<AbstractExpression> exprs = super.findAllSubexpressionsOfClass(aeClass);
 
         for (AbstractExpression expr : columns.values()) {
             if (expr != null) {

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -395,7 +395,7 @@ public class PlanAssembler {
         }
 
         // Get the best plans for the expression subqueries ( IN/EXISTS (SELECT...) )
-        List<AbstractExpression> subqueryExprs = parsedStmt.findAllSubexpressionsOfClass(
+        Set<AbstractExpression> subqueryExprs = parsedStmt.findAllSubexpressionsOfClass(
                 SelectSubqueryExpression.class);
         if ( ! subqueryExprs.isEmpty() ) {
             if (parsedStmt instanceof ParsedSelectStmt == false) {
@@ -530,7 +530,7 @@ public class PlanAssembler {
      * @param subqueryExprs - list of subquery expressions
      * @return true if a best plan was generated for each subquery, false otherwise
      */
-    private boolean getBestCostPlanForExpressionSubQueries(List<AbstractExpression> subqueryExprs) {
+    private boolean getBestCostPlanForExpressionSubQueries(Set<AbstractExpression> subqueryExprs) {
         int nextPlanId = m_planSelector.m_planId;
 
         for (AbstractExpression expr : subqueryExprs) {

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -1014,7 +1014,7 @@ public class TestSubQueriesSuite extends RegressionSuite {
     public void testSelectScalarSubSelects() throws Exception
     {
         Client client = getClient();
-        loadData(false);
+        loadData(true);
         VoltTable vt;
 
         vt = client.callProcedure("@AdHoc",
@@ -1027,12 +1027,12 @@ public class TestSubQueriesSuite extends RegressionSuite {
 
         vt = client.callProcedure("@AdHoc",
                 "select R1.ID, R1.DEPT, (SELECT ID FROM R2 where R2.ID = R1.ID and R2.WAGE = 50) FROM R1 where R1.ID > 3 order by R1.ID desc;").getResults()[0];
-        validateTableOfLongs(vt, new long[][] {  {5l, 2l, 5l}, {4l, 2l, Long.MIN_VALUE} });
+        validateTableOfLongs(vt, new long[][] {  {7, 2, Long.MIN_VALUE}, {6, 2, Long.MIN_VALUE}, {5, 2, 5}, {4, 2, Long.MIN_VALUE} });
 
         // Seq scan
         vt = client.callProcedure("@AdHoc",
                 "select R1.DEPT, (SELECT ID FROM R2 where R2.ID = 1) FROM R1 where R1.DEPT = 2;").getResults()[0];
-        validateTableOfLongs(vt, new long[][] {  {2, 1}, {2, 1} });
+        validateTableOfLongs(vt, new long[][] {  {2, 1}, {2, 1}, {2, 1}, {2, 1} });
 
         // with group by correlated
         // Hsqldb back end bug: ENG-8273
@@ -1040,14 +1040,61 @@ public class TestSubQueriesSuite extends RegressionSuite {
             vt = client.callProcedure("@AdHoc",
                     "select R1.DEPT, count(*), (SELECT max(dept) FROM R2 where R2.wage = R1.wage) FROM R1 "
                     + " GROUP BY dept, wage order by dept, wage;").getResults()[0];
-            validateTableOfLongs(vt, new long[][] {  {1,1,1}, {1,1,1}, {1,1,1}, {2, 1, 2}, {2,1,2} });
+            validateTableOfLongs(vt, new long[][] {  {1,1,2}, {1,1,1}, {1,1,1}, {2, 1, 2}, {2, 2, 2}, {2,1,2} });
 
             vt = client.callProcedure("@AdHoc",
                     "select R1.DEPT, count(*), (SELECT sum(dept) FROM R2 where R2.wage > r1.dept * 10) FROM R1 "
                     + " GROUP BY dept order by dept;").getResults()[0];
-            validateTableOfLongs(vt, new long[][] {  {1,3,6}, {2, 2, 5} });
+            validateTableOfLongs(vt, new long[][] {  {1,3,8}, {2, 4, 7} });
         }
 
+        // ENG-8263: group by scalar value expression
+        String sql = "select R1.DEPT, count(*) as tag FROM R1 "
+                + "GROUP BY dept, (SELECT count(dept) FROM R2 where R2.wage = R1.wage) order by dept, tag;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableOfLongs(vt, new long[][] {  {1, 1}, {1, 2}, {2, 1}, {2, 3} });
+
+        vt = client.callProcedure("@AdHoc", "select R1.DEPT, count(*) as tag FROM R1 "
+                + "GROUP BY dept, (SELECT count(dept) FROM R2 where R2.wage > 15) order by dept, tag;").getResults()[0];
+        validateTableOfLongs(vt, new long[][] {  {1,3}, {2, 4} });
+
+        vt = client.callProcedure("@AdHoc", "select R1.DEPT, abs((SELECT count(dept) FROM R2 where R2.wage > R1.wage) / 2 - 3) as ct, count(*) as tag FROM R1 "
+                + "GROUP BY dept, ct order by dept, tag;").getResults()[0];
+        validateTableOfLongs(vt, new long[][] { {1,2,1}, {1,1,2}, {2,1,1}, {2,3,3} });
+
+        // duplicates the subquery expression
+        vt = client.callProcedure("@AdHoc", "select R1.DEPT, count(*) as tag FROM R1 "
+                + "GROUP BY dept, (SELECT count(dept) FROM R2 where R2.wage > 15), "
+                + "(SELECT count(dept) FROM R2 where R2.wage > 15) order by dept, tag;").getResults()[0];
+        validateTableOfLongs(vt, new long[][] {  {1,3}, {2, 4} });
+
+        // changes a little bit on the subquery
+        vt = client.callProcedure("@AdHoc", "select R1.DEPT, count(*) as tag FROM R1 "
+                + "GROUP BY dept, (SELECT count(dept) FROM R2 where R2.wage > 15), "
+                + "(SELECT count(dept) FROM R2 where R2.wage > 14) order by dept, tag;").getResults()[0];
+        validateTableOfLongs(vt, new long[][] {  {1,3}, {2, 4} });
+
+        // expression with subuqery
+        vt = client.callProcedure("@AdHoc", "select R1.DEPT, count(*) as tag FROM R1 "
+                + "GROUP BY dept, (SELECT count(dept) FROM R2 where R2.wage > 15), "
+                + "(1 + (SELECT count(dept) FROM R2 where R2.wage > 14) ) order by dept, tag;").getResults()[0];
+        validateTableOfLongs(vt, new long[][] {  {1,3}, {2, 4} });
+
+        // duplicates the subquery expression
+        vt = client.callProcedure("@AdHoc", "select R1.DEPT, "
+                + "abs((SELECT count(dept) FROM R2 where R2.wage > R1.wage) / 2 - 3) as ct1, "
+                + "abs((SELECT count(dept) FROM R2 where R2.wage > R1.wage) / 2 - 3) as ct2, "
+                + "count(*) as tag FROM R1 "
+                + "GROUP BY dept, ct1 order by dept, tag;").getResults()[0];
+        validateTableOfLongs(vt, new long[][] { {1,2,2,1}, {1,1,1,2}, {2,1,1,1}, {2,3,3,3} });
+
+        // expression with subuqery
+        vt = client.callProcedure("@AdHoc", "select R1.DEPT, "
+                + "abs((SELECT count(dept) FROM R2 where R2.wage > R1.wage) / 2 - 3) as ct1, "
+                + "(5 + abs((SELECT count(dept) FROM R2 where R2.wage > R1.wage) / 2 - 3)) as ct2, "
+                + "count(*) as tag FROM R1 "
+                + "GROUP BY dept, ct1 order by dept, tag;").getResults()[0];
+        validateTableOfLongs(vt, new long[][] { {1,2,7,1}, {1,1,6,2}, {2,1,6,1}, {2,3,8,3} });
         try {
             vt = client.callProcedure("@AdHoc",
                     "select R1.ID, R1.DEPT, (SELECT ID FROM R2) FROM R1 where R1.ID > 3 order by R1.ID desc;").getResults()[0];


### PR DESCRIPTION
1. Added some fixes (hashCode, equals) trying to dedupe the duplicates expression. 

2. Add the guards not to support subquery inside of aggregation function.

3. Add the fix to be able to group by scalar value expression. 