### PR TITLE
Updates to advanced-scalar-subquery.sql: already reviewed by Paul for…

### DIFF
--- a/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
+++ b/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
@@ -5,64 +5,84 @@ DELETE FROM @dmltable
 INSERT INTO @dmltable VALUES (@insertvals)
 
 --- Define "place-holders" used in the queries below
+--- comparison operators in 3 groups, to save execution time
+{_cmp1 |= "="}
+{_cmp1 |= "<>"}
+{_cmp2 |= "<"}
+{_cmp2 |= ">="}
+{_cmp3 |= ">"}
+{_cmp3 |= "<="}
+--{_cmp3 |= "!="} -- Apparently, an HSQL-supported alias for the standard <>
+{_cmp13 |= "_cmp1"}
+{_cmp13 |= "_cmp3"}
+
 {_optionaloffset |= ""}
 {_optionaloffset |= "OFFSET 2"}
 {_optionallimitoffset |= ""}
 {_optionallimitoffset |= "LIMIT 4 _optionaloffset"}
+
 {_optionalorderbyidlimitoffset |= ""}
 {_optionalorderbyidlimitoffset |= "LIMIT 1000"}
 {_optionalorderbyidlimitoffset |= "ORDER BY @idcol _sortorder _optionallimitoffset"}
+
 {_optionalorderby1limitoffset |= ""}
 {_optionalorderby1limitoffset |= "LIMIT 1000"}
 {_optionalorderby1limitoffset |= "ORDER BY 1 _sortorder _optionallimitoffset"}
-{_optionalorderbyvarlimitoffset |= ""}
-{_optionalorderbyvarlimitoffset |= "LIMIT 1000"}
-{_optionalorderbyvarlimitoffset |= "ORDER BY __[#ord] _sortorder _optionallimitoffset"}
 
---- TODO: delete these, once ENG-8234 is fixed, so these are no longer needed to avoid mismatches:
-{_tempoptionalorderbylimitoffset |= ""}
-{_tempoptionalorderbylimitoffset |= "LIMIT 1000"}
-{_tempoptionalorderbylimitoffset |= "ORDER BY __[#ord]     _optionallimitoffset"}
-{_tempoptionalorderbylimitoffset |= "ORDER BY __[#ord] ASC _optionallimitoffset"}
+--- TODO: merge these with _grouporderbyvarlimoffhaving below, once ENG-8234 is fixed, so
+--- these are no longer needed to avoid mismatches, in cases with ORDER BY foo DESC LIMIT:
+{_temp0grouporderbyvarlimoffhaving |= ""}
+{_temp0grouporderbyvarlimoffhaving |= "LIMIT 1000"}
+{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord]"}
+{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord] HAVING @agg(_variable[@comparabletype]) _cmp 12"}
+{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord] HAVING _genericagg(_variable[string])   _cmp 'Z'"}
+
+{_grouporderbyvarlimoffhaving |= "_temp0grouporderbyvarlimoffhaving"}
+{_grouporderbyvarlimoffhaving |= "ORDER BY __[#ord] _sortorder _optionallimitoffset"}
+
+--- TODO: delete these, once ENG-8234 is fixed, so these are no longer
+--- needed to avoid mismatches, in cases with ORDER BY foo DESC LIMIT:
+{_tempgrouporderbyvarlimoffhaving |= "_temp0grouporderbyvarlimoffhaving"}
+{_tempgrouporderbyvarlimoffhaving |= "ORDER BY __[#ord]     _optionallimitoffset"}
+{_tempgrouporderbyvarlimoffhaving |= "ORDER BY __[#ord] ASC _optionallimitoffset"}
 
 -- TEMP, for debugging, just so I can quickly see what data was generated:
 --SELECT * FROM @fromtables ORDER BY @idcol
 
 --- Test Scalar Subquery Advanced cases
 
---- Queries with scalar subqueries in the SELECT clause (with optional ORDER BY, LIMIT or OFFSET clauses)
-SELECT @idcol, (SELECT @agg(_variable) FROM @fromtables                                                                          ) FROM @fromtables    A1 _optionalorderbyidlimitoffset
-SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A2.__[#agg]                   _cmp                   __[#agg]) FROM @fromtables AS A2 _optionalorderbyidlimitoffset
-SELECT @idcol, (SELECT @agg(_variable)       FROM @fromtables WHERE A3._variable[@comparabletype] _cmp _variable[@comparabletype]) FROM @fromtables AS A3 _optionalorderbyidlimitoffset
+--- Queries with scalar subqueries in the SELECT clause (with optional ORDER BY, LIMIT, OFFSET, GROUP BY or HAVING clauses)
+SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables                                                                     ) FROM @fromtables    A1 _optionalorderbyidlimitoffset
+SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A2.__[#agg]                   _cmp13                  __[#agg]) FROM @fromtables AS A2 _optionalorderbyidlimitoffset
+SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A3._variable[@comparabletype] _cmp2 _variable[@comparabletype]) FROM @fromtables    A3 _optionalorderbyidlimitoffset
 
---- Queries with scalar subqueries in the FROM clause (with optional ORDER BY, LIMIT or OFFSET clauses)
-SELECT * FROM (SELECT @agg(_variable)       FROM @fromtables                                                                 )    A4 _optionalorderby1limitoffset
-SELECT * FROM (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp                   __[#agg]) AS A5 _optionalorderby1limitoffset
-SELECT * FROM (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp _variable[@comparabletype]) AS A6 _optionalorderby1limitoffset
+--- Queries with scalar subqueries in the WHERE clause (with optional ORDER BY, LIMIT, OFFSET, GROUP BY or HAVING clauses)
+SELECT _variable[#ord]         FROM @fromtables A11 WHERE __[#ord] _cmp1 (SELECT @agg(       __[#ord]) FROM @fromtables                                      ) _grouporderbyvarlimoffhaving
+SELECT _variable[#ord numeric] FROM @fromtables A12 WHERE __[#ord] _cmp2 (SELECT @agg(_variable[#agg]) FROM @fromtables                                      ) _grouporderbyvarlimoffhaving
+SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#ord] _cmp3 (SELECT @agg(       __[#ord]) FROM @fromtables WHERE     __[#ord] _cmp3 A13.__[#ord]) _grouporderbyvarlimoffhaving
+SELECT _variable[#ord numeric] FROM @fromtables A14 WHERE __[#ord] _cmp2 (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A14.__[#agg] _cmp2     __[#agg]) _grouporderbyvarlimoffhaving
 
---- Queries with scalar subqueries in the WHERE clause (with optional ORDER BY, LIMIT or OFFSET clauses)
-SELECT _variable[#ord]         FROM @fromtables A7  WHERE __[#ord] _cmp (SELECT @agg(       __[#ord]) FROM @fromtables                                      ) _optionalorderbyvarlimitoffset
-SELECT _variable[#ord numeric] FROM @fromtables A8  WHERE __[#ord] _cmp (SELECT @agg(_variable[#agg]) FROM @fromtables                                      ) _optionalorderbyvarlimitoffset
-SELECT _variable[#ord]         FROM @fromtables A9  WHERE __[#ord] _cmp (SELECT @agg(       __[#ord]) FROM @fromtables WHERE        __[#ord] =   A9.__[#ord]) _optionalorderbyvarlimitoffset
-SELECT _variable[#ord]         FROM @fromtables A10 WHERE __[#ord] _cmp (SELECT @agg(       __[#ord]) FROM @fromtables WHERE        __[#ord] <> A10.__[#ord]) _optionalorderbyvarlimitoffset
-SELECT _variable[#ord numeric] FROM @fromtables A11 WHERE __[#ord] _cmp (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE    A11.__[#agg] <      __[#agg]) _optionalorderbyvarlimitoffset
-SELECT _variable[#ord numeric] FROM @fromtables A12 WHERE __[#ord] _cmp (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE    A12.__[#agg] >=     __[#agg]) _optionalorderbyvarlimitoffset
+--- TODO: uncomment this, once ENG-8234 is fixed, so the mismatches disappear:
+--SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _cmp3 (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[#sub] _cmp3 A15.__[#sub]) _grouporderbyvarlimoffhaving
+--- TODO: delete this, once ENG-8234 is fixed, so the above mismatches disappear:
+SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _cmp3 (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[#sub] _cmp3 A15.__[#sub]) _tempgrouporderbyvarlimoffhaving
 
---- TODO: uncomment these, once ENG-8234 is fixed, so the mismatches disappear:
---SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#agg] _cmp (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[#sub] <= A13.__[#sub]) _optionalorderbyvarlimitoffset
---SELECT _variable[#ord]         FROM @fromtables A14 WHERE __[#agg] _cmp (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[#sub] >  A14.__[#sub]) _optionalorderbyvarlimitoffset
---- TODO: delete these, once ENG-8234 is fixed, so the above mismatches disappear:
-SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#agg] _cmp (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[#sub] <= A13.__[#sub]) _tempoptionalorderbylimitoffset
-SELECT _variable[#ord]         FROM @fromtables A14 WHERE __[#agg] _cmp (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[#sub] >  A14.__[#sub]) _tempoptionalorderbylimitoffset
+--- Queries with scalar subqueries in the ORDER BY clause (these currently return errors, but probably should not - see ENG-8239)
+--- TODO: uncomment out, if/when ENG-8239 is fixed (meanwhile, commented out to save execution time)
+--SELECT @idcol FROM @fromtables A22 ORDER BY (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp1 A22.__[#agg]                  ) _sortorder _optionallimitoffset
+--SELECT @idcol FROM @fromtables A23 ORDER BY (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp2 A23._variable[@comparabletype]) _sortorder _optionallimitoffset
+--SELECT (SELECT @agg(_variable)       FROM @fromtables                                                                      ) C0 FROM @fromtables A24 ORDER BY C0 _sortorder _optionallimitoffset
+--SELECT (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp3 A25.__[#agg]                  )    FROM @fromtables A25 ORDER BY 1  _sortorder _optionallimitoffset
+--SELECT (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp1 A26._variable[@comparabletype]) C0 FROM @fromtables A26 ORDER BY C0 _sortorder _optionallimitoffset
 
---- Queries with scalar subqueries in the ORDER BY clause (these currently return errors, but probably should not)
-SELECT @idcol FROM @fromtables A15 ORDER BY (SELECT @agg(_variable)       FROM @fromtables                                                                     ) _sortorder _optionallimitoffset
-SELECT @idcol FROM @fromtables A16 ORDER BY (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp A16.__[#agg]                  ) _sortorder _optionallimitoffset
-SELECT @idcol FROM @fromtables A17 ORDER BY (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp A17._variable[@comparabletype]) _sortorder _optionallimitoffset
-SELECT (SELECT @agg(_variable)       FROM @fromtables                                                                     ) C0 FROM @fromtables A18 ORDER BY C0 _sortorder _optionallimitoffset
-SELECT (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp A19.__[#agg]                  )    FROM @fromtables A19 ORDER BY 1  _sortorder _optionallimitoffset
-SELECT (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp A20._variable[@comparabletype]) C0 FROM @fromtables A20 ORDER BY C0 _sortorder _optionallimitoffset
+--- Queries with scalar subqueries in the GROUP BY or HAVING clause (these work)
+SELECT (SELECT @agg(_variable[#agg])                 FROM @fromtables WHERE _variable[@comparabletype] _cmp1 A31._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A31 GROUP BY C0
+SELECT (SELECT @agg(_variable[#agg @comparabletype]) FROM @fromtables WHERE _variable[@comparabletype] _cmp2 A32._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A32 GROUP BY C0 HAVING @agg(__[#agg]) _cmp 12
+SELECT (SELECT _genericagg(_variable[#agg string])   FROM @fromtables WHERE _variable[@comparabletype] _cmp3 A33._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A33 GROUP BY C0 HAVING @agg(__[#agg]) _cmp 'Z'
+--- These do not currently work (meanwhile, commented out to save execution time)
+--SELECT (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _cmp A34._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A34 GROUP BY C0 HAVING C1 _cmp 12
+--SELECT _variable[#grp] C0, @agg(_variable[#agg]) C1  FROM @fromtables A35 GROUP BY C0 HAVING (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _cmp A35._variable[@comparabletype]) _cmp 12
+SELECT _variable[#grp] C0, @agg(_variable[#agg]) C1 FROM @fromtables A36 GROUP BY C0 HAVING @agg(__[#agg]) _cmp (SELECT @agg(__[#agg]) FROM @fromtables WHERE __[#grp] _cmp A36.__[#grp])
 
---- Queries with scalar subqueries in the LIMIT or OFFSET clause (these should, and do, return errors)
-SELECT _variable AS C0 FROM @fromtables A21 ORDER BY C0 _sortorder LIMIT (SELECT @agg(_variable) FROM @fromtables) _optionaloffset
-SELECT _variable AS C0 FROM @fromtables A22 ORDER BY C0 _sortorder LIMIT 3 OFFSET (SELECT @agg(_variable) FROM @fromtables)
+--- Queries with scalar subqueries containing a UNION (these ??)
+-- TBD


### PR DESCRIPTION
… merge to master, with responses, including:

deleted several GROUP BY id and GROUP BY 1 [HAVING] clauses; refactored and renamed _grouporderbyvarlimoffhaving (was _optionalorderbyvarlimitoffset), with related _temp0grouporderbyvarlimoffhaving (new) and _tempgrouporderbyvarlimoffhaving (was _tempoptionalorderbylimitoffset); changed @agg to _genericagg, where a string column was being used; deleted 'A4' query, but tweaked 'A2', to cover all comparison operators; deleted all 'Queries with scalar subqueries in the FROM clause'; deleted 'A21' query, with ORDER BY uncorrelated scalar subquery; deleted both 'Queries with scalar subqueries in the LIMIT or OFFSET clause' (already commented out); deleted all 'Queries with a simple UNION of one or more scalar subqueries'.