### PR TITLE
advanced-scalar-subquery.sql: commented out the 'A13' query, since it

### DIFF
--- a/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
+++ b/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
@@ -59,7 +59,8 @@ SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A3._variable
 --- Queries with scalar subqueries in the WHERE clause (with optional ORDER BY, LIMIT, OFFSET, GROUP BY or HAVING clauses)
 SELECT _variable[#ord]         FROM @fromtables A11 WHERE __[#ord] _cmp1 (SELECT @agg(       __[#ord]) FROM @fromtables                                      ) _grouporderbyvarlimoffhaving
 SELECT _variable[#ord numeric] FROM @fromtables A12 WHERE __[#ord] _cmp2 (SELECT @agg(_variable[#agg]) FROM @fromtables                                      ) _grouporderbyvarlimoffhaving
-SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#ord] _cmp3 (SELECT @agg(       __[#ord]) FROM @fromtables WHERE     __[#ord] _cmp3 A13.__[#ord]) _grouporderbyvarlimoffhaving
+--- TODO: uncomment, once ENG-8292 (NPE in Hsql for HAVING query, causing sqlCoverage mismatches) is fixed
+--SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#ord] _cmp3 (SELECT @agg(       __[#ord]) FROM @fromtables WHERE     __[#ord] _cmp3 A13.__[#ord]) _grouporderbyvarlimoffhaving
 SELECT _variable[#ord numeric] FROM @fromtables A14 WHERE __[#ord] _cmp2 (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A14.__[#agg] _cmp2     __[#agg]) _grouporderbyvarlimoffhaving
 
 --- TODO: uncomment this, once ENG-8234 is fixed, so the mismatches disappear:


### PR DESCRIPTION
was causing mismatches (ENG-8292).