### PR TITLE
Eng 8299 no exclude join conditions

### DIFF
--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -256,6 +256,8 @@ public class PlannerTool {
                 }
             } catch (Exception e) {
                 throw new RuntimeException("Error compiling query: " + e.toString(), e);
+            } catch (AssertionError ae) {
+                throw new RuntimeException("Assertion Error compiling query: " + ae.toString(), ae);
             }
 
             if (plan == null) {

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
@@ -2014,7 +2014,6 @@ public class RangeVariable {
             Expression indexConds = Expression.voltCombineWithAnd(indexCond);
             Expression indexEndConds = Expression.voltCombineWithAnd(indexEndCond);
             return Expression.voltCombineWithAnd(indexEndCondition,
-                                                 excludeConditions,
                                                  nonIndexCondition,
                                                  terminalCondition,
                                                  indexConds,

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/VoltXMLElement.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/VoltXMLElement.java
@@ -75,21 +75,37 @@ public class VoltXMLElement {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        append(sb, "");
+        append(sb, 0);
         return sb.toString();
     }
 
-    private void append(StringBuilder sb, String indent) {
-        sb.append(indent).append("ELEMENT: ").append(name).append("\n");
+    private String indentString(int indent) {
+        final int indentSize = 4;
+        final String indentString = "...|";
+        StringBuffer sb = new StringBuffer(indent);
+        int idx;
+        for (idx = 0; (idx + indentSize) <= indent; idx += indentSize) {
+            sb.append(indentString);
+        }
+        for (;idx < indent; idx += 1) {
+            sb.append(".");
+        }
+        return sb.toString();
+    }
+    private void append(StringBuilder sb, int indent) {
+        String is = indentString(indent);
+        String is2 = indentString(indent+3);
+        sb.append(is).append("ELEMENT: ").append(name).append("\n");
         for (Entry<String, String> e : attributes.entrySet()) {
-            sb.append(indent).append(" ").append(e.getKey());
+            sb.append(is2).append(e.getKey());
             sb.append(" = ").append(e.getValue()).append("\n");
         }
         if ( ! children.isEmpty()) {
-            sb.append(indent).append("[").append("\n");
+            sb.append(is).append("[\n");
             for (VoltXMLElement e : children) {
-                e.append(sb, indent + "   ");
+                e.append(sb, indent + 3);
             }
+            sb.append(is).append("]\n");
         }
     }
 

--- a/tests/log4j-allconsole.xml
+++ b/tests/log4j-allconsole.xml
@@ -40,6 +40,10 @@
         <level value="INFO"/>
     </logger -->
 
+    <!--logger name="HSQLCOMPILER">
+        <level value="DEBUG"/>
+    </logger -->
+
     <!-- logger name="ADHOC">
         <level value="INFO"/>
     </logger -->


### PR DESCRIPTION
In this commit I do three things.

1. I make it possible to dump SQL statements, HSQLDB ASTs and VoltXML ASTs using the standard Volt logging mechanism.
1. I fix ENG-8299, which caused expressions to seem to ignore the right hand operand of binary operators.
1. I fix ENG-8262, which caused hangs when assertion failures in the PlannerTool circumvented the return of responses from the server to the client.  This needs to be merged to master sooner rather than later.