### PR TITLE
fixes run.sh demo

### DIFF
--- a/examples/uniquedevices/run.sh
+++ b/examples/uniquedevices/run.sh
@@ -106,7 +106,7 @@ function init() {
 
 # wait for backgrounded server to start up
 function wait_for_startup() {
-    until sqlcmd  --query=' exec @SystemInformation, OVERVIEW;' > /dev/null 2>&1
+    until echo "exec @SystemInformation, OVERVIEW;" | sqlcmd &> /dev/null
     do
         sleep 2
         echo " ... Waiting for VoltDB to start"

--- a/examples/uniquedevices/run.sh
+++ b/examples/uniquedevices/run.sh
@@ -106,7 +106,7 @@ function init() {
 
 # wait for backgrounded server to start up
 function wait_for_startup() {
-    until echo "exec @SystemInformation, OVERVIEW;" | sqlcmd &> /dev/null
+    until echo "exec @SystemInformation, OVERVIEW;" | sqlcmd > /dev/null 2>&1
     do
         sleep 2
         echo " ... Waiting for VoltDB to start"

--- a/examples/voter/run.sh
+++ b/examples/voter/run.sh
@@ -93,7 +93,7 @@ function init() {
 
 # wait for backgrounded server to start up
 function wait_for_startup() {
-    until sqlcmd  --query=' exec @SystemInformation, OVERVIEW;' > /dev/null 2>&1
+    until echo "exec @SystemInformation, OVERVIEW;" | sqlcmd &> /dev/null
     do
         sleep 2
         echo " ... Waiting for VoltDB to start"

--- a/examples/voter/run.sh
+++ b/examples/voter/run.sh
@@ -93,7 +93,7 @@ function init() {
 
 # wait for backgrounded server to start up
 function wait_for_startup() {
-    until echo "exec @SystemInformation, OVERVIEW;" | sqlcmd &> /dev/null
+    until echo "exec @SystemInformation, OVERVIEW;" | sqlcmd > /dev/null 2>&1
     do
         sleep 2
         echo " ... Waiting for VoltDB to start"


### PR DESCRIPTION
Several customers have reported problems running the voter demo.  It gets stuck on "... Waiting for VoltDB to start".  It stops printing this because it has actually succeeded, but sqlcmd is waiting for entry or somehow not exiting properly when invoked using the --query parameter and redirecting output.  When it is invoked using STDIN, it exits as expected.  This behavior is only seen on a Mac, on Linux (even old versions) it works as expected.

I filed a ticket for sqlcmd to exit properly in this scenario, but this minor change to the run.sh script fixes the demo on a Mac.  I will be making the same changes to the separate app-* demos on github.