### PR TITLE
ENG-8222

### DIFF
--- a/tests/frontend/org/voltdb/TestJdbcDatabaseMetaDataGenerator.java
+++ b/tests/frontend/org/voltdb/TestJdbcDatabaseMetaDataGenerator.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import junit.framework.TestCase;
 
 import org.hsqldb_voltpatches.HSQLInterface;
+import org.json_voltpatches.JSONObject;
 import org.voltdb.compiler.VoltCompiler;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.types.VoltDecimalHelper;
@@ -96,10 +97,10 @@ public class TestJdbcDatabaseMetaDataGenerator extends TestCase
         assertEquals(null, tables.get("REMARKS", VoltType.STRING));
         assertTrue(VoltTableTestHelpers.moveToMatchingRow(tables, "TABLE_NAME", "View1"));
         assertTrue(tables.get("TABLE_TYPE", VoltType.STRING).equals("VIEW"));
-        assertTrue(tables.get("REMARKS", VoltType.STRING).equals("{\"partitionColumn\":\"COLUMN1\",\"sourceTable\":\"TABLE1\"}"));
+        assertTrue(tables.get("REMARKS", VoltType.STRING).equals(new JSONObject("{\"partitionColumn\":\"COLUMN1\",\"sourceTable\":\"TABLE1\"}").toString()));
         assertTrue(VoltTableTestHelpers.moveToMatchingRow(tables, "TABLE_NAME", "View2"));
         assertTrue(tables.get("TABLE_TYPE", VoltType.STRING).equals("VIEW"));
-        assertTrue(tables.get("REMARKS", VoltType.STRING).equals("{\"partitionColumn\":\"COLUMN1\",\"sourceTable\":\"TABLE1\"}"));
+        assertTrue(tables.get("REMARKS", VoltType.STRING).equals(new JSONObject("{\"partitionColumn\":\"COLUMN1\",\"sourceTable\":\"TABLE1\"}").toString()));
         assertTrue(VoltTableTestHelpers.moveToMatchingRow(tables, "TABLE_NAME", "Export1"));
         assertTrue(tables.get("TABLE_TYPE", VoltType.STRING).equals("EXPORT"));
         assertTrue(VoltTableTestHelpers.moveToMatchingRow(tables, "TABLE_NAME", "Export2"));

--- a/tests/frontend/org/voltdb/compilereport/TestReportMaker.java
+++ b/tests/frontend/org/voltdb/compilereport/TestReportMaker.java
@@ -22,6 +22,7 @@
  */
 
 package org.voltdb.compilereport;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;

--- a/tests/frontend/org/voltdb/compilereport/TestReportMaker.java
+++ b/tests/frontend/org/voltdb/compilereport/TestReportMaker.java
@@ -22,7 +22,6 @@
  */
 
 package org.voltdb.compilereport;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
@@ -120,7 +119,10 @@ public class TestReportMaker extends TestCase {
 
         // "Explain Plan" output should also be escaped:
         // (spaces in explain plan are replaced by &nbsp;)
-        assertTrue(report.contains("filter&nbsp;by&nbsp;((I&nbsp;&lt;&nbsp;?0)&nbsp;AND&nbsp;(I&nbsp;&gt;&nbsp;?1))"));
+        assertTrue(report.contains("filter&nbsp;by&nbsp;"));
+        assertTrue(report.contains("(I&nbsp;&gt;&nbsp;?1)"));
+        assertTrue(report.contains("&nbsp;AND&nbsp;"));
+        assertTrue(report.contains("(I&nbsp;&lt;&nbsp;?0)"));
 
         // Warnings in the Overview tab should have escaped ", &, <, >, etc.
         assertTrue(report.contains("To eliminate this warning, specify &quot;VARCHAR(262145 BYTES)&quot;"));

--- a/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
@@ -80,30 +80,30 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             // Check param indexes
             AbstractExpression e = nps.getPredicate();
             AbstractExpression le = e.getLeft();
-            if (le.getExpressionType().equals(ExpressionType.COMPARE_GREATERTHAN)) {
-            	assertEquals(ExpressionType.COMPARE_GREATERTHAN, le.getExpressionType());
-            	AbstractExpression pve = le.getRight();
-            	assertEquals(ExpressionType.VALUE_PARAMETER, pve.getExpressionType());
-            	assertEquals(new Integer(0), ((ParameterValueExpression)pve).getParameterIndex());
-            	AbstractExpression re = e.getRight();
-            	assertEquals(ExpressionType.OPERATOR_EXISTS, re.getExpressionType());
-            	AbstractSubqueryExpression se = (AbstractSubqueryExpression) re.getLeft();
-            	assertEquals(1, se.getArgs().size());
-            	assertEquals(1, se.getParameterIdxList().size());
-            	assertEquals(Integer.valueOf(1), se.getParameterIdxList().get(0));
+            if (le.getExpressionType().equals(ExpressionType.COMPARE_GREATERTHAN))  {
+                assertEquals(ExpressionType.COMPARE_GREATERTHAN, le.getExpressionType());
+                AbstractExpression pve = le.getRight();
+                assertEquals(ExpressionType.VALUE_PARAMETER, pve.getExpressionType());
+                assertEquals(new Integer(0), ((ParameterValueExpression)pve).getParameterIndex());
+                AbstractExpression re = e.getRight();
+                assertEquals(ExpressionType.OPERATOR_EXISTS, re.getExpressionType());
+                AbstractSubqueryExpression se = (AbstractSubqueryExpression) re.getLeft();
+                assertEquals(1, se.getArgs().size());
+                assertEquals(1, se.getParameterIdxList().size());
+                assertEquals(Integer.valueOf(1), se.getParameterIdxList().get(0));
             }
             else{
-            	le = e.getRight();
-            	assertEquals(ExpressionType.COMPARE_GREATERTHAN, le.getExpressionType());
-            	AbstractExpression pve = le.getRight();
-            	assertEquals(ExpressionType.VALUE_PARAMETER, pve.getExpressionType());
-            	assertEquals(new Integer(0), ((ParameterValueExpression)pve).getParameterIndex());
-            	AbstractExpression re = e.getLeft();
-            	assertEquals(ExpressionType.OPERATOR_EXISTS, re.getExpressionType());
-            	AbstractSubqueryExpression se = (AbstractSubqueryExpression) re.getLeft();
-            	assertEquals(1, se.getArgs().size());
-            	assertEquals(1, se.getParameterIdxList().size());
-            	assertEquals(Integer.valueOf(1), se.getParameterIdxList().get(0));
+                le = e.getRight();
+                assertEquals(ExpressionType.COMPARE_GREATERTHAN, le.getExpressionType());
+                AbstractExpression pve = le.getRight();
+                assertEquals(ExpressionType.VALUE_PARAMETER, pve.getExpressionType());
+                assertEquals(new Integer(0), ((ParameterValueExpression)pve).getParameterIndex());
+                AbstractExpression re = e.getLeft();
+                assertEquals(ExpressionType.OPERATOR_EXISTS, re.getExpressionType());
+                AbstractSubqueryExpression se = (AbstractSubqueryExpression) re.getLeft();
+                assertEquals(1, se.getArgs().size());
+                assertEquals(1, se.getParameterIdxList().size());
+                assertEquals(Integer.valueOf(1), se.getParameterIdxList().get(0));
             }
         }
         {
@@ -313,17 +313,17 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             // order of elements in TubleVauleExperssion is not consistent on Java 7 and Java 8
             TupleValueExpression tve = (TupleValueExpression)args.get(0);
             if (tve.getTableName().equals("R2")) {
-            	assertEquals("A", tve.getColumnName());
-            	tve = (TupleValueExpression)args.get(1);
-            	assertEquals("R1", tve.getTableName());
-            	assertEquals("D", tve.getColumnName());
+                assertEquals("A", tve.getColumnName());
+                tve = (TupleValueExpression)args.get(1);
+                assertEquals("R1", tve.getTableName());
+                assertEquals("D", tve.getColumnName());
             }
             else {
-            	assertEquals("R1", tve.getTableName());
-            	assertEquals("D", tve.getColumnName());
-            	tve = (TupleValueExpression)args.get(1);
-            	assertEquals("R2", tve.getTableName());
-            	assertEquals("A", tve.getColumnName());
+                assertEquals("R1", tve.getTableName());
+                assertEquals("D", tve.getColumnName());
+                tve = (TupleValueExpression)args.get(1);
+                assertEquals("R2", tve.getTableName());
+                assertEquals("A", tve.getColumnName());
             }
             assertEquals(2, se.getParameterIdxList().size());
             // Child query
@@ -360,17 +360,17 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             assertEquals(2, args.size());
             TupleValueExpression tve = (TupleValueExpression)args.get(0);
             if (tve.getTableName().equals("R2")) {
-            	assertEquals("C", tve.getColumnName());
-            	tve = (TupleValueExpression)args.get(1);
-            	assertEquals("R1", tve.getTableName());
-            	assertEquals("A", tve.getColumnName());
+                assertEquals("C", tve.getColumnName());
+                tve = (TupleValueExpression)args.get(1);
+                assertEquals("R1", tve.getTableName());
+                assertEquals("A", tve.getColumnName());
             }
             else {
-            	assertEquals("R1", tve.getTableName());
-            	assertEquals("A", tve.getColumnName());
-            	tve = (TupleValueExpression)args.get(1);
-            	assertEquals("R2", tve.getTableName());
-            	assertEquals("C", tve.getColumnName());
+                assertEquals("R1", tve.getTableName());
+                assertEquals("A", tve.getColumnName());
+                tve = (TupleValueExpression)args.get(1);
+                assertEquals("R2", tve.getTableName());
+                assertEquals("C", tve.getColumnName());
             }
             assertEquals(2, se.getParameterIdxList().size());
             // Child query
@@ -471,25 +471,25 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             failToCompile(sql, HavingErrorMsg);
 
             // ENG-8306: Uncomment next block when HAVING with subquery is supported
-//            AbstractPlanNode pn = compile(sql);
-//            pn = pn.getChild(0);
-//            assertTrue(pn instanceof ProjectionPlanNode);
-//            pn = pn.getChild(0);
-//            assertTrue(pn instanceof SeqScanPlanNode);
-//            AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(pn);
-//            assertNotNull(aggNode);
-//            NodeSchema ns = aggNode.getOutputSchema();
-//            assertEquals(2, ns.size());
-//            SchemaColumn aggColumn = ns.getColumns().get(1);
-//            assertEquals("$$_MAX_$$_1", aggColumn.getColumnAlias());
-//            AbstractExpression having = aggNode.getPostPredicate();
-//            assertEquals(ExpressionType.OPERATOR_EXISTS, having.getExpressionType());
-//            AbstractExpression se = having.getLeft();
-//            assertEquals(1, se.getArgs().size());
-//            assertTrue(se.getArgs().get(0) instanceof TupleValueExpression);
-//            TupleValueExpression argTve = (TupleValueExpression) se.getArgs().get(0);
-//            assertEquals(1, argTve.getColumnIndex());
-//            assertEquals("$$_MAX_$$_1", argTve.getColumnAlias());
+            //            AbstractPlanNode pn = compile(sql);
+            //            pn = pn.getChild(0);
+            //            assertTrue(pn instanceof ProjectionPlanNode);
+            //            pn = pn.getChild(0);
+            //            assertTrue(pn instanceof SeqScanPlanNode);
+            //            AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(pn);
+            //            assertNotNull(aggNode);
+            //            NodeSchema ns = aggNode.getOutputSchema();
+            //            assertEquals(2, ns.size());
+            //            SchemaColumn aggColumn = ns.getColumns().get(1);
+            //            assertEquals("$$_MAX_$$_1", aggColumn.getColumnAlias());
+            //            AbstractExpression having = aggNode.getPostPredicate();
+            //            assertEquals(ExpressionType.OPERATOR_EXISTS, having.getExpressionType());
+            //            AbstractExpression se = having.getLeft();
+            //            assertEquals(1, se.getArgs().size());
+            //            assertTrue(se.getArgs().get(0) instanceof TupleValueExpression);
+            //            TupleValueExpression argTve = (TupleValueExpression) se.getArgs().get(0);
+            //            assertEquals(1, argTve.getColumnIndex());
+            //            assertEquals("$$_MAX_$$_1", argTve.getColumnAlias());
         }
         {
             // HAVING expression evaluates to TRUE and dropped
@@ -645,23 +645,23 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             /**
              * Uncomment these tests when ENG-8306 is finished
              */
-//            // parent correlated TVE in the aggregate expression.
-//            AbstractPlanNode pn = compile("select max(c) from r1 group by a " +
-//                    " having count(*) = (select c from r2 where r2.c = r1.a)");
-//
-//            pn = pn.getChild(0);
-//            assertTrue(pn instanceof  ProjectionPlanNode);
-//            pn = pn.getChild(0);
-//            assertTrue(pn instanceof SeqScanPlanNode);
-//            AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(pn);
-//            assertNotNull(aggNode);
-//            assertNotNull(aggNode instanceof HashAggregatePlanNode);
-//            assertEquals(3, aggNode.getOutputSchema().size()); // group by key, max, count
-//
-//            AbstractExpression aggrExpr = aggNode.getPostPredicate();
-//            assertEquals(ExpressionType.COMPARE_EQUAL, aggrExpr.getExpressionType());
-//            assertTrue(aggrExpr.getLeft() instanceof TupleValueExpression);
-//            assertTrue(aggrExpr.getRight() instanceof SelectSubqueryExpression);
+            //            // parent correlated TVE in the aggregate expression.
+            //            AbstractPlanNode pn = compile("select max(c) from r1 group by a " +
+            //                    " having count(*) = (select c from r2 where r2.c = r1.a)");
+            //
+            //            pn = pn.getChild(0);
+            //            assertTrue(pn instanceof  ProjectionPlanNode);
+            //            pn = pn.getChild(0);
+            //            assertTrue(pn instanceof SeqScanPlanNode);
+            //            AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(pn);
+            //            assertNotNull(aggNode);
+            //            assertNotNull(aggNode instanceof HashAggregatePlanNode);
+            //            assertEquals(3, aggNode.getOutputSchema().size()); // group by key, max, count
+            //
+            //            AbstractExpression aggrExpr = aggNode.getPostPredicate();
+            //            assertEquals(ExpressionType.COMPARE_EQUAL, aggrExpr.getExpressionType());
+            //            assertTrue(aggrExpr.getLeft() instanceof TupleValueExpression);
+            //            assertTrue(aggrExpr.getRight() instanceof SelectSubqueryExpression);
         }
     }
 
@@ -669,21 +669,21 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         {
             // LIMIT is 0 EXISTS => FALSE
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                " (select a, c  from r2 limit 0) ");
+                    " (select a, c  from r2 limit 0) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyCVEPredicate(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), false);
         }
         {
             // LIMIT is 0 EXISTS => FALSE
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                " (select count(*)  from r2 limit 0) ");
+                    " (select count(*)  from r2 limit 0) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyCVEPredicate(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), false);
         }
         {
             //EXISTS => TRUE, join predicate is TRUE or EXPR = > TRUE and dropped
             AbstractPlanNode pn = compile("select a from r1 join r2 on (exists " +
-                " (select max(a)  from r2) or r2.a > 0)");
+                    " (select max(a)  from r2) or r2.a > 0)");
             assertEquals(true, pn.getChild(0).getChild(0) instanceof AbstractJoinPlanNode);
             AbstractJoinPlanNode jpn = (AbstractJoinPlanNode) pn.getChild(0).getChild(0);
             assertEquals(true, jpn.getWherePredicate() == null);
@@ -691,7 +691,7 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         {
             //EXISTS => FALSE, join predicate is retained
             AbstractPlanNode pn = compile("select a from r1 join r2 on exists " +
-                " (select max(a)  from r2 offset 1) ");
+                    " (select max(a)  from r2 offset 1) ");
             assertEquals(true, pn.getChild(0).getChild(0) instanceof NestLoopPlanNode);
             NestLoopPlanNode jpn = (NestLoopPlanNode) pn.getChild(0).getChild(0);
             verifyCVEPredicate(jpn.getJoinPredicate(), false);
@@ -699,21 +699,21 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         {
             // table-agg-without-having-groupby OFFSET > 0 => FALSE
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                " (select count(*)  from r2 offset 1) ");
+                    " (select count(*)  from r2 offset 1) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyCVEPredicate(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), false);
         }
         {
             // table-agg-without-having-groupby  => TRUE
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                " (select max(a)  from r2) ");
+                    " (select max(a)  from r2) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             assertEquals(true, ((SeqScanPlanNode) pn.getChild(0)).getPredicate() == null);
         }
         {
             // table-agg-without-having-groupby by limit is a parameter => EXISTS
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                " (select max(a)  from r2 limit ?) ");
+                    " (select max(a)  from r2 limit ?) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             AbstractExpression p = ((SeqScanPlanNode) pn.getChild(0)).getPredicate();
             assertEquals(true, p != null);
@@ -722,7 +722,7 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         {
             // Subquery => select 1 from r2 limit 1 offset 2
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                " (select a, c  from r2 order by a offset 2) ");
+                    " (select a, c  from r2 order by a offset 2) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyTrivialSchemaLimitOffset(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), 1, 2);
         }
@@ -730,21 +730,21 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             // User's limit ?
             // Subquery => EXISTS (select 1 from r2 limit ?)
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                " (select a, c  from r2 order by a limit ?) ");
+                    " (select a, c  from r2 order by a limit ?) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyTrivialSchemaLimitOffset(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), -1, 0);
         }
         {
             // Subquery subquery-without-having with group by and no limit => select max(c) from r2 limit 1
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                " (select a, max(c) from r2 group by a order by max(c))");
+                    " (select a, max(c) from r2 group by a order by max(c))");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyAggregateSubquery(((SeqScanPlanNode)pn.getChild(0)).getPredicate(), 1, 0, false);
         }
         {
-         // Subquery subquery-without-having with group by and offset 3 => subquery-without-having with group by and offset 3
+            // Subquery subquery-without-having with group by and offset 3 => subquery-without-having with group by and offset 3
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                " (select a, max(c) from r2 group by a order by max(c) offset 2)");
+                    " (select a, max(c) from r2 group by a order by max(c) offset 2)");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyAggregateSubquery(((SeqScanPlanNode)pn.getChild(0)).getPredicate(), 2, 1, false);
         }

--- a/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
@@ -471,25 +471,25 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             failToCompile(sql, HavingErrorMsg);
 
             // ENG-8306: Uncomment next block when HAVING with subquery is supported
-            //            AbstractPlanNode pn = compile(sql);
-            //            pn = pn.getChild(0);
-            //            assertTrue(pn instanceof ProjectionPlanNode);
-            //            pn = pn.getChild(0);
-            //            assertTrue(pn instanceof SeqScanPlanNode);
-            //            AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(pn);
-            //            assertNotNull(aggNode);
-            //            NodeSchema ns = aggNode.getOutputSchema();
-            //            assertEquals(2, ns.size());
-            //            SchemaColumn aggColumn = ns.getColumns().get(1);
-            //            assertEquals("$$_MAX_$$_1", aggColumn.getColumnAlias());
-            //            AbstractExpression having = aggNode.getPostPredicate();
-            //            assertEquals(ExpressionType.OPERATOR_EXISTS, having.getExpressionType());
-            //            AbstractExpression se = having.getLeft();
-            //            assertEquals(1, se.getArgs().size());
-            //            assertTrue(se.getArgs().get(0) instanceof TupleValueExpression);
-            //            TupleValueExpression argTve = (TupleValueExpression) se.getArgs().get(0);
-            //            assertEquals(1, argTve.getColumnIndex());
-            //            assertEquals("$$_MAX_$$_1", argTve.getColumnAlias());
+//            AbstractPlanNode pn = compile(sql);
+//            pn = pn.getChild(0);
+//            assertTrue(pn instanceof ProjectionPlanNode);
+//            pn = pn.getChild(0);
+//            assertTrue(pn instanceof SeqScanPlanNode);
+//            AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(pn);
+//            assertNotNull(aggNode);
+//            NodeSchema ns = aggNode.getOutputSchema();
+//            assertEquals(2, ns.size());
+//            SchemaColumn aggColumn = ns.getColumns().get(1);
+//            assertEquals("$$_MAX_$$_1", aggColumn.getColumnAlias());
+//            AbstractExpression having = aggNode.getPostPredicate();
+//            assertEquals(ExpressionType.OPERATOR_EXISTS, having.getExpressionType());
+//            AbstractExpression se = having.getLeft();
+//            assertEquals(1, se.getArgs().size());
+//            assertTrue(se.getArgs().get(0) instanceof TupleValueExpression);
+//            TupleValueExpression argTve = (TupleValueExpression) se.getArgs().get(0);
+//            assertEquals(1, argTve.getColumnIndex());
+//            assertEquals("$$_MAX_$$_1", argTve.getColumnAlias());
         }
         {
             // HAVING expression evaluates to TRUE and dropped
@@ -645,23 +645,23 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             /**
              * Uncomment these tests when ENG-8306 is finished
              */
-            //            // parent correlated TVE in the aggregate expression.
-            //            AbstractPlanNode pn = compile("select max(c) from r1 group by a " +
-            //                    " having count(*) = (select c from r2 where r2.c = r1.a)");
-            //
-            //            pn = pn.getChild(0);
-            //            assertTrue(pn instanceof  ProjectionPlanNode);
-            //            pn = pn.getChild(0);
-            //            assertTrue(pn instanceof SeqScanPlanNode);
-            //            AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(pn);
-            //            assertNotNull(aggNode);
-            //            assertNotNull(aggNode instanceof HashAggregatePlanNode);
-            //            assertEquals(3, aggNode.getOutputSchema().size()); // group by key, max, count
-            //
-            //            AbstractExpression aggrExpr = aggNode.getPostPredicate();
-            //            assertEquals(ExpressionType.COMPARE_EQUAL, aggrExpr.getExpressionType());
-            //            assertTrue(aggrExpr.getLeft() instanceof TupleValueExpression);
-            //            assertTrue(aggrExpr.getRight() instanceof SelectSubqueryExpression);
+//            // parent correlated TVE in the aggregate expression.
+//            AbstractPlanNode pn = compile("select max(c) from r1 group by a " +
+//                    " having count(*) = (select c from r2 where r2.c = r1.a)");
+//
+//            pn = pn.getChild(0);
+//            assertTrue(pn instanceof  ProjectionPlanNode);
+//            pn = pn.getChild(0);
+//            assertTrue(pn instanceof SeqScanPlanNode);
+//            AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(pn);
+//            assertNotNull(aggNode);
+//            assertNotNull(aggNode instanceof HashAggregatePlanNode);
+//            assertEquals(3, aggNode.getOutputSchema().size()); // group by key, max, count
+//
+//            AbstractExpression aggrExpr = aggNode.getPostPredicate();
+//            assertEquals(ExpressionType.COMPARE_EQUAL, aggrExpr.getExpressionType());
+//            assertTrue(aggrExpr.getLeft() instanceof TupleValueExpression);
+//            assertTrue(aggrExpr.getRight() instanceof SelectSubqueryExpression);
         }
     }
 
@@ -669,21 +669,21 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         {
             // LIMIT is 0 EXISTS => FALSE
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                    " (select a, c  from r2 limit 0) ");
+                " (select a, c  from r2 limit 0) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyCVEPredicate(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), false);
         }
         {
             // LIMIT is 0 EXISTS => FALSE
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                    " (select count(*)  from r2 limit 0) ");
+                " (select count(*)  from r2 limit 0) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyCVEPredicate(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), false);
         }
         {
             //EXISTS => TRUE, join predicate is TRUE or EXPR = > TRUE and dropped
             AbstractPlanNode pn = compile("select a from r1 join r2 on (exists " +
-                    " (select max(a)  from r2) or r2.a > 0)");
+                " (select max(a)  from r2) or r2.a > 0)");
             assertEquals(true, pn.getChild(0).getChild(0) instanceof AbstractJoinPlanNode);
             AbstractJoinPlanNode jpn = (AbstractJoinPlanNode) pn.getChild(0).getChild(0);
             assertEquals(true, jpn.getWherePredicate() == null);
@@ -691,7 +691,7 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         {
             //EXISTS => FALSE, join predicate is retained
             AbstractPlanNode pn = compile("select a from r1 join r2 on exists " +
-                    " (select max(a)  from r2 offset 1) ");
+                " (select max(a)  from r2 offset 1) ");
             assertEquals(true, pn.getChild(0).getChild(0) instanceof NestLoopPlanNode);
             NestLoopPlanNode jpn = (NestLoopPlanNode) pn.getChild(0).getChild(0);
             verifyCVEPredicate(jpn.getJoinPredicate(), false);
@@ -699,21 +699,21 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         {
             // table-agg-without-having-groupby OFFSET > 0 => FALSE
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                    " (select count(*)  from r2 offset 1) ");
+                " (select count(*)  from r2 offset 1) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyCVEPredicate(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), false);
         }
         {
             // table-agg-without-having-groupby  => TRUE
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                    " (select max(a)  from r2) ");
+                " (select max(a)  from r2) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             assertEquals(true, ((SeqScanPlanNode) pn.getChild(0)).getPredicate() == null);
         }
         {
             // table-agg-without-having-groupby by limit is a parameter => EXISTS
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                    " (select max(a)  from r2 limit ?) ");
+                " (select max(a)  from r2 limit ?) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             AbstractExpression p = ((SeqScanPlanNode) pn.getChild(0)).getPredicate();
             assertEquals(true, p != null);
@@ -722,7 +722,7 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         {
             // Subquery => select 1 from r2 limit 1 offset 2
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                    " (select a, c  from r2 order by a offset 2) ");
+                " (select a, c  from r2 order by a offset 2) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyTrivialSchemaLimitOffset(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), 1, 2);
         }
@@ -730,21 +730,21 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             // User's limit ?
             // Subquery => EXISTS (select 1 from r2 limit ?)
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                    " (select a, c  from r2 order by a limit ?) ");
+                " (select a, c  from r2 order by a limit ?) ");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyTrivialSchemaLimitOffset(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), -1, 0);
         }
         {
             // Subquery subquery-without-having with group by and no limit => select max(c) from r2 limit 1
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                    " (select a, max(c) from r2 group by a order by max(c))");
+                " (select a, max(c) from r2 group by a order by max(c))");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyAggregateSubquery(((SeqScanPlanNode)pn.getChild(0)).getPredicate(), 1, 0, false);
         }
         {
-            // Subquery subquery-without-having with group by and offset 3 => subquery-without-having with group by and offset 3
+         // Subquery subquery-without-having with group by and offset 3 => subquery-without-having with group by and offset 3
             AbstractPlanNode pn = compile("select a from r1 where exists " +
-                    " (select a, max(c) from r2 group by a order by max(c) offset 2)");
+                " (select a, max(c) from r2 group by a order by max(c) offset 2)");
             assertEquals(true, pn.getChild(0) instanceof SeqScanPlanNode);
             verifyAggregateSubquery(((SeqScanPlanNode)pn.getChild(0)).getPredicate(), 2, 1, false);
         }

--- a/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
@@ -80,16 +80,31 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             // Check param indexes
             AbstractExpression e = nps.getPredicate();
             AbstractExpression le = e.getLeft();
-            assertEquals(ExpressionType.COMPARE_GREATERTHAN, le.getExpressionType());
-            AbstractExpression pve = le.getRight();
-            assertEquals(ExpressionType.VALUE_PARAMETER, pve.getExpressionType());
-            assertEquals(new Integer(0), ((ParameterValueExpression)pve).getParameterIndex());
-            AbstractExpression re = e.getRight();
-            assertEquals(ExpressionType.OPERATOR_EXISTS, re.getExpressionType());
-            AbstractSubqueryExpression se = (AbstractSubqueryExpression) re.getLeft();
-            assertEquals(1, se.getArgs().size());
-            assertEquals(1, se.getParameterIdxList().size());
-            assertEquals(Integer.valueOf(1), se.getParameterIdxList().get(0));
+            if (le.getExpressionType().equals(ExpressionType.COMPARE_GREATERTHAN)) {
+            	assertEquals(ExpressionType.COMPARE_GREATERTHAN, le.getExpressionType());
+            	AbstractExpression pve = le.getRight();
+            	assertEquals(ExpressionType.VALUE_PARAMETER, pve.getExpressionType());
+            	assertEquals(new Integer(0), ((ParameterValueExpression)pve).getParameterIndex());
+            	AbstractExpression re = e.getRight();
+            	assertEquals(ExpressionType.OPERATOR_EXISTS, re.getExpressionType());
+            	AbstractSubqueryExpression se = (AbstractSubqueryExpression) re.getLeft();
+            	assertEquals(1, se.getArgs().size());
+            	assertEquals(1, se.getParameterIdxList().size());
+            	assertEquals(Integer.valueOf(1), se.getParameterIdxList().get(0));
+            }
+            else{
+            	le = e.getRight();
+            	assertEquals(ExpressionType.COMPARE_GREATERTHAN, le.getExpressionType());
+            	AbstractExpression pve = le.getRight();
+            	assertEquals(ExpressionType.VALUE_PARAMETER, pve.getExpressionType());
+            	assertEquals(new Integer(0), ((ParameterValueExpression)pve).getParameterIndex());
+            	AbstractExpression re = e.getLeft();
+            	assertEquals(ExpressionType.OPERATOR_EXISTS, re.getExpressionType());
+            	AbstractSubqueryExpression se = (AbstractSubqueryExpression) re.getLeft();
+            	assertEquals(1, se.getArgs().size());
+            	assertEquals(1, se.getParameterIdxList().size());
+            	assertEquals(Integer.valueOf(1), se.getParameterIdxList().get(0));
+            }
         }
         {
             // Subqueries  with  grand-parent TVE
@@ -295,12 +310,21 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             AbstractSubqueryExpression se = (AbstractSubqueryExpression) e.getLeft();
             List<AbstractExpression> args = se.getArgs();
             assertEquals(2, args.size());
+            // order of elements in TubleVauleExperssion is not consistent on Java 7 and Java 8
             TupleValueExpression tve = (TupleValueExpression)args.get(0);
-            assertEquals("R2", tve.getTableName());
-            assertEquals("A", tve.getColumnName());
-            tve = (TupleValueExpression)args.get(1);
-            assertEquals("R1", tve.getTableName());
-            assertEquals("D", tve.getColumnName());
+            if (tve.getTableName().equals("R2")) {
+            	assertEquals("A", tve.getColumnName());
+            	tve = (TupleValueExpression)args.get(1);
+            	assertEquals("R1", tve.getTableName());
+            	assertEquals("D", tve.getColumnName());
+            }
+            else {
+            	assertEquals("R1", tve.getTableName());
+            	assertEquals("D", tve.getColumnName());
+            	tve = (TupleValueExpression)args.get(1);
+            	assertEquals("R2", tve.getTableName());
+            	assertEquals("A", tve.getColumnName());
+            }
             assertEquals(2, se.getParameterIdxList().size());
             // Child query
             pn = se.getSubqueryNode();
@@ -335,11 +359,19 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
             List<AbstractExpression> args = se.getArgs();
             assertEquals(2, args.size());
             TupleValueExpression tve = (TupleValueExpression)args.get(0);
-            assertEquals("R2", tve.getTableName());
-            assertEquals("C", tve.getColumnName());
-            tve = (TupleValueExpression)args.get(1);
-            assertEquals("R1", tve.getTableName());
-            assertEquals("A", tve.getColumnName());
+            if (tve.getTableName().equals("R2")) {
+            	assertEquals("C", tve.getColumnName());
+            	tve = (TupleValueExpression)args.get(1);
+            	assertEquals("R1", tve.getTableName());
+            	assertEquals("A", tve.getColumnName());
+            }
+            else {
+            	assertEquals("R1", tve.getTableName());
+            	assertEquals("A", tve.getColumnName());
+            	tve = (TupleValueExpression)args.get(1);
+            	assertEquals("R2", tve.getTableName());
+            	assertEquals("C", tve.getColumnName());
+            }
             assertEquals(2, se.getParameterIdxList().size());
             // Child query
             pn = se.getSubqueryNode();

--- a/tests/frontend/org/voltdb/regressionsuites/TestSystemCatalogSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSystemCatalogSuite.java
@@ -31,6 +31,8 @@ import java.sql.SQLException;
 
 import junit.framework.Test;
 
+import org.json_voltpatches.JSONException;
+import org.json_voltpatches.JSONObject;
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
@@ -59,7 +61,7 @@ public class TestSystemCatalogSuite extends RegressionSuite {
         fail("Invalid selector should have resulted in a ProcCallException but didn't");
     }
 
-    public void testTablesSelector() throws IOException, ProcCallException
+    public void testTablesSelector() throws IOException, ProcCallException, JSONException
     {
         Client client = getClient();
         VoltTable results = client.callProcedure("@SystemCatalog", "TABLES").getResults()[0];
@@ -74,7 +76,7 @@ public class TestSystemCatalogSuite extends RegressionSuite {
 
         results.advanceRow();
         assertEquals("BB_V", results.get("TABLE_NAME", VoltType.STRING));
-        assertEquals("{\"partitionColumn\":\"A1\",\"sourceTable\":\"AA_T\"}", results.get("REMARKS", VoltType.STRING));
+        assertEquals(new JSONObject("{\"partitionColumn\":\"A1\",\"sourceTable\":\"AA_T\"}").toString(), results.get("REMARKS", VoltType.STRING));
 
         results.advanceRow();
         assertEquals("CC_T_WITH_EXEC_DELETE", results.get("TABLE_NAME", VoltType.STRING));


### PR DESCRIPTION
Java 8 has change  entries  from using a linked list of elements or entries to a balanced tree. 
There are no guarantees that hash map entries will be retrieved in the same order that they were inserted in the map. 
In testing, the fixed order of database metadata information  should be changed.