### PR TITLE
Change column name describing segments in use

### DIFF
--- a/src/frontend/org/voltdb/CommandLogStats.java
+++ b/src/frontend/org/voltdb/CommandLogStats.java
@@ -29,7 +29,7 @@ public class CommandLogStats extends StatsSource {
     public enum StatName {
         OUTSTANDING_BYTES,
         OUTSTANDING_TXNS,
-        LOANED_SEGMENT_COUNT,
+        IN_USE_SEGMENT_COUNT,
         SEGMENT_COUNT,
         FSYNC_INTERVAL
     };
@@ -44,7 +44,7 @@ public class CommandLogStats extends StatsSource {
         super.populateColumnSchema(columns);
         columns.add(new VoltTable.ColumnInfo(StatName.OUTSTANDING_BYTES.name(), VoltType.BIGINT));
         columns.add(new VoltTable.ColumnInfo(StatName.OUTSTANDING_TXNS.name(), VoltType.BIGINT));
-        columns.add(new VoltTable.ColumnInfo(StatName.LOANED_SEGMENT_COUNT.name(), VoltType.INTEGER));
+        columns.add(new VoltTable.ColumnInfo(StatName.IN_USE_SEGMENT_COUNT.name(), VoltType.INTEGER));
         columns.add(new VoltTable.ColumnInfo(StatName.SEGMENT_COUNT.name(), VoltType.INTEGER));
         columns.add(new VoltTable.ColumnInfo(StatName.FSYNC_INTERVAL.name(), VoltType.INTEGER));
     }

--- a/src/frontend/org/voltdb/DummyCommandLog.java
+++ b/src/frontend/org/voltdb/DummyCommandLog.java
@@ -77,7 +77,7 @@ public class DummyCommandLog implements CommandLog {
             Object[] rowValues) {
         rowValues[columnNameToIndex.get(CommandLogStats.StatName.OUTSTANDING_BYTES.name())] = 0;
         rowValues[columnNameToIndex.get(CommandLogStats.StatName.OUTSTANDING_TXNS.name())] = 0;
-        rowValues[columnNameToIndex.get(CommandLogStats.StatName.LOANED_SEGMENT_COUNT.name())] = 0;
+        rowValues[columnNameToIndex.get(CommandLogStats.StatName.IN_USE_SEGMENT_COUNT.name())] = 0;
         rowValues[columnNameToIndex.get(CommandLogStats.StatName.SEGMENT_COUNT.name())] = 0;
         rowValues[columnNameToIndex.get(CommandLogStats.StatName.FSYNC_INTERVAL.name())] = 0;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestStatisticsSuite.java
@@ -1228,7 +1228,7 @@ public class TestStatisticsSuite extends SaveRestoreBase {
         expectedSchema[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
         expectedSchema[3] = new ColumnInfo(CommandLogStats.StatName.OUTSTANDING_BYTES.name(), VoltType.BIGINT);
         expectedSchema[4] = new ColumnInfo(CommandLogStats.StatName.OUTSTANDING_TXNS.name(), VoltType.BIGINT);
-        expectedSchema[5] = new ColumnInfo(CommandLogStats.StatName.LOANED_SEGMENT_COUNT.name(), VoltType.INTEGER);
+        expectedSchema[5] = new ColumnInfo(CommandLogStats.StatName.IN_USE_SEGMENT_COUNT.name(), VoltType.INTEGER);
         expectedSchema[6] = new ColumnInfo(CommandLogStats.StatName.SEGMENT_COUNT.name(), VoltType.INTEGER);
         expectedSchema[7] = new ColumnInfo(CommandLogStats.StatName.FSYNC_INTERVAL.name(), VoltType.INTEGER);
         VoltTable expectedTable = new VoltTable(expectedSchema);
@@ -1276,7 +1276,7 @@ public class TestStatisticsSuite extends SaveRestoreBase {
 
                 // Test segment counts
                 if (i == 1) {
-                    int actualLoanedSegmentCount = (int) results[0].getLong(CommandLogStats.StatName.LOANED_SEGMENT_COUNT.name());
+                    int actualLoanedSegmentCount = (int) results[0].getLong(CommandLogStats.StatName.IN_USE_SEGMENT_COUNT.name());
                     int actualSegmentCount = (int) results[0].getLong(CommandLogStats.StatName.SEGMENT_COUNT.name());
                     String message = "Unexpected segment count: should be 2";
                     assertTrue(message, actualSegmentCount == 2);


### PR DESCRIPTION
Change column name from LOANED_SEGMENT_COUNT to IN_USE_SEGMENT_COUNT so it is more user-friendly.