### PR TITLE
Eng 8343 round decimal scale

### DIFF
--- a/src/ee/expressions/abstractexpression.cpp
+++ b/src/ee/expressions/abstractexpression.cpp
@@ -105,7 +105,9 @@ AbstractExpression::initParamShortCircuits()
 std::string
 AbstractExpression::debug() const
 {
-    if (this == NULL) {
+    // Subvert a g++ error message;
+    const AbstractExpression *thisProxy = this;
+    if (thisProxy == NULL) {
         return "NULL";
     }
     std::ostringstream buffer;
@@ -117,7 +119,9 @@ AbstractExpression::debug() const
 std::string
 AbstractExpression::debug(bool traverse) const
 {
-    if (this == NULL) {
+    // Subvert a g++ error message;
+    const AbstractExpression *thisProxy = this;
+    if (thisProxy == NULL) {
         return "NULL";
     }
     return (traverse ? debug(std::string("")) : debug());
@@ -126,7 +130,9 @@ AbstractExpression::debug(bool traverse) const
 std::string
 AbstractExpression::debug(const std::string &spacer) const
 {
-    if (this == NULL) {
+    // Subvert a g++ error message;
+    const AbstractExpression *thisProxy = this;
+    if (thisProxy == NULL) {
         return "NULL";
     }
     std::ostringstream buffer;

--- a/src/frontend/org/voltdb/types/VoltDecimalHelper.java
+++ b/src/frontend/org/voltdb/types/VoltDecimalHelper.java
@@ -142,7 +142,7 @@ public class VoltDecimalHelper {
 
     /**
      * Round a BigDecimal number to a scale given the rounding mode.
-     * Note that rounding may return the precision.  For example,
+     * Note that rounding may increase the precision.  For example,
      * rounding 9.99999 and 9.1999 to a scale of 2 gives 10.00 and 9.20.
      * The latter has precision 3, and the former has precision 4.
      * @param bd

--- a/tests/frontend/org/voltcore/utils/TestCOWNavigableSet.java
+++ b/tests/frontend/org/voltcore/utils/TestCOWNavigableSet.java
@@ -219,9 +219,9 @@ public class TestCOWNavigableSet extends JSR166TestCase {
     public void testAddNonComparable() {
         try {
             COWNavigableSet q = new COWNavigableSet();
-            q.add(new Object());
-            q.add(new Object());
-            q.add(new Object());
+            q.add((Comparable) new Object());
+            q.add((Comparable) new Object());
+            q.add((Comparable) new Object());
             shouldThrow();
         } catch (ClassCastException success) {}
     }

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.DriverManager;
@@ -418,6 +419,33 @@ public class TestJDBCQueries {
             for (int i = 0; i < data2.length; i++) {
                 assertEquals(i, data2[i]);
             }
+        }
+    }
+
+    @Test
+    public void testDecimalRounding() throws Exception
+    {
+        testDecimalRounding(1, "9.1999999999999999",  "9.200000000000");
+        testDecimalRounding(2, "9.9999999999999999",  "10.000000000000");
+        testDecimalRounding(3, "9.1999999999999999",  "9.200000000000");
+        testDecimalRounding(4, "-9.9999999999999999", "-10.000000000000");
+        testDecimalRounding(5, "-9.1999999999999999", "-9.200000000000");
+    }
+
+    public void testDecimalRounding(int id, String input, String output) throws Exception
+    {
+        PreparedStatement ps = conn.prepareStatement("insert into T_DECIMAL values (?, ?);");
+        String stringdata = String.format("My Nuncle Vanya says: case %d: (%s -> %s)",
+                                          id, input, output);
+        ps.setBigDecimal(1, new BigDecimal(input));
+        ps.setString(2, stringdata);
+        ps.executeUpdate();
+        ps = conn.prepareStatement("select ID from T_DECIMAL where value = ?;");
+        ps.setString(1, stringdata);
+        ResultSet rs = ps.executeQuery();
+        while (rs.next()) {
+            BigDecimal value = rs.getBigDecimal(1);
+            assertEquals(new BigDecimal(output), value);
         }
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
@@ -24,6 +24,7 @@
 package org.voltdb.regressionsuites;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.net.ConnectException;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
@@ -305,6 +306,14 @@ public class RegressionSuite extends TestCase {
         return isLocalCluster() ? ((LocalCluster)m_config).internalPort(hostId) : VoltDB.DEFAULT_INTERNAL_PORT+hostId;
     }
 
+    public void validateTableOfDecimal(Client c, String sql, BigDecimal[][] expected)
+            throws Exception, IOException, ProcCallException {
+        assertNotNull(expected);
+        VoltTable vt = c.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableOfDecimal(vt, expected);
+    }
+
+
     public void validateTableOfLongs(Client c, String sql, long[][] expected)
             throws Exception, IOException, ProcCallException {
         assertNotNull(expected);
@@ -383,6 +392,41 @@ public class RegressionSuite extends TestCase {
         for (int i=0; i < len; i++) {
             assertTrue(vt.advanceRow());
             assertEquals(expected[i], vt.getString(col));
+        }
+    }
+
+    public void validateRowOfDecimal(VoltTable vt, BigDecimal [] expected) {
+        int len = expected.length;
+        assertTrue(vt.advanceRow());
+        for (int i=0; i < len; i++) {
+            BigDecimal actual = null;
+            try {
+                actual = vt.getDecimalAsBigDecimal(i);
+            } catch (IllegalArgumentException ex) {
+                ex.printStackTrace();
+                fail();
+            }
+            if (expected[i] != null) {
+                assertNotSame(null, actual);
+                assertEquals(expected[i], actual);
+            } else {
+                if (isHSQL()) {
+                    // We don't actually use this with
+                    // HSQL.  So, just assert failure here.
+                    fail("HSQL is not used to test the Volt DECIMAL type.");
+                } else {
+                    assertTrue(vt.wasNull());
+                }
+            }
+        }
+    }
+
+    public void validateTableOfDecimal(VoltTable vt, BigDecimal[][] expected) {
+        assertNotNull(expected);
+        assertEquals(expected.length, vt.getRowCount());
+        int len = expected.length;
+        for (int i=0; i < len; i++) {
+            validateRowOfDecimal(vt, expected[i]);
         }
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
@@ -868,7 +868,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         try
         {
             sql = "SELECT * FROM R1_DECIMAL WHERE " +
-            "(R1_DECIMAL.CASH <= 0.0622493314185)" +
+            "(R1_DECIMAL.CASH <= 999999999999999999999999999.0622493314185)" +
             " AND (R1_DECIMAL.ID > R1_DECIMAL.CASH)";
             client.callProcedure("@AdHoc", sql);
         }

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionParamSerializationError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionParamSerializationError.java
@@ -38,7 +38,7 @@ public class MultiPartitionParamSerializationError extends VoltProcedure {
     public final SQLStmt insert = new SQLStmt("INSERT INTO ALL_TYPES (ID, MONEY) VALUES (?, ?);");
 
     public VoltTable[] run(int id) {
-        final BigDecimal killer = new BigDecimal(BigInteger.valueOf(7700000000000L), 20);
+        final BigDecimal killer = new BigDecimal("99999999999999999999999999999999999999.999999999");
         voltQueueSQL(insert, id, killer);
         voltExecuteSQL();
         return null;

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionParamSerializationError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionParamSerializationError.java
@@ -39,7 +39,7 @@ public class SinglePartitionParamSerializationError extends VoltProcedure {
     public final SQLStmt insert = new SQLStmt("INSERT INTO ALL_TYPES (ID, MONEY) VALUES (?, ?);");
 
     public VoltTable[] run(int id) {
-        final BigDecimal killer = new BigDecimal(BigInteger.valueOf(7700000000000L), 20);
+        final BigDecimal killer = new BigDecimal("9999999999999999999999999999999999999999.999");
         voltQueueSQL(insert, id, killer);
         voltExecuteSQL();
         return null;


### PR DESCRIPTION
When we see a string which has more scale than we support, we will now round it up to the
closest supported value.  We round a value equidistant between two supported values up.
This is all done using BigDecimal's round function and the ROUND_UP rounding mode.

I had to make some inessential changes in a C++ file and a java test file.  Apparently
the C++ compiler on my macbook thinks "this" can never be null, and it is offended that 
someone would test for it.  I had to work around that.  Also, Eclipse was unhappy about
a test, so I had to cast an Object to be Comparable.  The test was testing that such a
cast would cause a ClassCastException.  This is really kind of a silly test, and tests
the Java compiler more than the VoltDB code.


