### PR TITLE
This seems like a very simple change which will cure some of the hanging behavior.

### DIFF
--- a/src/frontend/org/voltdb/compiler/AsyncCompilerAgent.java
+++ b/src/frontend/org/voltdb/compiler/AsyncCompilerAgent.java
@@ -372,6 +372,8 @@ public class AsyncCompilerAgent {
             }
             catch (Exception e) {
                 errorMsgs.add("Unexpected Ad Hoc Planning Error: " + e);
+            } catch (AssertionError ae) {
+                errorMsgs.add("Assertion Error in Ad Hoc Planning: " + ae);
             }
         }
         String errorSummary = null;


### PR DESCRIPTION
Catch AssertError exceptions in the planner, and return a proper
response.  Don't hang the client waiting for a response.

Note that this is not to be merged to master, but to ENG-8070-hsqldb232-upgrade.  The master version will come soon.

