### PR TITLE
 ENG-8228: Add a global JDBC property QUERY_TIMEOUT_UNIT

### DIFF
--- a/src/frontend/org/voltdb/jdbc/JDBC4ClientConnection.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ClientConnection.java
@@ -270,13 +270,13 @@ public class JDBC4ClientConnection implements Closeable {
      * @throws NoConnectionsException
      * @throws ProcCallException
      */
-    public ClientResponse execute(String procedure, long timeout, Object... parameters)
+   public ClientResponse execute(String procedure, long timeout, TimeUnit unit, Object... parameters)
             throws NoConnectionsException, IOException, ProcCallException {
         long start = System.currentTimeMillis();
         ClientImpl currentClient = this.getClient();
         try {
             // If connections are lost try reconnecting.
-            ClientResponse response = currentClient.callProcedureWithTimeout(procedure, timeout, TimeUnit.SECONDS, parameters);
+            ClientResponse response = currentClient.callProcedureWithTimeout(procedure, timeout, unit, parameters);
             return response;
         }
         catch (ProcCallException pce) {

--- a/src/frontend/org/voltdb/jdbc/JDBC4ClientConnection.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ClientConnection.java
@@ -274,6 +274,9 @@ public class JDBC4ClientConnection implements Closeable {
             throws NoConnectionsException, IOException, ProcCallException {
         long start = System.currentTimeMillis();
         ClientImpl currentClient = this.getClient();
+        if (unit == null) {
+            unit = TimeUnit.SECONDS;
+        }
         try {
             // If connections are lost try reconnecting.
             ClientResponse response = currentClient.callProcedureWithTimeout(procedure, timeout, unit, parameters);

--- a/src/frontend/org/voltdb/jdbc/JDBC4Connection.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4Connection.java
@@ -44,11 +44,11 @@ public class JDBC4Connection implements java.sql.Connection, IVoltDBConnection
 {
     public static final String COMMIT_THROW_EXCEPTION = "jdbc.committhrowexception";
     public static final String ROLLBACK_THROW_EXCEPTION = "jdbc.rollbackthrowexception";
-    public static final String QUERY_TIMEOUT_UNIT = "jdbc.querytimeoutunit";
+    public static final String QUERYTIMEOUT_UNIT = "jdbc.querytimeout.unit";
 
     protected final JDBC4ClientConnection NativeConnection;
     protected final String User;
-    protected final TimeUnit QueryTimeOutUnit ;
+    protected TimeUnit QueryTimeOutUnit = TimeUnit.SECONDS;
     private boolean isClosed = false;
     private Properties props;
     private boolean autoCommit = true;
@@ -58,13 +58,9 @@ public class JDBC4Connection implements java.sql.Connection, IVoltDBConnection
         this.NativeConnection = connection;
         this.props = props;
         this.User = this.props.getProperty("user", "");
-        if (this.props.getProperty(JDBC4Connection.QUERY_TIMEOUT_UNIT, "TimeUnit.Seconds").equalsIgnoreCase(TimeUnit.MILLISECONDS.toString())) {
+        if (this.props.getProperty(JDBC4Connection.QUERYTIMEOUT_UNIT, "Seconds").equalsIgnoreCase("milliseconds")) {
             this.QueryTimeOutUnit = TimeUnit.MILLISECONDS;
         }
-        else {
-            this.QueryTimeOutUnit = TimeUnit.SECONDS;
-        }
-
     }
 
     private void checkClosed() throws SQLException

--- a/src/frontend/org/voltdb/jdbc/JDBC4Connection.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4Connection.java
@@ -35,6 +35,7 @@ import java.sql.Struct;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 import org.voltdb.client.ClientStats;
 import org.voltdb.client.ClientStatsContext;
@@ -43,9 +44,11 @@ public class JDBC4Connection implements java.sql.Connection, IVoltDBConnection
 {
     public static final String COMMIT_THROW_EXCEPTION = "jdbc.committhrowexception";
     public static final String ROLLBACK_THROW_EXCEPTION = "jdbc.rollbackthrowexception";
+    public static final String QUERY_TIMEOUT_UNIT = "jdbc.querytimeoutunit";
 
     protected final JDBC4ClientConnection NativeConnection;
     protected final String User;
+    protected final TimeUnit QueryTimeOutUnit ;
     private boolean isClosed = false;
     private Properties props;
     private boolean autoCommit = true;
@@ -55,6 +58,13 @@ public class JDBC4Connection implements java.sql.Connection, IVoltDBConnection
         this.NativeConnection = connection;
         this.props = props;
         this.User = this.props.getProperty("user", "");
+        if (this.props.getProperty(JDBC4Connection.QUERY_TIMEOUT_UNIT, "TimeUnit.Seconds").equalsIgnoreCase(TimeUnit.MILLISECONDS.toString())) {
+            this.QueryTimeOutUnit = TimeUnit.MILLISECONDS;
+        }
+        else {
+            this.QueryTimeOutUnit = TimeUnit.SECONDS;
+        }
+
     }
 
     private void checkClosed() throws SQLException

--- a/src/frontend/org/voltdb/jdbc/JDBC4Connection.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4Connection.java
@@ -48,7 +48,7 @@ public class JDBC4Connection implements java.sql.Connection, IVoltDBConnection
 
     protected final JDBC4ClientConnection NativeConnection;
     protected final String User;
-    protected TimeUnit QueryTimeOutUnit = TimeUnit.SECONDS;
+    protected TimeUnit queryTimeOutUnit = TimeUnit.SECONDS;
     private boolean isClosed = false;
     private Properties props;
     private boolean autoCommit = true;
@@ -59,7 +59,7 @@ public class JDBC4Connection implements java.sql.Connection, IVoltDBConnection
         this.props = props;
         this.User = this.props.getProperty("user", "");
         if (this.props.getProperty(JDBC4Connection.QUERYTIMEOUT_UNIT, "Seconds").equalsIgnoreCase("milliseconds")) {
-            this.QueryTimeOutUnit = TimeUnit.MILLISECONDS;
+            this.queryTimeOutUnit = TimeUnit.MILLISECONDS;
         }
     }
 

--- a/src/frontend/org/voltdb/jdbc/JDBC4Statement.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4Statement.java
@@ -368,12 +368,12 @@ public class JDBC4Statement implements java.sql.Statement
         checkClosed();
         if (query.isQueryOfType(VoltSQL.TYPE_SELECT,VoltSQL.TYPE_EXEC))
         {
-            setCurrentResult(query.execute(this.sourceConnection.NativeConnection, this.m_timeout,this.sourceConnection.QueryTimeOutUnit), -1);
+            setCurrentResult(query.execute(this.sourceConnection.NativeConnection, this.m_timeout,this.sourceConnection.queryTimeOutUnit), -1);
             return true;
         }
         else
         {
-            setCurrentResult(null, (int) query.execute(this.sourceConnection.NativeConnection, this.m_timeout,this.sourceConnection.QueryTimeOutUnit)[0].fetchRow(0).getLong(0));
+            setCurrentResult(null, (int) query.execute(this.sourceConnection.NativeConnection, this.m_timeout,this.sourceConnection.queryTimeOutUnit)[0].fetchRow(0).getLong(0));
             return false;
         }
     }
@@ -430,7 +430,7 @@ public class JDBC4Statement implements java.sql.Statement
             try
             {
                 setCurrentResult(null, (int) batch.get(i).execute(sourceConnection.NativeConnection,
-                        this.m_timeout,sourceConnection.QueryTimeOutUnit)[0].fetchRow(0).getLong(0));
+                        this.m_timeout,sourceConnection.queryTimeOutUnit)[0].fetchRow(0).getLong(0));
                 updateCounts[i] = this.lastUpdateCount;
                 runningUpdateCount += this.lastUpdateCount;
             }
@@ -450,7 +450,7 @@ public class JDBC4Statement implements java.sql.Statement
 
     protected ResultSet executeQuery(VoltSQL query) throws SQLException
     {
-        setCurrentResult(query.execute(this.sourceConnection.NativeConnection, this.m_timeout, this.sourceConnection.QueryTimeOutUnit), -1);
+        setCurrentResult(query.execute(this.sourceConnection.NativeConnection, this.m_timeout, this.sourceConnection.queryTimeOutUnit), -1);
         return this.result;
     }
 
@@ -468,7 +468,7 @@ public class JDBC4Statement implements java.sql.Statement
 
     protected int executeUpdate(VoltSQL query) throws SQLException
     {
-        setCurrentResult(null, (int) query.execute(this.sourceConnection.NativeConnection, this.m_timeout,this.sourceConnection.QueryTimeOutUnit)[0].fetchRow(0).getLong(0));
+        setCurrentResult(null, (int) query.execute(this.sourceConnection.NativeConnection, this.m_timeout,this.sourceConnection.queryTimeOutUnit)[0].fetchRow(0).getLong(0));
         return this.lastUpdateCount;
     }
 


### PR DESCRIPTION
if set as "MILLISECONDS", will override the default time unit Seconds