### PR TITLE
ENG-8423: Push truncation into PBDSegment implementations

### DIFF
--- a/src/frontend/org/voltdb/utils/PBDMMapSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDMMapSegment.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
 
 import org.voltcore.logging.VoltLogger;
@@ -39,14 +38,9 @@ import org.xerial.snappy.Snappy;
  * for reading and writing, but not both at the same time.
  *
  */
-class PBDMMapSegment implements PBDSegment {
+class PBDMMapSegment extends PBDSegment {
     private static final VoltLogger LOG = new VoltLogger("HOST");
 
-    //Avoid unecessary sync with this flag
-    private boolean m_syncedSinceLastEdit;
-    final File m_file;
-    private RandomAccessFile m_ras;
-    private FileChannel m_fc;
     private MBBContainer m_buf;
     private ByteBuffer m_readBuf;
 
@@ -69,8 +63,8 @@ class PBDMMapSegment implements PBDSegment {
     private int m_discardCount;
 
     public PBDMMapSegment(Long index, File file) {
+        super(file);
         m_index = index;
-        m_file = file;
         reset();
         if (LOG.isDebugEnabled()) {
             LOG.debug("Creating Segment: " + file.getName() + " At Index: " + m_index);
@@ -118,7 +112,8 @@ class PBDMMapSegment implements PBDSegment {
         return m_objectReadIndex;
     }
 
-    private void initNumEntries(int count, int size) throws IOException {
+    @Override
+    protected void initNumEntries(int count, int size) throws IOException {
         final ByteBuffer buf = m_buf.b();
         buf.putInt(0, count);
         buf.putInt(4, size);
@@ -138,12 +133,8 @@ class PBDMMapSegment implements PBDSegment {
         open(forWrite, forWrite);
     }
 
-    /**
-     * @param forWrite    Open the file in read/write mode
-     * @param truncate    true to overwrite the header with 0 entries
-     * @throws IOException
-     */
-    private void open(boolean forWrite, boolean truncate) throws IOException {
+    @Override
+    protected void open(boolean forWrite, boolean truncate) throws IOException {
         if (!m_closed) {
             throw new IOException("Segment is already opened");
         }
@@ -367,74 +358,6 @@ class PBDMMapSegment implements PBDSegment {
         };
     }
 
-    @Override
-    public int parseAndTruncate(BinaryDeque.BinaryDequeTruncator truncator) throws IOException
-    {
-        if (!m_closed) throw new IOException(("Segment should not be open before truncation"));
-
-        open(true, false);
-
-        // Do stuff
-        final int initialEntryCount = getNumEntries();
-        int entriesTruncated = 0;
-        int sizeInBytes = 0;
-
-        BBContainer cont;
-        while (true) {
-            final int beforePos = m_readBuf.position();
-
-            cont = poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            if (cont == null) {
-                break;
-            }
-
-            final int compressedLength = m_readBuf.position() - beforePos - OBJECT_HEADER_BYTES;
-            final int uncompressedLength = cont.b().limit();
-
-            try {
-                //Handoff the object to the truncator and await a decision
-                BinaryDeque.TruncatorResponse retval = truncator.parse(cont);
-                if (retval == null) {
-                    //Nothing to do, leave the object alone and move to the next
-                    sizeInBytes += uncompressedLength;
-                } else {
-                    //If the returned bytebuffer is empty, remove the object and truncate the file
-                    if (retval.status == BinaryDeque.TruncatorResponse.Status.FULL_TRUNCATE) {
-                        if (readIndex() == 1) {
-                            /*
-                             * If truncation is occuring at the first object
-                             * Whammo! Delete the file.
-                             */
-                            entriesTruncated = -1;
-                        } else {
-                            entriesTruncated = initialEntryCount - (readIndex() - 1);
-                            //Don't forget to update the number of entries in the file
-                            initNumEntries(readIndex() - 1, sizeInBytes);
-                            m_fc.truncate(m_readBuf.position() - (compressedLength + PBDSegment.OBJECT_HEADER_BYTES));
-                        }
-                    } else {
-                        assert retval.status == BinaryDeque.TruncatorResponse.Status.PARTIAL_TRUNCATE;
-                        entriesTruncated = initialEntryCount - readIndex();
-                        //Partial object truncation
-                        m_readBuf.position(m_readBuf.position() - (compressedLength + PBDSegment.OBJECT_HEADER_BYTES));
-                        sizeInBytes += retval.writeTruncatedObject(m_readBuf);
-
-                        initNumEntries(readIndex(), sizeInBytes);
-                        m_fc.truncate(m_readBuf.position());
-                    }
-
-                    break;
-                }
-            } finally {
-                cont.discard();
-            }
-        }
-
-        close();
-
-        return entriesTruncated;
-    }
-
     /*
      * Don't use size in bytes to determine empty, could potentially
      * diverge from object count on crash or power failure
@@ -444,5 +367,23 @@ class PBDMMapSegment implements PBDSegment {
     public int uncompressedBytesToRead() {
         if (m_closed) throw new RuntimeException("closed");
         return Math.max(0, m_buf.b().getInt(SIZE_OFFSET) - m_bytesRead);
+    }
+
+    @Override
+    protected long readOffset()
+    {
+        return m_readBuf.position();
+    }
+
+    @Override
+    protected void rewindReadOffset(int byBytes)
+    {
+        m_readBuf.position(m_readBuf.position() - byBytes);
+    }
+
+    @Override
+    protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry, int length) throws IOException
+    {
+        return entry.writeTruncatedObject(m_readBuf);
     }
 }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -130,10 +130,10 @@ public class PBDRegularSegment implements PBDSegment {
 
     /**
      * @param forWrite    Open the file in read/write mode
-     * @param truncate    true to overwrite the header with 0 entries
+     * @param emptyFile   true to overwrite the header with 0 entries, essentially emptying the file
      * @throws IOException
      */
-    private void open(boolean forWrite, boolean truncate) throws IOException
+    private void open(boolean forWrite, boolean emptyFile) throws IOException
     {
         if (!m_closed) {
             throw new IOException("Segment is already opened");
@@ -150,7 +150,7 @@ public class PBDRegularSegment implements PBDSegment {
         m_fc = m_ras.getChannel();
         m_tmpHeaderBuf = DBBPool.allocateDirect(SEGMENT_HEADER_BYTES);
 
-        if (truncate) {
+        if (emptyFile) {
             initNumEntries(0, 0);
         }
         m_fc.position(SEGMENT_HEADER_BYTES);

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -125,6 +125,16 @@ public class PBDRegularSegment implements PBDSegment {
     @Override
     public void open(boolean forWrite) throws IOException
     {
+        open(forWrite, forWrite);
+    }
+
+    /**
+     * @param forWrite    Open the file in read/write mode
+     * @param truncate    true to overwrite the header with 0 entries
+     * @throws IOException
+     */
+    private void open(boolean forWrite, boolean truncate) throws IOException
+    {
         if (!m_closed) {
             throw new IOException("Segment is already opened");
         }
@@ -140,17 +150,17 @@ public class PBDRegularSegment implements PBDSegment {
         m_fc = m_ras.getChannel();
         m_tmpHeaderBuf = DBBPool.allocateDirect(SEGMENT_HEADER_BYTES);
 
-        if (forWrite) {
-            initNumEntries();
+        if (truncate) {
+            initNumEntries(0, 0);
         }
         m_fc.position(SEGMENT_HEADER_BYTES);
 
         m_closed = false;
     }
 
-    private void initNumEntries() throws IOException {
-        m_numOfEntries = 0;
-        m_size = 0;
+    private void initNumEntries(int count, int size) throws IOException {
+        m_numOfEntries = count;
+        m_size = size;
 
         m_tmpHeaderBuf.b().clear();
         m_tmpHeaderBuf.b().putInt(m_numOfEntries);

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -65,6 +65,15 @@ public interface PBDSegment {
 
     DBBPool.BBContainer poll(BinaryDeque.OutputContainerFactory factory) throws IOException;
 
+    /**
+     * Parse the segment and truncate the file if necessary.
+     * @param truncator    A caller-supplied truncator that decides where in the segment to truncate
+     * @return The number of objects that was truncated. This number will be subtracted from the total number
+     * of available objects in the PBD. -1 means that this whole segment should be removed.
+     * @throws IOException
+     */
+    int parseAndTruncate(BinaryDeque.BinaryDequeTruncator truncator) throws IOException;
+
     /*
      * Don't use size in bytes to determine empty, could potentially
      * diverge from object count on crash or power failure

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -560,123 +560,30 @@ public class PersistentBinaryDeque implements BinaryDeque {
             return;
         }
 
+        // Close the last write segment for now, will reopen after truncation
+        m_segments.getLast().close();
+
         /*
          * Iterator all the objects in all the segments and pass them to the truncator
          * When it finds the truncation point
          */
         Long lastSegmentIndex = null;
-        BBContainer decompressionBuffer = DBBPool.allocateDirect(1024 * 512);
-        try {
-            for (PBDSegment segment : m_segments) {
-                long segmentIndex = segment.segmentId();
+        for (PBDSegment segment : m_segments) {
+            final long segmentIndex = segment.segmentId();
 
-                File segmentFile = segment.file();
-                RandomAccessFile ras = new RandomAccessFile(segmentFile, "rw");
-                FileChannel fc = ras.getChannel();
-                MBBContainer readBufferC = DBBPool.wrapMBB(fc.map(MapMode.READ_WRITE, 0, fc.size()));
-                final ByteBuffer readBuffer = readBufferC.b();
-                final long buffAddr = readBufferC.address();
-                try {
-                    //Get the number of objects and then iterator over them
-                    int numObjects = readBuffer.getInt();
-                    readBuffer.position(PBDSegment.SIZE_OFFSET + 4);
-                    int sizeInBytes = 0;
+            final int truncatedEntries = segment.parseAndTruncate(truncator);
 
-                    int objectsProcessed = 0;
-                    m_usageSpecificLog.debug("PBD " + m_nonce + " has " + numObjects + " objects to parse and truncate");
-                    for (int ii = 0; ii < numObjects; ii++) {
-                        final int nextObjectLength = readBuffer.getInt();
-                        final int nextObjectFlags = readBuffer.getInt();
-                        final boolean compressed = (nextObjectFlags & PBDSegment.FLAG_COMPRESSED) != 0;
-                        final int uncompressedLength = compressed ? (int)Snappy.uncompressedLength(buffAddr + readBuffer.position(), nextObjectLength) : nextObjectLength;
-                        objectsProcessed++;
-                        //Copy the next object into a separate heap byte buffer
-                        //do the old limit stashing trick to avoid buffer overflow
-                        BBContainer nextObject = null;
-                        if (compressed) {
-                            decompressionBuffer.b().clear();
-                            if (decompressionBuffer.b().remaining() < uncompressedLength ) {
-                                decompressionBuffer.discard();
-                                decompressionBuffer = DBBPool.allocateDirect(uncompressedLength);
-                            }
-                            nextObject = DBBPool.dummyWrapBB(decompressionBuffer.b());
-                            final long sourceAddr = (buffAddr + readBuffer.position());
-                            final long destAddr = nextObject.address();
-                            Snappy.rawUncompress(sourceAddr, nextObjectLength, destAddr);
-                            readBuffer.position(readBuffer.position() + nextObjectLength);
-                        } else {
-                            final int oldLimit = readBuffer.limit();
-                            readBuffer.limit(readBuffer.position() + nextObjectLength);
-                            nextObject = DBBPool.dummyWrapBB(readBuffer.slice());
-                            readBuffer.position(readBuffer.limit());
-                            readBuffer.limit(oldLimit);
-                        }
-                        try {
-                            //Handoff the object to the truncator and await a decision
-                            TruncatorResponse retval = truncator.parse(nextObject);
-                            if (retval == null) {
-                                //Nothing to do, leave the object alone and move to the next
-                                sizeInBytes += uncompressedLength;
-                                continue;
-                            } else {
-                                //If the returned bytebuffer is empty, remove the object and truncate the file
-                                if (retval.status == Status.FULL_TRUNCATE) {
-                                    if (ii == 0) {
-                                        /*
-                                         * If truncation is occuring at the first object
-                                         * Whammo! Delete the file. Do it by setting the lastSegmentIndex
-                                         * to 1 previous. We may end up with an empty finished segment
-                                         * set.
-                                         */
-                                        lastSegmentIndex = segmentIndex - 1;
-                                    } else {
-                                        addToNumObjects(-(numObjects - (objectsProcessed - 1)));
-                                        //Don't forget to update the number of entries in the file
-                                        ByteBuffer numObjectsBuffer = ByteBuffer.allocate(8);
-                                        numObjectsBuffer.putInt(ii);
-                                        numObjectsBuffer.putInt(sizeInBytes);
-                                        numObjectsBuffer.flip();
-                                        fc.position(0);
-                                        while (numObjectsBuffer.hasRemaining()) {
-                                            fc.write(numObjectsBuffer);
-                                        }
-                                        fc.truncate(readBuffer.position() - (nextObjectLength + PBDSegment.OBJECT_HEADER_BYTES));
-                                    }
-                                } else {
-                                    assert retval.status == Status.PARTIAL_TRUNCATE;
-                                    addToNumObjects(-(numObjects - objectsProcessed));
-                                    //Partial object truncation
-                                    readBuffer.position(readBuffer.position() - (nextObjectLength + PBDSegment.OBJECT_HEADER_BYTES));
-                                    sizeInBytes += retval.writeTruncatedObject(readBuffer);
-                                    readBuffer.putInt(PBDSegment.COUNT_OFFSET, ii + 1);
-                                    readBuffer.putInt(PBDSegment.SIZE_OFFSET, sizeInBytes);
-                                    /*
-                                     * SHOULD REALLY make a copy of the original and then swap them with renaming
-                                     */
-                                    fc.truncate(readBuffer.position());
-                                }
-                                //Set last segment and break the loop over this segment
-                                if (lastSegmentIndex == null) {
-                                    lastSegmentIndex = segmentIndex;
-                                }
-                                break;
-                            }
-                        } finally {
-                            nextObject.discard();
-                        }
-                    }
-
-                    //If this is set the just processed segment was the last one
-                    if (lastSegmentIndex != null) {
-                        break;
-                    }
-                } finally {
-                    fc.close();
-                    readBufferC.discard();
-                }
+            if (truncatedEntries == -1) {
+                lastSegmentIndex = segmentIndex - 1;
+                break;
+            } else if (truncatedEntries > 0) {
+                addToNumObjects(-truncatedEntries);
+                //Set last segment and break the loop over this segment
+                lastSegmentIndex = segmentIndex;
+                break;
             }
-        } finally {
-            decompressionBuffer.discard();
+            // truncatedEntries == 0 means nothing is truncated in this segment,
+            // should move on to the next segment.
         }
 
         /*
@@ -684,6 +591,8 @@ public class PersistentBinaryDeque implements BinaryDeque {
          * Return and the parseAndTruncate is a noop.
          */
         if (lastSegmentIndex == null)  {
+            // Reopen the last segment for write
+            m_segments.getLast().open(true);
             return;
         }
         /*
@@ -707,10 +616,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         Long newSegmentIndex = 0L;
         if (m_segments.peekLast() != null) newSegmentIndex = m_segments.peekLast().segmentId() + 1;
 
-        PBDSegment newSegment =
-            newSegment(
-                    newSegmentIndex,
-                    new VoltFile(m_path, m_nonce + "." + newSegmentIndex + ".pbd"));
+        PBDSegment newSegment = newSegment(newSegmentIndex, new VoltFile(m_path, m_nonce + "." + newSegmentIndex + ".pbd"));
         newSegment.open(true);
         m_segments.offer(newSegment);
         assertions();

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -289,6 +289,8 @@ public class TestPersistentBinaryDeque {
 
         });
 
+        assertEquals(95420416, m_pbd.sizeInBytes());
+
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 2);
 


### PR DESCRIPTION
As part of the work to get the cached count and size updated correctly on PersistentBinaryDeque truncation, I pushed the truncation code down into each PBDSegment implementation.