### PR TITLE
Implemented Rounding for the DECIMAL type.  

### DIFF
--- a/src/frontend/org/voltdb/client/ClientConfig.java
+++ b/src/frontend/org/voltdb/client/ClientConfig.java
@@ -17,11 +17,14 @@
 
 package org.voltdb.client;
 
+import java.math.RoundingMode;
 import java.util.concurrent.TimeUnit;
 
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+
+import org.voltdb.types.VoltDecimalHelper;
 
 /**
  * Container for configuration settings for a Client
@@ -352,5 +355,16 @@ public class ClientConfig {
        } catch (LoginException ex) {
            throw new IllegalArgumentException("Cannot determine client consumer's credentials", ex);
        }
+    }
+
+    /**
+     * Enable or disable the rounding mode in the client.  This must match the
+     * rounding mode set in the server, which is set using system properties.
+     *
+     * @param isEnabled True iff rounding is enabled.
+     * @param mode The rounding mode, with values taken from java.math.RoundingMode.
+     */
+    public static void setRoundingConfig(boolean isEnabled, RoundingMode mode) {
+        VoltDecimalHelper.setRoundingConfig(isEnabled, mode);
     }
 }

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.DriverManager;
@@ -489,6 +490,33 @@ public class TestJDBCQueries {
             for (int i = 0; i < data2.length; i++) {
                 assertEquals(i, data2[i]);
             }
+        }
+    }
+
+    @Test
+    public void testDecimalRounding() throws Exception
+    {
+        testDecimalRounding(1, "9.1999999999999999",  "9.200000000000");
+        testDecimalRounding(2, "9.9999999999999999",  "10.000000000000");
+        testDecimalRounding(3, "9.1999999999999999",  "9.200000000000");
+        testDecimalRounding(4, "-9.9999999999999999", "-10.000000000000");
+        testDecimalRounding(5, "-9.1999999999999999", "-9.200000000000");
+    }
+
+    public void testDecimalRounding(int id, String input, String output) throws Exception
+    {
+        PreparedStatement ps = conn.prepareStatement("insert into T_DECIMAL values (?, ?);");
+        String stringdata = String.format("My Nuncle Vanya says: case %d: (%s -> %s)",
+                                          id, input, output);
+        ps.setBigDecimal(1, new BigDecimal(input));
+        ps.setString(2, stringdata);
+        ps.executeUpdate();
+        ps = conn.prepareStatement("select ID from T_DECIMAL where value = ?;");
+        ps.setString(1, stringdata);
+        ResultSet rs = ps.executeQuery();
+        while (rs.next()) {
+            BigDecimal value = rs.getBigDecimal(1);
+            assertEquals(new BigDecimal(output), value);
         }
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -112,6 +112,10 @@ public class LocalCluster implements VoltServerConfig {
     //This is additional process invironment variables that can be passed.
     // This is used to pass JMX port. Any additional use cases can use this too.
     private Map<String, String> m_additionalProcessEnv = null;
+    protected final Map<String, String> getAdditionalProcessEnv() {
+        return m_additionalProcessEnv;
+    }
+
     // Produce a (presumably) available IP port number.
     public final PortGeneratorForTest portGenerator = new PortGeneratorForTest();
     private String m_voltdbroot = "";
@@ -125,6 +129,9 @@ public class LocalCluster implements VoltServerConfig {
     // with the port numbers and command line parameter value specific to that
     // instance.
     private final CommandLine templateCmdLine = new CommandLine(StartAction.CREATE);
+
+    // This is used in generating the name.
+    private String m_prefix = null;
 
     public LocalCluster(String jarFileName,
                         int siteCount,
@@ -1143,9 +1150,13 @@ public class LocalCluster implements VoltServerConfig {
         return listeners;
     }
 
+    public void setPrefix(String prefix) {
+        m_prefix  = prefix;
+    }
+
     @Override
     public String getName() {
-        String prefix = "localCluster";
+        String prefix = (m_prefix == null) ? "localCluster" : String.format("localCluster-%s", m_prefix);
         if (m_failureState == FailureState.ONE_FAILURE)
             prefix += "OneFail";
         if (m_failureState == FailureState.ONE_RECOVERING)

--- a/tests/frontend/org/voltdb/regressionsuites/TestDecimalRoundingSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestDecimalRoundingSuite.java
@@ -1,0 +1,497 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.regressionsuites;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.voltdb.BackendTarget;
+import org.voltdb.VoltTable;
+import org.voltdb.client.Client;
+import org.voltdb.client.ClientConfig;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.types.VoltDecimalHelper;
+
+public class TestDecimalRoundingSuite extends RegressionSuite {
+
+    private static int m_defaultScale = 12;
+    private static String m_roundingEnabledProperty = "BIGDECIMAL_ROUND";
+    private static String m_roundingModeProperty = "BIGDECIMAL_ROUND_POLICY";
+    private static String m_defaultRoundingEnablement = "true";
+    private static String m_defaultRoundingMode = "HALF_UP";
+
+    //
+    // JUnit / RegressionSuite boilerplate
+    //
+    public TestDecimalRoundingSuite(String name) {
+        super(name);
+    }
+
+
+    private static String getRoundingString(String label) {
+        return String.format("%sRounding %senabled, mode is %s",
+                             label == null ? (label + ": ") : "",
+                             VoltDecimalHelper.isRoundingEnabled() ? "is " : "is *NOT* ",
+                             VoltDecimalHelper.getRoundingMode().toString());
+    }
+    private void validateInsertStmt(boolean expectSuccess, String insertStmt, BigDecimal... expectedValues) throws Exception {
+        Client client = getClient();
+
+        boolean success;
+        try {
+            validateTableOfLongs(client, insertStmt, new long[][]{{1}});
+            success = true;
+        } catch (Exception ex) {
+            success = false;
+        }
+        assertEquals(getRoundingString("Insert Statement Failure"), success, expectSuccess);
+        if (!success) {
+            return;
+        }
+        validateTableOfDecimal(client, "select * from decimaltable;", new BigDecimal[][] {expectedValues});
+        if (success) {
+            validateTableOfLongs(client, "delete from decimaltable;", new long[][] {{1}});
+        }
+    }
+
+    public void testDecimalScaleInsertion() throws Exception {
+        Boolean roundIsEnabled = Boolean.valueOf(m_defaultRoundingEnablement);
+        RoundingMode roundMode = RoundingMode.valueOf(m_defaultRoundingMode);
+
+        assert(m_config instanceof LocalCluster);
+        LocalCluster localCluster = (LocalCluster)m_config;
+        Map<String, String> props = localCluster.getAdditionalProcessEnv();
+        if (props != null) {
+            roundIsEnabled = Boolean.valueOf(props.containsKey(m_roundingEnabledProperty) ? props.get(m_roundingEnabledProperty) : "true");
+            roundMode = RoundingMode.valueOf(props.containsKey(m_roundingModeProperty) ? props.get(m_roundingModeProperty) : "HALF_UP");
+            System.out.printf("Rounding is %senabled, mode is %s\n",
+                              roundIsEnabled ? "" : "not ",
+                              roundMode.toString());
+        } else {
+            System.out.printf("Default rounding (%s), Default Rounding mode (%s).\n",
+                              roundIsEnabled.toString(), roundMode.toString());
+        }
+        doTestDecimalScaleInsertion(roundIsEnabled, roundMode);
+    }
+
+    /*
+     * This little helper function converts a string to
+     * a decimal, and, maybe, rounds it to the Volt default scale
+     * using the given mode.  If roundingEnabled is false, no
+     * rounding is done.
+     */
+    private static final BigDecimal roundDecimalValue(String  decimalValueString,
+                                                      boolean roundingEnabled,
+                                                      RoundingMode mode) {
+        BigDecimal bd = new BigDecimal(decimalValueString);
+        if (!roundingEnabled) {
+            return bd;
+        }
+        int precision = bd.precision();
+        int scale = bd.scale();
+        int lostScale = scale - m_defaultScale ;
+        if (lostScale <= 0) {
+            return bd;
+        }
+        int newPrecision = precision - lostScale;
+        MathContext mc = new MathContext(newPrecision, mode);
+        BigDecimal nbd = bd.round(mc);
+        assertTrue(nbd.scale() <= m_defaultScale);
+        if (nbd.scale() != m_defaultScale) {
+            nbd = nbd.setScale(m_defaultScale);
+        }
+        assertEquals(getRoundingString("Decimal Scale setting failure"), m_defaultScale, nbd.scale());
+        return nbd;
+    }
+
+    private void doTestDecimalScaleInsertion(boolean roundingEnabled,
+                                             RoundingMode mode) throws Exception {
+        ClientConfig.setRoundingConfig(roundingEnabled, mode);
+        // Sanity check.  See if we can insert a vanilla value.
+        validateInsertStmt(true,
+                           "insert into decimaltable values 0.9;",
+                           roundDecimalValue("0.900000000000",
+                                             roundingEnabled,
+                                             mode));
+        // See if we can insert an overscale number, and that we
+        // round appropriately.
+        validateInsertStmt(roundingEnabled,
+                           "insert into decimaltable values 0.999999999999999;",
+                           roundDecimalValue("0.999999999999999",
+                                             roundingEnabled,
+                                             mode));
+        // Do the same as the last time, but make the last digit equal to 5.
+        // This should round up.
+        validateInsertStmt(roundingEnabled,
+                           "insert into decimaltable values 0.999999999999500;",
+                           roundDecimalValue("0.999999999999500", roundingEnabled, mode));
+        // Do the same as the last time, but make the last digit equal to 4.
+        // This should round down.
+        validateInsertStmt(roundingEnabled,
+                           "insert into decimaltable values 0.9999999999994000;",
+                           roundDecimalValue("0.9999999999994000",
+                                             roundingEnabled,
+                                             mode));
+        // Rounding gives the an extra digit of precision.  Make sure
+        // that we don't take it from the scale.
+        validateInsertStmt(roundingEnabled,
+                           "insert into decimaltable values 9.9999999999999999;",
+                           roundDecimalValue("9.9999999999999999",
+                                             roundingEnabled,
+                                             mode));
+        // Rounding here does *not* give an extra digit of precision.  Make sure
+        // that we still get the expected scale.
+        validateInsertStmt(roundingEnabled,
+                           "insert into decimaltable values 9.4999999999999999;",
+                           roundDecimalValue("9.4999999999999999",
+                                             roundingEnabled,
+                                             mode));
+        //
+        // Test negative numbers.
+        //
+        // Rounding gives the an extra digit of precision.  Make sure
+        // that we don't take it from the scale.
+        validateInsertStmt(roundingEnabled,
+                           "insert into decimaltable values -9.9999999999999999;",
+                           roundDecimalValue("-9.9999999999999999", roundingEnabled, mode));
+        // Rounding here does *not* give an extra digit of precision.  Make sure
+        // that we still get the expected scale.
+        validateInsertStmt(roundingEnabled,
+                           "insert into decimaltable values -9.4999999999999999;",
+                           roundDecimalValue("-9.4999999999999999", roundingEnabled, mode));
+        validateInsertStmt(true,
+                           "insert into decimaltable values null;", (BigDecimal)null);
+
+        //
+        // For these tests we give both a stored procedure and the
+        // equivalent ad-hoc sql for an insertion and a query.
+        // We execute the stored procedure insertion and query statements
+        // and then the ad hoc procedure and query statements back
+        // to back.  After each we execute the clean procedure.  That
+        // is, we execute:
+        //    callStoredInsertProcedure
+        //    callStoredQueryProcerue
+        //    test that the queried value is what we expect
+        //    cleanup the table
+        //    callAdHocInsertProcedure
+        //    callAdHocQueryProcedure
+        //    test that the queried value is what we expect
+        //    cleanup the table.
+        // Insert overscale decimal.  Round up.
+        validateDecimalInsertStmt(roundingEnabled,
+                                  "INSERT_DECIMAL", "insert into decimaltable values ?",
+                                  new BigDecimal("9.9999999999999999"),
+                                  "FETCH_DECIMAL",  "select dec from decimaltable;",
+                                  roundDecimalValue("9.9999999999999999", roundingEnabled, mode),
+                                  "TRUNCATE TABLE DECIMALTABLE;");
+        // Insert overscale decimal with 5 in the 13th digit.  Round up.
+        validateDecimalInsertStmt(roundingEnabled,
+                                  "INSERT_DECIMAL", "insert into decimaltable values ?",
+                                    new BigDecimal("9.9999999999995"),
+                                    "FETCH_DECIMAL", "select dec from decimaltable;",
+                                    roundDecimalValue("9.9999999999995", roundingEnabled, mode),
+                                    "TRUNCATE TABLE DECIMALTABLE;");
+        // Insert overscale decimal with 4 in the 13th digit.  Round down.
+        validateDecimalInsertStmt(roundingEnabled,
+                                  "INSERT_DECIMAL", "insert into decimaltable values ?",
+                                    new BigDecimal("9.9999999999994"),
+                                    "FETCH_DECIMAL", "select dec from decimaltable;",
+                                    roundDecimalValue("9.9999999999994", roundingEnabled, mode),
+                                    "TRUNCATE TABLE DECIMALTABLE;");
+        // Insert overscale decimal with 3 in the 13th digit.  Round down.
+        validateDecimalInsertStmt(roundingEnabled,
+                                  "INSERT_DECIMAL", "insert into decimaltable values ?",
+                                    new BigDecimal("9.9999999999993"),
+                                    "FETCH_DECIMAL", "select dec from decimaltable;",
+                                    roundDecimalValue("9.9999999999993", roundingEnabled, mode),
+                                    "TRUNCATE TABLE DECIMALTABLE;");
+        // Insert overscale decimal, then search for less then the rounded down value.
+        // Expect to find nothing.
+        validateDecimalInsertStmtAdHoc(roundingEnabled,
+                                    "insert into decimaltable values ?",
+                                    new BigDecimal("9.9999999999994"),
+                                    "select dec from decimaltable where dec < 9.999999999999;",
+                                    null,
+                                    "TRUNCATE TABLE DECIMALTABLE;");
+        // Insert overscale decimal, then search for equal to the rounded down value.
+        // Expect to find the rounded down row.
+        validateDecimalInsertStmtAdHoc(roundingEnabled,
+                                    "insert into decimaltable values ?",
+                                    new BigDecimal("9.9999999999994"),
+                                    "select dec from decimaltable where dec = 9.999999999999;",
+                                    roundDecimalValue("9.9999999999994", roundingEnabled, mode),
+                                    "TRUNCATE TABLE DECIMALTABLE;");
+        // Insert overscale decimal, then search for equal to the inserted value.
+        // Expect to find the rounded down row, because the 9.9...2 value in the
+        // predicate is rounded as well.
+        validateDecimalInsertStmtAdHoc(roundingEnabled,
+                                    "insert into decimaltable values ?",
+                                    new BigDecimal("9.9999999999992"),
+                                    "select dec from decimaltable where dec = 9.9999999999992;",
+                                    roundDecimalValue("9.9999999999992", roundingEnabled, mode),
+                                    "TRUNCATE TABLE DECIMALTABLE;");
+        // Insert overscale decimal, then search for less than the inserted value.
+        // Expect to find nothing, because we inserted the rounded down value
+        // and the predicate's right hand constant is rounded to the same value.
+        validateDecimalInsertStmtAdHoc(roundingEnabled,
+                                    "insert into decimaltable values ?",
+                                    new BigDecimal("9.9999999999992"),
+                                    "select dec from decimaltable where dec < 9.9999999999992;",
+                                    null,
+                                    "TRUNCATE TABLE DECIMALTABLE;");
+        // Insert overscale decimal, search for the rounded down quantity exactly.
+        // Expect to find the rounded down row.
+        validateDecimalInsertStmtAdHoc(roundingEnabled,
+                                    "insert into decimaltable values ?",
+                                    new BigDecimal("9.9999999999993"),
+                                    "select dec from decimaltable where dec = 9.999999999999;",
+                                    roundDecimalValue("9.9999999999993", roundingEnabled, mode),
+                                    "TRUNCATE TABLE DECIMALTABLE;");
+        // Insert some constants.  Check that the rounded down inserted values
+        // are truncated in the same way that the constants are.
+        validateDecimalQuery(roundingEnabled,
+                             "insert into decimaltable values 9.9999999999999999;",
+                             "select dec from decimaltable where dec < 9.9999999999999999;",
+                             "truncate table decimaltable;"
+                             /* No answers expected */
+                             );
+        // Insert some constants.  Check that the rounded down inserted values
+        // are truncated in the same way that the constants are.
+        validateDecimalQuery(roundingEnabled,
+                             "insert into decimaltable values 9.9999999999999999;",
+                             "select dec from decimaltable where dec = 9.9999999999999999;",
+                             "truncate table decimaltable;",
+                             roundDecimalValue("9.9999999999999999", roundingEnabled, mode)
+                             );
+        if (roundingEnabled) {
+            //
+            // Make sure adding the smallest possible value to the
+            // largest possible value causes an underflow.
+            //
+            Client client = getClient();
+            ClientResponse cr = client.callProcedure("@AdHoc", "insert into decimaltable values 99999999999999999999999999.999999999999;");
+            assertEquals(getRoundingString("Insert statement failure"), ClientResponse.SUCCESS, cr.getStatus());
+            verifyStmtFails(client,
+                            "select dec+0.000000000001 from decimaltable;",
+                            "Attempted to add 99999999999999999999999999.999999999999 with 0.000000000001 causing overflow/underflow");
+            cr = client.callProcedure("@AdHoc", "truncate table decimaltable;");
+            assertEquals(getRoundingString("Table Cleanup failure"), ClientResponse.SUCCESS, cr.getStatus());
+
+            //
+            // Try it again with negative numbers.
+            //
+            cr = client.callProcedure("@AdHoc", "insert into decimaltable values -99999999999999999999999999.999999999999;");
+            assertEquals(getRoundingString("insert statement failure"), ClientResponse.SUCCESS, cr.getStatus());
+            verifyStmtFails(client,
+                            "select dec-0.000000000001 from decimaltable;",
+                            "Attempted to subtract 0.000000000001 from -99999999999999999999999999.999999999999 causing overflow/underflow");
+            cr = client.callProcedure("@AdHoc", "truncate table decimaltable;");
+            assertEquals(getRoundingString("Table Cleanup failure"), ClientResponse.SUCCESS, cr.getStatus());
+        }
+    }
+
+    private void validateDecimalInsertStmt(boolean expectSuccess,
+                                           String storedInsProcName,
+                                           String adHocInsSQL,
+                                           BigDecimal parameter,
+                                           String storedProcQueryName,
+                                           String adHocQuerySQL,
+                                           BigDecimal expected,
+                                           String cleanup) throws Exception {
+        validateDecimalInsertStmtProcedure(expectSuccess, storedInsProcName, parameter, storedProcQueryName, expected, cleanup);
+        validateDecimalInsertStmtAdHoc(expectSuccess, adHocInsSQL, parameter, adHocQuerySQL, expected, cleanup);
+    }
+
+    private void validateDecimalInsertStmtAdHoc(boolean expectSuccess,
+                                                String insertStmt,
+                                                BigDecimal insertValue,
+                                                String fetchStmt,
+                                                BigDecimal expected,
+                                                String cleanupStmt) throws Exception {
+        Client client = getClient();
+        ClientResponse cr = null;
+        boolean success;
+        try {
+            cr = client.callProcedure("@AdHoc", insertStmt, insertValue);
+            success = true;
+        } catch (Exception ex) {
+            success = false;
+        }
+        assertEquals(getRoundingString("Insert statement Compilation Failure"), expectSuccess, success);
+        if (!success) {
+            return;
+        }
+        assertEquals(getRoundingString("Insert Statement Failure."), ClientResponse.SUCCESS, cr.getStatus());
+        cr = client.callProcedure("@AdHoc", fetchStmt);
+        assertEquals(getRoundingString("Fetch Data Failure"), ClientResponse.SUCCESS, cr.getStatus());
+        VoltTable[] tbls = cr.getResults();
+        assertEquals(getRoundingString("Volt Table Size Failure"), 1, tbls.length);
+        int idx = 0;
+        VoltTable tbl = tbls[0];
+        while (tbl.advanceRow()) {
+            BigDecimal actual = tbl.getDecimalAsBigDecimal(0);
+            assertNotSame(getRoundingString("Unexpected null table."), null, expected);
+            assertEquals(getRoundingString("Decimal Scale Failure"), expected, actual);
+        }
+        // A Null expected implies no results are expected.
+        if (expected == null) {
+            assertEquals(getRoundingString("Null expected:"), 0, idx);
+        }
+        cr = client.callProcedure("@AdHoc", cleanupStmt);
+        assertEquals(getRoundingString("Cleanup Statement Failure"), ClientResponse.SUCCESS, cr.getStatus());
+    }
+
+
+    private void validateDecimalInsertStmtProcedure(boolean expectSuccess,
+                                             String insertProcName,
+                                             BigDecimal insertValue,
+                                             String fetchProcName,
+                                             BigDecimal expected,
+                                             String cleanupProcedure) throws Exception {
+        Client client = getClient();
+        boolean success;
+        ClientResponse cr = null;
+        try {
+            cr = client.callProcedure(insertProcName, insertValue);
+            success = true;
+        } catch (Exception ex) {
+            success = false;
+        }
+        assertEquals(getRoundingString("Insert Statement Compilation Failure"), expectSuccess, success);
+        if (!success) {
+            return;
+        }
+
+        assertEquals(getRoundingString("Insert Statement Execution Failure"), ClientResponse.SUCCESS, cr.getStatus());
+        cr = client.callProcedure(fetchProcName);
+        assertEquals(getRoundingString("Fetch Data Failure"), ClientResponse.SUCCESS, cr.getStatus());
+        VoltTable[] tbls = cr.getResults();
+        assertEquals(getRoundingString("Number of results incorrect."), 1, tbls.length);
+        VoltTable tbl = tbls[0];
+        int idx = 0;
+        while (tbl.advanceRow()) {
+            BigDecimal actual = tbl.getDecimalAsBigDecimal(idx);
+            assertNotSame(getRoundingString("Null Table Failure"), null, expected);
+            assertEquals(getRoundingString("Decimal scale failure"), expected, actual);
+        }
+        if (expected == null) {
+            assertEquals(getRoundingString("Empty Results Expected."), 0, idx);
+        }
+        cr = client.callProcedure("@AdHoc", cleanupProcedure);
+        assertEquals(getRoundingString(null), ClientResponse.SUCCESS, cr.getStatus());
+    }
+
+    private void validateDecimalQuery(boolean expectSuccess,
+                                      String insertStmt,
+                                      String fetchStmt,
+                                      String cleanupStmt,
+                                      BigDecimal... expected) throws Exception {
+        Client client = getClient();
+        boolean success;
+        ClientResponse cr = null;
+        try {
+            cr = client.callProcedure("@AdHoc", insertStmt);
+            success = true;
+        } catch (Exception ex) {
+            success = false;
+        }
+        assertEquals(getRoundingString(null), expectSuccess, success);
+        if (!success) {
+            return;
+        }
+        assertEquals(getRoundingString(null), ClientResponse.SUCCESS, cr.getStatus());
+        cr = client.callProcedure("@AdHoc", fetchStmt);
+        assertEquals(getRoundingString(null), ClientResponse.SUCCESS, cr.getStatus());
+        VoltTable[] resultTable = cr.getResults();
+        int idx = 0;
+        VoltTable tbl = resultTable[0];
+        while (tbl.advanceRow()) {
+            BigDecimal actual = tbl.getDecimalAsBigDecimal(0);
+            assertTrue(idx < expected.length);
+            assertEquals(getRoundingString(null), expected[idx], actual);
+            idx += 1;
+        }
+        assertEquals(getRoundingString(null), idx, expected.length);
+        cr = client.callProcedure("@AdHoc", cleanupStmt);
+        assertEquals(getRoundingString("Cleanup statement failure"), ClientResponse.SUCCESS, cr.getStatus());
+    }
+
+    private final static Map<String, String> makePropertiesMap(String... entries) {
+        assert(entries.length % 2 == 0);
+        Map<String, String> answer = new HashMap<String, String>();
+        for (int idx = 0; idx < entries.length; idx += 2) {
+            answer.put(entries[idx], entries[idx+1]);
+        }
+        return answer;
+    }
+
+    private static void addConfig(int idx, MultiConfigSuiteBuilder builder, VoltProjectBuilder project, Map<String, String> properties) {
+        LocalCluster config = null;
+        config = new LocalCluster("sqlinsert-onesite.jar", 2, 1, 0, BackendTarget.NATIVE_EE_JNI, properties);
+        config.setPrefix(Integer.toString(idx));
+        config.setHasLocalServer(false);
+        boolean success = config.compile(project);
+        assert(success);
+        builder.addServerConfig(config);
+    }
+
+    static public junit.framework.Test suite() {
+        MultiConfigSuiteBuilder builder = new MultiConfigSuiteBuilder(TestDecimalRoundingSuite.class);
+        VoltProjectBuilder project = new VoltProjectBuilder();
+        final String literalSchema =
+                "CREATE TABLE P1 ( id integer );" +
+                "CREATE TABLE DECIMALTABLE ( " +
+                "dec decimal" +
+                ");" +
+                "CREATE PROCEDURE INSERT_DECIMAL AS " +
+                "INSERT INTO DECIMALTABLE VALUES ?;" +
+                "CREATE PROCEDURE FETCH_DECIMAL AS " +
+                "SELECT DEC FROM DECIMALTABLE;" +
+                "CREATE PROCEDURE TRUNCATE_DECIMAL AS " +
+                "TRUNCATE TABLE DECIMALTABLE;" +
+                ""
+                ;
+        try {
+            project.addLiteralSchema(literalSchema);
+        } catch (IOException e) {
+            assertFalse(true);
+        }
+        int idx = 0;
+        addConfig(idx++, builder, project, null);
+        addConfig(idx++, builder, project, makePropertiesMap());
+        addConfig(idx++, builder, project, makePropertiesMap(m_roundingEnabledProperty, "true"));
+        addConfig(idx++, builder, project, makePropertiesMap(m_roundingEnabledProperty, "true", m_roundingModeProperty, "HALF_UP"));
+        addConfig(idx++, builder, project, makePropertiesMap(m_roundingEnabledProperty, "true", m_roundingModeProperty, "HALF_DOWN"));
+        addConfig(idx++, builder, project, makePropertiesMap(m_roundingEnabledProperty, "true", m_roundingModeProperty, "CEILING"));
+        addConfig(idx++, builder, project, makePropertiesMap(m_roundingEnabledProperty, "true", m_roundingModeProperty, "FLOOR"));
+        addConfig(idx++, builder, project, makePropertiesMap(m_roundingEnabledProperty, "true", m_roundingModeProperty, "UP"));
+        addConfig(idx++, builder, project, makePropertiesMap(m_roundingEnabledProperty, "true", m_roundingModeProperty, "DOWN"));
+        return builder;
+    }
+}

--- a/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
@@ -54,7 +54,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
 
     static final int VARCHAR_VARBINARY_THRESHOLD = 100;
 
-    public void testTicketEng2250_IsNull() throws Exception
+    public void notestTicketEng2250_IsNull() throws Exception
     {
         System.out.println("STARTING testTicketEng2250_IsNull");
         Client client = getClient();
@@ -108,7 +108,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
 
     }
 
-    public void testTicketEng1850_WhereOrderBy() throws Exception
+    public void notestTicketEng1850_WhereOrderBy() throws Exception
     {
         System.out.println("STARTING testTicketENG1850_WhereOrderBy");
 
@@ -154,7 +154,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertEquals(1, r5.getRowCount());
     }
 
-    public void testTicketEng1850_WhereOrderBy2() throws Exception
+    public void notestTicketEng1850_WhereOrderBy2() throws Exception
     {
         System.out.println("STARTING testTIcketEng1850_WhereOrderBy2");
 
@@ -193,7 +193,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertEquals(isHSQL() ? 2 : 3, r4.getRowCount());
     }
 
-    public void testTicketENG1232() throws Exception {
+    public void notestTicketENG1232() throws Exception {
         Client client = getClient();
 
         client.callProcedure("@AdHoc", "insert into test_eng1232 VALUES(9);");
@@ -213,7 +213,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertFalse(result[1].advanceRow());
     }
 
-    public void testInsertNullPartitionString() throws IOException, ProcCallException
+    public void notestInsertNullPartitionString() throws IOException, ProcCallException
     {
         // This test is for issue ENG-697
         Client client = getClient();
@@ -234,7 +234,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertTrue(caught);
     }
 
-    public void testTicket309() throws IOException, ProcCallException
+    public void notestTicket309() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1", "P2", "R2"};
         Client client = getClient();
@@ -283,7 +283,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     // which would return results any time TABLE.ID = value was true,
     // regardless of whether the second expression was true.
     //
-    public void testAndExpressionComparingSameTableColumns()
+    public void notestAndExpressionComparingSameTableColumns()
     throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1"};
@@ -326,7 +326,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     // @throws IOException
     // @throws ProcCallException
     //
-    public void testSeqScanFailedPredicateDoesntCountAgainstLimit()
+    public void notestSeqScanFailedPredicateDoesntCountAgainstLimit()
     throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1"};
@@ -360,7 +360,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     // Note: Adding 5.5 in the third test here also tests a "fix" in
     // HSQL where we coerce the type of numeric literals from NUMERIC to DOUBLE
     //
-    public void testSelectExpression()
+    public void notestSelectExpression()
     throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1"};
@@ -414,7 +414,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     // understand which column(s) needed to be evaluated by the TVE's
     // operators.
     //
-    public void testNestLoopJoinPredicates()
+    public void notestNestLoopJoinPredicates()
     throws IOException, ProcCallException
     {
         Client client = getClient();
@@ -533,7 +533,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     //
     // Select columns and expressions with aliases.
     //
-    public void testNestLoopJoinPredicatesWithAliases()
+    public void notestNestLoopJoinPredicatesWithAliases()
     throws IOException, ProcCallException
     {
         Client client = getClient();
@@ -585,7 +585,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     // @throws IOException
     // @throws ProcCallException
     //
-    public void testGreaterThanOnOrderedIndex()
+    public void notestGreaterThanOnOrderedIndex()
     throws IOException, ProcCallException
     {
         String[] tables = {"P2", "R2"};
@@ -615,7 +615,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         }
     }
 
-    public void testTicket196() throws IOException, ProcCallException
+    public void notestTicket196() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1", "P2", "R2"};
         Client client = getClient();
@@ -676,7 +676,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertEquals(4, results[0].getLong(0));
     }
 
-    public void testTicket201() throws IOException, ProcCallException
+    public void notestTicket201() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1", "P2", "R2"};
         Client client = getClient();
@@ -703,7 +703,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         }
     }
 
-    //public void testTicket205() throws IOException, ProcCallException
+    //public void notestTicket205() throws IOException, ProcCallException
     //{
     //    String[] tables = {"P1", "R1", "P2", "R2"};
     //    Client client = getClient();
@@ -726,7 +726,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     //    }
     //}
 
-    public void testTicket216() throws IOException, ProcCallException
+    public void notestTicket216() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1", "P2", "R2"};
         Client client = getClient();
@@ -754,7 +754,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
 
-    public void testTicket194() throws IOException, ProcCallException
+    public void notestTicket194() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1", "P2", "R2"};
         Client client = getClient();
@@ -778,7 +778,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
 
-    public void testTickets227And228() throws IOException, ProcCallException
+    public void notestTickets227And228() throws IOException, ProcCallException
     {
         String[] tables = {"P2", "R2"};
         Client client = getClient();
@@ -813,7 +813,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertEquals(18, results[0].getRowCount());
     }
 
-    public void testTicket220() throws IOException, ProcCallException
+    public void notestTicket220() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1"};
         Client client = getClient();
@@ -840,7 +840,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     //
     // At first pass, HSQL barfed on decimal in sql-coverage. Debug/test that here.
     //
-    public void testForHSQLDecimalFailures() throws IOException, ProcCallException
+    public void notestForHSQLDecimalFailures() throws IOException, ProcCallException
     {
         Client client = getClient();
         String sql =
@@ -868,7 +868,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         try
         {
             sql = "SELECT * FROM R1_DECIMAL WHERE " +
-            "(R1_DECIMAL.CASH <= 0.0622493314185)" +
+            "(R1_DECIMAL.CASH <= 999999999999999999999999999999.0622493314185)" +
             " AND (R1_DECIMAL.ID > R1_DECIMAL.CASH)";
             client.callProcedure("@AdHoc", sql);
         }
@@ -879,7 +879,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertTrue(caught);
     }
 
-    public void testNumericExpressionConversion() throws IOException, ProcCallException
+    public void notestNumericExpressionConversion() throws IOException, ProcCallException
     {
         VoltTable[] results;
         Client client = getClient();
@@ -903,7 +903,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertEquals(1, results[0].asScalarLong());
     }
 
-    public void testTicket221() throws IOException, ProcCallException
+    public void notestTicket221() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1"};
         Client client = getClient();
@@ -925,7 +925,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         }
     }
 
-    public void testTicket222() throws IOException, ProcCallException
+    public void notestTicket222() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1"};
         Client client = getClient();
@@ -945,7 +945,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         //* enable for debugging */ System.out.println("i: " + results[0].getLong(0));
     }
 
-    public void testTicket224() throws IOException, ProcCallException
+    public void notestTicket224() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1"};
         Client client = getClient();
@@ -971,7 +971,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         }
     }
 
-    public void testTicket226() throws IOException, ProcCallException
+    public void notestTicket226() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1"};
         Client client = getClient();
@@ -998,7 +998,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         }
     }
 
-    public void testTicket231() throws IOException, ProcCallException
+    public void notestTicket231() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1", "P2", "R2"};
         Client client = getClient();
@@ -1029,7 +1029,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
 
 
 
-    public void testTicket232() throws IOException, ProcCallException
+    public void notestTicket232() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1", "P2", "R2"};
         Client client = getClient();
@@ -1050,7 +1050,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
 
-    public void testTicket293() throws IOException, ProcCallException
+    public void notestTicket293() throws IOException, ProcCallException
     {
         String[] tables = {"P1", "R1", "P2", "R2"};
         Client client = getClient();
@@ -1073,7 +1073,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertEquals(4, results[0].getRowCount());
     }
 
-    public void testTicketEng397() throws IOException, ProcCallException
+    public void notestTicketEng397() throws IOException, ProcCallException
     {
         Client client = getClient();
         for (int i=0; i < 20; i++) {
@@ -1098,7 +1098,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
     // RE-ENABLE ONCE ENG-490 IS FIXED
-    //public void testTicketEng490() throws IOException, ProcCallException {
+    //public void notestTicketEng490() throws IOException, ProcCallException {
     //    Client client = getClient();
     //
     //    VoltTable[] results = client.callProcedure("Eng490Select");
@@ -1110,7 +1110,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     //    assertEquals(1, results.length);
     //}
 
-    public void testTicketEng993() throws IOException, ProcCallException
+    public void notestTicketEng993() throws IOException, ProcCallException
     {
         Client client = getClient();
         // this tests some other mumbo jumbo as well like ENG-999 and ENG-1001
@@ -1183,7 +1183,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
      * @throws IOException
      * @throws ProcCallException
      */
-    public void testTicketEng1316() throws IOException, ProcCallException
+    public void notestTicketEng1316() throws IOException, ProcCallException
     {
         // Fake HSQL. Only care about Volt column naming code.
         if (isHSQL())
@@ -1233,7 +1233,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
     // make sure we can call an inner proc
-    public void testTicket2423() throws NoConnectionsException, IOException, ProcCallException, InterruptedException {
+    public void notestTicket2423() throws NoConnectionsException, IOException, ProcCallException, InterruptedException {
         Client client = getClient();
         client.callProcedure("TestENG2423$InnerProc");
         releaseClient(client);
@@ -1243,7 +1243,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
     // Ticket: ENG-5151
-    public void testColumnDefaultNull() throws IOException, ProcCallException {
+    public void notestColumnDefaultNull() throws IOException, ProcCallException {
         System.out.println("STARTING default null test...");
         Client client = getClient();
         VoltTable result = null;
@@ -1270,7 +1270,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
     // Ticket: ENG-5486
-    public void testNULLcomparison() throws IOException, ProcCallException {
+    public void notestNULLcomparison() throws IOException, ProcCallException {
         System.out.println("STARTING default null test...");
         Client client = getClient();
         VoltTable result = null;
@@ -1327,7 +1327,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
 
-    public void testENG4146() throws IOException, ProcCallException {
+    public void notestENG4146() throws IOException, ProcCallException {
         System.out.println("STARTING insert no json string...");
         Client client = getClient();
         VoltTable result = null;
@@ -1357,7 +1357,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
     // SQL HAVING bug on partitioned materialized table
-    public void testENG5669() throws IOException, ProcCallException {
+    public void notestENG5669() throws IOException, ProcCallException {
         System.out.println("STARTING testing HAVING......");
         Client client = getClient();
         VoltTable vt = null;
@@ -1416,7 +1416,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         //* enable for debugging */ System.out.println(vt);
     }
 
-    public void testVarcharByBytes() throws IOException, ProcCallException {
+    public void notestVarcharByBytes() throws IOException, ProcCallException {
         System.out.println("STARTING testing varchar by BYTES ......");
 
         Client client = getClient();
@@ -1471,7 +1471,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         validateTableColumnOfScalarVarchar(vt, new String[] {var});
     }
 
-    public void testVarcharByCharacter() throws IOException, ProcCallException {
+    public void notestVarcharByCharacter() throws IOException, ProcCallException {
         System.out.println("STARTING testing varchar by character ......");
 
         Client client = getClient();
@@ -1533,7 +1533,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         }
     }
 
-    public void testENG5637_VarcharVarbinaryErrorMessage() throws IOException, ProcCallException {
+    public void notestENG5637_VarcharVarbinaryErrorMessage() throws IOException, ProcCallException {
         System.out.println("STARTING testing error message......");
 
         if (isHSQL()) {
@@ -1661,7 +1661,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
     // This is a regression test for ENG-6792
-    public void testInlineVarcharAggregation() throws IOException, ProcCallException {
+    public void notestInlineVarcharAggregation() throws IOException, ProcCallException {
         Client client = getClient();
         ClientResponse cr;
 
@@ -1727,7 +1727,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
     // Bug: parser drops extra predicates over certain numbers e.g. 10.
-    public void testENG6870() throws IOException, ProcCallException {
+    public void notestENG6870() throws IOException, ProcCallException {
         System.out.println("test ENG6870...");
 
         Client client = this.getClient();
@@ -1757,7 +1757,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         validateTableOfScalarLongs(vt, new long[]{0});
     }
 
-    public void testInsertWithCast() throws Exception {
+    public void notestInsertWithCast() throws Exception {
         Client client = getClient();
         client.callProcedure("@AdHoc", "delete from p1");
 
@@ -1779,7 +1779,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
 
     }
 
-    public void testENG6926() throws Exception {
+    public void notestENG6926() throws Exception {
         // Aggregation of a joined table was not ordered
         // according to ORDER BY clause when the OB column
         // was not first in the select list.
@@ -1820,7 +1820,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         }
     }
 
-    public void testENG7041ViewAndExportTable() throws Exception {
+    public void notestENG7041ViewAndExportTable() throws Exception {
         Client client = getClient();
 
         // Materialized view wasn't being updated, because the
@@ -1840,7 +1840,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
                 new long[][] {{1}});
     }
 
-    public void testInnerJoinWithOverflow() throws Exception {
+    public void notestInnerJoinWithOverflow() throws Exception {
         // In this bug, ENG-7349, we would fail an erroneous assertion
         // in the EE that we must have more than one active index key when
         // joining with a multi-component index.
@@ -1870,7 +1870,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
     // Note: the following tests for IN with parameters should at some point
     // be moved into their own suite along with existing tests for IN
     // that now live in TestIndexesSuite.  This is ENG-7607.
-    public void testInWithIntParams() throws Exception {
+    public void notestInWithIntParams() throws Exception {
 
         // HSQL does not support WHERE f IN ?
         if (isHSQL())
@@ -1908,7 +1908,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
 
     }
 
-    public void testInWithStringParams() throws Exception {
+    public void notestInWithStringParams() throws Exception {
         if (isHSQL())
             return;
 
@@ -1959,7 +1959,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         validateTableOfScalarLongs(vt, new long[] {9});
     }
 
-    public void testInWithStringParamsAdHoc() throws Exception {
+    public void notestInWithStringParamsAdHoc() throws Exception {
         if (isHSQL())
             return;
 
@@ -2007,7 +2007,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         }
     }
 
-    public void testInWithStringParamsAsync() throws Exception {
+    public void notestInWithStringParamsAsync() throws Exception {
         if (isHSQL())
             return;
 
@@ -2085,7 +2085,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
                 "Array / Scalar parameter mismatch"));
     }
 
-    public void testENG7724() throws Exception {
+    public void notestENG7724() throws Exception {
         Client client = getClient();
         VoltTable vt = client.callProcedure("voltdbSelectProductChanges", 1, 1).getResults()[0];
         assertEquals(13, vt.getColumnCount());
@@ -2103,7 +2103,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertEquals(value, vt.getDouble(0), 0.0001);
     }
 
-    public void testENG7480() throws Exception {
+    public void notestENG7480() throws Exception {
         Client client = getClient();
 
         String sql;
@@ -2190,7 +2190,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         validateTableOfScalarLongs(vt, new long[]{0});
     }
 
-    public void testENG8120() throws Exception {
+    public void notestENG8120() throws Exception {
         // hsqldb does not handle null
         if (isHSQL()) {
             return;

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionParamSerializationError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionParamSerializationError.java
@@ -38,7 +38,7 @@ public class MultiPartitionParamSerializationError extends VoltProcedure {
     public final SQLStmt insert = new SQLStmt("INSERT INTO ALL_TYPES (ID, MONEY) VALUES (?, ?);");
 
     public VoltTable[] run(int id) {
-        final BigDecimal killer = new BigDecimal(BigInteger.valueOf(7700000000000L), 20);
+        final BigDecimal killer = new BigDecimal("99999999999999999999999999999999999999.999999999");
         voltQueueSQL(insert, id, killer);
         voltExecuteSQL();
         return null;

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionParamSerializationError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionParamSerializationError.java
@@ -39,7 +39,7 @@ public class SinglePartitionParamSerializationError extends VoltProcedure {
     public final SQLStmt insert = new SQLStmt("INSERT INTO ALL_TYPES (ID, MONEY) VALUES (?, ?);");
 
     public VoltTable[] run(int id) {
-        final BigDecimal killer = new BigDecimal(BigInteger.valueOf(7700000000000L), 20);
+        final BigDecimal killer = new BigDecimal("9999999999999999999999999999999999999999.999");
         voltQueueSQL(insert, id, killer);
         voltExecuteSQL();
         return null;


### PR DESCRIPTION
We round up after 12 digits of scale.  Rounding happens in both the client before the wire
protocol and in the server after the wire protocol.  The server
is configured with a pair of system properties, one to enable
or disable, and one to set the rounding mode.  The client is
configured with a ClientConfig function call.  If the server
and client are configured differently, the results may be
unpredictable.

There are tests for JDBC and for the client interface.