### PR TITLE
Eng 8526 always listen if dr tag present

### DIFF
--- a/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
+++ b/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
@@ -370,7 +370,7 @@
         <xs:element name="connection" type="connectionType" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
     <xs:attribute name="id" type="clusterIdType" use="required"/>
-    <xs:attribute name="listen" type="xs:boolean" default="false" />
+    <xs:attribute name="listen" type="xs:boolean" default="true" />
     <xs:attribute name="port" type="xs:int" default="5555"/>
   </xs:complexType>
 

--- a/tests/frontend/org/voltdb/utils/TestCatalogUtil.java
+++ b/tests/frontend/org/voltdb/utils/TestCatalogUtil.java
@@ -1371,7 +1371,7 @@ public class TestCatalogUtil extends TestCase {
         assertTrue("Deployment file failed to parse", msg == null);
 
         assertEquals("master", catalog.getClusters().get("cluster").getDrmasterhost());
-        assertFalse(catalog.getClusters().get("cluster").getDrproducerenabled());
+        assertTrue(catalog.getClusters().get("cluster").getDrproducerenabled());
         assertTrue(catalog.getClusters().get("cluster").getDrclusterid() == 1);
 
         final File tmpEnabled = VoltProjectBuilder.writeStringToTempFile(oneEnabledConnection);
@@ -1383,7 +1383,7 @@ public class TestCatalogUtil extends TestCase {
         assertTrue("Deployment file failed to parse", msg == null);
 
         assertEquals("master", catalog.getClusters().get("cluster").getDrmasterhost());
-        assertFalse(catalog.getClusters().get("cluster").getDrproducerenabled());
+        assertTrue(catalog.getClusters().get("cluster").getDrproducerenabled());
         assertTrue(catalog.getClusters().get("cluster").getDrclusterid() == 1);
 
         final File tmpDisabled = VoltProjectBuilder.writeStringToTempFile(drDisabled);


### PR DESCRIPTION
The proposed new DR UI document requires the master node to always "listen" to network, even the "listen" attribute in the deployment file is not being set. 
