### PR TITLE
ENG-8546 Fix crash bug in findExistingTuple

### DIFF
--- a/src/ee/storage/MaterializedViewMetadata.cpp
+++ b/src/ee/storage/MaterializedViewMetadata.cpp
@@ -667,7 +667,7 @@ bool MaterializedViewMetadata::findExistingTuple(const TableTuple &tuple)
     if (m_groupByColumnCount == 0) {
         TableIterator iterator = m_target->iteratorDeletingAsWeGo();
         iterator.next(m_existingTuple);
-        return true;
+        return ! m_existingTuple.isNullTuple();
     }
 
     // find the key for this tuple (which is the group by columns)


### PR DESCRIPTION
There is a bug in findExistingTuple that can make a materialized view crash if the source table is not empty before view creation.