### PR TITLE
Various AdHoc constants value fixes

### DIFF
--- a/src/frontend/org/voltdb/VoltType.java
+++ b/src/frontend/org/voltdb/VoltType.java
@@ -518,6 +518,10 @@ public enum VoltType {
         return "VoltType." + name();
     }
 
+    public String getName() {
+        return name();
+    }
+
     /**
      * Get the number of bytes required to store the type for types
      * with fixed length.

--- a/src/frontend/org/voltdb/planner/ParameterizationInfo.java
+++ b/src/frontend/org/voltdb/planner/ParameterizationInfo.java
@@ -177,16 +177,31 @@ class ParameterizationInfo {
 
                 VoltXMLElement paramIndexNode = new VoltXMLElement("parameter");
                 paramIndexNode.attributes.put("index", String.valueOf(paramIndex));
-                String typeStr = node.attributes.get("valuetype");
-                paramIndexNode.attributes.put("valuetype", typeStr);
                 paramIndexNode.attributes.put("id", idStr);
                 paramsNode.children.add(paramIndexNode);
 
+                // handle parameter value type
+                String typeStr = node.attributes.get("valuetype");
+                VoltType vt = VoltType.typeFromString(typeStr);
+
                 String value = null;
-                if (VoltType.typeFromString(typeStr) != VoltType.NULL) {
+                if (vt != VoltType.NULL) {
                     value = node.attributes.get("value");
                 }
                 paramValues.add(value);
+
+                if (vt == VoltType.NUMERIC) {
+                    vt = VoltType.BIGINT;
+                    try {
+                        Long.parseLong(value);
+                    } catch (NumberFormatException e) {
+                        // DECIMAL probably is not bigger/smaller enough than our decimal range.
+                        vt = VoltType.DECIMAL;
+                    }
+                }
+
+                node.attributes.put("valuetype", vt.getName());
+                paramIndexNode.attributes.put("valuetype", vt.getName());
             }
 
             // Assume that all values, whether or not their ids have been seen before, can

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -691,7 +691,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
     private void parseDisplayColumn(VoltXMLElement child, boolean isDistributed) {
         ParsedColInfo col = new ParsedColInfo();
         m_aggregationList.clear();
-        AbstractExpression colExpr = parseExpressionTree(child);;
+        AbstractExpression colExpr = parseExpressionTree(child);
         if (colExpr instanceof ConstantValueExpression) {
             assert(colExpr.getValueType() != VoltType.NUMERIC);
         }

--- a/tests/frontend/org/voltdb/regressionsuites/TestAdHocPlannerCache.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestAdHocPlannerCache.java
@@ -24,6 +24,7 @@
 package org.voltdb.regressionsuites;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
@@ -141,9 +142,9 @@ public class TestAdHocPlannerCache extends RegressionSuite {
 
          subtest2AdHocParameters(client);
 
-         subtest3AdHocBadParameters(client);
+         subtest3AdHocParameterTypes(client);
 
-         subtest4AdvancedBadParameters(client);
+         subtest4AdvancedParameterTypes(client);
 
          subtest5ExplainPlans(client);
 
@@ -159,22 +160,18 @@ public class TestAdHocPlannerCache extends RegressionSuite {
         // No constants AdHoc queries
         //
         sql = "SELECT ID FROM R1 sub1 order by ID;";
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{1, 2, 3});
+        validateTableOfScalarLongs(client, sql, new long[]{1, 2, 3});
         checkPlannerCache(client, CACHE_MISS2_ADD1);
 
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{1, 2, 3});
+        validateTableOfScalarLongs(client, sql, new long[]{1, 2, 3});
         checkPlannerCache(client, CACHE_HIT1);
 
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{1, 2, 3});
+        validateTableOfScalarLongs(client, sql, new long[]{1, 2, 3});
         checkPlannerCache(client, CACHE_HIT1);
 
         // rename table alias
         sql = "SELECT ID FROM R1 sub1_C order by ID;";
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{1, 2, 3});
+        validateTableOfScalarLongs(client, sql, new long[]{1, 2, 3});
         checkPlannerCache(client, CACHE_MISS2_ADD1);
 
 
@@ -182,17 +179,14 @@ public class TestAdHocPlannerCache extends RegressionSuite {
         // Contain constants AdHoc Queries
         //
         sql = "SELECT ID FROM R1 sub1 WHERE ID > 1 order by ID;";
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{2, 3});
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
         checkPlannerCache(client, CACHE_MISS2_ADD1);
 
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{2, 3});
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
         checkPlannerCache(client, CACHE_HIT1);
 
         sql = "SELECT ID FROM R1 sub1 WHERE ID > 2 order by ID;";
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{3});
+        validateTableOfScalarLongs(client, sql, new long[]{3});
         checkPlannerCache(client, CACHE_HIT2_ADD1);
 
 
@@ -330,38 +324,44 @@ public class TestAdHocPlannerCache extends RegressionSuite {
         checkPlannerCache(client, CACHE_SKIPPED);
     }
 
-    public void subtest3AdHocBadParameters(Client client) throws IOException, ProcCallException {
-        System.out.println("subtest3AdHocBadParameters...");
+    public void subtest3AdHocParameterTypes(Client client) throws IOException, ProcCallException {
+        System.out.println("subtest3AdHocParameterTypes...");
 
         String sql;
         VoltTable vt;
 
-        // Integer <-> Float
+        // decimal constants
         sql = "SELECT ID FROM R1 sub3 WHERE ID > 1.8 order by ID;";
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{2, 3});
-        checkPlannerCache(client, CACHE_MISS1);
-
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{2, 3});
-        checkPlannerCache(client, CACHE_HIT1);
-
-        sql = "SELECT ID FROM R1 sub3 WHERE ID > 1 order by ID;";
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{2, 3});
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
         checkPlannerCache(client, CACHE_MISS2_ADD1);
 
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{2, 3});
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_HIT1);
+
+        sql = "SELECT ID FROM R1 sub3 WHERE ID > 1.9 order by ID;";
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        // same query but use Integer constants
+        // Then it's a completely new sql pattern to the cache,
+        // as the cache is parameter type sensitive now.
+        sql = "SELECT ID FROM R1 sub3 WHERE ID > 1 order by ID;";
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
         checkPlannerCache(client, CACHE_HIT1);
 
         sql = "SELECT ID FROM R1 sub3 WHERE ID > 2 order by ID;";
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{3});
+        validateTableOfScalarLongs(client, sql, new long[]{3});
         checkPlannerCache(client, CACHE_HIT2_ADD1);
 
+        //
+        // query with user parameters
+        //
         sql = "SELECT ID FROM R1 sub3 WHERE ID > ? order by ID;";
         String errorMsg = "java.lang.Double is not a match or is out of range for the target parameter type: long";
+        // TODO: the message should say: decimal not able to be converted to integer ?
         verifyAdHocFails(client, errorMsg, sql, 1.8);
         checkPlannerCache(client, CACHE_MISS2);
 
@@ -373,28 +373,139 @@ public class TestAdHocPlannerCache extends RegressionSuite {
         validateTableOfScalarLongs(vt, new long[]{3});
         checkPlannerCache(client, CACHE_HIT2);
 
+        // user parameter with CAST operation
+        sql = "SELECT ID FROM R1 sub3 WHERE ID > cast(? as float) order by ID;";
+        vt = client.callProcedure("@AdHoc", sql, 1.8).getResults()[0];
+        validateTableOfScalarLongs(vt, new long[]{2,3});
+        checkPlannerCache(client, CACHE_MISS2);
+
+        vt = client.callProcedure("@AdHoc", sql, 2).getResults()[0];
+        validateTableOfScalarLongs(vt, new long[]{3});
+        checkPlannerCache(client, CACHE_HIT2);
+
+        vt = client.callProcedure("@AdHoc", sql, 1.5).getResults()[0];
+        validateTableOfScalarLongs(vt, new long[]{2,3});
+        checkPlannerCache(client, CACHE_HIT2);
+
+        //
         // change the where clause to get the new query pattern
+        //
 
         // try the normal integer value first
         sql = "SELECT ID FROM R1 sub3 WHERE NUM > 0 order by ID;";
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{3});
+        validateTableOfScalarLongs(client, sql, new long[]{3});
         checkPlannerCache(client, CACHE_MISS2_ADD1);
 
-        // try the float value second, it has bad parameterization
+        // try the decimal value second, it has bad parameterization
         sql = "SELECT ID FROM R1 sub3 WHERE NUM > 0.8 order by ID;";
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{3});
-        checkPlannerCache(client, CACHE_MISS1);
+        validateTableOfScalarLongs(client, sql, new long[]{3});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
 
         sql = "SELECT ID FROM R1 sub3 WHERE NUM > 0.9 order by ID;";
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{3});
-        checkPlannerCache(client, CACHE_MISS1);
+        validateTableOfScalarLongs(client, sql, new long[]{3});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+
+        //
+        // test the AVG function
+        //
+        sql = "SELECT AVG(ID) + 0.1 FROM R1 sub3;";
+        validateTableColumnOfScalarDecimal(client, sql, new BigDecimal[]{new BigDecimal(2.1)});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        validateTableColumnOfScalarDecimal(client, sql, new BigDecimal[]{new BigDecimal(2.1)});
+        checkPlannerCache(client, CACHE_HIT1);
+
+        sql = "SELECT AVG(ID) + 0.2 FROM R1 sub3;";
+        validateTableColumnOfScalarDecimal(client, sql, new BigDecimal[]{new BigDecimal(2.2)});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        // integer constants is a new SQL pattern to the planner cache
+        sql = "SELECT AVG(ID) + 2 FROM R1 sub3;";
+        validateTableOfScalarLongs(client, sql, new long[]{4});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        validateTableOfScalarLongs(client, sql, new long[]{4});
+        checkPlannerCache(client, CACHE_HIT1);
+
+        sql = "SELECT AVG(ID) + 3 FROM R1 sub3;";
+        validateTableOfScalarLongs(client, sql, new long[]{5});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        // float constants is a new SQL pattern to the planner cache
+        sql = "SELECT AVG(ID) + 1.0e-1 FROM R1 sub3;";
+        validateTableColumnOfScalarFloat(client, sql, new double[]{2.1});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        validateTableColumnOfScalarFloat(client, sql, new double[]{2.1});
+        checkPlannerCache(client, CACHE_HIT1);
+
+        sql = "SELECT AVG(ID) + 2.0e-1 FROM R1 sub3;";
+        validateTableColumnOfScalarFloat(client, sql, new double[]{2.2});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        //
+        // change the table alias to get a completely new base line
+        //
+        sql = "SELECT AVG(ID) + 2 FROM R1 sub3_1;";
+        validateTableOfScalarLongs(client, sql, new long[]{4});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        validateTableOfScalarLongs(client, sql, new long[]{4});
+        checkPlannerCache(client, CACHE_HIT1);
+
+        sql = "SELECT AVG(ID) + 3 FROM R1 sub3_1;";
+        validateTableOfScalarLongs(client, sql, new long[]{5});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        // decimal constants is a new SQL pattern to the planner cache
+        sql = "SELECT AVG(ID) + 0.1 FROM R1 sub3_1;";
+        validateTableColumnOfScalarDecimal(client, sql, new BigDecimal[]{new BigDecimal(2.1)});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+
+        // change the table name for new baseline
+        //
+        // float constants
+        //
+        sql = "SELECT ID FROM R1 sub3_2 WHERE ID > 0.18E1 order by ID;";
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_HIT1);
+
+        sql = "SELECT ID FROM R1 sub3_2 WHERE ID > 0.19E1 order by ID;";
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        // same query but use Integer constants
+        sql = "SELECT ID FROM R1 sub3_2 WHERE ID > 1 order by ID;";
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_HIT1);
+
+        sql = "SELECT ID FROM R1 sub3_2 WHERE ID > 2 order by ID;";
+        validateTableOfScalarLongs(client, sql, new long[]{3});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        // same query but use Decimal constants
+        sql = "SELECT ID FROM R1 sub3_2 WHERE ID > 1.8 order by ID;";
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_HIT1);
+
+        sql = "SELECT ID FROM R1 sub3_2 WHERE ID > 1.9 order by ID;";
+        validateTableOfScalarLongs(client, sql, new long[]{2, 3});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
     }
 
-    public void subtest4AdvancedBadParameters(Client client) throws IOException, ProcCallException {
-        System.out.println("subtest4AdvancedBadParameters...");
+    public void subtest4AdvancedParameterTypes(Client client) throws IOException, ProcCallException {
+        System.out.println("subtest4AdvancedParameterTypes...");
 
         String sql;
         VoltTable vt;
@@ -481,6 +592,100 @@ public class TestAdHocPlannerCache extends RegressionSuite {
 
         verifyAdHocFails(client, String.format(pattern, 2, 0), sql);
         checkPlannerCache(client, CACHE_PARAMS_EXCEPTION);
+
+
+        //
+        // ENG-8238: AVG with decimal operation truncated to integer
+        // FIXED in V5.4.
+        //
+
+        // start with decimal first
+        sql = "select ID, (select AVG(ID) + 0.1 from R1) from R1 sub4;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarDecimal(vt, 1,
+                new BigDecimal[]{new BigDecimal(2.1), new BigDecimal(2.1), new BigDecimal(2.1)});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 1 from R1) from R1 sub4;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarLong(vt, 1, new long[]{3, 3, 3});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 2 from R1) from R1 sub4;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarLong(vt, 1, new long[]{4, 4, 4});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 0.2 from R1) from R1 sub4;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarDecimal(vt, 1,
+                new BigDecimal[]{new BigDecimal(2.2), new BigDecimal(2.2), new BigDecimal(2.2)});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 2.0E-1 from R1) from R1 sub4;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarFloat(vt, 1, new double[]{2.2, 2.2, 2.2});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 3.0E-1 from R1) from R1 sub4;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarFloat(vt, 1, new double[]{2.3, 2.3, 2.3});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        // new SQL pattern with new alias
+
+        // start with integer first
+        sql = "select ID, (select AVG(ID) + 1 from R1) from R1 sub4_1;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarLong(vt, 1, new long[]{3, 3, 3});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 0.1 from R1) from R1 sub4_1;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarDecimal(vt, 1,
+                new BigDecimal[]{new BigDecimal(2.1), new BigDecimal(2.1), new BigDecimal(2.1)});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 2 from R1) from R1 sub4_1;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarLong(vt, 1, new long[]{4, 4, 4});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 0.2 from R1) from R1 sub4_1;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarDecimal(vt, 1,
+                new BigDecimal[]{new BigDecimal(2.2), new BigDecimal(2.2), new BigDecimal(2.2)});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+
+        // new SQL pattern with new alias
+
+        // start with float first
+        sql = "select ID, (select AVG(ID) + 1.0E-1 from R1) from R1 sub4_2;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarFloat(vt, 1, new double[]{2.1, 2.1, 2.1});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 1 from R1) from R1 sub4_2;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarLong(vt, 1, new long[]{3, 3, 3});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 2 from R1) from R1 sub4_2;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarLong(vt, 1, new long[]{4, 4, 4});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 3.0E-1 from R1) from R1 sub4_2;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarFloat(vt, 1, new double[]{2.3, 2.3, 2.3});
+        checkPlannerCache(client, CACHE_HIT2_ADD1);
+
+        sql = "select ID, (select AVG(ID) + 0.2 from R1) from R1 sub4_2;";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableColumnOfScalarDecimal(vt, 1,
+                new BigDecimal[]{new BigDecimal(2.2), new BigDecimal(2.2), new BigDecimal(2.2)});
+        checkPlannerCache(client, CACHE_MISS2_ADD1);
     }
 
     public void subtest5ExplainPlans(Client client) throws IOException, ProcCallException {
@@ -600,8 +805,7 @@ public class TestAdHocPlannerCache extends RegressionSuite {
         assertTrue(vt.toString().contains("ABSIDX"));
         checkPlannerCache(client, CACHE_MISS2_ADD1);
 
-        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        validateTableOfScalarLongs(vt, new long[]{1, 2});
+        validateTableOfScalarLongs(client, sql, new long[]{1, 2});
         checkPlannerCache(client, CACHE_HIT1);
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestDecimalRoundingSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestDecimalRoundingSuite.java
@@ -25,7 +25,6 @@ package org.voltdb.regressionsuites;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,15 +35,8 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
-import org.voltdb.types.VoltDecimalHelper;
 
 public class TestDecimalRoundingSuite extends RegressionSuite {
-
-    private static int m_defaultScale = 12;
-    private static String m_roundingEnabledProperty = "BIGDECIMAL_ROUND";
-    private static String m_roundingModeProperty = "BIGDECIMAL_ROUND_POLICY";
-    private static String m_defaultRoundingEnablement = "true";
-    private static String m_defaultRoundingMode = "HALF_UP";
 
     //
     // JUnit / RegressionSuite boilerplate
@@ -53,13 +45,6 @@ public class TestDecimalRoundingSuite extends RegressionSuite {
         super(name);
     }
 
-
-    private static String getRoundingString(String label) {
-        return String.format("%sRounding %senabled, mode is %s",
-                             label == null ? (label + ": ") : "",
-                             VoltDecimalHelper.isRoundingEnabled() ? "is " : "is *NOT* ",
-                             VoltDecimalHelper.getRoundingMode().toString());
-    }
     private void validateInsertStmt(boolean expectSuccess, String insertStmt, BigDecimal... expectedValues) throws Exception {
         Client client = getClient();
 
@@ -98,36 +83,6 @@ public class TestDecimalRoundingSuite extends RegressionSuite {
                               roundIsEnabled.toString(), roundMode.toString());
         }
         doTestDecimalScaleInsertion(roundIsEnabled, roundMode);
-    }
-
-    /*
-     * This little helper function converts a string to
-     * a decimal, and, maybe, rounds it to the Volt default scale
-     * using the given mode.  If roundingEnabled is false, no
-     * rounding is done.
-     */
-    private static final BigDecimal roundDecimalValue(String  decimalValueString,
-                                                      boolean roundingEnabled,
-                                                      RoundingMode mode) {
-        BigDecimal bd = new BigDecimal(decimalValueString);
-        if (!roundingEnabled) {
-            return bd;
-        }
-        int precision = bd.precision();
-        int scale = bd.scale();
-        int lostScale = scale - m_defaultScale ;
-        if (lostScale <= 0) {
-            return bd;
-        }
-        int newPrecision = precision - lostScale;
-        MathContext mc = new MathContext(newPrecision, mode);
-        BigDecimal nbd = bd.round(mc);
-        assertTrue(nbd.scale() <= m_defaultScale);
-        if (nbd.scale() != m_defaultScale) {
-            nbd = nbd.setScale(m_defaultScale);
-        }
-        assertEquals(getRoundingString("Decimal Scale setting failure"), m_defaultScale, nbd.scale());
-        return nbd;
     }
 
     private void doTestDecimalScaleInsertion(boolean roundingEnabled,

--- a/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
@@ -2143,11 +2143,6 @@ public class TestFixedSQLSuite extends RegressionSuite {
         //
         // operation between decimal and integer
         //
-        if (isHSQL()) {
-            // not compatible with Hsql
-            return;
-        }
-
         sql = "SELECT 0.1 + (1-0.1) + NUM FROM R1";
         runQueryGetDecimal(client, sql, 3.0);
 
@@ -2155,23 +2150,23 @@ public class TestFixedSQLSuite extends RegressionSuite {
         runQueryGetDecimal(client, sql, -1.0);
 
         sql = "SELECT 0.1 + (1-0.1) / NUM FROM R1";
-        runQueryGetDouble(client, sql, 0.55);
+        runQueryGetDecimal(client, sql, 0.55);
 
         sql = "SELECT 0.1 + (1-0.1) * NUM FROM R1";
-        runQueryGetDouble(client, sql, 1.9);
+        runQueryGetDecimal(client, sql, 1.9);
 
         // reverse order
         sql = "SELECT 0.1 + NUM + (1-0.1) FROM R1";
-        runQueryGetDouble(client, sql, 3.0);
+        runQueryGetDecimal(client, sql, 3.0);
 
         sql = "SELECT 0.1 + NUM - (1-0.1) FROM R1";
-        runQueryGetDouble(client, sql, 1.2);
+        runQueryGetDecimal(client, sql, 1.2);
 
         sql = "SELECT 0.1 + NUM / (1-0.1) FROM R1";
-        runQueryGetDouble(client, sql, 2.322222222222);
+        runQueryGetDecimal(client, sql, 2.322222222222);
 
         sql = "SELECT 0.1 + NUM * (1-0.1) FROM R1";
-        runQueryGetDouble(client, sql, 1.9);
+        runQueryGetDecimal(client, sql, 1.9);
     }
 
     private void nullIndexSearchKeyChecker(Client client, String sql) throws Exception {

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
@@ -85,53 +85,13 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         cr = client.callProcedure("@AdHoc", "select SQL_ERROR(123, 'abc') from P1 where ID = 0");
         assertEquals(cr.getStatus(), ClientResponse.SUCCESS);
 
-        boolean caught = false;
+        // negative tests
+        verifyStmtFails(client, "select SQL_ERROR(123, 'abc') from P1", "abc");
+        verifyStmtFails(client, "select SQL_ERROR('abc') from P1", "abc");
+        verifyStmtFails(client, "select SQL_ERROR(123, 123) from P1", ".*SQL ERROR\n.*VARCHAR.*");
 
-        caught = false;
-        try {
-            cr = client.callProcedure("@AdHoc", "select SQL_ERROR(123, 'abc') from P1");
-            assertTrue(cr.getStatus() != ClientResponse.SUCCESS);
-        } catch (ProcCallException e) {
-            String msg = e.getMessage();
-            assertTrue(msg.indexOf("abc") != -1);
-            caught = true;
-        }
-        assertTrue(caught);
-
-        caught = false;
-        try {
-            cr = client.callProcedure("@AdHoc", "select SQL_ERROR(123.5) from P1");
-            assertTrue(cr.getStatus() != ClientResponse.SUCCESS);
-        } catch (ProcCallException e) {
-            String msg = e.getMessage();
-            assertTrue(msg.indexOf("Type FLOAT can't be cast as BIGINT") != -1);
-            caught = true;
-        }
-        assertTrue(caught);
-
-        caught = false;
-        try {
-            cr = client.callProcedure("@AdHoc", "select SQL_ERROR('abc') from P1");
-            assertTrue(cr.getStatus() != ClientResponse.SUCCESS);
-        } catch (ProcCallException e) {
-            String msg = e.getMessage();
-            assertTrue(msg.indexOf("abc") != -1);
-            caught = true;
-        }
-        assertTrue(caught);
-
-        caught = false;
-        try {
-            // This wants to be a statement compile-time error.
-            cr = client.callProcedure("@AdHoc", "select SQL_ERROR(123, 123) from P1");
-            assertTrue(cr.getStatus() != ClientResponse.SUCCESS);
-        } catch (ProcCallException e) {
-            String msg = e.getMessage();
-            assertTrue(msg.matches(".*SQL ERROR\n.*VARCHAR.*"));
-            caught = true;
-        }
-        assertTrue(caught);
-
+        verifyStmtFails(client, "select SQL_ERROR(123.5) from P1", "Type DECIMAL can't be cast as BIGINT");
+        verifyStmtFails(client, "select SQL_ERROR(123.5E-2) from P1", "Type FLOAT can't be cast as BIGINT");
     }
 
     public void testOctetLength() throws NoConnectionsException, IOException, ProcCallException {

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -3467,13 +3467,7 @@ public class TestFunctionsSuite extends RegressionSuite {
         }
 
         bitwiseFunctionChecker(21, Long.MAX_VALUE, Long.MIN_VALUE);
-
-        try {
-            bitwiseFunctionChecker(22, Long.MIN_VALUE, Long.MAX_VALUE);
-            fail();
-        } catch (Exception ex) {
-            assertTrue(ex.getMessage().contains("Constant value underflows BIGINT type"));
-        }
+        bitwiseFunctionChecker(22, Long.MIN_VALUE, Long.MAX_VALUE);
 
         // try the out of range exception
         client.callProcedure("@AdHoc", "insert into NUMBER_TYPES(INTEGERNUM, bignum) values(50, ?);", Long.MIN_VALUE + 1);

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -1877,11 +1877,11 @@ public class TestSubQueriesSuite extends RegressionSuite {
         vt = client.callProcedure("@AdHoc",
                 "SELECT RATIO "
                 + "FROM R4 "
-                + "WHERE RATIO = 0.6944855793154526 "
+                + "WHERE RATIO = 6.944855793154526e-1 "
                 + "UNION "
                 + "  SELECT RATIO "
                 + "  FROM R4 "
-                + "  WHERE RATIO = 0.6944855793154526;")
+                + "  WHERE RATIO = 6.944855793154526e-1;")
                 .getResults()[0];
         assertTrue(vt.advanceRow());
         assertEquals(0.6944855793154526, vt.getDouble(0), 0.000001);


### PR DESCRIPTION
AdHoc query fix:
1. Treat constants in SQL literal numbers either as integer or decimal.
2. Add tests for float E sign.
3. Fix the various of AdHoc planner caching with type issues.
4. Refactor and add more testing utils.
---
Missing stored procedure fix (Can be done separately from this ticket):
5. Stored procedure constants literal value fix either integer or decimal.
6. More tests on out of range of our decimal literal value if needed.

