### PR TITLE
Move Rounding Semantics to the Execution Engine.

### DIFF
--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -27,7 +27,6 @@
 #include <set>
 
 namespace voltdb {
-
 Pool* NValue::getTempStringPool() {
     return ExecutorContext::getTempStringPool();
 }
@@ -215,6 +214,7 @@ std::string NValue::createStringFromDecimal() const {
  *   This function does not handle scientific notation string, Java planner should convert that to plan string first.
  */
 void NValue::createDecimalFromString(const std::string &txt) {
+    std::cout << "createDecimalFromString(" << txt << ");\n";
     if (txt.length() == 0) {
         throw SQLException(SQLException::volt_decimal_serialization_error,
                                        "Empty string provided");
@@ -259,27 +259,54 @@ void NValue::createDecimalFromString(const std::string &txt) {
                            "Too many decimal points");
     }
 
-    const std::string wholeString = txt.substr( setSign ? 1 : 0, separatorPos - (setSign ? 1 : 0));
-    const std::size_t wholeStringSize = wholeString.size();
-    if (wholeStringSize > 26) {
-        throw SQLException(SQLException::volt_decimal_serialization_error,
-                           "Maximum precision exceeded. Maximum of 26 digits to the left of the decimal point");
-    }
-    TTInt whole(wholeString);
+	// This is set to 1 if we carry in the scale.
+    int carryScale = 0;
+    // This is set to 1 if we carry from the scale to the whole.
+    int carryWhole = 0;
+
+    // Start with the fractional part.  We need to
+    // see if we need to carry from it first.
     std::string fractionalString = txt.substr( separatorPos + 1, txt.size() - (separatorPos + 1));
     // remove trailing zeros
     while (fractionalString.size() > 0 && fractionalString[fractionalString.size() - 1] == '0')
         fractionalString.erase(fractionalString.size() - 1, 1);
     // check if too many decimal places
-    if (fractionalString.size() > 12) {
-        throw SQLException(SQLException::volt_decimal_serialization_error,
-                           "Maximum scale exceeded. Maximum of 12 digits to the right of the decimal point");
-    }
-    while(fractionalString.size() < NValue::kMaxDecScale) {
-        fractionalString.push_back('0');
+    if (fractionalString.size() > kMaxDecScale) {
+        carryScale = ('5' <= fractionalString[kMaxDecScale]) ? 1 : 0;
+        fractionalString = fractionalString.substr(0, kMaxDecScale);
+    } else {
+        while(fractionalString.size() < NValue::kMaxDecScale) {
+            fractionalString.push_back('0');
+        }
     }
     TTInt fractional(fractionalString);
 
+    // If we decided to carry above, then do it here.
+    // The fractional string is set up so that it represents
+    // 1.0e-12 * units.
+    fractional += carryScale;
+    if (TTInt((uint64_t)kMaxScaleFactor) <= fractional) {
+        // We know fractional was < kMaxScaleFactor before
+        // we rounded, since fractional is 12 digits and
+        // kMaxScaleFactor is 13.  So, if carrying makes
+        // the fractional number too big, it must be eactly
+        // too big.  That is to say, the rounded fractional
+        // number number has become zero, and we need to
+        // carry to the whole number.
+        fractional = 0;
+        carryWhole = 1;
+    }
+
+    // Process the whole number string.
+    const std::string wholeString = txt.substr( setSign ? 1 : 0, separatorPos - (setSign ? 1 : 0));
+    // We will check for oversize numbers below, so don't waste time
+    // doing it now.
+    TTInt whole(wholeString);
+    whole += carryWhole;
+    if (oversizeWholeDecimal(whole)) {
+        throw SQLException(SQLException::volt_decimal_serialization_error,
+                           "Maximum precision exceeded. Maximum of 26 digits to the left of the decimal point");
+    }
     whole *= kMaxScaleFactor;
     whole += fractional;
 

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -569,8 +569,19 @@ class NValue {
     // Precision and scale (inherent in the schema)
     static const uint16_t kMaxDecPrec = 38;
     static const uint16_t kMaxDecScale = 12;
-    static const int64_t kMaxScaleFactor = 1000000000000;
-
+    static const int64_t kMaxScaleFactor = 1000000000000;         // == 10**12
+  private:
+    // Our maximum scale is 12.  Our maximum precision is 38.  So,
+    // the maximum number of decimal digits is 38 - 12 = 26.  We can't
+    // represent 10**26 in a 64 bit integer, but we can represent 10**18.
+    // So, to test if a TTInt named m is too big we test if
+    // m/kMaxWholeDivisor < kMaxWholeFactor
+    static const uint64_t kMaxWholeDivisor = 100000000;             // == 10**8
+    static const uint64_t kMaxWholeFactor = 1000000000000000000;    // == 10**18
+    static bool inline oversizeWholeDecimal(TTInt ii) {
+        return (TTInt(kMaxWholeFactor) <= ii / kMaxWholeDivisor);
+    }
+  public:
     // setArrayElements is a const method since it doesn't actually mutate any NValue state, just
     // the state of the contained NValues which are referenced via the allocated object storage.
     // For example, it is not intended to ever "grow the array" which would require the NValue's

--- a/tests/ee/common/nvalue_test.cpp
+++ b/tests/ee/common/nvalue_test.cpp
@@ -247,6 +247,83 @@ TEST_F(NValueTest, DeserializeDecimal)
     ASSERT_EQ(value, TTInt(static_cast<int64_t>(-12340000000000)));
     ASSERT_EQ(str, "-12.340000000000");
 
+    // Test to see that we round down appropriately.
+    deserDecValidator("0.8999999999994");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt((uint64_t)899999999999), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round up appropriately.
+    deserDecValidator("0.8999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt((uint64_t)900000000000), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a zero decimal part.
+    deserDecValidator("0.9999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(1), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a non-zero decimal part.
+    deserDecValidator("99.9999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(100), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a non-zero decimal part.
+    deserDecValidator("98.9999999999999");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(99), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round down appropriately with a signed number.
+    deserDecValidator("-0.8999999999994");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    TTInt sfrac = ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor);
+    TTInt sexpFrac("-899999999999");
+    ASSERT_EQ(sexpFrac, sfrac);
+
+    // Test to see that we round up appropriately with a signed number
+    deserDecValidator("-0.8999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt("-900000000000"), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a zero decimal part with a signed number.
+    deserDecValidator("-0.9999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt("-1"), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt("0"), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a non-zero decimal part.
+    deserDecValidator("-99.9999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt("-100"), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt("0"), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a non-zero decimal part.
+    deserDecValidator("-98.9999999999999");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt("-99"), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt("0"), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
     // illegal deserializations
     try {
         // too few digits
@@ -294,6 +371,21 @@ TEST_F(NValueTest, DeserializeDecimal)
         ASSERT_EQ(0,1);
     }
     catch (SerializableEEException &e) {
+    }
+
+    try {
+        // This will round to a number which has
+        // 39 digits of precision, which is invalid.
+        nv = ValueFactory::getDecimalValueFromString("99999999999999999999999999.9999999999995999999");
+    } catch (SerializableEEException &e) {
+
+    }
+    try {
+        // This will round to a number which has
+        // 39 digits of precision, which is invalid.
+        nv = ValueFactory::getDecimalValueFromString("-99999999999999999999999999.9999999999995");
+    } catch (SerializableEEException &e) {
+
     }
 }
 


### PR DESCRIPTION
When we create a decimal number from a string in the EE,
and the resulting decimal number would have a scale which
is too large, we round the decimal number to 12 decimal digits.
If the resulting rounded number is still too large we throw
and exception.

There are java unit tests and C++ unit tests.