### PR TITLE
Decimal Rounding in the EE.

### DIFF
--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -27,7 +27,6 @@
 #include <set>
 
 namespace voltdb {
-
 Pool* NValue::getTempStringPool() {
     return ExecutorContext::getTempStringPool();
 }
@@ -259,27 +258,65 @@ void NValue::createDecimalFromString(const std::string &txt) {
                            "Too many decimal points");
     }
 
-    const std::string wholeString = txt.substr( setSign ? 1 : 0, separatorPos - (setSign ? 1 : 0));
-    const std::size_t wholeStringSize = wholeString.size();
-    if (wholeStringSize > 26) {
-        throw SQLException(SQLException::volt_decimal_serialization_error,
-                           "Maximum precision exceeded. Maximum of 26 digits to the left of the decimal point");
-    }
-    TTInt whole(wholeString);
+    // This is set to 1 if we carry in the scale.
+    int carryScale = 0;
+    // This is set to 1 if we carry from the scale to the whole.
+    int carryWhole = 0;
+
+    // Start with the fractional part.  We need to
+    // see if we need to carry from it first.
     std::string fractionalString = txt.substr( separatorPos + 1, txt.size() - (separatorPos + 1));
     // remove trailing zeros
     while (fractionalString.size() > 0 && fractionalString[fractionalString.size() - 1] == '0')
         fractionalString.erase(fractionalString.size() - 1, 1);
-    // check if too many decimal places
-    if (fractionalString.size() > 12) {
-        throw SQLException(SQLException::volt_decimal_serialization_error,
-                           "Maximum scale exceeded. Maximum of 12 digits to the right of the decimal point");
-    }
-    while(fractionalString.size() < NValue::kMaxDecScale) {
-        fractionalString.push_back('0');
+    //
+    // If the scale is too large, then we will round
+    // the number to the nearest 10**-12, and to the
+    // furthest from zero if the number is equidistant
+    // from the next highest and lowest.  This is the
+    // definition of the Java rounding mode HALF_UP.
+    //
+    // At some point we will read a rounding mode from the
+    // Java side at Engine configuration time, or something
+    // like that, and have a whole flurry of rounding modes
+    // here.  However, for now we have just the one.
+    //
+    if (fractionalString.size() > kMaxDecScale) {
+        carryScale = ('5' <= fractionalString[kMaxDecScale]) ? 1 : 0;
+        fractionalString = fractionalString.substr(0, kMaxDecScale);
+    } else {
+        while(fractionalString.size() < NValue::kMaxDecScale) {
+            fractionalString.push_back('0');
+        }
     }
     TTInt fractional(fractionalString);
 
+    // If we decided to carry above, then do it here.
+    // The fractional string is set up so that it represents
+    // 1.0e-12 * units.
+    fractional += carryScale;
+    if (TTInt((uint64_t)kMaxScaleFactor) <= fractional) {
+        // We know fractional was < kMaxScaleFactor before
+        // we rounded, since fractional is 12 digits and
+        // kMaxScaleFactor is 13.  So, if carrying makes
+        // the fractional number too big, it must be eactly
+        // too big.  That is to say, the rounded fractional
+        // number number has become zero, and we need to
+        // carry to the whole number.
+        fractional = 0;
+        carryWhole = 1;
+    }
+
+    // Process the whole number string.
+    const std::string wholeString = txt.substr( setSign ? 1 : 0, separatorPos - (setSign ? 1 : 0));
+    // We will check for oversize numbers below, so don't waste time
+    // doing it now.
+    TTInt whole(wholeString);
+    whole += carryWhole;
+    if (oversizeWholeDecimal(whole)) {
+        throw SQLException(SQLException::volt_decimal_serialization_error,
+                           "Maximum precision exceeded. Maximum of 26 digits to the left of the decimal point");
+    }
     whole *= kMaxScaleFactor;
     whole += fractional;
 

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -569,8 +569,19 @@ class NValue {
     // Precision and scale (inherent in the schema)
     static const uint16_t kMaxDecPrec = 38;
     static const uint16_t kMaxDecScale = 12;
-    static const int64_t kMaxScaleFactor = 1000000000000;
-
+    static const int64_t kMaxScaleFactor = 1000000000000;         // == 10**12
+  private:
+    // Our maximum scale is 12.  Our maximum precision is 38.  So,
+    // the maximum number of decimal digits is 38 - 12 = 26.  We can't
+    // represent 10**26 in a 64 bit integer, but we can represent 10**18.
+    // So, to test if a TTInt named m is too big we test if
+    // m/kMaxWholeDivisor < kMaxWholeFactor
+    static const uint64_t kMaxWholeDivisor = 100000000;             // == 10**8
+    static const uint64_t kMaxWholeFactor = 1000000000000000000;    // == 10**18
+    static bool inline oversizeWholeDecimal(TTInt ii) {
+        return (TTInt(kMaxWholeFactor) <= ii / kMaxWholeDivisor);
+    }
+  public:
     // setArrayElements is a const method since it doesn't actually mutate any NValue state, just
     // the state of the contained NValues which are referenced via the allocated object storage.
     // For example, it is not intended to ever "grow the array" which would require the NValue's

--- a/tests/ee/common/nvalue_test.cpp
+++ b/tests/ee/common/nvalue_test.cpp
@@ -247,6 +247,83 @@ TEST_F(NValueTest, DeserializeDecimal)
     ASSERT_EQ(value, TTInt(static_cast<int64_t>(-12340000000000)));
     ASSERT_EQ(str, "-12.340000000000");
 
+    // Test to see that we round down appropriately.
+    deserDecValidator("0.8999999999994");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt((uint64_t)899999999999), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round up appropriately.
+    deserDecValidator("0.8999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt((uint64_t)900000000000), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a zero decimal part.
+    deserDecValidator("0.9999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(1), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a non-zero decimal part.
+    deserDecValidator("99.9999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(100), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a non-zero decimal part.
+    deserDecValidator("98.9999999999999");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(99), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round down appropriately with a signed number.
+    deserDecValidator("-0.8999999999994");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    TTInt sfrac = ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor);
+    TTInt sexpFrac("-899999999999");
+    ASSERT_EQ(sexpFrac, sfrac);
+
+    // Test to see that we round up appropriately with a signed number
+    deserDecValidator("-0.8999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt(0), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt("-900000000000"), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a zero decimal part with a signed number.
+    deserDecValidator("-0.9999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt("-1"), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt("0"), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a non-zero decimal part.
+    deserDecValidator("-99.9999999999995");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt("-100"), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt("0"), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
+
+    // Test to see that we round from the fractional
+    // part to a non-zero decimal part.
+    deserDecValidator("-98.9999999999999");
+    ASSERT_FALSE(nv.isNull());
+    ASSERT_EQ(vt, VALUE_TYPE_DECIMAL);
+    ASSERT_EQ(TTInt("-99"), ValuePeeker::peekDecimal(nv)/TTInt(NValue::kMaxScaleFactor));
+    ASSERT_EQ(TTInt("0"), ValuePeeker::peekDecimal(nv) % TTInt(NValue::kMaxScaleFactor));
     // illegal deserializations
     try {
         // too few digits
@@ -294,6 +371,21 @@ TEST_F(NValueTest, DeserializeDecimal)
         ASSERT_EQ(0,1);
     }
     catch (SerializableEEException &e) {
+    }
+
+    try {
+        // This will round to a number which has
+        // 39 digits of precision, which is invalid.
+        nv = ValueFactory::getDecimalValueFromString("99999999999999999999999999.9999999999995999999");
+    } catch (SerializableEEException &e) {
+
+    }
+    try {
+        // This will round to a number which has
+        // 39 digits of precision, which is invalid.
+        nv = ValueFactory::getDecimalValueFromString("-99999999999999999999999999.9999999999995");
+    } catch (SerializableEEException &e) {
+
     }
 }
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestDecimalRoundingSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestDecimalRoundingSuite.java
@@ -35,6 +35,7 @@ import org.voltdb.VoltTable;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.types.VoltDecimalHelper;
 
@@ -442,6 +443,159 @@ public class TestDecimalRoundingSuite extends RegressionSuite {
         assertEquals(getRoundingString("Cleanup statement failure"), ClientResponse.SUCCESS, cr.getStatus());
     }
 
+    public void testEEDecimalScale() throws Exception {
+        Boolean roundIsEnabled = Boolean.valueOf(m_defaultRoundingEnablement);
+        RoundingMode roundMode = RoundingMode.valueOf(m_defaultRoundingMode);
+
+        assert(m_config instanceof LocalCluster);
+        LocalCluster localCluster = (LocalCluster)m_config;
+        Map<String, String> props = localCluster.getAdditionalProcessEnv();
+        if (props != null) {
+            roundIsEnabled = Boolean.valueOf(props.containsKey(m_roundingEnabledProperty) ? props.get(m_roundingEnabledProperty) : "true");
+            roundMode = RoundingMode.valueOf(props.containsKey(m_roundingModeProperty) ? props.get(m_roundingModeProperty) : "HALF_UP");
+        }
+        doTestEEDecimalScale(roundIsEnabled, roundMode);
+    }
+
+    private void doTestEEDecimalScale(boolean roundEnabled, RoundingMode roundMode) throws Exception {
+        // We currently only support one rounding mode in the EE, and
+        // we always round.
+        if (roundEnabled && roundMode == RoundingMode.HALF_UP) {
+            Client client = getClient();
+            ClientResponse cr;
+            String[] values = new String[] {
+                // Don't round.
+                "0.8999999999994",
+                // Do round.
+                "0.8999999999995",
+                // Do round to the left of the dot.
+                "0.9999999999995",
+                // Do round to the left of the dot with non-zero integer part.
+                "1.9999999999995",
+                // Do round to the left of the dot with more digits.
+                "99.9999999999995",
+                // Do round to the left of the dot with no more digits.
+                "98.9999999999995",
+                // Don't round, but the result is the largest
+                // representable decimal value.
+                "99999999999999999999999999.9999999999994999999",
+                // The following cases replicate the cases above,
+                // but with a sign.
+                "-0.8999999999994",
+                "-0.8999999999995",
+                "-0.9999999999995",
+                "-1.9999999999995",
+                "-99.9999999999995",
+                "-98.9999999999995",
+                "-99999999999999999999999999.9999999999994999999"
+            };
+            String[] badValues = new String[] {
+                // Too many integer digits.
+                "999999999999999999999999999999.0",
+                // Round to an unrepresentable value.
+                "99999999999999999999999999.9999999999995999999",
+                // Round to an unrepresentable value.
+                "-99999999999999999999999999.9999999999995999999"
+            };
+            // Insert some data.
+            for (String val : values) {
+                cr = client.callProcedure("EEDecimal.Insert", val);
+                assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+            }
+            // Insert some bad data.
+            // We will find this is bad later on.
+            for (int idx = 0; idx < badValues.length; idx += 1) {
+                String val = badValues[idx];
+                cr = client.callProcedure("EEBadDecimal.Insert", idx, val);
+                assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+            }
+            // Query the data.  Just get them all for now.
+            cr = client.callProcedure("EEDecimalFetch");
+            assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+            VoltTable tbl = cr.getResults()[0];
+            while (tbl.advanceRow()) {
+                String expectedStr = tbl.getString(0);
+                BigDecimal rounded = tbl.getDecimalAsBigDecimal(1);
+                BigDecimal expected = roundDecimalValue(expectedStr, roundEnabled, roundMode);
+                assertEquals(expected, rounded);
+            }
+            // Query the data for bad values.  Get them one at a time,
+            // because they are all bad in their own way.
+            for (int idx = 0; idx < badValues.length; idx += 1) {
+                try {
+                    cr = client.callProcedure("EEBadDecimalFetch", idx);
+                    fail(String.format("Unexpected success, case %d, decimal string \"%s\"",
+                         idx, badValues[idx]));
+                } catch (ProcCallException ex) {
+                    assertTrue(true);
+                }
+            }
+        } else {
+            assertTrue(true);
+        }
+    }
+
+    /**
+     * Test rounding on columns with decimal default.  HSQLDB does not give us the
+     * right value for decimal strings, so until ENG-8557 is
+     * @param roundEnabled
+     * @param roundMode
+     * @throws Exception
+     */
+    public final void notestDecimalDefault(boolean roundEnabled, RoundingMode roundMode) throws Exception {
+                    validateDecimalDefault("pRoundDecimalDownNC", false, roundEnabled, roundMode,  "0.8999999999994");
+            validateDecimalDefault("pRoundDecimalUpNC",   false, roundEnabled, roundMode,  "0.8999999999995");
+            validateDecimalDefault("pRoundDecimalDownC",  false, roundEnabled, roundMode,  "0.9999999999994");
+            validateDecimalDefault("pRoundDecimalUpC",    false, roundEnabled, roundMode,  "0.9999999999995");
+            validateDecimalDefault("pRoundDecimalDownC2", false, roundEnabled, roundMode, "99.9999999999994");
+            validateDecimalDefault("pRoundDecimalUpC2",   false, roundEnabled, roundMode, "99.9999999999995");
+            validateDecimalDefault("pRoundDecimalMax",    false, roundEnabled, roundMode, "99999999999999999999999999.9999999999994");
+            validateDecimalDefault("pRoundDecimalNotRep", true,  roundEnabled, roundMode, "99999999999999999999999999.9999999999995");
+            validateDecimalDefault("nRoundDecimalDownNC", false, roundEnabled, roundMode,  "-0.8999999999994");
+            validateDecimalDefault("nRoundDecimalUpNC",   false, roundEnabled, roundMode,  "-0.8999999999995");
+            validateDecimalDefault("nRoundDecimalDownC",  false, roundEnabled, roundMode,  "-0.9999999999994");
+            validateDecimalDefault("nRoundDecimalUpC",    false, roundEnabled, roundMode,  "-0.9999999999995");
+            validateDecimalDefault("nRoundDecimalDownC2", false, roundEnabled, roundMode, "-99.9999999999994");
+            validateDecimalDefault("nRoundDecimalUpC2",   false, roundEnabled, roundMode, "-99.9999999999995");
+            validateDecimalDefault("nRoundDecimalMax",    false, roundEnabled, roundMode, "-99999999999999999999999999.9999999999994");
+            validateDecimalDefault("nRoundDecimalNotRep", true,  roundEnabled, roundMode, "-99999999999999999999999999.9999999999995");
+
+    }
+    private final void validateDecimalDefault(String tableName,
+                                              boolean shouldFail,
+                                              boolean roundEnabled,
+                                              RoundingMode roundMode,
+                                              String value) throws Exception {
+        Client client = getClient();
+        ClientResponse cr;
+        boolean sawFail = false;
+        VoltTable tbl = null;
+        BigDecimal found = null;
+        try {
+            cr = client.callProcedure("@AdHoc", String.format("insert into %s (id) values ?;", tableName), 100);
+            assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+            sawFail = false;
+            cr = client.callProcedure("@AdHoc", String.format("select (dec) from %s;", tableName));
+            assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+            tbl = cr.getResults()[0];
+            assertTrue(tbl.advanceRow());
+            found = tbl.getDecimalAsBigDecimal(0);
+        } catch (ProcCallException ex) {
+            sawFail = true;
+        }
+        assertEquals(shouldFail ? "Expected a failure here" : "Unexpected failure here",
+                    shouldFail, sawFail);
+        if (shouldFail) {
+            return;
+        }
+        BigDecimal expected = roundDecimalValue(value, roundEnabled, roundMode);
+        assertEquals(String.format("Default decimal value failed: rounding is %s, mode is %s",
+                                  roundEnabled ? "enabled" : "not enabled",
+                                  roundMode),
+                    expected,
+                    found);
+
+    }
     private final static Map<String, String> makePropertiesMap(String... entries) {
         assert(entries.length % 2 == 0);
         Map<String, String> answer = new HashMap<String, String>();
@@ -467,7 +621,7 @@ public class TestDecimalRoundingSuite extends RegressionSuite {
         final String literalSchema =
                 "CREATE TABLE P1 ( id integer );" +
                 "CREATE TABLE DECIMALTABLE ( " +
-                "dec decimal" +
+                    "dec decimal"     +
                 ");" +
                 "CREATE PROCEDURE INSERT_DECIMAL AS " +
                 "INSERT INTO DECIMALTABLE VALUES ?;" +
@@ -475,6 +629,33 @@ public class TestDecimalRoundingSuite extends RegressionSuite {
                 "SELECT DEC FROM DECIMALTABLE;" +
                 "CREATE PROCEDURE TRUNCATE_DECIMAL AS " +
                 "TRUNCATE TABLE DECIMALTABLE;" +
+                "create table EEDecimal (" +
+                "  valueIn    varChar(128)" +
+                ");" +
+                "create procedure EEDecimalFetch as " +
+                "select valueIn, cast(valueIn as decimal) from EEDecimal;" +
+                "create table EEBadDecimal (" +
+                "  id integer primary key not null," +
+                "  valueIn    varChar(128)" +
+                ");" +
+                "create procedure EEBadDecimalFetch as " +
+                "select valueIn, cast(valueIn as decimal) from EEBadDecimal where id = ?;" +
+                "create table pRoundDecimalDownNC ( id integer, dec decimal default  '0.8999999999994' );" +
+                "create table pRoundDecimalUpNC   ( id integer, dec decimal default  '0.8999999999995' );" +
+                "create table pRoundDecimalDownC  ( id integer, dec decimal default  '0.9999999999994' );" +
+                "create table pRoundDecimalUpC    ( id integer, dec decimal default  '0.9999999999995' );" +
+                "create table pRoundDecimalDownC2 ( id integer, dec decimal default '99.9999999999994' );" +
+                "create table pRoundDecimalUpC2   ( id integer, dec decimal default '99.9999999999995' );" +
+                "create table pRoundDecimalMax    ( id integer, dec decimal default '99999999999999999999999999.9999999999994' );" +
+                "create table pRoundDecimalNotRep ( id integer, dec decimal default '99999999999999999999999999.9999999999995' );" +
+                "create table nRoundDecimalDownNC ( id integer, dec decimal default  '-0.8999999999994' );" +
+                "create table nRoundDecimalUpNC   ( id integer, dec decimal default  '-0.8999999999995' );" +
+                "create table nRoundDecimalDownC  ( id integer, dec decimal default  '-0.9999999999994' );" +
+                "create table nRoundDecimalUpC    ( id integer, dec decimal default  '-0.9999999999995' );" +
+                "create table nRoundDecimalDownC2 ( id integer, dec decimal default '-99.9999999999994' );" +
+                "create table nRoundDecimalUpC2   ( id integer, dec decimal default '-99.9999999999995' );" +
+                "create table nRoundDecimalMax    ( id integer, dec decimal default '-99999999999999999999999999.9999999999994' );" +
+                "create table nRoundDecimalNotRep ( id integer, dec decimal default '-99999999999999999999999999.9999999999995' );" +
                 ""
                 ;
         try {


### PR DESCRIPTION
When we create a decimal number from a string in the EE,
and the resulting decimal number would have a scale which
is too large, we round the decimal number to 12 decimal digits.
If the resulting rounded number is still too large we throw
and exception.

There are java unit tests and C++ unit tests.