### PR TITLE
Always set use.javalib property in LocalCluster. This makes sure that…

### DIFF
--- a/lib/python/voltcli/runner.py
+++ b/lib/python/voltcli/runner.py
@@ -135,6 +135,7 @@ class JavaRunner(object):
         java_opts = utility.merge_java_options(environment.java_opts, java_opts_override)
         java_args.extend(java_opts)
         java_args.append('-Dlog4j.configuration=file://%s' % os.environ['LOG4J_CONFIG_PATH'])
+	java_args.append('-Djava.library.path=dummyvalue')
         java_args.extend(('-classpath', classpath))
         java_args.append(java_class)
         for arg in args:

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -25,6 +25,7 @@ package org.voltdb.regressionsuites;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -191,7 +192,9 @@ public class LocalCluster implements VoltServerConfig {
         assert (siteCount > 0);
         assert (hostCount > 0);
 
-        m_additionalProcessEnv = env;
+        m_additionalProcessEnv = env==null ? new HashMap<String, String>() : env;
+        // always set use.javalib for LocalCluster so that Eclipse runs will always be OK.
+        m_additionalProcessEnv.put(EELibraryLoader.USE_JAVA_LIBRARY_PATH, "true");
         // get the name of the calling class
         StackTraceElement[] traces = Thread.currentThread().getStackTrace();
         m_callingClassName = "UnknownClass";
@@ -241,25 +244,14 @@ public class LocalCluster implements VoltServerConfig {
         }
 
         String classPath = System.getProperty("java.class.path") + ":" +
-            buildDir + File.separator + m_jarFileName;
+                buildDir + File.separator + m_jarFileName + ":" + buildDir + File.separator + "prod";
 
-        String javaLibraryPath = null;
-        if (m_additionalProcessEnv != null && m_additionalProcessEnv.containsKey(EELibraryLoader.USE_JAVA_LIBRARY_PATH)) {
-            if (Boolean.parseBoolean(m_additionalProcessEnv.get(EELibraryLoader.USE_JAVA_LIBRARY_PATH))) {
-                // set the java lib path to the one for this process - Add obj/release/nativelibs
-                javaLibraryPath = System.getProperty("java.library.path");
-                if (javaLibraryPath == null || javaLibraryPath.trim().length() == 0) {
-                    javaLibraryPath = buildDir + "/nativelibs";
-                } else {
-                    javaLibraryPath += ":" + buildDir + "/nativelibs";
-                }
-            }
-        }
-
-        if (javaLibraryPath==null) {
-            // need this in classpath to find native library. Otherwise, don't add it to classpath to
-            // test override of loading EE lib from jar.
-            classPath = classPath + ":" + buildDir + File.separator + "prod";
+        // set the java lib path to the one for this process - Add obj/release/nativelibs
+        String javaLibraryPath = System.getProperty("java.library.path");
+        if (javaLibraryPath == null || javaLibraryPath.trim().length() == 0) {
+            javaLibraryPath = buildDir + "/nativelibs";
+        } else {
+            javaLibraryPath += ":" + buildDir + "/nativelibs";
         }
 
         // Remove the stored procedures from the classpath.  Out-of-process nodes will
@@ -884,6 +876,11 @@ public class LocalCluster implements VoltServerConfig {
             rejoinCmdLn.m_zkInterface = "127.0.0.1:" + portGenerator.next();
             rejoinCmdLn.m_internalPort = portGenerator.nextInternalPort();
             setPortsFromConfig(hostId, rejoinCmdLn);
+            if (this.m_additionalProcessEnv != null) {
+                for (String name : this.m_additionalProcessEnv.keySet()) {
+                    rejoinCmdLn.setJavaProperty(name, this.m_additionalProcessEnv.get(name));
+                }
+            }
 
             if ((m_versionOverrides != null) && (m_versionOverrides.length > hostId)) {
                 assert(m_versionOverrides[hostId] != null);

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -193,8 +193,10 @@ public class LocalCluster implements VoltServerConfig {
         assert (hostCount > 0);
 
         m_additionalProcessEnv = env==null ? new HashMap<String, String>() : env;
-        // always set use.javalib for LocalCluster so that Eclipse runs will always be OK.
-        m_additionalProcessEnv.put(EELibraryLoader.USE_JAVA_LIBRARY_PATH, "true");
+        if (Boolean.getBoolean(EELibraryLoader.USE_JAVA_LIBRARY_PATH)) {
+            // set use.javalib for LocalCluster so that Eclipse runs will be OK.
+            m_additionalProcessEnv.put(EELibraryLoader.USE_JAVA_LIBRARY_PATH, "true");
+        }
         // get the name of the calling class
         StackTraceElement[] traces = Thread.currentThread().getStackTrace();
         m_callingClassName = "UnknownClass";


### PR DESCRIPTION
… junits from Eclipse will always pass.