### PR TITLE
 ENG-8531:clear Batch for each time call executeBatch

### DIFF
--- a/src/frontend/org/voltdb/jdbc/JDBC4Statement.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4Statement.java
@@ -425,22 +425,24 @@ public class JDBC4Statement implements java.sql.Statement
         // keep a running total of update counts
         int runningUpdateCount = 0;
 
-        for(int i = 0; i < batch.size(); i++)
+        int i = 0;
+        try
         {
-            try
-            {
+        for(; i < batch.size(); i++)
+        {
+
                 setCurrentResult(null, (int) batch.get(i).execute(sourceConnection.NativeConnection,
                         this.m_timeout,sourceConnection.queryTimeOutUnit)[0].fetchRow(0).getLong(0));
                 updateCounts[i] = this.lastUpdateCount;
                 runningUpdateCount += this.lastUpdateCount;
-            }
-            catch(SQLException x)
-            {
-                updateCounts[i] = EXECUTE_FAILED;
-                throw new BatchUpdateException(Arrays.copyOf(updateCounts, i+1), x);
-            }
         }
-
+        }catch(SQLException x)
+        {
+            updateCounts[i] = EXECUTE_FAILED;
+            throw new BatchUpdateException(Arrays.copyOf(updateCounts, i+1), x);
+        }finally {
+            clearBatch();
+        }
         // replace the update count from the last statement with the update count
         // from the last batch.
         this.lastUpdateCount = runningUpdateCount;

--- a/src/frontend/org/voltdb/jdbc/JDBC4Statement.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4Statement.java
@@ -426,21 +426,24 @@ public class JDBC4Statement implements java.sql.Statement
         int runningUpdateCount = 0;
 
         int i = 0;
-        try
-        {
-        for(; i < batch.size(); i++)
-        {
+        try {
+            for (; i < batch.size(); i++) {
 
-                setCurrentResult(null, (int) batch.get(i).execute(sourceConnection.NativeConnection,
-                        this.m_timeout,sourceConnection.queryTimeOutUnit)[0].fetchRow(0).getLong(0));
+                setCurrentResult(
+                        null,
+                        (int) batch.get(i).execute(
+                                sourceConnection.NativeConnection,
+                                this.m_timeout,
+                                sourceConnection.queryTimeOutUnit)[0].fetchRow(
+                                0).getLong(0));
                 updateCounts[i] = this.lastUpdateCount;
                 runningUpdateCount += this.lastUpdateCount;
-        }
-        }catch(SQLException x)
-        {
+            }
+        } catch (SQLException x) {
             updateCounts[i] = EXECUTE_FAILED;
-            throw new BatchUpdateException(Arrays.copyOf(updateCounts, i+1), x);
-        }finally {
+            throw new BatchUpdateException(Arrays.copyOf(updateCounts, i + 1),
+                    x);
+        } finally {
             clearBatch();
         }
         // replace the update count from the last statement with the update count

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
@@ -481,6 +481,25 @@ public class TestJDBCQueries {
     }
 
     @Test
+    public void testQueryBatchRepeat() throws Exception
+    {
+
+        String q = String.format("insert into %s(id) values(?)", data[2].tablename);
+        PreparedStatement pStmt = conn.prepareStatement(q);
+
+        for (int i = 1; i < 5000; i++) {
+            pStmt.setInt(1, i);
+            pStmt.addBatch();
+            if (i % 200 == 0) {
+                int[] resultCodes = pStmt.executeBatch();
+                // The batch will be reset to empty , per ENG-8531.
+                assertEquals(200, resultCodes.length);
+            }
+        }
+
+    }
+
+    @Test
     public void testParameterizedQueries() throws Exception
     {
         for (Data d : data) {


### PR DESCRIPTION
As per JDBC 4.1 Spec, The statement’s batch is reset to empty once executeBatch returns.