### PR TITLE
Relax hsql232 describe for supposed float-type constants

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/types/NumberType.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/types/NumberType.java
@@ -1230,6 +1230,20 @@ public final class NumberType extends Type {
 
             case Types.SQL_REAL :
             case Types.SQL_DOUBLE :
+                // A VoltDB extension to allow "describe" to handle BigDecimal
+                // or Integer initializers for FLOAT values.
+                // This is apparently acceptable elsewhere?
+                if (a instanceof BigDecimal) {
+                    // To minimize code change, taking the winding path:
+                    // BigDecimal -> double -> Double -> double -> String.
+                    a = ((BigDecimal) a).doubleValue();
+                }
+                else if (a instanceof Integer) {
+                    // To minimize code change, taking the winding path:
+                    // Integer -> double -> Double -> double -> String.
+                    a = ((Integer) a).doubleValue();
+                }
+                // End of VoltDB extension
                 double value = ((Double) a).doubleValue();
 
                 /** @todo - java 5 format change */


### PR DESCRIPTION
In trying to identify TestFunctionsSuite issues, I discovered that the diagnostic hsql describe function would generate a lot of stack trace noise. This patch allows describe (and anything else that may try to string-format a supposedly float-typed constant) to succeed in cases where it used to throw a cast exception.