### PR TITLE
Rework hsql232 volt patches -- imports, commentary, 1 harmless code t…

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
@@ -40,6 +40,9 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.hsqldb_voltpatches.HSQLInterface.HSQLParseException;
+import org.hsqldb_voltpatches.types.BinaryData;
+import org.hsqldb_voltpatches.types.NumberType;
+import org.hsqldb_voltpatches.types.TimestampData;
 // End of VoltDB extension
 import org.hsqldb_voltpatches.HsqlNameManager.HsqlName;
 import org.hsqldb_voltpatches.HsqlNameManager.SimpleName;
@@ -59,12 +62,9 @@ import org.hsqldb_voltpatches.navigator.RowSetNavigatorData;
 import org.hsqldb_voltpatches.persist.PersistentStore;
 import org.hsqldb_voltpatches.result.Result;
 import org.hsqldb_voltpatches.types.ArrayType;
-import org.hsqldb_voltpatches.types.BinaryData;
 import org.hsqldb_voltpatches.types.CharacterType;
 import org.hsqldb_voltpatches.types.Collation;
 import org.hsqldb_voltpatches.types.NullType;
-import org.hsqldb_voltpatches.types.NumberType;
-import org.hsqldb_voltpatches.types.TimestampData;
 import org.hsqldb_voltpatches.types.Type;
 import org.hsqldb_voltpatches.types.Types;
 

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionCustom.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionCustom.java
@@ -395,10 +395,12 @@ public class FunctionCustom extends FunctionSQL {
 
     static {
         customValueFuncMap.put(Tokens.TODAY, FUNC_CURRENT_DATE);
-        customValueFuncMap.put(Tokens.NOW, FUNC_LOCALTIMESTAMP);
         // A VoltDB extension to override NOW as an alias
         // for CURRENT TIMESTAMP vs. LOCAL TIMESTAMP.
         customValueFuncMap.put(Tokens.NOW, FUNC_CURRENT_TIMESTAMP);
+        /* disable 1 line.
+        customValueFuncMap.put(Tokens.NOW, FUNC_LOCALTIMESTAMP);
+        ... disabled 1 line. */
         // End of VoltDB extension
     }
 
@@ -3744,13 +3746,13 @@ public class FunctionCustom extends FunctionSQL {
             case FUNC_BITAND :
             case FUNC_BITANDNOT :
             case FUNC_BITOR :
-            // A VoltDB extension: Hsqldb uses Integer type by default,
+            // A VoltDB extension: Hsqldb misidentifies BITNOT as a 2-arg function
                 return new StringBuffer(name).append('(')         //
                         .append(nodes[0].getSQL()).append(Tokens.T_COMMA)     //
                         .append(nodes[1].getSQL()).append(')').toString();
             // End of VoltDB extension
             case FUNC_BITNOT :
-            // A VoltDB extension: Hsqldb uses Integer type by default,
+            // A VoltDB extension: Hsqldb misidentifies BITNOT as a 2-arg function
                 return new StringBuffer(name).append('(')         //
                         .append(nodes[0].getSQL()).append(')').toString();
             // End of VoltDB extension


### PR DESCRIPTION
…weak.
The code tweak -- to how we override hsql232's new "NOW" alias in favor of our slightly different original "NOW" alias -- should have no real effect -- it's just a tad more logical.

I DOUBT that it will have any effect at all on our current mysterious NOW-related failures, but I can always hope.

Some of these changes may not be pretty, but they're more true to the original hsql source, which at least for now is still considered a CORE VALUE.