### PR TITLE
Add ability to create hidden columns to TupleSchema

### DIFF
--- a/build.py
+++ b/build.py
@@ -380,13 +380,14 @@ if whichtests in ("${eetestsuite}", "logging"):
 if whichtests in ("${eetestsuite}", "common"):
     CTX.TESTS['common'] = """
      debuglog_test
-     serializeio_test
-     undolog_test
-     valuearray_test
+     elastic_hashinator_test
      nvalue_test
      pool_test
+     serializeio_test
      tabletuple_test
-     elastic_hashinator_test
+     tupleschema_test
+     undolog_test
+     valuearray_test
     """
 
 if whichtests in ("${eetestsuite}", "execution"):

--- a/src/ee/common/TupleSchema.cpp
+++ b/src/ee/common/TupleSchema.cpp
@@ -22,6 +22,38 @@
 
 namespace voltdb {
 
+static inline int memSizeForTupleSchema(uint16_t columnCount,
+                                        uint16_t uninlineableObjectColumnCount,
+                                        uint16_t hiddenColumnCount) {
+    // We must allocate enough memory for any data members plus enough
+    // for columnCount + hiddenColumnCount + 1 "ColumnInfo" fields.
+    // We use the last ColumnInfo object as a placeholder to store the
+    // offset of the end of a tuple (that is, the offset of the first
+    // byte after the tuple).
+    //
+    // Also allocate space for an int16_t for each uninlineable object
+    // column so that the indices of uninlineable columns can be
+    // stored at the front and aid in iteration.
+    return static_cast<int>(sizeof(TupleSchema) +
+                            (uninlineableObjectColumnCount * sizeof(int16_t)) +
+                            (sizeof(TupleSchema::ColumnInfo) * (hiddenColumnCount +
+                                                                columnCount + 1)));
+}
+
+static inline bool isInlineable(ValueType vt, int32_t length, bool inBytes) {
+    if (vt == VALUE_TYPE_VARCHAR || vt == VALUE_TYPE_VARBINARY) {
+
+        if (vt == VALUE_TYPE_VARBINARY || inBytes) {
+            return length < UNINLINEABLE_OBJECT_LENGTH;
+        }
+
+        // must be a VARCHAR field without inBytes flag set
+        return length < UNINLINEABLE_CHARACTER_LENGTH;
+    }
+
+    return true;
+}
+
 TupleSchema* TupleSchema::createTupleSchemaForTest(const std::vector<ValueType> columnTypes,
                                             const std::vector<int32_t> columnSizes,
                                             const std::vector<bool> allowNull)
@@ -35,16 +67,36 @@ TupleSchema* TupleSchema::createTupleSchema(const std::vector<ValueType> columnT
                                             const std::vector<bool> allowNull,
                                             const std::vector<bool> columnInBytes)
 {
+    const std::vector<ValueType> hiddenTypes(0);
+    const std::vector<int32_t> hiddenSizes(0);
+    const std::vector<bool> hiddenAllowNull(0);
+    const std::vector<bool> hiddenColumnInBytes(0);
+    return TupleSchema::createTupleSchema(columnTypes,
+                                          columnSizes,
+                                          allowNull,
+                                          columnInBytes,
+                                          hiddenTypes,
+                                          hiddenSizes,
+                                          hiddenAllowNull,
+                                          hiddenColumnInBytes);
+}
+
+TupleSchema* TupleSchema::createTupleSchema(const std::vector<ValueType> columnTypes,
+                                            const std::vector<int32_t>   columnSizes,
+                                            const std::vector<bool>      allowNull,
+                                            const std::vector<bool>      columnInBytes,
+                                            const std::vector<ValueType> hiddenColumnTypes,
+                                            const std::vector<int32_t>   hiddenColumnSizes,
+                                            const std::vector<bool>      hiddenAllowNull,
+                                            const std::vector<bool>      hiddenColumnInBytes)
+{
     const uint16_t uninlineableObjectColumnCount =
       TupleSchema::countUninlineableObjectColumns(columnTypes, columnSizes, columnInBytes);
     const uint16_t columnCount = static_cast<uint16_t>(columnTypes.size());
-    // big enough for any data members plus big enough for tupleCount + 1 "ColumnInfo"
-    //  fields. We need CI+1 because we get the length of a column by offset subtraction
-    // Also allocate space for an int16_t for each uninlineable object column so that
-    // the indices of uninlineable columns can be stored at the front and aid in iteration
-    int memSize = (int)(sizeof(TupleSchema) +
-                        (sizeof(ColumnInfo) * (columnCount + 1)) +
-                        (uninlineableObjectColumnCount * sizeof(int16_t)));
+    const uint16_t hiddenColumnCount = static_cast<uint16_t>(hiddenColumnTypes.size());
+    int memSize = memSizeForTupleSchema(columnCount,
+                                        uninlineableObjectColumnCount,
+                                        hiddenColumnCount);
 
     // allocate the set amount of memory and cast it to a tuple pointer
     TupleSchema *retval = reinterpret_cast<TupleSchema*>(new char[memSize]);
@@ -53,6 +105,7 @@ TupleSchema* TupleSchema::createTupleSchema(const std::vector<ValueType> columnT
     memset(retval, 0, memSize);
     retval->m_columnCount = columnCount;
     retval->m_uninlinedObjectColumnCount = uninlineableObjectColumnCount;
+    retval->m_hiddenColumnCount = hiddenColumnCount;
 
     uint16_t uninlinedObjectColumnIndex = 0;
     for (uint16_t ii = 0; ii < columnCount; ii++) {
@@ -63,21 +116,36 @@ TupleSchema* TupleSchema::createTupleSchema(const std::vector<ValueType> columnT
         retval->setColumnMetaData(ii, type, length, columnAllowNull, uninlinedObjectColumnIndex, inBytes);
     }
 
+    for (uint16_t ii = 0; ii < hiddenColumnCount; ++ii) {
+        const ValueType type = hiddenColumnTypes[ii];
+        const uint32_t length = hiddenColumnSizes[ii];
+        const bool columnAllowNull = hiddenAllowNull[ii];
+        const bool inBytes = hiddenColumnInBytes[ii];
+
+        // We can't allow uninlineable data in hidden columns yet
+        if (! isInlineable(type, length, inBytes)) {
+            throwFatalLogicErrorStreamed("Attempt to create uninlineable hidden column");
+        }
+
+        retval->setColumnMetaData(static_cast<uint16_t>(columnCount + ii),
+                                  type,
+                                  length,
+                                  columnAllowNull,
+                                  uninlinedObjectColumnIndex,
+                                  inBytes);
+    }
+
     return retval;
 }
 
 TupleSchema* TupleSchema::createTupleSchema(const TupleSchema *schema) {
-    // big enough for any data members plus big enough for tupleCount + 1 "ColumnInfo"
-    //  fields. We need CI+1 because we get the length of a column by offset subtraction
-    int memSize =
-            (int)(sizeof(TupleSchema) +
-                    (sizeof(ColumnInfo) * (schema->m_columnCount + 1)) +
-                    (schema->m_uninlinedObjectColumnCount * sizeof(uint16_t)));
+    int memSize = memSizeForTupleSchema(schema->m_columnCount,
+                                        schema->m_uninlinedObjectColumnCount,
+                                        schema->m_hiddenColumnCount);
 
     // allocate the set amount of memory and cast it to a tuple pointer
     TupleSchema *retval = reinterpret_cast<TupleSchema*>(new char[memSize]);
 
-    // clear all the offset values
     memcpy(retval, schema, memSize);
 
     return retval;
@@ -165,48 +233,31 @@ void TupleSchema::setColumnMetaData(uint16_t index, ValueType type, const int32_
     uint32_t offset = 0;
 
     // set the type
-    ColumnInfo *columnInfo = getColumnInfo(index);
+    ColumnInfo *columnInfo = getColumnInfoPrivate(index);
     columnInfo->type = static_cast<char>(type);
     columnInfo->allowNull = (char)(allowNull ? 1 : 0);
     columnInfo->length = length;
     columnInfo->inBytes = inBytes;
 
-    if ((type == VALUE_TYPE_VARCHAR && inBytes) || type == VALUE_TYPE_VARBINARY) {
+    if (type == VALUE_TYPE_VARCHAR || type == VALUE_TYPE_VARBINARY) {
         if (length == 0) {
             throwFatalLogicErrorStreamed("Zero length for object type " << valueToString((ValueType)type));
         }
-        if (length < UNINLINEABLE_OBJECT_LENGTH) {
-            /*
-             * Inline the string if it is less then UNINLINEABLE_OBJECT_LENGTH bytes.
-             */
+
+        if (isInlineable(type, length, inBytes)) {
             columnInfo->inlined = true;
-            // One byte to store the size
-            offset = static_cast<uint32_t>(length + SHORT_OBJECT_LENGTHLENGTH);
+
+            // If the length was specified in characters, convert to bytes.
+            int32_t factor = (type == VALUE_TYPE_VARCHAR && !inBytes) ? MAX_BYTES_PER_UTF8_CHARACTER : 1;
+
+            // inlined variable length columns have a size prefix (1 byte)
+            offset = static_cast<uint32_t>(SHORT_OBJECT_LENGTHLENGTH + (length * factor));
         } else {
-            /*
-             * Set the length to the size of a String pointer since it won't be inlined.
-             */
-            offset = static_cast<uint32_t>(NValue::getTupleStorageSize(type));
             columnInfo->inlined = false;
-            setUninlinedObjectColumnInfoIndex(uninlinedObjectColumnIndex++, index);
-        }
-    } else if (type == VALUE_TYPE_VARCHAR) {
-        if (length == 0) {
-            throwFatalLogicErrorStreamed("Zero length for object type " << valueToString((ValueType)type));
-        }
-        if (length < UNINLINEABLE_CHARACTER_LENGTH) {
-            /*
-             * Inline the string if it is less then UNINLINEABLE_CHARACTER_LENGTH characters.
-             */
-            columnInfo->inlined = true;
-            // One byte to store the size
-            offset = static_cast<uint32_t>(length * 4 + SHORT_OBJECT_LENGTHLENGTH);
-        } else {
-            /*
-             * Set the length to the size of a String pointer since it won't be inlined.
-             */
+
+            // Set the length to the size of a String pointer since it won't be inlined.
             offset = static_cast<uint32_t>(NValue::getTupleStorageSize(type));
-            columnInfo->inlined = false;
+
             setUninlinedObjectColumnInfoIndex(uninlinedObjectColumnIndex++, index);
         }
     } else {
@@ -218,45 +269,64 @@ void TupleSchema::setColumnMetaData(uint16_t index, ValueType type, const int32_
     // make the column offsets right for all columns past this one
     int oldsize = columnLengthPrivate(index);
     ColumnInfo *nextColumnInfo = NULL;
-    for (int i = index + 1; i <= m_columnCount; i++) {
-        nextColumnInfo = getColumnInfo(i);
+    for (int i = index + 1; i <= totalColumnCount(); i++) {
+        nextColumnInfo = getColumnInfoPrivate(i);
         nextColumnInfo->offset = static_cast<uint32_t>(nextColumnInfo->offset + offset - oldsize);
     }
     assert(index == 0 ? columnInfo->offset == 0 : true);
 }
 
+std::string TupleSchema::ColumnInfo::debug() const {
+    std::ostringstream buffer;
+    buffer << "type = " << getTypeName(getVoltType()) << ", "
+           << "offset = " << offset << ", "
+           << "length = " << length << ", "
+           << "nullable = " << (allowNull ? "true" : "false") << ", "
+           << "isInlined = " << inlined;
+    return buffer.str();
+}
+
 std::string TupleSchema::debug() const {
     std::ostringstream buffer;
 
-    buffer << "Schema has " << columnCount() << " columns, length = " << tupleLength()
-           <<  ", uninlinedObjectColumns "  << m_uninlinedObjectColumnCount << std::endl;
+    buffer << "Schema has "
+           << columnCount() << " columns, "
+           << hiddenColumnCount() << " hidden columns, "
+           << "length = " << tupleLength() << ", "
+           <<  "uninlinedObjectColumns "  << m_uninlinedObjectColumnCount << std::endl;
 
     for (uint16_t i = 0; i < columnCount(); i++) {
         const TupleSchema::ColumnInfo *columnInfo = getColumnInfo(i);
-
-        buffer << " column " << i << ": type = " << getTypeName(columnInfo->getVoltType());
-        buffer << ", length = " << columnInfo->length << ", nullable = ";
-        buffer << (columnInfo->allowNull ? "true" : "false") << ", isInlined = " << columnInfo->inlined <<  std::endl;
+        buffer << " column " << i << ": " << columnInfo->debug() << std::endl;
     }
+
+    for (uint16_t i = 0; i < hiddenColumnCount(); i++) {
+        const TupleSchema::ColumnInfo *columnInfo = getHiddenColumnInfo(i);
+        buffer << " hidden column " << i << ": " << columnInfo->debug() << std::endl;
+    }
+
+    buffer << " terminator column info: "
+           << getColumnInfoPrivate(totalColumnCount())->debug() << std::endl;
 
     std::string ret(buffer.str());
     return ret;
 }
 
-bool TupleSchema::isCompatibleForCopy(const TupleSchema *other) const
+bool TupleSchema::isCompatibleForMemcpy(const TupleSchema *other) const
 {
     if (this == other) {
         return true;
     }
     if (other->m_columnCount != m_columnCount ||
+        other->m_hiddenColumnCount != m_hiddenColumnCount ||
         other->m_uninlinedObjectColumnCount != m_uninlinedObjectColumnCount ||
         other->tupleLength() != tupleLength()) {
         return false;
     }
 
-    for (int ii = 0; ii < m_columnCount; ii++) {
-        const ColumnInfo *columnInfo = getColumnInfo(ii);
-        const ColumnInfo *ocolumnInfo = other->getColumnInfo(ii);
+    for (int ii = 0; ii < totalColumnCount(); ii++) {
+        const ColumnInfo *columnInfo = getColumnInfoPrivate(ii);
+        const ColumnInfo *ocolumnInfo = other->getColumnInfoPrivate(ii);
         if (columnInfo->offset != ocolumnInfo->offset ||
                 columnInfo->type != ocolumnInfo->type ||
                 columnInfo->inlined != ocolumnInfo->inlined) {
@@ -270,13 +340,14 @@ bool TupleSchema::isCompatibleForCopy(const TupleSchema *other) const
 bool TupleSchema::equals(const TupleSchema *other) const
 {
     // First check for structural equality.
-    if ( ! isCompatibleForCopy(other)) {
+    if ( ! isCompatibleForMemcpy(other)) {
         return false;
     }
+
     // Finally, rule out behavior differences.
-    for (int ii = 0; ii < m_columnCount; ii++) {
-        const ColumnInfo *columnInfo = getColumnInfo(ii);
-        const ColumnInfo *ocolumnInfo = other->getColumnInfo(ii);
+    for (int ii = 0; ii < totalColumnCount(); ii++) {
+        const ColumnInfo *columnInfo = getColumnInfoPrivate(ii);
+        const ColumnInfo *ocolumnInfo = other->getColumnInfoPrivate(ii);
         if (columnInfo->allowNull != ocolumnInfo->allowNull) {
             return false;
         }

--- a/src/ee/common/TupleSchema.h
+++ b/src/ee/common/TupleSchema.h
@@ -38,6 +38,9 @@ namespace voltdb {
  * Represents the schema of a tuple or table row. Used to define table rows, as
  * well as index keys. Note: due to arbitrary size embedded array data, this class
  * cannot be created on the stack; all constructors are private.
+ *
+ * Consider using the helper class TupleSchemaBuilder to create
+ * TupleSchema objects.
  */
 class TupleSchema {
 public:
@@ -54,25 +57,43 @@ public:
         const ValueType getVoltType() const {
             return static_cast<ValueType>(type);
         }
+
+        std::string debug() const;
     };
 
     // This needs to keep in synch with the VoltType.MAX_VALUE_LENGTH defined in java.
     enum class_constants { COLUMN_MAX_VALUE_LENGTH = 1048576 };
 
-    /** Static factory method to create a TupleSchema object with a fixed number of columns */
-
-    static TupleSchema* createTupleSchemaForTest(const std::vector<ValueType> columnTypes,
-            const std::vector<int32_t> columnSizes, const std::vector<bool> allowNull);
-
+    /** Static factory method to create a TupleSchema a fixed number
+     *  of all visible columns */
     static TupleSchema* createTupleSchema(const std::vector<ValueType> columnTypes,
-            const std::vector<int32_t> columnSizes, const std::vector<bool> allowNull,
-            const std::vector<bool> columnInBytes);
-    /** Static factory method fakes a copy constructor */
+                                          const std::vector<int32_t>   columnSizes,
+                                          const std::vector<bool>      allowNull,
+                                          const std::vector<bool>      columnInBytes);
+
+    /** Static factory method to create a TupleSchema that contains hidden columns */
+    static TupleSchema* createTupleSchema(const std::vector<ValueType> columnTypes,
+                                          const std::vector<int32_t>   columnSizes,
+                                          const std::vector<bool>      allowNull,
+                                          const std::vector<bool>      columnInBytes,
+                                          const std::vector<ValueType> hiddenColumnTypes,
+                                          const std::vector<int32_t>   hiddenColumnSizes,
+                                          const std::vector<bool>      hiddenAllowNull,
+                                          const std::vector<bool>      hiddenColumnInBytes);
+
+    /** A simplified factory method for ease of testing */
+    static TupleSchema* createTupleSchemaForTest(const std::vector<ValueType> columnTypes,
+                                                 const std::vector<int32_t> columnSizes,
+                                                 const std::vector<bool> allowNull);
+
+    /** Static factory method fakes a copy constructor (will also
+     *  duplicate hidden columns) */
     static TupleSchema* createTupleSchema(const TupleSchema *schema);
 
     /**
      * Static factory method to create a TupleSchema object by copying the
      * specified columns of the given schema.
+     * (Hidden column will be omitted.)
      */
     static TupleSchema* createTupleSchema(const TupleSchema *schema,
                                           const std::vector<uint16_t> set);
@@ -84,6 +105,8 @@ public:
      *
      * This method has the same limitation that the number of columns of a
      * schema has to be less than or equal to 64.
+     *
+     * Hidden column will be omitted from the created schema.
      */
     static TupleSchema* createTupleSchema(const TupleSchema *first,
                                           const TupleSchema *second);
@@ -92,6 +115,8 @@ public:
      * Static factory method to create a TupleSchema object by including the
      * specified columns of the two given TupleSchema objects. The result
      * contains only those columns specified in the bitmasks.
+     *
+     * Hidden columns will be omitted from the created schema.
      */
     static TupleSchema* createTupleSchema(const TupleSchema *first,
                                           const std::vector<uint16_t> firstSet,
@@ -101,35 +126,64 @@ public:
     /** Static factory method to destroy a TupleSchema object. Set to null after this call */
     static void freeTupleSchema(TupleSchema *schema);
 
-    /** Return the number of columns in the schema for the tuple. */
+    /** Return the number of (visible) columns in the schema for the tuple. */
     inline uint16_t columnCount() const;
+
+    /** Return the number of hidden columns in the schema for the tuple. */
+    inline uint16_t hiddenColumnCount() const;
+
     /** Return the number of bytes used by one tuple. */
     inline uint32_t tupleLength() const;
 
     /** Get a string representation of this schema for debugging */
     std::string debug() const;
 
+    /** Returns the number of variable-length columns that are too long
+     * to be inlined into tuple storage. */
     uint16_t getUninlinedObjectColumnCount() const ;
 
+    /** Returns the index of the n-th uninlined column in the
+     * column info array. */
     uint16_t getUninlinedObjectColumnInfoIndex(const int objectColumnIndex) const;
 
+    /** Returns true if other TupleSchema is equal to this one.  Both
+     *  visible and hidden columns must match for schemas to be
+     *  equal. */
     bool equals(const TupleSchema *other) const;
-    bool isCompatibleForCopy(const TupleSchema *other) const;
 
+    /* Returns true if number of columns and their data types are the
+     * same.  Includes hidden columns. */
+    bool isCompatibleForMemcpy(const TupleSchema *other) const;
+
+    /** Returns column info object for columnIndex-th (visible) column.  */
     const ColumnInfo* getColumnInfo(int columnIndex) const;
     ColumnInfo* getColumnInfo(int columnIndex);
 
+    /** Returns the value type for idx-th (visible) column.  */
     ValueType columnType(int idx) const {
         const TupleSchema::ColumnInfo *columnInfo = getColumnInfo(idx);
         return columnInfo->getVoltType();
     }
 
+    /** Returns the inlined-ness for idx-th (visible) column.  */
     bool columnIsInlined(int idx) const {
         const TupleSchema::ColumnInfo *columnInfo = getColumnInfo(idx);
         return columnInfo->inlined;
     }
 
+    /** Returns column info object for columnIndex-th hidden column.  */
+    const ColumnInfo* getHiddenColumnInfo(int columnIndex) const;
+    ColumnInfo* getHiddenColumnInfo(int columnIndex);
+
 private:
+
+    uint16_t totalColumnCount() const;
+
+    /** These methods are like their public counterparts, but accepts
+     *  indexes >= m_columnCount, in order to access hidden columns or
+     *  the terminating ColumnInfo object. */
+    ColumnInfo* getColumnInfoPrivate(int columnIndex);
+    const ColumnInfo* getColumnInfoPrivate(int columnIndex) const;
 
     /*
      * Report the actual length in bytes of a column. For inlined strings this will include the two byte length prefix and null terminator.
@@ -163,8 +217,19 @@ private:
     uint16_t m_columnCount;
     uint16_t m_uninlinedObjectColumnCount;
 
+    // number of hidden columns
+    // currently unlined values in hidden columns are not possible
+    uint16_t m_hiddenColumnCount;
+
     /*
-     * Data storage for column info and for indices of string columns
+     * Data storage for:
+     *   - An array of int16_t, containing the 0-based ordinal position
+     *       of each non-inlined column
+     *   - An array of ColumnInfo objects, in this order:
+     *       - normal, visible columns
+     *       - hidden columns (must be accessed via getHiddenColumnInfo)
+     *       - A terminating ColumnInfo containing the offset of the first byte
+     *         after the tuple (i.e., the tuple length)
      */
     char m_data[0];
 };
@@ -174,9 +239,9 @@ private:
 ///////////////////////////////////
 
 inline uint32_t TupleSchema::columnLengthPrivate(const int index) const {
-    assert(index < m_columnCount);
-    const ColumnInfo *columnInfo = getColumnInfo(index);
-    const ColumnInfo *columnInfoPlusOne = getColumnInfo(index + 1);
+    assert(index < totalColumnCount());
+    const ColumnInfo *columnInfo = getColumnInfoPrivate(index);
+    const ColumnInfo *columnInfoPlusOne = getColumnInfoPrivate(index + 1);
     // calculate the real column length in raw bytes
     return static_cast<uint32_t>(columnInfoPlusOne->offset - columnInfo->offset);
 }
@@ -185,18 +250,47 @@ inline uint16_t TupleSchema::columnCount() const {
     return m_columnCount;
 }
 
-inline uint32_t TupleSchema::tupleLength() const {
-    // index "m_count" has the offset for the end of the tuple
-    // index "m_count-1" has the offset for the last column
-    return getColumnInfo(m_columnCount)->offset;
+inline uint16_t TupleSchema::hiddenColumnCount() const {
+    return m_hiddenColumnCount;
 }
 
-inline const TupleSchema::ColumnInfo* TupleSchema::getColumnInfo(int columnIndex) const {
+inline uint16_t TupleSchema::totalColumnCount() const {
+    return static_cast<uint16_t>(m_columnCount + m_hiddenColumnCount);
+}
+
+inline uint32_t TupleSchema::tupleLength() const {
+    // index "m_columnCount + m_hiddenColumnCount" has the offset for the end of the tuple
+    // index "m_columnCount + m_hiddenColumnCount - 1" has the offset for the last hidden column
+    // index "m_columnCount - 1" has the offset for the last visible column
+    return getColumnInfoPrivate(totalColumnCount())->offset;
+}
+
+inline const TupleSchema::ColumnInfo* TupleSchema::getColumnInfoPrivate(int columnIndex) const {
     return &reinterpret_cast<const ColumnInfo*>(m_data + (sizeof(uint16_t) * m_uninlinedObjectColumnCount))[columnIndex];
 }
 
-inline TupleSchema::ColumnInfo* TupleSchema::getColumnInfo(int columnIndex) {
+inline TupleSchema::ColumnInfo* TupleSchema::getColumnInfoPrivate(int columnIndex) {
     return &reinterpret_cast<ColumnInfo*>(m_data + (sizeof(uint16_t) * m_uninlinedObjectColumnCount))[columnIndex];
+}
+
+inline const TupleSchema::ColumnInfo* TupleSchema::getColumnInfo(int columnIndex) const {
+    assert(columnIndex < m_columnCount);
+    return getColumnInfoPrivate(columnIndex);
+}
+
+inline TupleSchema::ColumnInfo* TupleSchema::getColumnInfo(int columnIndex) {
+    assert(columnIndex < m_columnCount);
+    return getColumnInfoPrivate(columnIndex);
+}
+
+inline const TupleSchema::ColumnInfo* TupleSchema::getHiddenColumnInfo(int hiddenColumnIndex) const {
+    assert(hiddenColumnIndex < m_hiddenColumnCount);
+    return getColumnInfoPrivate(m_columnCount + hiddenColumnIndex);
+}
+
+inline TupleSchema::ColumnInfo* TupleSchema::getHiddenColumnInfo(int hiddenColumnIndex) {
+    assert(hiddenColumnIndex < m_hiddenColumnCount);
+    return getColumnInfoPrivate(m_columnCount + hiddenColumnIndex);
 }
 
 inline uint16_t TupleSchema::getUninlinedObjectColumnCount() const { return m_uninlinedObjectColumnCount; }

--- a/src/ee/common/TupleSchemaBuilder.h
+++ b/src/ee/common/TupleSchemaBuilder.h
@@ -1,0 +1,209 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <vector>
+
+#include "common/NValue.hpp"
+#include "common/types.h"
+#include "common/TupleSchema.h"
+
+#ifndef TUPLESCHEMABUILDER_H_
+#define TUPLESCHEMABUILDER_H_
+
+namespace voltdb {
+
+/** A helper class to create TupleSchema objects.
+ * Example:
+ *
+ *   TupleSchemaBuilder builder(3); // 3 columns
+ *   builder.setColumnAtIndex(0, VALUE_TYPE_BIGINT);
+ *   builder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR, 32);
+ *   builder.setColumnAtIndex(2, VALUE_TYPE_INTEGER);
+ *   TupleSchema *schema = builder.build();
+ */
+class TupleSchemaBuilder {
+public:
+
+    /** Create a builder that will build a schema with the given
+     * number of columns. */
+    explicit TupleSchemaBuilder(size_t numCols)
+        : m_types(numCols)
+        , m_sizes(numCols)
+        , m_allowNullFlags(numCols)
+        , m_inBytesFlags(numCols)
+        , m_hiddenTypes(0)
+        , m_hiddenSizes(0)
+        , m_hiddenAllowNullFlags(0)
+        , m_hiddenInBytesFlags(0)
+    {
+    }
+
+    /** Create a builder that will build a schema with the given
+     * number of columns and hidden columns. */
+    TupleSchemaBuilder(size_t numCols, size_t numHiddenCols)
+        : m_types(numCols)
+        , m_sizes(numCols)
+        , m_allowNullFlags(numCols)
+        , m_inBytesFlags(numCols)
+        , m_hiddenTypes(numHiddenCols)
+        , m_hiddenSizes(numHiddenCols)
+        , m_hiddenAllowNullFlags(numHiddenCols)
+        , m_hiddenInBytesFlags(numHiddenCols)
+    {
+    }
+
+    /** Set the attributes of the index-th column for the schema to be
+     *  built. */
+    void setColumnAtIndex(size_t index,
+                          ValueType valueType,
+                          int32_t colSize,
+                          bool allowNull,
+                          bool inBytes)
+    {
+        assert(index < m_types.size());
+        m_types[index] = valueType;
+        m_sizes[index] = colSize;
+        m_allowNullFlags[index] = allowNull;
+        m_inBytesFlags[index] = inBytes;
+    }
+
+    /** Set the attributes of the index-th hidden column for the
+     *  schema to be built. */
+    void setHiddenColumnAtIndex(size_t index,
+                                ValueType valueType,
+                                int32_t colSize,
+                                bool allowNull,
+                                bool inBytes)
+    {
+        assert(index < m_hiddenTypes.size());
+        m_hiddenTypes[index] = valueType;
+        m_hiddenSizes[index] = colSize;
+        m_hiddenAllowNullFlags[index] = allowNull;
+        m_hiddenInBytesFlags[index] = inBytes;
+    }
+
+    /** Finally, build the schema with the attributes specified. */
+    TupleSchema* build() const
+    {
+        return TupleSchema::createTupleSchema(m_types,
+                                              m_sizes,
+                                              m_allowNullFlags,
+                                              m_inBytesFlags,
+                                              m_hiddenTypes,
+                                              m_hiddenSizes,
+                                              m_hiddenAllowNullFlags,
+                                              m_hiddenInBytesFlags);
+    }
+
+    /* Below are convenience methods for setting column attributes,
+     * with reasonable defaults:
+     *   - Size attribute is implied for non-variable-length types
+     *   - nullability is true by default
+     *   - inBytes flag is false by default
+     */
+
+    void setColumnAtIndex(size_t index,
+                          ValueType valueType,
+                          int32_t colSize,
+                          bool allowNull)
+    {
+        setColumnAtIndex(index,
+                         valueType,
+                         colSize,
+                         allowNull,
+                         false); // size not in bytes
+    }
+
+    void setColumnAtIndex(size_t index,
+                          ValueType valueType,
+                          int32_t colSize)
+    {
+        setColumnAtIndex(index,
+                         valueType,
+                         colSize,
+                         true,   // allow nulls
+                         false); // size not in bytes
+    }
+
+    void setColumnAtIndex(size_t index,
+                          ValueType valueType)
+    {
+        // sizes for variable length types
+        // must be explicitly specified
+        assert (valueType != VALUE_TYPE_VARCHAR
+                && valueType != VALUE_TYPE_VARBINARY);
+
+        setColumnAtIndex(index, valueType,
+                         NValue::getTupleStorageSize(valueType),
+                         true,   // allow nulls
+                         false); // size not in bytes
+    }
+
+    void setHiddenColumnAtIndex(size_t index,
+                                ValueType valueType,
+                                int32_t colSize,
+                                bool allowNull)
+    {
+        setHiddenColumnAtIndex(index,
+                               valueType,
+                               colSize,
+                               allowNull,
+                               false);  // size not in bytes
+    }
+
+    void setHiddenColumnAtIndex(size_t index,
+                                ValueType valueType,
+                                int32_t colSize)
+    {
+        setHiddenColumnAtIndex(index,
+                               valueType,
+                               colSize,
+                               true,    // allow nulls
+                               false);  // size not in bytes
+    }
+
+    void setHiddenColumnAtIndex(size_t index,
+                                ValueType valueType)
+    {
+        // sizes for variable length types
+        // must be explicitly specified
+        assert (valueType != VALUE_TYPE_VARCHAR
+                && valueType != VALUE_TYPE_VARBINARY);
+
+        setHiddenColumnAtIndex(index,
+                               valueType,
+                               NValue::getTupleStorageSize(valueType),
+                               true,    // allow nulls
+                               false);  // size not in bytes
+    }
+
+private:
+    std::vector<ValueType> m_types;
+    std::vector<int32_t> m_sizes;
+    std::vector<bool> m_allowNullFlags;
+    std::vector<bool> m_inBytesFlags;
+
+    std::vector<ValueType> m_hiddenTypes;
+    std::vector<int32_t> m_hiddenSizes;
+    std::vector<bool> m_hiddenAllowNullFlags;
+    std::vector<bool> m_hiddenInBytesFlags;
+
+};
+
+} // end namespace voltdb
+
+#endif // TUPLESCHEMABUILDER_H_

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -597,7 +597,7 @@ inline void TableTuple::copyForPersistentInsert(const voltdb::TableTuple &source
     const uint16_t uninlineableObjectColumnCount = m_schema->getUninlinedObjectColumnCount();
 
 #ifndef NDEBUG
-    if( ! m_schema->isCompatibleForCopy(source.m_schema)) {
+    if( ! m_schema->isCompatibleForMemcpy(source.m_schema)) {
         std::ostringstream message;
         message << "src  tuple: " << source.debug("") << std::endl;
         message << "src schema: " << source.m_schema->debug() << std::endl;
@@ -703,7 +703,7 @@ inline void TableTuple::copy(const TableTuple &source) {
     assert(m_data);
 
 #ifndef NDEBUG
-    if( ! m_schema->isCompatibleForCopy(source.m_schema)) {
+    if( ! m_schema->isCompatibleForMemcpy(source.m_schema)) {
         std::ostringstream message;
         message << "src  tuple: " << source.debug("") << std::endl;
         message << "src schema: " << source.m_schema->debug() << std::endl;

--- a/tests/ee/common/tupleschema_test.cpp
+++ b/tests/ee/common/tupleschema_test.cpp
@@ -1,0 +1,235 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <vector>
+
+#include "harness.h"
+#include "common/TupleSchema.h"
+#include "common/TupleSchemaBuilder.h"
+
+using voltdb::TupleSchema;
+using voltdb::ValueType;
+using voltdb::VALUE_TYPE_BIGINT;
+using voltdb::VALUE_TYPE_DECIMAL;
+using voltdb::VALUE_TYPE_INTEGER;
+using voltdb::VALUE_TYPE_TIMESTAMP;
+using voltdb::VALUE_TYPE_VARCHAR;
+
+class TupleSchemaTest : public Test
+{
+};
+
+// A class to automatically free TupleSchema instances, which cannot
+// be allocated on the stack due to variable-length data that follows
+// each instance.  Modeled after boost::scoped_ptr.
+class ScopedSchema {
+public:
+    ScopedSchema(TupleSchema* schema)
+        : m_schema(schema)
+    {
+    }
+
+    TupleSchema* get() {
+        return m_schema;
+    }
+
+    TupleSchema& operator*() {
+        return *m_schema;
+    }
+
+    TupleSchema* operator->() {
+        return m_schema;
+    }
+
+    ~ScopedSchema() {
+        TupleSchema::freeTupleSchema(m_schema);
+    }
+
+private:
+    TupleSchema* m_schema;
+};
+
+TEST_F(TupleSchemaTest, Basic)
+{
+    voltdb::TupleSchemaBuilder builder(2);
+
+    builder.setColumnAtIndex(0, VALUE_TYPE_INTEGER);
+    builder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR,
+                             256, // column size
+                             false, // do not allow nulls
+                             true); // size is in bytes
+
+    ScopedSchema schema(builder.build());
+
+    ASSERT_NE(NULL, schema.get());
+    ASSERT_EQ(2, schema->columnCount());
+
+    EXPECT_EQ(1, schema->getUninlinedObjectColumnCount());
+    EXPECT_EQ(1, schema->getUninlinedObjectColumnInfoIndex(0));
+
+    // 4 bytes for the integer
+    // 8 bytes for the string pointer
+    EXPECT_EQ(12, schema->tupleLength());
+
+    const TupleSchema::ColumnInfo *colInfo = schema->getColumnInfo(0);
+    ASSERT_NE(NULL, colInfo);
+    EXPECT_EQ(0, colInfo->offset);
+    EXPECT_EQ(4, colInfo->length);
+    EXPECT_EQ(VALUE_TYPE_INTEGER, colInfo->type);
+    EXPECT_EQ(1, colInfo->allowNull);
+    EXPECT_EQ(true, colInfo->inlined);
+    EXPECT_EQ(false, colInfo->inBytes);
+
+    colInfo = schema->getColumnInfo(1);
+    ASSERT_NE(NULL, colInfo);
+    EXPECT_EQ(4, colInfo->offset);
+    EXPECT_EQ(256, colInfo->length);
+    EXPECT_EQ(VALUE_TYPE_VARCHAR, colInfo->type);
+    EXPECT_EQ(false, colInfo->allowNull);
+    EXPECT_EQ(false, colInfo->inlined);
+    EXPECT_EQ(true, colInfo->inBytes);
+}
+
+TEST_F(TupleSchemaTest, HiddenColumn)
+{
+    voltdb::TupleSchemaBuilder builder(2,  // 2 visible columns
+                                       1); // 1 hidden column
+    builder.setColumnAtIndex(0, VALUE_TYPE_INTEGER);
+    builder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR,
+                             256,   // column size
+                             false, // do not allow nulls
+                             true); // size is in bytes
+
+    builder.setHiddenColumnAtIndex(0, VALUE_TYPE_BIGINT);
+
+    ScopedSchema schema(builder.build());
+
+    ASSERT_NE(NULL, schema.get());
+    ASSERT_EQ(2, schema->columnCount());
+    ASSERT_EQ(1, schema->hiddenColumnCount());
+
+    EXPECT_EQ(1, schema->getUninlinedObjectColumnCount());
+    EXPECT_EQ(1, schema->getUninlinedObjectColumnInfoIndex(0));
+
+    // 8 bytes for the hidden bigint
+    // 4 bytes for the integer
+    // 8 bytes for the string pointer
+    EXPECT_EQ(20, schema->tupleLength());
+
+    // Verify that the visible columns are as expected
+    const TupleSchema::ColumnInfo *colInfo = schema->getColumnInfo(0);
+    ASSERT_NE(NULL, colInfo);
+    EXPECT_EQ(0, colInfo->offset);
+    EXPECT_EQ(4, colInfo->length);
+    EXPECT_EQ(VALUE_TYPE_INTEGER, colInfo->type);
+    EXPECT_EQ(1, colInfo->allowNull);
+    EXPECT_EQ(true, colInfo->inlined);
+    EXPECT_EQ(false, colInfo->inBytes);
+
+    colInfo = schema->getColumnInfo(1);
+    ASSERT_NE(NULL, colInfo);
+    EXPECT_EQ(4, colInfo->offset);
+    EXPECT_EQ(256, colInfo->length);
+    EXPECT_EQ(VALUE_TYPE_VARCHAR, colInfo->type);
+    EXPECT_EQ(false, colInfo->allowNull);
+    EXPECT_EQ(false, colInfo->inlined);
+    EXPECT_EQ(true, colInfo->inBytes);
+
+    // Now check the hidden column
+    colInfo = schema->getHiddenColumnInfo(0);
+    ASSERT_NE(NULL, colInfo);
+    EXPECT_EQ(12, colInfo->offset);
+    EXPECT_EQ(8, colInfo->length);
+    EXPECT_EQ(VALUE_TYPE_BIGINT, colInfo->type);
+    EXPECT_EQ(true, colInfo->allowNull);
+    EXPECT_EQ(true, colInfo->inlined);
+    EXPECT_EQ(false, colInfo->inBytes);
+}
+
+TEST_F(TupleSchemaTest, EqualsAndCompatibleForMemcpy)
+{
+    voltdb::TupleSchemaBuilder builder(3); // 3 visible columns
+    builder.setColumnAtIndex(0, VALUE_TYPE_DECIMAL);
+    builder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR,
+                             64,     // length
+                             true,   // allow nulls
+                             false); // length not in bytes
+    builder.setColumnAtIndex(2, VALUE_TYPE_TIMESTAMP);
+    ScopedSchema schema1(builder.build());
+
+    voltdb::TupleSchemaBuilder hiddenBuilder(3, 2); // 3 visible columns
+    hiddenBuilder.setColumnAtIndex(0, VALUE_TYPE_DECIMAL);
+    hiddenBuilder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR,
+                             64,     // length
+                             true,   // allow nulls
+                             false); // length not in bytes
+    hiddenBuilder.setColumnAtIndex(2, VALUE_TYPE_TIMESTAMP);
+
+    hiddenBuilder.setHiddenColumnAtIndex(0, VALUE_TYPE_BIGINT);
+    hiddenBuilder.setHiddenColumnAtIndex(1, VALUE_TYPE_VARCHAR, 10);
+
+    ScopedSchema schema2(hiddenBuilder.build());
+
+    ASSERT_NE(NULL, schema1.get());
+    ASSERT_NE(NULL, schema2.get());
+
+    // Table tuples whose schemas that differ only in hidden columns
+    // are not suitable for memcpy.
+    EXPECT_FALSE(schema1->isCompatibleForMemcpy(schema2.get()));
+    EXPECT_FALSE(schema2->isCompatibleForMemcpy(schema1.get()));
+    EXPECT_FALSE(schema1->equals(schema2.get()));
+    EXPECT_FALSE(schema2->equals(schema1.get()));
+
+    // Create another schema where the varchar column is longer (but
+    // still uninlined)
+    builder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR, 128);
+    ScopedSchema schema3(builder.build());
+
+    // Structural layout is the same
+    EXPECT_TRUE(schema1->isCompatibleForMemcpy(schema3.get()));
+    EXPECT_TRUE(schema3->isCompatibleForMemcpy(schema1.get()));
+
+    // But schemas are not equal due to length difference
+    EXPECT_FALSE(schema1->equals(schema3.get()));
+    EXPECT_FALSE(schema3->equals(schema1.get()));
+
+    // Now do a similar test comparing two schemas with hidden columns.
+    hiddenBuilder.setHiddenColumnAtIndex(0,
+                                         VALUE_TYPE_BIGINT,
+                                         8,
+                                         false); // nulls not allowed
+    ScopedSchema schema4(hiddenBuilder.build());
+
+    // Structural layout is the same
+    EXPECT_TRUE(schema2->isCompatibleForMemcpy(schema4.get()));
+    EXPECT_TRUE(schema4->isCompatibleForMemcpy(schema2.get()));
+
+    // But schemas are not equal due to difference in nullability in
+    // first hidden column.
+    EXPECT_FALSE(schema2->equals(schema4.get()));
+    EXPECT_FALSE(schema4->equals(schema2.get()));
+}
+
+int main() {
+    return TestSuite::globalInstance()->runAll();
+}


### PR DESCRIPTION
Add cpptest for TupleSchema

Implmement a TupleSchemaBuilder class

A stubbed out version of hiddenColumnCount()

Reflect number of hidden columns correctly

Now passing the tuple length test

Verify details of hidden columns

Add convenience method for getting total number of columns

Add comments to TupleSchema header

Make isCompatibleForCopy work right

Also rename it it to isCompatibleForMemcpy, and other small changes.

Add more tests for schema equality involving hidden columns

Add more comments

Make TableCatalogDelegate use TupleSchemaBuilder

Refactor field inlining logic

Convert from chars to bytes in refactored logic