### PR TITLE
ENG-8646 improve checkout error handling and set default to master

### DIFF
--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -3,6 +3,8 @@
 import os, sys, shutil, datetime
 from fabric.api import run, cd, local, get, settings, lcd, put
 from fabric_ssh_config import getSSHInfoForHost
+from fabric.context_managers import shell_env
+from fabric.utils import abort
 
 username='test'
 builddir = "/tmp/" + username + "Kits/buildtemp"
@@ -21,13 +23,28 @@ def checkoutCode(voltdbGit, proGit, rbmqExportGit):
     run("mkdir -p " + builddir)
     # change to it
     with cd(builddir):
-        # do the checkouts
+        # do the checkouts, collect checkout errors on both community &
+        # pro repos so user gets status on both checkouts
+        message = ""
         run("git clone git@github.com:VoltDB/voltdb.git")
-        run("cd voltdb; git checkout %s" % voltdbGit)
+        result = run("cd voltdb; git checkout %s" % voltdbGit, warn_only=True)
+        if result.failed:
+            message = "VoltDB checkout failed. Missing branch %s." % rbmqExportGit
+
         run("git clone git@github.com:VoltDB/pro.git")
-        run("cd pro; git checkout %s" % proGit)
+        result = run("cd pro; git checkout %s" % proGit, warn_only=True)
+        if result.failed:
+            message += "\nPro checkout failed. Missing branch %s." % rbmqExportGit
+
         run("git clone git@github.com:VoltDB/export-rabbitmq.git")
-        run("cd export-rabbitmq; git checkout %s" % rbmqExportGit)
+        result = run("cd export-rabbitmq; git checkout %s" % rbmqExportGit, warn_only=True)
+        # Probably ok to use master for export-rabbitmq.
+        if result.failed:
+            print "\nExport-rabbitmg branch %s checkout failed. Defaulting to master." % rbmqExportGit
+
+        if len(message) > 0:
+            abort(message)
+
         return run("cat voltdb/version.txt").strip()
 
 ################################################
@@ -286,7 +303,7 @@ try:
         copyMavenJarsToReleaseDir(releaseDir, versionCentos)
 
 except Exception as e:
-    print "Coult not build LINUX kit: " + str(e)
+    print "Could not build LINUX kit. Exception: " + str(e) + ", Type: " + str(type(e))
     build_errors=True
 
 try:
@@ -300,7 +317,7 @@ try:
         buildRabbitMQExport(versionMac)
         copyEnterpriseFilesToReleaseDir(releaseDir, versionMac, "MAC")
 except Exception as e:
-    print "Coult not build MAC kit: " + str(e)
+    print "Could not build MAC kit. Exception: " + str(e) + ", Type: " + str(type(e))
     build_errors=True
 
 # build debian kit
@@ -323,7 +340,7 @@ try:
             run ("sudo python voltdb-install.py -D " + entbld)
             get("voltdb-ent_%s-1_amd64.deb" % (versionCentos), releaseDir)
 except Exception as e:
-    print "Coult not build debian kit: " + str(e)
+    print "Could not build debian kit. Exception: " + str(e) + ", Type: " + str(type(e))
     build_errors=True
 
 try:
@@ -347,7 +364,7 @@ try:
             get("voltdb-ent-%s-1.x86_64.rpm" % (versionCentos), releaseDir)
 
 except Exception as e:
-    print "Coult not build rpm kit: " + str(e)
+    print "Could not build rpm kit. Exception: " + str(e) + ", Type: " + str(type(e))
     build_errors=True
 
 computeChecksums(releaseDir)


### PR DESCRIPTION
Change to build_kit.py to try to checkout all branches and provide all errors rather than exiting on each error in sequence.

Second, if there's no RabbitMQ of the same branch name, fall through which defaults it to master.