### PR TITLE
Eng 8638 too strict column names

### DIFF
--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -868,7 +868,11 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         // tagging the actual display column as being also an order by column
         // helps later when trying to determine ORDER BY coverage (for determinism).
         for (ParsedColInfo col : m_displayColumns) {
+            // A VoltDB extension to avoid an NPE.
+            if ((col.alias != null && col.alias.equals(order_col.alias)) || col.expression.equals(order_exp)) {
+            /* disable 1 line
             if (col.alias.equals(order_col.alias) || col.expression.equals(order_exp)) {
+            ... disabled 1 line. */
                 col.orderBy = true;
                 col.ascending = order_col.ascending;
 

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -868,11 +868,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         // tagging the actual display column as being also an order by column
         // helps later when trying to determine ORDER BY coverage (for determinism).
         for (ParsedColInfo col : m_displayColumns) {
-            // A VoltDB extension to avoid an NPE.
             if ((col.alias != null && col.alias.equals(order_col.alias)) || col.expression.equals(order_exp)) {
-            /* disable 1 line
-            if (col.alias.equals(order_col.alias) || col.expression.equals(order_exp)) {
-            ... disabled 1 line. */
                 col.orderBy = true;
                 col.ascending = order_col.ascending;
 

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
@@ -2098,13 +2098,23 @@ public class RangeVariable {
 
         if (rangeTable.tableType == TableBase.SYSTEM_SUBQUERY) {
             if (rangeTable instanceof TableDerived) {
-                if (tableAlias == null || tableAlias.name == null) {
-                    // VoltDB require derived sub select table with user specified alias
-                    throw new org.hsqldb_voltpatches.HSQLInterface.HSQLParseException(
-                            "SQL Syntax error: Every derived table must have its own alias.");
+                String tableName = null;
+                if (tableAlias != null && tableAlias.name != null) {
+                    // If we have an alias, then use it.
+                    tableName = tableAlias.name;
+                } else {
+                    // If we don't have an alias, try to get the name from
+                    // the range table.
+                    tableName = rangeTable.getName().getNameString();
+                    if (tableName == null) {
+                        // If we've got nothing, then give up.
+                        // VoltDB require derived sub select table with user specified alias
+                        throw new org.hsqldb_voltpatches.HSQLInterface.HSQLParseException(
+                                "SQL Syntax error: Every derived table must have its own alias.");
+                    }
                 }
 
-                scan.attributes.put("table", tableAlias.name.toUpperCase());
+                scan.attributes.put("table", tableName.toUpperCase());
 
                 // The parameter list will be appended to the top-level statement,
                 // so just pass an empty parameter list for the inner statements.

--- a/tests/frontend/org/voltdb/planner/TestWithClause.java
+++ b/tests/frontend/org/voltdb/planner/TestWithClause.java
@@ -25,7 +25,7 @@ package org.voltdb.planner;
 
 public class TestWithClause extends PlannerTestCase {
     private static final boolean allTests = false;
-    private static final boolean HSQL232_ENG_8638_DONE = true;
+    // hsql232 ENG-8626
     private static final boolean HSQL232_ENG_8626_DONE = false;
     private static final boolean doTest(boolean condition) {
         return allTests || condition;

--- a/tests/frontend/org/voltdb/planner/TestWithClause.java
+++ b/tests/frontend/org/voltdb/planner/TestWithClause.java
@@ -1,0 +1,245 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.planner;
+
+public class TestWithClause extends PlannerTestCase {
+    private static final boolean allTests = false;
+    private static final boolean HSQL232_ENG_8638_DONE = true;
+    private static final boolean HSQL232_ENG_8626_DONE = false;
+    private static final boolean doTest(boolean condition) {
+        return allTests || condition;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        final boolean planForSinglePartitionFalse = false;
+        setupSchema(TestFunctions.class.getResource("testwithclause.sql"),
+                    "testwithclause", planForSinglePartitionFalse);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    private final void doCompileTest(boolean enabled, String sql) {
+        if (doTest(enabled)) {
+            compile(sql);
+        } else {
+            failToCompile(sql);
+        }
+    }
+
+    public void testSimpleWith() throws Exception {
+        compile("WITH dept_count AS (\n" +
+                "  SELECT deptno, COUNT(*) AS dc\n" +
+                "  FROM   employee\n" +
+                "  GROUP BY deptno)\n" +
+                "SELECT e.name AS employee_name,\n" +
+                "       dc AS emp_dept_count\n" +
+                "FROM   employee e,\n" +
+                "       dept_count as ddd\n" +
+                "WHERE  e.deptno = ddd.deptno;" +
+                "");
+    }
+
+    public void testSimpleWithNoDot() throws Exception {
+        // This seems like a plausible query.  The unqualified variable
+        // dept_no in the where clause can only be satisfied by the
+        // table dept_count.  But HSQLDB tells us every derived table
+        // needs an alias, including dept_count in the FROM clause.
+        // I think this is an error, and is discussed in ENG-8638.
+        //
+        compile("WITH dept_count AS (\n" +
+                "  SELECT deptno, COUNT(*) as dc\n" +
+                "  FROM   employee\n" +
+                "  GROUP BY deptno)\n" +
+                "SELECT e.name AS employee_name,\n" +
+                "       dept_count.dc AS emp_dept_count\n" +
+                "FROM   employee e,\n" +
+                "       dept_count\n" +
+                "WHERE  e.deptno = deptno;" +
+                "");
+    }
+
+    public void testDoubleWith() throws Exception {
+        compile("WITH dept_count AS (\n" +
+                "  SELECT deptno, COUNT(*) AS dept_count\n" +
+                "  FROM   employee\n" +
+                "  GROUP BY deptno),\n" +
+                "  current_proj AS (\n" +
+                "  select e.empno as empno,\n" +
+                "         p.description as pdesc\n" +
+                "  from\n" +
+                "   employee as e,\n" +
+                "        project as p,\n" +
+                "   project_participation pd\n" +
+                "  where e.empno = pd.empno\n" +
+                "  and   p.projectno = pd.projectno\n" +
+                "  and   pd.end_date is null )\n" +
+                "SELECT e.name AS employee_name,\n" +
+                "       dc.dept_count AS emp_dept_count,\n" +
+                "       cp.pdesc\n" +
+                "FROM   employee e,\n" +
+                "       dept_count dc,\n" +
+                "       current_proj cp\n" +
+                "WHERE  e.deptno = dc.deptno\n" +
+                "and    cp.empno = e.empno;\n" +
+                "");
+    }
+
+    public void testWithInFrom() throws Exception {
+        compile("SELECT e.name AS employee_name, \n" +
+                "       dc.dept_count AS emp_dept_count \n" +
+                "FROM   employee e, \n" +
+                "       (WITH dept_count AS ( \n" +
+                "         SELECT deptno, COUNT(*) AS dept_count \n" +
+                "        FROM   employee \n" +
+                "        GROUP BY deptno) \n" +
+                "       select * from dept_count) as dc \n" +
+                "WHERE  e.deptno = dc.deptno; \n" +
+                "");
+    }
+    public void testWithInIn() throws Exception {
+        // Logically the "dc.deptno" and "as dc" in the RHS of the
+        // "in" operation is not necessary.  However, HSQLDB gives
+        // an error without it.  When ENG-8638 is
+        compile("SELECT e.name AS employee_name\n " +
+                "FROM   employee e\n " +
+                "WHERE  e.deptno in ( WITH dept_count AS (\n " +
+                "                              SELECT deptno, COUNT(*) AS dept_count\n " +
+                "                        FROM   employee emp\n " +
+                "                        GROUP BY deptno\n " +
+                "                        HAVING count(*) > 5)\n " +
+                "                    select dc.deptno from dept_count as dc);\n " +
+                "");
+        // This is very close to the previous query.  But it does not have
+        // the logically unnecessary alias for dept_count.
+        compile("SELECT e.name AS employee_name\n " +
+                "FROM   employee e\n " +
+                "WHERE  e.deptno in ( WITH dept_count AS (\n " +
+                "                              SELECT deptno\n " +
+                "                        FROM   employee emp\n " +
+                "                        GROUP BY deptno\n " +
+                "                        HAVING count(*) > 5)\n " +
+                "                    select deptno from dept_count);\n " +
+                "");
+
+        // This fails because the From clause in the main select statement
+        // references the with-view named "dept_ident" without an alias.
+        // This is an HSQLDB error condition which may be incorrect.
+        // However, if we give it an alias, then the compilation fails
+        // because the parenthesized expression "e.deptno in (deptno)"
+        // generates a VALUELIST which we don't know what to do with.
+        doCompileTest(HSQL232_ENG_8626_DONE,
+                      "WITH dept_ident AS (\n" +
+                      "  SELECT deptno \n" +
+                      "  FROM   employee\n" +
+                      "  GROUP BY deptno)\n" +
+                      "SELECT e.name AS employee_name\n" +
+                      "FROM   employee e,\n" +
+                      "       dept_ident\n" +
+                      "WHERE  e.deptno IN ( deptno );" +
+                      "");
+
+        // This fails because the WHERE expression "e.deptno IN ( di.deptno )"
+        // generates a tree with a VALUELIST in the HSQLDB AST, and we cannot
+        // translate it yet.  This is the complaint of ENG-8626.
+        doCompileTest(HSQL232_ENG_8626_DONE,
+                      "WITH dept_ident AS (\n" +
+                      "  SELECT deptno \n" +
+                      "  FROM   employee\n" +
+                      "  GROUP BY deptno)\n" +
+                      "SELECT e.name AS employee_name\n" +
+                      "FROM   employee e,\n" +
+                      "       dept_ident as di\n" +
+                      "WHERE  e.deptno IN ( di.deptno );" +
+                      "");
+
+    }
+
+    public void testWithInExists() throws Exception {
+        // The alias "dept_count as dc" is logically unnecessary in the
+        // main select of the argument to exists.  It is required by
+        // the HSQLDB bug ENG-8638.
+        compile("SELECT e.name AS employee_name\n" +
+                "FROM   employee e\n" +
+                "WHERE  exists ( WITH dept_count AS (\n" +
+                "                       SELECT deptno, COUNT(*) AS dept_size\n" +
+                "               FROM   employee\n" +
+                "               GROUP BY deptno\n" +
+                "               HAVING count(*) > 5)\n" +
+                "               select dc.deptno from dept_count as dc);\n" +
+                "");
+        // This is the same query as above, but without the logically unnecessary
+        // alias.
+        compile("SELECT e.name AS employee_name\n" +
+                "FROM   employee e\n" +
+                "WHERE  exists ( WITH dept_count AS (\n" +
+                "                       SELECT deptno, COUNT(*) AS dept_size\n" +
+                "               FROM   employee\n" +
+                "               GROUP BY deptno\n" +
+                "               HAVING count(*) > 5)\n" +
+                "               select deptno from dept_count);\n" +
+                "");
+    }
+
+    /**
+     * This is here only because I want to compare withs and subqueries.
+     * It should be an inessential variation of the multiple-with test.
+     *
+     * @throws Exception
+     */
+    public void testSubquery1() throws Exception {
+        compile("SELECT e.name AS employee_name,\n" +
+                "       dc.dept_count AS emp_dept_count,\n" +
+                "       cp.pdesc as Project_Description\n" +
+                "FROM   employee e,\n" +
+                "       (SELECT deptno, COUNT(*) AS dept_count\n" +
+                "         FROM   employee\n" +
+                "             GROUP BY deptno) dc,\n" +
+                "       (select e.empno as empno,\n" +
+                "               p.description as pdesc\n" +
+                "       from\n" +
+                "              employee as e,\n" +
+                "               project as p,\n" +
+                "              project_participation pd\n" +
+                "        where e.empno = pd.empno\n" +
+                "        and   p.projectno = pd.projectno\n" +
+                "        and   pd.end_date is null) as cp\n" +
+                "WHERE  e.deptno = dc.deptno\n" +
+                "and    cp.empno = e.empno;\n" +
+                "");
+    }
+
+    public void testSubquery2() throws Exception {
+        compile("SELECT e.name AS employee_name,\n" +
+                "       dc.deptno AS emp_dept_count\n" +
+                "FROM   employee e,\n" +
+                "       (SELECT *\n" +
+                "         FROM   employee) dc\n" +
+                "WHERE  e.deptno = dc.deptno;\n" +
+                "");
+    }
+}

--- a/tests/frontend/org/voltdb/planner/testwithclause.sql
+++ b/tests/frontend/org/voltdb/planner/testwithclause.sql
@@ -1,0 +1,63 @@
+-- creates some test-tables and data
+-- DROP TABLE EMPLOYEE;
+-- DROP TABLE DEPARTMENT;
+-- DROP TABLE SALARYGRADE;
+-- DROP TABLE BONUS;
+-- DROP TABLE PROJECT;
+-- DROP TABLE PROJECT_PARTICIPATION;
+-- DROP TABLE ROLE;
+
+CREATE TABLE EMPLOYEE(
+   empno      INTEGER DEFAULT 0 NOT NULL PRIMARY KEY,
+   name       VARCHAR(10),
+   job        VARCHAR(9),
+   boss       INTEGER,
+   hiredate   VARCHAR(12),
+   salary     DECIMAL(7, 2),
+   comm       DECIMAL(7, 2),
+   deptno     INTEGER
+);
+ 
+CREATE TABLE DEPARTMENT(
+   deptno     INTEGER NOT NULL PRIMARY KEY,
+   dept_count INTEGER NOT NULL,
+   name       VARCHAR(14),
+   location   VARCHAR(13)
+);
+
+CREATE TABLE SALARYGRADE(
+   grade      INTEGER NOT NULL PRIMARY KEY,
+   losal      INTEGER NOT NULL,
+   hisal      INTEGER NOT NULL
+);
+
+CREATE TABLE BONUS (
+   ename      VARCHAR(10) NOT NULL,
+   job        VARCHAR(9) NOT NULL,
+   sal        DECIMAL(7, 2),
+   comm       DECIMAL(7, 2),
+   PRIMARY KEY (ename, job)
+);
+
+CREATE TABLE PROJECT(
+   projectno    INTEGER NOT NULL PRIMARY KEY,
+   description  VARCHAR(100),
+   start_date   VARCHAR(12),
+   end_date     VARCHAR(12)
+);
+
+CREATE TABLE PROJECT_PARTICIPATION(
+   projectno    INTEGER NOT NULL,
+   empno        INTEGER NOT NULL,
+   start_date   VARCHAR(12) NOT NULL,
+   end_date     VARCHAR(12),
+   role_id      INTEGER,
+   PRIMARY KEY (projectno, empno, start_date)
+);
+
+CREATE TABLE ROLE(
+   role_id      INTEGER NOT NULL PRIMARY KEY,
+   description  VARCHAR(100)
+);
+
+

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -43,6 +43,22 @@ public class TestSubQueriesSuite extends RegressionSuite {
     private static final String [] replicated_tbs = {"R1", "R2"};
     private static final long[][] EMPTY_TABLE = new long[][] {};
 
+    /*
+     * These constants tell which tests have been enabled
+     * or disabled.
+     */
+    private static final boolean doAllTests    = false;
+    private static final boolean ENG_8306_DONE = false;
+    private static final boolean ENG_8325_DONE = false;
+    private static final boolean ENG_8628_DONE = false;
+    private static final boolean ENG_8633_DONE = false;
+    private static final boolean ENG_8636_DONE = false;
+    private static final boolean ENG_8638_DONE = false;
+
+    private static final boolean doTest(boolean flag) {
+        return doAllTests || flag;
+    }
+
     private void loadData(boolean extra) throws Exception {
         Client client = this.getClient();
         ClientResponse cr = null;
@@ -629,11 +645,12 @@ public class TestSubQueriesSuite extends RegressionSuite {
                     "having max(wage) IN " +
                     "       (select wage from R1) " +
                     "order by dept desc";
-            /*/ Uncomment these tests when ENG-8306 "HAVING with subquery" is fixed
-            validateTableOfLongs(client, sql, new long[][] {{2}, {1}});
-            /*/
-            verifyStmtFails(client, sql, TestPlansInExistsSubQueries.HavingErrorMsg); // for now
-            //*/
+            if (doTest(ENG_8306_DONE)) {
+                // Uncomment these tests when ENG-8306 "HAVING with subquery" is fixed
+                validateTableOfLongs(client, sql, new long[][] {{2}, {1}});
+            } else {
+                verifyStmtFails(client, sql, TestPlansInExistsSubQueries.HavingErrorMsg);
+            }
 
             sql =   "select dept " +
                     "from " + tb + " " +
@@ -641,11 +658,12 @@ public class TestSubQueriesSuite extends RegressionSuite {
                     "having max(wage) + 1 - 1 " +
                     "       IN (select wage from R1) " +
                     "order by dept desc";
-            /*/ Uncomment these tests when ENG-8306 "HAVING with subquery" is fixed
-            validateTableOfLongs(client, sql, new long[][] {{2}, {1}});
-            /*/
-            verifyStmtFails(client, sql, TestPlansInExistsSubQueries.HavingErrorMsg); // for now
-            //*/
+            if (doTest(ENG_8306_DONE)) {
+                // Uncomment these tests when ENG-8306 "HAVING with subquery" is fixed
+                validateTableOfLongs(client, sql, new long[][] {{2}, {1}});
+            } else {
+                verifyStmtFails(client, sql, TestPlansInExistsSubQueries.HavingErrorMsg); // for now
+            }
         }
     }
 
@@ -957,7 +975,9 @@ public class TestSubQueriesSuite extends RegressionSuite {
                 "       (select WAGE, DEPT from R2 where ID = R1.ID))" +
                 "      IS NULL " +
                 "order by ID;";
-        validateTableOfLongs(client, sql, new long[][] {{100}, {101}, {102}});
+        if (doTest(ENG_8633_DONE)) {
+            validateTableOfLongs(client, sql, new long[][] {{100}, {101}, {102}});
+        }
 
         // Both outer and inner are empty. The expression is NULL
         sql =   "select ID from R1 " +
@@ -967,8 +987,9 @@ public class TestSubQueriesSuite extends RegressionSuite {
                 "        where ID = 107))" +
                 "      IS NULL " +
                 "order by ID;";
-        validateTableOfLongs(client, sql, new long[][] {{100}, {101}, {102}});
-
+        if (doTest(ENG_8633_DONE)) {
+            validateTableOfLongs(client, sql, new long[][] {{100}, {101}, {102}});
+        }
     }
 
     /**
@@ -1909,17 +1930,20 @@ public class TestSubQueriesSuite extends RegressionSuite {
         validateTableOfLongs(client, sql, EMPTY_TABLE);
 
         if (!isHSQL()) {
-            sql =   "select ID from R1 " +
-                    "where WAGE NOT IN " +
-                    "      (select WAGE from R2 " +
-                    "       where ID IN (100, 102, 103));";
-            validateTableOfLongs(client, sql, EMPTY_TABLE);
-
-            sql =   "select ID from R1 " +
-                    "where NOT WAGE IN " +
-                    "          (select WAGE from R2 " +
-                    "           where ID IN (100, 102, 103));";
-            validateTableOfLongs(client, sql, EMPTY_TABLE);
+            if (doTest(ENG_8325_DONE)) {
+                sql =   "select ID from R1 " +
+                        "where WAGE NOT IN " +
+                        "      (select WAGE from R2 " +
+                        "       where ID IN (100, 102, 103));";
+                validateTableOfLongs(client, sql, EMPTY_TABLE);
+            }
+            if (doTest(ENG_8325_DONE)) {
+                sql =   "select ID from R1 " +
+                        "where NOT WAGE IN " +
+                        "          (select WAGE from R2 " +
+                        "           where ID IN (100, 102, 103));";
+                validateTableOfLongs(client, sql, EMPTY_TABLE);
+            }
         }
     }
 
@@ -2094,34 +2118,35 @@ public class TestSubQueriesSuite extends RegressionSuite {
                 "       where ID > 107);";
         validateTableOfLongs(client, sql, new long[][] {{100}});
 
-        // The inner set consists only of NULLs
-        sql =   "select ID from R1 " +
-                "where WAGE = ALL " +
-                "      (select WAGE from R2 " +
-                "       where ID in (100, 101));";
-        validateTableOfLongs(client, sql, EMPTY_TABLE);
+        if (doTest(ENG_8325_DONE)) {
+            // The inner set consists only of NULLs
+            sql =   "select ID from R1 " +
+                    "where WAGE = ALL " +
+                    "      (select WAGE from R2 " +
+                    "       where ID in (100, 101));";
+            validateTableOfLongs(client, sql, EMPTY_TABLE);
 
-        sql =   "select ID from R1 " +
-                "where (WAGE = ALL " +
-                "       (select WAGE from R2 " +
-                "        where ID in (100, 101))) " +
-                "      IS NULL;";
-        validateTableOfLongs(client, sql, new long[][] {{100}});
+            sql =   "select ID from R1 " +
+                    "where (WAGE = ALL " +
+                    "       (select WAGE from R2 " +
+                    "        where ID in (100, 101))) " +
+                    "      IS NULL;";
+            validateTableOfLongs(client, sql, new long[][] {{100}});
 
-        // If inner_expr contains NULL and outer_expr OP inner_expr is TRUE
-        // for all other inner values
-        sql =   "select ID from R1 " +
-                "where WAGE = ALL " +
-                "      (select WAGE from R2 " +
-                "       where ID in (100, 104, 105));";
-        validateTableOfLongs(client, sql, EMPTY_TABLE);
+            // If inner_expr contains NULL and outer_expr OP inner_expr is TRUE
+            // for all other inner values
+            sql =   "select ID from R1 " +
+                    "where WAGE = ALL " +
+                    "      (select WAGE from R2 " +
+                    "       where ID in (100, 104, 105));";
+            validateTableOfLongs(client, sql, EMPTY_TABLE);
 
-        sql =   "select ID from R1 " +
-                "where (WAGE = ALL " +
-                "       (select WAGE from R2 where ID in (100, 104, 105))) " +
-                "      IS NULL;";
-        validateTableOfLongs(client, sql, new long[][] {{100}});
-
+            sql =   "select ID from R1 " +
+                    "where (WAGE = ALL " +
+                    "       (select WAGE from R2 where ID in (100, 104, 105))) " +
+                    "      IS NULL;";
+            validateTableOfLongs(client, sql, new long[][] {{100}});
+        }
         // If inner_expr contains NULL and
         // outer_expr OP inner_expr is FALSE for some other inner values,
         // the result is FALSE
@@ -2194,7 +2219,7 @@ public class TestSubQueriesSuite extends RegressionSuite {
     }
 
     // Test subqueries on partitioned table cases not yet supported
-    public void notestSubSelects_from_partitioned() throws Exception
+    public void testSubSelects_from_partitioned() throws Exception
     {
         Client client = getClient();
         loadData(false);
@@ -2251,7 +2276,9 @@ public class TestSubQueriesSuite extends RegressionSuite {
                 "     ON T1.ID = P2.DEPT " +
                 "where T1.ID = 3 " +
                 "order by T1.ID;";
-        validateTableOfLongs(client, sql, new long[][] {{3, 1}});
+        if (doTest(ENG_8633_DONE)) {
+            validateTableOfLongs(client, sql, new long[][] {{3, 1}});
+        }
 
         sql =   "select T1.ID, T1.DEPT, P2.WAGE " +
                 "from (select ID, DEPT from P1) T1 " +
@@ -2338,16 +2365,19 @@ public class TestSubQueriesSuite extends RegressionSuite {
                     "from R1 " +
                     "group by dept, wage " +
                     "order by dept, wage;";
-            validateTableOfLongs(client, sql, new long[][] {
-                    {1, 1, 2}, {1, 1, 1}, {1, 1, 1}, {2, 1, 2}, {2, 2, 2}, {2,1,2}});
-
+            if (doTest(ENG_8628_DONE)) {
+                validateTableOfLongs(client, sql, new long[][] {
+                        {1, 1, 2}, {1, 1, 1}, {1, 1, 1}, {2, 1, 2}, {2, 2, 2}, {2,1,2}});
+            }
             sql =   "select R1.DEPT, count(*), " +
                     "       (select sum(dept) from R2" +
                     "        where R2.wage > r1.dept * 10) " +
                     "from R1 " +
                     "group by dept " +
                     "order by dept;";
-            validateTableOfLongs(client, sql, new long[][] {{1,3,8}, {2, 4, 7}});
+            if (doTest(ENG_8628_DONE)) {
+                validateTableOfLongs(client, sql, new long[][] {{1,3,8}, {2, 4, 7}});
+            }
         }
 
         subTestGroupByScalarSubquery(client);
@@ -2415,14 +2445,28 @@ public class TestSubQueriesSuite extends RegressionSuite {
         validateTableOfLongs(client, sql, new long[][] {{1,3}, {2, 4}});
 
         // duplicates the subquery expression
-        sql =   "select R1.DEPT, " +
+        if (doTest(ENG_8636_DONE)) {
+            sql =   "select R1.DEPT, " +
+                    "       abs((select count(dept) from R2 where R2.wage > R1.wage) / 2 - 3) as tag1, " +
+                    "       abs((select count(dept) from R2 where R2.wage > R1.wage) / 2 - 3) as tag2, " +
+                    "       count(*) as ct " +
+                    "from R1 " +
+                    "group by dept, tag1 " +
+                    "order by dept, ct;";
+            validateTableOfLongs(client, sql, new long[][] {{1,2,2,1}, {1,1,1,2}, {2,1,1,1}, {2,3,3,3}});
+        } else {
+            /*
+             * This is like the test above, except that the output column is not
+             * replicated.  This passes.
+             */
+            sql =   "select R1.DEPT, " +
                 "       abs((select count(dept) from R2 where R2.wage > R1.wage) / 2 - 3) as tag1, " +
-                "       abs((select count(dept) from R2 where R2.wage > R1.wage) / 2 - 3) as tag2, " +
                 "       count(*) as ct " +
                 "from R1 " +
                 "group by dept, tag1 " +
                 "order by dept, ct;";
-        validateTableOfLongs(client, sql, new long[][] {{1,2,2,1}, {1,1,1,2}, {2,1,1,1}, {2,3,3,3}});
+            validateTableOfLongs(client, sql, new long[][] {{1,2,1}, {1,1,2}, {2,1,1}, {2,3,3}});
+        }
 
         // expression with subquery
         sql =   "select R1.DEPT, " +
@@ -2431,7 +2475,9 @@ public class TestSubQueriesSuite extends RegressionSuite {
                 "count(*) as ct from R1 " +
                 "group by dept, tag1 " +
                 "order by dept, ct;";
-        validateTableOfLongs(client, sql, new long[][] {{1,2,7,1}, {1,1,6,2}, {2,1,6,1}, {2,3,8,3}});
+        if (doTest(ENG_8636_DONE)) {
+            validateTableOfLongs(client, sql, new long[][] {{1,2,7,1}, {1,1,6,2}, {2,1,6,1}, {2,3,8,3}});
+        }
 
         // check for cardinality error from grouped by scalar
         try {
@@ -2477,33 +2523,37 @@ public class TestSubQueriesSuite extends RegressionSuite {
                 "from R_ENG8145_2 parent " +
                 "group by id " +
                 "order by id;";
-        validateTableOfLongs(client, sql, expected);
+        if (doTest(ENG_8636_DONE)) {
+            validateTableOfLongs(client, sql, expected);
+        }
 
         // ENG-8173
         client.callProcedure("@AdHoc", "insert into R_ENG8173_1 values (0, 'foo', 50);");
         client.callProcedure("@AdHoc", "insert into R_ENG8173_1 values (1, 'goo', 25);");
 
-        // These queries were failing because we weren't calling "resolveColumnIndexes"
-        // for subqueries that appeared on the select list (as part of a projection node).
-        VoltTable vt = client.callProcedure("@AdHoc",
-                "select *, (select SUM(NUM) from R_ENG8173_1) " +
-                "from R_ENG8173_1 A1 " +
-                "order by DESC;").getResults()[0];
+        VoltTable vt = null;
+        if (doTest(ENG_8638_DONE)) {
+            // These queries were failing because we weren't calling "resolveColumnIndexes"
+            // for subqueries that appeared on the select list (as part of a projection node).
+            vt = client.callProcedure("@AdHoc",
+                    "select *, (select SUM(NUM) from R_ENG8173_1) " +
+                    "from R_ENG8173_1 A1 " +
+                    "order by DESC;").getResults()[0];
 
-        assertTrue (vt.advanceRow());
-        assertEquals(0, vt.getLong(0));
-        assertEquals("foo", vt.getString(1));
-        assertEquals(50, vt.getLong(2));
-        assertEquals(75, vt.getLong(3));
+            assertTrue (vt.advanceRow());
+            assertEquals(0, vt.getLong(0));
+            assertEquals("foo", vt.getString(1));
+            assertEquals(50, vt.getLong(2));
+            assertEquals(75, vt.getLong(3));
 
-        assertTrue (vt.advanceRow());
-        assertEquals(1, vt.getLong(0));
-        assertEquals("goo", vt.getString(1));
-        assertEquals(25, vt.getLong(2));
-        assertEquals(75, vt.getLong(3));
+            assertTrue (vt.advanceRow());
+            assertEquals(1, vt.getLong(0));
+            assertEquals("goo", vt.getString(1));
+            assertEquals(25, vt.getLong(2));
+            assertEquals(75, vt.getLong(3));
 
-        assertFalse(vt.advanceRow());
-
+            assertFalse(vt.advanceRow());
+        }
         sql =   "select (select SUM(NUM) + SUM(ID) from R_ENG8173_1) " +
                 "from R_ENG8173_1 A1 order by DESC;";
         validateTableOfLongs(client, sql, new long[][] {{76}, {76}});
@@ -2807,11 +2857,13 @@ public class TestSubQueriesSuite extends RegressionSuite {
                 "order by ID;";
         validateTableOfLongs(client, sql, new long[][] {{1}, {2}});
 
-        // R1 2, 10, 1 = R2 4, 10, 1 and 5, 10, 1
-        sql =   "select R1.ID from R1 " +
-                "where (R1.WAGE, R1.DEPT) = ALL " +
-                "      (select WAGE, DEPT from R2 where ID in (4,5));";
-        validateTableOfLongs(client, sql, new long[][] {{2}});
+        if (doTest(ENG_8325_DONE)) {
+            // R1 2, 10, 1 = R2 4, 10, 1 and 5, 10, 1
+            sql =   "select R1.ID from R1 " +
+                    "where (R1.WAGE, R1.DEPT) = ALL " +
+                    "      (select WAGE, DEPT from R2 where ID in (4,5));";
+            validateTableOfLongs(client, sql, new long[][] {{2}});
+        }
 
         sql =   "select R1.ID from R1 " +
                 "where (R1.WAGE, R1.DEPT) = ALL " +
@@ -2917,13 +2969,15 @@ public class TestSubQueriesSuite extends RegressionSuite {
         validateTableOfScalarLongs(client, "select wage from r1 where wage = (select max(wage) from r1)", new long[] {300});
         validateTableOfScalarLongs(client, "select wage from r1 where wage = (select max(wage) - 30 from r1) + 30", new long[] {300});
 
-        // The IN operator takes a VectorExpression on its RHS, which uses the "args" field.
-        // Make sure that we can handle subqueries in there too.
-        validateTableOfScalarLongs(client,
-                "select wage from r1 " +
-                "where wage in (7, 8, (select max(wage) from r1), 9, 10, 200) " +
-                "order by wage",
-                new long[] {200, 300});
+        if (doTest(ENG_8325_DONE)) {
+            // The IN operator takes a VectorExpression on its RHS, which uses the "args" field.
+            // Make sure that we can handle subqueries in there too.
+            validateTableOfScalarLongs(client,
+                    "select wage from r1 " +
+                    "where wage in (7, 8, (select max(wage) from r1), 9, 10, 200) " +
+                    "order by wage",
+                    new long[] {200, 300});
+        }
     }
 
     public void testExistsSimplification() throws Exception


### PR DESCRIPTION
The only real change is in RangeVariable.java, where I rummage around to find a table name when tables don't have aliases.  The change in TestSubqueriesSuite and TestWithStatment are just to reflect that this has been fixed.
