### PR TITLE
For A/A DR, tag DR'd rows with timestamp

### DIFF
--- a/build.py
+++ b/build.py
@@ -420,20 +420,21 @@ if whichtests in ("${eetestsuite}", "indexes"):
 if whichtests in ("${eetestsuite}", "storage"):
     CTX.TESTS['storage'] = """
      CompactionTest
-     constraint_test
      CopyOnWriteTest
+     DRBinaryLog_test
+     DRTupleStream_test
+     ExportTupleStream_test
+     PersistentTableMemStatsTest
+     StreamedTable_test
+     TempTableLimitsTest
+     constraint_test
      filter_test
      persistent_table_log_test
-     PersistentTableMemStatsTest
+     persistenttable_test
      serialize_test
-     StreamedTable_test
      table_and_indexes_test
      table_test
      tabletuple_export_test
-     TempTableLimitsTest
-     ExportTupleStream_test
-     DRTupleStream_test
-     DRBinaryLog_test
     """
 
 if whichtests in ("${eetestsuite}", "structures"):

--- a/src/ee/common/tabletuple.cpp
+++ b/src/ee/common/tabletuple.cpp
@@ -76,7 +76,22 @@ std::string TableTuple::debug(const std::string& tableName) const {
             }
             buffer << ")";
         }
+
+        if (m_schema->hiddenColumnCount() > 0) {
+            buffer << " hidden->";
+            for (int ctr = 0; ctr < m_schema->hiddenColumnCount(); ctr++) {
+                buffer << "(";
+                if (isNull(ctr)) {
+                    buffer << "<NULL>";
+                } else {
+                    buffer << getHiddenNValue(ctr).debug();
+                }
+                buffer << ")";
+            }
+        }
     }
+
+
 
     uint64_t addressNum = (uint64_t)address();
     buffer << " @" << addressNum;
@@ -88,19 +103,7 @@ std::string TableTuple::debug(const std::string& tableName) const {
 std::string TableTuple::debugNoHeader() const {
     assert(m_schema);
     assert(m_data);
-
-    std::ostringstream buffer;
-    buffer << "TableTuple(notable) ->";
-
-    for (int ctr = 0; ctr < m_schema->columnCount(); ctr++) {
-        if (isNull(ctr)) {
-            buffer << "<NULL>";
-        } else {
-            buffer << "(" << getNValue(ctr).debug() << ")";
-        }
-    }
-    std::string ret(buffer.str());
-    return ret;
+    return debug("");
 }
 
 }

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -277,7 +277,7 @@ public:
     inline const NValue getHiddenNValue(const int idx) const {
         assert(m_schema);
         assert(m_data);
-        assert(idx < m_schema->columnCount());
+        assert(idx < m_schema->hiddenColumnCount());
 
         const TupleSchema::ColumnInfo *columnInfo = m_schema->getHiddenColumnInfo(idx);
         const voltdb::ValueType columnType = columnInfo->getVoltType();

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -202,6 +202,13 @@ public:
      * a persistent table!
      */
     void setNValue(const int idx, voltdb::NValue value) const;
+
+    /*
+     * Like the above method except for "hidden" fields, not
+     * accessible in the normal codepath.
+     */
+    void setHiddenNValue(const int idx, voltdb::NValue value) const;
+
     /*
      * Copies range of NValues from one tuple to another.
      */
@@ -259,6 +266,20 @@ public:
         assert(idx < m_schema->columnCount());
 
         const TupleSchema::ColumnInfo *columnInfo = m_schema->getColumnInfo(idx);
+        const voltdb::ValueType columnType = columnInfo->getVoltType();
+        const char* dataPtr = getDataPtr(columnInfo);
+        const bool isInlined = columnInfo->inlined;
+
+        return NValue::initFromTupleStorage(dataPtr, columnType, isInlined);
+    }
+
+    /** Like the above method but for hidden columns. */
+    inline const NValue getHiddenNValue(const int idx) const {
+        assert(m_schema);
+        assert(m_data);
+        assert(idx < m_schema->columnCount());
+
+        const TupleSchema::ColumnInfo *columnInfo = m_schema->getHiddenColumnInfo(idx);
         const voltdb::ValueType columnType = columnInfo->getVoltType();
         const char* dataPtr = getDataPtr(columnInfo);
         const bool isInlined = columnInfo->inlined;
@@ -555,6 +576,20 @@ inline void TableTuple::setNValue(const int idx, voltdb::NValue value) const
     value.serializeToTupleStorage(dataPtr, isInlined, columnLength, isInBytes);
 }
 
+inline void TableTuple::setHiddenNValue(const int idx, voltdb::NValue value) const
+{
+    assert(m_schema);
+    assert(m_data);
+
+    const TupleSchema::ColumnInfo *columnInfo = m_schema->getHiddenColumnInfo(idx);
+    value = value.castAs(columnInfo->getVoltType());
+    const bool isInlined = columnInfo->inlined;
+    const bool isInBytes = columnInfo->inBytes;
+    char *dataPtr = getWritableDataPtr(columnInfo);
+    const int32_t columnLength = columnInfo->length;
+    value.serializeToTupleStorage(dataPtr, isInlined, columnLength, isInBytes);
+}
+
 /** Multi column version. */
 inline void TableTuple::setNValues(int beginIdx, TableTuple lhs, int begin, int end) const
 {
@@ -687,6 +722,17 @@ inline void TableTuple::copyForPersistentUpdate(const TableTuple &source,
                 setNValueAllocateForObjectCopies(ii, source.getNValue(ii), NULL);
             }
         }
+
+        // Copy any hidden columns that follow normal visible ones.
+        if (m_schema->hiddenColumnCount() > 0) {
+            // If we ever add support for uninlined hidden columns,
+            // we'll need to do update this code.
+            assert(m_schema->getUninlinedObjectHiddenColumnCount() == 0);
+            ::memcpy(m_data + TUPLE_HEADER_SIZE + m_schema->offsetOfHiddenColumns(),
+                     source.m_data + TUPLE_HEADER_SIZE + m_schema->offsetOfHiddenColumns(),
+                     m_schema->lengthOfAllHiddenColumns());
+        }
+
         // This obscure assignment is propagating the tuple flags rather than leaving it to the caller.
         // TODO: It would be easier for the caller to simply set the values it wants upon return.
         m_data[0] = source.m_data[0];

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -143,6 +143,8 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
     // determine which indices are updated by this executor
     // iterate through all target table indices and see if they contain
     // columns mutated by this executor
+    //
+    // Shouldn't this be done in p_init?  See ticket ENG-8668.
     std::vector<TableIndex*> indexesToUpdate;
     const std::vector<TableIndex*>& allIndexes = targetTable->allIndexes();
     BOOST_FOREACH(TableIndex *index, allIndexes) {

--- a/src/ee/storage/TableCatalogDelegate.hpp
+++ b/src/ee/storage/TableCatalogDelegate.hpp
@@ -73,7 +73,8 @@ class TableCatalogDelegate : public CatalogDelegate {
                                      voltdb::PersistentTable* existingTable,
                                      voltdb::PersistentTable* newTable);
 
-    static TupleSchema *createTupleSchema(catalog::Table const &catalogTable);
+    static TupleSchema *createTupleSchema(catalog::Database const &catalogDatabase,
+                                          catalog::Table const &catalogTable);
 
     static bool getIndexScheme(catalog::Table const &catalogTable,
                                catalog::Index const &catalogIndex,

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -396,13 +396,17 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
         return m_tupleLimit;
     }
 
+    /** Returns true if DR is enabled for this table */
     bool isDREnabled() const { return m_drEnabled; }
 
+    /** Returns true if there is a hidden column in this table for the
+        DR timestamp (used to resolve active/active conflicts) */
     bool hasDRTimestampColumn() const { return m_drTimestampColumnIndex != -1; }
 
-    bool getDRTimestampColumnIndex() const { return m_drTimestampColumnIndex; }
-
-    void setDRTimestampForTuple(ExecutorContext* ec, TableTuple &tuple);
+    /** Returns the index of the DR timestamp column (relative to the
+        hidden columns for the table).  If there's no DR timestamp
+        column, returns -1. */
+    int getDRTimestampColumnIndex() const { return m_drTimestampColumnIndex; }
 
     // for test purpose
     void setDR(bool flag) { m_drEnabled = flag; }
@@ -584,6 +588,8 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
             return ec->drStream();
         }
     }
+
+    void setDRTimestampForTuple(ExecutorContext* ec, TableTuple &tuple);
 
     void computeSmallestUniqueIndex();
 

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -203,6 +203,10 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     // default iterator
     TableIterator m_iter;
 
+ protected:
+
+    virtual void initializeWithColumns(TupleSchema *schema, const std::vector<std::string> &columnNames, bool ownsTupleSchema, int32_t compactionThreshold = 95);
+
   public:
     virtual ~PersistentTable();
 
@@ -393,6 +397,12 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     }
 
     bool isDREnabled() const { return m_drEnabled; }
+
+    bool hasDRTimestampColumn() const { return m_drTimestampColumnIndex != -1; }
+
+    bool getDRTimestampColumnIndex() const { return m_drTimestampColumnIndex; }
+
+    void setDRTimestampForTuple(ExecutorContext* ec, TableTuple &tuple);
 
     // for test purpose
     void setDR(bool flag) { m_drEnabled = flag; }
@@ -641,6 +651,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     bool m_noAvailableUniqueIndex;
     TableIndex* m_smallestUniqueIndex;
     uint32_t m_smallestUniqueIndexCrc;
+    int m_drTimestampColumnIndex;
 };
 
 inline PersistentTableSurgeon::PersistentTableSurgeon(PersistentTable &table) :

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -387,7 +387,7 @@ protected:
         return allocatedTupleCount() - activeTupleCount() > std::max(static_cast<int64_t>((m_tuplesPerBlock * 3)), (allocatedTupleCount() * (100 - m_compactionThreshold)) / 100);  /* using the integer percentage */
     }
 
-    void initializeWithColumns(TupleSchema *schema, const std::vector<std::string> &columnNames, bool ownsTupleSchema, int32_t compactionThreshold = 95);
+    virtual void initializeWithColumns(TupleSchema *schema, const std::vector<std::string> &columnNames, bool ownsTupleSchema, int32_t compactionThreshold = 95);
 
     // per table-type initialization
     virtual void onSetColumns() {

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -81,7 +81,13 @@ Table* TableFactory::getPersistentTable(
         table = new PersistentTable(partitionColumn, signature, tableIsMaterialized, tableAllocationTargetSize, tupleLimit, drEnabled);
     }
 
-    initCommon(databaseId, table, name, schema, columnNames, true, compactionThreshold);
+    initCommon(databaseId,
+               table,
+               name,
+               schema,
+               columnNames,
+               true,  // table will take ownership of TupleSchema object
+               compactionThreshold);
 
     // initialize stats for the table
     configureStats(databaseId, name, table);

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -1,0 +1,286 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <vector>
+#include <string>
+
+#include "boost/scoped_ptr.hpp"
+
+#include "harness.h"
+#include "test_utils/ScopedTupleSchema.hpp"
+
+#include "common/tabletuple.h"
+#include "common/types.h"
+#include "common/TupleSchemaBuilder.h"
+#include "common/ValueFactory.hpp"
+#include "execution/VoltDBEngine.h"
+#include "storage/table.h"
+#include "storage/persistenttable.h"
+#include "storage/tablefactory.h"
+
+
+using voltdb::ExecutorContext;
+using voltdb::NValue;
+using voltdb::PersistentTable;
+using voltdb::Table;
+using voltdb::TableFactory;
+using voltdb::TableIterator;
+using voltdb::TableTuple;
+using voltdb::TupleSchemaBuilder;
+using voltdb::VALUE_TYPE_BIGINT;
+using voltdb::VALUE_TYPE_VARCHAR;
+using voltdb::ValueFactory;
+using voltdb::VoltDBEngine;
+
+
+class PersistentTableTest : public Test {
+public:
+    PersistentTableTest()
+        : m_engine(new VoltDBEngine())
+        , m_undoToken(0)
+        , m_uniqueId(0)
+    {
+        m_engine->initialize(1,     // clusterIndex
+                             1,     // siteId
+                             0,     // partitionId
+                             0,     // hostId
+                             "",    // hostname
+                             voltdb::DEFAULT_TEMP_TABLE_MEMORY,
+                             false, // don't create DR replicated stream
+                             95);   // compaction threshold
+        m_engine->setUndoToken(m_undoToken);
+    }
+
+protected:
+
+    voltdb::VoltDBEngine* getEngine() const {
+        return m_engine.get();
+    }
+
+    // Calling this will bump the unique ID in the executor context
+    // and create a new DR timestamp value.
+    void beginWork() {
+        ExecutorContext::getExecutorContext()->setupForPlanFragments(
+            m_engine->getCurrentUndoQuantum(),
+            0,  // txn id
+            0,  // sp handle
+            0,  // last committed sp handle
+            m_uniqueId);
+        // DR timestamp discards the low 14 bits of the unique ID,
+        // so we must increment by this amount to produce a new DR
+        // timestamp next time around.
+        m_uniqueId += (1 << 14);
+    }
+
+    void commit() {
+        m_engine->releaseUndoToken(m_undoToken);
+        ++m_undoToken;
+        m_engine->setUndoToken(m_undoToken);
+    }
+
+    void rollback() {
+        m_engine->undoUndoToken(m_undoToken);
+        ++m_undoToken;
+        m_engine->setUndoToken(m_undoToken);
+    }
+
+    static const std::string& catalogPayload() {
+        static const std::string payload(
+            "add / clusters cluster\n"
+            "set /clusters#cluster localepoch 1199145600\n"
+            "add /clusters#cluster databases database\n"
+            "set /clusters#cluster/databases#database schema \"eJwDAAAAAAE=\"\n"
+            "set $PREV isActiveActiveDRed true\n"
+            ""
+            "set /clusters#cluster/databases#database schema \"eJwlTDkCgDAI230NDSWUtdX/f8mgAzkBeoLBkZMBEw6C59cwrDRumLJiap5O07L9rStkqd0M8ZGa36ehHXZL52rGcng4USjf1wuc0Rgz\"\n"
+            "add /clusters#cluster/databases#database tables T\n"
+            "set /clusters#cluster/databases#database/tables#T isreplicated true\n"
+            "set $PREV partitioncolumn null\n"
+            "set $PREV estimatedtuplecount 0\n"
+            "set $PREV materializer null\n"
+            "set $PREV signature \"T|bv\"\n"
+            "set $PREV tuplelimit 2147483647\n"
+            "set $PREV isDRed true\n"
+            "add /clusters#cluster/databases#database/tables#T columns DATA\n"
+            "set /clusters#cluster/databases#database/tables#T/columns#DATA index 1\n"
+            "set $PREV type 9\n"
+            "set $PREV size 256\n"
+            "set $PREV nullable true\n"
+            "set $PREV name \"DATA\"\n"
+            "set $PREV defaultvalue null\n"
+            "set $PREV defaulttype 0\n"
+            "set $PREV matview null\n"
+            "set $PREV aggregatetype 0\n"
+            "set $PREV matviewsource null\n"
+            "set $PREV inbytes false\n"
+            "add /clusters#cluster/databases#database/tables#T columns PK\n"
+            "set /clusters#cluster/databases#database/tables#T/columns#PK index 0\n"
+            "set $PREV type 6\n"
+            "set $PREV size 8\n"
+            "set $PREV nullable false\n"
+            "set $PREV name \"PK\"\n"
+            "set $PREV defaultvalue null\n"
+            "set $PREV defaulttype 0\n"
+            "set $PREV matview null\n"
+            "set $PREV aggregatetype 0\n"
+            "set $PREV matviewsource null\n"
+            "set $PREV inbytes false\n"
+            "add /clusters#cluster/databases#database/tables#T indexes VOLTDB_AUTOGEN_IDX_PK_T_PK\n"
+            "set /clusters#cluster/databases#database/tables#T/indexes#VOLTDB_AUTOGEN_IDX_PK_T_PK unique true\n"
+            "set $PREV assumeUnique false\n"
+            "set $PREV countable true\n"
+            "set $PREV type 1\n"
+            "set $PREV expressionsjson \"\"\n"
+            "set $PREV predicatejson \"\"\n"
+            "add /clusters#cluster/databases#database/tables#T/indexes#VOLTDB_AUTOGEN_IDX_PK_T_PK columns PK\n"
+            "set /clusters#cluster/databases#database/tables#T/indexes#VOLTDB_AUTOGEN_IDX_PK_T_PK/columns#PK index 0\n"
+            "set $PREV column /clusters#cluster/databases#database/tables#T/columns#PK\n"
+            "add /clusters#cluster/databases#database/tables#T constraints VOLTDB_AUTOGEN_IDX_PK_T_PK\n"
+            "set /clusters#cluster/databases#database/tables#T/constraints#VOLTDB_AUTOGEN_IDX_PK_T_PK type 4\n"
+            "set $PREV oncommit \"\"\n"
+            "set $PREV index /clusters#cluster/databases#database/tables#T/indexes#VOLTDB_AUTOGEN_IDX_PK_T_PK\n"
+            "set $PREV foreignkeytable null\n"
+            "");
+        return payload;
+    }
+
+private:
+    boost::scoped_ptr<VoltDBEngine> m_engine;
+    int64_t m_undoToken;
+    int64_t m_uniqueId;
+};
+
+TEST_F(PersistentTableTest, DRTimestampColumn) {
+
+    // Load a catalog where active/active DR is turned on for the database,
+    // And we have a table "T" which is being DRed.
+    getEngine()->loadCatalog(0, catalogPayload());
+    PersistentTable *table = dynamic_cast<PersistentTable*>(
+        getEngine()->getTable("T"));
+    ASSERT_NE(NULL, table);
+    ASSERT_EQ(true, table->hasDRTimestampColumn());
+    ASSERT_EQ(0, table->getDRTimestampColumnIndex());
+
+    const voltdb::TupleSchema* schema = table->schema();
+    ASSERT_EQ(1, schema->hiddenColumnCount());
+
+    voltdb::StandAloneTupleStorage storage(schema);
+    TableTuple &srcTuple = const_cast<TableTuple&>(storage.tuple());
+
+    NValue bigintNValues[] = {
+        ValueFactory::getBigIntValue(1900),
+        ValueFactory::getBigIntValue(1901),
+        ValueFactory::getBigIntValue(1902)
+    };
+
+    NValue stringNValues[] = {
+        ValueFactory::getTempStringValue("Je me souviens"),
+        ValueFactory::getTempStringValue("Ut Incepit Fidelis Sic Permanet"),
+        ValueFactory::getTempStringValue("Splendor sine occasu")
+    };
+
+    // Let's do some inserts into the table.
+    beginWork();
+    for (int i = 0; i < 3; ++i) {
+        srcTuple.setNValue(0, bigintNValues[i]);
+        srcTuple.setNValue(1, stringNValues[i]);
+        table->insertTuple(srcTuple);
+    }
+
+    commit();
+
+    // Now verify that the right DR timestamp was created in the
+    // hidden column for each row.
+    int64_t drTimestampOrig = ExecutorContext::getExecutorContext()->currentDRTimestamp();
+    NValue drTimestampValueOrig = ValueFactory::getBigIntValue(drTimestampOrig);
+
+    TableTuple tuple(schema);
+    TableIterator iterator = table->iteratorDeletingAsWeGo();
+    int i = 0;
+    const int timestampColIndex = table->getDRTimestampColumnIndex();
+    while (iterator.next(tuple)) {
+        // DR timestamp is set for each row.
+        EXPECT_EQ(0, tuple.getHiddenNValue(timestampColIndex).compare(drTimestampValueOrig));
+
+        EXPECT_EQ(0, tuple.getNValue(0).compare(bigintNValues[i]));
+        EXPECT_EQ(0, tuple.getNValue(1).compare(stringNValues[i]));
+
+        ++i;
+    }
+
+    // Now let's update the middle tuple with a new value, and make
+    // sure the DR timestamp changes.
+    beginWork();
+
+    NValue newStringData = ValueFactory::getTempStringValue("Nunavut Sannginivut");
+    iterator = table->iteratorDeletingAsWeGo();
+    ASSERT_TRUE(iterator.next(tuple));
+    ASSERT_TRUE(iterator.next(tuple));
+    srcTuple = table->getTempTupleInlined(tuple);
+    srcTuple.setNValue(1, newStringData);
+
+    table->updateTupleWithSpecificIndexes(tuple,
+                                          srcTuple,
+                                          table->allIndexes(),
+                                          true);
+
+    // verify the updated tuple has the new timestamp.
+    int64_t drTimestampNew = ExecutorContext::getExecutorContext()->currentDRTimestamp();
+    ASSERT_NE(drTimestampNew, drTimestampOrig);
+
+    NValue drTimestampValueNew = ValueFactory::getBigIntValue(drTimestampNew);
+    iterator = table->iteratorDeletingAsWeGo();
+    i = 0;
+    while (iterator.next(tuple)) {
+        if (i == 1) {
+            EXPECT_EQ(0, tuple.getHiddenNValue(timestampColIndex).compare(drTimestampValueNew));
+            EXPECT_EQ(0, tuple.getNValue(0).compare(bigintNValues[i]));
+            EXPECT_EQ(0, tuple.getNValue(1).compare(newStringData));
+        }
+        else {
+            EXPECT_EQ(0, tuple.getHiddenNValue(timestampColIndex).compare(drTimestampValueOrig));
+            EXPECT_EQ(0, tuple.getNValue(0).compare(bigintNValues[i]));
+            EXPECT_EQ(0, tuple.getNValue(1).compare(stringNValues[i]));
+        }
+
+        ++i;
+    }
+
+    // After rolling back, we should have all our original values,
+    // including the DR timestamp.
+    rollback();
+
+    i = 0;
+    iterator = table->iteratorDeletingAsWeGo();
+    while (iterator.next(tuple)) {
+        EXPECT_EQ(0, tuple.getHiddenNValue(timestampColIndex).compare(drTimestampValueOrig));
+        EXPECT_EQ(0, tuple.getNValue(0).compare(bigintNValues[i]));
+        EXPECT_EQ(0, tuple.getNValue(1).compare(stringNValues[i]));
+
+        ++i;
+    }
+}
+
+int main() {
+    return TestSuite::globalInstance()->runAll();
+}

--- a/tests/ee/test_utils/ScopedTupleSchema.hpp
+++ b/tests/ee/test_utils/ScopedTupleSchema.hpp
@@ -1,0 +1,67 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "common/TupleSchema.h"
+
+// A class to automatically free TupleSchema instances, which cannot
+// be allocated on the stack due to variable-length data that follows
+// each instance.  Modeled after boost::scoped_ptr.
+//
+// This is not typdef'd to boost::scoped_ptr<TupleSchema> because we
+// need to call freeTupleSchema to free memory for TupleSchema
+// objects.
+//
+// In the future we should:
+//   - Replace code that calls freeTupleSchema with smart pointers
+//     where possible (this seems to be most uses, with a few
+//     exceptions)
+//   - Overload the delete operator for TupleSchema, so we can use
+//     smart pointers out of the box.  I.e., the code below could be
+//     replaced with
+//         typedef boost::scoped_ptr<TupleSchema> ScopedTupleSchema;
+class ScopedTupleSchema {
+public:
+    ScopedTupleSchema(voltdb::TupleSchema* schema)
+        : m_schema(schema)
+    {
+    }
+
+    voltdb::TupleSchema* get() {
+        return m_schema;
+    }
+
+    voltdb::TupleSchema& operator*() {
+        return *m_schema;
+    }
+
+    voltdb::TupleSchema* operator->() {
+        return m_schema;
+    }
+
+    ~ScopedTupleSchema() {
+        voltdb::TupleSchema::freeTupleSchema(m_schema);
+    }
+
+private:
+    voltdb::TupleSchema* m_schema;
+};


### PR DESCRIPTION
When creating a persistent table from the catalog, add a hidden column
for the DR timestamp to the schema if active/active DR is enabled and
the table is being DR'd.

When rows are inserted or updated in such a table, update the hidden
column with the current DR timestamp.

Add unit tests for this work.