### PR TITLE
Eng 8509 geb trim failures

### DIFF
--- a/tests/geb/vmc/src/tests/TestBase.groovy
+++ b/tests/geb/vmc/src/tests/TestBase.groovy
@@ -201,16 +201,30 @@ class TestBase extends GebReportingSpec {
      * comment, which should be ignored (default is '#').
      * @param includeBlankLines - whether or not to include blank (or
      * white-space only) lines in the output (default is true).
+     * @param finalChars - the character(s) that, if specified, indicate the
+     * end of a 'line', or command; consecutive lines will be concatenated
+     * (separated by a space) and returned as a single line, until this is
+     * found at the end of a line; default is '', an empty string, meaning
+     * each line will be returned separately.
      * @return a list of lines from the specified file.
      */
     def List<String> getFileLines(File file, String commentChars='#',
-                                  boolean includeBlankLines=true) {
+                                  boolean includeBlankLines=true,
+                                  String finalChars='') {
         def lines = []
         if (file.size() > 0) {
+            String tmp = ''
             file.eachLine { line ->
                 def trimmedLine = line.trim()
                 if ((includeBlankLines || !trimmedLine.isEmpty()) &&
-                    !trimmedLine.startsWith(commentChars)) { lines.add(line) }
+                        !trimmedLine.startsWith(commentChars)) {
+                    if (line.endsWith(finalChars)) {
+                        lines.add(tmp + line)
+                        tmp = ''
+                    } else {
+                        tmp += line + ' '
+                    }
+                }
             }
         }
         return lines

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateBaseProc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateBaseProc.java
@@ -111,7 +111,7 @@ public class UpdateBaseProc extends VoltProcedure {
         // not seen by the server, hopefully this will bisect where they're occuring.
         data = retval[3];
         validateCIDData(data, getClass().getName());
-        
+
         VoltTableRow row = data.fetchRow(0);
         if (row.getVarbinary("value").length == 0)
             throw new VoltAbortException("Value column contained no data in UpdateBaseProc");
@@ -173,7 +173,7 @@ public class UpdateBaseProc extends VoltProcedure {
         // not seen by the server, hopefully this will bisect where they're occurring.
         data = retval[3];
         validateCIDData(data, getClass().getName());
-        
+
         VoltTableRow row = data.fetchRow(0);
         if (row.getVarbinary("value").length == 0)
             throw new VoltAbortException("Value column contained no data in UpdateBaseProc");


### PR DESCRIPTION
Code to fix ENG-8509, which is caused by Selenium trimming (removing leading & trailing whitespace) the query results. Plus some of the code for ENG-8617.