### PR TITLE
Clear existing children when connecting subqueries to plan

### DIFF
--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -812,6 +812,7 @@ public class PlanAssembler {
                 assert (betsCostPlan != null);
                 AbstractPlanNode subQueryRoot = betsCostPlan.rootPlanGraph;
                 subQueryRoot.disconnectParents();
+                scanNode.clearChildren();
                 scanNode.addAndLinkChild(subQueryRoot);
             }
         } else {

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -808,9 +808,9 @@ public class PlanAssembler {
             AbstractScanPlanNode scanNode = (AbstractScanPlanNode) parentPlan;
             StmtTableScan tableScan = scanNode.getTableScan();
             if (tableScan instanceof StmtSubqueryScan) {
-                CompiledPlan betsCostPlan = ((StmtSubqueryScan)tableScan).getBestCostPlan();
-                assert (betsCostPlan != null);
-                AbstractPlanNode subQueryRoot = betsCostPlan.rootPlanGraph;
+                CompiledPlan bestCostPlan = ((StmtSubqueryScan)tableScan).getBestCostPlan();
+                assert (bestCostPlan != null);
+                AbstractPlanNode subQueryRoot = bestCostPlan.rootPlanGraph;
                 subQueryRoot.disconnectParents();
                 scanNode.clearChildren();
                 scanNode.addAndLinkChild(subQueryRoot);

--- a/tests/frontend/org/voltdb/planner/TestPlansCount.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansCount.java
@@ -476,7 +476,11 @@ public class TestPlansCount extends PlannerTestCase {
     public void testCountSubquery() {
         List<AbstractPlanNode> pn = compileToFragments("SELECT count(distinct RATIO) from (SELECT * FROM P1) a");
         checkIndexCounter(pn, false);
+
+        pn = compileToFragments("SELECT * from T1, (SELECT count(age) FROM T1) as subq");
+        checkIndexCounter(pn, false);
     }
+
     /**
      * Check Whether or not the original plan is replaced with CountingIndexPlanNode.
      *


### PR DESCRIPTION
When I was writing some planner tests, I was encountering failed
assertions because a scan plan node had more than one child.  I
traced the cause to the method `connectChildrenBestPlans` which seems
to have been added as part of in/exists/scalar subquery support.

I wasn't able to recreate this issue using sqlcmd (I tried both ad hoc
and procedures), but seems like this issue might manifest in a
real-world scenario?

The added test was failing assertions in the planner before the fix.