### PR TITLE
Eng 8289 snapshot blocks with large payload

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -98,6 +98,7 @@ import org.voltdb.compiler.AsyncCompilerAgent;
 import org.voltdb.compiler.ClusterConfig;
 import org.voltdb.compiler.deploymentfile.DeploymentType;
 import org.voltdb.compiler.deploymentfile.HeartbeatType;
+import org.voltdb.compiler.deploymentfile.PathsType;
 import org.voltdb.compiler.deploymentfile.SystemSettingsType;
 import org.voltdb.dtxn.InitiatorStats;
 import org.voltdb.dtxn.LatencyHistogramStats;
@@ -673,8 +674,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
                 try {
                     Class<?> ndrgwClass = null;
                     ndrgwClass = Class.forName("org.voltdb.dr2.DRProducer");
-                    Constructor<?> ndrgwConstructor = ndrgwClass.getConstructor(File.class, boolean.class, int.class, int.class);
+                    Constructor<?> ndrgwConstructor = ndrgwClass.getConstructor(File.class, File.class, boolean.class, int.class, int.class);
                     m_producerDRGateway = (ProducerDRGateway) ndrgwConstructor.newInstance(new File(m_catalogContext.cluster.getDroverflow()),
+                                                                                   getSnapshotPath(m_catalogContext),
                                                                                    m_replicationActive,
                                                                                    m_configuredNumberOfPartitions,
                                                                                    m_catalogContext.getDeployment().getCluster().getHostcount());
@@ -2900,5 +2902,11 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
         m_clusterCreateTime = clusterCreateTime;
         hostLog.info("The internal DR cluster timestamp being restored from a snapshot is " +
                 new Date(m_clusterCreateTime).toString() + ".");
+    }
+
+    private File getSnapshotPath(CatalogContext catalogContext) {
+        PathsType paths = catalogContext.getDeployment().getPaths();
+        File voltDbRoot = CatalogUtil.getVoltDbRoot(paths);
+        return CatalogUtil.getSnapshot(paths.getSnapshots(), voltDbRoot);
     }
 }

--- a/src/frontend/org/voltdb/SnapshotDaemon.java
+++ b/src/frontend/org/voltdb/SnapshotDaemon.java
@@ -675,12 +675,11 @@ public class SnapshotDaemon implements SnapshotCompletionInterest {
         // for the snapshot save invocations
         JSONObject jsObj = new JSONObject();
         try {
+            assert truncReqId != null;
             String sData = "";
-            if (truncReqId != null) {
-                JSONObject jsData = new JSONObject();
-                jsData.put("truncReqId", truncReqId);
-                sData = jsData.toString();
-            }
+            JSONObject jsData = new JSONObject();
+            jsData.put("truncReqId", truncReqId);
+            sData = jsData.toString();
             jsObj.put("path", snapshotPath );
             jsObj.put("nonce", nonce);
             jsObj.put("perPartitionTxnIds", retrievePerPartitionTransactionIds());

--- a/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
+++ b/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
@@ -79,7 +79,7 @@ public interface SystemProcedureExecutionContext {
 
     boolean activateTableStream(int tableId, TableStreamType type, boolean undo, byte[] predicates);
 
-    public void forceAllBuffersToDiskForDRAndExport(final boolean nofsync);
+    public void forceAllDRNodeBuffersToDisk(final boolean nofsync);
 
     Pair<Long, int[]> tableStreamSerializeMore(int tableId, TableStreamType type,
                                                List<DBBPool.BBContainer> outputBuffers);

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -222,7 +222,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
         }
 
         @Override
-        public void forceAllBuffersToDiskForDRAndExport(final boolean nofsync)
+        public void forceAllDRNodeBuffersToDisk(final boolean nofsync)
         {
             throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
         }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -73,7 +73,6 @@ import org.voltdb.dtxn.SiteTracker;
 import org.voltdb.dtxn.TransactionState;
 import org.voltdb.dtxn.UndoAction;
 import org.voltdb.exceptions.EEException;
-import org.voltdb.export.ExportManager;
 import org.voltdb.jni.ExecutionEngine;
 import org.voltdb.jni.ExecutionEngine.TaskType;
 import org.voltdb.jni.ExecutionEngineIPC;
@@ -375,13 +374,12 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         }
 
         @Override
-        public void forceAllBuffersToDiskForDRAndExport(final boolean nofsync)
+        public void forceAllDRNodeBuffersToDisk(final boolean nofsync)
         {
             m_drGateway.forceAllDRNodeBuffersToDisk(nofsync);
             if (m_mpDrGateway != null) {
                 m_mpDrGateway.forceAllDRNodeBuffersToDisk(nofsync);
             }
-            ExportManager.sync(nofsync);
         }
 
         @Override

--- a/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
@@ -43,6 +43,7 @@ import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.catalog.Table;
 import org.voltdb.dtxn.SiteTracker;
+import org.voltdb.export.ExportManager;
 import org.voltdb.sysprocs.SnapshotRegistry;
 import org.voltdb.utils.CatalogUtil;
 
@@ -214,10 +215,18 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
                         @Override
                         public void run()
                         {
-                            context.forceAllBuffersToDiskForDRAndExport(false);
+                            context.forceAllDRNodeBuffersToDisk(false);
                         }
                     });
                 }
+                // Sync export buffer for all types of snapshot
+                SnapshotSiteProcessor.m_tasksOnSnapshotCompletion.offer(new Runnable() {
+                    @Override
+                    public void run()
+                    {
+                        ExportManager.sync(false);
+                    }
+                });
 
                 return true;
             }


### PR DESCRIPTION
This patch is for the problem that when disk I/O is busy(e.g. large transactions), client transaction per second (tps) might drop to 0 for a while when DR replica starts the sync snapshot, it recovers after the sync snapshot.
This patch addressed the problem by:
1) Don't syncing DR buffers to disk when non-truncation snapshot happens,
2) putting DR sync snapshot to the same directory of snapshot path defined in the deployment.
