### PR TITLE
Add use of insert into ... select to the txnid-selfcheck app

### DIFF
--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/LoadTableLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/LoadTableLoader.java
@@ -242,7 +242,7 @@ public class LoadTableLoader extends BenchmarkThread {
                     }
                     CountDownLatch clatch = new CountDownLatch(workList.size());
                     for (Long lcid : workList) {
-                        client.callProcedure(new InsertCopyCallback(clatch), m_cpprocName, lcid);
+                        client.callProcedure(new InsertCopyCallback(clatch), m_cpprocName, lcid, r.nextInt(2));
                     }
                     clatch.await();
                     CountDownLatch dlatch = new CountDownLatch(workList.size());

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedBase.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedBase.java
@@ -30,22 +30,33 @@ import org.voltdb.VoltTable;
 public class CopyLoadPartitionedBase extends VoltProcedure {
 
     public VoltTable[] doWork(SQLStmt select, SQLStmt insert, long cid) {
-        // Get row for cid and copy to new table.
-        voltQueueSQL(select, cid);
-        VoltTable[] results = voltExecuteSQL();
-        VoltTable data = results[0];
-        if (data.getRowCount() != 1) {
-            throw new VoltAbortException("Failed to find cid that should exist: cid=" + cid);
+        if (select != null) { // use select
+            // Get row for cid and copy to new table.
+            voltQueueSQL(select, cid);
+            VoltTable[] results = voltExecuteSQL();
+            VoltTable data = results[0];
+            if (data.getRowCount() != 1) {
+                throw new VoltAbortException("Failed to find cid that should exist: cid=" + cid);
+            }
+            data.advanceRow();
+            long rcid = data.getLong(0);
+            if (rcid != cid) {
+                throw new VoltAbortException("Failed to find cid does not match. (" + rcid + ":" + cid + ")");
+            }
+            long txnid = data.getLong(1);
+            long rowid = data.getLong(2);
+            voltQueueSQL(insert, rcid, txnid, rowid);
+            return voltExecuteSQL();
+        } else { // use insert into
+            voltQueueSQL(insert,cid);
+            VoltTable[] results = voltExecuteSQL();
+            VoltTable data = results[0];
+            int cnt = (int) data.fetchRow(0).getLong(0);
+            if (cnt != 1) {
+                throw new VoltAbortException("incorrect number of inserted rows=" + cnt + " for cid=" + cid);
+            }
+            return results;
         }
-        data.advanceRow();
-        long rcid = data.getLong(0);
-        if (rcid != cid) {
-            throw new VoltAbortException("Failed to find cid does not match. (" + rcid + ":" + cid + ")");
-        }
-        long txnid = data.getLong(1);
-        long rowid = data.getLong(2);
-        voltQueueSQL(insert, rcid, txnid, rowid);
-        return voltExecuteSQL();
     }
 
     public long run() {

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedMP.java
@@ -30,8 +30,11 @@ public class CopyLoadPartitionedMP extends CopyLoadPartitionedBase {
 
     private final SQLStmt selectStmt = new SQLStmt("SELECT cid,txnid,rowid from loadmp WHERE cid=? ORDER BY cid LIMIT 1;");
     private final SQLStmt insertStmt = new SQLStmt("INSERT INTO  cploadmp VALUES (?, ?, ?);");
+    private final SQLStmt insertIntoStmt = new SQLStmt("INSERT INTO cploadmp SELECT cid,txnid,rowid FROM loadmp WHERE cid=? ORDER BY cid;");
 
-    public VoltTable[] run(long cid) {
-        return doWork(selectStmt, insertStmt, cid);
+    public VoltTable[] run(long cid, int useSelect) {
+        if (useSelect == 0)
+            return doWork(selectStmt, insertStmt, cid);
+        return doWork(null, insertIntoStmt, cid);
     }
 }

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedSP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedSP.java
@@ -30,8 +30,11 @@ public class CopyLoadPartitionedSP extends CopyLoadPartitionedBase {
 
     private final SQLStmt selectStmt = new SQLStmt("SELECT cid,txnid,rowid from loadp WHERE cid=? ORDER BY cid LIMIT 1;");
     private final SQLStmt insertStmt = new SQLStmt("INSERT INTO  cploadp VALUES (?, ?, ?);");
+    private final SQLStmt insertIntoStmt = new SQLStmt("INSERT INTO cploadp SELECT cid,txnid,rowid FROM loadp WHERE cid=? ORDER BY cid;");
 
-    public VoltTable[] run(long cid) {
-        return doWork(selectStmt, insertStmt, cid);
+    public VoltTable[] run(long cid, int useSelect) {
+        if (useSelect == 0)
+            return doWork(selectStmt, insertStmt, cid);
+        return doWork(null, insertIntoStmt, cid);
     }
 }


### PR DESCRIPTION
Altered the CopyLoadPartitioned procs to use insert into instead of a select followed by an insert, as the select and insert sql commands are tested in many places besides this. Took random number generation out of stored procedure, so that the hash check does not fail.