### PR TITLE
ENG-8723: snapshot hidden column (also ENG-8665)

### DIFF
--- a/build.py
+++ b/build.py
@@ -204,6 +204,7 @@ CTX.INPUT['common'] = """
  RecoveryProtoMessage.cpp
  RecoveryProtoMessageBuilder.cpp
  DefaultTupleSerializer.cpp
+ FullTupleSerializer.cpp
  executorcontext.cpp
  serializeio.cpp
  StreamPredicateList.cpp

--- a/src/ee/common/DefaultTupleSerializer.cpp
+++ b/src/ee/common/DefaultTupleSerializer.cpp
@@ -29,21 +29,7 @@ void DefaultTupleSerializer::serializeTo(TableTuple tuple, ReferenceSerializeOut
 /**
  * Calculate the maximum size of a serialized tuple based upon the schema of the table/tuple
  */
-int DefaultTupleSerializer::getMaxSerializedTupleSize(const TupleSchema *schema) {
-    size_t size = 4;
-    size += static_cast<size_t>(schema->tupleLength());
-    for (int ii = 0; ii < schema->columnCount(); ii++) {
-        const TupleSchema::ColumnInfo *columnInfo = schema->getColumnInfo(ii);
-        voltdb::ValueType columnType = columnInfo->getVoltType();
-
-        if (!columnInfo->inlined) {
-            size -= sizeof(void*);
-            size += 4 + columnInfo->length;
-        } else if ((columnType == VALUE_TYPE_VARCHAR) || (columnType == VALUE_TYPE_VARBINARY)) {
-            size += 3;//Serialization always uses a 4-byte length prefix
-        }
-    }
-    return static_cast<int>(size);
+size_t DefaultTupleSerializer::getMaxSerializedTupleSize(const TupleSchema *schema) {
+    return schema->getMaxSerializedTupleSize();
 }
 }
-

--- a/src/ee/common/DefaultTupleSerializer.h
+++ b/src/ee/common/DefaultTupleSerializer.h
@@ -24,6 +24,10 @@ namespace voltdb {
 class ReferenceSerializeOutput;
 class TupleSchema;
 
+/**
+ * DefaultTupleSerializer provides delegate methods to serialize only visible columns
+ * of the given tuple. It also gives corresponding max serialization size for buffer allocation.
+ */
 class DefaultTupleSerializer : public TupleSerializer {
 public:
     /**

--- a/src/ee/common/FullTupleSerializer.cpp
+++ b/src/ee/common/FullTupleSerializer.cpp
@@ -14,30 +14,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef DEFAULTTUPLESERIALIZER_H_
-#define DEFAULTTUPLESERIALIZER_H_
-#include "common/TupleSerializer.h"
-#include "common/tabletuple.h"
+#include "common/FullTupleSerializer.h"
+#include "common/serializeio.h"
+#include "common/TupleSchema.h"
 
 namespace voltdb {
-class ReferenceSerializeOutput;
-class TupleSchema;
-
-class DefaultTupleSerializer : public TupleSerializer {
-public:
-    /**
-     * Serialize the provided tuple to the provide serialize output
-     */
-    void serializeTo(TableTuple tuple, ReferenceSerializeOutput *out);
-
-    /**
-     * Calculate the maximum size of a serialized tuple based upon the schema of the table/tuple
-     */
-    size_t getMaxSerializedTupleSize(const TupleSchema *schema);
-
-    virtual ~DefaultTupleSerializer() {}
-};
+/**
+ * Serialize the provided tuple to the provide serialize output
+ */
+void FullTupleSerializer::serializeTo(TableTuple tuple, ReferenceSerializeOutput *out) {
+    tuple.serializeTo(*out, true);
 }
 
-#endif /* DEFAULTTUPLESERIALIZER_H_ */
+/**
+ * Calculate the maximum size of a serialized tuple based upon the schema of the table/tuple
+ */
+size_t FullTupleSerializer::getMaxSerializedTupleSize(const TupleSchema *schema) {
+    return schema->getMaxSerializedTupleSize(true);
+}
+}

--- a/src/ee/common/FullTupleSerializer.h
+++ b/src/ee/common/FullTupleSerializer.h
@@ -24,6 +24,10 @@ namespace voltdb {
 class ReferenceSerializeOutput;
 class TupleSchema;
 
+/**
+ * FullTupleSerializer provides delegate methods to serialize visible and hidden columns
+ * of the given tuple. It also gives corresponding max serialization size for buffer allocation.
+ */
 class FullTupleSerializer : public TupleSerializer {
 public:
     /**

--- a/src/ee/common/FullTupleSerializer.h
+++ b/src/ee/common/FullTupleSerializer.h
@@ -15,8 +15,8 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DEFAULTTUPLESERIALIZER_H_
-#define DEFAULTTUPLESERIALIZER_H_
+#ifndef FULLTUPLESERIALIZER_H_
+#define FULLTUPLESERIALIZER_H_
 #include "common/TupleSerializer.h"
 #include "common/tabletuple.h"
 
@@ -24,7 +24,7 @@ namespace voltdb {
 class ReferenceSerializeOutput;
 class TupleSchema;
 
-class DefaultTupleSerializer : public TupleSerializer {
+class FullTupleSerializer : public TupleSerializer {
 public:
     /**
      * Serialize the provided tuple to the provide serialize output
@@ -36,8 +36,8 @@ public:
      */
     size_t getMaxSerializedTupleSize(const TupleSchema *schema);
 
-    virtual ~DefaultTupleSerializer() {}
+    virtual ~FullTupleSerializer() {}
 };
 }
 
-#endif /* DEFAULTTUPLESERIALIZER_H_ */
+#endif /* FULLTUPLESERIALIZER_H_ */

--- a/src/ee/common/RecoveryProtoMessageBuilder.h
+++ b/src/ee/common/RecoveryProtoMessageBuilder.h
@@ -86,7 +86,7 @@ private:
      */
     int32_t m_tupleCount;
 
-    int32_t m_maxSerializedSize;
+    size_t m_maxSerializedSize;
 };
 }
 #endif //RECOVERY_PROTO_MESSAGE_BUILDER_

--- a/src/ee/common/TupleSchema.cpp
+++ b/src/ee/common/TupleSchema.cpp
@@ -287,8 +287,7 @@ std::string TupleSchema::ColumnInfo::debug() const {
 }
 
 size_t TupleSchema::getMaxSerializedTupleSize(bool includeHiddenColumns) const {
-    size_t int32size = sizeof(int32_t);
-    size_t bytes = int32size; // placeholder for tuple length
+    size_t bytes = sizeof(int32_t); // placeholder for tuple length
     int serializeColumnCount = m_columnCount;
     if (includeHiddenColumns) {
         serializeColumnCount += m_hiddenColumnCount;
@@ -298,7 +297,7 @@ size_t TupleSchema::getMaxSerializedTupleSize(bool includeHiddenColumns) const {
         const TupleSchema::ColumnInfo* columnInfo = getColumnInfoPrivate(i);
         int32_t factor = (columnInfo->type == VALUE_TYPE_VARCHAR && !columnInfo->inBytes) ? MAX_BYTES_PER_UTF8_CHARACTER : 1;
         if (columnInfo->type == VALUE_TYPE_VARCHAR || columnInfo->type == VALUE_TYPE_VARBINARY) {
-            bytes += int32size; // value length placeholder for variable length columns
+            bytes += sizeof(int32_t); // value length placeholder for variable length columns
         }
         bytes += columnInfo->length * factor;
     }

--- a/src/ee/common/TupleSchema.h
+++ b/src/ee/common/TupleSchema.h
@@ -135,6 +135,8 @@ public:
     /** Return the number of bytes used by one tuple. */
     inline uint32_t tupleLength() const;
 
+    size_t getMaxSerializedTupleSize(bool includeHiddenColumns = false) const;
+
     /** Get a string representation of this schema for debugging */
     std::string debug() const;
 

--- a/src/ee/common/TupleSerializer.h
+++ b/src/ee/common/TupleSerializer.h
@@ -35,7 +35,7 @@ public:
     /**
      * Calculate the maximum size of a serialized tuple based upon the schema of the table/tuple
      */
-    virtual int getMaxSerializedTupleSize(const TupleSchema *schema) = 0;
+    virtual size_t getMaxSerializedTupleSize(const TupleSchema *schema) = 0;
 
     virtual ~TupleSerializer() {}
 };

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -773,8 +773,10 @@ inline void TableTuple::deserializeFrom(voltdb::SerializeInputBE &tupleIn, Pool 
     assert(m_schema);
     assert(m_data);
 
+    const int32_t columnCount  = m_schema->columnCount();
+    const int32_t hiddenColumnCount  = m_schema->hiddenColumnCount();
     tupleIn.readInt();
-    for (int j = 0; j < m_schema->columnCount(); ++j) {
+    for (int j = 0; j < columnCount; ++j) {
         const TupleSchema::ColumnInfo *columnInfo = m_schema->getColumnInfo(j);
 
         /**
@@ -789,6 +791,14 @@ inline void TableTuple::deserializeFrom(voltdb::SerializeInputBE &tupleIn, Pool 
          * TableTuple. The memory allocation will be performed when
          * serializing to tuple storage.
          */
+        char *dataPtr = getWritableDataPtr(columnInfo);
+        NValue::deserializeFrom(tupleIn, dataPool, dataPtr, columnInfo->getVoltType(),
+                columnInfo->inlined, static_cast<int32_t>(columnInfo->length), columnInfo->inBytes);
+    }
+
+    for (int j = 0; j < hiddenColumnCount; ++j) {
+        const TupleSchema::ColumnInfo *columnInfo = m_schema->getHiddenColumnInfo(j);
+
         char *dataPtr = getWritableDataPtr(columnInfo);
         NValue::deserializeFrom(tupleIn, dataPool, dataPtr, columnInfo->getVoltType(),
                 columnInfo->inlined, static_cast<int32_t>(columnInfo->length), columnInfo->inBytes);

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -317,7 +317,7 @@ public:
 
     void deserializeFrom(voltdb::SerializeInputBE &tupleIn, Pool *stringPool);
     void deserializeFromDR(voltdb::SerializeInputLE &tupleIn, Pool *stringPool);
-    void serializeTo(voltdb::SerializeOutput &output);
+    void serializeTo(voltdb::SerializeOutput &output, bool includeHiddenColumns = false);
     void serializeToExport(voltdb::ExportSerializeOutput &io,
                           int colOffset, uint8_t *nullArray);
     void serializeAllColumnsToDR(ExportSerializeOutput &io,
@@ -833,13 +833,20 @@ inline void TableTuple::deserializeFromDR(voltdb::SerializeInputLE &tupleIn,  Po
     }
 }
 
-inline void TableTuple::serializeTo(voltdb::SerializeOutput &output) {
+inline void TableTuple::serializeTo(voltdb::SerializeOutput &output, bool includeHiddenColumns) {
     size_t start = output.reserveBytes(4);
 
     for (int j = 0; j < m_schema->columnCount(); ++j) {
         //int fieldStart = output.position();
         NValue value = getNValue(j);
         value.serializeTo(output);
+    }
+
+    if (includeHiddenColumns) {
+        for (int j = 0; j < m_schema->hiddenColumnCount(); ++j) {
+            NValue value = getHiddenNValue(j);
+            value.serializeTo(output);
+        }
     }
 
     // write the length of the tuple

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -46,7 +46,7 @@
 #ifndef VOLTDBENGINE_H
 #define VOLTDBENGINE_H
 
-#include "common/DefaultTupleSerializer.h"
+#include "common/FullTupleSerializer.h"
 #include "common/Pool.hpp"
 #include "common/serializeio.h"
 #include "common/ThreadLocalPool.h"
@@ -578,7 +578,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         // other components. (Components MUST NOT depend on VoltDBEngine.h).
         ExecutorContext *m_executorContext;
 
-        DefaultTupleSerializer m_tupleSerializer;
+        FullTupleSerializer m_tupleSerializer;
 
         int32_t m_compactionThreshold;
 

--- a/src/ee/storage/RecoveryContext.cpp
+++ b/src/ee/storage/RecoveryContext.cpp
@@ -73,7 +73,6 @@ bool RecoveryContext::nextMessage(ReferenceSerializeOutput *out) {
         //No tuple count added to message because completion message is only used in Java
         return false;
     }
-    DefaultTupleSerializer serializer;
     //Use allocated tuple count to size stuff at the other end
     uint32_t allocatedTupleCount = static_cast<uint32_t>(getTable().allocatedTupleCount());
     RecoveryProtoMsgBuilder message(
@@ -81,7 +80,7 @@ bool RecoveryContext::nextMessage(ReferenceSerializeOutput *out) {
             m_tableId,
             allocatedTupleCount,
             out,
-            &m_serializer,
+            &getSerializer(),
             getTable().schema());
     TableTuple tuple(getTable().schema());
     while (message.canAddMoreTuples() && m_iterator.next(tuple)) {

--- a/src/ee/storage/RecoveryContext.h
+++ b/src/ee/storage/RecoveryContext.h
@@ -20,7 +20,6 @@
 #include "storage/tableiterator.h"
 #include "storage/TableStreamer.h"
 #include "storage/TableStreamerContext.h"
-#include "common/DefaultTupleSerializer.h"
 
 /*
  * A log of changes to tuple data that has already been sent to a recovering
@@ -90,8 +89,6 @@ private:
      * Phase 3 is to ship deletes
      */
     RecoveryMsgType m_recoveryPhase;
-
-    DefaultTupleSerializer m_serializer;
 };
 }
 #endif /* RECOVERYCONTEXT_H_ */

--- a/src/ee/storage/TableStreamerContext.h
+++ b/src/ee/storage/TableStreamerContext.h
@@ -137,7 +137,7 @@ public:
     /**
      * Tuple length accessor.
      */
-    int getMaxTupleLength() const
+    size_t getMaxTupleLength() const
     {
         return m_maxTupleLength;
     }
@@ -219,7 +219,7 @@ private:
     /**
      * Maximum serialized length of a tuple
      */
-    const int m_maxTupleLength;
+    const size_t m_maxTupleLength;
 
     /**
      * Serializer for tuples

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -470,6 +470,7 @@ void PersistentTable::insertTupleCommon(TableTuple &source, TableTuple &target, 
                 CONSTRAINT_TYPE_UNIQUE);
     }
 
+    ExecutorContext *ec = ExecutorContext::getExecutorContext();
     DRTupleStream *drStream = getDRTupleStream(ec);
     size_t drMark = 0;
     if (drStream && !m_isMaterialized && m_drEnabled && shouldDRStream) {

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -382,9 +382,9 @@ void setSearchKeyFromTuple(TableTuple &source) {
     keyTuple.setNValue(1, source.getNValue(2));
 }
 
-void PersistentTable::setDRTimestampForTuple(ExecutorContext* ec, TableTuple& tuple) {
+void PersistentTable::setDRTimestampForTuple(ExecutorContext* ec, TableTuple& tuple, bool update) {
     assert(hasDRTimestampColumn());
-    if (tuple.getHiddenNValue(getDRTimestampColumnIndex()).isNull()) {
+    if (update || tuple.getHiddenNValue(getDRTimestampColumnIndex()).isNull()) {
         const int64_t drTimestamp = ec->currentDRTimestamp();
         tuple.setHiddenNValue(getDRTimestampColumnIndex(), ValueFactory::getBigIntValue(drTimestamp));
     }
@@ -467,7 +467,7 @@ void PersistentTable::insertTupleCommon(TableTuple &source, TableTuple &target, 
 
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
     if (hasDRTimestampColumn()) {
-        setDRTimestampForTuple(ec, target);
+        setDRTimestampForTuple(ec, target, false);
     }
 
     DRTupleStream *drStream = getDRTupleStream(ec);
@@ -611,7 +611,7 @@ bool PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUp
 
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
     if (hasDRTimestampColumn()) {
-        setDRTimestampForTuple(ec, sourceTupleWithNewValues);
+        setDRTimestampForTuple(ec, sourceTupleWithNewValues, true);
     }
 
     DRTupleStream *drStream = getDRTupleStream(ec);

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -589,7 +589,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
         }
     }
 
-    void setDRTimestampForTuple(ExecutorContext* ec, TableTuple &tuple);
+    void setDRTimestampForTuple(ExecutorContext* ec, TableTuple &tuple, bool update);
 
     void computeSmallestUniqueIndex();
 

--- a/src/ee/storage/table.cpp
+++ b/src/ee/storage/table.cpp
@@ -472,11 +472,12 @@ void Table::loadTuplesFrom(SerializeInputBE &serialize_io,
     }
 
     // Check if the column count matches what the temp table is expecting
-    if (colcount != m_schema->columnCount()) {
+    int16_t expectedColumnCount = static_cast<int16_t>(m_schema->columnCount() + m_schema->hiddenColumnCount());
+    if (colcount != expectedColumnCount) {
         std::stringstream message(std::stringstream::in
                                   | std::stringstream::out);
         message << "Column count mismatch. Expecting "
-                << m_schema->columnCount()
+                << expectedColumnCount
                 << ", but " << colcount << " given" << std::endl;
         message << "Expecting the following columns:" << std::endl;
         message << debug() << std::endl;

--- a/src/ee/storage/table.cpp
+++ b/src/ee/storage/table.cpp
@@ -151,6 +151,10 @@ void Table::initializeWithColumns(TupleSchema *schema, const std::vector<string>
     m_tempTupleMemory.reset(new char[m_schema->tupleLength() + TUPLE_HEADER_SIZE]);
     m_tempTuple = TableTuple(m_tempTupleMemory.get(), m_schema);
     ::memset(m_tempTupleMemory.get(), 0, m_tempTuple.tupleLength());
+    // default value of hidden dr timestamp is null
+    if (m_schema->hiddenColumnCount() > 0) {
+        m_tempTuple.setHiddenNValue(0, NValue::getNullValue(VALUE_TYPE_BIGINT));
+    }
     m_tempTuple.setActiveTrue();
 
     // set the data to be empty

--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -247,7 +247,7 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
             for (int i = 0; i < columnCount; i++) {
                 augmentedSchema[i] = new ColumnInfo(schemaTable.getColumnName(i), schemaTable.getColumnType(i));
             }
-            augmentedSchema[columnCount] = new ColumnInfo("dr_clusterid_timestamp", VoltType.BIGINT);
+            augmentedSchema[columnCount] = new ColumnInfo(VoltTable.DR_HIDDEN_COLUMN_NAME, VoltType.BIGINT);
             schemaBytes = PrivateVoltTableFactory.getSchemaBytes(new VoltTable(augmentedSchema));
         }
         else {

--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -149,7 +149,6 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
             final boolean isReplicated,
             final List<Integer> partitionIds,
             final VoltTable schemaTable,
-            final boolean addDRHiddenColumn,
             final long txnId,
             final long timestamp) throws IOException {
         this(
@@ -162,7 +161,6 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
                 isReplicated,
                 partitionIds,
                 schemaTable,
-                addDRHiddenColumn,
                 txnId,
                 timestamp,
                 new int[] { 0, 0, 0, 2 });
@@ -178,7 +176,6 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
             final boolean isReplicated,
             final List<Integer> partitionIds,
             final VoltTable schemaTable,
-            final boolean addDRHiddenColumn,
             final long txnId,
             final long timestamp,
             int version[]
@@ -241,18 +238,7 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
         container.b().position(0);
 
         final byte schemaBytes[];
-        if (addDRHiddenColumn) {
-            int columnCount = schemaTable.getColumnCount();
-            ColumnInfo[] augmentedSchema = new ColumnInfo[columnCount + 1];
-            for (int i = 0; i < columnCount; i++) {
-                augmentedSchema[i] = new ColumnInfo(schemaTable.getColumnName(i), schemaTable.getColumnType(i));
-            }
-            augmentedSchema[columnCount] = new ColumnInfo(VoltTable.DR_HIDDEN_COLUMN_NAME, VoltType.BIGINT);
-            schemaBytes = PrivateVoltTableFactory.getSchemaBytes(new VoltTable(augmentedSchema));
-        }
-        else {
-            schemaBytes = PrivateVoltTableFactory.getSchemaBytes(schemaTable);
-        }
+        schemaBytes = PrivateVoltTableFactory.getSchemaBytes(schemaTable);
 
         final PureJavaCrc32 crc = new PureJavaCrc32();
         ByteBuffer aggregateBuffer = ByteBuffer.allocate(container.b().remaining() + schemaBytes.length);

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -142,6 +142,8 @@ public final class VoltTable extends VoltTableRow implements JSONString {
     static final String JSON_DATA_KEY = "data";
     static final String JSON_STATUS_KEY = "status";
 
+    public static final String DR_HIDDEN_COLUMN_NAME = "dr_clusterid_timestamp";
+
     /**
      * <p>Object that represents the name and schema for a {@link VoltTable} column.
      * Primarily used to construct in the constructor {@link VoltTable#VoltTable(ColumnInfo...)}

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -142,8 +142,6 @@ public final class VoltTable extends VoltTableRow implements JSONString {
     static final String JSON_DATA_KEY = "data";
     static final String JSON_STATUS_KEY = "status";
 
-    public static final String DR_HIDDEN_COLUMN_NAME = "dr_clusterid_timestamp";
-
     /**
      * <p>Object that represents the name and schema for a {@link VoltTable} column.
      * Primarily used to construct in the constructor {@link VoltTable#VoltTable(ColumnInfo...)}

--- a/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
@@ -222,6 +222,7 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
                     target = createDataTargetForTable(file_path, file_nonce, task.m_table, txnId,
                             context.getHostId(), context.getCluster().getTypeName(),
                             context.getDatabase().getTypeName(), context.getNumberOfPartitions(),
+                            context.getDatabase().getIsactiveactivedred(),
                             tracker, timestamp, numTables, snapshotRecord);
                     m_createdTargets.put(task.m_table.getRelativeIndex(), target);
                 }
@@ -238,6 +239,7 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
                                                         String clusterName,
                                                         String databaseName,
                                                         int partitionCount,
+                                                        boolean isActiveActiveDRed,
                                                         SiteTracker tracker,
                                                         long timestamp,
                                                         AtomicInteger numTables,
@@ -262,6 +264,7 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
                 table.getIsreplicated(),
                 tracker.getPartitionsForHost(hostId),
                 CatalogUtil.getVoltTable(table),
+                (isActiveActiveDRed && table.getIsdred()),
                 txnId,
                 timestamp);
 

--- a/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
@@ -255,18 +255,32 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
                 SnapshotFormat.NATIVE,
                 hostId);
 
-        sdt = new DefaultSnapshotDataTarget(saveFilePath,
-                hostId,
-                clusterName,
-                databaseName,
-                table.getTypeName(),
-                partitionCount,
-                table.getIsreplicated(),
-                tracker.getPartitionsForHost(hostId),
-                CatalogUtil.getVoltTable(table),
-                (isActiveActiveDRed && table.getIsdred()),
-                txnId,
-                timestamp);
+        if (isActiveActiveDRed && table.getIsdred()) {
+            sdt = new DefaultSnapshotDataTarget(saveFilePath,
+                    hostId,
+                    clusterName,
+                    databaseName,
+                    table.getTypeName(),
+                    partitionCount,
+                    table.getIsreplicated(),
+                    tracker.getPartitionsForHost(hostId),
+                    CatalogUtil.getVoltTable(table, CatalogUtil.DR_HIDDEN_COLUMN_INFO),
+                    txnId,
+                    timestamp);
+        }
+        else {
+            sdt = new DefaultSnapshotDataTarget(saveFilePath,
+                    hostId,
+                    clusterName,
+                    databaseName,
+                    table.getTypeName(),
+                    partitionCount,
+                    table.getIsreplicated(),
+                    tracker.getPartitionsForHost(hostId),
+                    CatalogUtil.getVoltTable(table),
+                    txnId,
+                    timestamp);
+        }
 
         m_targets.add(sdt);
         final Runnable onClose = new TargetStatsClosure(sdt, table.getTypeName(), numTables, snapshotRecord);

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
@@ -35,7 +35,8 @@ public abstract class SavedTableConverter
 {
 
     public static Boolean needsConversion(VoltTable inputTable,
-                                          Table outputTableSchema) {
+                                          Table outputTableSchema,
+                                          boolean shouldPreserveDRHiddenColumn) {
         if (inputTable.getColumnCount() != outputTableSchema.getColumns().size()) {
             return true;
         }
@@ -45,6 +46,12 @@ public abstract class SavedTableConverter
             final Column column = outputTableSchema.getColumns().get(name);
 
             if (column == null) {
+                if (shouldPreserveDRHiddenColumn &&
+                        type == VoltType.BIGINT &&
+                        (ii == (inputTable.getColumnCount() - 1)) &&
+                        (ii == outputTableSchema.getColumns().size())) {
+                    return false;
+                }
                 return true;
             }
 

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
@@ -93,12 +93,12 @@ public abstract class SavedTableConverter
         Column catalogColumnForHiddenColumn = null;
         if (addDRHiddenColumn) {
             catalogColumnForHiddenColumn = new Column();
-            catalogColumnForHiddenColumn.setDefaulttype(VoltType.BIGINT.getValue());
-            catalogColumnForHiddenColumn.setDefaultvalue("0");
+            //catalogColumnForHiddenColumn.setDefaulttype(VoltType.BIGINT.getValue());
+            //catalogColumnForHiddenColumn.setDefaultvalue("0");
             catalogColumnForHiddenColumn.setName(VoltTable.DR_HIDDEN_COLUMN_NAME);
             catalogColumnForHiddenColumn.setInbytes(true);
             catalogColumnForHiddenColumn.setSize(Long.SIZE / 8);
-            catalogColumnForHiddenColumn.setNullable(false);
+            catalogColumnForHiddenColumn.setNullable(true);
 
             // in this DR passive to active transition scenario, we may take advantage of
             // status code in VoltTable to tell EE to change the value of these tuples from

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
@@ -93,17 +93,14 @@ public abstract class SavedTableConverter
         Column catalogColumnForHiddenColumn = null;
         if (addDRHiddenColumn) {
             catalogColumnForHiddenColumn = new Column();
-            //catalogColumnForHiddenColumn.setDefaulttype(VoltType.BIGINT.getValue());
-            //catalogColumnForHiddenColumn.setDefaultvalue("0");
             catalogColumnForHiddenColumn.setName(VoltTable.DR_HIDDEN_COLUMN_NAME);
-            catalogColumnForHiddenColumn.setInbytes(true);
+            catalogColumnForHiddenColumn.setType(VoltType.BIGINT.getValue());
             catalogColumnForHiddenColumn.setSize(Long.SIZE / 8);
+            catalogColumnForHiddenColumn.setInbytes(false);
+            // small hack here to let logic below fill VoltType.NULL_BIGINT in for the hidden column
+            // actually this column is not nullable in EE, but it will be set to correct value before
+            // insert(restore) to the corresponding table
             catalogColumnForHiddenColumn.setNullable(true);
-
-            // in this DR passive to active transition scenario, we may take advantage of
-            // status code in VoltTable to tell EE to change the value of these tuples from
-            // 0 to DRTimestamp calculated from uniqueId from this snapshot restore transaction
-            //new_table.setStatusCode(UNINITIALIZED_DR_TIMESTAMP_STATUS_CODE);
         }
 
         // Copy all the old tuples into the new table

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
@@ -137,7 +137,7 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
                 for (int i = 0; i < columnCount; i++) {
                     augmentedSchema[i] = new VoltTable.ColumnInfo(schemaTable.getColumnName(i), schemaTable.getColumnType(i));
                 }
-                augmentedSchema[columnCount] = new VoltTable.ColumnInfo("dr_clusterid_timestamp", VoltType.BIGINT);
+                augmentedSchema[columnCount] = new VoltTable.ColumnInfo(VoltTable.DR_HIDDEN_COLUMN_NAME, VoltType.BIGINT);
                 schemaTable = new VoltTable(augmentedSchema);
             }
 

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
@@ -129,16 +129,12 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
         // table schemas for all the tables we'll snapshot on this partition
         Map<Integer, byte[]> schemas = new HashMap<Integer, byte[]>();
         for (final Table table : config.tables) {
-            VoltTable schemaTable = CatalogUtil.getVoltTable(table);
-
+            VoltTable schemaTable;
             if (context.getDatabase().getIsactiveactivedred() && table.getIsdred()) {
-                int columnCount = schemaTable.getColumnCount();
-                VoltTable.ColumnInfo[] augmentedSchema = new VoltTable.ColumnInfo[columnCount + 1];
-                for (int i = 0; i < columnCount; i++) {
-                    augmentedSchema[i] = new VoltTable.ColumnInfo(schemaTable.getColumnName(i), schemaTable.getColumnType(i));
-                }
-                augmentedSchema[columnCount] = new VoltTable.ColumnInfo(VoltTable.DR_HIDDEN_COLUMN_NAME, VoltType.BIGINT);
-                schemaTable = new VoltTable(augmentedSchema);
+                schemaTable = CatalogUtil.getVoltTable(table, CatalogUtil.DR_HIDDEN_COLUMN_INFO);
+            }
+            else {
+                schemaTable = CatalogUtil.getVoltTable(table);
             }
 
             schemas.put(table.getRelativeIndex(), PrivateVoltTableFactory.getSchemaBytes(schemaTable));

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -153,6 +153,10 @@ public abstract class CatalogUtil {
     public static final String DEFAULT_DR_CONFLICTS_EXPORT_TYPE = "csv";
     public static final String DEFAULT_DR_CONFLICTS_NONCE = "MyExport";
     public static final String DEFAULT_DR_CONFLICTS_DIR = "dr_conflicts";
+    public static final String DR_HIDDEN_COLUMN_NAME = "dr_clusterid_timestamp";
+
+    public static final VoltTable.ColumnInfo DR_HIDDEN_COLUMN_INFO =
+            new VoltTable.ColumnInfo(DR_HIDDEN_COLUMN_NAME, VoltType.BIGINT);
 
     private static JAXBContext m_jc;
     private static Schema m_schema;
@@ -286,7 +290,7 @@ public abstract class CatalogUtil {
 
     /**
      *
-     * @param catalogTable
+     * @param catalogTable a catalog table providing the schema
      * @return An empty table with the same schema as a given catalog table.
      */
     public static VoltTable getVoltTable(Table catalogTable) {
@@ -297,6 +301,28 @@ public abstract class CatalogUtil {
         int i = 0;
         for (Column catCol : catalogColumns) {
             columns[i++] = new VoltTable.ColumnInfo(catCol.getTypeName(), VoltType.get((byte)catCol.getType()));
+        }
+
+        return new VoltTable(columns);
+    }
+
+    /**
+     *
+     * @param catalogTable a catalog table providing the schema
+     * @param hiddenColumnInfos variable-length ColumnInfo objects for hidden columns
+     * @return An empty table with the same schema as a given catalog table.
+     */
+    public static VoltTable getVoltTable(Table catalogTable, VoltTable.ColumnInfo... hiddenColumns) {
+        List<Column> catalogColumns = CatalogUtil.getSortedCatalogItems(catalogTable.getColumns(), "index");
+
+        VoltTable.ColumnInfo[] columns = new VoltTable.ColumnInfo[catalogColumns.size() + hiddenColumns.length];
+
+        int i = 0;
+        for (Column catCol : catalogColumns) {
+            columns[i++] = new VoltTable.ColumnInfo(catCol.getTypeName(), VoltType.get((byte)catCol.getType()));
+        }
+        for (VoltTable.ColumnInfo hiddenColumnInfo : hiddenColumns) {
+            columns[i++] = hiddenColumnInfo;
         }
 
         return new VoltTable(columns);

--- a/tests/ee/common/tupleschema_test.cpp
+++ b/tests/ee/common/tupleschema_test.cpp
@@ -205,6 +205,34 @@ TEST_F(TupleSchemaTest, EqualsAndCompatibleForMemcpy)
     EXPECT_FALSE(schema4->equals(schema2.get()));
 }
 
+TEST_F(TupleSchemaTest, MaxSerializedTupleSize) {
+    voltdb::TupleSchemaBuilder builder(3); // 3 visible columns
+    builder.setColumnAtIndex(0, VALUE_TYPE_DECIMAL);
+    builder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR,
+                             64,     // length
+                             true,   // allow nulls
+                             false); // length not in bytes
+    builder.setColumnAtIndex(2, VALUE_TYPE_TIMESTAMP);
+    ScopedTupleSchema schema(builder.build());
+
+    EXPECT_EQ((4 + 16 + (4 + 64 * 4) + 8),
+              schema.get()->getMaxSerializedTupleSize());
+
+    voltdb::TupleSchemaBuilder hiddenBuilder(3, 2); // 3 visible columns, 2 hidden columns
+    hiddenBuilder.setColumnAtIndex(0, VALUE_TYPE_DECIMAL);
+    hiddenBuilder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR,
+                             64,     // length
+                             true,   // allow nulls
+                             false); // length not in bytes
+    hiddenBuilder.setColumnAtIndex(2, VALUE_TYPE_TIMESTAMP);
+    hiddenBuilder.setHiddenColumnAtIndex(0, VALUE_TYPE_BIGINT);
+    hiddenBuilder.setHiddenColumnAtIndex(1, VALUE_TYPE_VARCHAR, 10, true, true);
+    ScopedTupleSchema schemaWithHidden(hiddenBuilder.build());
+
+    EXPECT_EQ((4 + 16 + (4 + 64 * 4) + 8 + 8 + (4 + 10)),
+              schemaWithHidden.get()->getMaxSerializedTupleSize(true));
+}
+
 int main() {
     return TestSuite::globalInstance()->runAll();
 }

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -370,7 +370,7 @@ TEST_F(DRBinaryLogTest, VerifyHiddenColumns) {
     NValue drTimestamp = tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex());
     NValue drTimestampReplica = tuple.getHiddenNValue(m_tableReplica->getDRTimestampColumnIndex());
     EXPECT_EQ(ValuePeeker::peekAsBigInt(drTimestamp), 70);
-    ASSERT_TRUE(drTimestamp.compare(drTimestampReplica) == 0);
+    EXPECT_EQ(0, drTimestamp.compare(drTimestampReplica));
 }
 
 TEST_F(DRBinaryLogTest, PartitionedTableNoRollbacks) {


### PR DESCRIPTION
1. Make the serializer used in snapshot in EE include hidden columns by default (FullTupleSerializer).

2. Make table loading in EE in snapshot restore count for hidden columns (direct load for active-active, another ticket for restore passive to active DR).

3. Add support for hidden columns in frontend when DR is in active-active mode, by 1) augmenting the DR table schema data written along with each snapshotted tuple block during snapshot save. 2) augmenting target DR table schema during snapshot restore.

4. Added unit tests which goes over save/restore/save/compare process.

5. ENG-8665: When restoring a snapshot that does not contain hidden DR column to a Active DR table, add this column, set its value in all rows to NULL_BIGINT. When EE sees NULL_BIGINT in this column, it will correctly sets it based on the uniqueId of current snapshot restore transaction before loading the tuple into the table, otherwise EE will directly load it.