### PR TITLE
ENG-8813: Fix wrong order of parameters provided for nativeLoadTable

### DIFF
--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -233,7 +233,7 @@ typedef struct {
     int64_t lastCommittedSpHandle;
     int64_t uniqueId;
     int64_t undoToken;
-    int32_t undo;
+    int32_t returnUniqueViolations;
     int32_t shouldDRStream;
     char data[0];
 }__attribute__((packed)) load_table_cmd;
@@ -799,7 +799,7 @@ int8_t VoltDBIPC::loadTable(struct ipc_command *cmd) {
     const int64_t lastCommittedSpHandle = ntohll(loadTableCommand->lastCommittedSpHandle);
     const int64_t uniqueId = ntohll(loadTableCommand->uniqueId);
     const int64_t undoToken = ntohll(loadTableCommand->undoToken);
-    const bool undo = loadTableCommand->undo != 0;
+    const bool returnUniqueViolations = loadTableCommand->returnUniqueViolations != 0;
     const bool shouldDRStream = loadTableCommand->shouldDRStream != 0;
     // ...and fast serialized table last.
     void* offset = loadTableCommand->data;
@@ -808,7 +808,9 @@ int8_t VoltDBIPC::loadTable(struct ipc_command *cmd) {
         ReferenceSerializeInputBE serialize_in(offset, sz);
         m_engine->setUndoToken(undoToken);
 
-        bool success = m_engine->loadTable(tableId, serialize_in, txnId, spHandle, lastCommittedSpHandle, uniqueId, undo, shouldDRStream);
+        bool success = m_engine->loadTable(tableId, serialize_in,
+                                           txnId, spHandle, lastCommittedSpHandle, uniqueId,
+                                           returnUniqueViolations, shouldDRStream);
         if (success) {
             return kErrorCode_Success;
         } else {

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -390,9 +390,9 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
         //Clear is destructive, do it before the native call
         deserializer.clear();
-        final int errorCode = nativeLoadTable(pointer, tableId, serialized_table, txnId,
-                                              spHandle, uniqueId, lastCommittedSpHandle, returnUniqueViolations, shouldDRStream,
-                                              undoToken);
+        final int errorCode = nativeLoadTable(pointer, tableId, serialized_table,
+                                              txnId, spHandle, lastCommittedSpHandle, uniqueId,
+                                              returnUniqueViolations, shouldDRStream, undoToken);
         checkErrorCode(errorCode);
 
         try {


### PR DESCRIPTION
uniqueId should be after lastCommittedSpHandle, not before