### PR TITLE
Fixed getDefaultStoredProcedures & getUserStoredProcedures

### DIFF
--- a/tests/geb/vmc/src/pages/SqlQueryPage.groovy
+++ b/tests/geb/vmc/src/pages/SqlQueryPage.groovy
@@ -45,10 +45,11 @@ class SqlQueryPage extends VoltDBManagementCenterPage {
         viewsNames  { listsArea.find('#accordionViews').find('h3') }
         storedProcs { listsArea.find('#accordionProcedures') }
         systemStoredProcsHeader  { storedProcs.find('.systemHeader').first() }
-        defaultStoredProcsHeader { storedProcs.find('.systemHeader').first().next('h3') }
+        defaultStoredProcsHeader { systemStoredProcsHeader.next('.systemHeader') }
+        userStoredProcsHeader    { storedProcs.find('.systemHeader').last() }
         systemStoredProcs   { storedProcs.find('#systemProcedure').find('h3') }
         defaultStoredProcs  { storedProcs.find('#defaultProcedure').find('h3') }
-        userStoredProcs { defaultStoredProcsHeader.nextAll('h3') }
+        userStoredProcs     { storedProcs.find('#userProcedure').find('h3') }
         allStoredProcs  { storedProcs.find('h3') }
 
         queryStatus			{ $("th", text:"STATUS") }
@@ -161,6 +162,37 @@ class SqlQueryPage extends VoltDBManagementCenterPage {
     }
 
     /**
+     * Given two Navigators, for a specific category of Stored Procedures
+     * (System, Default or User), returns the list of that category of Stored
+     * Procedures (as displayed on the "Stored Procedures" tab, under the
+     * specified heading).<p>
+     * Note: as a side effect, the "Stored Procedures" tab is opened (if
+     * needed), and the specfied list of Stored Procedures  is opened (if
+     * needed), and then closed.
+     * @param storedProcsHeaderNav - a Navigator specifiying the header for
+     * the desired category (System, Default or User) of Stored Procedures.
+     * @param storedProcsNav - a Navigator specifiying each of the Stored
+     * Procedures the desired category (System, Default or User).
+     * @return the list of Default Stored Procedure names.
+     */
+    private List<String> getSpecifiedStoredProcedures(Navigator storedProcsHeaderNav,
+                                                      Navigator storedProcsNav) {
+        def storedProcs = []
+        try {
+            showStoredProcedures()
+            clickToDisplay(storedProcsHeaderNav, storedProcsNav)
+            storedProcsNav.each {
+                scrollIntoView(it)
+                storedProcs.add(it.text())
+            }
+            clickToNotDisplay(storedProcsHeaderNav, storedProcsNav)
+        } catch (RequiredPageContentNotPresent e) {
+            // do nothing: empty list will be returned
+        }
+        return storedProcs
+    }
+
+    /**
      * Returns the list of System Stored Procedures (as displayed on the
      * "Stored Procedures" tab, under the "System Stored Procedures" heading).<p>
      * Note: as a side effect, the "Stored Procedures" tab is opened (if
@@ -169,15 +201,7 @@ class SqlQueryPage extends VoltDBManagementCenterPage {
      * @return the list of System Stored Procedure names.
      */
     def List<String> getSystemStoredProcedures() {
-        def storedProcs = []
-        showStoredProcedures()
-        clickToDisplay(systemStoredProcsHeader, systemStoredProcs)
-        systemStoredProcs.each {
-            scrollIntoView(it);
-            storedProcs.add(it.text())
-        }
-        clickToNotDisplay(systemStoredProcsHeader, systemStoredProcs)
-        return storedProcs
+        return getSpecifiedStoredProcedures(systemStoredProcsHeader, systemStoredProcs)
     }
 
     /**
@@ -189,15 +213,7 @@ class SqlQueryPage extends VoltDBManagementCenterPage {
      * @return the list of Default Stored Procedure names.
      */
     def List<String> getDefaultStoredProcedures() { // defaultStoredProcsHeader
-        def storedProcs = []
-        showStoredProcedures()
-        clickToDisplay(defaultStoredProcsHeader, defaultStoredProcs)
-        defaultStoredProcs.each {
-            scrollIntoView(it);
-            storedProcs.add(it.text())
-        }
-        clickToNotDisplay(defaultStoredProcsHeader, defaultStoredProcs)
-        return storedProcs
+        return getSpecifiedStoredProcedures(defaultStoredProcsHeader, defaultStoredProcs)
     }
 
     /**
@@ -209,18 +225,7 @@ class SqlQueryPage extends VoltDBManagementCenterPage {
      * @return the list of User-defined Stored Procedure names.
      */
     def List<String> getUserStoredProcedures() {
-        def storedProcs = []
-        showStoredProcedures()
-        //clickToDisplay(userStoredProcsHeader, userStoredProcs)
-        try {
-            userStoredProcs.each {
-                scrollIntoView(it)
-                storedProcs.add(it.text())
-            }
-        } catch (RequiredPageContentNotPresent e) {
-            // do nothing: empty list will be returned
-        }
-        return storedProcs
+        return getSpecifiedStoredProcedures(userStoredProcsHeader, userStoredProcs)
     }
 
     /**

--- a/tests/geb/vmc/src/resources/expectedSystemStoredProcs.txt
+++ b/tests/geb/vmc/src/resources/expectedSystemStoredProcs.txt
@@ -20,5 +20,3 @@
 @Promote
 @ValidatePartitioning
 @GetPartitionKeys
-#This was added (late) to Web Studio, but is currently missing from VMC:
-#@ApplyBinaryLogSP

--- a/tests/geb/vmc/src/tests/SqlQueriesTest.groovy
+++ b/tests/geb/vmc/src/tests/SqlQueriesTest.groovy
@@ -570,7 +570,7 @@ class SqlQueriesTest extends SqlQueriesTestBase {
         }
 
         and: 'for a non-matching result, check if it is just a trim issue, and print details'
-        if (expectedResponse.result != qResult) {
+        if (qResult instanceof Map && expectedResponse.result instanceof Map && qResult != expectedResponse.result) {
             println "\nWARNING: query result does not match expected, for column(s):"
             boolean allDiffsCausedByTrim = true
             def expCols = expectedResponse.result.keySet()


### PR DESCRIPTION
This is the squashed version of VMC-223-fix-sql-queries, which includes:
SqlQueryPage.groovy: fixed getDefaultStoredProcedures & getUserStoredProcedures, and simplified those and getSystemStoredProcedures, by calling a new private method, getSpecifiedStoredProcedures, and, more importantly, correctly updating the Navigators they use (defaultStoredProcsHeader, userStoredProcsHeader & userStoredProcs), which were changed by VMC-210.
SqlQueriesTest.groovy: fixed problem where an unexpected error causes an
exception (introduced by my fix for ENG-8509).
expectedSystemStoredProcs.txt: just removed an obsolete comment.