### PR TITLE
Fix sporadic failures of load_remove_classes, in sqlcmdtest

### DIFF
--- a/tests/sqlcmd/baselines/batching/file_batch_positive.outbaseline
+++ b/tests/sqlcmd/baselines/batching/file_batch_positive.outbaseline
@@ -50,3 +50,9 @@ I  VCC
  3 platypii  
 
 (Returned 2 rows in #.##s)
+
+drop table t;
+Command succeeded.
+
+drop table s;
+Command succeeded.

--- a/tests/sqlcmd/baselines/simple/exec.outbaseline
+++ b/tests/sqlcmd/baselines/simple/exec.outbaseline
@@ -2,6 +2,9 @@
 drop table t if exists;
 Command succeeded.
 
+drop table t2 if exists;
+Command succeeded.
+
 create table t ( c integer, d varchar(4) );
 Command succeeded.
 

--- a/tests/sqlcmd/scripts/batching/file_batch_positive.in
+++ b/tests/sqlcmd/scripts/batching/file_batch_positive.in
@@ -12,3 +12,6 @@ insert into s values (3, 'platypii');
 select * from t order by i;
 
 select * from s order by i;
+
+drop table t;
+drop table s;

--- a/tests/sqlcmd/scripts/simple/exec.in
+++ b/tests/sqlcmd/scripts/simple/exec.in
@@ -1,4 +1,6 @@
 drop table t if exists;
+drop table t2 if exists;
+
 create table t ( c integer, d varchar(4) );
 create procedure p as
     select * from t where d between ? and ?;


### PR DESCRIPTION
file_batch_positive.in: added "drop table t;" and "drop table s;" to the end, to clean up the tables that are created by this test (which were sporadically causing load_remove_classes to fail).
file_batch_positive.outbaseline: added lines to the end, expecting the new "drop table t;" and "drop table s;" lines, plus two "Command succeeded." in response.
exec.in: added "drop table t2;" to (near) the beginning, just as a precaution.
exec.outbaseline: added lines to (near) the beginning, expecting the new "drop table t2;" line, plus a "Command succeeded." in response.