### PR TITLE
Fix catgen's bug

### DIFF
--- a/src/catgen/catalog.py
+++ b/src/catgen/catalog.py
@@ -463,7 +463,7 @@ def gencpp( classes, javaOnlyClasses, prepath, postpath ):
         for field in actualFields:
             if field.type[-1] == '*':
                 ftype = field.type.rstrip('*')
-                itr = ftype.lower() + '_iter'
+                itr = field.name.lower() + '_iter'
                 privname = 'm_' + field.name
                 tab = '   '
                 write(interp('$tab std::map<std::string, $ftype*>::const_iterator $itr = $privname.begin();', locals()))


### PR DESCRIPTION
If one catalogType class has more than one catalogMaps with same type signature, catalog.py will generate wrong C++ code.