### PR TITLE
Disallow aliases in DML

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDQL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDQL.java
@@ -1843,6 +1843,12 @@ public class ParserDQL extends ParserBase {
         Table      table = readTableName();
         SimpleName alias = null;
 
+        // A VoltDB extension to not allow aliases in DML
+        // This may need to change if/when we support subqueries in
+        // DELETE or UPDATE WHERE clauses.  For now it wreaks havoc
+        // with "DELETE FROM t LIMIT 1;" because the LIMIT is treated
+        // as an alias.
+        /* Disabling 13 lines ...
         if (operation != StatementTypes.TRUNCATE
                 && operation != StatementTypes.INSERT) {
             if (token.tokenType == Tokens.AS) {
@@ -1857,6 +1863,8 @@ public class ParserDQL extends ParserBase {
                 read();
             }
         }
+        ... 13 lines disabled */
+        // End of VoltDB extension
 
         if (table.isView) {
             switch (operation) {

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompilerErrorMsgs.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompilerErrorMsgs.java
@@ -208,12 +208,10 @@ public class TestVoltCompilerErrorMsgs extends TestCase {
                 + "constraint row_limit limit partition rows 5 "
                 + "execute (delete from partitioned_blah));");
 
-        /* hsql232: ENG-8298, limit constraints with delete statements
-        ddlErrorTest("Table T1 has invalid DELETE statement for LIMIT PARTITION ROWS constraint: parse error: SQL Syntax error",
+        ddlErrorTest("Table T1 has invalid DELETE statement for LIMIT PARTITION ROWS constraint: parse error: Syntax error",
                 "create table t1 (i integer, "
                 + "constraint row_limit limit partition rows 5 "
                 + "execute (delete frm partitioned_blah));");
-         */
     }
 
     public void testHexLiterals() throws Exception {

--- a/tests/frontend/org/voltdb/planner/TestPlansDML.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansDML.java
@@ -114,6 +114,20 @@ public class TestPlansDML extends PlannerTestCase {
 
     }
 
+    public void testDMLAliases() {
+        // These statements are all valid standard SQL, but we don't support them
+        // yet, as they wreak havoc with DELETE FROM foo ORDER BY ... LIMIT ...;
+        failToCompile("delete from p1 as foo", "Syntax error", "unexpected token: AS");
+        failToCompile("delete from p1 foo", "Syntax error", "unexpected token: FOO");
+        failToCompile("delete from p1 as foo where a = 0", "Syntax error", "unexpected token: AS");
+        failToCompile("delete from p1 foo where a = 1", "Syntax error", "unexpected token: FOO");
+
+        failToCompile("update p1 as foo set a = 1", "Syntax error", "unexpected token: AS");
+        failToCompile("update p1 foo set a = 30", "Syntax error", "unexpected token: FOO");
+        failToCompile("update p1 as foo set a = 50 where a = 0", "Syntax error", "unexpected token: AS");
+        failToCompile("update p1 foo set a = 99 where a = 1", "Syntax error", "unexpected token: FOO");
+    }
+
     public void testTruncateTable() {
         String tbs[] = {"R1", "P1"};
         for (String tb: tbs) {

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlDeleteSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlDeleteSuite.java
@@ -398,8 +398,7 @@ public class TestSqlDeleteSuite extends RegressionSuite {
         verifyStmtFails(
                 client,
                 "DELETE FROM R1 LIMIT 1",
-                //hsql232 ENG-8639 DELETE with LIMIT: "DELETE statement with LIMIT or OFFSET but no ORDER BY would produce non-deterministic results.");
-                "Syntax error in \"DELETE FROM R1 LIMIT 1\" unexpected token: 1"); //hsql232 ENG-8639 current undesirable behavior for DELETE with LIMIT:
+                "DELETE statement with LIMIT or OFFSET but no ORDER BY would produce non-deterministic results.");
 
         // This fails in a different way due to a bug in HSQL. OFFSET with no
         // LIMIT confuses HSQL.
@@ -409,13 +408,13 @@ public class TestSqlDeleteSuite extends RegressionSuite {
         verifyStmtFails(
                 client,
                 "DELETE FROM R1 LIMIT 1 OFFSET 1",
-                //hsql232 ENG-8639 DELETE with LIMIT: "DELETE statement with LIMIT or OFFSET but no ORDER BY would produce non-deterministic results.");
-                "Syntax error in \"DELETE FROM R1 LIMIT 1 OFFSET 1\" unexpected token: 1"); //hsql232 ENG-8639 current undesirable behavior for DELETE with LIMIT:
+                "DELETE statement with LIMIT or OFFSET but no ORDER BY would produce non-deterministic results.");
+
         verifyStmtFails(
                 client,
                 "DELETE FROM R1 OFFSET 1 LIMIT 1",
-                //hsql232 ENG-8639 DELETE with LIMIT: "DELETE statement with LIMIT or OFFSET but no ORDER BY would produce non-deterministic results.");
-                "Syntax error in \"DELETE FROM R1 OFFSET 1 LIMIT 1\" unexpected token: 1"); //hsql232 ENG-8639 current undesirable behavior for DELETE with LIMIT:
+                "DELETE statement with LIMIT or OFFSET but no ORDER BY would produce non-deterministic results.");
+
         verifyStmtFails(client, "DELETE FROM P1_VIEW ORDER BY ID ASC LIMIT 1",
                 "INSERT, UPDATE, DELETE or TRUNCATE not permitted for table or view");
 


### PR DESCRIPTION
This also fixes ENG-8298, which was just a trivial error message change.