### PR TITLE
Fix crash when creating expression index

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/types/NumberType.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/types/NumberType.java
@@ -1164,6 +1164,11 @@ public final class NumberType extends Type {
 
             case Types.SQL_REAL :
             case Types.SQL_DOUBLE :
+                // A VoltDB extension to avoid a crash when a is not an instance of Double
+                if (! (a instanceof Double)) {
+                    a = new Double(a.toString());
+                }
+                // End of VoltDB extension
                 double value = ((Double) a).doubleValue();
 
                 /** @todo - java 5 format change */
@@ -1258,6 +1263,11 @@ public final class NumberType extends Type {
 
             case Types.SQL_NUMERIC :
             case Types.SQL_DECIMAL :
+                // A VoltDB extension to avoid a crash when a is not an instance of BigDecimal
+                if (! (a instanceof BigDecimal)) {
+                    a = new BigDecimal(a.toString());
+                }
+                // End of VoltDB extension
                 return JavaSystem.toString((BigDecimal) a);
 
             default :

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -1909,7 +1909,8 @@ public class TestVoltCompiler extends TestCase {
         final String s =
                 "create table t(id integer not null, num integer not null);\n" +
                 "create unique index idx_ft_unique on t(abs(id+num));\n" +
-                "create index idx_ft on t(abs(num));";
+                "create index idx_ft on t(abs(num));\n" +
+                "create index poweridx on t(power(id, 2));";
         VoltCompiler c = compileForDDLTest(getPathForSchema(s), true);
         assertFalse(c.hasErrors());
         Database d = c.m_catalog.getClusters().get("cluster").getDatabases().get("database");


### PR DESCRIPTION
This issue was in code called from Expression.getSQL.  It seems like we only use this method when creating expression indexes.  We use the expression text to create a hash for the index in case we need an auto-generated name.  So the SQL text generated via this method isn't actually executed, it's just used to generate unique names.  So this is a low-risk change.

We don't use this method for other places where we capture SQL, e.g., views.  In those cases we capture text at the token level.
