### PR TITLE
Eng 8564 sqlcov adv sc subq slow

### DIFF
--- a/tests/scripts/SQLGenerator.py
+++ b/tests/scripts/SQLGenerator.py
@@ -33,6 +33,7 @@ from voltdbclient import * # for VoltDB types
 from optparse import OptionParser # for use in standalone test mode
 # Need these to print non-ascii characters:
 import codecs
+import sys
 UTF8Writer = codecs.getwriter('utf8')
 sys.stdout = UTF8Writer(sys.stdout)
 
@@ -280,7 +281,7 @@ class BaseGenerator:
     #                   |       |             |
     TYPE_PATTERN_GROUP  =                                           "type" # optional type for columns, values
     #                   |       |             |                      |
-    __EXPR_TEMPLATE = r"%s" r"(\[\s*" r"(#(?P<label>\w+)\s*)?" r"(?P<type>[\w=<>!]+)?\s*" \
+    __EXPR_TEMPLATE = r"%s" r"(\[\s*" r"(#(?P<label>\w+)\s*)?" r"(?P<type>\w+|[=<>!]{1,2})?\s*" \
                       r"(:(?P<min>(-?\d*)),(?P<max>(-?\d*)))?\s*" r"(null(?P<nullpct>(\d*)))?" r"\])?"
     #                         |                |                             |                   |
     #                         |                |                             |       end of [] attribute section
@@ -482,28 +483,29 @@ class ColumnGenerator(BaseGenerator):
         return prior_generators
 
 
-class TextGenerator(BaseGenerator):
-    """This replaces occurrences of token _text with a piece of text, such as a function name.
-       Within a statement, intended occurrences of the same text must use the same '#label'.
-       Attributes only matter on the first occurrence of "_text" for a given label.
-       As a convenience, forward references can use the __[#label] syntax instead of _text[#label]
-       to defer locking in attribute settings until a later _text occurrence.
+class SymbolGenerator(BaseGenerator):
+    """This replaces occurrences of token _symbol with a piece of text, such as a function name
+       or a comparison operator.
+       Within a statement, intended occurrences of the same symbol must use the same '#label'.
+       Attributes only matter on the first occurrence of "_symbol" for a given label.
+       As a convenience, forward references can use the __[#label] syntax instead of _symbol[#label]
+       to defer locking in attribute settings until a later _symbol occurrence.
     """
 
     def __init__(self):
-        BaseGenerator.__init__(self, "_text")
+        BaseGenerator.__init__(self, "_symbol")
 
     def prepare_params(self, attribute_groups):
-        self.__supertype = attribute_groups[BaseGenerator.TYPE_PATTERN_GROUP]
-        if not self.__supertype:
-            self.__supertype = ""
+        self.__symbol = attribute_groups[BaseGenerator.TYPE_PATTERN_GROUP]
+        if not self.__symbol:
+            self.__symbol = ""
 
     def configure_from_schema(self, schema, prior_generators):
         """ Get matching text values; does not actually use the schema.
         """
-        self.values.append(self.__supertype)
-        self.prior_generator = prior_generators.get("text")
-        prior_generators["text"] = self # new text generator at the head of the chain
+        self.values.append(self.__symbol)
+        self.prior_generator = prior_generators.get("symbol")
+        prior_generators["symbol"] = self # new symbol generator at the head of the chain
         return prior_generators
 
 
@@ -850,7 +852,7 @@ class SQLGenerator:
         self.__max_statements_per_pattern = -1
         self.__num_insert_statements      = 0
 
-    GENERATOR_TYPES = (TableGenerator, ColumnGenerator, TextGenerator, ConstantGenerator, IdGenerator)
+    GENERATOR_TYPES = (TableGenerator, ColumnGenerator, SymbolGenerator, ConstantGenerator, IdGenerator)
 
     UNRESOLVED_PUNCTUATION = re.compile(r'[][#@]') # Literally, ']', '[', '#', or '@'.
     UNRESOLVED_GENERATOR = re.compile(r'(^|\W)[_]')

--- a/tests/scripts/SQLGenerator.py
+++ b/tests/scripts/SQLGenerator.py
@@ -280,7 +280,7 @@ class BaseGenerator:
     #                   |       |             |
     TYPE_PATTERN_GROUP  =                                           "type" # optional type for columns, values
     #                   |       |             |                      |
-    __EXPR_TEMPLATE = r"%s" r"(\[\s*" r"(#(?P<label>\w+)\s*)?" r"(?P<type>\w+)?\s*" \
+    __EXPR_TEMPLATE = r"%s" r"(\[\s*" r"(#(?P<label>\w+)\s*)?" r"(?P<type>[\w=<>!]+)?\s*" \
                       r"(:(?P<min>(-?\d*)),(?P<max>(-?\d*)))?\s*" r"(null(?P<nullpct>(\d*)))?" r"\])?"
     #                         |                |                             |                   |
     #                         |                |                             |       end of [] attribute section
@@ -847,7 +847,7 @@ class SQLGenerator:
         self.__statements = self.__template.get_statements()
 
         self.__min_statements_per_pattern = sys.maxint
-        self.__max_statements_per_pattern = 0
+        self.__max_statements_per_pattern = -1
         self.__num_insert_statements      = 0
 
     GENERATOR_TYPES = (TableGenerator, ColumnGenerator, TextGenerator, ConstantGenerator, IdGenerator)

--- a/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
+++ b/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
@@ -5,17 +5,6 @@ DELETE FROM @dmltable
 INSERT INTO @dmltable VALUES (@insertvals)
 
 --- Define "place-holders" used in the queries below
---- comparison operators in 3 groups, to save execution time
-{_cmp1 |= "="}
-{_cmp1 |= "<>"}
-{_cmp2 |= "<"}
-{_cmp2 |= ">="}
-{_cmp3 |= ">"}
-{_cmp3 |= "<="}
---{_cmp3 |= "!="} -- Apparently, an HSQL-supported alias for the standard <>
-{_cmp13 |= "_cmp1"}
-{_cmp13 |= "_cmp3"}
-
 {_optionaloffset |= ""}
 {_optionaloffset |= "OFFSET 2"}
 {_optionallimitoffset |= ""}
@@ -53,9 +42,9 @@ INSERT INTO @dmltable VALUES (@insertvals)
 --- Test Scalar Subquery Advanced cases
 
 --- Queries with scalar subqueries in the SELECT clause (with optional ORDER BY, LIMIT, OFFSET, GROUP BY or HAVING clauses)
-SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables                                                                     ) FROM @fromtables    A1 _optionalorderbyidlimitoffset
-SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A2.__[#agg]                   _cmp13                  __[#agg]) FROM @fromtables AS A2 _optionalorderbyidlimitoffset
-SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A3._variable[@comparabletype] _cmp2 _variable[@comparabletype]) FROM @fromtables    A3 _optionalorderbyidlimitoffset
+SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables                                                                    ) FROM @fromtables    A1 _optionalorderbyidlimitoffset
+SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A2.__[#agg]                   _cmp                   __[#agg]) FROM @fromtables AS A2 _optionalorderbyidlimitoffset
+SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A3._variable[@comparabletype] _cmp _variable[@comparabletype]) FROM @fromtables    A3 _optionalorderbyidlimitoffset
 
 --- Queries with scalar subqueries in the WHERE clause (with optional ORDER BY, LIMIT, OFFSET, GROUP BY or HAVING clauses)
 SELECT _variable[#ord]         FROM @fromtables A11 WHERE __[#ord] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](       __[#ord]) FROM @fromtables                                         )    _grouporderbyvarlimoffhaving
@@ -77,11 +66,12 @@ SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _symbol[#cmp 
 --SELECT (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp A25.__[#agg]                  )    FROM @fromtables A25 ORDER BY 1   _sortorder _optionallimitoffset
 --SELECT (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp A26._variable[@comparabletype]) C0 FROM @fromtables A26 ORDER BY C0  _sortorder _optionallimitoffset
 
---- Queries with scalar subqueries in the GROUP BY or HAVING clause (these work)
-SELECT (SELECT _symbol[#agfcn @agg](_variable[#agg])                 FROM @fromtables WHERE _variable[@comparabletype]            _cmp  A31._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A31 GROUP BY C0
+--- Queries with scalar subqueries in the GROUP BY clause (these work)
+SELECT (SELECT _symbol[#agfcn @agg](_variable[#agg])                 FROM @fromtables WHERE _variable[@comparabletype]              _cmp  A31._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A31 GROUP BY C0
 SELECT (SELECT _symbol[#agfcn @agg](_variable[#agg @comparabletype]) FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A32._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A32 GROUP BY C0 HAVING __[#agfcn](__[#agg]) __[#cmp] 12
 SELECT (SELECT _symbol[#agfcn _stringagg](_variable[#agg string])    FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A33._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A33 GROUP BY C0 HAVING __[#agfcn](__[#agg]) __[#cmp] 'Z'
---- These do not currently work (meanwhile, commented out to save execution time)
+--- Queries with scalar subqueries (or just 'C1') in the HAVING clause
+--- These do not currently work, due to ENG-8915 & ENG-8306 (meanwhile, commented out to save execution time)
 --SELECT (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A34._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A34 GROUP BY C0 HAVING C1 __[#cmp] 12
 --SELECT _variable[#grp] C0, _symbol[#agfcn @agg](_variable[#agg]) C1 FROM @fromtables A35 GROUP BY C0 HAVING (SELECT __[#agfcn](_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A35._variable[@comparabletype]) __[#cmp] 12
 --SELECT _variable[#grp] C0, _symbol[#agfcn @agg](_variable[#agg]) C1 FROM @fromtables A36 GROUP BY C0 HAVING __[#agfcn](__[#agg]) _symbol[#cmp _cmp] (SELECT __[#agfcn](__[#agg]) FROM @fromtables WHERE __[#grp] __[#cmp] A36.__[#grp])

--- a/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
+++ b/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
@@ -58,16 +58,16 @@ SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A2.__[#agg] 
 SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A3._variable[@comparabletype] _cmp2 _variable[@comparabletype]) FROM @fromtables    A3 _optionalorderbyidlimitoffset
 
 --- Queries with scalar subqueries in the WHERE clause (with optional ORDER BY, LIMIT, OFFSET, GROUP BY or HAVING clauses)
-SELECT _variable[#ord]         FROM @fromtables A11 WHERE __[#ord] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](       __[#ord]) FROM @fromtables                                         )    _grouporderbyvarlimoffhaving
-SELECT _variable[#ord numeric] FROM @fromtables A12 WHERE __[#ord] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](_variable[#agg]) FROM @fromtables                                         )    _grouporderbyvarlimoffhaving
+SELECT _variable[#ord]         FROM @fromtables A11 WHERE __[#ord] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](       __[#ord]) FROM @fromtables                                         )    _grouporderbyvarlimoffhaving
+SELECT _variable[#ord numeric] FROM @fromtables A12 WHERE __[#ord] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables                                         )    _grouporderbyvarlimoffhaving
 --- TODO: uncomment, once ENG-8292 (NPE in Hsql for HAVING query, causing sqlCoverage mismatches) is fixed
---SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#ord] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](       __[#ord]) FROM @fromtables WHERE     __[#ord] __[#cmp] A13.__[#ord])    _grouporderbyvarlimoffhaving
-SELECT _variable[#ord numeric] FROM @fromtables A14 WHERE __[#ord] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE A14.__[#agg] __[#cmp]     __[#agg])    _grouporderbyvarlimoffhaving
+--SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#ord] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](       __[#ord]) FROM @fromtables WHERE     __[#ord] __[#cmp] A13.__[#ord])    _grouporderbyvarlimoffhaving
+SELECT _variable[#ord numeric] FROM @fromtables A14 WHERE __[#ord] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE A14.__[#agg] __[#cmp]     __[#agg])    _grouporderbyvarlimoffhaving
 
 --- TODO: uncomment this, once ENG-8234 is fixed, so the mismatches disappear:
---SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[#sub] __[#cmp] A15.__[#sub]) _grouporderbyvarlimoffhaving
+--SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[#sub] __[#cmp] A15.__[#sub]) _grouporderbyvarlimoffhaving
 --- TODO: delete this, once ENG-8234 is fixed, so the above mismatches disappear:
-SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[#sub] __[#cmp] A15.__[#sub]) _tempgrouporderbyvarlimoffhaving
+SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[#sub] __[#cmp] A15.__[#sub]) _tempgrouporderbyvarlimoffhaving
 
 --- Queries with scalar subqueries in the ORDER BY clause (these currently return errors, but probably should not - see ENG-8239)
 --- TODO: uncomment out, if/when ENG-8239 is fixed (meanwhile, commented out to save execution time)
@@ -78,10 +78,10 @@ SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _text[#cmp _c
 --SELECT (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp A26._variable[@comparabletype]) C0 FROM @fromtables A26 ORDER BY C0  _sortorder _optionallimitoffset
 
 --- Queries with scalar subqueries in the GROUP BY or HAVING clause (these work)
-SELECT (SELECT _text[#agfcn @agg](_variable[#agg])                 FROM @fromtables WHERE _variable[@comparabletype]            _cmp  A31._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A31 GROUP BY C0
-SELECT (SELECT _text[#agfcn @agg](_variable[#agg @comparabletype]) FROM @fromtables WHERE _variable[@comparabletype] _text[#cmp _cmp] A32._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A32 GROUP BY C0 HAVING __[#agfcn](__[#agg]) __[#cmp] 12
-SELECT (SELECT _text[#agfcn _stringagg](_variable[#agg string])    FROM @fromtables WHERE _variable[@comparabletype] _text[#cmp _cmp] A33._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A33 GROUP BY C0 HAVING __[#agfcn](__[#agg]) __[#cmp] 'Z'
+SELECT (SELECT _symbol[#agfcn @agg](_variable[#agg])                 FROM @fromtables WHERE _variable[@comparabletype]            _cmp  A31._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A31 GROUP BY C0
+SELECT (SELECT _symbol[#agfcn @agg](_variable[#agg @comparabletype]) FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A32._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A32 GROUP BY C0 HAVING __[#agfcn](__[#agg]) __[#cmp] 12
+SELECT (SELECT _symbol[#agfcn _stringagg](_variable[#agg string])    FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A33._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A33 GROUP BY C0 HAVING __[#agfcn](__[#agg]) __[#cmp] 'Z'
 --- These do not currently work (meanwhile, commented out to save execution time)
---SELECT (SELECT _text[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _text[#cmp _cmp] A34._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A34 GROUP BY C0 HAVING C1 __[#cmp] 12
---SELECT _variable[#grp] C0, _text[#agfcn @agg](_variable[#agg]) C1 FROM @fromtables A35 GROUP BY C0 HAVING (SELECT __[#agfcn](_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _text[#cmp _cmp] A35._variable[@comparabletype]) __[#cmp] 12
---SELECT _variable[#grp] C0, _text[#agfcn @agg](_variable[#agg]) C1 FROM @fromtables A36 GROUP BY C0 HAVING __[#agfcn](__[#agg]) _text[#cmp _cmp] (SELECT __[#agfcn](__[#agg]) FROM @fromtables WHERE __[#grp] __[#cmp] A36.__[#grp])
+--SELECT (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A34._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A34 GROUP BY C0 HAVING C1 __[#cmp] 12
+--SELECT _variable[#grp] C0, _symbol[#agfcn @agg](_variable[#agg]) C1 FROM @fromtables A35 GROUP BY C0 HAVING (SELECT __[#agfcn](_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A35._variable[@comparabletype]) __[#cmp] 12
+--SELECT _variable[#grp] C0, _symbol[#agfcn @agg](_variable[#agg]) C1 FROM @fromtables A36 GROUP BY C0 HAVING __[#agfcn](__[#agg]) _symbol[#cmp _cmp] (SELECT __[#agfcn](__[#agg]) FROM @fromtables WHERE __[#grp] __[#cmp] A36.__[#grp])

--- a/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
+++ b/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
@@ -34,8 +34,8 @@ INSERT INTO @dmltable VALUES (@insertvals)
 {_temp0grouporderbyvarlimoffhaving |= ""}
 {_temp0grouporderbyvarlimoffhaving |= "LIMIT 1000"}
 {_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord]"}
-{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord] HAVING @agg(_variable[@comparabletype]) _cmp 12"}
-{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord] HAVING _genericagg(_variable[string])   _cmp 'Z'"}
+{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord] HAVING __[#agfcn](_variable[@comparabletype]) __[#cmp] 12"}
+{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord] HAVING _stringagg(_variable[string])          __[#cmp] 'Z'"}
 
 {_grouporderbyvarlimoffhaving |= "_temp0grouporderbyvarlimoffhaving"}
 {_grouporderbyvarlimoffhaving |= "ORDER BY __[#ord] _sortorder _optionallimitoffset"}
@@ -58,30 +58,30 @@ SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A2.__[#agg] 
 SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A3._variable[@comparabletype] _cmp2 _variable[@comparabletype]) FROM @fromtables    A3 _optionalorderbyidlimitoffset
 
 --- Queries with scalar subqueries in the WHERE clause (with optional ORDER BY, LIMIT, OFFSET, GROUP BY or HAVING clauses)
-SELECT _variable[#ord]         FROM @fromtables A11 WHERE __[#ord] _cmp1 (SELECT @agg(       __[#ord]) FROM @fromtables                                      ) _grouporderbyvarlimoffhaving
-SELECT _variable[#ord numeric] FROM @fromtables A12 WHERE __[#ord] _cmp2 (SELECT @agg(_variable[#agg]) FROM @fromtables                                      ) _grouporderbyvarlimoffhaving
+SELECT _variable[#ord]         FROM @fromtables A11 WHERE __[#ord] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](       __[#ord]) FROM @fromtables                                         )    _grouporderbyvarlimoffhaving
+SELECT _variable[#ord numeric] FROM @fromtables A12 WHERE __[#ord] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](_variable[#agg]) FROM @fromtables                                         )    _grouporderbyvarlimoffhaving
 --- TODO: uncomment, once ENG-8292 (NPE in Hsql for HAVING query, causing sqlCoverage mismatches) is fixed
---SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#ord] _cmp3 (SELECT @agg(       __[#ord]) FROM @fromtables WHERE     __[#ord] _cmp3 A13.__[#ord]) _grouporderbyvarlimoffhaving
-SELECT _variable[#ord numeric] FROM @fromtables A14 WHERE __[#ord] _cmp2 (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A14.__[#agg] _cmp2     __[#agg]) _grouporderbyvarlimoffhaving
+--SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#ord] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](       __[#ord]) FROM @fromtables WHERE     __[#ord] __[#cmp] A13.__[#ord])    _grouporderbyvarlimoffhaving
+SELECT _variable[#ord numeric] FROM @fromtables A14 WHERE __[#ord] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE A14.__[#agg] __[#cmp]     __[#agg])    _grouporderbyvarlimoffhaving
 
 --- TODO: uncomment this, once ENG-8234 is fixed, so the mismatches disappear:
---SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _cmp3 (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[#sub] _cmp3 A15.__[#sub]) _grouporderbyvarlimoffhaving
+--SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[#sub] __[#cmp] A15.__[#sub]) _grouporderbyvarlimoffhaving
 --- TODO: delete this, once ENG-8234 is fixed, so the above mismatches disappear:
-SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _cmp3 (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[#sub] _cmp3 A15.__[#sub]) _tempgrouporderbyvarlimoffhaving
+SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _text[#cmp _cmp] (SELECT _text[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[#sub] __[#cmp] A15.__[#sub]) _tempgrouporderbyvarlimoffhaving
 
 --- Queries with scalar subqueries in the ORDER BY clause (these currently return errors, but probably should not - see ENG-8239)
 --- TODO: uncomment out, if/when ENG-8239 is fixed (meanwhile, commented out to save execution time)
---SELECT @idcol FROM @fromtables A22 ORDER BY (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp1 A22.__[#agg]                  ) _sortorder _optionallimitoffset
---SELECT @idcol FROM @fromtables A23 ORDER BY (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp2 A23._variable[@comparabletype]) _sortorder _optionallimitoffset
---SELECT (SELECT @agg(_variable)       FROM @fromtables                                                                      ) C0 FROM @fromtables A24 ORDER BY C0 _sortorder _optionallimitoffset
---SELECT (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp3 A25.__[#agg]                  )    FROM @fromtables A25 ORDER BY 1  _sortorder _optionallimitoffset
---SELECT (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp1 A26._variable[@comparabletype]) C0 FROM @fromtables A26 ORDER BY C0 _sortorder _optionallimitoffset
+--SELECT @idcol FROM @fromtables A22 ORDER BY (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp A22.__[#agg]                  ) _sortorder _optionallimitoffset
+--SELECT @idcol FROM @fromtables A23 ORDER BY (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp A23._variable[@comparabletype]) _sortorder _optionallimitoffset
+--SELECT (SELECT @agg(_variable)       FROM @fromtables                                                                     ) C0 FROM @fromtables A24 ORDER BY C0  _sortorder _optionallimitoffset
+--SELECT (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp A25.__[#agg]                  )    FROM @fromtables A25 ORDER BY 1   _sortorder _optionallimitoffset
+--SELECT (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp A26._variable[@comparabletype]) C0 FROM @fromtables A26 ORDER BY C0  _sortorder _optionallimitoffset
 
 --- Queries with scalar subqueries in the GROUP BY or HAVING clause (these work)
-SELECT (SELECT @agg(_variable[#agg])                 FROM @fromtables WHERE _variable[@comparabletype] _cmp1 A31._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A31 GROUP BY C0
-SELECT (SELECT @agg(_variable[#agg @comparabletype]) FROM @fromtables WHERE _variable[@comparabletype] _cmp2 A32._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A32 GROUP BY C0 HAVING @agg(__[#agg]) _cmp 12
-SELECT (SELECT _genericagg(_variable[#agg string])   FROM @fromtables WHERE _variable[@comparabletype] _cmp3 A33._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A33 GROUP BY C0 HAVING @agg(__[#agg]) _cmp 'Z'
+SELECT (SELECT _text[#agfcn @agg](_variable[#agg])                 FROM @fromtables WHERE _variable[@comparabletype]            _cmp  A31._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A31 GROUP BY C0
+SELECT (SELECT _text[#agfcn @agg](_variable[#agg @comparabletype]) FROM @fromtables WHERE _variable[@comparabletype] _text[#cmp _cmp] A32._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A32 GROUP BY C0 HAVING __[#agfcn](__[#agg]) __[#cmp] 12
+SELECT (SELECT _text[#agfcn _stringagg](_variable[#agg string])    FROM @fromtables WHERE _variable[@comparabletype] _text[#cmp _cmp] A33._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A33 GROUP BY C0 HAVING __[#agfcn](__[#agg]) __[#cmp] 'Z'
 --- These do not currently work (meanwhile, commented out to save execution time)
---SELECT (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _cmp A34._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A34 GROUP BY C0 HAVING C1 _cmp 12
---SELECT _variable[#grp] C0, @agg(_variable[#agg]) C1  FROM @fromtables A35 GROUP BY C0 HAVING (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _cmp A35._variable[@comparabletype]) _cmp 12
-SELECT _variable[#grp] C0, @agg(_variable[#agg]) C1 FROM @fromtables A36 GROUP BY C0 HAVING @agg(__[#agg]) _cmp (SELECT @agg(__[#agg]) FROM @fromtables WHERE __[#grp] _cmp A36.__[#grp])
+--SELECT (SELECT _text[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _text[#cmp _cmp] A34._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A34 GROUP BY C0 HAVING C1 __[#cmp] 12
+--SELECT _variable[#grp] C0, _text[#agfcn @agg](_variable[#agg]) C1 FROM @fromtables A35 GROUP BY C0 HAVING (SELECT __[#agfcn](_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _text[#cmp _cmp] A35._variable[@comparabletype]) __[#cmp] 12
+--SELECT _variable[#grp] C0, _text[#agfcn @agg](_variable[#agg]) C1 FROM @fromtables A36 GROUP BY C0 HAVING __[#agfcn](__[#agg]) _text[#cmp _cmp] (SELECT __[#agfcn](__[#agg]) FROM @fromtables WHERE __[#grp] __[#cmp] A36.__[#grp])

--- a/tests/scripts/examples/sql_coverage/grammar.sql
+++ b/tests/scripts/examples/sql_coverage/grammar.sql
@@ -14,8 +14,11 @@
 --{_stringfun |= "LOWER"}
 --{_stringfun |= "UPPER"}
 
-{_genericagg |= "MIN"}
-{_genericagg |= "MAX"}
+-- Aggregate functions that accept a string (or numeric) column and return the same type
+{_stringagg |= "MIN"}
+{_stringagg |= "MAX"}
+
+{_genericagg |= "_stringagg"}
 {_genericagg |= "COUNT"}
 
 {_numagg |= "SUM"}


### PR DESCRIPTION
Makes the advanced-scalar-subquery test suite (of sqlCoverage) much faster, mainly by reusing the same aggregate function multiple times in the same query, and similarly, using the same comparison operator multiple times in the same query (instead of every possible combination of aggregate functions and comparison operators); with code changes to support this.