### PR TITLE
Adds txnid2 testing for missing cmdlogs after a recover.

### DIFF
--- a/tests/test_apps/txnid-selfcheck2/run.sh
+++ b/tests/test_apps/txnid-selfcheck2/run.sh
@@ -71,6 +71,10 @@ function server() {
     $VOLTDB create -d deployment.xml -l $LICENSE -H $HOST $APPNAME.jar
 }
 
+function recover() {
+    $VOLTDB recover -d deployment.xml -l $LICENSE -H $HOST
+}
+
 # run the client that drives the example
 function client() {
     benchmark
@@ -106,7 +110,7 @@ function async-benchmark() {
 }
 
 function help() {
-    echo "Usage: ./run.sh {clean|catalog|server|async-benchmark|aysnc-benchmark-help}"
+    echo "Usage: ./run.sh {clean|catalog|server|recover|async-benchmark|aysnc-benchmark-help}"
 }
 
 # Run the target passed as the first arg on the command line

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/Benchmark.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/Benchmark.java
@@ -24,6 +24,7 @@
 package txnIdSelfCheck;
 
 import java.text.SimpleDateFormat;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -67,6 +68,7 @@ public class Benchmark {
     static final String HORIZONTAL_RULE =
             "----------" + "----------" + "----------" + "----------" +
             "----------" + "----------" + "----------" + "----------";
+    final DecimalFormat twoDForm = new DecimalFormat("#.##");
 
     // validated command line configuration
     final Config config;
@@ -94,6 +96,8 @@ public class Benchmark {
     public static AtomicLong txnCount = new AtomicLong();
     private long txnCountAtLastCheck;
     private long lastProgressTimestamp = System.currentTimeMillis();
+    private VoltTable sysinfo;
+    private boolean isSynchronous = false;
 
     // For retry connections
     private final ExecutorService es = Executors.newCachedThreadPool(new ThreadFactory() {
@@ -521,6 +525,18 @@ public class Benchmark {
         }
     };
 
+    private void printClientStats() {
+        int least = ClientThread.leastMissingCmds;
+        log.info("Starting stats output for client threads.  \n"
+                + "Number of Running Client Threads --------------- : "+ClientThread.numTotalClients+"\n"
+                + "Clients Missing Transactions After Recover ----- : "+ClientThread.numClientsMissingCmds+"\n"
+                + "Max Missing Transactions For One Client -------- : "+ClientThread.maxMissingCmds+"\n"
+                + "Min Missing Transactions For One Client -------- : "+(least == Short.MAX_VALUE ? 0 : least)+"\n"
+                + "Total Missing Transactions For All Clients ----- : "+ClientThread.totalMissingCmds+"\n"
+                + "Avg Missing Transactions Per Client Missing Data : "+(least == Short.MAX_VALUE ? "n/a" :
+                    Double.valueOf(twoDForm.format((double) ClientThread.totalMissingCmds/ClientThread.numClientsMissingCmds))));
+    }
+
     BigTableLoader partBiglt = null;
     BigTableLoader replBiglt = null;
     TruncateTableLoader partTrunclt = null;
@@ -559,6 +575,25 @@ public class Benchmark {
 
         // connect to one or more servers, loop until success
         connect();
+        long connectTime = System.currentTimeMillis();
+
+        sysinfo = client.callProcedure("@SystemInformation", "deployment").getResults()[0];
+        while (sysinfo.advanceRow()) {
+            String property = sysinfo.getString(0);
+            if (property.equals("commandlogmode")) {
+                String value = sysinfo.getString(1);
+                if (value.equals("sync"))
+                    isSynchronous = true;
+            }
+        }
+
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() {
+                if (isSynchronous)
+                    printClientStats();
+            }
+        });
+
 
         // get partition count
         int partitionCount = 0;
@@ -601,7 +636,7 @@ public class Benchmark {
         if (!config.disabledThreads.contains("clients")) {
             for (byte cid = (byte) config.threadoffset; cid < config.threadoffset + config.threads; cid++) {
                 ClientThread clientThread = new ClientThread(cid, txnCount, client, processor, permits,
-                        config.allowinprocadhoc, config.mpratio);
+                        config.allowinprocadhoc, config.mpratio, isSynchronous);
                 //clientThread.start(); # started after preload is complete
                 clientThreads.add(clientThread);
             }
@@ -709,10 +744,18 @@ public class Benchmark {
             // XXX/PSR ddlt.start();
         }
 
-        log.info("All threads started...");
-
+        log.info("All threads started in "+(System.currentTimeMillis() - connectTime)+" ms ...");
+        // waiting for things to initialize
+        Thread.sleep(5000);
         while (true) {
-            Thread.sleep(Integer.MAX_VALUE);
+            while (!isSynchronous || ClientThread.currActiveClients > 0) {
+                Thread.sleep(1000);
+            }
+            while (ClientThread.currActiveClients < ClientThread.numTotalClients || ClientThread.numTotalClients == 0) {
+                Thread.sleep(1000);
+            }
+            if (ClientThread.numClientsMissingCmds > 0)
+                printClientStats();
         }
     }
 
@@ -731,31 +774,34 @@ public class Benchmark {
                 int exitcode = 0;
 
                 // check if loaders are done or still working
-                int lpcc = partBiglt.getPercentLoadComplete();
-                if (!partBiglt.isAlive() && lpcc < 100) {
-                    exitcode = reportDeadThread(partBiglt, " yet only " + Integer.toString(lpcc) + "% rows have been loaded");
-                } else
-                    log.info(partBiglt + " was at " + lpcc + "% of rows loaded");
-                lpcc = replBiglt.getPercentLoadComplete();
-                if (!replBiglt.isAlive() && lpcc < 100) {
-                    exitcode = reportDeadThread(replBiglt, " yet only " + Integer.toString(lpcc) + "% rows have been loaded");
-                } else
-                    log.info(replBiglt + " was at " + lpcc + "% of rows loaded");
+                if (partBiglt != null) {
+                    int lpcc = partBiglt.getPercentLoadComplete();
+                    if (!partBiglt.isAlive() && lpcc < 100) {
+                        exitcode = reportDeadThread(partBiglt, " yet only " + Integer.toString(lpcc) + "% rows have been loaded");
+                    } else
+                        log.info(partBiglt + " was at " + lpcc + "% of rows loaded");
+                } if (replBiglt != null) {
+                    int lpcc = replBiglt.getPercentLoadComplete();
+                    if (!replBiglt.isAlive() && lpcc < 100) {
+                        exitcode = reportDeadThread(replBiglt, " yet only " + Integer.toString(lpcc) + "% rows have been loaded");
+                    } else
+                        log.info(replBiglt + " was at " + lpcc + "% of rows loaded");
+                }
                 // check if all threads still alive
-                if (!partTrunclt.isAlive())
+                if (partTrunclt != null && !partTrunclt.isAlive())
                     exitcode = reportDeadThread(partTrunclt);
-                if (!replTrunclt.isAlive())
+                if (replTrunclt != null && !replTrunclt.isAlive())
                     exitcode = reportDeadThread(replTrunclt);
                 /* XXX if (! partLoadlt.isAlive())
                     exitcode = reportDeadThread(partLoadlt);
                 if (! replLoadlt.isAlive())
                     exitcode = reportDeadThread(replLoadlt);
                 */
-                if (!readThread.isAlive())
+                if (readThread != null && !readThread.isAlive())
                     exitcode = reportDeadThread(readThread);
-                if (!config.disableadhoc && !adHocMayhemThread.isAlive())
+                if (adHocMayhemThread != null && !config.disableadhoc && !adHocMayhemThread.isAlive())
                     exitcode = reportDeadThread(adHocMayhemThread);
-                if (!idpt.isAlive())
+                if (idpt != null && !idpt.isAlive())
                     exitcode = reportDeadThread(idpt);
                 /* XXX if (! ddlt.isAlive())
                     exitcode = reportDeadThread(ddlt);*/
@@ -813,9 +859,9 @@ public class Benchmark {
                 }
                 System.exit(exitcode);
             }
-    };
-    runTimer.schedule(runEndTask, config.duration * 1000);
-}
+        };
+        runTimer.schedule(runEndTask, config.duration * 1000);
+    }
 
     /**
      * Main routine creates a benchmark instance and kicks off the run method.

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateBaseProc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateBaseProc.java
@@ -112,15 +112,26 @@ public class UpdateBaseProc extends VoltProcedure {
         data = retval[3];
         validateCIDData(data, getClass().getName());
 
+        if (data.getRowCount() > 0) {
         VoltTableRow row = data.fetchRow(0);
-        if (row.getVarbinary("value").length == 0)
-            throw new VoltAbortException("Value column contained no data in UpdateBaseProc");
-
+            if (row.getVarbinary("value").length == 0)
+                throw new VoltAbortException("Value column contained no data in UpdateBaseProc");
+    }
         if (shouldRollback != 0) {
             throw new VoltAbortException("EXPECTED ROLLBACK");
         }
+    return retval;
+    }
 
-        return retval;
+    private String getArrayString(int[] ary) {
+        String ret = "[";
+        if (ary.length > 0)
+            ret += "cid0:"+ary[0];
+        for (int i=1;i<ary.length;i++) {
+            ret += ",cid"+i+":"+ary[i];
+        }
+        ret += "]";
+        return ret;
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
This feature can be configured by disabling all threads besides the client threads by copying the list of threads in the async-benchmark function of the run.sh script, pasting it to the disabled threads parameter, and deleting the "clients" item from the list. 