### PR TITLE
ENG-8889: Fix concurrent modification of the durability listener.

### DIFF
--- a/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
+++ b/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
@@ -23,6 +23,9 @@ import org.voltdb.CommandLog;
 import org.voltdb.CommandLog.DurabilityListener;
 import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
 
+/**
+ * This class is not thread-safe. Most of its usage is on the Site thread.
+ */
 public class SpDurabilityListener implements DurabilityListener {
 
     // No command logging

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -151,6 +151,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     // Need to track when command log replay is complete (even if not performed) so that
     // we know when we can start writing viable replay sets to the fault log.
     boolean m_replayComplete = false;
+    // The DurabilityListener is not thread-safe. Access it only on the Site thread.
     private final DurabilityListener m_durabilityListener;
     //Generator of pre-IV2ish timestamp based unique IDs
     private final UniqueIdGenerator m_uniqueIdGenerator;
@@ -182,8 +183,14 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     }
 
     @Override
-    public void setDurableUniqueIdListener(DurableUniqueIdListener listener) {
-        m_durabilityListener.setUniqueIdListener(listener);
+    public void setDurableUniqueIdListener(final DurableUniqueIdListener listener) {
+        m_tasks.offer(new SiteTaskerRunnable() {
+            @Override
+            void run()
+            {
+                m_durabilityListener.setUniqueIdListener(listener);
+            }
+        });
     }
 
     public void setDRGateway(PartitionDRGateway gateway)


### PR DESCRIPTION
The DR consumer may add itself to the durability listener after node
initialization. The DurabilityListener is not thread-safe, the accesses
to the listener list should be on the Site thread.