### PR TITLE
ENG-8872: Update persistent table logic so that it will have atleast one block assigned to it 

### DIFF
--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -886,7 +886,9 @@ inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block)
 
     bool transitioningToBlockWithSpace = !block->hasFreeTuples();
 
+    //uint32_t activeTuples = block->activeTuples();
     int retval = block->freeTuple(tuple.address());
+    //std::cout<<"Active Tuples: before free: "<< activeTuples << " after free: "<<block->activeTuples() << " number of blocks: " << m_data.size()<<std::endl;
     if (retval != -1) {
         //Check if if the block is currently pending snapshot
         if (m_blocksNotPendingSnapshot.find(block) != m_blocksNotPendingSnapshot.end()) {
@@ -901,7 +903,10 @@ inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block)
         }
     }
 
-    if (block->isEmpty()) {
+    // if the current block is empty and there are more than one blocks, release the existing
+    // empty block.
+    if (block->isEmpty() && m_data.size() > 1) {
+        //std::cout<<"release the block"<<std::endl;
         m_data.erase(block->address());
         m_blocksWithSpace.erase(block);
         m_blocksNotPendingSnapshot.erase(block);

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -92,6 +92,16 @@ Table* TableFactory::getPersistentTable(
     // initialize stats for the table
     configureStats(databaseId, name, table);
 
+    if(!exportOnly) {
+        PersistentTable *persistentTable = dynamic_cast<PersistentTable*>(table);
+        assert(persistentTable);
+        if(persistentTable) {
+            TBPtr block = persistentTable->allocateNextBlock();
+            if (block->hasFreeTuples()) {
+                persistentTable->m_blocksWithSpace.insert(block);
+            }
+        }
+    }
     return dynamic_cast<Table*>(table);
 }
 

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -93,16 +93,12 @@ Table* TableFactory::getPersistentTable(
     configureStats(databaseId, name, table);
 
     if(!exportOnly) {
-        PersistentTable *persistentTable = dynamic_cast<PersistentTable*>(table);
-        assert(persistentTable);
-        if(persistentTable) {
-            TBPtr block = persistentTable->allocateNextBlock();
-            if (block->hasFreeTuples()) {
-                persistentTable->m_blocksWithSpace.insert(block);
-            }
-        }
+        PersistentTable *persistentTable = static_cast<PersistentTable*>(table);
+        TBPtr block = persistentTable->allocateNextBlock();
+        assert(block->hasFreeTuples());
+        persistentTable->m_blocksWithSpace.insert(block);
     }
-    return dynamic_cast<Table*>(table);
+    return table;
 }
 
 TempTable* TableFactory::getTempTable(

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -364,7 +364,9 @@ TEST_F(CompactionTest, BasicCompaction) {
         m_table->deleteTuple(tuple, true);
     }
     m_table->doForcedCompaction();
-    ASSERT_EQ( m_table->m_data.size(), 0);
+    // ENG-8872: at any given point, persistent table will have atleast one block available with m_data
+    // even if that block is empty
+    ASSERT_EQ( m_table->m_data.size(), 1);
     ASSERT_EQ( m_table->activeTupleCount(), 0);
 }
 
@@ -507,7 +509,7 @@ TEST_F(CompactionTest, CompactionWithCopyOnWrite) {
 
     }
     m_table->doForcedCompaction();
-    ASSERT_EQ( m_table->m_data.size(), 0);
+    ASSERT_EQ( m_table->m_data.size(), 1);
     ASSERT_EQ( m_table->activeTupleCount(), 0);
     for (int ii = 0; ii < tupleCount; ii++) {
         ASSERT_TRUE(COWTuples.find(ii) != COWTuples.end());

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -290,7 +290,8 @@ TEST_F(PersistentTableTest, TruncateTableTest) {
         engine->getTable("T"));
     ASSERT_NE(NULL, table);
 
-    int tuplesToInsert = 10;
+    const int tuplesToInsert = 10;
+    (void) tuplesToInsert;  // to make compiler happy
     ASSERT_EQ(1, table->allocatedBlockCount());
     assert(tableutil::addRandomTuples(table, tuplesToInsert));
     size_t blockCount = table->allocatedBlockCount();

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -37,7 +37,7 @@
 #include "storage/table.h"
 #include "storage/persistenttable.h"
 #include "storage/tablefactory.h"
-
+#include "storage/tableutil.h"
 
 using voltdb::ExecutorContext;
 using voltdb::NValue;
@@ -51,6 +51,7 @@ using voltdb::VALUE_TYPE_BIGINT;
 using voltdb::VALUE_TYPE_VARCHAR;
 using voltdb::ValueFactory;
 using voltdb::VoltDBEngine;
+using voltdb::tableutil;
 
 
 class PersistentTableTest : public Test {
@@ -170,6 +171,7 @@ private:
     int64_t m_uniqueId;
 };
 
+
 TEST_F(PersistentTableTest, DRTimestampColumn) {
 
     // Load a catalog where active/active DR is turned on for the database,
@@ -279,6 +281,31 @@ TEST_F(PersistentTableTest, DRTimestampColumn) {
 
         ++i;
     }
+}
+
+TEST_F(PersistentTableTest, TruncateTableTest) {
+    VoltDBEngine* engine = getEngine();
+    engine->loadCatalog(0, catalogPayload());
+    PersistentTable *table = dynamic_cast<PersistentTable*>(
+        engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+
+    int tuplesToInsert = 10;
+    ASSERT_EQ(1, table->allocatedBlockCount());
+    assert(tableutil::addRandomTuples(table, tuplesToInsert));
+    size_t blockCount = table->allocatedBlockCount();
+
+    table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+    ASSERT_EQ(blockCount, table->allocatedBlockCount());
+    assert(tableutil::addRandomTuples(table, tuplesToInsert));
+    table->truncateTable(engine);
+
+    // refresh table pointer by fetching the table from catalog as in truncate old table
+    // gets replaced with new cloned empty table
+    table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+    ASSERT_EQ(1, table->allocatedBlockCount());
 }
 
 int main() {


### PR DESCRIPTION
Logic updates include:
- Allocate the block to hold tuples gets assigned to persistent table when one requested from table factory instead of doing so on first tuple insertion.
- When freeing up tuple storage during tuple delete, don't release the empty block if it's the only remaining block.