### PR TITLE
SQLGenerator.py: added a new class SymbolGenerator (sub-class of

### DIFF
--- a/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
+++ b/tests/scripts/examples/sql_coverage/advanced-scalar-subquery.sql
@@ -5,17 +5,6 @@ DELETE FROM @dmltable
 INSERT INTO @dmltable VALUES (@insertvals)
 
 --- Define "place-holders" used in the queries below
---- comparison operators in 3 groups, to save execution time
-{_cmp1 |= "="}
-{_cmp1 |= "<>"}
-{_cmp2 |= "<"}
-{_cmp2 |= ">="}
-{_cmp3 |= ">"}
-{_cmp3 |= "<="}
---{_cmp3 |= "!="} -- Apparently, an HSQL-supported alias for the standard <>
-{_cmp13 |= "_cmp1"}
-{_cmp13 |= "_cmp3"}
-
 {_optionaloffset |= ""}
 {_optionaloffset |= "OFFSET 2"}
 {_optionallimitoffset |= ""}
@@ -34,8 +23,8 @@ INSERT INTO @dmltable VALUES (@insertvals)
 {_temp0grouporderbyvarlimoffhaving |= ""}
 {_temp0grouporderbyvarlimoffhaving |= "LIMIT 1000"}
 {_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord]"}
-{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord] HAVING @agg(_variable[@comparabletype]) _cmp 12"}
-{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord] HAVING _genericagg(_variable[string])   _cmp 'Z'"}
+{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord] HAVING __[#agfcn](_variable[@comparabletype]) __[#cmp] 12"}
+{_temp0grouporderbyvarlimoffhaving |= "GROUP BY __[#ord] HAVING _stringagg(_variable[string])          __[#cmp] 'Z'"}
 
 {_grouporderbyvarlimoffhaving |= "_temp0grouporderbyvarlimoffhaving"}
 {_grouporderbyvarlimoffhaving |= "ORDER BY __[#ord] _sortorder _optionallimitoffset"}
@@ -53,35 +42,36 @@ INSERT INTO @dmltable VALUES (@insertvals)
 --- Test Scalar Subquery Advanced cases
 
 --- Queries with scalar subqueries in the SELECT clause (with optional ORDER BY, LIMIT, OFFSET, GROUP BY or HAVING clauses)
-SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables                                                                     ) FROM @fromtables    A1 _optionalorderbyidlimitoffset
-SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A2.__[#agg]                   _cmp13                  __[#agg]) FROM @fromtables AS A2 _optionalorderbyidlimitoffset
-SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A3._variable[@comparabletype] _cmp2 _variable[@comparabletype]) FROM @fromtables    A3 _optionalorderbyidlimitoffset
+SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables                                                                    ) FROM @fromtables    A1 _optionalorderbyidlimitoffset
+SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A2.__[#agg]                   _cmp                   __[#agg]) FROM @fromtables AS A2 _optionalorderbyidlimitoffset
+SELECT @idcol, (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A3._variable[@comparabletype] _cmp _variable[@comparabletype]) FROM @fromtables    A3 _optionalorderbyidlimitoffset
 
 --- Queries with scalar subqueries in the WHERE clause (with optional ORDER BY, LIMIT, OFFSET, GROUP BY or HAVING clauses)
-SELECT _variable[#ord]         FROM @fromtables A11 WHERE __[#ord] _cmp1 (SELECT @agg(       __[#ord]) FROM @fromtables                                      ) _grouporderbyvarlimoffhaving
-SELECT _variable[#ord numeric] FROM @fromtables A12 WHERE __[#ord] _cmp2 (SELECT @agg(_variable[#agg]) FROM @fromtables                                      ) _grouporderbyvarlimoffhaving
+SELECT _variable[#ord]         FROM @fromtables A11 WHERE __[#ord] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](       __[#ord]) FROM @fromtables                                         )    _grouporderbyvarlimoffhaving
+SELECT _variable[#ord numeric] FROM @fromtables A12 WHERE __[#ord] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables                                         )    _grouporderbyvarlimoffhaving
 --- TODO: uncomment, once ENG-8292 (NPE in Hsql for HAVING query, causing sqlCoverage mismatches) is fixed
---SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#ord] _cmp3 (SELECT @agg(       __[#ord]) FROM @fromtables WHERE     __[#ord] _cmp3 A13.__[#ord]) _grouporderbyvarlimoffhaving
-SELECT _variable[#ord numeric] FROM @fromtables A14 WHERE __[#ord] _cmp2 (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE A14.__[#agg] _cmp2     __[#agg]) _grouporderbyvarlimoffhaving
+--SELECT _variable[#ord]         FROM @fromtables A13 WHERE __[#ord] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](       __[#ord]) FROM @fromtables WHERE     __[#ord] __[#cmp] A13.__[#ord])    _grouporderbyvarlimoffhaving
+SELECT _variable[#ord numeric] FROM @fromtables A14 WHERE __[#ord] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE A14.__[#agg] __[#cmp]     __[#agg])    _grouporderbyvarlimoffhaving
 
 --- TODO: uncomment this, once ENG-8234 is fixed, so the mismatches disappear:
---SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _cmp3 (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[#sub] _cmp3 A15.__[#sub]) _grouporderbyvarlimoffhaving
+--SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[#sub] __[#cmp] A15.__[#sub]) _grouporderbyvarlimoffhaving
 --- TODO: delete this, once ENG-8234 is fixed, so the above mismatches disappear:
-SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _cmp3 (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[#sub] _cmp3 A15.__[#sub]) _tempgrouporderbyvarlimoffhaving
+SELECT _variable[#ord]         FROM @fromtables A15 WHERE __[#agg] _symbol[#cmp _cmp] (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[#sub] __[#cmp] A15.__[#sub]) _tempgrouporderbyvarlimoffhaving
 
 --- Queries with scalar subqueries in the ORDER BY clause (these currently return errors, but probably should not - see ENG-8239)
 --- TODO: uncomment out, if/when ENG-8239 is fixed (meanwhile, commented out to save execution time)
---SELECT @idcol FROM @fromtables A22 ORDER BY (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp1 A22.__[#agg]                  ) _sortorder _optionallimitoffset
---SELECT @idcol FROM @fromtables A23 ORDER BY (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp2 A23._variable[@comparabletype]) _sortorder _optionallimitoffset
---SELECT (SELECT @agg(_variable)       FROM @fromtables                                                                      ) C0 FROM @fromtables A24 ORDER BY C0 _sortorder _optionallimitoffset
---SELECT (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp3 A25.__[#agg]                  )    FROM @fromtables A25 ORDER BY 1  _sortorder _optionallimitoffset
---SELECT (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp1 A26._variable[@comparabletype]) C0 FROM @fromtables A26 ORDER BY C0 _sortorder _optionallimitoffset
+--SELECT @idcol FROM @fromtables A22 ORDER BY (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp A22.__[#agg]                  ) _sortorder _optionallimitoffset
+--SELECT @idcol FROM @fromtables A23 ORDER BY (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp A23._variable[@comparabletype]) _sortorder _optionallimitoffset
+--SELECT (SELECT @agg(_variable)       FROM @fromtables                                                                     ) C0 FROM @fromtables A24 ORDER BY C0  _sortorder _optionallimitoffset
+--SELECT (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE __[#agg]                   _cmp A25.__[#agg]                  )    FROM @fromtables A25 ORDER BY 1   _sortorder _optionallimitoffset
+--SELECT (SELECT @agg(_variable)       FROM @fromtables WHERE _variable[@comparabletype] _cmp A26._variable[@comparabletype]) C0 FROM @fromtables A26 ORDER BY C0  _sortorder _optionallimitoffset
 
---- Queries with scalar subqueries in the GROUP BY or HAVING clause (these work)
-SELECT (SELECT @agg(_variable[#agg])                 FROM @fromtables WHERE _variable[@comparabletype] _cmp1 A31._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A31 GROUP BY C0
-SELECT (SELECT @agg(_variable[#agg @comparabletype]) FROM @fromtables WHERE _variable[@comparabletype] _cmp2 A32._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A32 GROUP BY C0 HAVING @agg(__[#agg]) _cmp 12
-SELECT (SELECT _genericagg(_variable[#agg string])   FROM @fromtables WHERE _variable[@comparabletype] _cmp3 A33._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A33 GROUP BY C0 HAVING @agg(__[#agg]) _cmp 'Z'
---- These do not currently work (meanwhile, commented out to save execution time)
---SELECT (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _cmp A34._variable[@comparabletype]) C0, @agg(__[#agg]) C1 FROM @fromtables A34 GROUP BY C0 HAVING C1 _cmp 12
---SELECT _variable[#grp] C0, @agg(_variable[#agg]) C1  FROM @fromtables A35 GROUP BY C0 HAVING (SELECT @agg(_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _cmp A35._variable[@comparabletype]) _cmp 12
-SELECT _variable[#grp] C0, @agg(_variable[#agg]) C1 FROM @fromtables A36 GROUP BY C0 HAVING @agg(__[#agg]) _cmp (SELECT @agg(__[#agg]) FROM @fromtables WHERE __[#grp] _cmp A36.__[#grp])
+--- Queries with scalar subqueries in the GROUP BY clause (these work)
+SELECT (SELECT _symbol[#agfcn @agg](_variable[#agg])                 FROM @fromtables WHERE _variable[@comparabletype]              _cmp  A31._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A31 GROUP BY C0
+SELECT (SELECT _symbol[#agfcn @agg](_variable[#agg @comparabletype]) FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A32._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A32 GROUP BY C0 HAVING __[#agfcn](__[#agg]) __[#cmp] 12
+SELECT (SELECT _symbol[#agfcn _stringagg](_variable[#agg string])    FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A33._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A33 GROUP BY C0 HAVING __[#agfcn](__[#agg]) __[#cmp] 'Z'
+--- Queries with scalar subqueries (or just 'C1') in the HAVING clause
+--- These do not currently work, due to ENG-8915 & ENG-8306 (meanwhile, commented out to save execution time)
+--SELECT (SELECT _symbol[#agfcn @agg](_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A34._variable[@comparabletype]) C0, __[#agfcn](__[#agg]) C1 FROM @fromtables A34 GROUP BY C0 HAVING C1 __[#cmp] 12
+--SELECT _variable[#grp] C0, _symbol[#agfcn @agg](_variable[#agg]) C1 FROM @fromtables A35 GROUP BY C0 HAVING (SELECT __[#agfcn](_variable[#agg]) FROM @fromtables WHERE _variable[@comparabletype] _symbol[#cmp _cmp] A35._variable[@comparabletype]) __[#cmp] 12
+--SELECT _variable[#grp] C0, _symbol[#agfcn @agg](_variable[#agg]) C1 FROM @fromtables A36 GROUP BY C0 HAVING __[#agfcn](__[#agg]) _symbol[#cmp _cmp] (SELECT __[#agfcn](__[#agg]) FROM @fromtables WHERE __[#grp] __[#cmp] A36.__[#grp])

--- a/tests/scripts/examples/sql_coverage/grammar.sql
+++ b/tests/scripts/examples/sql_coverage/grammar.sql
@@ -14,8 +14,11 @@
 --{_stringfun |= "LOWER"}
 --{_stringfun |= "UPPER"}
 
-{_genericagg |= "MIN"}
-{_genericagg |= "MAX"}
+-- Aggregate functions that accept a string (or numeric) column and return the same type
+{_stringagg |= "MIN"}
+{_stringagg |= "MAX"}
+
+{_genericagg |= "_stringagg"}
 {_genericagg |= "COUNT"}
 
 {_numagg |= "SUM"}


### PR DESCRIPTION
BaseGenerator), to allow re-using the same text (for example, the same
aggregate function name) multiple times within the same query, to allow
reducing the number of queries generated by a single pattern. And, to
allow the same comparison operator to be used multiple times within the
same query (as for function names), tweaked the regular expression for a
'type'. Also, changed the default value for max_statements_per_pattern
to -1 (rather than 0), to match min_statements_per_pattern. Also, added
'import sys' near the beginning, which may help a separate issue
(ENG-8756).
advanced-scalar-subquery.sql: reduced the number of queries generated by
most patterns (and therefore the execution time), by using the new
'_symbol' feature to represent the same aggregate function (MIN, MAX,
COUNT, SUM or AVG) used two or more times within the same query (rather
than combinations of every possible agg function); and similarly, to
represent the same comparison operator (=, <>, <, >, <=, >= or !=) used
two or more times within the same query (rather than combinations of
every comparison operator). Also, improved the comments for the GROUP BY
and HAVING queries at the end (per Paul's suggestions) - and I submitted
a new bug, ENG-8915, for one of those.
grammar.sql: added _stringagg, defined as either MIN or MAX (the only
aggregate functions that accept a string (or numeric) column and return
the same type); kept _genericagg, as those plus COUNT (and _numagg, as
all those plus SUM, AVG).