### PR TITLE
Eng 8872 new

### DIFF
--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -855,7 +855,7 @@ void PersistentTable::deleteTupleFinalize(TableTuple &target)
  */
 void PersistentTable::deleteTupleForSchemaChange(TableTuple &target) {
     TBPtr block = findBlock(target.address(), m_data, m_tableAllocationSize);
-    deleteTupleStorage(target, block, true); // also frees object columns
+    deleteTupleStorage(target, block, true); // also frees object columns along with empty tuple block storage
 }
 
 /*

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -854,7 +854,7 @@ void PersistentTable::deleteTupleFinalize(TableTuple &target)
  *  Indexes and views have been destroyed first.
  */
 void PersistentTable::deleteTupleForSchemaChange(TableTuple &target) {
-	TBPtr block = findBlock(target.address(), m_data, m_tableAllocationSize);
+    TBPtr block = findBlock(target.address(), m_data, m_tableAllocationSize);
     deleteTupleStorage(target, block, true); // also frees object columns
 }
 

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -854,7 +854,8 @@ void PersistentTable::deleteTupleFinalize(TableTuple &target)
  *  Indexes and views have been destroyed first.
  */
 void PersistentTable::deleteTupleForSchemaChange(TableTuple &target) {
-    deleteTupleStorage(target); // also frees object columns
+	TBPtr block = findBlock(target.address(), m_data, m_tableAllocationSize);
+    deleteTupleStorage(target, block, true); // also frees object columns
 }
 
 /*

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -902,8 +902,12 @@ inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block, 
         }
     }
 
-    // if the current block is empty and there are more than one blocks, release the existing
-    // empty block.
+    // if the current block is empty and there are more than one storage blocks, release the
+    // existing empty block. If there is only tuple block storage block remaining and is empty,
+    // if and caller has not requested to release the last remaining storage block, don't release
+    // the last empty tuple storage block. Intend of not releasing the last remaining empty block
+    // is to improve performance at time of inserting first tuple in the table next time by
+    // avoiding to fetch new storage tuple block for storing tuples at time of insertion
     if (block->isEmpty() && (m_data.size() > 1 || deleteLastEmptyBlock)) {
         m_data.erase(block->address());
         m_blocksWithSpace.erase(block);

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -566,7 +566,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
      * Normally this will return the tuple storage to the free list.
      * In the memcheck build it will return the storage to the heap.
      */
-    void deleteTupleStorage(TableTuple &tuple, TBPtr block = TBPtr(NULL));
+    void deleteTupleStorage(TableTuple &tuple, TBPtr block = TBPtr(NULL), bool deleteLastEmptyBlock=false);
 
     /*
      * Implemented by persistent table and called by Table::loadTuplesFrom
@@ -855,7 +855,7 @@ inline TableTuple& PersistentTable::getTempTupleInlined(TableTuple &source) {
 }
 
 
-inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block)
+inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block, bool deleteLastEmptyBlock)
 {
     // May not delete an already deleted tuple.
     assert(tuple.isActive());
@@ -902,7 +902,9 @@ inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block)
         }
     }
 
-    if (block->isEmpty()) {
+    // if the current block is empty and there are more than one blocks, release the existing
+    // empty block.
+    if (block->isEmpty() && (m_data.size() > 1 || deleteLastEmptyBlock)) {
         m_data.erase(block->address());
         m_blocksWithSpace.erase(block);
         m_blocksNotPendingSnapshot.erase(block);

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -902,12 +902,12 @@ inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block, 
         }
     }
 
-    // if the current block is empty and there are more than one storage blocks, release the
-    // existing empty block. If there is only tuple block storage block remaining and is empty,
-    // if and caller has not requested to release the last remaining storage block, don't release
+    // If the current block is empty and there are more than one storage blocks, release the
+    // existing empty block. If there is only 1 tuple block storage block remaining, which is empty,
+    // and if caller has not requested to release the last remaining storage block, don't release
     // the last empty tuple storage block. Intend of not releasing the last remaining empty block
-    // is to improve performance at time of inserting first tuple in the table next time by
-    // avoiding to fetch new storage tuple block for storing tuples at time of insertion
+    // is to improve first tuple insertion performance in the table next time by avoiding to fetch
+    // new storage tuple block for storing tuples from pool at time of first tuple insertion
     if (block->isEmpty() && (m_data.size() > 1 || deleteLastEmptyBlock)) {
         m_data.erase(block->address());
         m_blocksWithSpace.erase(block);

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -902,6 +902,7 @@ inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block, 
         }
     }
 
+
     // If the current block is empty and there are more than one storage blocks, release the
     // existing empty block. If there is only 1 tuple block storage block remaining, which is empty,
     // and if caller has not requested to release the last remaining storage block, don't release

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -902,7 +902,6 @@ inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block, 
         }
     }
 
-
     // If the current block is empty and there are more than one storage blocks, release the
     // existing empty block. If there is only 1 tuple block storage block remaining, which is empty,
     // and if caller has not requested to release the last remaining storage block, don't release

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -93,8 +93,9 @@ Table* TableFactory::getPersistentTable(
     configureStats(databaseId, name, table);
 
     if(!exportOnly) {
-        // allocate tuple storage block ahead of time instead of waiting till first tuple insertion.
-        // Intend of allocating tuple block storage ahead is to improve performance on first tuple insertion.
+        // allocate tuple storage block for the persistent table ahead of time
+        // instead of waiting till first tuple insertion. Intend of allocating tuple
+        // block storage ahead is to improve performance on first tuple insertion.
         PersistentTable *persistentTable = static_cast<PersistentTable*>(table);
         TBPtr block = persistentTable->allocateNextBlock();
         assert(block->hasFreeTuples());

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -92,7 +92,13 @@ Table* TableFactory::getPersistentTable(
     // initialize stats for the table
     configureStats(databaseId, name, table);
 
-    return dynamic_cast<Table*>(table);
+    if(!exportOnly) {
+        PersistentTable *persistentTable = static_cast<PersistentTable*>(table);
+        TBPtr block = persistentTable->allocateNextBlock();
+        assert(block->hasFreeTuples());
+        persistentTable->m_blocksWithSpace.insert(block);
+    }
+    return table;
 }
 
 TempTable* TableFactory::getTempTable(

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -93,6 +93,8 @@ Table* TableFactory::getPersistentTable(
     configureStats(databaseId, name, table);
 
     if(!exportOnly) {
+        // allocate tuple storage block ahead of time instead of waiting till first tuple insertion.
+        // Intend of allocating tuple block storage ahead is to improve performance on first tuple insertion.
         PersistentTable *persistentTable = static_cast<PersistentTable*>(table);
         TBPtr block = persistentTable->allocateNextBlock();
         assert(block->hasFreeTuples());

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -363,7 +363,9 @@ TEST_F(CompactionTest, BasicCompaction) {
         m_table->deleteTuple(tuple, true);
     }
     m_table->doForcedCompaction();
-    ASSERT_EQ( m_table->m_data.size(), 0);
+    // ENG-8872: at any given point, persistent table will have atleast one block available with m_data
+    // even if that block is empty
+    ASSERT_EQ( m_table->m_data.size(), 1);
     ASSERT_EQ( m_table->activeTupleCount(), 0);
 }
 
@@ -492,7 +494,7 @@ TEST_F(CompactionTest, CompactionWithCopyOnWrite) {
         }
     }
     m_table->doForcedCompaction();
-    ASSERT_EQ( m_table->m_data.size(), 0);
+    ASSERT_EQ( m_table->m_data.size(), 1);
     ASSERT_EQ( m_table->activeTupleCount(), 0);
     for (int ii = 0; ii < tupleCount; ii++) {
         ASSERT_TRUE(COWTuples.exists(ii));

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -363,6 +363,7 @@ TEST_F(CompactionTest, BasicCompaction) {
         m_table->deleteTuple(tuple, true);
     }
     m_table->doForcedCompaction();
+
     // At any given point, persistent table will have atleast one block available
     // with m_data even if that block is empty
     ASSERT_EQ( m_table->m_data.size(), 1);

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -363,8 +363,8 @@ TEST_F(CompactionTest, BasicCompaction) {
         m_table->deleteTuple(tuple, true);
     }
     m_table->doForcedCompaction();
-    // ENG-8872: at any given point, persistent table will have atleast one block available with m_data
-    // even if that block is empty
+    // At any given point, persistent table will have atleast one block available
+    // with m_data even if that block is empty
     ASSERT_EQ( m_table->m_data.size(), 1);
     ASSERT_EQ( m_table->activeTupleCount(), 0);
 }

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -37,7 +37,7 @@
 #include "storage/table.h"
 #include "storage/persistenttable.h"
 #include "storage/tablefactory.h"
-
+#include "storage/tableutil.h"
 
 using voltdb::ExecutorContext;
 using voltdb::NValue;
@@ -51,6 +51,7 @@ using voltdb::VALUE_TYPE_BIGINT;
 using voltdb::VALUE_TYPE_VARCHAR;
 using voltdb::ValueFactory;
 using voltdb::VoltDBEngine;
+using voltdb::tableutil;
 
 
 class PersistentTableTest : public Test {
@@ -170,6 +171,7 @@ private:
     int64_t m_uniqueId;
 };
 
+
 TEST_F(PersistentTableTest, DRTimestampColumn) {
 
     // Load a catalog where active/active DR is turned on for the database,
@@ -279,6 +281,32 @@ TEST_F(PersistentTableTest, DRTimestampColumn) {
 
         ++i;
     }
+}
+
+TEST_F(PersistentTableTest, TruncateTableTest) {
+    VoltDBEngine* engine = getEngine();
+    engine->loadCatalog(0, catalogPayload());
+    PersistentTable *table = dynamic_cast<PersistentTable*>(
+        engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+
+    const int tuplesToInsert = 10;
+    (void) tuplesToInsert;  // to make compiler happy
+    ASSERT_EQ(1, table->allocatedBlockCount());
+    assert(tableutil::addRandomTuples(table, tuplesToInsert));
+    size_t blockCount = table->allocatedBlockCount();
+
+    table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+    ASSERT_EQ(blockCount, table->allocatedBlockCount());
+    assert(tableutil::addRandomTuples(table, tuplesToInsert));
+    table->truncateTable(engine);
+
+    // refresh table pointer by fetching the table from catalog as in truncate old table
+    // gets replaced with new cloned empty table
+    table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+    ASSERT_EQ(1, table->allocatedBlockCount());
 }
 
 int main() {


### PR DESCRIPTION
Logic updates include:
-  Allocation of the tuple storage block to persistent table happens when creating persistent table via table factory method instead of doing so on demand - first tuple insertion.
- When freeing up tuple storage during tuple delete, caller can specify whether to release the empty tuple storage block if it's the only remaining block.
- Added unit test for truncate table case.