### PR TITLE
Need to have name for hidden columns for snapshot restore to work

### DIFF
--- a/build.py
+++ b/build.py
@@ -204,6 +204,7 @@ CTX.INPUT['common'] = """
  RecoveryProtoMessage.cpp
  RecoveryProtoMessageBuilder.cpp
  DefaultTupleSerializer.cpp
+ FullTupleSerializer.cpp
  executorcontext.cpp
  serializeio.cpp
  StreamPredicateList.cpp

--- a/src/ee/common/DefaultTupleSerializer.cpp
+++ b/src/ee/common/DefaultTupleSerializer.cpp
@@ -29,21 +29,7 @@ void DefaultTupleSerializer::serializeTo(TableTuple tuple, ReferenceSerializeOut
 /**
  * Calculate the maximum size of a serialized tuple based upon the schema of the table/tuple
  */
-int DefaultTupleSerializer::getMaxSerializedTupleSize(const TupleSchema *schema) {
-    size_t size = 4;
-    size += static_cast<size_t>(schema->tupleLength());
-    for (int ii = 0; ii < schema->columnCount(); ii++) {
-        const TupleSchema::ColumnInfo *columnInfo = schema->getColumnInfo(ii);
-        voltdb::ValueType columnType = columnInfo->getVoltType();
-
-        if (!columnInfo->inlined) {
-            size -= sizeof(void*);
-            size += 4 + columnInfo->length;
-        } else if ((columnType == VALUE_TYPE_VARCHAR) || (columnType == VALUE_TYPE_VARBINARY)) {
-            size += 3;//Serialization always uses a 4-byte length prefix
-        }
-    }
-    return static_cast<int>(size);
+size_t DefaultTupleSerializer::getMaxSerializedTupleSize(const TupleSchema *schema) {
+    return schema->getMaxSerializedTupleSize();
 }
 }
-

--- a/src/ee/common/FullTupleSerializer.cpp
+++ b/src/ee/common/FullTupleSerializer.cpp
@@ -14,30 +14,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef TUPLESERIALIZER_H_
-#define TUPLESERIALIZER_H_
-
-#include "common/TupleSchema.h"
-#include "common/tabletuple.h"
+#include "common/FullTupleSerializer.h"
 #include "common/serializeio.h"
+#include "common/TupleSchema.h"
+
+namespace voltdb {
+/**
+ * Serialize the provided tuple to the provide serialize output
+ */
+void FullTupleSerializer::serializeTo(TableTuple tuple, ReferenceSerializeOutput *out) {
+    tuple.serializeTo(*out, true);
+}
 
 /**
- * Base class for tuple serializers
+ * Calculate the maximum size of a serialized tuple based upon the schema of the table/tuple
  */
-namespace voltdb {
-class TupleSerializer {
-public:
-    /**
-     * Serialize the provided tuple to the provide serialize output
-     */
-    virtual void serializeTo(TableTuple tuple, ReferenceSerializeOutput *out) = 0;
-
-    /**
-     * Calculate the maximum size of a serialized tuple based upon the schema of the table/tuple
-     */
-    virtual size_t getMaxSerializedTupleSize(const TupleSchema *schema) = 0;
-
-    virtual ~TupleSerializer() {}
-};
+size_t FullTupleSerializer::getMaxSerializedTupleSize(const TupleSchema *schema) {
+    return schema->getMaxSerializedTupleSize(true);
 }
-#endif /* TUPLESERIALIZER_H_ */
+}

--- a/src/ee/common/FullTupleSerializer.h
+++ b/src/ee/common/FullTupleSerializer.h
@@ -15,8 +15,8 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef DEFAULTTUPLESERIALIZER_H_
-#define DEFAULTTUPLESERIALIZER_H_
+#ifndef FULLTUPLESERIALIZER_H_
+#define FULLTUPLESERIALIZER_H_
 #include "common/TupleSerializer.h"
 #include "common/tabletuple.h"
 
@@ -25,10 +25,10 @@ class ReferenceSerializeOutput;
 class TupleSchema;
 
 /**
- * DefaultTupleSerializer provides delegate methods to serialize only visible columns
+ * FullTupleSerializer provides delegate methods to serialize visible and hidden columns
  * of the given tuple. It also gives corresponding max serialization size for buffer allocation.
  */
-class DefaultTupleSerializer : public TupleSerializer {
+class FullTupleSerializer : public TupleSerializer {
 public:
     /**
      * Serialize the provided tuple to the provide serialize output
@@ -40,8 +40,8 @@ public:
      */
     size_t getMaxSerializedTupleSize(const TupleSchema *schema);
 
-    virtual ~DefaultTupleSerializer() {}
+    virtual ~FullTupleSerializer() {}
 };
 }
 
-#endif /* DEFAULTTUPLESERIALIZER_H_ */
+#endif /* FULLTUPLESERIALIZER_H_ */

--- a/src/ee/common/RecoveryProtoMessageBuilder.h
+++ b/src/ee/common/RecoveryProtoMessageBuilder.h
@@ -86,7 +86,7 @@ private:
      */
     int32_t m_tupleCount;
 
-    int32_t m_maxSerializedSize;
+    size_t m_maxSerializedSize;
 };
 }
 #endif //RECOVERY_PROTO_MESSAGE_BUILDER_

--- a/src/ee/common/TupleSchema.cpp
+++ b/src/ee/common/TupleSchema.cpp
@@ -286,6 +286,25 @@ std::string TupleSchema::ColumnInfo::debug() const {
     return buffer.str();
 }
 
+size_t TupleSchema::getMaxSerializedTupleSize(bool includeHiddenColumns) const {
+    size_t bytes = sizeof(int32_t); // placeholder for tuple length
+    int serializeColumnCount = m_columnCount;
+    if (includeHiddenColumns) {
+        serializeColumnCount += m_hiddenColumnCount;
+    }
+
+    for (int i = 0;i < serializeColumnCount; ++i) {
+        const TupleSchema::ColumnInfo* columnInfo = getColumnInfoPrivate(i);
+        int32_t factor = (columnInfo->type == VALUE_TYPE_VARCHAR && !columnInfo->inBytes) ? MAX_BYTES_PER_UTF8_CHARACTER : 1;
+        if (columnInfo->type == VALUE_TYPE_VARCHAR || columnInfo->type == VALUE_TYPE_VARBINARY) {
+            bytes += sizeof(int32_t); // value length placeholder for variable length columns
+        }
+        bytes += columnInfo->length * factor;
+    }
+
+    return bytes;
+}
+
 std::string TupleSchema::debug() const {
     std::ostringstream buffer;
 

--- a/src/ee/common/TupleSchema.h
+++ b/src/ee/common/TupleSchema.h
@@ -135,6 +135,8 @@ public:
     /** Return the number of bytes used by one tuple. */
     inline uint32_t tupleLength() const;
 
+    size_t getMaxSerializedTupleSize(bool includeHiddenColumns = false) const;
+
     /** Get a string representation of this schema for debugging */
     std::string debug() const;
 

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -46,7 +46,7 @@
 #ifndef VOLTDBENGINE_H
 #define VOLTDBENGINE_H
 
-#include "common/DefaultTupleSerializer.h"
+#include "common/FullTupleSerializer.h"
 #include "common/Pool.hpp"
 #include "common/serializeio.h"
 #include "common/ThreadLocalPool.h"
@@ -578,7 +578,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         // other components. (Components MUST NOT depend on VoltDBEngine.h).
         ExecutorContext *m_executorContext;
 
-        DefaultTupleSerializer m_tupleSerializer;
+        FullTupleSerializer m_tupleSerializer;
 
         int32_t m_compactionThreshold;
 

--- a/src/ee/storage/RecoveryContext.cpp
+++ b/src/ee/storage/RecoveryContext.cpp
@@ -73,7 +73,6 @@ bool RecoveryContext::nextMessage(ReferenceSerializeOutput *out) {
         //No tuple count added to message because completion message is only used in Java
         return false;
     }
-    DefaultTupleSerializer serializer;
     //Use allocated tuple count to size stuff at the other end
     uint32_t allocatedTupleCount = static_cast<uint32_t>(getTable().allocatedTupleCount());
     RecoveryProtoMsgBuilder message(
@@ -81,7 +80,7 @@ bool RecoveryContext::nextMessage(ReferenceSerializeOutput *out) {
             m_tableId,
             allocatedTupleCount,
             out,
-            &m_serializer,
+            &getSerializer(),
             getTable().schema());
     TableTuple tuple(getTable().schema());
     while (message.canAddMoreTuples() && m_iterator.next(tuple)) {

--- a/src/ee/storage/RecoveryContext.h
+++ b/src/ee/storage/RecoveryContext.h
@@ -20,7 +20,6 @@
 #include "storage/tableiterator.h"
 #include "storage/TableStreamer.h"
 #include "storage/TableStreamerContext.h"
-#include "common/DefaultTupleSerializer.h"
 
 /*
  * A log of changes to tuple data that has already been sent to a recovering
@@ -90,8 +89,6 @@ private:
      * Phase 3 is to ship deletes
      */
     RecoveryMsgType m_recoveryPhase;
-
-    DefaultTupleSerializer m_serializer;
 };
 }
 #endif /* RECOVERYCONTEXT_H_ */

--- a/src/ee/storage/TableStreamerContext.h
+++ b/src/ee/storage/TableStreamerContext.h
@@ -137,7 +137,7 @@ public:
     /**
      * Tuple length accessor.
      */
-    int getMaxTupleLength() const
+    size_t getMaxTupleLength() const
     {
         return m_maxTupleLength;
     }
@@ -219,7 +219,7 @@ private:
     /**
      * Maximum serialized length of a tuple
      */
-    const int m_maxTupleLength;
+    const size_t m_maxTupleLength;
 
     /**
      * Serializer for tuples

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -382,11 +382,12 @@ void setSearchKeyFromTuple(TableTuple &source) {
     keyTuple.setNValue(1, source.getNValue(2));
 }
 
-void PersistentTable::setDRTimestampForTuple(ExecutorContext* ec, TableTuple& tuple) {
+void PersistentTable::setDRTimestampForTuple(ExecutorContext* ec, TableTuple& tuple, bool update) {
     assert(hasDRTimestampColumn());
-    const int64_t drTimestamp = ec->currentDRTimestamp();
-    tuple.setHiddenNValue(getDRTimestampColumnIndex(),
-                          ValueFactory::getBigIntValue(drTimestamp));
+    if (update || tuple.getHiddenNValue(getDRTimestampColumnIndex()).isNull()) {
+        const int64_t drTimestamp = ec->currentDRTimestamp();
+        tuple.setHiddenNValue(getDRTimestampColumnIndex(), ValueFactory::getBigIntValue(drTimestamp));
+    }
 }
 
 /*
@@ -465,8 +466,9 @@ void PersistentTable::insertTupleCommon(TableTuple &source, TableTuple &target, 
     }
 
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
-    if (hasDRTimestampColumn())
-        setDRTimestampForTuple(ec, target);
+    if (hasDRTimestampColumn()) {
+        setDRTimestampForTuple(ec, target, false);
+    }
 
     DRTupleStream *drStream = getDRTupleStream(ec);
     size_t drMark = 0;
@@ -608,8 +610,9 @@ bool PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUp
     }
 
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
-    if (hasDRTimestampColumn())
-        setDRTimestampForTuple(ec, sourceTupleWithNewValues);
+    if (hasDRTimestampColumn()) {
+        setDRTimestampForTuple(ec, sourceTupleWithNewValues, true);
+    }
 
     DRTupleStream *drStream = getDRTupleStream(ec);
     size_t drMark = 0;

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -590,7 +590,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
         }
     }
 
-    void setDRTimestampForTuple(ExecutorContext* ec, TableTuple &tuple);
+    void setDRTimestampForTuple(ExecutorContext* ec, TableTuple &tuple, bool update);
 
     void computeSmallestUniqueIndex();
 

--- a/src/ee/storage/table.cpp
+++ b/src/ee/storage/table.cpp
@@ -151,6 +151,10 @@ void Table::initializeWithColumns(TupleSchema *schema, const std::vector<string>
     m_tempTupleMemory.reset(new char[m_schema->tupleLength() + TUPLE_HEADER_SIZE]);
     m_tempTuple = TableTuple(m_tempTupleMemory.get(), m_schema);
     ::memset(m_tempTupleMemory.get(), 0, m_tempTuple.tupleLength());
+    // default value of hidden dr timestamp is null
+    if (m_schema->hiddenColumnCount() > 0) {
+        m_tempTuple.setHiddenNValue(0, NValue::getNullValue(VALUE_TYPE_BIGINT));
+    }
     m_tempTuple.setActiveTrue();
 
     // set the data to be empty
@@ -472,11 +476,12 @@ void Table::loadTuplesFrom(SerializeInputBE &serialize_io,
     }
 
     // Check if the column count matches what the temp table is expecting
-    if (colcount != m_schema->columnCount()) {
+    int16_t expectedColumnCount = static_cast<int16_t>(m_schema->columnCount() + m_schema->hiddenColumnCount());
+    if (colcount != expectedColumnCount) {
         std::stringstream message(std::stringstream::in
                                   | std::stringstream::out);
         message << "Column count mismatch. Expecting "
-                << m_schema->columnCount()
+                << expectedColumnCount
                 << ", but " << colcount << " given" << std::endl;
         message << "Expecting the following columns:" << std::endl;
         message << debug() << std::endl;

--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -48,6 +48,7 @@ import org.voltdb.messaging.FastSerializer;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.PosixAdvise;
+import org.voltdb.VoltTable.ColumnInfo;
 
 import com.google_voltpatches.common.util.concurrent.Callables;
 import com.google_voltpatches.common.util.concurrent.Futures;
@@ -236,7 +237,8 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
         container.b().putInt(container.b().remaining() - 4);
         container.b().position(0);
 
-        final byte schemaBytes[] = PrivateVoltTableFactory.getSchemaBytes(schemaTable);
+        final byte schemaBytes[];
+        schemaBytes = PrivateVoltTableFactory.getSchemaBytes(schemaTable);
 
         final PureJavaCrc32 crc = new PureJavaCrc32();
         ByteBuffer aggregateBuffer = ByteBuffer.allocate(container.b().remaining() + schemaBytes.length);

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
 import org.voltdb.ParameterConverter;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
@@ -35,11 +36,29 @@ public abstract class SavedTableConverter
 {
 
     public static Boolean needsConversion(VoltTable inputTable,
-                                          Table outputTableSchema) {
-        if (inputTable.getColumnCount() != outputTableSchema.getColumns().size()) {
-            return true;
+                                          Table outputTableSchema,
+                                          boolean shouldPreserveDRHiddenColumn) {
+        int columnsToMatch;
+        if (shouldPreserveDRHiddenColumn) {
+            // We are expecting the hidden column in inputTable
+            columnsToMatch = inputTable.getColumnCount() - 1;
+            if (columnsToMatch != outputTableSchema.getColumns().size()) {
+                return true;
+            }
+            if (!inputTable.getColumnName(columnsToMatch).equalsIgnoreCase(CatalogUtil.DR_HIDDEN_COLUMN_NAME) ||
+                    inputTable.getColumnType(columnsToMatch) != VoltType.BIGINT) {
+                // Make sure input isn't using the reserved column name of the hidden column
+                // passive DR table to active DR table, must be converted
+                return true;
+            }
         }
-        for (int ii = 0; ii < inputTable.getColumnCount(); ii++) {
+        else {
+            columnsToMatch = inputTable.getColumnCount();
+            if (columnsToMatch != outputTableSchema.getColumns().size()) {
+                return true;
+            }
+        }
+        for (int ii = 0; ii < columnsToMatch; ii++) {
             final String name = inputTable.getColumnName(ii);
             final VoltType type = inputTable.getColumnType(ii);
             final Column column = outputTableSchema.getColumns().get(name);
@@ -60,14 +79,37 @@ public abstract class SavedTableConverter
     }
 
     public static VoltTable convertTable(VoltTable inputTable,
-                                         Table outputTableSchema)
+                                         Table outputTableSchema,
+                                         boolean shouldPreserveDRHiddenColumn)
     throws VoltTypeException
     {
-        VoltTable new_table =
-            CatalogUtil.getVoltTable(outputTableSchema);
+        VoltTable new_table;
+
+        if (shouldPreserveDRHiddenColumn) {
+            // if the DR hidden column should be preserved in conversion, append it to the end of target schema
+            new_table = CatalogUtil.getVoltTable(outputTableSchema, CatalogUtil.DR_HIDDEN_COLUMN_INFO);
+        } else {
+            new_table = CatalogUtil.getVoltTable(outputTableSchema);
+        }
 
         Map<Integer, Integer> column_copy_index_map =
             computeColumnCopyIndexMap(inputTable, new_table);
+
+        // if original table does not have hidden column present, we need to add
+        boolean addDRHiddenColumn = shouldPreserveDRHiddenColumn &&
+                !column_copy_index_map.containsKey(new_table.getColumnCount() - 1);
+        Column catalogColumnForHiddenColumn = null;
+        if (addDRHiddenColumn) {
+            catalogColumnForHiddenColumn = new Column();
+            catalogColumnForHiddenColumn.setName(CatalogUtil.DR_HIDDEN_COLUMN_NAME);
+            catalogColumnForHiddenColumn.setType(VoltType.BIGINT.getValue());
+            catalogColumnForHiddenColumn.setSize(VoltType.BIGINT.getLengthInBytesForFixedTypes());
+            catalogColumnForHiddenColumn.setInbytes(false);
+            // small hack here to let logic below fill VoltType.NULL_BIGINT in for the hidden column
+            // actually this column is not nullable in EE, but it will be set to correct value before
+            // insert(restore) to the corresponding table
+            catalogColumnForHiddenColumn.setNullable(true);
+        }
 
         // Copy all the old tuples into the new table
         while (inputTable.advanceRow())
@@ -92,6 +134,10 @@ public abstract class SavedTableConverter
                     Column catalog_column =
                         outputTableSchema.getColumns().
                         get(new_table.getColumnName(i));
+                    // construct an artificial catalog column for dr hidden column
+                    if (shouldPreserveDRHiddenColumn && catalog_column == null) {
+                        catalog_column = catalogColumnForHiddenColumn;
+                    }
                     VoltType default_type =
                         VoltType.get((byte)catalog_column.getDefaulttype());
                     if (default_type != VoltType.INVALID)
@@ -103,8 +149,7 @@ public abstract class SavedTableConverter
                             coerced_values[i] =
                                 VoltTypeUtil.
                                 getObjectFromString(default_type,
-                                                    catalog_column.
-                                                    getDefaultvalue());
+                                                    catalog_column.getDefaultvalue());
                         }
                         catch (ParseException e)
                         {

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
@@ -34,15 +34,7 @@ import org.json_voltpatches.JSONObject;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
-import org.voltdb.PostSnapshotTask;
-import org.voltdb.PrivateVoltTableFactory;
-import org.voltdb.SnapshotDataFilter;
-import org.voltdb.SnapshotFormat;
-import org.voltdb.SnapshotSiteProcessor;
-import org.voltdb.SnapshotTableTask;
-import org.voltdb.SystemProcedureExecutionContext;
-import org.voltdb.VoltDB;
-import org.voltdb.VoltTable;
+import org.voltdb.*;
 import org.voltdb.catalog.Table;
 import org.voltdb.dtxn.SiteTracker;
 import org.voltdb.rejoin.StreamSnapshotAckReceiver;
@@ -137,7 +129,14 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
         // table schemas for all the tables we'll snapshot on this partition
         Map<Integer, byte[]> schemas = new HashMap<Integer, byte[]>();
         for (final Table table : config.tables) {
-            VoltTable schemaTable = CatalogUtil.getVoltTable(table);
+            VoltTable schemaTable;
+            if (context.getDatabase().getIsactiveactivedred() && table.getIsdred()) {
+                schemaTable = CatalogUtil.getVoltTable(table, CatalogUtil.DR_HIDDEN_COLUMN_INFO);
+            }
+            else {
+                schemaTable = CatalogUtil.getVoltTable(table);
+            }
+
             schemas.put(table.getRelativeIndex(), PrivateVoltTableFactory.getSchemaBytes(schemaTable));
         }
 

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -153,6 +153,10 @@ public abstract class CatalogUtil {
     public static final String DEFAULT_DR_CONFLICTS_EXPORT_TYPE = "csv";
     public static final String DEFAULT_DR_CONFLICTS_NONCE = "MyExport";
     public static final String DEFAULT_DR_CONFLICTS_DIR = "dr_conflicts";
+    public static final String DR_HIDDEN_COLUMN_NAME = "dr_clusterid_timestamp";
+
+    public static final VoltTable.ColumnInfo DR_HIDDEN_COLUMN_INFO =
+            new VoltTable.ColumnInfo(DR_HIDDEN_COLUMN_NAME, VoltType.BIGINT);
 
     private static JAXBContext m_jc;
     private static Schema m_schema;
@@ -286,7 +290,7 @@ public abstract class CatalogUtil {
 
     /**
      *
-     * @param catalogTable
+     * @param catalogTable a catalog table providing the schema
      * @return An empty table with the same schema as a given catalog table.
      */
     public static VoltTable getVoltTable(Table catalogTable) {
@@ -297,6 +301,28 @@ public abstract class CatalogUtil {
         int i = 0;
         for (Column catCol : catalogColumns) {
             columns[i++] = new VoltTable.ColumnInfo(catCol.getTypeName(), VoltType.get((byte)catCol.getType()));
+        }
+
+        return new VoltTable(columns);
+    }
+
+    /**
+     *
+     * @param catalogTable a catalog table providing the schema
+     * @param hiddenColumnInfos variable-length ColumnInfo objects for hidden columns
+     * @return An empty table with the same schema as a given catalog table.
+     */
+    public static VoltTable getVoltTable(Table catalogTable, VoltTable.ColumnInfo... hiddenColumns) {
+        List<Column> catalogColumns = CatalogUtil.getSortedCatalogItems(catalogTable.getColumns(), "index");
+
+        VoltTable.ColumnInfo[] columns = new VoltTable.ColumnInfo[catalogColumns.size() + hiddenColumns.length];
+
+        int i = 0;
+        for (Column catCol : catalogColumns) {
+            columns[i++] = new VoltTable.ColumnInfo(catCol.getTypeName(), VoltType.get((byte)catCol.getType()));
+        }
+        for (VoltTable.ColumnInfo hiddenColumnInfo : hiddenColumns) {
+            columns[i++] = hiddenColumnInfo;
         }
 
         return new VoltTable(columns);

--- a/tests/ee/common/tupleschema_test.cpp
+++ b/tests/ee/common/tupleschema_test.cpp
@@ -205,6 +205,34 @@ TEST_F(TupleSchemaTest, EqualsAndCompatibleForMemcpy)
     EXPECT_FALSE(schema4->equals(schema2.get()));
 }
 
+TEST_F(TupleSchemaTest, MaxSerializedTupleSize) {
+    voltdb::TupleSchemaBuilder builder(3); // 3 visible columns
+    builder.setColumnAtIndex(0, VALUE_TYPE_DECIMAL);
+    builder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR,
+                             64,     // length
+                             true,   // allow nulls
+                             false); // length not in bytes
+    builder.setColumnAtIndex(2, VALUE_TYPE_TIMESTAMP);
+    ScopedTupleSchema schema(builder.build());
+
+    EXPECT_EQ((4 + 16 + (4 + 64 * 4) + 8),
+              schema.get()->getMaxSerializedTupleSize());
+
+    voltdb::TupleSchemaBuilder hiddenBuilder(3, 2); // 3 visible columns, 2 hidden columns
+    hiddenBuilder.setColumnAtIndex(0, VALUE_TYPE_DECIMAL);
+    hiddenBuilder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR,
+                             64,     // length
+                             true,   // allow nulls
+                             false); // length not in bytes
+    hiddenBuilder.setColumnAtIndex(2, VALUE_TYPE_TIMESTAMP);
+    hiddenBuilder.setHiddenColumnAtIndex(0, VALUE_TYPE_BIGINT);
+    hiddenBuilder.setHiddenColumnAtIndex(1, VALUE_TYPE_VARCHAR, 10, true, true);
+    ScopedTupleSchema schemaWithHidden(hiddenBuilder.build());
+
+    EXPECT_EQ((4 + 16 + (4 + 64 * 4) + 8 + 8 + (4 + 10)),
+              schemaWithHidden.get()->getMaxSerializedTupleSize(true));
+}
+
 int main() {
     return TestSuite::globalInstance()->runAll();
 }

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -370,7 +370,7 @@ TEST_F(DRBinaryLogTest, VerifyHiddenColumns) {
     NValue drTimestamp = tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex());
     NValue drTimestampReplica = tuple.getHiddenNValue(m_tableReplica->getDRTimestampColumnIndex());
     EXPECT_EQ(ValuePeeker::peekAsBigInt(drTimestamp), 70);
-    ASSERT_TRUE(drTimestamp.compare(drTimestampReplica) == 0);
+    EXPECT_EQ(0, drTimestamp.compare(drTimestampReplica));
 }
 
 TEST_F(DRBinaryLogTest, PartitionedTableNoRollbacks) {


### PR DESCRIPTION
serialize/deserialize to DR has no knowledge of hidden columns, normal serialize/deserialize now has; native & stream snapshot can now save/restore hidden columns, index snapshot needs investigation

Make restore procedure DR-aware, add related tests

Consider hidden columns when loading table in EE

Move setDRTimestamp outside insertTupleCommon for snapshot restore purpose

Fix missing declaration

Refactor add hidden column logic in table converter

Add logic for EE to set uninitialized DR timestamp column during snapshot restore

Clean up unnecessary code

ENG-8723, address remaining review comments, also rebase with master branch.

Change-Id: I34d50894d866b7f1174dea5fcaab86300cf323e5

ENG-8723, if schema contains hidden DR timestamp, tempTuple creation shoule initialize the hidden column value to NULL.
Update hidden DR timestamp is always allowed but insert new value to DR timestamp column need to check if it is NULL.

Change-Id: Ia27e6050212b10afb5378a6f876b67cd8ab93843