### PR TITLE
Add EE to frontend callback interface for logging DR conflicts

### DIFF
--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -67,6 +67,13 @@ namespace voltdb {
         return pushDRBufferRetval;
     }
 
+    int DummyTopend::reportDRConflict(int32_t partitionId,
+                int64_t remoteSequenceNumber, int64_t remoteUniqueId,
+                std::string tableName, Table* input, Table* output) {
+        // TODO conform to return value contract of reportDRConflict()
+        return 0;
+    }
+
     void DummyTopend::fallbackToEEAllocatedBuffer(char *buffer, size_t length) {}
 
     std::string DummyTopend::decodeBase64AndDecompress(const std::string& buffer) {

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -64,6 +64,10 @@ class Topend {
 
     virtual int64_t pushDRBuffer(int32_t partitionId, StreamBlock *block) = 0;
 
+    virtual int reportDRConflict(int32_t partitionId,
+            int64_t remoteSequenceNumber, int64_t remoteUniqueId,
+            std::string tableName, Table* input, Table* output) = 0;
+
     virtual void fallbackToEEAllocatedBuffer(char *buffer, size_t length) = 0;
 
     /** Calls the java method in org.voltdb.utils.Encoder */
@@ -94,6 +98,10 @@ public:
     virtual void pushExportBuffer(int64_t generation, int32_t partitionId, std::string signature, StreamBlock *block, bool sync, bool endOfStream);
 
     int64_t pushDRBuffer(int32_t partitionId, voltdb::StreamBlock *block);
+
+    int reportDRConflict(int32_t partitionId,
+            int64_t remoteSequenceNumber, int64_t remoteUniqueId,
+            std::string tableName, Table* input, Table* output);
 
     void fallbackToEEAllocatedBuffer(char *buffer, size_t length);
 

--- a/src/ee/common/types.cpp
+++ b/src/ee/common/types.cpp
@@ -71,7 +71,7 @@ bool isIntegralType(ValueType type) {
     throw exception();
 }
 
-NValue getRandomValue(ValueType type) {
+NValue getRandomValue(ValueType type, uint32_t maxLength) {
     switch (type) {
         case VALUE_TYPE_TIMESTAMP:
             return ValueFactory::getTimestampValue(static_cast<int64_t>(time(NULL)));
@@ -83,11 +83,24 @@ NValue getRandomValue(ValueType type) {
             return ValueFactory::getIntegerValue(rand() % (1 << 31));
         case VALUE_TYPE_BIGINT:
             return ValueFactory::getBigIntValue(rand());
+        case VALUE_TYPE_DECIMAL: {
+            char characters[29];
+            int i;
+            for (i = 0; i < 15; ++i) {
+                characters[i] = (char)(48 + (rand() % 10));
+            }
+            characters[i] = '.';
+            for (i = 16; i < 28; ++i) {
+                characters[i] = (char)(48 + (rand() % 10));
+            }
+            characters[i] = '\0';
+            return ValueFactory::getDecimalValueFromString(string(characters));
+        }
         case VALUE_TYPE_DOUBLE:
             return ValueFactory::getDoubleValue((rand() % 10000) / (double)(rand() % 10000));
         case VALUE_TYPE_VARCHAR: {
-            int length = (rand() % 10);
-            char characters[11];
+            int length = (rand() % maxLength);
+            char characters[maxLength];
             for (int ii = 0; ii < length; ii++) {
                 characters[ii] = (char)(32 + (rand() % 94)); //printable characters
             }
@@ -96,8 +109,8 @@ NValue getRandomValue(ValueType type) {
             return ValueFactory::getStringValue(string(characters));
         }
         case VALUE_TYPE_VARBINARY: {
-            int length = (rand() % 16);
-            unsigned char bytes[17];
+            int length = (rand() % maxLength);
+            unsigned char bytes[maxLength];
             for (int ii = 0; ii < length; ii++) {
                 bytes[ii] = (unsigned char)rand() % 256; //printable characters
             }

--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -527,7 +527,7 @@ bool isNumeric(ValueType type);
 bool isIntegralType(ValueType type);
 
 // for testing, obtain a random instance of the specified type
-NValue getRandomValue(ValueType type);
+NValue getRandomValue(ValueType type, uint32_t maxLength);
 
 std::string valueToString(ValueType type);
 ValueType stringToValue(std::string str );

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -48,6 +48,10 @@ public:
 
     int64_t pushDRBuffer(int32_t partitionId, StreamBlock *block);
 
+    int reportDRConflict(int32_t partitionId,
+            int64_t remoteSequenceNumber, int64_t remoteUniqueId,
+            std::string tableName, Table* input, Table* output);
+
     void fallbackToEEAllocatedBuffer(char *buffer, size_t length);
 
     std::string decodeBase64AndDecompress(const std::string& buffer);
@@ -68,6 +72,7 @@ private:
     jmethodID m_pushExportBufferMID;
     jmethodID m_getQueuedExportBytesMID;
     jmethodID m_pushDRBufferMID;
+    jmethodID m_reportDRConflictMID;
     jmethodID m_decodeBase64AndDecompressToBytesMID;
     jclass m_exportManagerClass;
     jclass m_partitionDRGatewayClass;

--- a/src/ee/storage/table.cpp
+++ b/src/ee/storage/table.cpp
@@ -233,6 +233,54 @@ int Table::getApproximateSizeToSerialize() const {
     return 1024 * 1024 * 10;
 }
 
+/*
+ * Warn: Iterate all tuples to get accurate size, don't use it on
+ * performance critical path if table is large.
+ */
+size_t Table::getAccurateSizeToSerialize(bool includeTotalSize) {
+
+    // column header size
+    size_t bytes = getColumnHeaderSizeToSerialize(includeTotalSize);
+
+    // tuples
+    bytes += sizeof(int32_t);  // tuple count
+    int64_t written_count = 0;
+    TableIterator titer = iterator();
+    TableTuple tuple(m_schema);
+    while (titer.next(tuple)) {
+        bytes += tuple.serializationSize();  // tuple size
+        ++written_count;
+    }
+    assert(written_count == m_tupleCount);
+
+    return bytes;
+}
+
+size_t Table::getColumnHeaderSizeToSerialize(bool includeTotalSize) const {
+    // table size
+    size_t bytes = includeTotalSize ? sizeof(int32_t) : 0;
+
+    // use a cache if possible
+    if (m_columnHeaderData) {
+        assert(m_columnHeaderSize != -1);
+        bytes += m_columnHeaderSize;
+    }
+    else {
+        // column header size, status code, column count
+        bytes += sizeof(int32_t) + sizeof(int8_t) + sizeof(int16_t);
+        // column types
+        bytes += sizeof(int8_t) * m_columnCount;
+        // column names
+        bytes += sizeof(int32_t) * m_columnCount;
+        for (int i = 0; i < m_columnCount; ++i) {
+            bytes += static_cast<int32_t>(columnName(i).size());
+        }
+    }
+
+    return bytes;
+}
+
+
 bool Table::serializeColumnHeaderTo(SerializeOutput &serialize_io) {
 
     /* NOTE:
@@ -332,6 +380,24 @@ bool Table::serializeTo(SerializeOutput &serialize_io) {
     int32_t sz = static_cast<int32_t>(serialize_io.position() - pos - sizeof(int32_t));
     assert(sz > 0);
     serialize_io.writeIntAt(pos, sz);
+
+    return true;
+}
+
+bool Table::serializeToWithoutTotalSize(SerializeOutput &serialize_io) {
+    if (!serializeColumnHeaderTo(serialize_io))
+        return false;
+
+    // active tuple counts
+    serialize_io.writeInt(static_cast<int32_t>(m_tupleCount));
+    int64_t written_count = 0;
+    TableIterator titer = iterator();
+    TableTuple tuple(m_schema);
+    while (titer.next(tuple)) {
+        tuple.serializeTo(serialize_io);
+        ++written_count;
+    }
+    assert(written_count == m_tupleCount);
 
     return true;
 }

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -241,7 +241,10 @@ class Table {
     // SERIALIZATION
     // ------------------------------------------------------------------
     int getApproximateSizeToSerialize() const;
+    size_t getColumnHeaderSizeToSerialize(bool includeTotalSize) const;
+    size_t getAccurateSizeToSerialize(bool includeTotalSize);
     bool serializeTo(SerializeOutput &serialize_out);
+    bool serializeToWithoutTotalSize(SerializeOutput &serialize_io);
     bool serializeColumnHeaderTo(SerializeOutput &serialize_io);
 
     /*

--- a/src/ee/storage/tableutil.cpp
+++ b/src/ee/storage/tableutil.cpp
@@ -81,7 +81,7 @@ void tableutil::setRandomTupleValues(Table* table, TableTuple *tuple)
     assert(tuple);
     for (int col_ctr = 0, col_cnt = table->columnCount(); col_ctr < col_cnt; col_ctr++) {
         const TupleSchema::ColumnInfo *columnInfo = table->schema()->getColumnInfo(col_ctr);
-        NValue value = getRandomValue(columnInfo->getVoltType());
+        NValue value = getRandomValue(columnInfo->getVoltType(), columnInfo->length);
 
         tuple->setNValue(col_ctr, value);
 

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -49,6 +49,7 @@ using namespace std;
 namespace voltdb {
 class Pool;
 class StreamBlock;
+class Table;
 }
 
 class VoltDBIPC : public voltdb::Topend {
@@ -130,6 +131,9 @@ public:
 
     int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);
     void pushExportBuffer(int64_t exportGeneration, int32_t partitionId, std::string signature, voltdb::StreamBlock *block, bool sync, bool endOfStream);
+    int reportDRConflict(int32_t partitionId,
+            int64_t remoteSequenceNumber, int64_t remoteUniqueId,
+            std::string tableName, voltdb::Table* input, voltdb::Table* output);
 private:
     voltdb::VoltDBEngine *m_engine;
     long int m_counter;
@@ -1554,6 +1558,12 @@ int64_t VoltDBIPC::pushDRBuffer(int32_t partitionId, voltdb::StreamBlock *block)
         delete []block->rawPtr();
     }
     return -1;
+}
+
+int VoltDBIPC::reportDRConflict(int32_t partitionId,
+            int64_t remoteSequenceNumber, int64_t remoteUniqueId,
+            std::string tableName, voltdb::Table* input, voltdb::Table* output) {
+    return 0;
 }
 
 void *eethread(void *ptr) {

--- a/tests/ee/common/tupleschema_test.cpp
+++ b/tests/ee/common/tupleschema_test.cpp
@@ -205,6 +205,7 @@ TEST_F(TupleSchemaTest, EqualsAndCompatibleForMemcpy)
     EXPECT_FALSE(schema4->equals(schema2.get()));
 }
 
+
 TEST_F(TupleSchemaTest, MaxSerializedTupleSize) {
     voltdb::TupleSchemaBuilder builder(3); // 3 visible columns
     builder.setColumnAtIndex(0, VALUE_TYPE_DECIMAL);

--- a/tests/ee/storage/table_test.cpp
+++ b/tests/ee/storage/table_test.cpp
@@ -72,24 +72,33 @@
 using namespace std;
 using namespace voltdb;
 
-#define NUM_OF_COLUMNS 5
-#define NUM_OF_TUPLES 10000
+#define NUM_OF_COLUMNS 9
+#define NUM_OF_TUPLES 5000
 
-ValueType COLUMN_TYPES[NUM_OF_COLUMNS]  = { VALUE_TYPE_BIGINT,
-                                            VALUE_TYPE_TINYINT,
+ValueType COLUMN_TYPES[NUM_OF_COLUMNS]  = { VALUE_TYPE_TINYINT,
                                             VALUE_TYPE_SMALLINT,
                                             VALUE_TYPE_INTEGER,
-                                            VALUE_TYPE_BIGINT };
+                                            VALUE_TYPE_BIGINT,
+                                            VALUE_TYPE_DECIMAL,
+                                            VALUE_TYPE_DOUBLE,
+                                            VALUE_TYPE_TIMESTAMP,
+                                            VALUE_TYPE_VARCHAR,
+                                            VALUE_TYPE_VARBINARY };
 
 int32_t COLUMN_SIZES[NUM_OF_COLUMNS] =
     {
-        NValue::getTupleStorageSize(VALUE_TYPE_BIGINT),
-        NValue::getTupleStorageSize(VALUE_TYPE_TINYINT),
-        NValue::getTupleStorageSize(VALUE_TYPE_SMALLINT),
-        NValue::getTupleStorageSize(VALUE_TYPE_INTEGER),
-        NValue::getTupleStorageSize(VALUE_TYPE_BIGINT)
+        NValue::getTupleStorageSize(VALUE_TYPE_TINYINT),    // 1
+        NValue::getTupleStorageSize(VALUE_TYPE_SMALLINT),   // 2
+        NValue::getTupleStorageSize(VALUE_TYPE_INTEGER),    // 4
+        NValue::getTupleStorageSize(VALUE_TYPE_BIGINT),     // 8
+        NValue::getTupleStorageSize(VALUE_TYPE_DECIMAL),    // 16
+        NValue::getTupleStorageSize(VALUE_TYPE_DOUBLE),     // 8
+        NValue::getTupleStorageSize(VALUE_TYPE_TIMESTAMP),  // 8
+        10,    /* The test uses getRandomValue() to generate random value,
+                  make sure the column size not conflict with the value it generates. */
+        16     /* same as above */
     };
-bool COLUMN_ALLOW_NULLS[NUM_OF_COLUMNS] = { true, true, true, true, true };
+bool COLUMN_ALLOW_NULLS[NUM_OF_COLUMNS] = { true, true, true, true, true, true, true, true, true };
 
 class TableTest : public Test {
 public:
@@ -106,7 +115,6 @@ public:
 protected:
     void init(bool xact) {
         CatalogId database_id = 1000;
-        vector<boost::shared_ptr<const TableColumn> > columns;
         char buffer[32];
 
         vector<string> columnNames(NUM_OF_COLUMNS);
@@ -128,7 +136,7 @@ protected:
             temp_table = TableFactory::getTempTable(database_id, "test_temp_table", schema, columnNames, &limits);
             m_table = temp_table;
         }
-        assert(tableutil::addRandomTuples(m_table, NUM_OF_TUPLES));
+        ASSERT_TRUE(tableutil::addRandomTuples(m_table, NUM_OF_TUPLES));
     }
 
     Table* m_table;
@@ -153,6 +161,28 @@ TEST_F(TableTest, ValueTypes) {
             EXPECT_EQ(COLUMN_TYPES[ctr], columnInfo->getVoltType());
         }
     }
+}
+
+TEST_F(TableTest, TableSerialize) {
+    size_t serializeSize = m_table->getAccurateSizeToSerialize(true);
+    char* backingCharArray = new char[serializeSize];
+    ReferenceSerializeOutput conflictSerializeOutput(backingCharArray, serializeSize);
+    m_table->serializeTo(conflictSerializeOutput);
+
+    EXPECT_EQ(serializeSize, conflictSerializeOutput.size());
+
+    delete[] backingCharArray;
+}
+
+TEST_F(TableTest, TableSerializeWithoutTotalSize) {
+    size_t serializeSize = m_table->getAccurateSizeToSerialize(false);
+    char* backingCharArray = new char[serializeSize];
+    ReferenceSerializeOutput conflictSerializeOutput(backingCharArray, serializeSize);
+    m_table->serializeToWithoutTotalSize(conflictSerializeOutput);
+
+    EXPECT_EQ(serializeSize, conflictSerializeOutput.size());
+
+    delete[] backingCharArray;
 }
 
 TEST_F(TableTest, TupleInsert) {


### PR DESCRIPTION
Add test for new function in TupleSchema

Delete global refs in destructor of JNITopend

Add NULL check for output table parameter

Count length placeholder for variable length columns

ENG-8596, rename function to make the intention more obiviously.

Change-Id: I48a68c0e22dff20baecc11a7f74eb86182695a8a

ENG-8596, eliminate reduntant code, fix ee unit test, remove unnecessary call of deleteLocalRef().

Change-Id: Id8a2774828d915aff0f10adae311ee9c92ad076d

ENG-8596, fix license check.

Change-Id: Ia2aa636cda48b42208fd5bd042e05886c180fe0a

ENG-8596, fix ee test case that only fails on all Linux platforms (but not OSX).

Change-Id: Ica8ef0f30386a1d9f76d707601540d3413c6bc32