### PR TITLE
Check that executors map is not null in temp tables emptiness check

### DIFF
--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -218,8 +218,18 @@ void ExecutorContext::cleanupExecutorsForSubquery(int subqueryId) const
 
 bool ExecutorContext::allOutputTempTablesAreEmpty() const {
     typedef std::map<int, std::vector<AbstractExecutor*>* >::value_type MapEntry;
+
+    // if we're recovering from an error, the executors map may never
+    // have been initialized.
+    if (m_executorsMap == NULL) {
+        // if there's no executors, there's no temp tables to check,
+        // so return true.
+        return true;
+    }
+
     BOOST_FOREACH (MapEntry &entry, *m_executorsMap) {
         BOOST_FOREACH(AbstractExecutor* executor, *(entry.second)) {
+            assert(executor != NULL);
             if (! executor->outputTempTableIsEmpty()) {
                 return false;
             }


### PR DESCRIPTION
This caused a hard EE crash during development.  (I had new functions
added to the planner not yet implemented in the EE.  This should have
just returned an exception to the user.)