### PR TITLE
ENG-8987: Give an error if a procedure returns more than Short.MAX_VA…

### DIFF
--- a/src/frontend/org/voltdb/ClientResponseImpl.java
+++ b/src/frontend/org/voltdb/ClientResponseImpl.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONString;
 import org.json_voltpatches.JSONStringer;
+import org.voltcore.logging.VoltLogger;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ClientUtils;
 import org.voltdb.common.Constants;
@@ -35,6 +36,8 @@ import org.voltdb.utils.SerializationHelper;
  *
  */
 public class ClientResponseImpl implements ClientResponse, JSONString {
+    private static final VoltLogger m_logger = new VoltLogger("ClientResponse");
+
     private boolean setProperly = false;
     private byte status = 0;
     private String statusString = null;
@@ -167,6 +170,13 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
         }
         int tableCount = buf.getShort();
         if (tableCount < 0) {
+            m_logger.error("Got negative table count. ByteBuffer content is: ");
+            byte[] bbArray = buf.array();
+            StringBuffer sb = new StringBuffer();
+            for (int i=0; i<bbArray.length; i++) {
+                sb.append(bbArray[i] + " ");
+            }
+            m_logger.error(sb);
             throw new IOException("Table count is negative: " + tableCount);
         }
         results = new VoltTable[tableCount];

--- a/src/frontend/org/voltdb/ClientResponseImpl.java
+++ b/src/frontend/org/voltdb/ClientResponseImpl.java
@@ -165,7 +165,7 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
         } else {
             m_hash = null;
         }
-        int tableCount = buf.getInt();
+        int tableCount = buf.getShort();
         if (tableCount < 0) {
             throw new IOException("Table count is negative: " + tableCount);
         }
@@ -189,7 +189,7 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
             + 1 // status
             + 1 // app status
             + 4 // cluster roundtrip time
-            + 4; // number of result tables
+            + 2; // number of result tables
 
         if (appStatusString != null) {
             encodedAppStatusString = appStatusString.getBytes(Constants.UTF8ENCODING);
@@ -241,7 +241,7 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
         if (m_hash != null) {
             buf.putInt(m_hash.intValue());
         }
-        buf.putInt(results.length);
+        buf.putShort((short) results.length);
         for (VoltTable vt : results)
         {
             vt.flattenToBuffer(buf);

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -398,7 +398,16 @@ public class ProcedureRunner {
             // don't leave empty handed
             if (results == null) {
                 results = new VoltTable[0];
+            } else if (results.length > Short.MAX_VALUE) {
+                String statusString = "Output from procedure exceeded the limit of " + Short.MAX_VALUE + " tables";
+                retval = new ClientResponseImpl(
+                        ClientResponse.GRACEFUL_FAILURE,
+                        ClientResponse.GRACEFUL_FAILURE,
+                        statusString,
+                        new VoltTable[0],
+                        statusString);
             }
+
 
             if (retval == null) {
                 retval = new ClientResponseImpl(

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -399,7 +399,7 @@ public class ProcedureRunner {
             if (results == null) {
                 results = new VoltTable[0];
             } else if (results.length > Short.MAX_VALUE) {
-                String statusString = "Output from procedure exceeded the limit of " + Short.MAX_VALUE + " tables";
+                String statusString = "Stored procedure returns too much data. Exceeded  maximum number of VoltTables: " + Short.MAX_VALUE;
                 retval = new ClientResponseImpl(
                         ClientResponse.GRACEFUL_FAILURE,
                         ClientResponse.GRACEFUL_FAILURE,

--- a/tests/frontend/org/voltdb/TestVoltProcedure.java
+++ b/tests/frontend/org/voltdb/TestVoltProcedure.java
@@ -50,7 +50,8 @@
 
 package org.voltdb;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -58,6 +59,7 @@ import java.util.Date;
 import junit.framework.TestCase;
 
 import org.voltcore.utils.CoreUtils;
+import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.types.TimestampType;
 
@@ -214,6 +216,23 @@ public class TestVoltProcedure extends TestCase {
         }
     }
 
+    static class LargeNumberOfTablesProc extends NullProcedureWrapper
+    {
+        public static VoltTable[] run(String arg)
+        {
+            ColumnInfo columnInfo = new ColumnInfo("intcol", VoltType.INTEGER);
+            VoltTable table = new VoltTable(columnInfo);
+            table.addRow(10);
+            int count = Short.MAX_VALUE + 1;
+            VoltTable[] results = new VoltTable[count];
+            for (int i=0; i<count; i++) {
+                results[i] = table;
+            }
+
+            return results;
+        }
+    }
+
     static class NullProcedureWrapper extends VoltProcedure {
         VoltTable runQueryStatement(SQLStmt stmt, Object... params) {
             assert false;
@@ -272,6 +291,7 @@ public class TestVoltProcedure extends TestCase {
         manager.addProcedureForTest(BoxedDoubleProcedure.class.getName());
         manager.addProcedureForTest(LongArrayProcedure.class.getName());
         manager.addProcedureForTest(NPEProcedure.class.getName());
+        manager.addProcedureForTest(LargeNumberOfTablesProc.class.getName());
         manager.addProcedureForTest(UnexpectedFailureFourProcedure.class.getName());
         site = mock(SiteProcedureConnection.class);
         doReturn(42).when(site).getCorrespondingPartitionId();
@@ -383,6 +403,13 @@ public class TestVoltProcedure extends TestCase {
         assertEquals(ClientResponse.UNEXPECTED_FAILURE, r.getStatus());
         System.out.println(r.getStatusString());
         assertTrue(r.getStatusString().contains("java.lang.NullPointerException"));
+    }
+
+    public void testLargeNumberOfTablesError() {
+        ClientResponse r = call(LargeNumberOfTablesProc.class);
+        assertEquals(ClientResponse.GRACEFUL_FAILURE, r.getStatus());
+        System.out.println(r.getStatusString());
+        assertTrue(r.getStatusString().contains("exceeded the limit"));
     }
 
     public void testNegativeWiderType() {

--- a/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
+++ b/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
@@ -36,7 +36,6 @@ import org.voltdb.ClientResponseImpl;
 import org.voltdb.ParameterSet;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.VoltTable;
-import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.exceptions.EEException;
@@ -460,35 +459,6 @@ public class TestVoltMessageSerialization extends TestCase {
         assertEquals(r1.getHashinatorVersionedConfig().getFirst(),new Long(2));
     }
 
-    public void testLargeNumberOfTableResults() throws Exception
-    {
-        ColumnInfo columnInfo = new ColumnInfo("intcol", VoltType.INTEGER);
-        VoltTable table = new VoltTable(columnInfo);
-        table.addRow(10);
-        int count = Short.MAX_VALUE + 1;
-        VoltTable[] results = new VoltTable[count];
-        for (int i=0; i<count; i++) {
-            results[i] = table;
-        }
-        String statusStr = "Success!";
-        ClientResponseImpl expected = new ClientResponseImpl(ClientResponse.SUCCESS, results, statusStr);
-        assertEquals(count, expected.getResults().length);
-        assertEquals(ClientResponse.SUCCESS, expected.getStatus());
-        assertEquals(statusStr, expected.getStatusString());
-
-        int size = expected.getSerializedSize();
-        ByteBuffer buf = ByteBuffer.allocate(size);
-        expected.flattenToBuffer(buf);
-        buf.flip();
-
-        ClientResponseImpl deserialized = new ClientResponseImpl();
-        deserialized.initFromBuffer(buf);
-
-        assertEquals(expected.getStatus(), deserialized.getStatus());
-        assertEquals(expected.getStatusString(), deserialized.getStatusString());
-        assertEquals(expected.getResults().length, deserialized.getResults().length);
-    }
-
     public void testInvalidTableCount() throws Exception
     {
         int size = 1 // version
@@ -497,7 +467,7 @@ public class TestVoltMessageSerialization extends TestCase {
             + 1 // status
             + 1 // app status
             + 4 // cluster roundtrip time
-            + 4; // number of result tables
+            + 2; // number of result tables
         ByteBuffer buf = ByteBuffer.allocate(size);
         buf.put((byte)0); //version
         buf.putLong(1L);
@@ -506,7 +476,7 @@ public class TestVoltMessageSerialization extends TestCase {
         buf.put(ClientResponse.SUCCESS);
         buf.put(ClientResponse.SUCCESS);
         buf.putInt(100);
-        buf.putInt(Integer.MAX_VALUE + 1);
+        buf.putShort( (short) (Short.MAX_VALUE + 1));
         buf.flip();
 
         ClientResponseImpl deserialized = new ClientResponseImpl();


### PR DESCRIPTION
…LUE number of tables.

Revert previous change that allowed up Integer.MAX_VALUE number of tables because it
broke backward compatibility for client protocol.