### PR TITLE
ENG-8907: Changes to make initiator stats work with internal connecti…

### DIFF
--- a/src/frontend/org/voltcore/network/Connection.java
+++ b/src/frontend/org/voltcore/network/Connection.java
@@ -17,8 +17,8 @@
 
 package org.voltcore.network;
 
-import java.util.concurrent.Future;
 import java.net.InetSocketAddress;
+import java.util.concurrent.Future;
 
 public interface Connection {
     /**
@@ -51,10 +51,26 @@ public interface Connection {
      * Returns the hostname if it was resolved, otherwise it returns the IP. Doesn't do a reverse DNS lookup
      */
     String getHostnameOrIP();
+    /**
+     * Returns a value identifying the caller of this connection. This is useful with connections like
+     * InternalClientResponseAdapter, which is used by multiple internal callers.
+     *
+     * @param clientHandle clientHandle identifying the caller
+     * @return value identifying the caller of this connection
+     */
+    String getHostnameOrIP(long clientHandle);
+
     int getRemotePort();
     InetSocketAddress getRemoteSocketAddress();
 
     long connectionId();
+    /**
+     * Returns an internal connection id for the caller of this Connection identified by input parameter.
+     * This is useful with connections like InternalClientResponseAdatper, which is used by multiple internal callers.
+     * @param clientHandle clientHandle identifying the caller
+     * @return an internal connection id for the caller of this Connection identified by input parameter
+     */
+    long connectionId(long clientHandle);
 
     void queueTask(Runnable r);
 

--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -465,6 +465,11 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
     }
 
     @Override
+    public String getHostnameOrIP(long clientHandle) {
+        return getHostnameOrIP();
+    }
+
+    @Override
     public int getRemotePort() {
         return m_remoteSocketAddress.getPort();
     }
@@ -477,6 +482,11 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
     @Override
     public long connectionId() {
         return m_ih.connectionId();
+    }
+
+    @Override
+    public long connectionId(long clientHandle) {
+        return connectionId();
     }
 
     @Override

--- a/src/frontend/org/voltcore/network/VoltPort.java
+++ b/src/frontend/org/voltcore/network/VoltPort.java
@@ -425,6 +425,11 @@ public class VoltPort implements Connection
     }
 
     @Override
+    public String getHostnameOrIP(long clientHandle) {
+        return getHostnameOrIP();
+    }
+
+    @Override
     public String getHostnameAndIPAndPort() {
         return m_remoteHostAndAddressAndPort;
     }
@@ -442,6 +447,11 @@ public class VoltPort implements Connection
     @Override
     public long connectionId() {
         return m_handler.connectionId();
+    }
+
+    @Override
+    public long connectionId(long clientHandle) {
+        return connectionId();
     }
 
     @Override

--- a/src/frontend/org/voltcore/network/VoltProtocolHandler.java
+++ b/src/frontend/org/voltcore/network/VoltProtocolHandler.java
@@ -46,6 +46,10 @@ public abstract class VoltProtocolHandler implements InputHandler {
         m_connectionId = m_globalConnectionCounter.incrementAndGet();
     }
 
+    public static long getNextConnectionId() {
+        return m_globalConnectionCounter.incrementAndGet();
+    }
+
     @Override
     public ByteBuffer retrieveNextMessage(final NIOReadStream inputStream) throws BadMessageLength {
 

--- a/src/frontend/org/voltdb/InternalClientResponseAdapter.java
+++ b/src/frontend/org/voltdb/InternalClientResponseAdapter.java
@@ -38,6 +38,7 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.LocalObjectMessage;
 import org.voltcore.network.Connection;
 import org.voltcore.network.NIOReadStream;
+import org.voltcore.network.VoltProtocolHandler;
 import org.voltcore.network.WriteStream;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DeferredSerialization;
@@ -73,8 +74,11 @@ public class InternalClientResponseAdapter implements Connection, WriteStream {
     private final long m_connectionId;
     private final AtomicLong m_handles = new AtomicLong();
     private final AtomicLong m_failures = new AtomicLong(0);
-    private final Map<Long, Callback> m_callbacks = Collections.synchronizedMap(new HashMap<Long, Callback>());
+    private final Map<Long, InternalCallback> m_callbacks = Collections.synchronizedMap(new HashMap<Long, InternalCallback>());
     private final ConcurrentMap<Integer, ExecutorService> m_partitionExecutor = new ConcurrentHashMap<>();
+    // Maintain internal connection ids per caller id. This is useful when collecting statistics
+    // so that information can be grouped per user of this Connection.
+    private final ConcurrentMap<String, Long> m_internalConnectionIds = new ConcurrentHashMap<>();
 
     private InternalConnectionContext m_context;
     private ProcedureCallback m_proccb;
@@ -235,6 +239,10 @@ public class InternalClientResponseAdapter implements Connection, WriteStream {
 
         if (!m_partitionExecutor.containsKey(partition)) {
             m_partitionExecutor.putIfAbsent(partition, CoreUtils.getSingleThreadExecutor("InternalHandlerExecutor - " + partition));
+        }
+
+        if (!m_internalConnectionIds.containsKey(context.getName())) {
+            m_internalConnectionIds.putIfAbsent(context.getName(), VoltProtocolHandler.getNextConnectionId());
         }
         ExecutorService executor = m_partitionExecutor.get(partition);
         try {
@@ -426,6 +434,17 @@ public class InternalClientResponseAdapter implements Connection, WriteStream {
     }
 
     @Override
+    public String getHostnameOrIP(long clientHandle) {
+        InternalCallback callback = m_callbacks.get(clientHandle);
+        if (callback==null) {
+            m_logger.warn("Could not find caller details for client handle " + clientHandle + ". Using internal adapter name");
+            return getHostnameOrIP();
+        } else {
+            return callback.getInternalContext().getName();
+        }
+    }
+
+    @Override
     public int getRemotePort() {
         return -1;
     }
@@ -438,6 +457,23 @@ public class InternalClientResponseAdapter implements Connection, WriteStream {
     @Override
     public long connectionId() {
         return m_connectionId;
+    }
+
+    @Override
+    public long connectionId(long clientHandle) {
+        InternalCallback callback = m_callbacks.get(clientHandle);
+        if (callback==null) {
+            m_logger.warn("Could not find caller details for client handle " + clientHandle + ". Using internal adapter level connection id");
+            return connectionId();
+        }
+
+        Long internalId = m_internalConnectionIds.get(callback.getInternalContext().getName());
+        if (internalId==null) {
+            m_logger.warn("Could not find internal connection id for client handle " + clientHandle + ". Using internal adapter level connection id");
+            return connectionId();
+        } else {
+            return internalId;
+        }
     }
 
     @Override

--- a/src/frontend/org/voltdb/SimpleClientResponseAdapter.java
+++ b/src/frontend/org/voltdb/SimpleClientResponseAdapter.java
@@ -17,9 +17,18 @@
 
 package org.voltdb;
 
-import com.google_voltpatches.common.base.Supplier;
-import com.google_voltpatches.common.util.concurrent.ListenableFuture;
-import com.google_voltpatches.common.util.concurrent.SettableFuture;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.voltcore.network.Connection;
 import org.voltcore.network.NIOReadStream;
 import org.voltcore.network.WriteStream;
@@ -27,14 +36,9 @@ import org.voltcore.utils.DeferredSerialization;
 import org.voltcore.utils.Pair;
 import org.voltdb.client.ClientResponse;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicLong;
+import com.google_voltpatches.common.base.Supplier;
+import com.google_voltpatches.common.util.concurrent.ListenableFuture;
+import com.google_voltpatches.common.util.concurrent.SettableFuture;
 
 /**
  * A very simple adapter that deserializes bytes into client responses. It calls
@@ -266,6 +270,11 @@ public class SimpleClientResponseAdapter implements Connection, WriteStream {
     }
 
     @Override
+    public String getHostnameOrIP(long clientHandle) {
+        return getHostnameOrIP();
+    }
+
+    @Override
     public int getRemotePort() {
         return -1;
     }
@@ -278,6 +287,11 @@ public class SimpleClientResponseAdapter implements Connection, WriteStream {
     @Override
     public long connectionId() {
         return m_connectionId;
+    }
+
+    @Override
+    public long connectionId(long clientHandle) {
+        return connectionId();
     }
 
     @Override

--- a/tests/frontend/org/voltcore/network/MockConnection.java
+++ b/tests/frontend/org/voltcore/network/MockConnection.java
@@ -59,6 +59,11 @@ public class MockConnection implements Connection {
     }
 
     @Override
+    public String getHostnameOrIP(long clientHandle) {
+        return getHostnameOrIP();
+    }
+
+    @Override
     public int getRemotePort() {
         throw new UnsupportedOperationException();
     }
@@ -71,6 +76,11 @@ public class MockConnection implements Connection {
     @Override
     public long connectionId() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long connectionId(long clientHandle) {
+        return connectionId();
     }
 
     @Override

--- a/tests/test_apps/log4jsocketimporter/deployment.xml
+++ b/tests/test_apps/log4jsocketimporter/deployment.xml
@@ -8,6 +8,7 @@
         <configuration module="log4jsocketimporter.jar" type="custom" enabled="true">
             <property name="port">6060</property>
             <property name="log-event-table">log_events</property>
+            <property name="procedure">log_events.insert</property>
         </configuration>
     </import>
 </deployment>


### PR DESCRIPTION
…on used by importers --
New methods in Connection to get name and id per caller (importer) of the internal connection.

This must be merged along with the pull request on pro side because of changes in Connection interface.