### PR TITLE
ENG-9116, change the index array iteration order so now check the pri…

### DIFF
--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -969,13 +969,13 @@ void PersistentTable::deleteFromAllIndexes(TableTuple *tuple) {
 }
 
 void PersistentTable::tryInsertOnAllIndexes(TableTuple *tuple, TableTuple *conflict) {
-    for (int i = static_cast<int>(m_indexes.size()) - 1; i >= 0; --i) {
+    for (int i = 0; i < static_cast<int>(m_indexes.size()); ++i) {
         m_indexes[i]->addEntry(tuple, conflict);
         FAIL_IF(!conflict->isNullTuple()) {
             VOLT_DEBUG("Failed to insert into index %s,%s",
                        m_indexes[i]->getTypeName().c_str(),
                        m_indexes[i]->getName().c_str());
-            for (int j = i + 1; j < m_indexes.size(); ++j) {
+            for (int j = 0; j < i; ++j) {
                 m_indexes[j]->deleteEntry(tuple);
             }
             return;


### PR DESCRIPTION
…mary key first.

If the insertion is going to trigger constraint violation, fails early to reduce the occurences of rewinding.
This is also useful for A/A conflict detection, which needs to report primary key constraint violation first.

Change-Id: Ieda75da8743387e7282f856e76c0aa60348f7a65