### PR TITLE
Simplify ThreadLocalPool memory management API

### DIFF
--- a/src/ee/common/StringRef.h
+++ b/src/ee/common/StringRef.h
@@ -49,11 +49,12 @@ namespace voltdb
         /// allocated out of the ThreadLocalPool.
         static StringRef* create(std::size_t size, Pool* dataPool);
 
-        /// Destroy the given StringRef object and free any memory, if
-        /// any, allocated from pools to store the object.
+        /// Destroy the given StringRef object and free any memory
+        /// allocated from persistet pools to store the object.
         /// sref must have been allocated and returned by a call to
-        /// StringRef::create() and must not have been created in a
-        /// temporary Pool
+        /// StringRef::create() and is a no-op for strings created in
+        /// a temporary Pool -- they simply leak their allocations
+        /// until the Pool is purged or destroyed.
         static void destroy(StringRef* sref);
 
         char* get();
@@ -62,7 +63,11 @@ namespace voltdb
     private:
         StringRef(std::size_t size);
         StringRef(std::size_t size, Pool* dataPool);
+        // Only called from destroy and only for persistent strings.
         ~StringRef();
+
+        // Only called from destroy and only for persistent strings.
+        void operator delete(void* object);
 
         /// Callback used via the back-pointer in order to update the
         /// pointer to the memory backing this string reference

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -18,21 +18,10 @@
 #ifndef THREADLOCALPOOL_H_
 #define THREADLOCALPOOL_H_
 
-#include "CompactingStringStorage.h"
-
 #include "boost/pool/pool.hpp"
 #include "boost/shared_ptr.hpp"
 
 namespace voltdb {
-
-struct voltdb_pool_allocator_new_delete
-{
-  typedef std::size_t size_type;
-  typedef std::ptrdiff_t difference_type;
-
-  static char * malloc(const size_type bytes);
-  static void free(char * const block);
-};
 
 /**
  * A wrapper around a set of pools that are local to the current thread.
@@ -50,24 +39,70 @@ public:
     /**
      * Return the nearest power-of-two-plus-or-minus buffer size that
      * will be allocated for an object of the given length
+     * TODO: internalize this function and CompactingStringStorage into
+     * ThreadLocalPool.cpp.
      */
     static std::size_t getAllocationSizeForObject(std::size_t length);
 
     /**
-     * Retrieve a pool that allocates approximately sized chunks of memory. Provides pools that
-     * are powers of two and powers of two + the previous power of two.
+     * Allocate space from a page of objects of the requested size.
+     * Each new size of object splinters the allocated memory into a new pool
+     * which is a collection of pages of objects of that exact size.
+     * Each pool will allocate additional space that is initally unused.
+     * This is not an issue when the allocated objects will be instances of a
+     * class that has many instances to quickly fill up the unused space. So,
+     * an optimal use case is a custom operator new for a commonly used class.
+     * Page sizes in a pool may vary as the number of required pages grows,
+     * but will be bounded to 2MB or to the size of two objects if they are
+     * larger than 256KB (not typical). There is no fixed upper limit to the
+     * size of object that can be requested.
+     * This allocation method would be a poor choice for variable-length
+     * buffers whose sizes depend on user input and may be unlikely to repeat.
+     * allocateRelocatable is the better fit for that use case.
      */
-    static boost::shared_ptr<boost::pool<voltdb_pool_allocator_new_delete> > get(std::size_t size);
+    static void* allocateExactSizedObject(std::size_t size);
 
     /**
-     * Retrieve a pool that allocate chunks that are exactly the requested size. Only creates
-     * pools up to 1 megabyte + 4 bytes.
+     * Deallocate the object returned by allocateExactSizedObject.
      */
-    static boost::shared_ptr<boost::pool<voltdb_pool_allocator_new_delete> > getExact(std::size_t size);
+    static void freeExactSizedObject(std::size_t, void* object);
 
     static std::size_t getPoolAllocationSize();
 
-    static CompactingStringStorage* getStringPool();
+    /**
+     * Allocate space from a page of objects of approximately the requested
+     * size. There will be relatively small gaps of unused space between the
+     * objects. This is caused by aligning them to a slightly larger size.
+     * This allows allocations within a pool of similarly-sized objects
+     * to always fit when they are relocated to fill a hole left by a
+     * deallocation. This enables continuous compaction to prevent deallocation
+     * from accumulating large unused holes in the page.
+     * For the relocation to work, there can only be one persistent pointer
+     * to an allocation and the pointer's address must be registered with the
+     * allocator so that the allocator can reset the pointer at that address
+     * when its referent needs to be relocated.
+     * Allocation requests of greater than 1 megabyte + 12 bytes will throw a
+     * fatal exception. This limit is arbitrary and could be extended if
+     * needed. The caller is expected to guard against this fatal condition.
+     * This allocation method is ideal for variable-length user data that is
+     * managed through a single point of reference (See class StringRef).
+     * The relocation feature makes this allocation method a poor choice for
+     * objects that could be referenced by multiple persistent pointers.
+     * allocateExactSizedObject uses a simpler, more general allocator that
+     * works well with fixed-sized allocations and counted references.
+     * Also, the sole persistent pointer is assumed to remain at a fixed
+     * address for the lifetime of the allocation, but it would be easy to add
+     * a function that allowed the persistent pointer to be safely relocated
+     * and re-registered.
+     */
+    static char* allocateRelocatable(std::size_t sz);
+
+    /**
+     * Deallocate the object returned by allocateRelocatable.
+     * This implements continuous compaction which can have the side effect of
+     * relocating some other allocation.
+     */
+    static void freeRelocatable(std::size_t sz, char* string);
 };
 }
 

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -936,9 +936,10 @@ inline TBPtr PersistentTable::findBlock(char *tuple, TBMap &blocks, int blockSiz
     return TBPtr(NULL);
 }
 
-inline TBPtr PersistentTable::allocateNextBlock() {
-    TBPtr block(new (ThreadLocalPool::getExact(sizeof(TupleBlock))->malloc()) TupleBlock(this, m_blocksNotPendingSnapshotLoad[0]));
-    m_data.insert( block->address(), block);
+inline TBPtr PersistentTable::allocateNextBlock()
+{
+    TBPtr block(new TupleBlock(this, m_blocksNotPendingSnapshotLoad[0]));
+    m_data.insert(block->address(), block);
     m_blocksNotPendingSnapshot.insert(block);
     return block;
 }

--- a/src/ee/storage/temptable.h
+++ b/src/ee/storage/temptable.h
@@ -248,7 +248,7 @@ inline void TempTable::deleteAllTuplesNonVirtual(bool freeAllocatedStrings) {
 }
 
 inline TBPtr TempTable::allocateNextBlock() {
-    TBPtr block(new (ThreadLocalPool::getExact(sizeof(TupleBlock))->malloc()) TupleBlock(this, TBBucketPtr()));
+    TBPtr block(new TupleBlock(this, TBBucketPtr()));
     m_data.push_back(block);
 
     if (m_limits) {

--- a/tests/ee/storage/persistent_table_log_test.cpp
+++ b/tests/ee/storage/persistent_table_log_test.cpp
@@ -364,9 +364,9 @@ TEST_F(PersistentTableLogTest, FindBlockTest) {
     TBBucketPtr bucket(new TBBucket());
 
     // these will be used as artificial tuple block addresses
-    TBPtr block1(new (ThreadLocalPool::getExact(sizeof(TupleBlock))->malloc()) TupleBlock(m_table, bucket));
-    TBPtr block2(new (ThreadLocalPool::getExact(sizeof(TupleBlock))->malloc()) TupleBlock(m_table, bucket));
-    TBPtr block3(new (ThreadLocalPool::getExact(sizeof(TupleBlock))->malloc()) TupleBlock(m_table, bucket));
+    TBPtr block1(new TupleBlock(m_table, bucket));
+    TBPtr block2(new TupleBlock(m_table, bucket));
+    TBPtr block3(new TupleBlock(m_table, bucket));
 
     TBMap blocks;
     char *base = block1->address();

--- a/third_party/cpp/boost_ext/FastAllocator.hpp
+++ b/third_party/cpp/boost_ext/FastAllocator.hpp
@@ -111,7 +111,7 @@ public:
         }
         const pointer ret = (n == 1) ?
                 static_cast<pointer>(
-                        ThreadLocalPool::getExact(sizeof(T))->malloc()) :
+                        ThreadLocalPool::allocateExactSizedObject(sizeof(T))) :
                         reinterpret_cast<pointer>(new char[sizeof(T) * n]);
         if (ret == 0) {
             boost::throw_exception(std::bad_alloc());
@@ -124,8 +124,7 @@ public:
     }
 
     pointer allocate() {
-        boost::shared_ptr<boost::pool<voltdb::voltdb_pool_allocator_new_delete> > pool = ThreadLocalPool::getExact(sizeof(T));
-        const pointer ret = pool->malloc();
+        const pointer ret = ThreadLocalPool::allocateExactSizedObject(sizeof(T));
         if (ret == 0) {
             boost::throw_exception(std::bad_alloc());
         }
@@ -137,8 +136,9 @@ public:
             return;
         }
         if (n == 1) {
-            ThreadLocalPool::getExact(sizeof(T))->free(ptr);
-        } else {
+            ThreadLocalPool::freeExactSizedObject(sizeof(T), ptr);
+        }
+        else {
             delete [] reinterpret_cast<const char*>(ptr);
         }
     }
@@ -147,8 +147,7 @@ public:
         if (ptr == NULL) {
             return;
         }
-        boost::shared_ptr<boost::pool<voltdb::voltdb_pool_allocator_new_delete> > pool = ThreadLocalPool::getExact(sizeof(T));
-        pool->free(ptr);
+        ThreadLocalPool::freeExactSizedObject(sizeof(T), ptr);
     }
 };
 }


### PR DESCRIPTION
This changeset is mostly refactoring for simplified interfaces and adding comments.
The two small intended behavior changes are:
    a bug fix specific to MEMCHECK builds where strings that SHOULD be leaked into the temp string pool were being explicitly deleted -- not sure why memcheck runs seemed to only sometimes complain.
    an odd failure mode when freeing an invalid allocation in ThreadLocalPool that arose from too much
shared code between the allocate and free code paths. If the ThreadLocalPool could not find a pool from which to deallocate an object, based on the claimed size of the object, instead of failing, it tried to allocate a new pool for that object size (DOH!) before complaining that the pool did not contain the object (DUH!). This should never happen in production, but it has historically been a great way to turn a small bug (corruption of an object's self-recorded allocation size) into a big mess - an attempt to needlessly allocate a potentially huge pool.