### PR TITLE
ENG-9248: With the changes to include lib in the jar, symbol generati…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -938,7 +938,7 @@ DISTRIBUTION
 </target>
 
 <target name="prep_libvoltdb">
-    <copy todir='voltdb'>
+    <copy todir='voltdb' overwrite="true">
         <fileset dir="${build.dir}/nativelibs">
             <include name="libvoltdb-${dist.version}.*"/>
         </fileset>


### PR DESCRIPTION
…on could be called twice for 'dist' target. When it is called a second time, the symbol file was being overwritten by symbol file generated from stipped lib file. Fixed build to use overwrite when preparing lib file.