### PR TITLE
Detect content determinism in Read/Write stored procedures.

### DIFF
--- a/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
+++ b/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
@@ -17,8 +17,6 @@
 
 package org.voltdb.compiler;
 
-import groovy.lang.Closure;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -60,6 +58,8 @@ import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.InMemoryJarfile;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
+
+import groovy.lang.Closure;
 
 /**
  * Compiles stored procedures into a given catalog,
@@ -504,31 +504,7 @@ public abstract class ProcedureCompiler implements GroovyCodeBlockConstants {
 
         procedure.setHasseqscans(procHasSeqScans);
 
-        for (Statement catalogStmt : procedure.getStatements()) {
-            if (catalogStmt.getIscontentdeterministic() == false) {
-                String potentialErrMsg =
-                    "Procedure " + shortName + " has a statement with a non-deterministic result - statement: \"" +
-                    catalogStmt.getSqltext() + "\" , reason: " + catalogStmt.getNondeterminismdetail();
-                // throw compiler.new VoltCompilerException(potentialErrMsg);
-                compiler.addWarn(potentialErrMsg);
-            }
-            else if (catalogStmt.getIsorderdeterministic() == false) {
-                String warnMsg;
-                if (procHasWriteStmts) {
-                    String rwPotentialErrMsg = "Procedure " + shortName +
-                            " is RW and has a statement whose result has a non-deterministic ordering - statement: \"" +
-                            catalogStmt.getSqltext() + "\", reason: " + catalogStmt.getNondeterminismdetail();
-                    // throw compiler.new VoltCompilerException(rwPotentialErrMsg);
-                    warnMsg = rwPotentialErrMsg;
-                }
-                else {
-                    warnMsg = "Procedure " + shortName +
-                        " has a statement with a non-deterministic result - statement: \"" +
-                        catalogStmt.getSqltext() + "\", reason: " + catalogStmt.getNondeterminismdetail();
-                }
-                compiler.addWarn(warnMsg);
-            }
-        }
+        checkForDeterminismWarnings(compiler, shortName, procedure, procHasWriteStmts);
 
         // set procedure parameter types
         CatalogMap<ProcParameter> params = procedure.getParameters();
@@ -635,6 +611,35 @@ public abstract class ProcedureCompiler implements GroovyCodeBlockConstants {
             ancestor = ancestor.getEnclosingClass();
         }
         compiler.addClassToJar(jarOutput, ancestor);
+    }
+
+    private static void checkForDeterminismWarnings(VoltCompiler compiler, String shortName, final Procedure procedure,
+                                         boolean procHasWriteStmts) {
+        for (Statement catalogStmt : procedure.getStatements()) {
+            if (catalogStmt.getIscontentdeterministic() == false) {
+                String potentialErrMsg =
+                    "Procedure " + shortName + " has a statement with a non-deterministic result - statement: \"" +
+                    catalogStmt.getSqltext() + "\" , reason: " + catalogStmt.getNondeterminismdetail();
+                // throw compiler.new VoltCompilerException(potentialErrMsg);
+                compiler.addWarn(potentialErrMsg);
+            }
+            else if (catalogStmt.getIsorderdeterministic() == false) {
+                String warnMsg;
+                if (procHasWriteStmts) {
+                    String rwPotentialErrMsg = "Procedure " + shortName +
+                            " is RW and has a statement whose result has a non-deterministic ordering - statement: \"" +
+                            catalogStmt.getSqltext() + "\", reason: " + catalogStmt.getNondeterminismdetail();
+                    // throw compiler.new VoltCompilerException(rwPotentialErrMsg);
+                    warnMsg = rwPotentialErrMsg;
+                }
+                else {
+                    warnMsg = "Procedure " + shortName +
+                        " has a statement with a non-deterministic result - statement: \"" +
+                        catalogStmt.getSqltext() + "\", reason: " + catalogStmt.getNondeterminismdetail();
+                }
+                compiler.addWarn(warnMsg);
+            }
+        }
     }
 
     static void compileSingleStmtProcedure(VoltCompiler compiler,

--- a/src/frontend/org/voltdb/compiler/StatementCompiler.java
+++ b/src/frontend/org/voltdb/compiler/StatementCompiler.java
@@ -209,10 +209,12 @@ public abstract class StatementCompiler {
                 " must not exceed the maximum " + CompiledPlan.MAX_PARAM_COUNT);
         }
 
-        // Check order determinism before accessing the detail which it caches.
+        // Check order and content determinism before accessing the detail which
+        // it caches.
         boolean orderDeterministic = plan.isOrderDeterministic();
         catalogStmt.setIsorderdeterministic(orderDeterministic);
-        boolean contentDeterministic = orderDeterministic || ! plan.hasLimitOrOffset();
+        boolean contentDeterministic = plan.isContentDeterministic()
+                                       && (orderDeterministic || !plan.hasLimitOrOffset());
         catalogStmt.setIscontentdeterministic(contentDeterministic);
         String nondeterminismDetail = plan.nondeterminismDetail();
         catalogStmt.setNondeterminismdetail(nondeterminismDetail);

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -67,7 +67,6 @@ public abstract class AbstractParsedStmt {
     public static int NEXT_STMT_ID = 0;
     // Internal parameter counter
     public static int NEXT_PARAMETER_ID = 0;
-
     // The unique id to identify the statement
     public int m_stmtId;
 
@@ -1664,6 +1663,20 @@ public abstract class AbstractParsedStmt {
         Set<AbstractExpression> subqueryExprs = findAllSubexpressionsOfClass(
                 SelectSubqueryExpression.class);
         return !subqueryExprs.isEmpty();
+    }
+
+    /**
+     * Return an error message iff this statement is inherently content
+     * deterministic. Some operations can cause non-determinism. Notably,
+     * aggregate functions of floating point type can cause non-deterministic
+     * round-off error. The default is to return null, which means the query is
+     * inherently deterministic.
+     *
+     * @return An error message if this statement is *not* content
+     *         deterministic. Otherwise we return null.
+     */
+    public String isContentDeterministic() {
+        return null;
     }
 
 }

--- a/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
@@ -239,4 +239,15 @@ public class ParsedInsertStmt extends AbstractParsedStmt {
 
         return exprs;
     }
+
+    /**
+     * Return the content determinism string of the subquery if there is one.
+     */
+    @Override
+    public String isContentDeterministic() {
+        if (m_subquery != null) {
+            return m_subquery.isContentDeterministic();
+        }
+        return null;
+    }
 }

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -1968,4 +1968,21 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         }
         return exprs;
     }
+
+    @Override
+
+    public String isContentDeterministic() {
+        String ans = null;
+        for (ParsedColInfo displayCol : m_displayColumns) {
+            AbstractExpression displayExpr = displayCol.expression;
+            for (AbstractExpression absExpr : displayExpr.findAllSubexpressionsOfClass(AggregateExpression.class)) {
+                AggregateExpression aggExpr = (AggregateExpression) absExpr;
+                if (aggExpr.getValueType() == VoltType.FLOAT) {
+                    return "Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.";
+                }
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
@@ -411,4 +411,20 @@ public class ParsedUnionStmt extends AbstractParsedStmt {
             orderCol.expression = expr;
         }
     }
+
+    /**
+     * Here we search all the children, finding if each is content
+     * deterministic. If it is we return right away.
+     */
+    @Override
+    public String isContentDeterministic() {
+        String ans = null;
+        for (AbstractParsedStmt child : m_children) {
+            ans = child.isContentDeterministic();
+            if (ans != null) {
+                return ans;
+            }
+        }
+        return null;
+    }
 }

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -449,4 +449,8 @@ public class StmtSubqueryScan extends StmtTableScan {
     public List<SchemaColumn> getOutputSchema() {
         return m_outputColumnList;
     }
+
+    public String isContentDeterministic() {
+        return m_subqueryStmt.isContentDeterministic();
+    }
 }

--- a/tests/frontend/org/voltdb/planner/TestDeterminism.java
+++ b/tests/frontend/org/voltdb/planner/TestDeterminism.java
@@ -35,8 +35,18 @@ public class TestDeterminism extends PlannerTestCase {
 
     private final static boolean m_staticRetryForDebugOnFailure = /**/ false; //*/ = true;//to debug
 
-    private void assertPlanDeterminismCore(String sql, boolean order, boolean content,
-            DeterminismMode detMode)
+    private void assertPlanDeterminismCore(String sql,
+                                           boolean order,
+                                           boolean orderLimitContent,
+                                           DeterminismMode detMode) {
+        assertPlanDeterminismFullCore(sql, order, orderLimitContent, true, detMode);
+    }
+
+    private void assertPlanDeterminismFullCore(String sql,
+                                               boolean order,
+                                               boolean orderLimitContent,
+                                               boolean inherentContent,
+                                               DeterminismMode detMode)
     {
         CompiledPlan cp = compileAdHocPlan(sql, detMode);
         if (order != cp.isOrderDeterministic()) {
@@ -47,16 +57,27 @@ public class TestDeterminism extends PlannerTestCase {
             }
         }
         assertEquals(order, cp.isOrderDeterministic());
-        if (content != (cp.isOrderDeterministic() || ! cp.hasLimitOrOffset())) {
-            System.out.println((content ? "EXPECTED CONSISTENT CONTENT: " : "UNEXPECTED CONSISTENT CONTENT: ") + sql);
+        if (orderLimitContent != (cp.isOrderDeterministic() || !cp.hasLimitOrOffset())) {
+            System.out.println((orderLimitContent ? "EXPECTED CONSISTENT CONTENT: " : "UNEXPECTED CONSISTENT CONTENT: ")
+                               + sql);
             // retry failed case for debugging
             if (m_staticRetryForDebugOnFailure) {
                 // retry failed case for debugging
                 cp = compileAdHocPlan(sql, detMode);
             }
         }
-        assertEquals(content, cp.isOrderDeterministic() || ! cp.hasLimitOrOffset());
+        assertEquals(orderLimitContent, cp.isOrderDeterministic() || !cp.hasLimitOrOffset());
         assertTrue(cp.isOrderDeterministic() || (null != cp.nondeterminismDetail()));
+        if (inherentContent != cp.isContentDeterministic()) {
+            System.out.println((inherentContent ? "EXPECTED CONSISTENT CONTENT: " : "UNEXPECTED CONSISTENT CONTENT: ")
+                               + sql);
+            // retry failed case for debugging
+            if (m_staticRetryForDebugOnFailure) {
+                // retry failed case for debugging
+                cp = compileAdHocPlan(sql, detMode);
+            }
+        }
+        assertEquals(cp.isContentDeterministic(), inherentContent);
     }
 
     // This is a weakened version of assertPlanDeterminismCore that only complains to the system output
@@ -554,6 +575,14 @@ public class TestDeterminism extends PlannerTestCase {
         assertPlanDeterminismCore("(select a, b, c from ttree_with_key order by a, b, c limit 1) union (select a, b, c from ttree_with_key);", !ENG8790IsFixed, true, DeterminismMode.FASTER);
         assertPlanDeterminismCore("(select a, b, c from ttree_with_key) union (select a, b, c from ttree_with_key order by a, b, c limit 1);", ENG8790IsFixed, true, DeterminismMode.FASTER);
         assertPlanDeterminismCore("select a from tonecolumn order by abs(a)", false, true, DeterminismMode.FASTER);
+    }
+
+    public void testFloatingAggs() throws Exception {
+        assertPlanDeterminismFullCore("select sum(alpha + beta + gamma) as fsum from floataggs order by fsum;",
+                                      true,
+                                      true,
+                                      false,
+                                      DeterminismMode.FASTER);
     }
 
     private void assertMPPlanDeterminismCore(String sql, boolean order, boolean content,

--- a/tests/frontend/org/voltdb/planner/testplans-determinism-ddl.sql
+++ b/tests/frontend/org/voltdb/planner/testplans-determinism-ddl.sql
@@ -115,3 +115,9 @@ create table ppk (
 );
 
 partition table ppk on column a;
+
+create table floataggs (
+    alpha float,
+    beta  float,
+    gamma float
+);

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/FloatingInsertAggregates.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/FloatingInsertAggregates.java
@@ -1,0 +1,57 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */package org.voltdb_testprocs.regressionsuites.failureprocs;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+
+public class FloatingInsertAggregates extends VoltProcedure {
+    public static final SQLStmt insertAmbiguousRows = new SQLStmt("insert into floatingaggs_output select sum(alpha) from floatingaggs_input");
+
+    public long run() {
+        voltQueueSQL(insertAmbiguousRows);
+        voltExecuteSQL();
+        voltExecuteSQL();
+        // zero is a successful return
+        return 0;
+    }
+}

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/FloatingUpdateAggregates.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/FloatingUpdateAggregates.java
@@ -1,0 +1,64 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */package org.voltdb_testprocs.regressionsuites.failureprocs;
+
+import org.voltdb.ProcInfo;
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+
+@ProcInfo(singlePartition = false)
+
+public class FloatingUpdateAggregates extends VoltProcedure {
+    public static final SQLStmt queryAmbiguousRows = new SQLStmt("select sum(alpha) from floatingaggs_input");
+    public static final SQLStmt updateAmbiguously  = new SQLStmt("update blah set sval = ?");
+
+    public long run() {
+        voltQueueSQL(queryAmbiguousRows);
+        voltExecuteSQL();
+        String updateArg = "garbage in as if based on ND query";
+        voltQueueSQL(updateAmbiguously, updateArg);
+        voltExecuteSQL();
+        // zero is a successful return
+        return 0;
+    }
+
+}


### PR DESCRIPTION
We detect some kinds of content determinism in Read/Write stored
procedures during planning.  After we compute the best plan, we look at
the AbstractParsedExpression to find expressions which may be content
non-deterministic.  Right now we only detect aggregate functions of
floating point columns, but the mechanism is deliberately general.  This
determinism determination is propagated up to the Procedure.  In the
ProcedureCompiler, both in compileJavaProcedure and
compileSingleStmtProcedure, we check for content non-determinism and
cause a warning to be logged to the console and the log file.

Note that limit-order deterministic queries, by which I mean queries
which are order deterministic or else have no limit or offset, may be
inherently content non-deterministic, and inherently content
deterministic queries may be limit-order non-deterministic.  These are
mostly orthogonal notions.  If a stored procedure is non-deterministic,
either by limit-order or inherent non-determinism, we throw an
exception.

Note also that Read-only stored procedures are not affected by this at
all.