### PR TITLE
Fix the language standard for gcc 4.6.3 (Ubuntu 12.04).

### DIFF
--- a/build.py
+++ b/build.py
@@ -83,18 +83,18 @@ if CTX.compilerName() == 'gcc':
 	print("GCC Version %d.%d.%d is too old\n" 
 	       % (CTX.compilerMajorVersion(), CTX.compilerMinorVersion(), CTX.compilerPatchLevel())); 
 	sys.exit(-1);
-    if CTX.compilerMinorVersion() == 4:
-	CTX.CXX_VERSION_FLAG = "--std=c++0x"
-	print("Building with C++ 0x\n")
+    if 4 <= CTX.compilerMinorVersion() <= 6:
+	   CTX.CXX_VERSION_FLAG = "--std=c++0x"
+	   print("Building with C++ 0x\n")
     else:
-	CTX.CXX_VERSION_FLAG ="--std=c++11"
+	   CTX.CXX_VERSION_FLAG ="--std=c++11"
 	print("Building with C++11")
 elif CTX.compilerName() == 'clang':
     CTX.CXX_VERSION_FLAG="--std=c++11"
 CTX.CPPFLAGS += " " + CTX.CXX_VERSION_FLAG
 
 # linker flags
-CTX.LDFLAGS += """ -g3"""
+CTX.LDFLAGS += """ -g3 """
 CTX.LASTLDFLAGS = """ -ldl """
 CTX.LASTIPCLDFLAGS = """ """
 

--- a/build.py
+++ b/build.py
@@ -54,6 +54,8 @@ if CTX.compilerName() == 'gcc':
     CTX.LDFLAGS += " -rdynamic"
     if (CTX.compilerMajorVersion() >= 4):
         CTX.CPPFLAGS += " -Wno-deprecated-declarations  -Wno-unknown-pragmas"
+	if (CTX.compilerMinorVersion() == 6):
+	    CTX.CPPFLAGS += " -Wno-unused-but-set-variable"
 	if (CTX.compilerMinorVersion() == 9):
             CTX.CPPFLAGS += " -Wno-float-conversion -Wno-unused-but-set-variable -Wno-unused-local-typedefs"
         elif (CTX.compilerMinorVersion() == 8):
@@ -84,10 +86,10 @@ if CTX.compilerName() == 'gcc':
 	       % (CTX.compilerMajorVersion(), CTX.compilerMinorVersion(), CTX.compilerPatchLevel())); 
 	sys.exit(-1);
     if 4 <= CTX.compilerMinorVersion() <= 6:
-	   CTX.CXX_VERSION_FLAG = "--std=c++0x"
-	   print("Building with C++ 0x\n")
+	CTX.CXX_VERSION_FLAG = "--std=c++0x"
+	print("Building with C++ 0x\n")
     else:
-	   CTX.CXX_VERSION_FLAG ="--std=c++11"
+	CTX.CXX_VERSION_FLAG ="--std=c++11"
 	print("Building with C++11")
 elif CTX.compilerName() == 'clang':
     CTX.CXX_VERSION_FLAG="--std=c++11"


### PR DESCRIPTION
The python rules for choosing the C++ language setting were correctly
stated but incorrectly coded.  On Ubuntu 12.04 the system compiler is gcc 4.6.3.  We need
to compile with --std=03 there.  Also, we need to include -Wno-unused-set-variables.
