### PR TITLE
Handle geospatial data from the VMC.

### DIFF
--- a/src/frontend/org/voltdb/ParameterConverter.java
+++ b/src/frontend/org/voltdb/ParameterConverter.java
@@ -494,10 +494,36 @@ public class ParameterConverter {
                 throw new VoltTypeException(String.format("deserialize BigDecimal from string failed. (%s to %s)",
                         inputClz.getName(), expectedClz.getName()));
             }
-        } else if (expectedClz == PointType.class && inputClz == PointType.class) {
-            return param;
-        } else if (expectedClz == GeographyValue.class && inputClz == GeographyValue.class) {
-            return param;
+        } else if (expectedClz == PointType.class) {
+            // Is it a point already?  If so, just return it.
+            if (inputClz == PointType.class) {
+                return param;
+            }
+            // Is it a string from which we can construct a point?
+            // If so, return the newly constructed point.
+            if (inputClz == String.class) {
+                try {
+                    PointType pt = PointType.pointFromText((String)param);
+                    return pt;
+                } catch (IllegalArgumentException e) {
+                    throw new VoltTypeException(String.format("deserialize PointType from string failed (string %s)",
+                                                              (String)param));
+                }
+            }
+        } else if (expectedClz == GeographyValue.class) {
+            if (inputClz == GeographyValue.class) {
+                return param;
+            }
+            if (inputClz == String.class) {
+                String paramStr = (String)param;
+                try {
+                    GeographyValue gv = GeographyValue.geographyValueFromText(paramStr);
+                    return gv;
+                } catch (IllegalArgumentException e) {
+                    throw new VoltTypeException(String.format("deserialize GeographyValue from string failed (string %s)",
+                                                              paramStr));
+                }
+            }
         } else if (expectedClz == VoltTable.class && inputClz == VoltTable.class) {
             return param;
         } else if (expectedClz == String.class) {

--- a/src/frontend/org/voltdb/VoltTableRow.java
+++ b/src/frontend/org/voltdb/VoltTableRow.java
@@ -20,6 +20,7 @@ package org.voltdb;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.List;
 
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONStringer;
@@ -785,6 +786,10 @@ public abstract class VoltTableRow {
         return getDecimalAsBigDecimal(colIndex);
     }
 
+    static final String GEOJSON_TYPE_KEY           = "type";
+    static final String GEOJSON_COORDS_KEY         = "coordinates";
+    static final String GEOJSON_POINT_TYPE_SIGIL   = "Point";
+    static final String GEOJSON_POLYGON_TYPE_SIGIL = "Polygon";
     /**
      *
      * @param columnIndex
@@ -853,8 +858,13 @@ public abstract class VoltTableRow {
                 js.value(dec.toString());
             break;
         case POINT:
+            PointType pt = getPoint(columnIndex);
+            js.value(pt.toString());
+            break;
         case GEOGRAPHY:
-            throw new IllegalArgumentException("Instances of GEOGRAPHY and POINT are not yet serializable to JSON");
+            GeographyValue gv = getGeographyValue(columnIndex);
+            js.value(gv.toString());
+            break;
         // VoltType includes a few values that aren't valid column value types
         case INVALID:
             break;
@@ -868,6 +878,57 @@ public abstract class VoltTableRow {
             break;
         }
     }
+
+    /**
+     * This converts a GeographyValue to GEOJSON. We currently don't use it
+     * because the VMC does not know what to do with GEOJSON. But it's left here
+     * in the hope that it will be useful in the future.
+     *
+     * @param gv
+     * @param js
+     * @throws JSONException
+    @SuppressWarnings("unused")
+    static private void geographyValueToJSON(GeographyValue gv, JSONStringer js) throws JSONException {
+        js.object()
+          .key(GEOJSON_TYPE_KEY)
+          .value(GEOJSON_POLYGON_TYPE_SIGIL)
+          .key(GEOJSON_COORDS_KEY)
+          .array();
+        for (List<PointType> loops : gv.getLoops()) {
+            js.array();
+            for (PointType pt : loops) {
+                js.array();
+                js.value(pt.getLatitude())
+                  .value(pt.getLongitude());
+                js.endArray();
+            }
+            js.endArray();
+        }
+        js.endArray();
+    }
+     */
+
+    /**
+     * This converts a GeographyValue to GEOJSON. We currently don't use it
+     * because the VMC does not know what to do with GEOJSON. But it's left here
+     * in the hope that it will be useful in the future.
+     *
+     * @param gv
+     * @param js
+     * @throws JSONException
+    @SuppressWarnings("unused")
+    static private void pointToJSON(PointType pt, JSONStringer js) throws JSONException {
+        js.object()
+          .key(GEOJSON_TYPE_KEY)
+          .value(GEOJSON_POINT_TYPE_SIGIL)
+          .key(GEOJSON_COORDS_KEY)
+          .array()
+          .value(pt.getLatitude())
+          .value(pt.getLongitude())
+          .endArray()
+          .endObject();
+    }
+     */
 
     /** Validates that type and columnIndex match and are valid. */
     final void validateColumnType(int columnIndex, VoltType... types) {

--- a/src/frontend/org/voltdb/types/GeographyValue.java
+++ b/src/frontend/org/voltdb/types/GeographyValue.java
@@ -66,6 +66,10 @@ public class GeographyValue {
         }
     }
 
+    public static GeographyValue geographyValueFromText(String text) {
+        return new GeographyValue(text);
+    }
+
     /**
      * Gets the loops that make up the polygon, with the outer loop first.
      * @return  The loops in the polygon as a list of a list of points
@@ -290,5 +294,4 @@ public class GeographyValue {
 
         return loops;
     }
-
 }

--- a/tests/frontend/org/voltdb/TestParameterConverter.java
+++ b/tests/frontend/org/voltdb/TestParameterConverter.java
@@ -24,14 +24,19 @@
 
 package org.voltdb;
 
-import junit.framework.TestCase;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 
+import org.voltdb.types.GeographyValue;
+import org.voltdb.types.PointType;
 import org.voltdb.types.TimestampType;
 import org.voltdb.utils.Encoder;
 
-import java.math.BigDecimal;
-import java.sql.Timestamp;
-import java.util.Date;
+import junit.framework.TestCase;
 
 
 public class TestParameterConverter extends TestCase
@@ -128,6 +133,60 @@ public class TestParameterConverter extends TestCase
             tryToMakeCompatible(byte[].class, t);
         assertTrue("expect varbinary", r.getClass() == byte[].class);
         assertEquals(t, Encoder.hexEncode((byte[])r));
+    }
+
+    public void testOneStringToPoint(String rep, PointType pt, double epsilon) throws Exception {
+        Object r = ParameterConverter.tryToMakeCompatible(PointType.class, rep);
+        assertTrue("expected PointType", r.getClass() == PointType.class);
+        PointType rpt = (PointType)r;
+        assertEquals("Cannot convert string to point.", pt.getLatitude(),  rpt.getLatitude(),  epsilon); 
+        assertEquals("Cannot convert string to point.", pt.getLongitude(), rpt.getLongitude(), epsilon); 
+    }
+
+    public void testOneStringToPolygon(String rep, GeographyValue gv) throws Exception {
+        Object r = ParameterConverter.tryToMakeCompatible(GeographyValue.class, rep);
+        assertTrue("expected GeographyValue", r.getClass() == GeographyValue.class);
+        assertEquals("Cannot convert string to polygon.", gv.toString(), r.toString());
+    }
+
+    public void testStringToPointType() throws Exception {
+        double epsilon = 1.0e-3;
+        testOneStringToPoint("point(10.333 20.666)",               new PointType( 10.333,  20.666), epsilon);
+        testOneStringToPoint("  point  (10.333   20.666)    ",     new PointType( 10.333,  20.666), epsilon);
+        testOneStringToPoint("point(-10.333 -20.666)",             new PointType(-10.333, -20.666), epsilon);
+        testOneStringToPoint("  point  (-10.333   -20.666)    ",   new PointType(-10.333, -20.666), epsilon);
+        testOneStringToPoint("point(10 10)",                       new PointType(10.0,    10.0),    epsilon);
+        testOneStringToPoint("point(10.0 10.0)",                   new PointType(10.0, 10.0),       epsilon);
+        testOneStringToPoint("point(10 10)",                       new PointType(10.0, 10.0),       epsilon);
+        // testOneStringToPoint(null, "null");
+    }
+
+    public void testStringToPolygonType() throws Exception {
+        testOneStringToPolygon("polygon((0 0, 0 1, 1 1, 1 0, 0 0))",
+                               new GeographyValue(Collections.singletonList(Arrays.asList(new PointType[]{ new PointType(0,0),
+                                                                                                           new PointType(0, 1),
+                                                                                                           new PointType(1, 1),
+                                                                                                           new PointType(1, 0),
+                                                                                                           new PointType(0, 0) }))));
+        GeographyValue geog;
+        // The Bermuda Triangle
+        List<PointType> outerLoop = Arrays.asList(new PointType(32.305, -64.751),
+                                                  new PointType(25.244, -80.437),
+                                                  new PointType(18.476, -66.371),
+                                                  new PointType(32.305, -64.751));
+
+        // A triangular hole
+        List<PointType> innerLoop = Arrays.asList(new PointType(28.066, -68.874),
+                                                  new PointType(25.361, -68.855),
+                                                  new PointType(28.376, -73.381),
+                                                  new PointType(28.066, -68.874));
+
+        geog = new GeographyValue(Arrays.asList(outerLoop, innerLoop));
+        String geogRep = "POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751), " + "(28.066 -68.874, 25.361 -68.855, 28.376 -73.381, 28.066 -68.874))";
+        testOneStringToPolygon(geogRep, geog);
+        // round trip
+        geog = new GeographyValue(geogRep);
+        testOneStringToPolygon(geogRep, geog);
     }
 
     public void testNulls()


### PR DESCRIPTION
Both sqlcmd and the VMC parameters to the server to use with stored
procedures.  For sqlcmd these parameters are serialized PointType and
GeographyValue values, and the user types WKT strings.  For VMC the user
types WKT strings as well, but VMC didn't know how to convert the
strings to geospatial types, and didn't even know the types of
parameters.  So, the strings are sent to the server and converted there.
Geospatial values in tables are serialized as WKT strings and sent back
to the VMC.  So, from the standpoint of the VMC user, the data starts
and end as WKT strings.  This is less than completely desirable.  The
user should be able to send GEOJson as parameters, and the server should
be able to reply in GEOJson values.  But this is not completely
necessary now, and probably needs a second ticket.