### PR TITLE
Don't print too many stack traces.

### DIFF
--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -47,6 +47,7 @@ import org.voltdb.utils.Encoder;
  */
 public class PlannerTool {
     private static final VoltLogger hostLog = new VoltLogger("HOST");
+    private static final VoltLogger compileLog = new VoltLogger("COMPILE");
 
     private final Database m_database;
     private final Cluster m_cluster;
@@ -109,7 +110,7 @@ public class PlannerTool {
     }
 
     private void logException(Exception e, String fmtLabel) {
-        hostLog.error(fmtLabel + ": ", e);
+        compileLog.error(fmtLabel + ": ", e);
     }
 
     /**
@@ -131,8 +132,16 @@ public class PlannerTool {
             assert(plan != null);
         }
         catch (Exception e) {
-            logException(e, "Error compiling query");
-            throw new RuntimeException("Error compiling query: " + e.toString() + " (Stack trace has been logged).", e);
+            /*
+             * Don't log PlanningErrorExceptions or HSQLParseExceptions, as they
+             * are at least somewhat expected.
+             */
+            String loggedMsg = "";
+            if (!(e instanceof PlanningErrorException || e instanceof HSQLParseException)) {
+                logException(e, "Error compiling query");
+                loggedMsg = " (Stack trace has been written to the log.)";
+            }
+            throw new RuntimeException("Error compiling query: " + e.toString() + loggedMsg, e);
         }
 
         if (plan == null) {
@@ -260,8 +269,16 @@ public class PlannerTool {
                     partitioning = plan.getStatementPartitioning();
                 }
             } catch (Exception e) {
-                logException(e, "Error compiling query");
-                throw new RuntimeException("Error compiling query: " + e.toString() + " (Stack trace has been logged.)",
+                /*
+                 * Don't log PlanningErrorExceptions or HSQLParseExceptions, as
+                 * they are at least somewhat expected.
+                 */
+                String loggedMsg = "";
+                if (!((e instanceof PlanningErrorException) || (e instanceof HSQLParseException))) {
+                    logException(e, "Error compiling query");
+                    loggedMsg = " (Stack trace has been written to the log.)";
+                }
+                throw new RuntimeException("Error compiling query: " + e.toString() + loggedMsg,
                                            e);
             }
 


### PR DESCRIPTION
PlanningErrorExceptions and HSQLParseExcptions are extected behavior in
the planner.  So, we don't want stack traces for them.  Also, log to the
COMPILE logger, not the HOST logger.

I'm not 100% sure this solves the problem.  I'm not sure how to reproduce it.
