### PR TITLE
Remove unused table name and table size parameters

### DIFF
--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -27,9 +27,12 @@ namespace voltdb {
         return 0;
     }
 
-    int64_t DummyTopend::fragmentProgressUpdate(int32_t batchIndex, std::string planNodeName,
-            std::string targetTableName, int64_t targetTableSize, int64_t tuplesFound,
-            int64_t currMemoryInBytes, int64_t peakMemoryInBytes) {
+    int64_t DummyTopend::fragmentProgressUpdate(
+            int32_t batchIndex,
+            const std::string& planNodeName,
+            int64_t tuplesFound,
+            int64_t currMemoryInBytes,
+            int64_t peakMemoryInBytes) {
         return 1000000000; // larger means less likely/frequent callbacks to ignore
     }
 

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -46,9 +46,12 @@ class Topend {
     // query to stop.
     // Return 0 if the Topend wants the EE to stop processing the current fragment
     // or the number of tuples the EE should process before repeating this call.
-    virtual int64_t fragmentProgressUpdate(int32_t batchIndex, std::string planNodeName,
-                std::string targetTableName, int64_t targetTableSize, int64_t tuplesProcessed,
-                int64_t currMemoryInBytes, int64_t peakMemoryInBytes) = 0;
+    virtual int64_t fragmentProgressUpdate(
+                int32_t batchIndex,
+                const std::string& planNodeName,
+                int64_t tuplesProcessed,
+                int64_t currMemoryInBytes,
+                int64_t peakMemoryInBytes) = 0;
 
     virtual std::string planForFragmentId(int64_t fragmentId) = 0;
 
@@ -87,9 +90,12 @@ public:
     int loadNextDependency(
         int32_t dependencyId, voltdb::Pool *pool, Table* destination);
 
-    virtual int64_t fragmentProgressUpdate(int32_t batchIndex, std::string planNodeName,
-            std::string targetTableName, int64_t targetTableSize, int64_t tuplesFound,
-            int64_t currMemoryInBytes, int64_t peakMemoryInBytes);
+    virtual int64_t fragmentProgressUpdate(
+            int32_t batchIndex,
+            const std::string &planNodeName,
+            int64_t tuplesFound,
+            int64_t currMemoryInBytes,
+            int64_t peakMemoryInBytes);
 
     std::string planForFragmentId(int64_t fragmentId);
 

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -32,9 +32,12 @@ public:
 
     inline JNITopend* updateJNIEnv(JNIEnv *env) { m_jniEnv = env; return this; }
     int loadNextDependency(int32_t dependencyId, Pool *stringPool, Table* destination);
-    int64_t fragmentProgressUpdate(int32_t batchIndex, std::string planNodeName,
-                std::string lastAccessedTable, int64_t lastAccessedTableSize, int64_t tuplesProcessed,
-                int64_t currMemoryInBytes, int64_t peakMemoryInBytes);
+    int64_t fragmentProgressUpdate(
+                int32_t batchIndex,
+                const std::string &planNodeName,
+                int64_t tuplesProcessed,
+                int64_t currMemoryInBytes,
+                int64_t peakMemoryInBytes);
     std::string planForFragmentId(int64_t fragmentId);
     void crashVoltDB(FatalException e);
     int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1774,11 +1774,6 @@ void VoltDBEngine::executePurgeFragment(PersistentTable* table) {
 static std::string dummy_last_accessed_plan_node_name("no plan node in progress");
 
 void VoltDBEngine::reportProgressToTopend() {
-    // TableName and tableSize are not really used in the JNI call
-    // Very low risk fix is make them constants
-    // TODO: refer ENG-8903 to deal with them
-    std::string tableName = "None";
-    int64_t tableSize = 0;
     assert(m_currExecutorVec);
 
     //Update stats in java and let java determine if we should cancel this query.
@@ -1786,9 +1781,7 @@ void VoltDBEngine::reportProgressToTopend() {
     int64_t tupleReportThreshold = m_topend->fragmentProgressUpdate(m_currentIndexInBatch,
                                         (m_lastAccessedExec == NULL) ?
                                         dummy_last_accessed_plan_node_name :
-                                        planNodeToString(m_lastAccessedExec->getPlanNode()->getPlanNodeType()),
-                                        tableName,
-                                        tableSize,
+                                          planNodeToString(m_lastAccessedExec->getPlanNode()->getPlanNodeType()),
                                         m_tuplesProcessedInBatch + m_tuplesProcessedInFragment,
                                         m_currExecutorVec->limits().getAllocated(),
                                         m_currExecutorVec->limits().getPeakMemoryInBytes());

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -94,9 +94,12 @@ public:
      */
     char *retrieveDependency(int32_t dependencyId, size_t *dependencySz);
 
-    int64_t fragmentProgressUpdate(int32_t batchIndex, std::string planNodeName,
-            std::string lastAccessedTable, int64_t lastAccessedTableSize, int64_t tuplesProcessed,
-            int64_t currMemoryInBytes, int64_t peakMemoryInBytes);
+    int64_t fragmentProgressUpdate(
+            int32_t batchIndex,
+            const std::string& planNodeName,
+            int64_t tuplesProcessed,
+            int64_t currMemoryInBytes,
+            int64_t peakMemoryInBytes);
 
     std::string decodeBase64AndDecompress(const std::string& base64Data);
 
@@ -939,19 +942,15 @@ char *VoltDBIPC::retrieveDependency(int32_t dependencyId, size_t *dependencySz) 
     return dependencyData;
 }
 
-int64_t VoltDBIPC::fragmentProgressUpdate(int32_t batchIndex,
-        std::string planNodeName,
-        std::string targetTableName,
-        int64_t targetTableSize,
+int64_t VoltDBIPC::fragmentProgressUpdate(
+        int32_t batchIndex,
+        const std::string &planNodeName,
         int64_t tuplesProcessed,
         int64_t currMemoryInBytes,
         int64_t peakMemoryInBytes) {
     char message[sizeof(int8_t) +
                  sizeof(int16_t) +
                  planNodeName.size() +
-                 sizeof(int16_t) +
-                 targetTableName.size() +
-                 sizeof(targetTableSize) +
                  sizeof(tuplesProcessed) +
                  sizeof(currMemoryInBytes) +
                  sizeof(peakMemoryInBytes)];
@@ -966,15 +965,6 @@ int64_t VoltDBIPC::fragmentProgressUpdate(int32_t batchIndex,
     offset += sizeof(strSize);
     ::memcpy( &message[offset], planNodeName.c_str(), strSize);
     offset += strSize;
-
-    strSize = static_cast<int16_t>(targetTableName.size());
-    *reinterpret_cast<int16_t*>(&message[offset]) = htons(strSize);
-    offset += sizeof(strSize);
-    ::memcpy( &message[offset], targetTableName.c_str(), strSize);
-    offset += strSize;
-
-    *reinterpret_cast<int64_t*>(&message[offset]) = htonll(targetTableSize);
-    offset += sizeof(targetTableSize);
 
     *reinterpret_cast<int64_t*>(&message[offset]) = htonll(tuplesProcessed);
     offset += sizeof(tuplesProcessed);

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -355,8 +355,6 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
 
     public long fragmentProgressUpdate(int indexFromFragmentTask,
             String planNodeName,
-            String lastAccessedTable,
-            long lastAccessedTableSize,
             long tuplesProcessed,
             long currMemoryInBytes,
             long peakMemoryInBytes)

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -886,12 +886,10 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                     short size = m_connection.readShort();
                     String planNodeName = m_connection.readString(size);
                     size = m_connection.readShort();
-                    String lastAccessedTable = m_connection.readString(size);
-                    long lastAccessedTableSize = m_connection.readLong();
                     long tuplesFound = m_connection.readLong();
                     long currMemoryInBytes = m_connection.readLong();
                     long peakMemoryInBytes = m_connection.readLong();
-                    long nextStep = fragmentProgressUpdate(batchIndex, planNodeName, lastAccessedTable, lastAccessedTableSize, tuplesFound,
+                    long nextStep = fragmentProgressUpdate(batchIndex, planNodeName, tuplesFound,
                             currMemoryInBytes, peakMemoryInBytes);
                     m_data.clear();
                     m_data.putLong(nextStep);


### PR DESCRIPTION
This removes unused parameters from our Java/C++ interface for reporting long-running queries.  Among them is a table name parameter of type std::string which may be implicated in the crash described in ENG-9290.

Xin recommended doing this in ENG-8903, I'll close that ticket as a duplicate.