### PR TITLE
Remove some complexity from long-running fragment progress report API

### DIFF
--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -27,9 +27,12 @@ namespace voltdb {
         return 0;
     }
 
-    int64_t DummyTopend::fragmentProgressUpdate(int32_t batchIndex, std::string planNodeName,
-            std::string targetTableName, int64_t targetTableSize, int64_t tuplesFound,
-            int64_t currMemoryInBytes, int64_t peakMemoryInBytes) {
+    int64_t DummyTopend::fragmentProgressUpdate(
+            int32_t batchIndex,
+            PlanNodeType planNodeType,
+            int64_t tuplesFound,
+            int64_t currMemoryInBytes,
+            int64_t peakMemoryInBytes) {
         return 1000000000; // larger means less likely/frequent callbacks to ignore
     }
 

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -46,9 +46,12 @@ class Topend {
     // query to stop.
     // Return 0 if the Topend wants the EE to stop processing the current fragment
     // or the number of tuples the EE should process before repeating this call.
-    virtual int64_t fragmentProgressUpdate(int32_t batchIndex, std::string planNodeName,
-                std::string targetTableName, int64_t targetTableSize, int64_t tuplesProcessed,
-                int64_t currMemoryInBytes, int64_t peakMemoryInBytes) = 0;
+    virtual int64_t fragmentProgressUpdate(
+                int32_t batchIndex,
+                PlanNodeType planNodeType,
+                int64_t tuplesProcessed,
+                int64_t currMemoryInBytes,
+                int64_t peakMemoryInBytes) = 0;
 
     virtual std::string planForFragmentId(int64_t fragmentId) = 0;
 
@@ -87,9 +90,12 @@ public:
     int loadNextDependency(
         int32_t dependencyId, voltdb::Pool *pool, Table* destination);
 
-    virtual int64_t fragmentProgressUpdate(int32_t batchIndex, std::string planNodeName,
-            std::string targetTableName, int64_t targetTableSize, int64_t tuplesFound,
-            int64_t currMemoryInBytes, int64_t peakMemoryInBytes);
+    virtual int64_t fragmentProgressUpdate(
+            int32_t batchIndex,
+            PlanNodeType planNodeType,
+            int64_t tuplesFound,
+            int64_t currMemoryInBytes,
+            int64_t peakMemoryInBytes);
 
     std::string planForFragmentId(int64_t fragmentId);
 

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -98,7 +98,7 @@ JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecuti
         throw std::exception();
     }
 
-    m_fragmentProgressUpdateMID = m_jniEnv->GetMethodID(jniClass, "fragmentProgressUpdate", "(ILjava/lang/String;Ljava/lang/String;JJJJ)J");
+    m_fragmentProgressUpdateMID = m_jniEnv->GetMethodID(jniClass, "fragmentProgressUpdate", "(IIJJJ)J");
     if (m_fragmentProgressUpdateMID == NULL) {
         m_jniEnv->ExceptionDescribe();
         assert(m_fragmentProgressUpdateMID != 0);
@@ -270,33 +270,19 @@ int JNITopend::loadNextDependency(int32_t dependencyId, voltdb::Pool *stringPool
     }
 }
 
-int64_t JNITopend::fragmentProgressUpdate(int32_t batchIndex,
-                std::string planNodeName,
-                std::string targetTableName,
-                int64_t targetTableSize,
+int64_t JNITopend::fragmentProgressUpdate(
+                int32_t batchIndex,
+                PlanNodeType planNodeType,
                 int64_t tuplesProcessed,
                 int64_t currMemoryInBytes,
                 int64_t peakMemoryInBytes) {
-        JNILocalFrameBarrier jni_frame = JNILocalFrameBarrier(m_jniEnv, 10);
-        if (jni_frame.checkResult() < 0) {
-                VOLT_ERROR("Unable to load dependency: jni frame error.");
-                throw std::exception();
-        }
-
-        jstring jPlanNodeName = m_jniEnv->NewStringUTF(planNodeName.c_str());
-        if (m_jniEnv->ExceptionCheck()) {
-                m_jniEnv->ExceptionDescribe();
-                throw std::exception();
-        }
-        jstring jTargetTableName = m_jniEnv->NewStringUTF(targetTableName.c_str());
-        if (m_jniEnv->ExceptionCheck()) {
-                m_jniEnv->ExceptionDescribe();
-                throw std::exception();
-        }
-
-    jlong nextStep = m_jniEnv->CallLongMethod(m_javaExecutionEngine,m_fragmentProgressUpdateMID,
-                batchIndex, jPlanNodeName, jTargetTableName, targetTableSize, tuplesProcessed,
-                currMemoryInBytes, peakMemoryInBytes);
+    jlong nextStep = m_jniEnv->CallLongMethod(m_javaExecutionEngine,
+                                              m_fragmentProgressUpdateMID,
+                                              batchIndex,
+                                              static_cast<int32_t>(planNodeType),
+                                              tuplesProcessed,
+                                              currMemoryInBytes,
+                                              peakMemoryInBytes);
     return (int64_t)nextStep;
 }
 

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -32,9 +32,12 @@ public:
 
     inline JNITopend* updateJNIEnv(JNIEnv *env) { m_jniEnv = env; return this; }
     int loadNextDependency(int32_t dependencyId, Pool *stringPool, Table* destination);
-    int64_t fragmentProgressUpdate(int32_t batchIndex, std::string planNodeName,
-                std::string lastAccessedTable, int64_t lastAccessedTableSize, int64_t tuplesProcessed,
-                int64_t currMemoryInBytes, int64_t peakMemoryInBytes);
+    int64_t fragmentProgressUpdate(
+                int32_t batchIndex,
+                PlanNodeType planNodeType,
+                int64_t tuplesProcessed,
+                int64_t currMemoryInBytes,
+                int64_t peakMemoryInBytes);
     std::string planForFragmentId(int64_t fragmentId);
     void crashVoltDB(FatalException e);
     int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);

--- a/src/ee/execution/ProgressMonitorProxy.h
+++ b/src/ee/execution/ProgressMonitorProxy.h
@@ -24,9 +24,10 @@ namespace voltdb {
 
 class ProgressMonitorProxy {
 public:
-    ProgressMonitorProxy(VoltDBEngine* engine, AbstractExecutor* exec, Table* target_table = NULL)
+    ProgressMonitorProxy(VoltDBEngine* engine, AbstractExecutor* exec)
         : m_engine(engine)
-        , m_tuplesRemainingUntilReport(engine->pullTuplesRemainingUntilProgressReport(exec, target_table))
+        , m_tuplesRemainingUntilReport(
+              engine->pullTuplesRemainingUntilProgressReport(exec->getPlanNode()->getPlanNodeType()))
         , m_countDown(m_tuplesRemainingUntilReport)
     { }
 

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -140,7 +140,7 @@ VoltDBEngine::VoltDBEngine(Topend *topend, LogProxy *logProxy)
       m_tuplesProcessedInFragment(0),
       m_tuplesProcessedSinceReport(0),
       m_tupleReportThreshold(LONG_OP_THRESHOLD),
-      m_lastAccessedTable(NULL),
+      m_lastAccessedPlanNodeType(PLAN_NODE_TYPE_INVALID),
       m_currentUndoQuantum(NULL),
       m_hashinator(NULL),
       m_staticParams(MAX_PARAM_COUNT),
@@ -1774,21 +1774,12 @@ void VoltDBEngine::executePurgeFragment(PersistentTable* table) {
 static std::string dummy_last_accessed_plan_node_name("no plan node in progress");
 
 void VoltDBEngine::reportProgressToTopend() {
-    // TableName and tableSize are not really used in the JNI call
-    // Very low risk fix is make them constants
-    // TODO: refer ENG-8903 to deal with them
-    std::string tableName = "None";
-    int64_t tableSize = 0;
     assert(m_currExecutorVec);
 
     //Update stats in java and let java determine if we should cancel this query.
     m_tuplesProcessedInFragment += m_tuplesProcessedSinceReport;
     int64_t tupleReportThreshold = m_topend->fragmentProgressUpdate(m_currentIndexInBatch,
-                                        (m_lastAccessedExec == NULL) ?
-                                        dummy_last_accessed_plan_node_name :
-                                        planNodeToString(m_lastAccessedExec->getPlanNode()->getPlanNodeType()),
-                                        tableName,
-                                        tableSize,
+                                        m_lastAccessedPlanNodeType,
                                         m_tuplesProcessedInBatch + m_tuplesProcessedInFragment,
                                         m_currExecutorVec->limits().getAllocated(),
                                         m_currExecutorVec->limits().getPeakMemoryInBytes());

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -161,7 +161,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
 
         // Executors can call this to note a certain number of tuples have been
         // scanned or processed.index
-        inline int64_t pullTuplesRemainingUntilProgressReport(AbstractExecutor* exec, Table* target_table);
+        inline int64_t pullTuplesRemainingUntilProgressReport(PlanNodeType planNodeType);
         inline int64_t pushTuplesProcessedForProgressMonitoring(int64_t tuplesProcessed);
         inline void pushFinalTuplesProcessedForProgressMonitoring(int64_t tuplesProcessed);
 
@@ -453,8 +453,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         int64_t m_tuplesProcessedInFragment;
         int64_t m_tuplesProcessedSinceReport;
         int64_t m_tupleReportThreshold;
-        Table *m_lastAccessedTable;
-        AbstractExecutor* m_lastAccessedExec;
+        PlanNodeType m_lastAccessedPlanNodeType;
 
         boost::scoped_ptr<EnginePlanSet> m_plans;
         voltdb::UndoLog m_undoLog;
@@ -620,13 +619,9 @@ inline void VoltDBEngine::resetReusedResultOutputBuffer(const size_t headerSize)
  * Track total tuples accessed for this query.
  * Set up statistics for long running operations thru m_engine if total tuples accessed passes the threshold.
  */
-inline int64_t VoltDBEngine::pullTuplesRemainingUntilProgressReport(AbstractExecutor* exec,
-                                                                    Table* target_table)
+inline int64_t VoltDBEngine::pullTuplesRemainingUntilProgressReport(PlanNodeType planNodeType)
 {
-    if (target_table) {
-        m_lastAccessedTable = target_table;
-    }
-    m_lastAccessedExec = exec;
+    m_lastAccessedPlanNodeType = planNodeType;
     return m_tupleReportThreshold - m_tuplesProcessedSinceReport;
 }
 
@@ -647,7 +642,7 @@ inline void VoltDBEngine::pushFinalTuplesProcessedForProgressMonitoring(int64_t 
         e.serialize(getExceptionOutputSerializer());
     }
 
-    m_lastAccessedExec = NULL;
+    m_lastAccessedPlanNodeType = PLAN_NODE_TYPE_INVALID;
 }
 
 } // namespace voltdb

--- a/src/ee/executors/indexscanexecutor.cpp
+++ b/src/ee/executors/indexscanexecutor.cpp
@@ -168,7 +168,7 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
     LimitPlanNode* limit_node = dynamic_cast<LimitPlanNode*>(m_abstractNode->getInlinePlanNode(PLAN_NODE_TYPE_LIMIT));
 
     TableTuple temp_tuple;
-    ProgressMonitorProxy pmp(m_engine, this, targetTable);
+    ProgressMonitorProxy pmp(m_engine, this);
     if (m_aggExec != NULL) {
         const TupleSchema * inputSchema = tableIndex->getTupleSchema();
         if (m_projectionNode != NULL) {

--- a/src/ee/executors/nestloopexecutor.cpp
+++ b/src/ee/executors/nestloopexecutor.cpp
@@ -161,7 +161,7 @@ bool NestLoopExecutor::p_execute(const NValueArray &params) {
     TableIterator iterator0 = outer_table->iteratorDeletingAsWeGo();
     int tuple_ctr = 0;
     int tuple_skipped = 0;
-    ProgressMonitorProxy pmp(m_engine, this, inner_table);
+    ProgressMonitorProxy pmp(m_engine, this);
 
     TableTuple join_tuple;
     if (m_aggExec != NULL) {

--- a/src/ee/executors/nestloopindexexecutor.cpp
+++ b/src/ee/executors/nestloopindexexecutor.cpp
@@ -245,7 +245,7 @@ bool NestLoopIndexExecutor::p_execute(const NValueArray &params)
     assert (inner_tuple.sizeInValues() == inner_table->columnCount());
     const TableTuple &null_tuple = m_null_tuple.tuple();
     int num_of_inner_cols = (m_joinType == JOIN_TYPE_LEFT)? null_tuple.sizeInValues() : 0;
-    ProgressMonitorProxy pmp(m_engine, this, inner_table);
+    ProgressMonitorProxy pmp(m_engine, this);
 
     TableTuple join_tuple;
     if (m_aggExec != NULL) {

--- a/src/ee/executors/seqscanexecutor.cpp
+++ b/src/ee/executors/seqscanexecutor.cpp
@@ -187,7 +187,7 @@ bool SeqScanExecutor::p_execute(const NValueArray &params) {
         int tuple_skipped = 0;
         TempTable* output_temp_table = dynamic_cast<TempTable*>(output_table);
 
-        ProgressMonitorProxy pmp(m_engine, this, node->isSubQuery() ? NULL : input_table);
+        ProgressMonitorProxy pmp(m_engine, this);
         TableTuple temp_tuple;
         if (m_aggExec != NULL) {
             const TupleSchema * inputSchema = input_table->schema();

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -96,7 +96,7 @@ public:
 
     int64_t fragmentProgressUpdate(
             int32_t batchIndex,
-            PlanNodeType planNodeType,
+            voltdb::PlanNodeType planNodeType,
             int64_t tuplesProcessed,
             int64_t currMemoryInBytes,
             int64_t peakMemoryInBytes);
@@ -944,13 +944,14 @@ char *VoltDBIPC::retrieveDependency(int32_t dependencyId, size_t *dependencySz) 
 
 int64_t VoltDBIPC::fragmentProgressUpdate(
         int32_t batchIndex,
-        PlanNodeType planNodeType,
+        voltdb::PlanNodeType planNodeType,
         int64_t tuplesProcessed,
         int64_t currMemoryInBytes,
         int64_t peakMemoryInBytes) {
+    int32_t nodeTypeAsInt32 = static_cast<int32_t>(planNodeType);
     char message[sizeof(int8_t) +
-                 sizeof(int16_t) +
-                 planNodeName.size() +
+                 sizeof(batchIndex) +
+                 sizeof(nodeTypeAsInt32) +
                  sizeof(tuplesProcessed) +
                  sizeof(currMemoryInBytes) +
                  sizeof(peakMemoryInBytes)];
@@ -960,7 +961,6 @@ int64_t VoltDBIPC::fragmentProgressUpdate(
     *reinterpret_cast<int32_t*>(&message[offset]) = htonl(batchIndex);
     offset += sizeof(batchIndex);
 
-    int32_t nodeTypeAsInt32 = static_cast<int32_t>(planNodeType);
     *reinterpret_cast<int32_t*>(&message[offset]) = htonl(nodeTypeAsInt32);
     offset += sizeof(nodeTypeAsInt32);
 

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -94,9 +94,12 @@ public:
      */
     char *retrieveDependency(int32_t dependencyId, size_t *dependencySz);
 
-    int64_t fragmentProgressUpdate(int32_t batchIndex, std::string planNodeName,
-            std::string lastAccessedTable, int64_t lastAccessedTableSize, int64_t tuplesProcessed,
-            int64_t currMemoryInBytes, int64_t peakMemoryInBytes);
+    int64_t fragmentProgressUpdate(
+            int32_t batchIndex,
+            PlanNodeType planNodeType,
+            int64_t tuplesProcessed,
+            int64_t currMemoryInBytes,
+            int64_t peakMemoryInBytes);
 
     std::string decodeBase64AndDecompress(const std::string& base64Data);
 
@@ -939,19 +942,15 @@ char *VoltDBIPC::retrieveDependency(int32_t dependencyId, size_t *dependencySz) 
     return dependencyData;
 }
 
-int64_t VoltDBIPC::fragmentProgressUpdate(int32_t batchIndex,
-        std::string planNodeName,
-        std::string targetTableName,
-        int64_t targetTableSize,
+int64_t VoltDBIPC::fragmentProgressUpdate(
+        int32_t batchIndex,
+        PlanNodeType planNodeType,
         int64_t tuplesProcessed,
         int64_t currMemoryInBytes,
         int64_t peakMemoryInBytes) {
     char message[sizeof(int8_t) +
                  sizeof(int16_t) +
                  planNodeName.size() +
-                 sizeof(int16_t) +
-                 targetTableName.size() +
-                 sizeof(targetTableSize) +
                  sizeof(tuplesProcessed) +
                  sizeof(currMemoryInBytes) +
                  sizeof(peakMemoryInBytes)];
@@ -961,20 +960,9 @@ int64_t VoltDBIPC::fragmentProgressUpdate(int32_t batchIndex,
     *reinterpret_cast<int32_t*>(&message[offset]) = htonl(batchIndex);
     offset += sizeof(batchIndex);
 
-    int16_t strSize = static_cast<int16_t>(planNodeName.size());
-    *reinterpret_cast<int16_t*>(&message[offset]) = htons(strSize);
-    offset += sizeof(strSize);
-    ::memcpy( &message[offset], planNodeName.c_str(), strSize);
-    offset += strSize;
-
-    strSize = static_cast<int16_t>(targetTableName.size());
-    *reinterpret_cast<int16_t*>(&message[offset]) = htons(strSize);
-    offset += sizeof(strSize);
-    ::memcpy( &message[offset], targetTableName.c_str(), strSize);
-    offset += strSize;
-
-    *reinterpret_cast<int64_t*>(&message[offset]) = htonll(targetTableSize);
-    offset += sizeof(targetTableSize);
+    int32_t nodeTypeAsInt32 = static_cast<int32_t>(planNodeType);
+    *reinterpret_cast<int32_t*>(&message[offset]) = htonl(nodeTypeAsInt32);
+    offset += sizeof(nodeTypeAsInt32);
 
     *reinterpret_cast<int64_t*>(&message[offset]) = htonll(tuplesProcessed);
     offset += sizeof(tuplesProcessed);

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -883,15 +883,11 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                 }
                 else if (result == ExecutionEngine.ERRORCODE_PROGRESS_UPDATE) {
                     int batchIndex = m_connection.readInt();
-                    short size = m_connection.readShort();
-                    String planNodeName = m_connection.readString(size);
-                    size = m_connection.readShort();
-                    String lastAccessedTable = m_connection.readString(size);
-                    long lastAccessedTableSize = m_connection.readLong();
+                    int planNodeTypeAsInt = m_connection.readInt();
                     long tuplesFound = m_connection.readLong();
                     long currMemoryInBytes = m_connection.readLong();
                     long peakMemoryInBytes = m_connection.readLong();
-                    long nextStep = fragmentProgressUpdate(batchIndex, planNodeName, lastAccessedTable, lastAccessedTableSize, tuplesFound,
+                    long nextStep = fragmentProgressUpdate(batchIndex, planNodeTypeAsInt, tuplesFound,
                             currMemoryInBytes, peakMemoryInBytes);
                     m_data.clear();
                     m_data.putLong(nextStep);


### PR DESCRIPTION
Here's another try at simplifying how we log long-running fragment messages.
