### PR TITLE
Calculate non-determinism of aggregates of floating point types.

### DIFF
--- a/src/frontend/org/voltdb/compiler/StatementCompiler.java
+++ b/src/frontend/org/voltdb/compiler/StatementCompiler.java
@@ -209,10 +209,12 @@ public abstract class StatementCompiler {
                 " must not exceed the maximum " + CompiledPlan.MAX_PARAM_COUNT);
         }
 
-        // Check order determinism before accessing the detail which it caches.
+        // Check order and content determinism before accessing the detail which
+        // it caches.
         boolean orderDeterministic = plan.isOrderDeterministic();
         catalogStmt.setIsorderdeterministic(orderDeterministic);
-        boolean contentDeterministic = orderDeterministic || ! plan.hasLimitOrOffset();
+        boolean contentDeterministic = plan.isContentDeterministic()
+                                       && (orderDeterministic || !plan.hasLimitOrOffset());
         catalogStmt.setIscontentdeterministic(contentDeterministic);
         String nondeterminismDetail = plan.nondeterminismDetail();
         catalogStmt.setNondeterminismdetail(nondeterminismDetail);

--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -58,7 +58,37 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
     protected VoltType m_valueType = null;
     protected int m_valueSize = 0;
     protected boolean m_inBytes = false;
+    /*
+     * We set this to non-null iff the expression has a non-deterministic
+     * operation. The most common kind of non-deterministic operation is an
+     * aggregate function applied to a floating point expression.
+     */
+    private String m_contentDeterminismMessage = null;
 
+    /**
+     * Note that this expression is inherently non-deterministic. This may be
+     * called if the expression is already known to be non-deterministic, even
+     * if the value is false, because we are careful to never go from true to
+     * false here. Perhaps we should concatenate the messages. But since we only
+     * have one now it would result in unnecessary duplication.
+     *
+     * @param value
+     */
+    public void updateContentDeterminismMessage(String value) {
+        if (m_contentDeterminismMessage == null) {
+            m_contentDeterminismMessage = value;
+        }
+    }
+
+    /**
+     * Get the inherent non-determinism state of this expression. This is not
+     * valid before finalizeValueTypes is called.
+     *
+     * @return The state.
+     */
+    public String getContentDeterminismMessage() {
+        return m_contentDeterminismMessage;
+    }
     // Keep this flag turned off in production or when testing user-accessible EXPLAIN output or when
     // using EXPLAIN output to validate plans.
     protected static boolean m_verboseExplainForDebugging = false; // CODE REVIEWER! this SHOULD be false!
@@ -706,8 +736,9 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
                 tve.setOrigStmtId(((TupleValueExpression)this).getOrigStmtId());
             }
             // To prevent pushdown of LIMIT when ORDER BY references an agg. ENG-3487.
-            if (hasAnySubexpressionOfClass(AggregateExpression.class))
+            if (hasAnySubexpressionOfClass(AggregateExpression.class)) {
                 tve.setHasAggregate(true);
+            }
 
             return tve;
         }
@@ -1084,15 +1115,23 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
      */
     public abstract void finalizeValueTypes();
 
-    /** Do the recursive part of finalizeValueTypes as requested. */
+    /**
+     * Do the recursive part of finalizeValueTypes as requested. Note that this
+     * updates the content non-determinism state.
+     */
     protected final void finalizeChildValueTypes() {
-        if (m_left != null)
+        if (m_left != null) {
             m_left.finalizeValueTypes();
-        if (m_right != null)
+            updateContentDeterminismMessage(m_left.getContentDeterminismMessage());
+        }
+        if (m_right != null) {
             m_right.finalizeValueTypes();
+            updateContentDeterminismMessage(m_right.getContentDeterminismMessage());
+        }
         if (m_args != null) {
             for (AbstractExpression argument : m_args) {
                 argument.finalizeValueTypes();
+                updateContentDeterminismMessage(argument.getContentDeterminismMessage());
             }
         }
     }

--- a/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
@@ -188,4 +188,8 @@ public abstract class AbstractSubqueryExpression extends AbstractExpression {
             m_subqueryNode.generateOutputSchema(db);
         }
     }
+
+    public String getContentDeterminismMessage() {
+        return null;
+    }
 }

--- a/src/frontend/org/voltdb/expressions/AggregateExpression.java
+++ b/src/frontend/org/voltdb/expressions/AggregateExpression.java
@@ -58,7 +58,7 @@ public class AggregateExpression extends AbstractExpression {
         return result;
     }
 
-
+    private final String FLOAT_AGG_ERR_MSG = "Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.";
     @Override
     public void finalizeValueTypes()
     {
@@ -87,6 +87,9 @@ public class AggregateExpression extends AbstractExpression {
             //
             m_valueType = m_left.getValueType();
             m_valueSize = m_left.getValueSize();
+            if (m_valueType == VoltType.FLOAT) {
+                updateContentDeterminismMessage(FLOAT_AGG_ERR_MSG);
+            }
             break;
         case AGGREGATE_SUM:
             if (m_left.getValueType() == VoltType.TINYINT ||
@@ -97,6 +100,9 @@ public class AggregateExpression extends AbstractExpression {
             } else {
                 m_valueType = m_left.getValueType();
                 m_valueSize = m_left.getValueSize();
+            }
+            if (m_valueType == VoltType.FLOAT) {
+                updateContentDeterminismMessage(FLOAT_AGG_ERR_MSG);
             }
             break;
         default:

--- a/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
@@ -270,4 +270,7 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
         subqueryStmt.m_parameterTveMap.clear();
     }
 
+    public String calculateContentDeterminismMessage() {
+        return m_subquery.calculateContentDeterminismMessage();
+    }
 }

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -63,11 +63,12 @@ import org.voltdb.types.QuantifierType;
 
 public abstract class AbstractParsedStmt {
 
+    protected String m_contentDeterminismMessage = null;
+
      // Internal statement counter
     public static int NEXT_STMT_ID = 0;
     // Internal parameter counter
     public static int NEXT_PARAMETER_ID = 0;
-
     // The unique id to identify the statement
     public int m_stmtId;
 
@@ -975,6 +976,7 @@ public abstract class AbstractParsedStmt {
         } else {
             assert(tableScan instanceof StmtSubqueryScan);
             leafNode = new SubqueryLeafNode(nodeId, joinExpr, whereExpr, (StmtSubqueryScan)tableScan);
+            leafNode.updateContentDeterminismMessage(((StmtSubqueryScan) tableScan).calculateContentDeterminismMessage());
         }
 
         if (m_joinTree == null) {
@@ -1023,7 +1025,17 @@ public abstract class AbstractParsedStmt {
     }
 
     /**
-     * Populate the statement's paramList from the "parameters" element
+     * Populate the statement's paramList from the "parameters" element. Each
+     * parameter has an id and an index, both of which are numeric. It also has
+     * a type and an indication of whether it's a vector parameter. For each
+     * parameter, we create a ParameterValueExpression, named pve, which holds
+     * the type and vector parameter indication. We add the pve to two maps,
+     * m_paramsById and m_paramsByIndex.
+     *
+     * We also set a counter, MAX_PARAMETER_ID, to the largest id in the
+     * expression. This helps give ids to references to correlated expressions
+     * of subqueries.
+     *
      * @param paramsNode
      */
     protected void parseParameters(VoltXMLElement root) {
@@ -1174,6 +1186,7 @@ public abstract class AbstractParsedStmt {
         subQuery.m_paramsById.putAll(m_paramsById);
 
         AbstractParsedStmt.parse(subQuery, m_sql, suqueryElmt, m_db, m_joinOrder);
+        updateContentDeterminismMessage(subQuery.calculateContentDeterminismMessage());
         return subQuery;
     }
 
@@ -1665,7 +1678,6 @@ public abstract class AbstractParsedStmt {
                 SelectSubqueryExpression.class);
         return !subqueryExprs.isEmpty();
     }
-
     public abstract boolean isDML();
 
     /**
@@ -1694,4 +1706,39 @@ public abstract class AbstractParsedStmt {
         return m_parentStmt.topmostParentStatementIsDML();
     }
 
+    /**
+     * Return an error message iff this statement is inherently content
+     * deterministic. Some operations can cause non-determinism. Notably,
+     * aggregate functions of floating point type can cause non-deterministic
+     * round-off error. The default is to return null, which means the query is
+     * inherently deterministic.
+     *
+     * Note that this has nothing to do with limit-order non-determinism.
+     *
+     * @return An error message if this statement is *not* inherently content
+     *         deterministic. Otherwise we return null.
+     */
+    public abstract String calculateContentDeterminismMessage();
+
+    /**
+     * Just fetch the content determinism message. Don't do any calculations.
+     */
+    protected final String getContentDeterminismMessage() {
+        return m_contentDeterminismMessage;
+    }
+
+    /**
+     * Set the content determinism message, but only if it's currently non-null.
+     *
+     * @param msg
+     */
+    protected void updateContentDeterminismMessage(String msg) {
+        if (m_contentDeterminismMessage == null) {
+            m_contentDeterminismMessage = msg;
+        }
+    }
+
+    public boolean isContentDetermistic() {
+        return m_contentDeterminismMessage != null;
+    }
 }

--- a/src/frontend/org/voltdb/planner/CompiledPlan.java
+++ b/src/frontend/org/voltdb/planner/CompiledPlan.java
@@ -96,6 +96,16 @@ public class CompiledPlan {
      */
     private boolean m_statementIsOrderDeterministic = false;
 
+    /**
+     * This string describes the reason a plan is not content deterministic.
+     * This is non-null iff the statement has some calculation which is in
+     * itself content non-deterministic. The most typical example is an
+     * aggregate of a column whose type is floating point. The floating point
+     * arithmetic may be slightly different with different plans or different
+     * row orders.
+     */
+    private String m_contentDeterminismDetail = null;
+
     /** Which extracted param is the partitioning object (assuming parameterized plans) */
     public int partitioningKeyIndex = -1;
 
@@ -129,12 +139,17 @@ public class CompiledPlan {
     }
 
     /**
-     * Mark the level of result determinism imposed by the statement,
-     * which can save us from a difficult determination based on the plan graph.
+     * Mark the level of result determinism imposed by the statement, which can
+     * save us from a difficult determination based on the plan graph.
      */
-    public void statementGuaranteesDeterminism(boolean hasLimitOrOffset, boolean order) {
+    public void statementGuaranteesDeterminism(boolean hasLimitOrOffset,
+                                               boolean order,
+                                               String contentDeterminismDetail) {
         m_statementHasLimitOrOffset = hasLimitOrOffset;
         m_statementIsOrderDeterministic = order;
+        if (contentDeterminismDetail != null) {
+            m_contentDeterminismDetail = contentDeterminismDetail;
+        }
     }
 
     /**
@@ -149,13 +164,20 @@ public class CompiledPlan {
         return rootPlanGraph.isOrderDeterministic();
     }
 
+    public boolean isContentDeterministic() {
+        return m_contentDeterminismDetail == null;
+    }
+
     /**
-     * Accessor for flag marking the original statement as guaranteeing an identical result/effect
-     * when "replayed" against the same database state, such as during replication or CL recovery.
+     * Accessor for flag marking the original statement as guaranteeing an
+     * identical result/effect when "replayed" against the same database state,
+     * such as during replication or CL recovery. If
+     * m_statementIsContentDeterministic is false we want to check this. This is
+     * the one area in which content and limit-order determinism interact.
      */
     public boolean hasDeterministicStatement()
     {
-        return m_statementIsOrderDeterministic;
+        return m_statementIsOrderDeterministic && isContentDeterministic();
     }
 
     /**
@@ -168,10 +190,15 @@ public class CompiledPlan {
     }
 
     /**
-     * Accessor for description of plan non-determinism.
+     * Accessor for description of plan non-determinism. Note that we prefer the
+     * content determinism message to the rootPlanGraph's message.
+     *
      * @return the corresponding value from the first fragment
      */
     public String nondeterminismDetail() {
+        if (!isContentDeterministic()) {
+            return m_contentDeterminismDetail;
+        }
         return rootPlanGraph.nondeterminismDetail();
     }
 
@@ -321,5 +348,9 @@ public class CompiledPlan {
         else {
             return "CompiledPlan: [null plan graph]";
         }
+    }
+
+    public void setNondeterminismDetail(String contentDeterminismMessage) {
+        m_contentDeterminismDetail = contentDeterminismMessage;
     }
 }

--- a/src/frontend/org/voltdb/planner/ParsedDeleteStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedDeleteStmt.java
@@ -166,5 +166,10 @@ public class ParsedDeleteStmt extends AbstractParsedStmt {
     }
 
     @Override
+    public String calculateContentDeterminismMessage() {
+        return null;
+    }
+
+    @Override
     public boolean isDML() { return true; }
 }

--- a/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
@@ -101,6 +101,7 @@ public class ParsedInsertStmt extends AbstractParsedStmt {
                         "INSERT INTO ... SELECT is not supported for UNION or other set operations.");
             }
         }
+        calculateContentDeterminismMessage();
     }
 
     @Override
@@ -241,6 +242,31 @@ public class ParsedInsertStmt extends AbstractParsedStmt {
         }
 
         return exprs;
+    }
+
+    /**
+     * Return the content determinism string of the subquery if there is one.
+     */
+    @Override
+    public String calculateContentDeterminismMessage() {
+        String ans = getContentDeterminismMessage();
+        if (ans != null) {
+            return ans;
+        }
+        if (m_subquery != null) {
+            updateContentDeterminismMessage(m_subquery.calculateContentDeterminismMessage());
+            return getContentDeterminismMessage();
+        }
+        if (m_columns != null) {
+            for (AbstractExpression expr : m_columns.values()) {
+                String emsg = expr.getContentDeterminismMessage();
+                if (emsg != null) {
+                    updateContentDeterminismMessage(emsg);
+                    return emsg;
+                }
+            }
+        }
+        return null;
     }
 
     @Override

--- a/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
@@ -412,6 +412,22 @@ public class ParsedUnionStmt extends AbstractParsedStmt {
         }
     }
 
+    /**
+     * Here we search all the children, finding if each is content
+     * deterministic. If it is we return right away.
+     */
+    @Override
+    public String calculateContentDeterminismMessage() {
+        String ans = null;
+        for (AbstractParsedStmt child : m_children) {
+            ans = child.getContentDeterminismMessage();
+            if (ans != null) {
+                return ans;
+            }
+        }
+        return null;
+    }
+
     @Override
     public boolean isDML() { return false; }
 

--- a/src/frontend/org/voltdb/planner/ParsedUpdateStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedUpdateStmt.java
@@ -89,6 +89,12 @@ public class ParsedUpdateStmt extends AbstractParsedStmt {
     }
 
     @Override
+    public String calculateContentDeterminismMessage() {
+        updateContentDeterminismMessage(getContentDeterminismMessage());
+        return getContentDeterminismMessage();
+    }
+
+    @Override
     public boolean isDML() { return true; }
 
 }

--- a/src/frontend/org/voltdb/planner/parseinfo/BranchNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/BranchNode.java
@@ -54,6 +54,8 @@ public class BranchNode extends JoinNode {
         m_joinType = joinType;
         m_leftNode = leftNode;
         m_rightNode = rightNode;
+        updateContentDeterminismMessage(leftNode.getContentDeterminismMessage());
+        updateContentDeterminismMessage(rightNode.getContentDeterminismMessage());
     }
 
     /**

--- a/src/frontend/org/voltdb/planner/parseinfo/JoinNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/JoinNode.java
@@ -494,4 +494,15 @@ public abstract class JoinNode implements Cloneable {
         return null;
     }
 
+    private String m_contentDeterminismMessage = null;
+
+    public String getContentDeterminismMessage() {
+        return m_contentDeterminismMessage;
+    }
+
+    public void updateContentDeterminismMessage(String msg) {
+        if (m_contentDeterminismMessage == null) {
+            m_contentDeterminismMessage = msg;
+        }
+    }
 }

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -464,4 +464,8 @@ public class StmtSubqueryScan extends StmtTableScan {
     public List<SchemaColumn> getOutputSchema() {
         return m_outputColumnList;
     }
+
+    public String calculateContentDeterminismMessage() {
+        return m_subqueryStmt.calculateContentDeterminismMessage();
+    }
 }

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompilerAnnotationsAndWarnings.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompilerAnnotationsAndWarnings.java
@@ -26,10 +26,11 @@ package org.voltdb.compiler;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import junit.framework.TestCase;
-
 import org.voltdb.VoltDB.Configuration;
 import org.voltdb.compiler.procedures.FloatParamToGetNiceComplaint;
+import org.voltdb.compiler.procedures.InsertAggregatesOfFloat;
+import org.voltdb.compiler.procedures.InsertAggregatesOfFloatInHaving;
+import org.voltdb.compiler.procedures.InsertAggregatesOfFloatWithSetops;
 import org.voltdb_testprocs.regressionsuites.failureprocs.DeterministicRONonSeqProc;
 import org.voltdb_testprocs.regressionsuites.failureprocs.DeterministicROSeqProc;
 import org.voltdb_testprocs.regressionsuites.failureprocs.DeterministicRWProc1;
@@ -50,30 +51,258 @@ import org.voltdb_testprocs.regressionsuites.failureprocs.ProcSPcandidate5;
 import org.voltdb_testprocs.regressionsuites.failureprocs.ProcSPcandidate6;
 import org.voltdb_testprocs.regressionsuites.failureprocs.ProcSPcandidate7;
 
+import junit.framework.TestCase;
+
 public class TestVoltCompilerAnnotationsAndWarnings extends TestCase {
 
+    /**
+     * Test whether a DDL stored procedure does not compile properly. The test
+     * testSimple cannot test compilation failure. It's sometimes useful to have
+     * a single test to test compilation success.
+     *
+     * @param simpleSchema
+     *            A string containing the test schema.
+     * @param procObject
+     *            This tells what procedure to test. If this is an object of
+     *            type Class<?> we we add its procedures to the builder. If it's
+     *            an array of two strings we add a statement procedure whose
+     *            name is the first string and whose DDL definition is the
+     *            second string. Note that the "create procedure as" part is
+     *            added for you, so all you need is the SQL text for the
+     *            procedure.
+     * @param errorMessages
+     *            The error messages we expect to see, as Java regular
+     *            expressions. This may be true of no errors are expected.
+     * @param expectSuccess
+     *            If this is true, the compilation should succeed.
+     * @throws Exception
+     */
+    public void testCompilationFailure(String     testName,
+                                       String     simpleSchema,
+                                       Object     procObject,
+                                       String[]   errorMessages,
+                                       boolean    expectSuccess) throws Exception {
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        ByteArrayOutputStream capturer = new ByteArrayOutputStream();
+        PrintStream capturing = new PrintStream(capturer);
+        builder.setCompilerDebugPrintStream(capturing);
+        builder.addLiteralSchema(simpleSchema);
+        if (procObject instanceof String[]) {
+            String[] stmtProcDescrip = (String[]) procObject;
+            assertTrue(stmtProcDescrip.length == 2);
+            builder.addStmtProcedure(stmtProcDescrip[0], stmtProcDescrip[1]);
+        } else if (procObject instanceof Class<?>) {
+            Class<?> procKlazz = (Class<?>) procObject;
+            builder.addProcedures(procKlazz);
+        } else {
+            assertTrue("Bad type of object for parameter \"procObject\"", false);
+        }
+
+        boolean success = builder.compile(Configuration.getPathToCatalogForTest("annotations.jar"));
+        assertEquals(String.format("Expected compilation %s",
+                                   (expectSuccess ? "success" : "failure")),
+                     expectSuccess, success);
+        if (errorMessages != null) {
+            String captured = capturer.toString("UTF-8");
+            String[] lines = captured.split("\n");
+            System.out.printf("\n" + ":----------------------------------------------------------------------:\n" + ":  %s: Start of captured output\n" + ":----------------------------------------------------------------------:\n",
+                              testName);
+            System.out.println(captured);
+            System.out.printf("\n" + ":----------------------------------------------------------------------:\n" + ":  %s: End of captured output\n" + ":----------------------------------------------------------------------:\n",
+                              testName);
+            // Output should include a line suggesting replacement of float with
+            // double.
+            for (String oneMessagePattern : errorMessages) {
+                assertTrue(foundLineMatching(lines, oneMessagePattern));
+            }
+        }
+    }
+
+    /**
+     * Test that a stored procedure with a parameter type of float will not
+     * compile. The Java type float is not legal for stored procedures.
+     *
+     * @throws Exception
+     */
     public void testFloatParamComplaint() throws Exception {
         String simpleSchema =
             "create table floatie (" +
             "ival bigint default 0 not null, " +
             "fval float not null," +
             "PRIMARY KEY(ival)" +
-            ");";
+            ");" +
+            "partition table floatie on column ival;";
+        String[][] partitionInfo = new String[][] { { "floatie", "ival" } };
+        testCompilationFailure("testFloatParamComplaint",
+                               simpleSchema,
+                               FloatParamToGetNiceComplaint.class,
+                               new String[] { ".*FloatParamToGetNiceComplaint.* float.* double.*" },
+                               false);
+    }
 
-        VoltProjectBuilder builder = new VoltProjectBuilder();
-        ByteArrayOutputStream capturer = new ByteArrayOutputStream();
-        PrintStream capturing = new PrintStream(capturer);
-        builder.setCompilerDebugPrintStream(capturing);
-        builder.addLiteralSchema(simpleSchema);
-        builder.addPartitionInfo("floatie", "ival");
-        builder.addProcedures(FloatParamToGetNiceComplaint.class);
+    /**
+     * Test that a stored procedure with an aggregate whose parameter is FLOAT
+     * causes a compilation error.
+     *
+     * @throws Exception
+     */
+    public void testInsertAggregatesOfFloat() throws Exception {
+        String simpleSchema =
+                "create table floatingaggs_input ( alpha float );" +
+                "create table floatingaggs_output ( beta float );" +
+                "";
+        testCompilationFailure("testInsertAggregatesOfFloat",
+                               simpleSchema,
+                               InsertAggregatesOfFloat.class,
+                               new String[] { ".*InsertAggregatesOfFloat.*Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.*" },
+                               false);
+    }
 
-        boolean success = builder.compile(Configuration.getPathToCatalogForTest("annotations.jar"));
-        assertFalse(success);
-        String captured = capturer.toString("UTF-8");
-        String[] lines = captured.split("\n");
-        // Output should include a line suggesting replacement of float with double.
-        assertTrue(foundLineMatching(lines, ".*FloatParamToGetNiceComplaint.* float.* double.*"));
+    /**
+     * Test that a stored procedure with an aggregate of floating point type in
+     * a having clause causes a compilation error.
+     *
+     * @throws Exception
+     */
+    public void testInsertAggregatesOfFloatInHaving() throws Exception {
+        String simpleSchema =
+                "create table floatingaggs_input ( alpha float );" +
+                "create table floatingaggs_output ( beta float );" +
+                "create table intaggs ( gamma integer );" +
+                "";
+        testCompilationFailure("testInsertAggregatesOfFloatInHaving",
+                               simpleSchema,
+                               InsertAggregatesOfFloatInHaving.class,
+                               new String[] { ".*InsertAggregatesOfFloatInHaving.*Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.*" },
+                               false);
+    }
+
+    /**
+     * Test that a statement procedure with an aggregate of floating point type
+     * causes a compilation error.
+     *
+     * @throws Exception
+     */
+    public void testAggregatesOfFloatDDL() throws Exception {
+        String simpleSchema = "create table floatingaggs_input ( alpha float );" + "create table floatingaggs_output ( beta float );" + "";
+        testCompilationFailure("testAggregatesOfFloatDDL",
+                               simpleSchema,
+                               new String[] { "InsertAggregatesOfFloatDDL", "insert into floatingaggs_output select sum(alpha) from floatingaggs_input;",
+                               },
+                               new String[] { ".*InsertAggregatesOfFloatDDL.*Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.*" },
+                               false);
+    }
+
+    /**
+     * Test that a statement procedure with an aggregate of floating point type
+     * in a subquery in a from clause causes an error.
+     *
+     * @throws Exception
+     */
+    public void testAggregatesOfFloatInSubquery() throws Exception {
+        String simpleSchema = "create table floatingaggs_input ( alpha float );" + "create table floatingaggs_output ( beta float );" + "";
+        testCompilationFailure("testAggregatesOfFloatInSubquery",
+                               simpleSchema,
+                               new String[] { "AggregatesOfFloatInSubquery", "insert into floatingaggs_output select sq.ss from ( select sum(alpha) as ss from floatingaggs_input where alpha > 0.0 order by ss ) as sq;" },
+                               new String[] { ".*AggregatesOfFloatInSubquery.*Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.*" },
+                               false);
+    }
+
+    /**
+     * Test that a statement procedure with an expression which has a
+     * subexpression which is an aggregate of floating point type in a subquery
+     * in a from clause causes an error.
+     *
+     * @throws Exception
+     */
+    public void testAggregatesOfFloatInComplexSubquery() throws Exception {
+        String simpleSchema = "create table floatingaggs_input ( alpha float );" + "create table floatingaggs_output ( beta float );" + "";
+        testCompilationFailure("testAggregatesOfFloatInComplexSubquery",
+                               simpleSchema,
+                               new String[] { "AggregatesOfFloatInComplexSubquery", "insert into floatingaggs_output select sq.ss + 100 from ( select sum(alpha) as ss from floatingaggs_input where alpha > 0.0 order by ss ) as sq;" },
+                               new String[] { ".*AggregatesOfFloatInComplexSubquery.*Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.*" },
+                               false);
+    }
+
+    /**
+     * Test that a statement procedure with an expression which has a
+     * subexpression which is an aggregate whose type is float and whose
+     * expression is more than a column reference and which is also part of a
+     * larger expression causes a compilation error.
+     *
+     * @throws Exception
+     */
+    public void testAggregatesOfFloatInComplexSubquery2() throws Exception {
+        String simpleSchema = "create table floatingaggs_input ( alpha float );" + "create table floatingaggs_output ( beta float );" + "";
+        testCompilationFailure("testAggregatesOfFloatInComplexSubquery2",
+                               simpleSchema,
+                               new String[] { "AggregatesOfFloatInComplexSubquery2", "insert into floatingaggs_output select sq.ss + 100 from ( select sum(alpha + 42) as ss from floatingaggs_input where alpha > 0.0 order by ss ) as sq;" },
+                               new String[] { ".*AggregatesOfFloatInComplexSubquery2.*Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.*" },
+                               false);
+    }
+
+    /**
+     * Test that a statement procedure with an expression which has a
+     * subexpression which is an aggregate whose type is float and is in a
+     * subquery causes a compilation error.
+     *
+     * @throws Exception
+     */
+    public void testAggregatesOfFloatInLeftOfJoin() throws Exception {
+        String simpleSchema = "create table alpha ( af float );" + "create table beta ( bf float );" + "";
+        testCompilationFailure("testAggregatesOfFloatInLeftOfJoin",
+                               simpleSchema,
+                               new String[] { "AggregatesOfFloatInLeftOfJoin",
+                                              "insert into alpha select lf.ss+rf.ss from (select sum(af) as ss from alpha ) as lf inner join ( select bf as ss from beta ) as rf on true;" },
+                               new String[] { ".*AggregatesOfFloatInLeftOfJoin.*Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.*" },
+                               false);
+    }
+
+    /**
+     * Test that a statement procedure with an expression which has a
+     * subexpression which is an aggregate whose type is float and is in a
+     * subquery causes a compilation error.
+     *
+     * @throws Exception
+     */
+    public void testAggregatesOfFloatInRightOfJoins() throws Exception {
+        String simpleSchema = "create table alpha ( af float );" + "create table beta ( bf float );" + "";
+        testCompilationFailure("testAggregatesOfFloatInRightOfJoin",
+                               simpleSchema,
+                               new String[] { "AggregatesOfFloatInRightOfJoin",
+                                              "insert into alpha select lf.ss+rf.ss from (select af as ss from alpha ) as lf inner join ( select sum(bf) as ss from beta ) as rf on true;" },
+                               new String[] { ".*AggregatesOfFloatInRightOfJoin.*Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.*" },
+                               false);
+    }
+
+    /**
+     * Test that a statement procedure with an aggregate expression of floating
+     * point type in a subquery which is found in a union expression causes a
+     * compilation error. This can't be a single statement procedure. It has to
+     * be a Java Stored Procedure. This will only be a warning, so the
+     * compilation will pass.
+     */
+    public void testAggregatesOfFloatInSetops() throws Exception {
+        String simpleSchema = "create table floatingaggs_input ( alpha float );" + "create table floatingaggs_output ( beta float );" + "";
+        testCompilationFailure("testAggregatesOfFloatInSetops",
+                               simpleSchema,
+                               InsertAggregatesOfFloatWithSetops.class,
+                               new String[] { ".*InsertAggregatesOfFloatWithSetops.*Aggregate functions of floating point columns may not be deterministic.  We suggest converting to DECIMAL.*" },
+                               true);
+    }
+
+    /**
+     * Test that we haven't broken the obvious good case.
+     *
+     * @throws Exception
+     */
+    public void testGoodInsert() throws Exception {
+        String simpleSchema = "create table floatingaggs_input ( alpha float );" + "create table floatingaggs_output ( beta float );" + "";
+        testCompilationFailure("testAggregatesOfFloatInComplexSubquery2",
+                               simpleSchema,
+                               new String[] { "AggregatesOfFloatInComplexSubquery2", "insert into floatingaggs_output select alpha from floatingaggs_input;" },
+                               null,
+                               true);
     }
 
     public void testSimple() throws Exception {
@@ -91,6 +320,12 @@ public class TestVoltCompilerAnnotationsAndWarnings extends TestCase {
             "ival bigint default 0 not null, " +
             "sval varchar(255) not null, " +
             "PRIMARY KEY(ival)" +
+            ");" +
+            "create table floatingaggs_input (" +
+            "alpha float" +
+            ");" +
+            "create table floatingaggs_output (" +
+            "beta float" +
             ");" +
             "";
 
@@ -141,12 +376,18 @@ public class TestVoltCompilerAnnotationsAndWarnings extends TestCase {
         builder.addStmtProcedure("StmtSPNoncandidate2", "select count(*) from blah where sval = '12345678'", null);
         builder.addStmtProcedure("StmtSPNoncandidate3", "select count(*) from indexed_replicated_blah where ival = ?", null);
         builder.addStmtProcedure("FullIndexScan", "select ival, sval from indexed_replicated_blah", null);
-
-
         boolean success = builder.compile(Configuration.getPathToCatalogForTest("annotations.jar"));
         assert(success);
         String captured = capturer.toString("UTF-8");
+        System.out.print("\n"
+                         + ":----------------------------------------------------------------------:\n"
+                         + ":  Start of captured output\n"
+                         + ":----------------------------------------------------------------------:\n");
         System.out.println(captured);
+        System.out.print("\n"
+                        + ":----------------------------------------------------------------------:\n"
+                        + ":  End of captured output\n"
+                        + ":----------------------------------------------------------------------:\n");
         String[] lines = captured.split("\n");
 
         assertTrue(foundLineMatching(lines, ".*\\[READ].*NondeterministicROProc.*"));
@@ -157,7 +398,6 @@ public class TestVoltCompilerAnnotationsAndWarnings extends TestCase {
         assertTrue(foundLineMatching(lines, ".*\\[WRITE].*NondeterministicRWProc.*"));
         assertTrue(foundLineMatching(lines, ".*\\[WRITE].*DeterministicRWProc.*"));
         assertTrue(foundLineMatching(lines, ".*\\[TABLE SCAN].*select ival, sval from indexed_replicated_blah.*"));
-
         assertEquals(1, countLinesMatching(lines, ".*\\[NDC].*NDC=true.*"));
 
         assertFalse(foundLineMatching(lines, ".*\\[NDC].*NDC=false.*"));
@@ -212,7 +452,6 @@ public class TestVoltCompilerAnnotationsAndWarnings extends TestCase {
         assertFalse(foundLineMatching(lines, "^ .*values.*\\s\\s.*")); // includes 2 successive embedded or trailing whitespace of any kind
         assertTrue(foundLineMatching(lines, "^[^ ].*nsert.*\\s\\s.*values.*")); // includes 2 successive embedded whitespace of any kind
         assertFalse(foundLineMatching(lines, "^ .*nsert.*\\s\\s.*values.*")); // includes 2 successive embedded whitespace of any kind
-
     }
 
     private boolean foundLineMatching(String[] lines, String pattern) {

--- a/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloat.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloat.java
@@ -1,0 +1,58 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.voltdb.compiler.procedures;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+
+public class InsertAggregatesOfFloat extends VoltProcedure {
+    public static final SQLStmt insertAmbiguousRows = new SQLStmt("insert into floatingaggs_output select sum(alpha) from floatingaggs_input");
+
+    public long run() {
+        voltQueueSQL(insertAmbiguousRows);
+        voltExecuteSQL();
+        // zero is a successful return
+        return 0;
+    }
+}

--- a/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloatInHaving.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloatInHaving.java
@@ -1,0 +1,57 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */package org.voltdb.compiler.procedures;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+
+public class InsertAggregatesOfFloatInHaving extends VoltProcedure {
+    public static final SQLStmt insertAmbiguousRows = new SQLStmt("insert into floatingaggs_output select alpha from floatingaggs_input group by alpha having sum(alpha) + 6.02 > 0 order by alpha;");
+
+    public long run() {
+        voltQueueSQL(insertAmbiguousRows);
+        voltExecuteSQL();
+        // zero is a successful return
+        return 0;
+    }
+
+}

--- a/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloatWithSetops.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloatWithSetops.java
@@ -1,0 +1,59 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.voltdb.compiler.procedures;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+
+public class InsertAggregatesOfFloatWithSetops extends VoltProcedure {
+    public static final SQLStmt insertSetOps = new SQLStmt("insert into floatingaggs_output select alpha from floatingaggs_input order by alpha;");
+    public static final SQLStmt queryOp = new SQLStmt("select lf from ( select sum(alpha) as lf from floatingaggs_input union select beta from floatingaggs_output ) as ll;");
+
+    public long run() {
+        voltQueueSQL(insertSetOps);
+        voltQueueSQL(queryOp);
+        voltExecuteSQL();
+        // zero is a successful return
+        return 0;
+    }
+}

--- a/tests/frontend/org/voltdb/planner/testplans-determinism-ddl.sql
+++ b/tests/frontend/org/voltdb/planner/testplans-determinism-ddl.sql
@@ -115,3 +115,9 @@ create table ppk (
 );
 
 partition table ppk on column a;
+
+create table floataggs (
+    alpha float,
+    beta  float,
+    gamma float
+);


### PR DESCRIPTION
If some aggregate functions are applied to floating point parameters the
result may be non-deterministic, due to floating point numeric
differences.  We need to causes errors or warnings in this case.  This
is complicated by the fact that the error messages need to propagated up
from the aggregate call expression through the containing expressions,
into the subquery statement object.  From there it may need to propagate
into a join tree or in ParsedUnionStatement objects if the expression is
in a subquery of a joined table or in a subquery of a union or
intersection expression.