### PR TITLE
Change the timeout message to allow millisecond precision.

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1789,7 +1789,7 @@ void VoltDBEngine::reportProgressToTopend() {
         VOLT_DEBUG("Interrupt query.");
         char buff[100];
         snprintf(buff, 100,
-                "A SQL query was terminated after %.2f seconds because it exceeded the query timeout period.",
+                "A SQL query was terminated after %.03f seconds because it exceeded the query timeout period.",
                 static_cast<double>(tupleReportThreshold) / -1000.0);
 
         throw InterruptException(std::string(buff));

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -29,8 +29,6 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 
-import junit.framework.TestCase;
-
 import org.mockito.Mockito;
 import org.voltcore.logging.VoltLogger;
 import org.voltdb.LegacyHashinator;
@@ -50,6 +48,8 @@ import org.voltdb.catalog.Statement;
 import org.voltdb.planner.ActivePlanRepository;
 import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.Encoder;
+
+import junit.framework.TestCase;
 
 public class TestFragmentProgressUpdate extends TestCase {
 
@@ -476,7 +476,7 @@ public class TestFragmentProgressUpdate extends TestCase {
                 fail();
             }
         } catch (Exception ex) {
-            String msg = String.format("A SQL query was terminated after %.2f seconds "
+            String msg = String.format("A SQL query was terminated after %.03f seconds "
                     + "because it exceeded the query timeout period.",
                     timeout/1000.0);
             assertEquals(msg, ex.getMessage());


### PR DESCRIPTION
The sqlcmd query timeout message in the EE only printed 2 decimal digits
of precision.  This did not allow for millisecond precision.  This
change increased this to 3 decimal digits.

https://issues.voltdb.com/browse/ENG-9246