### PR TITLE
Min and Max of float are deterministic.

### DIFF
--- a/src/frontend/org/voltdb/expressions/AggregateExpression.java
+++ b/src/frontend/org/voltdb/expressions/AggregateExpression.java
@@ -87,7 +87,9 @@ public class AggregateExpression extends AbstractExpression {
             //
             m_valueType = m_left.getValueType();
             m_valueSize = m_left.getValueSize();
-            if (m_valueType == VoltType.FLOAT) {
+            // Of these aggregate functions, only AVG is
+            // non-deterministic on floating point types.
+            if (m_valueType == VoltType.FLOAT && type == ExpressionType.AGGREGATE_AVG) {
                 updateContentDeterminismMessage(FLOAT_AGG_ERR_MSG);
             }
             break;

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompilerAnnotationsAndWarnings.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompilerAnnotationsAndWarnings.java
@@ -292,6 +292,34 @@ public class TestVoltCompilerAnnotationsAndWarnings extends TestCase {
     }
 
     /**
+     * Test that Min does not trigger non-determinism errors.
+     *
+     * @throws Exception
+     */
+    public void testMinOfFloatIsOk() throws Exception {
+        String simpleSchema = "create table alpha ( af float );" + "create table beta ( bf float );" + "";
+        testCompilationFailure("testMinOfFloat",
+                               simpleSchema,
+                               new String[] { "MinOfFloat", "insert into alpha select lf.ss+rf.ss from (select af as ss from alpha ) as lf inner join ( select min(bf) as ss from beta ) as rf on true;" },
+                               null,
+                               true);
+    }
+
+    /**
+     * Test that Max does not trigger non-determinism errors.
+     *
+     * @throws Exception
+     */
+    public void testMaxOfFloatIsOk() throws Exception {
+        String simpleSchema = "create table alpha ( af float );" + "create table beta ( bf float );" + "";
+        testCompilationFailure("testMaxOfFloat",
+                               simpleSchema,
+                               new String[] { "MaxOfFloat", "insert into alpha select lf.ss+rf.ss from (select af as ss from alpha ) as lf inner join ( select max(bf) as ss from beta ) as rf on true;" },
+                               null,
+                               true);
+    }
+
+    /**
      * Test that we haven't broken the obvious good case.
      *
      * @throws Exception


### PR DESCRIPTION
The aggregate functions min and max of floating point expressions are
deterministic.  In the previous commit, 758efd3, we incorrectly called
them non-deterministic.

https://issues.voltdb.com/browse/ENG-9358
