### PR TITLE
ENG-9283 & ENG-9362 allow ad hoc ddl after an index with timestamp in…

### DIFF
--- a/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
@@ -309,8 +309,17 @@ public class ConstantValueExpression extends AbstractValueExpression {
         if (neededType == VoltType.TIMESTAMP) {
             if (m_valueType == VoltType.STRING) {
                 try {
-                    // Convert date value in whatever format is supported by TimeStampType
-                    // into VoltDB native microsecond count.
+                    // Convert date value in whatever format is supported by
+                    // TimeStampType into VoltDB native microsecond count.
+                    // TODO: Should datetime string be supported as the new
+                    // canonical internal format for timestamp constants?
+                    // Historically, the long micros value made sense because
+                    // it was initially the only way and later the most
+                    // direct way to initialize timestamp values in the EE.
+                    // But now that long value can not be used to "explain"
+                    // an expression as a valid SQL timestamp value for DDL
+                    // round trips, forcing a reverse conversion back through
+                    // TimeStampType to a datetime string.
                     TimestampType ts = new TimestampType(m_value);
                     m_value = String.valueOf(ts.getTime());
                 }
@@ -463,6 +472,24 @@ public class ConstantValueExpression extends AbstractValueExpression {
         }
         if (m_valueType == VoltType.STRING) {
             return "'" + m_value + "'";
+        }
+        if (m_valueType == VoltType.TIMESTAMP) {
+            try {
+                // Convert the datetime value in its canonical internal form,
+                // currently a count of epoch microseconds,
+                // through TimeStampType into a timestamp string.
+                long micros = Long.valueOf(m_value);
+                TimestampType ts = new TimestampType(micros);
+                return "'" + ts.toString() + "'";
+            }
+            // It couldn't be converted to timestamp.
+            catch (IllegalArgumentException e) {
+                throw new PlanningErrorException("Value (" + getValue() +
+                                                 ") has an invalid format for a constant " +
+                                                 VoltType.TIMESTAMP.toSQLString() + " value");
+
+            }
+
         }
         return m_value;
     }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Table.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Table.java
@@ -287,6 +287,7 @@ public class Table extends TableBase implements SchemaObject {
                                          this, true);
     }
 
+    @Override
     public int getType() {
         return SchemaObject.TABLE;
     }
@@ -294,6 +295,7 @@ public class Table extends TableBase implements SchemaObject {
     /**
      *  Returns the HsqlName object fo the table
      */
+    @Override
     public final HsqlName getName() {
         return tableName;
     }
@@ -301,6 +303,7 @@ public class Table extends TableBase implements SchemaObject {
     /**
      * Returns the catalog name or null, depending on a database property.
      */
+    @Override
     public HsqlName getCatalogName() {
         return database.getCatalogName();
     }
@@ -308,14 +311,17 @@ public class Table extends TableBase implements SchemaObject {
     /**
      * Returns the schema name.
      */
+    @Override
     public HsqlName getSchemaName() {
         return tableName.schema;
     }
 
+    @Override
     public Grantee getOwner() {
         return tableName.schema.owner;
     }
 
+    @Override
     public OrderedHashSet getReferences() {
 
         OrderedHashSet set = new OrderedHashSet();
@@ -331,6 +337,7 @@ public class Table extends TableBase implements SchemaObject {
         return set;
     }
 
+    @Override
     public OrderedHashSet getComponents() {
 
         OrderedHashSet set = new OrderedHashSet();
@@ -347,6 +354,7 @@ public class Table extends TableBase implements SchemaObject {
         return set;
     }
 
+    @Override
     public void compile(Session session) {}
 
     String[] getSQL(OrderedHashSet resolved, OrderedHashSet unresolved) {
@@ -422,6 +430,7 @@ public class Table extends TableBase implements SchemaObject {
         return array;
     }
 
+    @Override
     public String getSQL() {
 
         StringBuffer sb = new StringBuffer();
@@ -532,6 +541,7 @@ public class Table extends TableBase implements SchemaObject {
     /**
      * Used to create row id's
      */
+    @Override
     public int getId() {
         return tableName.hashCode();
     }
@@ -1043,6 +1053,7 @@ public class Table extends TableBase implements SchemaObject {
             // A VoltDB extension to support indexed expressions and assume unique attribute
             Expression[] exprArr = idx.getExpressions();
             boolean assumeUnique = idx.isAssumeUnique();
+            Expression predicate = idx.getPredicate();
             // End of VoltDB extension
             idx = tn.createIndexStructure(idx.getName(), colarr,
                                           idx.getColumnDesc(), null,
@@ -1053,8 +1064,8 @@ public class Table extends TableBase implements SchemaObject {
             if (exprArr != null) {
                 idx = idx.withExpressions(adjustExprs(exprArr, colIndex, adjust));
             }
-            if (idx.getPredicate() != null) {
-                idx = idx.withPredicate(idx.getPredicate());
+            if (predicate != null) {
+                idx = idx.withPredicate(adjustExpr(predicate, colIndex, adjust));
             }
             idx = idx.setAssumeUnique(assumeUnique);
             // End of VoltDB extension
@@ -1960,7 +1971,7 @@ public class Table extends TableBase implements SchemaObject {
 
                 for (int j = 0; j < constraints.length; j++) {
                     constraints[j].checkCheckConstraint(session, this,
-                                                        (Object) data[i]);
+                                                        data[i]);
                 }
             }
 
@@ -2253,7 +2264,7 @@ public class Table extends TableBase implements SchemaObject {
         RowSetNavigator nav   = result.initialiseNavigator();
 
         while (nav.hasNext()) {
-            Object[] data = (Object[]) nav.getNext();
+            Object[] data = nav.getNext();
             Object[] newData =
                 (Object[]) ArrayUtil.resizeArrayIfDifferent(data,
                     getColumnCount());
@@ -2302,7 +2313,7 @@ public class Table extends TableBase implements SchemaObject {
         int             count = 0;
 
         while (nav.hasNext()) {
-            insertSys(store, (Object[]) nav.getNext());
+            insertSys(store, nav.getNext());
 
             count++;
         }
@@ -2319,7 +2330,7 @@ public class Table extends TableBase implements SchemaObject {
         RowSetNavigator nav = ins.initialiseNavigator();
 
         while (nav.hasNext()) {
-            Object[] data = (Object[]) nav.getNext();
+            Object[] data = nav.getNext();
             Object[] newData =
                 (Object[]) ArrayUtil.resizeArrayIfDifferent(data,
                     getColumnCount());
@@ -2606,6 +2617,7 @@ public class Table extends TableBase implements SchemaObject {
         }
     }
 
+    @Override
     public void clearAllData(Session session) {
 
         super.clearAllData(session);
@@ -2615,6 +2627,7 @@ public class Table extends TableBase implements SchemaObject {
         }
     }
 
+    @Override
     public void clearAllData(PersistentStore store) {
 
         super.clearAllData(store);
@@ -2648,6 +2661,16 @@ public class Table extends TableBase implements SchemaObject {
      */
     private Expression[] adjustExprs(Expression[] exprArr, int colIndex, int adjust) {
         return exprArr;
+    }
+
+    /** Index expressions as exported to VoltDB are "column name based" not "column index based",
+     *  so they are not thrown off by column re-numbering.
+     *  VoltDB is responsible for re-resolving the names to the moved columns (changed column index numbers).
+     *  This stubbed pass-through method is here in case that someday changes in a way that would require
+     *  processing of the expression trees.
+     */
+    private Expression adjustExpr(Expression expr, int colIndex, int adjust) {
+        return expr;
     }
 
     /**

--- a/tests/frontend/org/voltdb/TestAdhocAlterTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocAlterTable.java
@@ -880,8 +880,15 @@ public class TestAdhocAlterTable extends AdhocDDLTestBase {
             startSystem(config);
 
             try {
+                // Partial indexes were found to be fragile to schema changes that
+                // should have had zero effect on them. Add one here before trying
+                // an alter table that should be completely harmless to it.
+                m_client.callProcedure("@AdHoc",
+                        "create index partial on FOO (VAL) where VAL is NOT NULL;");
                 m_client.callProcedure("@AdHoc",
                         "alter table FOO add column NEWCOL varchar(50) not null;");
+                m_client.callProcedure("@AdHoc",
+                        "drop index partial;");
             }
             catch (ProcCallException pce) {
                 fail(pce.getLocalizedMessage());


### PR DESCRIPTION
… predicate

ENG-9283 is fixed by fixing conversion to SQL of a timestamp-valued ConstantValueExpression
ENG-9362 is fixed by making hsql preserve index predicates on table redefinition.

The DDLCompiler changes are intended to limit visibility of DDLCompiler functions and variables.
I liberally applied "private", "static" and "final" modifiers and removed "public" wherever possible.
This helped me make sense of how/when these other pieces of code came into play. 
