### PR TITLE
ENG-9372, change the "decision" column of conflict export log from th…

### DIFF
--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -542,8 +542,8 @@ enum DRConflictRowType {
 };
 
 enum DRRowDecision {
-   KEEP_ROW,
-   DELETE_ROW
+   ACCEPT,
+   REJECT,
 };
 
 enum DRDivergence {

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -50,7 +50,7 @@ const static int DR_ROW_TYPE_COLUMN_INDEX = 0;
 const static int DR_LOG_ACTION_COLUMN_INDEX = 1;
 const static int DR_CONFLICT_COLUMN_INDEX = 2;
 const static int DR_CONFLICTS_ON_PK_COLUMN_INDEX = 3;
-const static int DR_ROW_DECISION_COLUMN_INDEX = 4;
+const static int DR_ACTION_DECISION_COLUMN_INDEX = 4;
 const static int DR_CLUSTER_ID_COLUMN_INDEX = 5;
 const static int DR_TIMESTAMP_COLUMN_INDEX = 6;
 const static int DR_DIVERGENCE_COLUMN_INDEX = 7;
@@ -111,12 +111,12 @@ static inline std::string DRConflictTypeStr(DRConflictType type) {
 }
 
 // 1 letter
-static inline std::string DRRowDecisionStr(DRRowDecision type) {
+static inline std::string DRDecisionStr(DRRowDecision type) {
     switch (type) {
-    case KEEP_ROW:
-        return "K";
-    case DELETE_ROW:
-        return "D";
+    case ACCEPT:
+        return "A";
+    case REJECT:
+        return "R";
     default:
         return "";
     }
@@ -142,12 +142,12 @@ static bool isResolved(int32_t retval) {
     return (retval & RESOLVED_BIT) == RESOLVED_BIT;
 }
 
-static void setConflictOutcome(boost::shared_ptr<TempTable> metadataTable, bool deleteRow, bool convergent) {
+static void setConflictOutcome(boost::shared_ptr<TempTable> metadataTable, bool acceptRemoteChange, bool convergent) {
     TableTuple tuple(metadataTable->schema());
     TableIterator iter = metadataTable->iterator();
     while (iter.next(tuple)) {
-        tuple.setNValue(DR_ROW_DECISION_COLUMN_INDEX,
-                        ValueFactory::getTempStringValue(DRRowDecisionStr(deleteRow ? DELETE_ROW : KEEP_ROW)));
+        tuple.setNValue(DR_ACTION_DECISION_COLUMN_INDEX,
+                        ValueFactory::getTempStringValue(DRDecisionStr(acceptRemoteChange ? ACCEPT : REJECT)));
         tuple.setNValue(DR_DIVERGENCE_COLUMN_INDEX,
                         ValueFactory::getTempStringValue(DRDivergenceStr(convergent ? NOT_DIVERGE : DIVERGE)));
     }
@@ -532,19 +532,9 @@ static void createConflictExportTuple(TempTable *outputMetaTable, TempTable *out
     tempMetaTuple.setNValue(DR_LOG_ACTION_COLUMN_INDEX, ValueFactory::getTempStringValue(DRRecordTypeStr(actionType)));
     tempMetaTuple.setNValue(DR_CONFLICT_COLUMN_INDEX, ValueFactory::getTempStringValue(DRConflictTypeStr(conflictType)));
     tempMetaTuple.setNValue(DR_CONFLICTS_ON_PK_COLUMN_INDEX, ValueFactory::getTinyIntValue(conflictOnPKType));
-    switch (rowType) {
-    case EXISTING_ROW:
-    case EXPECTED_ROW:
-        tempMetaTuple.setNValue(DR_ROW_DECISION_COLUMN_INDEX, ValueFactory::getTempStringValue(DRRowDecisionStr(KEEP_ROW)));
-        break;
-    case NEW_ROW:
-        tempMetaTuple.setNValue(DR_ROW_DECISION_COLUMN_INDEX, ValueFactory::getTempStringValue(DRRowDecisionStr(DELETE_ROW)));
-        break;
-    default:
-        break;
-    }
-    tempMetaTuple.setNValue(DR_CLUSTER_ID_COLUMN_INDEX, ValueFactory::getTinyIntValue((ExecutorContext::getClusterIdFromHiddenNValue(hiddenValue))));    // clusterId
-    tempMetaTuple.setNValue(DR_TIMESTAMP_COLUMN_INDEX, ValueFactory::getBigIntValue(ExecutorContext::getDRTimestampFromHiddenNValue(hiddenValue)));     // timestamp
+    tempMetaTuple.setNValue(DR_ACTION_DECISION_COLUMN_INDEX, ValueFactory::getTempStringValue(DRDecisionStr(REJECT)));
+    tempMetaTuple.setNValue(DR_CLUSTER_ID_COLUMN_INDEX, ValueFactory::getTinyIntValue((ExecutorContext::getClusterIdFromHiddenNValue(hiddenValue))));
+    tempMetaTuple.setNValue(DR_TIMESTAMP_COLUMN_INDEX, ValueFactory::getBigIntValue(ExecutorContext::getDRTimestampFromHiddenNValue(hiddenValue)));
     tempMetaTuple.setNValue(DR_DIVERGENCE_COLUMN_INDEX, ValueFactory::getTempStringValue(DRDivergenceStr(NOT_DIVERGE)));
     tempMetaTuple.setNValue(DR_TABLE_NAME_COLUMN_INDEX, ValueFactory::getTempStringValue(drTable->name()));
     tempMetaTuple.setNValue(DR_TUPLE_COLUMN_INDEX, ValueFactory::getNullStringValue());
@@ -692,13 +682,13 @@ bool BinaryLogSink::handleConflict(VoltDBEngine *engine, PersistentTable *drTabl
         setConflictOutcome(existingMetaTableForDelete, applyRemoteChange, resolved);
     }
     if (expectedMetaTableForDelete) {
-        setConflictOutcome(expectedMetaTableForDelete, /* decision is meaningless */ false, resolved);
+        setConflictOutcome(expectedMetaTableForDelete, applyRemoteChange, resolved);
     }
     if (existingMetaTableForInsert) {
         setConflictOutcome(existingMetaTableForInsert, applyRemoteChange, resolved);
     }
     if (newMetaTableForInsert) {
-        setConflictOutcome(newMetaTableForInsert, !applyRemoteChange, resolved);
+        setConflictOutcome(newMetaTableForInsert, applyRemoteChange, resolved);
     }
 
     if (applyRemoteChange) {

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -134,9 +134,14 @@ public:
 
     int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);
     void pushExportBuffer(int64_t exportGeneration, int32_t partitionId, std::string signature, voltdb::StreamBlock *block, bool sync, bool endOfStream);
-    int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, voltdb::DRRecordType action,
-                        voltdb::DRConflictType deleteConflict, voltdb::Table *existingTableForDelete, voltdb::Table *expectedTableForDelete,
-                        voltdb::DRConflictType insertConflict, voltdb::Table *existingTableForInsert, voltdb::Table *newTableForInsert);
+    int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName,
+                         voltdb::DRRecordType action,
+                         voltdb::DRConflictType deleteConflict,
+                         voltdb::Table *existingMetaTableForDelete, voltdb::Table *existingTupleTableForDelete,
+                         voltdb::Table *expectedMetaTableForDelete, voltdb::Table *expectedTupleTableForDelete,
+                         voltdb::DRConflictType insertConflict,
+                         voltdb::Table *existingMetaTableForInsert, voltdb::Table *existingTupleTableForInsert,
+                         voltdb::Table *newMetaTableForInsert, voltdb::Table *newTupleTableForInsert);
 private:
     voltdb::VoltDBEngine *m_engine;
     long int m_counter;
@@ -1551,10 +1556,13 @@ int64_t VoltDBIPC::pushDRBuffer(int32_t partitionId, voltdb::StreamBlock *block)
 }
 
 int VoltDBIPC::reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp,
-                        std::string tableName, voltdb::DRRecordType action,
-                        voltdb::DRConflictType deleteConflict, voltdb::Table *existingTableForDelete,
-                        voltdb::Table *expectedTableForDelete, voltdb::DRConflictType insertConflict,
-                        voltdb::Table *existingTableForInsert, voltdb::Table *newTableForInsert) {
+                                std::string tableName, voltdb::DRRecordType action,
+                                voltdb::DRConflictType deleteConflict,
+                                voltdb::Table *existingMetaTableForDelete, voltdb::Table *existingTupleTableForDelete,
+                                voltdb::Table *expectedMetaTableForDelete, voltdb::Table *expectedTupleTableForDelete,
+                                voltdb::DRConflictType insertConflict,
+                                voltdb::Table *existingMetaTableForInsert, voltdb::Table *existingTupleTableForInsert,
+                                voltdb::Table *newMetaTableForInsert, voltdb::Table *newTupleTableForInsert) {
     return 0;
 }
 

--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -142,7 +142,7 @@ public class DDLCompiler {
     public static String DR_LOG_ACTION_COLUMN_NAME = "ACTION_TYPE";
     public static String DR_CONFLICT_COLUMN_NAME = "CONFLICT_TYPE";
     public static String DR_CONFLICTS_ON_PK_COLUMN_NAME = "CONFLICTS_ON_PRIMARY_KEY";
-    public static String DR_ROW_DECISION_COLUMN_NAME = "ROW_DECISION";
+    public static String DR_DECISION_COLUMN_NAME = "DECISION";
     public static String DR_CLUSTER_ID_COLUMN_NAME = "CLUSTER_ID";
     public static String DR_TIMESTAMP_COLUMN_NAME = "TIMESTAMP";
     public static String DR_DIVERGENCE_COLUMN_NAME = "DIVERGENCE";
@@ -155,15 +155,13 @@ public class DDLCompiler {
         {DR_LOG_ACTION_COLUMN_NAME, "VARCHAR(1 BYTES) NOT NULL"},
         {DR_CONFLICT_COLUMN_NAME, "VARCHAR(4 BYTES)"},
         {DR_CONFLICTS_ON_PK_COLUMN_NAME, "TINYINT"},
-        {DR_ROW_DECISION_COLUMN_NAME, "VARCHAR(1 BYTES) NOT NULL"},
+        {DR_DECISION_COLUMN_NAME, "VARCHAR(1 BYTES) NOT NULL"},
         {DR_CLUSTER_ID_COLUMN_NAME, "TINYINT NOT NULL"},
         {DR_TIMESTAMP_COLUMN_NAME, "BIGINT NOT NULL"},
         {DR_DIVERGENCE_COLUMN_NAME, "VARCHAR(1 BYTES) NOT NULL"},
         {DR_TABLE_NAME_COLUMN_NAME, "VARCHAR(1024 BYTES)"},
         {DR_TUPLE_COLUMN_NAME, "VARCHAR(1048576 BYTES)"},
     };
-
-    static final int DR_CONFLICTS_EXPORT_TABLE_META_COLUMNS_SIZE = 1 + 1 + 1 + 1 + 1 + 1 + 8 + 1;
 
     private class DDLStatement {
         public DDLStatement() {

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -151,9 +151,9 @@ public abstract class CatalogUtil {
     public static final String DR_CONFLICTS_PARTITIONED_EXPORT_TABLE = "VOLTDB_AUTOGEN_DR_CONFLICTS_PARTITIONED";
     public static final String DR_CONFLICTS_REPLICATED_EXPORT_TABLE = "VOLTDB_AUTOGEN_DR_CONFLICTS_REPLICATED";
     // DR conflicts export group name
-    public static final String DR_CONFLICTS_TABLE_EXPORT_GROUP = "VOLTDB_AUTOGEN_DR_CONFLICTS";
+    public static final String DR_CONFLICTS_TABLE_EXPORT_GROUP = "VOLTDB_DR_CONFLICTS";
     public static final String DEFAULT_DR_CONFLICTS_EXPORT_TYPE = "csv";
-    public static final String DEFAULT_DR_CONFLICTS_NONCE = "MyExport";
+    public static final String DEFAULT_DR_CONFLICTS_NONCE = "LOG";
     public static final String DEFAULT_DR_CONFLICTS_DIR = "dr_conflicts";
     public static final String DR_HIDDEN_COLUMN_NAME = "dr_clusterid_timestamp";
 

--- a/tests/frontend/org/voltdb/compiler/TestDDLCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestDDLCompiler.java
@@ -782,7 +782,7 @@ public class TestDDLCompiler extends TestCase {
         Column c4 = t.getColumns().get(DDLCompiler.DR_CONFLICTS_ON_PK_COLUMN_NAME);
         assertNotNull(c4);
         assertTrue(c4.getType() == VoltType.TINYINT.getValue());
-        Column c5 = t.getColumns().get(DDLCompiler.DR_ROW_DECISION_COLUMN_NAME);
+        Column c5 = t.getColumns().get(DDLCompiler.DR_DECISION_COLUMN_NAME);
         assertNotNull(c5);
         assertTrue(c5.getType() == VoltType.STRING.getValue());
         Column c6 = t.getColumns().get(DDLCompiler.DR_CLUSTER_ID_COLUMN_NAME);


### PR DESCRIPTION
…e per-row based "decision" to action

level "decision", the value could be either "A" (Apply remote change) or "R" (Reject remote change).

Change-Id: I65fc08a5990a08d8fa69f7bbb6e3bae5f0089e3a