### PR TITLE
sqlcmdtest.py, timeout.errbaseline: fix sqlcmdtest: Bill's fix for

### DIFF
--- a/tests/sqlcmd/baselines/querytimeout/timeout.errbaseline
+++ b/tests/sqlcmd/baselines/querytimeout/timeout.errbaseline
@@ -1,3 +1,3 @@
 VOLTDB ERROR: Transaction Interrupted
-  A SQL query was terminated after 1.00 seconds because it exceeded the query timeout period.
+  A SQL query was terminated after 1.00# seconds because it exceeded the query timeout period.
     at org.voltdb.sysprocs.AdHoc_RO_SP.run(AdHoc_RO_SP.java:52)


### PR DESCRIPTION
ENG-9246 added an extra digit to the query-timeout error message (now
showing milliseconds), which broke sqlcmdtest. This fixes that, by
changing the expected message from "1.00 seconds" to "1.00# seconds",
and alters the clean_output method, to ignore that final millisecond
digit, replacing it with "#", so they now match.