### PR TITLE
Optimize table truncate path for fewer numbers of rows

### DIFF
--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -96,7 +96,6 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
     int64_t modified_tuples = 0;
 
     if (m_truncate) {
-        bool truncate = false;
         VOLT_TRACE("truncating table %s...", targetTable->name().c_str());
         // count the truncated tuples as deleted
         modified_tuples = targetTable->visibleTupleCount();
@@ -107,15 +106,8 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
                    (int)targetTable->visibleTupleCount(),
                    (int)targetTable->allocatedTupleCount());
 
-        truncate = targetTable->isTruncateFavorable();
-        if (truncate) {
-            // delete using table swap: undo by table not by each tuple.
-            targetTable->truncateTable(m_engine);
-        }
-        else {
-            // delete tuple by tuple
-            targetTable->deleteAllTuples(true);
-        }
+        // empty the table either by table swap or iteratively deleting tuple-by-tuple
+        targetTable->truncateTable(m_engine);
     }
     else {
         assert(m_inputTable);

--- a/src/ee/storage/TupleBlock.h
+++ b/src/ee/storage/TupleBlock.h
@@ -101,7 +101,7 @@ public:
     { return ThreadLocalPool::freeExactSizedObject(sizeof(TupleBlock), object); }
 
     double loadFactor() {
-        return m_activeTuples / m_tuplesPerBlock;
+        return (double) m_activeTuples / m_tuplesPerBlock;
     }
 
     inline bool hasFreeTuples() {

--- a/src/ee/storage/TupleBlock.h
+++ b/src/ee/storage/TupleBlock.h
@@ -101,7 +101,7 @@ public:
     { return ThreadLocalPool::freeExactSizedObject(sizeof(TupleBlock), object); }
 
     double loadFactor() {
-        return (double) m_activeTuples / m_tuplesPerBlock;
+        return static_cast <double> (m_activeTuples) / m_tuplesPerBlock;
     }
 
     inline bool hasFreeTuples() {

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -339,13 +339,13 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
         // - tables with indexes
 
         // cut-off for table with no views
-        const double TABLE_LF_CUTOFF_FOR_TRUNC = 0.105666;
+        const double tableLFCutoffForTrunc = 0.105666;
         //cut-off for table with views
-        const double TABLE_WITH_VIEWS_LF_CUTOFF_FOR_TRUNC = 0.015416;
+        const double tableWithViewsLFCutoffForTrunc = 0.015416;
 
         const double blockLoadFactor = m_data.begin()->getValue()->loadFactor();
-        if ((blockLoadFactor <= TABLE_LF_CUTOFF_FOR_TRUNC) ||
-            (m_views.size() > 0 && blockLoadFactor <= TABLE_WITH_VIEWS_LF_CUTOFF_FOR_TRUNC)) {
+        if ((blockLoadFactor <= tableLFCutoffForTrunc) ||
+            (m_views.size() > 0 && blockLoadFactor <= tableWithViewsLFCutoffForTrunc)) {
             return deleteAllTuples(true);
         }
     }

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -320,8 +320,8 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
         return;
     }
 
-    // if is the only tuple-storage block table has, it may be better to truncate
-    // table by iteratively deleting table rows. Evalute if that's the case
+    // If the table has only one tuple-storage block, it may be better to truncate
+    // table by iteratively deleting table rows. Evalute if this is the case
     // based on the block and tuple block load factor
     if (m_data.size() == 1) {
         // threshold cutoff in terms of block load factor at which truncate is

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -107,6 +107,12 @@ private:
     TableTuple &m_target;
 };
 
+
+// cut-off for table with no views
+const double PersistentTable::TABLE_LF_CUTOFF_FOR_TRUNC = 0.105666;
+//cut-off for table with views
+const double PersistentTable::TABLE_WITH_VIEWS_LF_CUTOFF_FOR_TRUNC = 0.015416;
+
 PersistentTable::PersistentTable(int partitionColumn, char * signature, bool isMaterialized, int tableAllocationTargetSize, int tupleLimit, bool drEnabled) :
     Table(tableAllocationTargetSize == 0 ? TABLE_BLOCKSIZE : tableAllocationTargetSize),
     m_iter(this),

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -107,12 +107,6 @@ private:
     TableTuple &m_target;
 };
 
-
-// cut-off for table with no views
-const double PersistentTable::TABLE_LF_CUTOFF_FOR_TRUNC = 0.105666;
-//cut-off for table with views
-const double PersistentTable::TABLE_WITH_VIEWS_LF_CUTOFF_FOR_TRUNC = 0.015416;
-
 PersistentTable::PersistentTable(int partitionColumn, char * signature, bool isMaterialized, int tableAllocationTargetSize, int tupleLimit, bool drEnabled) :
     Table(tableAllocationTargetSize == 0 ? TABLE_BLOCKSIZE : tableAllocationTargetSize),
     m_iter(this),
@@ -322,6 +316,40 @@ void PersistentTable::truncateTableRelease(PersistentTable *originalTable) {
 
 
 void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
+    if (isPersistentTableEmpty() == true) {
+        return;
+    }
+
+    // if is the only tuple-storage block table has, it may be better to truncate
+    // table by iteratively deleting table rows. Evalute if that's the case
+    // based on the block and tuple block load factor
+    if (m_data.size() == 1) {
+        // threshold cutoff in terms of block load factor at which truncate is
+        // better than tuple-by-tuple delete. Cut-off values are based on worst
+        // case scenarios with intent to improve performance and to avoid
+        // performance regression by not getting too greedy for performance -
+        // in here cut-off have been lowered to favor truncate instead of
+        // tuple-by-tuple delete. Cut-off numbers were obtained from benchmark
+        // tests performing inserts and truncate under different scenarios outline
+        // and comparing them for deleting all rows with a predicate that's always
+        // true. Following are scenarios based on which cut-off were obtained:
+        // - varying table schema - effect of tables having more columns
+        // - varying number of views on table
+        // - tables with more varchar columns with size below and above 16
+        // - tables with indexes
+
+        // cut-off for table with no views
+        const double TABLE_LF_CUTOFF_FOR_TRUNC = 0.105666;
+        //cut-off for table with views
+        const double TABLE_WITH_VIEWS_LF_CUTOFF_FOR_TRUNC = 0.015416;
+
+        const double blockLoadFactor = m_data.begin()->getValue()->loadFactor();
+        if ((blockLoadFactor <= TABLE_LF_CUTOFF_FOR_TRUNC) ||
+            (m_views.size() > 0 && blockLoadFactor <= TABLE_WITH_VIEWS_LF_CUTOFF_FOR_TRUNC)) {
+            return deleteAllTuples(true);
+        }
+    }
+
     TableCatalogDelegate * tcd = engine->getTableDelegate(m_name);
     assert(tcd);
 

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -93,7 +93,7 @@ class PersistentTableSurgeon {
 
 public:
 
-    TBMap &getData();
+    TBMap &getData() const;
     PersistentTable& getTable();
     void insertTupleForUndo(char *tuple);
     void updateTupleForUndo(char* targetTupleToUpdate,
@@ -426,7 +426,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
         m_tupleLimit = newLimit;
     }
 
-    bool isPersistentTableEmpty()
+    bool isPersistentTableEmpty() const
     {
         // The narrow usage of this function (while updating the catalog)
         // suggests that it could also mean "table is new and never had tuples".
@@ -442,7 +442,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     void truncateTableForUndo(VoltDBEngine * engine, TableCatalogDelegate * tcd, PersistentTable *originalTable);
     void truncateTableRelease(PersistentTable *originalTable);
 
-    PersistentTable * getPreTruncateTable() {
+    PersistentTable * getPreTruncateTable() const {
         return m_preTruncateTable;
     }
 
@@ -499,6 +499,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     }
 
     std::pair<const TableIndex*, uint32_t> getUniqueIndexForDR();
+    inline bool isTruncateFavorable() const;
 
   private:
 
@@ -669,6 +670,17 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     TableIndex* m_smallestUniqueIndex;
     uint32_t m_smallestUniqueIndexCrc;
     int m_drTimestampColumnIndex;
+
+    // threshold cutoff in terms of block load factor at which truncate is better
+    // than tuple-by-tuple delete. Cut-off values are picked based on worst case
+    // scenarios with intent to improve performance and to avoid performance
+    // regression by not getting too greedy for performance by favoring truncate
+    // truncate instead of tuple-by-tuple delete.
+
+    // cut-off for table with no views
+    static const double TABLE_LF_CUTOFF_FOR_TRUNC;
+    //cut-off for table with views
+    static const double TABLE_WITH_VIEWS_LF_CUTOFF_FOR_TRUNC;
 };
 
 inline PersistentTableSurgeon::PersistentTableSurgeon(PersistentTable &table) :
@@ -679,7 +691,7 @@ inline PersistentTableSurgeon::PersistentTableSurgeon(PersistentTable &table) :
 inline PersistentTableSurgeon::~PersistentTableSurgeon()
 {}
 
-inline TBMap &PersistentTableSurgeon::getData() {
+inline TBMap &PersistentTableSurgeon::getData() const {
     return m_table.m_data;
 }
 
@@ -964,6 +976,24 @@ inline TableTuple PersistentTable::lookupTupleForUndo(TableTuple tuple) {
 
 inline TableTuple PersistentTable::lookupTupleForDR(TableTuple tuple) {
     return lookupTuple(tuple, LOOKUP_FOR_DR);
+}
+
+inline bool PersistentTable::isTruncateFavorable() const {
+    // truncate may not optimal way to delete entries from table
+    // for case where there is only block and block load factor
+    // is below certain threshold value. the threshold value is
+    // different if the table has views on it
+    if (m_data.size() == 1) {
+        const double blockLoadFactor = m_data.begin()->getValue()->loadFactor();
+        //const double blockLoadFactor = (double) visibleTupleCount() / m_tuplesPerBlock;
+        if ((blockLoadFactor <= TABLE_LF_CUTOFF_FOR_TRUNC) ||
+            (m_views.size() > 0 && blockLoadFactor <= TABLE_WITH_VIEWS_LF_CUTOFF_FOR_TRUNC)) {
+            return false;
+        }
+    } else if (isPersistentTableEmpty() == true) {
+        return false;
+    }
+    return true;
 }
 
 }

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -499,7 +499,6 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     }
 
     std::pair<const TableIndex*, uint32_t> getUniqueIndexForDR();
-    inline bool isTruncateFavorable() const;
 
   private:
 
@@ -670,17 +669,6 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     TableIndex* m_smallestUniqueIndex;
     uint32_t m_smallestUniqueIndexCrc;
     int m_drTimestampColumnIndex;
-
-    // threshold cutoff in terms of block load factor at which truncate is better
-    // than tuple-by-tuple delete. Cut-off values are picked based on worst case
-    // scenarios with intent to improve performance and to avoid performance
-    // regression by not getting too greedy for performance by favoring truncate
-    // truncate instead of tuple-by-tuple delete.
-
-    // cut-off for table with no views
-    static const double TABLE_LF_CUTOFF_FOR_TRUNC;
-    //cut-off for table with views
-    static const double TABLE_WITH_VIEWS_LF_CUTOFF_FOR_TRUNC;
 };
 
 inline PersistentTableSurgeon::PersistentTableSurgeon(PersistentTable &table) :
@@ -976,24 +964,6 @@ inline TableTuple PersistentTable::lookupTupleForUndo(TableTuple tuple) {
 
 inline TableTuple PersistentTable::lookupTupleForDR(TableTuple tuple) {
     return lookupTuple(tuple, LOOKUP_FOR_DR);
-}
-
-inline bool PersistentTable::isTruncateFavorable() const {
-    // truncate may not optimal way to delete entries from table
-    // for case where there is only block and block load factor
-    // is below certain threshold value. the threshold value is
-    // different if the table has views on it
-    if (m_data.size() == 1) {
-        const double blockLoadFactor = m_data.begin()->getValue()->loadFactor();
-        //const double blockLoadFactor = (double) visibleTupleCount() / m_tuplesPerBlock;
-        if ((blockLoadFactor <= TABLE_LF_CUTOFF_FOR_TRUNC) ||
-            (m_views.size() > 0 && blockLoadFactor <= TABLE_WITH_VIEWS_LF_CUTOFF_FOR_TRUNC)) {
-            return false;
-        }
-    } else if (isPersistentTableEmpty() == true) {
-        return false;
-    }
-    return true;
 }
 
 }

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -92,7 +92,7 @@ Table* TableFactory::getPersistentTable(
     // initialize stats for the table
     configureStats(databaseId, name, table);
 
-    return dynamic_cast<Table*>(table);
+    return table;
 }
 
 // This is a convenient wrapper for test only.

--- a/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
@@ -79,10 +79,9 @@ public class TestSQLFeaturesNewSuite extends RegressionSuite {
         // and executed in single SP call.
         int rowsToInsert = 50000;
         final int rowsInsertionEachChunk = 10000;
-        for (int rowsInserted = 0; rowsInserted < rowsToInsert;) {
+        for (int rowsInserted = 0; rowsInserted < rowsToInsert; rowsInserted += rowsInsertionEachChunk) {
             // Insert data
             client.callProcedure("PopulateTruncateTable", rowsInserted + 1, rowsInsertionEachChunk);
-            rowsInserted = rowsInserted + rowsInsertionEachChunk;
         }
 
         for (String tb: tbs) {

--- a/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
@@ -38,11 +38,13 @@ import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb_testprocs.regressionsuites.sqlfeatureprocs.BatchedMultiPartitionTest;
 import org.voltdb_testprocs.regressionsuites.sqlfeatureprocs.TruncateTable;
+import org.voltdb_testprocs.regressionsuites.sqlfeatureprocs.PopulateTruncateTable;
 
 public class TestSQLFeaturesNewSuite extends RegressionSuite {
     // procedures used by these tests
     static final Class<?>[] PROCEDURES = {
-        TruncateTable.class
+        TruncateTable.class,
+        PopulateTruncateTable.class
     };
 
     /**
@@ -71,12 +73,21 @@ public class TestSQLFeaturesNewSuite extends RegressionSuite {
 
         String[] procs = {"RTABLE.insert", "PTABLE.insert"};
         String[] tbs = {"RTABLE", "PTABLE"};
-        // Insert data
-        loadTableForTruncateTest(client, procs);
+
+        // Populate table with large # of rows (using SP) to exercise swap path for truncate also.
+        // Perform row insertion in chunks as there is upper limit on # on calls that be queued
+        // and executed in single SP call.
+        int rowsToInsert = 50000;
+        final int rowsInsertionEachChunk = 10000;
+        for (int rowsInserted = 0; rowsInserted < rowsToInsert;) {
+            // Insert data
+            client.callProcedure("PopulateTruncateTable", rowsInserted + 1, rowsInsertionEachChunk);
+            rowsInserted = rowsInserted + rowsInsertionEachChunk;
+        }
 
         for (String tb: tbs) {
             vt = client.callProcedure("@AdHoc", "select count(*) from " + tb).getResults()[0];
-            validateTableOfScalarLongs(vt, new long[] {6});
+            validateTableOfScalarLongs(vt, new long[] {rowsToInsert});
         }
 
         if (isHSQL()) {
@@ -95,12 +106,14 @@ public class TestSQLFeaturesNewSuite extends RegressionSuite {
         }
         for (String tb: tbs) {
             vt = client.callProcedure("@AdHoc", "select count(*) from " + tb).getResults()[0];
-            validateTableOfScalarLongs(vt, new long[] {6});
+            validateTableOfScalarLongs(vt, new long[] {rowsToInsert});
 
-            client.callProcedure("@AdHoc", "INSERT INTO "+ tb +" VALUES (7,  30,  1.1, 'Jedi','Winchester');");
+            int nextId = rowsToInsert + 1;
+            client.callProcedure("@AdHoc", "INSERT INTO "+ tb +" VALUES (" +
+                                            nextId + ", 30,  1.1, 'Jedi','Winchester');");
 
             vt = client.callProcedure("@AdHoc", "select count(ID) from " + tb).getResults()[0];
-            validateTableOfScalarLongs(vt, new long[] {7});
+            validateTableOfScalarLongs(vt, new long[] {nextId});
 
 
             vt = client.callProcedure("@AdHoc", "Truncate table " + tb).getResults()[0];

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/PopulateTruncateTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/PopulateTruncateTable.java
@@ -1,0 +1,60 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.regressionsuites.sqlfeatureprocs;
+
+import org.voltdb.ProcInfo;
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+
+@ProcInfo (
+    singlePartition = false
+)
+public class PopulateTruncateTable extends VoltProcedure {
+
+    public final SQLStmt insertPTable = new SQLStmt("INSERT INTO PTABLE VALUES(?, ?, ?, ?, ?);");
+    public final SQLStmt insertRTable = new SQLStmt("INSERT INTO RTABLE VALUES(?, ?, ?, ?, ?);");
+
+    public VoltTable[] run(int startID, int rowsToInsert) {
+        for (int i = 0; i < rowsToInsert; i++) {
+            int id = startID + i;
+            int age = id % 100;
+            voltQueueSQL(insertPTable,
+                    id,
+                    age,
+                    id / 3,
+                    "ID" + id,
+                    "AreaCode" + id);
+            voltQueueSQL(insertRTable,
+                    id,
+                    age,
+                    id / 3,
+                    "ID" + id,
+                    "AreaCode" + id);
+        }
+
+        return voltExecuteSQL();
+    }
+
+}


### PR DESCRIPTION
Changes are to optimize truncate operation where instead of performing table swap of existing table with newly created empty persistent table, logic will perform deletion of all the tuple entries in the table iteratively and retain existing objects associated to table instead of creating afresh.This helps truncate operation for table with few rows to be as fast as when performing delete all rows using predicate that is true (result in deletion of all iteratively internally does).