### PR TITLE
ENG-9383: Fix durability notification after rejoin.

### DIFF
--- a/src/frontend/org/voltdb/CommandLog.java
+++ b/src/frontend/org/voltdb/CommandLog.java
@@ -77,6 +77,13 @@ public interface CommandLog {
     public abstract void logIv2Fault(long writerHSId, Set<Long> survivorHSId,
             int partitionId, long spHandle);
 
+    /**
+     * Called on the very first message a rejoined SpScheduler receives to initialize the last durable value.
+     * Thread it through here because the durability listener is owned by the command log thread.
+     * @param uniqueId    The last durable unique ID passed from the master.
+     */
+    void initializeLastDurableUniqueId(DurabilityListener listener, long uniqueId);
+
     interface CompletionChecks {
         /**
          * Use the current CompletionChecks object to create a new CompletionChecks object
@@ -89,8 +96,14 @@ public interface CommandLog {
          * Add a new transaction to the per-scheduler durable transaction tracker
          * @param task
          */
-
         public void addTask(TransactionTask task);
+
+        /**
+         * Called on the very first message a rejoined SpScheduler receives to initialize the last durable value.
+         * @param uniqueId    The last durable unique ID passed from the master.
+         */
+        void setLastDurableUniqueId(long uniqueId);
+
         /**
          * Get the number of TransactionTasks tracked by this instance of CompletionChecks
          * @return
@@ -102,13 +115,6 @@ public interface CommandLog {
          * Durability Listener notifications
          */
         public void processChecks();
-
-        /**
-         * This is like processChecks but executed when we started a sync but there were no
-         * new transactions. This is used to start non-commmand-logged system procedures
-         * when synchronous command logging is set
-         */
-        public void checkForSyncLoggedSysProcs();
     }
 
     public interface DurabilityListener {
@@ -133,6 +139,12 @@ public interface CommandLog {
         public void addTransaction(TransactionTask pendingTask);
 
         /**
+         * Called on the very first message a rejoined SpScheduler receives to initialize the last durable value.
+         * @param uniqueId    The last durable unique ID passed from the master.
+         */
+        void initializeLastDurableUniqueId(long uniqueId);
+
+        /**
          * Used by CommandLog to calculate the next task list size
          */
         public int getNumberOfTasks();
@@ -148,13 +160,6 @@ public interface CommandLog {
          * @param completionChecks
          */
         void processDurabilityChecks(CompletionChecks completionChecks);
-
-        /**
-        * Make sure Non-Durable SysProcs get executed with Synchronous Command Logging
-        * and no other pending transactions
-        * @param completionChecks
-        */
-        void checkForSyncLoggedSysProcs(CompletionChecks completionChecks);
     }
 
     /**

--- a/src/frontend/org/voltdb/DummyCommandLog.java
+++ b/src/frontend/org/voltdb/DummyCommandLog.java
@@ -60,6 +60,9 @@ public class DummyCommandLog implements CommandLog {
     }
 
     @Override
+    public void initializeLastDurableUniqueId(DurabilityListener listener, long uniqueId) {}
+
+    @Override
     public boolean isEnabled()
     {
         // No real command log, obviously not enabled

--- a/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
+++ b/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
@@ -19,6 +19,7 @@ package org.voltdb.iv2;
 
 import java.util.ArrayList;
 
+import org.voltcore.logging.VoltLogger;
 import org.voltdb.CommandLog;
 import org.voltdb.CommandLog.DurabilityListener;
 import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
@@ -27,6 +28,7 @@ import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
  * This class is not thread-safe. Most of its usage is on the Site thread.
  */
 public class SpDurabilityListener implements DurabilityListener {
+    private static final VoltLogger log = new VoltLogger("LOGGING");
 
     // No command logging
     class NoCompletionChecks implements CommandLog.CompletionChecks {
@@ -40,20 +42,21 @@ public class SpDurabilityListener implements DurabilityListener {
         public void addTask(TransactionTask task) {}
 
         @Override
+        public void setLastDurableUniqueId(long uniqueId) {}
+
+        @Override
         public int getTaskListSize() {
             return 0;
         }
 
         @Override
         public void processChecks() {}
-
-        @Override
-        public void checkForSyncLoggedSysProcs() {}
-    };
+    }
 
     class AsyncCompletionChecks implements CommandLog.CompletionChecks {
         protected long m_lastSpUniqueId;
         protected long m_lastMpUniqueId;
+        protected boolean m_changed = false;
 
         AsyncCompletionChecks(long lastSpUniqueId, long lastMpUniqueId) {
             m_lastSpUniqueId = lastSpUniqueId;
@@ -67,12 +70,20 @@ public class SpDurabilityListener implements DurabilityListener {
 
         @Override
         public void addTask(TransactionTask task) {
-            if (UniqueIdGenerator.getPartitionIdFromUniqueId(task.m_txnState.uniqueId) == MpInitiator.MP_INIT_PID) {
-                m_lastMpUniqueId = task.m_txnState.uniqueId;
+            setLastDurableUniqueId(task.m_txnState.uniqueId);
+        }
+
+        @Override
+        public void setLastDurableUniqueId(long uniqueId) {
+            if (UniqueIdGenerator.getPartitionIdFromUniqueId(uniqueId) == MpInitiator.MP_INIT_PID) {
+                assert m_lastMpUniqueId <= uniqueId;
+                m_lastMpUniqueId = uniqueId;
             }
             else {
-                m_lastSpUniqueId = task.m_txnState.uniqueId;
+                assert m_lastSpUniqueId <= uniqueId;
+                m_lastSpUniqueId = uniqueId;
             }
+            m_changed = true;
         }
 
         @Override
@@ -82,14 +93,17 @@ public class SpDurabilityListener implements DurabilityListener {
 
         @Override
         public void processChecks() {
-            // Notify the SP UniqueId listeners
-            for (DurableUniqueIdListener listener : m_uniqueIdListeners) {
-                listener.lastUniqueIdsMadeDurable(m_lastSpUniqueId, m_lastMpUniqueId);
+            if (m_changed) {
+                if (log.isTraceEnabled()) {
+                    log.trace("Notifying of last made durable: SP " + UniqueIdGenerator.toShortString(m_lastSpUniqueId) +
+                              ", MP " + UniqueIdGenerator.toShortString(m_lastMpUniqueId));
+                }
+                // Notify the SP UniqueId listeners
+                for (DurableUniqueIdListener listener : m_uniqueIdListeners) {
+                    listener.lastUniqueIdsMadeDurable(m_lastSpUniqueId, m_lastMpUniqueId);
+                }
             }
         }
-
-        @Override
-        public void checkForSyncLoggedSysProcs() {}
     };
 
     class SyncCompletionChecks extends AsyncCompletionChecks {
@@ -132,12 +146,6 @@ public class SpDurabilityListener implements DurabilityListener {
             queuePendingTasks();
             super.processChecks();
         }
-
-        @Override
-        public void checkForSyncLoggedSysProcs() {
-            queuePendingTasks();
-        }
-
     }
 
     private CommandLog.CompletionChecks m_currentCompletionChecks = null;
@@ -165,6 +173,11 @@ public class SpDurabilityListener implements DurabilityListener {
     @Override
     public void addTransaction(TransactionTask pendingTask) {
         m_currentCompletionChecks.addTask(pendingTask);
+    }
+
+    @Override
+    public void initializeLastDurableUniqueId(long uniqueId) {
+        m_currentCompletionChecks.setLastDurableUniqueId(uniqueId);
     }
 
     @Override
@@ -206,11 +219,6 @@ public class SpDurabilityListener implements DurabilityListener {
     @Override
     public void processDurabilityChecks(CommandLog.CompletionChecks completionChecks) {
         m_spScheduler.processDurabilityChecks(completionChecks);
-    }
-
-    @Override
-    public void checkForSyncLoggedSysProcs(CommandLog.CompletionChecks completionChecks) {
-        m_spScheduler.checkForSyncLoggedSysProcs(completionChecks);
     }
 
 }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -520,7 +520,11 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         else {
             setMaxSeenTxnId(msg.getSpHandle());
             newSpHandle = msg.getSpHandle();
-            uniqueId = msg.getUniqueId();
+
+            // Don't update the uniqueID if this is a run-everywhere txn, because it has an MPI unique ID.
+            if (UniqueIdGenerator.getPartitionIdFromUniqueId(msg.getUniqueId()) == m_partitionId) {
+                m_uniqueIdGenerator.updateMostRecentlyGeneratedUniqueId(msg.getUniqueId());
+            }
         }
         Iv2Trace.logIv2InitiateTaskMessage(message, m_mailbox.getHSId(), msg.getTxnId(), newSpHandle);
         doLocalInitiateOffer(msg);
@@ -965,6 +969,11 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         // the provided SP handle
         writeIv2ViableReplayEntryInternal(message.getSpHandle());
         setMaxSeenTxnId(message.getSpHandle());
+
+        // Also initialize the unique ID generator and the last durable unique ID using
+        // the value sent by the master
+        m_uniqueIdGenerator.updateMostRecentlyGeneratedUniqueId(message.getSpUniqueId());
+        m_cl.initializeLastDurableUniqueId(m_durabilityListener, m_uniqueIdGenerator.getLastUniqueId());
     }
 
     public void handleDumpMessage()
@@ -1017,7 +1026,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
                 long faultSpHandle = advanceTxnEgo().getTxnId();
                 writeIv2ViableReplayEntryInternal(faultSpHandle);
                 // Generate Iv2LogFault message and send it to replicas
-                Iv2LogFaultMessage faultMsg = new Iv2LogFaultMessage(faultSpHandle);
+                Iv2LogFaultMessage faultMsg = new Iv2LogFaultMessage(faultSpHandle, m_uniqueIdGenerator.getLastUniqueId());
                 m_mailbox.send(m_sendToHSIds,
                         faultMsg);
             }
@@ -1059,24 +1068,6 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         if (InitiatorMailbox.SCHEDULE_IN_SITE_THREAD) {
             m_tasks.offer(r);
         } else {
-            r.run();
-        }
-    }
-
-    public void checkForSyncLoggedSysProcs(final CommandLog.CompletionChecks currentChecks) {
-        final SiteTaskerRunnable r = new SiteTasker.SiteTaskerRunnable() {
-            @Override
-            void run() {
-                assert (currentChecks != null);
-                synchronized (m_lock) {
-                    currentChecks.checkForSyncLoggedSysProcs();
-                }
-            }
-        };
-        if (InitiatorMailbox.SCHEDULE_IN_SITE_THREAD) {
-            m_tasks.offer(r);
-        }
-        else {
             r.run();
         }
     }

--- a/src/frontend/org/voltdb/iv2/UniqueIdGenerator.java
+++ b/src/frontend/org/voltdb/iv2/UniqueIdGenerator.java
@@ -69,7 +69,7 @@ public class UniqueIdGenerator {
     static final long PARTITIONID_MAX_VALUE = (1L << PARTITIONID_BITS) - 1L;
 
     // the local siteid
-    long partitionId;
+    int partitionId;
     // the time of the previous unique id generation
     long lastUsedTime = -1;
     // the number of unique ids generated during the same value
@@ -77,7 +77,7 @@ public class UniqueIdGenerator {
     long counterValue = 0;
 
     // remembers the last unique id generated
-    long lastUniqueId = 0;
+    long lastUniqueId;
 
 
     // salt used for testing to simulate clock skew
@@ -102,7 +102,7 @@ public class UniqueIdGenerator {
 
     private final Clock m_clock;
 
-    public UniqueIdGenerator(long partitionId, long timestampTestingSalt) {
+    public UniqueIdGenerator(int partitionId, long timestampTestingSalt) {
         this(partitionId, timestampTestingSalt, new Clock() {
             @Override
             public long get() {
@@ -121,7 +121,7 @@ public class UniqueIdGenerator {
      * @param partitionId The partitionId of the site generating ids
      * @param timestampTestingSalt Value of the salt used to skew a clock in testing.
      */
-    public UniqueIdGenerator(long partitionId, long timestampTestingSalt, Clock clock) {
+    public UniqueIdGenerator(int partitionId, long timestampTestingSalt, Clock clock) {
         this.partitionId = partitionId;
 
         m_timestampTestingSalt = timestampTestingSalt;
@@ -134,6 +134,9 @@ public class UniqueIdGenerator {
             log.warn(String.format("Partition (id=%d) running in test mode with non-zero timestamp testing value: %d",
                      partitionId, timestampTestingSalt));
         }
+
+        // initialize the last used unique ID to a valid value
+        lastUniqueId = makeZero(this.partitionId);
     }
 
     public void updateMostRecentlyGeneratedUniqueId(long uniqueId) {

--- a/src/frontend/org/voltdb/messaging/Iv2LogFaultMessage.java
+++ b/src/frontend/org/voltdb/messaging/Iv2LogFaultMessage.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
+import org.voltdb.iv2.UniqueIdGenerator;
 
 /**
  * Message from a client interface to an initiator, instructing the
@@ -32,16 +33,18 @@ import org.voltcore.utils.CoreUtils;
 public class Iv2LogFaultMessage extends VoltMessage
 {
     private long m_spHandle;
+    private long m_spUniqueId;
 
     /** Empty constructor for de-serialization */
     Iv2LogFaultMessage() {
         super();
     }
 
-    public Iv2LogFaultMessage(long spHandle)
+    public Iv2LogFaultMessage(long spHandle, long spUniqueId)
     {
         super();
         m_spHandle = spHandle;
+        m_spUniqueId = spUniqueId;
     }
 
     public long getSpHandle()
@@ -49,11 +52,16 @@ public class Iv2LogFaultMessage extends VoltMessage
         return m_spHandle;
     }
 
+    public long getSpUniqueId() {
+        return m_spUniqueId;
+    }
+
     @Override
     public int getSerializedSize()
     {
         int msgsize = super.getSerializedSize();
-        msgsize += 8; // spHandle
+        msgsize += 8  // spHandle
+                 + 8; // spUniqueId
         return msgsize;
     }
 
@@ -62,6 +70,7 @@ public class Iv2LogFaultMessage extends VoltMessage
     {
         buf.put(VoltDbMessageFactory.IV2_LOG_FAULT_ID);
         buf.putLong(m_spHandle);
+        buf.putLong(m_spUniqueId);
 
         assert(buf.capacity() == buf.position());
         buf.limit(buf.position());
@@ -70,6 +79,7 @@ public class Iv2LogFaultMessage extends VoltMessage
     @Override
     public void initFromBuffer(ByteBuffer buf) throws IOException {
         m_spHandle = buf.getLong();
+        m_spUniqueId = buf.getLong();
     }
 
     @Override
@@ -80,6 +90,8 @@ public class Iv2LogFaultMessage extends VoltMessage
         sb.append(CoreUtils.hsIdToString(m_sourceHSId));
         sb.append(" SPHANDLE: ");
         sb.append(m_spHandle);
+        sb.append(" SPUNIQUEID: ");
+        sb.append(UniqueIdGenerator.toShortString(m_spUniqueId));
         return sb.toString();
     }
 }

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
@@ -117,7 +117,7 @@ public class TestSpSchedulerDedupe extends TestCase
                                        Long.MIN_VALUE, // coordHSID
                                        txnId - 1, // truncationHandle
                                        txnId,     // txnId
-                                       System.currentTimeMillis(), // timestamp
+                                       UniqueIdGenerator.makeIdFromComponents(System.currentTimeMillis(), 0, 0), // uniqueID
                                        readOnly, // readonly
                                        singlePart, // single-part
                                        spi, // invocation


### PR DESCRIPTION
On rejoin, the durability listener won't be notified until the first SP
and MP transactions are logged. This means that if the cluster is idle,
nothing is made durable. However, we do know that anything on disk prior
to the node failing must have been made durable by other nodes.

- Notify the durability listeners even if the last txn was a sysproc
  that doesn't require durability. Previously, we were just letting it
  through without notifying any listener.

- Propogate the last unique ID from the master SPI to the rejoining SPI
  using the Iv2LogFaultMessage, which is the very first message a
  rejoining SPI will get. Then initialize the durability listener with
  this unique ID.

Change-Id: Iadfa4c86d53314ee06e4c912cecbbbd20cdd4e80