### PR TITLE
ENG-9419: Fix invalid memory access.

### DIFF
--- a/src/catgen/in/cppsrc/catalog.cpp
+++ b/src/catgen/in/cppsrc/catalog.cpp
@@ -365,11 +365,11 @@ void Catalog::hexDecodeString(const string &hexString, char *buffer) {
     buffer[i] = '\0';
 }
 
-/** pass in a buffer at least (2*len(string)+1) */
-void Catalog::hexEncodeString(const char *string, char *buffer) {
+/** pass in a buffer at least (2*len+1) */
+void Catalog::hexEncodeString(const char *string, char *buffer, size_t len) {
     assert (buffer);
     int32_t i = 0;
-    for (; i < strlen(string); i++) {
+    for (; i < len; i++) {
         char ch[2];
         snprintf(ch, 2, "%x", (string[i] >> 4) & 0xF);
         buffer[i * 2] = ch[0];

--- a/src/catgen/in/cppsrc/catalog.h
+++ b/src/catgen/in/cppsrc/catalog.h
@@ -105,7 +105,7 @@ public:
     static void hexDecodeString(const std::string &hexString, char *buffer);
 
     /** pass in a buffer at twice as long as the string */
-    static void hexEncodeString(const char *string, char *buffer);
+    static void hexEncodeString(const char *string, char *buffer, size_t len);
 
     /** return by out-param a copy of the recently deleted paths. */
     void getDeletedPaths(std::vector<std::string> &deletions);

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -593,9 +593,12 @@ class NValue {
             return std::string(reinterpret_cast<char*>(getObjectValue_withoutNull()),
                                getObjectLength_withoutNull());
         case VALUE_TYPE_VARBINARY: {
-            char buf[getObjectLength_withoutNull() * 2 + 1];
-            catalog::Catalog::hexEncodeString(reinterpret_cast<char*>(getObjectValue_withoutNull()), buf);
-            return std::string(buf, getObjectLength_withoutNull() * 2);
+            size_t objLen = getObjectLength_withoutNull();
+            char *buf = new char[objLen * 2 + 1];
+            catalog::Catalog::hexEncodeString(reinterpret_cast<char*>(getObjectValue_withoutNull()), buf, objLen);
+            std::string retval(buf, objLen * 2);
+            delete [] buf;
+            return retval;
         }
         case VALUE_TYPE_TIMESTAMP: {
             streamTimestamp(value);


### PR DESCRIPTION
Catalog::hexEncodeString() assumes that the input string is always
null-terminated, which is not true. Add a length parameter to the
function so that it doesn't rely on strlen() to find the string length.

Also added some outline strings and binary data to the DRBinaryLog tests
to exercise this path.

Change-Id: I0c12ddda9f7843d2a8305979d4520b3a0120c57a