### PR TITLE
ENG-9431: Fix DR binary log update.

### DIFF
--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -348,7 +348,7 @@ int64_t BinaryLogSink::apply(const char *taskParams, boost::unordered_map<int64_
             }
 
             try {
-                table->updateTupleWithSpecificIndexes(oldTuple, tempTuple, table->allIndexes());
+                table->updateTupleWithSpecificIndexes(oldTuple, tempTuple, table->allIndexes(), true, false);
             } catch (ConstraintFailureException &e) {
                 if (engine->getIsActiveActiveDREnabled()) {
                     if (handleConflict(engine, table, pool, NULL, e.getOriginalTuple(), const_cast<TableTuple *>(e.getConflictTuple()), uniqueId, remoteClusterId, DR_RECORD_UPDATE, NO_CONFLICT, CONFLICT_CONSTRAINT_VIOLATION)) {
@@ -426,7 +426,7 @@ int64_t BinaryLogSink::apply(const char *taskParams, boost::unordered_map<int64_
             ReferenceSerializeInputLE newRowInput(newRowData, newRowLength);
             tempTuple.deserializeFromDR(newRowInput, pool);
 
-            table->updateTupleWithSpecificIndexes(oldTuple, tempTuple, table->allIndexes());
+            table->updateTupleWithSpecificIndexes(oldTuple, tempTuple, table->allIndexes(), true, false);
             break;
         }
         case DR_RECORD_BEGIN_TXN: {

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -560,7 +560,8 @@ void PersistentTable::insertTupleForUndo(char *tuple)
 bool PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUpdate,
                                                      TableTuple &sourceTupleWithNewValues,
                                                      std::vector<TableIndex*> const &indexesToUpdate,
-                                                     bool fallible)
+                                                     bool fallible,
+                                                     bool updateDRTimestamp)
 {
     UndoQuantum *uq = NULL;
     char* oldTupleData = NULL;
@@ -634,7 +635,7 @@ bool PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUp
     }
 
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
-    if (hasDRTimestampColumn()) {
+    if (hasDRTimestampColumn() && updateDRTimestamp) {
         setDRTimestampForTuple(ec, sourceTupleWithNewValues, true);
     }
 

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -266,7 +266,8 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     virtual bool updateTupleWithSpecificIndexes(TableTuple &targetTupleToUpdate,
                                                 TableTuple &sourceTupleWithNewValues,
                                                 std::vector<TableIndex*> const &indexesToUpdate,
-                                                bool fallible=true);
+                                                bool fallible=true,
+                                                bool updateDRTimestamp=true);
 
     virtual void addIndex(TableIndex *index) {
         Table::addIndex(index);


### PR DESCRIPTION
DR update was incorrectly updating the hidden DR timestamp when it
applies the binary log, which causes the row to have the wrong hidden
column value. The next update or delete on the same tuple will be a
timestamp mismatch conflict.

Now the DR update path doesn't update the DR timestamp.

I'm still working on the tests. Don't delete the branch yet.