### PR TITLE
ENG-9396, remove redundant call to initialize().

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2245,7 +2245,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
                 for (Initiator iv2init : m_iv2Initiators.values()) {
                     iv2init.setConsumerDRGateway(m_consumerDRGateway);
                 }
-                m_consumerDRGateway.initialize(false);
             }
             // 6.2. If we are a DR replica, we may care about a
             // deployment update


### PR DESCRIPTION
Change-Id: Ibabd213ddadc8bb35862993e970c7c4ecf37d0aa

There is a timing window which will trigger RejectedExecutionException. When DR active-active is set and DR consumer connection is not enabled, @UpdateApplicationCatalog path will create and initialize the DR consumer first, which will let DR consumer to enter DISABLE state and shutdown the executor service thread. But the sequencing call to update DR consumer's catalog will fail to submit a task to executor service thread if the initialization task happens first.