### PR TITLE
ENG-9431: Update DR binary log unit tests.

### DIFF
--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -104,8 +104,6 @@ ExecutorContext::ExecutorContext(int64_t siteId,
 ExecutorContext::~ExecutorContext() {
     // currently does not own any of its pointers
 
-    // There can be only one (per thread).
-    assert(pthread_getspecific( static_key) == this);
     // ... or none, now that the one is going away.
     VOLT_DEBUG("De-installing EC(%ld)", (long)this);
 
@@ -114,8 +112,6 @@ ExecutorContext::~ExecutorContext() {
 
 void ExecutorContext::bindToThread()
 {
-    // There can be only one (per thread).
-    assert(pthread_getspecific(static_key) == NULL);
     pthread_setspecific(static_key, this);
     VOLT_DEBUG("Installing EC(%ld)", (long)this);
 }


### PR DESCRIPTION
Separate the execution engines, one for master, one for replica, so they
can have two cluster IDs and such. Check for the DR timestamp after
updates.

Change-Id: I45b57d1742ae021092528c64ae980398997e6d3b