### PR TITLE
ENG-9431: Update DR binary log unit tests.

### DIFF
--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -104,8 +104,6 @@ ExecutorContext::ExecutorContext(int64_t siteId,
 ExecutorContext::~ExecutorContext() {
     // currently does not own any of its pointers
 
-    // There can be only one (per thread).
-    assert(pthread_getspecific( static_key) == this);
     // ... or none, now that the one is going away.
     VOLT_DEBUG("De-installing EC(%ld)", (long)this);
 
@@ -114,8 +112,6 @@ ExecutorContext::~ExecutorContext() {
 
 void ExecutorContext::bindToThread()
 {
-    // There can be only one (per thread).
-    assert(pthread_getspecific(static_key) == NULL);
     pthread_setspecific(static_key, this);
     VOLT_DEBUG("Installing EC(%ld)", (long)this);
 }

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -51,7 +51,8 @@ using namespace voltdb;
 
 const int COLUMN_COUNT = 7;
 const int HIDDEN_COLUMN_COUNT = 1;
-const int CLUSTER_ID = 0;
+const int CLUSTER_ID = 1;
+const int CLUSTER_ID_REPLICA = 2;
 
 static int64_t addPartitionId(int64_t value) {
     return (value << 14) | 42;
@@ -75,10 +76,10 @@ public:
 
 class MockVoltDBEngine : public VoltDBEngine {
 public:
-    MockVoltDBEngine(bool isActiveActiveEnabled, Topend* topend, Pool* pool, DRTupleStream* drStream, DRTupleStream* drReplicatedStream) {
+    MockVoltDBEngine(bool isActiveActiveEnabled, int clusterId, Topend* topend, Pool* pool, DRTupleStream* drStream, DRTupleStream* drReplicatedStream) {
         m_isActiveActiveEnabled = isActiveActiveEnabled;
         m_context.reset(new ExecutorContext(1, 1, NULL, topend, pool,
-                                            NULL, this, "localhost", 2, drStream, drReplicatedStream, CLUSTER_ID));
+                                            NULL, this, "localhost", 2, drStream, drReplicatedStream, clusterId));
 
         std::vector<ValueType> exportColumnType;
         std::vector<int32_t> exportColumnLength;
@@ -118,6 +119,7 @@ public:
     Table* getPartitionedDRConflictTable() const{ return m_conflictExportTable; }
     ExportTupleStream* getExportTupleStream() { return m_exportStream; }
     ExecutorContext* getExecutorContext() { return m_context.get(); }
+    void prepareContext() { m_context.get()->bindToThread(); }
 
 private:
     bool m_isActiveActiveEnabled;
@@ -131,10 +133,15 @@ class DRBinaryLogTest : public Test {
 public:
     DRBinaryLogTest()
       : m_undoToken(0),
-        m_engine (new MockVoltDBEngine(false, &m_topend, &m_pool, &m_drStream, &m_drReplicatedStream))
+        m_spHandleReplica(0),
+        m_engine (new MockVoltDBEngine(false, CLUSTER_ID, &m_topend, &m_pool, &m_drStream, &m_drReplicatedStream)),
+        m_engineReplica (new MockVoltDBEngine(false, CLUSTER_ID_REPLICA, &m_topend, &m_pool, &m_drStreamReplica, &m_drReplicatedStreamReplica))
     {
         m_drStream.m_enabled = true;
         m_drReplicatedStream.m_enabled = true;
+        m_drStreamReplica.m_enabled = false;
+        m_drReplicatedStreamReplica.m_enabled = false;
+
         *reinterpret_cast<int64_t*>(tableHandle) = 42;
         *reinterpret_cast<int64_t*>(replicatedTableHandle) = 24;
         *reinterpret_cast<int64_t*>(otherTableHandleWithIndex) = 43;
@@ -244,6 +251,7 @@ public:
             (*cit).free();
         }
         delete m_engine;
+        delete m_engineReplica;
         delete m_table;
         delete m_replicatedTable;
         delete m_tableReplica;
@@ -255,21 +263,26 @@ public:
         delete m_otherTableWithoutIndexReplica;
     }
 
-    void beginTxn(int64_t txnId, int64_t spHandle, int64_t lastCommittedSpHandle, int64_t uniqueId) {
+    void beginTxn(MockVoltDBEngine *engine, int64_t txnId, int64_t spHandle, int64_t lastCommittedSpHandle, int64_t uniqueId) {
+        engine->prepareContext();
         m_currTxnUniqueId = addPartitionId(uniqueId);
 
         UndoQuantum* uq = m_undoLog.generateUndoQuantum(m_undoToken);
-        m_engine->getExecutorContext()->setupForPlanFragments(uq, addPartitionId(txnId), addPartitionId(spHandle),
-                addPartitionId(lastCommittedSpHandle), addPartitionId(uniqueId));
+        engine->getExecutorContext()->setupForPlanFragments(uq, addPartitionId(txnId), addPartitionId(spHandle),
+                                                            addPartitionId(lastCommittedSpHandle), addPartitionId(uniqueId));
     }
 
-    void endTxn(bool success) {
+    void endTxn(MockVoltDBEngine *engine, bool success) {
         if (!success) {
             m_undoLog.undo(m_undoToken);
         } else {
             m_undoLog.release(m_undoToken++);
-            m_drStream.endTransaction(m_currTxnUniqueId);
-            m_drReplicatedStream.endTransaction(m_currTxnUniqueId);
+            if (engine->getExecutorContext()->drStream() != NULL) {
+                engine->getExecutorContext()->drStream()->endTransaction(m_currTxnUniqueId);
+            }
+            if (engine->getExecutorContext()->drReplicatedStream() != NULL) {
+                engine->getExecutorContext()->drReplicatedStream()->endTransaction(m_currTxnUniqueId);
+            }
         }
     }
 
@@ -299,7 +312,7 @@ public:
         m_cachedStringValues.push_back(ValueFactory::getStringValue(new_nonindex_value));
         new_tuple.setNValue(3, m_cachedStringValues.back());
         table->updateTuple(tuple_to_update, new_tuple);
-        return new_tuple;
+        return table->lookupTupleForDR(new_tuple);
     }
 
     TableTuple updateTupleFirstAndSecondColumn(PersistentTable* table, TableTuple tuple, int8_t new_tinyint_value, int64_t new_bigint_value) {
@@ -356,7 +369,13 @@ public:
     void flushAndApply(int64_t lastCommittedSpHandle, bool success = true) {
         ASSERT_TRUE(flush(lastCommittedSpHandle));
 
-        m_engine->getExecutorContext()->setupForPlanFragments(m_undoLog.generateUndoQuantum(m_undoToken));
+        beginTxn(m_engineReplica,
+                 addPartitionId(m_spHandleReplica), // txnid
+                 addPartitionId(m_spHandleReplica), // sphandle
+                 addPartitionId(m_spHandleReplica - 1), // last sphandle
+                 addPartitionId(m_spHandleReplica)); // fake uniqueid
+        m_spHandleReplica++;
+
         boost::unordered_map<int64_t, PersistentTable*> tables;
         tables[42] = m_tableReplica;
         tables[43] = m_otherTableWithIndexReplica;
@@ -373,12 +392,14 @@ public:
             *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
             m_drStream.m_enabled = false;
             m_drReplicatedStream.m_enabled = false;
-            m_sink.apply(&data[startPos], tables, &m_pool, m_engine, 1);
+            m_sink.apply(&data[startPos], tables, &m_pool, m_engineReplica, 1);
             m_drStream.m_enabled = true;
             m_drReplicatedStream.m_enabled = true;
         }
         m_topend.receivedDRBuffer = false;
-        endTxn(success);
+        endTxn(m_engineReplica, success);
+
+        m_engine->prepareContext();
     }
 
     void createIndexes() {
@@ -491,20 +512,20 @@ public:
         ASSERT_FALSE(indexPairReplica.first == NULL);
         EXPECT_EQ(indexPair.second, indexPairReplica.second);
 
-        beginTxn(99, 99, 98, 70);
+        beginTxn(m_engine, 99, 99, 98, 70);
         TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
         TableTuple second_tuple = insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
         TableTuple third_tuple = insertTuple(m_table, prepareTempTuple(m_table, 72, 345, "4256.345", "something", "more tuple data, really not the same", 1812));
-        endTxn(true);
+        endTxn(m_engine, true);
 
         flushAndApply(99);
 
         EXPECT_EQ(3, m_tableReplica->activeTupleCount());
 
-        beginTxn(100, 100, 99, 71);
+        beginTxn(m_engine, 100, 100, 99, 71);
         deleteTuple(m_table, first_tuple);
         deleteTuple(m_table, second_tuple);
-        endTxn(true);
+        endTxn(m_engine, true);
 
         flushAndApply(100);
 
@@ -514,19 +535,19 @@ public:
     }
 
     void simpleUpdateTest() {
-        beginTxn(99, 99, 98, 70);
+        beginTxn(m_engine, 99, 99, 98, 70);
         TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
         TableTuple second_tuple = insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
-        endTxn(true);
+        endTxn(m_engine, true);
 
         flushAndApply(99);
 
         EXPECT_EQ(2, m_tableReplica->activeTupleCount());
 
-        beginTxn(100, 100, 99, 71);
+        beginTxn(m_engine, 100, 100, 99, 71);
         // update the non-index column only
-        updateTuple(m_table, first_tuple, 42, "not that");
-        endTxn(true);
+        TableTuple first_updated_tuple = updateTuple(m_table, first_tuple, 42, "not that");
+        endTxn(m_engine, true);
 
         flushAndApply(100);
 
@@ -534,13 +555,17 @@ public:
         TableTuple expected_tuple = prepareTempTuple(m_table, 42, 55555, "349508345.34583", "not that", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433);
         TableTuple tuple = m_tableReplica->lookupTupleByValues(expected_tuple);
         ASSERT_FALSE(tuple.isNullTuple());
+        if (m_table->schema()->hiddenColumnCount() > 0) {
+            NValue expectedTimestamp = first_updated_tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex());
+            EXPECT_EQ(0, expectedTimestamp.compare(tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex())));
+        }
         tuple = m_table->lookupTupleForDR(second_tuple);
         ASSERT_FALSE(tuple.isNullTuple());
 
-        beginTxn(101, 101, 100, 72);
+        beginTxn(m_engine, 101, 101, 100, 72);
         // update the index column only
-        updateTuple(m_table, second_tuple, 99, "and another");
-        endTxn(true);
+        TableTuple second_updated_tuple = updateTuple(m_table, second_tuple, 99, "and another");
+        endTxn(m_engine, true);
 
         flushAndApply(101);
 
@@ -550,24 +575,28 @@ public:
         expected_tuple = prepareTempTuple(m_table, 99, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222);
         tuple = m_table->lookupTupleForDR(second_tuple);
         ASSERT_FALSE(tuple.isNullTuple());
+        if (m_table->schema()->hiddenColumnCount() > 0) {
+            NValue expectedTimestamp = second_updated_tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex());
+            EXPECT_EQ(0, expectedTimestamp.compare(tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex())));
+        }
     }
 
     void updateWithNullsTest() {
-        beginTxn(99, 99, 98, 70);
+        beginTxn(m_engine, 99, 99, 98, 70);
         TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 31241, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
         TableTuple second_tuple = insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
-        endTxn(true);
+        endTxn(m_engine, true);
 
         flushAndApply(99);
 
         EXPECT_EQ(2, m_tableReplica->activeTupleCount());
 
-        beginTxn(100, 100, 99, 71);
+        beginTxn(m_engine, 100, 100, 99, 71);
         TableTuple tuple_to_update = m_table->lookupTupleForDR(first_tuple);
         ASSERT_FALSE(tuple_to_update.isNullTuple());
         TableTuple updated_tuple = secondTupleWithNulls(m_table);
         m_table->updateTuple(tuple_to_update, updated_tuple);
-        endTxn(true);
+        endTxn(m_engine, true);
 
         flushAndApply(100);
 
@@ -582,6 +611,9 @@ public:
 protected:
     DRTupleStream m_drStream;
     DRTupleStream m_drReplicatedStream;
+
+    DRTupleStream m_drStreamReplica;
+    DRTupleStream m_drReplicatedStreamReplica;
 
     TupleSchema* m_schema;
     TupleSchema* m_replicatedSchema;
@@ -609,10 +641,13 @@ protected:
     int64_t m_undoToken;
     int64_t m_currTxnUniqueId;
 
+    int64_t m_spHandleReplica;
+
     DummyTopend m_topend;
     Pool m_pool;
     BinaryLogSink m_sink;
     MockVoltDBEngine* m_engine;
+    MockVoltDBEngine* m_engineReplica;
     char tableHandle[20];
     char replicatedTableHandle[20];
     char otherTableHandleWithIndex[20];
@@ -636,35 +671,36 @@ TEST_F(DRBinaryLogTest, VerifyHiddenColumns) {
     ASSERT_FALSE(flush(98));
 
     // single row write transaction
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(99);
 
     TableTuple tuple = m_tableReplica->lookupTupleForDR(first_tuple);
+    ASSERT_FALSE(tuple.isNullTuple());
     NValue drTimestamp = tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex());
     NValue drTimestampReplica = tuple.getHiddenNValue(m_tableReplica->getDRTimestampColumnIndex());
-    EXPECT_EQ(ValuePeeker::peekAsBigInt(drTimestamp), 70);
+    EXPECT_EQ(ValuePeeker::peekAsBigInt(drTimestamp), ExecutorContext::createDRTimestampHiddenValue(CLUSTER_ID, addPartitionId(70)));
     EXPECT_EQ(0, drTimestamp.compare(drTimestampReplica));
 }
 
 TEST_F(DRBinaryLogTest, VerifyHiddenColumnLookup) {
-    beginTxn(98, 98, 97, 69);
+    beginTxn(m_engine, 98, 98, 97, 69);
     for (int i = 0; i < 10; i++) {
         insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     }
-    endTxn(true);
+    endTxn(m_engine, true);
 
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
-    endTxn(true);
+    endTxn(m_engine, true);
 
-    beginTxn(100, 100, 98, 71);
+    beginTxn(m_engine, 100, 100, 98, 71);
     for (int i = 0; i < 10; i++) {
         insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     }
-    endTxn(true);
+    endTxn(m_engine, true);
 
     NValue expectedTimestamp = first_tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex());
     TableTuple lookup_tuple = prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433);
@@ -674,9 +710,9 @@ TEST_F(DRBinaryLogTest, VerifyHiddenColumnLookup) {
     NValue drTimestamp = tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex());
     EXPECT_EQ(0, expectedTimestamp.compare(drTimestamp));
 
-    beginTxn(101, 101, 99, 72);
+    beginTxn(m_engine, 101, 101, 99, 72);
     deleteTuple(m_table, tuple);
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(101);
 
@@ -691,14 +727,14 @@ TEST_F(DRBinaryLogTest, PartitionedTableNoRollbacks) {
     ASSERT_FALSE(flush(98));
 
     // single row write transaction
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     // single row write transaction
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     TableTuple second_tuple = insertTuple(m_table, prepareTempTuple(m_table, 99, 29058, "92384598.2342", "what", "really, why am I writing anything in these?", 3455));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(100);
 
@@ -709,22 +745,22 @@ TEST_F(DRBinaryLogTest, PartitionedTableNoRollbacks) {
     ASSERT_FALSE(tuple.isNullTuple());
 
     // multiple row, multipart write transaction
-    beginTxn(111, 101, 100, 72);
+    beginTxn(m_engine, 111, 101, 100, 72);
     first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 72, 345, "4256.345", "something", "more tuple data, really not the same", 1812));
 
     // Tick during an ongoing txn -- should not push out a buffer
     ASSERT_FALSE(flush(100));
 
     second_tuple = insertTuple(m_table, prepareTempTuple(m_table, 7, 234, "23452436.54", "what", "this is starting to get silly", 2342));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     // delete the second row inserted in the last write
-    beginTxn(112, 102, 101, 73);
+    beginTxn(m_engine, 112, 102, 101, 73);
     deleteTuple(m_table, second_tuple);
     // Tick before the delete
     ASSERT_TRUE(flush(101));
-    endTxn(true);
-    // Apply the binary log after endTxn() to get a valid undoToken.
+    endTxn(m_engine, true);
+    // Apply the binary log after endTxn(m_engine, ) to get a valid undoToken.
     flushAndApply(101);
 
     EXPECT_EQ(4, m_tableReplica->activeTupleCount());
@@ -749,9 +785,9 @@ TEST_F(DRBinaryLogTest, PartitionedTableNoRollbacks) {
 TEST_F(DRBinaryLogTest, PartitionedTableRollbacks) {
     m_singleColumnTable->setDR(false);
 
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple source_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
-    endTxn(false);
+    endTxn(m_engine, false);
 
     // Intentionally ignore the fact that a rollback wouldn't have actually advanced the
     // lastCommittedSpHandle. Our goal is to tick such that, if data had been produced,
@@ -762,16 +798,16 @@ TEST_F(DRBinaryLogTest, PartitionedTableRollbacks) {
     EXPECT_EQ(-1, committed.seqNum);
     EXPECT_EQ(0, m_tableReplica->activeTupleCount());
 
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     source_tuple = insertTuple(m_table, prepareTempTuple(m_table, 99, 29058, "92384598.2342", "what", "really, why am I writing anything in these?", 3455));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     // Roll back a txn that hasn't applied any binary log data
-    beginTxn(101, 101, 100, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     TableTuple temp_tuple = m_singleColumnTable->tempTuple();
     temp_tuple.setNValue(0, ValueFactory::getTinyIntValue(1));
     insertTuple(m_singleColumnTable, temp_tuple);
-    endTxn(false);
+    endTxn(m_engine, false);
 
     flushAndApply(101);
 
@@ -785,9 +821,9 @@ TEST_F(DRBinaryLogTest, PartitionedTableRollbacks) {
 
 TEST_F(DRBinaryLogTest, ReplicatedTableWrites) {
     // write to only the replicated table
-    beginTxn(109, 99, 98, 70);
+    beginTxn(m_engine, 109, 99, 98, 70);
     TableTuple first_tuple = insertTuple(m_replicatedTable, prepareTempTuple(m_replicatedTable, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(99);
 
@@ -797,10 +833,10 @@ TEST_F(DRBinaryLogTest, ReplicatedTableWrites) {
     ASSERT_FALSE(tuple.isNullTuple());
 
     // write to both the partitioned and replicated table
-    beginTxn(110, 100, 99, 71);
+    beginTxn(m_engine, 110, 100, 99, 71);
     first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 72, 345, "4256.345", "something", "more tuple data, really not the same", 1812));
     TableTuple second_tuple = insertTuple(m_replicatedTable, prepareTempTuple(m_replicatedTable, 7, 234, "23452436.54", "what", "this is starting to get silly", 2342));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(100);
 
@@ -812,17 +848,17 @@ TEST_F(DRBinaryLogTest, ReplicatedTableWrites) {
     ASSERT_FALSE(tuple.isNullTuple());
 
     // write to the partitioned and replicated table and roll it back
-    beginTxn(111, 101, 100, 72);
+    beginTxn(m_engine, 111, 101, 100, 72);
     first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 11, 34534, "3453.4545", "another", "blah blah blah blah blah blah", 2344));
     second_tuple = insertTuple(m_replicatedTable, prepareTempTuple(m_replicatedTable, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
-    endTxn(false);
+    endTxn(m_engine, false);
 
     ASSERT_FALSE(flush(101));
 
     // one more write to the replicated table for good measure
-    beginTxn(112, 102, 101, 73);
+    beginTxn(m_engine, 112, 102, 101, 73);
     second_tuple = insertTuple(m_replicatedTable, prepareTempTuple(m_replicatedTable, 99, 29058, "92384598.2342", "what", "really, why am I writing anything in these?", 3455));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(102);
     EXPECT_EQ(1, m_tableReplica->activeTupleCount());
@@ -837,10 +873,10 @@ TEST_F(DRBinaryLogTest, ReplicatedTableWrites) {
 }
 
 TEST_F(DRBinaryLogTest, SerializeNulls) {
-    beginTxn(109, 99, 98, 70);
+    beginTxn(m_engine, 109, 99, 98, 70);
     TableTuple first_tuple = insertTuple(m_replicatedTable, firstTupleWithNulls(m_replicatedTable));
     TableTuple second_tuple = insertTuple(m_replicatedTable, secondTupleWithNulls(m_replicatedTable));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(99);
 
@@ -852,13 +888,13 @@ TEST_F(DRBinaryLogTest, SerializeNulls) {
 }
 
 TEST_F(DRBinaryLogTest, RollbackNulls) {
-    beginTxn(109, 99, 98, 70);
+    beginTxn(m_engine, 109, 99, 98, 70);
     insertTuple(m_replicatedTable, firstTupleWithNulls(m_replicatedTable));
-    endTxn(false);
+    endTxn(m_engine, false);
 
-    beginTxn(110, 100, 99, 71);
+    beginTxn(m_engine, 110, 100, 99, 71);
     TableTuple source_tuple = insertTuple(m_replicatedTable, prepareTempTuple(m_replicatedTable, 99, 29058, "92384598.2342", "what", "really, why am I writing anything in these?", 3455));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(100);
 
@@ -869,9 +905,9 @@ TEST_F(DRBinaryLogTest, RollbackNulls) {
 
 TEST_F(DRBinaryLogTest, RollbackOnReplica) {
     // single row write transaction
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     // try and fail to apply this on the replica
     flushAndApply(99, false);
@@ -879,9 +915,9 @@ TEST_F(DRBinaryLogTest, RollbackOnReplica) {
     EXPECT_EQ(0, m_tableReplica->activeTupleCount());
 
     // successfully apply some data for, I don't know, verisimilitude?
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     TableTuple source_tuple = insertTuple(m_table, prepareTempTuple(m_table, 99, 29058, "92384598.2342", "what", "really, why am I writing anything in these?", 3455));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(100);
 
@@ -890,13 +926,13 @@ TEST_F(DRBinaryLogTest, RollbackOnReplica) {
     ASSERT_FALSE(tuple.isNullTuple());
 
     // inserts followed by some deletes
-    beginTxn(101, 101, 100, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 11, 34534, "3453.4545", "another", "blah blah blah blah blah blah", 2344));
     TableTuple second_tuple = insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
     insertTuple(m_table, prepareTempTuple(m_table, 72, 345, "4256.345", "something", "more tuple data, really not the same", 1812));
     deleteTuple(m_table, first_tuple);
     deleteTuple(m_table, second_tuple);
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(101, false);
 
@@ -906,18 +942,18 @@ TEST_F(DRBinaryLogTest, RollbackOnReplica) {
 }
 
 TEST_F(DRBinaryLogTest, CantFindTable) {
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple temp_tuple = m_singleColumnTable->tempTuple();
     temp_tuple.setNValue(0, ValueFactory::getTinyIntValue(1));
     insertTuple(m_singleColumnTable, temp_tuple);
-    endTxn(true);
+    endTxn(m_engine, true);
 
     // try and fail to apply this on the replica because the table cannot be found.
     // should not throw fatal exception.
     try {
         flushAndApply(99, false);
     } catch (SerializableEEException &e) {
-        endTxn(false);
+        endTxn(m_engine, false);
     } catch (...) {
         ASSERT_TRUE(false);
     }
@@ -929,7 +965,9 @@ TEST_F(DRBinaryLogTest, DeleteWithUniqueIndex) {
 }
 
 TEST_F(DRBinaryLogTest, DeleteWithUniqueIndexWhenAAEnabled) {
+    m_engine->prepareContext();
     m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
     createIndexes();
     std::pair<const TableIndex*, uint32_t> indexPair = m_table->getUniqueIndexForDR();
     std::pair<const TableIndex*, uint32_t> indexPairReplica = m_tableReplica->getUniqueIndexForDR();
@@ -938,20 +976,20 @@ TEST_F(DRBinaryLogTest, DeleteWithUniqueIndexWhenAAEnabled) {
     EXPECT_EQ(indexPair.second, 0);
     EXPECT_EQ(indexPairReplica.second, 0);
 
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     TableTuple second_tuple = insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
     TableTuple third_tuple = insertTuple(m_table, prepareTempTuple(m_table, 72, 345, "4256.345", "something", "more tuple data, really not the same", 1812));
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(99);
 
     EXPECT_EQ(3, m_tableReplica->activeTupleCount());
 
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     deleteTuple(m_table, first_tuple);
     deleteTuple(m_table, second_tuple);
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(100);
 
@@ -968,7 +1006,7 @@ TEST_F(DRBinaryLogTest, DeleteWithUniqueIndexMultipleTables) {
     ASSERT_FALSE(indexPair1.first == NULL);
     ASSERT_TRUE(indexPair2.first == NULL);
 
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     TableTuple second_tuple = insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
     TableTuple temp_tuple = m_otherTableWithIndex->tempTuple();
@@ -979,7 +1017,7 @@ TEST_F(DRBinaryLogTest, DeleteWithUniqueIndexMultipleTables) {
     temp_tuple.setNValue(0, ValueFactory::getTinyIntValue(2));
     temp_tuple.setNValue(1, ValueFactory::getBigIntValue(3));
     TableTuple fourth_tuple = insertTuple(m_otherTableWithoutIndex, temp_tuple);
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(99);
 
@@ -987,7 +1025,7 @@ TEST_F(DRBinaryLogTest, DeleteWithUniqueIndexMultipleTables) {
     EXPECT_EQ(1, m_otherTableWithIndexReplica->activeTupleCount());
     EXPECT_EQ(1, m_otherTableWithoutIndexReplica->activeTupleCount());
 
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     deleteTuple(m_table, first_tuple);
     temp_tuple = m_otherTableWithIndex->tempTuple();
     temp_tuple.setNValue(0, ValueFactory::getTinyIntValue(4));
@@ -996,7 +1034,7 @@ TEST_F(DRBinaryLogTest, DeleteWithUniqueIndexMultipleTables) {
     deleteTuple(m_otherTableWithIndex, third_tuple);
     deleteTuple(m_table, second_tuple);
     deleteTuple(m_otherTableWithoutIndex, fourth_tuple);
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(100);
 
@@ -1041,7 +1079,9 @@ TEST_F(DRBinaryLogTest, UpdateWithUniqueIndex) {
 }
 
 TEST_F(DRBinaryLogTest, UpdateWithUniqueIndexWhenAAEnabled) {
+    m_engine->prepareContext();
     m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
     createIndexes();
     std::pair<const TableIndex*, uint32_t> indexPair = m_table->getUniqueIndexForDR();
     std::pair<const TableIndex*, uint32_t> indexPairReplica = m_tableReplica->getUniqueIndexForDR();
@@ -1053,11 +1093,11 @@ TEST_F(DRBinaryLogTest, UpdateWithUniqueIndexWhenAAEnabled) {
 }
 
 TEST_F(DRBinaryLogTest, PartialTxnRollback) {
-    beginTxn(98, 98, 97, 69);
+    beginTxn(m_engine, 98, 98, 97, 69);
     TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 99, 29058, "92384598.2342", "what", "really, why am I writing anything in these?", 3455));
-    endTxn(true);
+    endTxn(m_engine, true);
 
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
 
     TableTuple second_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
 
@@ -1070,7 +1110,7 @@ TEST_F(DRBinaryLogTest, PartialTxnRollback) {
 
     m_undoLog.undo(m_undoToken + 1);
 
-    endTxn(true);
+    endTxn(m_engine, true);
 
     flushAndApply(100);
 
@@ -1113,6 +1153,7 @@ TEST_F(DRBinaryLogTest, UpdateWithNullsAndUniqueIndex) {
  */
 TEST_F(DRBinaryLogTest, DetectInsertUniqueConstraintViolation) {
     m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
     createUniqueIndex(m_table, 0, true);
     createUniqueIndex(m_tableReplica, 0, true);
     createUniqueIndex(m_table, 1);
@@ -1120,19 +1161,19 @@ TEST_F(DRBinaryLogTest, DetectInsertUniqueConstraintViolation) {
     ASSERT_FALSE(flush(99));
 
     // write transactions on replica
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engineReplica, 100, 100, 99, 71);
     insertTuple(m_tableReplica, prepareTempTuple(m_tableReplica, 99, 55555,
             "92384598.2342", "what", "really, why am I writing anything in these?", 3455));
     TableTuple existingTuple = insertTuple(m_tableReplica, prepareTempTuple(m_tableReplica, 42, 34523,
                 "7565464.2342", "yes", "no no no, writing more words to make it outline?", 1234));
-    endTxn(true);
+    endTxn(m_engineReplica, true);
     flushButDontApply(100);
 
     // write transactions on master
-    beginTxn(101, 101, 100, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     TableTuple newTuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 34523,
             "92384598.2342", "what", "really, why am I writing anything in these?", 3455));
-    endTxn(true);
+    endTxn(m_engine, true);
     // trigger a insert unique constraint violation conflict
     flushAndApply(101);
 
@@ -1151,7 +1192,7 @@ TEST_F(DRBinaryLogTest, DetectInsertUniqueConstraintViolation) {
     /*TableTuple exportTuple2 = */verifyNewTableForInsert(newTuple);
 
     // check export
-    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engine->getExportTupleStream());
+    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engineReplica->getExportTupleStream());
     EXPECT_EQ(2, exportStream->receivedTuples.size());
 }
 
@@ -1173,32 +1214,33 @@ TEST_F(DRBinaryLogTest, DetectInsertUniqueConstraintViolation) {
  */
 TEST_F(DRBinaryLogTest, DetectDeleteMissingTuple) {
     m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
     createUniqueIndex(m_table, 0, true);
     createUniqueIndex(m_tableReplica, 0, true);
     createUniqueIndex(m_table, 1);
     createUniqueIndex(m_tableReplica, 1);
 
     // insert rows on both side
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple tempExpectedTuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     // do a deep copy because temp tuple of m_table will be rewritten later
     TableTuple expectedTuple (m_table->schema());
     boost::shared_array<char> expectedData;
     expectedData = deepCopy(tempExpectedTuple, expectedTuple, expectedData);
     StackCleaner cleaner(expectedTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     flushAndApply(99);
 
     // delete row on replica
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     deleteTuple(m_tableReplica, tempExpectedTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     flushButDontApply(100);
 
     // delete the same row on master then wait to trigger conflict on replica
-    beginTxn(101, 101, 100, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     deleteTuple(m_table, tempExpectedTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     // trigger a delete missing tuple conflict
     flushAndApply(101);
 
@@ -1218,7 +1260,7 @@ TEST_F(DRBinaryLogTest, DetectDeleteMissingTuple) {
     ASSERT_TRUE(m_topend.newTupleRowsForInsert.get() == NULL);
 
     // 3. check export
-    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engine->getExportTupleStream());
+    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engineReplica->getExportTupleStream());
     EXPECT_EQ(1, exportStream->receivedTuples.size());
 }
 
@@ -1240,37 +1282,38 @@ TEST_F(DRBinaryLogTest, DetectDeleteMissingTuple) {
  */
 TEST_F(DRBinaryLogTest, DetectDeleteTimestampMismatch) {
     m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
     createUniqueIndex(m_table, 0, true);
     createUniqueIndex(m_tableReplica, 0, true);
     createUniqueIndex(m_table, 1);
     createUniqueIndex(m_tableReplica, 1);
 
     // insert one row on both side
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple tempExpectedTuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     // do a deep copy because temp tuple of relica table will be rewritten later
     TableTuple expectedTuple (m_table->schema());
     boost::shared_array<char> expectedData;
     expectedData = deepCopy(tempExpectedTuple, expectedTuple, expectedData);
     StackCleaner expectedTupleCleaner(expectedTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     flushAndApply(99);
 
     // insert a few rows and update one row on replica
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     TableTuple tempExistingTuple = updateTupleFirstAndSecondColumn(m_tableReplica, tempExpectedTuple, 42/*causes a constraint violation*/, 1234);
     // do a deep copy because temp tuple of relica table will be overwriten when applying binary log
     TableTuple existingTuple(m_tableReplica->schema());
     boost::shared_array<char> data;
     data = deepCopy(tempExistingTuple, existingTuple, data);
     StackCleaner existingTupleCleaner(existingTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     flushButDontApply(100);
 
     // delete the row on master then wait to trigger conflict on replica
-    beginTxn(101, 101, 100, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     deleteTuple(m_table, tempExpectedTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     // trigger a delete timestamp mismatch conflict
     flushAndApply(101);
 
@@ -1291,7 +1334,7 @@ TEST_F(DRBinaryLogTest, DetectDeleteTimestampMismatch) {
     ASSERT_TRUE(m_topend.newTupleRowsForInsert.get() == NULL);
 
     // 3. check export
-    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engine->getExportTupleStream());
+    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engineReplica->getExportTupleStream());
     EXPECT_EQ(2, exportStream->receivedTuples.size());
 }
 
@@ -1314,6 +1357,7 @@ TEST_F(DRBinaryLogTest, DetectDeleteTimestampMismatch) {
  */
 TEST_F(DRBinaryLogTest, DetectUpdateUniqueConstraintViolation) {
     m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
     createUniqueIndex(m_table, 0, true);
     createUniqueIndex(m_tableReplica, 0, true);
     createUniqueIndex(m_table, 1);
@@ -1321,7 +1365,7 @@ TEST_F(DRBinaryLogTest, DetectUpdateUniqueConstraintViolation) {
     ASSERT_FALSE(flush(98));
 
     // insert row on both side
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple tempExpectedTuple = insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
     // do a deep copy because temp tuple of relica table will be rewritten later
     TableTuple expectedTuple (m_tableReplica->schema());
@@ -1331,11 +1375,11 @@ TEST_F(DRBinaryLogTest, DetectUpdateUniqueConstraintViolation) {
 
     insertTuple(m_table, prepareTempTuple(m_table, 111, 11111, "11111.1111", "second", "this is starting to get even sillier", 2222));
     insertTuple(m_table, prepareTempTuple(m_table, 65, 22222, "22222.2222", "third", "this is starting to get even sillier", 2222));
-    endTxn(true);
+    endTxn(m_engine, true);
     flushAndApply(99);
 
     // insert rows on replica side
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     insertTuple(m_tableReplica, prepareTempTuple(m_tableReplica, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
 
     TableTuple tempExistingTuple = insertTuple(m_tableReplica, prepareTempTuple(m_tableReplica, 123, 33333, "122308345.34583", "another thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
@@ -1344,13 +1388,13 @@ TEST_F(DRBinaryLogTest, DetectUpdateUniqueConstraintViolation) {
     boost::shared_array<char> existingData;
     existingData = deepCopy(tempExistingTuple, existingTuple, existingData);
     StackCleaner existingTupleCleaner(existingTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     flushButDontApply(100);
 
     // update row on master to create conflict
-    beginTxn(101, 101, 100, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     TableTuple newTuple = updateTupleFirstAndSecondColumn(m_table, tempExpectedTuple, 12, 33333/*causes a constraint violation*/);
-    endTxn(true);
+    endTxn(m_engine, true);
 
     // trigger a update unique constraint violation conflict
     flushAndApply(101);
@@ -1373,7 +1417,7 @@ TEST_F(DRBinaryLogTest, DetectUpdateUniqueConstraintViolation) {
     /*TableTuple exportTuple2 = */verifyNewTableForInsert(newTuple);
 
     // 3. check export
-    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engine->getExportTupleStream());
+    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engineReplica->getExportTupleStream());
     EXPECT_EQ(3, exportStream->receivedTuples.size());
 }
 
@@ -1395,37 +1439,38 @@ TEST_F(DRBinaryLogTest, DetectUpdateUniqueConstraintViolation) {
  */
 TEST_F(DRBinaryLogTest, DetectUpdateMissingTuple) {
     m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
     createUniqueIndex(m_table, 0, true);
     createUniqueIndex(m_tableReplica, 0, true);
     createUniqueIndex(m_table, 1);
     createUniqueIndex(m_tableReplica, 1);
 
     // insert rows on both side
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple tempExpectedTuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     // do a deep copy because temp tuple of table will be overwritten later
     TableTuple expectedTuple (m_table->schema());
     boost::shared_array<char> expectedData;
     expectedData = deepCopy(tempExpectedTuple, expectedTuple, expectedData);
     StackCleaner expectedTupleCleaner(expectedTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     flushAndApply(99);
 
     // update one row on replica
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     updateTupleFirstAndSecondColumn(m_tableReplica, tempExpectedTuple, 35, 12345);
-    endTxn(true);
+    endTxn(m_engine, true);
     flushButDontApply(100);
 
     // update the same row on master then wait to trigger conflict on replica
-    beginTxn(101, 101, 100, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     TableTuple tempNewTuple = updateTupleFirstAndSecondColumn(m_table, expectedTuple, 42, 54321);
     // do a deep copy because temp tuple of table will be overwritten later
     TableTuple newTuple (m_table->schema());
     boost::shared_array<char> newData;
     newData = deepCopy(tempNewTuple, newTuple, newData);
     StackCleaner newTupleCleaner(newTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     // trigger a update missing tuple conflict
     flushAndApply(101);
 
@@ -1446,7 +1491,7 @@ TEST_F(DRBinaryLogTest, DetectUpdateMissingTuple) {
     /*TableTuple exportTuple2 = */verifyNewTableForInsert(newTuple);
 
     // 3. check export
-    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engine->getExportTupleStream());
+    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engineReplica->getExportTupleStream());
     EXPECT_EQ(2, exportStream->receivedTuples.size());
 }
 
@@ -1472,13 +1517,14 @@ TEST_F(DRBinaryLogTest, DetectUpdateMissingTuple) {
  */
 TEST_F(DRBinaryLogTest, DetectUpdateMissingTupleAndNewRowConstraint) {
     m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
     createUniqueIndex(m_table, 0, true);
     createUniqueIndex(m_tableReplica, 0, true);
     createUniqueIndex(m_table, 1);
     createUniqueIndex(m_tableReplica, 1);
 
     // insert rows on both side
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple tempExpectedTuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     // do a deep copy because temp tuple of table will be overwritten later
     TableTuple expectedTuple (m_table->schema());
@@ -1487,11 +1533,11 @@ TEST_F(DRBinaryLogTest, DetectUpdateMissingTupleAndNewRowConstraint) {
     StackCleaner expectedTupleCleaner(expectedTuple);
     insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
     insertTuple(m_table, prepareTempTuple(m_table, 72, 345, "4256.345", "something", "more tuple data, really not the same", 1812));
-    endTxn(true);
+    endTxn(m_engine, true);
     flushAndApply(99);
 
     // update one row on replica
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     deleteTuple(m_tableReplica, tempExpectedTuple);
     TableTuple tempExistingTuple = insertTuple(m_tableReplica, prepareTempTuple(m_tableReplica, 36, 12345, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     // do a deep copy because temp tuple of relica table will be overwritten when applying binary log
@@ -1499,13 +1545,13 @@ TEST_F(DRBinaryLogTest, DetectUpdateMissingTupleAndNewRowConstraint) {
     boost::shared_array<char> existingData;
     existingData = deepCopy(tempExistingTuple, existingTuple, existingData);
     StackCleaner existingTupleCleaner(existingTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     flushButDontApply(100);
 
     // update the same row on master then wait to trigger conflict on replica
-    beginTxn(101, 101, 100, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     TableTuple newTuple = updateTupleFirstAndSecondColumn(m_table, tempExpectedTuple, 42, 12345/*causes a constraint violation*/);
-    endTxn(true);
+    endTxn(m_engine, true);
     // trigger a update missing tuple conflict
     flushAndApply(101);
 
@@ -1529,7 +1575,7 @@ TEST_F(DRBinaryLogTest, DetectUpdateMissingTupleAndNewRowConstraint) {
     /*TableTuple exportTuple3 = */verifyNewTableForInsert(newTuple);
 
     // 3. check export
-    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engine->getExportTupleStream());
+    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engineReplica->getExportTupleStream());
     EXPECT_EQ(3, exportStream->receivedTuples.size());
 }
 
@@ -1553,13 +1599,14 @@ TEST_F(DRBinaryLogTest, DetectUpdateMissingTupleAndNewRowConstraint) {
  */
 TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatch) {
     m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
     createUniqueIndex(m_table, 0, true);
     createUniqueIndex(m_tableReplica, 0, true);
     createUniqueIndex(m_table, 1);
     createUniqueIndex(m_tableReplica, 1);
 
     // insert one row on both side
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple tempExpectedTuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     // do a deep copy because temp tuple of table will be overwritten later
     TableTuple expectedTuple (m_table->schema());
@@ -1568,29 +1615,29 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatch) {
     StackCleaner expectedTupleCleaner(expectedTuple);
     insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
     insertTuple(m_table, prepareTempTuple(m_table, 72, 345, "4256.345", "something", "more tuple data, really not the same", 1812));
-    endTxn(true);
+    endTxn(m_engine, true);
     flushAndApply(99);
 
     // update one row on replica
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     TableTuple tempExistingTuple = updateTupleFirstAndSecondColumn(m_tableReplica, tempExpectedTuple, 42, 12345);
     // do a deep copy because temp tuple of relica table will be overwritten when applying binary log
     TableTuple existingTuple (m_tableReplica->schema());
     boost::shared_array<char> existingData;
     existingData = deepCopy(tempExistingTuple, existingTuple, existingData);
     StackCleaner existingTupleCleaner(existingTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     flushButDontApply(100);
 
     // update the same row on master then wait to trigger conflict on replica
-    beginTxn(101, 101, 100, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     TableTuple tempNewTuple = updateTupleFirstAndSecondColumn(m_table, tempExpectedTuple, 42, 12345);
     // do a deep copy because temp tuple of table will be overwritten later
     TableTuple newTuple (m_table->schema());
     boost::shared_array<char> newData;
     newData = deepCopy(tempNewTuple, newTuple, newData);
     StackCleaner newTupleCleaner(newTuple);
-    endTxn(true);
+    endTxn(m_engine, true);
     // trigger a update timestamp mismatch conflict
     flushAndApply(101);
 
@@ -1612,7 +1659,7 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatch) {
     /*TableTuple exportTuple3 = */verifyNewTableForInsert(newTuple);
 
     // 3. check export
-    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engine->getExportTupleStream());
+    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engineReplica->getExportTupleStream());
     EXPECT_EQ(3, exportStream->receivedTuples.size());
 }
 
@@ -1637,13 +1684,14 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatch) {
  */
 TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatchAndNewRowConstraint) {
     m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
     createUniqueIndex(m_table, 0, true);
     createUniqueIndex(m_tableReplica, 0, true);
     createUniqueIndex(m_table, 1);
     createUniqueIndex(m_tableReplica, 1);
 
     // insert one row on both side
-    beginTxn(99, 99, 98, 70);
+    beginTxn(m_engine, 99, 99, 98, 70);
     TableTuple tempExpectedTuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     // do a deep copy because temp tuple of table will be overwritten later
     TableTuple expectedTuple (m_table->schema());
@@ -1651,11 +1699,11 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatchAndNewRowConstraint) {
     expectedData = deepCopy(tempExpectedTuple, expectedTuple, expectedData);
     StackCleaner expectedTupleCleaner(expectedTuple);
     insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
-    endTxn(true);
+    endTxn(m_engine, true);
     flushAndApply(99);
 
     // update one row on replica
-    beginTxn(100, 100, 99, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     TableTuple tempExistingTupleFirst = updateTupleFirstAndSecondColumn(m_tableReplica, tempExpectedTuple, 42, 12345);
     // do a deep copy because temp tuple of relica table will be overwritten when applying binary log
     TableTuple existingTupleFirst (m_tableReplica->schema());
@@ -1668,13 +1716,13 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatchAndNewRowConstraint) {
     boost::shared_array<char> existingDataSecond;
     existingDataSecond = deepCopy(tempExistingTupleSecond, existingTupleSecond, existingDataSecond);
     StackCleaner secondExistingTupleCleaner(existingTupleSecond);
-    endTxn(true);
+    endTxn(m_engine, true);
     flushButDontApply(100);
 
     // update the same row on master then wait to trigger conflict on replica
-    beginTxn(101, 101, 100, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     TableTuple newTuple = updateTupleFirstAndSecondColumn(m_table, tempExpectedTuple, 42, 345/*cause a constraint violation*/);
-    endTxn(true);
+    endTxn(m_engine, true);
     // trigger a update timestamp mismatch conflict
     flushAndApply(101);
 
@@ -1700,7 +1748,7 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatchAndNewRowConstraint) {
     /*TableTuple exportTuple4 = */verifyNewTableForInsert(newTuple);
 
     // 3. check export
-    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engine->getExportTupleStream());
+    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engineReplica->getExportTupleStream());
     EXPECT_EQ(4, exportStream->receivedTuples.size());
 }
 


### PR DESCRIPTION
Separate the execution engines, one for master, one for replica, so they
can have two cluster IDs and such. Check for the DR timestamp after
updates.

Change-Id: I45b57d1742ae021092528c64ae980398997e6d3b