### PR TITLE
Add gcc 5+ version to build script

### DIFF
--- a/build.py
+++ b/build.py
@@ -66,7 +66,7 @@ if (CTX.compilerName() == 'clang') and (CTX.compilerMajorVersion() == 3 and CTX.
 if (CTX.compilerName() == 'clang') and (CTX.compilerMajorVersion() == 7):
     CTX.CPPFLAGS += " -Wno-unused-local-typedefs -Wno-absolute-value"
 
-if (CTX.compilerName() != 'gcc') or (CTX.compilerMajorVersion() == 4 and CTX.compilerMinorVersion() >= 3):
+if (CTX.compilerName() != 'gcc') or (CTX.compilerMajorVersion() == 4 and CTX.compilerMinorVersion() >= 3) or (CTX.compilerMajorVersion() == 5):
     CTX.CPPFLAGS += " -Wno-ignored-qualifiers -fno-strict-aliasing"
 
 

--- a/src/ee/common/types.cpp
+++ b/src/ee/common/types.cpp
@@ -112,7 +112,7 @@ NValue getRandomValue(ValueType type, uint32_t maxLength) {
             int length = (rand() % maxLength);
             unsigned char bytes[maxLength];
             for (int ii = 0; ii < length; ii++) {
-                bytes[ii] = (unsigned char)rand() % 256; //printable characters
+                bytes[ii] = static_cast<char> (rand() % 256); //printable characters
             }
             bytes[length] = '\0';
             //printf("Characters are \"%s\"\n", characters);

--- a/src/ee/common/types.cpp
+++ b/src/ee/common/types.cpp
@@ -112,7 +112,7 @@ NValue getRandomValue(ValueType type, uint32_t maxLength) {
             int length = (rand() % maxLength);
             unsigned char bytes[maxLength];
             for (int ii = 0; ii < length; ii++) {
-                bytes[ii] = static_cast<char> (rand() % 256); //printable characters
+                bytes[ii] = static_cast<unsigned char> (rand() % 256); //printable characters
             }
             bytes[length] = '\0';
             //printf("Characters are \"%s\"\n", characters);


### PR DESCRIPTION
Updated build script to build code using gcc 5.* in same way as it does today for gcc versions 4.3 or higher.