### PR TITLE
ENG-8559 planner NPE on partitioned matviews and subqueries

### DIFF
--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -18,6 +18,7 @@
 package org.voltdb.planner;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -98,7 +99,7 @@ public abstract class AbstractParsedStmt {
     // User specified join order, null if none is specified
     public String m_joinOrder = null;
 
-    public HashMap<String, StmtTableScan> m_tableAliasMap = new HashMap<String, StmtTableScan>();
+    protected final HashMap<String, StmtTableScan> m_tableAliasMap = new HashMap<String, StmtTableScan>();
 
     // This list is used to identify the order of the table aliases returned by
     // the parser for possible use as a default join order.
@@ -457,7 +458,7 @@ public abstract class AbstractParsedStmt {
         // Resolve the tve and add it to the scan's cache of referenced columns
         // Get tableScan where this TVE is originated from. In case of the
         // correlated queries it may not be THIS statement but its parent
-        StmtTableScan tableScan = getStmtTableScanByAlias(tableAlias);
+        StmtTableScan tableScan = resolveStmtTableScanByAlias(tableAlias);
         if (tableScan == null) {
             // This never used to happen.  HSQL should make sure all the
             // identifiers are defined.  But something has gone wrong.
@@ -509,38 +510,46 @@ public abstract class AbstractParsedStmt {
    }
 
    /**
-   *
-   * @param exprNode
-   * @return
-   */
-  private AbstractExpression parseRowExpression(List<VoltXMLElement> exprNodes) {
-      // Parse individual columnref expressions from the IN output schema
-      List<AbstractExpression> exprs = new ArrayList<AbstractExpression>();
-      for (VoltXMLElement exprNode : exprNodes) {
-          AbstractExpression expr = parseExpressionNode(exprNode);
-          exprs.add(expr);
-      }
-      return new RowSubqueryExpression(exprs);
-  }
+    *
+    * @param exprNode
+    * @return
+    */
+   private AbstractExpression parseRowExpression(List<VoltXMLElement> exprNodes) {
+       // Parse individual columnref expressions from the IN output schema
+       List<AbstractExpression> exprs = new ArrayList<AbstractExpression>();
+       for (VoltXMLElement exprNode : exprNodes) {
+           AbstractExpression expr = parseExpressionNode(exprNode);
+           exprs.add(expr);
+       }
+       return new RowSubqueryExpression(exprs);
+   }
 
-    /**
-     * Return StmtTableScan by table alias. In case of correlated queries, would need
-     * to walk the statement tree up.
-     *
-     * @param stmt
-     * @param tableAlias
-     */
-    private StmtTableScan getStmtTableScanByAlias(String tableAlias) {
-        StmtTableScan tableScan = m_tableAliasMap.get(tableAlias);
-        if (tableScan != null) {
-            return tableScan;
-        }
-        if (m_parentStmt != null) {
-            // This may be a correlated subquery
-            return m_parentStmt.getStmtTableScanByAlias(tableAlias);
-        }
-        return null;
-    }
+   public Collection<StmtTableScan> allScans()
+   { return m_tableAliasMap.values(); }
+
+   /**
+    * Return locally defined StmtTableScan by table alias.
+    * @param tableAlias
+    */
+   public StmtTableScan getStmtTableScanByAlias(String tableAlias)
+   { return m_tableAliasMap.get(tableAlias); }
+
+   /**
+    * Return StmtTableScan by table alias. In case of correlated queries,
+    * may need to walk up the statement tree.
+    * @param tableAlias
+    */
+   private StmtTableScan resolveStmtTableScanByAlias(String tableAlias) {
+       StmtTableScan tableScan = getStmtTableScanByAlias(tableAlias);
+       if (tableScan != null) {
+           return tableScan;
+       }
+       if (m_parentStmt != null) {
+           // This may be a correlated subquery
+           return m_parentStmt.resolveStmtTableScanByAlias(tableAlias);
+       }
+       return null;
+   }
 
     /**
      * Add a table to the statement cache.
@@ -571,8 +580,7 @@ public abstract class AbstractParsedStmt {
         if (tableAlias == null) {
             tableAlias = "VOLT_TEMP_TABLE_" + subquery.m_stmtId;
         }
-        StmtTableScan tableScan = m_tableAliasMap.get(tableAlias);
-        assert(tableScan == null);
+        assert(m_tableAliasMap.get(tableAlias) == null);
         StmtSubqueryScan subqueryScan = new StmtSubqueryScan(subquery, tableAlias, m_stmtId);
         m_tableAliasMap.put(tableAlias, subqueryScan);
         return subqueryScan;
@@ -1139,7 +1147,7 @@ public abstract class AbstractParsedStmt {
         List<StmtSubqueryScan> subqueries = new ArrayList<>();
 
         if (m_joinTree != null) {
-          m_joinTree.extractSubQueries(subqueries);
+            m_joinTree.extractSubQueries(subqueries);
         }
 
         return subqueries;
@@ -1515,7 +1523,7 @@ public abstract class AbstractParsedStmt {
         boolean allScansAreDeterministic = true;
         for (Entry<String, List<AbstractExpression>> orderedAlias : baseTableAliases.entrySet()) {
             List<AbstractExpression> orderedAliasExprs = orderedAlias.getValue();
-            StmtTableScan tableScan = m_tableAliasMap.get(orderedAlias.getKey());
+            StmtTableScan tableScan = getStmtTableScanByAlias(orderedAlias.getKey());
             if (tableScan == null) {
                 assert(false);
                 return false;

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -340,7 +340,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         // Handle joined query case case.
         // MV partitioned table without partition column can only join with replicated tables.
         // For all tables in this query, the # of tables that need to be fixed should not exceed one.
-        for (StmtTableScan mvTableScan: m_tableAliasMap.values()) {
+        for (StmtTableScan mvTableScan: allScans()) {
             Set<SchemaColumn> mvNewScanColumns = new HashSet<SchemaColumn>();
 
             Collection<SchemaColumn> columns = mvTableScan.getScanColumns();
@@ -1316,7 +1316,9 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
             String alias = element.trim().toUpperCase();
             tableAliases.add(alias);
             if (!dupCheck.add(alias)) {
-                if (m_hasLargeNumberOfTableJoins) return false;
+                if (m_hasLargeNumberOfTableJoins) {
+                    return false;
+                }
 
                 StringBuilder sb = new StringBuilder();
                 sb.append("The specified join order \"").append(joinOrder);
@@ -1329,7 +1331,9 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         // here and in isValidJoinOrder should be combined in one AbstractParsedStmt function
         // that generates a JoinNode tree or throws an exception.
         if (m_tableAliasMap.size() != tableAliases.size()) {
-            if (m_hasLargeNumberOfTableJoins) return false;
+            if (m_hasLargeNumberOfTableJoins) {
+                return false;
+            }
 
             StringBuilder sb = new StringBuilder();
             sb.append("The specified join order \"");
@@ -1343,7 +1347,9 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         Set<String> specifiedNames = new HashSet<String>(tableAliases);
         specifiedNames.removeAll(aliasSet);
         if (specifiedNames.isEmpty() == false) {
-            if (m_hasLargeNumberOfTableJoins) return false;
+            if (m_hasLargeNumberOfTableJoins) {
+                return false;
+            }
 
             StringBuilder sb = new StringBuilder();
             sb.append("The specified join order \"");
@@ -1815,7 +1821,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
     }
 
     private boolean hasTopLevelScans() {
-        for (StmtTableScan scan : m_tableAliasMap.values()) {
+        for (StmtTableScan scan : allScans()) {
             if (scan instanceof StmtTargetTableScan) {
                 return true;
             }

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -37,6 +37,7 @@ import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Index;
 import org.voltdb.catalog.Table;
 import org.voltdb.expressions.AbstractExpression;
+import org.voltdb.expressions.AbstractSubqueryExpression;
 import org.voltdb.expressions.AggregateExpression;
 import org.voltdb.expressions.ConstantValueExpression;
 import org.voltdb.expressions.ExpressionUtil;
@@ -61,6 +62,7 @@ import org.voltdb.plannodes.IndexScanPlanNode;
 import org.voltdb.plannodes.InsertPlanNode;
 import org.voltdb.plannodes.LimitPlanNode;
 import org.voltdb.plannodes.MaterializePlanNode;
+import org.voltdb.plannodes.MergeReceivePlanNode;
 import org.voltdb.plannodes.NestLoopPlanNode;
 import org.voltdb.plannodes.NodeSchema;
 import org.voltdb.plannodes.OrderByPlanNode;
@@ -213,7 +215,7 @@ public class PlanAssembler {
         }
 
         for (ParsedColInfo groupbyCol: groupbyColumns) {
-            StmtTableScan scanTable = m_parsedSelect.m_tableAliasMap.get(groupbyCol.tableAlias);
+            StmtTableScan scanTable = m_parsedSelect.getStmtTableScanByAlias(groupbyCol.tableAlias);
             // table alias may be from "VOLT_TEMP_TABLE".
             if (scanTable != null && scanTable.getPartitioningColumns() != null) {
                 for (SchemaColumn pcol : scanTable.getPartitioningColumns()) {
@@ -245,7 +247,8 @@ public class PlanAssembler {
             return false;
         }
         TupleValueExpression tve = (TupleValueExpression) aggArg;
-        StmtTableScan scanTable = m_parsedSelect.m_tableAliasMap.get(tve.getTableAlias());
+        String tableAlias = tve.getTableAlias();
+        StmtTableScan scanTable = m_parsedSelect.getStmtTableScanByAlias(tableAlias);
         // table alias may be from "VOLT_TEMP_TABLE".
         if (scanTable == null || scanTable.getPartitioningColumns() == null) {
             return false;
@@ -266,7 +269,7 @@ public class PlanAssembler {
      */
     private void setupForNewPlans(AbstractParsedStmt parsedStmt) {
         m_bestAndOnlyPlanWasGenerated = false;
-        m_partitioning.analyzeTablePartitioning(parsedStmt.m_tableAliasMap.values());
+        m_partitioning.analyzeTablePartitioning(parsedStmt.allScans());
 
         if (parsedStmt instanceof ParsedUnionStmt) {
             m_parsedUnion = (ParsedUnionStmt) parsedStmt;
@@ -357,7 +360,7 @@ public class PlanAssembler {
             // per-join-order basis, and so, so must this analysis.
             HashMap<AbstractExpression, Set<AbstractExpression>>
                 valueEquivalence = parsedStmt.analyzeValueEquivalence();
-            m_partitioning.analyzeForMultiPartitionAccess(parsedStmt.m_tableAliasMap.values(), valueEquivalence);
+            m_partitioning.analyzeForMultiPartitionAccess(parsedStmt.allScans(), valueEquivalence);
         }
         m_subAssembler = new WriterSubPlanAssembler(m_catalogDb, parsedStmt, m_partitioning);
     }
@@ -695,10 +698,10 @@ public class PlanAssembler {
         int planId = 0;
         for (AbstractParsedStmt parsedChildStmt : m_parsedUnion.m_children) {
             StatementPartitioning partitioning = (StatementPartitioning)m_partitioning.clone();
-            PlanSelector processor = (PlanSelector) m_planSelector.clone();
-            processor.m_planId = planId;
+            PlanSelector planSelector = (PlanSelector) m_planSelector.clone();
+            planSelector.m_planId = planId;
             PlanAssembler assembler = new PlanAssembler(
-                    m_catalogCluster, m_catalogDb, partitioning, processor);
+                    m_catalogCluster, m_catalogDb, partitioning, planSelector);
             CompiledPlan bestChildPlan = assembler.getBestCostPlan(parsedChildStmt);
             partitioning = assembler.m_partitioning;
 
@@ -718,7 +721,7 @@ public class PlanAssembler {
             }
 
             // Make sure that next child's plans won't override current ones.
-            planId = processor.m_planId;
+            planId = planSelector.m_planId;
 
             // Decide whether child statements' partitioning is compatible.
             if (commonPartitioning == null) {
@@ -806,30 +809,87 @@ public class PlanAssembler {
     private int planForParsedSubquery(StmtSubqueryScan subqueryScan, int planId) {
         AbstractParsedStmt subQuery = subqueryScan.getSubqueryStmt();
         assert(subQuery != null);
-        PlanSelector selector = (PlanSelector) m_planSelector.clone();
-        selector.m_planId = planId;
+        PlanSelector planSelector = (PlanSelector) m_planSelector.clone();
+        planSelector.m_planId = planId;
         StatementPartitioning currentPartitioning = (StatementPartitioning)m_partitioning.clone();
         PlanAssembler assembler = new PlanAssembler(
-                m_catalogCluster, m_catalogDb, currentPartitioning, selector);
+                m_catalogCluster, m_catalogDb, currentPartitioning, planSelector);
         CompiledPlan compiledPlan = assembler.getBestCostPlan(subQuery);
         // make sure we got a winner
         if (compiledPlan == null) {
             String tbAlias = subqueryScan.getTableAlias();
             m_recentErrorMsg = "Subquery statement for table " + tbAlias
                     + " has error: " + assembler.getErrorMessage();
-            if (m_recentErrorMsg == null) {
-                m_recentErrorMsg = "Unable to plan for subquery statement for table " + tbAlias;
-            }
-            return selector.m_planId;
+            return planSelector.m_planId;
         }
         subqueryScan.setSubqueriesPartitioning(currentPartitioning);
 
         // Remove the coordinator send/receive pair.
-        // It will be added later for the whole plan
-        compiledPlan.rootPlanGraph = subqueryScan.processReceiveNode(compiledPlan.rootPlanGraph);
-
+        // It will be added later for the whole plan.
+        //TODO: It may make more sense to plan ahead and not generate the send/receive pair
+        // at all for subquery contexts where it is not needed.
+        if (subqueryScan.canRunInOneFragment()) {
+            // The MergeReceivePlanNode always has an inline ORDER BY node and may have
+            // LIMIT/OFFSET and aggregation node(s). Removing the MergeReceivePlanNode will
+            // also remove its inline node(s) which may produce an invalid access plan.
+            // For example,
+            // SELECT TC1 FROM (SELECT C1 AS TC1 FROM P ORDER BY C1) PT LIMIT 4;
+            // where P is partitioned and C1 is a non-partitioned index column.
+            // Removing the subquery MergeReceivePlnaNode and its ORDER BY node results
+            // in the invalid access plan - the subquery result order is significant in this case
+            // The concern with generally keeping the (Merge)Receive node in the subquery is
+            // that it would needlessly generate more-than-2-fragment plans in cases
+            // where 2 fragments could have done the job.
+            if ( ! compiledPlan.rootPlanGraph.hasAnyNodeOfClass(MergeReceivePlanNode.class)) {
+                compiledPlan.rootPlanGraph = removeCoordinatorSendReceivePair(compiledPlan.rootPlanGraph);
+            }
+        }
         subqueryScan.setBestCostPlan(compiledPlan);
-        return selector.m_planId;
+        return planSelector.m_planId;
+    }
+
+    /**
+     * Remove the coordinator send/receive pair if any from the graph.
+     *
+     * @param root the complete plan node.
+     * @return the plan without the send/receive pair.
+     */
+    static public AbstractPlanNode removeCoordinatorSendReceivePair(AbstractPlanNode root) {
+        assert(root != null);
+        return removeCoordinatorSendReceivePairRecursive(root, root);
+    }
+
+    static private AbstractPlanNode removeCoordinatorSendReceivePairRecursive(AbstractPlanNode root,
+            AbstractPlanNode current) {
+        if (current instanceof AbstractReceivePlanNode) {
+            assert(current.getChildCount() == 1);
+
+            AbstractPlanNode child = current.getChild(0);
+            assert(child instanceof SendPlanNode);
+
+            assert(child.getChildCount() == 1);
+            child = child.getChild(0);
+            child.clearParents();
+            if (current == root) {
+                return child;
+            }
+            assert(current.getParentCount() == 1);
+            AbstractPlanNode parent = current.getParent(0);
+            parent.unlinkChild(current);
+            parent.addAndLinkChild(child);
+            return root;
+        }
+        if (current.getChildCount() == 1) {
+            // This is still a coordinator node
+            return removeCoordinatorSendReceivePairRecursive(root, current.getChild(0));
+        }
+        // We have hit a multi-child plan node -- a nestloop join or a union.
+        // Can we really assume that there is no send/receive below this point?
+        // TODO: It seems to me (--paul) that for a replicated-to-partitioned
+        // left outer join, we should be following the second (partitioned)
+        // child node of a nestloop join.
+        // I'm not sure what the correct behavior is for a union.
+        return root;
     }
 
     /**
@@ -859,6 +919,43 @@ public class PlanAssembler {
 
     private CompiledPlan getNextSelectPlan() {
         assert (m_subAssembler != null);
+
+        // A matview reaggregation template plan may have been initialized
+        // with a post-predicate expression moved from the statement's
+        // join tree prior to any subquery planning.
+        // Since normally subquery planning is driven from the join tree,
+        // any subqueries that are moved out of the join tree would need
+        // to be planned separately.
+        // This planning would need to be done prior to calling
+        // m_subAssembler.nextPlan()
+        // because it can have query partitioning implications.
+        // Under the current query limitations, the partitioning implications
+        // are very simple -- subqueries are not allowed in multipartition
+        // queries against partitioned data, so detection of a subquery in
+        // the same query as a matview reaggregation can just return an error,
+        // without any need for subquery planning here.
+        HashAggregatePlanNode reAggNode = null;
+        HashAggregatePlanNode mvReAggTemplate = m_parsedSelect.m_mvFixInfo.getReAggregationPlanNode();
+        if (mvReAggTemplate != null) {
+            reAggNode = new HashAggregatePlanNode(mvReAggTemplate);
+            List<AbstractExpression> subqueryExprs =
+                    ExpressionUtil.findAllExpressionsOfClass(reAggNode.getPostPredicate(),
+                    AbstractSubqueryExpression.class);
+            if ( ! subqueryExprs.isEmpty()) {
+                // For now, this is just a special case violation of the limitation on
+                // use of expression subqueries in MP queries on partitioned data.
+                // That special case was going undetected when we didn't flag it here.
+                m_recentErrorMsg = IN_EXISTS_SCALAR_ERROR_MESSAGE;
+                return null;
+            }
+            // // Something more along these lines would have to be enabled
+            // // to allow expression subqueries to be used in multi-partition
+            // // matview queries.
+            // if (!getBestCostPlanForExpressionSubQueries(subqueryExprs)) {
+            //     // There was at least one sub-query and we should have a compiled plan for it
+            //    return null;
+            // }
+        }
 
         AbstractPlanNode subSelectRoot = m_subAssembler.nextPlan();
 
@@ -903,14 +1000,16 @@ public class PlanAssembler {
                         if (nljs.size() + nlijs.size() == 0) {
                             mvFixInfoEdgeCaseOuterJoin = true;
                         }
-                        root = handleMVBasedMultiPartQuery(root, mvFixInfoEdgeCaseOuterJoin);
+                        root = handleMVBasedMultiPartQuery(reAggNode, root, mvFixInfoEdgeCaseOuterJoin);
                     }
                 }
-            } else if (receivers.size() > 0) {
-                throw new PlanningErrorException(
-                        "This special case join between an outer replicated table and " +
-                        "an inner partitioned table is too complex and is not supported.");
-            } else {
+            }
+            else {
+                if (receivers.size() > 0) {
+                    throw new PlanningErrorException(
+                            "This special case join between an outer replicated table and " +
+                            "an inner partitioned table is too complex and is not supported.");
+                }
                 root = SubPlanAssembler.addSendReceivePair(root);
                 // Root is a receive node here.
                 assert(root instanceof ReceivePlanNode);
@@ -932,12 +1031,13 @@ public class PlanAssembler {
             // Process the re-aggregate plan node and insert it into the plan.
             if (m_parsedSelect.m_mvFixInfo.needed() && mvFixInfoCoordinatorNeeded) {
                 AbstractPlanNode tmpRoot = root;
-                root = handleMVBasedMultiPartQuery(root, mvFixInfoEdgeCaseOuterJoin);
+                root = handleMVBasedMultiPartQuery(reAggNode, root, mvFixInfoEdgeCaseOuterJoin);
                 if (root != tmpRoot) {
                     mvFixNeedsProjection = true;
                 }
             }
-        } else {
+        }
+        else {
             /*
              * There is no receive node and root is a single partition plan.
              */
@@ -964,9 +1064,10 @@ public class PlanAssembler {
 
                     // update the new root
                     root = child;
-                } else if (m_parsedSelect.hasDistinctWithGroupBy() &&
-                    child.getPlanNodeType() == PlanNodeType.HASHAGGREGATE &&
-                    grandChild.getPlanNodeType() == PlanNodeType.PROJECTION) {
+                }
+                else if (m_parsedSelect.hasDistinctWithGroupBy() &&
+                        child.getPlanNodeType() == PlanNodeType.HASHAGGREGATE &&
+                        grandChild.getPlanNodeType() == PlanNodeType.PROJECTION) {
 
                     AbstractPlanNode grandGrandChild = grandChild.getChild(0);
                     child.clearParents();
@@ -1746,12 +1847,9 @@ public class PlanAssembler {
     }
 
 
-    private AbstractPlanNode handleMVBasedMultiPartQuery (AbstractPlanNode root, boolean edgeCaseOuterJoin) {
+    private AbstractPlanNode handleMVBasedMultiPartQuery(
+            HashAggregatePlanNode reAggNode, AbstractPlanNode root, boolean edgeCaseOuterJoin) {
         MaterializedViewFixInfo mvFixInfo = m_parsedSelect.m_mvFixInfo;
-
-        HashAggregatePlanNode reAggNode = new HashAggregatePlanNode(mvFixInfo.getReAggregationPlanNode());
-        reAggNode.clearChildren();
-        reAggNode.clearParents();
 
         AbstractPlanNode receiveNode = root;
         AbstractPlanNode reAggParent = null;
@@ -2262,9 +2360,9 @@ public class PlanAssembler {
                     break;
                 }
             }
-
-        } else {
-            StmtTableScan fromTableScan = m_parsedSelect.m_tableAliasMap.get(fromTableAlias);
+        }
+        else {
+            StmtTableScan fromTableScan = m_parsedSelect.getStmtTableScanByAlias(fromTableAlias);
             // either pure expression index or mix of expressions and simple columns
             List<AbstractExpression> indexedExprs = null;
             try {
@@ -2275,28 +2373,20 @@ public class PlanAssembler {
                 return coveredGroupByColumns;
             }
 
-            for (int j = 0; j < indexedExprs.size(); j++) {
-                AbstractExpression indexExpr = indexedExprs.get(j);
+            for (AbstractExpression indexExpr : indexedExprs) {
                 // ignore order of keys in GROUP BY expr
-
-                int ithCovered = 0;
                 List<AbstractExpression> binding = null;
-                for (; ithCovered < groupBys.size(); ithCovered++) {
+                for (int ithCovered = 0; ithCovered < groupBys.size(); ithCovered++) {
                     AbstractExpression gbExpr = groupBys.get(ithCovered).expression;
                     binding = gbExpr.bindingToIndexedExpression(indexExpr);
                     if (binding != null) {
+                        bindings.addAll(binding);
+                        coveredGroupByColumns.add(ithCovered);
                         break;
                     }
                 }
-                if (binding == null) {
-                    // no prefix match any more or covered all group by columns already
-                    break;
-                }
-                bindings.addAll(binding);
-                coveredGroupByColumns.add(ithCovered);
-
-                if (coveredGroupByColumns.size() == groupBys.size()) {
-                    // covered all group by columns already
+                // no prefix match any more or covered all group by columns already
+                if (binding == null || coveredGroupByColumns.size() == groupBys.size()) {
                     break;
                 }
             }

--- a/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
@@ -35,8 +35,8 @@ import org.voltdb.planner.parseinfo.StmtSubqueryScan;
 import org.voltdb.planner.parseinfo.StmtTableScan;
 import org.voltdb.planner.parseinfo.SubqueryLeafNode;
 import org.voltdb.plannodes.AbstractJoinPlanNode;
-import org.voltdb.plannodes.AbstractReceivePlanNode;
 import org.voltdb.plannodes.AbstractPlanNode;
+import org.voltdb.plannodes.AbstractReceivePlanNode;
 import org.voltdb.plannodes.IndexScanPlanNode;
 import org.voltdb.plannodes.NestLoopIndexPlanNode;
 import org.voltdb.plannodes.NestLoopPlanNode;
@@ -213,8 +213,8 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
                 // should propagate an error message identifying partitioning as the problem.
                 HashMap<AbstractExpression, Set<AbstractExpression>>
                     valueEquivalence = joinTree.getAllEquivalenceFilters();
-                m_partitioning.analyzeForMultiPartitionAccess(m_parsedStmt.m_tableAliasMap.values(),
-                                                                      valueEquivalence);
+                Collection<StmtTableScan> scans = m_parsedStmt.allScans();
+                m_partitioning.analyzeForMultiPartitionAccess(scans, valueEquivalence);
                 if ( ! m_partitioning.isJoinValid() ) {
                     // The case of more than one independent partitioned table
                     // would result in an illegal plan with more than two fragments.

--- a/src/frontend/org/voltdb/planner/StatementPartitioning.java
+++ b/src/frontend/org/voltdb/planner/StatementPartitioning.java
@@ -31,6 +31,7 @@ import org.voltdb.expressions.ParameterValueExpression;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.planner.parseinfo.StmtSubqueryScan;
 import org.voltdb.planner.parseinfo.StmtTableScan;
+import org.voltdb.plannodes.AbstractReceivePlanNode;
 import org.voltdb.plannodes.SchemaColumn;
 
 /**
@@ -410,8 +411,10 @@ public class StatementPartitioning implements Cloneable{
             if (tableScan instanceof StmtSubqueryScan) {
                 StmtSubqueryScan subScan = (StmtSubqueryScan) tableScan;
                 subScan.promoteSinglePartitionInfo(valueEquivalence, eqSets);
-
-                if (subScan.hasReceiveNode()) {
+                CompiledPlan subqueryPlan = subScan.getBestCostPlan();
+                if (( ! subScan.canRunInOneFragment()) ||
+                        ((subqueryPlan != null) &&
+                         subqueryPlan.rootPlanGraph.hasAnyNodeOfClass(AbstractReceivePlanNode.class))) {
                     if (subqueryHasReceiveNode) {
                         // Has found another subquery with receive node on the same level
                         // Not going to support this kind of subquery join with 2 fragment plan.

--- a/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexLimit.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexLimit.java
@@ -221,9 +221,10 @@ public class ReplaceWithIndexLimit extends MicroOptimization {
          * where bindings will be added.
          */
         Index indexToUse = ispn.getCatalogIndex();
+        String tableAlias = ispn.getTargetTableAlias();
         List<AbstractExpression> indexedExprs = null;
         if ( ! indexToUse.getExpressionsjson().isEmpty() ) {
-            StmtTableScan tableScan = m_parsedStmt.m_tableAliasMap.get(ispn.getTargetTableAlias());
+            StmtTableScan tableScan = m_parsedStmt.getStmtTableScanByAlias(tableAlias);
             try {
                 indexedExprs = AbstractExpression.fromJSONArrayString(indexToUse.getExpressionsjson(), tableScan);
             } catch (JSONException e) {
@@ -297,7 +298,7 @@ public class ReplaceWithIndexLimit extends MicroOptimization {
         // do not aggressively evaluate all indexes, just examine the index currently in use;
         // because for all qualified indexes, one access plan must have been generated already,
         // and we can take advantage of that
-        if (!checkIndex(ispn.getCatalogIndex(), aggExpr, exprs, ispn.getBindings(), ispn.getTargetTableAlias())) {
+        if (!checkIndex(ispn.getCatalogIndex(), aggExpr, exprs, ispn.getBindings(), tableAlias)) {
             return plan;
         } else {
             // we know which end we want to fetch, set the sort direction
@@ -390,8 +391,7 @@ public class ReplaceWithIndexLimit extends MicroOptimization {
         } else {
             // either pure expression index or mix of expressions and simple columns
             List<AbstractExpression> indexedExprs = null;
-            StmtTableScan tableScan = m_parsedStmt.m_tableAliasMap.get(fromTableAlias);
-
+            StmtTableScan tableScan = m_parsedStmt.getStmtTableScanByAlias(fromTableAlias);
             try {
                 indexedExprs = AbstractExpression.fromJSONArrayString(exprsjson, tableScan);
             } catch (JSONException e) {

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -34,11 +34,7 @@ import org.voltdb.planner.ParsedSelectStmt;
 import org.voltdb.planner.ParsedUnionStmt;
 import org.voltdb.planner.PlanningErrorException;
 import org.voltdb.planner.StatementPartitioning;
-import org.voltdb.plannodes.AbstractPlanNode;
-import org.voltdb.plannodes.AbstractReceivePlanNode;
-import org.voltdb.plannodes.MergeReceivePlanNode;
 import org.voltdb.plannodes.SchemaColumn;
-import org.voltdb.plannodes.SendPlanNode;
 
 /**
  * StmtTableScan caches data related to a given instance of a sub-query within the statement scope
@@ -53,7 +49,7 @@ public class StmtSubqueryScan extends StmtTableScan {
 
     private StatementPartitioning m_subqueriesPartitioning = null;
 
-    private boolean m_hasReceiveNode = false;
+    private boolean m_failedSingleFragmentTest = false;
 
     private boolean m_tableAggregateSubquery = false;
 
@@ -85,10 +81,6 @@ public class StmtSubqueryScan extends StmtTableScan {
         this(subqueryStmt, tableAlias, 0);
     }
 
-    public StatementPartitioning getPartitioningForStatement() {
-        return m_subqueriesPartitioning;
-    }
-
     public void setSubqueriesPartitioning(StatementPartitioning subqueriesPartitioning) {
         assert(subqueriesPartitioning != null);
         m_subqueriesPartitioning = subqueriesPartitioning;
@@ -105,15 +97,14 @@ public class StmtSubqueryScan extends StmtTableScan {
             HashMap<AbstractExpression, Set<AbstractExpression>> valueEquivalence,
             Set< Set<AbstractExpression> > eqSets)
     {
-        StatementPartitioning stmtPartitioning = getPartitioningForStatement();
-
-        if (stmtPartitioning.getCountOfPartitionedTables() == 0 ||
-            stmtPartitioning.requiresTwoFragments()) {
+        assert(m_subqueriesPartitioning != null);
+        if (m_subqueriesPartitioning.getCountOfPartitionedTables() == 0 ||
+                m_subqueriesPartitioning.requiresTwoFragments()) {
             return;
         }
-        // this sub-query is single partitioned query on partitioned tables
-        // promoting the single partition express up the its parent level
-        AbstractExpression spExpr = stmtPartitioning.singlePartitioningExpression();
+        // This subquery is a single partitioned query on partitioned tables
+        // promoting the single partition expression up to its parent level.
+        AbstractExpression spExpr = m_subqueriesPartitioning.singlePartitioningExpression();
 
         for (SchemaColumn col: m_partitioningColumns) {
             AbstractExpression tveKey = col.getExpression();
@@ -170,10 +161,8 @@ public class StmtSubqueryScan extends StmtTableScan {
         assert(m_subqueriesPartitioning != null);
 
         if (m_subqueriesPartitioning.getCountOfPartitionedTables() > 0) {
-            for (StmtTableScan tableScan : m_subqueryStmt.m_tableAliasMap.values()) {
-
-                List<SchemaColumn> scols;
-                scols = tableScan.getPartitioningColumns();
+            for (StmtTableScan tableScan : m_subqueryStmt.allScans()) {
+                List<SchemaColumn> scols = tableScan.getPartitioningColumns();
                 addPartitioningColumns(scols);
             }
         }
@@ -229,10 +218,8 @@ public class StmtSubqueryScan extends StmtTableScan {
      */
     @Override
     public boolean getIsReplicated() {
-        boolean isReplicated = true;
-        for (StmtTableScan tableScan : m_subqueryStmt.m_tableAliasMap.values()) {
-            isReplicated = isReplicated && tableScan.getIsReplicated();
-            if ( ! isReplicated) {
+        for (StmtTableScan tableScan : m_subqueryStmt.allScans()) {
+            if ( ! tableScan.getIsReplicated()) {
                 return false;
             }
         }
@@ -241,7 +228,7 @@ public class StmtSubqueryScan extends StmtTableScan {
 
     public List<StmtTargetTableScan> getAllTargetTables() {
         List <StmtTargetTableScan> stmtTables = new ArrayList<StmtTargetTableScan>();
-        for (StmtTableScan tableScan : m_subqueryStmt.m_tableAliasMap.values()) {
+        for (StmtTableScan tableScan : m_subqueryStmt.allScans()) {
             if (tableScan instanceof StmtTargetTableScan) {
                 stmtTables.add((StmtTargetTableScan)tableScan);
             } else {
@@ -291,122 +278,104 @@ public class StmtSubqueryScan extends StmtTableScan {
 
     }
 
-
     /**
-     * Some subquery results can only be joined with a partitioned table after it finishes work
-     * on the coordinator. With 2 fragment plan limit, those queries should not be supported.
-     * Other than that, planner can get rid of the send/receive pair and push down the join.
+     * Some subquery results can only be joined with a partitioned table after
+     * it finishes some work on the coordinator. With the 2 fragment plan limit,
+     * those queries can not be supported.
+     * Other than that case, the planner will typically have added a
+     * send/receive pair to the subquery plan that is actually only suitable to
+     * a stand-alone plan. This function distinguishes subqueries that should NOT
+     * have a send/receive pair.
      * @param root
-     * @return
+     * @return true if there is no aspect to the plan that requires execution on the coordinator.
      */
-    public AbstractPlanNode processReceiveNode(AbstractPlanNode root) {
+    public boolean canRunInOneFragment() {
         assert(m_subqueriesPartitioning != null);
         if (! m_subqueriesPartitioning.requiresTwoFragments()) {
-            return root;
+            return false;
         }
-        assert(root.findAllNodesOfClass(AbstractReceivePlanNode.class).size() == 1);
         assert(m_subqueryStmt != null);
 
         // recursive check for its nested subqueries for should have receive node.
-        if (hasReceiveNode()) {
-            m_hasReceiveNode = true;
-            return root;
+        if (failsSingleFragmentTest()) {
+            return false;
         }
 
-        m_hasReceiveNode = true;
-
-        if (root.hasAnyNodeOfClass(MergeReceivePlanNode.class)) {
-            // The MergeReceivePlanNode always has an inline ORDER BY node and may have
-            // LIMIT/OFFSET and aggregation node(s). Removing the MergeReceivePlanNode will
-            // also remove its inline node(s) which may produce an invalid access plan. For example
-            // SELECT TC1 FROM (SELECT C1 AS TC1 FROM P ORDER BY C1) PT LIMIT 4;
-            // where P is partitioned and C1 is a non-partitioned index column.
-            // Removing the subquery MergeReceivePlnaNode and its ORDER BY node results
-            // in the invalid access plan - the subquery result order is significant in this case
-            // The concern with generally keeping the (Merge)Receive node in the subquery is
-            // that it would needlessly generate more-than-2-fragment plans in cases
-            // where 2 fragments could have done the job.
-            return root;
-        }
+        // Tentative assignment in case of early return.
+        // This gets immediately reset if it passes all the tests.
+        m_failedSingleFragmentTest = true;
 
         if (m_subqueryStmt instanceof ParsedUnionStmt) {
             // Union are just returned
-            assert(m_subqueryStmt instanceof ParsedUnionStmt);
-            return root;
+            return false;
         }
 
-        if (m_subqueryStmt instanceof ParsedSelectStmt == false) {
+        if ( ! (m_subqueryStmt instanceof ParsedSelectStmt)) {
             throw new PlanningErrorException("Unsupported subquery found in FROM clause:" + m_subqueryStmt.toString());
         }
 
         ParsedSelectStmt selectStmt = (ParsedSelectStmt)m_subqueryStmt;
-        assert(selectStmt != null);
 
         // Now If query has LIMIT/OFFSET/DISTINCT on a replicated table column,
-        // we should get rid of the receive node.
+        // we should get rid of the receive node. I (--paul) don't know what this means.
         if (selectStmt.hasLimitOrOffset() || selectStmt.hasDistinctWithGroupBy()) {
-            return root;
+            return false;
         }
 
-        // If the query contains the partition materialized table with the need to Re-aggregate,
-        // then we can not get rid of the receive node.
-        // This is also caught in StatementPartitioning when analysing the join criteria,
-        // because it contains a partitioned view that does not have partition column.
+        // If the query uses the partitioned materialized view table with the
+        // need to Re-aggregate, then we can not get rid of the receive node.
+        // This is also caught in StatementPartitioning when analyzing the join criteria,
+        // because it contains a partitioned view that does not have a partition column.
         if (selectStmt.m_mvFixInfo.needed()) {
-            return root;
+            return false;
         }
 
         // Table aggregate cases should not get rid of the receive node
         if (selectStmt.hasAggregateOrGroupby()) {
             if (!selectStmt.isGrouped()) {
                 m_tableAggregateSubquery = true;
-                return root;
+                return false;
             }
             // For group by queries, there are two cases on group by columns.
-            // (1) Does not Contain the partition columns: If join with partition table on outer
-            //     level, it will violates the join criteria.
+            // (1) Does not contain a partition column:
+            // If joined with a partitioned table in the parent query, it will
+            // violate the partitioned table join criteria.
             // Detect case (1) to mark receive node.
             if (! selectStmt.hasPartitionColumnInGroupby()) {
-                return root;
+                return false;
             }
 
             //
-            // (2) Group by columns contain the partition columns:
+            // (2) Contains a partition column:
             //     This is the interesting case that we are going to support.
             //     At this point, subquery does not contain LIMIT/OFFSET.
-            //     But if the aggregate has distinct, we have to compute on coordinator.
+            //     But if the statement has a distinct aggregate, retain the
+            //     send/receive and compute the distinct result on the coordinator.
             if ( selectStmt.hasAggregateDistinct() ) {
-                return root;
+                return false;
             }
-
-            //     Now. If this sub-query joins with partition table on outer level,
-            //     we are able to push the join down by removing the send/receive plan node pair.
         }
-
-        //
-        // Remove the send/receive pair on distributed node
-        //
-        root = removeCoordinatorSendReceivePair(root);
-
-        m_hasReceiveNode = false;
-        return root;
+        // Now. If this sub-query joins with a partitioned table in the parent statement,
+        // push the join down by removing the send/receive plan node pair.
+        m_failedSingleFragmentTest = false;
+        return true;
     }
 
-    public boolean hasReceiveNode() {
-        if (m_hasReceiveNode) {
+    public boolean failsSingleFragmentTest() {
+        if (m_failedSingleFragmentTest) {
             return true;
         }
-
-        for (StmtTableScan tableScan : m_subqueryStmt.m_tableAliasMap.values()) {
+        for (StmtTableScan tableScan : m_subqueryStmt.allScans()) {
             if (tableScan instanceof StmtSubqueryScan) {
                 StmtSubqueryScan subScan = (StmtSubqueryScan)tableScan;
-                if (subScan.hasReceiveNode()) {
+                if (subScan.failsSingleFragmentTest()) {
+                    // Cache known test failures on parent subqueries.
+                    m_failedSingleFragmentTest = true;
                     return true;
                 }
             }
         }
-
-        return m_hasReceiveNode;
+        return false;
     }
 
     public boolean isTableAggregate() {
@@ -419,46 +388,6 @@ public class StmtSubqueryScan extends StmtTableScan {
         TupleValueExpression tve = new TupleValueExpression(getTableAlias(), getTableAlias(),
                 schemaCol.getColumnAlias(), schemaCol.getColumnAlias(), index);
         return tve;
-    }
-
-    /**
-     * Remove the coordinator send/receive pair if any from the graph.
-     *
-     * @param root the complete plan node.
-     * @return the plan without the send/receive pair.
-     */
-    static public AbstractPlanNode removeCoordinatorSendReceivePair(AbstractPlanNode root) {
-        assert(root != null);
-        return removeCoordinatorSendReceivePairRecursive(root, root);
-    }
-
-    static public AbstractPlanNode removeCoordinatorSendReceivePairRecursive(AbstractPlanNode root,
-            AbstractPlanNode current) {
-        if (current instanceof AbstractReceivePlanNode) {
-            assert(current.getChildCount() == 1);
-
-            AbstractPlanNode child = current.getChild(0);
-            assert(child instanceof SendPlanNode);
-
-            assert(child.getChildCount() == 1);
-            child = child.getChild(0);
-            child.clearParents();
-            if (current.getParentCount() == 0) {
-                return child;
-            } else {
-                assert(current.getParentCount() == 1);
-                AbstractPlanNode parent = current.getParent(0);
-                parent.unlinkChild(current);
-                parent.addAndLinkChild(child);
-                return root;
-            }
-        } else if (current.getChildCount() == 1) {
-            // This is still a coordinator node
-            return removeCoordinatorSendReceivePairRecursive(root, current.getChild(0));
-        } else {
-            // We are about to branch and leave the coordinator
-            return root;
-        }
     }
 
     public List<SchemaColumn> getOutputSchema() {

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -427,12 +427,14 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
      * @param child The node to add.
      */
     public void addAndLinkChild(AbstractPlanNode child) {
+        assert(child != null);
         m_children.add(child);
         child.m_parents.add(this);
     }
 
     // called by PushDownLimit, re-link the child without changing the order
     public void setAndLinkChild(int index, AbstractPlanNode child) {
+        assert(child != null);
         m_children.set(index, child);
         child.m_parents.add(this);
     }
@@ -441,6 +443,7 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
      * @param child to remove.
      */
     public void unlinkChild(AbstractPlanNode child) {
+        assert(child != null);
         m_children.remove(child);
         child.m_parents.remove(this);
     }
@@ -452,6 +455,8 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
      * @return true if the child was replaced
      */
     public boolean replaceChild(AbstractPlanNode oldChild, AbstractPlanNode newChild) {
+        assert(oldChild != null);
+        assert(newChild != null);
         int idx = 0;
         for (AbstractPlanNode child : m_children) {
             if (child.equals(oldChild)) {
@@ -464,15 +469,13 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         return false;
     }
 
-    public boolean replaceChild(int oldChildIdx, AbstractPlanNode newChild) {
-        if (oldChildIdx < 0 || oldChildIdx >= getChildCount()) {
-            return false;
-        }
-
+    public void replaceChild(int oldChildIdx, AbstractPlanNode newChild) {
+        assert(oldChildIdx >= 0 && oldChildIdx < getChildCount());
+        assert(newChild != null);
         AbstractPlanNode oldChild = m_children.get(oldChildIdx);
+        assert(oldChild != null);
         oldChild.m_parents.clear();
         setAndLinkChild(oldChildIdx, newChild);
-        return true;
     }
 
 

--- a/tests/frontend/org/voltdb/planner/PlannerTestCase.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestCase.java
@@ -26,13 +26,13 @@ package org.voltdb.planner;
 import java.net.URL;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.lang3.StringUtils;
 import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DeterminismMode;
 import org.voltdb.plannodes.AbstractPlanNode;
 import org.voltdb.types.PlanNodeType;
+
+import junit.framework.TestCase;
 
 public class PlannerTestCase extends TestCase {
 
@@ -63,8 +63,9 @@ public class PlannerTestCase extends TestCase {
     {
         int paramCount = countQuestionMarks(sql);
         try {
-            m_aide.compile(sql, paramCount,
+            List<AbstractPlanNode> unexpected = m_aide.compile(sql, paramCount,
                     m_byDefaultInferPartitioning, m_byDefaultPlanForSinglePartition, null);
+            printExplainPlan(unexpected);
             fail("Expected planner failure, but found success.");
         }
         catch (Exception ex) {

--- a/tests/frontend/org/voltdb/planner/TestPlansMatView.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansMatView.java
@@ -164,4 +164,105 @@ public class TestPlansMatView extends PlannerTestCase {
 
     }
 
+    public void testFixedENG8559ExistsPartitionedWithSubqueryNPE() {
+        System.out.println("Running testFixedENG8559ExistsPartitionedWithSubqueryNPE:");
+        List<AbstractPlanNode> pns;
+
+        try {
+            pns = compileToFragments("SELECT * FROM P X WHERE EXISTS (SELECT * FROM VNP Y WHERE Y.SUM_V1 = X.VAL1)");
+            //* enable to debug */ System.out.println(pns.get(0).toExplainPlanString());
+            //* enable to debug */ System.out.println(pns.get(1).toExplainPlanString());
+            fail("unexpected success for partitioned view query with subquery.");
+        }
+        catch (PlanningErrorException pex) {
+            assertTrue(pex.getMessage().contains(
+                    "Subquery expressions are only supported for single partition procedures and AdHoc queries referencing only replicated tables."
+                    ));
+        }
+
+        try {
+            pns = compileToFragments("SELECT * FROM VNP X WHERE EXISTS (SELECT * FROM R Y WHERE Y.VAL1 = X.SUM_V1)");
+            //* enable to debug */ System.out.println(pns.get(0).toExplainPlanString());
+            //* enable to debug */ System.out.println(pns.get(1).toExplainPlanString());
+            fail("unexpected success for partitioned view query with subquery.");
+        }
+        catch (PlanningErrorException pex) {
+            assertTrue(pex.getMessage().contains(
+                    "Subquery expressions are only supported for single partition procedures and AdHoc queries referencing only replicated tables."
+                    ));
+        }
+
+        try {
+            pns = compileToFragments("SELECT * FROM R X WHERE EXISTS (SELECT * FROM VNP Y WHERE Y.SUM_V1 = X.VAL1)");
+            //* enable to debug */ System.out.println(pns.get(0).toExplainPlanString());
+            //* enable to debug */ System.out.println(pns.get(1).toExplainPlanString());
+            fail("unexpected success for partitioned view query with subquery.");
+        }
+        catch (PlanningErrorException pex) {
+            assertTrue(pex.getMessage().contains(
+                    "Subquery expressions are only supported for single partition procedures and AdHoc queries referencing only replicated tables."
+                    ));
+        }
+
+        try {
+            pns = compileToFragments("SELECT * FROM VNP X WHERE EXISTS (SELECT * FROM P Y WHERE Y.VAL1 = X.SUM_V1)");
+            //* enable to debug */ System.out.println(pns.get(0).toExplainPlanString());
+            //* enable to debug */ System.out.println(pns.get(1).toExplainPlanString());
+            fail("unexpected success for partitioned view query with subquery.");
+        }
+        catch (PlanningErrorException pex) {
+            assertTrue(pex.getMessage().contains(
+                    "Subquery expressions are only supported for single partition procedures and AdHoc queries referencing only replicated tables."
+                    ));
+        }
+
+        try {
+            pns = compileToFragments("SELECT * FROM VNP X WHERE EXISTS (SELECT * FROM VNP Y WHERE Y.SUM_V1 = X.SUM_V1)");
+            //* enable to debug */ System.out.println(pns.get(0).toExplainPlanString());
+            //* enable to debug */ System.out.println(pns.get(1).toExplainPlanString());
+            fail("unexpected success for partitioned view query with subquery.");
+        }
+        catch (PlanningErrorException pex) {
+            assertTrue(pex.getMessage().contains(
+                    "Subquery expressions are only supported for single partition procedures and AdHoc queries referencing only replicated tables."
+                    ));
+        }
+
+        try {
+            pns = compileToFragments("SELECT * FROM VP X WHERE EXISTS (SELECT * FROM VP Y WHERE Y.SUM_V1 = X.SUM_V1)");
+            //* enable to debug */ System.out.println(pns.get(0).toExplainPlanString());
+            //* enable to debug */ System.out.println(pns.get(1).toExplainPlanString());
+            fail("unexpected success for partitioned view query with subquery.");
+        }
+        catch (PlanningErrorException pex) {
+            assertTrue(pex.getMessage().contains(
+                    "Subquery expressions are only supported for single partition procedures and AdHoc queries referencing only replicated tables."
+                    ));
+        }
+
+        try {
+            pns = compileToFragments("SELECT * FROM VP X WHERE EXISTS (SELECT * FROM VR Y WHERE Y.SUM_V2 = X.SUM_V1)");
+            //* enable to debug */ System.out.println(pns.get(0).toExplainPlanString());
+            //* enable to debug */ System.out.println(pns.get(1).toExplainPlanString());
+            fail("unexpected success for partitioned view query with subquery.");
+        }
+        catch (PlanningErrorException pex) {
+            assertTrue(pex.getMessage().contains(
+                    "Subquery expressions are only supported for single partition procedures and AdHoc queries referencing only replicated tables."
+                    ));
+        }
+
+        try {
+            pns = compileToFragments("SELECT * FROM VNP X WHERE EXISTS (SELECT * FROM VR Y WHERE Y.SUM_V2 = X.SUM_V1)");
+            /* enable to debug */ System.out.println(pns.get(0).toExplainPlanString());
+            /* enable to debug */ System.out.println(pns.get(1).toExplainPlanString());
+            fail("unexpected success for partitioned view query with subquery.");
+        }
+        catch (PlanningErrorException pex) {
+            assertTrue(pex.getMessage().contains(
+                    "Subquery expressions are only supported for single partition procedures and AdHoc queries referencing only replicated tables."
+                    ));
+        }
+    }
+
 }

--- a/tests/frontend/org/voltdb/planner/TestPlansOrderBy.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansOrderBy.java
@@ -510,7 +510,7 @@ public class TestPlansOrderBy extends PlannerTestCase {
         {
             // The subquery SEND/MERGERECEIVE is preserved during the subquery post-processing
             // resulting in the multi-partitioned join that gets rejected.
-            // In this case, the subquery MERGERECEIVE node is techically redundant but at the moment,
+            // In this case, the subquery MERGERECEIVE node is technically redundant but at the moment,
             // the subquery post-processing still keeps it.
             failToCompile(
                     "select PT_D1 from (select P_D1 as PT_D1, P_D0 as PT_D0 from P order by P_D1) P_T, P where P.P_D0 = P_T.PT_D0;",


### PR DESCRIPTION
renamed getStmtTableScanByAlias to resolveStmtTableScanByAlias, so I could use the former name as a simpler accessor, allowing m_tableAliasMap to be hidden better.

The wide visibility of m_tableAliasMap had me chasing ghosts looking for root causes of the NPE.

Moved some AbstractPlanNode dependencies out of StmtSubqueryScan where they don't belong and into PlanAssembler where they do belong and a little into StatementPartitioning (where maybe it really doesn't, but the alternative was not obvious).
