### PR TITLE
ENG-9432: Base DR conflict timestamps off Unix epoch; move VOLT_EPOCH…

### DIFF
--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -21,6 +21,8 @@
 
 #include "boost/foreach.hpp"
 
+#include "expressions/functionexpression.h" // Really for datefunctions and its dependencies.
+
 #include <pthread.h>
 #ifdef LINUX
 #include <malloc.h>
@@ -29,6 +31,8 @@
 using namespace std;
 
 namespace voltdb {
+
+const int64_t VOLT_EPOCH = epoch_microseconds_from_components(2008);
 
 static pthread_key_t static_key;
 static pthread_once_t static_keyOnce = PTHREAD_ONCE_INIT;
@@ -94,8 +98,7 @@ ExecutorContext::ExecutorContext(int64_t siteId,
     m_partitionId(partitionId),
     m_hostname(hostname),
     m_hostId(hostId),
-    m_drClusterId(drClusterId),
-    m_epoch(0) // set later
+    m_drClusterId(drClusterId)
 {
     (void)pthread_once(&static_keyOnce, globalInitOrCreateOncePerProcess);
     bindToThread();

--- a/src/ee/common/executorcontext.hpp
+++ b/src/ee/common/executorcontext.hpp
@@ -29,12 +29,12 @@
 
 namespace voltdb {
 
+extern const int64_t VOLT_EPOCH;
 const int64_t HIDDEN_VALUE_TIMESTAMP_MASK = (1LL << 49) - 1LL;
 
 class AbstractExecutor;
 class DRTupleStream;
 class VoltDBEngine;
-
 
 /*
  * EE site global data required by executors at runtime.
@@ -72,11 +72,6 @@ class ExecutorContext {
         m_partitionId = partitionId;
     }
 
-    // not always known at initial construction
-    void setEpoch(int64_t epoch) {
-        m_epoch = epoch;
-    }
-
     // helper to configure the context for a new jni call
     void setupForPlanFragments(UndoQuantum *undoQuantum,
                                int64_t txnId,
@@ -88,7 +83,7 @@ class ExecutorContext {
         m_spHandle = spHandle;
         m_txnId = txnId;
         m_lastCommittedSpHandle = lastCommittedSpHandle;
-        m_currentTxnTimestamp = (m_uniqueId >> 23) + m_epoch;
+        m_currentTxnTimestamp = (m_uniqueId >> 23) + VOLT_EPOCH;
         m_uniqueId = uniqueId;
         m_currentDRTimestamp = createDRTimestampHiddenValue(static_cast<int64_t>(m_drClusterId), m_uniqueId);
     }
@@ -127,7 +122,10 @@ class ExecutorContext {
 
     static int64_t getDRTimestampFromHiddenNValue(NValue &value) {
         int64_t hiddenValue = ValuePeeker::peekAsBigInt(value);
-        return hiddenValue & HIDDEN_VALUE_TIMESTAMP_MASK;
+        // Convert this into a microsecond-resolution timestamp; treat the time
+        // portion as the time in milliseconds, and the sequence number as if
+        // it is a time in microseconds
+        return (hiddenValue >> 23) * 1000 + VOLT_EPOCH + (hiddenValue & 0x1ff);
     }
 
     static int8_t getClusterIdFromHiddenNValue(NValue &value) {
@@ -276,9 +274,6 @@ class ExecutorContext {
     std::string m_hostname;
     CatalogId m_hostId;
     CatalogId m_drClusterId;
-
-    /** local epoch for voltdb, somtime around 2008, pulled from catalog */
-    int64_t m_epoch;
 };
 
 }

--- a/src/ee/common/executorcontext.hpp
+++ b/src/ee/common/executorcontext.hpp
@@ -30,7 +30,6 @@
 namespace voltdb {
 
 extern const int64_t VOLT_EPOCH;
-const int64_t HIDDEN_VALUE_TIMESTAMP_MASK = (1LL << 49) - 1LL;
 
 class AbstractExecutor;
 class DRTupleStream;
@@ -125,7 +124,8 @@ class ExecutorContext {
         // Convert this into a microsecond-resolution timestamp; treat the time
         // portion as the time in milliseconds, and the sequence number as if
         // it is a time in microseconds
-        return (hiddenValue >> 23) * 1000 + VOLT_EPOCH + (hiddenValue & 0x1ff);
+        int64_t ts = hiddenValue & ((1LL << 49) - 1LL);
+        return (ts >> 9) * 1000 + VOLT_EPOCH + (ts & 0x1ff);
     }
 
     static int8_t getClusterIdFromHiddenNValue(NValue &value) {

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -560,12 +560,8 @@ bool VoltDBEngine::loadCatalog(const int64_t timestamp, const std::string &catal
         return false;
     }
 
-    // deal with the epoch
-    catalog::Cluster* catalogCluster = m_catalog->clusters().get("cluster");
-    int64_t epoch = catalogCluster->localepoch() * (int64_t)1000;
-    m_executorContext->setEpoch(epoch);
-
     // Set DR flag based on current catalog state
+    catalog::Cluster* catalogCluster = m_catalog->clusters().get("cluster");
     m_drStream->m_enabled = catalogCluster->drProducerEnabled();
     m_drStream->m_flushInterval = catalogCluster->drFlushInterval();
     if (m_drReplicatedStream) {

--- a/src/ee/expressions/datefunctions.h
+++ b/src/ee/expressions/datefunctions.h
@@ -82,7 +82,6 @@ namespace voltdb {
 
 static const long COUNTER_BITS = 9;
 static const long PARTITIONID_BITS = 14;
-static const int64_t VOLT_EPOCH = epoch_microseconds_from_components(2008);
 
 /** implement the timestamp YEAR extract function **/
 template<> inline NValue NValue::callUnary<FUNC_EXTRACT_YEAR>() const {


### PR DESCRIPTION
… definition to executorcontext