### PR TITLE
 ENG-8980: an override to let VoltDB start even if THP is enabled

### DIFF
--- a/lib/python/voltcli/checkconfig.py
+++ b/lib/python/voltcli/checkconfig.py
@@ -29,6 +29,10 @@ import platform
 import subprocess
 import sys
 import os.path
+# Define HardRequirements (full name)
+# and possible SkippableleRequirements(fullname:init)
+hardRequirements = ['TransparentHugePage']
+skippableRequirements = {'TransparentHugePage':'thp'}
 
 # Helper functions
 
@@ -229,6 +233,9 @@ def test_full_config(output):
 def test_hard_requirements():
     """ Returns any errors resulting from hard config requirement violations
     """
-    return _check_thp_config()
+    output = {}
+    test_full_config(output)
+    return dict([(k,v) for k,v in output.items() if k in hardRequirements])
+    # return _check_thp_config()
 
 

--- a/lib/python/voltcli/verbs.py
+++ b/lib/python/voltcli/verbs.py
@@ -425,9 +425,9 @@ class ServerBundle(JavaBundle):
     def initialize(self, verb):
         JavaBundle.initialize(self, verb)
 	verb.add_options(
-            cli.StringListOption(None, '--skip-check', 'skip_requirements',
+            cli.StringListOption(None, '--ignore', 'skip_requirements',
                              '''requirements to skip when start voltdb:
-			     thp - ignore transparent huge page check at your peril, you could run out of memory''',
+			     thp - Checking for Transparent Huge Pages (THP) has been disabled.  Use of THP can cause VoltDB to run out of memory. Do not disable this check on production systems.''',
                              default = None))
         verb.add_options(
             cli.StringOption('-d', '--deployment', 'deployment',
@@ -471,9 +471,9 @@ class ServerBundle(JavaBundle):
                 state = v[0]
                 if state == 'PASS' :
                     pass
-                if state == "WARN":
+                elif state == "WARN":
                     utility.warning(v[1])
-                if state == 'FAIL' :
+                elif state == 'FAIL' :
                     if k in checkconfig.skippableRequirements.keys() and runner.opts.skip_requirements and checkconfig.skippableRequirements[k] in runner.opts.skip_requirements:
                         utility.warning(v[1])
                     else:


### PR DESCRIPTION
manually test:
 on thp enabled machine, voltdb  create --skip-check=thp will start voltdb with warning

voltdb check won't be affected