### PR TITLE
ENG-9461, as spUniqueId or mpUniqueId of the invocation buffer may be…

### DIFF
--- a/src/frontend/org/voltdb/DRLogSegmentId.java
+++ b/src/frontend/org/voltdb/DRLogSegmentId.java
@@ -92,14 +92,14 @@ public class DRLogSegmentId implements Serializable {
 
         public MutableBinaryLogInfo() {
             drId = Long.MIN_VALUE;
-            spUniqueId = Long.MIN_VALUE;
-            mpUniqueId = Long.MIN_VALUE;
+            spUniqueId = 0;
+            mpUniqueId = 0;
         }
 
         public void reset() {
             drId = Long.MIN_VALUE;
-            spUniqueId = Long.MIN_VALUE;
-            mpUniqueId = Long.MIN_VALUE;
+            spUniqueId = 0;
+            mpUniqueId = 0;
         }
 
         public DRLogSegmentId toImmutable() {

--- a/src/frontend/org/voltdb/DRLogSegmentId.java
+++ b/src/frontend/org/voltdb/DRLogSegmentId.java
@@ -70,7 +70,7 @@ public class DRLogSegmentId implements Serializable {
     }
 
     public static boolean isEmptyDRId (long drId) {
-        return (drId >>> 63) == (long)1;
+        return (drId >>> 63) == 1L;
     }
 
     public static int getClusterIdFromDRId(long drId) {
@@ -91,6 +91,12 @@ public class DRLogSegmentId implements Serializable {
         public long mpUniqueId;
 
         public MutableBinaryLogInfo() {
+            drId = Long.MIN_VALUE;
+            spUniqueId = Long.MIN_VALUE;
+            mpUniqueId = Long.MIN_VALUE;
+        }
+
+        public void reset() {
             drId = Long.MIN_VALUE;
             spUniqueId = Long.MIN_VALUE;
             mpUniqueId = Long.MIN_VALUE;


### PR DESCRIPTION
… 0 if the buffer contains only sp or mp txn,

fix the incorrect statistics of lastQueuedSegmentId and lastAckedSegmentId.

Change-Id: I91207c20dc72339bdbe2d6aaf78650dcfaffc65b