### PR TITLE
ENG-9519.  Make javac use Java7

### DIFF
--- a/build-client.xml
+++ b/build-client.xml
@@ -20,6 +20,8 @@
     <attribute name="includes" default=""/>
     <sequential>
         <javac
+            fork="yes"
+            executable="${java7home}/bin/javac"
             target="1.6"
             source="1.6"
             srcdir="@{srcdir}"
@@ -38,6 +40,9 @@
 
 <!-- make environment var foo available as env.foo -->
 <property environment="env"/>
+
+<!-- find the location of java7 -->
+<exec executable="tools/findjava7.sh" outputproperty="java7home" />
 
 <!-- allow env.VOLTBUILD to override "build" property -->
 <envdefault prop="build" var="VOLTBUILD" default="release" />

--- a/build.xml
+++ b/build.xml
@@ -20,6 +20,8 @@
     <attribute name="includes" default=""/>
     <sequential>
         <javac
+            fork="yes"
+            executable="${java7home}/bin/javac"
             target="1.7"
             source="1.7"
             srcdir="@{srcdir}"
@@ -40,6 +42,9 @@
 
 <!-- make environment var foo available as env.foo -->
 <property environment="env"/>
+
+<!-- find the location of java7 -->
+<exec executable="tools/findjava7.sh" outputproperty="java7home" />
 
 <!-- allow env.VOLTBUILD to override "build" property -->
 <envdefault prop="build" var="VOLTBUILD" default="release" />

--- a/tools/findjava7.sh
+++ b/tools/findjava7.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#Find java7 home directory and writes it to stdout
+
+version=`javac -version 2>&1`
+
+if [[ $version == *"7"* ]]
+then
+    whichjavac=`which javac`
+    readlink -m $whichjavac/../..
+elif  [ -d '/usr/lib/jvm/java-1.7.0' ]
+then
+    jhome='/usr/lib/jvm/java-1.7.0'
+    echo $jhome
+    exit
+fi


### PR DESCRIPTION
Ant runs tools/findjava7.sh to find the java_home for java7 then uses this for the javac compilation step.