### PR TITLE
sql_coverage_test.py, SQLCoverageReport.py: keep track separately of

### DIFF
--- a/tests/scripts/sql_coverage_test.py
+++ b/tests/scripts/sql_coverage_test.py
@@ -355,6 +355,7 @@ def run_config(suite_name, config, basedir, output_dir, random_seed, report_all,
                       gray_zero_html_table_element + gray_zero_html_table_element +
                       gray_zero_html_table_element + gray_zero_html_table_element +
                       gray_zero_html_table_element + gray_zero_html_table_element +
+                      gray_zero_html_table_element +
                       get_numerical_html_table_element(num_crashes, error_above=0) + someStats + '</tr>' )
         success = {"keyStats": errorStats, "mis": -1}
 
@@ -392,7 +393,8 @@ def run_config(suite_name, config, basedir, output_dir, random_seed, report_all,
     global invalid_statements
     global mismatched_statements
     global keyStats_start_index
-    global total_num_npes
+    global total_volt_npes
+    global total_cmp_npes
     global total_num_crashes
     global total_num_inserts
     global total_num_patterns
@@ -406,7 +408,8 @@ def run_config(suite_name, config, basedir, output_dir, random_seed, report_all,
     total_statements      += int(next_keyStats_column_value())
     mismatched_statements += int(next_keyStats_column_value())
     next_keyStats_column_value()  # ignore Mismatched %
-    total_num_npes        += int(next_keyStats_column_value())
+    total_volt_npes       += int(next_keyStats_column_value())
+    total_cmp_npes        += int(next_keyStats_column_value())
     total_num_crashes     += num_crashes
     total_num_inserts     += num_inserts
     total_num_patterns    += num_patterns
@@ -614,7 +617,8 @@ if __name__ == "__main__":
     invalid_statements = 0
     mismatched_statements = 0
     total_statements = 0
-    total_num_npes = 0
+    total_volt_npes = 0
+    total_cmp_npes = 0
     total_num_crashes  = 0
     total_num_inserts  = 0
     total_num_patterns = 0
@@ -735,7 +739,8 @@ if __name__ == "__main__":
                            "\n<td align=right>" + str(total_statements) + "</td>" + \
                            "\n<td align=right>" + str(mismatched_statements) + "</td>" + \
                            "\n<td align=right>" + mismatched_percent + "%</td>" + \
-                           "\n<td align=right>" + str(total_num_npes) + "</td>" + \
+                           "\n<td align=right>" + str(total_volt_npes) + "</td>" + \
+                           "\n<td align=right>" + str(total_cmp_npes) + "</td>" + \
                            "\n<td align=right>" + str(total_num_crashes) + "</td>" + \
                            "\n<td align=right>" + str(min_all_statements_per_pattern) + "</td>" + \
                            "\n<td align=right>" + str(max_all_statements_per_pattern) + "</td>" + \
@@ -755,12 +760,18 @@ if __name__ == "__main__":
     print_seconds(total_compar_time, "for comparing ALL DB results")
     print_elapsed_seconds("for generating the output report", time1, "Total   time: ")
     print_elapsed_seconds("for the entire run", time0, "Total   time: ")
-    if total_num_npes > 0:
-        print "Total number of (VoltDB or " + comparison_database + ") NullPointerExceptions (NPEs): %d" % total_num_npes
+    if total_cmp_npes > 0:
+        print "Total number of " + comparison_database + " NullPointerExceptions (NPEs): %d" % total_cmp_npes
+    if total_volt_npes > 0:
+        success = False
+        print "Total number of VoltDB NullPointerExceptions (NPEs): %d" % total_volt_npes
+    if mismatched_statements > 0:
+        print "Total number of mismatched statements (i.e., test failures): %d" % mismatched_statements
     if total_num_crashes > 0:
         print "Total number of (VoltDB, " + comparison_database + ", or compare results) crashes: %d" % total_num_crashes
 
     if not success:
+        sys.stdout.flush()
+        sys.stderr.flush()
         print >> sys.stderr, "SQL coverage has errors."
         exit(1)
-


### PR DESCRIPTION
NPE's from VoltDB and from the comparison database (HSqlDB or
PostgreSQL), and now fail (& red, in the HTML "SQL Coverage Test
Summary") for the former, and a strong warning (in orange) for the
latter. Also, add a command-line message giving the total number of
mismatches, when that is greater than zero (matching the ones for NPE's
- 2 separate ones, now - and for crashes).