### PR TITLE
points.in, points.sql, points.outbaseline: drop procedure make_point and

### DIFF
--- a/tests/sqlcmd/baselines/geospatial/points.outbaseline
+++ b/tests/sqlcmd/baselines/geospatial/points.outbaseline
@@ -1,6 +1,9 @@
 
 FILE scripts/geospatial/points.sql
 
+drop procedure make_point if exists;
+Command succeeded.
+
 drop table points if exists;
 Command succeeded.
 
@@ -57,3 +60,9 @@ ID   LOCATION
  200 NULL                    
 
 (Returned 6 rows in #.##s)
+
+drop procedure make_point;
+Command succeeded.
+
+drop table points;
+Command succeeded.

--- a/tests/sqlcmd/scripts/geospatial/points.in
+++ b/tests/sqlcmd/scripts/geospatial/points.in
@@ -20,3 +20,5 @@ exec make_point 200 null;
 
 select * from points;
 
+drop procedure make_point;
+drop table points;

--- a/tests/sqlcmd/scripts/geospatial/points.sql
+++ b/tests/sqlcmd/scripts/geospatial/points.sql
@@ -1,3 +1,4 @@
+drop procedure make_point if exists;
 drop table points if exists;
 
 create table points (


### PR DESCRIPTION
table points at the end (to clean up); also, drop both "if exists", at
the beginning (this was already done for table points, so just added
procedure make_point).