### PR TITLE
Swap latitude and longitude in geo points.

### DIFF
--- a/src/ee/common/Point.hpp
+++ b/src/ee/common/Point.hpp
@@ -44,7 +44,7 @@ public:
     {
     }
 
-    Point(Coord latitude, Coord longitude)
+    Point(Coord longitude, Coord latitude)
         : m_latitude(latitude)
         , m_longitude(longitude)
     {
@@ -124,13 +124,13 @@ public:
 
     template<class Deserializer>
     static Point deserializeFrom(Deserializer& input) {
-        Coord lat = input.readDouble();
         Coord lng = input.readDouble();
+        Coord lat = input.readDouble();
         if (lat == nullCoord() && lng == nullCoord()) {
             return Point();
         }
 
-        return Point(lat, lng);
+        return Point(lng, lat);
     }
 
     template<class Serializer>

--- a/src/ee/common/Point.hpp
+++ b/src/ee/common/Point.hpp
@@ -89,7 +89,7 @@ public:
     }
 
     S2Point toS2Point() const {
-    	// Note: This is for S2LatLng.  So latitude is first and longitude is second.
+        // Note: This is for S2LatLng.  So latitude is first and longitude is second.
         return S2LatLng::FromDegrees(getLatitude(), getLongitude()).ToPoint();
     }
 

--- a/src/ee/common/Point.hpp
+++ b/src/ee/common/Point.hpp
@@ -89,6 +89,7 @@ public:
     }
 
     S2Point toS2Point() const {
+    	// Note: This is for S2LatLng.  So latitude is first and longitude is second.
         return S2LatLng::FromDegrees(getLatitude(), getLongitude()).ToPoint();
     }
 
@@ -98,6 +99,17 @@ public:
         assert(! isNull());
         assert(! rhs.isNull());
 
+        Coord lhsLong = getLongitude();
+        Coord rhsLong = rhs.getLongitude();
+        if (lhsLong < rhsLong) {
+            return VALUE_COMPARE_LESSTHAN;
+        }
+
+        if (lhsLong > rhsLong) {
+            return VALUE_COMPARE_GREATERTHAN;
+        }
+
+        // latitude is equal; compare longitude
         Coord lhsLat = getLatitude();
         Coord rhsLat = rhs.getLatitude();
         if (lhsLat < rhsLat) {
@@ -105,17 +117,6 @@ public:
         }
 
         if (lhsLat > rhsLat) {
-            return VALUE_COMPARE_GREATERTHAN;
-        }
-
-        // latitude is equal; compare longitude
-        Coord lhsLng = getLongitude();
-        Coord rhsLng = rhs.getLongitude();
-        if (lhsLng < rhsLng) {
-            return VALUE_COMPARE_LESSTHAN;
-        }
-
-        if (lhsLng > rhsLng) {
             return VALUE_COMPARE_GREATERTHAN;
         }
 
@@ -135,18 +136,18 @@ public:
 
     template<class Serializer>
     void serializeTo(Serializer& output) const {
-        output.writeDouble(getLatitude());
         output.writeDouble(getLongitude());
+        output.writeDouble(getLatitude());
     }
 
     void hashCombine(std::size_t& seed) const {
-        MiscUtil::hashCombineFloatingPoint(seed, m_latitude);
         MiscUtil::hashCombineFloatingPoint(seed, m_longitude);
+        MiscUtil::hashCombineFloatingPoint(seed, m_latitude);
     }
 
     std::string toString() const {
         std::ostringstream oss;
-        oss << "point(" << m_latitude << " " << m_longitude << ")";
+        oss << "point(" << m_longitude << " " << m_latitude << ")";
         return oss.str();
     }
 

--- a/src/ee/expressions/geofunctions.cpp
+++ b/src/ee/expressions/geofunctions.cpp
@@ -102,10 +102,10 @@ template<> NValue NValue::callUnary<FUNC_VOLT_POINTFROMTEXT>() const
     ++it;
 
 
-    Point::Coord lat = stringToCoord(POINT, wkt, *it);
+    Point::Coord lng = stringToCoord(POINT, wkt, *it);
     ++it;
 
-    Point::Coord lng = stringToCoord(POINT, wkt, *it);
+    Point::Coord lat = stringToCoord(POINT, wkt, *it);
     ++it;
 
     if (! boost::iequals(*it, ")")) {
@@ -118,7 +118,7 @@ template<> NValue NValue::callUnary<FUNC_VOLT_POINTFROMTEXT>() const
     }
 
     NValue returnValue(VALUE_TYPE_POINT);
-    returnValue.getPoint() = Point(lat, lng);
+    returnValue.getPoint() = Point(lng, lat);
 
     return returnValue;
 }
@@ -135,12 +135,14 @@ static void readLoop(const std::string &wkt,
 
     std::vector<S2Point> points;
     while (it != end && *it != ")") {
-        Point::Coord lat = stringToCoord(POLY, wkt, *it);
-        ++it;
-
         Point::Coord lng = stringToCoord(POLY, wkt, *it);
         ++it;
 
+        Point::Coord lat = stringToCoord(POLY, wkt, *it);
+        ++it;
+
+        // Note: This is S2.  It takes latitude, longitude, not
+        //       longitude, latitude.
         points.push_back(S2LatLng::FromDegrees(lat, lng).ToPoint());
 
         if (*it == ",") {

--- a/src/frontend/org/voltdb/types/GeographyValue.java
+++ b/src/frontend/org/voltdb/types/GeographyValue.java
@@ -290,7 +290,7 @@ public class GeographyValue {
 
             double latDegrees = latRadians * (180 / Math.PI);
             double lngDegrees = lngRadians * (180 / Math.PI);
-            return new PointType(latDegrees, lngDegrees);
+            return new PointType(lngDegrees, latDegrees);
         }
     }
 
@@ -429,13 +429,13 @@ public class GeographyValue {
                         throw new IllegalArgumentException(msgPrefix + "missing opening parenthesis");
                     }
 
-                    double lat = tokenizer.nval;
+                    double lng = tokenizer.nval;
                     token = tokenizer.nextToken();
                     if (token != StreamTokenizer.TT_NUMBER) {
                         throw new IllegalArgumentException(msgPrefix + "missing longitude in lat long pair");
                     }
-                    double lng = tokenizer.nval;
-                    currentLoop.add(XYZPoint.fromPointType(new PointType(lat, lng)));
+                    double lat = tokenizer.nval;
+                    currentLoop.add(XYZPoint.fromPointType(new PointType(lng, lat)));
 
                     token = tokenizer.nextToken();
                     if (token != ',') {

--- a/src/frontend/org/voltdb/types/GeographyValue.java
+++ b/src/frontend/org/voltdb/types/GeographyValue.java
@@ -118,12 +118,12 @@ public class GeographyValue {
 
             sb.append("(");
             for (XYZPoint xyz : loop) {
-                sb.append(xyz.toPointType().formatLatLng());
+                sb.append(xyz.toPointType().formatLngLat());
                 sb.append(", ");
             }
 
             // Repeat the first vertex to close the loop as WKT requires.
-            sb.append(loop.get(0).toPointType().formatLatLng());
+            sb.append(loop.get(0).toPointType().formatLngLat());
             sb.append(")");
         }
 

--- a/src/frontend/org/voltdb/types/PointType.java
+++ b/src/frontend/org/voltdb/types/PointType.java
@@ -104,7 +104,7 @@ public class PointType {
         return m_longitude;
     }
 
-    public String formatLatLng() {
+    public String formatLngLat() {
         // Display a maximum of 9 decimal digits after the point.
         // This gives us precision of around 1 mm.
         DecimalFormat df = new DecimalFormat("##0.0########");
@@ -113,7 +113,7 @@ public class PointType {
 
     @Override
     public String toString() {
-        return "POINT (" + formatLatLng() + ")";
+        return "POINT (" + formatLngLat() + ")";
     }
 
     // Returns true for two points that have the same latitude and

--- a/src/frontend/org/voltdb/types/PointType.java
+++ b/src/frontend/org/voltdb/types/PointType.java
@@ -56,7 +56,7 @@ public class PointType {
     // VoltTable.)
     static final double NULL_COORD = 360.0;
 
-    public PointType(double latitude, double longitude) {
+    public PointType(double longitude, double latitude) {
         m_latitude = latitude;
         m_longitude = longitude;
 
@@ -82,15 +82,15 @@ public class PointType {
         }
         Matcher m = wktPattern.matcher(param);
         if (m.find()) {
-            double latitude  = toDouble(m.group(1), m.group(2));
-            double longitude = toDouble(m.group(3), m.group(4));
+            double longitude  = toDouble(m.group(1), m.group(2));
+            double latitude = toDouble(m.group(3), m.group(4));
             if (Math.abs(latitude) > 90.0) {
                 throw new IllegalArgumentException(String.format("Latitude \"%f\" out of bounds.", latitude));
             }
             if (Math.abs(longitude) > 180.0) {
                 throw new IllegalArgumentException(String.format("Longitude \"%f\" out of bounds.", longitude));
             }
-            return new PointType(latitude, longitude);
+            return new PointType(longitude, latitude);
         } else {
             throw new IllegalArgumentException("Cannot construct PointType value from \"" + param + "\"");
         }
@@ -108,7 +108,7 @@ public class PointType {
         // Display a maximum of 9 decimal digits after the point.
         // This gives us precision of around 1 mm.
         DecimalFormat df = new DecimalFormat("##0.0########");
-        return df.format(m_latitude) + " " + df.format(m_longitude);
+        return df.format(m_longitude) + " " + df.format(m_latitude);
     }
 
     @Override
@@ -145,8 +145,8 @@ public class PointType {
      * @param buffer
      */
     public void flattenToBuffer(ByteBuffer buffer) {
-        buffer.putDouble(getLatitude());
         buffer.putDouble(getLongitude());
+        buffer.putDouble(getLatitude());
     }
 
     /**
@@ -156,14 +156,14 @@ public class PointType {
      * @return a new instance of PointType
      */
     public static PointType unflattenFromBuffer(ByteBuffer inBuffer, int offset) {
-        double lat = inBuffer.getDouble(offset);
-        double lng = inBuffer.getDouble(offset + BYTES_IN_A_COORD);
+        double lng = inBuffer.getDouble(offset);
+        double lat = inBuffer.getDouble(offset + BYTES_IN_A_COORD);
         if (lat == 360.0 && lng == 360.0) {
             // This is a null point.
             return null;
         }
 
-        return new PointType(lat, lng);
+        return new PointType(lng, lat);
     }
 
     /**
@@ -173,14 +173,14 @@ public class PointType {
      * @return a new instance of PointType
      */
     public static PointType unflattenFromBuffer(ByteBuffer inBuffer) {
-        double lat = inBuffer.getDouble();
         double lng = inBuffer.getDouble();
+        double lat = inBuffer.getDouble();
         if (lat == 360.0 && lng == 360.0) {
             // This is a null point.
             return null;
         }
 
-        return new PointType(lat, lng);
+        return new PointType(lng, lat);
     }
 
     /**

--- a/tests/frontend/org/voltdb/TestParameterConverter.java
+++ b/tests/frontend/org/voltdb/TestParameterConverter.java
@@ -151,10 +151,11 @@ public class TestParameterConverter extends TestCase
 
     public void testStringToPointType() throws Exception {
         double epsilon = 1.0e-3;
-        testOneStringToPoint("point(10.333 20.666)",               new PointType( 10.333,  20.666), epsilon);
-        testOneStringToPoint("  point  (10.333   20.666)    ",     new PointType( 10.333,  20.666), epsilon);
-        testOneStringToPoint("point(-10.333 -20.666)",             new PointType(-10.333, -20.666), epsilon);
-        testOneStringToPoint("  point  (-10.333   -20.666)    ",   new PointType(-10.333, -20.666), epsilon);
+        // The unfortunately eccentric spacing here is to test parsing white space.
+        testOneStringToPoint("point(20.666 10.333)",               new PointType( 20.666,  10.333), epsilon);
+        testOneStringToPoint("  point  (20.666 10.333)    ",       new PointType( 20.666,  10.333), epsilon);
+        testOneStringToPoint("point(-20.666 -10.333)",             new PointType(-20.666, -10.333), epsilon);
+        testOneStringToPoint("  point  (-20.666   -10.333)    ",   new PointType(-20.666, -10.333), epsilon);
         testOneStringToPoint("point(10 10)",                       new PointType(10.0,    10.0),    epsilon);
         testOneStringToPoint("point(10.0 10.0)",                   new PointType(10.0, 10.0),       epsilon);
         testOneStringToPoint("point(10 10)",                       new PointType(10.0, 10.0),       epsilon);
@@ -162,27 +163,27 @@ public class TestParameterConverter extends TestCase
     }
 
     public void testStringToPolygonType() throws Exception {
-        testOneStringToPolygon("polygon((0 0, 0 1, 1 1, 1 0, 0 0))",
+        testOneStringToPolygon("polygon((0 0, 1 0, 1 1, 0 1, 0 0))",
                                new GeographyValue(Collections.singletonList(Arrays.asList(new PointType[]{ new PointType(0,0),
-                                                                                                           new PointType(0, 1),
-                                                                                                           new PointType(1, 1),
                                                                                                            new PointType(1, 0),
+                                                                                                           new PointType(1, 1),
+                                                                                                           new PointType(0, 1),
                                                                                                            new PointType(0, 0) }))));
         GeographyValue geog;
         // The Bermuda Triangle
-        List<PointType> outerLoop = Arrays.asList(new PointType(32.305, -64.751),
-                                                  new PointType(25.244, -80.437),
-                                                  new PointType(18.476, -66.371),
-                                                  new PointType(32.305, -64.751));
+        List<PointType> outerLoop = Arrays.asList(new PointType(-64.751, 32.305),
+                                                  new PointType(-80.437, 25.244),
+                                                  new PointType(-66.371, 18.476),
+                                                  new PointType(-64.751, 32.305));
 
         // A triangular hole
-        List<PointType> innerLoop = Arrays.asList(new PointType(28.066, -68.874),
-                                                  new PointType(25.361, -68.855),
-                                                  new PointType(28.376, -73.381),
-                                                  new PointType(28.066, -68.874));
+        List<PointType> innerLoop = Arrays.asList(new PointType(-68.874, 28.066),
+                                                  new PointType(-68.855, 25.361),
+                                                  new PointType(-73.381, 28.376),
+                                                  new PointType(-68.874, 28.066));
 
         geog = new GeographyValue(Arrays.asList(outerLoop, innerLoop));
-        String geogRep = "POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751), " + "(28.066 -68.874, 25.361 -68.855, 28.376 -73.381, 28.066 -68.874))";
+        String geogRep = "POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), " + "(-68.874 28.066,-68.855 25.361, -73.381 28.376,-68.874 28.066))";
         testOneStringToPolygon(geogRep, geog);
         // round trip
         geog = new GeographyValue(geogRep);

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
@@ -39,39 +39,39 @@ public class TestGeographyValueQueries extends RegressionSuite {
     }
 
     private final String BERMUDA_TRIANGLE_WKT = "POLYGON("
-            + "(32.305 -64.751, "
-            + "25.244 -80.437, "
-            + "18.476 -66.371, "
-            + "32.305 -64.751))";
+            + "(-64.751 32.305, "
+            + "-80.437 25.244, "
+            + "-66.371 18.476, "
+            + "-64.751 32.305))";
 
     // The Bermuda Triangle with a square hole inside
     private final String BERMUDA_TRIANGLE_HOLE_WKT = "POLYGON("
-            + "(32.305 -64.751, "
-            + "25.244 -80.437, "
-            + "18.476 -66.371, "
-            + "32.305 -64.751), "
-            + "(27.026 -67.448, "
-            + "27.026 -68.992, "
-            + "25.968 -68.992, "
-            + "25.968 -67.448, "
-            + "27.026 -67.448))";
+            + "(-64.751 32.305, "
+            + "-80.437 25.244, "
+            + "-66.371 18.476, "
+            + "-64.751 32.305), "
+            + "(-67.448 27.026, "
+            + "-68.992 27.026, "
+            + "-68.992 25.968, "
+            + "-67.448 25.968, "
+            + "-67.448 27.026))";
 
     // (Useful for testing comparisons since it has the same number of vertices as
     // the Bermuda Triangle)
     private final String BILLERICA_TRIANGLE_WKT = "POLYGON("
-            + "(42.571 -71.276, "
-            + "42.547 -71.308, "
-            + "42.533 -71.231, "
-            + "42.571 -71.276))";
+            + "(-71.276 42.571, "
+            + "-71.308 42.547, "
+            + "-71.231 42.533, "
+            + "-71.276 42.571))";
 
     // The dreaded "Lowell Square".  One loop,
     // five vertices (last is the same as the first)
     private final String LOWELL_SQUARE_WKT = "POLYGON("
-            + "(42.641 -71.338, "
-            + "42.619 -71.340, "
-            + "42.617 -71.313, "
-            + "42.639 -71.316, "
-            + "42.641 -71.338))";
+            + "(-71.338 42.641, "
+            + "-71.340 42.619, "
+            + "-71.313 42.617, "
+            + "-71.316 42.639, "
+            + "-71.338 42.641))";
 
     private final GeographyValue BERMUDA_TRIANGLE_POLY = new GeographyValue(BERMUDA_TRIANGLE_WKT);
     private final GeographyValue BERMUDA_TRIANGLE_HOLE_POLY = new GeographyValue(BERMUDA_TRIANGLE_HOLE_WKT);
@@ -195,6 +195,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
             assertTrue(vt.advanceRow());
             assertEquals(0, vt.getLong(0));
             assertEquals("Bermuda Triangle", vt.getString(1));
+            String btString = vt.getGeographyValue(2).toString();
+            String testString = BERMUDA_TRIANGLE_WKT;
             assertEquals(BERMUDA_TRIANGLE_WKT, vt.getGeographyValue(2).toString());
             assertFalse(vt.advanceRow());
 
@@ -401,16 +403,16 @@ public class TestGeographyValueQueries extends RegressionSuite {
         Client client = getClient();
 
         String santaCruzWkt = "POLYGON("
-                + "(36.999 -122.061, "
-                + "36.950 -122.058, "
-                + "36.955 -121.974, "
-                + "36.999 -122.061))";
+                + "(-122.061 36.999, "
+                + "-122.058 36.950, "
+                + "-121.974 36.955, "
+                + "-122.061 36.999))";
 
         String southValleyWkt = "POLYGON("
-                + "(37.367 -122.038, "
-                + "37.232 -121.980, "
-                +" 37.339 -121.887, "
-                + "37.367 -122.038))";
+                + "(-122.038 37.367, "
+                + "-121.980 37.232, "
+                + "-121.887 37.339, "
+                + "-122.038 37.367))";
 
 
         for (String tbl : TABLES) {
@@ -511,34 +513,33 @@ public class TestGeographyValueQueries extends RegressionSuite {
         Client client = getClient();
         validateTableOfScalarLongs(client, "insert into t (pk) values (0)", new long[] {1});
 
-        String expected = "POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751))";
+        String expected = "POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305))";
 
         // Just a simple round trip with reasonable WKT.
         assertEquals(expected, wktRoundTrip(client, expected));
 
         // polygonfromtext should be case-insensitve.
         assertEquals(expected, wktRoundTrip(client,
-                "Polygon((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751))"));
+                "Polygon((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305))"));
         assertEquals(expected, wktRoundTrip(client,
-                "polygon((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751))"));
+                "polygon((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305))"));
         assertEquals(expected, wktRoundTrip(client,
-                "PoLyGoN((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751))"));
+                "PoLyGoN((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305))"));
 
         assertEquals(expected, wktRoundTrip(client,
-                "\n\nPOLYGON\n(\n(\n32.305\n-64.751\n,\n25.244\n-80.437\n,\n18.476\n-66.371\n,\n32.305\n-64.751\n)\n)\n"));
+                "\n\nPOLYGON\n(\n(\n-64.751\n32.305\n,\n-80.437\n25.244\n,\n-66.371\n18.476\n,\n-64.751\n32.305\n)\n)\n"));
         assertEquals(expected, wktRoundTrip(client,
-                "\t\tPOLYGON\t(\t(\t32.305\t-64.751\t,\t25.244\t-80.437\t,\t18.476\t-66.371\t,\t32.305\t-64.751\t)\t)\t"));
+                "\t\tPOLYGON\t(\t(\t-64.751\t32.305\t,\t-80.437\t25.244\t,\t-66.371\t18.476\t,\t-64.751\t32.305\t)\t)\t"));
         assertEquals(expected, wktRoundTrip(client,
-                "    POLYGON  (  (  32.305  -64.751  ,  25.244  -80.437  ,  18.476  -66.371  ,  32.305  -64.751  )  )  "));
+                "    POLYGON  (  (  -64.751  32.305  ,  -80.437  25.244  ,  -66.371  18.476  ,  -64.751  32.305  )  )  "));
 
         // Parsing with more than one loop should work the same.
-        expected = "POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751), "
-                + "(27.026 -67.448, 27.026 -68.992, 25.968 -68.992, 25.968 -67.448, 27.026 -67.448))";
+        expected = "POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), "
+                + "(-67.448 27.026, -68.992 27.026, -68.992 25.968, -67.448 25.968, -67.448 27.026))";
 
-        expected = BERMUDA_TRIANGLE_HOLE_WKT;
         assertEquals(expected, wktRoundTrip(client,
-                "PoLyGoN\t(  (\n32.305\n-64.751   ,    25.244\t-80.437\n,18.476 -66.371,32.305\t\t\t-64.751   ),\t "
-                        + "(\n27.026\t-67.448,\t27.026    -68.992\n,25.968      -68.992,25.968\n\n-67.448   ,   27.026\n-67.448\t)\n)\t"));
+                "PoLyGoN\t(  (\n-64.751\n32.305   ,    -80.437\t25.244\n,-66.371 18.476,-64.751\t\t\t32.305   ),\t "
+                        + "(\n-67.448\t27.026,\t-68.992    27.026\n, -68.992     25.968,-67.448\n\n25.968   , -67.448  \n27.026\t)\n)\t"));
     }
 
     private void assertWktParseError(Client client, String expectedMsg, String wkt) throws Exception {

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctions.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctions.java
@@ -72,60 +72,60 @@ public class TestGeospatialFunctions extends RegressionSuite {
      */
     private static Borders borders[] = {
         new Borders(0, "Colorado", new GeographyValue("POLYGON(("
-                                                  + "41.002 -102.052, "
-                                                  + "41.002 -109.045,"
-                                                  + "36.999 -109.045,"
-                                                  + "36.999 -102.052,"
-                                                  + "41.002 -102.052))")),
+                                                  + "-102.052 41.002, "
+                                                  + "-109.045 41.002,"
+                                                  + "-109.045 36.999,"
+                                                  + "-102.052 36.999,"
+                                                  + "-102.052 41.002))")),
         new Borders(1, "Wyoming", new GeographyValue("POLYGON(("
-                                                + "44.978 -104.061, "
-                                                + "44.978 -111.046, "
-                                                + "40.998 -111.046, "
-                                                + "40.998 -104.061, "
-                                                + "44.978 -104.061))")),
+                                                + "-104.061 44.978, "
+                                                + "-111.046 44.978, "
+                                                + "-111.046 40.998, "
+                                                + "-104.061 40.998, "
+                                                + "-104.061 44.978))")),
        new Borders(2, "Colorado with a hole around Denver",
                new GeographyValue("POLYGON("
-                                  + "(41.002 -102.052, "
-                                  + "41.002 -109.045,"
-                                  + "36.999 -109.045,"
-                                  + "36.999 -102.052,"
-                                  + "41.002 -102.052), "
-                                  + "(40.240 -104.035, "
-                                  + "40.240 -105.714, "
-                                  + "39.188 -105.714, "
-                                  + "39.188 -104.035,"
-                                  + "40.240 -104.035))")),
+                                  + "(-102.052 41.002, "
+                                  + "-109.045 41.002,"
+                                  + "-109.045 36.999,"
+                                  + "-102.052 36.999,"
+                                  + "-102.052 41.002), "
+                                  + "(-104.035 40.240, "
+                                  + "-105.714 40.240, "
+                                  + "-105.714 39.188, "
+                                  + "-104.035 39.188,"
+                                  + "-104.035 40.240))")),
        new Borders(3, "Wonderland", null)
     };
     private static void populateTables(Client client) throws Exception {
         client.callProcedure("places.Insert", 0, "Denver",
-                PointType.pointFromText("POINT(39.704 -104.959)"));
+                PointType.pointFromText("POINT(-104.959 39.704)"));
         client.callProcedure("places.Insert", 1, "Albuquerque",
-                PointType.pointFromText("POINT(35.113 -106.599)"));
+                PointType.pointFromText("POINT(-106.599 35.113)"));
         client.callProcedure("places.Insert", 2, "Cheyenne",
-                PointType.pointFromText("POINT(41.134 -104.813)"));
+                PointType.pointFromText("POINT(-104.813 41.134)"));
         client.callProcedure("places.Insert", 3, "Fort Collins",
-                PointType.pointFromText("POINT(40.585 -105.077)"));
+                PointType.pointFromText("POINT(-105.077 40.585)"));
         client.callProcedure("places.Insert", 4, "Point near N Colorado border",
-                PointType.pointFromText("POINT(41.002 -105.04)"));
+                PointType.pointFromText("POINT(-105.04 41.002)"));
         client.callProcedure("places.Insert", 5, "Point Not On N Colorado Border",
-                PointType.pointFromText("POINT(41.005 -109.025)"));
+                PointType.pointFromText("POINT(-109.025 41.005)"));
         client.callProcedure("places.Insert", 6, "Point on N Wyoming Border",
-                PointType.pointFromText("POINT(44.978 -105.058)"));
+                PointType.pointFromText("POINT(-105.058 44.978)"));
         client.callProcedure("places.Insert", 7, "North Point Not On Wyoming Border",
-                PointType.pointFromText("POINT(45.119 -105.060)"));
+                PointType.pointFromText("POINT(-105.060 45.119)"));
         client.callProcedure("places.Insert", 8, "Point on E Wyoming Border",
-                PointType.pointFromText("POINT(42.988 -104.078)"));
+                PointType.pointFromText("POINT(-104.078 42.988)"));
         client.callProcedure("places.Insert", 9, "East Point Not On Wyoming Border",
-                PointType.pointFromText("POINT(42.986 -104.061)"));
+                PointType.pointFromText("POINT(-104.061 42.986)"));
         client.callProcedure("places.Insert", 10, "Point On S Wyoming Border",
-                PointType.pointFromText("POINT(41.099 -110.998)"));
+                PointType.pointFromText("POINT(-110.998 41.099)"));
         client.callProcedure("places.Insert", 11, "Point On S Colorado Border",
-                PointType.pointFromText("POINT(37.002 -103.008)"));
+                PointType.pointFromText("POINT(-103.008 37.002)"));
         client.callProcedure("places.Insert", 12, "Point On W Wyoming Border",
-                PointType.pointFromText("POINT(42.999 -110.998)"));
+                PointType.pointFromText("POINT(-110.998 42.999)"));
         client.callProcedure("places.Insert", 13, "West not On South Wyoming Border",
-                PointType.pointFromText("POINT(41.999 -111.052)"));
+                PointType.pointFromText("POINT(-111.052 41.999)"));
 
         // A null-valued point
         client.callProcedure("places.Insert", 99, "Neverwhere", null);
@@ -221,43 +221,43 @@ public class TestGeospatialFunctions extends RegressionSuite {
         Client client = getClient();
         populateTables(client);
 
-        String sql = "select places.name, LATITUDE(places.loc), LONGITUDE(places.loc) "
+        String sql = "select places.name, LONGITUDE(places.loc), LATITUDE(places.loc) "
                         + "from places order by places.pk";
         VoltTable vt = client.callProcedure("@AdHoc", sql).getResults()[0];
         assertContentOfTable(new Object[][]
-                {{"Denver",                             39.704, -104.959},
-                 {"Albuquerque",                        35.113, -106.599},
-                 {"Cheyenne",                           41.134, -104.813},
-                 {"Fort Collins",                       40.585, -105.077},
-                 {"Point near N Colorado border",       41.002, -105.04},
-                 {"Point Not On N Colorado Border",     41.005, -109.025},
-                 {"Point on N Wyoming Border",          44.978, -105.058},
-                 {"North Point Not On Wyoming Border",  45.119, -105.06},
-                 {"Point on E Wyoming Border",          42.988, -104.078},
-                 {"East Point Not On Wyoming Border",   42.986, -104.061},
-                 {"Point On S Wyoming Border",          41.099, -110.998},
-                 {"Point On S Colorado Border",         37.002, -103.008},
-                 {"Point On W Wyoming Border",          42.999, -110.998},
-                 {"West not On South Wyoming Border",   41.999, -111.052},
-                 {"Neverwhere",     Double.MIN_VALUE,   Double.MIN_VALUE},
-                }, vt);
+            {{"Denver",                             -104.959, 39.704},
+             {"Albuquerque",                        -106.599, 35.113},
+             {"Cheyenne",                           -104.813, 41.134},
+             {"Fort Collins",                       -105.077, 40.585},
+             {"Point near N Colorado border",       -105.04, 41.002},
+             {"Point Not On N Colorado Border",     -109.025, 41.005},
+             {"Point on N Wyoming Border",          -105.058, 44.978},
+             {"North Point Not On Wyoming Border",  -105.06, 45.119},
+             {"Point on E Wyoming Border",          -104.078, 42.988},
+             {"East Point Not On Wyoming Border",   -104.061, 42.986},
+             {"Point On S Wyoming Border",          -110.998, 41.099},
+             {"Point On S Colorado Border",         -103.008, 37.002},
+             {"Point On W Wyoming Border",          -110.998, 42.999},
+             {"West not On South Wyoming Border",   -111.052, 41.999},
+             {"Neverwhere",     Double.MIN_VALUE,   Double.MIN_VALUE},
+            }, vt);
 
-        sql = "select places.name, LATITUDE(places.loc), LONGITUDE(places.loc) "
+        sql = "select places.name, LONGITUDE(places.loc), LATITUDE(places.loc) "
                 + "from places, borders "
                 + "where contains(borders.region, places.loc) "
                 + "group by places.name, places.loc "
                 + "order by places.name";
         vt = client.callProcedure("@AdHoc", sql).getResults()[0];
         assertContentOfTable(new Object[][]
-                {{"Cheyenne",                       41.134,  -104.813},
-                 {"Denver",                         39.704,  -104.959},
-                 {"Fort Collins",                   40.585, -105.077},
-                 {"Point On S Wyoming Border",      41.099, -110.998},
-                 {"Point On W Wyoming Border",      42.999, -110.998},
-                 {"Point near N Colorado border",   41.002, -105.04},
-                 {"Point on E Wyoming Border",      42.988, -104.078},
-                 {"Point on N Wyoming Border",      44.978, -105.058},
-                }, vt);
+            {{"Cheyenne",                       -104.813, 41.134 },
+             {"Denver",                         -104.959, 39.704 },
+             {"Fort Collins",                   -105.077, 40.585},
+             {"Point On S Wyoming Border",      -110.998, 41.099},
+             {"Point On W Wyoming Border",      -110.998, 42.999},
+             {"Point near N Colorado border",   -105.04, 41.002},
+             {"Point on E Wyoming Border",      -104.078, 42.988},
+             {"Point on N Wyoming Border",      -105.058, 44.978},
+            }, vt);
     }
 
     public void testPolygonFloatingPrecision() throws Exception {
@@ -278,26 +278,46 @@ public class TestGeospatialFunctions extends RegressionSuite {
     }
 
     public void testPolygonCentroidAndArea() throws Exception {
+        // The AREA_EPSILON here is 1.0e-1, because the values are in the range
+        // 1.0e11, and we expect 1.0e12 precision.
+        final double AREA_EPSILON=1.0e-1;
         Client client = getClient();
         populateTables(client);
 
-        String sql = "select borders.name, Area(borders.region), LATITUDE(centroid(borders.region)), LONGITUDE(centroid(borders.region)) "
+        String sql = "select borders.name, Area(borders.region) "
                         + "from borders order by borders.pk";
         VoltTable vt = client.callProcedure("@AdHoc", sql).getResults()[0];
         // in the calculation below, areas of states are close to actual area of the state (vertices
         // used for polygon are close approximations, not exact, values of the state vertices).
         // Area for Colorado - 269601 sq km and Wyoming 253350 sq km
-        // For centroid, the value in table is based on the answer provide by S2 for the given polygons
-        assertContentOfTable(new Object[][]
-                {{ "Colorado",      2.6886542912139893E11,  39.03372408765194,      -105.5485 },
-                 { "Wyoming",       2.5126863189309894E11,  43.01953179182205,      -107.55349999999999 },
+        assertApproximateContentOfTable(new Object[][]
+                {{ "Colorado",      2.6886542912139893E11},
+                 { "Wyoming",       2.5126863189309894E11},
                  { "Colorado with a hole around Denver",
-                                    2.5206603914764166E11,  38.98811213712535,      -105.5929789796371 },
-                 { "Wonderland",    Double.MIN_VALUE,       Double.MIN_VALUE,       Double.MIN_VALUE},
-                }, vt);
+                                    2.5206603914764166E11},
+                 { "Wonderland",    Double.MIN_VALUE},
+                }, vt, AREA_EPSILON);
+        // Test the centroids.  For centroid, the value in table is based on the answer provide by S2 for the given polygons
+        // The CENTROID relative precision is greater than the AREA relative precision.
+        final double CENTROID_EPSILON=1.0e-12;
+        sql = "select borders.name, LATITUDE(centroid(borders.region)), LONGITUDE(centroid(borders.region)) "
+                + "from borders order by borders.pk";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        assertApproximateContentOfTable(new Object[][]
+                {{ "Colorado",      39.03372408765194,      -105.5485 },
+                 { "Wyoming",       43.01953179182205,      -107.55349999999999 },
+                 { "Colorado with a hole around Denver",
+                                    38.98811213712535,      -105.5929789796371 },
+                 { "Wonderland",    Double.MIN_VALUE,       Double.MIN_VALUE},
+                }, vt, CENTROID_EPSILON);
     }
 
     public void testPolygonPointDistance() throws Exception {
+        // The distances we consider are all in the thousands of square
+        // meters.  We expect 1.0e-12 precision, so that's 1.0e-8 relative
+        // precision.  Note that we have determined empirically that
+        // 1.0e-9 fails.
+        final double DISTANCE_EPSILON = 1.0e-8;
         Client client = getClient();
         populateTables(client);
 
@@ -308,7 +328,7 @@ public class TestGeospatialFunctions extends RegressionSuite {
                 + "from borders, places where borders.pk = 1"
                 + "order by distance, places.pk";
         vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        assertContentOfTable(new Object[][]
+        assertApproximateContentOfTable(new Object[][]
                 {{"Wyoming",    "Neverwhere",                       Double.MIN_VALUE},
                  {"Wyoming",    "Cheyenne",                         0.0},
                  {"Wyoming",    "Point on N Wyoming Border",        0.0},
@@ -325,7 +345,7 @@ public class TestGeospatialFunctions extends RegressionSuite {
                  {"Wyoming",    "Point On S Colorado Border",       453545.4800250064},
                  {"Wyoming",    "Albuquerque",                      659769.4012428687}
 
-                }, vt);
+                }, vt, DISTANCE_EPSILON);
 
         // Validate result set obtained using distance between point and polygon is same as
         // distance between polygon and point
@@ -346,7 +366,7 @@ public class TestGeospatialFunctions extends RegressionSuite {
                 + "from borders, places where contains(borders.region, places.loc) "
                 + "order by distance";
         vt = client.callProcedure("@AdHoc", sql).getResults()[0];
-        assertContentOfTable(new Object[][]
+        assertApproximateContentOfTable(new Object[][]
                 {{"Colorado",   "Denver",                               90126.31686125314},
                  {"Colorado",   "Fort Collins",                         177132.44115469826},
                  {"Colorado with a hole around Denver", "Fort Collins", 182956.3035588355},
@@ -358,7 +378,7 @@ public class TestGeospatialFunctions extends RegressionSuite {
                  {"Wyoming",    "Point on N Wyoming Border",            295383.69047235645},
                  {"Wyoming",    "Cheyenne",                             308378.4910583776},
                  {"Wyoming",    "Point On S Wyoming Border",            355573.95574694296}
-                }, vt);
+                }, vt, DISTANCE_EPSILON);
 
         // distance between polygon and polygon - currently not supported and should generate
         // exception saying incompatible data type supplied

--- a/tests/frontend/org/voltdb/regressionsuites/TestPointType.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestPointType.java
@@ -38,9 +38,9 @@ public class TestPointType extends RegressionSuite {
         super(name);
     }
 
-    private static final PointType BEDFORD_PT = new PointType(42.4906, -71.2767);
-    private static final PointType SANTA_CLARA_PT = new PointType(37.3544, -121.9692);
-    private static final PointType LOWELL_PT = new PointType(42.6200, -71.3273);
+    private static final PointType BEDFORD_PT = new PointType(-71.2767, 42.4906);
+    private static final PointType SANTA_CLARA_PT = new PointType(-121.9692, 37.3544);
+    private static final PointType LOWELL_PT = new PointType(-71.3273, 42.6200);
 
     private int fillTable(Client client, int startPk) throws Exception {
         validateTableOfScalarLongs(client,
@@ -104,7 +104,7 @@ public class TestPointType extends RegressionSuite {
                 new long[] {1});
 
         VoltTable vt = client.callProcedure("@AdHoc",
-                "select pointfromtext('point (42.4906 -71.2767)') from t;").getResults()[0];
+                "select pointfromtext('point (-71.2767 42.4906)') from t;").getResults()[0];
         assertTrue(vt.advanceRow());
         PointType pt = vt.getPoint(0);
         assertFalse(vt.wasNull());
@@ -241,8 +241,8 @@ public class TestPointType extends RegressionSuite {
 
         fillTable(client, 0);
 
-        final PointType CAMBRIDGE_PT = new PointType(42.3736, -71.1106);
-        final PointType SAN_JOSE_PT = new PointType(37.3362, -121.8906);
+        final PointType CAMBRIDGE_PT = new PointType(-71.1106, 42.3736);
+        final PointType SAN_JOSE_PT = new PointType(-121.8906, 37.3362);
 
         validateTableOfScalarLongs(client,
                 "update t set "
@@ -295,7 +295,7 @@ public class TestPointType extends RegressionSuite {
                 "CONSTRAINT VIOLATION");
 
         validateTableOfScalarLongs(client,
-                "insert into t_not_null (pk, name, pt) values (0, 'Singapore', pointfromtext('point(1.2905 103.8521)'))",
+                "insert into t_not_null (pk, name, pt) values (0, 'Singapore', pointfromtext('point(103.8521 1.2905)'))",
                 new long[] {1});
 
         VoltTable vt = client.callProcedure("@AdHoc",
@@ -303,7 +303,7 @@ public class TestPointType extends RegressionSuite {
                 .getResults()[0];
 
         assertContentOfTable (new Object[][] {
-                {0, "Singapore", new PointType(1.2905, 103.8521)}},
+                {0, "Singapore", new PointType(103.8521, 1.2905)}},
                 vt);
     }
 

--- a/tests/frontend/org/voltdb/types/TestGeographyValue.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyValue.java
@@ -35,28 +35,28 @@ public class TestGeographyValue extends TestCase {
         GeographyValue geog;
         // The Bermuda Triangle
         List<PointType> outerLoop = Arrays.asList(
-                new PointType(32.305, -64.751),
-                new PointType(25.244, -80.437),
-                new PointType(18.476, -66.371),
-                new PointType(32.305, -64.751));
+                new PointType(-64.751, 32.305),
+                new PointType(-80.437, 25.244),
+                new PointType(-66.371, 18.476),
+                new PointType(-64.751, 32.305));
 
         // A triangular hole
         List<PointType> innerLoop = Arrays.asList(
-                new PointType(28.066, -68.874),
-                new PointType(25.361, -68.855),
-                new PointType(28.376, -73.381),
-                new PointType(28.066, -68.874));
+                new PointType(-68.874, 28.066),
+                new PointType(-68.855, 25.361),
+                new PointType(-73.381, 28.376),
+                new PointType(-68.874, 28.066));
 
         geog = new GeographyValue(Arrays.asList(outerLoop, innerLoop));
-        assertEquals("POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751), "
-                + "(28.066 -68.874, 25.361 -68.855, 28.376 -73.381, 28.066 -68.874))",
+        assertEquals("POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), "
+                + "(-68.874 28.066, -68.855 25.361, -73.381 28.376, -68.874 28.066))",
                 geog.toString());
 
         // round trip
-        geog = new GeographyValue("POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751), "
-                + "(28.066 -68.874, 25.361 -68.855, 28.376 -73.381, 28.066 -68.874))");
-        assertEquals("POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751), "
-                + "(28.066 -68.874, 25.361 -68.855, 28.376 -73.381, 28.066 -68.874))",
+        geog = new GeographyValue("POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), "
+                + "(-68.874 28.066,-68.855 25.361, -73.381 28.376, -68.874 28.066))");
+        assertEquals("POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), "
+                + "(-68.874 28.066,-68.855 25.361, -73.381 28.376, -68.874 28.066))",
                 geog.toString());
 
         ByteBuffer buf = ByteBuffer.allocate(geog.getLengthInBytes());
@@ -65,16 +65,16 @@ public class TestGeographyValue extends TestCase {
 
         buf.position(0);
         GeographyValue newGeog = GeographyValue.unflattenFromBuffer(buf);
-        assertEquals("POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751), "
-                + "(28.066 -68.874, 25.361 -68.855, 28.376 -73.381, 28.066 -68.874))",
+        assertEquals("POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), "
+                + "(-68.874 28.066, -68.855 25.361, -73.381 28.376, -68.874 28.066))",
                 newGeog.toString());
         assertEquals(270, buf.position());
 
         // Try the absolute version of unflattening
         buf.position(77);
         newGeog = GeographyValue.unflattenFromBuffer(buf, 0);
-        assertEquals("POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751), "
-                + "(28.066 -68.874, 25.361 -68.855, 28.376 -73.381, 28.066 -68.874))",
+        assertEquals("POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, 32.305  -64.751, "
+                + "(-68.874 28.066, -68.855 25.361, -73.381 28.376, -68.874 28.066))",
                 newGeog.toString());
         assertEquals(77, buf.position());
     }
@@ -86,21 +86,21 @@ public class TestGeographyValue extends TestCase {
     public void testWktParsingPositive() {
 
         // Parsing is case-insensitive
-        String expected = "POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751))";
-        assertEquals(expected, canonicalizeWkt("Polygon((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751))"));
-        assertEquals(expected, canonicalizeWkt("polygon((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751))"));
-        assertEquals(expected, canonicalizeWkt("PoLyGoN((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751))"));
+        String expected = "POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305))";
+        assertEquals(expected, canonicalizeWkt("Polygon((-64.751 32.305,-80.437  25.244,-66.371  18.476,-64.751  32.305))"));
+        assertEquals(expected, canonicalizeWkt("polygon((-64.751 32.305,-80.437  25.244,-66.371  18.476,-64.751  32.305))"));
+        assertEquals(expected, canonicalizeWkt("PoLyGoN((-64.751 32.305,-80.437  25.244,-66.371  18.476,-64.751  32.305))"));
 
         // Parsing is whitespace-insensitive
-        assertEquals(expected, canonicalizeWkt("  POLYGON  (  (  32.305  -64.751  ,  25.244  -80.437  ,  18.476  -66.371  ,  32.305   -64.751  )  ) "));
-        assertEquals(expected, canonicalizeWkt("\nPOLYGON\n(\n(\n32.305\n-64.751\n,\n25.244\n-80.437\n,\n18.476\n-66.371\n,32.305\n-64.751\n)\n)\n"));
-        assertEquals(expected, canonicalizeWkt("\tPOLYGON\t(\t(\t32.305\t-64.751\t,\t25.244\t-80.437\t,\t18.476\t-66.371\t,\t32.305\t-64.751\t)\t)\t"));
+        assertEquals(expected, canonicalizeWkt("  POLYGON  (  (   32.305  -64.751 ,   25.244  -80.437 ,   18.476  -66.371 ,   32.305   -64.751 )  ) "));
+        assertEquals(expected, canonicalizeWkt("\nPOLYGON\n(\n(\n-64.751\n32.305\n,\n-80.437\n25.244\n,\n-66.371\n18.476\n,-64.751\n32.305\n)\n)\n"));
+        assertEquals(expected, canonicalizeWkt("\tPOLYGON\t(\t(\t-64.751\t32.305\t,\t-80.437\t25.244\t,\t-66.371\t18.476\t,\t-64.751\t32.305\t)\t)\t"));
 
         // Parsing with more than one loop should work the same.
-        expected = "POLYGON((32.305 -64.751, 25.244 -80.437, 18.476 -66.371, 32.305 -64.751), "
-                + "(28.066 -68.874, 25.361 -68.855, 28.376 -73.381, 28.066 -68.874))";
-        assertEquals(expected, canonicalizeWkt("PoLyGoN\t(  (\n32.305\n-64.751   ,    25.244\t-80.437\n,18.476-66.371,32.305\t\t\t-64.751   ),\t "
-                + "(\n28.066-68.874,\t25.361    -68.855\n,28.376      -73.381,28.066\n\n-68.874\t)\n)\t"));
+        expected = "POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), "
+                + "(-68.874 28.066, -68.855 25.361, -73.381 28.376, -68.874 28.066 ))";
+        assertEquals(expected, canonicalizeWkt("PoLyGoN\t(  (\n-64.751\n32.305   ,    25.244\t-80.437\n, -66.371 18.476,-64.751\t\t\t32.305   ),\t "
+                + "(\n-68.874 28.066,\t    -68.855\n25.361\n,      -73.381\t28.376,\n\n-68.874\t28.066\t)\n)\t"));
     }
 
     private void assertWktParseError(String error, String wkt) {
@@ -114,64 +114,6 @@ public class TestGeographyValue extends TestCase {
                     + "in exception message\n"
                     + "  \"" + iae.getMessage() + "\"\n",
                     iae.getMessage().contains(error));
-        }
-    }
-    /**
-     * This tests that the maximum error when we transform a latitude/longitude pair to an
-     * S2, 3-dimensinal point and then back again is less than 1.0e-13.
-     *
-     * We sample the sphere, looking at NUM_PTS X NUM_PTS pairs.  At each pair, <m, n>,
-     * we calculate a latitude and longitude, convert the PointType with this latitude and
-     * longitude to an XYZPoint, and then back.  We then take the maximum error over the
-     * entire sphere.
-     *
-     * Setting NUM_PTS to 2000000 is a very bad idea.
-     *
-     * The error bound is 1.0e-13, which is the value of EPSILON below.  We tested 1.0e-14,
-     * but that fails.
-     *
-     * Note that no conversions from text to floating point happen anywhere here, so that
-     * is not a source of precision loss.  Only calculation cause these precision losses.
-     *
-     * @throws Exception
-     */
-    public void testXYZPoint() throws Exception {
-        final double EPSILON = 1.0e-13;
-        // We transform from latitude, longitude to XYZ this many
-        // times for each point.  This could be set higher.  At about 85, there
-        // is more than 1.0e-13 error.  I leave this at 1, because the test
-        // time burden is somewhat severe at higher numbers.
-        final int    NUMBER_TRANSFORMS = 1;
-        // This has been tested at 10000, but it takes too long.
-        final int NUM_PTS = 2000;
-        final int MIN_PTS = -(NUM_PTS/2);
-        final int MAX_PTS = (NUM_PTS/2);
-        double max_latitude_error = 0;
-        double max_longitude_error = 0;
-        for (int ycoord = MIN_PTS; ycoord <= MAX_PTS; ycoord += 1) {
-            double latitude = ycoord*(90.0/NUM_PTS);
-            for (int xcoord = MIN_PTS; xcoord <= MAX_PTS; xcoord += 1) {
-                double longitude = xcoord*(180.0/NUM_PTS);
-                PointType PT_point = new PointType(latitude, longitude);
-                for (int idx = 0; idx < NUMBER_TRANSFORMS; idx += 1) {
-                    GeographyValue.XYZPoint xyz_point = GeographyValue.XYZPoint.fromPointType(PT_point);
-                    PT_point = xyz_point.toPointType();
-                    double laterr = Math.abs(latitude-PT_point.getLatitude());
-                    double lngerr = Math.abs(longitude-PT_point.getLongitude());
-                    if (laterr > max_latitude_error) {
-                        max_latitude_error = laterr;
-                        assertTrue(String.format("Maximum Latitude Error out of range: error=%e >= epsilon = %e, latitude = %f, num_transforms = %d\n",
-                                                 max_latitude_error, EPSILON, latitude, idx),
-                                max_latitude_error < EPSILON);
-                    }
-                    if (lngerr > max_longitude_error) {
-                        max_longitude_error = lngerr;
-                        assertTrue(String.format("Maximum LongitudeError out of range: error=%e >= epsilon = %e, longitude = %f, num_transforms = %d\n",
-                                                 max_longitude_error, EPSILON, longitude, idx),
-                                   max_longitude_error < EPSILON);
-                    }
-                }
-            }
         }
     }
 

--- a/tests/frontend/org/voltdb/types/TestGeographyValue.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyValue.java
@@ -56,7 +56,7 @@ public class TestGeographyValue extends TestCase {
         geog = new GeographyValue("POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), "
                 + "(-68.874 28.066,-68.855 25.361, -73.381 28.376, -68.874 28.066))");
         assertEquals("POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), "
-                + "(-68.874 28.066,-68.855 25.361, -73.381 28.376, -68.874 28.066))",
+                + "(-68.874 28.066, -68.855 25.361, -73.381 28.376, -68.874 28.066))",
                 geog.toString());
 
         ByteBuffer buf = ByteBuffer.allocate(geog.getLengthInBytes());
@@ -73,7 +73,7 @@ public class TestGeographyValue extends TestCase {
         // Try the absolute version of unflattening
         buf.position(77);
         newGeog = GeographyValue.unflattenFromBuffer(buf, 0);
-        assertEquals("POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, 32.305  -64.751, "
+        assertEquals("POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), "
                 + "(-68.874 28.066, -68.855 25.361, -73.381 28.376, -68.874 28.066))",
                 newGeog.toString());
         assertEquals(77, buf.position());
@@ -92,14 +92,14 @@ public class TestGeographyValue extends TestCase {
         assertEquals(expected, canonicalizeWkt("PoLyGoN((-64.751 32.305,-80.437  25.244,-66.371  18.476,-64.751  32.305))"));
 
         // Parsing is whitespace-insensitive
-        assertEquals(expected, canonicalizeWkt("  POLYGON  (  (   32.305  -64.751 ,   25.244  -80.437 ,   18.476  -66.371 ,   32.305   -64.751 )  ) "));
+        assertEquals(expected, canonicalizeWkt("  POLYGON  (  (   -64.751 32.305  ,   -80.437   25.244  ,   -66.371  18.476  ,   -64.751 32.305   )  ) "));
         assertEquals(expected, canonicalizeWkt("\nPOLYGON\n(\n(\n-64.751\n32.305\n,\n-80.437\n25.244\n,\n-66.371\n18.476\n,-64.751\n32.305\n)\n)\n"));
         assertEquals(expected, canonicalizeWkt("\tPOLYGON\t(\t(\t-64.751\t32.305\t,\t-80.437\t25.244\t,\t-66.371\t18.476\t,\t-64.751\t32.305\t)\t)\t"));
 
         // Parsing with more than one loop should work the same.
         expected = "POLYGON((-64.751 32.305, -80.437 25.244, -66.371 18.476, -64.751 32.305), "
-                + "(-68.874 28.066, -68.855 25.361, -73.381 28.376, -68.874 28.066 ))";
-        assertEquals(expected, canonicalizeWkt("PoLyGoN\t(  (\n-64.751\n32.305   ,    25.244\t-80.437\n, -66.371 18.476,-64.751\t\t\t32.305   ),\t "
+                + "(-68.874 28.066, -68.855 25.361, -73.381 28.376, -68.874 28.066))";
+        assertEquals(expected, canonicalizeWkt("PoLyGoN\t(  (\n-64.751\n32.305   ,    -80.437\t25.244\n, -66.371 18.476,-64.751\t\t\t32.305   ),\t "
                 + "(\n-68.874 28.066,\t    -68.855\n25.361\n,      -73.381\t28.376,\n\n-68.874\t28.066\t)\n)\t"));
     }
 


### PR DESCRIPTION
Many vendors list points as (longitude, latitude).  This matches
our normal (x, y) intuition.  This is not universal, but it seems
to be more common than (latitude, longitude).  So, we have switched
these.

https://issues.voltdb.com/browse/ENG-9493
