### PR TITLE
Schema of the null_tuple for outer joins should match inner_tuple

### DIFF
--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -272,7 +272,15 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         // These have the effect of repeatably generating the correct output
         // schema if called again and again, but also allowing the planner
         // to overwrite the inline projection and still have the right thing
-        // happen
+        // happen.
+        //
+        // Note that when an index scan is inlined into a join node (as with
+        // nested loop index joins), then there will be a project node inlined into
+        // the index scan node that determines which columns from the inner table
+        // are used as an output of the join, but that predicates evaluated against
+        // this table should use the complete schema of the table being scanned.
+        // See also the comments in NestLoopIndexPlanNode.resolveColumnIndexes.
+        // Related tickets: ENG-9389, ENG-9533.
         ProjectionPlanNode proj =
             (ProjectionPlanNode)getInlinePlanNode(PlanNodeType.PROJECTION);
         if (proj != null) {

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -282,7 +282,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
             m_outputSchema = proj.getOutputSchema().copyAndReplaceWithTVE();
             m_hasSignificantOutputSchema = false; // It's just a cheap knock-off of the projection's
         }
-        else if (m_tableScanSchema.size() != 0 && m_isInline == false) {
+        else if (m_tableScanSchema.size() != 0) {
             // Order the scan columns according to the table schema
             // before we stick them in the projection output
             List<TupleValueExpression> scan_tves =
@@ -308,10 +308,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
             m_hasSignificantOutputSchema = false; // It's just a cheap knock-off of the projection's
         }
         else {
-            // We come here if this node is an inline scan node, or if m_tableScanSchema is empty.
-            //
-            // If this scan node is inlined into another node, then there is no output temp
-            // table for this node, so the output schema will be the same as the table being scanned.
+            // We come here if m_tableScanSchema is empty.
             //
             // m_tableScanSchema might be empty for cases like
             //   select now from table;

--- a/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
@@ -109,12 +109,9 @@ public class NestLoopIndexPlanNode extends AbstractJoinPlanNode {
         resolvePredicate(inline_scan.getSkipNullPredicate(), outer_schema, index_schema);
         resolvePredicate(inline_scan.getSearchKeyExpressions(), outer_schema, index_schema);
 
-        final NodeSchema inline_scan_output_schema = inline_scan.getOutputSchema();
-
-        // resolve other predicates based on inline index scan node output schema
-        resolvePredicate(m_preJoinPredicate, outer_schema, inline_scan_output_schema);
-        resolvePredicate(m_joinPredicate, outer_schema, inline_scan_output_schema);
-        resolvePredicate(m_wherePredicate, outer_schema, inline_scan_output_schema);
+        resolvePredicate(m_preJoinPredicate, outer_schema, index_schema);
+        resolvePredicate(m_joinPredicate, outer_schema, index_schema);
+        resolvePredicate(m_wherePredicate, outer_schema, index_schema);
 
         // resolve subqueries
         Collection<AbstractExpression> exprs = findAllExpressionsOfClass(AbstractSubqueryExpression.class);

--- a/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
@@ -63,7 +63,11 @@ public class NestLoopIndexPlanNode extends AbstractJoinPlanNode {
         m_children.get(0).generateOutputSchema(db);
         // Join the schema together to form the output schema
         // The child subplan's output is the outer table
-        // The inlined node's output is the inner table
+        // The inlined node's output is the inner table.
+        //
+        // Note that the inner table's contribution to the join_tuple doesn't include
+        // all the columns from the inner table---just the ones needed as determined by
+        // the inlined scan's own inlined projection, as described above.
         m_outputSchemaPreInlineAgg =
             m_children.get(0).getOutputSchema().
             join(inlineScan.getOutputSchema()).copyAndReplaceWithTVE();
@@ -97,21 +101,25 @@ public class NestLoopIndexPlanNode extends AbstractJoinPlanNode {
         }
 
         // We need the schema from the target table from the inlined index
-        final NodeSchema index_schema = inline_scan.getTableSchema();
+        final NodeSchema complete_schema_of_inner_table = inline_scan.getTableSchema();
         // We need the output schema from the child node
         final NodeSchema outer_schema = m_children.get(0).getOutputSchema();
 
         // pull every expression out of the inlined index scan
         // and resolve all of the TVEs against our two input schema from above.
-        resolvePredicate(inline_scan.getPredicate(), outer_schema, index_schema);
-        resolvePredicate(inline_scan.getEndExpression(), outer_schema, index_schema);
-        resolvePredicate(inline_scan.getInitialExpression(), outer_schema, index_schema);
-        resolvePredicate(inline_scan.getSkipNullPredicate(), outer_schema, index_schema);
-        resolvePredicate(inline_scan.getSearchKeyExpressions(), outer_schema, index_schema);
-
-        resolvePredicate(m_preJoinPredicate, outer_schema, index_schema);
-        resolvePredicate(m_joinPredicate, outer_schema, index_schema);
-        resolvePredicate(m_wherePredicate, outer_schema, index_schema);
+        //
+        // Tickets ENG-9389, ENG-9533: we use the complete schema for the inner table
+        // (rather than the smaller schema from the inlined index scan's inlined project node)
+        // because the inlined scan has no temp table, so predicates will be accessing the
+        // scanned table directly.
+        resolvePredicate(inline_scan.getPredicate(), outer_schema, complete_schema_of_inner_table);
+        resolvePredicate(inline_scan.getEndExpression(), outer_schema, complete_schema_of_inner_table);
+        resolvePredicate(inline_scan.getInitialExpression(), outer_schema, complete_schema_of_inner_table);
+        resolvePredicate(inline_scan.getSkipNullPredicate(), outer_schema, complete_schema_of_inner_table);
+        resolvePredicate(inline_scan.getSearchKeyExpressions(), outer_schema, complete_schema_of_inner_table);
+        resolvePredicate(m_preJoinPredicate, outer_schema, complete_schema_of_inner_table);
+        resolvePredicate(m_joinPredicate, outer_schema, complete_schema_of_inner_table);
+        resolvePredicate(m_wherePredicate, outer_schema, complete_schema_of_inner_table);
 
         // resolve subqueries
         Collection<AbstractExpression> exprs = findAllExpressionsOfClass(AbstractSubqueryExpression.class);
@@ -132,7 +140,7 @@ public class NestLoopIndexPlanNode extends AbstractJoinPlanNode {
             int tableIdx = 0;   // 0 for outer table
             if (index == -1)
             {
-                index = tve.resolveColumnIndexesUsingSchema(index_schema);
+                index = tve.resolveColumnIndexesUsingSchema(complete_schema_of_inner_table);
                 if (index == -1)
                 {
                     throw new RuntimeException("Unable to find index for column: " +

--- a/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
@@ -463,7 +463,7 @@ public class TestPlansSubQueries extends PlannerTestCase {
 
         assertEquals(nlpn.getInlinePlanNodes().size(), 1);
         pn = nlpn.getInlinePlanNode(PlanNodeType.INDEXSCAN);
-        checkPrimaryKeyIndexScan(pn, "P2", "A", "C", "D");
+        checkPrimaryKeyIndexScan(pn, "P2", "A");
     }
 
     public void testReplicatedGroupbyLIMIT() {
@@ -829,7 +829,7 @@ public class TestPlansSubQueries extends PlannerTestCase {
         checkPrimaryKeyIndexScan(pn, "P1", "A", "C");
         // Check inlined index scan
         pn = ((NestLoopIndexPlanNode) nlpn).getInlinePlanNode(PlanNodeType.INDEXSCAN);
-        checkPrimaryKeyIndexScan(pn, "P2", "A","C", "D");
+        checkPrimaryKeyIndexScan(pn, "P2", "A", "D");
 
 
         planNodes = compileToFragments("SELECT A, C FROM P2, (SELECT A, C FROM P1) T1 " +

--- a/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
@@ -2518,12 +2518,12 @@ public class TestFixedSQLSuite extends RegressionSuite {
 
         sql = "INSERT INTO t3 VALUES (2, 2, NULL);";
         client.callProcedure("@AdHoc", sql);
-        sql = "INSERT INTO t3 VALUES (3, 3, 3);";
+        sql = "INSERT INTO t3 VALUES (3, 3, 10);";
         client.callProcedure("@AdHoc", sql);
 
         sql = "INSERT INTO t3_no_index VALUES (2, 2, NULL);";
         client.callProcedure("@AdHoc", sql);
-        sql = "INSERT INTO t3_no_index VALUES (3, 3, 3);";
+        sql = "INSERT INTO t3_no_index VALUES (3, 3, 10);";
         client.callProcedure("@AdHoc", sql);
 
         // NULL padded row in T3 will trigger the bug ENG-9389
@@ -2553,6 +2553,15 @@ public class TestFixedSQLSuite extends RegressionSuite {
                     + "where t2.D is null and t3.D is null and t2.B = 2 "
                     + "order by t1.a;";
             validateTableOfScalarLongs(client, sql, new long[]{1, 2});
+
+            sql = "select t1.b + t3.d as thesum "
+                    + "from t1 "
+                    + "left outer join " + innerTable + " as t3 "
+                    + "on t1.a = t3.a "
+                    + "where t1.b > 1 "
+                    + "order by thesum;";
+            System.out.println(client.callProcedure("@Explain", sql).getResults()[0]);
+            validateTableOfScalarLongs(client, sql, new long[]{Long.MIN_VALUE, Long.MIN_VALUE, 12});
         }
 
         truncateTables(client, new String[]{"T1", "T2", "T3", "T3_NO_INDEX"});

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/fixed-sql-ddl.sql
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/fixed-sql-ddl.sql
@@ -369,6 +369,11 @@ CREATE TABLE t3(
 create unique index t3_idx1 on t3 (a);
 create unique index t3_idx2 on t3 (d);
 
+CREATE TABLE t3_no_index (
+ a INTEGER,
+ x INTEGER,
+ d integer);
+
 -- ENG-9533
 CREATE TABLE test1_eng_9533 (
   id bigint not null,


### PR DESCRIPTION
There's three issues here that are solved by these commits:
- ENG-9389 (EE assertion on query with outer join and is null predicate)
- ENG-9533 (erroneous plan produced for outer join query with an OR predicate)
- ENG-9573 (Q19 runs out of temp table space in the aggbench perf tests)

I believe that the fix for ENG-9389 caused ENG-9533, and the fix for ENG-9533 caused ENG-9573.  The change here is just to manually rollback the fixes for the first two tickets, and add a different fix for ENG-9389 that solves the issue in a different way.

The issue in ENG-9389 is related to the nested loop index executor in the EE.  The null_tuple (an immutable tuple used to produce the null-padded results for unmatching rows in a left outer join) didn't have enough columns and the plan was looking for columns that weren't there.  My fix for this is to give the null_tuple the same schema as the inner_tuple (the tuple that is used to produce output if there is a match).

I've verified that these changes fix all three of these issues.

