### PR TITLE
Tighten an assertion.

### DIFF
--- a/src/ee/common/GeographyValue.hpp
+++ b/src/ee/common/GeographyValue.hpp
@@ -522,7 +522,7 @@ inline void Loop::initFromBuffer(Deserializer& input)
 
     set_origin_inside(input.readByte());
     set_depth(input.readInt());
-    assert(depth() >= 0 && depth() < 2);
+    assert(depth() >= 0);
 
     S2LatLngRect bound;
     initBoundFromBuffer(&bound, input);
@@ -535,7 +535,7 @@ void Loop::saveToBuffer(Serializer& output) const {
     output.writeInt(num_vertices());
     output.writeBinaryString(vertices(), sizeof(*(vertices())) * num_vertices());
     output.writeBool(origin_inside());
-    assert(depth() >= 0 && depth() < 2);
+    assert(depth() >= 0);
     output.writeInt(depth());
 
     S2LatLngRect bound = GetRectBound();


### PR DESCRIPTION
There is an assertion in the include file src/ee/common/GeographyValue.hpp which is too strict.  It used to demand that the depth of a loop is less than 2.  However, since these values may come from a user directly, and we don't validate polygons unless we are asked, the database could very well have a loop at different depth than 0 or 1.  The resulting polygons would be invalid, but that should not cause the EE to crash.

Note that this only affects debug builds, where assertions are enabled.  Note also that we still check that the depth is non-negative.  The depth is calculated by S2.  The java code adds a depth value, but it is not really calculated there, and is only a constant when a polygon is sent to the EE directly from Java.  The EE constructs the polygon value again using the vertex data from Java, and this causes depths to be calculated.  If polygons come from Java to the EE, back to Java then back to the EE, the EE will know this and not calculate depth or bounding boxes in the second transmission.

