### PR TITLE
Update geo-point test for decimal rounding

### DIFF
--- a/build.py
+++ b/build.py
@@ -74,7 +74,6 @@ if (CTX.compilerName() == 'clang') and (CTX.compilerMajorVersion() == 7):
 if (CTX.compilerName() != 'gcc') or (CTX.compilerMajorVersion() == 4 and CTX.compilerMinorVersion() >= 3) or (CTX.compilerMajorVersion() == 5):
     CTX.CPPFLAGS += " -Wno-ignored-qualifiers -fno-strict-aliasing"
 
-
 if CTX.PROFILE:
     CTX.CPPFLAGS += " -fvisibility=default -DPROFILE_ENABLED"
 

--- a/build.py
+++ b/build.py
@@ -64,7 +64,6 @@ if CTX.compilerName() == 'gcc':
     if (CTX.compilerMajorVersion() == 5):
         CTX.CPPFLAGS += " -Wno-unused-local-typedefs"
 
-
 if (CTX.compilerName() == 'clang') and (CTX.compilerMajorVersion() == 3 and CTX.compilerMinorVersion() >= 4):
     CTX.CPPFLAGS += " -Wno-varargs"
 
@@ -73,6 +72,7 @@ if (CTX.compilerName() == 'clang') and (CTX.compilerMajorVersion() == 7):
 
 if (CTX.compilerName() != 'gcc') or (CTX.compilerMajorVersion() == 4 and CTX.compilerMinorVersion() >= 3) or (CTX.compilerMajorVersion() == 5):
     CTX.CPPFLAGS += " -Wno-ignored-qualifiers -fno-strict-aliasing"
+
 
 if CTX.PROFILE:
     CTX.CPPFLAGS += " -fvisibility=default -DPROFILE_ENABLED"

--- a/build.py
+++ b/build.py
@@ -61,6 +61,10 @@ if CTX.compilerName() == 'gcc':
         elif (CTX.compilerMinorVersion() == 8):
 	    CTX.CPPFLAGS += " -Wno-conversion -Wno-unused-but-set-variable -Wno-unused-local-typedefs"
 
+    if (CTX.compilerMajorVersion() == 5):
+        CTX.CPPFLAGS += " -Wno-unused-local-typedefs"
+
+
 if (CTX.compilerName() == 'clang') and (CTX.compilerMajorVersion() == 3 and CTX.compilerMinorVersion() >= 4):
     CTX.CPPFLAGS += " -Wno-varargs"
 

--- a/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
@@ -833,10 +833,10 @@ public class RegressionSuite extends TestCase {
                 assertTrue(msg, actualRow.wasNull());
             }
             else if (expectedObj instanceof GeographyPointValue) {
-                assertEquals(msg, expectedObj, actualRow.getPoint(i));
+                assertApproximatelyEquals(msg, (GeographyPointValue) expectedObj, actualRow.getPoint(i), epsilon);
             }
             else if (expectedObj instanceof GeographyValue) {
-                assertApproximatelyEquals(msg, (GeographyValue)expectedObj, actualRow.getGeographyValue(i), epsilon);
+                assertApproximatelyEquals(msg, (GeographyValue) expectedObj, actualRow.getGeographyValue(i), epsilon);
             }
             else if (expectedObj instanceof Long) {
                 long val = ((Long)expectedObj).longValue();

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeograpyPointValue.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeograpyPointValue.java
@@ -38,6 +38,7 @@ public class TestGeograpyPointValue extends RegressionSuite {
         super(name);
     }
 
+    private static final double EPSILON = 1.0e-12;
     private static final GeographyPointValue BEDFORD_PT = new GeographyPointValue(-71.2767, 42.4906);
     private static final GeographyPointValue SANTA_CLARA_PT = new GeographyPointValue(-121.9692, 37.3544);
     private static final GeographyPointValue LOWELL_PT = new GeographyPointValue(-71.3273, 42.6200);
@@ -374,6 +375,4 @@ public class TestGeograpyPointValue extends RegressionSuite {
 
         return builder;
     }
-
-    private final double EPSILON = 1.0e-12;
 }

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeograpyPointValue.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeograpyPointValue.java
@@ -97,7 +97,6 @@ public class TestGeograpyPointValue extends RegressionSuite {
     }
 
     public void testPointFromText() throws Exception {
-        final double EPSILON = 1.0e-14;
         Client client = getClient();
 
         validateTableOfScalarLongs(client,
@@ -126,10 +125,10 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 + "where t1.pt = t2.pt "
                 + "order by t1.pk;").getResults()[0];
 
-        assertContentOfTable(new Object[][] {
+        assertApproximateContentOfTable(new Object[][] {
                 {0, "Bedford", BEDFORD_PT},
                 {1, "Santa Clara", SANTA_CLARA_PT}},
-                vt);
+                vt, EPSILON);
 
         // Self join to test not equals operator
         vt = client.callProcedure("@AdHoc",
@@ -138,10 +137,10 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 + "where t1.pt <> t2.pt "
                 + "order by t1.pk, t1.pt;").getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {0, BEDFORD_PT, SANTA_CLARA_PT},
                 {1, SANTA_CLARA_PT, BEDFORD_PT}},
-                vt);
+                vt, EPSILON);
 
         // Self join to test < operator
         vt = client.callProcedure("@AdHoc",
@@ -150,9 +149,9 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 + "where t1.pt < t2.pt "
                 + "order by t1.pk, t1.pt;").getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {1, SANTA_CLARA_PT, BEDFORD_PT}},
-                vt);
+                vt, EPSILON);
 
         // Self join to test <= operator
         vt = client.callProcedure("@AdHoc",
@@ -161,11 +160,11 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 + "where t1.pt <= t2.pt "
                 + "order by t1.pk, t1.pt, t2.pt;").getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {0, BEDFORD_PT, BEDFORD_PT},
                 {1, SANTA_CLARA_PT, SANTA_CLARA_PT},
                 {1, SANTA_CLARA_PT, BEDFORD_PT}},
-                vt);
+                vt, EPSILON);
 
         // Self join to test > operator
         vt = client.callProcedure("@AdHoc",
@@ -174,9 +173,9 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 + "where t1.pt > t2.pt "
                 + "order by t1.pk, t1.pt;").getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {0, BEDFORD_PT, SANTA_CLARA_PT}},
-                vt);
+                vt, EPSILON);
 
         // Self join to test >= operator
         vt = client.callProcedure("@AdHoc",
@@ -185,11 +184,11 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 + "where t1.pt >= t2.pt "
                 + "order by t1.pk, t1.pt, t2.pt;").getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {0, BEDFORD_PT, SANTA_CLARA_PT},
                 {0, BEDFORD_PT, BEDFORD_PT},
                 {1, SANTA_CLARA_PT, SANTA_CLARA_PT}},
-                vt);
+                vt, EPSILON);
 
         // Test IS NULL
         vt = client.callProcedure("@AdHoc",
@@ -198,9 +197,9 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 + "where t1.pt is null "
                 + "order by t1.pk, t1.pt;").getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {2, "Atlantis", null}},
-                vt);
+                vt, EPSILON);
 
         // Test IS NOT NULL
         vt = client.callProcedure("@AdHoc",
@@ -209,10 +208,10 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 + "where t1.pt is not null "
                 + "order by t1.pk, t1.pt;").getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {0, "Bedford", BEDFORD_PT},
                 {1, "Santa Clara", SANTA_CLARA_PT}},
-                vt);
+                vt, EPSILON);
     }
 
     public void testPointGroupBy() throws Exception {
@@ -230,11 +229,11 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 + "order by pt asc")
                 .getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {null, 3},
                 {SANTA_CLARA_PT, 3},
                 {BEDFORD_PT, 3}},
-                vt);
+                vt, EPSILON);
     }
 
     public void testPointUpdate() throws Exception {
@@ -263,11 +262,11 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 "select pk, name, pt from t order by pk")
                 .getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {0, "Cambridge", CAMBRIDGE_PT},
                 {1, "San Jose", SAN_JOSE_PT},
                 {2, "Atlantis", null}},
-                vt);
+                vt, EPSILON);
     }
 
     public void testPointArithmetic() throws Exception {
@@ -303,9 +302,9 @@ public class TestGeograpyPointValue extends RegressionSuite {
                 "select pk, name, pt from t_not_null order by pk")
                 .getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {0, "Singapore", new GeographyPointValue(103.8521, 1.2905)}},
-                vt);
+                vt, EPSILON);
     }
 
     public void testPointIn() throws Exception {
@@ -317,9 +316,9 @@ public class TestGeograpyPointValue extends RegressionSuite {
         VoltTable vt = client.callProcedure("sel_in", listParam)
                 .getResults()[0];
 
-        assertContentOfTable (new Object[][] {
+        assertApproximateContentOfTable (new Object[][] {
                 {1, SANTA_CLARA_PT}},
-                vt);
+                vt, EPSILON);
 
         try {
             vt = client.callProcedure("sel_in",
@@ -375,4 +374,6 @@ public class TestGeograpyPointValue extends RegressionSuite {
 
         return builder;
     }
+
+    private final double EPSILON = 1.0e-12;
 }


### PR DESCRIPTION
- Updated  GeographyPointValue test to take to precision of 12 decimal places when comparing two points.
- Minor changes to build script to ignore warnings for unused defines for gcc version 5. This started happening with version 5.2.1 abd results in build to fail due to unused defs flagged from s2-google apis.

Testing:
- Don't see asserts reported for points being different with changes locally that were on integration branch in memcheck environment.
- Jenkins run on the changes is under-way
