### PR TITLE
Fixed simple typo in RuntimeException message

### DIFF
--- a/src/frontend/org/voltdb/client/ProcedureInvocationType.java
+++ b/src/frontend/org/voltdb/client/ProcedureInvocationType.java
@@ -50,7 +50,7 @@ public enum ProcedureInvocationType {
         case -128:
             return REPLICATED;
         default:
-            throw new RuntimeException("Unkonwn ProcedureInvocationType " + b);
+            throw new RuntimeException("Unknown ProcedureInvocationType " + b);
         }
     }
 


### PR DESCRIPTION
Nothing Major... just found it when debugging wire protocol client