### PR TITLE
Work around new runtime conversion restrictions

### DIFF
--- a/tests/test_apps/ycsb/src/com/procedures/Scan.java
+++ b/tests/test_apps/ycsb/src/com/procedures/Scan.java
@@ -22,11 +22,15 @@
  */
 package com.procedures;
 
+import java.nio.charset.CharSet;
+
 import org.voltdb.SQLStmt;
 import org.voltdb.VoltProcedure;
 import org.voltdb.VoltTable;
 
 public class Scan extends VoltProcedure {
+    public final static CharSet CHARSET = new CharSet("UTF-8");
+
     public final SQLStmt getBddStmt = new SQLStmt("SELECT value FROM Store WHERE keyspace = ? AND key >= ? LIMIT ?");
     public final SQLStmt getUnbddStmt = new SQLStmt("SELECT value FROM Store WHERE keyspace = ? LIMIT ?");
 
@@ -34,7 +38,7 @@ public class Scan extends VoltProcedure {
     {
         if (rangeMin != null)
         {
-            voltQueueSQL(getBddStmt, keyspace, rangeMin, count);
+            voltQueueSQL(getBddStmt, keyspace, new String(rangeMin, CHARSET), count);
         }
         else
         {

--- a/tests/test_apps/ycsb/ycsb_ddl.sql
+++ b/tests/test_apps/ycsb/ycsb_ddl.sql
@@ -1,6 +1,6 @@
 CREATE TABLE Store
 (
-    keyspace VARCHAR(128)    NOT NULL
+    keyspace VARBINARY(128)  NOT NULL
 ,   key      VARCHAR(128)    NOT NULL
 ,   value    VARBINARY(2056) NOT NULL
 ,   PRIMARY KEY (keyspace, key)


### PR DESCRIPTION
Changing keyspace to VARBINARY makes it compatible with the query inputs.
Converting Scan's rangeMin parameter to a java String makes it compatible but may hurt the benchmark numbers. If that's the case, we may want to define and use a UTF8INTERPRET sql function to do the UTF8 VARBINARY to VARCHAR "conversion" more efficiently in C++ where it is a trivial shallow copy into an NValue with a different type field setting.