### PR TITLE
Use the name fromWKT to construct geo objects from text.

### DIFF
--- a/src/frontend/org/voltdb/ParameterConverter.java
+++ b/src/frontend/org/voltdb/ParameterConverter.java
@@ -505,7 +505,7 @@ public class ParameterConverter {
             // If so, return the newly constructed point.
             if (inputClz == String.class) {
                 try {
-                    GeographyPointValue pt = GeographyPointValue.geographyPointFromText((String)param);
+                    GeographyPointValue pt = GeographyPointValue.fromWKT((String)param);
                     return pt;
                 } catch (IllegalArgumentException e) {
                     throw new VoltTypeException(String.format("deserialize GeographyPointValue from string failed (string %s)",
@@ -519,7 +519,7 @@ public class ParameterConverter {
             if (inputClz == String.class) {
                 String paramStr = (String)param;
                 try {
-                    GeographyValue gv = GeographyValue.fromText(paramStr);
+                    GeographyValue gv = GeographyValue.fromWKT(paramStr);
                     return gv;
                 } catch (IllegalArgumentException e) {
                     throw new VoltTypeException(String.format("deserialize GeographyValue from string failed (string %s)",

--- a/src/frontend/org/voltdb/parser/SQLParser.java
+++ b/src/frontend/org/voltdb/parser/SQLParser.java
@@ -1387,7 +1387,7 @@ public class SQLParser extends SQLPatternFactory
         if (epos < 0) {
             epos = param.length();
         }
-        return GeographyPointValue.geographyPointFromText(param.substring(spos+1, epos));
+        return GeographyPointValue.fromWKT(param.substring(spos+1, epos));
     }
 
     public static GeographyValue parseGeography(String param) {
@@ -1399,7 +1399,7 @@ public class SQLParser extends SQLPatternFactory
         if (epos < 0) {
             epos = param.length();
         }
-        return GeographyValue.fromText(param.substring(spos+1, epos));
+        return GeographyValue.fromWKT(param.substring(spos+1, epos));
     }
 
 

--- a/src/frontend/org/voltdb/types/GeographyPointValue.java
+++ b/src/frontend/org/voltdb/types/GeographyPointValue.java
@@ -77,7 +77,7 @@ public class GeographyPointValue {
      * Create a GeographyPointValue from a WellKnownText string.
      * @param param
      */
-    public static GeographyPointValue geographyPointFromText(String param) {
+    public static GeographyPointValue fromWKT(String param) {
         if (param == null) {
             throw new IllegalArgumentException("Null well known text argument to GeographyPointValue constructor.");
         }
@@ -122,8 +122,15 @@ public class GeographyPointValue {
         return df.format(lng) + " " + df.format(lat);
     }
 
+    /**
+     * Print this point as a string.  We currently use WKT.
+     */
     @Override
     public String toString() {
+        return toWKT();
+    }
+
+    public String toWKT() {
         // This is not GEOGRAPHY_POINT.  This is wkt syntax.
         return "POINT (" + formatLngLat() + ")";
     }

--- a/src/frontend/org/voltdb/types/GeographyValue.java
+++ b/src/frontend/org/voltdb/types/GeographyValue.java
@@ -132,7 +132,7 @@ public class GeographyValue {
      * @param text
      * @return
      */
-    public static GeographyValue fromText(String text) {
+    public static GeographyValue fromWKT(String text) {
         return new GeographyValue(text);
     }
 
@@ -178,10 +178,17 @@ public class GeographyValue {
     }
 
     /**
-     * Print out this polygon in WKT format.  Use 12 digits of precision.
+     * Print out this polygon as text.  We currently use WKT.
      */
     @Override
     public String toString() {
+        return toWKT();
+    }
+
+    /**
+     * Print out this polygon in WKT format.  Use 12 digits of precision.
+     */
+    public String toWKT() {
         StringBuffer sb = new StringBuffer();
         sb.append("POLYGON (");
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
@@ -406,8 +406,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
     private final String cheesyShellWKT = "POLYGON ((-5.0 46.0, -50.0 10.0, -40.0 -35.0, 25.0 -45.0, 30.0 20.0, -5.0 46.0))";
 
     private void fillCheesyTable(Client client) throws Exception {
-        GeographyValue cheesyPolygon = GeographyValue.fromText(cheesyWKT);
-        GeographyValue cheesyShellPolygon = GeographyValue.fromText(cheesyShellWKT);
+        GeographyValue cheesyPolygon = GeographyValue.fromWKT(cheesyWKT);
+        GeographyValue cheesyShellPolygon = GeographyValue.fromWKT(cheesyShellWKT);
         //
         // Get the holes from the cheesy polygon, and make them
         // into polygons in their own right.  This means we need
@@ -440,16 +440,16 @@ public class TestGeographyValueQueries extends RegressionSuite {
             GeographyValue hole = cheesyHoles.get(idx);
             client.callProcedure("T.INSERT", idx + 100, "hole"+ idx + 100, hole);
         }
-        client.callProcedure("LOCATION.INSERT", 0, "ORIGIN", GeographyPointValue.geographyPointFromText(cheesyOrigin));
-        client.callProcedure("LOCATION.INSERT", 1, "INHOLE", GeographyPointValue.geographyPointFromText(cheesyInHole));
+        client.callProcedure("LOCATION.INSERT", 0, "ORIGIN", GeographyPointValue.fromWKT(cheesyOrigin));
+        client.callProcedure("LOCATION.INSERT", 1, "INHOLE", GeographyPointValue.fromWKT(cheesyInHole));
         for (int idx = 0; idx < exteriorPoints.size(); idx += 1) {
             String exPt = exteriorPoints.get(idx);
-            client.callProcedure("LOCATION.INSERT", idx + 200, exPt, GeographyPointValue.geographyPointFromText(exPt));
+            client.callProcedure("LOCATION.INSERT", idx + 200, exPt, GeographyPointValue.fromWKT(exPt));
             idx += 1;
         }
         for (int idx = 0; idx < centers.size(); idx += 1) {
             String ctrPt = centers.get(idx);
-            client.callProcedure("LOCATION.INSERT", idx + 300, ctrPt, GeographyPointValue.geographyPointFromText(ctrPt));
+            client.callProcedure("LOCATION.INSERT", idx + 300, ctrPt, GeographyPointValue.fromWKT(ctrPt));
         }
         // Make sure that all the polygons
         // are valid.
@@ -461,7 +461,7 @@ public class TestGeographyValueQueries extends RegressionSuite {
         final double EPSILON = 1.0e-13;
         Client client = getClient();
         fillCheesyTable(client);
-        GeographyValue cheesyPolygon = GeographyValue.fromText(cheesyWKT);
+        GeographyValue cheesyPolygon = GeographyValue.fromWKT(cheesyWKT);
         VoltTable vt = client.callProcedure("@AdHoc", "select t.poly from t where t.pk = 1 order by t.pk;").getResults()[0];
         assertEquals("Expected only one row.", 1, vt.getRowCount());
         assertTrue(vt.advanceRow());
@@ -792,7 +792,7 @@ public class TestGeographyValueQueries extends RegressionSuite {
         // than the column's current size.
 
         String wktFourVerts = "POLYGON ((1.0 1.0, -1.0 1.0, -1.0 -1.0, 1.0 -1.0, 1.0 1.0))";
-        GeographyValue gv = GeographyValue.fromText(wktFourVerts);
+        GeographyValue gv = GeographyValue.fromWKT(wktFourVerts);
         assertEquals(179, gv.getLengthInBytes());
 
         VoltTable vt = client.callProcedure("tiny_polygon.Insert", 0, gv).getResults()[0];
@@ -805,7 +805,7 @@ public class TestGeographyValueQueries extends RegressionSuite {
                 + "1.0 -1.0, "
                 + "0.0 0.0, "
                 + "1.0 1.0))";
-        gv = GeographyValue.fromText(wktFiveVerts);
+        gv = GeographyValue.fromWKT(wktFiveVerts);
         assertEquals(203, gv.getLengthInBytes());
         verifyProcFails(client, "The size 203 of the value exceeds the size of the GEOGRAPHY column \\(179 bytes\\)",
                 "tiny_polygon.Insert", 1, gv);

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctions.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctions.java
@@ -127,33 +127,33 @@ public class TestGeospatialFunctions extends RegressionSuite {
         // Note: These are all WellKnownText strings.  So they should
         //       be "POINT(...)" and not "GEOGRAPHY_POINT(...)".
         client.callProcedure("places.Insert", 0, "Denver",
-                GeographyPointValue.geographyPointFromText("POINT(-104.959 39.704)"));
+                GeographyPointValue.fromWKT("POINT(-104.959 39.704)"));
         client.callProcedure("places.Insert", 1, "Albuquerque",
-                GeographyPointValue.geographyPointFromText("POINT(-106.599 35.113)"));
+                GeographyPointValue.fromWKT("POINT(-106.599 35.113)"));
         client.callProcedure("places.Insert", 2, "Cheyenne",
-                GeographyPointValue.geographyPointFromText("POINT(-104.813 41.134)"));
+                GeographyPointValue.fromWKT("POINT(-104.813 41.134)"));
         client.callProcedure("places.Insert", 3, "Fort Collins",
-                GeographyPointValue.geographyPointFromText("POINT(-105.077 40.585)"));
+                GeographyPointValue.fromWKT("POINT(-105.077 40.585)"));
         client.callProcedure("places.Insert", 4, "Point near N Colorado border",
-                GeographyPointValue.geographyPointFromText("POINT(-105.04 41.002)"));
+                GeographyPointValue.fromWKT("POINT(-105.04 41.002)"));
         client.callProcedure("places.Insert", 5, "North Point Not On Colorado Border",
-                GeographyPointValue.geographyPointFromText("POINT(-109.025 41.005)"));
+                GeographyPointValue.fromWKT("POINT(-109.025 41.005)"));
         client.callProcedure("places.Insert", 6, "Point on N Wyoming Border",
-                GeographyPointValue.geographyPointFromText("POINT(-105.058 44.978)"));
+                GeographyPointValue.fromWKT("POINT(-105.058 44.978)"));
         client.callProcedure("places.Insert", 7, "North Point Not On Wyoming Border",
-                GeographyPointValue.geographyPointFromText("POINT(-105.060 45.119)"));
+                GeographyPointValue.fromWKT("POINT(-105.060 45.119)"));
         client.callProcedure("places.Insert", 8, "Point on E Wyoming Border",
-                GeographyPointValue.geographyPointFromText("POINT(-104.078 42.988)"));
+                GeographyPointValue.fromWKT("POINT(-104.078 42.988)"));
         client.callProcedure("places.Insert", 9, "East Point Not On Wyoming Border",
-                GeographyPointValue.geographyPointFromText("POINT(-104.061 42.986)"));
+                GeographyPointValue.fromWKT("POINT(-104.061 42.986)"));
         client.callProcedure("places.Insert", 10, "Point On S Wyoming Border",
-                GeographyPointValue.geographyPointFromText("POINT(-110.998 41.099)"));
+                GeographyPointValue.fromWKT("POINT(-110.998 41.099)"));
         client.callProcedure("places.Insert", 11, "South Point Not On Colorado Border",
-                GeographyPointValue.geographyPointFromText("POINT(-103.008 37.002)"));
+                GeographyPointValue.fromWKT("POINT(-103.008 37.002)"));
         client.callProcedure("places.Insert", 12, "Point On W Wyoming Border",
-                GeographyPointValue.geographyPointFromText("POINT(-110.998 42.999)"));
+                GeographyPointValue.fromWKT("POINT(-110.998 42.999)"));
         client.callProcedure("places.Insert", 13, "West Point Not on Wyoming Border",
-                GeographyPointValue.geographyPointFromText("POINT(-111.052 41.999)"));
+                GeographyPointValue.fromWKT("POINT(-111.052 41.999)"));
 
         // A null-valued point
         client.callProcedure("places.Insert", 99, "Neverwhere", null);
@@ -395,9 +395,9 @@ public class TestGeospatialFunctions extends RegressionSuite {
         populateTables(client);
 
         client.callProcedure("places.Insert", 50, "San Jose",
-                GeographyPointValue.geographyPointFromText("POINT(-121.903692 37.325464)"));
+                GeographyPointValue.fromWKT("POINT(-121.903692 37.325464)"));
         client.callProcedure("places.Insert", 51, "Boston",
-                GeographyPointValue.geographyPointFromText("POINT(-71.069862 42.338100)"));
+                GeographyPointValue.fromWKT("POINT(-71.069862 42.338100)"));
 
         VoltTable vt;
         String sql;
@@ -653,25 +653,25 @@ public class TestGeospatialFunctions extends RegressionSuite {
 
    private static Border invalidBorders[] = {
        new Border(100, "CrossedEdges", "Edges 1 and 3 cross",
-                  GeographyValue.fromText(CROSSED_EDGES)),
+                  GeographyValue.fromWKT(CROSSED_EDGES)),
        new Border(101, "Sunwise", "Loop 0 encloses more than half the sphere",
-                  GeographyValue.fromText(CW_EDGES)),
+                  GeographyValue.fromWKT(CW_EDGES)),
        new Border(102, "MultiPolygon", "Polygons can have only one shell",
-                  GeographyValue.fromText(MULTI_POLYGON)),
+                  GeographyValue.fromWKT(MULTI_POLYGON)),
        new Border(103, "SharedInnerVertices", "Loop 1 crosses loop 2",
-                  GeographyValue.fromText(SHARED_INNER_VERTICES)),
+                  GeographyValue.fromWKT(SHARED_INNER_VERTICES)),
        new Border(104, "SharedInnerEdges", "Loop 1 crosses loop 2",
-                  GeographyValue.fromText(SHARED_INNER_EDGES)),
+                  GeographyValue.fromWKT(SHARED_INNER_EDGES)),
        new Border(105, "IntersectingHoles", "Loop 1 crosses loop 2",
-                  GeographyValue.fromText(INTERSECTING_HOLES)),
+                  GeographyValue.fromWKT(INTERSECTING_HOLES)),
        new Border(106, "OuterInnerIntersect", "Loop 1 crosses loop 2",
-                  GeographyValue.fromText(OUTER_INNER_INTERSECT)),
+                  GeographyValue.fromWKT(OUTER_INNER_INTERSECT)),
        new Border(108, "TwoNestedSunwise", "Loop 0 encloses more than half the sphere",
-                  GeographyValue.fromText(TWO_NESTED_SUNWISE)),
+                  GeographyValue.fromWKT(TWO_NESTED_SUNWISE)),
        new Border(109, "TwoNestedWiddershins", "Loop 0 encloses more than half the sphere",
-                  GeographyValue.fromText(TWO_NESTED_WIDDERSHINS)),
+                  GeographyValue.fromWKT(TWO_NESTED_WIDDERSHINS)),
        new Border(110, "IslandInALake", "Polygons can have only one shell.",
-                  GeographyValue.fromText(ISLAND_IN_A_LAKE)),
+                  GeographyValue.fromWKT(ISLAND_IN_A_LAKE)),
       /*
        * These are apparently legal. Should they be?
        */
@@ -720,10 +720,10 @@ public class TestGeospatialFunctions extends RegressionSuite {
 
         // test for border case of rounding up the decimal number
         client.callProcedure("places.Insert", 50, "Someplace1",
-                GeographyPointValue.geographyPointFromText("POINT(13.4999999999995 17)"));
+                GeographyPointValue.fromWKT("POINT(13.4999999999995 17)"));
         // test for border case of rounding up the decimal number
         client.callProcedure("places.Insert", 51, "Someplace2",
-                GeographyPointValue.geographyPointFromText("POINT(-13.499999999999999995 -17)"));
+                GeographyPointValue.fromWKT("POINT(-13.499999999999999995 -17)"));
 
         // get WKT representation using asText()
         VoltTable asTextVT = client.callProcedure("@AdHoc",

--- a/tests/frontend/org/voltdb/types/TestGeographyPointValue.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyPointValue.java
@@ -106,7 +106,7 @@ public class TestGeographyPointValue extends TestCase {
      */
     private void testOnePointFromFactory(String aWKT, double aLatitude, double aLongitude, double aEpsilon, String aErrMsg) {
         try {
-            GeographyPointValue point = GeographyPointValue.geographyPointFromText(aWKT);
+            GeographyPointValue point = GeographyPointValue.fromWKT(aWKT);
             assertEquals(aLatitude, point.getLatitude(), aEpsilon);
             if (aErrMsg != null) {
                 assertTrue(String.format("Expected error message matching \"%s\", but got no error.", aErrMsg), aErrMsg == null);

--- a/tests/frontend/org/voltdb/types/TestGeographyValue.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyValue.java
@@ -114,7 +114,7 @@ public class TestGeographyValue extends TestCase {
     //
     public void testGeographyValueOverDiscontinuities() {
         String geoWKT = "POLYGON ((160.0 40.0, -160.0 40.0, -160.0 60.0, 160.0 60.0, 160.0 40.0))";
-        GeographyValue disPoly = GeographyValue.fromText(geoWKT);
+        GeographyValue disPoly = GeographyValue.fromWKT(geoWKT);
         assertEquals(geoWKT, disPoly.toString());
         GeographyPointValue offset = new GeographyPointValue(10.0, -10.0);
         GeographyValue disPolyOver = disPoly.add(offset);


### PR DESCRIPTION
In the past we used GeographyValue.fromText and
GeographyPointValue.geographyPointValueFromText to construct geo objects
from text strings.  The text strings are always in Well Known Text
format (WKT).  This commit changes the name of both functions to fromWKT
for uniformity.

https://issues.voltdb.com/browse/ENG-9708