### PR TITLE
Update  geo function name to be consistent with geo type names

### DIFF
--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -177,10 +177,10 @@ std::string NValue::debug() const {
         buffer << createStringFromDecimal();
         break;
     case VALUE_TYPE_POINT:
-        buffer << getPoint().toString();
+        buffer << getGeographyPointValue().toString();
         break;
     case VALUE_TYPE_GEOGRAPHY:
-        buffer << getGeography().toString();
+        buffer << getGeographyValue().toString();
         break;
     default:
         buffer << "(no details)";

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -955,12 +955,12 @@ private:
         return *reinterpret_cast<bool*>(m_data);
     }
 
-    GeographyPointValue& getPoint() {
+    GeographyPointValue& getGeographyPointValue() {
         assert(getValueType() == VALUE_TYPE_POINT);
         return *reinterpret_cast<GeographyPointValue*>(m_data);
     }
 
-    const GeographyPointValue& getPoint() const {
+    const GeographyPointValue& getGeographyPointValue() const {
 
         BOOST_STATIC_ASSERT_MSG(sizeof(GeographyPointValue) <= sizeof(m_data),
                                 "Size of Point is too large for NValue m_data");
@@ -969,7 +969,7 @@ private:
         return *reinterpret_cast<const GeographyPointValue*>(m_data);
     }
 
-    const GeographyValue getGeography() const {
+    const GeographyValue getGeographyValue() const {
         assert(getValueType() == VALUE_TYPE_GEOGRAPHY);
 
         if (isNull()) {
@@ -1508,11 +1508,11 @@ private:
             break;
         }
         case VALUE_TYPE_POINT: {
-            value << getPoint().toWKT();
+            value << getGeographyPointValue().toWKT();
             break;
         }
         case VALUE_TYPE_GEOGRAPHY: {
-            value << getGeography().toWKT();
+            value << getGeographyValue().toWKT();
             break;
         }
         default:
@@ -2014,7 +2014,7 @@ private:
         assert(m_valueType == VALUE_TYPE_POINT);
         switch (rhs.getValueType()) {
         case VALUE_TYPE_POINT:
-            return getPoint().compareWith(rhs.getPoint());
+            return getGeographyPointValue().compareWith(rhs.getGeographyPointValue());
         default:
             std::ostringstream oss;
             oss << "Type " << valueToString(rhs.getValueType())
@@ -2031,7 +2031,7 @@ private:
         assert(m_valueType == VALUE_TYPE_GEOGRAPHY);
         switch (rhs.getValueType()) {
         case VALUE_TYPE_GEOGRAPHY:
-            return getGeography().compareWith(rhs.getGeography());
+            return getGeographyValue().compareWith(rhs.getGeographyValue());
         default:
             std::ostringstream oss;
             oss << "Type " << valueToString(rhs.getValueType())
@@ -2634,7 +2634,7 @@ inline void NValue::setNull() {
         getDecimal().SetMin();
         break;
     case VALUE_TYPE_POINT:
-        getPoint() = GeographyPointValue();
+        getGeographyPointValue() = GeographyPointValue();
         break;
     default: {
         throwDynamicSQLException("NValue::setNull() called with unsupported ValueType '%d'", getValueType());
@@ -2718,7 +2718,7 @@ inline NValue NValue::initFromTupleStorage(const void *storage, ValueType type, 
         break;
     case VALUE_TYPE_POINT:
     {
-        retval.getPoint() = *reinterpret_cast<const GeographyPointValue*>(storage);
+        retval.getGeographyPointValue() = *reinterpret_cast<const GeographyPointValue*>(storage);
         break;
     }
     default:
@@ -3000,7 +3000,7 @@ inline void NValue::deserializeFromAllocateForStorage(ValueType type, SerializeI
         return;
     }
     case VALUE_TYPE_POINT: {
-        getPoint() = GeographyPointValue::deserializeFrom(input);
+        getGeographyPointValue() = GeographyPointValue::deserializeFrom(input);
         return;
     }
     case VALUE_TYPE_NULL: {
@@ -3046,7 +3046,7 @@ inline void NValue::serializeTo(SerializeOutput &output) const {
         else {
             // geography gets its own serialization to deal with
             // byteswapping and endianness
-            getGeography().serializeTo(output);
+            getGeographyValue().serializeTo(output);
         }
         return;
     }
@@ -3080,7 +3080,7 @@ inline void NValue::serializeTo(SerializeOutput &output) const {
         return;
 
     case VALUE_TYPE_POINT:
-        getPoint().serializeTo(output);
+        getGeographyPointValue().serializeTo(output);
         return;
 
     default:
@@ -3129,7 +3129,7 @@ inline void NValue::serializeToExport_withoutNull(ExportSerializeOutput &io) con
         io.writeLong(htonll(getDecimal().table[0]));
         return;
     case VALUE_TYPE_POINT: {
-        getPoint().serializeTo(io);
+        getGeographyPointValue().serializeTo(io);
         return;
     }
     case VALUE_TYPE_GEOGRAPHY:
@@ -3222,7 +3222,7 @@ inline bool NValue::isNull() const {
         return getDecimal() == min;
     }
     else if (getValueType() == VALUE_TYPE_POINT) {
-        return getPoint().isNull();
+        return getGeographyPointValue().isNull();
     }
 
     return m_data[13] == OBJECT_NULL_BIT;
@@ -3352,10 +3352,10 @@ inline void NValue::hashCombine(std::size_t &seed) const {
         getDecimal().hash(seed);
         return;
     case VALUE_TYPE_POINT:
-        getPoint().hashCombine(seed);
+        getGeographyPointValue().hashCombine(seed);
         return;
     case VALUE_TYPE_GEOGRAPHY:
-        getGeography().hashCombine(seed);
+        getGeographyValue().hashCombine(seed);
         return;
     default:
         break;

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1321,7 +1321,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                     }
                     break;
                 case GEOGRAPHY_POINT:
-                    GeographyPointValue pt = r.getPoint(i);
+                    GeographyPointValue pt = r.getGeographyPointValue(i);
                     if (r.wasNull()) {
                         buffer.append("NULL");
                     }

--- a/src/frontend/org/voltdb/VoltTableRow.java
+++ b/src/frontend/org/voltdb/VoltTableRow.java
@@ -297,7 +297,7 @@ public abstract class VoltTableRow {
             ret = getDecimalAsBigDecimal(columnIndex);
             break;
         case GEOGRAPHY_POINT:
-            ret = getPoint(columnIndex);
+            ret = getGeographyPointValue(columnIndex);
             break;
         case GEOGRAPHY:
             ret = getGeographyValue(columnIndex);
@@ -620,18 +620,45 @@ public abstract class VoltTableRow {
         return getVarbinary(colIndex);
     }
 
-    public final GeographyPointValue getPoint(int columnIndex) {
+    /**
+     * Retrieve the GeographyPointValue value stored in the column specified by index.
+     * Looking at the return value is not a reliable way to check if the value is
+     * <tt>null</tt>. Use {@link #wasNull()} instead.
+     * @param columnIndex Index of the column
+     * @return GeographyPointValue value stored in the specified column
+     * @see #wasNull()
+     */
+    public final GeographyPointValue getGeographyPointValue(int columnIndex) {
         validateColumnType(columnIndex, VoltType.GEOGRAPHY_POINT);
         GeographyPointValue pt = GeographyPointValue.unflattenFromBuffer(m_buffer, getOffset(columnIndex));
         m_wasNull = (pt == null);
         return pt;
     }
 
-    public final GeographyPointValue getPoint(String columnName) {
+    /**
+     * Retrieve the GeographyPointValue value stored in the column specified by name.
+     * Avoid retrieving via this method as it is slower than specifying the column
+     * by index. Use {@link #getGeographyPointValue(int)} instead.
+     * Looking at the return value is not a reliable way to check if the value
+     * is <tt>null</tt>. Use {@link #wasNull()} instead.
+     * @param columnName Name of the column
+     * @return GeographyPointValue value stored in the specified column
+     * @see #wasNull()
+     * @see #getGeographyPointValue(int)
+     */
+    public final GeographyPointValue getGeographyPointValue(String columnName) {
         final int colIndex = getColumnIndex(columnName);
-        return getPoint(colIndex);
+        return getGeographyPointValue(colIndex);
     }
 
+    /**
+     * Retrieve the GeographyValue value stored in the column specified by index.
+     * Looking at the return value is not a reliable way to check if the value is
+     * <tt>null</tt>. Use {@link #wasNull()} instead.
+     * @param columnIndex Index of the column
+     * @return GeographyValue value stored in the specified column
+     * @see #wasNull()
+     */
     public final GeographyValue getGeographyValue(int columnIndex) {
         validateColumnType(columnIndex, VoltType.GEOGRAPHY);
         int offset = getOffset(columnIndex);
@@ -646,6 +673,17 @@ public abstract class VoltTableRow {
         return gv;
     }
 
+    /**
+     * Retrieve the GeographyValue value stored in the column specified by name.
+     * Avoid retrieving via this method as it is slower than specifying the column
+     * by index. Use {@link #getGeographyValue(int)} instead.
+     * Looking at the return value is not a reliable way to check if the value
+     * is <tt>null</tt>. Use {@link #wasNull()} instead.
+     * @param columnName Name of the column
+     * @return GeographyValue value stored in the specified column
+     * @see #wasNull()
+     * @see #getGeographyPointValue(int)
+     */
     public final GeographyValue getGeographyValue(String columnName) {
         final int colIndex = getColumnIndex(columnName);
         return getGeographyValue(colIndex);
@@ -874,7 +912,7 @@ public abstract class VoltTableRow {
             }
             break;
         case GEOGRAPHY_POINT:
-            GeographyPointValue pt = getPoint(columnIndex);
+            GeographyPointValue pt = getGeographyPointValue(columnIndex);
             if (wasNull()) {
                 js.value(null);
             }

--- a/src/frontend/org/voltdb/utils/VoltTableUtil.java
+++ b/src/frontend/org/voltdb/utils/VoltTableUtil.java
@@ -119,7 +119,7 @@ public class VoltTableUtil {
                    }
                 }
                 else if (type == VoltType.GEOGRAPHY_POINT) {
-                    final GeographyPointValue pt = vt.getPoint(ii);
+                    final GeographyPointValue pt = vt.getGeographyPointValue(ii);
                     if (vt.wasNull()) {
                         fields[ii] = Constants.CSV_NULL;
                     }

--- a/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
@@ -833,7 +833,7 @@ public class RegressionSuite extends TestCase {
                 assertTrue(msg, actualRow.wasNull());
             }
             else if (expectedObj instanceof GeographyPointValue) {
-                assertApproximatelyEquals(msg, (GeographyPointValue) expectedObj, actualRow.getPoint(i), epsilon);
+                assertApproximatelyEquals(msg, (GeographyPointValue) expectedObj, actualRow.getGeographyPointValue(i), epsilon);
             }
             else if (expectedObj instanceof GeographyValue) {
                 assertApproximatelyEquals(msg, (GeographyValue) expectedObj, actualRow.getGeographyValue(i), epsilon);

--- a/tests/frontend/org/voltdb/regressionsuites/SaveRestoreBase.java
+++ b/tests/frontend/org/voltdb/regressionsuites/SaveRestoreBase.java
@@ -126,7 +126,7 @@ public class SaveRestoreBase extends RegressionSuite {
         }
     }
 
-    static protected GeographyPointValue getPoint(int index) {
+    static protected GeographyPointValue getGeographyPointValue(int index) {
         double lat = index % 90;
         double lng = (index * 2) % 180;
         if ((index & 0x1) != 0) {
@@ -140,10 +140,10 @@ public class SaveRestoreBase extends RegressionSuite {
         return new GeographyPointValue(lng, lat);
     }
 
-    static protected GeographyValue getGeography(int index) {
+    static protected GeographyValue getGeographyValue(int index) {
         List<GeographyPointValue> loop = new ArrayList<GeographyPointValue>();
         for (int i = 0; i < 3; ++i) {
-            loop.add(getPoint(index + i));
+            loop.add(getGeographyPointValue(index + i));
         }
         loop.add(loop.get(0));
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyPointValue.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyPointValue.java
@@ -81,11 +81,11 @@ public class TestGeographyPointValue extends RegressionSuite {
         assertTrue(vt.advanceRow());
         long id = vt.getLong(0);
         assertEquals(1, id);
-        GeographyPointValue ptByIndex = vt.getPoint(1);
+        GeographyPointValue ptByIndex = vt.getGeographyPointValue(1);
         assertTrue(vt.wasNull());
         assertNull(ptByIndex);
 
-        GeographyPointValue ptByColumnName = vt.getPoint("pt");
+        GeographyPointValue ptByColumnName = vt.getGeographyPointValue("pt");
         assertTrue(vt.wasNull());
         assertNull(ptByColumnName);
 
@@ -93,7 +93,7 @@ public class TestGeographyPointValue extends RegressionSuite {
 
         vt = client.callProcedure("@AdHoc", "select pt from t where pt is null;").getResults()[0];
         assertTrue(vt.advanceRow());
-        ptByIndex = vt.getPoint(0);
+        ptByIndex = vt.getGeographyPointValue(0);
         assert(vt.wasNull());
     }
 
@@ -107,7 +107,7 @@ public class TestGeographyPointValue extends RegressionSuite {
         VoltTable vt = client.callProcedure("@AdHoc",
                 "select pointfromtext('point (-71.2767 42.4906)') from t;").getResults()[0];
         assertTrue(vt.advanceRow());
-        GeographyPointValue pt = vt.getPoint(0);
+        GeographyPointValue pt = vt.getGeographyPointValue(0);
         assertFalse(vt.wasNull());
         assertEquals(42.4906, pt.getLatitude(), EPSILON);
         assertEquals(-71.2767, pt.getLongitude(), EPSILON);

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctions.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctions.java
@@ -735,7 +735,7 @@ public class TestGeospatialFunctions extends RegressionSuite {
 
         // verify results of asText from EE matches WKT format defined in frontend/java
         while (asTextVT.advanceRow()) {
-            GeographyPointValue gpv = asTextVT.getPoint(0);
+            GeographyPointValue gpv = asTextVT.getGeographyPointValue(0);
             if (gpv == null) {
                 assertEquals(null, asTextVT.getString(1));
             }


### PR DESCRIPTION
With changes verified TestGeospatialFunction regression test passes and documentation are picked up in java docs ("ant -f mmt.xml dist.pro check"). There were no changes needed in geospatial demo apps. For sanity purpose verified, demo app runs fine with the changes.

To do: have to ping Andrew about the changes so that any documentation around it can be updated.