### PR TITLE
ENG-9770: Fix EE IPC interface error in exeucteTask().

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1747,6 +1747,7 @@ void VoltDBEngine::executeTask(TaskType taskType, const char* taskParams) {
         if (m_executorContext->drReplicatedStream() && mpSequenceNumber >= 0) {
             m_executorContext->drReplicatedStream()->setLastCommittedSequenceNumber(mpSequenceNumber);
         }
+        m_resultOutput.writeInt(0);
         break;
     }
     case TASK_TYPE_SET_DR_PROTOCOL_VERSION: {
@@ -1764,6 +1765,7 @@ void VoltDBEngine::executeTask(TaskType taskType, const char* taskParams) {
             }
         }
         m_drVersion = drVersion;
+        m_resultOutput.writeInt(0);
         break;
     }
     default:


### PR DESCRIPTION
The Java side expects executeTask() to return something, so return 0 for
those tasks that don't have any return value to write. Otherwise, the
Java side will wait forever.