### PR TITLE
In EE, fix point comparison at poles and antimeridian

### DIFF
--- a/src/ee/common/GeographyPointValue.hpp
+++ b/src/ee/common/GeographyPointValue.hpp
@@ -80,6 +80,8 @@ public:
     // function should return a value that is the same as in Java
     // code: GeographyPointValue.EPSILON.
     static Coord epsilon() {
+        // Making this a static method rather than a static member
+        // variable for the same reason as nullCoord(), above.
         return 1e-12;
     }
 
@@ -229,7 +231,7 @@ private:
 
         // For longitudes within epsilon of the antimeridian
         // (on the east side), canonicalize to 180.0.
-        if (m_longitude < 0.0 && 180.0 + m_longitude < epsilon()) {
+        if (180.0 + m_longitude < epsilon()) {
             newLng = 180.0;
         }
 

--- a/src/ee/common/GeographyPointValue.hpp
+++ b/src/ee/common/GeographyPointValue.hpp
@@ -74,6 +74,15 @@ public:
         return 360.0;
     }
 
+    // Due to conversion to and from (x,y,z) coordinates needed to
+    // support our polygon representation, we consider points whose
+    // coordinates vary by less than this epsilon to be equal.  This
+    // function should return a value that is the same as in Java
+    // code: GeographyPointValue.EPSILON.
+    static Coord epsilon() {
+        return 1e-12;
+    }
+
     // The null point has 360 for both lat and long.
     bool isNull() const {
         return (m_latitude == nullCoord()) &&
@@ -98,24 +107,26 @@ public:
         assert(! isNull());
         assert(! rhs.isNull());
 
-        Coord lhsLong = getLongitude();
-        Coord rhsLong = rhs.getLongitude();
-        if (lhsLong < rhsLong) {
+        const GeographyPointValue canonThis = canonicalize();
+        const GeographyPointValue canonRhs = rhs.canonicalize();
+        Coord lhsLong = canonThis.getLongitude();
+        Coord rhsLong = canonRhs.getLongitude();
+        if (rhsLong - lhsLong > epsilon()) {
             return VALUE_COMPARE_LESSTHAN;
         }
 
-        if (lhsLong > rhsLong) {
+        if (lhsLong - rhsLong > epsilon()) {
             return VALUE_COMPARE_GREATERTHAN;
         }
 
         // latitude is equal; compare longitude
-        Coord lhsLat = getLatitude();
-        Coord rhsLat = rhs.getLatitude();
-        if (lhsLat < rhsLat) {
+        Coord lhsLat = canonThis.getLatitude();
+        Coord rhsLat = canonRhs.getLatitude();
+        if (rhsLat - lhsLat > epsilon()) {
             return VALUE_COMPARE_LESSTHAN;
         }
 
-        if (lhsLat > rhsLat) {
+        if (lhsLat - rhsLat > epsilon()) {
             return VALUE_COMPARE_GREATERTHAN;
         }
 
@@ -201,6 +212,28 @@ private:
 
         // decimal number
         return false;
+    }
+
+    // return a point that is equivalent to this but make sure that
+    // longitude is always 0 at either pole, and longitude of -180 is
+    // converted to 180.  Canonicalized points whose coordinates are
+    // within epsilon of each other are equal.
+    GeographyPointValue canonicalize() const {
+        Coord newLng = m_longitude;
+
+        if (90.0 - fabs(m_latitude) < epsilon()) {
+            // We are at one of the poles;
+            // longitude doesn't matter, so choose 0.
+            newLng = 0.0;
+        }
+
+        // For longitudes within epsilon of the antimeridian
+        // (on the east side), canonicalize to 180.0.
+        if (m_longitude < 0.0 && 180.0 + m_longitude < epsilon()) {
+            newLng = 180.0;
+        }
+
+        return GeographyPointValue(newLng, m_latitude);
     }
 
     Coord m_latitude;

--- a/src/ee/common/GeographyValue.hpp
+++ b/src/ee/common/GeographyValue.hpp
@@ -289,15 +289,11 @@ inline int GeographyValue::compareWith(const GeographyValue& rhs) const {
         S2Loop* rhsLoop = rhsPoly.loop(i);
 
         for (int j = 0; j < lhsLoop->num_vertices(); ++j) {
-            S2LatLng lhsLL(lhsLoop->vertex(j));
-            S2LatLng rhsLL(rhsLoop->vertex(j));
-
-            if (lhsLL < rhsLL) {
-                return VALUE_COMPARE_LESSTHAN;
-            }
-
-            if (lhsLL > rhsLL) {
-                return VALUE_COMPARE_GREATERTHAN;
+            const GeographyPointValue lhsVert(lhsLoop->vertex(j));
+            const GeographyPointValue rhsVert(rhsLoop->vertex(j));
+            int cmp = lhsVert.compareWith(rhsVert);
+            if (cmp != VALUE_COMPARE_EQUAL) {
+                return cmp;
             }
         }
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyPointValue.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyPointValue.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.client.Client;
+import org.voltdb.client.NoConnectionsException;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.types.GeographyPointValue;
@@ -213,6 +214,86 @@ public class TestGeographyPointValue extends RegressionSuite {
                 {0, "Bedford", BEDFORD_PT},
                 {1, "Santa Clara", SANTA_CLARA_PT}},
                 vt, EPSILON);
+    }
+
+    private void fillTableWithFunnyPoints(Client client) throws Exception {
+        final double lessThanEps = 1e-13; // 1/2 of epsilon
+        final double moreThanEps = 2e-12; // two times epsilon
+
+        int i = 0;
+        client.callProcedure("t.Insert", i++, "point", new GeographyPointValue(10.333, 20.666));
+        client.callProcedure("t.Insert", i++, "closePoint", new GeographyPointValue(10.333 + lessThanEps, 20.666 - lessThanEps));
+        client.callProcedure("t.Insert", i++, "farPoint", new GeographyPointValue(0.0, 10.0));
+        client.callProcedure("t.Insert", i++, "northPole1", new GeographyPointValue( 50.0, 90.0));
+        client.callProcedure("t.Insert", i++, "northPole2", new GeographyPointValue(-70.0, 90.0));
+        client.callProcedure("t.Insert", i++, "northPole3", new GeographyPointValue( 10.0, 90.0 - lessThanEps));
+        client.callProcedure("t.Insert", i++, "notNorthPole", new GeographyPointValue( 10.0, 90.0 - moreThanEps));
+        client.callProcedure("t.Insert", i++, "southPole1", new GeographyPointValue( 50.0, -90.0));
+        client.callProcedure("t.Insert", i++, "southPole2", new GeographyPointValue(-70.0, -90.0));
+        client.callProcedure("t.Insert", i++, "southPole3", new GeographyPointValue( 10.0, -90.0 + lessThanEps));
+        client.callProcedure("t.Insert", i++, "notSouthPole", new GeographyPointValue( 10.0, -90.0 + moreThanEps));
+        client.callProcedure("t.Insert", i++, "onAntimeridianNeg1", new GeographyPointValue(-180.0              , 37.0));
+        client.callProcedure("t.Insert", i++, "onAntimeridianNeg2", new GeographyPointValue(-180.0 + lessThanEps, 37.0));
+        client.callProcedure("t.Insert", i++, "onAntimeridianPos1", new GeographyPointValue( 180.0              , 37.0));
+        client.callProcedure("t.Insert", i++, "onAntimeridianPos2", new GeographyPointValue( 180.0 - lessThanEps, 37.0));
+        client.callProcedure("t.Insert", i++, "notOnIDLNeg", new GeographyPointValue(-180.0 + moreThanEps, 37.0));
+        client.callProcedure("t.Insert", i++, "notOnIDLPos", new GeographyPointValue( 180.0 - moreThanEps, 37.0));
+    }
+
+    // Make sure that points at the poles compare as equal.
+    // Also make sure that longitude 180 and -180 are seen as equal.
+    // Finally, make sure that points within our epsilon are considered equal.
+    public void testFunnyPointComparison() throws Exception {
+        Client client = getClient();
+        fillTableWithFunnyPoints(client);
+
+        VoltTable vt;
+        String query = "select t2.name "
+                + "from t as t1 inner join t as t2 "
+                + "  on t1.pt = t2.pt "
+                + "where t1.name = ? "
+                + "order by t1.pk";
+
+        vt = client.callProcedure("@AdHoc", query, "point").getResults()[0];
+        System.out.println(vt);
+        assertContentOfTable(new Object[][] {
+                {"point"},
+                {"closePoint"}},
+                vt);
+
+        vt = client.callProcedure("@AdHoc", query, "northPole1").getResults()[0];
+        System.out.println(vt);
+        assertContentOfTable(new Object[][] {
+                {"northPole1"},
+                {"northPole2"},
+                {"northPole3"}},
+                vt);
+
+        vt = client.callProcedure("@AdHoc", query, "southPole1").getResults()[0];
+        System.out.println(vt);
+        assertContentOfTable(new Object[][] {
+                {"southPole1"},
+                {"southPole2"},
+                {"southPole3"}},
+                vt);
+
+        vt = client.callProcedure("@AdHoc", query, "onAntimeridianNeg1").getResults()[0];
+        System.out.println(vt);
+        assertContentOfTable(new Object[][] {
+                {"onAntimeridianNeg1"},
+                {"onAntimeridianNeg2"},
+                {"onAntimeridianPos1"},
+                {"onAntimeridianPos2"}},
+                vt);
+
+        vt = client.callProcedure("@AdHoc", query, "onAntimeridianPos2").getResults()[0];
+        System.out.println(vt);
+        assertContentOfTable(new Object[][] {
+                {"onAntimeridianNeg1"},
+                {"onAntimeridianNeg2"},
+                {"onAntimeridianPos1"},
+                {"onAntimeridianPos2"}},
+                vt);
     }
 
     public void testPointGroupBy() throws Exception {

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
@@ -290,11 +290,11 @@ public class TestGeographyValueQueries extends RegressionSuite {
                             + "where t1.poly < t2.poly "
                             + "order by t1.pk, t2.pk").getResults()[0];
             assertContentOfTable(new Object[][] {
-                    {0, "Bermuda Triangle" , 1, "Bermuda Triangle with a hole"},
-                    {0, "Bermuda Triangle", 2, "Billerica Triangle"},
+                    {0, "Bermuda Triangle", 1, "Bermuda Triangle with a hole"},
                     {0, "Bermuda Triangle", 3, "Lowell Square"},
+                    {2, "Billerica Triangle", 0, "Bermuda Triangle"},
                     {2, "Billerica Triangle", 1, "Bermuda Triangle with a hole"},
-                    {2, "Billerica Triangle" , 3, "Lowell Square"},
+                    {2, "Billerica Triangle", 3, "Lowell Square"},
                     {3, "Lowell Square", 1, "Bermuda Triangle with a hole"}},
                     vt);
 
@@ -305,14 +305,14 @@ public class TestGeographyValueQueries extends RegressionSuite {
                             + "where t1.poly <= t2.poly "
                             + "order by t1.pk, t2.pk").getResults()[0];
             assertContentOfTable(new Object[][] {
-                    {0, "Bermuda Triangle" , 0, "Bermuda Triangle"},
-                    {0, "Bermuda Triangle" , 1, "Bermuda Triangle with a hole"},
-                    {0, "Bermuda Triangle", 2, "Billerica Triangle"},
+                    {0, "Bermuda Triangle", 0, "Bermuda Triangle"},
+                    {0, "Bermuda Triangle", 1, "Bermuda Triangle with a hole"},
                     {0, "Bermuda Triangle", 3, "Lowell Square"},
-                    {1, "Bermuda Triangle with a hole" , 1, "Bermuda Triangle with a hole"},
+                    {1, "Bermuda Triangle with a hole", 1, "Bermuda Triangle with a hole"},
+                    {2, "Billerica Triangle", 0, "Bermuda Triangle"},
                     {2, "Billerica Triangle", 1, "Bermuda Triangle with a hole"},
                     {2, "Billerica Triangle", 2, "Billerica Triangle"},
-                    {2, "Billerica Triangle" , 3, "Lowell Square"},
+                    {2, "Billerica Triangle", 3, "Lowell Square"},
                     {3, "Lowell Square", 1, "Bermuda Triangle with a hole"},
                     {3, "Lowell Square", 3, "Lowell Square"}},
                     vt);
@@ -324,10 +324,10 @@ public class TestGeographyValueQueries extends RegressionSuite {
                             + "where t1.poly > t2.poly "
                             + "order by t1.pk, t2.pk").getResults()[0];
             assertContentOfTable(new Object[][] {
+                    {0, "Bermuda Triangle", 2, "Billerica Triangle"},
                     {1, "Bermuda Triangle with a hole", 0, "Bermuda Triangle"},
                     {1, "Bermuda Triangle with a hole", 2, "Billerica Triangle"},
                     {1, "Bermuda Triangle with a hole", 3, "Lowell Square"},
-                    {2, "Billerica Triangle",0 ,"Bermuda Triangle"},
                     {3, "Lowell Square", 0, "Bermuda Triangle"},
                     {3, "Lowell Square", 2, "Billerica Triangle"}},
                     vt);
@@ -340,11 +340,11 @@ public class TestGeographyValueQueries extends RegressionSuite {
                             + "order by t1.pk, t2.pk").getResults()[0];
             assertContentOfTable(new Object[][] {
                     {0, "Bermuda Triangle", 0, "Bermuda Triangle"},
+                    {0, "Bermuda Triangle", 2, "Billerica Triangle"},
                     {1, "Bermuda Triangle with a hole", 0, "Bermuda Triangle"},
                     {1, "Bermuda Triangle with a hole", 1, "Bermuda Triangle with a hole"},
                     {1, "Bermuda Triangle with a hole", 2, "Billerica Triangle"},
                     {1, "Bermuda Triangle with a hole", 3, "Lowell Square"},
-                    {2, "Billerica Triangle", 0 ,"Bermuda Triangle"},
                     {2, "Billerica Triangle", 2, "Billerica Triangle"},
                     {3, "Lowell Square", 0, "Bermuda Triangle"},
                     {3, "Lowell Square", 2, "Billerica Triangle"},
@@ -589,8 +589,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
                             .getResults()[0];
             assertContentOfTable(new Object[][] {
                     {null, 3},
-                    {BERMUDA_TRIANGLE_POLY, 3},
                     {BILLERICA_TRIANGLE_POLY, 3},
+                    {BERMUDA_TRIANGLE_POLY, 3},
                     {LOWELL_SQUARE_POLY, 3},
                     {BERMUDA_TRIANGLE_HOLE_POLY, 3}},
                     vt);


### PR DESCRIPTION
We previously fixed a similar problem with our Java GeographyPointValue class.  This is the corresponding change for when we do point comparison in the EE.

Also make polygon comparison use the point comparison method for vertices.  Previously we were using S2's point compare, which puts latitude first.  This resulted in having to change some unit tests.