### PR TITLE
ENG-9759: Fix serialization in optimized DR UPDATE/DELETE path.

### DIFF
--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -437,18 +437,18 @@ private:
         return &m_data[TUPLE_HEADER_SIZE + colInfo->offset];
     }
 
-    inline void serializeColumnToExport(ExportSerializeOutput &io, int colOffset, int colIndex, uint8_t *nullArray) const {
+    inline void serializeColumnToExport(ExportSerializeOutput &io, int offset, const NValue &value, uint8_t *nullArray) const {
         // NULL doesn't produce any bytes for the NValue
         // Handle it here to consolidate manipulation of
         // the null array.
-        if (isNull(colIndex)) {
-            // turn on colIndex'th bit of nullArray
-            int byte = (colOffset + colIndex) >> 3;
-            int bit = (colOffset + colIndex) % 8;
+        if (value.isNull()) {
+            // turn on offset'th bit of nullArray
+            int byte = offset >> 3;
+            int bit = offset % 8;
             int mask = 0x80 >> bit;
             nullArray[byte] = (uint8_t)(nullArray[byte] | mask);
         } else {
-            getNValue(colIndex).serializeToExport_withoutNull(io);
+            value.serializeToExport_withoutNull(io);
         }
     }
 
@@ -929,7 +929,7 @@ inline void TableTuple::serializeToExport(ExportSerializeOutput &io,
 {
     int columnCount = sizeInValues();
     for (int i = 0; i < columnCount; i++) {
-        serializeColumnToExport(io, colOffset, i, nullArray);
+        serializeColumnToExport(io, colOffset + i, getNValue(i), nullArray);
     }
 }
 
@@ -940,9 +940,11 @@ inline void TableTuple::serializeToDR(ExportSerializeOutput &io,
         serializeToExport(io, colOffset, nullArray);
         serializeHiddenColumnsToDR(io);
     } else {
+        // relative index in the interesting column vector, used to find the correct bit in the null array
+        int colIndex = 0;
         std::vector<int> cols = *interestingColumns;
-        for (std::vector<int>::const_iterator cit = cols.begin(); cit != cols.end(); ++cit) {
-            serializeColumnToExport(io, colOffset, *cit, nullArray);
+        for (std::vector<int>::const_iterator cit = cols.begin(); cit != cols.end(); ++cit, ++colIndex) {
+            serializeColumnToExport(io, colOffset + colIndex, getNValue(*cit), nullArray);
         }
         serializeHiddenColumnsToDR(io);
     }

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -195,6 +195,7 @@ public:
         std::vector<bool> otherColumnAllowNull(2, false);
         otherColumnTypes.push_back(VALUE_TYPE_TINYINT); otherColumnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_TINYINT));
         otherColumnTypes.push_back(VALUE_TYPE_BIGINT);  otherColumnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_BIGINT));
+        otherColumnAllowNull[1] = true;
 
         m_otherSchemaWithIndex = TupleSchema::createTupleSchemaForTest(otherColumnTypes, otherColumnLengths, otherColumnAllowNull);
         m_otherSchemaWithoutIndex = TupleSchema::createTupleSchemaForTest(otherColumnTypes, otherColumnLengths, otherColumnAllowNull);
@@ -209,7 +210,9 @@ public:
         m_otherTableWithIndexReplica = reinterpret_cast<PersistentTable*>(voltdb::TableFactory::getPersistentTable(0, "OTHER_TABLE_1", m_otherSchemaWithIndexReplica, otherColumnNames, otherTableHandleWithIndex, false, 0));
         m_otherTableWithoutIndexReplica = reinterpret_cast<PersistentTable*>(voltdb::TableFactory::getPersistentTable(0, "OTHER_TABLE_2", m_otherSchemaWithoutIndexReplica, otherColumnNames, otherTableHandleWithoutIndex, false, 0));
 
-        vector<int> columnIndices(1, 0);
+        vector<int> columnIndices;
+        columnIndices.push_back(1);
+        columnIndices.push_back(0);
         TableIndexScheme scheme = TableIndexScheme("the_index", HASH_TABLE_INDEX,
                                                    columnIndices, TableIndex::simplyIndexColumns(),
                                                    true, true, m_otherSchemaWithIndex);
@@ -1043,6 +1046,32 @@ TEST_F(DRBinaryLogTest, DeleteWithUniqueIndexMultipleTables) {
     TableTuple tuple = m_otherTableWithIndexReplica->lookupTupleForDR(fifth_tuple);
     ASSERT_FALSE(tuple.isNullTuple());
     EXPECT_EQ(0, m_otherTableWithoutIndexReplica->activeTupleCount());
+}
+
+TEST_F(DRBinaryLogTest, DeleteWithUniqueIndexNullColumn) {
+    createIndexes();
+
+    std::pair<const TableIndex*, uint32_t> indexPair1 = m_otherTableWithIndex->getUniqueIndexForDR();
+    ASSERT_FALSE(indexPair1.first == NULL);
+
+    beginTxn(m_engine, 99, 99, 98, 70);
+    TableTuple temp_tuple = m_otherTableWithIndex->tempTuple();
+    temp_tuple.setNValue(0, ValueFactory::getTinyIntValue(0));
+    temp_tuple.setNValue(1, NValue::getNullValue(VALUE_TYPE_BIGINT));
+    TableTuple tuple = insertTuple(m_otherTableWithIndex, temp_tuple);
+    endTxn(m_engine, true);
+
+    flushAndApply(99);
+
+    EXPECT_EQ(1, m_otherTableWithIndexReplica->activeTupleCount());
+
+    beginTxn(m_engine, 100, 100, 99, 71);
+    deleteTuple(m_otherTableWithIndex, tuple);
+    endTxn(m_engine, true);
+
+    flushAndApply(100);
+
+    EXPECT_EQ(0, m_otherTableWithIndexReplica->activeTupleCount());
 }
 
 TEST_F(DRBinaryLogTest, DeleteWithUniqueIndexNoninlineVarchar) {


### PR DESCRIPTION
The optimized UPDATE/DELETE path only serializes the indexed
columns. The offset in the null array should use the relative position
of the column in the interesting column vector, not the actual table
column index.