### PR TITLE
ENG-9779, advance SpHandle for both SP and MP when replays CL.

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -237,16 +237,12 @@ public class MpScheduler extends Scheduler
             if (UniqueIdGenerator.getPartitionIdFromUniqueId(timestamp) == m_partitionId) {
                 m_uniqueIdGenerator.updateMostRecentlyGeneratedUniqueId(timestamp);
             }
-        }
-
-        if (message.isForReplay()) {
-            mpTxnId = message.getTxnId();
-            setMaxSeenTxnId(mpTxnId);
-        } else {
-            TxnEgo ego = advanceTxnEgo();
-            mpTxnId = ego.getTxnId();
+        } else  {
             timestamp = m_uniqueIdGenerator.getNextUniqueId();
         }
+
+        TxnEgo ego = advanceTxnEgo();
+        mpTxnId = ego.getTxnId();
 
         // Don't have an SP HANDLE at the MPI, so fill in the unused value
         Iv2Trace.logIv2InitiateTaskMessage(message, m_mailbox.getHSId(), mpTxnId, Long.MIN_VALUE);

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -445,13 +445,6 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             if (message.isForReplay()) {
                 TxnEgo ego = advanceTxnEgo();
                 newSpHandle = ego.getTxnId();
-                // ENG-9779
-                if (!m_outstandingTxns.isEmpty()) {
-                    m_replaySequencer.dump(m_mailbox.getHSId());
-                    tmLog.error("Detecting attempt to run SP txn(txnId=" + TxnEgo.txnIdToString(newSpHandle) +
-                            ") while there are outstanding MP txns: " + m_outstandingTxns.keySet() + " " +
-                            TxnEgo.txnIdCollectionToString(m_outstandingTxns.keySet()));
-                }
             } else if (m_isLeader && !message.isReadOnly()) {
                 TxnEgo ego = advanceTxnEgo();
                 newSpHandle = ego.getTxnId();


### PR DESCRIPTION
When replaySequencer receives sentinel and first fragment of MP txn,
it will remove the replay entry if there is no SP txn blocked by, and directly
sends following SP txn or remaining MP fragments to SP site's TransactionTaskQueue.
So the root cause is that during replay the sequence of txns arrive to SpScheduler are
not always same with the sequence in CL, we can't just get SpHandle from CL for
SP and advance the SpHandle for MP.

Change-Id: I6db1512ee966f22a155646dc5b76f7ffb4acaa43