### PR TITLE
Make ambiguous columns in order by expressions be errors.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1553,24 +1553,7 @@ NATIVE EE STUFF
     <antcall target="prep_libvoltdb"/>
 </target>
 
-<target name='ee_makefile.uptodate'>
-  <condition property="makefile.uptodate">
-    <and>
-    <!--set if makefile up to date and makefile non-zero length
-            Eliminates timeconsuming build.py in ee -->
-    <uptodate>
-      <srcfiles dir='${src.ee.dir}' includes='**/*' />
-      <srcfiles dir='${vendor.cpp.dir}'  includes='**/*' />
-      <srcfiles dir='${src.ee.test.dir}'  includes='**/*' />
-      <mapper type="merge" to="${build.dir}/makefile"/>
-    </uptodate>
-    <length file="${build.dir}/makefile" when="greater" length="0" />
-    </and>
-  </condition>
-</target>
-
-<target name='ee_buildmakefile' depends="catalog, jnicompile, buildinfo, ee_makefile.uptodate"
-    unless="makefile.uptodate"
+<target name='ee_buildmakefile' depends="catalog, jnicompile, buildinfo"
     description="Just make the makefile for the C++ JNI library.">
     <exec dir='.' executable='python' failonerror='true'>
         <env key="EEONLYBUILDMAKEFILE" value="true"/>

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
@@ -1309,9 +1309,10 @@ public class ExpressionColumn extends Expression {
                 // Column references which name columns in tables in the
                 // from clause are handled later an.
                 java.util.Set<SelectListAliasResolution> foundNames = new java.util.TreeSet<SelectListAliasResolution>();
-                Expression lastExpr = null;
+                Expression firstFoundExpr = null;
                 for (int i = 0; i < length; i++) {
-                     // Ferret out the table name, column name
+                    ExpressionColumn ecol = (columns[i] instanceof ExpressionColumn) ? (ExpressionColumn)columns[i] : null;
+                    // Ferret out the table name, column name
                     // and alias name from this select column.
                     // If the alias name is null, then use the column name.
                     // This may be null as well.
@@ -1349,7 +1350,7 @@ public class ExpressionColumn extends Expression {
                             }
                         }
                     }
-
+                }
                 // If we only got one answer, then we just return it.
                 // If we got more than one, then we print an ambiguous
                 // error message.  If we got no message, we let HSQL

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/QuerySpecification.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/QuerySpecification.java
@@ -256,7 +256,7 @@ public class QuerySpecification extends QueryExpression {
         resolveColumnReferencesInGroupBy();
     /**********************************************************************/
 
-        resolveColumnRefernecesInOrderBy(sortAndSlice);
+        resolveColumnReferencesInOrderBy(sortAndSlice);
     }
 
     /************************* Volt DB Extensions *************************/
@@ -350,7 +350,7 @@ public class QuerySpecification extends QueryExpression {
     }
     /**********************************************************************/
 
-    void resolveColumnRefernecesInOrderBy(SortAndSlice sortAndSlice) {
+    void resolveColumnReferencesInOrderBy(SortAndSlice sortAndSlice) {
 
         // replace the aliases with expressions
         // replace column names with expressions and resolve the table columns

--- a/tests/frontend/org/voltdb/planner/TestPlansJoin.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansJoin.java
@@ -1236,10 +1236,11 @@ public class TestPlansJoin extends PlannerTestCase {
        failToCompile("SELECT R3.C, C FROM R1 INNER JOIN R2 USING(C) INNER JOIN R3 ON C=R3.A;",
                      "Column \"C\" is ambiguous.  It's in tables: USING(C), R3");
        // Ambiguous columns in an order by expression.
-       failToCompile("select LR.A, RR.A from R1 LR, R1 RR order by A;", "Column \"A\" is ambiguous.  It's in tables: LR, RR");
+
+
+       failToCompile("select LR.A, RR.A from R1 LR, R1 RR order by A;", "The name \"A\" in an order by expression is ambiguous.  It's in columns: LR.A, RR.A.");
        // Note that LT.A and RT.A are not considered here.
        failToCompile("select LT.A as LA, RT.A as RA from R1 as LT, R1 as RT order by A;", "Column \"A\" is ambiguous.  It's in tables: LT, RT");
-       failToCompile("select LT.A, RT.A from R1 as LT, R1 as RT order by A", "Column \"A\" is ambiguous.  It's in tables: LT, RT");
        // Two columns in the select list with the same name.  This complicates
        // checking for order by aliases.
        failToCompile("select LT.A as LA, RT.A as LA from R1 as LT, R1 as RT order by LA;", "The name \"LA\" in an order by expression is ambiguous.  It's in columns: LA(0), LA(1)");

--- a/tests/frontend/org/voltdb/planner/TestPlansJoin.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansJoin.java
@@ -1245,6 +1245,27 @@ public class TestPlansJoin extends PlannerTestCase {
        failToCompile("select LT.A as LA, RT.A as LA from R1 as LT, R1 as RT order by LA;", "The name \"LA\" in an order by expression is ambiguous.  It's in columns: LA(0), LA(1)");
        failToCompile("select NOTC from R1, R3_NOC order by A;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
        failToCompile("select NOTC from R1, R3_NOC order by sqrt(A);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       // Ambiguous columns in an order by expression.
+       failToCompile("select LR.A, RR.A from R1 LR, R1 RR order by A;", "The name \"A\" in an order by expression is ambiguous.  It's in columns: LR.A, RR.A");
+       // Note that LT.A and RT.A are not considered here.
+       failToCompile("select LT.A as LA, RT.A as RA from R1 as LT, R1 as RT order by A;", "Column \"A\" is ambiguous.  It's in tables: LT, RT");
+       failToCompile("select LT.A, RT.A from R1 as LT, R1 as RT order by A", "The name \"A\" in an order by expression is ambiguous.  It's in columns: LT.A, RT.A");
+       // Two columns in the select list with the same name.  This complicates
+       // checking for order by aliases.
+       failToCompile("select (R1.A + 1) A, A from R1 order by A", "The name \"A\" in an order by expression is ambiguous.  It's in columns: A(0), R1.A.");
+       failToCompile("select LT.A as LA, RT.A as LA from R1 as LT, R1 as RT order by LA;", "The name \"LA\" in an order by expression is ambiguous.  It's in columns: LA(0), LA(1)");
+       failToCompile("select NOTC from R1, R3_NOC order by A;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       failToCompile("select NOTC from R1, R3_NOC order by sqrt(A);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       // This is not ambiguous.  The two aliases reference the same column.
+       compile("select R1.A, A from R1 where A > 0;");
+       compile("select lr.a from r1 lr, r1 rr order by a;");
+       failToCompile("select lr.a a, rr.a a from r1 lr, r2 rr order by a;", "The name \"A\" in an order by expression is ambiguous.  It's in columns: LR.A, RR.A");
+       // Since A is in the using list, lr.a and rr.a are the same.
+       compile("select lr.a alias, lr.a, a, lr.a + 1 aliasexp, lr.a + 1, a + 1 from r1 lr order by a;");
+       compile("select lr.a a, a from r1 lr join r1 rr using (a) order by a;");
+       compile("select lr.a a, rr.a from r1 lr join r1 rr using (a) order by a;");
+       // R1 join R2 on R1.A = R2.A is not R1 join R2 using(A).
+       failToCompile("select lr.a a, rr.a a from r1 lr join r1 rr on lr.a = rr.a order by a;", "The name \"A\" in an order by expression is ambiguous.  It's in columns: LR.A, RR.A");
        // This is not actually an ambiguous query.  This is actually ok.
        compile("select * from R2 where A in (select A from R1);");
        compile("SELECT R3.C, C FROM R1 INNER JOIN R2 USING(C) INNER JOIN R3 USING(C);");

--- a/tests/frontend/org/voltdb/planner/TestPlansJoin.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansJoin.java
@@ -1215,6 +1215,8 @@ public class TestPlansJoin extends PlannerTestCase {
        // Ambiguous reference in a where clause.
        failToCompile("select NOTC from R1, R3_NOC where A > 100;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
        failToCompile("select NOTC from R1, R3_NOC where A > sqrt(NOTC);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       failToCompile("select NOTC from R1, R3_NOC where sqrt(A) > sqrt(NOTC);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       failToCompile("select NOTC from R1 join R3_NOC on sqrt(A) > sqrt(NOTC);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
        // Ambiguous reference to an unconstrained column in a join.  That is,
        // C is in both R1 and R3, R1 and R3 are joined together, but not on C.
        // Note that we test above for a similar case, with three joined tables.
@@ -1223,6 +1225,7 @@ public class TestPlansJoin extends PlannerTestCase {
        // Ambiguous references in group by expressions.
        failToCompile("select NOTC from R1, R3_NOC group by A;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
        failToCompile("select NOTC from R1, R3_NOC group by sqrt(A);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       failToCompile("select sqrt(R1.A) from R1, R3_NOC group by R1.A having count(A) + 2 * sum(A) > 2;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
        // Ambiguous references in subqueries.
        failToCompile("select ALPHA from (select SQRT(A) as ALPHA from R1) as S1, (select SQRT(C) as ALPHA from R1) as S2;",
                      "Column \"ALPHA\" is ambiguous.  It's in tables: S1, S2");
@@ -1232,6 +1235,16 @@ public class TestPlansJoin extends PlannerTestCase {
                      "Column \"C\" is ambiguous.  It's in tables: USING(C), R3");
        failToCompile("SELECT R3.C, C FROM R1 INNER JOIN R2 USING(C) INNER JOIN R3 ON C=R3.A;",
                      "Column \"C\" is ambiguous.  It's in tables: USING(C), R3");
+       // Ambiguous columns in an order by expression.
+       failToCompile("select LR.A, RR.A from R1 LR, R1 RR order by A;", "Column \"A\" is ambiguous.  It's in tables: LR, RR");
+       // Note that LT.A and RT.A are not considered here.
+       failToCompile("select LT.A as LA, RT.A as RA from R1 as LT, R1 as RT order by A;", "Column \"A\" is ambiguous.  It's in tables: LT, RT");
+       failToCompile("select LT.A, RT.A from R1 as LT, R1 as RT order by A", "Column \"A\" is ambiguous.  It's in tables: LT, RT");
+       // Two columns in the select list with the same name.  This complicates
+       // checking for order by aliases.
+       failToCompile("select LT.A as LA, RT.A as LA from R1 as LT, R1 as RT order by LA;", "The name \"LA\" in an order by expression is ambiguous.  It's in columns: LA(0), LA(1)");
+       failToCompile("select NOTC from R1, R3_NOC order by A;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       failToCompile("select NOTC from R1, R3_NOC order by sqrt(A);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
        // This is not actually an ambiguous query.  This is actually ok.
        compile("select * from R2 where A in (select A from R1);");
        compile("SELECT R3.C, C FROM R1 INNER JOIN R2 USING(C) INNER JOIN R3 USING(C);");
@@ -1242,6 +1255,7 @@ public class TestPlansJoin extends PlannerTestCase {
        compile("SELECT R2.C FROM R1 INNER JOIN R2 USING (C), R3");
        compile("SELECT R1.C FROM R1 INNER JOIN R2 USING (C), R3 WHERE R1.A = R3.A");
        compile("SELECT R3.C, R1.C FROM R1 INNER JOIN R2 USING(C), R3;");
+       compile("SELECT C, C FROM R1 GROUP BY C ORDER BY C;");
    }
 
     @Override

--- a/tests/frontend/org/voltdb/regressionsuites/TestGroupByComplexSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGroupByComplexSuite.java
@@ -222,8 +222,8 @@ public class TestGroupByComplexSuite extends RegressionSuite {
 
             // (3) Test Order by with FUNCTION expression, no group by column in display columns
             // Test Order by without tag
-            cr = client.callProcedure("@AdHoc", "SELECT ABS(dept) as tag, SUM(ABS(wage) - 1) as tag, " +
-                    "(count(*)+sum(dept*2))/2 from " + tb + " GROUP BY dept ORDER BY tag");
+            cr = client.callProcedure("@AdHoc", "SELECT ABS(dept) as tag1, SUM(ABS(wage) - 1) as tag2, " +
+                    "(count(*)+sum(dept*2))/2 from " + tb + " GROUP BY dept ORDER BY tag1");
             assertEquals(ClientResponse.SUCCESS, cr.getStatus());
             vt = cr.getResults()[0];
             expected = new long[][] { {1, 57, 4} , {2, 88, 5}};

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -489,7 +489,7 @@ public class TestSubQueriesSuite extends RegressionSuite {
                     "where T1.id = T2.id " +
                     "and exists " +
                     "    (select 1 from R1 where R1.dept * 2 = T2.dept) " +
-                    "order by id;";
+                    "order by t1.id;";
             validateTableOfLongs(client, sql, new long[][] {{4}, {5}});
 
             sql =   "select t1.id, t2.id from r1 t1, " + tb + " t2 " +

--- a/tests/sqlcmd/baselines/querytimeout/notimeout.outbaseline
+++ b/tests/sqlcmd/baselines/querytimeout/notimeout.outbaseline
@@ -307,7 +307,7 @@ INSERT INTO T VALUES(98, 8, 3);
 INSERT INTO T VALUES(99, 9, 4);
 (Returned 1 rows in #.##s)
 
-SELECT t1.b, t2.c, COUNT(*) as tag FROM t t1, t t2 WHERE t1.b > ANY (SELECT t4.a from t t3, t t4, t t5 WHERE t5.a=t4.a AND t1.a > t3.c) AND T2.b > -1 GROUP BY t1.b, t2.c ORDER BY b, c LIMIT 10;
+SELECT t1.b, t2.c, COUNT(*) as tag FROM t t1, t t2 WHERE t1.b > ANY (SELECT t4.a from t t3, t t4, t t5 WHERE t5.a=t4.a AND t1.a > t3.c) AND T2.b > -1 GROUP BY t1.b, t2.c ORDER BY t1.b, t2.c LIMIT 10;
 B  C  TAG 
 -- -- ----
  1  0  200

--- a/tests/sqlcmd/baselines/querytimeout/timeout.outbaseline
+++ b/tests/sqlcmd/baselines/querytimeout/timeout.outbaseline
@@ -307,4 +307,4 @@ INSERT INTO T VALUES(98, 8, 3);
 INSERT INTO T VALUES(99, 9, 4);
 (Returned 1 rows in #.##s)
 
-SELECT t1.b, t2.c, COUNT(*) as tag FROM t t1, t t2 WHERE t1.b > ANY (SELECT t4.a from t t3, t t4, t t5 WHERE t5.a=t4.a AND t1.a > t3.c) AND T2.b > -1 GROUP BY t1.b, t2.c ORDER BY b, c LIMIT 10;
+SELECT t1.b, t2.c, COUNT(*) as tag FROM t t1, t t2 WHERE t1.b > ANY (SELECT t4.a from t t3, t t4, t t5 WHERE t5.a=t4.a AND t1.a > t3.c) AND T2.b > -1 GROUP BY t1.b, t2.c ORDER BY t1.b, t2.c LIMIT 10;

--- a/tests/sqlcmd/scripts/querytimeout/notimeout.in
+++ b/tests/sqlcmd/scripts/querytimeout/notimeout.in
@@ -2,6 +2,6 @@ drop table t if exists;
 create table t ( a INTEGER NOT NULL, b INTEGER NOT NULL, c INTEGER NOT NULL);
 file ./scripts/querytimeout/datainput.sql
 
-SELECT t1.b, t2.c, COUNT(*) as tag FROM t t1, t t2 WHERE t1.b > ANY (SELECT t4.a from t t3, t t4, t t5 WHERE t5.a=t4.a AND t1.a > t3.c) AND T2.b > -1 GROUP BY t1.b, t2.c ORDER BY b, c LIMIT 10;
+SELECT t1.b, t2.c, COUNT(*) as tag FROM t t1, t t2 WHERE t1.b > ANY (SELECT t4.a from t t3, t t4, t t5 WHERE t5.a=t4.a AND t1.a > t3.c) AND T2.b > -1 GROUP BY t1.b, t2.c ORDER BY t1.b, t2.c LIMIT 10;
 
 drop table t;

--- a/tests/sqlcmd/scripts/querytimeout/timeout.in
+++ b/tests/sqlcmd/scripts/querytimeout/timeout.in
@@ -2,6 +2,6 @@ drop table t if exists;
 create table t ( a INTEGER NOT NULL, b INTEGER NOT NULL, c INTEGER NOT NULL);
 file ./scripts/querytimeout/datainput.sql
 
-SELECT t1.b, t2.c, COUNT(*) as tag FROM t t1, t t2 WHERE t1.b > ANY (SELECT t4.a from t t3, t t4, t t5 WHERE t5.a=t4.a AND t1.a > t3.c) AND T2.b > -1 GROUP BY t1.b, t2.c ORDER BY b, c LIMIT 10;
+SELECT t1.b, t2.c, COUNT(*) as tag FROM t t1, t t2 WHERE t1.b > ANY (SELECT t4.a from t t3, t t4, t t5 WHERE t5.a=t4.a AND t1.a > t3.c) AND T2.b > -1 GROUP BY t1.b, t2.c ORDER BY t1.b, t2.c LIMIT 10;
 
 drop table t;


### PR DESCRIPTION
In HSQLDB there is some code to replace aliases in the order by list
with the expressions which the aliases name.  This code had the same
diseases the regular column reference resolution code did, in that it
stopped when it found one definition.  This means that ambiguous
definitions are not discovered.

This fix finds ambiguous column references in the order by list and
throws errors.  Tests were added for group by, order by and having.
There were already several tests for where and joins.

There are still some problems with aliases in group by expressions.
These are to be addressed in ENG-9782.

https://issues.voltdb.com/browse/ENG-9828