### PR TITLE
Eng 9828 Make Ambiguous Column References in order by expressions be errors.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1553,24 +1553,7 @@ NATIVE EE STUFF
     <antcall target="prep_libvoltdb"/>
 </target>
 
-<target name='ee_makefile.uptodate'>
-  <condition property="makefile.uptodate">
-    <and>
-    <!--set if makefile up to date and makefile non-zero length
-            Eliminates timeconsuming build.py in ee -->
-    <uptodate>
-      <srcfiles dir='${src.ee.dir}' includes='**/*' />
-      <srcfiles dir='${vendor.cpp.dir}'  includes='**/*' />
-      <srcfiles dir='${src.ee.test.dir}'  includes='**/*' />
-      <mapper type="merge" to="${build.dir}/makefile"/>
-    </uptodate>
-    <length file="${build.dir}/makefile" when="greater" length="0" />
-    </and>
-  </condition>
-</target>
-
-<target name='ee_buildmakefile' depends="catalog, jnicompile, buildinfo, ee_makefile.uptodate"
-    unless="makefile.uptodate"
+<target name='ee_buildmakefile' depends="catalog, jnicompile, buildinfo"
     description="Just make the makefile for the C++ JNI library.">
     <exec dir='.' executable='python' failonerror='true'>
         <env key="EEONLYBUILDMAKEFILE" value="true"/>

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -59,6 +59,10 @@
 #include <vector>
 #include <jsoncpp/jsoncpp.h>
 
+#ifndef NDEBUG
+#include "debuglog.h"
+#endif /* !define(NDEBUG) */
+
 class CopyOnWriteTest_TestTableTupleFlags;
 
 namespace voltdb {
@@ -110,7 +114,12 @@ public:
      * backing store
      */
     inline void move(void *address) {
-        assert(m_schema);
+#ifndef  NDEBUG
+        if (m_schema == NULL && address != NULL) {
+            StackTrace::printStackTrace();
+        }
+#endif
+        assert(m_schema != NULL || address == NULL);
         m_data = reinterpret_cast<char*> (address);
     }
 

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
@@ -394,17 +394,11 @@ public class ExpressionColumn extends Expression {
                     //       in name order.
                     if (usingResolutions.size() > 0) {
                         sb.append("USING(");
-                        for (ColumnReferenceResolution crr : usingResolutions) {
-                            sb.append(sep).append(crr.getName());
-                            sep = ", ";
-                        }
+                        appendNameList(sb, usingResolutions, "");
                         sb.append(")");
                         sep = ", ";
                     }
-                    for (ColumnReferenceResolution crr : rangeVariableResolutions) {
-                        sb.append(sep).append(crr.getName());
-                        sep = ", ";
-                    }
+                    appendNameList(sb, rangeVariableResolutions, sep);
                     throw new HsqlException(sb.toString(), "", 0);
                 }
                 // If we get here we didn't find anything.  So, add this expression
@@ -419,6 +413,19 @@ public class ExpressionColumn extends Expression {
         return unresolvedSet;
     }
 
+    /*
+     * Append the names of all the elements in the set of resolutions to the
+     * string buffer.  This is only used for error messages.
+     */
+    private <T> void appendNameList(StringBuffer sb,
+                                    java.util.Set<T> resolutions,
+                                    String sep) {
+        for (T oneRes : resolutions) {
+            sb.append(sep).append(oneRes.toString());
+            sep = ", ";
+        }
+    }
+
     /**
      * Return a sort of closure which is useful for resolving a column reference.
      * The column reference is either an expression or a column in a table, which
@@ -428,7 +435,7 @@ public class ExpressionColumn extends Expression {
      * until we have examined all of them.  So, we defer changing this object
      * until we are more sure of the reference.
      *
-     * We store these in a java.util.HashSet.  So we need to have our own
+     * We store these in a java.util.TreeSet.  So we need to have our own
      * notion of equality.
      */
     private interface ColumnReferenceResolution {
@@ -484,6 +491,7 @@ public class ExpressionColumn extends Expression {
         }
 
     }
+
     /**
      * This class implements the interface for expression columns.
      * An expression column is created for a "USING(C)" join condition.
@@ -612,7 +620,7 @@ public class ExpressionColumn extends Expression {
 
         @Override
         public String getName() {
-            // We prefer to aliases.  If we can't find an
+            // We prefer to use aliases.  If we can't find an
             // alias, we use the table name.
             if (m_rangeVariable.tableAlias != null && m_rangeVariable.tableAlias.name != null) {
                 return m_rangeVariable.tableAlias.name;
@@ -1000,9 +1008,272 @@ public class ExpressionColumn extends Expression {
         }
     }
 
+
+    /*
+     * This class holds the name of an expression to which a column
+     * reference in an order by resolves.  This is actually for error messages, not debugging.
+     * The indices are useful only if tableName != null.
+     *
+     * The T.C case occurs when one references a select list
+     * element T.C in a column reference. For example:
+     *
+     *       select T.C, T.C from T where T.C > 0;
+     *
+     * In this case, T.C is repeated twice, but it's always the same column in the
+     * same table. So, the indices, which is to say the order in the select list,
+     * would be irrelevant. That's why the compareTo method only cares about
+     * names if there is a table name. If we see this SQL:
+     *
+     *     select C, C from T where C > 0;
+     *
+     * We know C is not an alias, and so we look up C first, and then we
+     * look up C's table name. So we will be in the non-null table name case.
+     *
+     * If there is not a table name, that is to say if tableName == null,
+     * then we are looking at an alias. This would be the case for this SQL:
+     *
+     *   select T.C as CC, T.E, T.D as CC from T where CC > 0;
+     *
+     * In this case the aliases CC are equal and we care about the indices.
+     * We want to give an error message which says
+     *        "CC occurs in columns: CC(1), CC(3)".
+     * The numbers in parentheses are the indices, and the order in which
+     * the alias occurs in the select list.  Note that in this case,
+     * with two select list expressions aliased as CC, the name CC is not
+     * resolvable anywhere.
+     */
+    private static class SelectListAliasResolution implements Comparable<SelectListAliasResolution> {
+        // This is the expression in the select list.
+        private final Expression m_expression;
+        // The table name.  This may be null for a general expression.
+        private final String m_tableName;
+        // The table alias from the range variable.  This is different
+        // from the table name in queries like "select .. from T as A..."
+        // where A is the alias and T is the name.
+        private final String m_tableAlias;
+        // The column name.  This may be null for a general expression.
+        private final String m_columnName;
+        // The alias of the column from the select list.  If there
+        // is no alias, this is the column name.
+        private final String m_alias;
+        // The zero-based index of the column.  This is the order
+        // of this column in the select list.
+        //
+        // This is mostly used to disambiguate if the name is
+        // not equal.
+        private final int m_index;
+
+        public SelectListAliasResolution(Expression expr, String selectTableName, String selectTableAlias, String selectColumnName, String alias, int index) {
+            m_expression = expr;
+            m_tableName = selectTableName;
+            m_tableAlias = selectTableAlias;
+            m_columnName = selectColumnName;
+            // If we were not given an alias, then
+            // use the column name as an alias.  If
+            // m_columnName is null this is ok, and can
+            // happen in statements like: SELECT T.X * R.Y AS PROD FROM T, R
+            // where we don't have any canonical table name or column name
+            // for PROD.
+            m_alias = (alias == null) ? m_columnName : alias;
+            m_index = index;
+        }
+
+        public final ExpressionColumn getExpressionColumn() {
+            if (m_expression instanceof ExpressionColumn) {
+                return (ExpressionColumn)m_expression;
+            } else {
+                return null;
+            }
+        }
+
+        public String getName() {
+            if (m_tableAlias == null) {
+                return m_alias;
+            } else if (m_tableAlias.length() == 0) {
+                return m_columnName;
+            } else {
+                return m_tableAlias + "." + m_columnName;
+            }
+        }
+
+        @Override
+        public String toString() {
+            if (m_alias != null && !m_alias.equals(m_columnName)) {
+                return m_alias + "(" + m_index + ")";
+            } else {
+                return getName();
+            }
+        }
+        @Override
+        public boolean equals(Object other) {
+            if (other == null) {
+                return false;
+            }
+            if (!(other instanceof SelectListAliasResolution)) {
+                return false;
+            }
+            // The real equals test is here.  We defer to compareTo.
+            SelectListAliasResolution aliasOther = (SelectListAliasResolution)other;
+            int nc = compareTo(aliasOther);
+            return nc == 0;
+        }
+
+        /*
+         * We are comparing two select list elements.
+         *   o The simple case is that they are neither column references.
+         *     This can happen if they are more general expressions, such
+         *     as "(x + 1) as a" compared to a column reference a.
+         *     The m_expressionColumn will be null in the general expression
+         *     case.  In this case we just compare the index.  Mostly
+         *     these will not be equal, but we need a reliable order.
+         *   o The more complicated case is if they are both column references.
+         *     In this case, m_expressionColumn will be non-null, and this
+         *     ExpressionColumn should have a range variable.  We mostly
+         *     ignore any column aliases, since we want to know if these
+         *     two column references are to the same column.  So we compare
+         *     table aliases and column names, and we look up the column
+         *     name in the using list.  These will be in the range variable.
+         * Note that we don't care about aliases at all here.
+         */
+        @Override
+        public int compareTo(SelectListAliasResolution o) {
+            ExpressionColumn ecol = getExpressionColumn();
+            ExpressionColumn oecol = o.getExpressionColumn();
+            if (ecol == null || oecol == null) {
+                // We only want to be equal if the other's index is
+                // equal to ours.  This will always be false, I think.
+                return m_index - o.m_index;
+            } else {
+                // They are both column references.  We want to return
+                // 0 if they refer to the same table expression column.
+                // This is to say, if they have the same column name and
+                // the same table alias or else their column name is in
+                // the using list for their range variables.  It has to
+                // be in the using list for both range variables.  In
+                // a query like this:
+                //   select C from R as LR join R as CR using(C), R as RR order by C;
+                // C is in the using list of the first join (LR and CR) but
+                // not the third (RR).  So, this would be ambiguous.
+                int nc = m_columnName.compareTo(o.m_columnName);
+                if (nc != 0) {
+                    return nc;
+                } else {
+                    RangeVariable rv = ecol.getRangeVariable();
+                    RangeVariable orv = oecol.getRangeVariable();
+                    if (rv == null) {
+                        if (orv == null) {
+                            return m_index - o.m_index;
+                        } else {
+                            // Find out if this column name is in the
+                            // using list of orv.  If it is, these both
+                            // denote the same column.  We want to use the
+                            // alias here because we always have an alias
+                            // and we may not have a column name.
+                            if (orv.getColumnExpression(m_alias) != null) {
+                                return 0;
+                            } else {
+                                return m_index - o.m_index;
+                            }
+                        }
+                    } else if (orv == null) {
+                        // If orv == null but the column names are equal, it
+                        // could be that orv is an instance of a using variable
+                        // and rv is the range variable for the column with
+                        // the same column name.  Remember, getColumnExpression()
+                        // just gets ExpressionColumns for USING column names.
+                        if (rv.getColumnExpression(m_columnName) != null) {
+                            return 0;
+                        } else {
+                            return m_index - o.m_index;
+                        }
+                    } else {
+                        ExpressionColumn myEC = rv.getColumnExpression(m_columnName);
+                        ExpressionColumn oEC = orv.getColumnExpression(m_columnName);
+
+                        if (myEC != null && oEC != null && myEC == oEC) {
+                            // They are the same in a using list.
+                            return 0;
+                        } else {
+                            assert(m_tableAlias != null);
+                            return m_tableAlias.compareTo(o.m_tableAlias);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /*
+     * If we see an ExpressionColumn in an order by expression,
+     * we we look to see if it's an alias for something in the
+     * select list.  If it is, we replace the column expression
+     * with the expression to which the alias refers.  Note that
+     * this creates a kind of scoping.  If a column reference
+     * name matches an alias or an unaliased column name in a
+     * select list it has replaced, and is not ambiguous with
+     * any other column in the table expression.
+     *
+     * For example,
+     *   select r1.b, b from r1 order by b;
+     *   -- b is not ambiguous.  Both select list possibilities,
+     *   -- lr.b and b, are to the same table.
+     *
+     *   select lr.b from r1 lr, r1 rr order by b;
+     *   -- b is not ambiguous.  The b in the order by is
+     *   -- replaced by lr.b from the select list.
+     *
+     *   select lr.b b, rr.b b from r1 lr, r2 rr order by b;
+     *   -- b is ambiguous.  There are two aliases named b.
+     *   select lr.b b, b from r1 lr join r1 rr using (b) order by b;
+     *   -- Mysql and postgresql differ in this case.  It may
+     *   -- be because of different rules for using.
+     *   -- This is ambiguous with postgresql, but not
+     *   -- with mysql.  A close reading of the standard might
+     *   -- suggest that the first reference to lr.b is illegal,
+     *   -- since the USING removes column "b" from the table expression
+     *   -- columns, so perhaps both are wrong.  If we ignore that,
+     *   -- it makes sense that this is unambiguous, since the
+     *   -- "b" in the order by, the "b" in the select list and
+     *   -- the "b" in "lr.b" are all references of the same
+     *   -- column.
+     *   select lr.b b, rr.b b from r1 lr join r1 rr using (b) order by b;
+     *   -- It's interesting that this, which is almost exactly the
+     *      same as the previous case, is ambiguous for both mysql and
+     *      postgresql.  Apparently rr.b and ll.b are different to the
+     *      mysql SQL compiler, even though the using(b) forces them to
+     *      be identical.
+     *
+     * This function calculates the replacement expression.  We
+     * look through the select list, whose expressions are in
+     * the parameter columns[0:length-1].  This array may have
+     * some other columns, but these are the only ones we care
+     * about.  For each such Expression, expr, if this column
+     * reference matches the expression, then put the expression
+     * in the list of candidates. Since we only want one, we
+     * will remember the last Expression we added.  At the
+     * end, if there is only one candidate, we return the last
+     * expression we added.  Otherwise we craft an error message
+     * from the list of candidates.  If there are no candidates
+     * we just return this, and let HSQL return its cryptic not-found
+     * message.
+     *
+     * Consider a variant of the first example above.
+     *   select lr.a, lr.a a, a from r1 lr order by a;
+     * Here all of these are references to the same table
+     * expression column.  So, these are all unambiguous.
+     * So, when we add each of these columns to the set,
+     * of candidates we want only one to be added.  We
+     * need to know when two such expressions refer to the
+     * same table expression column.  We also want to know
+     * if the column reference from the select list is
+     * in a using list.
+     */
     @Override
     Expression replaceAliasInOrderBy(Expression[] columns, int length) {
 
+        // Recurse into sub-expressions.  For example, if
+        // this expression is e0 + e1, nodes[0] is e0 and
+        // nodes[1] is e1.
         for (int i = 0; i < nodes.length; i++) {
             if (nodes[i] == null) {
                 continue;
@@ -1010,41 +1281,89 @@ public class ExpressionColumn extends Expression {
 
             nodes[i] = nodes[i].replaceAliasInOrderBy(columns, length);
         }
-
+        // Now process the node itself.
         switch (opType) {
 
             case OpTypes.COALESCE :
             case OpTypes.COLUMN : {
+                // Look through all the columns in columns.  These are
+                // the select list, and they may have aliases equal to
+                // the column which we are trying to resolve.  In that
+                // case we really want to use the expression in the
+                // select list.  Note that we only look for aliases here.
+                // Column references which name columns in tables in the
+                // from clause are handled later on.
+                java.util.Set<SelectListAliasResolution> foundNames = new java.util.TreeSet<SelectListAliasResolution>();
+                Expression firstFoundExpr = null;
                 for (int i = 0; i < length; i++) {
-                    SimpleName aliasName = columns[i].alias;
-                    String     alias     = aliasName == null ? null
-                                                             : aliasName.name;
-
-                    if (schema == null && tableName == null
-                            && columnName.equals(alias)) {
-                        return columns[i];
+                    ExpressionColumn ecol = (columns[i] instanceof ExpressionColumn) ? (ExpressionColumn)columns[i] : null;
+                    // Ferret out the table name, column name
+                    // and alias name from this select column.
+                    // If the alias name is null, then use the column name.
+                    // This may be null as well.
+                    String     selectTableName = null;
+                    String     selectTableAlias = null;
+                    String     selectColumnName = null;
+                    if (ecol != null) {
+                        selectTableName = ecol.getTableName();
+                        selectTableAlias = ecol.getTableAlias();
+                        if (selectTableAlias == null) {
+                            selectTableAlias = selectTableName;
+                        }
+                        selectColumnName = ecol.columnName;
+                    }
+                    SimpleName selectAliasName = columns[i].alias;
+                    String     selectAlias     = selectAliasName == null ? null : selectAliasName.name;
+                    if (selectAlias == null) {
+                        selectAlias = selectColumnName;
+                    }
+                    // For VoltDB, schema will always be null.
+                    if (schema == null) {
+                        // If this reference has no table name, then
+                        // just compare the aliases.  If this reference
+                        // has a table name this is handled
+                        // by the usual lookup rules.
+                        if (tableName == null) {
+                            if (columnName.equals(selectAlias)) {
+                                foundNames.add(new SelectListAliasResolution(columns[i],
+                                                                             selectTableName,
+                                                                             selectTableAlias,
+                                                                             selectColumnName,
+                                                                             selectAlias,
+                                                                             i));
+                                if (firstFoundExpr == null) {
+                                    firstFoundExpr = columns[i];
+                                }
+                            }
+                        }
                     }
                 }
-
-                for (int i = 0; i < length; i++) {
-                    if (columns[i] instanceof ExpressionColumn) {
-                        if (this.equals(columns[i])) {
-                            return columns[i];
-                        }
-
-                        if (tableName == null && schema == null
-                                && columnName
-                                    .equals(((ExpressionColumn) columns[i])
-                                        .columnName)) {
-                            return columns[i];
-                        }
-                    }
+                // If we only got one answer, then we just return it.
+                // If we got more than one, then we print an ambiguous
+                // error message.  If we got no answer, we let HSQL
+                // handle it in the usual way.
+                if (foundNames.size() == 1) {
+                    return firstFoundExpr;
+                } else if (foundNames.size() > 1) {
+                    StringBuffer sb = new StringBuffer();
+                    sb.append(String.format("The name \"%s\" in an order by expression is ambiguous.  It's in columns: ", columnName));
+                    appendNameList(sb, foundNames, "");
+                    sb.append(".");
+                    throw new HsqlException(sb.toString(), "", 0);
                 }
             }
             default :
         }
 
         return this;
+    }
+
+    private String getTableAlias() {
+        if (getRangeVariable() == null
+                || getRangeVariable().tableAlias == null) {
+            return null;
+        }
+        return getRangeVariable().tableAlias.name;
     }
 
     @Override
@@ -1155,7 +1474,7 @@ public class ExpressionColumn extends Expression {
                 exp.attributes.put("table", tableName.toUpperCase());
             }
         }
-        //TODO: also indicate RangeVariable in case table is ambiguus (for self-joins).
+        //TODO: also indicate RangeVariable in case table is ambiguous (for self-joins).
         exp.attributes.put("column", columnName.toUpperCase());
         if ((alias == null) || (getAlias().length() == 0)) {
             exp.attributes.put("alias", columnName.toUpperCase());

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/QuerySpecification.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/QuerySpecification.java
@@ -256,7 +256,7 @@ public class QuerySpecification extends QueryExpression {
         resolveColumnReferencesInGroupBy();
     /**********************************************************************/
 
-        resolveColumnRefernecesInOrderBy(sortAndSlice);
+        resolveColumnReferencesInOrderBy(sortAndSlice);
     }
 
     /************************* Volt DB Extensions *************************/
@@ -350,7 +350,7 @@ public class QuerySpecification extends QueryExpression {
     }
     /**********************************************************************/
 
-    void resolveColumnRefernecesInOrderBy(SortAndSlice sortAndSlice) {
+    void resolveColumnReferencesInOrderBy(SortAndSlice sortAndSlice) {
 
         // replace the aliases with expressions
         // replace column names with expressions and resolve the table columns

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
@@ -237,7 +237,7 @@ final class RangeVariable {
      *
      * @param tableName
      * @param columnName
-     * @return
+     * @return the column index or -1 if the column name is in a using list.
      */
     public int findColumn(String tableName, String columnName) {
         // The namedJoinColumnExpressions are ExpressionColumn objects

--- a/tests/frontend/org/voltdb/planner/TestPlansJoin.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansJoin.java
@@ -1215,6 +1215,8 @@ public class TestPlansJoin extends PlannerTestCase {
        // Ambiguous reference in a where clause.
        failToCompile("select NOTC from R1, R3_NOC where A > 100;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
        failToCompile("select NOTC from R1, R3_NOC where A > sqrt(NOTC);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       failToCompile("select NOTC from R1, R3_NOC where sqrt(A) > sqrt(NOTC);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       failToCompile("select NOTC from R1 join R3_NOC on sqrt(A) > sqrt(NOTC);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
        // Ambiguous reference to an unconstrained column in a join.  That is,
        // C is in both R1 and R3, R1 and R3 are joined together, but not on C.
        // Note that we test above for a similar case, with three joined tables.
@@ -1223,6 +1225,7 @@ public class TestPlansJoin extends PlannerTestCase {
        // Ambiguous references in group by expressions.
        failToCompile("select NOTC from R1, R3_NOC group by A;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
        failToCompile("select NOTC from R1, R3_NOC group by sqrt(A);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       failToCompile("select sqrt(R1.A) from R1, R3_NOC group by R1.A having count(A) + 2 * sum(A) > 2;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
        // Ambiguous references in subqueries.
        failToCompile("select ALPHA from (select SQRT(A) as ALPHA from R1) as S1, (select SQRT(C) as ALPHA from R1) as S2;",
                      "Column \"ALPHA\" is ambiguous.  It's in tables: S1, S2");
@@ -1232,6 +1235,38 @@ public class TestPlansJoin extends PlannerTestCase {
                      "Column \"C\" is ambiguous.  It's in tables: USING(C), R3");
        failToCompile("SELECT R3.C, C FROM R1 INNER JOIN R2 USING(C) INNER JOIN R3 ON C=R3.A;",
                      "Column \"C\" is ambiguous.  It's in tables: USING(C), R3");
+       // Ambiguous columns in an order by expression.
+
+
+       failToCompile("select LR.A, RR.A from R1 LR, R1 RR order by A;", "The name \"A\" in an order by expression is ambiguous.  It's in columns: LR.A, RR.A.");
+       // Note that LT.A and RT.A are not considered here.
+       failToCompile("select LT.A as LA, RT.A as RA from R1 as LT, R1 as RT order by A;", "Column \"A\" is ambiguous.  It's in tables: LT, RT");
+       // Two columns in the select list with the same name.  This complicates
+       // checking for order by aliases.
+       failToCompile("select LT.A as LA, RT.A as LA from R1 as LT, R1 as RT order by LA;", "The name \"LA\" in an order by expression is ambiguous.  It's in columns: LA(0), LA(1)");
+       failToCompile("select NOTC from R1, R3_NOC order by A;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       failToCompile("select NOTC from R1, R3_NOC order by sqrt(A);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       // Ambiguous columns in an order by expression.
+       failToCompile("select LR.A, RR.A from R1 LR, R1 RR order by A;", "The name \"A\" in an order by expression is ambiguous.  It's in columns: LR.A, RR.A");
+       // Note that LT.A and RT.A are not considered here.
+       failToCompile("select LT.A as LA, RT.A as RA from R1 as LT, R1 as RT order by A;", "Column \"A\" is ambiguous.  It's in tables: LT, RT");
+       failToCompile("select LT.A, RT.A from R1 as LT, R1 as RT order by A", "The name \"A\" in an order by expression is ambiguous.  It's in columns: LT.A, RT.A");
+       // Two columns in the select list with the same name.  This complicates
+       // checking for order by aliases.
+       failToCompile("select (R1.A + 1) A, A from R1 order by A", "The name \"A\" in an order by expression is ambiguous.  It's in columns: A(0), R1.A.");
+       failToCompile("select LT.A as LA, RT.A as LA from R1 as LT, R1 as RT order by LA;", "The name \"LA\" in an order by expression is ambiguous.  It's in columns: LA(0), LA(1)");
+       failToCompile("select NOTC from R1, R3_NOC order by A;", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       failToCompile("select NOTC from R1, R3_NOC order by sqrt(A);", "Column \"A\" is ambiguous.  It's in tables: R1, R3_NOC");
+       // This is not ambiguous.  The two aliases reference the same column.
+       compile("select R1.A, A from R1 where A > 0;");
+       compile("select lr.a from r1 lr, r1 rr order by a;");
+       failToCompile("select lr.a a, rr.a a from r1 lr, r2 rr order by a;", "The name \"A\" in an order by expression is ambiguous.  It's in columns: LR.A, RR.A");
+       // Since A is in the using list, lr.a and rr.a are the same.
+       compile("select lr.a alias, lr.a, a, lr.a + 1 aliasexp, lr.a + 1, a + 1 from r1 lr order by a;");
+       compile("select lr.a a, a from r1 lr join r1 rr using (a) order by a;");
+       compile("select lr.a a, rr.a from r1 lr join r1 rr using (a) order by a;");
+       // R1 join R2 on R1.A = R2.A is not R1 join R2 using(A).
+       failToCompile("select lr.a a, rr.a a from r1 lr join r1 rr on lr.a = rr.a order by a;", "The name \"A\" in an order by expression is ambiguous.  It's in columns: LR.A, RR.A");
        // This is not actually an ambiguous query.  This is actually ok.
        compile("select * from R2 where A in (select A from R1);");
        compile("SELECT R3.C, C FROM R1 INNER JOIN R2 USING(C) INNER JOIN R3 USING(C);");
@@ -1242,6 +1277,7 @@ public class TestPlansJoin extends PlannerTestCase {
        compile("SELECT R2.C FROM R1 INNER JOIN R2 USING (C), R3");
        compile("SELECT R1.C FROM R1 INNER JOIN R2 USING (C), R3 WHERE R1.A = R3.A");
        compile("SELECT R3.C, R1.C FROM R1 INNER JOIN R2 USING(C), R3;");
+       compile("SELECT C, C FROM R1 GROUP BY C ORDER BY C;");
    }
 
     @Override

--- a/tests/frontend/org/voltdb/regressionsuites/TestGroupByComplexSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGroupByComplexSuite.java
@@ -221,15 +221,15 @@ public class TestGroupByComplexSuite extends RegressionSuite {
 
 
             // (3) Test Order by with FUNCTION expression, no group by column in display columns
-            // Test Order by without tag
-            cr = client.callProcedure("@AdHoc", "SELECT ABS(dept) as tag, SUM(ABS(wage) - 1) as tag, " +
-                    "(count(*)+sum(dept*2))/2 from " + tb + " GROUP BY dept ORDER BY tag");
+            // Test Order by with unambiguous alias.
+            cr = client.callProcedure("@AdHoc", "SELECT ABS(dept) as tag1, SUM(ABS(wage) - 1) as tag2, " +
+                    "(count(*)+sum(dept*2))/2 from " + tb + " GROUP BY dept ORDER BY tag1");
             assertEquals(ClientResponse.SUCCESS, cr.getStatus());
             vt = cr.getResults()[0];
             expected = new long[][] { {1, 57, 4} , {2, 88, 5}};
             validateTableOfLongs(vt, expected);
 
-            // Test Order by without tag
+            // Test Order by without any alias.
             cr = client.callProcedure("@AdHoc", "SELECT ABS(dept), SUM(ABS(wage) - 1) as tag, " +
                     "(count(*)+sum(dept*2))/2 from " + tb + " GROUP BY dept ORDER BY ABS(dept)");
             assertEquals(ClientResponse.SUCCESS, cr.getStatus());
@@ -1204,6 +1204,8 @@ public class TestGroupByComplexSuite extends RegressionSuite {
                 "ID INTEGER DEFAULT 0 NOT NULL, " +
                 "STATE VARCHAR(2), " +
                 "PRIMARY KEY (ID) );" +
+
+                "create table t ( a INTEGER NOT NULL, b INTEGER NOT NULL, c INTEGER NOT NULL); " +
 
                 addProcs
                 ;


### PR DESCRIPTION
In HSQLDB there is some code to replace aliases in the order by list
with the expressions which the aliases name. This code had the same
diseases the regular column reference resolution code did, in that it
stopped when it found one definition. This means that ambiguous
definitions are not discovered.

This fix finds ambiguous column references in the order by list and
throws errors. Tests were added for group by, order by and having.
There were already several tests for where and joins.

There are still some problems with aliases in group by expressions.
These are to be addressed in ENG-9782.

https://issues.voltdb.com/browse/ENG-9828