### PR TITLE
ENG-9830: Fix DR buffer rolling.

### DIFF
--- a/tests/ee/storage/DRTupleStream_test.cpp
+++ b/tests/ee/storage/DRTupleStream_test.cpp
@@ -486,6 +486,45 @@ TEST_F(DRTupleStreamTest, TxnSpanBufferThrowException)
 }
 
 /**
+ * Verify that we can roll buffers for back to back large transactions.
+ * Each large transaction fits in one large buffer, but not more than one.
+ */
+TEST_F(DRTupleStreamTest, BigTxnsRollBuffers)
+{
+    int tuples_to_fill = (LARGE_BUFFER_SIZE - MAGIC_TRANSACTION_SIZE) / MAGIC_TUPLE_SIZE;
+    const StreamBlock *firstBlock = m_wrapper.m_currBlock;
+    const StreamBlock *secondBlock = NULL;
+
+    // fill one large buffer
+    for (;;) {
+        appendTuple(0, 1);
+        if (m_wrapper.m_currBlock != firstBlock) {
+            secondBlock = m_wrapper.m_currBlock;
+            EXPECT_EQ(LARGE_STREAM_BLOCK, secondBlock->type());
+            break;
+        }
+    }
+    m_wrapper.endTransaction(addPartitionId(1));
+
+    ASSERT_FALSE(m_topend.receivedDRBuffer);
+
+    // fill the first large buffer, and roll to another large buffer
+    for (int i = 1; i <= tuples_to_fill; i++) {
+        appendTuple(1, 2);
+    }
+    m_wrapper.endTransaction(addPartitionId(2));
+
+    // make sure we rolled, and the new buffer is a large buffer
+    EXPECT_NE(secondBlock, m_wrapper.m_currBlock);
+    EXPECT_EQ(LARGE_STREAM_BLOCK, m_wrapper.m_currBlock->type());
+
+    m_wrapper.periodicFlush(-1, addPartitionId(2));
+
+    ASSERT_TRUE(m_topend.receivedDRBuffer);
+    EXPECT_EQ(2, m_topend.blocks.size());
+}
+
+/**
  * Fill a buffer with a single TXN, close it with the first tuple in
  * the next buffer, and then roll back that tuple, and verify that our
  * committed buffer is still there.


### PR DESCRIPTION
If a transaction does not fit in the current DR buffer, we create a new
one and move the whole transaction over to that buffer. If the
transaction is larger than the largest single buffer we can allocate, it
fails. At least, this is how it's supposed to work.

However, instead of looking at the space needed, it was looking at the
size of the current buffer to determine how big the next buffer should
be. If the current buffer is already a large buffer, it will refuse to
roll to a new buffer even though the currently open transaction can fit
the new buffer perfectly. This caused DR to fail prematurely.

Change-Id: Ic7948d00f0d4200779f2bbbf9e1690c0fda7e6e9