### PR TITLE
ENG-9830: Fix DR buffer rolling.

### DIFF
--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -469,19 +469,12 @@ bool DRTupleStream::checkOpenTransaction(StreamBlock* sb, size_t minLength, size
     if (sb && sb->hasDRBeginTxn()   /* this block contains a DR begin txn */
            && m_opened) {
         size_t partialTxnLength = sb->offset() - sb->lastDRBeginTxnOffset();
-        if (partialTxnLength + minLength >= (m_defaultCapacity - m_headerSpace)) {
-            switch (sb->type()) {
-                case voltdb::NORMAL_STREAM_BLOCK:
-                {
-                    blockSize = m_secondaryCapacity;
-                    break;
-                }
-                case voltdb::LARGE_STREAM_BLOCK:
-                {
-                    blockSize = 0;
-                    break;
-                }
-            }
+        size_t spaceNeeded = m_headerSpace + partialTxnLength + minLength;
+        if (spaceNeeded > m_secondaryCapacity) {
+            // txn larger than the max buffer size, set blockSize to 0 so that caller will abort
+            blockSize = 0;
+        } else if (spaceNeeded > m_defaultCapacity) {
+            blockSize = m_secondaryCapacity;
         }
         if (blockSize != 0) {
             uso -= partialTxnLength;


### PR DESCRIPTION
If a transaction does not fit in the current DR buffer, we create a new
one and move the whole transaction over to that buffer. If the
transaction is larger than the largest single buffer we can allocate, it
fails. At least, this is how it's supposed to work.

However, instead of looking at the space needed, it was looking at the
size of the current buffer to determine how big the next buffer should
be. If the current buffer is already a large buffer, it will refuse to
roll to a new buffer even though the currently open transaction can fit
the new buffer perfectly. This caused DR to fail prematurely.

Change-Id: Ic7948d00f0d4200779f2bbbf9e1690c0fda7e6e9