### PR TITLE
Add regression-test to test end-to-end functionality for Contains() with geospatial index

### DIFF
--- a/tests/frontend/org/voltdb/regressionsuites/TestGeospatialIndexes.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeospatialIndexes.java
@@ -49,9 +49,8 @@ public class TestGeospatialIndexes extends RegressionSuite{
     private class PolygonPoints {
         private GeographyValue      m_polygon;
         private GeographyPointValue m_center;
-        private GeographyPointValue m_pointInside;                          // point inside polygon which is not the center
-        private GeographyPointValue m_pointNearCellOutsidePolygon;            // point which is the near cell boundary covering regular polygon and is outside the polygon
-        private GeographyPointValue m_pointOutsidePolygonCell;              // point which is outside the polygon's surrounding cell
+        // stores that are inside and outside polygons
+        private List<GeographyPointValue> m_pointsForPolygons = new ArrayList<GeographyPointValue>();
         private final double        m_incrementFactor = 0.01;               // used to calculate point inside polygon with or without hole
 
         PolygonPoints(GeographyPointValue center,
@@ -62,47 +61,74 @@ public class TestGeospatialIndexes extends RegressionSuite{
             assert(numOfVertexes >= 3);
 
             m_center = center;
+            int numbOfAdditionalPointsInsideShell = 8;
 
-            GeographyPointValue zeroDegreePoint  = GeographyPointValue.normalizeLngLat(m_center.getLongitude() + radiusInDegrees,
-                                                                                       m_center.getLatitude());
-            // randomly generate first vertex w.r.t. center given the radius of polygon. First vertex can be placed anywhere between 1 to 359 degrees;
+            if (isValgrind()) {
+                // generate only limited number of points for test in valgrind environment
+                // else the resultant result set for not contains is too large for IPC backend
+                // in valgrind environment to handle
+                numbOfAdditionalPointsInsideShell = 4;
+            }
+
+            double centerLatitude =  m_center.getLatitude();
+            double centerLongitude = m_center.getLongitude();
+
+            GeographyPointValue zeroDegreePoint  = GeographyPointValue.normalizeLngLat(centerLongitude + radiusInDegrees,
+                                                                                       centerLatitude);
+            // generate a random first vertex w.r.t. center given the distance of vertex from center of polygon.
+            // First vertex can be placed anywhere between 1 to 359 degrees;
             int degreeRotate = m_random.nextInt(358) + 1;
             GeographyPointValue firstVertex = zeroDegreePoint.rotate(degreeRotate, m_center);
-            m_polygon = PolygonFactory.CreateRegularConvex(m_center, firstVertex, 5, sizeOfHole);
+            m_polygon = PolygonFactory.CreateRegularConvex(m_center, firstVertex, numOfVertexes, sizeOfHole);
+            assert(m_polygon.getRings().size() > 0);
 
-            // generate point inside polygon
-            m_pointInside = firstVertex.scale(m_center, sizeOfHole + m_incrementFactor);
+            // fetch the vertices of the polygon
+            List<GeographyPointValue> outerRing = m_polygon.getRings().get(0);
+            outerRing.remove(0);        // drop the first vertex - first and last vertex are duplicates
+            assert (outerRing.size() == numOfVertexes);
 
-            // get the point which is near or on the vertex of the cell covering the polygon and outside of the polygon
-            m_pointNearCellOutsidePolygon = GeographyPointValue.normalizeLngLat(m_center.getLongitude() + radiusInDegrees, m_center.getLatitude() + radiusInDegrees);
+            // cultivate some points that are inside the polygon
+            for (GeographyPointValue geographyPointValue : outerRing) {
+                m_pointsForPolygons.add(geographyPointValue.scale(m_center, sizeOfHole + m_incrementFactor));
+            }
+
+            // generate points inside polygon's outer shell. For simplicity, when generating points,
+            // logic does not take into account if polygon has hole or not
+            for (int i = 0; i < numbOfAdditionalPointsInsideShell; i++) {
+                m_pointsForPolygons.add(outerRing.get(i % numOfVertexes).scale(m_center, m_random.nextDouble()));
+            }
+
+            // get the point which are near the cell covering the polygon and outside of the polygon
+            m_pointsForPolygons.add(GeographyPointValue.normalizeLngLat(centerLongitude + radiusInDegrees, centerLatitude + radiusInDegrees));
+            m_pointsForPolygons.add(GeographyPointValue.normalizeLngLat(centerLongitude - radiusInDegrees, centerLatitude + radiusInDegrees));
+            m_pointsForPolygons.add(GeographyPointValue.normalizeLngLat(centerLongitude - radiusInDegrees, centerLatitude - radiusInDegrees));
+            m_pointsForPolygons.add(GeographyPointValue.normalizeLngLat(centerLongitude + radiusInDegrees, centerLatitude - radiusInDegrees));
+
             // point outside the cell
-            m_pointOutsidePolygonCell = GeographyPointValue.normalizeLngLat(m_center.getLongitude() + radiusInDegrees + 1, m_center.getLatitude() + radiusInDegrees + 1);
+            m_pointsForPolygons.add(GeographyPointValue.normalizeLngLat(centerLongitude + radiusInDegrees + 1, centerLatitude + radiusInDegrees + 1));
         }
 
         GeographyValue getPolygon() { return m_polygon; }
-        GeographyPointValue getCenter() { return m_center; }
-        GeographyPointValue getInsidePoint() { return m_pointInside; }
-        GeographyPointValue getPointNearCellOutsidePolygon() { return m_pointNearCellOutsidePolygon; }
-        GeographyPointValue getPointOutSidePolygon() { return m_pointOutsidePolygonCell; }
+        List<GeographyPointValue> getPoints() { return m_pointsForPolygons; }
     };
 
     private List<PolygonPoints> m_generatedPolygonPoints = new ArrayList<PolygonPoints>();
 
     // Polygon vertex just shy of the vertexes of it's bounding box
-    static private GeographyValue polygonWithVertexNearBoundingBox
+    static private GeographyValue fixedPolygonWithVertexNearBoundingBox
             = new GeographyValue("POLYGON((-102.001 41.001, -102.003 41.003, -107.009 41.001, -107.012 38.003, -107.009 38.001, -102.003 38.001, -102.001 38.003, -102.001 41.001,))");
 
-    // Polygon with couples of holes formed using same outer ring as of polygon above
-    static private GeographyValue polygonWithVertexNearBoundingBoxWithHoles
+    // Polygon with couples of holes formed using same outer ring as polygon above
+    static private GeographyValue fixedPolygonWithHolesWithVertexNearBoundingBox
             = new GeographyValue("POLYGON((-102.001 41.001, -102.003 41.003, -107.009 41.001, -107.012 38.003, -107.009 38.001, -102.003 38.001, -102.001 38.003, -102.001 41.001,),"
                                        + "(-105.001 40.8, -104.798 40.798, -104.798 40.298, -105.001 40.298, -105.001 40.8), "
                                        + "(-104.412 39.612, -104.412 39.412, -105.512 39.412, -105.512 39.612, -104.412 39.612), "
                                        + "(-103.001 40.8, -102.798 40.798, -102.798 40.298, -103.001 40.298, -103.001 40.8))");
 
-    static private GeographyPointValue pointBBVertexOutsidePolygon = new GeographyPointValue(-102.001, 41.003);         // vertex of bounding box
-    static private GeographyPointValue pointDisjointRegionCellNPolygon = new GeographyPointValue(-102.0011, 41.002);    // in disjoint region of polygon and bounding box
-    static private GeographyPointValue pointOutSidePolygon = new GeographyPointValue(-107.015, 41.002);                 // outside bounding box and polygon
-    static private GeographyPointValue pointCentroidOfPolygonWithNoHole = new GeographyPointValue(-104.505, 39.517);
+    static private GeographyPointValue fixedPointOnBBVertexOutsidePolygon = new GeographyPointValue(-102.001, 41.003);      // vertex of bounding box
+    static private GeographyPointValue fixedPointInDisjointRegionCellNPolygon = new GeographyPointValue(-102.0011, 41.002);        // in disjoint region of polygon and bounding box
+    static private GeographyPointValue fixedPointOutsidePolygon = new GeographyPointValue(-107.015, 41.002);                // outside bounding box and polygon
+    static private GeographyPointValue fixedPointCentroidOfPolygonWithNoHole = new GeographyPointValue(-104.505, 39.517);
 
     static private void setupGeoSchema(VoltProjectBuilder project) throws IOException {
         String geoSchema =
@@ -115,16 +141,23 @@ public class TestGeospatialIndexes extends RegressionSuite{
                 + "  region     GEOGRAPHY\n"
                 + ");\n"
                 + "\n"
-                + "CREATE TABLE INDEXED_PLACES (\n"
-                + "  id         INTEGER NOT NULL,\n"
-                + "  loc        GEOGRAPHY_POINT\n"
-                + ");\n"
                 + "CREATE TABLE INDEXED_BORDERS (\n"
                 + "  id         INTEGER NOT NULL,\n"
                 + "  region     GEOGRAPHY\n"
                 + ");\n"
-                //+ "CREATE INDEX INDEX_LOC_INDEXED_PLACES ON INDEXED_PLACES(loc)\n;"           // Enable this once Geo Indexes are implemented
-                //+ "CREATE INDEX INDEX_REGION_INDEXED_PLACES ON INDEXED_BORDERS(region)\n;"    // Enable this once Geo Indexes are implemented
+                //+ "CREATE INDEX INDEX_REGION ON INDEXED_BORDERS(Region)\n;"    // Enable this once Geo Indexes are integrated
+                + "CREATE PROCEDURE P_CONTAINS_INDEXED AS "
+                + "  SELECT A.Region FROM INDEXED_BORDERS A \n"
+                + "         WHERE CONTAINS(A.region, ?) ORDER BY A.Region;\n"
+                + "CREATE PROCEDURE P_CONTAINS AS "
+                + "  SELECT A.Region FROM BORDERS A \n"
+                + "         WHERE CONTAINS(A.region, ?) ORDER BY A.Region;\n"
+                + "CREATE PROCEDURE P_NOT_CONTAINS_INDEXED AS "
+                + "  SELECT A.Region FROM INDEXED_BORDERS A \n"
+                + "         WHERE NOT CONTAINS(A.region, ?) ORDER BY A.Region;\n"
+                + "CREATE PROCEDURE P_NOT_CONTAINS AS "
+                + "  SELECT A.Region FROM BORDERS A \n"
+                + "         WHERE NOT CONTAINS(A.region, ?) ORDER BY A.Region;\n"
                 + "\n"
                 ;
         project.addLiteralSchema(geoSchema);
@@ -144,103 +177,86 @@ public class TestGeospatialIndexes extends RegressionSuite{
         return center;
     }
 
-    // generates and fills table with polygon and points. For each generated polygon, there are corresponding points
-    // also generated such that:
-    // - center of polygon
-    // - one is inside the polygon,
-    // - one is at the vertex of bounding box of polygon and
+    // function generates and fills table with polygon and points. For each generated polygon, there are corresponding points
+    // generated such that:
+    // - n points that are inside polygon's (this number is equal to number of vertex the polygon has)
+    // - 8 random points (4 in valgrind env) that are inside polygon's outer shell and along the axis line of vertex
+    // - 4 points that are outside polygon and near cell covering polygon
     // - another one that is outside the bounding box of polygon.
-    // All the generated data is populated in borders and places tables - indexed and non-indexed version.
+    // All the generated data is populated in (indexed/non-indexed) borders and places tables.
+    // Polygons are generated along horizontal grid
     // Generated data is cached in m_polygonPoints list and used in data verification later
     private void populateGeoTables(Client client) throws NoConnectionsException, IOException, ProcCallException {
         final int polygonRadius = 3;
-        final int numberOfPolygonPoints = 8;
+        final int numberOfPolygonPointsForEachShape;
+        if (isValgrind()) {
+            // limit the data for valgrind environment as IPC can't handle data beyond 5000 rows.
+            // Not Contains query hangs otherwise in valgrind environment
+            numberOfPolygonPointsForEachShape = 2;
+        }
+        else {
+            numberOfPolygonPointsForEachShape = 10;
+        }
 
         // generate latitude and longitudes for somewhere in north-west hemisphere
         final int longitude = m_random.nextInt(10) - 178;   // generate longitude between -178 to -168
         final int latitude = m_random.nextInt(10) + 72;     // generate latitude between 82 to 72
         GeographyPointValue center = new GeographyPointValue(longitude, latitude);
         // offset to use for generating new center of polygon. this is not randomized, it will generate polygons in same order
-        // almost around regular steps running from north-west to south-east
-        final GeographyPointValue centerShiftOffset = new GeographyPointValue(2.1 * polygonRadius, -1 * polygonRadius);
+        // in horizontal grid running along latitude line
+        final GeographyPointValue centerShiftOffset = new GeographyPointValue(0.33 * polygonRadius, 0);
 
         // triangles without holes
-        //System.out.println("Generate triangles without hole, center: " + center.toString());
-        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 3, 0, numberOfPolygonPoints);
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 3, 0, numberOfPolygonPointsForEachShape);
 
         // triangles with holes
-        //System.out.println("Generate triangles with hole, center: " + center.toString());
-        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 3, 0.33, numberOfPolygonPoints);
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 3, 0.33, numberOfPolygonPointsForEachShape);
 
         // pentagons without holes
-        //System.out.println("Generate pentagon without hole, center: " + center.toString());
-        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 5, 0, numberOfPolygonPoints);
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 5, 0, numberOfPolygonPointsForEachShape);
 
-        //System.out.println("Generate pentagon with hole, center: " + center.toString());
         // pentagons with holes
-        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 5, 0.33, numberOfPolygonPoints);
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 5, 0.33, numberOfPolygonPointsForEachShape);
 
         // octagon without holes
-        //System.out.println("Generate octagon without hole, center: " + center.toString());
-        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 8, 0, numberOfPolygonPoints);
-
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 8, 0, numberOfPolygonPointsForEachShape);
 
         // octagons with holes
-        //System.out.println("Generate octagon with hole, center: " + center.toString());
-        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 8, 0.33, numberOfPolygonPoints);
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 8, 0.33, numberOfPolygonPointsForEachShape);
 
-        //System.out.println("LAST OCTAGON CENTER: " + center.toString());
-
-        client.callProcedure("PLACES.Insert", 0, pointCentroidOfPolygonWithNoHole);
-        client.callProcedure("PLACES.Insert", 0, pointDisjointRegionCellNPolygon);
-        client.callProcedure("PLACES.Insert", 0, pointBBVertexOutsidePolygon);
-        client.callProcedure("PLACES.Insert", 0, pointOutSidePolygon);
-
-        client.callProcedure("BORDERS.INSERT", 0, polygonWithVertexNearBoundingBox);
-        client.callProcedure("BORDERS.INSERT", 0, polygonWithVertexNearBoundingBoxWithHoles);
-
-        client.callProcedure("INDEXED_PLACES.Insert", 0, pointCentroidOfPolygonWithNoHole);
-        client.callProcedure("INDEXED_PLACES.Insert", 0, pointDisjointRegionCellNPolygon);
-        client.callProcedure("INDEXED_PLACES.Insert", 0, pointBBVertexOutsidePolygon);
-        client.callProcedure("INDEXED_PLACES.Insert", 0, pointOutSidePolygon);
-
-        client.callProcedure("INDEXED_BORDERS.INSERT", 0, polygonWithVertexNearBoundingBox);
-        client.callProcedure("INDEXED_BORDERS.INSERT", 0, polygonWithVertexNearBoundingBoxWithHoles);
-
-        int entryIndex = 0;
+        int polygonEntries = 0;
+        int pointEntries = 0;
+        List<GeographyPointValue> listOfPoints;
         for(PolygonPoints polygonPoints: m_generatedPolygonPoints) {
-            entryIndex++;
-            client.callProcedure("PLACES.Insert", entryIndex, polygonPoints.getCenter());
-            client.callProcedure("PLACES.Insert", entryIndex, polygonPoints.getInsidePoint());
-            client.callProcedure("PLACES.Insert", entryIndex, polygonPoints.getPointNearCellOutsidePolygon());
-            client.callProcedure("PLACES.Insert", entryIndex, polygonPoints.getPointOutSidePolygon());
-            client.callProcedure("BORDERS.Insert", entryIndex, polygonPoints.getPolygon());
-
-            client.callProcedure("INDEXED_PLACES.Insert", entryIndex, polygonPoints.getCenter());
-            client.callProcedure("INDEXED_PLACES.Insert", entryIndex, polygonPoints.getInsidePoint());
-            client.callProcedure("INDEXED_PLACES.Insert", entryIndex, polygonPoints.getPointNearCellOutsidePolygon());
-            client.callProcedure("INDEXED_PLACES.Insert", entryIndex, polygonPoints.getPointOutSidePolygon());
-            client.callProcedure("INDEXED_BORDERS.Insert", entryIndex, polygonPoints.getPolygon());
+            listOfPoints = polygonPoints.getPoints();
+            for(GeographyPointValue point : listOfPoints) {
+                client.callProcedure("PLACES.Insert", pointEntries, point);
+                pointEntries++;
+            }
+            client.callProcedure("BORDERS.Insert", polygonEntries, polygonPoints.getPolygon());
+            client.callProcedure("INDEXED_BORDERS.Insert", polygonEntries, polygonPoints.getPolygon());
+            polygonEntries++;
         }
     }
 
-    public void testContains() throws Exception{
-        System.out.println("Starting tests for Contains() ... ");
-        Client client = getClient();
+    private void populateGeoTableWithFixedData(Client client) throws NoConnectionsException, IOException, ProcCallException {
+        client.callProcedure("PLACES.Insert", 0, fixedPointCentroidOfPolygonWithNoHole);
+        client.callProcedure("PLACES.Insert", 1, fixedPointInDisjointRegionCellNPolygon);
+        client.callProcedure("PLACES.Insert", 2, fixedPointOnBBVertexOutsidePolygon);
+        client.callProcedure("PLACES.Insert", 3, fixedPointOutsidePolygon);
 
-        populateGeoTables(client);
+        client.callProcedure("BORDERS.INSERT", 0, fixedPolygonWithVertexNearBoundingBox);
+        client.callProcedure("BORDERS.INSERT", 1, fixedPolygonWithHolesWithVertexNearBoundingBox);
+
+        client.callProcedure("INDEXED_BORDERS.INSERT", 0, fixedPolygonWithVertexNearBoundingBox);
+        client.callProcedure("INDEXED_BORDERS.INSERT", 1, fixedPolygonWithHolesWithVertexNearBoundingBox);
+    }
+
+    // verifies the data in indexed and non-indexed borders table is same
+    private void subTestVerifyBordersData(Client client) throws NoConnectionsException, IOException, ProcCallException {
         VoltTable resultsUsingGeoIndex, resultsFromNonGeoIndex;
         String sql;
         String prefixMsg;
-        final double EPSILON = 1.0e-12;
-
-        sql = "Select * from PLACES order by id, loc;";
-        resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-
-        sql = "Select * from INDEXED_PLACES order by id, loc;";
-        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-        prefixMsg = "Assertion failed comparing contents of places and indexed_places to be same: ";
-        assertTablesAreEqual(prefixMsg, resultsUsingGeoIndex, resultsFromNonGeoIndex);
 
         sql = "Select * from BORDERS order by id, region;";
         resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
@@ -249,144 +265,152 @@ public class TestGeospatialIndexes extends RegressionSuite{
         resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
         prefixMsg = "Assertion failed comparing contents of places and indexed_borders to be same: ";
         assertTablesAreEqual(prefixMsg, resultsUsingGeoIndex, resultsFromNonGeoIndex);
+    }
 
-        // test contains with fixed data
-        sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
-              + "where Contains(A.region, B.loc) and A.id = B.id and A.id = 0 "
-              + "order by A.id, A.region, B.loc;";
+    // simple test contains and not contains with tables populate with fixed data
+    public void testContainsWithFixedData() throws NoConnectionsException, IOException, ProcCallException {
+        System.out.println("Starting tests Contains() with fixed data ... ");
+
+        VoltTable resultsUsingGeoIndex, resultsFromNonGeoIndex;
+        String sql;
+        String prefixMsg;
+        final double EPSILON = 1.0e-12;
+        Client client = getClient();
+
+        populateGeoTableWithFixedData(client);
+        subTestVerifyBordersData(client);
+
+        // Test contains with fixed data
+        sql = "Select A.region, B.loc from INDEXED_BORDERS A, PLACES B "
+              + "where Contains(A.region, B.loc) "
+              + "order by A.region, B.loc;";
         resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-        assertApproximateContentOfTable(new Object[][]{{0, polygonWithVertexNearBoundingBox,            pointCentroidOfPolygonWithNoHole}},
+        assertApproximateContentOfTable(new Object[][]{{fixedPolygonWithVertexNearBoundingBox,            fixedPointCentroidOfPolygonWithNoHole}},
                                         resultsUsingGeoIndex, EPSILON);
+        resultsUsingGeoIndex.resetRowPosition();
 
         // match the results of indexed and non-indexed tables
-        sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
-                + "where Contains(A.region, B.loc) and A.id = B.id and A.id = 0 "
-                + "order by A.id, A.region, B.loc;";
-        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
         prefixMsg = "Assertion failed comparing results of Contains on fixed data set: ";
-        resultsUsingGeoIndex.resetRowPosition();
+        sql = "Select A.region, B.loc from BORDERS A, PLACES B "
+                + "where Contains(A.region, B.loc) "
+                + "order by A.region, B.loc;";
+        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
         assertTablesAreEqual(prefixMsg, resultsUsingGeoIndex, resultsFromNonGeoIndex);
 
         // test not contains with fixed data
-        sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
-                + "where NOT Contains(A.region, B.loc) and A.id = B.id and A.id = 0 "
-                + "order by A.id, A.region, B.loc;";
+        sql = "Select A.region, B.loc from INDEXED_BORDERS A, PLACES B "
+                + "where NOT Contains(A.region, B.loc) "
+                + "order by A.region, B.loc;";
         resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-        assertApproximateContentOfTable(new Object[][]{{0, polygonWithVertexNearBoundingBox,           pointOutSidePolygon},
-                                                       {0, polygonWithVertexNearBoundingBox,           pointDisjointRegionCellNPolygon},
-                                                       {0, polygonWithVertexNearBoundingBox,           pointBBVertexOutsidePolygon},
-                                                       {0, polygonWithVertexNearBoundingBoxWithHoles, pointOutSidePolygon},
-                                                       {0, polygonWithVertexNearBoundingBoxWithHoles, pointCentroidOfPolygonWithNoHole},
-                                                       {0, polygonWithVertexNearBoundingBoxWithHoles, pointDisjointRegionCellNPolygon},
-                                                       {0, polygonWithVertexNearBoundingBoxWithHoles, pointBBVertexOutsidePolygon}},
+        assertApproximateContentOfTable(new Object[][]{{fixedPolygonWithVertexNearBoundingBox,           fixedPointOutsidePolygon},
+                                                       {fixedPolygonWithVertexNearBoundingBox,           fixedPointInDisjointRegionCellNPolygon},
+                                                       {fixedPolygonWithVertexNearBoundingBox,           fixedPointOnBBVertexOutsidePolygon},
+                                                       {fixedPolygonWithHolesWithVertexNearBoundingBox, fixedPointOutsidePolygon},
+                                                       {fixedPolygonWithHolesWithVertexNearBoundingBox, fixedPointCentroidOfPolygonWithNoHole},
+                                                       {fixedPolygonWithHolesWithVertexNearBoundingBox, fixedPointInDisjointRegionCellNPolygon},
+                                                       {fixedPolygonWithHolesWithVertexNearBoundingBox, fixedPointOnBBVertexOutsidePolygon}},
                                         resultsUsingGeoIndex, EPSILON);
+        resultsUsingGeoIndex.resetRowPosition();
 
         // match the results of indexed and non-indexed tables
-        sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
-              + "where NOT Contains(A.region, B.loc) and A.id = B.id and A.id = 0 "
-              + "order by A.id, A.region, B.loc;";
-        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
         prefixMsg = "Assertion failed comparing results of Not Contains on fixed data set: ";
-        resultsUsingGeoIndex.resetRowPosition();
+        sql = "Select A.region, B.loc from BORDERS A, PLACES B "
+              + "where NOT Contains(A.region, B.loc) "
+              + "order by A.region, B.loc;";
+        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
         assertTablesAreEqual(prefixMsg, resultsUsingGeoIndex, resultsFromNonGeoIndex);
+        System.out.println("... completed testing Contains() with fixed data");
+    }
 
-        // Cross check Contains and NOT Contains result set from indexed and non-indexed tables
-        if (isValgrind()) {
-            // test result with large data-set in test result does not work well in valgrind environment.
-            // So perform test by breaking it down into multiple queries so that each produces limited
-            // data-set produced for now in valgrind environment
+    private void subTestParameterizedContains(Client client, Boolean testContains) throws NoConnectionsException, IOException, ProcCallException {
+        VoltTable resultsUsingGeoIndex, resultsFromNonGeoIndex;
+        String indexedProcName, nonIndexProcName, predicate;
+        String prefixMsg;
 
-            // match the Contains results on indexed and non-indexed tables with complete data set - fixed and pseudo-random generated
-            sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
-                  + "where Contains(A.region, B.loc) and A.id = B.id and A.id < 25 "
-                  + "order by A.id, A.region, B.loc;";
-            resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
-                  + "where Contains(A.region, B.loc) and A.id = B.id and A.id < 25 "
-                  + "order by A.id, A.region, B.loc;";
-            resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            prefixMsg = "Assertion failed comparing results of Contains on indexed with non-indexed tables: ";
-            assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
-
-            sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
-                  + "where Contains(A.region, B.loc) and A.id = B.id and A.id >= 25 "
-                  + "order by A.id, A.region, B.loc;";
-            resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
-                  + "where Contains(A.region, B.loc) and A.id = B.id and A.id >= 25 "
-                  + "order by A.id, A.region, B.loc;";
-            resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            prefixMsg = "Assertion failed comparing results of Contains on indexed with non-indexed tables: ";
-            assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
-
-            // match the NOT Contains results on indexed and non-indexed tables with complete data set - fixed and pseudo-random generated
-            prefixMsg = "Assertion failed comparing results of Contains on indexed with non-indexed tables: ";
-            sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
-                  + "where NOT Contains(A.region, B.loc) and A.id = B.id and A.id < 25 "
-                  + "order by A.id, A.region, B.loc;";
-            resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
-                  + "where NOT Contains(A.region, B.loc) and A.id = B.id and A.id < 25 "
-                  + "order by A.id, A.region, B.loc;";
-            resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-
-            resultsUsingGeoIndex.resetRowPosition();
-            assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
-
-            sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
-                  + "where NOT Contains(A.region, B.loc) and A.id = B.id and A.id >= 25 "
-                  + "order by A.id, A.region, B.loc;";
-            resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
-                  + "where NOT Contains(A.region, B.loc) and A.id = B.id and A.id >= 25 "
-                  + "order by A.id, A.region, B.loc;";
-            resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
+        if (testContains) {
+            indexedProcName = "P_CONTAINS_INDEXED";
+            nonIndexProcName = "P_CONTAINS";
+            predicate = "Contains";
         }
         else {
-            // Cross check Contains and NOT Contains result set from indexed and non-indexed tables
-            // match the Contains results on indexed and non-indexed tables with complete data set - fixed and pseudo-random generated
-            sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
-                  + "where Contains(A.region, B.loc) and A.id = B.id "
-                  + "order by A.id, A.region, B.loc;";
-            resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
-                    + "where Contains(A.region, B.loc) and A.id = B.id "
-                    + "order by A.id, A.region, B.loc;";
-            resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            prefixMsg = "Assertion failed comparing results of Contains on indexed with non-indexed tables: ";
-            assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
-
-            // match the NOT Contains results on indexed and non-indexed tables with complete data set - fixed and pseudo-random generated
-            sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
-                  + "where NOT Contains(A.region, B.loc) and A.id = B.id "
-                  + "order by A.id, A.region, B.loc;";
-            resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
-                    + "where NOT Contains(A.region, B.loc) and A.id = B.id "
-                    + "order by A.id, A.region, B.loc;";
-            resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
-            prefixMsg = "Assertion failed comparing results of Contains on indexed with non-indexed tables: ";
-            assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
+            indexedProcName = "P_NOT_CONTAINS_INDEXED";
+            nonIndexProcName = "P_NOT_CONTAINS";
+            predicate = "Not Contains";
         }
+
+        int maxPolygonsContainSamePoint = 0;
+        prefixMsg = "Assertion failed comparing results of "+ predicate +" on indexed with non-indexed tables: ";
+        List<GeographyPointValue> points;
+        for (PolygonPoints polygonPoints: m_generatedPolygonPoints) {
+            points =  polygonPoints.getPoints();
+            for(GeographyPointValue point : points) {
+                resultsUsingGeoIndex = client.callProcedure(indexedProcName, point).getResults()[0];
+                resultsFromNonGeoIndex = client.callProcedure(nonIndexProcName, point).getResults()[0];
+                assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
+
+                maxPolygonsContainSamePoint = (maxPolygonsContainSamePoint < resultsUsingGeoIndex.getRowCount()) ?
+                        resultsUsingGeoIndex.getRowCount() : maxPolygonsContainSamePoint;
+            }
+        }
+
+        System.out.println("Max polygons for predicate '" + predicate +"': " + maxPolygonsContainSamePoint);
+    }
+
+    public void testContains() throws NoConnectionsException, IOException, ProcCallException {
+        System.out.println("Starting tests for Contains() ... ");
+
+        VoltTable resultsUsingGeoIndex, resultsFromNonGeoIndex;
+        String sql;
+        String prefixMsg;
+
+        Client client = getClient();
+        populateGeoTables(client);
+        subTestVerifyBordersData(client);
+
+        // Cross check Contains and NOT Contains result set from indexed and non-indexed tables
+
+        if(isValgrind())
+            System.out.println("*******Executing CONTAINS" );
+
+        // Cross check Contains and NOT Contains result set from indexed and non-indexed tables
+        // match the Contains results on indexed and non-indexed tables
+        prefixMsg = "Assertion failed comparing CONTAINS results of indexed with non-indexed tables: ";
+        sql = "Select A.region, B.loc from INDEXED_BORDERS A, PLACES B "
+                + "where CONTAINS(A.region, B.loc) "
+                + "order by A.region, B.loc;";
+        resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        sql = "Select A.region, B.loc from BORDERS A, PLACES B "
+                + "where CONTAINS(A.region, B.loc) "
+                + "order by A.region, B.loc;";
+        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
+
+        if(isValgrind())
+            System.out.println("*******Executing NOT CONTAINS" );
+
+        sql = "Select A.region, B.loc from INDEXED_BORDERS A, PLACES B "
+                + "where NOT CONTAINS(A.region, B.loc) "
+                + "order by A.id, B.id;";
+        resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        sql = "Select A.region, B.loc from BORDERS A, PLACES B "
+                + "where NOT CONTAINS(A.region, B.loc) "
+                + "order by A.id, B.id;";
+        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
+
 
         // Test parameterized Contains() - test with point argument to Contains() being parameterized
         // To verify this, point which is inside polygon is fetched from the cached generated data and is supplied to SP.
         // Output result of the query should have only one matching polygon that contains the supplied. This polygon is
         // same as geography value in corresponding entry of polygon-point data
+        if (isValgrind())
+            System.out.println("Test parameterized contains() ... ");
+        subTestParameterizedContains(client, true);
+        subTestParameterizedContains(client, false);
 
-        // Create procedure on Contains functions
-        sql = "Create procedure PointInPolygon as select A.region from INDEXED_BORDERS A "
-              + "where Contains(A.region, ?) and A.id > 0;";
-        client.callProcedure("@AdHoc", sql);
-
-        for (PolygonPoints polygonPoints: m_generatedPolygonPoints) {
-            resultsUsingGeoIndex = client.callProcedure("PointInPolygon", polygonPoints.getInsidePoint()).getResults()[0];
-            assertApproximateContentOfTable(new Object[][]{{polygonPoints.getPolygon()}}, resultsUsingGeoIndex, EPSILON);
-        }
-
-        System.out.println(" ... Completed tests for Contains().");
+        System.out.println(" ... completed tests for Contains().");
     }
+
 
     static public junit.framework.Test suite() {
         MultiConfigSuiteBuilder builder =
@@ -407,5 +431,4 @@ public class TestGeospatialIndexes extends RegressionSuite{
         }
         return builder;
     }
-
 }

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeospatialIndexes.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeospatialIndexes.java
@@ -1,3 +1,25 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.voltdb.regressionsuites;
 
 import java.io.IOException;

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeospatialIndexes.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeospatialIndexes.java
@@ -1,0 +1,336 @@
+package org.voltdb.regressionsuites;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.voltdb.BackendTarget;
+import org.voltdb.VoltTable;
+import org.voltdb.client.Client;
+import org.voltdb.client.NoConnectionsException;
+import org.voltdb.client.ProcCallException;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.types.GeographyPointValue;
+import org.voltdb.types.GeographyValue;
+import org.voltdb.utils.PolygonFactory;
+
+import scala.util.Random;
+
+public class TestGeospatialIndexes extends RegressionSuite{
+
+    public TestGeospatialIndexes(String name) {
+        super(name);
+    }
+
+    private class PolygonPoints {
+        private GeographyValue      m_polygon;
+        private GeographyPointValue m_center;
+        private GeographyPointValue m_pointInside;                          // point inside polygon which is not the center
+        private GeographyPointValue m_polygonCellVertex;                    // point which is the vertex of surrounding cell regular convex polygon but is outside the polygon
+        private GeographyPointValue m_pointOutSidePolygonCell;              // point which is outside the polygon's surrounding cell
+        private Random              m_random = new Random(999);             // used for randomly generating phi for first vertex of the polygon w.r.t center's latitude line
+        private final double        m_incrementFactor = 0.01;               // used to calculate point inside polygon with or without hole
+
+        PolygonPoints(GeographyPointValue center,
+                      double radiusInDegrees,
+                      int numOfVertexes,
+                      double sizeOfHole) {
+            assert((sizeOfHole >= 0) && (sizeOfHole + m_incrementFactor < 1));
+            assert(numOfVertexes >= 3);
+
+            m_center = center;
+
+            GeographyPointValue zeroDegreePoint  = GeographyPointValue.normalizeLngLat(m_center.getLongitude() + radiusInDegrees,
+                                                                                       m_center.getLatitude());
+            // randomly generate first vertex w.r.t. center given the radius of polygon. First vertex can be placed anywhere between 1 to 359 degrees;
+            int degreeRotate = m_random.nextInt(358) + 1;
+            GeographyPointValue firstVertex = zeroDegreePoint.rotate(degreeRotate, m_center);
+            m_polygon = PolygonFactory.CreateRegularConvex(m_center, firstVertex, 5, sizeOfHole);
+
+            // generate point inside polygon
+            m_pointInside = firstVertex.scale(m_center, sizeOfHole + m_incrementFactor);
+
+            // get the vertex of the cell covering the polygon
+            m_polygonCellVertex = GeographyPointValue.normalizeLngLat(m_center.getLongitude() + radiusInDegrees, m_center.getLatitude() + radiusInDegrees);
+            // point outside the cell
+            m_pointOutSidePolygonCell = GeographyPointValue.normalizeLngLat(m_center.getLongitude() + radiusInDegrees + 1, m_center.getLatitude() + radiusInDegrees + 1);
+        }
+
+        GeographyValue getPolygon() { return m_polygon; }
+        GeographyPointValue getCenter() { return m_center; }
+        GeographyPointValue getInsidePoint() { return m_pointInside; }
+        GeographyPointValue getPolygonCellVertex() { return m_polygonCellVertex; }
+        GeographyPointValue getPointOutSidePolygon() { return m_pointOutSidePolygonCell; }
+    };
+
+    private List<PolygonPoints> m_generatedPolygonPoints = new ArrayList<PolygonPoints>();
+
+    // Polygon vertex just shy of the vertexes of it's bounding box
+    static private GeographyValue polygonWithVertexNearBoundingBox
+            = new GeographyValue("POLYGON((-102.001 41.001, -102.003 41.003, -107.009 41.001, -107.012 38.003, -107.009 38.001, -102.003 38.001, -102.001 38.003, -102.001 41.001,))");
+
+    // Polygon almost in it's bounding box with 2 holes which are almost filling up most of it's bounding box
+    static private GeographyValue polygonWithVertexNearBoundingBoxWith2Holes
+            = new GeographyValue("POLYGON((-102.001 41.001, -102.003 41.003, -107.009 41.001, -107.012 38.003, -107.009 38.001, -102.003 38.001, -102.001 38.003, -102.001 41.001,),"
+                                       + "(-105.001 40.8, -104.798 40.798, -104.798 40.298, -105.001 40.298, -105.001 40.8), "
+                                       + "(-104.412 39.612, -104.412 39.412, -105.512 39.412, -105.512 39.612, -104.412 39.612), "
+                                       + "(-103.001 40.8, -102.798 40.798, -102.798 40.298, -103.001 40.298, -103.001 40.8))");
+
+    static private GeographyPointValue pointBBVertexOutsidePolygon = new GeographyPointValue(-102.001, 41.003);    // vertex of bounding box
+    static private GeographyPointValue pointDisjointRegionCellNPolygon = new GeographyPointValue(-102.0011, 41.002);    // in disjoint region of polygon and bounding box
+    static private GeographyPointValue pointOutSidePolygon = new GeographyPointValue(-107.015, 41.002);    // outside bounding box and polygon
+    static private GeographyPointValue pointCentroidOfPolygonWithNoHole = new GeographyPointValue(-104.505, 39.517);
+
+    static private void setupGeoSchema(VoltProjectBuilder project) throws IOException {
+        String geoSchema =
+                "CREATE TABLE PLACES (\n"
+                + "  id         INTEGER NOT NULL,\n"
+                + "  loc        GEOGRAPHY_POINT\n"
+                + ");\n"
+                + "CREATE TABLE BORDERS(\n"
+                + "  id         INTEGER NOT NULL,\n"
+                + "  region     GEOGRAPHY\n"
+                + ");\n"
+                + "\n"
+                + "CREATE TABLE INDEXED_PLACES (\n"
+                + "  id         INTEGER NOT NULL,\n"
+                + "  loc        GEOGRAPHY_POINT\n"
+                + ");\n"
+                + "CREATE TABLE INDEXED_BORDERS (\n"
+                + "  id         INTEGER NOT NULL,\n"
+                + "  region     GEOGRAPHY\n"
+                + ");\n"
+                //+ "CREATE INDEX INDEX_LOC_INDEXED_PLACES ON INDEXED_PLACES(loc)\n;"           // Enable this once Geo Indexes are implemented
+                //+ "CREATE INDEX INDEX_REGION_INDEXED_PLACES ON INDEXED_BORDERS(region)\n;"    // Enable this once Geo Indexes are implemented
+                + "\n"
+                ;
+        project.addLiteralSchema(geoSchema);
+    }
+
+    // function generates n number of uniform regular convex polygons with specified number of sides, radius and a hole. For
+    // each new polygon the center is shifted by an offset provided by caller.
+    // returns center of the last generated polygon
+    private GeographyPointValue generatePolygonPointData(GeographyPointValue center, GeographyPointValue centerShiftOffset,
+                                          double radiusInDegrees, int numOfVertexes, double sizeOfHole,
+                                          int numOfPolygonPoints) {
+        for(int generatedPolygons = 0; generatedPolygons < numOfPolygonPoints; generatedPolygons++) {
+            // shift center for next polygon
+            center = center.add(centerShiftOffset);
+            m_generatedPolygonPoints.add(new PolygonPoints(center, radiusInDegrees, numOfVertexes, sizeOfHole));
+        }
+        return center;
+    }
+
+    // generates and fills table with polygon and points. For each generated polygon, there are corresponding points
+    // also generated such that:
+    // - center of polygon
+    // - one is inside the polygon,
+    // - one is at the vertex of bounding box of polygon and
+    // - another one that is outside the bounding box of polygon.
+    // All the generated data is populated in borders and places tables - indexed and non-indexed version.
+    // Randomly generated data is cached in m_polygonPoints list
+    private void populateGeoTables(Client client) throws NoConnectionsException, IOException, ProcCallException {
+        final int polygonRadius = 3;
+        final int numberOfPolygonPoints = 8;
+
+        Random rand = new Random(777);
+        // generate latitude and longitudes for somewhere in north-west hemisphere
+        final int longitude = rand.nextInt(10) - 178;   // generate longitude between -178 to -168
+        final int latitude = rand.nextInt(10) + 72;     // generate latitude between 82 to 72
+        GeographyPointValue center = new GeographyPointValue(longitude, latitude);
+        // offset to use for generating new center of polygon.
+        final GeographyPointValue centerShiftOffset = new GeographyPointValue(2.1 * polygonRadius, -1 * polygonRadius);
+
+        // triangles without holes
+        //System.out.println("Generate triangles without hole, center: " + center.toString());
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 3, 0, numberOfPolygonPoints);
+
+        // triangles with holes
+        //System.out.println("Generate triangles with hole, center: " + center.toString());
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 3, 0.33, numberOfPolygonPoints);
+
+        // pentagons without holes
+        //System.out.println("Generate pentagon without hole, center: " + center.toString());
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 5, 0, numberOfPolygonPoints);
+
+        //System.out.println("Generate pentagon with hole, center: " + center.toString());
+        // pentagons with holes
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 5, 0.33, numberOfPolygonPoints);
+
+        // octagon without holes
+        //System.out.println("Generate octagon without hole, center: " + center.toString());
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 8, 0, numberOfPolygonPoints);
+
+
+        // octagons with holes
+        //System.out.println("Generate octagon with hole, center: " + center.toString());
+        center = generatePolygonPointData(center, centerShiftOffset, polygonRadius, 8, 0.33, numberOfPolygonPoints);
+
+        //System.out.println("LAST OCTAGON CENTER: " + center.toString());
+
+        client.callProcedure("PLACES.Insert", 0, pointCentroidOfPolygonWithNoHole);
+        client.callProcedure("PLACES.Insert", 0, pointDisjointRegionCellNPolygon);
+        client.callProcedure("PLACES.Insert", 0, pointBBVertexOutsidePolygon);
+        client.callProcedure("PLACES.Insert", 0, pointOutSidePolygon);
+
+        client.callProcedure("BORDERS.INSERT", 0, polygonWithVertexNearBoundingBox);
+        client.callProcedure("BORDERS.INSERT", 0, polygonWithVertexNearBoundingBoxWith2Holes);
+
+        client.callProcedure("INDEXED_PLACES.Insert", 0, pointCentroidOfPolygonWithNoHole);
+        client.callProcedure("INDEXED_PLACES.Insert", 0, pointDisjointRegionCellNPolygon);
+        client.callProcedure("INDEXED_PLACES.Insert", 0, pointBBVertexOutsidePolygon);
+        client.callProcedure("INDEXED_PLACES.Insert", 0, pointOutSidePolygon);
+
+        client.callProcedure("INDEXED_BORDERS.INSERT", 0, polygonWithVertexNearBoundingBox);
+        client.callProcedure("INDEXED_BORDERS.INSERT", 0, polygonWithVertexNearBoundingBoxWith2Holes);
+
+        int entryIndex = 0;
+        for(PolygonPoints polygonPoints: m_generatedPolygonPoints) {
+            entryIndex++;
+            client.callProcedure("PLACES.Insert", entryIndex, polygonPoints.getCenter());
+            client.callProcedure("PLACES.Insert", entryIndex, polygonPoints.getInsidePoint());
+            client.callProcedure("PLACES.Insert", entryIndex, polygonPoints.getPolygonCellVertex());
+            client.callProcedure("PLACES.Insert", entryIndex, polygonPoints.getPointOutSidePolygon());
+            client.callProcedure("BORDERS.Insert", entryIndex, polygonPoints.getPolygon());
+
+            client.callProcedure("INDEXED_PLACES.Insert", entryIndex, polygonPoints.getCenter());
+            client.callProcedure("INDEXED_PLACES.Insert", entryIndex, polygonPoints.getInsidePoint());
+            client.callProcedure("INDEXED_PLACES.Insert", entryIndex, polygonPoints.getPolygonCellVertex());
+            client.callProcedure("INDEXED_PLACES.Insert", entryIndex, polygonPoints.getPointOutSidePolygon());
+            client.callProcedure("INDEXED_BORDERS.Insert", entryIndex, polygonPoints.getPolygon());
+        }
+    }
+
+    public void testContains() throws Exception{
+        Client client = getClient();
+
+        populateGeoTables(client);
+        VoltTable resultsUsingGeoIndex, resultsFromNonGeoIndex;
+        String sql;
+        String prefixMsg;
+        final double EPSILON = 1.0e-12;
+
+        sql = "Select * from PLACES order by id, loc;";
+        resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+
+        sql = "Select * from INDEXED_PLACES order by id, loc;";
+        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        prefixMsg = "Assertion failed comparing contents of places and indexed_places to be same: ";
+        assertTablesAreEqual(prefixMsg, resultsUsingGeoIndex, resultsFromNonGeoIndex);
+
+        sql = "Select * from BORDERS order by id, region;";
+        resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        //System.out.println("borders: " + vt1.toString());
+
+        sql = "Select * from INDEXED_BORDERS order by id, region;";
+        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        prefixMsg = "Assertion failed comparing contents of places and indexed_borders to be same: ";
+        assertTablesAreEqual(prefixMsg, resultsUsingGeoIndex, resultsFromNonGeoIndex);
+
+        // test contains with fixed data
+        sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
+              + "where Contains(A.region, B.loc) and A.id = B.id and A.id = 0 "
+              + "order by A.id, A.region, B.loc;";
+        resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        assertApproximateContentOfTable(new Object[][]{{0, polygonWithVertexNearBoundingBox,            pointCentroidOfPolygonWithNoHole}},
+                                        resultsUsingGeoIndex, EPSILON);
+
+        // match the results of indexed and non-indexed tables
+        sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
+                + "where Contains(A.region, B.loc) and A.id = B.id and A.id = 0 "
+                + "order by A.id, A.region, B.loc;";
+        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        prefixMsg = "Assertion failed comparing results of Contains on fixed data set: ";
+        resultsUsingGeoIndex.resetRowPosition();
+        assertTablesAreEqual(prefixMsg, resultsUsingGeoIndex, resultsFromNonGeoIndex);
+
+        // test not contains with fixed data
+        sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
+                + "where NOT Contains(A.region, B.loc) and A.id = B.id and A.id = 0 "
+                + "order by A.id, A.region, B.loc;";
+        resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        assertApproximateContentOfTable(new Object[][]{{0, polygonWithVertexNearBoundingBox,           pointOutSidePolygon},
+                                                       {0, polygonWithVertexNearBoundingBox,           pointDisjointRegionCellNPolygon},
+                                                       {0, polygonWithVertexNearBoundingBox,           pointBBVertexOutsidePolygon},
+                                                       {0, polygonWithVertexNearBoundingBoxWith2Holes, pointOutSidePolygon},
+                                                       {0, polygonWithVertexNearBoundingBoxWith2Holes, pointCentroidOfPolygonWithNoHole},
+                                                       {0, polygonWithVertexNearBoundingBoxWith2Holes, pointDisjointRegionCellNPolygon},
+                                                       {0, polygonWithVertexNearBoundingBoxWith2Holes, pointBBVertexOutsidePolygon}},
+                                        resultsUsingGeoIndex, EPSILON);
+
+        // match the results of indexed and non-indexed tables
+        sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
+              + "where NOT Contains(A.region, B.loc) and A.id = B.id and A.id = 0 "
+              + "order by A.id, A.region, B.loc;";
+        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        prefixMsg = "Assertion failed comparing results of Not Contains on fixed data set: ";
+        resultsUsingGeoIndex.resetRowPosition();
+        assertTablesAreEqual(prefixMsg, resultsUsingGeoIndex, resultsFromNonGeoIndex);
+
+        // Cross check Contains and NOT Contains result set from indexed and non-indexed tables
+        // match the Contains results on indexed and non-indexed tables with complete data set - fixed and pseudo-random generated
+        sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
+              + "where Contains(A.region, B.loc) and A.id = B.id "
+              + "order by A.id, A.region, B.loc;";
+        resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
+                + "where Contains(A.region, B.loc) and A.id = B.id "
+                + "order by A.id, A.region, B.loc;";
+        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        prefixMsg = "Assertion failed comparing results of Contains on indexed with non-indexed tables: ";
+        resultsUsingGeoIndex.resetRowPosition();
+        assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
+
+        // match the NOT Contains results on indexed and non-indexed tables with complete data set - fixed and pseudo-random generated
+        sql = "Select A.id, A.region, B.loc from INDEXED_BORDERS A, INDEXED_PLACES B "
+              + "where NOT Contains(A.region, B.loc) and A.id = B.id "
+              + "order by A.id, A.region, B.loc;";
+        resultsUsingGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        sql = "Select A.id, A.region, B.loc from BORDERS A, PLACES B "
+                + "where NOT Contains(A.region, B.loc) and A.id = B.id "
+                + "order by A.id, A.region, B.loc;";
+        resultsFromNonGeoIndex = client.callProcedure("@AdHoc", sql).getResults()[0];
+        prefixMsg = "Assertion failed comparing results of Contains on indexed with non-indexed tables: ";
+        resultsUsingGeoIndex.resetRowPosition();
+        assertTablesAreEqual(prefixMsg, resultsFromNonGeoIndex, resultsUsingGeoIndex);
+
+        // Test parameterized Contains() - test with point argument to Contains() being parameterized
+        // To verify this, point which is inside polygon is fetched from the cached generated data and is supplied to SP.
+        // Output result of the query should have only one matching polygon that contains the supplied. This polygon is
+        // same as geography value in corresponding entry of polygon-point data
+
+        // Create procedure on Contains functions
+        sql = "Create procedure PointInPolygon as select A.region from INDEXED_BORDERS A "
+              + "where Contains(A.region, ?) and A.id > 0;";
+        client.callProcedure("@AdHoc", sql);
+
+        //int indexEntry = 0;
+        for (PolygonPoints polygonPoints: m_generatedPolygonPoints) {
+            //indexEntry ++;
+            resultsUsingGeoIndex = client.callProcedure("PointInPolygon", polygonPoints.getInsidePoint()).getResults()[0];
+            //System.out.println("Entry: " + indexEntry + " " + resultsUsingGeoIndex.toString() + " " + polygonPoints.getInsidePoint());
+            assertApproximateContentOfTable(new Object[][]{{polygonPoints.getPolygon()}}, resultsUsingGeoIndex, EPSILON);
+        }
+
+    }
+    static public junit.framework.Test suite() {
+        MultiConfigSuiteBuilder builder =
+            new MultiConfigSuiteBuilder(TestGeospatialIndexes.class);
+        VoltProjectBuilder project = new VoltProjectBuilder();
+        try {
+            VoltServerConfig config = null;
+            boolean success;
+
+            setupGeoSchema(project);
+            config = new LocalCluster("geography-indexes.jar", 1, 1, 0, BackendTarget.NATIVE_EE_JNI);
+            project.setUseDDLSchema(true);
+            success = config.compile(project);
+            assertTrue(success);
+            builder.addServerConfig(config);
+        } catch (IOException except) {
+            assert(false);
+        }
+        return builder;
+    }
+
+}


### PR DESCRIPTION
Adding test to regression suite to verify the Contains() operation on table which is indexed on geo columns produces correct answer by verify it against the result of contains on data-set using non-indexed table. 

In this review request create index on geo columns in commented out and can be enabled once the geo indexes are available.