### PR TITLE
ENG-9830: Fix DR buffer limit error handling.

### DIFF
--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -121,7 +121,7 @@ public:
     std::queue<int32_t> partitionIds;
     std::queue<std::string> signatures;
     std::deque<boost::shared_ptr<StreamBlock> > blocks;
-    std::vector<boost::shared_array<char> > data;
+    std::deque<boost::shared_array<char> > data;
     bool receivedDRBuffer;
     bool receivedExportBuffer;
     int64_t pushDRBufferRetval;

--- a/src/ee/storage/TupleStreamBase.cpp
+++ b/src/ee/storage/TupleStreamBase.cpp
@@ -224,7 +224,7 @@ void TupleStreamBase::rollbackTo(size_t mark, size_t)
     // working from newest to oldest block, throw
     // away blocks that are fully after mark; truncate
     // the block that contains mark.
-    if (!(m_currBlock->uso() >= mark)) {
+    if (m_currBlock != NULL && !(m_currBlock->uso() >= mark)) {
         m_currBlock->truncateTo(mark);
     }
     else {
@@ -259,8 +259,10 @@ void TupleStreamBase::rollbackTo(size_t mark, size_t)
  * be handed off
  */
 void TupleStreamBase::discardBlock(StreamBlock *sb) {
-    delete [] sb->rawPtr();
-    delete sb;
+    if (sb != NULL) {
+        delete [] sb->rawPtr();
+        delete sb;
+    }
 }
 
 /*
@@ -292,6 +294,10 @@ void TupleStreamBase::extendBufferChain(size_t minLength)
     size_t blockSize = m_defaultCapacity;
     bool openTransaction = checkOpenTransaction(oldBlock, minLength, blockSize, uso);
 
+    if (blockSize == 0) {
+        throw SQLException(SQLException::volt_output_buffer_overflow, "Transaction is bigger than DR Buffer size");
+    }
+
     char *buffer = new char[blockSize];
     if (!buffer) {
         throwFatalException("Failed to claim managed buffer for Export.");
@@ -299,11 +305,6 @@ void TupleStreamBase::extendBufferChain(size_t minLength)
     m_currBlock = new StreamBlock(buffer, m_headerSpace, blockSize, uso);
     if (blockSize > m_defaultCapacity) {
         m_currBlock->setType(LARGE_STREAM_BLOCK);
-    }
-
-    if (blockSize == 0) {
-        rollbackTo(uso, SIZE_MAX);
-        throw SQLException(SQLException::volt_output_buffer_overflow, "Transaction is bigger than DR Buffer size");
     }
 
     if (openTransaction) {

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -53,6 +53,9 @@ const int COLUMN_COUNT = 7;
 const int HIDDEN_COLUMN_COUNT = 1;
 const int CLUSTER_ID = 0;
 
+const int BUFFER_SIZE = 4096;
+const int LARGE_BUFFER_SIZE = 32768;
+
 static int64_t addPartitionId(int64_t value) {
     return (value << 14) | 42;
 }
@@ -133,6 +136,9 @@ public:
       : m_undoToken(0),
         m_engine (new MockVoltDBEngine(false, &m_topend, &m_pool, &m_drStream, &m_drReplicatedStream))
     {
+        m_drStream.setDefaultCapacity(BUFFER_SIZE);
+        m_drStream.setSecondaryCapacity(LARGE_BUFFER_SIZE);
+
         m_drStream.m_enabled = true;
         m_drReplicatedStream.m_enabled = true;
         *reinterpret_cast<int64_t*>(tableHandle) = 42;
@@ -287,6 +293,13 @@ public:
         return tuple;
     }
 
+    TableTuple updateTuple(PersistentTable* table, TableTuple oldTuple, TableTuple newTuple) {
+        table->updateTuple(oldTuple, newTuple);
+        TableTuple tuple = table->lookupTupleByValues(newTuple);
+        assert(!tuple.isNullTuple());
+        return tuple;
+    }
+
     void deleteTuple(PersistentTable* table, TableTuple tuple) {
         TableTuple tuple_to_delete = table->lookupTupleForDR(tuple);
         ASSERT_FALSE(tuple_to_delete.isNullTuple());
@@ -366,11 +379,11 @@ public:
         tables[44] = m_otherTableWithoutIndexReplica;
         tables[24] = m_replicatedTableReplica;
 
-        for (int i = static_cast<int>(m_topend.blocks.size()); i > 0; i--) {
-            boost::shared_ptr<StreamBlock> sb = m_topend.blocks[i - 1];
-            m_topend.blocks.pop_back();
-            boost::shared_array<char> data = m_topend.data[i - 1];
-            m_topend.data.pop_back();
+        while (!m_topend.blocks.empty()) {
+            boost::shared_ptr<StreamBlock> sb = m_topend.blocks.front();
+            m_topend.blocks.pop_front();
+            boost::shared_array<char> data = m_topend.data.front();
+            m_topend.data.pop_front();
 
             size_t startPos = sb->headerSize() - 4;
             *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
@@ -663,7 +676,7 @@ TEST_F(DRBinaryLogTest, VerifyHiddenColumnLookup) {
     TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     endTxn(true);
 
-    beginTxn(100, 100, 98, 71);
+    beginTxn(100, 100, 99, 71);
     for (int i = 0; i < 10; i++) {
         insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     }
@@ -677,7 +690,7 @@ TEST_F(DRBinaryLogTest, VerifyHiddenColumnLookup) {
     NValue drTimestamp = tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex());
     EXPECT_EQ(0, expectedTimestamp.compare(drTimestamp));
 
-    beginTxn(101, 101, 99, 72);
+    beginTxn(101, 101, 100, 72);
     deleteTuple(m_table, tuple);
     endTxn(true);
 
@@ -1731,6 +1744,122 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatchAndNewRowConstraint) {
     // 3. check export
     MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engine->getExportTupleStream());
     EXPECT_EQ(4, exportStream->receivedTuples.size());
+}
+
+TEST_F(DRBinaryLogTest, InsertOverBufferLimit) {
+    createIndexes();
+    const int total = 400;
+    int spHandle = 1;
+
+    beginTxn(spHandle, spHandle, spHandle-1, spHandle);
+    try {
+        for (int i = 1; i <= total; i++) {
+            insertTuple(m_table, prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+        }
+    } catch (SerializableEEException e) {
+        endTxn(false);
+        spHandle++;
+
+        for (int i = 1; i <= total; i++, spHandle++) {
+            beginTxn(spHandle, spHandle, spHandle-1, spHandle);
+            insertTuple(m_table, prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+            endTxn(true);
+        }
+
+        return;
+    }
+
+    ASSERT_TRUE(false);
+}
+
+TEST_F(DRBinaryLogTest, UpdateOverBufferLimit) {
+    createIndexes();
+    const int total = 150;
+    long spHandle = 1;
+
+    for (int i = 0; i < total; i++, spHandle++) {
+        beginTxn(spHandle, spHandle, spHandle-1, spHandle);
+        insertTuple(m_table, prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+        endTxn(true);
+    }
+
+    flushAndApply(spHandle-1);
+
+    // Update all tuples
+    beginTxn(spHandle, spHandle, spHandle-1, spHandle);
+    spHandle++;
+    try {
+        // Update all rows to new values and update them back to the original
+        // values. It would overflow the DR buffer limit and cause the txn to
+        // roll back.
+        for (int i = 0; i < total; i++) {
+            TableTuple newTuple = prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i);
+            TableTuple oldTuple = m_table->lookupTupleByValues(newTuple);
+            newTuple.setNValue(1, ValueFactory::getBigIntValue(i+total));
+            updateTuple(m_table, oldTuple, newTuple);
+        }
+        for (int i = 0; i < total; i++) {
+            TableTuple newTuple = prepareTempTuple(m_table, 42, i+total, "349508345.34583", "a thing", "a totally different thing altogether", i);
+            TableTuple oldTuple = m_table->lookupTupleByValues(newTuple);
+            newTuple.setNValue(1, ValueFactory::getBigIntValue(i));
+            updateTuple(m_table, oldTuple, newTuple);
+        }
+    } catch (SerializableEEException e) {
+        endTxn(false);
+
+        // Make sure all changes rolled back
+        for (int i = 0; i < total; i++) {
+            TableTuple tuple = m_table->lookupTupleByValues(prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+            ASSERT_FALSE(tuple.isNullTuple());
+
+            TableTuple tuple2 = m_table->lookupTupleByValues(prepareTempTuple(m_table, 42, i+total, "349508345.34583", "a thing", "a totally different thing altogether", i));
+            ASSERT_TRUE(tuple2.isNullTuple());
+        }
+
+        return;
+    }
+    ASSERT_TRUE(false);
+}
+
+TEST_F(DRBinaryLogTest, DeleteOverBufferLimit) {
+    createIndexes();
+    const int total = 2000;
+    int spHandle = 1;
+
+    for (int i = 1; i <= total; i++, spHandle++) {
+        beginTxn(spHandle, spHandle, spHandle-1, spHandle);
+        insertTuple(m_table, prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+        endTxn(true);
+    }
+
+    flushAndApply(spHandle - 1);
+
+    beginTxn(spHandle, spHandle, spHandle-1, spHandle);
+    try {
+        // Delete all rows. It would overflow the DR buffer limit and cause the
+        // txn to roll back.
+        for (int i = 1; i <= total; i++) {
+            TableTuple tuple = m_table->lookupTupleByValues(prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+            deleteTuple(m_table, tuple);
+        }
+    } catch (SerializableEEException e) {
+        endTxn(false);
+        spHandle++;
+
+        // Make sure all changes rolled back, try to delete each tuple in single
+        // txn to make sure indexes are also correct
+        for (int i = 1; i <= total; i++, spHandle++) {
+            beginTxn(spHandle, spHandle, spHandle-1, spHandle);
+            TableTuple tuple = m_table->lookupTupleByValues(prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+            ASSERT_FALSE(tuple.isNullTuple());
+
+            deleteTuple(m_table, tuple);
+            endTxn(true);
+        }
+
+        return;
+    }
+    ASSERT_TRUE(false);
 }
 
 int main() {


### PR DESCRIPTION
Move the DR stream append around in the INSERT/UPDATE/DELETE paths to
make sure it won't cause the operation half completed without proper
rollback. The INSERT/UPDATE/DELETE code paths assume that certain part
of the operation will always succeed. If it fails in the middle of those
critical sections, things won't rollback.

Change-Id: Idc28de35a73e08bf77b30f61dae63590886079e2