### PR TITLE
ENG-9830: Fix DR buffer limit error handling.

### DIFF
--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -121,7 +121,7 @@ public:
     std::queue<int32_t> partitionIds;
     std::queue<std::string> signatures;
     std::deque<boost::shared_ptr<StreamBlock> > blocks;
-    std::vector<boost::shared_array<char> > data;
+    std::deque<boost::shared_array<char> > data;
     bool receivedDRBuffer;
     bool receivedExportBuffer;
     int64_t pushDRBufferRetval;

--- a/src/ee/storage/CompatibleDRTupleStream.cpp
+++ b/src/ee/storage/CompatibleDRTupleStream.cpp
@@ -430,19 +430,13 @@ bool CompatibleDRTupleStream::checkOpenTransaction(StreamBlock* sb, size_t minLe
     if (sb && sb->hasDRBeginTxn()   /* this block contains a DR begin txn */
            && m_opened) {
         size_t partialTxnLength = sb->offset() - sb->lastDRBeginTxnOffset();
-        if (partialTxnLength + minLength >= (m_defaultCapacity - m_headerSpace)) {
-            switch (sb->type()) {
-                case voltdb::NORMAL_STREAM_BLOCK:
-                {
-                    blockSize = m_secondaryCapacity;
-                    break;
-                }
-                case voltdb::LARGE_STREAM_BLOCK:
-                {
-                    blockSize = 0;
-                    break;
-                }
-            }
+        size_t spaceNeeded = m_headerSpace + partialTxnLength + minLength;
+        if (spaceNeeded > m_secondaryCapacity) {
+            // txn larger than the max buffer size, set blockSize to 0 so that caller will abort
+            blockSize = 0;
+        } else if (spaceNeeded > m_defaultCapacity) {
+            blockSize = m_secondaryCapacity;
+
         }
         if (blockSize != 0) {
             uso -= partialTxnLength;

--- a/src/ee/storage/TupleStreamBase.cpp
+++ b/src/ee/storage/TupleStreamBase.cpp
@@ -24,6 +24,7 @@
 #include "common/tabletuple.h"
 #include "common/ExportSerializeIo.h"
 #include "common/executorcontext.hpp"
+#include "storage/TupleStreamException.h"
 
 #include <cstdio>
 #include <limits>
@@ -304,7 +305,7 @@ void TupleStreamBase::extendBufferChain(size_t minLength)
     bool openTransaction = checkOpenTransaction(oldBlock, minLength, blockSize, uso);
 
     if (blockSize == 0) {
-        throw SQLException(SQLException::volt_output_buffer_overflow, "Transaction is bigger than DR Buffer size");
+        throw TupleStreamException(SQLException::volt_output_buffer_overflow, "Transaction is bigger than DR Buffer size");
     }
 
     char *buffer = new char[blockSize];

--- a/src/ee/storage/TupleStreamException.h
+++ b/src/ee/storage/TupleStreamException.h
@@ -1,0 +1,35 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TUPLESTREAMEXCEPTION_H_
+#define TUPLESTREAMEXCEPTION_H_
+
+#include "common/SQLException.h"
+
+namespace voltdb {
+
+// Create a subclass so that we can differentiate exceptions thrown from the
+// tuple stream.
+class TupleStreamException : public SQLException {
+public:
+    TupleStreamException(std::string sqlState, std::string message) :
+        SQLException(sqlState, message) {}
+    virtual ~TupleStreamException() {}
+};
+}
+
+#endif /* TUPLESTREAMEXCEPTION_H_ */

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -476,7 +476,9 @@ void PersistentTable::insertPersistentTuple(TableTuple &source, bool fallible)
 
     try {
         insertTupleCommon(source, target, fallible);
-    } catch (ConstraintFailureException &e) {
+    } catch (...) {
+        // Free the target if insertTupleCommon() throws for any reason. It is
+        // likely that the undo action is not registered.
         deleteTupleStorage(target); // also frees object columns
         throw;
     }
@@ -490,6 +492,25 @@ void PersistentTable::insertTupleCommon(TableTuple &source, TableTuple &target, 
             throw ConstraintFailureException(this, source, TableTuple(), CONSTRAINT_TYPE_NOT_NULL);
         }
 
+    }
+
+    // Write to DR stream before everything else to ensure nothing gets left in
+    // the index if the append fails.
+    ExecutorContext *ec = ExecutorContext::getExecutorContext();
+    if (hasDRTimestampColumn()) {
+        setDRTimestampForTuple(ec, target, false);
+    }
+
+    AbstractDRTupleStream *drStream = getDRTupleStream(ec);
+    size_t drMark = INVALID_DR_MARK;
+    if (drStream && !m_isMaterialized && m_drEnabled && shouldDRStream) {
+        ExecutorContext *ec = ExecutorContext::getExecutorContext();
+        const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
+        const int64_t currentTxnId = ec->currentTxnId();
+        const int64_t currentSpHandle = ec->currentSpHandle();
+        const int64_t currentUniqueId = ec->currentUniqueId();
+        std::pair<const TableIndex*, uint32_t> uniqueIndex = getUniqueIndexForDR();
+        drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, currentTxnId, currentSpHandle, currentUniqueId, target, DR_RECORD_INSERT, uniqueIndex);
     }
 
     if (m_schema->getUninlinedObjectColumnCount() != 0) {
@@ -514,24 +535,9 @@ void PersistentTable::insertTupleCommon(TableTuple &source, TableTuple &target, 
     TableTuple conflict(m_schema);
     tryInsertOnAllIndexes(&target, &conflict);
     if (!conflict.isNullTuple()) {
+        // Roll the DR stream back because the undo action is not registered
+        m_surgeon.DRRollback(drMark, rowCostForDRRecord(DR_RECORD_INSERT));
         throw ConstraintFailureException(this, source, conflict, CONSTRAINT_TYPE_UNIQUE);
-    }
-
-    ExecutorContext *ec = ExecutorContext::getExecutorContext();
-    if (hasDRTimestampColumn()) {
-        setDRTimestampForTuple(ec, target, false);
-    }
-
-    AbstractDRTupleStream *drStream = getDRTupleStream(ec);
-    size_t drMark = INVALID_DR_MARK;
-    if (drStream && !m_isMaterialized && m_drEnabled && shouldDRStream) {
-        ExecutorContext *ec = ExecutorContext::getExecutorContext();
-        const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
-        const int64_t currentTxnId = ec->currentTxnId();
-        const int64_t currentSpHandle = ec->currentSpHandle();
-        const int64_t currentUniqueId = ec->currentUniqueId();
-        std::pair<const TableIndex*, uint32_t> uniqueIndex = getUniqueIndexForDR();
-        drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, currentTxnId, currentSpHandle, currentUniqueId, target, DR_RECORD_INSERT, uniqueIndex);
     }
 
     // this is skipped for inserts that are never expected to fail,
@@ -633,6 +639,25 @@ bool PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUp
         }
     }
 
+    // Write to the DR stream before doing anything else to ensure we don't
+    // leave a half updated tuple behind in case this throws.
+    ExecutorContext *ec = ExecutorContext::getExecutorContext();
+    if (hasDRTimestampColumn() && updateDRTimestamp) {
+        setDRTimestampForTuple(ec, sourceTupleWithNewValues, true);
+    }
+
+    AbstractDRTupleStream *drStream = getDRTupleStream(ec);
+    size_t drMark = INVALID_DR_MARK;
+    if (drStream && !m_isMaterialized && m_drEnabled) {
+        ExecutorContext *ec = ExecutorContext::getExecutorContext();
+        const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
+        const int64_t currentTxnId = ec->currentTxnId();
+        const int64_t currentSpHandle = ec->currentSpHandle();
+        const int64_t currentUniqueId = ec->currentUniqueId();
+        std::pair<const TableIndex*, uint32_t> uniqueIndex = getUniqueIndexForDR();
+        drMark = drStream->appendUpdateRecord(lastCommittedSpHandle, m_signature, currentTxnId, currentSpHandle, currentUniqueId, targetTupleToUpdate, sourceTupleWithNewValues, uniqueIndex);
+    }
+
     if (m_tableStreamer != NULL) {
         m_tableStreamer->notifyTupleUpdate(targetTupleToUpdate);
     }
@@ -666,23 +691,6 @@ bool PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUp
         for (int i = 0; i < m_views.size(); i++) {
             m_views[i]->processTupleDelete(targetTupleToUpdate, fallible);
         }
-    }
-
-    ExecutorContext *ec = ExecutorContext::getExecutorContext();
-    if (hasDRTimestampColumn() && updateDRTimestamp) {
-        setDRTimestampForTuple(ec, sourceTupleWithNewValues, true);
-    }
-
-    AbstractDRTupleStream *drStream = getDRTupleStream(ec);
-    size_t drMark = INVALID_DR_MARK;
-    if (drStream && !m_isMaterialized && m_drEnabled) {
-        ExecutorContext *ec = ExecutorContext::getExecutorContext();
-        const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
-        const int64_t currentTxnId = ec->currentTxnId();
-        const int64_t currentSpHandle = ec->currentSpHandle();
-        const int64_t currentUniqueId = ec->currentUniqueId();
-        std::pair<const TableIndex*, uint32_t> uniqueIndex = getUniqueIndexForDR();
-        drMark = drStream->appendUpdateRecord(lastCommittedSpHandle, m_signature, currentTxnId, currentSpHandle, currentUniqueId, targetTupleToUpdate, sourceTupleWithNewValues, uniqueIndex);
     }
 
     if (m_schema->getUninlinedObjectColumnCount() != 0) {
@@ -826,17 +834,8 @@ bool PersistentTable::deleteTuple(TableTuple &target, bool fallible) {
     // The tempTuple is forever!
     assert(&target != &m_tempTuple);
 
-    // Just like insert, we want to remove this tuple from all of our indexes
-    deleteFromAllIndexes(&target);
-
-    {
-        // handle any materialized views, hide the tuple from the scan temporarily.
-        SetAndRestorePendingDeleteFlag setPending(target);
-        for (int i = 0; i < m_views.size(); i++) {
-            m_views[i]->processTupleDelete(target, fallible);
-        }
-    }
-
+    // Write to the DR stream before doing anything else to ensure nothing will
+    // be left forgotten in case this throws.
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
     AbstractDRTupleStream *drStream = getDRTupleStream(ec);
     size_t drMark = INVALID_DR_MARK;
@@ -847,6 +846,17 @@ bool PersistentTable::deleteTuple(TableTuple &target, bool fallible) {
         const int64_t currentUniqueId = ec->currentUniqueId();
         std::pair<const TableIndex*, uint32_t> uniqueIndex = getUniqueIndexForDR();
         drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, currentTxnId, currentSpHandle, currentUniqueId, target, DR_RECORD_DELETE, uniqueIndex);
+    }
+
+    // Just like insert, we want to remove this tuple from all of our indexes
+    deleteFromAllIndexes(&target);
+
+    {
+        // handle any materialized views, hide the tuple from the scan temporarily.
+        SetAndRestorePendingDeleteFlag setPending(target);
+        for (int i = 0; i < m_views.size(); i++) {
+            m_views[i]->processTupleDelete(target, fallible);
+        }
     }
 
     if (fallible) {

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -54,6 +54,9 @@ const int HIDDEN_COLUMN_COUNT = 1;
 const int CLUSTER_ID = 1;
 const int CLUSTER_ID_REPLICA = 2;
 
+const int BUFFER_SIZE = 4096;
+const int LARGE_BUFFER_SIZE = 32768;
+
 static int64_t addPartitionId(int64_t value) {
     return (value << 14) | 42;
 }
@@ -137,6 +140,9 @@ public:
         m_engine (new MockVoltDBEngine(false, CLUSTER_ID, &m_topend, &m_pool, &m_drStream, &m_drReplicatedStream)),
         m_engineReplica (new MockVoltDBEngine(false, CLUSTER_ID_REPLICA, &m_topend, &m_pool, &m_drStreamReplica, &m_drReplicatedStreamReplica))
     {
+        m_drStream.setDefaultCapacity(BUFFER_SIZE);
+        m_drStream.setSecondaryCapacity(LARGE_BUFFER_SIZE);
+
         m_drStream.m_enabled = true;
         m_drReplicatedStream.m_enabled = true;
         m_drStreamReplica.m_enabled = false;
@@ -300,6 +306,13 @@ public:
         return tuple;
     }
 
+    TableTuple updateTuple(PersistentTable* table, TableTuple oldTuple, TableTuple newTuple) {
+        table->updateTuple(oldTuple, newTuple);
+        TableTuple tuple = table->lookupTupleByValues(newTuple);
+        assert(!tuple.isNullTuple());
+        return tuple;
+    }
+
     void deleteTuple(PersistentTable* table, TableTuple tuple) {
         TableTuple tuple_to_delete = table->lookupTupleForDR(tuple);
         ASSERT_FALSE(tuple_to_delete.isNullTuple());
@@ -385,11 +398,11 @@ public:
         tables[44] = m_otherTableWithoutIndexReplica;
         tables[24] = m_replicatedTableReplica;
 
-        for (int i = static_cast<int>(m_topend.blocks.size()); i > 0; i--) {
-            boost::shared_ptr<StreamBlock> sb = m_topend.blocks[i - 1];
-            m_topend.blocks.pop_back();
-            boost::shared_array<char> data = m_topend.data[i - 1];
-            m_topend.data.pop_back();
+        while (!m_topend.blocks.empty()) {
+            boost::shared_ptr<StreamBlock> sb = m_topend.blocks.front();
+            m_topend.blocks.pop_front();
+            boost::shared_array<char> data = m_topend.data.front();
+            m_topend.data.pop_front();
 
             size_t startPos = sb->headerSize() - 4;
             *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
@@ -699,7 +712,7 @@ TEST_F(DRBinaryLogTest, VerifyHiddenColumnLookup) {
     TableTuple first_tuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     endTxn(m_engine, true);
 
-    beginTxn(m_engine, 100, 100, 98, 71);
+    beginTxn(m_engine, 100, 100, 99, 71);
     for (int i = 0; i < 10; i++) {
         insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
     }
@@ -713,7 +726,7 @@ TEST_F(DRBinaryLogTest, VerifyHiddenColumnLookup) {
     NValue drTimestamp = tuple.getHiddenNValue(m_table->getDRTimestampColumnIndex());
     EXPECT_EQ(0, expectedTimestamp.compare(drTimestamp));
 
-    beginTxn(m_engine, 101, 101, 99, 72);
+    beginTxn(m_engine, 101, 101, 100, 72);
     deleteTuple(m_table, tuple);
     endTxn(m_engine, true);
 
@@ -1784,6 +1797,122 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatchAndNewRowConstraint) {
     // 3. check export
     MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engineReplica->getExportTupleStream());
     EXPECT_EQ(4, exportStream->receivedTuples.size());
+}
+
+TEST_F(DRBinaryLogTest, InsertOverBufferLimit) {
+    createIndexes();
+    const int total = 400;
+    int spHandle = 1;
+
+    beginTxn(m_engine, spHandle, spHandle, spHandle-1, spHandle);
+    try {
+        for (int i = 1; i <= total; i++) {
+            insertTuple(m_table, prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+        }
+    } catch (SerializableEEException e) {
+        endTxn(m_engine, false);
+        spHandle++;
+
+        for (int i = 1; i <= total; i++, spHandle++) {
+            beginTxn(m_engine, spHandle, spHandle, spHandle-1, spHandle);
+            insertTuple(m_table, prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+            endTxn(m_engine, true);
+        }
+
+        return;
+    }
+
+    ASSERT_TRUE(false);
+}
+
+TEST_F(DRBinaryLogTest, UpdateOverBufferLimit) {
+    createIndexes();
+    const int total = 150;
+    long spHandle = 1;
+
+    for (int i = 0; i < total; i++, spHandle++) {
+        beginTxn(m_engine, spHandle, spHandle, spHandle-1, spHandle);
+        insertTuple(m_table, prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+        endTxn(m_engine, true);
+    }
+
+    flushAndApply(spHandle-1);
+
+    // Update all tuples
+    beginTxn(m_engine, spHandle, spHandle, spHandle-1, spHandle);
+    spHandle++;
+    try {
+        // Update all rows to new values and update them back to the original
+        // values. It would overflow the DR buffer limit and cause the txn to
+        // roll back.
+        for (int i = 0; i < total; i++) {
+            TableTuple newTuple = prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i);
+            TableTuple oldTuple = m_table->lookupTupleByValues(newTuple);
+            newTuple.setNValue(1, ValueFactory::getBigIntValue(i+total));
+            updateTuple(m_table, oldTuple, newTuple);
+        }
+        for (int i = 0; i < total; i++) {
+            TableTuple newTuple = prepareTempTuple(m_table, 42, i+total, "349508345.34583", "a thing", "a totally different thing altogether", i);
+            TableTuple oldTuple = m_table->lookupTupleByValues(newTuple);
+            newTuple.setNValue(1, ValueFactory::getBigIntValue(i));
+            updateTuple(m_table, oldTuple, newTuple);
+        }
+    } catch (SerializableEEException e) {
+        endTxn(m_engine, false);
+
+        // Make sure all changes rolled back
+        for (int i = 0; i < total; i++) {
+            TableTuple tuple = m_table->lookupTupleByValues(prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+            ASSERT_FALSE(tuple.isNullTuple());
+
+            TableTuple tuple2 = m_table->lookupTupleByValues(prepareTempTuple(m_table, 42, i+total, "349508345.34583", "a thing", "a totally different thing altogether", i));
+            ASSERT_TRUE(tuple2.isNullTuple());
+        }
+
+        return;
+    }
+    ASSERT_TRUE(false);
+}
+
+TEST_F(DRBinaryLogTest, DeleteOverBufferLimit) {
+    createIndexes();
+    const int total = 2000;
+    int spHandle = 1;
+
+    for (int i = 1; i <= total; i++, spHandle++) {
+        beginTxn(m_engine, spHandle, spHandle, spHandle-1, spHandle);
+        insertTuple(m_table, prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+        endTxn(m_engine, true);
+    }
+
+    flushAndApply(spHandle - 1);
+
+    beginTxn(m_engine, spHandle, spHandle, spHandle-1, spHandle);
+    try {
+        // Delete all rows. It would overflow the DR buffer limit and cause the
+        // txn to roll back.
+        for (int i = 1; i <= total; i++) {
+            TableTuple tuple = m_table->lookupTupleByValues(prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+            deleteTuple(m_table, tuple);
+        }
+    } catch (SerializableEEException e) {
+        endTxn(m_engine, false);
+        spHandle++;
+
+        // Make sure all changes rolled back, try to delete each tuple in single
+        // txn to make sure indexes are also correct
+        for (int i = 1; i <= total; i++, spHandle++) {
+            beginTxn(m_engine, spHandle, spHandle, spHandle-1, spHandle);
+            TableTuple tuple = m_table->lookupTupleByValues(prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+            ASSERT_FALSE(tuple.isNullTuple());
+
+            deleteTuple(m_table, tuple);
+            endTxn(m_engine, true);
+        }
+
+        return;
+    }
+    ASSERT_TRUE(false);
 }
 
 int main() {


### PR DESCRIPTION
Move the DR stream append around in the INSERT/UPDATE/DELETE paths to
make sure it won't cause the operation half completed without proper
rollback. The INSERT/UPDATE/DELETE code paths assume that certain part
of the operation will always succeed. If it fails in the middle of those
critical sections, things won't rollback.

Change-Id: Idc28de35a73e08bf77b30f61dae63590886079e2