### PR TITLE
ENG-9875 Make VoltTableRow column methods public.

### DIFF
--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -545,17 +545,17 @@ public final class VoltTable extends VoltTableRow implements JSONString {
         }
 
         @Override
-        protected int getColumnCount() {
+        public int getColumnCount() {
             return VoltTable.this.getColumnCount();
         }
 
         @Override
-        protected int getColumnIndex(String columnName) {
+        public int getColumnIndex(String columnName) {
             return VoltTable.this.getColumnIndex(columnName);
         }
 
         @Override
-        protected VoltType getColumnType(int columnIndex) {
+        public VoltType getColumnType(int columnIndex) {
             return VoltTable.this.getColumnType(columnIndex);
         }
 

--- a/src/frontend/org/voltdb/VoltTableRow.java
+++ b/src/frontend/org/voltdb/VoltTableRow.java
@@ -100,20 +100,20 @@ public abstract class VoltTableRow {
      * @param columnIndex Index of the column
      * @return {@link VoltType VoltType} of the column
      */
-    abstract VoltType getColumnType(int columnIndex);
+    abstract public VoltType getColumnType(int columnIndex);
 
     /**
-     * Return the index of the column with the specified index.
+     * Return the index of the column with the specified column name.
      * @param columnName Name of the column
      * @return Index of the column
      */
-    abstract int getColumnIndex(String columnName);
+    abstract public int getColumnIndex(String columnName);
 
     /**
      * Returns the number of columns in the table schema
      * @return Number of columns in the table schema
      */
-    abstract int getColumnCount();
+    abstract public int getColumnCount();
 
     /**
      * Returns the number of rows.


### PR DESCRIPTION
These methods are already available on the VoltTable that provides the VoltTableRow.
Making them public also on VoltTableRow makes it more convenient to define stored procedure and client helper functions that accept a VoltTableRow (but not also its VoltTable) as input.