### PR TITLE
Eng 8932 full join

### DIFF
--- a/src/ee/executors/abstractjoinexecutor.cpp
+++ b/src/ee/executors/abstractjoinexecutor.cpp
@@ -54,10 +54,7 @@ using namespace voltdb;
 
 void AbstractJoinExecutor::outputTuple(CountingPostfilter& postfilter, TableTuple& join_tuple, ProgressMonitorProxy& pmp) {
     if (m_aggExec != NULL) {
-        if (m_aggExec->p_execute_tuple(join_tuple)) {
-            // Aggregate has reached the limit
-            postfilter.setAboveLimit();
-        }
+        m_aggExec->p_execute_tuple(join_tuple);
         return;
     }
     m_tmpOutputTable->insertTempTuple(join_tuple);

--- a/src/ee/executors/abstractjoinexecutor.cpp
+++ b/src/ee/executors/abstractjoinexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2015 VoltDB Inc.
+ * Copyright (C) 2008-2016 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following
@@ -64,7 +64,7 @@ void AbstractJoinExecutor::outputTuple(CountingPostfilter& postfilter, TableTupl
     pmp.countdownProgress();
 }
 
-void AbstractJoinExecutor::p_init_null_tuples(Table* inner_table, Table* outer_table) {
+void AbstractJoinExecutor::p_init_null_tuples(Table* outer_table, Table* inner_table) {
     if (m_joinType != JOIN_TYPE_INNER) {
         assert(inner_table);
         m_null_inner_tuple.init(inner_table->schema());

--- a/src/ee/executors/abstractjoinexecutor.h
+++ b/src/ee/executors/abstractjoinexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2015 VoltDB Inc.
+ * Copyright (C) 2008-2016 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following
@@ -71,7 +71,7 @@ class AbstractJoinExecutor : public AbstractExecutor {
 
         bool p_init(AbstractPlanNode*, TempTableLimits* limits);
 
-        void p_init_null_tuples(Table* inner_table, Table* outer_table);
+        void p_init_null_tuples(Table* outer_table, Table* inner_table);
 
         // Write tuple to the output table
         void outputTuple(CountingPostfilter& postfilter, TableTuple& join_tuple, ProgressMonitorProxy& pmp);

--- a/src/ee/executors/aggregateexecutor.cpp
+++ b/src/ee/executors/aggregateexecutor.cpp
@@ -638,7 +638,7 @@ inline TupleSchema* AggregateExecutorBase::constructGroupBySchema(bool partial) 
                                           groupByColumnInBytes);
 }
 
-inline void AggregateExecutorBase::executeAggBase(const NValueArray& params)
+inline void AggregateExecutorBase::initCountingPredicate(const NValueArray& params, CountingPostfilter* parentPostfilter)
 {
     VOLT_DEBUG("started AGGREGATE");
     assert(dynamic_cast<AggregatePlanNode*>(m_abstractNode));
@@ -646,14 +646,13 @@ inline void AggregateExecutorBase::executeAggBase(const NValueArray& params)
     //
     // OPTIMIZATION: NESTED LIMIT for serial aggregation
     //
-    m_limit = -1;
-    m_offset = -1;
-    m_tupleSkipped = 0;
-    m_earlyReturn = false;
+    int limit = CountingPostfilter::NO_LIMIT;
+    int offset = CountingPostfilter::NO_OFFSET;
     LimitPlanNode* inlineLimitNode = dynamic_cast<LimitPlanNode*>(m_abstractNode->getInlinePlanNode(PLAN_NODE_TYPE_LIMIT));
     if (inlineLimitNode) {
-        inlineLimitNode->getLimitAndOffsetByReference(params, m_limit, m_offset);
+        inlineLimitNode->getLimitAndOffsetByReference(params, limit, offset);
     }
+    m_postfilter = AggCountingPostfilter(m_tmpOutputTable, m_postPredicate, limit, offset, parentPostfilter);
 }
 
 /// Helper method responsible for inserting the results of the
@@ -661,7 +660,7 @@ inline void AggregateExecutorBase::executeAggBase(const NValueArray& params)
 /// through any additional columns from the input table.
 inline bool AggregateExecutorBase::insertOutputTuple(AggregateRow* aggregateRow)
 {
-    if (m_earlyReturn) {
+    if (!m_postfilter.isUnderLimit()) {
         return false;
     }
 
@@ -681,27 +680,13 @@ inline bool AggregateExecutorBase::insertOutputTuple(AggregateRow* aggregateRow)
                          m_outputColumnExpressions[output_col_index]->eval(&(aggregateRow->m_passThroughTuple)));
     }
 
-    bool inserted = false;
-    if (m_postPredicate == NULL || m_postPredicate->eval(&tempTuple, NULL).isTrue()) {
-        if (m_limit >= 0) {
-            // If there is an inlined limit for serial aggregate and
-            // it is possible for LIMIT 0.
-            if (m_offset > 0 && m_tupleSkipped < m_offset) {
-                m_tupleSkipped++;
-                return false;
-            }
-            if (m_tmpOutputTable->tempTableTupleCount() == m_limit) {
-                m_earlyReturn = true;
-                return false;
-            }
-        }
-
+    bool needInsert = m_postfilter.eval(&tempTuple);
+    if (needInsert) {
         m_tmpOutputTable->insertTupleNonVirtual(tempTuple);
-        inserted = true;
     }
 
     VOLT_TRACE("output_table:\n%s", m_tmpOutputTable->debug().c_str());
-    return inserted;
+    return needInsert;
 }
 
 inline void AggregateExecutorBase::advanceAggs(AggregateRow* aggregateRow, const TableTuple& tuple)
@@ -753,13 +738,13 @@ TableTuple& AggregateExecutorBase::swapWithInprogressGroupByKeyTuple() {
 }
 
 TableTuple AggregateExecutorBase::p_execute_init(const NValueArray& params,
-        ProgressMonitorProxy* pmp, const TupleSchema * schema, TempTable* newTempTable)
+        ProgressMonitorProxy* pmp, const TupleSchema * schema, TempTable* newTempTable, CountingPostfilter* parentPostfilter)
 {
     if (newTempTable != NULL) {
         m_tmpOutputTable = newTempTable;
     }
     m_memoryPool.purge();
-    executeAggBase(params);
+    initCountingPredicate(params, parentPostfilter);
     m_pmp = pmp;
 
     m_nextGroupByKeyStorage.init(m_groupByKeySchema, &m_memoryPool);
@@ -790,12 +775,12 @@ void AggregateExecutorBase::p_execute_finish()
 AggregateHashExecutor::~AggregateHashExecutor() {}
 
 TableTuple AggregateHashExecutor::p_execute_init(const NValueArray& params,
-        ProgressMonitorProxy* pmp, const TupleSchema * schema, TempTable* newTempTable)
+        ProgressMonitorProxy* pmp, const TupleSchema * schema, TempTable* newTempTable, CountingPostfilter* parentPostfilter)
 {
     VOLT_TRACE("hash aggregate executor init..");
     m_hash.clear();
 
-    return AggregateExecutorBase::p_execute_init(params, pmp, schema, newTempTable);
+    return AggregateExecutorBase::p_execute_init(params, pmp, schema, newTempTable, parentPostfilter);
 }
 
 bool AggregateHashExecutor::p_execute(const NValueArray& params)
@@ -810,11 +795,11 @@ bool AggregateHashExecutor::p_execute(const NValueArray& params)
     TableIterator it = input_table->iteratorDeletingAsWeGo();
     ProgressMonitorProxy pmp(m_engine, this);
 
-    TableTuple nextTuple = AggregateHashExecutor::p_execute_init(params, &pmp, inputSchema);
+    TableTuple nextTuple = AggregateHashExecutor::p_execute_init(params, &pmp, inputSchema, NULL);
 
     VOLT_TRACE("looping..");
     while (it.next(nextTuple)) {
-        assert(m_earlyReturn == false); // hash aggregation can not early return for limit
+        assert(m_postfilter.isUnderLimit()); // hash aggregation can not early return for limit
         AggregateHashExecutor::p_execute_tuple(nextTuple);
     }
     AggregateHashExecutor::p_execute_finish();
@@ -823,7 +808,7 @@ bool AggregateHashExecutor::p_execute(const NValueArray& params)
     return true;
 }
 
-bool AggregateHashExecutor::p_execute_tuple(const TableTuple& nextTuple) {
+void AggregateHashExecutor::p_execute_tuple(const TableTuple& nextTuple) {
     m_pmp->countdownProgress();
     initGroupByKeyTuple(nextTuple);
     AggregateRow* aggregateRow;
@@ -850,7 +835,7 @@ bool AggregateHashExecutor::p_execute_tuple(const TableTuple& nextTuple) {
 
         if (m_aggTypes.size() == 0) {
             insertOutputTuple(aggregateRow);
-            return false;
+            return;
         }
     } else {
         // otherwise, the agg row is the second item of the pair...
@@ -858,12 +843,7 @@ bool AggregateHashExecutor::p_execute_tuple(const TableTuple& nextTuple) {
     }
     // update the aggregation calculation.
     advanceAggs(aggregateRow, nextTuple);
-
-    if (m_earlyReturn) {
-        return true;
-    }
-    return false;
-}
+ }
 
 void AggregateHashExecutor::p_execute_finish() {
     VOLT_TRACE("finalizing..");
@@ -888,11 +868,11 @@ AggregateSerialExecutor::~AggregateSerialExecutor() {}
 
 
 TableTuple AggregateSerialExecutor::p_execute_init(const NValueArray& params,
-        ProgressMonitorProxy* pmp, const TupleSchema * schema, TempTable* newTempTable)
+        ProgressMonitorProxy* pmp, const TupleSchema * schema, TempTable* newTempTable, CountingPostfilter* parentPostfilter)
 {
     VOLT_TRACE("serial aggregate executor init..");
     TableTuple nextInputTuple = AggregateExecutorBase::p_execute_init(
-            params, pmp, schema, newTempTable);
+            params, pmp, schema, newTempTable, parentPostfilter);
 
     m_aggregateRow = new (m_memoryPool, m_aggTypes.size()) AggregateRow();
     m_noInputRows = true;
@@ -916,14 +896,11 @@ bool AggregateSerialExecutor::p_execute(const NValueArray& params)
     TableTuple nextTuple(input_table->schema());
 
     ProgressMonitorProxy pmp(m_engine, this);
-    AggregateSerialExecutor::p_execute_init(params, &pmp, input_table->schema());
+    AggregateSerialExecutor::p_execute_init(params, &pmp, input_table->schema(), NULL);
 
-    while (it.next(nextTuple)) {
+    while (m_postfilter.isUnderLimit() && it.next(nextTuple)) {
         m_pmp->countdownProgress();
         AggregateSerialExecutor::p_execute_tuple(nextTuple);
-        if (m_earlyReturn) {
-            break;
-        }
     }
     AggregateSerialExecutor::p_execute_finish();
     VOLT_TRACE("finalizing..");
@@ -932,7 +909,7 @@ bool AggregateSerialExecutor::p_execute(const NValueArray& params)
     return true;
 }
 
-bool AggregateSerialExecutor::p_execute_tuple(const TableTuple& nextTuple) {
+void AggregateSerialExecutor::p_execute_tuple(const TableTuple& nextTuple) {
     // Use the first input tuple to "prime" the system.
     if (m_noInputRows) {
         // ENG-1565: for this special case, can have only one input row, apply the predicate here
@@ -947,7 +924,7 @@ bool AggregateSerialExecutor::p_execute_tuple(const TableTuple& nextTuple) {
             m_failPrePredicateOnFirstRow = true;
         }
         m_noInputRows = false;
-        return false;
+        return;
     }
 
     TableTuple& nextGroupByKeyTuple = swapWithInprogressGroupByKeyTuple();
@@ -971,16 +948,11 @@ bool AggregateSerialExecutor::p_execute_tuple(const TableTuple& nextTuple) {
 
     // update the aggregation calculation.
     advanceAggs(m_aggregateRow, nextTuple);
-
-    if (m_earlyReturn) {
-        return true;
-    }
-    return false;
 }
 
 void AggregateSerialExecutor::p_execute_finish()
 {
-    if (!m_earlyReturn) {
+    if (m_postfilter.isUnderLimit()) {
         if (m_noInputRows || m_failPrePredicateOnFirstRow) {
             VOLT_TRACE("finalizing after no input rows..");
             // No input rows means either no group rows (when grouping) or an empty table row (otherwise).
@@ -1013,11 +985,11 @@ void AggregateSerialExecutor::p_execute_finish()
 AggregatePartialExecutor::~AggregatePartialExecutor() {}
 
 TableTuple AggregatePartialExecutor::p_execute_init(const NValueArray& params,
-        ProgressMonitorProxy* pmp, const TupleSchema * schema, TempTable* newTempTable)
+        ProgressMonitorProxy* pmp, const TupleSchema * schema, TempTable* newTempTable, CountingPostfilter* parentPostfilter)
 {
     VOLT_TRACE("partial aggregate executor init..");
     TableTuple nextInputTuple = AggregateExecutorBase::p_execute_init(
-            params, pmp, schema, newTempTable);
+            params, pmp, schema, newTempTable, parentPostfilter);
 
     m_atTheFirstRow = true;
     m_nextPartialGroupByKeyStorage.init(m_groupByKeyPartialHashSchema, &m_memoryPool);
@@ -1040,14 +1012,11 @@ bool AggregatePartialExecutor::p_execute(const NValueArray& params)
     TableTuple nextTuple(input_table->schema());
 
     ProgressMonitorProxy pmp(m_engine, this);
-    AggregatePartialExecutor::p_execute_init(params, &pmp, input_table->schema());
+    AggregatePartialExecutor::p_execute_init(params, &pmp, input_table->schema(), NULL);
 
-    while (it.next(nextTuple)) {
+    while (m_postfilter.isUnderLimit() && it.next(nextTuple)) {
         m_pmp->countdownProgress();
         AggregatePartialExecutor::p_execute_tuple(nextTuple);
-        if (m_earlyReturn) {
-            break;
-        }
     }
     AggregatePartialExecutor::p_execute_finish();
     VOLT_TRACE("finalizing..");
@@ -1070,7 +1039,7 @@ inline void AggregatePartialExecutor::initPartialHashGroupByKeyTuple(const Table
     }
 }
 
-bool AggregatePartialExecutor::p_execute_tuple(const TableTuple& nextTuple) {
+void AggregatePartialExecutor::p_execute_tuple(const TableTuple& nextTuple) {
     TableTuple& nextGroupByKeyTuple = swapWithInprogressGroupByKeyTuple();
 
     initGroupByKeyTuple(nextTuple);
@@ -1124,11 +1093,6 @@ bool AggregatePartialExecutor::p_execute_tuple(const TableTuple& nextTuple) {
 
     // update the aggregation calculation.
     advanceAggs(aggregateRow, nextTuple);
-
-    if (m_earlyReturn) {
-        return true;
-    }
-    return false;
 }
 // TODO: Refactoring the last half of the above function with HASH aggregation
 

--- a/src/ee/executors/aggregateexecutor.h
+++ b/src/ee/executors/aggregateexecutor.h
@@ -54,6 +54,7 @@
 #include "common/tabletuple.h"
 #include "expressions/abstractexpression.h"
 #include "execution/ProgressMonitorProxy.h"
+#include "executors/executorutil.h"
 
 namespace voltdb {
 
@@ -173,13 +174,12 @@ public:
      * but will use other's output table instead.
      */
     virtual TableTuple p_execute_init(const NValueArray& params, ProgressMonitorProxy* pmp,
-            const TupleSchema * schema, TempTable* newTempTable = NULL);
+            const TupleSchema * schema, TempTable* newTempTable = NULL, CountingPostfilter* parentPredicate = NULL);
 
     /**
-     * Return true when LIMIT has been met, the caller may stop executing.
-     * By default, return false.
+     * Evaluate a tuple. As a side effect, signals when LIMIT has been met, the caller may stop executing.
      */
-    virtual bool p_execute_tuple(const TableTuple& nextTuple) = 0;
+    virtual void p_execute_tuple(const TableTuple& nextTuple) = 0;
 
     /**
      * Last method to insert the results to output table and clean up memory or variables.
@@ -193,7 +193,7 @@ public:
 protected:
     virtual bool p_init(AbstractPlanNode*, TempTableLimits*);
 
-    void executeAggBase(const NValueArray& params);
+    void initCountingPredicate(const NValueArray& params, CountingPostfilter* parentPredicate);
 
     /// Helper method responsible for inserting the results of the
     /// aggregation into a new tuple in the output table as well as passing
@@ -247,10 +247,7 @@ protected:
     TupleSchema* m_groupByKeyPartialHashSchema;
 
     // used for inline limit for serial/partial aggregate
-    int m_limit;
-    int m_offset;
-    int m_tupleSkipped;
-    bool m_earlyReturn;
+    AggCountingPostfilter m_postfilter;
 
 private:
     TupleSchema* constructGroupBySchema(bool partial);
@@ -277,8 +274,9 @@ public:
     ~AggregateHashExecutor();
 
     TableTuple p_execute_init(const NValueArray& params, ProgressMonitorProxy* pmp,
-                              const TupleSchema * schema, TempTable* newTempTable  = NULL);
-    bool p_execute_tuple(const TableTuple& nextTuple);
+                              const TupleSchema * schema, TempTable* newTempTable  = NULL,
+                              CountingPostfilter* parentPredicate = NULL);
+    void p_execute_tuple(const TableTuple& nextTuple);
     void p_execute_finish();
 
 private:
@@ -301,8 +299,9 @@ public:
     ~AggregateSerialExecutor();
 
     TableTuple p_execute_init(const NValueArray& params, ProgressMonitorProxy* pmp,
-                              const TupleSchema * schema, TempTable* newTempTable  = NULL);
-    bool p_execute_tuple(const TableTuple& nextTuple);
+                              const TupleSchema * schema, TempTable* newTempTable  = NULL,
+                              CountingPostfilter* parentPredicate = NULL);
+    void p_execute_tuple(const TableTuple& nextTuple);
     void p_execute_finish();
 
 protected:
@@ -326,8 +325,9 @@ public:
     ~AggregatePartialExecutor();
 
     TableTuple p_execute_init(const NValueArray& params, ProgressMonitorProxy* pmp,
-                              const TupleSchema * schema, TempTable* newTempTable  = NULL);
-    bool p_execute_tuple(const TableTuple& nextTuple);
+                              const TupleSchema * schema, TempTable* newTempTable  = NULL,
+                              CountingPostfilter* parentPredicate = NULL);
+    void p_execute_tuple(const TableTuple& nextTuple);
     void p_execute_finish();
 
 private:

--- a/src/ee/executors/executorfactory.cpp
+++ b/src/ee/executors/executorfactory.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2015 VoltDB Inc.
+ * Copyright (C) 2008-2016 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/executorfactory.h
+++ b/src/ee/executors/executorfactory.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2015 VoltDB Inc.
+ * Copyright (C) 2008-2016 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/indexscanexecutor.cpp
+++ b/src/ee/executors/indexscanexecutor.cpp
@@ -167,6 +167,22 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
     // INLINE LIMIT
     //
     LimitPlanNode* limit_node = dynamic_cast<LimitPlanNode*>(m_abstractNode->getInlinePlanNode(PLAN_NODE_TYPE_LIMIT));
+    int limit = CountingPostfilter::NO_LIMIT;
+    int offset = CountingPostfilter::NO_OFFSET;
+    if (limit_node != NULL) {
+        limit_node->getLimitAndOffsetByReference(params, limit, offset);
+    }
+
+    //
+    // POST EXPRESSION
+    //
+    AbstractExpression* post_expression = m_node->getPredicate();
+    if (post_expression != NULL) {
+        VOLT_DEBUG("Post Expression:\n%s", post_expression->debug(true).c_str());
+    }
+
+    // Initialize the postfilter
+    CountingPostfilter postfilter(post_expression, limit, offset);
 
     TableTuple temp_tuple;
     ProgressMonitorProxy pmp(m_engine, this);
@@ -175,7 +191,7 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
         if (m_projectionNode != NULL) {
             inputSchema = m_projectionNode->getOutputTable()->schema();
         }
-        temp_tuple = m_aggExec->p_execute_init(params, &pmp, inputSchema, m_outputTable);
+        temp_tuple = m_aggExec->p_execute_init(params, &pmp, inputSchema, m_outputTable, &postfilter);
     } else {
         temp_tuple = m_outputTable->tempTuple();
     }
@@ -291,14 +307,6 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
         VOLT_DEBUG("End Expression:\n%s", end_expression->debug(true).c_str());
     }
 
-    //
-    // POST EXPRESSION
-    //
-    AbstractExpression* post_expression = m_node->getPredicate();
-    if (post_expression != NULL) {
-        VOLT_DEBUG("Post Expression:\n%s", post_expression->debug(true).c_str());
-    }
-
     // INITIAL EXPRESSION
     AbstractExpression* initial_expression = m_node->getInitialExpression();
     if (initial_expression != NULL) {
@@ -371,15 +379,6 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
         tableIndex->moveToEnd(toStartActually, indexCursor);
     }
 
-    int limit = -1;
-    int offset = -1;
-    if (limit_node != NULL) {
-        limit_node->getLimitAndOffsetByReference(params, limit, offset);
-    }
-
-    // Initialize the postfilter
-    CountingPostfilter postfilter(post_expression, limit, offset);
-
     //
     // We have to different nextValue() methods for different lookup types
     //
@@ -438,10 +437,7 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
 
 void IndexScanExecutor::outputTuple(CountingPostfilter& postfilter, TableTuple& tuple) {
     if (m_aggExec != NULL) {
-        if (m_aggExec->p_execute_tuple(tuple)) {
-            // Aggregate has reached the limit
-            postfilter.setAboveLimit();
-        }
+        m_aggExec->p_execute_tuple(tuple);
         return;
     }
     //

--- a/src/ee/executors/mergereceiveexecutor.h
+++ b/src/ee/executors/mergereceiveexecutor.h
@@ -62,6 +62,7 @@ namespace voltdb {
     class LimitPlanNode;
     class AggregateExecutorBase;
     class ProgressMonitorProxy;
+    struct CountingPostfilter;
 
     /**
      * The optimized replacement for an ORDER BY executor to be used at the coordinator node
@@ -77,8 +78,7 @@ namespace voltdb {
         static void merge_sort(const std::vector<TableTuple>& tuples,
                                std::vector<int64_t>& partitionTupleCounts,
                                AbstractExecutor::TupleComparer comp,
-                               int limit,
-                               int offset,
+                               CountingPostfilter& postfilter,
                                AggregateExecutorBase* agg_exec,
                                TempTable* output_table,
                                ProgressMonitorProxy* pmp);

--- a/src/ee/executors/nestloopexecutor.cpp
+++ b/src/ee/executors/nestloopexecutor.cpp
@@ -149,8 +149,8 @@ bool NestLoopExecutor::p_execute(const NValueArray &params) {
     }
 
     LimitPlanNode* limit_node = dynamic_cast<LimitPlanNode*>(node->getInlinePlanNode(PLAN_NODE_TYPE_LIMIT));
-    int limit = -1;
-    int offset = -1;
+    int limit = CountingPostfilter::NO_LIMIT;
+    int offset = CountingPostfilter::NO_OFFSET;
     if (limit_node) {
         limit_node->getLimitAndOffsetByReference(params, limit, offset);
     }
@@ -170,7 +170,7 @@ bool NestLoopExecutor::p_execute(const NValueArray &params) {
     if (m_aggExec != NULL) {
         VOLT_TRACE("Init inline aggregate...");
         const TupleSchema * aggInputSchema = node->getTupleSchemaPreAgg();
-        join_tuple = m_aggExec->p_execute_init(params, &pmp, aggInputSchema, m_tmpOutputTable);
+        join_tuple = m_aggExec->p_execute_init(params, &pmp, aggInputSchema, m_tmpOutputTable, &postfilter);
     } else {
         join_tuple = m_tmpOutputTable->tempTuple();
     }

--- a/src/ee/executors/nestloopexecutor.cpp
+++ b/src/ee/executors/nestloopexecutor.cpp
@@ -92,7 +92,7 @@ bool NestLoopExecutor::p_init(AbstractPlanNode* abstractNode,
     }
 
     // NULL tuples for left and full joins
-    p_init_null_tuples(node->getInputTable(1), node->getInputTable());
+    p_init_null_tuples(node->getInputTable(), node->getInputTable(1));
 
     return true;
 }

--- a/src/ee/executors/nestloopindexexecutor.cpp
+++ b/src/ee/executors/nestloopindexexecutor.cpp
@@ -141,7 +141,7 @@ bool NestLoopIndexExecutor::p_init(AbstractPlanNode* abstractNode,
     }
 
     // NULL tuples for left and full joins
-    p_init_null_tuples(m_indexNode->getOutputTable(), node->getInputTable());
+    p_init_null_tuples(node->getInputTable(), m_indexNode->getTargetTable());
 
     m_indexValues.init(index->getKeySchema());
     return true;

--- a/src/ee/storage/tabletuplefilter.h
+++ b/src/ee/storage/tabletuplefilter.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2015 VoltDB Inc.
+ * Copyright (C) 2008-2016 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following


### PR DESCRIPTION
Paul, 

I refactored the Aggregate and MergeReceive executors to use CountingPostfilter, plus couple of bug fixes for nestloopindex executor.
I think there was a bug in the AggregateExecutorBase::insertOutputTuple - the offset was evaluated only if limit is greater or equal to zero. If there were no limit set (-1), the offset was ignored. The new logic lives now inside the AggCountingPostfilter::eval and verifies the offset first prior to checking the limit (if tuple passes a predicate). I added a few test cases to verify the aggregated SQL with OFFSET only 

Mike