### PR TITLE
ENG-9830: Fix PersistentTable::insertTuple() exception handling.

### DIFF
--- a/src/ee/storage/TupleStreamBase.cpp
+++ b/src/ee/storage/TupleStreamBase.cpp
@@ -24,6 +24,7 @@
 #include "common/tabletuple.h"
 #include "common/ExportSerializeIo.h"
 #include "common/executorcontext.hpp"
+#include "storage/TupleStreamException.h"
 
 #include <cstdio>
 #include <limits>
@@ -295,7 +296,7 @@ void TupleStreamBase::extendBufferChain(size_t minLength)
     bool openTransaction = checkOpenTransaction(oldBlock, minLength, blockSize, uso);
 
     if (blockSize == 0) {
-        throw SQLException(SQLException::volt_output_buffer_overflow, "Transaction is bigger than DR Buffer size");
+        throw TupleStreamException(SQLException::volt_output_buffer_overflow, "Transaction is bigger than DR Buffer size");
     }
 
     char *buffer = new char[blockSize];

--- a/src/ee/storage/TupleStreamException.h
+++ b/src/ee/storage/TupleStreamException.h
@@ -1,0 +1,35 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TUPLESTREAMEXCEPTION_H_
+#define TUPLESTREAMEXCEPTION_H_
+
+#include "common/SQLException.h"
+
+namespace voltdb {
+
+// Create a subclass so that we can differentiate exceptions thrown from the
+// tuple stream.
+class TupleStreamException : public SQLException {
+public:
+    TupleStreamException(std::string sqlState, std::string message) :
+        SQLException(sqlState, message) {}
+    virtual ~TupleStreamException() {}
+};
+}
+
+#endif /* TUPLESTREAMEXCEPTION_H_ */

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -79,6 +79,7 @@
 #include "storage/PersistentTableUndoTruncateTableAction.h"
 #include "storage/PersistentTableUndoUpdateAction.h"
 #include "storage/ConstraintFailureException.h"
+#include "storage/TupleStreamException.h"
 #include "storage/CopyOnWriteContext.h"
 #include "storage/MaterializedViewMetadata.h"
 #include "storage/DRTupleStream.h"
@@ -442,9 +443,10 @@ void PersistentTable::insertPersistentTuple(TableTuple &source, bool fallible)
 
     try {
         insertTupleCommon(source, target, fallible);
-    } catch (...) {
-        // Free the target if insertTupleCommon() throws for any reason. It is
-        // likely that the undo action is not registered.
+    } catch (ConstraintFailureException &e) {
+        deleteTupleStorage(target); // also frees object columns
+        throw;
+    } catch (TupleStreamException &e) {
         deleteTupleStorage(target); // also frees object columns
         throw;
     }


### PR DESCRIPTION
Only catch constraint failure exception thrown by the index insert and
the exception thrown by tuple stream buffer overflow in
PersistentTable::insertTuple(). We can't catch all exceptions there
because the view update could also throw SQLException that doesn't
require target tuple deallocation.