### PR TITLE
Add gaurds in EE to geo-functions where caller can accidentally pass in string instead of geo-types

### DIFF
--- a/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctions.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctions.java
@@ -69,7 +69,7 @@ public class TestGeospatialFunctions extends RegressionSuite {
      * The message is for holding error messages.  It is inserted into the
      * table.
      */
-    private static class Border {
+    static class Border {
         Border(long pk, String name, String message, GeographyValue region) {
             m_pk = pk;
             m_name = name;
@@ -103,7 +103,7 @@ public class TestGeospatialFunctions extends RegressionSuite {
      * This is the array of borders we know about. We will insert these
      * borders and then extract them.
      */
-    private static Border borders[] = {
+    static Border borders[] = {
         new Border(0, "Colorado", null,
                    new GeographyValue("POLYGON(("
                                       + "-102.052 41.002, "

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctionsExtended.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctionsExtended.java
@@ -1,0 +1,123 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+package org.voltdb.regressionsuites;
+
+import java.io.IOException;
+
+import org.voltdb.BackendTarget;
+import org.voltdb.client.Client;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb_testprocs.regressionsuites.failureprocs.GeoPointProcsWithIncompatibleParameter;
+import org.voltdb_testprocs.regressionsuites.failureprocs.GeographyProcsWithIncompatibleParameter;
+
+// the negative test case that triggers assert in valgrind and debug environment are placed
+// in this file
+
+public class TestGeospatialFunctionsExtended extends RegressionSuite {
+
+    public TestGeospatialFunctionsExtended(String name) {
+        super(name);
+    }
+
+    static private void setupGeoSchema(VoltProjectBuilder project) throws IOException {
+        String literalSchema =
+                "CREATE TABLE places (\n"
+                + "  pk INTEGER NOT NULL PRIMARY KEY,\n"
+                + "  name VARCHAR(64),\n"
+                + "  loc GEOGRAPHY_POINT\n"
+                + ");\n"
+                + "CREATE TABLE borders (\n"
+                + "  pk INTEGER NOT NULL PRIMARY KEY,\n"
+                + "  name VARCHAR(64),\n"
+                + "  message VARCHAR(64),\n"
+                + "  region GEOGRAPHY\n"
+                + ");\n"
+                + "\n"
+                ;
+        project.addProcedures(GeographyProcsWithIncompatibleParameter.class);
+        project.addProcedures(GeoPointProcsWithIncompatibleParameter.class);
+        project.addLiteralSchema(literalSchema);
+        project.setUseDDLSchema(true);
+    }
+
+    public void testPolygonIncompatibleTypes() throws IOException {
+        if (isDebug() || isValgrind()) {
+            // Can't run the tests in debug/valgrind environment as EE has
+            // asserts at different places to validate types
+            return;
+        }
+
+        Client client = getClient();
+
+        // Supply legal wkt or GeographyValue arg from each test entry. Supplied value will not effect the result except it has to be
+        // legal wkt. The stored procedure's execution call uses hard-coded string wkt for parameterized Geography value for negative testing.
+        for (GeographyProcsWithIncompatibleParameter.TestEntries entry : GeographyProcsWithIncompatibleParameter.TestEntries.values()) {
+            verifyProcFails(client, entry.getFailureMsg(), "GeographyProcsWithIncompatibleParameter", entry.getParam());
+        }
+
+    }
+
+    public void testPointIncompatibleTypes() throws IOException {
+        if (isDebug() || isValgrind()) {
+            // Can't run this tests in debug/valgrind environment as EE has
+            // asserts at different places to validate types
+            return;
+        }
+
+        Client client = getClient();
+
+        // Supply legal wkt or GeographyPointValue arg from each test entry. Supplied value will not effect the result except it has to be
+        // legal wkt. The stored procedure's execution call uses hard-coded string wkt for parameterized point value for negative testing.
+        for (GeoPointProcsWithIncompatibleParameter.TestEntries entry : GeoPointProcsWithIncompatibleParameter.TestEntries.values()) {
+            verifyProcFails(client, entry.getFailureMsg(), "GeoPointProcsWithIncompatibleParameter", entry.getParam());
+        }
+    }
+
+    static public junit.framework.Test suite() {
+
+        VoltServerConfig config = null;
+        MultiConfigSuiteBuilder builder =
+            new MultiConfigSuiteBuilder(TestGeospatialFunctionsExtended.class);
+        boolean success = false;
+
+
+        try {
+            VoltProjectBuilder project = new VoltProjectBuilder();
+            setupGeoSchema(project);
+            config = new LocalCluster("geography-value-onesite.jar", 1, 1, 0, BackendTarget.NATIVE_EE_JNI);
+            success = config.compile(project);
+        }
+        catch (IOException excp) {
+            fail();
+        }
+
+
+        assertTrue(success);
+        builder.addServerConfig(config);
+
+        return builder;
+    }
+
+}

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/GeoPointProcsWithIncompatibleParameter.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/GeoPointProcsWithIncompatibleParameter.java
@@ -1,0 +1,106 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.regressionsuites.failureprocs;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+import org.voltdb.types.GeographyPointValue;
+
+public class GeoPointProcsWithIncompatibleParameter extends VoltProcedure {
+    // Form an enum entry for different for different geo functions that take in GeographyPointValue as argument.
+    // This enum entry stores sql statements with point value as parameter and the legal unique point wkt
+    // string that it uses as input paramter to voltQueueSql() for the given stored procedure to verify
+    // the wkt to geography point value conversion does not happen implicitly.
+    public final static SQLStmt containsGeo = new SQLStmt("select borders.name from borders "
+                + "  where Contains(borders.region, ?) order by borders.pk;");
+
+    public final static SQLStmt pointsEqual= new SQLStmt("select places.name from places where places.loc = ? "
+                + "  order by places.pk;");
+
+    public final static SQLStmt pointsLessThn = new SQLStmt("select places.name from places where places.loc < ? "
+                + "  order by places.pk;");
+
+    public final static SQLStmt pointsGreaterThn = new SQLStmt("select places.name from places where places.loc > ? "
+                + "  order by places.pk;");
+
+    public final static SQLStmt pointLongitude = new SQLStmt("select places.name from places where longitude(?) < longitude(places.loc) "
+                + "  order by places.pk;");
+
+
+    public static enum TestEntries {
+        CompareEquals(pointsEqual,
+                     "POINT(-104.959 39.704)",
+                     "Type VARCHAR cannot be cast for comparison to type POINT"),
+        CompareLessThn(pointsLessThn,
+                      "POINT(-104.959 39.705)",
+                      "Type VARCHAR cannot be cast for comparison to type POINT"),
+        CompareGreaterThn(pointsGreaterThn,
+                         "POINT(-104.959 39.714)",
+                          "Type VARCHAR cannot be cast for comparison to type POINT"),
+        Contains(containsGeo,
+                "POINT(-104.959 39.712)",
+                "Type VARCHAR can't be cast as POINT"),
+
+        Latitude(pointLongitude ,
+                "POINT(-104.959 39.732)",
+                "Type VARCHAR can't be cast as POINT");
+
+        private final SQLStmt stmt;
+        private final String paramWkt;
+        private final String failureMsg;
+        private final GeographyPointValue point;
+
+        TestEntries(SQLStmt stmt, String wkt, String msg) {
+            //this.id = id;
+            this.stmt = stmt;
+            paramWkt = wkt;
+            failureMsg = msg;
+            point = GeographyPointValue.fromWKT(wkt);
+        }
+
+        public String getFailureMsg() {
+            return failureMsg;
+        }
+
+        public SQLStmt getStmt() {
+            return stmt;
+        }
+
+        public String getParam() {
+            return paramWkt;
+        }
+
+    };
+
+    public VoltTable[] run(GeographyPointValue value) {
+
+        for (TestEntries entry : TestEntries.values()) {
+            if (entry.point.equals(value)) {
+                voltQueueSQL(entry.stmt, entry.paramWkt);
+            }
+        }
+        return voltExecuteSQL();
+    }
+}

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/GeoPointProcsWithIncompatibleParameter.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/GeoPointProcsWithIncompatibleParameter.java
@@ -30,9 +30,10 @@ import org.voltdb.types.GeographyPointValue;
 
 public class GeoPointProcsWithIncompatibleParameter extends VoltProcedure {
     // Form an enum entry for different geo functions that take in GeographyPointValue as argument. This enum
-    // entry stores sql statements that parameterize geography point value and legal unqiue point wkt string 
-    // which is used as input parameter for the given stored procedure to voltQueueSql(). Logic is crafted verify 
+    // entry stores sql statements that parameterize geography point value and legal unqiue point wkt string
+    // which is used as input parameter for the given stored procedure to voltQueueSql(). Logic is crafted verify
     // the wkt to Geography Point value conversion does not happen implicitly and results in EE exception.
+
     public final static SQLStmt containsGeo = new SQLStmt("select borders.name from borders "
                 + "  where Contains(borders.region, ?) order by borders.pk;");
 

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/GeoPointProcsWithIncompatibleParameter.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/GeoPointProcsWithIncompatibleParameter.java
@@ -29,10 +29,10 @@ import org.voltdb.VoltTable;
 import org.voltdb.types.GeographyPointValue;
 
 public class GeoPointProcsWithIncompatibleParameter extends VoltProcedure {
-    // Form an enum entry for different for different geo functions that take in GeographyPointValue as argument.
-    // This enum entry stores sql statements with point value as parameter and the legal unique point wkt
-    // string that it uses as input paramter to voltQueueSql() for the given stored procedure to verify
-    // the wkt to geography point value conversion does not happen implicitly.
+    // Form an enum entry for different geo functions that take in GeographyPointValue as argument. This enum
+    // entry stores sql statements that parameterize geography point value and legal unqiue point wkt string 
+    // which is used as input parameter for the given stored procedure to voltQueueSql(). Logic is crafted verify 
+    // the wkt to Geography Point value conversion does not happen implicitly and results in EE exception.
     public final static SQLStmt containsGeo = new SQLStmt("select borders.name from borders "
                 + "  where Contains(borders.region, ?) order by borders.pk;");
 

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/GeographyProcsWithIncompatibleParameter.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/GeographyProcsWithIncompatibleParameter.java
@@ -1,0 +1,111 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.regressionsuites.failureprocs;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+import org.voltdb.types.GeographyValue;
+
+public class GeographyProcsWithIncompatibleParameter extends VoltProcedure {
+
+    // Form an enum entry for different for different geo functions that take in GeographyValue as argument.
+    // This enum entry stores sql statements that parameterize geography value and the legal unqiue wkt string
+    // for polygon that it uses as input paramter to voltQueueSql() for the given stored procedure to verify
+    // the wkt to Geography value conversion does not happen implicitly.
+    public final static SQLStmt containsGeo = new SQLStmt("select places.name from places "
+                + "  where Contains(?, places.loc) order by places.pk;");
+
+    public final static SQLStmt polygonsEqual= new SQLStmt("select borders.name from borders where borders.region = ? "
+                 + "  order by borders.pk;");
+
+    public final static SQLStmt polygonsLessThn = new SQLStmt("select borders.name from borders where borders.region < ? "
+                + "  order by borders.pk;");
+
+    public final static SQLStmt polygonsGreaterThn = new SQLStmt("select borders.name from borders where borders.region > ? "
+                + "  order by borders.pk;");
+
+    // create dummy statements
+    public final static SQLStmt polygonsValid= new SQLStmt("select borders.name from borders where isValid(?) and borders.pk = 0"
+                + "  order by borders.pk;");
+
+    public final static SQLStmt polygonsArea = new SQLStmt("select borders.name from borders where area(?) < area(borders.region) "
+            + "  order by borders.pk;");
+
+    public static enum TestEntries {
+        CompareEquals(polygonsEqual,
+                     "POLYGON((-102.052 41.002, -109.045 41.002, -109.045 36.333, -102.052 36.999, -102.052 41.002))",
+                     "Type VARCHAR cannot be cast for comparison to type GEOGRAPHY"),
+        CompareLessThn(polygonsLessThn,
+                      "POLYGON((-102.052 41.002, -109.045 41.002, -109.045 36.444, -102.052 36.999, -102.052 41.002))",
+                      "Type VARCHAR cannot be cast for comparison to type GEOGRAPHY"),
+        CompareGreaterThn(polygonsGreaterThn,
+                         "POLYGON((-102.052 41.002, -109.045 41.002, -109.045 36.555, -102.052 36.999, -102.052 41.002))",
+                          "Type VARCHAR cannot be cast for comparison to type GEOGRAPHY"),
+        Contains(containsGeo,
+                "POLYGON((-102.052 41.002, -109.045 41.002, -109.045 36.666, -102.052 36.999, -102.052 41.002))",
+                "Type VARCHAR can't be cast as GEOGRAPHY"),
+        Area(polygonsArea,
+            "POLYGON((-102.052 41.002, -109.045 41.002, -109.045 36.667, -102.045 36.999, -102.052 41.002))",
+            "Type VARCHAR can't be cast as GEOGRAPHY"),
+        IsValid(polygonsValid,
+               "POLYGON((-102.052 41.002, -109.045 41.002, -109.045 36.777, -102.052 36.999, -102.052 41.002))",
+               "Type VARCHAR can't be cast as GEOGRAPHY");
+
+        private final SQLStmt stmt;
+        private final String paramWkt;
+        private final String failureMsg;
+        private final GeographyValue geo;
+
+        TestEntries(SQLStmt stmt, String wkt, String msg) {
+            //this.id = id;
+            this.stmt = stmt;
+            paramWkt = wkt;
+            failureMsg = msg;
+            geo = new GeographyValue(wkt);
+        }
+
+        public String getFailureMsg() {
+            return failureMsg;
+        }
+
+        public SQLStmt getStmt() {
+            return stmt;
+        }
+
+        public String getParam() {
+            return paramWkt;
+        }
+
+    };
+
+    public VoltTable[] run(GeographyValue value) {
+        for (TestEntries entry : TestEntries.values()) {
+            if (entry.geo.equals(value)) {
+                voltQueueSQL(entry.stmt, entry.paramWkt);
+            }
+        }
+        return voltExecuteSQL();
+    }
+}

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/GeographyProcsWithIncompatibleParameter.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/GeographyProcsWithIncompatibleParameter.java
@@ -30,10 +30,10 @@ import org.voltdb.types.GeographyValue;
 
 public class GeographyProcsWithIncompatibleParameter extends VoltProcedure {
 
-    // Form an enum entry for different for different geo functions that take in GeographyValue as argument.
-    // This enum entry stores sql statements that parameterize geography value and the legal unqiue wkt string
-    // for polygon that it uses as input paramter to voltQueueSql() for the given stored procedure to verify
-    // the wkt to Geography value conversion does not happen implicitly.
+    // Form an enum entry for different geo functions that take in GeographyValue as argument. This enum
+    // entry stores sql statements that parameterize geography value and legal unqiue polygon wkt string
+    // which is used as input parameter for the given stored procedure to voltQueueSql(). Logic is crafted
+    // verify the wkt to Geography value conversion does not happen implicitly and results in EE exception.
     public final static SQLStmt containsGeo = new SQLStmt("select places.name from places "
                 + "  where Contains(?, places.loc) order by places.pk;");
 


### PR DESCRIPTION
Theoretically user can pass in arguments of different types to voltQueueSql() than the one which has been planned for using the corresponding statement. This can result in incompatible type flowing to EE and if the implicit conversion is not defined it can result in undefined behavior in release build (for debug builds, logic today asserts) . For this ticket adding guards in EE for geo types, so that EE does not do process the request where the supplied argument is not as expected geo-type.