### PR TITLE
ENG-9949 DR BinaryLog Format v4

### DIFF
--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -498,7 +498,19 @@ enum DRRecordType {
     DR_RECORD_END_TXN = 4,
     DR_RECORD_TRUNCATE_TABLE = 5,
     DR_RECORD_DELETE_BY_INDEX = 6,
-    DR_RECORD_UPDATE_BY_INDEX = 7
+    DR_RECORD_UPDATE_BY_INDEX = 7,
+    DR_RECORD_HASH_DELIMITER = 8
+};
+
+// ------------------------------------------------------------------
+// Flags of DR Transaction Partition Hash
+// ------------------------------------------------------------------
+enum DRTxnPartitionHashFlag {
+    TXN_PAR_HASH_PLACEHOLDER = 0, // a sentinel for unassigned hash flag
+    TXN_PAR_HASH_REPLICATED = 1,  // txn is from DR stream for replicated table
+    TXN_PAR_HASH_SINGLE = 2,      // txn contains a single partition key hash
+    TXN_PAR_HASH_MULTI = 3,       // txn contains multiple partition key hashes
+    TXN_PAR_HASH_SPECIAL = 4      // txn contains TRUNCATE_TABLE record(s)
 };
 
 inline size_t rowCostForDRRecord(DRRecordType type) {

--- a/src/ee/storage/AbstractDRTupleStream.h
+++ b/src/ee/storage/AbstractDRTupleStream.h
@@ -106,9 +106,6 @@ protected:
     size_t m_secondaryCapacity;
     int64_t m_rowTarget;
     bool m_opened;
-    // If no pkHash for a txn exists, the value and the field in endTxn will be LONG_MIN
-    // If multiple pkHash values have been assigned for this txn, the endTxn will be LONG_MAX
-    int64_t m_txnPkHash;
     size_t m_txnRowCount;
 };
 

--- a/src/ee/storage/BinaryLogSink.h
+++ b/src/ee/storage/BinaryLogSink.h
@@ -35,8 +35,14 @@ class VoltDBEngine;
 class BinaryLogSink {
 public:
     BinaryLogSink();
+    int64_t applyTxn(ReferenceSerializeInputLE *taskInfo,
+                     boost::unordered_map<int64_t, PersistentTable*> &tables,
+                     Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
+                     const char *txnStart, int64_t *uniqueId,
+                     int64_t *sequenceNumber);
 
-    int64_t apply(ReferenceSerializeInputLE *taskInfo,
+private:
+    int64_t apply(ReferenceSerializeInputLE *taskInfo, const DRRecordType type,
                   boost::unordered_map<int64_t, PersistentTable*> &tables,
                   Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
                   const char *recordStart, int64_t *uniqueId,

--- a/src/ee/storage/BinaryLogSinkWrapper.cpp
+++ b/src/ee/storage/BinaryLogSinkWrapper.cpp
@@ -32,14 +32,14 @@ int64_t BinaryLogSinkWrapper::apply(const char* taskParams, boost::unordered_map
     int64_t __attribute__ ((unused)) uniqueId = 0;
     int64_t __attribute__ ((unused)) sequenceNumber = -1;
 
-    size_t rowCount = 0;
+    int64_t rowCount = 0;
     while (taskInfo.hasRemaining()) {
         pool->purge();
         const char* recordStart = taskInfo.getRawPointer();
         const uint8_t drVersion = taskInfo.readByte();
-        if (drVersion == DRTupleStream::PROTOCOL_VERSION) {
-            rowCount += m_sink.apply(&taskInfo, tables, pool, engine, remoteClusterId,
-                                     recordStart, &uniqueId, &sequenceNumber);
+        if (drVersion == DRTupleStream::PROTOCOL_VERSION) { // currently 4
+            rowCount += m_sink.applyTxn(&taskInfo, tables, pool, engine, remoteClusterId,
+                                        recordStart, &uniqueId, &sequenceNumber);
         } else if (drVersion == CompatibleDRTupleStream::COMPATIBLE_PROTOCOL_VERSION) {
             rowCount += m_compatibleSink.apply(&taskInfo, tables, pool, engine, remoteClusterId,
                                                recordStart, &uniqueId, &sequenceNumber);
@@ -47,5 +47,5 @@ int64_t BinaryLogSinkWrapper::apply(const char* taskParams, boost::unordered_map
             throwFatalException("Unsupported DR version %d", drVersion);
         }
     }
-    return static_cast<int64_t>(rowCount);
+    return rowCount;
 }

--- a/src/ee/storage/CompatibleDRTupleStream.cpp
+++ b/src/ee/storage/CompatibleDRTupleStream.cpp
@@ -456,7 +456,7 @@ bool CompatibleDRTupleStream::checkOpenTransaction(StreamBlock* sb, size_t minLe
     return false;
 }
 
-int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionKeyNValue, int32_t partitionId, char *outBytes) {
+int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionKeyValue, int32_t partitionId, char *outBytes) {
     CompatibleDRTupleStream stream;
     stream.configure(partitionId);
 
@@ -477,8 +477,8 @@ int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionKeyNValue, int
                                                                 columnAllowNull);
     char tupleMemory[(2 + 1) * 8];
     TableTuple tuple(tupleMemory, schema);
-    // update the primary key column
-    tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyNValue));
+    // set the partition key
+    tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValue));
 
     const TableIndex* index = NULL;
     std::pair<const TableIndex*, uint32_t> uniqueIndex = std::make_pair(index, -1);
@@ -495,10 +495,10 @@ int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionKeyNValue, int
 
     TupleSchema::freeTupleSchema(schema);
 
-//    int64_t lastUID = UniqueId::makeIdFromComponents(99, 0, 42);
-//    int64_t uid = UniqueId::makeIdFromComponents(100, 0, 42);
-//    stream.truncateTable(lastUID, tableHandle, "foobar", uid, uid, uid);
-//    stream.endTransaction(uid);
+    int64_t lastUID = UniqueId::makeIdFromComponents(99, 0, 42);
+    int64_t uid = UniqueId::makeIdFromComponents(100, 0, 42);
+    stream.truncateTable(lastUID, tableHandle, "foobar", uid, uid, uid);
+    stream.endTransaction(uid);
 
     int64_t committedUID = UniqueId::makeIdFromComponents(100, 0, partitionId);
     stream.commit(committedUID, committedUID, committedUID, committedUID, false, false);

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -59,30 +59,31 @@ size_t DRTupleStream::truncateTable(int64_t lastCommittedSpHandle,
     if (!m_enabled) return INVALID_DR_MARK;
 
     transactionChecks(lastCommittedSpHandle, txnId, spHandle, uniqueId);
+    bool requireHashDelimiter = (m_hashFlag == TXN_PAR_HASH_REPLICATED) ? false : updateParHash(LONG_MAX);
 
     if (!m_currBlock) {
         extendBufferChain(m_defaultCapacity);
     }
 
-    const size_t tupleMaxLength = 1 + 1 + 8 + 4 + tableName.size() + 4;//version, type, table handle, name length prefix, table name, checksum
+    size_t tupleMaxLength = TXN_RECORD_HEADER_SIZE + 4 + tableName.size(); // table name length and table name
+    if (requireHashDelimiter) {
+        tupleMaxLength += HASH_DELIMITER_SIZE;
+    }
     if (m_currBlock->remaining() < tupleMaxLength) {
         extendBufferChain(tupleMaxLength);
     }
 
-
     ExportSerializeOutput io(m_currBlock->mutableDataPtr(),
                              m_currBlock->remaining());
 
-    io.writeByte(static_cast<uint8_t>(PROTOCOL_VERSION));
+    if (requireHashDelimiter) {
+        io.writeByte(static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        io.writeInt(0);  // hash delimiter for TRUNCATE_TABLE records is always 0
+    }
     io.writeByte(static_cast<int8_t>(DR_RECORD_TRUNCATE_TABLE));
     io.writeLong(*reinterpret_cast<int64_t*>(tableHandle));
     io.writeInt(static_cast<int32_t>(tableName.size()));
     io.writeBytes(tableName.c_str(), tableName.size());
-
-    uint32_t crc = vdbcrc::crc32cInit();
-    crc = vdbcrc::crc32c( crc, m_currBlock->mutableDataPtr(), io.position());
-    crc = vdbcrc::crc32cFinish(crc);
-    io.writeInt(crc);
 
     // update m_offset
     m_currBlock->consumed(io.position());
@@ -96,15 +97,34 @@ size_t DRTupleStream::truncateTable(int64_t lastCommittedSpHandle,
     return startingUso;
 }
 
-void DRTupleStream::updateTxnHash(TableTuple &tuple, int partitionColumn) {
-    if (partitionColumn != -1 && m_txnPkHash != LONG_MAX) {
-        int64_t txnPkHash = (int64_t)tuple.getNValue(partitionColumn).murmurHash3();
-        if (m_txnPkHash == LONG_MIN) {
-            m_txnPkHash = txnPkHash;
-        } else if (txnPkHash != m_txnPkHash) {
-            m_txnPkHash = LONG_MAX;
-        }
+int64_t DRTupleStream::getParHashForTuple(TableTuple& tuple, int partitionColumn) {
+    return static_cast<int64_t>(tuple.getNValue(partitionColumn).murmurHash3());
+}
+
+bool DRTupleStream::updateParHash(int64_t parHash) {
+    if (m_hashFlag == TXN_PAR_HASH_PLACEHOLDER) {  // initial status, first record
+        m_lastParHash = parHash;
+        m_firstParHash = (parHash == LONG_MAX) ? 0 : parHash; // save first hash
+        // if the first record is TRUNCATE_TABLE, set to SPECIAL, otherwise SINGLE
+        m_hashFlag = (parHash == LONG_MAX) ? TXN_PAR_HASH_SPECIAL : TXN_PAR_HASH_SINGLE;
+        // no delimiter needed for first record
+        return false;
     }
+    else if (parHash != m_lastParHash) {
+        m_lastParHash = parHash;
+        // set to SPECIAL whenever we see a TRUNCATE_TABLE record
+        if (parHash == LONG_MAX) {
+            m_hashFlag = TXN_PAR_HASH_SPECIAL;
+        }
+        // set to MULTI if it was SINGLE
+        else if (m_hashFlag == TXN_PAR_HASH_SINGLE) {
+            m_hashFlag = TXN_PAR_HASH_MULTI;
+        }
+        // delimiter needed before the pending record
+        return true;
+    }
+    // no delimiter needed for contiguous identical hashes
+    return false;
 }
 
 /*
@@ -135,11 +155,14 @@ size_t DRTupleStream::appendTuple(int64_t lastCommittedSpHandle,
     const std::vector<int>* interestingColumns;
 
     transactionChecks(lastCommittedSpHandle, txnId, spHandle, uniqueId);
-    updateTxnHash(tuple, partitionColumn);
+    bool requireHashDelimiter = (m_hashFlag == TXN_PAR_HASH_REPLICATED) ? false : updateParHash(getParHashForTuple(tuple, partitionColumn));
 
     // Compute the upper bound on bytes required to serialize tuple.
     // exportxxx: can memoize this calculation.
     tupleMaxLength = computeOffsets(type, indexPair, tuple, rowHeaderSz, rowMetadataSz, interestingColumns) + TXN_RECORD_HEADER_SIZE;
+    if (requireHashDelimiter) {
+        tupleMaxLength += HASH_DELIMITER_SIZE;
+    }
 
     if (!m_currBlock) {
         extendBufferChain(m_defaultCapacity);
@@ -151,16 +174,16 @@ size_t DRTupleStream::appendTuple(int64_t lastCommittedSpHandle,
 
     ExportSerializeOutput io(m_currBlock->mutableDataPtr(),
                              m_currBlock->remaining());
-    io.writeByte(static_cast<uint8_t>(PROTOCOL_VERSION));
+
+    if (requireHashDelimiter) {
+        io.writeByte(static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        io.writeInt(static_cast<int32_t>(m_lastParHash));
+    }
+
     io.writeByte(static_cast<int8_t>(type));
     io.writeLong(*reinterpret_cast<int64_t*>(tableHandle));
 
     writeRowTuple(tuple, rowHeaderSz, rowMetadataSz, interestingColumns, indexPair, io);
-
-    uint32_t crc = vdbcrc::crc32cInit();
-    crc = vdbcrc::crc32c( crc, m_currBlock->mutableDataPtr(), io.position());
-    crc = vdbcrc::crc32cFinish(crc);
-    io.writeInt(crc);
 
     // update m_offset
     m_currBlock->consumed(io.position());
@@ -198,7 +221,7 @@ size_t DRTupleStream::appendUpdateRecord(int64_t lastCommittedSpHandle,
     const std::vector<int>* dummyInterestingColumns;
 
     transactionChecks(lastCommittedSpHandle, txnId, spHandle, uniqueId);
-    updateTxnHash(oldTuple, partitionColumn);
+    bool requireHashDelimiter = (m_hashFlag == TXN_PAR_HASH_REPLICATED) ? false : updateParHash(getParHashForTuple(oldTuple, partitionColumn));
 
     DRRecordType type = DR_RECORD_UPDATE;
     maxLength += computeOffsets(type, indexPair, oldTuple, oldRowHeaderSz, oldRowMetadataSz, oldRowInterestingColumns);
@@ -206,6 +229,9 @@ size_t DRTupleStream::appendUpdateRecord(int64_t lastCommittedSpHandle,
     // it has already done so in the above computeOffsets() call
     maxLength += computeOffsets(type, indexPair, newTuple, newRowHeaderSz, newRowMetadataSz, dummyInterestingColumns);
     assert(!dummyInterestingColumns);
+    if (requireHashDelimiter) {
+        maxLength += HASH_DELIMITER_SIZE;
+    }
 
     if (!m_currBlock) {
         extendBufferChain(m_defaultCapacity);
@@ -217,17 +243,17 @@ size_t DRTupleStream::appendUpdateRecord(int64_t lastCommittedSpHandle,
 
     ExportSerializeOutput io(m_currBlock->mutableDataPtr(),
                                  m_currBlock->remaining());
-    io.writeByte(static_cast<uint8_t>(PROTOCOL_VERSION));
+
+    if (requireHashDelimiter) {
+        io.writeByte(static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        io.writeInt(static_cast<int32_t>(m_lastParHash));
+    }
+
     io.writeByte(static_cast<int8_t>(type));
     io.writeLong(*reinterpret_cast<int64_t*>(tableHandle));
 
     writeRowTuple(oldTuple, oldRowHeaderSz, oldRowMetadataSz, oldRowInterestingColumns, indexPair, io);
     writeRowTuple(newTuple, newRowHeaderSz, newRowMetadataSz, NULL, indexPair, io);
-
-    uint32_t crc = vdbcrc::crc32cInit();
-    crc = vdbcrc::crc32c( crc, m_currBlock->mutableDataPtr(), io.position());
-    crc = vdbcrc::crc32cFinish(crc);
-    io.writeInt(crc);
 
     // update m_offset
     m_currBlock->consumed(io.position());
@@ -358,17 +384,16 @@ void DRTupleStream::beginTransaction(int64_t sequenceNumber, int64_t uniqueId) {
      io.writeByte(static_cast<int8_t>(DR_RECORD_BEGIN_TXN));
      io.writeLong(uniqueId);
      io.writeLong(sequenceNumber);
-     uint32_t crc = vdbcrc::crc32cInit();
-     crc = vdbcrc::crc32c( crc, m_currBlock->mutableDataPtr(), BEGIN_RECORD_SIZE - 4);
-     crc = vdbcrc::crc32cFinish(crc);
-     io.writeInt(crc);
+     io.writeByte(0); // placeholder for hash flag
+     io.writeInt(0); // placeholder for txn length
+     io.writeInt(0);  // placeholder for first partition hash
+
      m_currBlock->consumed(io.position());
 
+     m_beginTxnUso = m_uso;
      m_uso += io.position();
 
      m_opened = true;
-     // LONG_MIN means unassigned hash key; LONG_MAX means multiple hash keys
-     m_txnPkHash = LONG_MIN;
 }
 
 void DRTupleStream::endTransaction(int64_t uniqueId) {
@@ -419,19 +444,32 @@ void DRTupleStream::endTransaction(int64_t uniqueId) {
 
     ExportSerializeOutput io(m_currBlock->mutableDataPtr(),
                              m_currBlock->remaining());
-    io.writeByte(static_cast<uint8_t>(PROTOCOL_VERSION));
     io.writeByte(static_cast<int8_t>(DR_RECORD_END_TXN));
     io.writeLong(m_openSequenceNumber);
-    io.writeLong(m_txnPkHash);
-    uint32_t crc = vdbcrc::crc32cInit();
-    crc = vdbcrc::crc32c( crc, m_currBlock->mutableDataPtr(), END_RECORD_SIZE - 4);
-    crc = vdbcrc::crc32cFinish(crc);
-    io.writeInt(crc);
+    io.writeInt(0); // placeholder for checksum of the entire txn
+
     m_currBlock->consumed(io.position());
 
     m_uso += io.position();
 
+    size_t txnLength = m_uso - m_beginTxnUso;
+    ExportSerializeOutput extraio(m_currBlock->mutableDataPtr() - txnLength,
+                                  txnLength);
+    extraio.position(BEGIN_RECORD_HEADER_SIZE);
+    extraio.writeByte(static_cast<int8_t>(m_hashFlag));
+    extraio.writeInt(static_cast<uint32_t>(txnLength));
+    extraio.writeInt(static_cast<int32_t>(m_firstParHash));
+
+    uint32_t crc = vdbcrc::crc32cInit();
+    crc = vdbcrc::crc32c(crc, m_currBlock->mutableDataPtr() - txnLength, txnLength - 4);
+    crc = vdbcrc::crc32cFinish(crc);
+    extraio.position(txnLength - 4);
+    extraio.writeInt(crc);
+
     m_opened = false;
+    if (m_hashFlag != TXN_PAR_HASH_REPLICATED) {
+        m_hashFlag = TXN_PAR_HASH_PLACEHOLDER;
+    }
 
     size_t bufferRowCount = m_currBlock->updateRowCountForDR(m_txnRowCount);
     if (m_rowTarget >= 0 && bufferRowCount >= m_rowTarget) {
@@ -463,7 +501,10 @@ bool DRTupleStream::checkOpenTransaction(StreamBlock* sb, size_t minLength, size
     return false;
 }
 
-int32_t DRTupleStream::getTestDRBuffer(int32_t primaryKeyNValue, int32_t partitionId, char *outBytes) {
+int32_t DRTupleStream::getTestDRBuffer(int32_t partitionKeyValue, int32_t partitionId, int32_t flag, char *outBytes) {
+    if (flag == TXN_PAR_HASH_REPLICATED) {
+        partitionId = 16383;
+    }
     DRTupleStream stream;
     stream.configure(partitionId);
 
@@ -484,8 +525,8 @@ int32_t DRTupleStream::getTestDRBuffer(int32_t primaryKeyNValue, int32_t partiti
                                                                 columnAllowNull);
     char tupleMemory[(2 + 1) * 8];
     TableTuple tuple(tupleMemory, schema);
-    // update the primary key column
-    tuple.setNValue(0, ValueFactory::getIntegerValue(primaryKeyNValue));
+    // set the partition key
+    tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValue));
 
     const TableIndex* index = NULL;
     std::pair<const TableIndex*, uint32_t> uniqueIndex = std::make_pair(index, -1);
@@ -496,18 +537,27 @@ int32_t DRTupleStream::getTestDRBuffer(int32_t primaryKeyNValue, int32_t partiti
         for (int zz = 0; zz < 5; zz++) {
             stream.appendTuple(lastUID, tableHandle, 0, uid, uid, uid, tuple, DR_RECORD_INSERT, uniqueIndex);
         }
+
+        if (flag == TXN_PAR_HASH_REPLICATED || flag == TXN_PAR_HASH_SPECIAL) {
+            stream.truncateTable(lastUID, tableHandle, "foobar", uid, uid, uid);
+            stream.truncateTable(lastUID, tableHandle, "foobar", uid, uid, uid);
+        }
+
+        if (flag != TXN_PAR_HASH_SINGLE) {
+            tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValue + 1));
+            for (int zz = 0; zz < 5; zz++) {
+                stream.appendTuple(lastUID, tableHandle, 0, uid, uid, uid, tuple, DR_RECORD_INSERT, uniqueIndex);
+            }
+            tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValue));
+        }
+
         stream.endTransaction(uid);
         ii += 5;
     }
 
     TupleSchema::freeTupleSchema(schema);
 
-//    int64_t lastUID = UniqueId::makeIdFromComponents(99, 0, 42);
-//    int64_t uid = UniqueId::makeIdFromComponents(100, 0, 42);
-//    stream.truncateTable(lastUID, tableHandle, "foobar", uid, uid, uid);
-//    stream.endTransaction(uid);
-
-    int64_t committedUID = UniqueId::makeIdFromComponents(100, 0, partitionId);
+    int64_t committedUID = UniqueId::makeIdFromComponents(95, 0, partitionId);
     stream.commit(committedUID, committedUID, committedUID, committedUID, false, false);
 
     size_t headerSize = MAGIC_HEADER_SPACE_FOR_JAVA + MAGIC_DR_TRANSACTION_PADDING;

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -26,12 +26,16 @@ class TableIndex;
 
 class DRTupleStream : public voltdb::AbstractDRTupleStream {
 public:
-    //Version(1), type(1), drId(8), uniqueId(8), checksum(4)
-    static const size_t BEGIN_RECORD_SIZE = 1 + 1 + 8 + 8 + 4;
-    //Version(1), type(1), drId(8), partitionHash(8), checksum(4)
-    static const size_t END_RECORD_SIZE = 1 + 1 + 8 + 8 + 4;
-    //Version(1), type(1), table signature(8), checksum(4)
-    static const size_t TXN_RECORD_HEADER_SIZE = 1 + 1 + 8 + 4;
+    //Version(1), type(1), drId(8), uniqueId(8), hashFlag(1), txnLength(4), parHash(4)
+    static const size_t BEGIN_RECORD_SIZE = 1 + 1 + 8 + 8 + 1 + 4 + 4;
+    //Version(1), type(1), drId(8), uniqueId(8)
+    static const size_t BEGIN_RECORD_HEADER_SIZE = 1 + 1 + 8 + 8;
+    //Type(1), drId(8), checksum(4)
+    static const size_t END_RECORD_SIZE = 1 + 8 + 4;
+    //Type(1), table signature(8)
+    static const size_t TXN_RECORD_HEADER_SIZE = 1 + 8;
+    //Type(1), parHash(4)
+    static const size_t HASH_DELIMITER_SIZE = 1 + 4;
 
     // Also update DRProducerProtocol.java if version changes
     static const uint8_t PROTOCOL_VERSION = 4;
@@ -39,6 +43,12 @@ public:
     DRTupleStream();
 
     virtual ~DRTupleStream() {
+    }
+
+    void configure(CatalogId partitionId) {
+        AbstractDRTupleStream::configure(partitionId);
+        m_hashFlag = (partitionId == 16383) ? TXN_PAR_HASH_REPLICATED : TXN_PAR_HASH_PLACEHOLDER;
+        m_firstParHash = 0;
     }
 
     /**
@@ -87,7 +97,12 @@ public:
         return DRCommittedInfo(m_committedSequenceNumber, m_lastCommittedSpUniqueId, m_lastCommittedMpUniqueId);
     }
 
-    static int32_t getTestDRBuffer(int32_t parimaryKeyNValue, int32_t partitionId, char *out);
+    static int32_t getTestDRBuffer(int32_t partitionKeyValue, int32_t partitionId, int32_t flag, char *out);
+protected:
+    DRTxnPartitionHashFlag m_hashFlag;
+    int64_t m_firstParHash;
+    int64_t m_lastParHash;
+    size_t m_beginTxnUso;
 private:
     void transactionChecks(int64_t lastCommittedSpHandle, int64_t txnId, int64_t spHandle, int64_t uniqueId);
 
@@ -105,7 +120,20 @@ private:
             size_t &rowMetadataSz,
             const std::vector<int> *&interestingColumns);
 
-    void updateTxnHash(TableTuple &tuple, int partitionColumn);
+    /**
+     * calculate hash for the partition key of the given tuple,
+     * partitionColumn should be an non-negative integer
+     */
+    int64_t getParHashForTuple(TableTuple& tuple, int partitionColumn);
+
+    /**
+     * check the paritition key hash of the current record
+     * and return if it is different from the previous hash seen in the txn
+     * updates m_hashFlag based on the hashes and records the first hash in the txn
+     * first hash will be 0 if it is DR stream for replicated table
+     * or the first record is TRUNCATE_TABLE
+     */
+    bool updateParHash(int64_t parHash);
 
     int64_t m_lastCommittedSpUniqueId;
     int64_t m_lastCommittedMpUniqueId;

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1419,17 +1419,17 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExecu
 /*
  * Class:     org_voltdb_jni_ExecutionEngine
  * Method:    getTestDRBuffer
- * Signature: ()[B
+ * Signature: (ZIII)[B
  */
 SHAREDLIB_JNIEXPORT jbyteArray JNICALL Java_org_voltdb_jni_ExecutionEngine_getTestDRBuffer
-  (JNIEnv *env, jclass clazz, jboolean compatible, jint primaryKeyValue, jint partitionId) {
+  (JNIEnv *env, jclass clazz, jboolean compatible, jint partitionKeyValue, jint partitionId, jint flag) {
     try {
         char *output = new char[1024 * 256];
         int32_t length;
         if (compatible) {
-            length = CompatibleDRTupleStream::getTestDRBuffer(primaryKeyValue, partitionId, output);
+            length = CompatibleDRTupleStream::getTestDRBuffer(partitionKeyValue, partitionId, output);
         } else {
-            length = DRTupleStream::getTestDRBuffer(primaryKeyValue, partitionId, output);
+            length = DRTupleStream::getTestDRBuffer(partitionKeyValue, partitionId, flag, output);
         }
         jbyteArray array = env->NewByteArray(length);
         jbyte *arrayBytes = env->GetByteArrayElements( array, NULL);

--- a/src/frontend/org/voltdb/PartitionDRGateway.java
+++ b/src/frontend/org/voltdb/PartitionDRGateway.java
@@ -37,7 +37,15 @@ import com.google_voltpatches.common.collect.ImmutableMap;
 public class PartitionDRGateway implements DurableUniqueIdListener {
 
     public enum DRRecordType {
-        INSERT, DELETE, UPDATE, BEGIN_TXN, END_TXN, TRUNCATE_TABLE, DELETE_BY_INDEX, UPDATE_BY_INDEX;
+        INSERT, DELETE, UPDATE, BEGIN_TXN, END_TXN, TRUNCATE_TABLE, DELETE_BY_INDEX, UPDATE_BY_INDEX, HASH_DELIMITER;
+    }
+
+    public enum DRTxnPartitionHashFlag {
+        PLACEHOLDER,
+        REPLICATED,
+        SINGLE,
+        MULTI,
+        SPECIAL
     }
 
     public static enum DRRowType {

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -1011,7 +1011,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      */
     public native static long nativeGetRSS();
 
-    public native static byte[] getTestDRBuffer(boolean compatible, int primaryKeyValue, int partitionId);
+    public native static byte[] getTestDRBuffer(boolean compatible, int partitionKeyValue, int partitionId, int flag);
 
     /**
      * Start collecting statistics (starts timer).

--- a/tests/ee/storage/DRTupleStream_test.cpp
+++ b/tests/ee/storage/DRTupleStream_test.cpp
@@ -46,25 +46,23 @@ const int COLUMN_COUNT = 5;
 // size without incestuously using code we're trying to test.  I've
 // pre-computed this magic size for an Exported tuple of 5 integer
 // columns, which includes:
-// 1 version byte
 // 1 type byte
 // 8 table signature bytes
 // 4 row length bytes
 // 1 (5 columns rounds to 8, /8 = 1) null mask byte
 // 5 * sizeof(int32_t) = 20 data bytes
-// 4 checksum bytes
-// total: 39
-const int MAGIC_TUPLE_SIZE = 39;
-const int MAGIC_BEGIN_TRANSACTION_SIZE = 22;
-const int MAGIC_END_TRANSACTION_SIZE = 22;
+// total: 34
+const int MAGIC_TUPLE_SIZE = 34;
+const int MAGIC_BEGIN_TRANSACTION_SIZE = 27;
+const int MAGIC_END_TRANSACTION_SIZE = 13;
 const int MAGIC_TRANSACTION_SIZE = MAGIC_BEGIN_TRANSACTION_SIZE + MAGIC_END_TRANSACTION_SIZE;
 const int MAGIC_TUPLE_PLUS_TRANSACTION_SIZE = MAGIC_TUPLE_SIZE + MAGIC_TRANSACTION_SIZE;
 // More magic: assume we've indexed on precisely one of those integer
 // columns. Then our magic size should reduce the 5 * sizeof(int32_t) to:
 // 4 index checksum bytes
 // 1 * sizeof(int32_t) = 4 data bytes
-// new total: 27
-const int MAGIC_OPTIMIZED_TUPLE_SIZE = 27;
+// new total: 22
+const int MAGIC_OPTIMIZED_TUPLE_SIZE = 22;
 const int MAGIC_OPTIMIZED_TUPLE_PLUS_TRANSACTION_SIZE = MAGIC_OPTIMIZED_TUPLE_SIZE + MAGIC_TRANSACTION_SIZE;
 const int BUFFER_SIZE = 950;
 // roughly 22.5k
@@ -98,7 +96,7 @@ public:
                                          columnAllowNull);
 
         // allocate a new buffer and wrap it
-        m_wrapper.configure(42);
+        m_wrapper.configure(16383);
 
         // excercise a smaller buffer capacity
         m_wrapper.setDefaultCapacity(BUFFER_SIZE + MAGIC_HEADER_SPACE_FOR_JAVA + MAGIC_DR_TRANSACTION_PADDING);
@@ -733,7 +731,7 @@ TEST_F(DRTupleStreamTest, BigBufferAfterExtendOnBeginTxn) {
     for (int i = 1; i < tuples_to_fill; i++) {
         appendTuple(2, 3);
     }
-    ASSERT_TRUE(m_wrapper.m_currBlock->remaining() < MAGIC_TUPLE_SIZE);
+    ASSERT_TRUE(m_wrapper.m_currBlock->remaining() - MAGIC_END_TRANSACTION_SIZE < MAGIC_TUPLE_SIZE);
 
     appendTuple(2, 3);
     m_wrapper.endTransaction(addPartitionId(3));


### PR DESCRIPTION
1. Changed BinaryLog producer to the new version in DRTupleStream
2. Changed BinaryLogSink and BinaryLogSinkWrapper to consume the new version
3. Changed getTestDRBuffer to produce DR BinaryLog for different scenarios (Txn Partition Key Hash)
4. Fixed the MAGIC size numbers in DRTupleStream_test for the new version
