### PR TITLE
ENG-9949: DRBufferSplitter for strict SP case

### DIFF
--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -753,7 +753,6 @@ int64_t BinaryLogSink::apply(ReferenceSerializeInputLE *taskInfo, const DRRecord
 
         break;
     }
-    // for ee test only, records of this type should have been removed in Topend before reaching here
     case DR_RECORD_HASH_DELIMITER: {
         int32_t __attribute__ ((unused)) parHash = taskInfo->readInt();
         break;

--- a/src/ee/storage/CompatibleDRTupleStream.cpp
+++ b/src/ee/storage/CompatibleDRTupleStream.cpp
@@ -495,8 +495,8 @@ int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionKeyValue, int3
 
     TupleSchema::freeTupleSchema(schema);
 
-    int64_t lastUID = UniqueId::makeIdFromComponents(99, 0, 42);
-    int64_t uid = UniqueId::makeIdFromComponents(100, 0, 42);
+    int64_t lastUID = UniqueId::makeIdFromComponents(99, 0, partitionId);
+    int64_t uid = UniqueId::makeIdFromComponents(100, 0, partitionId);
     stream.truncateTable(lastUID, tableHandle, "foobar", uid, uid, uid);
     stream.endTransaction(uid);
 
@@ -507,5 +507,4 @@ int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionKeyValue, int3
     const int32_t adjustedLength = static_cast<int32_t>(stream.m_currBlock->rawLength() - headerSize);
     ::memcpy(outBytes, stream.m_currBlock->rawPtr() + headerSize, adjustedLength);
     return adjustedLength;
-
 }

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -535,7 +535,7 @@ int32_t DRTupleStream::getTestDRBuffer(int32_t partitionKeyValue, int32_t partit
         int64_t uid = UniqueId::makeIdFromComponents(ii, 0, partitionId);
 
         if (flag == TXN_PAR_HASH_SINGLE) {
-            tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValue + i / 5));
+            tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValue + ii / 5));
         }
 
         for (int zz = 0; zz < 5; zz++) {

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -393,6 +393,10 @@ void DRTupleStream::beginTransaction(int64_t sequenceNumber, int64_t uniqueId) {
      m_beginTxnUso = m_uso;
      m_uso += io.position();
 
+     if (m_hashFlag != TXN_PAR_HASH_REPLICATED) {
+         m_hashFlag = TXN_PAR_HASH_PLACEHOLDER;
+     }
+
      m_opened = true;
 }
 
@@ -467,9 +471,6 @@ void DRTupleStream::endTransaction(int64_t uniqueId) {
     extraio.writeInt(crc);
 
     m_opened = false;
-    if (m_hashFlag != TXN_PAR_HASH_REPLICATED) {
-        m_hashFlag = TXN_PAR_HASH_PLACEHOLDER;
-    }
 
     size_t bufferRowCount = m_currBlock->updateRowCountForDR(m_txnRowCount);
     if (m_rowTarget >= 0 && bufferRowCount >= m_rowTarget) {
@@ -568,5 +569,4 @@ int32_t DRTupleStream::getTestDRBuffer(int32_t partitionKeyValue, int32_t partit
     const int32_t adjustedLength = static_cast<int32_t>(stream.m_currBlock->rawLength() - headerSize);
     ::memcpy(outBytes, stream.m_currBlock->rawPtr() + headerSize, adjustedLength);
     return adjustedLength;
-
 }

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -452,12 +452,12 @@ void DRTupleStream::endTransaction(int64_t uniqueId) {
 
     m_uso += io.position();
 
-    size_t txnLength = m_uso - m_beginTxnUso;
+    int32_t txnLength = m_uso - m_beginTxnUso;
     ExportSerializeOutput extraio(m_currBlock->mutableDataPtr() - txnLength,
                                   txnLength);
     extraio.position(BEGIN_RECORD_HEADER_SIZE);
     extraio.writeByte(static_cast<int8_t>(m_hashFlag));
-    extraio.writeInt(static_cast<uint32_t>(txnLength));
+    extraio.writeInt(txnLength);
     extraio.writeInt(static_cast<int32_t>(m_firstParHash));
 
     uint32_t crc = vdbcrc::crc32cInit();
@@ -533,6 +533,10 @@ int32_t DRTupleStream::getTestDRBuffer(int32_t partitionKeyValue, int32_t partit
     for (int ii = 0; ii < 100;) {
         int64_t lastUID = UniqueId::makeIdFromComponents(ii - 5, 0, partitionId);
         int64_t uid = UniqueId::makeIdFromComponents(ii, 0, partitionId);
+
+        if (flag == TXN_PAR_HASH_SINGLE) {
+            tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValue + i / 5));
+        }
 
         for (int zz = 0; zz < 5; zz++) {
             stream.appendTuple(lastUID, tableHandle, 0, uid, uid, uid, tuple, DR_RECORD_INSERT, uniqueIndex);

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -535,7 +535,7 @@ int32_t DRTupleStream::getTestDRBuffer(int32_t partitionKeyValue, int32_t partit
         int64_t lastUID = UniqueId::makeIdFromComponents(ii - 5, 0, partitionId);
         int64_t uid = UniqueId::makeIdFromComponents(ii, 0, partitionId);
 
-        if (flag == TXN_PAR_HASH_SINGLE) {
+        if (flag == TXN_PAR_HASH_SINGLE && partitionKeyValue <= 2) {
             tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValue + ii / 5));
         }
 

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -128,7 +128,7 @@ private:
 
     /**
      * check the paritition key hash of the current record
-     * and return if it is different from the previous hash seen in the txn
+     * and return true if it is different from the previous hash seen in the txn
      * updates m_hashFlag based on the hashes and records the first hash in the txn
      * first hash will be 0 if it is DR stream for replicated table
      * or the first record is TRUNCATE_TABLE


### PR DESCRIPTION
1. Adjusted the getTestDRBuffer() for single hash case to generate txns with different hashes so that splitter can be tested
2. Addressed remaining review comments from last pull request.