### PR TITLE
Update catalog sizing for geo indexes

### DIFF
--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -151,7 +151,7 @@ bool TableCatalogDelegate::getIndexScheme(catalog::Table const &catalogTable,
                                indexedExpressions,
                                predicate,
                                catalogIndex.unique(),
-                               true, // support counting indexes (wherever supported)
+                               catalogIndex.countable(),
                                expressionsAsText,
                                predicateAsText,
                                schema);


### PR DESCRIPTION
Also set "countable" attribute correctly.

For stored procedure `@Statistics`, both INDEX and MEMORY make use of existing TableIndex methods getEstimatedMemory and getSize, so this was already working right.

We were setting the "countable" attribute incorrectly in the EE for hash and geospatial indexes, so I made the one-line change to fix this.  As far as I can tell, this really has no effect on behavior, since the "countable" attribute is being set correctly in the planner.

I didn't find a lot of unit tests for this stuff (maybe there are GEB tests for the sizing worksheet?).  