### PR TITLE
ENG-9976: Track partition column index of DR tables in the dispatcher

### DIFF
--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2393,7 +2393,7 @@ public abstract class CatalogUtil {
     public static Map<String, Integer> getDRTableNamePartitionColumnMapping(Database db) {
         Map<String, Integer> res = new HashMap<String, Integer>();
         for (Table tb : db.getTables()) {
-            if (tb.getIsdred()) {
+            if (!tb.getIsreplicated() && tb.getIsdred()) {
                 res.put(tb.getTypeName(), tb.getPartitioncolumn().getIndex());
             }
         }

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2389,4 +2389,14 @@ public abstract class CatalogUtil {
         }
         return exprsjson.isEmpty();
     }
+
+    public static Map<String, Integer> getDRTableNamePartitionColumnMapping(Database db) {
+        Map<String, Integer> res = new HashMap<String, Integer>();
+        for (Table tb : db.getTables()) {
+            if (tb.getIsdred()) {
+                res.put(tb.getTypeName(), tb.getPartitioncolumn().getIndex());
+            }
+        }
+        return res;
+    }
 }

--- a/tests/frontend/org/voltdb/utils/TestCatalogUtil.java
+++ b/tests/frontend/org/voltdb/utils/TestCatalogUtil.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 
-import org.junit.Test;
 import org.voltcore.utils.Pair;
 import org.voltdb.VoltDB;
 import org.voltdb.benchmark.tpcc.TPCCProjectBuilder;
@@ -1954,12 +1953,11 @@ public class TestCatalogUtil extends TestCase {
         }
     }
 
-    @Test
     public void testGetDRTableNamePartitionColumnMapping() throws Exception {
         String schema = "CREATE TABLE A (C1 INTEGER NOT NULL, C2 TIMESTAMP NOT NULL); PARTITION TABLE A ON COLUMN C1;\n" +
                 "CREATE TABLE B (C1 BIGINT NOT NULL, C2 SMALLINT NOT NULL); PARTITION TABLE B ON COLUMN C1;\n" +
-                "CREATE TABLE C (C1 TINYINT NOT NULL, C2 VARCHAR(3) NOT NULL); PARTITION TABLE C ON COLUMN C1;\n" +
-                "DR TABLE B;\n";
+                "CREATE TABLE C (C1 TINYINT NOT NULL, C2 VARCHAR(3) NOT NULL);\n" +
+                "DR TABLE B; DR TABLE C;\n";
         String testDir = BuildDirectoryUtils.getBuildDirectoryPath();
         final File file = VoltFile.createTempFile("DRTableNamePartitionColumnMapping", ".jar", new File(testDir));
 

--- a/tests/frontend/org/voltdb/utils/TestCatalogUtil.java
+++ b/tests/frontend/org/voltdb/utils/TestCatalogUtil.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 
+import org.junit.Test;
 import org.voltcore.utils.Pair;
 import org.voltdb.VoltDB;
 import org.voltdb.benchmark.tpcc.TPCCProjectBuilder;
@@ -1951,5 +1952,27 @@ public class TestCatalogUtil extends TestCase {
         for (Pair<String, String> expected : signatures) {
             assertEquals(expected.getSecond(), sig.get(expected.getFirst()));
         }
+    }
+
+    @Test
+    public void testGetDRTableNamePartitionColumnMapping() throws Exception {
+        String schema = "CREATE TABLE A (C1 INTEGER NOT NULL, C2 TIMESTAMP NOT NULL); PARTITION TABLE A ON COLUMN C1;\n" +
+                "CREATE TABLE B (C1 BIGINT NOT NULL, C2 SMALLINT NOT NULL); PARTITION TABLE B ON COLUMN C1;\n" +
+                "CREATE TABLE C (C1 TINYINT NOT NULL, C2 VARCHAR(3) NOT NULL); PARTITION TABLE C ON COLUMN C1;\n" +
+                "DR TABLE B;\n";
+        String testDir = BuildDirectoryUtils.getBuildDirectoryPath();
+        final File file = VoltFile.createTempFile("DRTableNamePartitionColumnMapping", ".jar", new File(testDir));
+
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        builder.addLiteralSchema(schema);
+        builder.compile(file.getPath());
+        Catalog cat = TestCatalogDiffs.catalogForJar(file.getPath());
+
+        file.delete();
+
+        Map<String, Integer> mapping = CatalogUtil.getDRTableNamePartitionColumnMapping(cat.getClusters().get("cluster").getDatabases().get("database"));
+        assertEquals(1, mapping.size());
+        assertEquals(true, mapping.containsKey("B"));
+        assertEquals(0, mapping.get("B").intValue());
     }
 }


### PR DESCRIPTION
1. Add a method in CatalogUtil to extract partition column index of DR tables for a given catalog database node
2. Add corresponding test in TestCatalogUtil