### PR TITLE
Make run.sh more consistent, cleaner and slightly shorter across examples

### DIFF
--- a/bin/voltenv
+++ b/bin/voltenv
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+#set -o nounset #exit if an unset variable is used
+set -o errexit #exit on any single command fail
+
+# next few lines to get the current script path from stackoverflow
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+VOLTDB_BIN="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+# check whether there is a VoltDB bin dir in the path (before we add one)
+if [ -n "$(which voltdb 2> /dev/null)" ]; then
+    PATH_VOLTDB_BIN=$(dirname "$(which voltdb)")
+else
+    PATH_VOLTDB_BIN=""
+fi
+
+# move voltdb commands into path for this script
+# (and for any script that is sourcing it)
+PATH=$VOLTDB_BIN:$PATH
+
+# installation layout has all libraries in $VOLTDB_ROOT/lib/voltdb
+if [ -d "$VOLTDB_BIN/../lib/voltdb" ]; then
+    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
+    VOLTDB_LIB="$VOLTDB_BASE/lib/voltdb"
+    VOLTDB_VOLTDB="$VOLTDB_LIB"
+# distribution layout has libraries in separate lib and voltdb directories
+else
+    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
+    VOLTDB_LIB="$VOLTDB_BASE/lib"
+    VOLTDB_VOLTDB="$VOLTDB_BASE/voltdb"
+fi
+
+# ensure classpath is set
+if [ -z ${CLASSPATH+x} ]; then
+    CLASSPATH=""
+fi
+
+# classpath setup for compiling stored procedures
+APPCLASSPATH=$CLASSPATH:$({ \
+    \ls -1 "$VOLTDB_VOLTDB"/voltdb-*.jar; \
+    \ls -1 "$VOLTDB_LIB"/*.jar; \
+    \ls -1 "$VOLTDB_LIB"/extension/*.jar; \
+} 2> /dev/null | paste -sd ':' - )
+
+# classpath setup for compiling client apps
+CLIENTCLASSPATH=$CLASSPATH:$({ \
+    \ls -1 "$VOLTDB_VOLTDB"/voltdbclient-*.jar; \
+} 2> /dev/null | paste -sd ':' - )
+
+# a sourcing script may want to add to this path like so:
+# CLIENTCLASSPATH=appname-client.jar:$CLIENTCLASSPATH 
+
+function help() {
+    echo
+    echo "Usage: voltenv {classpath|clientclasspath|checkpath}"
+    echo 
+    echo "voltenv classpath"
+    echo "  Print out a classpath that contains the VoltDB java jars"
+    echo
+    echo "voltenv clientclasspath"
+    echo "  Print out a classpath that contains the VoltDB client jars"
+    echo
+    echo "voltenv clientclasspath"
+    echo "  Print out a classpath that contains the VoltDB client jars"
+    echo
+    echo "A common use for this file is to source it from other scripts"
+    echo " in order to set up the VoltDB environment."
+    echo
+}
+
+# Print out a classpath that contains all of the VoltDB server jars
+function classpath() {
+    echo $APPCLASSPATH
+}
+
+# Print out a classpath that contains the VoltDB java jars
+function clientclasspath() {
+    echo $CLIENTCLASSPATH
+}
+
+# check for two problems
+# 1) VoltDB isn't in your path... so print an advisory
+# 2) VoltDB *is* in your path, but the current script is in a different
+#    folder. You have two VoltDB's So print an advisory.
+#
+# Neither is a real problem if you're aware of it, but could indicate a
+# real problem if it's something you didn't realize.
+#
+function checkpath() {
+    # find voltdb binaries in either installation or distribution directory.
+    if [ -n "$PATH_VOLTDB_BIN" ]; then
+        if [ "$PATH_VOLTDB_BIN" -ne "$VOLTDB_BIN" ]; then
+            echo "Warning: VoltDB exists in your path at:"
+            echo "    $PATH_VOLTDB_BIN"
+            echo "  But this script is using VoltDB at: "
+            echo "    $VOLTDB_BIN"
+            echo
+        fi
+    else
+        # assume this is the examples folder for a kit
+        echo "The VoltDB scripts are not in your PATH."
+        echo "For ease of use, add the VoltDB bin directory to your path: "
+        echo "    $VOLTDB_BIN"
+        echo
+    fi
+}
+
+# Run the target passed as the first arg on the command line
+# If no first arg, do nothing
+if [ $# -gt 1 ]; then help; exit; fi
+if [ $# = 1 ]; then $1; else checkpath; fi

--- a/bin/voltenv
+++ b/bin/voltenv
@@ -56,7 +56,7 @@ CLIENTCLASSPATH=$CLASSPATH:$({ \
 # a sourcing script may want to add to this path like so:
 # CLIENTCLASSPATH=appname-client.jar:$CLIENTCLASSPATH 
 
-function help() {
+function envhelp() {
     echo
     echo "Usage: voltenv {classpath|clientclasspath|checkpath}"
     echo 
@@ -111,7 +111,16 @@ function checkpath() {
     fi
 }
 
+# if this script is run directly:
 # Run the target passed as the first arg on the command line
 # If no first arg, do nothing
-if [ $# -gt 1 ]; then help; exit; fi
-if [ $# = 1 ]; then $1; else checkpath; fi
+if [ "${0}" = "$SOURCE" ]; then
+    if [ $# -gt 1 ]; then 
+        envhelp
+        exit 0
+    elif [ $# = 1 ]; then 
+        $1
+    fi
+else
+    checkpath
+fi

--- a/examples/contentionmark/run.sh
+++ b/examples/contentionmark/run.sh
@@ -1,57 +1,37 @@
 #!/usr/bin/env bash
 
-#set -o nounset #exit if an unset variable is used
-set -o errexit #exit on any single command fail
-
-# find voltdb binaries in either installation or distribution directory.
-if [ -n "$(which voltdb 2> /dev/null)" ]; then
+# find voltdb binaries
+if [ -e ../../bin/voltdb ]; then
+    # assume this is the examples folder for a kit
+    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
+elif [ -n "$(which voltdb 2> /dev/null)" ]; then
+    # assume we're using voltdb from the path
     VOLTDB_BIN=$(dirname "$(which voltdb)")
 else
-    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
-    echo "The VoltDB scripts are not in your PATH."
-    echo "For ease of use, add the VoltDB bin directory: "
-    echo
-    echo $VOLTDB_BIN
-    echo
-    echo "to your PATH."
-    echo
-fi
-# move voltdb commands into path for this script
-PATH=$VOLTDB_BIN:$PATH
-
-# installation layout has all libraries in $VOLTDB_ROOT/lib/voltdb
-if [ -d "$VOLTDB_BIN/../lib/voltdb" ]; then
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib/voltdb"
-    VOLTDB_VOLTDB="$VOLTDB_LIB"
-# distribution layout has libraries in separate lib and voltdb directories
-else
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib"
-    VOLTDB_VOLTDB="$VOLTDB_BASE/voltdb"
+    echo "Unable to find VoltDB installation."
+    echo "Please add VoltDB's bin directory to your path."
+    exit -1
 fi
 
-APPCLASSPATH=$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdb-*.jar; \
-    \ls -1 "$VOLTDB_LIB"/*.jar; \
-    \ls -1 "$VOLTDB_LIB"/extension/*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-CLIENTCLASSPATH=contentionmark-client.jar:$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdbclient-*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-LOG4J="$VOLTDB_VOLTDB/log4j.xml"
-HOST="localhost"
+# call script to set up paths, including
+# java classpaths and binary paths
+source $VOLTDB_BIN/voltenv
+
+# leader host for startup purposes only
+# (once running, all nodes are the same -- no leaders)
+STARTUPLEADERHOST="localhost"
+# list of cluster nodes separated by commas in host[:port] format
+SERVERS="localhost"
 
 # remove binaries, logs, runtime artifacts, etc... but keep the jars
 function clean() {
-    rm -rf debugoutput voltdbroot log catalog-report.html \
-         statement-plans \
-         *.class \
-         contentionmark-client.jar
+    rm -rf voltdbroot log *.class
 }
 
+# remove everything from "clean" as well as the jarfiles
 function cleanall() {
     clean
+    rm -rf contentionmark-client.jar
 }
 
 # compile the source code for procedures and the client into jarfiles
@@ -71,31 +51,38 @@ function jars-ifneeded() {
     fi
 }
 
-# Start DB, load schema, procedures, and static data
+# run the voltdb server locally
+function server() {
+    voltdb create -H $STARTUPLEADERHOST
+}
+
+# load schema and procedures
 function init() {
     jars-ifneeded
     sqlcmd < ddl.sql
 }
 
-function server() {
-    voltdb create -H $HOST
+# Use this target for argument help
+function client-help() {
+    jars-ifneeded
+    java -classpath contentionmark-client.jar:$CLIENTCLASSPATH ContentionMark --help
 }
 
-# run the client that drives the example
+# run the client that drives the example with some editable options
 function client() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH ContentionMark \
+    java -classpath contentionmark-client.jar:$CLIENTCLASSPATH ContentionMark \
         --duration=60 \
-    	--tuples=1 \
-    	--servers=localhost
+        --tuples=1 \
+        --servers=$SERVERS
 }
 
 function help() {
-    echo "Usage: ./run.sh {server|clean|init|client}"
+    echo "Usage: ./run.sh {clean|cleanall|jars|server|init|client|client-help}"
 }
 
 # Run the targets pass on the command line
-# If no first arg, run demo
+# If no first arg, run server
 if [ $# -eq 0 ]; then server; exit; fi
 for arg in "$@"
 do

--- a/examples/geospatial/run.sh
+++ b/examples/geospatial/run.sh
@@ -62,7 +62,7 @@ function init() {
 
 # run the voltdb server locally
 function server() {
-    voltdb create -H $HOST
+    voltdb create -H $STARTUPLEADERHOST
 }
 
 # run this target to see what command line options the client offers

--- a/examples/geospatial/run.sh
+++ b/examples/geospatial/run.sh
@@ -1,59 +1,37 @@
 #!/usr/bin/env bash
 
-#set -o nounset #exit if an unset variable is used
-set -o errexit #exit on any single command fail
-
-# find voltdb binaries in either installation or distribution directory.
-if [ -n "$(which voltdb 2> /dev/null)" ]; then
+# find voltdb binaries
+if [ -e ../../bin/voltdb ]; then
+    # assume this is the examples folder for a kit
+    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
+elif [ -n "$(which voltdb 2> /dev/null)" ]; then
+    # assume we're using voltdb from the path
     VOLTDB_BIN=$(dirname "$(which voltdb)")
 else
-    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
-    echo "The VoltDB scripts are not in your PATH."
-    echo "For ease of use, add the VoltDB bin directory: "
-    echo
-    echo $VOLTDB_BIN
-    echo
-    echo "to your PATH."
-    echo
-fi
-# move voltdb commands into path for this script
-PATH=$VOLTDB_BIN:$PATH
-
-# installation layout has all libraries in $VOLTDB_ROOT/lib/voltdb
-if [ -d "$VOLTDB_BIN/../lib/voltdb" ]; then
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib/voltdb"
-    VOLTDB_VOLTDB="$VOLTDB_LIB"
-# distribution layout has libraries in separate lib and voltdb directories
-else
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib"
-    VOLTDB_VOLTDB="$VOLTDB_BASE/voltdb"
+    echo "Unable to find VoltDB installation."
+    echo "Please add VoltDB's bin directory to your path."
+    exit -1
 fi
 
-APPCLASSPATH=$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdb-*.jar; \
-    \ls -1 "$VOLTDB_LIB"/*.jar; \
-    \ls -1 "$VOLTDB_LIB"/extension/*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-CLIENTCLASSPATH=geospatial-client.jar:$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdbclient-*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-LOG4J="$VOLTDB_VOLTDB/log4j.xml"
-LICENSE="$VOLTDB_VOLTDB/license.xml"
-HOST="localhost"
+# call script to set up paths, including
+# java classpaths and binary paths
+source $VOLTDB_BIN/voltenv
+
+# leader host for startup purposes only
+# (once running, all nodes are the same -- no leaders)
+STARTUPLEADERHOST="localhost"
+# list of cluster nodes separated by commas in host:[port] format
+SERVERS="localhost"
 
 # remove binaries, logs, runtime artifacts, etc... but keep the jars
 function clean() {
-    rm -rf debugoutput voltdbroot log catalog-report.html \
-         statement-plans procedures/geospatial/*.class \
-         client/geospatial/*.class \
-         geospatial-client.jar \
-         geospatial-procs.jar
+    rm -rf voltdbroot log procedures/geospatial/*.class client/geospatial/*.class
 }
 
+# remove everything from "clean" as well as the jarfiles
 function cleanall() {
     clean
+    rm -rf geospatial-procs.jar geospatial-client.jar
 }
 
 # compile the source code for procedures and the client into jarfiles
@@ -75,66 +53,38 @@ function jars-ifneeded() {
     fi
 }
 
-# Start DB, load schema, procedures, and static data
+# load schema, procedures, and static data
 function init() {
     jars-ifneeded
     sqlcmd < ddl.sql
     csvloader -f advertisers.csv advertisers
 }
 
+# run the voltdb server locally
 function server() {
-    echo "starting server in background..."
-    voltdb create -B -l $LICENSE -H $HOST > nohup.log 2>&1 &
-    wait_for_startup
+    voltdb create -H $HOST
 }
 
-# wait for backgrounded server to start up
-function wait_for_startup() {
-    until echo "exec @SystemInformation, OVERVIEW;" | sqlcmd > /dev/null 2>&1
-    do
-        sleep 2
-        echo " ... Waiting for VoltDB to start"
-        if [[ $SECONDS -gt 60 ]]
-        then
-            echo "Exiting.  VoltDB did not startup within 60 seconds" 1>&2; exit 1;
-        fi
-    done
+# run this target to see what command line options the client offers
+function client-help() {
+    jars-ifneeded
+    java -classpath geospatial-client.jar:$CLIENTCLASSPATH \
+        geospatial.AdBrokerBenchmark --help
 }
 
 # run the client that drives the example
 function client() {
-    adbroker-benchmark
-}
-
-function adbroker-benchmark() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
-        geospatial.AdBrokerBenchmark
-}
-
-function demo() {
-    # start database and load static data
-    server
-
-    # load the schema and advertiser csv file
-    init
-
-    # Run the demo app
-    client
-
-    echo
-    echo When you are done with the demo database, \
-        remember to use \"voltadmin shutdown\" to stop \
-        the server process.
+    java -classpath geospatial-client.jar:$CLIENTCLASSPATH geospatial.AdBrokerBenchmark
 }
 
 function help() {
-    echo "Usage: ./run.sh {server|clean|init|client|demo}"
+    echo "Usage: ./run.sh {clean|cleanall|jars|server|init|client|client-help}"
 }
 
 # Run the targets pass on the command line
-# If no first arg, run demo
-if [ $# -eq 0 ]; then demo; exit; fi
+# If no first arg, run server
+if [ $# -eq 0 ]; then server; exit; fi
 for arg in "$@"
 do
     echo "${0}: Performing $arg..."

--- a/examples/json-sessions/deployment.xml
+++ b/examples/json-sessions/deployment.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<deployment>
-    <cluster hostcount="1" kfactor="0" />
-    <httpd enabled="true">
-        <jsonapi enabled="true" />
-    </httpd>
-</deployment>

--- a/examples/json-sessions/run.sh
+++ b/examples/json-sessions/run.sh
@@ -55,7 +55,7 @@ function jars-ifneeded() {
 
 # run the voltdb server locally
 function server() {
-    voltdb create -H $HOST
+    voltdb create -H $STARTUPLEADERHOST
 }
 
 # load schema and procedures

--- a/examples/json-sessions/run.sh
+++ b/examples/json-sessions/run.sh
@@ -1,52 +1,31 @@
 #!/usr/bin/env bash
 
-#set -o nounset #exit if an unset variable is used
-set -o errexit #exit on any single command fail
-
-# find voltdb binaries in either installation or distribution directory.
-if [ -n "$(which voltdb 2> /dev/null)" ]; then
+# find voltdb binaries
+if [ -e ../../bin/voltdb ]; then
+    # assume this is the examples folder for a kit
+    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
+elif [ -n "$(which voltdb 2> /dev/null)" ]; then
+    # assume we're using voltdb from the path
     VOLTDB_BIN=$(dirname "$(which voltdb)")
 else
-    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
-    echo "The VoltDB scripts are not in your PATH."
-    echo "For ease of use, add the VoltDB bin directory: "
-    echo
-    echo $VOLTDB_BIN
-    echo
-    echo "to your PATH."
-    echo
-fi
-# move voltdb commands into path for this script
-PATH=$VOLTDB_BIN:$PATH
-
-# installation layout has all libraries in $VOLTDB_ROOT/lib/voltdb
-if [ -d "$VOLTDB_BIN/../lib/voltdb" ]; then
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib/voltdb"
-    VOLTDB_VOLTDB="$VOLTDB_LIB"
-# distribution layout has libraries in separate lib and voltdb directories
-else
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib"
-    VOLTDB_VOLTDB="$VOLTDB_BASE/voltdb"
+    echo "Unable to find VoltDB installation."
+    echo "Please add VoltDB's bin directory to your path."
+    exit -1
 fi
 
-APPCLASSPATH=$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdb-*.jar; \
-    \ls -1 "$VOLTDB_LIB"/*.jar; \
-    \ls -1 "$VOLTDB_LIB"/extension/*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-CLIENTCLASSPATH=json-client.jar:gson-2.2.2.jar:$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdbclient-*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-LOG4J="$VOLTDB_VOLTDB/log4j.xml"
-LICENSE="$VOLTDB_VOLTDB/license.xml"
-HOST="localhost"
+# call script to set up paths, including
+# java classpaths and binary paths
+source $VOLTDB_BIN/voltenv
+
+# leader host for startup purposes only
+# (once running, all nodes are the same -- no leaders)
+STARTUPLEADERHOST="localhost"
+# list of cluster nodes separated by commas in host[:port] format
+SERVERS="localhost"
 
 # remove binaries, logs, runtime artifacts, etc... but keep the jars
 function clean() {
-    rm -rf debugoutput voltdbroot catalog-report.html statement-plans \
-        log client/jsonsessions/*.class procedures/jsonsessions/*.class
+    rm -rf voltdbroot log client/jsonsessions/*.class procedures/jsonsessions/*.class
 }
 
 # remove everything from "clean" as well as the jarfiles
@@ -59,7 +38,7 @@ function cleanall() {
 function jars() {
     # compile java source
     javac -classpath $APPCLASSPATH procedures/jsonsessions/*.java
-    javac -classpath $CLIENTCLASSPATH client/jsonsessions/*.java
+    javac -classpath gson-2.2.2.jar:$CLIENTCLASSPATH client/jsonsessions/*.java
     # build procedure and client jars
     jar cf json-procs.jar -C procedures jsonsessions
     jar cf json-client.jar -C client jsonsessions
@@ -76,13 +55,7 @@ function jars-ifneeded() {
 
 # run the voltdb server locally
 function server() {
-    # run the server
-    echo "Starting the VoltDB server."
-    echo "To perform this action manually, use the command line: "
-    echo
-    echo "voltdb create -d deployment.xml -l $LICENSE -H $HOST"
-    echo
-    voltdb create -d deployment.xml -l $LICENSE -H $HOST
+    voltdb create -H $HOST
 }
 
 # load schema and procedures
@@ -91,24 +64,29 @@ function init() {
     sqlcmd < ddl.sql
 }
 
+# run this target to see what command line options the client offers
+function client-help() {
+    jars-ifneeded
+    java -classpath json-client.jar:gson-2.2.2.jar:$CLIENTCLASSPATH \
+        jsonsessions.JSONClient --help
+}
+
 # run the client that drives the example
 function client() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J jsonsessions.JSONClient
-}
-
-# JSON client sample
-# Use this target for argument help
-function client-help() {
-    jars-ifneeded
-    java -classpath $CLIENTCLASSPATH jsonsessions.JSONClient --help
+    java -classpath json-client.jar:gson-2.2.2.jar:$CLIENTCLASSPATH \
+        jsonsessions.JSONClient
 }
 
 function help() {
      echo "Usage: ./run.sh {clean|cleanall|jars|server|init|client|client-help}"
 }
 
-# Run the target passed as the first arg on the command line
+# Run the targets pass on the command line
 # If no first arg, run server
-if [ $# -gt 1 ]; then help; exit; fi
-if [ $# = 1 ]; then $1; else server; fi
+if [ $# -eq 0 ]; then server; exit; fi
+for arg in "$@"
+do
+    echo "${0}: Performing $arg..."
+    $arg
+done

--- a/examples/voltkv/run.sh
+++ b/examples/voltkv/run.sh
@@ -53,7 +53,7 @@ function jars-ifneeded() {
 
 # run the voltdb server locally
 function server() {
-    voltdb create -H $HOST
+    voltdb create -H $STARTUPLEADERHOST
 }
 
 # load schema and procedures

--- a/examples/voltkv/run.sh
+++ b/examples/voltkv/run.sh
@@ -1,52 +1,31 @@
 #!/usr/bin/env bash
 
-#set -o nounset #exit if an unset variable is used
-set -o errexit #exit on any single command fail
-
-# find voltdb binaries in either installation or distribution directory.
-if [ -n "$(which voltdb 2> /dev/null)" ]; then
+# find voltdb binaries
+if [ -e ../../bin/voltdb ]; then
+    # assume this is the examples folder for a kit
+    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
+elif [ -n "$(which voltdb 2> /dev/null)" ]; then
+    # assume we're using voltdb from the path
     VOLTDB_BIN=$(dirname "$(which voltdb)")
 else
-    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
-    echo "The VoltDB scripts are not in your PATH."
-    echo "For ease of use, add the VoltDB bin directory: "
-    echo
-    echo $VOLTDB_BIN
-    echo
-    echo "to your PATH."
-    echo
-fi
-# move voltdb commands into path for this script
-PATH=$VOLTDB_BIN:$PATH
-
-# installation layout has all libraries in $VOLTDB_ROOT/lib/voltdb
-if [ -d "$VOLTDB_BIN/../lib/voltdb" ]; then
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib/voltdb"
-    VOLTDB_VOLTDB="$VOLTDB_LIB"
-# distribution layout has libraries in separate lib and voltdb directories
-else
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib"
-    VOLTDB_VOLTDB="$VOLTDB_BASE/voltdb"
+    echo "Unable to find VoltDB installation."
+    echo "Please add VoltDB's bin directory to your path."
+    exit -1
 fi
 
-APPCLASSPATH=$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdb-*.jar; \
-    \ls -1 "$VOLTDB_LIB"/*.jar; \
-    \ls -1 "$VOLTDB_LIB"/extension/*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-CLIENTCLASSPATH=voltkv-client.jar:$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdbclient-*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-LOG4J="$VOLTDB_VOLTDB/log4j.xml"
-LICENSE="$VOLTDB_VOLTDB/license.xml"
-HOST="localhost"
+# call script to set up paths, including
+# java classpaths and binary paths
+source $VOLTDB_BIN/voltenv
+
+# leader host for startup purposes only
+# (once running, all nodes are the same -- no leaders)
+STARTUPLEADERHOST="localhost"
+# list of cluster nodes separated by commas in host:[port] format
+SERVERS="localhost"
 
 # remove binaries, logs, runtime artifacts, etc... but keep the client jar
 function clean() {
-    rm -rf client/voltkv/*.class debugoutput voltdbroot log \
-        catalog-report.html statement-plans
+    rm -rf client/voltkv/*.class voltdbroot log
 }
 
 # remove everything from "clean" as well as the jarfile
@@ -58,7 +37,7 @@ function cleanall() {
 # compile the source code for the client into a jarfile
 function jars() {
     # compile java source
-    javac -classpath $APPCLASSPATH client/voltkv/*.java
+    javac -classpath $CLIENTCLASSPATH client/voltkv/*.java
     # build client jar
     jar cf voltkv-client.jar -C client voltkv
     # remove compiled .class files
@@ -74,12 +53,7 @@ function jars-ifneeded() {
 
 # run the voltdb server locally
 function server() {
-    echo "Starting the VoltDB server."
-    echo "To perform this action manually, use the command line: "
-    echo
-    echo "voltdb create -d deployment.xml -l $LICENSE -H $HOST"
-    echo
-    voltdb create -d deployment.xml -l $LICENSE -H $HOST
+    voltdb create -H $HOST
 }
 
 # load schema and procedures
@@ -97,19 +71,18 @@ function client() {
 # Use this target for argument help
 function async-benchmark-help() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH voltkv.AsyncBenchmark --help
+    java -classpath voltkv-client.jar:$CLIENTCLASSPATH voltkv.AsyncBenchmark --help
 }
 
 # latencyreport: default is OFF
 # ratelimit: must be a reasonable value if lantencyreport is ON
-# Disable the comments to get latency report
+# Disable the comments (and add a preceding slash) to get latency report
 function async-benchmark() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
-        voltkv.AsyncBenchmark \
+    java -classpath voltkv-client.jar:$CLIENTCLASSPATH voltkv.AsyncBenchmark \
         --displayinterval=5 \
         --duration=120 \
-        --servers=localhost \
+        --servers=$SERVERS \
         --poolsize=100000 \
         --preload=true \
         --getputratio=0.90 \
@@ -126,16 +99,15 @@ function async-benchmark() {
 # Use this target for argument help
 function sync-benchmark-help() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH voltkv.SyncBenchmark --help
+    java -classpath voltkv-client.jar:$CLIENTCLASSPATH voltkv.SyncBenchmark --help
 }
 
 function sync-benchmark() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
-        voltkv.SyncBenchmark \
+    java -classpath voltkv-client.jar:$CLIENTCLASSPATH voltkv.SyncBenchmark \
         --displayinterval=5 \
         --duration=120 \
-        --servers=localhost \
+        --servers=$SERVERS \
         --poolsize=100000 \
         --preload=true \
         --getputratio=0.90 \
@@ -146,19 +118,19 @@ function sync-benchmark() {
         --threads=40
 }
 
+# JDBC benchmark sample
 # Use this target for argument help
 function jdbc-benchmark-help() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH voltkv.JDBCBenchmark --help
+    java -classpath voltkv-client.jar:$CLIENTCLASSPATH voltkv.JDBCBenchmark --help
 }
 
 function jdbc-benchmark() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
-        voltkv.JDBCBenchmark \
+    java -classpath voltkv-client.jar:$CLIENTCLASSPATH voltkv.JDBCBenchmark \
         --displayinterval=5 \
         --duration=120 \
-        --servers=localhost:21212 \
+        --servers=$SERVERS \
         --poolsize=100000 \
         --preload=true \
         --getputratio=0.90 \
@@ -174,7 +146,12 @@ function help() {
     echo "       {...|sync-benchmark|sync-benchmark-help|jdbc-benchmark|jdbc-benchmark-help}"
 }
 
-# Run the target passed as the first arg on the command line
+# Run the targets pass on the command line
 # If no first arg, run server
-if [ $# -gt 1 ]; then help; exit; fi
-if [ $# = 1 ]; then $1; else server; fi
+if [ $# -eq 0 ]; then server; exit; fi
+for arg in "$@"
+do
+    echo "${0}: Performing $arg..."
+    $arg
+done
+

--- a/examples/voter/run.sh
+++ b/examples/voter/run.sh
@@ -1,52 +1,31 @@
 #!/usr/bin/env bash
 
-#set -o nounset #exit if an unset variable is used
-set -o errexit #exit on any single command fail
-
-# find voltdb binaries in either installation or distribution directory.
-if [ -n "$(which voltdb 2> /dev/null)" ]; then
+# find voltdb binaries
+if [ -e ../../bin/voltdb ]; then
+    # assume this is the examples folder for a kit
+    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
+elif [ -n "$(which voltdb 2> /dev/null)" ]; then
+    # assume we're using voltdb from the path
     VOLTDB_BIN=$(dirname "$(which voltdb)")
 else
-    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
-    echo "The VoltDB scripts are not in your PATH."
-    echo "For ease of use, add the VoltDB bin directory: "
-    echo
-    echo $VOLTDB_BIN
-    echo
-    echo "to your PATH."
-    echo
-fi
-# move voltdb commands into path for this script
-PATH=$VOLTDB_BIN:$PATH
-
-# installation layout has all libraries in $VOLTDB_ROOT/lib/voltdb
-if [ -d "$VOLTDB_BIN/../lib/voltdb" ]; then
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib/voltdb"
-    VOLTDB_VOLTDB="$VOLTDB_LIB"
-# distribution layout has libraries in separate lib and voltdb directories
-else
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib"
-    VOLTDB_VOLTDB="$VOLTDB_BASE/voltdb"
+    echo "Unable to find VoltDB installation."
+    echo "Please add VoltDB's bin directory to your path."
+    exit -1
 fi
 
-APPCLASSPATH=$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdb-*.jar; \
-    \ls -1 "$VOLTDB_LIB"/*.jar; \
-    \ls -1 "$VOLTDB_LIB"/extension/*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-CLIENTCLASSPATH=voter-client.jar:$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdbclient-*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-LOG4J="$VOLTDB_VOLTDB/log4j.xml"
-LICENSE="$VOLTDB_VOLTDB/license.xml"
-HOST="localhost"
+# call script to set up paths, including
+# java classpaths and binary paths
+source $VOLTDB_BIN/voltenv
+
+# leader host for startup purposes only
+# (once running, all nodes are the same -- no leaders)
+STARTUPLEADERHOST="localhost"
+# list of cluster nodes separated by commas in host:[port] format
+SERVERS="localhost"
 
 # remove binaries, logs, runtime artifacts, etc... but keep the jars
 function clean() {
-    rm -rf debugoutput voltdbroot log catalog-report.html \
-         statement-plans procedures/voter/*.class client/voter/*.class
+    rm -rf voltdbroot log procedures/voter/*.class client/voter/*.class
 }
 
 # remove everything from "clean" as well as the jarfiles
@@ -76,39 +55,13 @@ function jars-ifneeded() {
 
 # run the voltdb server locally
 function server() {
-    echo "Starting the VoltDB server."
-    echo "To perform this action manually, use the command line: "
-    echo
-    echo "voltdb create -d deployment.xml -l $LICENSE -H $HOST"
-    echo
-    voltdb create -d deployment.xml -l $LICENSE -H $HOST
+    voltdb create -H $HOST
 }
 
 # load schema and procedures
 function init() {
     jars-ifneeded
     sqlcmd < ddl.sql
-}
-
-# wait for backgrounded server to start up
-function wait_for_startup() {
-    until echo "exec @SystemInformation, OVERVIEW;" | sqlcmd > /dev/null 2>&1
-    do
-        sleep 2
-        echo " ... Waiting for VoltDB to start"
-        if [[ $SECONDS -gt 60 ]]
-        then
-            echo "Exiting.  VoltDB did not startup within 60 seconds" 1>&2; exit 1;
-        fi
-    done
-}
-
-# startup server in background and load schema
-function background_server_andload() {
-    # run the server in the background
-    voltdb create -B -d deployment.xml -l $LICENSE -H $HOST > nohup.log 2>&1 &
-    wait_for_startup
-    init
 }
 
 # run the client that drives the example
@@ -120,7 +73,7 @@ function client() {
 # Use this target for argument help
 function async-benchmark-help() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH voter.AsyncBenchmark --help
+    java -classpath voter-client.jar:$CLIENTCLASSPATH voter.AsyncBenchmark --help
 }
 
 # latencyreport: default is OFF
@@ -128,39 +81,39 @@ function async-benchmark-help() {
 # Disable the comments to get latency report
 function async-benchmark() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
-        voter.AsyncBenchmark \
+    java -classpath voter-client.jar:$CLIENTCLASSPATH voter.AsyncBenchmark \
         --displayinterval=5 \
         --warmup=5 \
         --duration=120 \
-        --servers=localhost:21212 \
+        --servers=$SERVERS \
         --contestants=6 \
         --maxvotes=2 \
         --ratelimit=2000000
 #        --latencyreport=true \
 }
 
+# trivial client code for illustration purposes
 function simple-benchmark() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
-        voter.SimpleBenchmark localhost
+    java -classpath voter-client.jar:$CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
+        voter.SimpleBenchmark $SERVERS
 }
 
 # Multi-threaded synchronous benchmark sample
 # Use this target for argument help
 function sync-benchmark-help() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH voter.SyncBenchmark --help
+    java -classpath voter-client.jar:$CLIENTCLASSPATH voter.SyncBenchmark --help
 }
 
 function sync-benchmark() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
+    java -classpath voter-client.jar:$CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
         voter.SyncBenchmark \
         --displayinterval=5 \
         --warmup=5 \
         --duration=120 \
-        --servers=localhost:21212 \
+        --servers=$SERVERS \
         --contestants=6 \
         --maxvotes=2 \
         --threads=40
@@ -170,45 +123,31 @@ function sync-benchmark() {
 # Use this target for argument help
 function jdbc-benchmark-help() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH voter.JDBCBenchmark --help
+    java -classpath voter-client.jar:$CLIENTCLASSPATH voter.JDBCBenchmark --help
 }
 
 function jdbc-benchmark() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
+    java -classpath voter-client.jar:$CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
         voter.JDBCBenchmark \
         --displayinterval=5 \
         --duration=120 \
         --maxvotes=2 \
-        --servers=localhost:21212 \
+        --servers=$SERVERS \
         --contestants=6 \
         --threads=40
 }
 
-# The following two demo functions are used by the Docker package. Don't remove.
-# compile the jars for procs and client code
-function demo-compile() {
-    jars
-}
-
-function demo() {
-    echo "starting server in background..."
-    background_server_andload
-    echo "starting client..."
-    client
-
-    echo
-    echo When you are done with the demo database, \
-        remember to use \"voltadmin shutdown\" to stop \
-        the server process.
-}
-
 function help() {
-    echo "Usage: ./run.sh {clean|server|init|demo|client|async-benchmark|aysnc-benchmark-help|...}"
-    echo "       {...|sync-benchmark|sync-benchmark-help|jdbc-benchmark|jdbc-benchmark-help}"
+    echo "Usage: ./run.sh {clean|cleanall|jars|server|init|client|async-benchmark|aysnc-benchmark-help|...}"
+    echo "       {...|sync-benchmark|sync-benchmark-help|jdbc-benchmark|jdbc-benchmark-help|simple-benchmark}"
 }
 
-# Run the target passed as the first arg on the command line
+# Run the targets pass on the command line
 # If no first arg, run server
-if [ $# -gt 1 ]; then help; exit; fi
-if [ $# = 1 ]; then $1; else server; fi
+if [ $# -eq 0 ]; then server; exit; fi
+for arg in "$@"
+do
+    echo "${0}: Performing $arg..."
+    $arg
+done

--- a/examples/voter/run.sh
+++ b/examples/voter/run.sh
@@ -55,7 +55,7 @@ function jars-ifneeded() {
 
 # run the voltdb server locally
 function server() {
-    voltdb create -H $HOST
+    voltdb create -H $STARTUPLEADERHOST
 }
 
 # load schema and procedures

--- a/examples/windowing-with-ddl/run.sh
+++ b/examples/windowing-with-ddl/run.sh
@@ -1,52 +1,31 @@
 #!/usr/bin/env bash
 
-#set -o nounset #exit if an unset variable is used
-set -o errexit #exit on any single command fail
-
-# find voltdb binaries in either installation or distribution directory.
-if [ -n "$(which voltdb 2> /dev/null)" ]; then
+# find voltdb binaries
+if [ -e ../../bin/voltdb ]; then
+    # assume this is the examples folder for a kit
+    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
+elif [ -n "$(which voltdb 2> /dev/null)" ]; then
+    # assume we're using voltdb from the path
     VOLTDB_BIN=$(dirname "$(which voltdb)")
 else
-    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
-    echo "The VoltDB scripts are not in your PATH."
-    echo "For ease of use, add the VoltDB bin directory: "
-    echo
-    echo $VOLTDB_BIN
-    echo
-    echo "to your PATH."
-    echo
-fi
-# move voltdb commands into path for this script
-PATH=$VOLTDB_BIN:$PATH
-
-# installation layout has all libraries in $VOLTDB_ROOT/lib/voltdb
-if [ -d "$VOLTDB_BIN/../lib/voltdb" ]; then
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib/voltdb"
-    VOLTDB_VOLTDB="$VOLTDB_LIB"
-# distribution layout has libraries in separate lib and voltdb directories
-else
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib"
-    VOLTDB_VOLTDB="$VOLTDB_BASE/voltdb"
+    echo "Unable to find VoltDB installation."
+    echo "Please add VoltDB's bin directory to your path."
+    exit -1
 fi
 
-APPCLASSPATH=$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdb-*.jar; \
-    \ls -1 "$VOLTDB_LIB"/*.jar; \
-    \ls -1 "$VOLTDB_LIB"/extension/*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-CLIENTCLASSPATH=ddlwindowing-client.jar:$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdbclient-*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-LOG4J="$VOLTDB_VOLTDB/log4j.xml"
-LICENSE="$VOLTDB_VOLTDB/license.xml"
-HOST="localhost"
+# call script to set up paths, including
+# java classpaths and binary paths
+source $VOLTDB_BIN/voltenv
+
+# leader host for startup purposes only
+# (once running, all nodes are the same -- no leaders)
+STARTUPLEADERHOST="localhost"
+# list of cluster nodes separated by commas in host[:port] format
+SERVERS="localhost"
 
 # remove binaries, logs, runtime artifacts, etc... but keep the jars
 function clean() {
-    rm -rf client/ddlwindowing/*.class debugoutput \
-           voltdbroot log catalog-report.html statement-plans
+    rm -rf client/ddlwindowing/*.class debugoutput voltdbroot log
 }
 
 # remove everything from "clean" as well as the jarfiles
@@ -74,13 +53,7 @@ function jars-ifneeded() {
 
 # run the voltdb server locally
 function server() {
-    # run the server
-    echo "Starting the VoltDB server."
-    echo "To perform this action manually, use the command line: "
-    echo
-    echo "voltdb create -l $LICENSE -H $HOST"
-    echo
-    voltdb create -l $LICENSE -H $HOST
+    voltdb create -H $HOST
 }
 
 # load schema
@@ -89,32 +62,22 @@ function init() {
     sqlcmd < ddl.sql
 }
 
-# Use this target for argument help
+# run this target to see what command line options the client offers
 function client-help() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH ddlwindowing.WindowingApp --help
+    java -classpath ddlwindowing-client.jar:$CLIENTCLASSPATH \
+        ddlwindowing.WindowingApp --help
 }
 
-## USAGE FOR CLIENT TARGET ##
-# usage: ddlwindowing.WindowingApp
-#     --displayinterval <arg>   Interval for performance feedback, in
-#                               seconds.
-#     --duration <arg>          Duration, in seconds.
-#                               history target.
-#     --password <arg>          Password for connection.
-#     --ratelimit <arg>         Maximum TPS rate for inserts.
-#     --servers <arg>           Comma separated list of the form
-#                               server[:port] to connect to.
-#     --user <arg>              User name for connection.
-
+# run the client that drives the example with some editable options
 function client() {
     jars-ifneeded
     # Note that in the command below, maxrows and historyseconds can't both be non-zero.
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
+    java -classpath ddlwindowing-client.jar:$CLIENTCLASSPATH \
         ddlwindowing.WindowingApp \
         --displayinterval=5 \
         --duration=120 \
-        --servers=localhost:21212 \
+        --servers=$SERVERS \
         --ratelimit=20000
 }
 
@@ -122,7 +85,12 @@ function help() {
     echo "Usage: ./run.sh {clean|cleanall|jars|server|init|client|client-help}"
 }
 
-# Run the target passed as the first arg on the command line
+# Run the targets pass on the command line
 # If no first arg, run server
-if [ $# -gt 1 ]; then help; exit; fi
-if [ $# = 1 ]; then $1; else server; fi
+if [ $# -eq 0 ]; then server; exit; fi
+for arg in "$@"
+do
+    echo "${0}: Performing $arg..."
+    $arg
+done
+

--- a/examples/windowing-with-ddl/run.sh
+++ b/examples/windowing-with-ddl/run.sh
@@ -53,7 +53,7 @@ function jars-ifneeded() {
 
 # run the voltdb server locally
 function server() {
-    voltdb create -H $HOST
+    voltdb create -H $STARTUPLEADERHOST
 }
 
 # load schema

--- a/examples/windowing/run.sh
+++ b/examples/windowing/run.sh
@@ -1,52 +1,31 @@
 #!/usr/bin/env bash
 
-#set -o nounset #exit if an unset variable is used
-set -o errexit #exit on any single command fail
-
-# find voltdb binaries in either installation or distribution directory.
-if [ -n "$(which voltdb 2> /dev/null)" ]; then
+# find voltdb binaries
+if [ -e ../../bin/voltdb ]; then
+    # assume this is the examples folder for a kit
+    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
+elif [ -n "$(which voltdb 2> /dev/null)" ]; then
+    # assume we're using voltdb from the path
     VOLTDB_BIN=$(dirname "$(which voltdb)")
 else
-    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
-    echo "The VoltDB scripts are not in your PATH."
-    echo "For ease of use, add the VoltDB bin directory: "
-    echo
-    echo $VOLTDB_BIN
-    echo
-    echo "to your PATH."
-    echo
-fi
-# move voltdb commands into path for this script
-PATH=$VOLTDB_BIN:$PATH
-
-# installation layout has all libraries in $VOLTDB_ROOT/lib/voltdb
-if [ -d "$VOLTDB_BIN/../lib/voltdb" ]; then
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib/voltdb"
-    VOLTDB_VOLTDB="$VOLTDB_LIB"
-# distribution layout has libraries in separate lib and voltdb directories
-else
-    VOLTDB_BASE=$(dirname "$VOLTDB_BIN")
-    VOLTDB_LIB="$VOLTDB_BASE/lib"
-    VOLTDB_VOLTDB="$VOLTDB_BASE/voltdb"
+    echo "Unable to find VoltDB installation."
+    echo "Please add VoltDB's bin directory to your path."
+    exit -1
 fi
 
-APPCLASSPATH=$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdb-*.jar; \
-    \ls -1 "$VOLTDB_LIB"/*.jar; \
-    \ls -1 "$VOLTDB_LIB"/extension/*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-CLIENTCLASSPATH=windowing-client.jar:$CLASSPATH:$({ \
-    \ls -1 "$VOLTDB_VOLTDB"/voltdbclient-*.jar; \
-} 2> /dev/null | paste -sd ':' - )
-LOG4J="$VOLTDB_VOLTDB/log4j.xml"
-LICENSE="$VOLTDB_VOLTDB/license.xml"
-HOST="localhost"
+# call script to set up paths, including
+# java classpaths and binary paths
+source $VOLTDB_BIN/voltenv
+
+# leader host for startup purposes only
+# (once running, all nodes are the same -- no leaders)
+STARTUPLEADERHOST="localhost"
+# list of cluster nodes separated by commas in host:[port] format
+SERVERS="localhost"
 
 # remove binaries, logs, runtime artifacts, etc... but keep the jars
 function clean() {
-    rm -rf procedures/windowing/*.class client/windowing/*.class debugoutput \
-           voltdbroot log catalog-report.html statement-plans
+    rm -rf voltdbroot log procedures/windowing/*.class client/windowing/*.class
 }
 
 # remove everything from "clean" as well as the jarfiles
@@ -76,13 +55,7 @@ function jars-ifneeded() {
 
 # run the voltdb server locally
 function server() {
-    # run the server
-    echo "Starting the VoltDB server."
-    echo "To perform this action manually, use the command line: "
-    echo
-    echo "voltdb create -d deployment.xml -l $LICENSE -H $HOST"
-    echo
-    voltdb create -d deployment.xml -l $LICENSE -H $HOST
+    voltdb create -H $HOST
 }
 
 # load schema and procedures
@@ -91,41 +64,20 @@ function init() {
     sqlcmd < ddl.sql
 }
 
-# Use this target for argument help
+# run this target to see what command line options the client offers
 function client-help() {
     jars-ifneeded
-    java -classpath $CLIENTCLASSPATH windowing.WindowingApp --help
+    java -classpath windowing-client.jar:$CLIENTCLASSPATH windowing.WindowingApp --help
 }
 
-## USAGE FOR CLIENT TARGET ##
-# usage: windowing.WindowingApp
-#     --deletechunksize <arg>   Maximum number of rows to delete in one
-#                               transaction.
-#     --deleteyieldtime <arg>   Time to pause between deletes when there was
-#                               nothing to delete at last check.
-#     --displayinterval <arg>   Interval for performance feedback, in
-#                               seconds.
-#     --duration <arg>          Duration, in seconds.
-#     --historyseconds <arg>    Global maximum history targert. Zero if
-#                               using row count target.
-#     --inline <arg>            Run deletes in the same transaction as
-#                               inserts.
-#     --maxrows <arg>           Global maximum row target. Zero if using
-#                               history target.
-#     --password <arg>          Password for connection.
-#     --ratelimit <arg>         Maximum TPS rate for inserts.
-#     --servers <arg>           Comma separated list of the form
-#                               server[:port] to connect to.
-#     --user <arg>              User name for connection.
-
+# run the client that drives the example with some editable options
 function client() {
     jars-ifneeded
     # Note that in the command below, maxrows and historyseconds can't both be non-zero.
-    java -classpath $CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
-        windowing.WindowingApp \
+    java -classpath windowing-client.jar:$CLIENTCLASSPATH windowing.WindowingApp \
         --displayinterval=5 \
         --duration=120 \
-        --servers=localhost:21212 \
+        --servers=$SERVERS \
         --maxrows=0 \
         --historyseconds=30 \
         --inline=false \
@@ -138,7 +90,11 @@ function help() {
     echo "Usage: ./run.sh {clean|cleanall|jars|server|init|client|client-help}"
 }
 
-# Run the target passed as the first arg on the command line
+# Run the targets pass on the command line
 # If no first arg, run server
-if [ $# -gt 1 ]; then help; exit; fi
-if [ $# = 1 ]; then $1; else server; fi
+if [ $# -eq 0 ]; then server; exit; fi
+for arg in "$@"
+do
+    echo "${0}: Performing $arg..."
+    $arg
+done

--- a/examples/windowing/run.sh
+++ b/examples/windowing/run.sh
@@ -55,7 +55,7 @@ function jars-ifneeded() {
 
 # run the voltdb server locally
 function server() {
-    voltdb create -H $HOST
+    voltdb create -H $STARTUPLEADERHOST
 }
 
 # load schema and procedures


### PR DESCRIPTION
Add "voltenv" script to hide boilerplate for examples.
Unify run.sh across examples.
Other small cleanup.

I know many people don't care for run.sh. I don't really either? I've tried some alternatives personally, and haven't found something I like better. I encourage others with less tarnished minds to try as well.