### PR TITLE
ENG-9730 Update checks to 6.0 O/S and Python requirements

### DIFF
--- a/lib/python/voltcli/checkconfig.py
+++ b/lib/python/voltcli/checkconfig.py
@@ -97,10 +97,10 @@ def test_os_release(output):
         supported = False
         if distInfo[0] in ("centos", "redhat", "rhel"):
             releaseNum = ".".join(distInfo[1].split(".")[0:2]) # release goes to 3 parts in Centos/Redhat 7.x(.y)
-            if releaseNum >= "6.3":
+            if releaseNum >= "6.6":
                 supported = True
         elif "ubuntu" in distInfo[0].lower():
-            if distInfo[1] in ("10.04", "12.04", "14.04"):
+            if distInfo[1] in ("12.04", "14.04"):
                 supported = True
     elif platform.system() == "Darwin":
         output["OS"] = ["PASS", "MacOS X"]
@@ -110,7 +110,7 @@ def test_os_release(output):
             supported = True
     else:
         output['OS'] = ["WARN", "Only supports Linux based platforms"]
-        output['OS release'] = ["WARN", "Supported distributions are Ubuntu 10.04/12.04/14.04 and RedHat/CentOS 6.3 or later"]
+        output['OS release'] = ["WARN", "Supported distributions are Ubuntu 12.04/14.04 and RedHat/CentOS 6.6 or later"]
     if not supported:
         formatString = "Unsupported release: " + formatString
     output['OS release'] = ["PASS" if supported else "WARN", formatString.format(*distInfo)]


### PR DESCRIPTION
9730 is closed, but this isn't merged.  Why?