### PR TITLE
Fix for edge case for point at poles

### DIFF
--- a/src/ee/common/GeographyPointValue.hpp
+++ b/src/ee/common/GeographyPointValue.hpp
@@ -228,10 +228,9 @@ private:
             // longitude doesn't matter, so choose 0.
             newLng = 0.0;
         }
-
-        // If point is not at the poles, evaluate longitudes within epsilon
-        // of the antimeridian (on the east side), canonicalize to 180.0.
         else if (180.0 + m_longitude < epsilon()) {
+            // If point is not at the poles, evaluate longitudes within epsilon
+            // of the antimeridian (on the east side), canonicalize to 180.0.
             newLng = 180.0;
         }
 

--- a/src/ee/common/GeographyPointValue.hpp
+++ b/src/ee/common/GeographyPointValue.hpp
@@ -229,9 +229,9 @@ private:
             newLng = 0.0;
         }
 
-        // For longitudes within epsilon of the antimeridian
-        // (on the east side), canonicalize to 180.0.
-        if (180.0 + m_longitude < epsilon()) {
+        // If point is not at the poles, evaluate longitudes within epsilon
+        // of the antimeridian (on the east side), canonicalize to 180.0.
+        else if (180.0 + m_longitude < epsilon()) {
             newLng = 180.0;
         }
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyPointValue.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyPointValue.java
@@ -226,10 +226,14 @@ public class TestGeographyPointValue extends RegressionSuite {
         client.callProcedure("t.Insert", i++, "northPole1", new GeographyPointValue( 50.0, 90.0));
         client.callProcedure("t.Insert", i++, "northPole2", new GeographyPointValue(-70.0, 90.0));
         client.callProcedure("t.Insert", i++, "northPole3", new GeographyPointValue( 10.0, 90.0 - lessThanEps));
+        client.callProcedure("t.Insert", i++, "northPole4", new GeographyPointValue( 180.0, 90.0 - lessThanEps));
+        client.callProcedure("t.Insert", i++, "northPole5", new GeographyPointValue( -180.0, 90.0 - lessThanEps));
         client.callProcedure("t.Insert", i++, "notNorthPole", new GeographyPointValue( 10.0, 90.0 - moreThanEps));
         client.callProcedure("t.Insert", i++, "southPole1", new GeographyPointValue( 50.0, -90.0));
         client.callProcedure("t.Insert", i++, "southPole2", new GeographyPointValue(-70.0, -90.0));
         client.callProcedure("t.Insert", i++, "southPole3", new GeographyPointValue( 10.0, -90.0 + lessThanEps));
+        client.callProcedure("t.Insert", i++, "southPole4", new GeographyPointValue( 180.0, -90.0 + lessThanEps));
+        client.callProcedure("t.Insert", i++, "southPole5", new GeographyPointValue( -180.0, -90.0 + lessThanEps));
         client.callProcedure("t.Insert", i++, "notSouthPole", new GeographyPointValue( 10.0, -90.0 + moreThanEps));
         client.callProcedure("t.Insert", i++, "onAntimeridianNeg1", new GeographyPointValue(-180.0              , 37.0));
         client.callProcedure("t.Insert", i++, "onAntimeridianNeg2", new GeographyPointValue(-180.0 + lessThanEps, 37.0));
@@ -263,14 +267,18 @@ public class TestGeographyPointValue extends RegressionSuite {
         assertContentOfTable(new Object[][] {
                 {"northPole1"},
                 {"northPole2"},
-                {"northPole3"}},
+                {"northPole3"},
+                {"northPole4"},
+                {"northPole5"}},
                 vt);
 
         vt = client.callProcedure("@AdHoc", query, "southPole1").getResults()[0];
         assertContentOfTable(new Object[][] {
                 {"southPole1"},
                 {"southPole2"},
-                {"southPole3"}},
+                {"southPole3"},
+                {"southPole4"},
+                {"southPole5"}},
                 vt);
 
         vt = client.callProcedure("@AdHoc", query, "onAntimeridianNeg1").getResults()[0];

--- a/tests/frontend/org/voltdb/types/TestGeographyPointValue.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyPointValue.java
@@ -80,10 +80,16 @@ public class TestGeographyPointValue extends TestCase {
         GeographyPointValue northPole1 = new GeographyPointValue( 50.0, 90.0);
         GeographyPointValue northPole2 = new GeographyPointValue(-70.0, 90.0);
         GeographyPointValue northPole3 = new GeographyPointValue( 10.0, 90.0 - lessThanEps);
+        GeographyPointValue northPole4 = new GeographyPointValue( 180.0, 90.0 - lessThanEps);
+        GeographyPointValue northPole5 = new GeographyPointValue( -180.0, 90.0);
         assertTrue(northPole1.equals(northPole2));
         assertTrue(northPole2.equals(northPole1));
         assertTrue(northPole1.equals(northPole3));
         assertTrue(northPole3.equals(northPole1));
+        assertTrue(northPole1.equals(northPole4));
+        assertTrue(northPole4.equals(northPole1));
+        assertTrue(northPole3.equals(northPole5));
+        assertTrue(northPole5.equals(northPole3));
 
         GeographyPointValue notNorthPole = new GeographyPointValue( 10.0, 90.0 - moreThanEps);
         assertFalse(notNorthPole.equals(northPole1));
@@ -92,11 +98,16 @@ public class TestGeographyPointValue extends TestCase {
         GeographyPointValue southPole1 = new GeographyPointValue( 50.0, -90.0);
         GeographyPointValue southPole2 = new GeographyPointValue(-70.0, -90.0);
         GeographyPointValue southPole3 = new GeographyPointValue( 10.0, -90.0 + lessThanEps);
+        GeographyPointValue southPole4 = new GeographyPointValue( 180.0, -90.0);
+        GeographyPointValue southPole5 = new GeographyPointValue( -180.0, -90.0 + lessThanEps);
         assertTrue(southPole1.equals(southPole2));
         assertTrue(southPole2.equals(southPole1));
         assertTrue(southPole1.equals(southPole3));
         assertTrue(southPole3.equals(southPole1));
-        assertTrue(southPole3.equals(southPole1));
+        assertTrue(southPole3.equals(southPole5));
+        assertTrue(southPole5.equals(southPole4));
+        assertTrue(southPole3.equals(southPole5));
+        assertTrue(southPole1.equals(southPole4));
 
         GeographyPointValue notSouthPole = new GeographyPointValue( 10.0, -90.0 + moreThanEps);
         assertFalse(notSouthPole.equals(southPole1));


### PR DESCRIPTION
Fix edge case in canonicalize/normalize logic to not evaluate/update point for antimeridian condition when the point is at pole.