### PR TITLE
Add guards for geo index columns which are complex expressions.

### DIFF
--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -2066,10 +2066,16 @@ public class DDLCompiler {
                     has_nonint_col = true;
                     nonint_col_name = "<expression>";
                     has_geo_col = colType.equals(VoltType.GEOGRAPHY);
-                    if (has_geo_col && exprs.size() > 1) {
-                        String emsg = "Cannot create index \""+ name + "\" because " +
-                                colType.getName() + " values must be the only component of an index key.";
-                        throw compiler.new VoltCompilerException(emsg);
+                    if (has_geo_col) {
+                        if (exprs.size() > 1) {
+                            String emsg = "Cannot create index \""+ name + "\" because " +
+                                        colType.getName() + " values must be the only component of an index key.";
+                            throw compiler.new VoltCompilerException(emsg);
+                        } else if (!(expression instanceof TupleValueExpression)) {
+                            String emsg = "Cannot create index \"" + name + "\" because " +
+                                        colType.getName() + " expressions must be simple column expressions.";
+                            throw compiler.new VoltCompilerException(emsg);
+                        }
                     }
                 }
             }

--- a/tests/frontend/org/voltdb/compiler/TestDDLCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestDDLCompiler.java
@@ -806,7 +806,7 @@ public class TestDDLCompiler extends TestCase {
         tester.testSuccess("create table an_unquoted_table (an_unquoted_column integer)");
     }
 
-    public void testIndexExpresions() throws Exception {
+    public void testIndexExpressions() throws Exception {
         File jarOut = new File("indexExpressions.jar");
         jarOut.deleteOnExit();
 

--- a/tests/frontend/org/voltdb/compiler/TestDDLCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestDDLCompiler.java
@@ -30,8 +30,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLDecoder;
 
-import junit.framework.TestCase;
-
 import org.hsqldb_voltpatches.HSQLInterface;
 import org.hsqldb_voltpatches.HSQLInterface.HSQLParseException;
 import org.hsqldb_voltpatches.VoltXMLElement;
@@ -48,6 +46,8 @@ import org.voltdb.catalog.Table;
 import org.voltdb.compiler.VoltCompiler.VoltCompilerException;
 import org.voltdb.compilereport.TableAnnotation;
 import org.voltdb.utils.CatalogUtil;
+
+import junit.framework.TestCase;
 
 public class TestDDLCompiler extends TestCase {
 
@@ -804,6 +804,32 @@ public class TestDDLCompiler extends TestCase {
         tester.testFailure("create table an_unquoted_table (\"a_quoted_column_without_spaces\" integer)");
         tester.testFailure("create table an_unquoted_table (\"a quoted column with spaces\" integer)");
         tester.testSuccess("create table an_unquoted_table (an_unquoted_column integer)");
+    }
+
+    public void testIndexExpresions() throws Exception {
+        File jarOut = new File("indexExpressions.jar");
+        jarOut.deleteOnExit();
+
+        String tableCreation = "CREATE TABLE GEO ( ID INTEGER, REGION GEOGRAPHY ); ";
+
+        String schema[] = {
+                "CREATE INDEX POLY ON GEO ( POLYGONFROMTEXT( REGION ) );",
+                "CREATE INDEX POLY ON GEO ( POLYGONFROMVALIDTEXT( REGION ) );",
+        };
+
+        VoltCompiler compiler = new VoltCompiler();
+        for (int ii = 0; ii < schema.length; ++ii) {
+            File schemaFile = VoltProjectBuilder.writeStringToTempFile(tableCreation + schema[ii]);
+            String schemaPath = schemaFile.getPath();
+
+            // compile successfully
+            boolean success = compiler.compileFromDDL(jarOut.getPath(), schemaPath);
+            assertFalse(success);
+
+            // cleanup after the test
+            jarOut.delete();
+        }
+
     }
 
     public void testAutogenDRConflictTable() {


### PR DESCRIPTION
We can't actually create geospatial indices with columns which are more
complicated expressions than simple column references.

https://issues.voltdb.com/browse/ENG-9695