### PR TITLE
Don't include column names when skip meta data is set

### DIFF
--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1364,11 +1364,21 @@ public final class VoltTable extends VoltTableRow implements JSONString {
     }
 
     /**
-     * Return a "pretty print" representation of this table.  Output will be formatted
-     * in a tabular textual format suitable for display.
+     * Return a "pretty print" representation of this table with column names.  Output will
+     * be formatted in a tabular textual format suitable for display.
      * @return A string containing a pretty-print formatted representation of this table.
      */
     public String toFormattedString() {
+        return toFormattedString(true);
+    }
+
+    /**
+     * Return a "pretty print" representation of this table with or without column names.
+     * Output will be formatted in a tabular textual format suitable for display.
+     * @param includeColumnNames Flag to control if column names should be included or not.
+     * @return A string containing a pretty-print formatted representation of this table.
+     */
+    public String toFormattedString(boolean includeColumnNames) {
 
         final int MAX_PRINTABLE_CHARS = 30;
         // chose print width for geography column such that it can print polygon in
@@ -1429,6 +1439,8 @@ public final class VoltTable extends VoltTableRow implements JSONString {
         }
 
         String pad = ""; // no pad before first column header.
+        // calculate formating space based on columns.
+        // Append column names and separator line to buffer
         for (int i = 0; i < columnCount; i++) {
             padding[i] += 1;
             // Determine the formatting string for each column
@@ -1438,22 +1450,28 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                     colType == VoltType.GEOGRAPHY_POINT) ? "-" : "";
             fmt[i] = "%1$" + justification + padding[i] + "s";
 
-            // Serialize the column headers
-            sb.append(pad).append(String.format("%1$-" + padding[i] + "s",
-                    getColumnName(i)));
-            pad = " ";
+            if (includeColumnNames) {
+                // Serialize the column headers
+                sb.append(pad).append(String.format("%1$-" + padding[i] + "s",
+                        getColumnName(i)));
+                pad = " ";
             }
-        sb.append("\n");
-
-        // Serialize the separator between the column headers and the rows of data
-        pad = "";
-        for (int i = 0; i < columnCount; i++) {
-            char[] underline_array = new char[padding[i]];
-            Arrays.fill(underline_array, '-');
-            sb.append(pad).append(new String(underline_array));
-            pad = " ";
         }
-        sb.append("\n");
+
+        if (includeColumnNames) {
+            // construct separator to be used between column name header and table values
+            sb.append("\n");
+
+            // Serialize the separator between the column headers and the rows of data
+            pad = "";
+            for (int i = 0; i < columnCount; i++) {
+                char[] underline_array = new char[padding[i]];
+                Arrays.fill(underline_array, '-');
+                sb.append(pad).append(new String(underline_array));
+                pad = " ";
+            }
+            sb.append("\n");
+        }
 
         // Serialize each formatted row of data.
         resetRowPosition();

--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -874,6 +874,7 @@ public class SQLCommand
                 rowCount = t.getRowCount();
                 // Run it through the output formatter.
                 m_outputFormatter.printTable(System.out, t, m_outputShowMetadata);
+                //System.out.println("printable");
             }
             else {
                 rowCount = t.fetchRow(0).getLong(0);
@@ -1109,7 +1110,8 @@ public class SQLCommand
             Integer curr_val = proc_param_counts.get(this_proc);
             if (curr_val == null) {
                 curr_val = 1;
-            } else {
+            }
+            else {
                 ++curr_val;
             }
             proc_param_counts.put(this_proc, curr_val);
@@ -1219,17 +1221,23 @@ public class SQLCommand
             String arg = args[i];
             if (arg.startsWith("--servers=")) {
                 serverList = extractArgInput(arg);
-            } else if (arg.startsWith("--port=")) {
+            }
+            else if (arg.startsWith("--port=")) {
                 port = Integer.valueOf(extractArgInput(arg));
-            } else if (arg.startsWith("--user=")) {
+            }
+            else if (arg.startsWith("--user=")) {
                 user = extractArgInput(arg);
-            } else if (arg.startsWith("--password=")) {
+            }
+            else if (arg.startsWith("--password=")) {
                 password = extractArgInput(arg);
-            } else if (arg.startsWith("--kerberos=")) {
+            }
+            else if (arg.startsWith("--kerberos=")) {
                 kerberos = extractArgInput(arg);
-            } else if (arg.startsWith("--kerberos")) {
+            }
+            else if (arg.startsWith("--kerberos")) {
                 kerberos = "VoltDBClient";
-            } else if (arg.startsWith("--query=")) {
+            }
+            else if (arg.startsWith("--query=")) {
                 List<String> argQueries = SQLParser.parseQuery(arg.substring(8));
                 if (!argQueries.isEmpty()) {
                     if (queries == null) {

--- a/src/frontend/org/voltdb/utils/SQLCommandOutputFormatterDefault.java
+++ b/src/frontend/org/voltdb/utils/SQLCommandOutputFormatterDefault.java
@@ -28,10 +28,16 @@ import org.voltdb.VoltTable;
 class SQLCommandOutputFormatterDefault implements SQLCommandOutputFormatter
 {
     @Override
-    public void printTable(PrintStream stream, VoltTable t, boolean includeColumnNames)
+    public void printTable(PrintStream stream, VoltTable t, boolean includeMetaData)
             throws IOException
     {
         // Use the VoltTable pretty printer to display formatted output.
-        stream.println(t.toFormattedString());
+        if (includeMetaData) {
+            stream.println(t.toFormattedString(includeMetaData));
+        }
+        else {
+            // don't insert line break at end when not including meta data
+            stream.print(t.toFormattedString(includeMetaData));
+        }
     }
 }

--- a/tests/frontend/org/voltdb/TestVoltTable.java
+++ b/tests/frontend/org/voltdb/TestVoltTable.java
@@ -971,6 +971,17 @@ public class TestVoltTable extends TestCase {
         assertEquals(rowcounter, content.length);
     }
 
+    private void assertExpectedOutput(String expected, String actual) {
+        if (!actual.equals(expected))
+        {
+            System.out.println("Received formatted output:");
+            System.out.println(actual);
+            System.out.println("Expected output:");
+            System.out.println(expected);
+        }
+        assertEquals(expected, actual);
+    }
+
     public void testFormattedString() throws JSONException, IOException {
         // Set the default timezone since we're using a timestamp type.  Eliminate test flakeyness.
         VoltDB.setDefaultTimezone();
@@ -1005,7 +1016,6 @@ public class TestVoltTable extends TestCase {
                      new TimestampType(99),
                      new BigDecimal("123.45"));
         String formattedOutput = table.toFormattedString();
-
         String expectedOutput =
 "tinyint  smallint  integer  bigint       float     string  varbinary  timestamp                   decimal          \n" +
 "-------- --------- -------- ------------ --------- ------- ---------- --------------------------- -----------------\n" +
@@ -1013,14 +1023,7 @@ public class TestVoltTable extends TestCase {
 "    NULL      NULL     NULL         NULL      NULL NULL    NULL       NULL                                     NULL\n" +
 "     123     12345  1234567  12345678901  1.234567 aabbcc  0A1A0A     1970-01-01 00:00:00.000099   123.450000000000\n";
 
-        if (!formattedOutput.equals(expectedOutput))
-        {
-            System.out.println("Received formatted output:");
-            System.out.println(formattedOutput);
-            System.out.println("Expected output:");
-            System.out.println(expectedOutput);
-        }
-        assertTrue(formattedOutput.equals(expectedOutput));
+        assertExpectedOutput(expectedOutput, formattedOutput);
 
         // fetch formatted output without column names
         formattedOutput = table.toFormattedString(false);
@@ -1029,14 +1032,7 @@ public class TestVoltTable extends TestCase {
 "    NULL      NULL     NULL         NULL      NULL NULL    NULL       NULL                                     NULL\n" +
 "     123     12345  1234567  12345678901  1.234567 aabbcc  0A1A0A     1970-01-01 00:00:00.000099   123.450000000000\n";
 
-        if (!formattedOutput.equals(expectedOutput))
-        {
-            System.out.println("Received formatted output:");
-            System.out.println(formattedOutput);
-            System.out.println("Expected output:");
-            System.out.println(expectedOutput);
-        }
-        assertTrue(formattedOutput.equals(expectedOutput));
+        assertExpectedOutput(expectedOutput, formattedOutput);
 
         table = new VoltTable(new ColumnInfo("bigint",          VoltType.BIGINT),
                               new ColumnInfo("geography",       VoltType.GEOGRAPHY),
@@ -1060,14 +1056,7 @@ public class TestVoltTable extends TestCase {
 "      NULL NULL                                                         NULL                  NULL                       \n" +
 " 123456789 POLYGON ((1.1 9.9, -9.1 9.9, -9.1 -9.9, 9.1 -9.9, 1.1 9.9))  POINT (-179.0 -89.9)  1969-12-31 23:59:59.999999 \n";
 
-        if (!formattedOutput.equals(expectedOutput))
-        {
-            System.out.println("Received formatted output: (length: " + formattedOutput.length() +")");
-            System.out.println(formattedOutput);
-            System.out.println("Expected output: (length: " + expectedOutput.length() + ")");
-            System.out.println(expectedOutput);
-        }
-        assertTrue(formattedOutput.equals(expectedOutput));
+        assertExpectedOutput(expectedOutput, formattedOutput);
 
         // row with a polygon that max's output column width for geopgraphy column
         table.addRow(1234567890,
@@ -1087,14 +1076,7 @@ public class TestVoltTable extends TestCase {
 "  123456789 POLYGON ((1.1 9.9, -9.1 9.9, -9.1 -9.9, 9.1 -9.9, 1.1 9.9))                 POINT (-179.0 -89.9)  1969-12-31 23:59:59.999999 \n" +
 " 1234567890 POLYGON ((179.1 89.9, -179.1 89.9, -179.1 -89.9, 179.1 -89.9, 179.1 89.9))  POINT (-179.0 -89.9)  1970-01-01 00:00:00.000000 \n";
 
-        if (!formattedOutput.equals(expectedOutput))
-        {
-            System.out.println("Received formatted output: (length: " + formattedOutput.length() +")");
-            System.out.println(formattedOutput);
-            System.out.println("Expected output: (length: " + expectedOutput.length() + ")");
-            System.out.println(expectedOutput);
-        }
-        assertTrue(formattedOutput.equals(expectedOutput));
+        assertExpectedOutput(expectedOutput, formattedOutput);
 
         // row with a polygon that goes beyond max aligned display limit for polygon. This will result in
         // other columns following to appear further away from their original column
@@ -1118,14 +1100,7 @@ public class TestVoltTable extends TestCase {
 "  1234567890 POLYGON ((179.1 89.9, -179.1 89.9, -179.1 -89.9, 179.1 -89.9, 179.1 89.9))  POINT (-179.0 -89.9)  1970-01-01 00:00:00.000000 \n" +
 " 12345678901 POLYGON ((179.12 89.9, -179.12 89.9, -179.1 -89.9, 179.1 -89.9, 0.0 0.0, 1.123 1.11, 179.12 89.9)) POINT (0.0 0.0)       1970-01-01 00:00:00.000099 \n";
 
-        if (!formattedOutput.equals(expectedOutput))
-        {
-            System.out.println("Received formatted output: (length: " + formattedOutput.length() +")");
-            System.out.println(formattedOutput);
-            System.out.println("Expected output: (length: " + expectedOutput.length() + ")");
-            System.out.println(expectedOutput);
-        }
-        assertTrue(formattedOutput.equals(expectedOutput));
+        assertExpectedOutput(expectedOutput, formattedOutput);
 
         // test the final one without column names
         formattedOutput = table.toFormattedString(false);
@@ -1136,14 +1111,7 @@ public class TestVoltTable extends TestCase {
 "  1234567890 POLYGON ((179.1 89.9, -179.1 89.9, -179.1 -89.9, 179.1 -89.9, 179.1 89.9))  POINT (-179.0 -89.9)  1970-01-01 00:00:00.000000 \n" +
 " 12345678901 POLYGON ((179.12 89.9, -179.12 89.9, -179.1 -89.9, 179.1 -89.9, 0.0 0.0, 1.123 1.11, 179.12 89.9)) POINT (0.0 0.0)       1970-01-01 00:00:00.000099 \n";
 
-        if (!formattedOutput.equals(expectedOutput))
-        {
-            System.out.println("Received formatted output: (length: " + formattedOutput.length() +")");
-            System.out.println(formattedOutput);
-            System.out.println("Expected output: (length: " + expectedOutput.length() + ")");
-            System.out.println(expectedOutput);
-        }
-        assertTrue(formattedOutput.equals(expectedOutput));
+        assertExpectedOutput(expectedOutput, formattedOutput);
     }
 
     @SuppressWarnings("deprecation")

--- a/tests/frontend/org/voltdb/TestVoltTable.java
+++ b/tests/frontend/org/voltdb/TestVoltTable.java
@@ -1001,27 +1001,42 @@ public class TestVoltTable extends TestCase {
 
         // add a row of actual data.  Hard-code the timestamp so that we can compare deterministically
         table.addRow(123, 12345, 1234567, 12345678901L, 1.234567, "aabbcc",
-                new byte[] { 10, 26, 10 },
-                new TimestampType(99), new BigDecimal(
-                        "123.45"));
-        String formatted_string = table.toFormattedString();
+                     new byte[] { 10, 26, 10 },
+                     new TimestampType(99),
+                     new BigDecimal("123.45"));
+        String formattedOutput = table.toFormattedString();
 
-        String expected =
+        String expectedOutput =
 "tinyint  smallint  integer  bigint       float     string  varbinary  timestamp                   decimal          \n" +
 "-------- --------- -------- ------------ --------- ------- ---------- --------------------------- -----------------\n" +
 "    NULL      NULL     NULL         NULL      NULL NULL    NULL       NULL                                     NULL\n" +
 "    NULL      NULL     NULL         NULL      NULL NULL    NULL       NULL                                     NULL\n" +
 "     123     12345  1234567  12345678901  1.234567 aabbcc  0A1A0A     1970-01-01 00:00:00.000099   123.450000000000\n";
 
-        if (!formatted_string.equals(expected))
+        if (!formattedOutput.equals(expectedOutput))
         {
             System.out.println("Received formatted output:");
-            System.out.println(formatted_string);
+            System.out.println(formattedOutput);
             System.out.println("Expected output:");
-            System.out.println(expected);
+            System.out.println(expectedOutput);
         }
-        assertTrue(formatted_string.equals(expected));
+        assertTrue(formattedOutput.equals(expectedOutput));
 
+        // fetch formatted output without column names
+        formattedOutput = table.toFormattedString(false);
+        expectedOutput =
+"    NULL      NULL     NULL         NULL      NULL NULL    NULL       NULL                                     NULL\n" +
+"    NULL      NULL     NULL         NULL      NULL NULL    NULL       NULL                                     NULL\n" +
+"     123     12345  1234567  12345678901  1.234567 aabbcc  0A1A0A     1970-01-01 00:00:00.000099   123.450000000000\n";
+
+        if (!formattedOutput.equals(expectedOutput))
+        {
+            System.out.println("Received formatted output:");
+            System.out.println(formattedOutput);
+            System.out.println("Expected output:");
+            System.out.println(expectedOutput);
+        }
+        assertTrue(formattedOutput.equals(expectedOutput));
 
         table = new VoltTable(new ColumnInfo("bigint",          VoltType.BIGINT),
                               new ColumnInfo("geography",       VoltType.GEOGRAPHY),
@@ -1037,35 +1052,34 @@ public class TestVoltTable extends TestCase {
                                                   " 1.1  9.9))"),
                      new GeographyPointValue(-179.0, -89.9),
                      new TimestampType(-1));
-        formatted_string = table.toFormattedString();
-        expected =
+        formattedOutput = table.toFormattedString();
+        expectedOutput =
 "bigint     geography                                                    geography_point       timestamp                  \n" +
 "---------- ------------------------------------------------------------ --------------------- ---------------------------\n" +
 "      NULL NULL                                                         NULL                  NULL                       \n" +
 "      NULL NULL                                                         NULL                  NULL                       \n" +
 " 123456789 POLYGON ((1.1 9.9, -9.1 9.9, -9.1 -9.9, 9.1 -9.9, 1.1 9.9))  POINT (-179.0 -89.9)  1969-12-31 23:59:59.999999 \n";
 
-        if (!formatted_string.equals(expected))
+        if (!formattedOutput.equals(expectedOutput))
         {
-            System.out.println("Received formatted output: (length: " + formatted_string.length() +")");
-            System.out.println(formatted_string);
-            System.out.println("Expected output: (length: " + expected.length() + ")");
-            System.out.println(expected);
+            System.out.println("Received formatted output: (length: " + formattedOutput.length() +")");
+            System.out.println(formattedOutput);
+            System.out.println("Expected output: (length: " + expectedOutput.length() + ")");
+            System.out.println(expectedOutput);
         }
-        assertTrue(formatted_string.equals(expected));
-
+        assertTrue(formattedOutput.equals(expectedOutput));
 
         // row with a polygon that max's output column width for geopgraphy column
         table.addRow(1234567890,
-                    new GeographyValue("POLYGON (( 179.1  89.9, " +
+                     new GeographyValue("POLYGON (( 179.1  89.9, " +
                                                  "-179.1  89.9, " +
                                                  "-179.1 -89.9, " +
                                                  " 179.1 -89.9, " +
                                                  " 179.1  89.9))"),
-                    new GeographyPointValue(-179.0, -89.9),
-                    new TimestampType(0));
-        formatted_string = table.toFormattedString();
-        expected =
+                     new GeographyPointValue(-179.0, -89.9),
+                     new TimestampType(0));
+        formattedOutput = table.toFormattedString();
+        expectedOutput =
 "bigint      geography                                                                   geography_point       timestamp                  \n" +
 "----------- --------------------------------------------------------------------------- --------------------- ---------------------------\n" +
 "       NULL NULL                                                                        NULL                  NULL                       \n" +
@@ -1073,15 +1087,14 @@ public class TestVoltTable extends TestCase {
 "  123456789 POLYGON ((1.1 9.9, -9.1 9.9, -9.1 -9.9, 9.1 -9.9, 1.1 9.9))                 POINT (-179.0 -89.9)  1969-12-31 23:59:59.999999 \n" +
 " 1234567890 POLYGON ((179.1 89.9, -179.1 89.9, -179.1 -89.9, 179.1 -89.9, 179.1 89.9))  POINT (-179.0 -89.9)  1970-01-01 00:00:00.000000 \n";
 
-        if (!formatted_string.equals(expected))
+        if (!formattedOutput.equals(expectedOutput))
         {
-            System.out.println("Received formatted output: (length: " + formatted_string.length() +")");
-            System.out.println(formatted_string);
-            System.out.println("Expected output: (length: " + expected.length() + ")");
-            System.out.println(expected);
+            System.out.println("Received formatted output: (length: " + formattedOutput.length() +")");
+            System.out.println(formattedOutput);
+            System.out.println("Expected output: (length: " + expectedOutput.length() + ")");
+            System.out.println(expectedOutput);
         }
-        assertTrue(formatted_string.equals(expected));
-
+        assertTrue(formattedOutput.equals(expectedOutput));
 
         // row with a polygon that goes beyond max aligned display limit for polygon. This will result in
         // other columns following to appear further away from their original column
@@ -1095,8 +1108,8 @@ public class TestVoltTable extends TestCase {
                                              " 179.12  89.9))"),
                 new GeographyPointValue(0, 0),
                 new TimestampType(99));
-        formatted_string = table.toFormattedString();
-        expected =
+        formattedOutput = table.toFormattedString();
+        expectedOutput =
 "bigint       geography                                                                   geography_point       timestamp                  \n" +
 "------------ --------------------------------------------------------------------------- --------------------- ---------------------------\n" +
 "        NULL NULL                                                                        NULL                  NULL                       \n" +
@@ -1105,15 +1118,32 @@ public class TestVoltTable extends TestCase {
 "  1234567890 POLYGON ((179.1 89.9, -179.1 89.9, -179.1 -89.9, 179.1 -89.9, 179.1 89.9))  POINT (-179.0 -89.9)  1970-01-01 00:00:00.000000 \n" +
 " 12345678901 POLYGON ((179.12 89.9, -179.12 89.9, -179.1 -89.9, 179.1 -89.9, 0.0 0.0, 1.123 1.11, 179.12 89.9)) POINT (0.0 0.0)       1970-01-01 00:00:00.000099 \n";
 
-        if (!formatted_string.equals(expected))
+        if (!formattedOutput.equals(expectedOutput))
         {
-            System.out.println("Received formatted output: (length: " + formatted_string.length() +")");
-            System.out.println(formatted_string);
-            System.out.println("Expected output: (length: " + expected.length() + ")");
-            System.out.println(expected);
+            System.out.println("Received formatted output: (length: " + formattedOutput.length() +")");
+            System.out.println(formattedOutput);
+            System.out.println("Expected output: (length: " + expectedOutput.length() + ")");
+            System.out.println(expectedOutput);
         }
-        assertTrue(formatted_string.equals(expected));
+        assertTrue(formattedOutput.equals(expectedOutput));
 
+        // test the final one without column names
+        formattedOutput = table.toFormattedString(false);
+        expectedOutput =
+"        NULL NULL                                                                        NULL                  NULL                       \n" +
+"        NULL NULL                                                                        NULL                  NULL                       \n" +
+"   123456789 POLYGON ((1.1 9.9, -9.1 9.9, -9.1 -9.9, 9.1 -9.9, 1.1 9.9))                 POINT (-179.0 -89.9)  1969-12-31 23:59:59.999999 \n" +
+"  1234567890 POLYGON ((179.1 89.9, -179.1 89.9, -179.1 -89.9, 179.1 -89.9, 179.1 89.9))  POINT (-179.0 -89.9)  1970-01-01 00:00:00.000000 \n" +
+" 12345678901 POLYGON ((179.12 89.9, -179.12 89.9, -179.1 -89.9, 179.1 -89.9, 0.0 0.0, 1.123 1.11, 179.12 89.9)) POINT (0.0 0.0)       1970-01-01 00:00:00.000099 \n";
+
+        if (!formattedOutput.equals(expectedOutput))
+        {
+            System.out.println("Received formatted output: (length: " + formattedOutput.length() +")");
+            System.out.println(formattedOutput);
+            System.out.println("Expected output: (length: " + expectedOutput.length() + ")");
+            System.out.println(expectedOutput);
+        }
+        assertTrue(formattedOutput.equals(expectedOutput));
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Fixed issue for sqlcmd's fixed format output, to honor skip metadata flagso that column names and the  extract line break if skip meta-data flag was set. Skip meta-data flag works as expected for tabulated and csv ouput format, so no changes needed in there.