### PR TITLE
Additional update for skip meta-data and non-interactive mode

### DIFF
--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -735,7 +735,7 @@ public class SQLCommand
             m_testFrontEndResult += statement + ";\n";
             return;
         }
-        if ( ! m_interactive ) {
+        if ( !m_interactive && m_outputShowMetadata) {
             System.out.println();
             System.out.println(statement + ";");
         }


### PR DESCRIPTION
Additional update to avoid printing sql and extra line break in non-interactive mode if skip metadata flag is set. Tested manually the results are as expected (for interactive mode there junit tests and sqlcmd tests; for non-interactive mode have to created ticket so that we can test functionality in sql command test or similar) 

Manual test output:
- With skip metadata flag set and non-interactive mode: 

```
echo "select * from T" | sqlcmd --output-skip-metadata --output-format=tab
2
1
3
6
8
9
```

```
sqlcmd --output-skip-metadata --output-format=csv --query="select * from T;" 
"9"
"8"
"3"
"8"
"4"
```

- With show meta-data flag set:
```
sqlcmd --output-format=csv --query="select * from T;" 
select * from T;
"ID"
"9"
"8"
"3"
"8"
"4"
(Returned 5 rows in 0.00s)
```