### PR TITLE
ENG-9547: DR consumer tracker fix.

### DIFF
--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -425,8 +425,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                     }
                 }
                 else {
-                    Map.Entry<Long, Long> lastTrackerEntry = targetTracker.getDrIdRanges().lastEntry();
-                    if (lastTrackerEntry == null) {
+                    if (targetTracker.size() == 0) {
                         if (lastReceivedDRId == -1L) {
                             return (byte)0;
                         }
@@ -436,11 +435,12 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                         }
                     }
 
-                    if (lastTrackerEntry.getValue() == lastReceivedDRId) {
+                    final long lastDrId = targetTracker.getLastDrId();
+                    if (lastDrId == lastReceivedDRId) {
                         // This is what we expected
                         return (byte)0;
                     }
-                    if (lastTrackerEntry.getValue() > lastReceivedDRId) {
+                    if (lastDrId > lastReceivedDRId) {
                         // This is a duplicate
                         return (byte)-1;
                     }
@@ -453,7 +453,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         public void appendApplyBinaryLogTxns(int producerClusterId, int producerPartitionId,
                                              long localUniqueId, DRConsumerDrIdTracker tracker)
         {
-            assert(tracker.getDrIdRanges().size() > 0);
+            assert(tracker.size() > 0);
             if (UniqueIdGenerator.getPartitionIdFromUniqueId(localUniqueId) == MpInitiator.MP_INIT_PID) {
                 m_lastLocalMpUniqueId = localUniqueId;
             }
@@ -472,7 +472,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                     clusterSources.put(producerPartitionId, tracker);
                 }
                 else {
-                    targetTracker.appendTracker(tracker);
+                    targetTracker.mergeTracker(tracker);
                 }
             }
         }

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask_RO_SP.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask_RO_SP.java
@@ -88,7 +88,7 @@ public class ExecuteTask_RO_SP extends VoltSystemProcedure {
                 stringer.key(Integer.toString(clusterTrackers.getKey())).object();
                 for (Map.Entry<Integer, DRConsumerDrIdTracker> e : clusterTrackers.getValue().entrySet()) {
                     stringer.key(e.getKey().toString());
-                    stringer.value(ExtensibleSnapshotDigestData.serializeConsumerDrIdTrackerToJSON(e.getValue()));
+                    stringer.value(e.getValue().toJSON());
                 }
                 stringer.endObject();
             }


### PR DESCRIPTION
- Use Guava RangeSet instead of implementing from scratch.
- Allow overlaps when merging two trackers.
- Move JSON serialization/deserialization to the tracker class.
- Fix some logic around last ack point and the calculation of the safe
  point to use for acking. The last ack point could be way before the
  start of the first entry. It's incorrect to use the end of the first
  entry to ack. The range between the last ack point and the first entry
  should be counted as a gap. The last ack point should not be tracked
  separately. It acts the same way as a range in the range set. I added
  it to the first entry of the range set, which makes tracking a lot
  easier.