### PR TITLE
ENG-9547: Part 1

### DIFF
--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -556,7 +556,7 @@ int32_t DRTupleStream::getTestDRBuffer(int32_t partitionKeyValue, int32_t partit
         }
 
         for (int zz = 0; zz < 5; zz++) {
-            stream.appendTuple(lastUID, tableHandle, 0, uid, uid, uid, tuple, DR_RECORD_INSERT, uniqueIndex);
+            stream.appendTuple(lastUID, tableHandle, partitionId == 16383 ? -1 : 0, uid, uid, uid, tuple, DR_RECORD_INSERT, uniqueIndex);
         }
 
         if (flag == TXN_PAR_HASH_REPLICATED || flag == TXN_PAR_HASH_SPECIAL) {
@@ -567,7 +567,7 @@ int32_t DRTupleStream::getTestDRBuffer(int32_t partitionKeyValue, int32_t partit
         if (flag != TXN_PAR_HASH_SINGLE) {
             tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValue + 1));
             for (int zz = 0; zz < 5; zz++) {
-                stream.appendTuple(lastUID, tableHandle, 0, uid, uid, uid, tuple, DR_RECORD_INSERT, uniqueIndex);
+                stream.appendTuple(lastUID, tableHandle,  partitionId == 16383 ? -1 : 0, uid, uid, uid, tuple, DR_RECORD_INSERT, uniqueIndex);
             }
             tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValue));
         }

--- a/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
+++ b/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
@@ -145,6 +145,20 @@ public class DRConsumerDrIdTracker {
     }
 
     /**
+     * Add a range to the tracker.
+     * @param startDrId
+     * @param endDrId
+     * @param spUniqueId
+     * @param mpUniqueId
+     */
+    public void addRange(long startDrId, long endDrId, long spUniqueId, long mpUniqueId) {
+        // Note that any given range or tracker could have either sp or mp sentinel values
+        m_lastSpUniqueId = Math.max(m_lastSpUniqueId, spUniqueId);
+        m_lastMpUniqueId = Math.max(m_lastMpUniqueId, mpUniqueId);
+        m_map.add(range(startDrId, endDrId));
+    }
+
+    /**
      * Appends a range to the tracker. The range has to be after the last DrId
      * of the tracker.
      * @param startDrId
@@ -155,10 +169,7 @@ public class DRConsumerDrIdTracker {
     public void append(long startDrId, long endDrId, long spUniqueId, long mpUniqueId) {
         assert(startDrId <= endDrId && startDrId > end(m_map.span()));
 
-        // Note that any given range or tracker could have either sp or mp sentinel values
-        m_lastSpUniqueId = Math.max(m_lastSpUniqueId, spUniqueId);
-        m_lastMpUniqueId = Math.max(m_lastMpUniqueId, mpUniqueId);
-        m_map.add(range(startDrId, endDrId));
+        addRange(startDrId, endDrId, spUniqueId, mpUniqueId);
     }
 
     /**

--- a/tests/frontend/org/voltdb/TestDRConsumerDrIdTracker.java
+++ b/tests/frontend/org/voltdb/TestDRConsumerDrIdTracker.java
@@ -228,7 +228,6 @@ public class TestDRConsumerDrIdTracker {
         assertTrue(tracker.getDrIdRanges().equals(expectedMap));
     }
 
-
     @Test
     public void testAppendNeighborTracker() throws Exception {
         RangeSet<Long> expectedMap = TreeRangeSet.create();


### PR DESCRIPTION
1. Handle remote promotion, local promotion WIP
2. Use DRConsumerDrIdTracker instead of DRLogSegmentId in IdempotencyFilter and BufferSplitter
3. Update the unit tests for the BufferSplitter