### PR TITLE
Eng 10072 upsert with defaults

### DIFF
--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -123,6 +123,9 @@ bool InsertExecutor::p_init(AbstractPlanNode* abstractNode,
     TableTuple tuple = m_templateTuple.tuple();
 
     std::set<int> fieldsExplicitlySet(m_node->getFieldMap().begin(), m_node->getFieldMap().end());
+    // These default values are used for an INSERT including the INSERT sub-case of an UPSERT.
+    // The defaults are purposely ignored in favor of existing column values
+    // for the UPDATE subcase of an UPSERT.
     m_node->initTupleWithDefaultValues(m_engine,
                                        &m_memoryPool,
                                        fieldsExplicitlySet,
@@ -133,7 +136,7 @@ bool InsertExecutor::p_init(AbstractPlanNode* abstractNode,
     return true;
 }
 
-bool InsertExecutor::executePurgeFragmentIfNeeded(PersistentTable** ptrToTable) {
+void InsertExecutor::executePurgeFragmentIfNeeded(PersistentTable** ptrToTable) {
     PersistentTable* table = *ptrToTable;
     int tupleLimit = table->tupleLimit();
     int numTuples = table->visibleTupleCount();
@@ -155,8 +158,6 @@ bool InsertExecutor::executePurgeFragmentIfNeeded(PersistentTable** ptrToTable) 
         // the correct instance of PersistentTable.
         *ptrToTable = static_cast<PersistentTable*>(m_node->getTargetTable());
     }
-
-    return true;
 }
 
 bool InsertExecutor::p_execute(const NValueArray &params) {
@@ -183,6 +184,24 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
 
     Table* outputTable = m_node->getOutputTable();
     assert(outputTable);
+    TableTuple& count_tuple = outputTable->tempTuple();
+
+    // For export tables with no partition column,
+    // if the data is from a replicated source,
+    // only insert into one partition (the one for hash(0)).
+    // Other partitions can just return a 0 modified tuple count.
+    // OTOH, if the data is coming from a (sub)query with
+    // partitioned tables, perform the insert on every partition.
+    if (m_partitionColumn == -1 &&
+            m_isStreamed &&
+            m_multiPartition &&
+            !m_sourceIsPartitioned &&
+            !m_engine->isLocalSite(ValueFactory::getBigIntValue(0L))) {
+        count_tuple.setNValue(0, ValueFactory::getBigIntValue(0L));
+        // put the tuple into the output table
+        outputTable->insertTuple(count_tuple);
+        return true;
+    }
 
     TableTuple templateTuple = m_templateTuple.tuple();
 
@@ -213,11 +232,22 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
             // setNValueAllocateForObjectCopies.
             //
             // However, We need to call
-            // setNValueAlocateForObjectCopies here.  Sometimes the
+            // setNValueAllocateForObjectCopies here.  Sometimes the
             // input table's schema has an inlined string field, and
             // it's being assigned to the target table's outlined
             // string field.  In this case we need to tell the NValue
             // where to allocate the string data.
+            // For an "upsert", this templateTuple setup has two effects --
+            // It sets the primary key column(s) and it sets the
+            // updated columns to their new values.
+            // If the primary key value (combination) is new, the
+            // templateTuple is the exact combination of new values
+            // and default values required by the insert.
+            // If the primary key value (combination) already exists,
+            // only the NEW values stored on the templateTuple get updated
+            // in the existing tuple and its other columns keep their existing
+            // values -- the DEFAULT values that are stored in templateTuple
+            // DO NOT get copied to an existing tuple.
             templateTuple.setNValueAllocateForObjectCopies(fieldMap[i],
                                                            inputTuple.getNValue(i),
                                                            tempPool);
@@ -227,120 +257,80 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
                    templateTuple.debug(targetTable->name()).c_str(), targetTable->name().c_str(),
                    targetTable->schema()->debug().c_str());
 
-        // if there is a partition column for the target table
+        // If there is a partition column for the target table
         if (m_partitionColumn != -1) {
-
             // get the value for the partition column
             NValue value = templateTuple.getNValue(m_partitionColumn);
             bool isLocal = m_engine->isLocalSite(value);
 
-            // if it doesn't map to this site
+            // if it doesn't map to this partiton
             if (!isLocal) {
-                bool cont = true;
-                if (!m_multiPartition) {
-                    if (!m_isStreamed) {
-                        throw ConstraintFailureException(
-                                targetTable, templateTuple,
-                                "Mispartitioned tuple in single-partition insert statement.");
-                    } else {
-                        if (m_hasStreamView) {
-                            throw ConstraintFailureException(
-                                    targetTable, templateTuple,
-                                    "Mispartitioned tuple in single-partition insert statement.");
-                        } else {
-                            //when stream table has no views we let this insert slide and execute in
-                            //site where the SP is running. This was behavior when we had only export
-                            //table and no views on it. With views we have to be strict and throw mispartitioned
-                            //tuple see if block above.
-                            cont = false;
-                        }
-                    }
-                }
-                if (cont) {
-                    // don't insert
+                if (m_multiPartition) {
+                    // The same row is presumed to also be generated
+                    // on some other partition, where the partition key
+                    // belongs.
                     continue;
                 }
-            }
-        } else {
-            // for multi partition export tables, only insert into one
-            // place (the partition with hash(0)), if the data is from a
-            // replicated source.  If the data is coming from a subquery
-            // with partitioned tables, we need to perform the insert on
-            // every partition.
-            if (m_isStreamed && m_multiPartition && !m_sourceIsPartitioned) {
-                bool isLocal = m_engine->isLocalSite(ValueFactory::getBigIntValue(0));
-                if (!isLocal) continue;
+                // When a streamed table has no views, let an SP insert execute.
+                // This is backward compatible with when there were only export
+                // tables with no views on them.
+                // When there are views, be strict and throw mispartitioned
+                // tuples to force partitioned data to be generated only
+                // where partitoned view rows are maintained.
+                if (!m_isStreamed || m_hasStreamView) {
+                    throw ConstraintFailureException(
+                        targetTable, templateTuple,
+                        "Mispartitioned tuple in single-partition insert statement.");
+                }
             }
         }
 
-        if (! m_isUpsert) {
-            // try to put the tuple into the target table
-
-            if (m_hasPurgeFragment) {
-                if (!executePurgeFragmentIfNeeded(&persistentTable))
-                    return false;
-                // purge fragment might have truncated the table, and
-                // refreshed the persistent table pointer.  Make sure to
-                // use it when doing the insert below.
-                targetTable = persistentTable;
-            }
-
-            if (!targetTable->insertTuple(templateTuple)) {
-                VOLT_ERROR("Failed to insert tuple from input table '%s' into"
-                           " target table '%s'",
-                           m_inputTable->name().c_str(),
-                           targetTable->name().c_str());
-                return false;
-            }
-
-        } else {
+        if (m_isUpsert) {
             // upsert execution logic
             assert(persistentTable->primaryKeyIndex() != NULL);
             TableTuple existsTuple = persistentTable->lookupTupleByValues(templateTuple);
 
-            if (existsTuple.isNullTuple()) {
-                // try to put the tuple into the target table
-
-                if (m_hasPurgeFragment) {
-                    if (!executePurgeFragmentIfNeeded(&persistentTable))
-                        return false;
-                }
-
-                if (!persistentTable->insertTuple(templateTuple)) {
-                    VOLT_ERROR("Failed to insert tuple from input table '%s' into"
-                               " target table '%s'",
-                               m_inputTable->name().c_str(),
-                               persistentTable->name().c_str());
-                    return false;
-                }
-            } else {
-                // tuple exists already, try to update the tuple instead
+            if (!existsTuple.isNullTuple()) {
+                // The tuple exists already, update (only) the templateTuple columns
+                // that were initialized from the input tuple via the field map.
+                // Technically, this includes setting primary key values,
+                // but they are getting set to equivalent values, so that's OK.
+                // A simple setNValue works here because any required object
+                // allocations were handled when copying the input values into
+                // the templateTuple.
                 upsertTuple.move(templateTuple.address());
-                TableTuple &tempTuple = persistentTable->getTempTupleInlined(upsertTuple);
-
-                if (!persistentTable->updateTupleWithSpecificIndexes(existsTuple, tempTuple,
-                        persistentTable->allIndexes())) {
-                    VOLT_INFO("Failed to update existsTuple from table '%s'",
-                            persistentTable->name().c_str());
-                    return false;
+                TableTuple &tempTuple = persistentTable->copyIntoTempTuple(existsTuple);
+                for (int i = 0; i < mapSize; ++i) {
+                    tempTuple.setNValue(fieldMap[i],
+                                        templateTuple.getNValue(fieldMap[i]));
                 }
+
+                persistentTable->updateTupleWithSpecificIndexes(existsTuple, tempTuple,
+                                                                persistentTable->allIndexes());
+                // successfully updated
+                ++modifiedTuples;
+                continue;
             }
+            // else, the primary key did not match,
+            // so fall through to the "insert" logic
         }
 
-        // successfully inserted or updated
-        modifiedTuples++;
+        // try to put the tuple into the target table
+        if (m_hasPurgeFragment) {
+            executePurgeFragmentIfNeeded(&persistentTable);
+            // purge fragment might have truncated the table, and
+            // refreshed the persistent table pointer.  Make sure to
+            // use it when doing the insert below.
+            targetTable = persistentTable;
+        }
+        targetTable->insertTuple(templateTuple);
+        // successfully inserted
+        ++modifiedTuples;
     }
 
-    TableTuple& count_tuple = outputTable->tempTuple();
     count_tuple.setNValue(0, ValueFactory::getBigIntValue(modifiedTuples));
-    // try to put the tuple into the output table
-    if (!outputTable->insertTuple(count_tuple)) {
-        VOLT_ERROR("Failed to insert tuple count (%d) into"
-                   " output table '%s'",
-                   modifiedTuples,
-                   outputTable->name().c_str());
-        return false;
-    }
+    // put the tuple into the output table
+    outputTable->insertTuple(count_tuple);
 
     // add to the planfragments count of modified tuples
     m_engine->addToTuplesModified(modifiedTuples);

--- a/src/ee/executors/insertexecutor.h
+++ b/src/ee/executors/insertexecutor.h
@@ -107,7 +107,7 @@ public:
          * into might change.  Passing a pointer-to-pointer allows
          * the callee to update the persistent table pointer.
          */
-        bool executePurgeFragmentIfNeeded(PersistentTable** table);
+        void executePurgeFragmentIfNeeded(PersistentTable** table);
 
         /** A tuple with the target table's schema that is populated
          * with default values for each field. */

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -157,7 +157,9 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
                     break;
                 }
             }
-            if (indexKeyUpdated) break;
+            if (indexKeyUpdated) {
+                break;
+            }
         }
         if (indexKeyUpdated) {
             indexesToUpdate.push_back(index);
@@ -168,24 +170,19 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
     assert(targetTuple.sizeInValues() == targetTable->columnCount());
     TableIterator input_iterator = m_inputTable->iterator();
     while (input_iterator.next(m_inputTuple)) {
-        //
-        // OPTIMIZATION: Single-Sited Query Plans
-        // If our beloved UpdatePlanNode is apart of a single-site query plan,
-        // then the first column in the input table will be the address of a
-        // tuple on the target table that we will want to update. This saves us
-        // the trouble of having to do an index lookup
-        //
+        // The first column in the input table will be the address of a
+        // tuple to update in the target table.
         void *target_address = m_inputTuple.getNValue(0).castAsAddress();
         targetTuple.move(target_address);
 
         // Loop through INPUT_COL_IDX->TARGET_COL_IDX mapping and only update
         // the values that we need to. The key thing to note here is that we
         // grab a temp tuple that is a copy of the target tuple (i.e., the tuple
-        // we want to update). This insures that if the input tuple is somehow
+        // we want to update). This ensures that if the input tuple is somehow
         // bringing garbage with it, we're only going to copy what we really
         // need to into the target tuple.
         //
-        TableTuple &tempTuple = targetTable->getTempTupleInlined(targetTuple);
+        TableTuple &tempTuple = targetTable->copyIntoTempTuple(targetTuple);
         for (int map_ctr = 0; map_ctr < m_inputTargetMapSize; map_ctr++) {
             tempTuple.setNValue(m_inputTargetMap[map_ctr].second,
                                 m_inputTuple.getNValue(m_inputTargetMap[map_ctr].first));
@@ -205,24 +202,14 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
             }
         }
 
-        if (!targetTable->updateTupleWithSpecificIndexes(targetTuple, tempTuple,
-                                                           indexesToUpdate)) {
-            VOLT_INFO("Failed to update tuple from table '%s'",
-                      targetTable->name().c_str());
-            return false;
-        }
+        targetTable->updateTupleWithSpecificIndexes(targetTuple, tempTuple,
+                                                    indexesToUpdate);
     }
 
     TableTuple& count_tuple = m_node->getOutputTable()->tempTuple();
     count_tuple.setNValue(0, ValueFactory::getBigIntValue(m_inputTable->tempTableTupleCount()));
     // try to put the tuple into the output table
-    if (!m_node->getOutputTable()->insertTuple(count_tuple)) {
-        VOLT_ERROR("Failed to insert tuple count (%ld) into"
-                   " output table '%s'",
-                   static_cast<long int>(m_inputTable->activeTupleCount()),
-                   m_node->getOutputTable()->name().c_str());
-        return false;
-    }
+    m_node->getOutputTable()->insertTuple(count_tuple);
 
     VOLT_TRACE("TARGET TABLE - AFTER: %s\n", targetTable->debug().c_str());
     // TODO lets output result table here, not in result executor. same thing in

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -599,7 +599,7 @@ void PersistentTable::insertTupleForUndo(char *tuple)
  * updated strings and creates an UndoAction. Additional optimization
  * for callers that know which indexes to update.
  */
-bool PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUpdate,
+void PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUpdate,
                                                      TableTuple &sourceTupleWithNewValues,
                                                      std::vector<TableIndex*> const &indexesToUpdate,
                                                      bool fallible,
@@ -763,7 +763,6 @@ bool PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUp
     for (int i = 0; i < m_views.size(); i++) {
         m_views[i]->processTupleInsert(targetTupleToUpdate, fallible);
     }
-    return true;
 }
 
 /*

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -273,11 +273,11 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     // and/or adds a materialized view.
     // Constraint checks are bypassed and the change does not make use of "undo" support.
     // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
-    virtual bool updateTupleWithSpecificIndexes(TableTuple &targetTupleToUpdate,
-                                                TableTuple &sourceTupleWithNewValues,
-                                                std::vector<TableIndex*> const &indexesToUpdate,
-                                                bool fallible=true,
-                                                bool updateDRTimestamp=true);
+    void updateTupleWithSpecificIndexes(TableTuple &targetTupleToUpdate,
+                                        TableTuple &sourceTupleWithNewValues,
+                                        std::vector<TableIndex*> const &indexesToUpdate,
+                                        bool fallible=true,
+                                        bool updateDRTimestamp=true);
 
     virtual void addIndex(TableIndex *index) {
         Table::addIndex(index);
@@ -342,10 +342,11 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     }
     bool isMaterialized() { return m_isMaterialized; };
 
-    /** inlined here because it can't be inlined in base Table, as it
-     *  uses Tuple.copy.
-     */
-    TableTuple& getTempTupleInlined(TableTuple &source);
+    TableTuple& copyIntoTempTuple(TableTuple &source) {
+        assert (m_tempTuple.m_data);
+        m_tempTuple.copy(source);
+        return m_tempTuple;
+    }
 
     /** Add/drop/list materialized views to this table */
     void addMaterializedView(MaterializedViewMetadata *view);
@@ -900,13 +901,6 @@ PersistentTableSurgeon::DRRollback(size_t drMark, size_t drRowCost) {
         }
     }
 }
-
-inline TableTuple& PersistentTable::getTempTupleInlined(TableTuple &source) {
-    assert (m_tempTuple.m_data);
-    m_tempTuple.copy(source);
-    return m_tempTuple;
-}
-
 
 inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block)
 {

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -232,12 +232,6 @@ bool StreamedTable::insertTuple(TableTuple &source)
     return true;
 }
 
-bool StreamedTable::updateTupleWithSpecificIndexes(TableTuple &, TableTuple &, std::vector<TableIndex*> const&, bool)
-{
-    throwFatalException("May not update a streamed table.");
-    return true;
-}
-
 bool StreamedTable::deleteTuple(TableTuple &tuple, bool fallible)
 {
     size_t mark = 0;

--- a/src/ee/storage/streamedtable.h
+++ b/src/ee/storage/streamedtable.h
@@ -79,14 +79,6 @@ class StreamedTable : public Table {
     virtual bool deleteTuple(TableTuple &tuple, bool=true);
     // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
     virtual bool insertTuple(TableTuple &tuple);
-    // Updating streamed tuples is not supported
-    // Update is irrelevent to StreamedTable.
-    // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
-    virtual bool updateTupleWithSpecificIndexes(TableTuple &targetTupleToUpdate,
-                                                TableTuple &sourceTupleWithNewValues,
-                                                std::vector<TableIndex*> const &indexesToUpdate,
-                                                bool=true);
-
 
     virtual void loadTuplesFrom(SerializeInputBE &serialize_in, Pool *stringPool = NULL);
     virtual void flushOldTuples(int64_t timeInMillis);

--- a/src/ee/storage/temptable.cpp
+++ b/src/ee/storage/temptable.cpp
@@ -73,17 +73,6 @@ bool TempTable::insertTuple(TableTuple &source) {
     return true;
 }
 
-bool TempTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUpdate,
-                                               TableTuple &sourceTupleWithNewValues,
-                                               std::vector<TableIndex*> const &indexesToUpdate,
-                                               bool)
-{
-    throwFatalException("TempTable does not support update");
-    // Some day maybe, if we find a use case:
-    // Copy the source tuple into the target
-    // targetTupleToUpdate.copy(sourceTupleWithNewValues);
-}
-
 bool TempTable::deleteTuple(TableTuple &, bool)
 {
     throwFatalException("TempTable does not support deleting individual tuples");

--- a/src/ee/storage/temptable.h
+++ b/src/ee/storage/temptable.h
@@ -109,14 +109,6 @@ class TempTable : public Table {
     // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
     // -- Most callers should be using TempTable::insertTempTuple, anyway.
     virtual bool insertTuple(TableTuple &tuple);
-    // Updating temp tuples is not required in production code
-    // -- it may be used in tests, though, for no especially good reason.
-    // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
-    virtual bool updateTupleWithSpecificIndexes(TableTuple &targetTupleToUpdate,
-                                                TableTuple &sourceTupleWithNewValues,
-                                                std::vector<TableIndex*> const &indexesToUpdate,
-                                                bool);
-
 
     void deleteAllTuplesNonVirtual(bool freeAllocatedStrings);
 

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -33,6 +33,7 @@ import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.ColumnRef;
+import org.voltdb.catalog.Constraint;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Index;
 import org.voltdb.catalog.Table;
@@ -74,6 +75,7 @@ import org.voltdb.plannodes.SendPlanNode;
 import org.voltdb.plannodes.SeqScanPlanNode;
 import org.voltdb.plannodes.UnionPlanNode;
 import org.voltdb.plannodes.UpdatePlanNode;
+import org.voltdb.types.ConstraintType;
 import org.voltdb.types.ExpressionType;
 import org.voltdb.types.IndexType;
 import org.voltdb.types.JoinType;
@@ -1458,11 +1460,51 @@ public class PlanAssembler {
         retval.setReadOnly(false);
 
         // Iterate over each column in the table we're inserting into:
-        //   - Make sure we're supplying values for columns that require it
-        //   - Set partitioning expressions for VALUES (...) case
+        //   - Make sure we're supplying values for columns that require it.
+        //     For a normal INSERT, these are the usual non-nullable values that
+        //     don't have a default value.
+        //     For an UPSERT, the (only) required values are the primary key
+        //     components. Other required values can be supplied from the
+        //     existing row in "UPDATE mode". If some other value is required
+        //     for an INSERT, UPSERT's "INSERT mode" will throw a runtime
+        //     constraint violation as the INSERT operation tries to set the
+        //     non-nullable column to null.
+        //   - Set partitioning expressions for VALUES (...) case.
+        //     TODO: it would be good someday to do the same kind of processing
+        //      for the INSERT ... SELECT ... case, by analyzing the subquery.
+        if (m_parsedInsert.m_isUpsert) {
+            boolean hasPrimaryKey = false;
+            for (Constraint constraint : targetTable.getConstraints()) {
+                if (constraint.getType() != ConstraintType.PRIMARY_KEY.getValue()) {
+                    continue;
+                }
+                hasPrimaryKey = true;
+                boolean targetsPrimaryKey = false;
+                for (ColumnRef colRef : constraint.getIndex().getColumns()) {
+                    int primary = colRef.getColumn().getIndex();
+                    for (Column targetCol : m_parsedInsert.m_columns.keySet()) {
+                        if (targetCol.getIndex() == primary) {
+                            targetsPrimaryKey = true;
+                            break;
+                        }
+                    }
+                    if (! targetsPrimaryKey) {
+                        throw new PlanningErrorException("UPSERT on table \"" +
+                                targetTable.getTypeName() +
+                                "\" must specify a value for primary key \"" +
+                                colRef.getColumn().getTypeName() + "\".");
+                    }
+                }
+            }
+            if (! hasPrimaryKey) {
+                throw new PlanningErrorException("UPSERT is not allowed on table \"" +
+                        targetTable.getTypeName() + "\" that has no primary key.");
+            }
+        }
         CatalogMap<Column> targetTableColumns = targetTable.getColumns();
         for (Column col : targetTableColumns) {
-            boolean needsValue = col.getNullable() == false && col.getDefaulttype() == 0;
+            boolean needsValue = (!m_parsedInsert.m_isUpsert) &&
+                    (col.getNullable() == false) && (col.getDefaulttype() == 0);
             if (needsValue && !m_parsedInsert.m_columns.containsKey(col)) {
                 // This check could be done during parsing?
                 throw new PlanningErrorException("Column " + col.getName()

--- a/tests/ee/indexes/CoveringCellIndexTest.cpp
+++ b/tests/ee/indexes/CoveringCellIndexTest.cpp
@@ -564,10 +564,7 @@ TEST_F(CoveringCellIndexTest, Simple) {
     ASSERT_FALSE(foundTuple.isNullTuple());
 
     tempTuple.setNValue(GEOG_COL_INDEX, polygonWktToNval("polygon((10 10, 11 10, 10 11, 10 10))"));
-    bool success = table->updateTupleWithSpecificIndexes(foundTuple,
-                                                         tempTuple,
-                                                         {ccIndex});
-    ASSERT_TRUE(success);
+    table->updateTupleWithSpecificIndexes(foundTuple, tempTuple, {ccIndex});
 
     // Now tuple 0 should not contain this point.
     searchKey.tuple().setNValue(0, pointWktToNval("point(0.01 0.01)"));

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -238,13 +238,12 @@ TEST_F(PersistentTableTest, DRTimestampColumn) {
     iterator = table->iteratorDeletingAsWeGo();
     ASSERT_TRUE(iterator.next(tuple));
     ASSERT_TRUE(iterator.next(tuple));
-    srcTuple = table->getTempTupleInlined(tuple);
-    srcTuple.setNValue(1, newStringData);
+    TableTuple& tempTuple = table->copyIntoTempTuple(tuple);
+    tempTuple.setNValue(1, newStringData);
 
     table->updateTupleWithSpecificIndexes(tuple,
-                                          srcTuple,
-                                          table->allIndexes(),
-                                          true);
+                                          tempTuple,
+                                          table->allIndexes());
 
     // verify the updated tuple has the new timestamp.
     int64_t drTimestampNew = ExecutorContext::getExecutorContext()->currentDRTimestamp();

--- a/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
@@ -111,7 +111,8 @@ public class RegressionSuite extends TestCase {
             for (final SocketChannel sc : m_clientChannels) {
                 try {
                     ConnectionUtil.closeConnection(sc);
-                } catch (final IOException e) {
+                }
+                catch (final IOException e) {
                     e.printStackTrace();
                 }
             }
@@ -209,7 +210,8 @@ public class RegressionSuite extends TestCase {
         String listener = null;
         if (useAdmin) {
             listener = m_config.getAdminAddress(r.nextInt(m_config.getListenerCount()));
-        } else {
+        }
+        else {
             listener = m_config.getListenerAddress(r.nextInt(m_config.getListenerCount()));
         }
         ClientConfig config = new ClientConfigForTest(m_username, m_password, scheme);
@@ -224,7 +226,8 @@ public class RegressionSuite extends TestCase {
         catch (ConnectException e) {
             if (useAdmin) {
                 listener = m_config.getAdminAddress(r.nextInt(m_config.getListenerCount()));
-            } else {
+            }
+            else {
                 listener = m_config.getListenerAddress(r.nextInt(m_config.getListenerCount()));
             }
             client.createConnection(listener);
@@ -395,6 +398,12 @@ public class RegressionSuite extends TestCase {
         return isLocalCluster() ? ((LocalCluster)m_config).internalPort(hostId) : VoltDB.DEFAULT_INTERNAL_PORT+hostId;
     }
 
+    static protected void validateDMLTupleCount(Client c, String sql, long modifiedTupleCount)
+            throws NoConnectionsException, IOException, ProcCallException {
+        VoltTable vt = c.callProcedure("@AdHoc", sql).getResults()[0];
+        validateTableOfLongs(sql, vt, new long[][] {{modifiedTupleCount}});
+    }
+
     static protected void validateTableOfLongs(Client c, String sql, long[][] expected)
             throws NoConnectionsException, IOException, ProcCallException {
         VoltTable vt = c.callProcedure("@AdHoc", sql).getResults()[0];
@@ -444,44 +453,43 @@ public class RegressionSuite extends TestCase {
                         expected.length, vt.getRowCount());
         int len = expected.length;
         for (int i=0; i < len; i++) {
-            validateRowOfLongs(messagePrefix + " at row " + i + ", ", vt, expected[i]);
+            validateRowOfLongs(messagePrefix + " at row " + (i+1) + ", ", vt, expected[i]);
         }
     }
 
     public static void validateTableOfLongs(VoltTable vt, long[][] expected) {
-        assertNotNull(expected);
-        assertEquals("Wrong number of rows in table.  ",
-                        expected.length, vt.getRowCount());
-        int len = expected.length;
-        for (int i=0; i < len; i++) {
-            validateRowOfLongs("at row " + i + ", ", vt, expected[i]);
-        }
+        validateTableOfLongs("", vt, expected);
     }
 
     static protected void validateRowOfLongs(String messagePrefix, VoltTable vt, long [] expected) {
         int len = expected.length;
         assertTrue(vt.advanceRow());
         for (int i=0; i < len; i++) {
-            String message = messagePrefix + "at column " + i + ", ";
+            String message = messagePrefix + "at column " + (i+1) + ", ";
 
             long actual = -10000000;
             // ENG-4295: hsql bug: HSQLBackend sometimes returns wrong column type.
             try {
                 actual = vt.getLong(i);
-            } catch (IllegalArgumentException ex) {
+            }
+            catch (IllegalArgumentException ex) {
                 try {
                     actual = (long) vt.getDouble(i);
-                } catch (IllegalArgumentException newEx) {
+                }
+                catch (IllegalArgumentException newEx) {
                     try {
                         actual = vt.getTimestampAsLong(i);
-                    } catch (IllegalArgumentException exTm) {
+                    }
+                    catch (IllegalArgumentException exTm) {
                         try {
                             actual = vt.getDecimalAsBigDecimal(i).longValueExact();
-                        } catch (IllegalArgumentException newerEx) {
+                        }
+                        catch (IllegalArgumentException newerEx) {
                             newerEx.printStackTrace();
                             fail(message);
                         }
-                    } catch (ArithmeticException newestEx) {
+                    }
+                    catch (ArithmeticException newestEx) {
                         newestEx.printStackTrace();
                         fail(message);
                     }
@@ -491,7 +499,8 @@ public class RegressionSuite extends TestCase {
             // Long.MIN_VALUE is like a NULL
             if (expected[i] != Long.MIN_VALUE) {
                 assertEquals(message, expected[i], actual);
-            } else {
+            }
+            else {
                 VoltType type = vt.getColumnType(i);
                 assertEquals(message + "expected null: ", Long.parseLong(type.getNullValue().toString()), actual);
             }
@@ -513,7 +522,8 @@ public class RegressionSuite extends TestCase {
             if (expected[i] == Long.MIN_VALUE) {
                 assertTrue(vt.wasNull());
                 assertEquals(null, actual);
-            } else {
+            }
+            else {
                 assertEquals(expected[i], actual);
             }
         }
@@ -539,7 +549,8 @@ public class RegressionSuite extends TestCase {
                 String actual = vt.getString(col);
                 assertTrue(vt.wasNull());
                 assertEquals(null, actual);
-            } else {
+            }
+            else {
                 assertEquals(expected[i], vt.getString(col));
             }
         }
@@ -563,7 +574,8 @@ public class RegressionSuite extends TestCase {
               if (expected[i] == null) {
                   assertTrue(vt.wasNull());
                   assertEquals(null, actual);
-              } else {
+              }
+              else {
                   assertEquals(expected[i], Encoder.hexEncode(actual));
               }
           }
@@ -586,7 +598,8 @@ public class RegressionSuite extends TestCase {
               if (expected[i] == Double.MIN_VALUE) {
                   assertTrue(vt.wasNull());
                   assertEquals(null, actual);
-              } else {
+              }
+              else {
                   assertEquals(expected[i], actual, 0.00001);
               }
           }
@@ -599,19 +612,22 @@ public class RegressionSuite extends TestCase {
             BigDecimal actual = null;
             try {
                 actual = vt.getDecimalAsBigDecimal(i);
-            } catch (IllegalArgumentException ex) {
+            }
+            catch (IllegalArgumentException ex) {
                 ex.printStackTrace();
                 fail();
             }
             if (expected[i] != null) {
                 assertNotSame(null, actual);
                 assertEquals(expected[i], actual);
-            } else {
+            }
+            else {
                 if (isHSQL()) {
                     // We don't actually use this with
                     // HSQL.  So, just assert failure here.
                     fail("HSQL is not used to test the Volt DECIMAL type.");
-                } else {
+                }
+                else {
                     assertTrue(vt.wasNull());
                 }
             }
@@ -694,7 +710,8 @@ public class RegressionSuite extends TestCase {
             if (expected[i] == null) {
                 assertTrue(vt.wasNull());
                 assertEquals(null, actual);
-            } else {
+            }
+            else {
                 BigDecimal rounded = expected[i].setScale(m_defaultScale, RoundingMode.valueOf(m_defaultRoundingMode));
                 assertEquals(rounded, actual);
             }
@@ -743,7 +760,8 @@ public class RegressionSuite extends TestCase {
         if (epsilon > 0) {
             assertEquals(msg + " latitude: ", expected.getLatitude(), actual.getLatitude(), epsilon);
             assertEquals(msg + " longitude: ", expected.getLongitude(), actual.getLongitude(), epsilon);
-        } else {
+        }
+        else {
             assertEquals(msg + " latitude: ", expected.getLatitude(), actual.getLatitude());
             assertEquals(msg + " longitude: ", expected.getLongitude(), actual.getLongitude());
         }
@@ -858,7 +876,8 @@ public class RegressionSuite extends TestCase {
                 if (epsilon <= 0) {
                     String fullMsg = msg + String.format("Expected value %f != actual value %f", expectedValue, actualValue);
                     assertEquals(fullMsg, expectedValue, actualValue);
-                } else {
+                }
+                else {
                     String fullMsg = msg + String.format("abs(Expected Value - Actual Value) = %e >= %e",
                                                          Math.abs(expectedValue - actualValue), epsilon);
                     assertTrue(fullMsg, Math.abs(expectedValue - actualValue) < epsilon);


### PR DESCRIPTION
Fixed three problems: 
The reported problem was that UPSERT statements that did not provide values for some columns were resetting the missing columns back to their default values for the UPDATE case rather than leaving them alone.
Added testing showed two other problems:
1. The planner was forcing UPSERTs (just like INSERTs) to mention all NOT NULL columns that had NO/NULL default values. For UPSERTs, this needs to be let through and conditionally caught in a runtime check.
It is a completely irrelevant condition for UPSERT's UPDATE subcase as hinted by the first fix described above. For UPSERT's INSERT subcase, we will throw a null constraint violation from the EE. That is, we won't bother to distinguish this edge case of defaulting the NOT NULL column to null from the case of explicitly setting it to a NULL value.
2. The planner was NOT forcing UPSERTs to provide values for all primary key components. I may be wrong here, but using the default value, commonly null, for the primary key that the UPSERT will use for matching seems like it is most likely just going to be covering for a pilot error and not what they intended. Is this too presumptious?