### PR TITLE
PostgreSQLBackend.java: VARBINARY column types are now transformed to

### DIFF
--- a/tests/scripts/sql_coverage_test.py
+++ b/tests/scripts/sql_coverage_test.py
@@ -744,12 +744,7 @@ if __name__ == "__main__":
                             options.report_all, options.ascii_only, args, testConfigKits)
         statistics[config_name] = result["keyStats"]
         statistics["seed"] = seed
-        # For now, ignore certain mismatches in index-varbinary, when running against PostgreSQL
-        # TODO: fix those mismatches (see ENG-9448)
-        if options.postgresql and config_name == "index-varbinary":
-            if result["mis"] > 1520:
-                success = False
-        elif result["mis"] != 0:
+        if result["mis"] != 0:
             success = False
 
     # Write the summary


### PR DESCRIPTION
PostgreSQL's BYTEA type, which seems to be the closest analogue (was BIN
VARYING); and added a transformation for binary constants, e.g. x'12AF'
gets transformed to E'\\x12AF', which is in PostgreSQL's preferred
format for BYTEA data.
sql_coverage_test.py: removed the kludge that ignored the known failures
(up to 1520 of them) in the index-varbinary test suite, when running
against PostgreSQL.
StandardNormalizer.py: changed the output format of VARBINARY column
data, to roughly match the same format that is used upon input (in an
INSERT statement), rather than Python's crazy default format for binary
data.