### PR TITLE
load_remove_classes.outbaseline: removed the (last) line that reads:

### DIFF
--- a/tests/sqlcmd/baselines/ddl/load_remove_classes.outbaseline
+++ b/tests/sqlcmd/baselines/ddl/load_remove_classes.outbaseline
@@ -8,6 +8,21 @@ Command succeeded.
 drop table t if exists;
 Command succeeded.
 
+drop table t2 if exists;
+Command succeeded.
+
+drop table addable if exists;
+Command succeeded.
+
+drop table dropable if exists;
+Command succeeded.
+
+drop table prefixes if exists;
+Command succeeded.
+
+drop table raw if exists;
+Command succeeded.
+
 --- Empty Class List -----------------------
 
 
@@ -186,7 +201,6 @@ EMPLOYEE.delete           	integer
 EMPLOYEE.insert           	integer, varchar, varchar, varchar
 EMPLOYEE.update           	integer, varchar, varchar, varchar, integer
 EMPLOYEE.upsert           	integer, varchar, varchar, varchar
-InsertEmployee            	varchar, varchar, varchar
 
 
 --- Potential Procedure Classes ----------------------------

--- a/tests/sqlcmd/scripts/ddl/load_remove_classes.in
+++ b/tests/sqlcmd/scripts/ddl/load_remove_classes.in
@@ -2,6 +2,11 @@
 drop table r if exists;
 drop table s if exists;
 drop table t if exists;
+drop table t2 if exists;
+drop table addable if exists;
+drop table dropable if exists;
+drop table prefixes if exists;
+drop table raw if exists;
 
 show classes;
 load classes sqlcmdtest-procs.jar;


### PR DESCRIPTION
InsertEmployee            	varchar, varchar, varchar
since ENG-8532 has been fixed, this stored procedure is no longer listed
by SHOW PROCEDURES, *after* it has been dropped (though it is still
listed earlier); and added additional lines to match the ones added to
load_remove_classes.in.
load_remove_classes.in: added some additional:
    drop table FOO if exists;
statements (where FOO is t2, addable, dropable, prefixes, or raw); now
that ENG-8532 is fixed, such lines could actually help this test past,
by removing extraneous procedures from the ones listed by SHOW
PROCEDURES (whereas before, they had no real effect).