### PR TITLE
ENG-9547: Keep the size of the Site tracker as small as possible to a…

### DIFF
--- a/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
+++ b/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
@@ -338,7 +338,8 @@ public class DRConsumerDrIdTracker implements Serializable {
         }
         else {
             sb.append("span [").append(DRLogSegmentId.getSequenceNumberFromDRId(getFirstDrId())).append("-");
-            sb.append(DRLogSegmentId.getSequenceNumberFromDRId(getLastDrId())).append("]");
+            sb.append(DRLogSegmentId.getSequenceNumberFromDRId(getLastDrId()));
+            sb.append(", size=").append(size()).append("]");
         }
         return sb.toString();
     }

--- a/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
+++ b/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
@@ -84,11 +84,22 @@ public class DRConsumerDrIdTracker implements Serializable {
         }
     }
 
-    public DRConsumerDrIdTracker(long initialAckPoint, long spUniqueId, long mpUniqueId) {
+
+    private DRConsumerDrIdTracker(long spUniqueId, long mpUniqueId) {
         m_map = TreeRangeSet.create();
-        m_map.add(range(initialAckPoint, initialAckPoint));
         m_lastSpUniqueId = spUniqueId;
         m_lastMpUniqueId = mpUniqueId;
+    }
+
+    public static DRConsumerDrIdTracker createBufferTracker(long spUniqueId, long mpUniqueId) {
+        DRConsumerDrIdTracker newTracker = new DRConsumerDrIdTracker(spUniqueId, mpUniqueId);
+        return newTracker;
+    }
+
+    public static DRConsumerDrIdTracker createPartitionTracker(long initialAckPoint, long spUniqueId, long mpUniqueId) {
+        DRConsumerDrIdTracker newTracker = new DRConsumerDrIdTracker(spUniqueId, mpUniqueId);
+        newTracker.addRange(initialAckPoint, initialAckPoint);
+        return newTracker;
     }
 
     public DRConsumerDrIdTracker(DRConsumerDrIdTracker other) {
@@ -181,6 +192,15 @@ public class DRConsumerDrIdTracker implements Serializable {
      * Add a range to the tracker.
      * @param startDrId
      * @param endDrId
+     */
+    public void addRange(long startDrId, long endDrId) {
+        m_map.add(range(startDrId, endDrId));
+    }
+
+    /**
+     * Add a range to the tracker.
+     * @param startDrId
+     * @param endDrId
      * @param spUniqueId
      * @param mpUniqueId
      */
@@ -188,7 +208,7 @@ public class DRConsumerDrIdTracker implements Serializable {
         // Note that any given range or tracker could have either sp or mp sentinel values
         m_lastSpUniqueId = Math.max(m_lastSpUniqueId, spUniqueId);
         m_lastMpUniqueId = Math.max(m_lastMpUniqueId, mpUniqueId);
-        m_map.add(range(startDrId, endDrId));
+        addRange(startDrId, endDrId);
     }
 
     /**
@@ -304,6 +324,23 @@ public class DRConsumerDrIdTracker implements Serializable {
         }
         obj.put("drIdRanges", drIdRanges);
         return obj;
+    }
+
+    public String toShortString() {
+        if (m_map.isEmpty()) {
+            return "Empty Map";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("lastSpUniqueId ").append(UniqueIdGenerator.toShortString(m_lastSpUniqueId)).append(" ");
+        sb.append("lastMpUniqueId ").append(UniqueIdGenerator.toShortString(m_lastMpUniqueId)).append(" ");
+        if (m_map.isEmpty()) {
+            sb.append("[empty map]");
+        }
+        else {
+            sb.append("span [").append(DRLogSegmentId.getSequenceNumberFromDRId(getFirstDrId())).append("-");
+            sb.append(DRLogSegmentId.getSequenceNumberFromDRId(getLastDrId())).append("]");
+        }
+        return sb.toString();
     }
 
     @Override

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -215,7 +215,7 @@ public class SnapshotSiteProcessor {
             }
 
             long[] ackOffSetAndSequenceNumber =
-                context.getSiteProcedureConnection().getUSOForExportTable(t.getSignature());
+                    context.getSiteProcedureConnection().getUSOForExportTable(t.getSignature());
             sequenceNumbers.put(
                             context.getPartitionId(),
                             Pair.of(
@@ -231,7 +231,7 @@ public class SnapshotSiteProcessor {
 
     public static Map<String, Map<Integer, Pair<Long, Long>>> getExportSequenceNumbers() {
         HashMap<String, Map<Integer, Pair<Long, Long>>> sequenceNumbers =
-            new HashMap<String, Map<Integer, Pair<Long, Long>>>(m_exportSequenceNumbers);
+                new HashMap<String, Map<Integer, Pair<Long, Long>>>(m_exportSequenceNumbers);
         m_exportSequenceNumbers.clear();
         return sequenceNumbers;
     }
@@ -392,7 +392,7 @@ public class SnapshotSiteProcessor {
         for (Map.Entry<Integer, byte[]> tablePredicates : makeTablesAndPredicatesToSnapshot(tasks).entrySet()) {
             int tableId = tablePredicates.getKey();
             TableStreamer streamer =
-                new TableStreamer(tableId, format.getStreamType(), m_snapshotTableTasks.get(tableId));
+                    new TableStreamer(tableId, format.getStreamType(), m_snapshotTableTasks.get(tableId));
             if (!streamer.activate(context, tablePredicates.getValue())) {
                 VoltDB.crashLocalVoltDB("Failed to activate snapshot stream on table " +
                                         CatalogUtil.getTableNameFromId(context.getDatabase(), tableId), false, null);
@@ -567,7 +567,7 @@ public class SnapshotSiteProcessor {
          * transaction work.
          */
         Iterator<Map.Entry<Integer, Collection<SnapshotTableTask>>> taskIter =
-            m_snapshotTableTasks.asMap().entrySet().iterator();
+                m_snapshotTableTasks.asMap().entrySet().iterator();
         while (taskIter.hasNext()) {
             Map.Entry<Integer, Collection<SnapshotTableTask>> taskEntry = taskIter.next();
             final int tableId = taskEntry.getKey();
@@ -792,7 +792,11 @@ public class SnapshotSiteProcessor {
                     jsonObj.put("isTruncation", false);
                 }
                 extraSnapshotData.mergeToZooKeeper(jsonObj, SNAP_LOG);
-                zk.setData(snapshotPath, jsonObj.toString(4).getBytes("UTF-8"), stat.getVersion());
+                byte[] zkData = jsonObj.toString(4).getBytes("UTF-8");
+                if (zkData.length > 5000000) {
+                    SNAP_LOG.warn("ZooKeeper node for snapshot digest unexpectedly large: " + zkData.length);
+                }
+                zk.setData(snapshotPath, zkData, stat.getVersion());
             } catch (KeeperException.BadVersionException e) {
                 continue;
             } catch (Exception e) {

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -792,7 +792,7 @@ public class SnapshotSiteProcessor {
                     jsonObj.put("isTruncation", false);
                 }
                 extraSnapshotData.mergeToZooKeeper(jsonObj, SNAP_LOG);
-                byte[] zkData = jsonObj.toString(4).getBytes("UTF-8");
+                byte[] zkData = jsonObj.toString().getBytes("UTF-8");
                 if (zkData.length > 5000000) {
                     SNAP_LOG.warn("ZooKeeper node for snapshot digest unexpectedly large: " + zkData.length);
                 }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -97,13 +98,14 @@ import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.LogKeys;
 import org.voltdb.utils.MinimumRatioMaintainer;
 
-import com.google_voltpatches.common.base.Preconditions;
-
 import vanilla.java.affinity.impl.PosixJNAAffinity;
+
+import com.google_voltpatches.common.base.Preconditions;
 
 public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConnection
 {
     private static final VoltLogger hostLog = new VoltLogger("HOST");
+    private static final VoltLogger drLog = new VoltLogger("DRAGENT");
 
     private static final double m_taskLogReplayRatio =
             Double.valueOf(System.getProperty("TASKLOG_REPLAY_RATIO", "0.6"));
@@ -500,6 +502,14 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         @Override
         public Map<Integer, Map<Integer, DRConsumerDrIdTracker>> getDrAppliedTrackers()
         {
+            if (drLog.isTraceEnabled()) {
+                for (Entry<Integer, Map<Integer, DRConsumerDrIdTracker>> e1 : m_maxSeenDrLogsBySrcPartition.entrySet()) {
+                    for (Entry<Integer, DRConsumerDrIdTracker> e2 : e1.getValue().entrySet()) {
+                        drLog.trace("Tracker for Producer " + e1.getKey() + "'s PID " + e2.getKey() +
+                                " contains " + e2.getValue().toShortString());
+                    }
+                }
+            }
             return m_maxSeenDrLogsBySrcPartition;
         }
 

--- a/tests/frontend/org/voltdb/TestDRConsumerDrIdTracker.java
+++ b/tests/frontend/org/voltdb/TestDRConsumerDrIdTracker.java
@@ -31,13 +31,14 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google_voltpatches.common.collect.RangeSet;
-import com.google_voltpatches.common.collect.TreeRangeSet;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.google_voltpatches.common.collect.RangeSet;
+import com.google_voltpatches.common.collect.TreeRangeSet;
 
 public class TestDRConsumerDrIdTracker {
 
@@ -45,7 +46,7 @@ public class TestDRConsumerDrIdTracker {
 
     @Before
     public void setUp() throws IOException {
-        tracker = new DRConsumerDrIdTracker(-1L, 0L, 0L);
+        tracker = DRConsumerDrIdTracker.createPartitionTracker(-1L, 0L, 0L);
     }
 
     @After
@@ -130,7 +131,7 @@ public class TestDRConsumerDrIdTracker {
 
         tracker.append(90L, 90L, 0L, 0L);
 
-        DRConsumerDrIdTracker tracker2 = new DRConsumerDrIdTracker(5L, 0L, 0L);
+        DRConsumerDrIdTracker tracker2 = DRConsumerDrIdTracker.createPartitionTracker(5L, 0L, 0L);
         // This should insert a new entry before the beginning
         tracker2.append(6L, 6L, 0L, 0L);
         expectedMap.add(DRConsumerDrIdTracker.range(6L, 6L));
@@ -187,7 +188,7 @@ public class TestDRConsumerDrIdTracker {
         tracker.append(40L, 40L, 0L, 0L);
         tracker.append(50L, 60L, 0L, 0L);
 
-        DRConsumerDrIdTracker tracker2 = new DRConsumerDrIdTracker(6L, 0L, 0L);
+        DRConsumerDrIdTracker tracker2 = DRConsumerDrIdTracker.createPartitionTracker(6L, 0L, 0L);
         // overlaps with the beginning of the first entry
         tracker2.append(7L, 8L, 0L, 0L);
         expectedMap.add(DRConsumerDrIdTracker.range(8L, 9L));
@@ -213,7 +214,7 @@ public class TestDRConsumerDrIdTracker {
     @Test
     public void testAppendToEmptyTracker() {
         RangeSet<Long> expectedMap = TreeRangeSet.create();
-        DRConsumerDrIdTracker tracker2 = new DRConsumerDrIdTracker(5L, 0L, 0L);
+        DRConsumerDrIdTracker tracker2 = DRConsumerDrIdTracker.createPartitionTracker(5L, 0L, 0L);
         expectedMap.add(DRConsumerDrIdTracker.range(5L, 5L));
         tracker2.append(11L, 11L, 0L, 0L);
         expectedMap.add(DRConsumerDrIdTracker.range(11L, 11L));
@@ -232,7 +233,7 @@ public class TestDRConsumerDrIdTracker {
     public void testAppendNeighborTracker() throws Exception {
         RangeSet<Long> expectedMap = TreeRangeSet.create();
         tracker.append(6L, 10L, 0L, 0L);
-        DRConsumerDrIdTracker tracker2 = new DRConsumerDrIdTracker(2L, 0L, 0L);
+        DRConsumerDrIdTracker tracker2 = DRConsumerDrIdTracker.createPartitionTracker(2L, 0L, 0L);
         expectedMap.add(DRConsumerDrIdTracker.range(2L, 2L));
         tracker2.append(11L, 11L, 0L, 0L);
         expectedMap.add(DRConsumerDrIdTracker.range(6L, 11L));
@@ -252,7 +253,7 @@ public class TestDRConsumerDrIdTracker {
         RangeSet<Long> expectedMap = TreeRangeSet.create();
         tracker.append(6L, 10L, 0L, 0L);
         tracker.append(15L, 20L, 0L, 0L);
-        DRConsumerDrIdTracker tracker2 = new DRConsumerDrIdTracker(20L, 0L, 0L);
+        DRConsumerDrIdTracker tracker2 = DRConsumerDrIdTracker.createPartitionTracker(20L, 0L, 0L);
         expectedMap.add(DRConsumerDrIdTracker.range(20L, 20L));
         tracker2.append(22L, 30L, 0L, 0L);
         expectedMap.add(DRConsumerDrIdTracker.range(22L, 30L));
@@ -283,7 +284,7 @@ public class TestDRConsumerDrIdTracker {
     public void testJsonSerialization() throws Exception {
         tracker.append(5L, 5L, 0L, 0L);
         tracker.append(15L, 20L, 0L, 0L);
-        DRConsumerDrIdTracker tracker2 = new DRConsumerDrIdTracker(17L, 0L, 0L);
+        DRConsumerDrIdTracker tracker2 = DRConsumerDrIdTracker.createPartitionTracker(17L, 0L, 0L);
         tracker2.append(20L, 25L, 0L, 0L);
         tracker2.append(28L, 28L, 0L, 0L);
         Map<Integer, DRConsumerDrIdTracker> perProducerPartitionTrackers = new HashMap<Integer, DRConsumerDrIdTracker>();


### PR DESCRIPTION
…void very large snapshot digest files. We keep the tracker small by assigning the last acked to the tracker just before we send the tracker to the site.