### PR TITLE
Update statistic table/tuple column's for memory size to bigint instead of integer

### DIFF
--- a/src/ee/indexes/IndexStats.cpp
+++ b/src/ee/indexes/IndexStats.cpp
@@ -43,7 +43,8 @@ vector<string> IndexStats::generateIndexStatsColumnNames() {
     return columnNames;
 }
 
-// make sure to update schema in IndexStats.java when updating the index stats schema.
+// make sure to update schema in frontend sources (like IndexStats.java) and tests when updating
+// the index-stats schema in here.
 void IndexStats::populateIndexStatsSchema(
         vector<ValueType> &types,
         vector<int32_t> &columnLengths,

--- a/src/ee/indexes/IndexStats.cpp
+++ b/src/ee/indexes/IndexStats.cpp
@@ -43,6 +43,7 @@ vector<string> IndexStats::generateIndexStatsColumnNames() {
     return columnNames;
 }
 
+// make sure to update schema in IndexStats.java when updating the index stats schema.
 void IndexStats::populateIndexStatsSchema(
         vector<ValueType> &types,
         vector<int32_t> &columnLengths,
@@ -87,8 +88,8 @@ void IndexStats::populateIndexStatsSchema(
     inBytes.push_back(false);
 
     // memory usage
-    types.push_back(VALUE_TYPE_INTEGER);
-    columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_INTEGER));
+    types.push_back(VALUE_TYPE_BIGINT);
+    columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_BIGINT));
     allowNull.push_back(false);
     inBytes.push_back(false);
 }
@@ -183,11 +184,6 @@ void IndexStats::updateStatsTuple(TableTuple *tuple) {
         m_lastMemEstimate = m_index->getMemoryEstimate();
     }
 
-    if (mem_estimate_kb > INT32_MAX)
-    {
-        mem_estimate_kb = -1;
-    }
-
     tuple->setNValue(
             StatsSource::m_columnName2Index["IS_UNIQUE"],
             ValueFactory::getTinyIntValue(m_isUnique));
@@ -198,7 +194,7 @@ void IndexStats::updateStatsTuple(TableTuple *tuple) {
             ValueFactory::getBigIntValue(count));
     tuple->setNValue(StatsSource::m_columnName2Index["MEMORY_ESTIMATE"],
                      ValueFactory::
-                     getIntegerValue(static_cast<int32_t>(mem_estimate_kb)));
+                     getBigIntValue(mem_estimate_kb));
 }
 
 /**

--- a/src/ee/storage/TableStats.cpp
+++ b/src/ee/storage/TableStats.cpp
@@ -51,9 +51,9 @@ void TableStats::populateTableStatsSchema(
     types.push_back(VALUE_TYPE_VARCHAR); columnLengths.push_back(4096); allowNull.push_back(false);inBytes.push_back(false);
     types.push_back(VALUE_TYPE_VARCHAR); columnLengths.push_back(4096); allowNull.push_back(false);inBytes.push_back(false);
     types.push_back(VALUE_TYPE_BIGINT);  columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_BIGINT));  allowNull.push_back(false);inBytes.push_back(false);
-    types.push_back(VALUE_TYPE_INTEGER); columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_INTEGER)); allowNull.push_back(false);inBytes.push_back(false);
-    types.push_back(VALUE_TYPE_INTEGER); columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_INTEGER)); allowNull.push_back(false);inBytes.push_back(false);
-    types.push_back(VALUE_TYPE_INTEGER); columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_INTEGER)); allowNull.push_back(false);inBytes.push_back(false);
+    types.push_back(VALUE_TYPE_BIGINT); columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_BIGINT)); allowNull.push_back(false);inBytes.push_back(false);
+    types.push_back(VALUE_TYPE_BIGINT); columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_BIGINT)); allowNull.push_back(false);inBytes.push_back(false);
+    types.push_back(VALUE_TYPE_BIGINT); columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_BIGINT)); allowNull.push_back(false);inBytes.push_back(false);
     types.push_back(VALUE_TYPE_INTEGER); columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_INTEGER)); allowNull.push_back(false);inBytes.push_back(false);
     types.push_back(VALUE_TYPE_INTEGER); columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_INTEGER)); allowNull.push_back(false);inBytes.push_back(false);
 }
@@ -152,28 +152,15 @@ void TableStats::updateStatsTuple(TableTuple *tuple) {
         m_lastStringDataMemory = m_table->nonInlinedMemorySize();
     }
 
-    if (string_data_mem_kb > INT32_MAX)
-    {
-        string_data_mem_kb = -1;
-    }
-    if (allocated_tuple_mem_kb > INT32_MAX)
-    {
-        allocated_tuple_mem_kb = -1;
-    }
-    if (occupied_tuple_mem_kb > INT32_MAX)
-    {
-        occupied_tuple_mem_kb = -1;
-    }
-
     tuple->setNValue(
             StatsSource::m_columnName2Index["TUPLE_COUNT"],
             ValueFactory::getBigIntValue(tupleCount));
     tuple->setNValue(StatsSource::m_columnName2Index["TUPLE_ALLOCATED_MEMORY"],
-            ValueFactory::getIntegerValue(static_cast<int32_t>(allocated_tuple_mem_kb)));
+            ValueFactory::getBigIntValue(allocated_tuple_mem_kb));
     tuple->setNValue(StatsSource::m_columnName2Index["TUPLE_DATA_MEMORY"],
-            ValueFactory::getIntegerValue(static_cast<int32_t>(occupied_tuple_mem_kb)));
+            ValueFactory::getBigIntValue(occupied_tuple_mem_kb));
     tuple->setNValue(StatsSource::m_columnName2Index["STRING_DATA_MEMORY"],
-            ValueFactory::getIntegerValue(static_cast<int32_t>(string_data_mem_kb)));
+            ValueFactory::getBigIntValue(string_data_mem_kb));
 
     bool hasTupleLimit = tupleLimit == INT_MAX ? false : true;
     tuple->setNValue(StatsSource::m_columnName2Index["TUPLE_LIMIT"],

--- a/src/ee/storage/TableStats.cpp
+++ b/src/ee/storage/TableStats.cpp
@@ -42,7 +42,8 @@ vector<string> TableStats::generateTableStatsColumnNames() {
     return columnNames;
 }
 
-// make sure to update schema in IndexStats.java when updating the index stats schema.
+// make sure to update schema in frontend sources (like TableStats.java) and tests when updating
+// the index-stats schema in here.
 void TableStats::populateTableStatsSchema(
         vector<ValueType> &types,
         vector<int32_t> &columnLengths,

--- a/src/ee/storage/TableStats.cpp
+++ b/src/ee/storage/TableStats.cpp
@@ -42,6 +42,7 @@ vector<string> TableStats::generateTableStatsColumnNames() {
     return columnNames;
 }
 
+// make sure to update schema in IndexStats.java when updating the index stats schema.
 void TableStats::populateTableStatsSchema(
         vector<ValueType> &types,
         vector<int32_t> &columnLengths,

--- a/src/frontend/org/voltdb/IndexStats.java
+++ b/src/frontend/org/voltdb/IndexStats.java
@@ -46,6 +46,6 @@ public class IndexStats extends SiteStatsSource {
         columns.add(new ColumnInfo("IS_UNIQUE", VoltType.TINYINT));
         columns.add(new ColumnInfo("IS_COUNTABLE", VoltType.TINYINT));
         columns.add(new ColumnInfo("ENTRY_COUNT", VoltType.BIGINT));
-        columns.add(new ColumnInfo("MEMORY_ESTIMATE", VoltType.INTEGER));
+        columns.add(new ColumnInfo("MEMORY_ESTIMATE", VoltType.BIGINT));
     }
 }

--- a/src/frontend/org/voltdb/MemoryStats.java
+++ b/src/frontend/org/voltdb/MemoryStats.java
@@ -31,7 +31,7 @@ public class MemoryStats extends StatsSource {
         long tupleCount = 0;
         long tupleDataMem = 0;
         long tupleAllocatedMem = 0;
-        int indexMem = 0;
+        long indexMem = 0;
         long stringMem = 0;
         long pooledMem = 0;
     }
@@ -76,7 +76,7 @@ public class MemoryStats extends StatsSource {
         columns.add(new VoltTable.ColumnInfo("JAVAUNUSED", VoltType.INTEGER));
         columns.add(new VoltTable.ColumnInfo("TUPLEDATA", VoltType.BIGINT));
         columns.add(new VoltTable.ColumnInfo("TUPLEALLOCATED", VoltType.BIGINT));
-        columns.add(new VoltTable.ColumnInfo("INDEXMEMORY", VoltType.INTEGER));
+        columns.add(new VoltTable.ColumnInfo("INDEXMEMORY", VoltType.BIGINT));
         columns.add(new VoltTable.ColumnInfo("STRINGMEMORY", VoltType.BIGINT));
         columns.add(new VoltTable.ColumnInfo("TUPLECOUNT", VoltType.BIGINT));
         columns.add(new VoltTable.ColumnInfo("POOLEDMEMORY", VoltType.BIGINT));
@@ -126,7 +126,7 @@ public class MemoryStats extends StatsSource {
                                               long tupleCount,
                                               long tupleDataMem,
                                               long tupleAllocatedMem,
-                                              int indexMem,
+                                              long indexMem,
                                               long stringMem,
                                               long pooledMemory) {
         PartitionMemRow pmr = new PartitionMemRow();

--- a/src/frontend/org/voltdb/MemoryStats.java
+++ b/src/frontend/org/voltdb/MemoryStats.java
@@ -29,10 +29,10 @@ import org.voltdb.utils.SystemStatsCollector;
 public class MemoryStats extends StatsSource {
     static class PartitionMemRow {
         long tupleCount = 0;
-        int tupleDataMem = 0;
-        int tupleAllocatedMem = 0;
+        long tupleDataMem = 0;
+        long tupleAllocatedMem = 0;
         int indexMem = 0;
-        int stringMem = 0;
+        long stringMem = 0;
         long pooledMem = 0;
     }
     Map<Long, PartitionMemRow> m_memoryStats = new TreeMap<Long, PartitionMemRow>();
@@ -74,10 +74,10 @@ public class MemoryStats extends StatsSource {
         columns.add(new VoltTable.ColumnInfo("RSS", VoltType.INTEGER));
         columns.add(new VoltTable.ColumnInfo("JAVAUSED", VoltType.INTEGER));
         columns.add(new VoltTable.ColumnInfo("JAVAUNUSED", VoltType.INTEGER));
-        columns.add(new VoltTable.ColumnInfo("TUPLEDATA", VoltType.INTEGER));
-        columns.add(new VoltTable.ColumnInfo("TUPLEALLOCATED", VoltType.INTEGER));
+        columns.add(new VoltTable.ColumnInfo("TUPLEDATA", VoltType.BIGINT));
+        columns.add(new VoltTable.ColumnInfo("TUPLEALLOCATED", VoltType.BIGINT));
         columns.add(new VoltTable.ColumnInfo("INDEXMEMORY", VoltType.INTEGER));
-        columns.add(new VoltTable.ColumnInfo("STRINGMEMORY", VoltType.INTEGER));
+        columns.add(new VoltTable.ColumnInfo("STRINGMEMORY", VoltType.BIGINT));
         columns.add(new VoltTable.ColumnInfo("TUPLECOUNT", VoltType.BIGINT));
         columns.add(new VoltTable.ColumnInfo("POOLEDMEMORY", VoltType.BIGINT));
         columns.add(new VoltTable.ColumnInfo("PHYSICALMEMORY", VoltType.BIGINT));
@@ -124,10 +124,10 @@ public class MemoryStats extends StatsSource {
 
     public synchronized void eeUpdateMemStats(long siteId,
                                               long tupleCount,
-                                              int tupleDataMem,
-                                              int tupleAllocatedMem,
+                                              long tupleDataMem,
+                                              long tupleAllocatedMem,
                                               int indexMem,
-                                              int stringMem,
+                                              long stringMem,
                                               long pooledMemory) {
         PartitionMemRow pmr = new PartitionMemRow();
         pmr.tupleCount = tupleCount;

--- a/src/frontend/org/voltdb/TableStats.java
+++ b/src/frontend/org/voltdb/TableStats.java
@@ -43,9 +43,9 @@ public class TableStats extends SiteStatsSource {
         columns.add(new ColumnInfo("TABLE_NAME", VoltType.STRING));
         columns.add(new ColumnInfo("TABLE_TYPE", VoltType.STRING));
         columns.add(new ColumnInfo("TUPLE_COUNT", VoltType.BIGINT));
-        columns.add(new ColumnInfo("TUPLE_ALLOCATED_MEMORY", VoltType.INTEGER));
-        columns.add(new ColumnInfo("TUPLE_DATA_MEMORY", VoltType.INTEGER));
-        columns.add(new ColumnInfo("STRING_DATA_MEMORY", VoltType.INTEGER));
+        columns.add(new ColumnInfo("TUPLE_ALLOCATED_MEMORY", VoltType.BIGINT));
+        columns.add(new ColumnInfo("TUPLE_DATA_MEMORY", VoltType.BIGINT));
+        columns.add(new ColumnInfo("STRING_DATA_MEMORY", VoltType.BIGINT));
         columns.add(new ColumnInfo("TUPLE_LIMIT", VoltType.INTEGER));
         columns.add(new ColumnInfo("PERCENT_FULL", VoltType.INTEGER));
     }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -95,9 +95,9 @@ import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.LogKeys;
 import org.voltdb.utils.MinimumRatioMaintainer;
 
-import vanilla.java.affinity.impl.PosixJNAAffinity;
-
 import com.google_voltpatches.common.base.Preconditions;
+
+import vanilla.java.affinity.impl.PosixJNAAffinity;
 
 public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConnection
 {
@@ -1036,10 +1036,10 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
 
             // data to aggregate
             long tupleCount = 0;
-            int tupleDataMem = 0;
-            int tupleAllocatedMem = 0;
+            long tupleDataMem = 0;
+            long tupleAllocatedMem = 0;
             int indexMem = 0;
-            int stringMem = 0;
+            long stringMem = 0;
 
             // update table stats
             final VoltTable[] s1 =
@@ -1054,11 +1054,11 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                     assert(stats.getColumnName(7).equals("TUPLE_COUNT"));
                     tupleCount += stats.getLong(7);
                     assert(stats.getColumnName(8).equals("TUPLE_ALLOCATED_MEMORY"));
-                    tupleAllocatedMem += (int) stats.getLong(8);
+                    tupleAllocatedMem += stats.getLong(8);
                     assert(stats.getColumnName(9).equals("TUPLE_DATA_MEMORY"));
-                    tupleDataMem += (int) stats.getLong(9);
+                    tupleDataMem += stats.getLong(9);
                     assert(stats.getColumnName(10).equals("STRING_DATA_MEMORY"));
-                    stringMem += (int) stats.getLong(10);
+                    stringMem += stats.getLong(10);
                 }
                 stats.resetRowPosition();
 

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1038,7 +1038,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             long tupleCount = 0;
             long tupleDataMem = 0;
             long tupleAllocatedMem = 0;
-            int indexMem = 0;
+            long indexMem = 0;
             long stringMem = 0;
 
             // update table stats

--- a/tests/frontend/org/voltdb/regressionsuites/TestEmptySchema.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestEmptySchema.java
@@ -88,7 +88,7 @@ public class TestEmptySchema extends RegressionSuite
         expectedSchema[8] = new ColumnInfo("IS_UNIQUE", VoltType.TINYINT);
         expectedSchema[9] = new ColumnInfo("IS_COUNTABLE", VoltType.TINYINT);
         expectedSchema[10] = new ColumnInfo("ENTRY_COUNT", VoltType.BIGINT);
-        expectedSchema[11] = new ColumnInfo("MEMORY_ESTIMATE", VoltType.INTEGER);
+        expectedSchema[11] = new ColumnInfo("MEMORY_ESTIMATE", VoltType.BIGINT);
         expectedTable = new VoltTable(expectedSchema);
 
         results = client.callProcedure("@Statistics", "INDEX", 0).getResults();

--- a/tests/frontend/org/voltdb/regressionsuites/TestEmptySchema.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestEmptySchema.java
@@ -25,14 +25,14 @@ package org.voltdb.regressionsuites;
 
 import java.io.IOException;
 
-import junit.framework.Test;
-
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
 import org.voltdb.client.Client;
 import org.voltdb.compiler.VoltProjectBuilder;
+
+import junit.framework.Test;
 
 public class TestEmptySchema extends RegressionSuite
 {
@@ -63,9 +63,9 @@ public class TestEmptySchema extends RegressionSuite
         expectedSchema[5] = new ColumnInfo("TABLE_NAME", VoltType.STRING);
         expectedSchema[6] = new ColumnInfo("TABLE_TYPE", VoltType.STRING);
         expectedSchema[7] = new ColumnInfo("TUPLE_COUNT", VoltType.BIGINT);
-        expectedSchema[8] = new ColumnInfo("TUPLE_ALLOCATED_MEMORY", VoltType.INTEGER);
-        expectedSchema[9] = new ColumnInfo("TUPLE_DATA_MEMORY", VoltType.INTEGER);
-        expectedSchema[10] = new ColumnInfo("STRING_DATA_MEMORY", VoltType.INTEGER);
+        expectedSchema[8] = new ColumnInfo("TUPLE_ALLOCATED_MEMORY", VoltType.BIGINT);
+        expectedSchema[9] = new ColumnInfo("TUPLE_DATA_MEMORY", VoltType.BIGINT);
+        expectedSchema[10] = new ColumnInfo("STRING_DATA_MEMORY", VoltType.BIGINT);
         expectedSchema[11] = new ColumnInfo("TUPLE_LIMIT", VoltType.INTEGER);
         expectedSchema[12] = new ColumnInfo("PERCENT_FULL", VoltType.INTEGER);
         VoltTable expectedTable = new VoltTable(expectedSchema);

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -30,8 +30,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import junit.framework.Test;
-
 import org.HdrHistogram_voltpatches.AbstractHistogram;
 import org.HdrHistogram_voltpatches.Histogram;
 import org.voltcore.utils.CompressionStrategySnappy;
@@ -43,6 +41,8 @@ import org.voltdb.client.ProcCallException;
 import org.voltdb.iv2.MpInitiator;
 import org.voltdb.regressionsuites.StatisticsTestSuiteBase;
 import org.voltdb_testprocs.regressionsuites.malicious.GoSleep;
+
+import junit.framework.Test;
 
 public class TestStatisticsSuite extends StatisticsTestSuiteBase {
 
@@ -292,10 +292,10 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         expectedSchema[3] = new ColumnInfo("RSS", VoltType.INTEGER);
         expectedSchema[4] = new ColumnInfo("JAVAUSED", VoltType.INTEGER);
         expectedSchema[5] = new ColumnInfo("JAVAUNUSED", VoltType.INTEGER);
-        expectedSchema[6] = new ColumnInfo("TUPLEDATA", VoltType.INTEGER);
-        expectedSchema[7] = new ColumnInfo("TUPLEALLOCATED", VoltType.INTEGER);
+        expectedSchema[6] = new ColumnInfo("TUPLEDATA", VoltType.BIGINT);
+        expectedSchema[7] = new ColumnInfo("TUPLEALLOCATED", VoltType.BIGINT);
         expectedSchema[8] = new ColumnInfo("INDEXMEMORY", VoltType.INTEGER);
-        expectedSchema[9] = new ColumnInfo("STRINGMEMORY", VoltType.INTEGER);
+        expectedSchema[9] = new ColumnInfo("STRINGMEMORY", VoltType.BIGINT);
         expectedSchema[10] = new ColumnInfo("TUPLECOUNT", VoltType.BIGINT);
         expectedSchema[11] = new ColumnInfo("POOLEDMEMORY", VoltType.BIGINT);
         expectedSchema[12] = new ColumnInfo("PHYSICALMEMORY", VoltType.BIGINT);

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -294,7 +294,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         expectedSchema[5] = new ColumnInfo("JAVAUNUSED", VoltType.INTEGER);
         expectedSchema[6] = new ColumnInfo("TUPLEDATA", VoltType.BIGINT);
         expectedSchema[7] = new ColumnInfo("TUPLEALLOCATED", VoltType.BIGINT);
-        expectedSchema[8] = new ColumnInfo("INDEXMEMORY", VoltType.INTEGER);
+        expectedSchema[8] = new ColumnInfo("INDEXMEMORY", VoltType.BIGINT);
         expectedSchema[9] = new ColumnInfo("STRINGMEMORY", VoltType.BIGINT);
         expectedSchema[10] = new ColumnInfo("TUPLECOUNT", VoltType.BIGINT);
         expectedSchema[11] = new ColumnInfo("POOLEDMEMORY", VoltType.BIGINT);

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDatabaseElementStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDatabaseElementStats.java
@@ -150,7 +150,7 @@ public class TestStatisticsSuiteDatabaseElementStats extends StatisticsTestSuite
         expectedSchema[8] = new ColumnInfo("IS_UNIQUE", VoltType.TINYINT);
         expectedSchema[9] = new ColumnInfo("IS_COUNTABLE", VoltType.TINYINT);
         expectedSchema[10] = new ColumnInfo("ENTRY_COUNT", VoltType.BIGINT);
-        expectedSchema[11] = new ColumnInfo("MEMORY_ESTIMATE", VoltType.INTEGER);
+        expectedSchema[11] = new ColumnInfo("MEMORY_ESTIMATE", VoltType.BIGINT);
         VoltTable expectedTable = new VoltTable(expectedSchema);
 
         VoltTable[] results = null;

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDatabaseElementStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDatabaseElementStats.java
@@ -29,8 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Test;
-
 import org.hsqldb_voltpatches.HSQLInterface;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
@@ -39,6 +37,8 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.regressionsuites.StatisticsTestSuiteBase;
 import org.voltdb.utils.MiscUtils;
+
+import junit.framework.Test;
 
 public class TestStatisticsSuiteDatabaseElementStats extends StatisticsTestSuiteBase {
 
@@ -96,9 +96,9 @@ public class TestStatisticsSuiteDatabaseElementStats extends StatisticsTestSuite
         expectedSchema[5] = new ColumnInfo("TABLE_NAME", VoltType.STRING);
         expectedSchema[6] = new ColumnInfo("TABLE_TYPE", VoltType.STRING);
         expectedSchema[7] = new ColumnInfo("TUPLE_COUNT", VoltType.BIGINT);
-        expectedSchema[8] = new ColumnInfo("TUPLE_ALLOCATED_MEMORY", VoltType.INTEGER);
-        expectedSchema[9] = new ColumnInfo("TUPLE_DATA_MEMORY", VoltType.INTEGER);
-        expectedSchema[10] = new ColumnInfo("STRING_DATA_MEMORY", VoltType.INTEGER);
+        expectedSchema[8] = new ColumnInfo("TUPLE_ALLOCATED_MEMORY", VoltType.BIGINT);
+        expectedSchema[9] = new ColumnInfo("TUPLE_DATA_MEMORY", VoltType.BIGINT);
+        expectedSchema[10] = new ColumnInfo("STRING_DATA_MEMORY", VoltType.BIGINT);
         expectedSchema[11] = new ColumnInfo("TUPLE_LIMIT", VoltType.INTEGER);
         expectedSchema[12] = new ColumnInfo("PERCENT_FULL", VoltType.INTEGER);
         VoltTable expectedTable = new VoltTable(expectedSchema);


### PR DESCRIPTION
Update column type's for table and memory components of statistics system procedure to BigInt instead of Integer so that the reported memory storage size for does not get reported in negative for values > ~2TB. The updated columns are for reporting non-inlined memory, total block storage for the table (used + free) and storage used by total tuples.