### PR TITLE
ENG-9985: Ignore table row limit when applying DR data.

### DIFF
--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -416,7 +416,7 @@ bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, 
             }
         }
         if (newTuple) {
-            drTable->insertPersistentTuple(*newTuple, true);
+            drTable->insertPersistentTuple(*newTuple, true, true);
         }
     }
 
@@ -539,7 +539,7 @@ int64_t BinaryLogSink::apply(ReferenceSerializeInputLE *taskInfo, const DRRecord
         ReferenceSerializeInputLE rowInput(rowData, rowLength);
         tempTuple.deserializeFromDR(rowInput, pool);
         try {
-            table->insertPersistentTuple(tempTuple, true);
+            table->insertPersistentTuple(tempTuple, true, true);
         } catch (ConstraintFailureException &e) {
             if (engine->getIsActiveActiveDREnabled()) {
                 if (handleConflict(engine, table, pool, NULL, NULL, const_cast<TableTuple *>(e.getConflictTuple()),

--- a/src/ee/storage/CompatibleBinaryLogSink.cpp
+++ b/src/ee/storage/CompatibleBinaryLogSink.cpp
@@ -415,7 +415,7 @@ bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, 
             }
         }
         if (newTuple) {
-            drTable->insertPersistentTuple(*newTuple, true);
+            drTable->insertPersistentTuple(*newTuple, true, true);
         }
     }
 
@@ -486,7 +486,7 @@ int64_t CompatibleBinaryLogSink::apply(ReferenceSerializeInputLE *taskInfo,
         ReferenceSerializeInputLE rowInput(rowData, rowLength);
         tempTuple.deserializeFromDR(rowInput, pool);
         try {
-            table->insertPersistentTuple(tempTuple, true);
+            table->insertPersistentTuple(tempTuple, true, true);
         } catch (ConstraintFailureException &e) {
             if (engine->getIsActiveActiveDREnabled()) {
                 if (handleConflict(engine, table, pool, NULL, NULL, const_cast<TableTuple *>(e.getConflictTuple()), *uniqueId, remoteClusterId, DR_RECORD_INSERT, NO_CONFLICT, CONFLICT_CONSTRAINT_VIOLATION)) {
@@ -745,4 +745,3 @@ int64_t CompatibleBinaryLogSink::apply(ReferenceSerializeInputLE *taskInfo,
 }
 
 }
-

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -452,10 +452,10 @@ bool PersistentTable::insertTuple(TableTuple &source)
     return true;
 }
 
-void PersistentTable::insertPersistentTuple(TableTuple &source, bool fallible)
+void PersistentTable::insertPersistentTuple(TableTuple &source, bool fallible, bool ignoreTupleLimit)
 {
 
-    if (fallible && visibleTupleCount() >= m_tupleLimit) {
+    if (!ignoreTupleLimit && fallible && visibleTupleCount() >= m_tupleLimit) {
         char buffer [256];
         snprintf (buffer, 256, "Table %s exceeds table maximum row count %d",
                 m_name.c_str(), m_tupleLimit);

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -296,7 +296,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     // ------------------------------------------------------------------
     void deleteTupleForSchemaChange(TableTuple &target);
 
-    void insertPersistentTuple(TableTuple &source, bool fallible);
+    void insertPersistentTuple(TableTuple &source, bool fallible, bool ignoreTupleLimit=false);
 
     /// This is not used in any production code path -- it is a convenient wrapper used by tests.
     bool updateTuple(TableTuple &targetTupleToUpdate, TableTuple &sourceTupleWithNewValues)

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -1939,6 +1939,23 @@ TEST_F(DRBinaryLogTest, DeleteOverBufferLimit) {
     ASSERT_TRUE(false);
 }
 
+TEST_F(DRBinaryLogTest, IgnoreTableRowLimit) {
+    m_tableReplica->setTupleLimit(100);
+
+    const int total = 101;
+    int spHandle = 1;
+
+    for (int i = 1; i <= total; i++, spHandle++) {
+        beginTxn(m_engine, spHandle, spHandle, spHandle-1, spHandle);
+        insertTuple(m_table, prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+        endTxn(m_engine, true);
+    }
+
+    flushAndApply(spHandle - 1);
+
+    EXPECT_EQ(101, m_tableReplica->activeTupleCount());
+}
+
 int main() {
     return TestSuite::globalInstance()->runAll();
 }

--- a/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
@@ -217,8 +217,7 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T1;";
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, replicaSchema);
-        assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("field tuplelimit in schema object Table{T1}"));
+        assertTrue(diff.errors(), diff.supported());
     }
 
     @Test
@@ -233,8 +232,7 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T1;";
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, replicaSchema);
-        assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("field tuplelimit in schema object Table{T1}"));
+        assertTrue(diff.errors(), diff.supported());
     }
 
     @Test
@@ -249,8 +247,7 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T1;";
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, replicaSchema);
-        assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("field tuplelimit in schema object Table{T1}"));
+        assertTrue(diff.errors(), diff.supported());
     }
 
     @Test
@@ -265,8 +262,7 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T1;";
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, replicaSchema);
-        assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Statement{limit_delete} from Table{T1} on master"));
+        assertTrue(diff.errors(), diff.supported());
     }
 
     @Test
@@ -281,8 +277,7 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T1;";
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, replicaSchema);
-        assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Statement{limit_delete} from Table{T1} on replica"));
+        assertTrue(diff.errors(), diff.supported());
     }
 
     @Test
@@ -297,8 +292,7 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T1;";
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, replicaSchema);
-        assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("field sqltext in schema object Statement{limit_delete}"));
+        assertTrue(diff.errors(), diff.supported());
     }
 
     @Test
@@ -313,8 +307,7 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T1;";
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, replicaSchema);
-        assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("field sqltext in schema object Statement{limit_delete}"));
+        assertTrue(diff.errors(), diff.supported());
     }
 
     @Test
@@ -329,8 +322,7 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T1;";
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, replicaSchema);
-        assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("field sqltext in schema object Statement{limit_delete}"));
+        assertTrue(diff.errors(), diff.supported());
     }
 
     @Test
@@ -345,8 +337,7 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T1;";
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, replicaSchema);
-        assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("field tuplelimit in schema object Table{T1}"));
+        assertTrue(diff.errors(), diff.supported());
     }
 
     @Test


### PR DESCRIPTION
- Ignore table row limit when applying DR data.
- Allow different table row limits/delete policies on master and replica clusters.