### PR TITLE
ENG-10135: Fix XDCR timestmap mismatch conflict handling.

### DIFF
--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -97,6 +97,8 @@ namespace voltdb {
         this->actionType = action;
         this->deleteConflictType = deleteConflict;
         this->insertConflictType = insertConflict;
+        this->remoteClusterId = remoteClusterId;
+        this->remoteTimestamp = remoteTimestamp;
         char signature[20];
 
         if (existingMetaTableForDelete) {

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -128,6 +128,8 @@ public:
     DRRecordType actionType;
     DRConflictType deleteConflictType;
     DRConflictType insertConflictType;
+    int32_t remoteClusterId;
+    int64_t remoteTimestamp;
     boost::shared_ptr<Table> existingMetaRowsForDelete;
     boost::shared_ptr<Table> existingTupleRowsForDelete;
     boost::shared_ptr<Table> expectedMetaRowsForDelete;

--- a/src/ee/common/UniqueId.hpp
+++ b/src/ee/common/UniqueId.hpp
@@ -62,8 +62,15 @@ public:
         return pid(uid) == MP_INIT_PID;
     }
 
-    static int64_t timestampAndCounter(UniqueId uid) {
-        return (uid >> PARTITIONID_BITS) & TIMESTAMP_PLUS_COUNTER_MAX_VALUE;
+    static int64_t timestampSinceUnixEpoch(UniqueId uid) {
+        return tsCounterSinceUnixEpoch((uid >> PARTITIONID_BITS) & TIMESTAMP_PLUS_COUNTER_MAX_VALUE);
+    }
+
+    // Convert this into a microsecond-resolution timestamp based on Unix epoch;
+    // treat the time portion as the time in milliseconds, and the sequence
+    // number as if it is a time in microseconds
+    static int64_t tsCounterSinceUnixEpoch(int64_t tsCounter) {
+        return (tsCounter >> COUNTER_BITS) * 1000 + VOLT_EPOCH + (tsCounter & COUNTER_MAX_VALUE);
     }
 
     const int64_t uid;

--- a/src/ee/common/executorcontext.hpp
+++ b/src/ee/common/executorcontext.hpp
@@ -23,6 +23,7 @@
 #include "common/valuevector.h"
 #include "common/subquerycontext.h"
 #include "common/ValuePeeker.hpp"
+#include "common/UniqueId.hpp"
 
 #include <vector>
 #include <map>
@@ -119,16 +120,12 @@ class ExecutorContext {
         return (clusterId << 49) | (uniqueId >> 14);
     }
 
-    static int64_t getDRTimestampFromHiddenNValue(NValue &value) {
+    static int64_t getDRTimestampFromHiddenNValue(const NValue &value) {
         int64_t hiddenValue = ValuePeeker::peekAsBigInt(value);
-        // Convert this into a microsecond-resolution timestamp; treat the time
-        // portion as the time in milliseconds, and the sequence number as if
-        // it is a time in microseconds
-        int64_t ts = hiddenValue & ((1LL << 49) - 1LL);
-        return (ts >> 9) * 1000 + VOLT_EPOCH + (ts & 0x1ff);
+        return UniqueId::tsCounterSinceUnixEpoch(hiddenValue & ((1LL << 49) - 1LL));
     }
 
-    static int8_t getClusterIdFromHiddenNValue(NValue &value) {
+    static int8_t getClusterIdFromHiddenNValue(const NValue &value) {
         int64_t hiddenValue = ValuePeeker::peekAsBigInt(value);
         return static_cast<int8_t>(hiddenValue >> 49);
     }

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -365,6 +365,9 @@ bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, 
     }
 
     if (newTuple) {
+        assert(ExecutorContext::getDRTimestampFromHiddenNValue(newTuple->getHiddenNValue(drTable->getDRTimestampColumnIndex()))
+               == UniqueId::timestampSinceUnixEpoch(uniqueId));
+
         newMetaTableForInsert.reset(TableFactory::getCopiedTempTable(0, NEW_TABLE, conflictExportTable, NULL));
         newTupleTableForInsert.reset(TableFactory::getCopiedTempTable(0, NEW_TABLE, drTable, NULL));
         createConflictExportTuple(newMetaTableForInsert.get(), newTupleTableForInsert.get(),
@@ -373,7 +376,7 @@ bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, 
 
     int retval = ExecutorContext::getExecutorContext()->getTopend()->reportDRConflict(static_cast<int32_t>(UniqueId::pid(uniqueId)),
                                                                                       remoteClusterId,
-                                                                                      UniqueId::timestampAndCounter(uniqueId),
+                                                                                      UniqueId::timestampSinceUnixEpoch(uniqueId),
                                                                                       drTable->name(),
                                                                                       actionType,
                                                                                       deleteConflict,

--- a/src/ee/storage/CompatibleBinaryLogSink.cpp
+++ b/src/ee/storage/CompatibleBinaryLogSink.cpp
@@ -372,7 +372,7 @@ bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, 
 
     int retval = ExecutorContext::getExecutorContext()->getTopend()->reportDRConflict(static_cast<int32_t>(UniqueId::pid(uniqueId)),
                                                                                       remoteClusterId,
-                                                                                      UniqueId::timestampAndCounter(uniqueId),
+                                                                                      UniqueId::timestampSinceUnixEpoch(uniqueId),
                                                                                       drTable->name(),
                                                                                       actionType,
                                                                                       deleteConflict,
@@ -745,4 +745,3 @@ int64_t CompatibleBinaryLogSink::apply(ReferenceSerializeInputLE *taskInfo,
 }
 
 }
-

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -196,9 +196,9 @@ public:
         m_replicatedTableReplica = reinterpret_cast<PersistentTable*>(voltdb::TableFactory::getPersistentTable(0, "R_TABLE_REPLICA", m_replicatedSchemaReplica, columnNames, replicatedTableHandle, false, -1));
 
         m_table->setDR(true);
-        m_tableReplica->setDR(true);
+        m_tableReplica->setDR(false);
         m_replicatedTable->setDR(true);
-        m_replicatedTableReplica->setDR(true);
+        m_replicatedTableReplica->setDR(false);
 
         std::vector<ValueType> otherColumnTypes;
         std::vector<int32_t> otherColumnLengths;
@@ -501,9 +501,16 @@ public:
         }
     }
 
-    TableTuple verifyExistingTableForDelete(TableTuple &existingTuple) {
+    TableTuple verifyExistingTableForDelete(TableTuple &existingTuple, bool existingOlder) {
+        Table *metaTable = m_topend.existingMetaRowsForDelete.get();
+        TableTuple tempMetaTuple(metaTable->schema());
+        TableIterator metaIter = metaTable->iterator();
+        EXPECT_EQ(true, metaIter.next(tempMetaTuple));
+        EXPECT_EQ(existingOlder, ValuePeeker::peekAsBigInt(tempMetaTuple.getNValue(metaTable->columnIndex("TIMESTAMP"))) < m_topend.remoteTimestamp);
+
         TableTuple tuple = reinterpret_cast<PersistentTable*>(m_topend.existingTupleRowsForDelete.get())->lookupTupleForDR(existingTuple);
         EXPECT_EQ(tuple.isNullTuple(), false);
+
         return tuple;
     }
 
@@ -1374,7 +1381,7 @@ TEST_F(DRBinaryLogTest, DetectDeleteTimestampMismatch) {
     EXPECT_EQ(m_topend.deleteConflictType, CONFLICT_EXPECTED_ROW_MISMATCH);
     // verify existing table
     EXPECT_EQ(1, m_topend.existingTupleRowsForDelete->activeTupleCount());
-    /*TableTuple exportTuple1 = */verifyExistingTableForDelete(existingTuple);
+    /*TableTuple exportTuple1 = */verifyExistingTableForDelete(existingTuple, true);
     // verify expected table
     EXPECT_EQ(1, m_topend.expectedTupleRowsForDelete->activeTupleCount());
     /*TableTuple exportTuple2 = */verifyExpectedTableForDelete(expectedTuple);
@@ -1639,14 +1646,14 @@ TEST_F(DRBinaryLogTest, DetectUpdateMissingTupleAndNewRowConstraint) {
  * |      | insert 24 (pk), 2321 (uk), Y            | insert 24 (pk), 2321 (uk), Y             |
  * |      | insert 72 (pk), 345 (uk), Z             | insert 72 (pk), 345 (uk), Z              |
  * | T71  |                                         | update <42, 55555, X> to <42, 12345, X>  |
- * | T72  | update <42, 55555, X> to <42, 12345, X> |                                          |
+ * | T72  | update <42, 55555, X> to <42, 54321, X> |                                          |
  *
  * DB B reports: <DELETE timestamp mismatch>
  * existingRow: <42, 12345, X>
  * expectedRow: <42, 55555, X>
  *               <INSERT no conflict>
  * existingRow: <null>
- * newRow:      <42, 12345, X>
+ * newRow:      <42, 54321, X>
  */
 TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatch) {
     m_engine->setIsActiveActiveDREnabled(true);
@@ -1682,7 +1689,7 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatch) {
 
     // update the same row on master then wait to trigger conflict on replica
     beginTxn(m_engine, 101, 101, 100, 72);
-    TableTuple tempNewTuple = updateTupleFirstAndSecondColumn(m_table, tempExpectedTuple, 42, 12345);
+    TableTuple tempNewTuple = updateTupleFirstAndSecondColumn(m_table, tempExpectedTuple, 42, 54321);
     // do a deep copy because temp tuple of table will be overwritten later
     TableTuple newTuple (m_table->schema());
     boost::shared_array<char> newData;
@@ -1698,7 +1705,91 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatch) {
     EXPECT_EQ(m_topend.deleteConflictType, CONFLICT_EXPECTED_ROW_MISMATCH);
     // verify existing table
     EXPECT_EQ(1, m_topend.existingTupleRowsForDelete->activeTupleCount());
-    /*TableTuple exportTuple1 = */verifyExistingTableForDelete(existingTuple);
+    /*TableTuple exportTuple1 = */verifyExistingTableForDelete(existingTuple, true);
+    // verify expected table
+    EXPECT_EQ(1, m_topend.expectedTupleRowsForDelete->activeTupleCount());
+    /*TableTuple exportTuple2 = */verifyExpectedTableForDelete(expectedTuple);
+
+    // 2. check insert conflict part
+    EXPECT_EQ(m_topend.insertConflictType, NO_CONFLICT);
+    ASSERT_TRUE(m_topend.existingTupleRowsForInsert.get() == NULL);
+    EXPECT_EQ(1, m_topend.newTupleRowsForInsert->activeTupleCount());
+    /*TableTuple exportTuple3 = */verifyNewTableForInsert(newTuple);
+
+    // 3. check export
+    MockExportTupleStream *exportStream = reinterpret_cast<MockExportTupleStream*>(m_engineReplica->getExportTupleStream());
+    EXPECT_EQ(3, exportStream->receivedTuples.size());
+}
+
+/*
+ * Conflict detection test case - Update Timestamp Mismatch Rejected
+ *
+ * | Time | DB A                                    | DB B                                     |
+ * |------+-----------------------------------------+------------------------------------------|
+ * | T70  | insert 42 (pk), 55555 (uk), X           | insert 42 (pk), 55555 (uk), X            |
+ * |      | insert 24 (pk), 2321 (uk), Y            | insert 24 (pk), 2321 (uk), Y             |
+ * |      | insert 72 (pk), 345 (uk), Z             | insert 72 (pk), 345 (uk), Z              |
+ * | T71  | update <42, 55555, X> to <42, 12345, X> |                                          |
+ * | T72  |                                         | update <42, 55555, X> to <42, 54321, X>  |
+ *
+ * DB B reports: <DELETE timestamp mismatch>
+ * existingRow: <42, 54321, X>
+ * expectedRow: <42, 55555, X>
+ *               <INSERT no conflict>
+ * existingRow: <null>
+ * newRow:      <42, 12345, X>
+ */
+TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatchRejected) {
+    m_engine->setIsActiveActiveDREnabled(true);
+    m_engineReplica->setIsActiveActiveDREnabled(true);
+    createUniqueIndex(m_table, 0, true);
+    createUniqueIndex(m_tableReplica, 0, true);
+    createUniqueIndex(m_table, 1);
+    createUniqueIndex(m_tableReplica, 1);
+
+    // insert one row on both side
+    beginTxn(m_engine, 99, 99, 98, 70);
+    TableTuple tempExpectedTuple = insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
+    // do a deep copy because temp tuple of table will be overwritten later
+    TableTuple expectedTuple (m_table->schema());
+    boost::shared_array<char> expectedData;
+    expectedData = deepCopy(tempExpectedTuple, expectedTuple, expectedData);
+    StackCleaner expectedTupleCleaner(expectedTuple);
+    insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
+    insertTuple(m_table, prepareTempTuple(m_table, 72, 345, "4256.345", "something", "more tuple data, really not the same", 1812));
+    endTxn(m_engine, true);
+    flushAndApply(99);
+
+    // update one row on replica
+    beginTxn(m_engine, 100, 100, 99, 71);
+    TableTuple tempNewTuple = updateTupleFirstAndSecondColumn(m_table, tempExpectedTuple, 42, 12345);
+    // do a deep copy because temp tuple of table will be overwritten later
+    TableTuple newTuple (m_table->schema());
+    boost::shared_array<char> newData;
+    newData = deepCopy(tempNewTuple, newTuple, newData);
+    StackCleaner newTupleCleaner(newTuple);
+    endTxn(m_engine, true);
+    flush(100);
+
+    // update the same row on master then wait to trigger conflict on replica
+    beginTxn(m_engine, 101, 101, 100, 72);
+    TableTuple tempExistingTuple = updateTupleFirstAndSecondColumn(m_tableReplica, tempExpectedTuple, 42, 54321);
+    // do a deep copy because temp tuple of relica table will be overwritten when applying binary log
+    TableTuple existingTuple (m_tableReplica->schema());
+    boost::shared_array<char> existingData;
+    existingData = deepCopy(tempExistingTuple, existingTuple, existingData);
+    StackCleaner existingTupleCleaner(existingTuple);
+    endTxn(m_engine, true);
+    // trigger a update timestamp mismatch conflict
+    flushAndApply(101);
+
+    EXPECT_EQ(m_topend.actionType, DR_RECORD_UPDATE);
+
+    // 1. check delete conflict part
+    EXPECT_EQ(m_topend.deleteConflictType, CONFLICT_EXPECTED_ROW_MISMATCH);
+    // verify existing table
+    EXPECT_EQ(1, m_topend.existingTupleRowsForDelete->activeTupleCount());
+    /*TableTuple exportTuple1 = */verifyExistingTableForDelete(existingTuple, false);
     // verify expected table
     EXPECT_EQ(1, m_topend.expectedTupleRowsForDelete->activeTupleCount());
     /*TableTuple exportTuple2 = */verifyExpectedTableForDelete(expectedTuple);
@@ -1784,7 +1875,7 @@ TEST_F(DRBinaryLogTest, DetectUpdateTimestampMismatchAndNewRowConstraint) {
     EXPECT_EQ(m_topend.deleteConflictType, CONFLICT_EXPECTED_ROW_MISMATCH);
     // verify existing table
     EXPECT_EQ(1, m_topend.existingTupleRowsForDelete->activeTupleCount());
-    /*TableTuple exportTuple1 = */verifyExistingTableForDelete(existingTupleFirst);
+    /*TableTuple exportTuple1 = */verifyExistingTableForDelete(existingTupleFirst, true);
     // verify expected table
     EXPECT_EQ(1, m_topend.expectedTupleRowsForDelete->activeTupleCount());
     /*TableTuple exportTuple2 = */verifyExpectedTableForDelete(expectedTuple);


### PR DESCRIPTION
When a timestamp mismatch conflict occurs, the resolver receives
incorrect timestamps for comparison. The timestamp for the remote
operation is Volt-epoch-based, but the local existing tuple's timestamp
is Unix-epoch-based. This resulted in always rejecting remote changes.

Now all timestamps passed to the resolver are Unix-epoch-based.