### PR TITLE
Handle incompatible param types to timestamp sql functions in EE

### DIFF
--- a/src/ee/expressions/datefunctions.h
+++ b/src/ee/expressions/datefunctions.h
@@ -133,6 +133,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_YEAR>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -144,6 +149,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_MONTH>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -155,6 +165,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_DAY>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -166,6 +181,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_DAY_OF_WEEK>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -179,6 +199,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_WEEKDAY>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -190,6 +215,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_WEEK_OF_YEAR>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -201,6 +231,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_DAY_OF_YEAR>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -212,6 +247,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_QUARTER>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -223,6 +263,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_HOUR>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::posix_time::time_duration as_time;
     micros_to_time(epoch_micros, as_time);
@@ -234,6 +279,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_MINUTE>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::posix_time::time_duration as_time;
     micros_to_time(epoch_micros, as_time);
@@ -245,6 +295,11 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_SECOND>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::posix_time::time_duration as_time;
     micros_to_time(epoch_micros, as_time);
@@ -265,6 +320,11 @@ template<> inline NValue NValue::callUnary<FUNC_SINCE_EPOCH_SECOND>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     int64_t epoch_seconds = epoch_micros / 1000000;
     return getBigIntValue(epoch_seconds);
@@ -275,6 +335,11 @@ template<> inline NValue NValue::callUnary<FUNC_SINCE_EPOCH_MILLISECOND>() const
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     int64_t epoch_milliseconds = epoch_micros / 1000;
     return getBigIntValue(epoch_milliseconds);
@@ -285,6 +350,11 @@ template<> inline NValue NValue::callUnary<FUNC_SINCE_EPOCH_MICROSECOND>() const
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     return getBigIntValue(epoch_micros);
 }
@@ -323,6 +393,11 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_YEAR>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -335,6 +410,11 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_QUARTER>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -348,6 +428,11 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_MONTH>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -360,6 +445,11 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_DAY>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     micros_to_date(epoch_micros, as_date);
@@ -373,6 +463,11 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_HOUR>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     boost::posix_time::time_duration as_time;
@@ -387,6 +482,11 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_MINUTE>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     boost::posix_time::time_duration as_time;
@@ -401,6 +501,11 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_SECOND>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     boost::posix_time::time_duration as_time;
@@ -415,6 +520,11 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_MILLISECOND>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     int64_t epoch_millis = static_cast<int64_t>(epoch_micros / 1000);
     if (epoch_micros < 0) {
@@ -428,6 +538,11 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_MICROSECOND>() const {
     if (isNull()) {
         return *this;
     }
+
+    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     int64_t epoch_micros = getTimestamp();
     return getTimestampValue(epoch_micros);
 }
@@ -454,6 +569,10 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_YEAR>(const std::vector<
     int64_t interval = number.castAsBigIntAndGetValue();
     if (interval > PTIME_MAX_YEAR_INTERVAL || interval < PTIME_MIN_YEAR_INTERVAL) {
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
+    }
+
+    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
     boost::posix_time::ptime ts;
@@ -486,6 +605,10 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_QUARTER>(const std::vect
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
+    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     return getTimestampValue(addMonths(date.getTimestamp(), 3 * interval));
 }
 
@@ -507,6 +630,10 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_MONTH>(const std::vector
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
+    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     return getTimestampValue(addMonths(date.getTimestamp(), interval));
 }
 
@@ -526,6 +653,10 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_DAY>(const std::vector<N
     int64_t interval = number.castAsBigIntAndGetValue();
     if (interval > PTIME_MAX_DAY_INTERVAL || interval < PTIME_MIN_DAY_INTERVAL) {
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
+    }
+
+    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
     boost::posix_time::ptime ts;
@@ -558,6 +689,10 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_HOUR>(const std::vector<
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
+    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     boost::posix_time::ptime ts;
     micros_to_ptime(date.getTimestamp(), ts);
 
@@ -586,6 +721,10 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_MINUTE>(const std::vecto
     int64_t interval = number.castAsBigIntAndGetValue();
     if (interval > PTIME_MAX_MINUTE_INTERVAL || interval < PTIME_MIN_MINUTE_INTERVAL) {
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
+    }
+
+    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
     boost::posix_time::ptime ts;
@@ -618,6 +757,10 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_SECOND>(const std::vecto
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
+    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     boost::posix_time::ptime ts;
     micros_to_ptime(date.getTimestamp(), ts);
 
@@ -648,6 +791,10 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_MILLISECOND>(const std::
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
+    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
+    }
+
     boost::posix_time::ptime ts;
     micros_to_ptime(date.getTimestamp(), ts);
 
@@ -676,6 +823,10 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_MICROSECOND>(const std::
     int64_t interval = number.castAsBigIntAndGetValue();
     if (interval > PTIME_MAX_MICROSECOND_INTERVAL || interval < PTIME_MIN_MICROSECOND_INTERVAL) {
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
+    }
+
+    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+        throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
     boost::posix_time::ptime ts;

--- a/src/ee/expressions/datefunctions.h
+++ b/src/ee/expressions/datefunctions.h
@@ -134,7 +134,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_YEAR>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -150,7 +150,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_MONTH>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -166,7 +166,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_DAY>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -182,7 +182,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_DAY_OF_WEEK>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -200,7 +200,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_WEEKDAY>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -216,7 +216,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_WEEK_OF_YEAR>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -232,7 +232,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_DAY_OF_YEAR>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -248,7 +248,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_QUARTER>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -264,7 +264,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_HOUR>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -280,7 +280,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_MINUTE>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -296,7 +296,7 @@ template<> inline NValue NValue::callUnary<FUNC_EXTRACT_SECOND>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -321,7 +321,7 @@ template<> inline NValue NValue::callUnary<FUNC_SINCE_EPOCH_SECOND>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -336,7 +336,7 @@ template<> inline NValue NValue::callUnary<FUNC_SINCE_EPOCH_MILLISECOND>() const
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -351,7 +351,7 @@ template<> inline NValue NValue::callUnary<FUNC_SINCE_EPOCH_MICROSECOND>() const
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -394,7 +394,7 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_YEAR>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -411,7 +411,7 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_QUARTER>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -429,7 +429,7 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_MONTH>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -446,7 +446,7 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_DAY>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -464,7 +464,7 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_HOUR>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -483,7 +483,7 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_MINUTE>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -502,7 +502,7 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_SECOND>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -521,7 +521,7 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_MILLISECOND>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -539,7 +539,7 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_MICROSECOND>() const {
         return *this;
     }
 
-    if(getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -571,7 +571,7 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_YEAR>(const std::vector<
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
-    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (date.getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -605,7 +605,7 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_QUARTER>(const std::vect
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
-    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (date.getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -630,7 +630,7 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_MONTH>(const std::vector
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
-    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (date.getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -655,7 +655,7 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_DAY>(const std::vector<N
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
-    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (date.getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -689,7 +689,7 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_HOUR>(const std::vector<
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
-    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (date.getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -723,7 +723,7 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_MINUTE>(const std::vecto
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
-    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (date.getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -757,7 +757,7 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_SECOND>(const std::vecto
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
-    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (date.getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -791,7 +791,7 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_MILLISECOND>(const std::
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
-    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (date.getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 
@@ -825,7 +825,7 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_MICROSECOND>(const std::
         throw SQLException(SQLException::data_exception_numeric_value_out_of_range, "interval is too large for DATEADD function");
     }
 
-    if(date.getValueType() != VALUE_TYPE_TIMESTAMP) {
+    if (date.getValueType() != VALUE_TYPE_TIMESTAMP) {
         throwCastSQLException(date.getValueType(), VALUE_TYPE_TIMESTAMP);
     }
 

--- a/src/ee/expressions/logicfunctions.h
+++ b/src/ee/expressions/logicfunctions.h
@@ -21,8 +21,8 @@ namespace voltdb {
 
 /** implement the 2n/2n+1-argument DECODE function */
 template<> inline NValue NValue::call<FUNC_DECODE>(const std::vector<NValue>& arguments) {
-    int size = (int)arguments.size();
-    assert(size>=3);
+    int size = static_cast <int> (arguments.size());
+    assert(size >=3);
     int loopnum = ( size - 1 )/2;
     const NValue& baseval = arguments[0];
     for ( int i = 0; i < loopnum; i++ ) {

--- a/src/ee/expressions/stringfunctions.h
+++ b/src/ee/expressions/stringfunctions.h
@@ -40,8 +40,9 @@ namespace voltdb {
 
 /** implement the 1-argument SQL OCTET_LENGTH function */
 template<> inline NValue NValue::callUnary<FUNC_OCTET_LENGTH>() const {
-    if (isNull())
+    if (isNull()) {
         return getNullValue();
+    }
     int32_t length;
     getObject_withoutNull(&length);
     return getIntegerValue(length);
@@ -49,8 +50,9 @@ template<> inline NValue NValue::callUnary<FUNC_OCTET_LENGTH>() const {
 
 /** implement the 1-argument SQL CHAR function */
 template<> inline NValue NValue::callUnary<FUNC_CHAR>() const {
-    if (isNull())
+    if (isNull()) {
         return getNullValue();
+    }
 
     unsigned int point = static_cast<unsigned int>(castAsBigIntAndGetValue());
     std::string utf8 = boost::locale::conv::utf_to_utf<char>(&point, &point + 1);
@@ -60,8 +62,9 @@ template<> inline NValue NValue::callUnary<FUNC_CHAR>() const {
 
 /** implement the 1-argument SQL CHAR_LENGTH function */
 template<> inline NValue NValue::callUnary<FUNC_CHAR_LENGTH>() const {
-    if (isNull())
+    if (isNull()) {
         return getNullValue();
+    }
 
     int32_t lenValue;
     const char* valueChars = getObject_withoutNull(&lenValue);
@@ -70,8 +73,9 @@ template<> inline NValue NValue::callUnary<FUNC_CHAR_LENGTH>() const {
 
 /** implement the 1-argument SQL SPACE function */
 template<> inline NValue NValue::callUnary<FUNC_SPACE>() const {
-    if (isNull())
+    if (isNull()) {
         return getNullStringValue();
+    }
 
     int32_t count = static_cast<int32_t>(castAsBigIntAndGetValue());
     if (count < 0) {
@@ -86,8 +90,9 @@ template<> inline NValue NValue::callUnary<FUNC_SPACE>() const {
 }
 
 template<> inline NValue NValue::callUnary<FUNC_FOLD_LOWER>() const {
-    if (isNull())
+    if (isNull()) {
         return getNullStringValue();
+    }
 
     if (getValueType() != VALUE_TYPE_VARCHAR) {
         throwCastSQLException (getValueType(), VALUE_TYPE_VARCHAR);

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BadParamTypesForTimestamp.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BadParamTypesForTimestamp.java
@@ -1,0 +1,113 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.regressionsuites.failureprocs;
+
+import java.math.BigDecimal;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+
+public class BadParamTypesForTimestamp extends VoltProcedure {
+    private final static SQLStmt m_twoDaysFromTime = new SQLStmt("Select * from P2 where DATEADD(DAY, 2, ?) > TM order by ID");
+    private final static SQLStmt m_twoMonthsFromTime = new SQLStmt("Select * from P2 where DATEADD(MONTH, 2, ?) > TM order by ID");
+    private final static SQLStmt m_twoYearsFromTime = new SQLStmt("Select * from P2 where DATEADD(Year, 2, ?) > TM order by ID");
+
+    private final static SQLStmt m_sinceEpochSecond= new SQLStmt("Select * from P2 where since_epoch(second, ?) = 1000 order by ID");
+    private final static SQLStmt m_sinceEpochMilliSec = new SQLStmt("Select * from P2 where since_epoch(millis, ?) = 1000 order by ID");
+    private final static SQLStmt m_sinceEpochMicrosSec = new SQLStmt("Select * from P2 where since_epoch(micros, ?) = 1000 order by ID");
+
+    private final static SQLStmt m_truncateYear = new SQLStmt("Select truncate(YEAR, ?) from P2  order by ID");
+    private final static SQLStmt m_truncateQuarter= new SQLStmt("Select truncate(Quarter, ?) from P2  order by ID");
+    private final static SQLStmt m_truncateMonth= new SQLStmt("Select truncate(Month, ?) from P2  order by ID");
+    private final static SQLStmt m_truncateDay = new SQLStmt("Select truncate(Day, ?) from P2  order by ID");
+    private final static SQLStmt m_truncateHour= new SQLStmt("Select truncate(Hour, ?) from P2  order by ID");
+    private final static SQLStmt m_truncateMinute = new SQLStmt("Select truncate(Minute, ?) from P2  order by ID");
+    private final static SQLStmt m_truncateSecond = new SQLStmt("Select truncate(Second, ?) from P2  order by ID");
+    private final static SQLStmt m_truncateMilli = new SQLStmt("Select truncate(MILLIS, ?) from P2  order by ID");
+
+    /*
+    // SQL statements below are commented out as parameterization of timestamp (TS) argument is not
+    // supported. Revisit logic below to see the commented out sql statements can be enabled once
+    // ENG-10145 has been addressed. When enabling statements, please add these sql statements to
+    // ProcEntries also.
+    public final static SQLStmt m_getSecondDaysTS = new SQLStmt("Select * from P2 where DAY(?) = 2 order by ID");
+    public final static SQLStmt m_getSecondMonthsTS = new SQLStmt("Select * from P2 where MONTH(?) = 2 order by ID");
+    public final static SQLStmt m_getSecondYearTS = new SQLStmt("Select * from P2 where YEAR(?) = 2 order by ID");
+    public final static SQLStmt m_extractYear = new SQLStmt("Select extract(YEAR, ?) from P2  order by ID");
+    public final static SQLStmt m_extractQuarter= new SQLStmt("Select extract(Quarter, ?) from P2  order by ID");
+    public final static SQLStmt m_extractMonth= new SQLStmt("Select extract(Month, ?) from P2  order by ID");
+    public final static SQLStmt m_extractWeek = new SQLStmt("Select extract(Week from ?) from P2  order by ID");
+    public final static SQLStmt m_extractDay = new SQLStmt("Select extract(Day, ?) from P2  order by ID");
+    public final static SQLStmt m_extractDayOfMonth = new SQLStmt("Select extract(Day_OF_MOTNH, ?) from P2 order by ID");
+    public final static SQLStmt m_extractHour= new SQLStmt("Select extract(Hour from ?) from P2  order by ID");
+    public final static SQLStmt m_extractMinute = new SQLStmt("Select extract(Minute, ?) from P2  order by ID");
+    public final static SQLStmt m_extractSecond = new SQLStmt("Select extract(Second, ?) from P2  order by ID");
+    public final static SQLStmt m_extractMilli = new SQLStmt("Select extract(MILLIS, ?) from P2  order by ID");
+    */
+
+    private final static byte tinyIntValue = 127;
+    private final static short shortValue = 255;
+    private final static int intValue = 1000;
+    private final static long longValue = 1000000;
+    private final static double doubleValue = 1232324;
+    private final static BigDecimal bgValue = new BigDecimal(doubleValue);
+    private final static String strValue = "2000-04-01 01:00:00.000000";
+
+    public static enum ProcEntries {
+        DateaddDays (m_twoDaysFromTime),
+        DateaddMonths(m_twoMonthsFromTime),
+        DateaddYears(m_twoYearsFromTime),
+        EpochSeconds(m_sinceEpochSecond),
+        EpochMilliSeconds(m_sinceEpochMilliSec),
+        EpochMircoSeconds(m_sinceEpochMicrosSec),
+        TruncateYear(m_truncateYear),
+        TruncateQuarter(m_truncateQuarter),
+        TruncateMonth(m_truncateMonth),
+        TruncateDay(m_truncateDay),
+        TruncateHour(m_truncateHour),
+        TruncateMinute(m_truncateMinute),
+        TruncateSecond(m_truncateSecond),
+        TruncateMilli(m_truncateMilli);
+
+        ProcEntries (SQLStmt stmt) {
+            this.stmt = stmt;
+        }
+        public SQLStmt getStmt() {
+            return stmt;
+        }
+        private SQLStmt stmt;
+    }
+
+    public static final ProcEntries[] procs =  ProcEntries.values();
+    public final static Object[] values = {tinyIntValue, shortValue, intValue, longValue,
+                                           doubleValue, bgValue, strValue};
+
+    public VoltTable[] run(int procEntryIndex, int valueIndex) {
+        assert (procEntryIndex < procs.length);
+        assert (valueIndex < values.length);
+        voltQueueSQL(procs[procEntryIndex].getStmt(), values[valueIndex]);
+        return voltExecuteSQL();
+    }
+}


### PR DESCRIPTION
Updated logic to generate exception if the caller supplies value of different type for timestamp function where timestamp value is expected and if conversion of value of given type to timestamp is not applied.