### PR TITLE
ENG-9977, bug fix, DR consumer doesn't send sync snapshot request whe…

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -17,11 +17,6 @@
 
 package org.voltdb;
 
-import java.util.concurrent.ExecutionException;
-
-import org.apache.zookeeper_voltpatches.KeeperException;
-
-
 // Interface through which the outside world can interact with the consumer side
 // of DR. Currently, there's not much to do here, since the subsystem is
 // largely self-contained
@@ -37,30 +32,4 @@ public interface ConsumerDRGateway extends Promotable {
 
     public void restart() throws InterruptedException;
 
-    public abstract void completePromotePartition(int partitionId);
-
-    public static class DummyConsumerDRGateway implements ConsumerDRGateway {
-        @Override
-        public void initialize(boolean resumeReplication) {}
-
-        @Override
-        public void acceptPromotion() throws InterruptedException,
-                ExecutionException, KeeperException {}
-
-        @Override
-        public void updateCatalog(CatalogContext catalog) {}
-
-        @Override
-        public boolean isActive() { return false; }
-
-        @Override
-        public void shutdown(boolean blocking) {}
-
-        @Override
-        public void restart() throws InterruptedException {}
-
-        @Override
-        public void completePromotePartition(int partitionId) {}
-
-    }
 }

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -27,7 +27,6 @@ import org.voltdb.BackendTarget;
 import org.voltdb.CatalogContext;
 import org.voltdb.CatalogSpecificPlanner;
 import org.voltdb.CommandLog;
-import org.voltdb.ConsumerDRGateway;
 import org.voltdb.LoadedProcedureSet;
 import org.voltdb.MemoryStats;
 import org.voltdb.PartitionDRGateway;
@@ -62,7 +61,6 @@ public abstract class BaseInitiator implements Initiator
     protected Site m_executionSite = null;
     protected Thread m_siteThread = null;
     protected final RepairLog m_repairLog = new RepairLog();
-    protected ConsumerDRGateway m_consumerDRGateway = null;
 
     public BaseInitiator(String zkMailboxNode, HostMessenger messenger, Integer partition,
             Scheduler scheduler, String whoamiPrefix, StatsAgent agent,
@@ -131,11 +129,9 @@ public abstract class BaseInitiator implements Initiator
                           CommandLog cl,
                           String coreBindIds,
                           PartitionDRGateway drGateway,
-                          PartitionDRGateway mpDrGateway,
-                          ConsumerDRGateway consumerDRGateway)
+                          PartitionDRGateway mpDrGateway)
         throws KeeperException, ExecutionException, InterruptedException
     {
-            m_consumerDRGateway = consumerDRGateway;
             int snapshotPriority = 6;
             if (catalogContext.cluster.getDeployment().get("deployment") != null) {
                 snapshotPriority = catalogContext.cluster.getDeployment().get("deployment").
@@ -233,12 +229,6 @@ public abstract class BaseInitiator implements Initiator
     {
         // Durability Listeners should never be assigned to the MP Scheduler
         assert false;
-    }
-
-    @Override
-    public void setConsumerDRGateway(ConsumerDRGateway gateway) {
-        assert m_consumerDRGateway instanceof ConsumerDRGateway.DummyConsumerDRGateway;
-        m_consumerDRGateway = gateway;
     }
 
     abstract protected void acceptPromotion() throws Exception;

--- a/src/frontend/org/voltdb/iv2/Initiator.java
+++ b/src/frontend/org/voltdb/iv2/Initiator.java
@@ -25,7 +25,6 @@ import org.voltdb.BackendTarget;
 import org.voltdb.CatalogContext;
 import org.voltdb.CatalogSpecificPlanner;
 import org.voltdb.CommandLog;
-import org.voltdb.ConsumerDRGateway;
 import org.voltdb.MemoryStats;
 import org.voltdb.ProducerDRGateway;
 import org.voltdb.StartAction;
@@ -49,7 +48,6 @@ public interface Initiator
                           MemoryStats memStats,
                           CommandLog cl,
                           ProducerDRGateway nodeDRGateway,
-                          ConsumerDRGateway consumerDRGateway,
                           boolean createMpDRGateway, String coreBindIds)
         throws KeeperException, InterruptedException, ExecutionException;
 
@@ -74,7 +72,4 @@ public interface Initiator
 
     /** Assign a listener to the spScheduler for notification of CommandLogged (durable) UniqueIds */
     public void setDurableUniqueIdListener(DurableUniqueIdListener listener);
-
-    /** Hook a new ConsumerDRGateway into Initiator promotion */
-    public void setConsumerDRGateway(ConsumerDRGateway gateway);
 }

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -29,7 +29,6 @@ import org.voltdb.BackendTarget;
 import org.voltdb.CatalogContext;
 import org.voltdb.CatalogSpecificPlanner;
 import org.voltdb.CommandLog;
-import org.voltdb.ConsumerDRGateway;
 import org.voltdb.MemoryStats;
 import org.voltdb.ProducerDRGateway;
 import org.voltdb.Promotable;
@@ -75,7 +74,6 @@ public class MpInitiator extends BaseInitiator implements Promotable
                           MemoryStats memStats,
                           CommandLog cl,
                           ProducerDRGateway drGateway,
-                          ConsumerDRGateway consumerDRGateway,
                           boolean createMpDRGateway, String coreBindIds)
         throws KeeperException, InterruptedException, ExecutionException
     {
@@ -86,7 +84,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
 
         super.configureCommon(backend, catalogContext, serializedCatalog,
                 csp, numberOfPartitions, startAction, null, null, cl, coreBindIds,
-                null, null,consumerDRGateway);
+                null, null);
         // Hacky
         MpScheduler sched = (MpScheduler)m_scheduler;
         MpRoSitePool sitePool = new MpRoSitePool(m_initiatorMailbox.getHSId(),

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -28,7 +28,6 @@ import org.voltdb.BackendTarget;
 import org.voltdb.CatalogContext;
 import org.voltdb.CatalogSpecificPlanner;
 import org.voltdb.CommandLog;
-import org.voltdb.ConsumerDRGateway;
 import org.voltdb.MemoryStats;
 import org.voltdb.PartitionDRGateway;
 import org.voltdb.ProducerDRGateway;
@@ -94,7 +93,6 @@ public class SpInitiator extends BaseInitiator implements Promotable
                           MemoryStats memStats,
                           CommandLog cl,
                           ProducerDRGateway nodeDRGateway,
-                          ConsumerDRGateway consumerDRGateway,
                           boolean createMpDRGateway,
                           String coreBindIds)
         throws KeeperException, InterruptedException, ExecutionException
@@ -119,7 +117,7 @@ public class SpInitiator extends BaseInitiator implements Promotable
 
         super.configureCommon(backend, catalogContext, serializedCatalog,
                 csp, numberOfPartitions, startAction, agent, memStats, cl,
-                coreBindIds, drGateway, mpPDRG, consumerDRGateway);
+                coreBindIds, drGateway, mpPDRG);
 
         m_tickProducer.start();
 


### PR DESCRIPTION
…n DR is disabled at startup and enabled later.

if the database starts without DR enabled, the DR consumer won't be notified during the leader election.
After DR is enabled, DR consumer doesn't have the knowledge of who the locally led partitions are. So
all the dispatchers think they are not the leaders and wait for other to send the sync snapshot request.

Change-Id: I2e777a5ad6cb6d001e03e9b8392220d0c9b3f13b