### PR TITLE
Throw an exception for internal tables with duplicate column names

### DIFF
--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -453,7 +453,13 @@ public abstract class AbstractParsedStmt {
         String columnName = exprNode.attributes.get("column");
         String columnAlias = exprNode.attributes.get("alias");
         TupleValueExpression expr = new TupleValueExpression(tableName, tableAlias, columnName, columnAlias);
+
+        // Use the index produced by HSQL as a way to differentiate columns that have
+        // the same name with a single table (which can happen for subqueries containing joins).
+        int differentiator = Integer.parseInt(exprNode.attributes.get("index"));
+        expr.setDifferentiator(differentiator);
         // Collect the unique columns used in the plan for a given scan.
+
         // Resolve the tve and add it to the scan's cache of referenced columns
         // Get tableScan where this TVE is originated from. In case of the
         // correlated queries it may not be THIS statement but its parent

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -978,23 +978,6 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
     }
 
     public void explainPlan_recurse(StringBuilder sb, String indent) {
-        if (m_verboseExplainForDebugging && m_hasSignificantOutputSchema) {
-            sb.append(indent + "Detailed Output Schema: ");
-            JSONStringer stringer = new JSONStringer();
-            try
-            {
-                stringer.object();
-                outputSchemaToJSON(stringer);
-                stringer.endObject();
-                sb.append(stringer.toString());
-            }
-            catch (Exception e)
-            {
-                sb.append(indent + "CORRUPTED beyond the ability to format? " + e);
-                e.printStackTrace();
-            }
-            sb.append(indent + "from\n");
-        }
         String extraIndent = " ";
         // Except when verbosely debugging,
         // skip projection nodes basically (they're boring as all get out)
@@ -1006,7 +989,13 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
                 sb.append(indent);
             }
             String nodePlan = explainPlanForNode(indent);
-            sb.append(nodePlan + "\n");
+            sb.append(nodePlan);
+
+            if (m_verboseExplainForDebugging && m_outputSchema != null) {
+                sb.append(indent + " " + m_outputSchema.toExplainPlanString());
+            }
+
+            sb.append("\n");
         }
 
         // Agg < Proj < Limit < Scan

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -113,7 +113,7 @@ public class IndexScanPlanNode extends AbstractScanPlanNode {
     private int m_purpose = FOR_SCANNING_PERFORMANCE_OR_ORDERING;
 
     // Post-filters that got eliminated by exactly matched partial index filters
-    private List<AbstractExpression> m_eliminatedPostFilterExpressions = new ArrayList<AbstractExpression>();
+    private final List<AbstractExpression> m_eliminatedPostFilterExpressions = new ArrayList<AbstractExpression>();
 
     public IndexScanPlanNode() {
         super();

--- a/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
@@ -18,7 +18,6 @@
 package org.voltdb.plannodes;
 
 import java.util.Collection;
-import java.util.TreeMap;
 
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
@@ -127,42 +126,40 @@ public class NestLoopIndexPlanNode extends AbstractJoinPlanNode {
             ExpressionUtil.resolveSubqueryExpressionColumnIndexes(expr);
         }
 
-        // need to resolve the indexes of the output schema and
-        // order the combined output schema coherently
-        TreeMap<Integer, SchemaColumn> sort_cols =
-            new TreeMap<Integer, SchemaColumn>();
-        for (SchemaColumn col : m_outputSchemaPreInlineAgg.getColumns())
-        {
-            // Right now these all need to be TVEs
+        // Resolve TVE indexes for each schema column.
+        for (int i = 0; i < m_outputSchemaPreInlineAgg.size(); ++i) {
+            SchemaColumn col = m_outputSchemaPreInlineAgg.getColumns().get(i);
+
+            // These are all TVEs.
             assert(col.getExpression() instanceof TupleValueExpression);
             TupleValueExpression tve = (TupleValueExpression)col.getExpression();
-            int index = outer_schema.getIndexOfTve(tve);
-            int tableIdx = 0;   // 0 for outer table
-            if (index == -1)
-            {
+
+            int index;
+            int tableIdx;
+            if (i < outer_schema.size()) {
+                index = outer_schema.getIndexOfTve(tve);
+                tableIdx = 0; // 0 for outer table
+            }
+            else {
                 index = tve.resolveColumnIndexesUsingSchema(complete_schema_of_inner_table);
-                if (index == -1)
-                {
-                    throw new RuntimeException("Unable to find index for column: " +
-                                               col.toString());
-                }
-                sort_cols.put(index + outer_schema.size(), col);
                 tableIdx = 1;   // 1 for inner table
             }
-            else
-            {
-                sort_cols.put(index, col);
+
+            if (index == -1) {
+                throw new RuntimeException("Unable to find index for column: " +
+                                           col.toString());
             }
+
             tve.setColumnIndex(index);
             tve.setTableIndex(tableIdx);
         }
-        // rebuild the output schema from the tree-sorted columns
-        NodeSchema new_output_schema = new NodeSchema();
-        for (SchemaColumn col : sort_cols.values())
-        {
-            new_output_schema.addColumn(col);
-        }
-        m_outputSchemaPreInlineAgg = new_output_schema;
+
+        // We want the output columns to be ordered like [outer table columns][inner table columns],
+        // and further ordered by TVE index within the left- and righthand sides.
+        // generateOutputSchema already places outer columns on the left and inner on the right,
+        // so we just need to order the left- and righthand sides by TVE index separately.
+        m_outputSchemaPreInlineAgg.sortByTveIndex(0, outer_schema.size());
+        m_outputSchemaPreInlineAgg.sortByTveIndex(outer_schema.size(), m_outputSchemaPreInlineAgg.size());
         m_hasSignificantOutputSchema = true;
 
         resolveRealOutputSchema();

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
@@ -1356,6 +1356,7 @@ public class ExpressionColumn extends Expression {
         if (rangeVariable != null && rangeVariable.tableAlias != null) {
             exp.attributes.put("tablealias",  rangeVariable.tableAlias.name.toUpperCase());
         }
+        exp.attributes.put("index", Integer.toString(columnIndex));
         return exp;
     }
     /**********************************************************************/

--- a/tests/frontend/org/voltdb/planner/PlannerTestCase.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestCase.java
@@ -90,7 +90,7 @@ public class PlannerTestCase extends TestCase {
         }
         catch (Exception ex) {
             ex.printStackTrace();
-            fail();
+            fail(ex.getMessage());
         }
         return cp;
     }

--- a/tests/frontend/org/voltdb/planner/TestDeterminism.java
+++ b/tests/frontend/org/voltdb/planner/TestDeterminism.java
@@ -236,16 +236,16 @@ public class TestDeterminism extends PlannerTestCase {
 
     public void testDeterminismOfJoin() {
         assertPlanDeterminism(
-                "select X.a, X.z, Y.z from tuniqcombo X, tunique Y",
+                "select X.a, X.z as xz, Y.z as yz from tuniqcombo X, tunique Y",
                 "order by X.a, X.c, X.b, Y.a");
         assertPlanDeterminism(
-                "select X.a, X.z, Y.z from tuniqcombo X, tunique Y",
+                "select X.a, X.z as xz, Y.z as yz from tuniqcombo X, tunique Y",
                 "order by X.b, X.a, Y.a, X.c");
         assertPlanDeterminism(
-                "select X.a, X.z, Y.z from tuniqcombo X, tunique Y",
+                "select X.a, X.z as xz, Y.z as yz from tuniqcombo X, tunique Y",
                 "order by X.z, X.a, X.c, X.b, Y.a");
         assertPlanDeterminism(
-                "select X.a, X.z, Y.z, X.z + Y.z from tuniqcombo X, tunique Y",
+                "select X.a, X.z as xz, Y.z as yz, X.z + Y.z from tuniqcombo X, tunique Y",
                 "order by 4, X.z, X.a, X.c, X.b, Y.a");
         assertPlanDeterminismNeedsOrdering(
                 "select X.a l, X.z m, Y.z n from ttree X, tunique Y order by X.a, X.c, X.b, Y.a",
@@ -257,14 +257,14 @@ public class TestDeterminism extends PlannerTestCase {
                 "select X.a l, X.z m, Y.z n from ttree X, tunique Y order by X.z, X.a, X.c, X.b, Y.a",
                 ", X.z, Y.z", "order by l, m, n");
         assertPlanDeterminismNeedsOrdering(
-                "select X.a, X.z, Y.z, X.z + Y.z from ttree X, tunique Y order by 4, X.z, X.a, X.c, X.b, Y.a",
+                "select X.a, X.z as xz, Y.z as yz, X.z + Y.z from ttree X, tunique Y order by 4, X.z, X.a, X.c, X.b, Y.a",
                 ", Y.z", "order by 1, 2, 3, 4");
         assertPlanNeedsSaferDeterminismCombo(
-                "select X.a, X.z, Y.z from tuniqcombo X, tunique Y where X.a = Y.a");
+                "select X.a, X.z as xz, Y.z as yz from tuniqcombo X, tunique Y where X.a = Y.a");
         assertPlanNeedsSaferDeterminismCombo(
-            "select X.a, X.z, Y.z from tuniqcombo X, tunique Y order by X.a, X.b, Y.a");
+            "select X.a, X.z as xz, Y.z as yz from tuniqcombo X, tunique Y order by X.a, X.b, Y.a");
         assertPlanNeedsSaferDeterminismCombo(
-            "select X.a, X.z, Y.z from tuniqcombo X, tunique Y order by X.a, X.c + X.b, X.b, Y.a");
+            "select X.a, X.z as xz, Y.z as yz from tuniqcombo X, tunique Y order by X.a, X.c + X.b, X.b, Y.a");
     }
 
     public void testDeterminismOfSelectOrderGroupKeys() {
@@ -318,11 +318,11 @@ public class TestDeterminism extends PlannerTestCase {
     }
 
     public void testDeterminismOfJoinOrderAll() {
-        assertPlanDeterminismNeedsOrdering("select X.a, X.z, Y.z from ttree X, tunique Y where X.a = Y.a",
+        assertPlanDeterminismNeedsOrdering("select X.a, X.z as xz, Y.z as yz from ttree X, tunique Y where X.a = Y.a",
                 "order by 1, 2, 3");
         assertPlanDeterminismNeedsOrdering("select X.a l, X.z m, Y.z n from ttree X, tunique Y where X.a = Y.a",
                 "order by Y.z, X.a, X.z", "order by l, m, n");
-        assertPlanDeterminismNeedsOrdering("select X.a, X.z, Y.z from ttree X, tunique Y where X.a = Y.a",
+        assertPlanDeterminismNeedsOrdering("select X.a, X.z as xz, Y.z as yz from ttree X, tunique Y where X.a = Y.a",
                 "order by 3, 2, 1");
     }
 

--- a/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
@@ -205,9 +205,9 @@ public class TestPlansSubQueries extends PlannerTestCase {
         pn = pn.getChild(0);
         checkSeqScan(pn, "R1", "A1", "C");
 
-        pn = compile("select C1 FROM (SELECT A+3, C C1 FROM R1) T1 WHERE T1.C1 < 0");
+        pn = compile("select COL1 FROM (SELECT A+3, C COL1 FROM R1) T1 WHERE T1.COL1 < 0");
         pn = pn.getChild(0);
-        checkSeqScan(pn, tbName,  "C1");
+        checkSeqScan(pn, tbName,  "COL1");
         assertEquals(((SeqScanPlanNode) pn).getInlinePlanNodes().size(), 1);
         assertNotNull(((SeqScanPlanNode) pn).getInlinePlanNode(PlanNodeType.PROJECTION));
         checkPredicateComparisonExpression(pn, tbName);

--- a/tests/frontend/org/voltdb/plannodes/TestScanPlanNode.java
+++ b/tests/frontend/org/voltdb/plannodes/TestScanPlanNode.java
@@ -161,10 +161,10 @@ public class TestScanPlanNode extends TestCase
         col4_exp.setValueType(COLTYPES[4]);
         col4_exp.setValueSize(COLTYPES[4].getLengthInBytesForFixedTypes());
         col4_exp.setExpressionType(ExpressionType.OPERATOR_PLUS);
-        TupleValueExpression left = new TupleValueExpression(TABLE1, TABLE1, COLS[0], COLS[0]);
+        TupleValueExpression left = new TupleValueExpression(TABLE1, TABLE1, COLS[0], COLS[0], 0);
         left.setValueType(COLTYPES[0]);
         left.setValueSize(COLTYPES[0].getLengthInBytesForFixedTypes());
-        TupleValueExpression right = new TupleValueExpression(TABLE1, TABLE1, COLS[2], COLS[2]);
+        TupleValueExpression right = new TupleValueExpression(TABLE1, TABLE1, COLS[2], COLS[2], 0);
         right.setValueType(COLTYPES[2]);
         right.setValueSize(COLTYPES[2].getLengthInBytesForFixedTypes());
         col4_exp.setLeft(left);


### PR DESCRIPTION
This change set addresses incorrect behavior that can occur when doing a "select *" from a subquery that contains multiple columns with the same name.  This can happen in a couple of ways:
```SQL
SELECT * FROM (SELECT * FROM T, T) AS subq;
```
Where if persistent table T has columns (A, B) the output of the suquery wll be (subq.A, subq.B, subq.A, subq.B).  This can also happen for this case:
```SQL
SELECT * FROM (SELECT t1.a AS z, t2.a AS z FROM T AS t1, T AS t2) AS subq;
```
VoltDB's name-based column resolution pass does not deal well with these queries and was resulting in undefined behavior.

This change set only detects queries that would have caused incorrect behavior and throws an exception.  A more thorough solution should be implemented soon to make these queries execute in accordance with the SQL standard.