### PR TITLE
ENG-10189: Fix MP restart stale response handling.

### DIFF
--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -174,12 +174,9 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
         if (mapResults != null) {
             List<VoltTable> matchingTablesForId = mapResults.get(aggregatorOutputDependencyId);
             if (matchingTablesForId == null) {
-                if (mapResults.size() != 0 && log.isDebugEnabled()) {
-                    log.debug("Sysproc received a stale fragment response message from before the " +
-                              "transaction restart. This is possible for sysprocs because the dependency " +
-                              "IDs are always the same for a given sysproc. The result of this cannot be " +
-                              "trusted.");
-                }
+                log.error("Sysproc received a stale fragment response message from before the " +
+                          "transaction restart.");
+                throw new MpTransactionState.FragmentFailureException();
             } else {
                 results.add(matchingTablesForId.get(0));
             }

--- a/tests/frontend/org/voltdb/iv2/TestMpTransactionState.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpTransactionState.java
@@ -160,25 +160,26 @@ public class TestMpTransactionState extends TestCase
                     depsToResumeList.get(i), createDummyParameterSet());
         }
 
-       for (int i = 0; i < depsForLocalTask.size(); i++) {
-           if (depsForLocalTask.get(i) < 0) continue;
-           plan.localWork.addInputDepId(i, depsForLocalTask.get(i));
-       }
-       // create the FragmentResponse for the BorrowTask
-       FragmentResponseMessage resp =
-           new FragmentResponseMessage(plan.remoteWork, remoteHSIds[0]);
-       resp.setStatus(FragmentResponseMessage.SUCCESS, null);
-       for (int j = 0; j < batchSize ; j++) {
-           resp.addDependency(depsToResumeList.get(j),
-                              new VoltTable(new VoltTable.ColumnInfo("BOGO",
-                                                                     VoltType.BIGINT)));
-       }
-       System.out.println("BORROW RESPONSE: " + resp);
-       plan.generatedResponses.add(resp);
+        for (int i = 0; i < depsForLocalTask.size(); i++) {
+            if (depsForLocalTask.get(i) < 0) continue;
+            plan.localWork.addInputDepId(i, depsForLocalTask.get(i));
+        }
+        // create the FragmentResponse for the BorrowTask
+        FragmentResponseMessage resp =
+        new FragmentResponseMessage(plan.remoteWork, remoteHSIds[0]);
+        resp.m_sourceHSId = buddyHSId;
+        resp.setStatus(FragmentResponseMessage.SUCCESS, null);
+        for (int j = 0; j < batchSize ; j++) {
+            resp.addDependency(depsToResumeList.get(j),
+                               new VoltTable(new VoltTable.ColumnInfo("BOGO",
+                                                                      VoltType.BIGINT)));
+        }
+        System.out.println("BORROW RESPONSE: " + resp);
+        plan.generatedResponses.add(resp);
 
-       System.out.println("LOCAL TASK: " + plan.localWork.toString());
+        System.out.println("LOCAL TASK: " + plan.localWork.toString());
 
-       return plan;
+        return plan;
     }
 
     List<Long> allHsids;


### PR DESCRIPTION
It is possible to receive stale fragment responses on the MPI when an MP
txn is restarted. The normal fragment path handles this by checking the
received responses with the expected dependency IDs. Stale responses
will be ignored if they don't match the expected dependency.

However, the borrow fragment path does not take this into account when
receiving response. If a stale response from a remote site comes back
when the MP is expecting the borrow fragment response, it will mistake
it as the borrow response and return it to the procedure, which resulted
in dropping the real borrow response that comes later.

Imagine the following scenario for a sysproc:

* Sends out fragments (call them batch A)
* MP is restarted
* Sends out fragments again (batch A')
* Receives stale responses for batch A and treats them as the responses
  for batch A' (this is also bad, but I'm not fixing it in this commit)
* Sends out buddy framgent
* Receives responses for batch A' and mistakes it as the buddy response

This is typically not a problem for user procedures because each
fragment uses unique dependency ID. It is a serious issue for sysprocs
where dependency IDs are all statically defined, so stale responses
cannot be told apart from the fresh ones.

Change-Id: I24abec8de59611ee8fe992fd46adae05ff1ef614