### PR TITLE
ENG-10172, fix a bug that DR producer failed to resume an existing DR…

### DIFF
--- a/src/frontend/org/voltcore/zk/CoreZK.java
+++ b/src/frontend/org/voltcore/zk/CoreZK.java
@@ -36,6 +36,10 @@ public class CoreZK {
     // -- timestamp: (long) the timestamp at which the first zookeeper node was created
     public static final String instance_id = "/core/instance_id";
 
+    // persistent instance timestamp: (long) the timestamp at the very fist zookeeper node
+    // was created, not matter how many times the node has been recovered or rejoined
+    public static final String persistent_instance_ts = "/core/persistent_instance_ts";
+
     // hosts in the current system (ephemeral)
     public static final String hosts = "/core/hosts";
     public static final String hosts_host = "/core/hosts/host";

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -144,11 +144,17 @@ public interface VoltDBInterface
     public long getClusterCreateTime();
 
     /**
+     * @return The time the cluster's original Create start action, Recover
+     * and Rejoin doesn't change the time.
+     */
+    public long getPersistentClusterCreateTime();
+
+    /**
      * Set the time at which the cluster was created. This method is used when
      * in the Recover action and @SnapshotRestore paths to assign the cluster
      * create time that was preserved in the snapshot.
      */
-    public void setClusterCreateTime(long clusterCreateTime);
+    public void setPersistentClusterCreateTime(long clusterCreateTime);
 
     /**
      * Notify RealVoltDB that recovery is complete

--- a/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
@@ -309,7 +309,7 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
             Table[] tables) throws IOException
     {
         InstanceId instId = VoltDB.instance().getHostMessenger().getInstanceId();
-        long clusterCreateTime = VoltDB.instance().getClusterCreateTime();
+        long clusterCreateTime = VoltDB.instance().getPersistentClusterCreateTime();
         Runnable completionTask = SnapshotUtil.writeSnapshotDigest(
                 txnId,
                 context.getCatalogCRC(),

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -660,11 +660,16 @@ public class MockVoltDB implements VoltDBInterface
 
     @Override
     public long getClusterCreateTime() {
+        return 0;
+    }
+
+    @Override
+    public long getPersistentClusterCreateTime() {
         return m_clusterCreateTime;
     }
 
     @Override
-    public void setClusterCreateTime(long clusterCreateTime) {
+    public void setPersistentClusterCreateTime(long clusterCreateTime) {
         m_clusterCreateTime = clusterCreateTime;
     }
 


### PR DESCRIPTION
… conversation

After a recover followed by a rejoin, the cluster losts the original cluster create time which is used by
DR producer to verify whether the connection is from an existing conversation.

Solution: Create zookeeper node persistent_instance_ts to record the original cluster create time, the
timestamp can be only updated when we start a new DR conversation, any following rejoin or recover won't
change it.

Change-Id: I520557de02a57a1942e425ddcafc15f01aef51f4