### PR TITLE
Add geo type support to VoltDB JDBC driver

### DIFF
--- a/src/frontend/org/voltdb/VoltType.java
+++ b/src/frontend/org/voltdb/VoltType.java
@@ -266,7 +266,7 @@ public enum VoltType {
             java.sql.Types.OTHER, // JDBC type (this is used for vendor specific types)
             null, // literal prefix
             null, // literal suffix
-            null, // necessary params (like length for VARCHAR)
+            "max_length", // necessary params (like length for VARCHAR)
             false, // case sensitivity
             java.sql.DatabaseMetaData.typePredBasic, // basic where-clauses supported
             null, // signed/unsigned
@@ -1050,15 +1050,13 @@ public enum VoltType {
             col_size_radix[0] = 53;  // magic for double
             col_size_radix[1] = 2;
             break;
-        case STRING:
-            col_size_radix[0] = VoltType.MAX_VALUE_LENGTH;
-            col_size_radix[1] = null;
-            break;
         case DECIMAL:
             col_size_radix[0] = VoltDecimalHelper.kDefaultPrecision;
             col_size_radix[1] = 10;
             break;
+        case STRING:
         case VARBINARY:
+        case GEOGRAPHY:
             col_size_radix[0] = VoltType.MAX_VALUE_LENGTH;
             col_size_radix[1] = null;
             break;

--- a/src/frontend/org/voltdb/VoltType.java
+++ b/src/frontend/org/voltdb/VoltType.java
@@ -233,25 +233,46 @@ public enum VoltType {
             "java.lang.Boolean"), // getObject return type
 
     /**
-     * Point type, for a geographical point (lat, long)
+     * Point type, for a geographical point (long, lat)
      */
-    GEOGRAPHY_POINT ((byte)26,
+    GEOGRAPHY_POINT (
+            (byte)26, // enum value
             GeographyPointValue.getLengthInBytes(),
-            "GEOGRAPHY_POINT",
-            new Class[] {GeographyPointValue.class},
-            GeographyPointValue[].class,
-            'P'), // 'p' was taken by timestamp
+            "GEOGRAPHY_POINT", // SQL name
+            new Class[] {GeographyPointValue.class}, // Java types supported in conversion
+            GeographyPointValue[].class, // vector type
+            'P', // signature char
+            java.sql.Types.OTHER, // JDBC type (this is used for vendor specific types)
+            null, // literal prefix
+            null, // literal suffix
+            null, // necessary params (like length for VARCHAR)
+            false, // case sensitivity
+            java.sql.DatabaseMetaData.typePredBasic, // basic where-clauses supported
+            null, // signed/unsigned
+            null, // min scale
+            null, // max scale
+            "org.voltdb.types.GeographyPointValue"), // JDBC getObject return type
 
     /**
      * Geography type, for geographical objects (polygons, etc)
      */
-    GEOGRAPHY ((byte)27,
-            -1, // length in bytes (variable length)
-            "GEOGRAPHY",
-            new Class[] {GeographyValue.class},
-            GeographyValue[].class,
-            'g');
-
+    GEOGRAPHY (
+            (byte)27, // enum value
+            -1, // variable length
+            "GEOGRAPHY", // SQL name
+            new Class[] {GeographyValue.class}, // Java types supported in conversion
+            GeographyValue[].class, // vector type
+            'g', // signature char
+            java.sql.Types.OTHER, // JDBC type (this is used for vendor specific types)
+            null, // literal prefix
+            null, // literal suffix
+            null, // necessary params (like length for VARCHAR)
+            false, // case sensitivity
+            java.sql.DatabaseMetaData.typePredBasic, // basic where-clauses supported
+            null, // signed/unsigned
+            null, // min scale
+            null, // max scale
+            "org.voltdb.types.GeographyValue"); // JDBC getObject return type
     /**
      * Size in bytes of the maximum length for a VoltDB field value, presumably a
      * <code>STRING</code> or <code>VARBINARY</code>
@@ -319,8 +340,12 @@ public enum VoltType {
 
     // Constructor for JDBC-visible types.  Only types constructed in this way will
     // appear in the JDBC getTypeInfo() metadata.
-    private VoltType(byte val, int lengthInBytes, String sqlString,
-                     Class<?>[] classes, Class<?> vectorClass, char signatureChar,
+    private VoltType(byte val,
+                     int lengthInBytes,
+                     String sqlString,
+                     Class<?>[] classes,
+                     Class<?> vectorClass,
+                     char signatureChar,
                      int dataType,
                      String literalPrefix,
                      String literalSuffix,
@@ -1070,11 +1095,11 @@ public enum VoltType {
     public static final NullDecimalSigil NULL_DECIMAL = new NullDecimalSigil();
 
     private static final class NullPointSigil{}
-    /** Null value for <code>POINT</code>. */
+    /** Null value for <code>GEOGRAPHY_POINT</code>. */
     public static final NullPointSigil NULL_POINT = new NullPointSigil();
 
     private static final class NullGeographySigil{}
-    /** Null value for <code>POINT</code>. */
+    /** Null value for <code>GEOGRAPHY</code>. */
     public static final NullGeographySigil NULL_GEOGRAPHY = new NullGeographySigil();
 
     /**

--- a/src/frontend/org/voltdb/jdbc/JDBC4DatabaseMetaData.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4DatabaseMetaData.java
@@ -1212,6 +1212,7 @@ public class JDBC4DatabaseMetaData implements java.sql.DatabaseMetaData
         case java.sql.Types.VARCHAR:
         case java.sql.Types.VARBINARY:
         case java.sql.Types.TIMESTAMP:
+        case java.sql.Types.OTHER:
             switch (toType) {
             case java.sql.Types.VARCHAR:
                 return true;

--- a/src/frontend/org/voltdb/jdbc/JDBC4PreparedStatement.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4PreparedStatement.java
@@ -441,6 +441,7 @@ public class JDBC4PreparedStatement extends JDBC4Statement implements java.sql.P
             case Types.VARBINARY:
             case Types.VARCHAR:
             case Types.NVARCHAR:
+            case Types.OTHER:
             case Types.NULL:
                 this.parameters[parameterIndex-1] = VoltType.NULL_STRING_OR_VARBINARY;
                 break;
@@ -496,6 +497,9 @@ public class JDBC4PreparedStatement extends JDBC4Statement implements java.sql.P
             case Types.VARCHAR:
             case Types.NVARCHAR:
                 setString(parameterIndex, (String)x);
+                break;
+            case Types.OTHER:
+                setObject(parameterIndex, x);
                 break;
             default:
                 throw SQLError.get(SQLError.ILLEGAL_ARGUMENT);

--- a/src/frontend/org/voltdb/jdbc/JDBC4ResultSetMetaData.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ResultSetMetaData.java
@@ -18,11 +18,13 @@
 package org.voltdb.jdbc;
 
 import java.sql.*;
+
 import org.voltdb.*;
+import org.voltdb.types.GeographyPointValue;
 
 public class JDBC4ResultSetMetaData implements java.sql.ResultSetMetaData
 {
-    private JDBC4ResultSet sourceResultSet;
+    private final JDBC4ResultSet sourceResultSet;
     public JDBC4ResultSetMetaData(JDBC4ResultSet resultSet)
     {
         sourceResultSet = resultSet;
@@ -80,8 +82,11 @@ public class JDBC4ResultSetMetaData implements java.sql.ResultSetMetaData
                 return 40;
             case TIMESTAMP:
                 return 32;
+            case GEOGRAPHY_POINT:
+                return GeographyPointValue.getValueDisplaySize();
             case STRING:
             case VARBINARY:
+            case GEOGRAPHY:
                 return 128; // That is wrong: should be length in bytes / 3 (max bytes per char for UTF8), but we don't receive the length!
             default:
                 throw SQLError.get(SQLError.TRANSLATION_NOT_FOUND, type);

--- a/src/frontend/org/voltdb/types/GeographyPointValue.java
+++ b/src/frontend/org/voltdb/types/GeographyPointValue.java
@@ -168,7 +168,7 @@ public class GeographyPointValue {
      * @return number of characters needed for display
      */
     public static int getValueDisplaySize() {
-        return 8 // "POINT ("
+        return 7 // "POINT ("
                 + 1 + 3 + 1 + 12 // lng: sign, whole part, point, fraction digits
                 + 1 // space between coordinates
                 + 1 + 2 + 1 + 12 // lat: sign, whole part, point fraction digits

--- a/src/frontend/org/voltdb/types/GeographyPointValue.java
+++ b/src/frontend/org/voltdb/types/GeographyPointValue.java
@@ -163,6 +163,19 @@ public class GeographyPointValue {
     }
 
     /**
+     * The largest number of characters needed to represent
+     * a point value as a string.
+     * @return number of characters needed for display
+     */
+    public static int getValueDisplaySize() {
+        return 8 // "POINT ("
+                + 1 + 3 + 1 + 12 // lng: sign, whole part, point, fraction digits
+                + 1 // space between coordinates
+                + 1 + 2 + 1 + 12 // lat: sign, whole part, point fraction digits
+                + 1; // ")"
+        }
+
+    /**
      * Compare this point with another object. Returns true
      * if this point is being compared to another point that
      * represents the same location.

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
@@ -538,7 +538,7 @@ public class TestJDBCDriver {
         assertEquals(0, meta.getScale(11));
         assertFalse(meta.isCaseSensitive(11));
         assertFalse(meta.isSigned(11));
-        assertEquals(43, meta.getColumnDisplaySize(11));
+        assertEquals(42, meta.getColumnDisplaySize(11));
 
         assertEquals(org.voltdb.types.GeographyValue.class.getName(), meta.getColumnClassName(12));
         assertEquals(java.sql.Types.OTHER, meta.getColumnType(12));

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
@@ -457,6 +457,7 @@ public class TestJDBCDriver {
         assertEquals(0, meta.getScale(1));
         assertFalse(meta.isCaseSensitive(1));
         assertTrue(meta.isSigned(1));
+        assertEquals(4, meta.getColumnDisplaySize(1));
 
         assertEquals(Short.class.getName(), meta.getColumnClassName(3));
         assertEquals(java.sql.Types.SMALLINT, meta.getColumnType(3));
@@ -465,6 +466,7 @@ public class TestJDBCDriver {
         assertEquals(0, meta.getScale(3));
         assertFalse(meta.isCaseSensitive(3));
         assertTrue(meta.isSigned(3));
+        assertEquals(6, meta.getColumnDisplaySize(3));
 
         assertEquals(Integer.class.getName(), meta.getColumnClassName(4));
         assertEquals(java.sql.Types.INTEGER, meta.getColumnType(4));
@@ -473,6 +475,7 @@ public class TestJDBCDriver {
         assertEquals(0, meta.getScale(4));
         assertFalse(meta.isCaseSensitive(4));
         assertTrue(meta.isSigned(4));
+        assertEquals(11, meta.getColumnDisplaySize(4));
 
         assertEquals(Long.class.getName(), meta.getColumnClassName(5));
         assertEquals(java.sql.Types.BIGINT, meta.getColumnType(5));
@@ -481,6 +484,7 @@ public class TestJDBCDriver {
         assertEquals(0, meta.getScale(5));
         assertFalse(meta.isCaseSensitive(5));
         assertTrue(meta.isSigned(5));
+        assertEquals(20, meta.getColumnDisplaySize(5));
 
         assertEquals(Double.class.getName(), meta.getColumnClassName(6));
         assertEquals(java.sql.Types.FLOAT, meta.getColumnType(6));
@@ -489,6 +493,7 @@ public class TestJDBCDriver {
         assertEquals(0, meta.getScale(6));
         assertFalse(meta.isCaseSensitive(6));
         assertTrue(meta.isSigned(6));
+        assertEquals(8, meta.getColumnDisplaySize(6));
 
         assertEquals(String.class.getName(), meta.getColumnClassName(7));
         assertEquals(java.sql.Types.VARCHAR, meta.getColumnType(7));
@@ -497,15 +502,16 @@ public class TestJDBCDriver {
         assertEquals(0, meta.getScale(7));
         assertTrue(meta.isCaseSensitive(7));
         assertFalse(meta.isSigned(7));
+        assertEquals(128, meta.getColumnDisplaySize(7));
 
         assertEquals(Byte[].class.getCanonicalName(), meta.getColumnClassName(8));
         assertEquals(java.sql.Types.VARBINARY, meta.getColumnType(8));
-        assertEquals(128, meta.getColumnDisplaySize(8));
         assertEquals("VARBINARY", meta.getColumnTypeName(8));
         assertEquals(VoltType.MAX_VALUE_LENGTH, meta.getPrecision(8));
         assertEquals(0, meta.getScale(8));
         assertFalse(meta.isCaseSensitive(8));
         assertFalse(meta.isSigned(8));
+        assertEquals(128, meta.getColumnDisplaySize(8));
 
         assertEquals(Timestamp.class.getName(), meta.getColumnClassName(9));
         assertEquals(java.sql.Types.TIMESTAMP, meta.getColumnType(9));
@@ -514,6 +520,7 @@ public class TestJDBCDriver {
         assertEquals(0, meta.getScale(9));
         assertFalse(meta.isCaseSensitive(9));
         assertFalse(meta.isSigned(9));
+        assertEquals(32, meta.getColumnDisplaySize(9));
 
         assertEquals(BigDecimal.class.getName(), meta.getColumnClassName(10));
         assertEquals(java.sql.Types.DECIMAL, meta.getColumnType(10));
@@ -522,6 +529,7 @@ public class TestJDBCDriver {
         assertEquals(12, meta.getScale(10));
         assertFalse(meta.isCaseSensitive(10));
         assertTrue(meta.isSigned(10));
+        assertEquals(40, meta.getColumnDisplaySize(10));
 
         assertEquals(org.voltdb.types.GeographyPointValue.class.getName(), meta.getColumnClassName(11));
         assertEquals(java.sql.Types.OTHER, meta.getColumnType(11));
@@ -530,6 +538,7 @@ public class TestJDBCDriver {
         assertEquals(0, meta.getScale(11));
         assertFalse(meta.isCaseSensitive(11));
         assertFalse(meta.isSigned(11));
+        assertEquals(43, meta.getColumnDisplaySize(11));
 
         assertEquals(org.voltdb.types.GeographyValue.class.getName(), meta.getColumnClassName(12));
         assertEquals(java.sql.Types.OTHER, meta.getColumnType(12));
@@ -538,6 +547,7 @@ public class TestJDBCDriver {
         assertEquals(0, meta.getScale(12));
         assertFalse(meta.isCaseSensitive(12));
         assertFalse(meta.isSigned(12));
+        assertEquals(128, meta.getColumnDisplaySize(12));
     }
 
     @Test

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
@@ -543,7 +543,7 @@ public class TestJDBCDriver {
         assertEquals(org.voltdb.types.GeographyValue.class.getName(), meta.getColumnClassName(12));
         assertEquals(java.sql.Types.OTHER, meta.getColumnType(12));
         assertEquals("GEOGRAPHY", meta.getColumnTypeName(12));
-        assertEquals(0, meta.getPrecision(12));
+        assertEquals(1048576, meta.getPrecision(12));
         assertEquals(0, meta.getScale(12));
         assertFalse(meta.isCaseSensitive(12));
         assertFalse(meta.isSigned(12));

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
@@ -30,8 +30,6 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.math.MathContext;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.Date;
@@ -129,6 +127,12 @@ public class TestJDBCQueries {
             new Data("TIMESTAMP", 0,
                         new String[] {"9999999999999", "0", "1"},
                         new String[] {""}),
+            new Data("GEOGRAPHY_POINT", 0,
+                        new String[] {"point(-122.0 37.1)", "point(-100.0 49.1)", "point(-10.0 -49.1)"},
+                        new String[] {"pt(foo)"}),
+            new Data("GEOGRAPHY", 2048,
+                        new String[] {"polygon((0 0, 1 1, 1 0, 0 0))", "polygon((0 0, 3 3, 3 0, 0 0))", "polygon((0 0, 6 6, 6 0, 0 0))"},
+                        new String[] {"plygn(3"}),
     };
 
     static enum GetType {
@@ -566,6 +570,9 @@ public class TestJDBCQueries {
                         expectValStr = String.valueOf(rs
                                 .getBigDecimal(columnIndex));
                         break;
+                    case java.sql.Types.OTHER:
+                        expectValStr = rs.getObject(columnIndex).toString();
+                        break;
                     default:
                         throw new IllegalArgumentException("Invalid type '" + colType + "'");
                     }
@@ -895,7 +902,7 @@ public class TestJDBCQueries {
             // This query does work, per ENG-7306.
             String sql = "select * from votes;";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
         }
         catch (SQLException e) {
             System.err.println("ERROR(BASIC SELECT): " + e.getMessage());
@@ -907,7 +914,7 @@ public class TestJDBCQueries {
             // This query does work, per ENG-7306.
             String sql = "select * from (select * from contestants C1) alias;";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
         }
         catch (SQLException e) {
             System.err.println("ERROR(SUB-SELECT with no spaces): " + e.getMessage());
@@ -919,7 +926,7 @@ public class TestJDBCQueries {
             // Add a space before the sub-select. Reported in ENG-7306
             String sql = "select * from ( select * from contestants C1) alias;";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
         }
         catch (SQLException e) {
             System.err.println("ERROR(SUB-SELECT with spaces): " + e.getMessage());
@@ -972,7 +979,7 @@ public class TestJDBCQueries {
         {
             String sql = "ALTER TABLE CONTESTANTS ADD UNIQUE(contestant_name) ;";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
             System.err.println("ERROR(executeQuery(ALTER TABLE) succeeded, should have failed)");
             fail();
         }
@@ -1012,7 +1019,7 @@ public class TestJDBCQueries {
         {
             String sql = "create table t2(id integer not null, num integer not null);";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
             System.err.println("ERROR(executeQuery(CREATE TABLE) succeeded, should have failed)");
             fail();
         }
@@ -1060,7 +1067,7 @@ public class TestJDBCQueries {
         {
             String sql = "CREATE PROCEDURE CountContestants2 AS SELECT COUNT(*) FROM contestants;";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
             System.err.println("ERROR(executeQuery(CREATE PROCEDURE) succeeded, should have failed)");
             fail();
         }
@@ -1089,7 +1096,7 @@ public class TestJDBCQueries {
         {
             String sql = "drop table drop_table1;";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
             System.err.println("ERROR(executeQuery(DROP) succeeded, should have failed)");
             fail();
         }
@@ -1130,7 +1137,7 @@ public class TestJDBCQueries {
         {
             String sql = "truncate table votes;";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
             System.err.println("ERROR(executeQuery(TRUNCATE TABLE) succeeded, should have failed)");
             fail();
         }
@@ -1171,7 +1178,7 @@ public class TestJDBCQueries {
         {
             String sql = " upsert into contestants (contestant_number, contestant_name) values (23, 'Bruce Springsteen')";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
             System.err.println("ERROR(executeQuery(UPSERT) succeeded, should have failed)");
             fail();
         }
@@ -1224,7 +1231,7 @@ public class TestJDBCQueries {
         {
             String sql = "update votes set CONTESTANT_NUMBER = 7 where PHONE_NUMBER = 2150002906;";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
             System.err.println("ERROR(executeQuery(UPDATE) succeeded, should have failed)");
             fail();
         }
@@ -1265,7 +1272,7 @@ public class TestJDBCQueries {
         {
             String sql = "delete from votes where   PHONE_NUMBER = 3082086134      ";
             java.sql.Statement query = conn.createStatement();
-            ResultSet rs = query.executeQuery(sql);
+            query.executeQuery(sql);
             System.err.println("ERROR(executeQuery(DELETE) succeeded, should have failed)");
             fail();
         }

--- a/tests/frontend/org/voltdb/regressionsuites/TestSystemCatalogSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSystemCatalogSuite.java
@@ -131,7 +131,7 @@ public class TestSystemCatalogSuite extends RegressionSuite {
     {
         Client client = getClient();
         VoltTable[] results = client.callProcedure("@SystemCatalog", "TYPEINFO").getResults();
-        assertEquals(10, results[0].getRowCount()); // Will break if we add a type, hopefully gets
+        assertEquals(12, results[0].getRowCount()); // Will break if we add a type, hopefully gets
                                                    // type-adder to double-check they've got things right
         assertEquals(18, results[0].getColumnCount());
         System.out.println(results[0]);


### PR DESCRIPTION
This was pretty straightforward.  JDBC's type enumeration includes `OTHER` for vendor-specific types, which can be extracted from results and passed as parameters via `getObject` and `setObject` methods.