### PR TITLE
ENG-10249, DR consumer initialization should be called after recover …

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2306,7 +2306,11 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
                     ClientInterfaceRepairCallback callback = (ClientInterfaceRepairCallback) m_consumerDRGateway;
                     callback.repairCompleted(pid, m_cartographer.getHSIdForMaster(pid));
                 }
-                m_consumerDRGateway.initialize(false);
+                // If this is @UAC cl replay, don't initialize DR consumer until
+                // cluster recover finished.
+                if (m_mode != OperationMode.INITIALIZING) {
+                    m_consumerDRGateway.initialize(false);
+                }
             }
             // 6.2. If we are a DR replica, we may care about a
             // deployment update


### PR DESCRIPTION
…completed,

disallow @UAC to initiate DR consumer during cl replay.

Change-Id: I59326dcc00ba65f49a5cab638b9ecdf8290b239f