### PR TITLE
Fix an error message for unplannable queries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ doc/tutorials/auction/csvloader_*.csv
 /tests/sqlcmd/scripts/**/*.outdiffs
 out
 bundles
+*.lcbak

--- a/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
@@ -223,8 +223,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
                     // Don't throw a planning error here, in case the problem is just with this
                     // particular join order, but do leave a hint to the PlanAssembler in case
                     // the failure is unanimous -- a common case.
-                    m_recentErrorMsg =
-                        "Join of multiple partitioned tables has insufficient join criteria.";
+                    m_recentErrorMsg = m_partitioning.getJoinInvalidReason();
                     // This join order, at least, is not worth trying to plan.
                     continue;
                 }

--- a/src/frontend/org/voltdb/planner/StatementPartitioning.java
+++ b/src/frontend/org/voltdb/planner/StatementPartitioning.java
@@ -141,7 +141,7 @@ public class StatementPartitioning implements Cloneable{
     private String m_fullColumnName;
 
     private boolean m_joinValid = true;
-    
+
     // If m_joinValid is set to false, we also set
     // this string to a hint telling why it is false.
     private String m_recentInvalidReason = null;

--- a/tests/frontend/org/voltdb/AdHocQueryTester.java
+++ b/tests/frontend/org/voltdb/AdHocQueryTester.java
@@ -256,7 +256,8 @@ public abstract class AdHocQueryTester extends TestCase {
         try {
             runQueryTest(String.format("SELECT * FROM PARTED1 A LEFT JOIN PARTED2 B ON A.PARTVAL = %d and B.PARTVAL = %d;", hashableA, hashableA), hashableA, 0, 1, NOT_VALIDATING_SP_RESULT);
         } catch (Exception pce) {
-            assertTrue(pce.toString().contains("insufficient join criteria"));
+            String msg = pce.toString();
+            assertTrue(msg.contains("This query is not plannable.  The planner cannot guarantee that all rows would be in a single partition."));
         }
 
         // spPartialCount = runQueryTest(String.format("SELECT * FROM PARTED1 A, PARTED2 B WHERE A.PARTVAL = B.PARTVAL;"), hashableA, 0, 2, NOT_VALIDATING_SP_RESULT);

--- a/tests/frontend/org/voltdb/planner/TestPlansJoin.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansJoin.java
@@ -654,7 +654,7 @@ public class TestPlansJoin extends PlannerTestCase {
 
         // Two Distributed tables join on non-partitioned column
         failToCompile("select * FROM P1 JOIN P2 ON P1.C = P2.E",
-                      "Join of multiple partitioned tables has insufficient join criteria.");
+                      "This query is not plannable.  The planner cannot guarantee that all rows would be in a single partition.");
     }
 
     public void testBasicOuterJoin() {
@@ -864,7 +864,7 @@ public class TestPlansJoin extends PlannerTestCase {
 
         // Distributed Inner and Outer table joined on the non-partition column
         failToCompile("select * FROM P1 LEFT JOIN P4 ON P1.A = P4.E",
-                "Join of multiple partitioned tables has insufficient join criteria");
+                "This query is not plannable.  The planner cannot guarantee that all rows would be in a single partition");
     }
 
     public void testBasicIndexOuterJoin() {
@@ -1015,7 +1015,7 @@ public class TestPlansJoin extends PlannerTestCase {
 
         // Distributed Inner and Outer table joined on the non-partition column
         failToCompile("select * FROM P1 LEFT JOIN P4 ON P1.A = P4.E",
-                "Join of multiple partitioned tables has insufficient join criteria");
+                "This query is not plannable.  The planner cannot guarantee that all rows would be in a single partition");
     }
 
     public void testDistributedIndexJoinConditions() {

--- a/tests/frontend/org/voltdb/planner/TestPlansOrderBy.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansOrderBy.java
@@ -516,7 +516,7 @@ public class TestPlansOrderBy extends PlannerTestCase {
             failToCompile(
                     "select PT_D1 from (select P_D1 as PT_D1, P_D0 as PT_D0 from P order by P_D1) P_T, P where P.P_D0 = P_T.PT_D0;",
                     "This query is not plannable.  It has a subquery which needs cross-partition access.");
-            
+
         }
         {
             // The subquery with partition column (P_D0) in the GROUP BY columns.

--- a/tests/frontend/org/voltdb/planner/TestPlansOrderBy.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansOrderBy.java
@@ -515,7 +515,8 @@ public class TestPlansOrderBy extends PlannerTestCase {
             // the subquery post-processing still keeps it.
             failToCompile(
                     "select PT_D1 from (select P_D1 as PT_D1, P_D0 as PT_D0 from P order by P_D1) P_T, P where P.P_D0 = P_T.PT_D0;",
-                    "Join of multiple partitioned tables has insufficient join criteria.");
+                    "This query is not plannable.  It has a subquery which needs cross-partition access.");
+            
         }
         {
             // The subquery with partition column (P_D0) in the GROUP BY columns.

--- a/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
@@ -1492,7 +1492,7 @@ public class TestPlansSubQueries extends PlannerTestCase {
 
     }
 
-    private final String joinErrorMsg = "Join of multiple partitioned tables has insufficient join criteria.";
+    private final String joinErrorMsg = ".";
     public void testUnsupportedCases() {
         // (1)
         // sub-selected table must have an alias
@@ -1679,7 +1679,7 @@ public class TestPlansSubQueries extends PlannerTestCase {
 
         // Distinct with GROUP BY
         // TODO: group by partition column cases can be supported
-        String errorMessage = "Join of multiple partitioned tables has insufficient join criteria";
+        String errorMessage = "This query is not plannable.  It has a subquery which needs cross-partition access.";
         failToCompile(
                 "SELECT * FROM (SELECT DISTINCT A, C FROM P1 GROUP BY A, C) T1, P2 " +
                 "where T1.A = P2.A", errorMessage);
@@ -2099,7 +2099,7 @@ public class TestPlansSubQueries extends PlannerTestCase {
         pn = upn.getChild(2);
         checkSeqScan(pn, "R3", "A", "C");
 
-        String message = "Join of multiple partitioned tables has insufficient join criteria";
+        String message = "This query is not plannable.  It has a subquery which needs cross-partition access.";
         failToCompile("select * FROM " +
                 "(SELECT A, COUNT(*) FROM P1 GROUP BY A " +
                 "UNION " +

--- a/tests/frontend/org/voltdb/planner/TestSelfJoins.java
+++ b/tests/frontend/org/voltdb/planner/TestSelfJoins.java
@@ -128,10 +128,10 @@ public class TestSelfJoins  extends PlannerTestCase {
 
         // SELF JOIN on non-partitioned columns
         failToCompile("select * FROM P1 A JOIN P1 B ON A.C = B.A",
-                "Join of multiple partitioned tables has insufficient join criteria");
+                      "This query is not plannable.  The planner cannot guarantee that all rows would be in a single partition.");
         // SELF JOIN on non-partitioned column
         failToCompile("select * FROM P1 A JOIN P1 B ON A.C = B.C",
-                      "Join of multiple partitioned tables has insufficient join criteria");
+                      "This query is not plannable.  The planner cannot guarantee that all rows would be in a single partition.");
     }
 
     public void testInvalidSelfJoin() {

--- a/tests/frontend/org/voltdb/regressionsuites/TestInsertIntoSelectSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInsertIntoSelectSuite.java
@@ -757,7 +757,7 @@ public class TestInsertIntoSelectSuite extends RegressionSuite {
                         "select sp1.bi, sp2.vc, sp1.ii, sp2.ti " +
                         "from source_p1 as sp1 inner join source_p2 as sp2 " +
                         "on sp1.ii = sp2.ii",
-                        "Join of multiple partitioned tables has insufficient join criteria");
+                        "This query is not plannable.  The planner cannot guarantee that all rows would be in a single partition.");
 
         verifyStmtFails(client, "insert into target_r " +
                         "select sr1.bi, sr1.vc, sr1.ii, sr1.ti  " +
@@ -795,8 +795,8 @@ public class TestInsertIntoSelectSuite extends RegressionSuite {
         verifyStmtFails(client, "insert into target_p " +
                 "select 9, vc, ii, ti " +
                 "from source_p1 as sp1",
+                
                 "Partitioning could not be determined");
-
         // this whole statement should be single-partition!
         verifyStmtFails(client, "insert into target_p " +
                 "select 9, vc, ii, ti " +
@@ -811,9 +811,8 @@ public class TestInsertIntoSelectSuite extends RegressionSuite {
                 "inner join " +
                 "(select 9 as bi, vc, ii, ti from source_p1) as ins_sq " +
                 "on target_p.bi = ins_sq.bi",
-                "Join of multiple partitioned tables " +
-                "has insufficient join criteria"
-                );
+                "This query is not plannable.  "
+                + "The planner cannot guarantee that all rows would be in a single partition.");
     }
 
     public void testInsertIntoSelectGeneratedProcs() throws Exception

--- a/tests/frontend/org/voltdb/regressionsuites/TestInsertIntoSelectSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInsertIntoSelectSuite.java
@@ -795,7 +795,7 @@ public class TestInsertIntoSelectSuite extends RegressionSuite {
         verifyStmtFails(client, "insert into target_p " +
                 "select 9, vc, ii, ti " +
                 "from source_p1 as sp1",
-                
+
                 "Partitioning could not be determined");
         // this whole statement should be single-partition!
         verifyStmtFails(client, "insert into target_p " +


### PR DESCRIPTION
Some queries are not plannable because their joins cannot be computed
with our two fragment query model.  The error message for one such query
was misleading.  This commit fixes this.

Jira: ENG-10097.