### PR TITLE
Eng 10073 det

### DIFF
--- a/src/frontend/org/voltdb/planner/CompiledPlan.java
+++ b/src/frontend/org/voltdb/planner/CompiledPlan.java
@@ -161,7 +161,19 @@ public class CompiledPlan {
         if (m_statementIsOrderDeterministic) {
             return true;
         }
-        return rootPlanGraph.isOrderDeterministic();
+
+        if (rootPlanGraph.isOrderDeterministic()) {
+            return true;
+        }
+
+        // check if plans contains second fragment.
+        if (subPlanGraph != null) {
+            // If so evaluate case where the collector fragment will
+            // return at most one row to the co-ordinator fragment
+            return subPlanGraph.producesOneOutputRowOnly();
+        }
+        return false;
+
     }
 
     public boolean isContentDeterministic() {

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -497,8 +497,9 @@ public class PlanAssembler {
             rawplan = getNextPlan();
 
             // stop this while loop when no more plans are generated
-            if (rawplan == null)
+            if (rawplan == null) {
                 break;
+            }
             // Update the best cost plan so far
             m_planSelector.considerCandidatePlan(rawplan, parsedStmt);
         }

--- a/src/frontend/org/voltdb/planner/SubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SubPlanAssembler.java
@@ -1452,11 +1452,11 @@ public abstract class SubPlanAssembler {
      * assess the data from the table according to the path.
      *
      * @param table The table to get data from.
-     * @param path The access path to access the data in the table (index/scan/etc).
      * @return The root of a plan graph to get the data.
      */
     protected static AbstractPlanNode getAccessPlanForTable(JoinNode tableNode) {
         StmtTableScan tableScan = tableNode.getTableScan();
+        // Access path to access the data in the table (index/scan/etc).
         AccessPath path = tableNode.m_currentAccessPath;
         assert(path != null);
 

--- a/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
@@ -66,6 +66,16 @@ public abstract class AbstractOperationPlanNode extends AbstractPlanNode {
     @Override
     public abstract boolean isOrderDeterministic();
 
+    @Override
+    public boolean producesOneOutputRowOnly() {
+        // This function is not fully implemented for functional operation
+        // for update and delete at present, so it returns false for them.
+        // Insert operation can have a select statement, which can have result in
+        // index scan plan node. So for insert plan implementation is similar
+        // to AbstractPlanNode.
+        return false;
+    }
+
     /**
      * @return the target_table_name
      */

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -313,6 +313,28 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
     }
 
     /**
+     * Evaluates if the plan generates at most one row.
+     * At present, functionality to evaulate if plan node
+     * produces one row at most if implemented for index scan
+     * plan node. For the rest of the plan nodes, except insert plan
+     * node which can have embed index scan plan node too,
+     * their implementation of returns false indicating
+     * plan node has not be implemented yet.
+     */
+    public boolean producesOneOutputRowOnly() {
+        // iterate through the children nodes to see
+        // if the child nodes will return only one
+        // row at most.
+        assert(m_children != null);
+        for (AbstractPlanNode child : m_children) {
+            if (!child.producesOneOutputRowOnly()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Does the plan guarantee a result sorted according to the required sort order.
      * The default implementation delegates the question to its child if there is only one child.
      *

--- a/src/frontend/org/voltdb/plannodes/AbstractReceivePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractReceivePlanNode.java
@@ -64,6 +64,11 @@ public abstract class AbstractReceivePlanNode extends AbstractPlanNode {
         return false;
     }
 
+    @Override
+    public boolean producesOneOutputRowOnly() {
+        return false;
+    }
+
     /**
      * Accessor
      */

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -466,4 +466,9 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         return collected;
     }
 
+    @Override
+    public boolean producesOneOutputRowOnly() {
+        return false;
+    }
+
 }

--- a/src/frontend/org/voltdb/plannodes/InsertPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/InsertPlanNode.java
@@ -152,4 +152,19 @@ public class InsertPlanNode extends AbstractOperationPlanNode {
 
         return true;
     }
+
+    @Override
+    public boolean producesOneOutputRowOnly() {
+        assert(m_children != null);
+        assert(m_children.size() == 1);
+
+        // This implementation is very close to AbstractPlanNode's implementation of this
+        // method, except that we assert just one child.
+        AbstractPlanNode child = m_children.get(0);
+        if (! child.isOrderDeterministic()) {
+            m_nondeterminismDetail = child.m_nondeterminismDetail;
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
@@ -95,6 +95,11 @@ public class MaterializedScanPlanNode extends AbstractPlanNode {
     }
 
     @Override
+    public boolean producesOneOutputRowOnly() {
+        return false;
+    }
+
+    @Override
     public void computeCostEstimates(long childOutputTupleCountEstimate, Cluster cluster, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         // assume constant cost. Most of the cost of the SQL-IN will be measured by the NLIJ that is always paired with this element
         m_estimatedProcessedTupleCount = 1;

--- a/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
@@ -211,6 +211,11 @@ public class NestLoopIndexPlanNode extends AbstractJoinPlanNode {
     }
 
     @Override
+    public boolean producesOneOutputRowOnly() {
+        return false;
+    }
+
+    @Override
     public boolean hasInlinedIndexScanOfTable(String tableName) {
         IndexScanPlanNode index_scan = (IndexScanPlanNode) getInlinePlanNode(PlanNodeType.INDEXSCAN);
         assert(index_scan != null);

--- a/tests/frontend/org/voltdb/compiler/TestProcCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestProcCompiler.java
@@ -26,9 +26,9 @@ package org.voltdb.compiler;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import junit.framework.TestCase;
-
 import org.voltdb.VoltDB.Configuration;
+
+import junit.framework.TestCase;
 
 public class TestProcCompiler extends TestCase {
 

--- a/tests/frontend/org/voltdb/planner/PlannerTestAideDeCamp.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestAideDeCamp.java
@@ -97,6 +97,12 @@ public class PlannerTestAideDeCamp {
         return m_currentPlan;
     }
 
+    CompiledPlan compileAdHocPlan(String sql, boolean inferPartitioning, boolean singlePartition, DeterminismMode detMode)
+    {
+        compile(sql, 0, null, inferPartitioning, singlePartition, detMode);
+        return m_currentPlan;
+    }
+
     List<AbstractPlanNode> compile(String sql, int paramCount, boolean inferPartitioning, boolean singlePartition, String joinOrder) {
         return compile(sql, paramCount, joinOrder, inferPartitioning, singlePartition, DeterminismMode.SAFER);
     }

--- a/tests/frontend/org/voltdb/planner/PlannerTestCase.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestCase.java
@@ -95,7 +95,42 @@ public class PlannerTestCase extends TestCase {
         return cp;
     }
 
-    final int paramCount = 0;
+    /**
+     *  Fetch compiled planned based on provided partitioning information.
+     * @param sql: SQL statement
+     * @param inferPartitioning: Flag to indicate whether to use infer or forced partitioning when
+     *                           generating plan.
+     *                           True for infer partitioning info, false for forced partitioning
+     * @param forcedSP: Flag to indicate whether to generate plan for forced Single or Multi-partition
+     *                  If inferPartitioing flag is set to true, this flag is ignored
+     * @param detMode: Specifies determinism mode - Faster or Safer
+     * @return: Compiled plan based on specified input parameters
+     */
+
+    protected CompiledPlan compileAdHocPlan(String sql,
+                                            boolean inferPartitioning,
+                                            boolean forcedSP,
+                                            DeterminismMode detMode) {
+        CompiledPlan cp = null;
+        try {
+            cp = m_aide.compileAdHocPlan(sql, inferPartitioning, forcedSP, detMode);
+            assertTrue(cp != null);
+        }
+        catch (Exception ex) {
+            ex.printStackTrace();
+            fail();
+        }
+        return cp;
+    }
+
+    protected CompiledPlan compileAdHocPlan(String sql,
+                                            boolean inferPartitioning,
+                                            boolean forcedSP) {
+        return compileAdHocPlan(sql, inferPartitioning, forcedSP, DeterminismMode.SAFER);
+    }
+
+
+    final int m_defaultParamCount = 0;
     String noJoinOrder = null;
     /** A helper here where the junit test can assert success */
     protected List<AbstractPlanNode> compileToFragments(String sql)
@@ -157,7 +192,7 @@ public class PlannerTestCase extends TestCase {
 
     protected void compileWithInvalidJoinOrder(String sql, String joinOrder) throws Exception
     {
-        compileWithJoinOrderToFragments(sql, paramCount, m_byDefaultPlanForSinglePartition, joinOrder);
+        compileWithJoinOrderToFragments(sql, m_defaultParamCount, m_byDefaultPlanForSinglePartition, joinOrder);
     }
 
 

--- a/tests/frontend/org/voltdb/planner/TestDeterminism.java
+++ b/tests/frontend/org/voltdb/planner/TestDeterminism.java
@@ -492,20 +492,16 @@ public class TestDeterminism extends PlannerTestCase {
     }
 
     public void testMPDeterminismOfSelectIndexKeysOnly() {
-        /*
         assertMPPlanDeterminismNeedsOrdering("select a, b from ptree", "order by a, b");
         assertMPPlanDeterminismNeedsOrdering("select a, b, c from ptree", "order by a, b, c");
         // non-prefix keys don't help
         assertMPPlanDeterminismNeedsOrdering("select b, c from ptree", "order by b, c");
-        */
         // if a table has a unique index... it can be used to scan in a r/w transaction
         assertMPPlanNeedsSaferDeterminismCombo("select a from punique");
-        // assertMPPlanNeedsSaferDeterminismCombo("select a from ppk");
-        /*
+        assertMPPlanNeedsSaferDeterminismCombo("select a from ppk");
         // hashes don't help, here
         assertMPPlanDeterminismNeedsOrdering("select a, b from phash", "order by a, b");
         assertMPPlanDeterminismNeedsOrdering("select a, b, c from phash", "order by a, b, c");
-        */
     }
 
     public void testMPDeterminismOfSelectOneKeyValue() {

--- a/tests/frontend/org/voltdb/planner/testplans-determinism-ddl.sql
+++ b/tests/frontend/org/voltdb/planner/testplans-determinism-ddl.sql
@@ -121,3 +121,15 @@ create table floataggs (
     beta  float,
     gamma float
 );
+
+
+create table ppkcombo (
+  a bigint not null,
+  b bigint not null,
+  c bigint not null,
+  z bigint not null,
+  PRIMARY KEY (a, b ,c)
+);
+
+partition table ppkcombo on column a;
+

--- a/tests/frontend/org/voltdb/plannodes/MockPlanNode.java
+++ b/tests/frontend/org/voltdb/plannodes/MockPlanNode.java
@@ -33,6 +33,7 @@ public class MockPlanNode extends AbstractPlanNode
     String m_tableName;
     String[] m_columnNames;
     boolean m_isOrderDeterministic = false;
+    boolean m_producesOneRowOnly = false;
 
     MockPlanNode(String tableName, String[] columnNames)
     {
@@ -89,6 +90,11 @@ public class MockPlanNode extends AbstractPlanNode
         return m_isOrderDeterministic;
     }
 
+    @Override
+    public boolean producesOneOutputRowOnly() {
+        return false;
+    }
+
     /**
      * Write accessor for order determinism flag and optional description.
      * Also ensures consistency of content determinism flag (true -> true).
@@ -101,6 +107,10 @@ public class MockPlanNode extends AbstractPlanNode
         else {
             m_nondeterminismDetail = explanation;
         }
+    }
+
+    public void setProducesOneOutputRowOnly(boolean value) {
+        m_producesOneRowOnly = value;
     }
 
     @Override


### PR DESCRIPTION
Logic updates to evaluate determinism based on equivalence filters and unique constraints defined on the table for multi-fragment plan. If the query has parameterized / constant equivalence filters and the equivalence filter covers the unique filters defined on them such that it results in at most one output row, the query result is order deterministic irrespective if it's SP or MP. For eg  "Select * from T where a = ?;" where a is unique constrained defined on the table T will result in one output row. Today though similar query gets flagged as non-deterministic for multi-fragment plan. Logic updates with this pull request addresses this issue by adding additional logic to order-determinism evaluation where it evaluates collector fragment to see if the collector fragment will result in at most one output row. Currently logic to evaluate if the plan results in at most one output row has been implemented for Index scan plan only nodes to address the issue. In future we can add logic to other plan node logic to determine if they will result in at most one output row only where ever feasible.