### PR TITLE
update partition guard message

### DIFF
--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -1219,7 +1219,7 @@ public class VoltCompiler {
                             break;
                         default:
                             msg += "Partition column '" + tableName + "." + colName + "' is not a valid type. " +
-                            "Partition columns must be an integer or varchar type.";
+                            "Partition columns must be an integer, varchar or varbinary type.";
                             throw new VoltCompilerException(msg);
                     }
 

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -36,8 +36,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hsqldb_voltpatches.HsqlException;
@@ -66,6 +64,8 @@ import org.voltdb.types.IndexType;
 import org.voltdb.utils.BuildDirectoryUtils;
 import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.MiscUtils;
+
+import junit.framework.TestCase;
 
 public class TestVoltCompiler extends TestCase {
 
@@ -2814,7 +2814,7 @@ public class TestVoltCompiler extends TestCase {
     public void testGeographyPointValueNegative() throws Exception {
 
         // POINT cannot be a partition column
-        badDDLAgainstSimpleSchema(".*Partition columns must be an integer or varchar type.*",
+        badDDLAgainstSimpleSchema(".*Partition columns must be an integer, varchar or varbinary type.*",
                 "create table pts ("
                 + "  pt geography_point not null"
                 + ");"
@@ -2909,7 +2909,7 @@ public class TestVoltCompiler extends TestCase {
                      "partition table geogs on column geog;\n";
 
         // GEOGRAPHY cannot be a partition column
-        badDDLAgainstSimpleSchema(".*Partition columns must be an integer or varchar type.*", ddl);
+        badDDLAgainstSimpleSchema(".*Partition columns must be an integer, varchar or varbinary type.*", ddl);
 
         ddl = "create table geogs ( geog geography(0) not null );";
         badDDLAgainstSimpleSchema(".*precision or scale out of range.*", ddl);


### PR DESCRIPTION
Partitioning of table on varbinary type is permitted though the guard message does not indicate it (verfied murmur hash in EE on varbinary type is supported). A minor change updating partition-by guard message.

.................................
5> create table t (digest varbinary(128) NOT Null, pt geography_point NOT Null);
Command succeeded.
6> partition table T on column pt;
[null]: In database, Partition column 'T.pt' is not a valid type. Partition columns must be an integer, varchar or varbinary type.
7> partition table T on column digest;
Command succeeded.
.............................