### PR TITLE
ENG-10135: Fix XDCR timestmap mismatch conflict handling.

### DIFF
--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -97,6 +97,8 @@ namespace voltdb {
         this->actionType = action;
         this->deleteConflictType = deleteConflict;
         this->insertConflictType = insertConflict;
+        this->remoteClusterId = remoteClusterId;
+        this->remoteTimestamp = remoteTimestamp;
         char signature[20];
 
         if (existingMetaTableForDelete) {

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -128,6 +128,8 @@ public:
     DRRecordType actionType;
     DRConflictType deleteConflictType;
     DRConflictType insertConflictType;
+    int32_t remoteClusterId;
+    int64_t remoteTimestamp;
     boost::shared_ptr<Table> existingMetaRowsForDelete;
     boost::shared_ptr<Table> existingTupleRowsForDelete;
     boost::shared_ptr<Table> expectedMetaRowsForDelete;

--- a/src/ee/common/UniqueId.hpp
+++ b/src/ee/common/UniqueId.hpp
@@ -62,8 +62,15 @@ public:
         return pid(uid) == MP_INIT_PID;
     }
 
-    static int64_t timestampAndCounter(UniqueId uid) {
-        return (uid >> PARTITIONID_BITS) & TIMESTAMP_PLUS_COUNTER_MAX_VALUE;
+    static int64_t timestampSinceUnixEpoch(UniqueId uid) {
+        return tsCounterSinceUnixEpoch((uid >> PARTITIONID_BITS) & TIMESTAMP_PLUS_COUNTER_MAX_VALUE);
+    }
+
+    // Convert this into a microsecond-resolution timestamp based on Unix epoch;
+    // treat the time portion as the time in milliseconds, and the sequence
+    // number as if it is a time in microseconds
+    static int64_t tsCounterSinceUnixEpoch(int64_t tsCounter) {
+        return (tsCounter >> COUNTER_BITS) * 1000 + VOLT_EPOCH + (tsCounter & COUNTER_MAX_VALUE);
     }
 
     const int64_t uid;

--- a/src/ee/common/executorcontext.hpp
+++ b/src/ee/common/executorcontext.hpp
@@ -23,6 +23,7 @@
 #include "common/valuevector.h"
 #include "common/subquerycontext.h"
 #include "common/ValuePeeker.hpp"
+#include "common/UniqueId.hpp"
 
 #include <vector>
 #include <map>
@@ -119,16 +120,12 @@ class ExecutorContext {
         return (clusterId << 49) | (uniqueId >> 14);
     }
 
-    static int64_t getDRTimestampFromHiddenNValue(NValue &value) {
+    static int64_t getDRTimestampFromHiddenNValue(const NValue &value) {
         int64_t hiddenValue = ValuePeeker::peekAsBigInt(value);
-        // Convert this into a microsecond-resolution timestamp; treat the time
-        // portion as the time in milliseconds, and the sequence number as if
-        // it is a time in microseconds
-        int64_t ts = hiddenValue & ((1LL << 49) - 1LL);
-        return (ts >> 9) * 1000 + VOLT_EPOCH + (ts & 0x1ff);
+        return UniqueId::tsCounterSinceUnixEpoch(hiddenValue & ((1LL << 49) - 1LL));
     }
 
-    static int8_t getClusterIdFromHiddenNValue(NValue &value) {
+    static int8_t getClusterIdFromHiddenNValue(const NValue &value) {
         int64_t hiddenValue = ValuePeeker::peekAsBigInt(value);
         return static_cast<int8_t>(hiddenValue >> 49);
     }

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -653,6 +653,9 @@ bool BinaryLogSink::handleConflict(VoltDBEngine *engine, PersistentTable *drTabl
     }
 
     if (newTuple) {
+        assert(ExecutorContext::getDRTimestampFromHiddenNValue(newTuple->getHiddenNValue(drTable->getDRTimestampColumnIndex()))
+               == UniqueId::timestampSinceUnixEpoch(uniqueId));
+
         newMetaTableForInsert.reset(TableFactory::getCopiedTempTable(0, NEW_TABLE, conflictExportTable, NULL));
         newTupleTableForInsert.reset(TableFactory::getCopiedTempTable(0, NEW_TABLE, drTable, NULL));
         createConflictExportTuple(newMetaTableForInsert.get(), newTupleTableForInsert.get(),
@@ -661,7 +664,7 @@ bool BinaryLogSink::handleConflict(VoltDBEngine *engine, PersistentTable *drTabl
 
     int retval = ExecutorContext::getExecutorContext()->getTopend()->reportDRConflict(static_cast<int32_t>(UniqueId::pid(uniqueId)),
                                                                                       remoteClusterId,
-                                                                                      UniqueId::timestampAndCounter(uniqueId),
+                                                                                      UniqueId::timestampSinceUnixEpoch(uniqueId),
                                                                                       drTable->name(),
                                                                                       actionType,
                                                                                       deleteConflict,


### PR DESCRIPTION
When a timestamp mismatch conflict occurs, the resolver receives
incorrect timestamps for comparison. The timestamp for the remote
operation is Volt-epoch-based, but the local existing tuple's timestamp
is Unix-epoch-based. This resulted in always rejecting remote changes.

Now all timestamps passed to the resolver are Unix-epoch-based.