### PR TITLE
Eng 10073 - determinism updates for PK equivalence

### DIFF
--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -1817,7 +1817,8 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         if ( ( ! isGrouped() ) && displaysAgg()) {
             return true;
         }
-        return false;
+
+        return producesOneRowOuputUsingValueEquivalence();
     }
 
     private boolean hasTopLevelScans() {

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -1817,7 +1817,6 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         if ( ( ! isGrouped() ) && displaysAgg()) {
             return true;
         }
-
         return producesOneRowOutput();
     }
 

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -1818,7 +1818,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
             return true;
         }
 
-        return producesOneRowOuputUsingValueEquivalence();
+        return producesOneRowOutput();
     }
 
     private boolean hasTopLevelScans() {

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -497,8 +497,9 @@ public class PlanAssembler {
             rawplan = getNextPlan();
 
             // stop this while loop when no more plans are generated
-            if (rawplan == null)
+            if (rawplan == null) {
                 break;
+            }
             // Update the best cost plan so far
             m_planSelector.considerCandidatePlan(rawplan, parsedStmt);
         }

--- a/src/frontend/org/voltdb/planner/SubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SubPlanAssembler.java
@@ -1452,11 +1452,11 @@ public abstract class SubPlanAssembler {
      * assess the data from the table according to the path.
      *
      * @param table The table to get data from.
-     * @param path The access path to access the data in the table (index/scan/etc).
      * @return The root of a plan graph to get the data.
      */
     protected static AbstractPlanNode getAccessPlanForTable(JoinNode tableNode) {
         StmtTableScan tableScan = tableNode.getTableScan();
+        // Access path to access the data in the table (index/scan/etc).
         AccessPath path = tableNode.m_currentAccessPath;
         assert(path != null);
 

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -465,5 +465,4 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         collected.addAll(ExpressionUtil.findAllExpressionsOfClass(m_predicate, aeClass));
         return collected;
     }
-
 }

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -540,12 +540,31 @@ public class IndexScanPlanNode extends AbstractScanPlanNode {
         super.resolveColumnIndexes();
     }
 
+    private double getSearchExpressionKeyWidth(final double colCount) {
+        double keyWidth = m_searchkeyExpressions.size();
+        assert(keyWidth <= colCount);
+        // count a range scan as a half covered column
+        if (keyWidth > 0.0 &&
+                m_lookupType != IndexLookupType.EQ &&
+                m_lookupType != IndexLookupType.GEO_CONTAINS) {
+            keyWidth -= 0.5;
+        }
+        else if (keyWidth == 0.0 && m_endExpression != null) {
+            // When there is no start key, count an end-key as a single-column range scan key.
+
+            // TODO: ( (double) ExpressionUtil.uncombineAny(m_endExpression).size() ) - 0.5
+            // might give a result that is more in line with multi-component start-key-only scans.
+            keyWidth = 0.5;
+        }
+        return keyWidth;
+    }
+
     @Override
     public void computeCostEstimates(long unusedChildOutputTupleCountEstimate,
-            Cluster unusedCluster,
-            Database unusedDb,
-            DatabaseEstimates estimates,
-            ScalarValueHints[] unusedParamHints) {
+                                     Cluster unusedCluster,
+                                     Database unusedDb,
+                                     DatabaseEstimates estimates,
+                                     ScalarValueHints[] unusedParamHints) {
 
         // HOW WE COST INDEXES
         // unique, covering index always wins
@@ -558,25 +577,10 @@ public class IndexScanPlanNode extends AbstractScanPlanNode {
 
         DatabaseEstimates.TableEstimates tableEstimates = estimates.getEstimatesForTable(m_targetTableName);
 
-        // get the width of the index and number of columns used
+        // get the width of the index - number of columns or expression included in the index
         // need doubles for math
-        double colCount = CatalogUtil.getCatalogIndexSize(m_catalogIndex);
-        double keyWidth = m_searchkeyExpressions.size();
-        assert(keyWidth <= colCount);
-
-        // count a range scan as a half covered column
-        if (keyWidth > 0.0 &&
-                m_lookupType != IndexLookupType.EQ &&
-                m_lookupType != IndexLookupType.GEO_CONTAINS) {
-            keyWidth -= 0.5;
-        }
-        // When there is no start key, count an end-key as a single-column range scan key.
-        else if (keyWidth == 0.0 && m_endExpression != null) {
-            // TODO: ( (double) ExpressionUtil.uncombineAny(m_endExpression).size() ) - 0.5
-            // might give a result that is more in line with multi-component start-key-only scans.
-            keyWidth = 0.5;
-        }
-
+        final double colCount = CatalogUtil.getCatalogIndexSize(m_catalogIndex);
+        final double keyWidth = getSearchExpressionKeyWidth(colCount);
 
         // Estimate the cost of the scan (AND each projection and sort thereafter).
         // This "tuplesToRead" is not strictly speaking an expected count of tuples.

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -545,8 +545,8 @@ public class IndexScanPlanNode extends AbstractScanPlanNode {
         assert(keyWidth <= colCount);
         // count a range scan as a half covered column
         if (keyWidth > 0.0 &&
-                m_lookupType != IndexLookupType.EQ &&
-                m_lookupType != IndexLookupType.GEO_CONTAINS) {
+            m_lookupType != IndexLookupType.EQ &&
+            m_lookupType != IndexLookupType.GEO_CONTAINS) {
             keyWidth -= 0.5;
         }
         else if (keyWidth == 0.0 && m_endExpression != null) {

--- a/tests/frontend/org/voltdb/compiler/TestProcCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestProcCompiler.java
@@ -26,9 +26,9 @@ package org.voltdb.compiler;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import junit.framework.TestCase;
-
 import org.voltdb.VoltDB.Configuration;
+
+import junit.framework.TestCase;
 
 public class TestProcCompiler extends TestCase {
 

--- a/tests/frontend/org/voltdb/compiler/TestProcCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestProcCompiler.java
@@ -26,9 +26,9 @@ package org.voltdb.compiler;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import org.voltdb.VoltDB.Configuration;
-
 import junit.framework.TestCase;
+
+import org.voltdb.VoltDB.Configuration;
 
 public class TestProcCompiler extends TestCase {
 

--- a/tests/frontend/org/voltdb/planner/PlannerTestAideDeCamp.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestAideDeCamp.java
@@ -91,9 +91,13 @@ public class PlannerTestAideDeCamp {
      * @param sql
      * @param detMode
      */
-    CompiledPlan compileAdHocPlan(String sql, DeterminismMode detMode)
-    {
+    CompiledPlan compileAdHocPlan(String sql, DeterminismMode detMode) {
         compile(sql, 0, null, true, false, detMode);
+        return m_currentPlan;
+    }
+
+    CompiledPlan compileAdHocPlan(String sql, boolean inferPartitioning, boolean singlePartition, DeterminismMode detMode) {
+        compile(sql, 0, null, inferPartitioning, singlePartition, detMode);
         return m_currentPlan;
     }
 

--- a/tests/frontend/org/voltdb/planner/PlannerTestCase.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestCase.java
@@ -95,7 +95,42 @@ public class PlannerTestCase extends TestCase {
         return cp;
     }
 
-    final int paramCount = 0;
+    /**
+     *  Fetch compiled planned based on provided partitioning information.
+     * @param sql: SQL statement
+     * @param inferPartitioning: Flag to indicate whether to use infer or forced partitioning when
+     *                           generating plan.
+     *                           True for infer partitioning info, false for forced partitioning
+     * @param forcedSP: Flag to indicate whether to generate plan for forced Single or Multi-partition
+     *                  If inferPartitioing flag is set to true, this flag is ignored
+     * @param detMode: Specifies determinism mode - Faster or Safer
+     * @return: Compiled plan based on specified input parameters
+     */
+
+    protected CompiledPlan compileAdHocPlan(String sql,
+                                            boolean inferPartitioning,
+                                            boolean forcedSP,
+                                            DeterminismMode detMode) {
+        CompiledPlan cp = null;
+        try {
+            cp = m_aide.compileAdHocPlan(sql, inferPartitioning, forcedSP, detMode);
+            assertTrue(cp != null);
+        }
+        catch (Exception ex) {
+            ex.printStackTrace();
+            fail();
+        }
+        return cp;
+    }
+
+    protected CompiledPlan compileAdHocPlan(String sql,
+                                            boolean inferPartitioning,
+                                            boolean forcedSP) {
+        return compileAdHocPlan(sql, inferPartitioning, forcedSP, DeterminismMode.SAFER);
+    }
+
+
+    final int m_defaultParamCount = 0;
     String noJoinOrder = null;
     /** A helper here where the junit test can assert success */
     protected List<AbstractPlanNode> compileToFragments(String sql)
@@ -157,7 +192,7 @@ public class PlannerTestCase extends TestCase {
 
     protected void compileWithInvalidJoinOrder(String sql, String joinOrder) throws Exception
     {
-        compileWithJoinOrderToFragments(sql, paramCount, m_byDefaultPlanForSinglePartition, joinOrder);
+        compileWithJoinOrderToFragments(sql, m_defaultParamCount, m_byDefaultPlanForSinglePartition, joinOrder);
     }
 
 

--- a/tests/frontend/org/voltdb/planner/PlannerTestCase.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestCase.java
@@ -132,22 +132,19 @@ public class PlannerTestCase extends TestCase {
     }
 
     /** A helper here where the junit test can assert success */
-    protected List<AbstractPlanNode> compileToFragments(String sql)
-    {
+    protected List<AbstractPlanNode> compileToFragments(String sql) {
         boolean planForSinglePartitionFalse = false;
         return compileWithJoinOrderToFragments(sql, planForSinglePartitionFalse, m_noJoinOrder);
     }
 
-    protected List<AbstractPlanNode> compileToFragmentsForSinglePartition(String sql)
-    {
+    protected List<AbstractPlanNode> compileToFragmentsForSinglePartition(String sql) {
         boolean planForSinglePartitionFalse = false;
         return compileWithJoinOrderToFragments(sql, planForSinglePartitionFalse, m_noJoinOrder);
     }
 
 
     /** A helper here where the junit test can assert success */
-    protected List<AbstractPlanNode> compileWithJoinOrderToFragments(String sql, String joinOrder)
-    {
+    protected List<AbstractPlanNode> compileWithJoinOrderToFragments(String sql, String joinOrder) {
         boolean planForSinglePartitionFalse = false;
         return compileWithJoinOrderToFragments(sql, planForSinglePartitionFalse, joinOrder);
     }
@@ -155,8 +152,7 @@ public class PlannerTestCase extends TestCase {
     /** A helper here where the junit test can assert success */
     private List<AbstractPlanNode> compileWithJoinOrderToFragments(String sql,
                                                                    boolean planForSinglePartition,
-                                                                   String joinOrder)
-    {
+                                                                   String joinOrder) {
         // Yes, we ARE assuming that test queries don't contain quoted question marks.
         int paramCount = StringUtils.countMatches(sql, "?");
         return compileWithJoinOrderToFragments(sql, paramCount, planForSinglePartition, joinOrder);
@@ -165,8 +161,7 @@ public class PlannerTestCase extends TestCase {
     /** A helper here where the junit test can assert success */
     private List<AbstractPlanNode> compileWithJoinOrderToFragments(String sql, int paramCount,
                                                                    boolean planForSinglePartition,
-                                                                   String joinOrder)
-    {
+                                                                   String joinOrder) {
         List<AbstractPlanNode> pn = m_aide.compile(sql, paramCount, m_byDefaultInferPartitioning, m_byDefaultPlanForSinglePartition, joinOrder);
         assertTrue(pn != null);
         assertFalse(pn.isEmpty());
@@ -177,8 +172,7 @@ public class PlannerTestCase extends TestCase {
         return pn;
     }
 
-    protected AbstractPlanNode compileSPWithJoinOrder(String sql, String joinOrder)
-    {
+    protected AbstractPlanNode compileSPWithJoinOrder(String sql, String joinOrder) {
         try {
             return compileWithCountedParamsAndJoinOrder(sql, joinOrder);
         }
@@ -189,30 +183,27 @@ public class PlannerTestCase extends TestCase {
         }
     }
 
-    protected void compileWithInvalidJoinOrder(String sql, String joinOrder) throws Exception
-    {
+    protected void compileWithInvalidJoinOrder(String sql, String joinOrder) throws Exception {
         compileWithJoinOrderToFragments(sql, m_defaultParamCount, m_byDefaultPlanForSinglePartition, joinOrder);
     }
 
 
-    private AbstractPlanNode compileWithCountedParamsAndJoinOrder(String sql, String joinOrder) throws Exception
-    {
+    private AbstractPlanNode compileWithCountedParamsAndJoinOrder(String sql,
+                                                                  String joinOrder) throws Exception {
         // Yes, we ARE assuming that test queries don't contain quoted question marks.
         int paramCount = StringUtils.countMatches(sql, "?");
         return compileSPWithJoinOrder(sql, paramCount, joinOrder);
     }
 
     /** A helper here where the junit test can assert success */
-    protected AbstractPlanNode compile(String sql)
-    {
+    protected AbstractPlanNode compile(String sql) {
         // Yes, we ARE assuming that test queries don't contain quoted question marks.
         int paramCount = StringUtils.countMatches(sql, "?");
         return compileSPWithJoinOrder(sql, paramCount, null);
     }
 
     /** A helper here where the junit test can assert success */
-    protected AbstractPlanNode compileForSinglePartition(String sql)
-    {
+    protected AbstractPlanNode compileForSinglePartition(String sql) {
         // Yes, we ARE assuming that test queries don't contain quoted question marks.
         int paramCount = StringUtils.countMatches(sql, "?");
         boolean m_infer = m_byDefaultInferPartitioning;
@@ -227,8 +218,9 @@ public class PlannerTestCase extends TestCase {
     }
 
     /** A helper here where the junit test can assert success */
-    protected AbstractPlanNode compileSPWithJoinOrder(String sql, int paramCount, String joinOrder)
-    {
+    protected AbstractPlanNode compileSPWithJoinOrder(String sql,
+                                                      int paramCount,
+                                                      String joinOrder) {
         List<AbstractPlanNode> pns = null;
         try {
             pns = compileWithJoinOrderToFragments(sql, paramCount, m_byDefaultPlanForSinglePartition, joinOrder);
@@ -258,14 +250,13 @@ public class PlannerTestCase extends TestCase {
 
 
     protected void setupSchema(URL ddlURL, String basename,
-                               boolean planForSinglePartition) throws Exception
-    {
+                               boolean planForSinglePartition) throws Exception {
         m_aide = new PlannerTestAideDeCamp(ddlURL, basename);
         m_byDefaultPlanForSinglePartition = planForSinglePartition;
     }
 
-    protected void setupSchema(boolean inferPartitioning, URL ddlURL, String basename) throws Exception
-    {
+    protected void setupSchema(boolean inferPartitioning, URL ddlURL,
+                               String basename) throws Exception {
         m_byDefaultInferPartitioning = inferPartitioning;
         m_aide = new PlannerTestAideDeCamp(ddlURL, basename);
     }

--- a/tests/frontend/org/voltdb/planner/PlannerTestCase.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestCase.java
@@ -96,12 +96,12 @@ public class PlannerTestCase extends TestCase {
     }
 
     /**
-     *  Fetch compiled planned based on provided partitioning information.
+     * Fetch compiled planned based on provided partitioning information.
      * @param sql: SQL statement
-     * @param inferPartitioning: Flag to indicate whether to use infer or forced partitioning when
-     *                           generating plan.
-     *                           True for infer partitioning info, false for forced partitioning
-     * @param forcedSP: Flag to indicate whether to generate plan for forced Single or Multi-partition
+     * @param inferPartitioning: Flag to indicate whether to use infer or forced partitioning
+     *                           when generating plan. True to use infer partitioning info,
+     *                           false for forced partitioning
+     * @param forcedSP: Flag to indicate whether to generate plan for forced SP or MP.
      *                  If inferPartitioing flag is set to true, this flag is ignored
      * @param detMode: Specifies determinism mode - Faster or Safer
      * @return: Compiled plan based on specified input parameters

--- a/tests/frontend/org/voltdb/planner/PlannerTestCase.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestCase.java
@@ -39,6 +39,8 @@ public class PlannerTestCase extends TestCase {
     private PlannerTestAideDeCamp m_aide;
     private boolean m_byDefaultInferPartitioning = true;
     private boolean m_byDefaultPlanForSinglePartition;
+    final private int m_defaultParamCount = 0;
+    private String m_noJoinOrder = null;
 
     /**
      * @param sql
@@ -129,20 +131,17 @@ public class PlannerTestCase extends TestCase {
         return compileAdHocPlan(sql, inferPartitioning, forcedSP, DeterminismMode.SAFER);
     }
 
-
-    final int m_defaultParamCount = 0;
-    String noJoinOrder = null;
     /** A helper here where the junit test can assert success */
     protected List<AbstractPlanNode> compileToFragments(String sql)
     {
         boolean planForSinglePartitionFalse = false;
-        return compileWithJoinOrderToFragments(sql, planForSinglePartitionFalse, noJoinOrder);
+        return compileWithJoinOrderToFragments(sql, planForSinglePartitionFalse, m_noJoinOrder);
     }
 
     protected List<AbstractPlanNode> compileToFragmentsForSinglePartition(String sql)
     {
         boolean planForSinglePartitionFalse = false;
-        return compileWithJoinOrderToFragments(sql, planForSinglePartitionFalse, noJoinOrder);
+        return compileWithJoinOrderToFragments(sql, planForSinglePartitionFalse, m_noJoinOrder);
     }
 
 

--- a/tests/frontend/org/voltdb/planner/TestDeterminism.java
+++ b/tests/frontend/org/voltdb/planner/TestDeterminism.java
@@ -612,10 +612,86 @@ public class TestDeterminism extends PlannerTestCase {
                                       DeterminismMode.FASTER);
     }
 
+    public void testDeterminismOfUniqueConstraintEquivalence() {
+        String sql;
+
+        // equivalence filter in predicate clause using unique key with display list with
+        // different column than in where clause predicate.
+        sql = "select b from punique where a = ?";
+        assertMPPlanDeterminismCore(sql, ORDERED, CONSISTENT, true, DeterminismMode.FASTER);
+        assertMPPlanDeterminismCore(sql, ORDERED, CONSISTENT, true, DeterminismMode.SAFER);
+
+        // where clause using equivalence filter on table using all columns
+        // forming composite primary
+        // key as this select statement can be in insert clause too, test it for
+        // safer determinism also
+        sql = "select z from ppkcombo where a = 1 AND b = 2 AND c =3;";
+        assertMPPlanDeterminismCore(sql, ORDERED, CONSISTENT, true, DeterminismMode.FASTER);
+        assertMPPlanDeterminismCore(sql, ORDERED, CONSISTENT, true, DeterminismMode.SAFER);
+
+        // using parameters
+        sql = "select z from ppkcombo where a = ? AND b = ? AND c = ?;";
+        assertMPPlanDeterminismCore(sql, ORDERED, CONSISTENT, true, DeterminismMode.FASTER);
+        assertMPPlanDeterminismCore(sql, ORDERED, CONSISTENT, true, DeterminismMode.SAFER);
+
+        // predicate containing value-equivalence through transitive behavior that form unique
+        // index on table
+        sql = "select c, z from ppkcombo where a = ? AND A = B AND c = B;";
+        assertMPPlanDeterminismCore(sql, ORDERED, CONSISTENT, true, DeterminismMode.FASTER);
+        assertMPPlanDeterminismCore(sql, ORDERED, CONSISTENT, true, DeterminismMode.SAFER);
+
+        // predicate clause has equivalence filter but not value-equivalence
+        sql = "select c, z from ppkcombo where A = B AND C = B;";
+        assertMPPlanDeterminismCore(sql, UNORDERED, CONSISTENT, true, DeterminismMode.FASTER);
+
+        // query does not guarantee determinism if not all columns that form
+        // compound index, are present in part of value equivalence
+        sql = "select c, z from ppkcombo where a = 1 AND c = 3;";
+        assertMPPlanDeterminismCore(sql, UNORDERED, CONSISTENT, true, DeterminismMode.FASTER);
+
+        // predicate clause including all columns of compound key with
+        // OR operator, does not guarantee single row output
+        sql = "select c, z from ppkcombo where a = 1 OR B = ? AND c = 3;";
+        assertMPPlanDeterminismCore(sql, UNORDERED, CONSISTENT, true, DeterminismMode.FASTER);
+
+        // predicate clause including all columns of composite keys of composite but not
+        // value equivalence
+        sql = "select c, z from ppkcombo where a > 1 AND B = ? AND c = 3;";
+        assertMPPlanDeterminismCore(sql, UNORDERED, CONSISTENT, true, DeterminismMode.FASTER);
+
+        // non-equivalence filter on unique filter does not guarantee
+        // determinism
+        sql = "select a from ppk where a > 1;";
+        assertMPPlanDeterminismCore(sql, UNORDERED, CONSISTENT, true, DeterminismMode.FASTER);
+    }
+
+    private void assertMPPlanDeterminismCore(String sql, boolean order, boolean content, DeterminismMode detMode) {
+        assertMPPlanDeterminismCore(sql, order, content, false, detMode);
+        }
+
+    /**
+     * Tests MP compiled plan for the specified determinism properties
+     *
+     * @param sql - SQL statement
+     * @param order - Specifies whether the statement should result in order
+     *                determinism or not
+     * @param content - Specifies whether the statement should result in content
+     *                  determinism or not
+     *@param forcePartitioning - If set to true, applies force MP to generated compiled plan.
+     * @param detMode
+     */
     private void assertMPPlanDeterminismCore(String sql, boolean order, boolean content,
-            DeterminismMode detMode)
-    {
-        CompiledPlan cp = compileAdHocPlan(sql, detMode);
+            boolean forcePartitioning, DeterminismMode detMode) {
+        // Partitioning can be forced or inferred. If inferred, force
+        // partitioning is irrelevant
+        // If inferred is set to false, use forced MP by setting forceSP to
+        // false
+        boolean inferPartitioning = true; // by default, use the in
+        boolean forceSP = false;
+        if (forcePartitioning) {
+            inferPartitioning = false;
+        }
+        CompiledPlan cp = compileAdHocPlan(sql, inferPartitioning, forceSP, detMode);
         if (order != cp.isOrderDeterministic()) {
             System.out.println((order ? "EXPECTED ORDER: " : "UNEXPECTED ORDER: ") + sql);
             if (m_staticRetryForDebugOnFailure) {

--- a/tests/frontend/org/voltdb/planner/testplans-determinism-ddl.sql
+++ b/tests/frontend/org/voltdb/planner/testplans-determinism-ddl.sql
@@ -121,3 +121,17 @@ create table floataggs (
     beta  float,
     gamma float
 );
+
+
+create table ppkcombo (
+  a bigint not null,
+  b bigint not null,
+  c bigint not null,
+  z bigint not null,
+  PRIMARY KEY (a, b ,c)
+);
+
+create unique index pcover3_ppkCombo on ppkcombo (a, c, z);
+--create unique index pcover2_ppkCombo on ppkcombo (a, c);
+partition table ppkcombo on column a;
+

--- a/tests/frontend/org/voltdb/planner/testplans-determinism-ddl.sql
+++ b/tests/frontend/org/voltdb/planner/testplans-determinism-ddl.sql
@@ -130,8 +130,6 @@ create table ppkcombo (
   z bigint not null,
   PRIMARY KEY (a, b ,c)
 );
-
-create unique index pcover3_ppkCombo on ppkcombo (a, c, z);
---create unique index pcover2_ppkCombo on ppkcombo (a, c);
+create unique index pcover2_ppkCombo on ppkcombo (a, z);
 partition table ppkcombo on column a;
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
@@ -26,6 +26,8 @@ package org.voltdb.regressionsuites;
 import java.io.IOException;
 import java.util.UUID;
 
+import junit.framework.Test;
+
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
@@ -37,8 +39,6 @@ import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb_testprocs.regressionsuites.sqlfeatureprocs.BatchedMultiPartitionTest;
 import org.voltdb_testprocs.regressionsuites.sqlfeatureprocs.PopulateTruncateTable;
 import org.voltdb_testprocs.regressionsuites.sqlfeatureprocs.TruncateTable;
-
-import junit.framework.Test;
 
 public class TestSQLFeaturesNewSuite extends RegressionSuite {
     // procedures used by these tests


### PR DESCRIPTION
Logic updates to evaluate the SQL statement determinism based on value equivalence filters in the statement and unique indexes defined on the table. If the statement has parameterized/constant equivalence filters and the equivalence filter covers the unique indexes defined on the table such that it results in at most one output row, the query result is order deterministic irrespective if it result in single or two fragment plan. 

For eg "Select * from T where a = ?;" 
where a is unique constrained defined on the table T will result in atmost one output row. 

Today though similar statement gets flagged as non-deterministic for two fragment plan. Logic updates with this pull request addresses this issue by extending determinism logic in abstract parsed statement to also check if the statement will produce at most one output row based on value equivalence filters in the statement and unique indexes defined on the table.