### PR TITLE
ENG-10289: temporarily disable testAdHocLengthLimit in valgrind

### DIFF
--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -472,6 +472,10 @@ public class TestAdHocQueries extends AdHocQueryTester {
 
         try {
             env.setUp();
+            // by pass valgrind due to ENG-7843
+            if (env.isValgrind()) {
+                return;
+            }
             StringBuffer adHocQueryTemp = new StringBuffer("SELECT * FROM VOTES WHERE PHONE_NUMBER IN (");
             int i = 0;
             while (adHocQueryTemp.length() <= Short.MAX_VALUE*10) {
@@ -1109,6 +1113,12 @@ public class TestAdHocQueries extends AdHocQueryTester {
 
             // no clue how helpful this is
             System.gc();
+        }
+
+        boolean isValgrind() {
+            if (m_cluster != null)
+                return m_cluster.isValgrind();
+            return true;
         }
     }
 


### PR DESCRIPTION
tested locally
