### PR TITLE
Eng 10073 vmc upsert test

### DIFF
--- a/tests/geb/vmc/src/resources/expectedUserStoredProcs.txt
+++ b/tests/geb/vmc/src/resources/expectedUserStoredProcs.txt
@@ -4,5 +4,11 @@ CountPartitionedTable
 CountPartitionedTableByGroup
 CountReplicatedTable
 CountReplicatedTableByGroup
+# These EXPORT_... tables do not really belong here, but until ENG-?? is fixed,
+# this keeps the 'vmctest-headless' Jenkins build from being red:
+EXPORT_DONE_TABLE.insert
+EXPORT_PARTITIONED_TABLE.insert
+EXPORT_REPLICATED_TABLE.insert
+EXPORT_SKINNY_PARTITIONED_TABLE.insert
 InsertPartitionedTableZeroes
 InsertReplicatedTableZeroes

--- a/tests/geb/vmc/src/resources/expectedUserStoredProcs.txt
+++ b/tests/geb/vmc/src/resources/expectedUserStoredProcs.txt
@@ -4,8 +4,8 @@ CountPartitionedTable
 CountPartitionedTableByGroup
 CountReplicatedTable
 CountReplicatedTableByGroup
-# These EXPORT_... tables do not really belong here, but until ENG-?? is fixed,
-# this keeps the 'vmctest-headless' Jenkins build from being red:
+# These EXPORT_... tables do not really belong here, but until ENG-10137 is
+# fixed, this keeps the 'vmctest-headless' Jenkins build from being red:
 EXPORT_DONE_TABLE.insert
 EXPORT_PARTITIONED_TABLE.insert
 EXPORT_REPLICATED_TABLE.insert

--- a/tests/geb/vmc/src/resources/sqlQueries.txt
+++ b/tests/geb/vmc/src/resources/sqlQueries.txt
@@ -388,16 +388,31 @@
                        "type_null_point":["POINT (-23.0 23.0)"],"type_not_null_point":["POINT (24.0 -24.0)"],
                        "type_null_polygon":["POLYGON ((25.0 22.0, 25.0 21.0, 26.0 22.0, 25.0 22.0))"],"type_not_null_polygon":["POLYGON ((26.0 22.0, 25.0 23.0, 25.0 22.0, 26.0 22.0))"]},
              "status":"SUCCESS"}}
+# This Insert, with WHERE clause and ORDER BY, works fine (Select from Replicated, Upsert into Partitioned table):
 {"testName":"InsertIntoSelectRepl2Part",
    "sqlCmd":"INSERT INTO replicated_table VALUES(__standard_insert_values);\n
              INSERT INTO partitioned_table SELECT * FROM replicated_table WHERE rowid=1 ORDER BY rowid;\n
              SELECT * FROM partitioned_table",
  "response":{"result":"__standard_result",
              "status":"SUCCESS"}}
-# Same Insert, without Order By, works fine (unlike UPSERT, but correct):
+# Same Insert, with WHERE clause but no ORDER BY, works fine:
 {"testName":"InsertIntoSelectNoOrderBy",
    "sqlCmd":"INSERT INTO replicated_table VALUES(__standard_insert_values);\n
              INSERT INTO partitioned_table SELECT * FROM replicated_table WHERE rowid=1;\n
+             SELECT * FROM partitioned_table",
+ "response":{"result":"__standard_result",
+             "status":"SUCCESS"}}
+# Same Insert, with ORDER BY but no WHERE clause, works fine:
+{"testName":"InsertIntoSelectNoWhere",
+   "sqlCmd":"INSERT INTO replicated_table VALUES(__standard_insert_values);\n
+             INSERT INTO partitioned_table SELECT * FROM replicated_table ORDER BY rowid;\n
+             SELECT * FROM partitioned_table",
+ "response":{"result":"__standard_result",
+             "status":"SUCCESS"}}
+# Same Insert, without WHERE clause or ORDER BY, also works fine (unlike UPSERT, but correct):
+{"testName":"InsertIntoSelectNoWhereOrOrderBy",
+   "sqlCmd":"INSERT INTO replicated_table VALUES(__standard_insert_values);\n
+             INSERT INTO partitioned_table SELECT * FROM replicated_table;\n
              SELECT * FROM partitioned_table",
  "response":{"result":"__standard_result",
              "status":"SUCCESS"}}
@@ -437,16 +452,31 @@
                        "type_null_point":["POINT (-23.0 23.0)"],"type_not_null_point":["POINT (24.0 -24.0)"],
                        "type_null_polygon":["POLYGON ((25.0 22.0, 25.0 21.0, 26.0 22.0, 25.0 22.0))"],"type_not_null_polygon":["POLYGON ((26.0 22.0, 25.0 23.0, 25.0 22.0, 26.0 22.0))"]},
              "status":"SUCCESS"}}
+# This Upsert, with WHERE clause and ORDER BY, works fine (Select from Replicated, Upsert into Partitioned table):
 {"testName":"UpsertIntoSelectRepl2Part",
    "sqlCmd":"INSERT INTO replicated_table VALUES(__standard_insert_values);\n
              UPSERT INTO partitioned_table SELECT * FROM replicated_table WHERE rowid=1 ORDER BY rowid;\n
              SELECT * FROM partitioned_table",
  "response":{"result":"__standard_result",
              "status":"SUCCESS"}}
-# Same Upsert, without Order By, fails (DML error; unlike INSERT, but correct):
+# Same Upsert, with WHERE clause but no ORDER BY, now works fine (since ENG-10073 fixed, because WHERE clause specifies one row):
 {"testName":"UpsertIntoSelectNoOrderBy",
    "sqlCmd":"INSERT INTO replicated_table VALUES(__standard_insert_values);\n
-             UPSERT INTO partitioned_table SELECT * FROM replicated_table WHERE rowid=1;               ",
+             UPSERT INTO partitioned_table SELECT * FROM replicated_table WHERE rowid=1;\n
+             SELECT * FROM partitioned_table",
+ "response":{"result":"__standard_result",
+             "status":"SUCCESS"}}
+# Same Upsert, with ORDER BY but no WHERE clause, works fine:
+{"testName":"UpsertIntoSelectNoWhere",
+   "sqlCmd":"INSERT INTO replicated_table VALUES(__standard_insert_values);\n
+             UPSERT INTO partitioned_table SELECT * FROM replicated_table ORDER BY rowid;\n
+             SELECT * FROM partitioned_table",
+ "response":{"result":"__standard_result",
+             "status":"SUCCESS"}}
+# Same Upsert, without WHERE clause or ORDER BY, fails (non-deterministic error; unlike INSERT, but correct):
+{"testName":"UpsertIntoSelectNoWhereOrOrderBy",
+   "sqlCmd":"INSERT INTO replicated_table VALUES(__standard_insert_values);\n
+             UPSERT INTO partitioned_table SELECT * FROM replicated_table;",
  "response":{"result":"ERROR","status":"FAILURE","error":"non-deterministic"}}
 # Select from Partitioned, Upsert into Replicated should fail:
 {"testName":"UpsertIntoSelectPart2Repl",


### PR DESCRIPTION
Fixed the UPSERT test in sqlQueries.txt that has been failing since ENG-10073 was fixed; and added a few similar tests to confirm which cases do and still do not work (and should not). Also fixed unrelated problems with the SqlQueriesTest.checkUserStoredProcs test failing, due to new stored procedures showing up in the list (which I've now added, see ENG-10137), and due to new stream T25N (I fixed FullDdlSqlTest.groovy to now drop any streams that are added via a CREATE STREAM statement).