### PR TITLE
ENG-10262: When a replica node rejoins or recovers, it is assumed tha…

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -865,10 +865,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
 
                 // LeaderAppointer startup blocks if the initiators are not initialized.
                 // So create the LeaderAppointer after the initiators.
-                // arogers: The leader appointer should
-                // expect a sync snapshot. This needs to change when the replica supports different
-                // start actions
-                boolean expectSyncSnapshot = m_config.m_replicationRole == ReplicationRole.REPLICA;
+                boolean expectSyncSnapshot = m_config.m_replicationRole == ReplicationRole.REPLICA && config.m_startAction == StartAction.CREATE;
                 m_leaderAppointer = new LeaderAppointer(
                         m_messenger,
                         m_configuredNumberOfPartitions,


### PR DESCRIPTION
…t the cluster has already received the sync snapshot. Therefore we won't fail the rejoined node if another node goes down. Instead we assume that the prior instance of the cluster completed the snapshot processing. This prevents us from killing the rejoined node before it has connected to the producer cluster but after another node leaves.