### PR TITLE
Refactor VoltType in advance of ENG-9873 type checking improvements.

### DIFF
--- a/src/frontend/org/voltdb/ElasticHashinator.java
+++ b/src/frontend/org/voltdb/ElasticHashinator.java
@@ -96,7 +96,7 @@ public class ElasticHashinator extends TheHashinator {
 
     @Override
     public int pHashToPartition(VoltType type, Object obj) {
-        return hashinateBytes(valueToBytes(obj));
+        return hashinateBytes(VoltType.valueToBytes(obj));
     }
 
     /**

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -1399,7 +1399,7 @@ public final class InvocationDispatcher {
             byte[] param = null;
             if (partitionParam != null) {
                 type = VoltType.typeFromClass(partitionParam.getClass()).getValue();
-                param = TheHashinator.valueToBytes(partitionParam);
+                param = VoltType.valueToBytes(partitionParam);
             }
             partition = TheHashinator.getPartitionForParameter(type, partitionParam);
 

--- a/src/frontend/org/voltdb/NonVoltDBBackend.java
+++ b/src/frontend/org/voltdb/NonVoltDBBackend.java
@@ -670,7 +670,7 @@ public abstract class NonVoltDBBackend {
 
             VoltType type = VoltType.get(paramJavaTypes[i]);
 
-            if (VoltType.isNullVoltType(paramObjs[i])) {
+            if (VoltType.isVoltNullValue(paramObjs[i])) {
                 sqlOut.append("NULL");
             }
             else if (paramObjs[i] instanceof TimestampType) {

--- a/src/frontend/org/voltdb/ParameterConverter.java
+++ b/src/frontend/org/voltdb/ParameterConverter.java
@@ -547,33 +547,4 @@ public class ParameterConverter {
                 "tryToMakeCompatible: The provided value: (" + param.toString() + ") of type: " + inputClz.getName() +
                 " is not a match or is out of range for the target parameter type: " + expectedClz.getName());
     }
-
-
-    /**
-     * Convert string inputs to Longs for TheHashinator if possible
-     * @param param
-     * @param slot
-     * @return Object parsed as Number or null if types not compatible
-     * @throws Exception if a parse error occurs (consistent with above).
-     */
-    public static Object stringToLong(Object param, Class<?> slot)
-    throws VoltTypeException
-    {
-        try {
-            if (slot == byte.class ||
-                slot == short.class ||
-                slot == int.class ||
-                slot == long.class)
-            {
-                return Long.parseLong((String)param);
-            }
-            return null;
-        }
-        catch (NumberFormatException nfe) {
-            throw new VoltTypeException(
-                    "tryToMakeCompatible: Unable to convert string "
-                    + (String)param + " to "  + slot.getName()
-                    + " value for target parameter " + slot.getName());
-        }
-    }
 }

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
+import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
@@ -200,8 +201,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                    int size,
                    boolean nullable,
                    boolean unique,
-                   String defaultValue)
-        {
+                   String defaultValue) {
             this.name = name;
             this.type = type;
             this.size = size;
@@ -232,7 +232,8 @@ public final class VoltTable extends VoltTableRow implements JSONString {
         public ColumnInfo clone() {
             try {
                 return (ColumnInfo) super.clone();
-            } catch (CloneNotSupportedException e) {
+            }
+            catch (CloneNotSupportedException e) {
                 assert(false);
                 throw new RuntimeException(e);
             }
@@ -269,11 +270,21 @@ public final class VoltTable extends VoltTableRow implements JSONString {
             }
             VoltTable.ColumnInfo other = (VoltTable.ColumnInfo) obj;
 
-            if (nullable != other.nullable) return false;
-            if (unique != other.unique) return false;
-            if (defaultValue != other.defaultValue) return false;
-            if (size != other.size) return false;
-            if (type != other.type) return false;
+            if (nullable != other.nullable) {
+                return false;
+            }
+            if (unique != other.unique) {
+                return false;
+            }
+            if (defaultValue != other.defaultValue) {
+                return false;
+            }
+            if (size != other.size) {
+                return false;
+            }
+            if (type != other.type) {
+                return false;
+            }
             return name.equals(other.name);
         }
     }
@@ -297,8 +308,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
         ExtraMetadata(String name,
                       int partitionColIndex,
                       int[] pkeyIndexes,
-                      ColumnInfo... originalColumnInfos)
-        {
+                      ColumnInfo... originalColumnInfos) {
             this.name = name;
             this.partitionColIndex = partitionColIndex;
             this.pkeyIndexes = pkeyIndexes.clone();
@@ -752,10 +762,9 @@ public final class VoltTable extends VoltTableRow implements JSONString {
             maxColSize = m_extraMetadata.originalColumnInfos[col].size;
         }
 
-        if (VoltType.isNullVoltType(value))
-        {
+        if (VoltType.isVoltNullValue(value)) {
             // schema checking code that is used for some tests
-            // alllowNulls should always be true in production
+            // allowNulls should always be true in production
             if (allowNulls == false) {
                 throw new IllegalArgumentException(
                         String.format("Column %s at index %d doesn't allow NULL values.",
@@ -818,8 +827,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                         throw new ClassCastException();
                     }
                     final Number n1 = (Number) value;
-                    if (columnType.wouldCastOverflow(n1))
-                    {
+                    if (columnType.wouldCastOverflow(n1)) {
                         throw new VoltTypeException("Cast of " +
                                 n1.doubleValue() +
                                 " to " +
@@ -833,8 +841,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                         throw new ClassCastException();
                     }
                     final Number n2 = (Number) value;
-                    if (columnType.wouldCastOverflow(n2))
-                    {
+                    if (columnType.wouldCastOverflow(n2)) {
                         throw new VoltTypeException("Cast to " +
                                 columnType.toString() +
                                 " would overflow");
@@ -846,8 +853,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                         throw new ClassCastException();
                     }
                     final Number n3 = (Number) value;
-                    if (columnType.wouldCastOverflow(n3))
-                    {
+                    if (columnType.wouldCastOverflow(n3)) {
                         throw new VoltTypeException("Cast to " +
                                 columnType.toString() +
                                 " would overflow");
@@ -859,8 +865,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                         throw new ClassCastException();
                     }
                     final Number n4 = (Number) value;
-                    if (columnType.wouldCastOverflow(n4))
-                    {
+                    if (columnType.wouldCastOverflow(n4)) {
                         throw new VoltTypeException("Cast to " +
                                 columnType.toString() +
                                 " would overflow");
@@ -873,8 +878,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                         throw new ClassCastException();
                     }
                     final Number n5 = (Number) value;
-                    if (columnType.wouldCastOverflow(n5))
-                    {
+                    if (columnType.wouldCastOverflow(n5)) {
                         throw new VoltTypeException("Cast to " +
                                 columnType.toString() +
                                 " would overflow");
@@ -945,7 +949,8 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                     if (value instanceof java.util.Date ||
                             value instanceof TimestampType) {
                          micros = ParameterSet.timestampToMicroseconds(value);
-                    } else {
+                    }
+                    else {
                         micros = ((Number) value).longValue();
                     }
                     m_buffer.putLong(micros);
@@ -1053,8 +1058,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
             m_rowCount++;
             m_buffer.putInt(m_rowStart, m_rowCount);
         }
-        catch (VoltTypeException vte)
-        {
+        catch (VoltTypeException vte) {
             // revert the row size advance and any other
             // buffer additions
             m_buffer.position(pos);
@@ -1145,8 +1149,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
             m_rowCount++;
             m_buffer.putInt(m_rowStart, m_rowCount);
         }
-        catch (VoltTypeException vte)
-        {
+        catch (VoltTypeException vte) {
             // revert the row size advance and any other
             // buffer additions
             m_buffer.position(pos);
@@ -1299,7 +1302,8 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                     if (r.wasNull()) {
                         buffer.append("NULL");
                         assert (tstamp == null);
-                    } else {
+                    }
+                    else {
                         buffer.append(tstamp);
                     }
                     break;
@@ -1308,7 +1312,8 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                     if (r.wasNull()) {
                         buffer.append("NULL");
                         assert (string == null);
-                    } else {
+                    }
+                    else {
                         buffer.append(string);
                     }
                     break;
@@ -1317,8 +1322,9 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                     if (r.wasNull()) {
                         buffer.append("NULL");
                         assert (bin == null);
-                    } else {
-                        buffer.append(VoltType.varbinaryToPrintableString(bin));
+                    }
+                    else {
+                        buffer.append(varbinaryToPrintableString(bin));
                     }
                     break;
                 case DECIMAL:
@@ -1326,7 +1332,8 @@ public final class VoltTable extends VoltTableRow implements JSONString {
                     if (r.wasNull()) {
                         buffer.append("NULL");
                         assert (bd == null);
-                    } else {
+                    }
+                    else {
                         buffer.append(bd.toString());
                     }
                     break;
@@ -1361,6 +1368,36 @@ public final class VoltTable extends VoltTableRow implements JSONString {
 
         assert(verifyTableInvariants());
         return buffer.toString();
+    }
+
+    /**
+     * Make a printable, short string for a varbinary.
+     * String includes a CRC and the contents of the varbinary in hex.
+     * Contents longer than 13 chars are truncated and elipsized.
+     * Yes, "elipsized" is totally a word.
+     *
+     * Example: "bin[crc:1298399436,value:0xABCDEF12345...]"
+     *
+     * @param bin The bytes to print out.
+     * @return A string representation that is printable and short.
+     */
+    public static String varbinaryToPrintableString(byte[] bin) {
+        PureJavaCrc32 crc = new PureJavaCrc32();
+        StringBuilder sb = new StringBuilder();
+        sb.append("bin[crc:");
+        crc.update(bin);
+        sb.append(crc.getValue());
+        sb.append(",value:0x");
+        String hex = Encoder.hexEncode(bin);
+        if (hex.length() > 13) {
+            sb.append(hex.substring(0, 10));
+            sb.append("...");
+        }
+        else {
+            sb.append(hex);
+        }
+        sb.append("]");
+        return sb.toString();
     }
 
     /**
@@ -1653,7 +1690,9 @@ public final class VoltTable extends VoltTableRow implements JSONString {
      */
     public boolean hasSameContents(VoltTable other) {
         assert(verifyTableInvariants());
-        if (this == other) return true;
+        if (this == other) {
+            return true;
+        }
 
         int mypos = m_buffer.position();
         int theirpos = other.m_buffer.position();
@@ -1676,12 +1715,15 @@ public final class VoltTable extends VoltTableRow implements JSONString {
     @Deprecated
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof VoltTable)) return false;
+        if (!(o instanceof VoltTable)) {
+            return false;
+        }
         return hasSameContents((VoltTable) o);
     }
 
     /**
-     * Also overrides {@link java.lang.Object#hashCode()}  since we are overriding {@link java.lang.Object#equals(Object)}.
+     * Also overrides {@link java.lang.Object#hashCode()} since we are
+     * overriding {@link java.lang.Object#equals(Object)}.
      * Throws an {@link java.lang.UnsupportedOperationException}.
      *
      * @deprecated This only throws. Doesn't do anything.
@@ -1733,7 +1775,8 @@ public final class VoltTable extends VoltTableRow implements JSONString {
             // this doesn't prove definitively that the string is UTF-8
             // but will find many cases...
             new String(strbytes, "UTF-8");
-        } catch (Exception ex) {
+        }
+        catch (Exception ex) {
             throw new RuntimeException(ex);
         }
         return true;
@@ -1891,8 +1934,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
      *
      * @return An ordered array of {@link ColumnInfo} instances for each table column.
      */
-    public ColumnInfo[] getTableSchema()
-    {
+    public ColumnInfo[] getTableSchema() {
         ColumnInfo[] schema = new ColumnInfo[m_colCount];
         for (int i = 0; i < m_colCount; i++) {
             ColumnInfo col = new ColumnInfo(getColumnName(i), getColumnType(i));

--- a/src/frontend/org/voltdb/VoltType.java
+++ b/src/frontend/org/voltdb/VoltType.java
@@ -17,16 +17,17 @@
 
 package org.voltdb;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
+import org.voltdb.common.Constants;
 import org.voltdb.types.GeographyPointValue;
 import org.voltdb.types.GeographyValue;
 import org.voltdb.types.TimestampType;
 import org.voltdb.types.VoltDecimalHelper;
-import org.voltdb.utils.Encoder;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
 
@@ -43,378 +44,475 @@ public enum VoltType {
      * Used for uninitialized types in some places. Not a valid value
      * for actual user data.
      */
-    INVALID   ((byte)0, -1, null, new Class[] {}, null, '0'),
+    INVALID   ((byte)0, new Class[] {}, null),
 
     /**
      * Used to type java null values that have no type. Not a valid value
      * for actual user data.
      */
-    NULL      ((byte)1, -1, null, new Class[] {}, null, '0'),
+    NULL      ((byte)1, new Class[] {}, null),
 
     /**
      * Used for some literal constants parsed by our SQL parser. Not a
      * valid value for actual user data. See {@link #DECIMAL} for decimal
      * type.
      */
-    NUMERIC   ((byte)2, 0, null, new Class[] {}, null, '0'),
+    NUMERIC   ((byte)2, new Class[] {}, null),
 
     /**
      * 1-byte signed 2s-compliment byte.
      * Lowest value means NULL in the database.
      */
-    TINYINT   ((byte)3, 1, "tinyint", new Class[] {byte.class, Byte.class}, byte[].class, 't',
+    TINYINT   ((byte)3, "tinyint", 1,
+            new Class[] {byte.class, Byte.class},
+            byte[].class,
+            't',
             java.sql.Types.TINYINT,  // java.sql.Types DATA_TYPE
-            null, // prefix to specify a literal
-            null, // suffix to specify a literal
-            null, // necessary params to create
-            false, // case-sensitive
             java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
-            false, // unsigned?
-            0, // minimum scale
-            0, // maximum scale
             "java.lang.Byte"), // getObject return type
 
     /**
      * 2-byte signed 2s-compliment short.
      * Lowest value means NULL in the database.
      */
-    SMALLINT  ((byte)4, 2, "smallint", new Class[] {short.class, Short.class}, short[].class, 's',
+    SMALLINT  ((byte)4, "smallint", 2,
+            new Class[] {short.class, Short.class},
+            short[].class,
+            's',
             java.sql.Types.SMALLINT,  // java.sql.Types DATA_TYPE
-            null, // prefix to specify a literal
-            null, // suffix to specify a literal
-            null, // necessary params to create
-            false, // case-sensitive
             java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
-            false, // unsigned?
-            0, // minimum scale
-            0, // maximum scale
             "java.lang.Short"), // getObject return type
 
     /**
      * 4-byte signed 2s-compliment integer.
      * Lowest value means NULL in the database.
      */
-    INTEGER   ((byte)5, 4, "integer",
-               new Class[] {int.class, Integer.class, AtomicInteger.class}, int[].class, 'i',
+    INTEGER   ((byte)5, "integer", 4,
+            new Class[] {int.class, Integer.class, AtomicInteger.class},
+            int[].class,
+            'i',
             java.sql.Types.INTEGER,  // java.sql.Types DATA_TYPE
-            null, // prefix to specify a literal
-            null, // suffix to specify a literal
-            null, // necessary params to create
-            false, // case-sensitive
             java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
-            false, // unsigned?
-            0, // minimum scale
-            0, // maximum scale
             "java.lang.Integer"), // getObject return type
 
     /**
      * 8-byte signed 2s-compliment long.
      * Lowest value means NULL in the database.
      */
-    BIGINT    ((byte)6, 8, "bigint",
-               new Class[] {long.class, Long.class, AtomicLong.class}, long[].class, 'b',
+    BIGINT    ((byte)6, "bigint", 8,
+            new Class[] {long.class, Long.class, AtomicLong.class},
+            long[].class,
+            'b',
             java.sql.Types.BIGINT,  // java.sql.Types DATA_TYPE
-            null, // prefix to specify a literal
-            null, // suffix to specify a literal
-            null, // necessary params to create
-            false, // case-sensitive
             java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
-            false, // unsigned?
-            0, // minimum scale
-            0, // maximum scale
             "java.lang.Long"), // getObject return type
 
     /**
      * 8-bytes in IEEE 754 "double format".
      * Some NaN values may represent NULL in the database (TBD).
      */
-    FLOAT     ((byte)8, 8, "float",
-            new Class[] {double.class, Double.class, float.class, Float.class}, double[].class, 'f',
+    FLOAT     ((byte)8, "float", 8,
+            new Class[] {double.class, Double.class, float.class, Float.class},
+            double[].class,
+            'f',
             java.sql.Types.FLOAT,  // java.sql.Types DATA_TYPE
-            null, // prefix to specify a literal
-            null, // suffix to specify a literal
-            null, // necessary params to create
-            false, // case-sensitive
             java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
-            false, // unsigned?
-            null, // minimum scale
-            null, // maximum scale
             "java.lang.Double"), // getObject return type
-
-    /**
-     * 8-byte long value representing microseconds after the epoch.
-     * The epoch is Jan. 1 1970 00:00:00 GMT. Negative values represent
-     * time before the epoch. This covers roughly 4000BC to 8000AD.
-     */
-    TIMESTAMP ((byte)11, 8, "timestamp",
-            new Class[] {TimestampType.class,
-                         java.util.Date.class,
-                         java.sql.Date.class,
-                         java.sql.Timestamp.class}, TimestampType[].class, 'p',
-            java.sql.Types.TIMESTAMP,  // java.sql.Types DATA_TYPE
-            "'", // prefix to specify a literal
-            "'", // suffix to specify a literal
-            null, // necessary params to create
-            false, // case-sensitive
-            java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
-            null, // unsigned?
-            null, // minimum scale
-            null, // maximum scale
-            "java.sql.Timestamp"), // getObject return type
 
     /**
      * UTF-8 string with up to 32K chars.
      * The database supports char arrays and varchars
      * but the API uses strings.
      */
-    STRING    ((byte)9, -1, "varchar", new Class[] {String.class}, String[].class, 'v',
+    STRING    ((byte)9, "varchar", new LengthRange("max_length"),
+            new Class[] {String.class},
+            String[].class,
+            'v',
             java.sql.Types.VARCHAR,  // java.sql.Types DATA_TYPE
-            "'", // prefix to specify a literal
-            "'", // suffix to specify a literal
-            "max_length", // necessary params to create
-            true, // case-sensitive
             java.sql.DatabaseMetaData.typeSearchable, // where-clauses supported
-            null, // unsigned?
-            null, // minimum scale
-            null, // maximum scale
-            "java.lang.String"), // getObject return type
+            "java.lang.String") // getObject return type
+    {
+        @Override
+        public boolean isCaseSensitive() { return true; }
+
+        @Override
+        public String getLiteralPrefix() { return "'"; }
+
+        @Override
+        public String getLiteralSuffix() { return "'"; }
+
+        // Non-numeric and yet indexable.
+        @Override
+        public boolean isIndexable() { return true; }
+        @Override
+        public boolean isUniqueIndexable() { return true; }
+    },
+
+    /**
+     * 8-byte long value representing microseconds after the epoch.
+     * The epoch is Jan. 1 1970 00:00:00 GMT. Negative values represent
+     * time before the epoch. This covers roughly 4000BC to 8000AD.
+     */
+    TIMESTAMP ((byte)11, "timestamp", 8,
+            new Class[] {TimestampType.class,
+                         java.util.Date.class,
+                         java.sql.Date.class,
+                         java.sql.Timestamp.class},
+            TimestampType[].class,
+            'p',
+            java.sql.Types.TIMESTAMP,  // java.sql.Types DATA_TYPE
+            java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
+            "java.sql.Timestamp") // getObject return type
+    {
+        @Override
+        public String getLiteralPrefix() { return "'"; }
+
+        @Override
+        public String getLiteralSuffix() { return "'"; }
+
+        // Non-numeric and yet indexable.
+        @Override
+        public boolean isIndexable() { return true; }
+        @Override
+        public boolean isUniqueIndexable() { return true; }
+    },
 
     /**
      * VoltTable type for Procedure parameters
      */
-    VOLTTABLE ((byte)21, -1, null, new Class[] {VoltTable.class}, VoltTable[].class, '0'),
+    VOLTTABLE ((byte)21, new Class[] {VoltTable.class}, VoltTable[].class),
 
     /**
      * Fixed precision=38, scale=12 storing sign and null-status in a preceding byte
      */
-    DECIMAL  ((byte)22, 16, "decimal", new Class[] {BigDecimal.class}, BigDecimal[].class, 'd',
+    DECIMAL  ((byte)22, "decimal", 16,
+            new Class[] {BigDecimal.class},
+            BigDecimal[].class,
+            'd',
             java.sql.Types.DECIMAL,  // java.sql.Types DATA_TYPE
-            null, // prefix to specify a literal
-            null, // suffix to specify a literal
-            null, // necessary params to create
-            false, // case-sensitive
             java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
-            false, // unsigned?
-            12, // minimum scale
-            12, // maximum scale
-            "java.math.BigDecimal"), // getObject return type
+            "java.math.BigDecimal") // getObject return type
+    {
+        @Override
+        public Integer getMinimumScale() { return 12; }
+
+        @Override
+        public Integer getMaximumScale() { return 12; }
+    },
+
+    /**
+     * Boolean type. Not (yet) a valid value for actual user data.
+     */
+    BOOLEAN   ((byte)23, "boolean", 1,
+            new Class[] {boolean.class, Boolean.class},
+            boolean[].class,
+            'o', //'b' is taken by BIGINT
+            java.sql.Types.BOOLEAN,  // java.sql.Types DATA_TYPE
+            java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
+            "java.lang.Boolean") // getObject return type
+    {
+        // These MAY not actually be necessary,
+        // since BOOLEAN is not really a numeric type?
+        @Override
+        public Integer getMinimumScale() { return 0; }
+
+        @Override
+        public Integer getMaximumScale() { return 0; }
+    },
 
     /**
      * Array of bytes of variable length
      */
-    VARBINARY    ((byte)25, -1, "varbinary",
-            new Class[] {byte[].class,
-                         Byte[].class },
-                         byte[][].class, 'l',
+    VARBINARY ((byte)25, "varbinary", new LengthRange("max_length"),
+            // Normally, only NON-ARRAY compatible types are listed,
+            // but byte array is included here because it is also the default
+            // TARGET class for conversion FROM VARBINARY.
+            new Class[] {byte[].class, },
+            byte[][].class,
+            'l',
             java.sql.Types.VARBINARY,  // java.sql.Types DATA_TYPE
-            "'", // prefix to specify a literal
-            "'", // suffix to specify a literal
-            "max_length", // necessary params to create
-            false, // case-sensitive
             java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
-            null, // unsigned?
-            null, // minimum scale
-            null, // maximum scale
-            "java.lang.Byte[]"), // getObject return type
+            "java.lang.Byte[]")  // getObject return type
+    {
+        @Override
+        public boolean acceptsArray(Class<?> arrayArgClass) {
+            return byte[].class == arrayArgClass ||
+                    Byte[].class == arrayArgClass;
+        }
 
-    /**
-     * Boolean type. Not a valid value for actual user data.
-     */
-    BOOLEAN  ((byte)23, 1, "boolean", new Class[] {boolean.class, Boolean.class}, boolean[].class, 'o', //'b' is taken by BIGINT
-            java.sql.Types.BOOLEAN,  // java.sql.Types DATA_TYPE
-            null, // prefix to specify a literal
-            null, // suffix to specify a literal
-            null, // necessary params to create
-            false, // case-sensitive
-            java.sql.DatabaseMetaData.typePredBasic, // where-clauses supported
-            false, // unsigned?
-            0, // minimum scale
-            0, // maximum scale
-            "java.lang.Boolean"), // getObject return type
+        @Override
+        public String getLiteralPrefix() { return "'"; }
+
+        @Override
+        public String getLiteralSuffix() { return "'"; }
+
+        // Non-numeric and yet indexable.
+        @Override
+        public boolean isIndexable() { return true; }
+        @Override
+        public boolean isUniqueIndexable() { return true; }
+    },
 
     /**
      * Point type, for a geographical point (long, lat)
      */
-    GEOGRAPHY_POINT (
-            (byte)26, // enum value
-            GeographyPointValue.getLengthInBytes(),
+    GEOGRAPHY_POINT ((byte)26, // enum value
             "GEOGRAPHY_POINT", // SQL name
+            GeographyPointValue.getLengthInBytes(),
             new Class[] {GeographyPointValue.class}, // Java types supported in conversion
             GeographyPointValue[].class, // vector type
             'P', // signature char
             java.sql.Types.OTHER, // JDBC type (this is used for vendor specific types)
-            null, // literal prefix
-            null, // literal suffix
-            null, // necessary params (like length for VARCHAR)
-            false, // case sensitivity
             java.sql.DatabaseMetaData.typePredBasic, // basic where-clauses supported
-            null, // signed/unsigned
-            null, // min scale
-            null, // max scale
             "org.voltdb.types.GeographyPointValue"), // JDBC getObject return type
 
     /**
      * Geography type, for geographical objects (polygons, etc)
      */
-    GEOGRAPHY (
-            (byte)27, // enum value
-            -1, // variable length
+    GEOGRAPHY ((byte)27, // enum value
             "GEOGRAPHY", // SQL name
+            new LengthRange(GeographyValue.MIN_SERIALIZED_LENGTH,
+                    GeographyValue.MAX_SERIALIZED_LENGTH,
+                    GeographyValue.DEFAULT_LENGTH,
+                    "max_length"), // variable length
             new Class[] {GeographyValue.class}, // Java types supported in conversion
             GeographyValue[].class, // vector type
             'g', // signature char
             java.sql.Types.OTHER, // JDBC type (this is used for vendor specific types)
-            null, // literal prefix
-            null, // literal suffix
-            "max_length", // necessary params (like length for VARCHAR)
-            false, // case sensitivity
             java.sql.DatabaseMetaData.typePredBasic, // basic where-clauses supported
-            null, // signed/unsigned
-            null, // min scale
-            null, // max scale
-            "org.voltdb.types.GeographyValue"); // JDBC getObject return type
-    /**
-     * Size in bytes of the maximum length for a VoltDB field value, presumably a
-     * <code>STRING</code> or <code>VARBINARY</code>
-     */
+            "org.voltdb.types.GeographyValue") // JDBC getObject return type
+    {
+        /** GEOGRAPHY values ARE indexable within the limitations of the
+         * specialized geo indexes, but one of these limitations is no
+         * support for uniqueness. */
+        @Override
+        public boolean isIndexable() { return true; }
+        @Override
+        public boolean isUniqueIndexable() { return false; }
+    },
+    ;
+
+    // PUBLIC STATIC members
+
+    /** Size in bytes of the maximum length for a VoltDB field value, presumably a
+     * <code>STRING</code> or <code>VARBINARY</code> */
     public static final int MAX_VALUE_LENGTH = 1048576;
     public static final int MAX_VALUE_LENGTH_IN_CHARACTERS = MAX_VALUE_LENGTH / 4;
-    /**
-     * String representation of <code>MAX_VALUE_LENGTH</code>.
+
+    /** String representation of <code>MAX_VALUE_LENGTH</code>.
      * @param size The size you want to represent in human readable string.
-     * @return String representation of Size passed in.
-     */
-    public static String humanReadableSize(int size)
-    {
-        if (size > 9999) return String.valueOf(size / 1024) + "K";
+     * @return String representation of Size passed in. */
+    public static String humanReadableSize(int size) {
+        if (size > 9999) {
+            return String.valueOf(size / 1024) + "K";
+        }
         return String.valueOf(size) + "B";
     }
 
-    private final byte m_val;
+    // INSTANCE members
+
+    /** The unique enum value for this VoltType,
+     * allows a compact representation of the VoltType. */
+    private final byte m_value;
+    /** The value length in bytes if fixed length, otherwise -1 */
     private final int m_lengthInBytes;
+    /** The value length range and default in bytes if variable length,
+     * and the associated sql type length param name,
+     * otherwise null */
+    private LengthRange m_lengthAsBytesRange;
+    /** How this type is named in sql,
+     * for example, when declaring a column or "casting as". */
     private final String m_sqlString;
+    /** Java classes for values (normally not including arrays) that are
+     * convertible to this type.
+     * The first entry (if any) is considered the best matching Java class
+     * and is also used by default in the reverse process when converting
+     * FROM SQL column data TO java values. */
     private final Class<?>[] m_classes;
+    /** The java array type which is the preferred format for representing
+     * multiple values of the type. These make useful procedure parameter
+     * types. */
     private final Class<?> m_vectorClass;
+    /** Yet another compact unique representation for this VoltType,
+     * handier than m_value for concatenating into strings that describe
+     * compound type structures like table schema. */
     private final char m_signatureChar;
-    // Is this type visible to JDBC?
+
+    /** Is this type visible to JDBC?
+     * If false, the other m_jdbc* members are ignored. */
     private final boolean m_jdbcVisible;
+
     // JDBC getTypeInfo values
     // If we add yet more stuff to this for MySQL or ODBC or something,
     // it might be time to consider some sort of data-driven type specification
     // mechanism.
-    private final int m_dataType;
-    private final String m_literalPrefix;
-    private final String m_literalSuffix;
-    private final String m_createParams;
-    private final int m_nullable;
-    private final boolean m_caseSensitive;
-    private final int m_searchable;
-    private final Boolean m_unsignedAttribute;
-    private final Integer m_minimumScale;
-    private final Integer m_maximumScale;
-    // I wanted to use the first entry in m_classes, but it doesn't match what
-    // VoltTable.get() returns in some cases, and I'm fearful of arbitrarily changing
-    // what classFromType() returns to various parts of the system
-    // This is the type that will be returned by ResultSet.getObject(), which
-    // boils down to VoltTable.get(), with a special case for timestamps
+
+    /** Either a typical SQL column type well known to jdbc or the special
+     * OTHER value for VoltDB's non-standard vendor-specific column types. */
+    private final int m_jdbcSqlDataType;
+    /** It's unclear (at least to Paul) how the jdbc users/systems/tools
+     * makes use of this jdbc standard attribute. */
+    private final int m_jdbcSearchable;
+    /** This is the type that will be returned by JDBC's ResultSet.getObject(),
+     * which usually corresponds to to VoltTable.get(), except for timestamps. */
     private final String m_jdbcClass;
 
-    // Constructor for non-JDBC-visible types
-    private VoltType(byte val, int lengthInBytes, String sqlString,
-                     Class<?>[] classes, Class<?> vectorClass, char signatureChar)
-    {
-        this(val, lengthInBytes, sqlString, classes, vectorClass, signatureChar,
+    // CONSTRUCTORS
+
+    /** Constructor for non-JDBC-visible types.
+     * This can safely stub out any attributes that are only used by jdbc. */
+    private VoltType(byte value, Class<?>[] classes, Class<?> vectorClass) {
+        this(value, -1, null, null, classes, vectorClass, '0',
                 false,
-                java.sql.Types.OTHER,
-                null,
-                null,
-                null,
-                java.sql.DatabaseMetaData.typeNullable,
-                false,
-                Integer.MIN_VALUE,
-                null,
-                null,
-                null,
-                null);
+                // With m_jdbcVisible set false, these remaining attributes
+                // related to JDBC are just stubbed out with
+                // "don't care" values. They are actually N/A.
+                java.sql.Types.OTHER, Integer.MIN_VALUE, null);
     }
 
-    // Constructor for JDBC-visible types.  Only types constructed in this way will
-    // appear in the JDBC getTypeInfo() metadata.
-    private VoltType(byte val,
-                     int lengthInBytes,
+    /** Constructor for JDBC-visible types.  Only types constructed in this way
+     * appear in the JDBC getTypeInfo() metadata.
+     * Note that this includes the standard JDBC SQL types as well as VoltDB's
+     * vendor-specific types that are exposed as JDBC extensions.
+     * The latter specify a jdbcSqlDataType of OTHER and typically
+     * name a VoltDB defined class as their jdbcClass value. */
+    private VoltType(byte value,
                      String sqlString,
+                     int lengthInBytes,
                      Class<?>[] classes,
                      Class<?> vectorClass,
                      char signatureChar,
-                     int dataType,
-                     String literalPrefix,
-                     String literalSuffix,
-                     String createParams,
-                     boolean caseSensitive,
-                     int searchable,
-                     Boolean unsignedAttribute,
-                     Integer minimumScale,
-                     Integer maximumScale,
-                     String jdbcClass)
-    {
-        this(val, lengthInBytes, sqlString, classes, vectorClass, signatureChar,
+                     int jdbcSqlDataType,
+                     int jdbcSearchable,
+                     String jdbcClass) {
+        this(value, lengthInBytes, null, sqlString,
+                classes, vectorClass, signatureChar,
                 true,
-                dataType,
-                literalPrefix,
-                literalSuffix,
-                createParams,
-                java.sql.DatabaseMetaData.typeNullable,
-                caseSensitive,
-                searchable,
-                unsignedAttribute,
-                minimumScale,
-                maximumScale,
-                jdbcClass);
+                jdbcSqlDataType, jdbcSearchable, jdbcClass);
     }
 
-    private VoltType(byte val, int lengthInBytes, String sqlString,
-                     Class<?>[] classes, Class<?> vectorClass, char signatureChar,
-                     boolean jdbcVisible,
-                     int dataType,
-                     String literalPrefix,
-                     String literalSuffix,
-                     String createParams,
-                     int nullable,
-                     boolean caseSensitive,
-                     int searchable,
-                     Boolean unsignedAttribute,
-                     Integer minimumScale,
-                     Integer maximumScale,
-                     String jdbcClass)
-    {
-        m_val = val;
+    /** Constructor for JDBC-visible types.  Only types constructed in this way
+     * appear in the JDBC getTypeInfo() metadata.
+     * Note that this includes the standard JDBC SQL types as well as VoltDB's
+     * vendor-specific types that are exposed as JDBC extensions.
+     * The latter specify a jdbcSqlDataType of OTHER and typically
+     * name a VoltDB defined class as their jdbcClass value. */
+    private VoltType(byte value,
+                     String sqlString,
+                     LengthRange lengthAsBytesRange,
+                     Class<?>[] classes,
+                     Class<?> vectorClass,
+                     char signatureChar,
+                     int jdbcSqlDataType,
+                     int jdbcSearchable,
+                     String jdbcClass) {
+        this(value, -1, lengthAsBytesRange, sqlString,
+                classes, vectorClass, signatureChar,
+                true,
+                jdbcSqlDataType, jdbcSearchable, jdbcClass);
+    }
+
+    /** Common constructor implementation for JDBC-visible and JDBC-invisible types.
+     * This common code should ALWAYS be called and should ONLY be called through
+     * the other special-case constructors defined above. */
+    private VoltType(byte value,
+            int lengthInBytes,
+            LengthRange lengthAsBytesRange,
+            String sqlString,
+            Class<?>[] classes,
+            Class<?> vectorClass,
+            char signatureChar,
+            boolean jdbcVisible,
+            int jdbcSqlDataType,
+            int jdbcSearchable,
+            String jdbcClass) {
+        if (value > VOLT_TYPE_MAX_ENUM) {
+            // The last time Paul checked (admittedly back in Java 7), a
+            // RuntimeException gave better diagnostics than an assert when a
+            // programmer error caused an unrecoverable issue during class
+            // initialization.
+            // So, throw one here and hope it shows up somewhere in the noisy
+            // traces reported by the jvm.
+            throw new RuntimeException("The VoltType enum byte value " + value +
+                    "falls outside the expected range. Consider reassigning " +
+                    "the value to fill a gap within the existing range OR " +
+                    "extending the range from its current value of " +
+                    "VOLT_TYPE_MAX_ENUM = " + VOLT_TYPE_MAX_ENUM);
+        }
+        m_value = value;
         m_lengthInBytes = lengthInBytes;
+        m_lengthAsBytesRange = lengthAsBytesRange;
         m_sqlString = sqlString;
         m_classes = classes;
         m_vectorClass = vectorClass;
         m_signatureChar = signatureChar;
+
         m_jdbcVisible = jdbcVisible;
-        m_dataType = dataType;
-        m_literalPrefix = literalPrefix;
-        m_literalSuffix = literalSuffix;
-        m_createParams = createParams;
-        m_nullable = nullable;
-        m_caseSensitive = caseSensitive;
-        m_searchable = searchable;
-        m_unsignedAttribute = unsignedAttribute;
-        m_minimumScale = minimumScale;
-        m_maximumScale = maximumScale;
+
+        m_jdbcSqlDataType = jdbcSqlDataType;
+        m_jdbcSearchable = jdbcSearchable;
         m_jdbcClass = jdbcClass;
     }
 
+    /** Support class to represent optional value length variability. */
+    private static final class LengthRange {
+        private final int m_min;
+        private final int m_max;
+        private final int m_default;
+        private final String m_name;
+
+        /** The simplest variable length type model matches the usage of
+         * STRING and VARBINARY. */
+        LengthRange(String maxLengthParamName) {
+            this(1, MAX_VALUE_LENGTH, DEFAULT_COLUMN_SIZE, maxLengthParamName);
+        }
+
+        /** The variable length type model can also be customized to meet
+         * the needs of new classes with constraints different from
+         * STRING and VARBINARY, for example GEOGRAPHY. */
+        LengthRange(int minBytes, int maxBytes, int defaultLength,
+                String maxLengthParamName) {
+            m_min = minBytes;
+            m_max = maxBytes;
+            m_default = defaultLength;
+            m_name = maxLengthParamName;
+        }
+
+        // These constants should be kept up-to-date with those in DDLCompiler.
+        // Don't reference DDLCompiler here since this class is used in the client.
+        private static final int MAX_COLUMNS = 1024;
+        private static final int MAX_ROW_SIZE = 1024 * 1024 * 2;
+
+        private static final int DEFAULT_COLUMN_SIZE = MAX_ROW_SIZE / MAX_COLUMNS;
+
+        int getMaxLengthInBytes() { return m_max; }
+
+        int getMinLengthInBytes() { return m_min; }
+
+        int getDefaultLengthInBytes() { return m_default; }
+
+        String getLengthParamName() { return m_name; }
+
+    };
+
+    // PRIVATE STATIC members:
+
     private final static ImmutableMap<Class<?>, VoltType> s_classes;
-    //Update this if you add a type.
-    private final static VoltType s_types[] = new VoltType[28];
+    /** The maximum byte value that is allotted to a VoltType instance.
+     * Update this MAX if you MUST add a VoltType byte value beyond the
+     * current range -- instead of filling gaps in the range.
+     * This MAX allows s_types, the byte-value-to-VoltType-object "map" to be
+     * implemented with a simple (small, dense) VoltType array.
+     * There's a hard ceiling of 127 imposed by the use of signed bytes
+     * as unique keys/indexes. */
+    private final static byte VOLT_TYPE_MAX_ENUM = 30;
+    private final static VoltType s_types[] =
+            new VoltType[(VOLT_TYPE_MAX_ENUM)+1];
     static {
         ImmutableMap.Builder<Class<?>, VoltType> b = ImmutableMap.builder();
         HashMap<Class<?>, VoltType> validation = new HashMap<Class<?>, VoltType>();
         for (VoltType type : values()) {
-            s_types[type.m_val] = type;
+            s_types[type.m_value] = type;
             for (Class<?> cls : type.m_classes) {
                 // Avoid subtle effects when VoltTypes have duplicate m_classes entries (java classes),
                 // so that the association of a java class with the earlier VoltType gets obliterated
@@ -422,12 +520,11 @@ public enum VoltType {
                 // The effects of an assert in the middle of class initialization is surprisingly cryptic,
                 // at least when exercised by the "ant junit" suite, so for a SLIGHTLY less cryptic response,
                 // throw a generic runtime exception.
-                // Unfortunately, either response gets associated with the source lines of the first call to
-                // VoltType (like in DDLCompiler), rather than here.
                 // assert(s_classes.get(cls) == null);
                 if (validation.get(cls) != null) {
                     // This message seems to just get buried by the java runtime.
-                    throw new RuntimeException("Associate each java class with at most one VoltType.");
+                    throw new RuntimeException("Associate each java class like " +
+                            cls.getSimpleName() + " with at most one VoltType.");
                 }
                 validation.put(cls, type);
                 b.put(cls, type);
@@ -436,21 +533,17 @@ public enum VoltType {
         s_classes = b.build();
     }
 
-    /**
-     * Gets the byte that corresponds to the enum value (for serialization).
-     * @return A byte representing the enum value
-     */
-    public byte getValue() {
-        return m_val;
-    }
+    // PUBLIC ACCESSORS and other instance methods and static conversion methods
 
-    /**
-     * Return the java class that is matched to a given <tt>VoltType</tt>.
+    /** Gets the byte that corresponds to the VoltType (for serialization).
+     * @return A byte representing the VoltType */
+    public byte getValue() { return m_value; }
+
+    /** Return the java class that is matched to a given <tt>VoltType</tt>.
      * @return A java class object.
      * @throws RuntimeException if a type doesn't have an associated class,
      * such as {@link #INVALID}.
-     * @see #typeFromClass
-     */
+     * @see #typeFromClass */
     public Class<?> classFromType() {
         if (m_classes.length == 0) {
             throw new RuntimeException("Unsupported type " + this);
@@ -458,13 +551,11 @@ public enum VoltType {
         return m_classes[0];
     }
 
-    /**
-     * Return the java class that is matched to a given <tt>VoltType</tt>.
+    /** Return the java class that is matched to a given <tt>VoltType</tt>.
      * @return A java class object.
      * @throws RuntimeException if a type doesn't have an associated class,
      * such as {@link #INVALID}.
-     * @see #typeFromClass
-     */
+     * @see #typeFromClass */
     public Class<?> vectorClassFromType() {
         if (m_vectorClass == null) {
             throw new RuntimeException("Unsupported type " + this);
@@ -472,11 +563,9 @@ public enum VoltType {
         return m_vectorClass;
     }
 
-    /**
-     * Statically create an enum value from the corresponding byte.
+    /** Statically create an enum value from the corresponding byte.
      * @param val A byte representing an enum value
-     * @return The appropriate enum value
-     */
+     * @return The appropriate enum value */
     public static VoltType get(byte val) {
         VoltType type = (val < s_types.length) ? s_types[val] : null;
         if (type == null) {
@@ -486,15 +575,13 @@ public enum VoltType {
     }
 
     private boolean matchesString(String str) {
-        return str.toLowerCase().endsWith(name().toLowerCase());
+        return str.toUpperCase().endsWith(name());
     }
 
-    /**
-     * Converts string representations to an enum value.
+    /** Converts string representations to an enum value.
      * @param str A string in the form "TYPENAME" or "VoltType.TYPENAME",
      * e.g. "BIGINT" or "VoltType.VARCHAR"
-     * @return One of the valid enum values for VoltType
-     */
+     * @return One of the valid instances of VoltType */
     public static VoltType typeFromString(String str) {
         if (str == null) {
             return NULL;
@@ -513,19 +600,24 @@ public enum VoltType {
                 return type;
             }
         }
-        if (str.equalsIgnoreCase("DOUBLE")) return FLOAT;
-        if (str.equalsIgnoreCase("CHARACTER") || str.equalsIgnoreCase("CHAR") || str.equalsIgnoreCase("VARCHAR")) return STRING;
+        if (str.equalsIgnoreCase("DOUBLE")) {
+            return FLOAT;
+        }
+        if (str.equalsIgnoreCase("CHARACTER") ||
+                str.equalsIgnoreCase("CHAR") ||
+                str.equalsIgnoreCase("VARCHAR")) {
+            return STRING;
+        }
 
         throw new RuntimeException("Can't find type: " + str);
     }
 
-    /**
-     * Ascertain the most appropriate <tt>VoltType</tt> given a
+    /** Ascertain the most appropriate <tt>VoltType</tt> given a
      * java object.
      * @param obj The java object to type.
-     * @return A <tt>VoltType</tt> or invalid if none applies.
-     * @see #typeFromClass
-     */
+     * @return A <tt>VoltType</tt>.
+     * @throws VoltTypeException if none applies.
+     * @see #typeFromClass */
     public static VoltType typeFromObject(Object obj) {
         assert obj != null;
 
@@ -533,14 +625,13 @@ public enum VoltType {
         return typeFromClass(cls);
     }
 
-    /**
-     * Ascertain the most appropriate <tt>VoltType</tt> given a
+    /** Ascertain the most appropriate <tt>VoltType</tt> given a
      * java class.
      * @param cls The java class to type.
-     * @return A <tt>VoltType</tt> or invalid if none applies.
+     * @return A <tt>VoltType</tt>.
+     * @throws VoltTypeException if none applies.
      * @see #typeFromObject
-     * @see #classFromType
-     */
+     * @see #classFromType */
     public static VoltType typeFromClass(Class<?> cls) {
         VoltType type = s_classes.get(cls);
         if (type == null) {
@@ -549,140 +640,293 @@ public enum VoltType {
         return type;
     }
 
-    public static VoltType typeFromSignature(char signature) {
-        for (VoltType type : values()) {
-            if (type.m_signatureChar == signature) {
-                return type;
-            }
-        }
-        throw new VoltTypeException("Unknown type signature: " + signature);
-    }
-
-    /**
-     * Return the string representation of this type. Note that
-     * <tt>VoltType.typeFromString(voltTypeInstance.toString) == true</tt>.
-     * @return The string representation of this type.
-     */
+    /** Return the string representation of this type. Note that
+     * <tt>VoltType.typeFromString(voltTypeInstance.toString) == voltTypeInstance</tt>.
+     * @return The string representation of this type. */
     @Override public String toString() {
         return "VoltType." + name();
     }
 
-    public String getName() {
-        return name();
-    }
+    public String getName() { return name(); }
 
-    /**
-     * Get the number of bytes required to store the type for types
-     * with fixed length.
-     * @return An integer value representing a number of bytes.
-     */
+    public boolean isVariableLength() { return m_lengthAsBytesRange != null; }
+
+    /** Get the number of bytes required to store the fixed length type.
+     * Variable-length types should throw a RuntimeException.
+     * @return An integer value representing a number of bytes. */
     public int getLengthInBytesForFixedTypes() {
-        if (m_lengthInBytes == -1) {
+        if (m_lengthAsBytesRange != null) {
             throw new RuntimeException(
-                    "Asking for fixed size for non-fixed or unknown type.");
-
+                    "Asked for fixed size of non-fixed type " + m_sqlString);
         }
         return m_lengthInBytes;
     }
 
-    public int getLengthInBytesForFixedTypesWithoutCheck() {
-        return m_lengthInBytes;
-    }
+    // Variable-length types simply return -1.
+    public int getLengthInBytesForFixedTypesWithoutCheck() { return m_lengthInBytes; }
 
-    /**
-     * Get the maximum number of bytes required to store the type
-     * @return An integer value representing a number of bytes.
-     */
-    public int getMaxLengthInBytes() {
-        if (m_lengthInBytes == -1) {
-            return MAX_VALUE_LENGTH;
-        }
-        return m_lengthInBytes;
-    }
-
-    /**
-     * Get the minimum number of bytes required to store the type
-     * @return An integer value representing a number of bytes.
-     */
+    /** Get the minimum number of bytes required to store the type
+     * @return An integer value representing a number of bytes. */
     public int getMinLengthInBytes() {
-        if (m_lengthInBytes != -1) {
-            return getLengthInBytesForFixedTypes();
-        }
-
-        if (this == GEOGRAPHY) {
-            return GeographyValue.MIN_SERIALIZED_LENGTH;
-        }
-
-        return 1;
+        return m_lengthAsBytesRange == null ?
+                m_lengthInBytes :
+                    m_lengthAsBytesRange.getMinLengthInBytes();
     }
 
-    /** JDBC getTypeInfo() accessors */
-
-    /**
-     * Get the corresponding SQL type as for a given <tt>VoltType</tt> enum.
-     * For example, {@link #STRING} will probably convert to "VARCHAR".
-     * @return A string representing the SQL type.
-     */
-    public String toSQLString() {
-        return m_sqlString;
+    /** Get the maximum number of bytes required to store the type
+     * @return An integer value representing a number of bytes. */
+    public int getMaxLengthInBytes() {
+        return m_lengthAsBytesRange == null ?
+                m_lengthInBytes :
+                    m_lengthAsBytesRange.getMaxLengthInBytes();
     }
 
-    /**
-     * <p>Is this type visible to JDBC</p>
-     *
-     * @return JDBC visibility.
-     */
-    public boolean isJdbcVisible() {
-        return m_jdbcVisible;
-    }
+    // JDBC getTypeInfo() accessors
 
-    /**
-     * Get the java.sql.Types type of this type.
-     *
-     * @return int representing SQL type of the VoltDB type.
-     */
-    public int getJdbcSqlType() {
-        return m_dataType;
-    }
+    /** For JDBC, returns the prefix (if any, otherwise null)
+     * used with SQL literal constants of this type.
+     * Individual VoltTypes can override to enable this,
+     * typically to return a single quote.
+     * @return null, or, if overridden for a type,
+     * the prefix string. */
+    public String getLiteralPrefix() { return null; }
 
-    public String getLiteralPrefix() {
-        return m_literalPrefix;
-    }
+    /** For JDBC, returns the suffix (if any, otherwise null)
+     * used with SQL literal constants of this type.
+     * Individual VoltTypes can override to enable this,
+     * typically to return a single quote.
+     * @return null, or, if overridden for a type,
+     * the suffix string */
+    public String getLiteralSuffix() { return null; }
 
-    public String getLiteralSuffix() {
-        return m_literalSuffix;
-    }
-
+    /** For JDBC, the name(s) of any type-specific parameter(s),
+     * e.g. "max_length" used when defining sql columns of this type.
+     * FUTURE?: It's not clear what format the JDBC would expect if there
+     * were more than one -- maybe comma separated?
+     * @return null for fixed-length types,
+     * usually "max_length" for variable length type */
     public String getCreateParams() {
-        return m_createParams;
+        return m_lengthAsBytesRange == null ?
+                null :
+                    m_lengthAsBytesRange.getLengthParamName();
     }
 
-    public int getNullable() {
-        return m_nullable;
-    }
+    /** Individual VoltTypes like String can override to enable this functionality.
+     * Normally, other types ignore case when expressed as strings, like in
+     * hex values for varbinary, or wkt values for geo types.
+     * @return false unless overridden for a case sensitivite type like String */
+    public boolean isCaseSensitive() { return false; }
 
-    public boolean isCaseSensitive() {
-        return m_caseSensitive;
-    }
-
-    public int getSearchable() {
-        return m_searchable;
-    }
-
-    public Boolean isUnsigned() {
-        return m_unsignedAttribute;
-    }
-
+    /** Non-integer numeric VoltTypes must override this method.
+     * @return 0 for integer types, null for non-numeric, or some
+     * other value if overridden for a specific type like DECIMAL */
     public Integer getMinimumScale() {
-        return m_minimumScale;
+        return isAnyIntegerType() ? (Integer)0 : null;
     }
 
+    /** Non-integer numeric VoltTypes must override this method.
+     * @return 0 for integer types, null for non-numeric, or some
+     * other value if overridden for a specific type like DECIMAL */
     public Integer getMaximumScale() {
-        return m_maximumScale;
+        return isAnyIntegerType() ? (Integer)0 : null;
+    }
+
+    /** VoltTypes for indexable non-numeric values must override.
+     * @return true if the type is supported by VoltDB indexes */
+    public boolean isIndexable() { return isNumber(); }
+
+    /** VoltTypes with special restrictions about uniqueness support must override.
+     * @return true if the type is supported by VoltDB (assume)unique indexes */
+    public boolean isUniqueIndexable() { return isNumber(); }
+
+    /** Most VoltTypes are not compatible with an array-typed value.
+     * @see VARBINARY
+     * @param arrayArgClass a java array class like byte[] or String[]
+     * @return false, unless overridden to enable a specific VoltType
+     * (like VARBINARY) to support certain specific array types (like byte[]). */
+    public boolean acceptsArray(Class<?> arrayArgClass) { return false; }
+
+    /** Get the corresponding SQL type as for a given <tt>VoltType</tt> enum.
+     * For example, {@link #STRING} will probably convert to "VARCHAR".
+     * @return A string representing the SQL type. */
+    public String toSQLString() { return m_sqlString; }
+
+    /** <p>Is this type visible to JDBC</p>
+     * @return JDBC visibility */
+    public boolean isJdbcVisible() { return m_jdbcVisible; }
+
+    /** Get the java.sql.Types type of this type.
+     * @return int representing SQL type of the VoltDB type. */
+    public int getJdbcSqlType() { return m_jdbcSqlDataType; }
+
+    /** VoltDB treats nullability as orthogonal to type,
+     * so all types are nullable.
+     * @return the jdbc constant representing a nullable type */
+    public int getNullable() {
+        return java.sql.DatabaseMetaData.typeNullable;
+    }
+
+    public int getSearchable() { return m_jdbcSearchable; }
+
+    /** Numeric types are all signed types, so return false.
+     * isUnsigned is N/A to other types, so return null.
+     * If/when we support unsigned types, their VoltTypes
+     * should override this function to return true.
+     * @return null for non-numeric types, false for numeric,
+     * unless overridden by a (hypothetical) unsigned numeric type */
+    public Boolean isUnsigned() {
+        return isNumber() ? (Boolean)false : null;
     }
 
     public String getJdbcClass() {
         return m_jdbcClass;
+    }
+
+    /** Is the type a number and is it an exact value (no rounding errors)?
+     * @return true for integers and decimals. False for floats and strings
+     * and anything else */
+    public boolean isExactNumeric() {
+        return isAnyIntegerType() || this == DECIMAL;
+    }
+
+    /** Is this type an integer type in the EE?
+     * True for <code>TINYINT</code>, <code>SMALLINT</code>,
+     * <code>INTEGER</code>, <code>BIGINT</code> and <code>TIMESTAMP</code>.
+     * @return True if integer type. False if not */
+    public boolean isBackendIntegerType() {
+        return isAnyIntegerType() || this == TIMESTAMP;
+    }
+
+    /** Is this type an integer type? True for <code>TINYINT</code>, <code>SMALLINT</code>,
+     * <code>INTEGER</code>, <code>BIGINT</code>.
+     * @return True if integer type. False if not */
+    public boolean isAnyIntegerType() {
+        switch (this)  {
+        case TINYINT:
+        case SMALLINT:
+        case INTEGER:
+        case BIGINT:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+
+    public boolean isMaxValuePaddable() {
+        return getMaxValueForKeyPadding() != null;
+    }
+
+    public boolean isNumber() {
+        switch (this) {
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case FLOAT:
+            case DECIMAL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /* Indicate whether a value can be assigned to this type without loss of
+     * range or precision, important for index key and partition key
+     * initialization */
+    public boolean canExactlyRepresentAnyValueOf(VoltType otherType) {
+        // self to self conversion is obviously fine.
+        if (this == otherType)
+            return true;
+
+        if (otherType.isBackendIntegerType()) {
+            if (this.isBackendIntegerType()) {
+                // Don't allow integers getting smaller.
+                return this.getMaxLengthInBytes() >= otherType.getMaxLengthInBytes();
+            }
+            else if (this == VoltType.FLOAT) {
+                // Non-big integers make acceptable (exact) floats
+                if (otherType != VoltType.BIGINT) {
+                    return true;
+                }
+            }
+            // Not sure about integer-to-decimal: for now, just give up.
+        }
+        return false;
+    }
+
+    /** Get a char that uniquely identifies a type.
+     * Used to create concise schema signatures.
+     * @return A char representing the type. */
+    public char getSignatureChar() {
+        // This should never be called for an incomplete or invalid VoltType.
+        assert(m_signatureChar != '0');
+        return m_signatureChar;
+    }
+
+    // Integer[0] is the column size and Integer[1] is the radix
+    // I'd love to get this magic into the type construction, but
+    // not happening this go-round.  --izzy
+    public Integer[] getTypePrecisionAndRadix()
+    {
+        Integer[] col_size_radix = {null, null};
+        switch (this) {
+        case TINYINT:
+        case SMALLINT:
+        case INTEGER:
+        case BIGINT:
+        case TIMESTAMP:
+            col_size_radix[0] = (getLengthInBytesForFixedTypes() * 8) - 1;
+            col_size_radix[1] = 2;
+            break;
+        case FLOAT:
+            col_size_radix[0] = 53;  // magic for double
+            col_size_radix[1] = 2;
+            break;
+        case DECIMAL:
+            col_size_radix[0] = VoltDecimalHelper.kDefaultPrecision;
+            col_size_radix[1] = 10;
+            break;
+        case STRING:
+        case VARBINARY:
+        case GEOGRAPHY:
+            col_size_radix[0] = VoltType.MAX_VALUE_LENGTH;
+            break;
+        default:
+            // What's the right behavior here?
+        }
+        return col_size_radix;
+    }
+
+    /** The size specifier for columns with a variable-length type is optional in a
+     * CREATE TABLE or ALTER TABLE statement.  If no size is specified, VoltDB chooses
+     * a default size.
+     * @return the default size for the given type */
+    public int defaultLengthForVariableLengthType() {
+        assert(m_lengthAsBytesRange != null);
+        return m_lengthAsBytesRange.getDefaultLengthInBytes();
+    }
+
+    public String getMostCompatibleJavaTypeName() {
+        if (m_classes.length > 0) {
+            Class<?> javaClass = m_classes[0];
+            return javaClass.getSimpleName();
+        }
+        return "(unknown?)";
+    }
+
+    // OTHER METHODS that are as much about specific VALUES as about their TYPES
+
+    public Object getMaxValueForKeyPadding() {
+        switch (this) {
+        case TINYINT: return MAX_TINYINT;
+        case SMALLINT: return MAX_SMALLINT;
+        case INTEGER: return MAX_INTEGER;
+        case BIGINT: return MAX_BIGINT;
+        case TIMESTAMP: return MAX_TIMESTAMP;
+        case FLOAT: return MAX_FLOAT;
+        default: return null;
+        }
     }
 
     // Really hacky cast overflow detection for primitive types
@@ -690,73 +934,41 @@ public enum VoltType {
     // bit pattern
     // Probably eventually want a generic wouldCastDiscardInfo() call or
     // something
-    boolean wouldCastOverflow(Number value)
-    {
-        boolean retval = false;
-        switch (this)
-        {
+    boolean wouldCastOverflow(Number value) {
+        switch (this) {
         case TINYINT:
-            if (value.longValue() <= Byte.MIN_VALUE ||
-                    value.longValue() > Byte.MAX_VALUE)
-            {
-                retval = true;
-            }
-            break;
+            return (value.longValue() <= Byte.MIN_VALUE ||
+                    value.longValue() > Byte.MAX_VALUE);
         case SMALLINT:
-            if (value.longValue() <= Short.MIN_VALUE ||
-                    value.longValue() > Short.MAX_VALUE)
-            {
-                retval = true;
-            }
-            break;
+            return (value.longValue() <= Short.MIN_VALUE ||
+                    value.longValue() > Short.MAX_VALUE);
         case INTEGER:
-            if (value.longValue() <= Integer.MIN_VALUE ||
-                    value.longValue() > Integer.MAX_VALUE)
-            {
-                retval = true;
-            }
-            break;
+            return (value.longValue() <= Integer.MIN_VALUE ||
+                    value.longValue() > Integer.MAX_VALUE);
         case BIGINT:
             // overflow isn't detectable for Longs, just look for NULL value
             // In practice, I believe that we should never get here in VoltTable
             // since we check for NULL before checking for cast overflow
-            if (value.longValue() == NULL_BIGINT)
-            {
-                retval = true;
-            }
-            break;
+            return (value.longValue() == NULL_BIGINT);
         case FLOAT:
             // this really should never occur, also, just look for NULL
             // In practice, I believe that we should never get here in VoltTable
             // since we check for NULL before checking for cast overflow
-            if (value.doubleValue() == NULL_FLOAT)
-            {
-                retval = true;
-            }
-            break;
+            return (value.doubleValue() == NULL_FLOAT);
         default:
             throw new VoltTypeException("Unhandled cast overflow case, " +
                                         "casting to: " + toString());
         }
-        return retval;
     }
 
-    // I feel like it should be possible to jam this into the enum
-    // constructor somehow but java hates me when I move constant definitions
-    // above the enum constructors, so, meh
-
-    /**
-     * Get a value representing whichever null value is appropriate for
+    /** Get a value representing whichever null value is appropriate for
      * the current <tt>VoltType</tt> enum. For example, if this type is
      * {@link #TINYINT}, this will return a java <tt>byte</tt> with value
      * -128, which is the constant NULL_TINYINT in VoltDB.
      * @return A new final instance with value equal to null for a given
-     * type.
-     */
-    public Object getNullValue()
-    {
-        switch (this)
-        {
+     * type. */
+    public Object getNullValueForTest() {
+        switch (this) {
         case TINYINT:
             return NULL_TINYINT;
         case SMALLINT:
@@ -784,20 +996,18 @@ public enum VoltType {
         }
     }
 
-    public static boolean isNullVoltType(Object obj)
+    public static boolean isVoltNullValue(Object obj)
     {
         if ((obj == null) ||
             (obj == VoltType.NULL_TIMESTAMP) ||
             (obj == VoltType.NULL_STRING_OR_VARBINARY) ||
             (obj == VoltType.NULL_DECIMAL) ||
             (obj == VoltType.NULL_POINT) ||
-            (obj == VoltType.NULL_GEOGRAPHY))
-        {
+            (obj == VoltType.NULL_GEOGRAPHY)) {
             return true;
         }
 
-        switch(typeFromObject(obj))
-        {
+        switch (typeFromObject(obj)) {
         case TINYINT:
             return (((Number) obj).byteValue() == NULL_TINYINT);
         case SMALLINT:
@@ -822,274 +1032,108 @@ public enum VoltType {
         }
     }
 
-    public boolean isIndexable() {
-        switch(this) {
-        case GEOGRAPHY_POINT:
-        case BOOLEAN:
-            return false;
-        default:
-            return true;
-        }
-    }
-
-    public boolean isUniqueIndexable() {
-        switch(this) {
-        case GEOGRAPHY_POINT:
-        case GEOGRAPHY:
-        case BOOLEAN:
-            return false;
-        default:
-            return true;
-        }
-    }
-
-    /**
-     * Is the type a number and is it an exact value (no rounding errors)?
-     * @return true for integers and decimals. False for floats and strings
-     * and anything else.
-     */
-    public boolean isExactNumeric() {
-        switch(this)  {
-        case TINYINT:
-        case SMALLINT:
-        case INTEGER:
-        case BIGINT:
-        case DECIMAL:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    /**
-     * Is this type an integer type? True for <code>TINYINT</code>, <code>SMALLINT</code>,
-     * <code>INTEGER</code>, <code>BIGINT</code> and <code>TIMESTAMP</code>.
-     * @return True if integer type. False if not.
-     */
-    public boolean isBackendIntegerType() {
-        switch(this)  {
-        case TINYINT:
-        case SMALLINT:
-        case INTEGER:
-        case BIGINT:
-        case TIMESTAMP:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    public boolean isVariableLength() {
-        switch (this) {
-        case GEOGRAPHY:
-        case VARBINARY:
-        case STRING:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    /**
-     * Is this type an integer type? True for <code>TINYINT</code>, <code>SMALLINT</code>,
-     * <code>INTEGER</code>, <code>BIGINT</code>.
-     * @return True if integer type. False if not.
-     */
-    public boolean isAnyIntegerType() {
-        switch(this)  {
-        case TINYINT:
-        case SMALLINT:
-        case INTEGER:
-        case BIGINT:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-
-    public boolean isMaxValuePaddable() {
-        switch (this) {
-        case TINYINT:
-        case SMALLINT:
-        case INTEGER:
-        case BIGINT:
-        case TIMESTAMP:
-        case FLOAT:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    public static Object getPaddedMaxTypeValue(VoltType type) {
-        switch (type) {
-        case TINYINT: return new Byte(Byte.MAX_VALUE);
-        case SMALLINT: return new Short(Short.MAX_VALUE);
-        case INTEGER: return new Integer(Integer.MAX_VALUE);
-        case BIGINT:
-        case TIMESTAMP:
-            return new Long(Long.MAX_VALUE);
-        case FLOAT:
-            return new Float(Float.MAX_VALUE);
-        default:
+    /** Converts the object into bytes for hashing.
+     * @param obj a value to be hashed
+     * @return a byte array representation of obj
+     * OR null if the obj is java null or any other Volt representation
+     * of a null value. */
+    public static byte[] valueToBytes(Object obj) {
+        if (isVoltNullValue(obj)) {
             return null;
         }
+        if (obj instanceof byte[]) {
+            return (byte[]) obj;
+        }
+        if (obj instanceof String ) {
+            return ((String) obj).getBytes(Constants.UTF8ENCODING);
+        }
+
+        long value = 0;
+        if (obj instanceof Long) {
+            value = ((Long) obj).longValue();
+        }
+        else if (obj instanceof Integer) {
+            value = ((Integer)obj).intValue();
+        }
+        else if (obj instanceof Short) {
+            value = ((Short)obj).shortValue();
+        }
+        else if (obj instanceof Byte) {
+            value = ((Byte)obj).byteValue();
+        }
+
+        ByteBuffer buf = ByteBuffer.allocate(8);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+        buf.putLong(value);
+        return buf.array();
     }
 
-    public boolean isNumber() {
+    /** Converts a byte array with type back to the original partition value.
+     * This is the inverse of @see VoltType#valueToBytes(Object) valueToBytes
+     * @param value Byte array representation of partition parameter.
+     * @return Java object of the correct type. */
+    public Object bytesToValue(byte[] value) {
+        assert(value != null);
+        if ((this == NULL)) {
+            return null;
+        }
+        if (this == VARBINARY) {
+            return value;
+        }
+
+        ByteBuffer buf = ByteBuffer.wrap(value);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+
         switch (this) {
-            case TINYINT:
-            case SMALLINT:
-            case INTEGER:
-            case BIGINT:
-            case FLOAT:
-            case DECIMAL:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    // Used by TheHashinator.getPartitionForParameter() to determine if the
-    // type of the partition parameter is one that we can coerce from a string
-    // value.  isInteger includes TIMESTAMP, which is bad, and isNumber
-    // includes FLOAT, which is also bad, hence the creation of this method.
-    public boolean isPartitionableNumber() {
-        switch (this) {
-            case TINYINT:
-            case SMALLINT:
-            case INTEGER:
-            case BIGINT:
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    /* Indicate whether a value can be assigned to this type without loss of range or precision,
-     * important for index key and partition key initialization. */
-    public boolean canExactlyRepresentAnyValueOf(VoltType otherType) {
-        // self to self conversion is obviously fine.
-        if (this == otherType)
-            return true;
-
-        if (otherType.isBackendIntegerType()) {
-            if (this.isBackendIntegerType()) {
-                // Don't allow integers getting smaller.
-                return this.getMaxLengthInBytes() >= otherType.getMaxLengthInBytes();
-            }
-            else if (this == VoltType.FLOAT) {
-                // Non-big integers make acceptable (exact) floats
-                if (otherType != VoltType.BIGINT) {
-                    return true;
-                }
-            }
-            // Not sure about integer-to-decimal: for now, just give up.
-        }
-        return false;
-    }
-
-    /**
-     * Get a char that uniquely identifies a type. Used to create
-     * concise schema signatures.
-     * @return A char representing the type.
-     */
-    public char getSignatureChar() {
-        assert(m_signatureChar != '0');
-        return m_signatureChar;
-    }
-
-    /**
-     * Make a printable, short string for a varbinary.
-     * String includes a CRC and the contents of the varbinary in hex.
-     * Contents longer than 13 chars are truncated and elipsized.
-     * Yes, "elipsized" is totally a word.
-     *
-     * Example: "bin[crc:1298399436,value:0xABCDEF12345...]"
-     *
-     * @param bin The bytes to print out.
-     * @return A string representation that is printable and short.
-     */
-    public static String varbinaryToPrintableString(byte[] bin) {
-        PureJavaCrc32 crc = new PureJavaCrc32();
-        StringBuilder sb = new StringBuilder();
-        sb.append("bin[crc:");
-        crc.update(bin);
-        sb.append(crc.getValue());
-        sb.append(",value:0x");
-        String hex = Encoder.hexEncode(bin);
-        if (hex.length() > 13) {
-            sb.append(hex.substring(0, 10));
-            sb.append("...");
-        }
-        else {
-            sb.append(hex);
-        }
-        sb.append("]");
-        return sb.toString();
-    }
-
-    // Integer[0] is the column size and Integer[1] is the radix
-    // I'd love to get this magic into the type construction, but
-    // not happening this go-round.  --izzy
-    public Integer[] getTypePrecisionAndRadix()
-    {
-        Integer[] col_size_radix = {null, null};
-        switch(this)
-        {
-        case TINYINT:
-        case SMALLINT:
-        case INTEGER:
         case BIGINT:
-        case TIMESTAMP:
-            col_size_radix[0] = (getLengthInBytesForFixedTypes() * 8) - 1;
-            col_size_radix[1] = 2;
-            break;
-        case FLOAT:
-            col_size_radix[0] = 53;  // magic for double
-            col_size_radix[1] = 2;
-            break;
-        case DECIMAL:
-            col_size_radix[0] = VoltDecimalHelper.kDefaultPrecision;
-            col_size_radix[1] = 10;
-            break;
+            return buf.getLong();
         case STRING:
-        case VARBINARY:
-        case GEOGRAPHY:
-            col_size_radix[0] = VoltType.MAX_VALUE_LENGTH;
-            col_size_radix[1] = null;
-            break;
+            return new String(value, Constants.UTF8ENCODING);
+        case INTEGER:
+            return buf.getInt();
+        case SMALLINT:
+            return buf.getShort();
+        case TINYINT:
+            return buf.get();
         default:
-            // What's the right behavior here?
+            throw new RuntimeException(
+                    "bytesToValue failed to convert a non-partitionable type.");
         }
-        return col_size_radix;
     }
+
+    // VALUE constants
 
     /** Length value for a null string. */
     public static final int NULL_STRING_LENGTH = -1;
-    /** Null value for <code>TINYINT</code>.  */
+    /** Null value for <code>TINYINT</code>. */
     public static final byte NULL_TINYINT = Byte.MIN_VALUE;
-    /** Null value for <code>SMALLINT</code>.  */
+    /** Null value for <code>SMALLINT</code>. */
     public static final short NULL_SMALLINT = Short.MIN_VALUE;
-    /** Null value for <code>INTEGER</code>.  */
+    /** Null value for <code>INTEGER</code>. */
     public static final int NULL_INTEGER = Integer.MIN_VALUE;
-    /** Null value for <code>BIGINT</code>.  */
+    /** Null value for <code>BIGINT</code>. */
     public static final long NULL_BIGINT = Long.MIN_VALUE;
-    /** Null value for <code>FLOAT</code>.  */
+    /** Null value for <code>FLOAT</code>. */
     public static final double NULL_FLOAT = -1.7E+308;
+
+    private static final Byte MAX_TINYINT = new Byte(Byte.MAX_VALUE);
+    private static final Short MAX_SMALLINT = new Short(Short.MAX_VALUE);
+    private static final Integer MAX_INTEGER = new Integer(Integer.MAX_VALUE);
+    private static final Long MAX_BIGINT = new Long(Long.MAX_VALUE);
+    private static final Long MAX_TIMESTAMP = new Long(Long.MAX_VALUE);
+    private static final Float MAX_FLOAT = new Float(Float.MAX_VALUE);
 
     // for consistency at the API level, provide symbolic nulls for these types, too
     private static final class NullTimestampSigil{}
-    /** Null value for <code>TIMESTAMP</code>.  */
+    /** Null value for <code>TIMESTAMP</code>. */
     public static final NullTimestampSigil NULL_TIMESTAMP = new NullTimestampSigil();
 
     private static final class NullStringOrVarbinarySigil{}
-    /** Null value for <code>STRING</code> or <code>VARBINARY</code>.  */
+    /** Null value for <code>STRING</code> or <code>VARBINARY</code>. */
     public static final NullStringOrVarbinarySigil NULL_STRING_OR_VARBINARY = new NullStringOrVarbinarySigil();
 
     private static final class NullDecimalSigil{}
-    /** Null value for <code>DECIMAL</code>.  */
+    /** Null value for <code>DECIMAL</code>. */
     public static final NullDecimalSigil NULL_DECIMAL = new NullDecimalSigil();
 
     private static final class NullPointSigil{}
@@ -1099,26 +1143,5 @@ public enum VoltType {
     private static final class NullGeographySigil{}
     /** Null value for <code>GEOGRAPHY</code>. */
     public static final NullGeographySigil NULL_GEOGRAPHY = new NullGeographySigil();
-
-    /**
-     * The size specifier for columns with a variable-length type is optional in a
-     * CREATE TABLE or ALTER TABLE statement.  If no size is specified, VoltDB chooses
-     * a default size.
-     *
-     * @return the default size for the given type
-     */
-    public int defaultLengthForVariableLengthType() {
-        assert(isVariableLength());
-        if (this == GEOGRAPHY) {
-            return GeographyValue.DEFAULT_LENGTH;
-        }
-
-        // These constants should be kept up-to-date with those in DDLCompiler.
-        // We can't reference DDLCompiler here since this class is used in the client.
-        final int MAX_COLUMNS = 1024;
-        final int MAX_ROW_SIZE = 1024 * 1024 * 2;
-
-        return MAX_ROW_SIZE / MAX_COLUMNS;
-    }
 
 }

--- a/src/frontend/org/voltdb/client/VoltBulkLoader/PerPartitionTable.java
+++ b/src/frontend/org/voltdb/client/VoltBulkLoader/PerPartitionTable.java
@@ -31,9 +31,7 @@ import java.util.concurrent.TimeUnit;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.ClientResponseImpl;
-
 import org.voltdb.ParameterConverter;
-import org.voltdb.client.HashinatorLite;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
 import org.voltdb.VoltTypeException;
@@ -259,7 +257,7 @@ public class PerPartitionTable {
             if (m_isMP) {
                 m_clientImpl.callProcedure(callback, m_procName, m_tableName, m_upsert, toSend);
             } else {
-                Object rpartitionParam = HashinatorLite.valueToBytes(toSend.fetchRow(0).get(
+                Object rpartitionParam = VoltType.valueToBytes(toSend.fetchRow(0).get(
                         m_partitionedColumnIndex, m_partitionColumnType));
                 m_clientImpl.callProcedure(callback, m_procName, rpartitionParam, m_tableName, m_upsert, toSend);
             }

--- a/src/frontend/org/voltdb/compiler/StatementCompiler.java
+++ b/src/frontend/org/voltdb/compiler/StatementCompiler.java
@@ -35,6 +35,7 @@ import org.voltdb.catalog.Statement;
 import org.voltdb.catalog.StmtParameter;
 import org.voltdb.catalog.Table;
 import org.voltdb.compiler.VoltCompiler.VoltCompilerException;
+import org.voltdb.expressions.ParameterValueExpression;
 import org.voltdb.planner.CompiledPlan;
 import org.voltdb.planner.PlanningErrorException;
 import org.voltdb.planner.QueryPlanner;
@@ -414,9 +415,10 @@ public abstract class StatementCompiler {
         // We will need to update the system catalogs with this new information
         for (int i = 0; i < plan.parameters.length; ++i) {
             StmtParameter catalogParam = stmt.getParameters().add(String.valueOf(i));
-            catalogParam.setJavatype(plan.parameters[i].getValueType().getValue());
-            catalogParam.setIsarray(plan.parameters[i].getParamIsVector());
             catalogParam.setIndex(i);
+            ParameterValueExpression pve = plan.parameters[i];
+            catalogParam.setJavatype(pve.getValueType().getValue());
+            catalogParam.setIsarray(pve.getParamIsVector());
         }
 
         PlanFragment frag = stmt.getFragments().add("0");

--- a/src/frontend/org/voltdb/expressions/FunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/FunctionExpression.java
@@ -124,7 +124,8 @@ public class FunctionExpression extends AbstractExpression {
         if (value_type != param_type) {
             if (value_type == null) {
                 value_type = param_type;
-            } else if (value_type == VoltType.NUMERIC) {
+            }
+            else if (value_type == VoltType.NUMERIC) {
                 if (param_type != null) {
                     value_type = param_type;
                 }
@@ -141,7 +142,10 @@ public class FunctionExpression extends AbstractExpression {
         }
         if (value_type != null) {
             setValueType(value_type);
-            setValueSize(value_type.getMaxLengthInBytes());
+            if (value_type != VoltType.INVALID && value_type != VoltType.NUMERIC) {
+                int size = value_type.getMaxLengthInBytes();
+                setValueSize(size);
+            }
         }
     }
 

--- a/src/frontend/org/voltdb/planner/CorePlan.java
+++ b/src/frontend/org/voltdb/planner/CorePlan.java
@@ -57,7 +57,7 @@ public class CorePlan {
     /** What SHA-1 hash of the catalog is this plan good for? */
     private final byte[] catalogHash;
 
-    /** What are the types of the paramters this plan accepts? */
+    /** What are the types of the parameters this plan accepts? */
     public final VoltType[] parameterTypes;
 
     /**

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -719,7 +719,10 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
 
             // We don't support parameterized casting, such as specifically to "VARCHAR(3)" vs. VARCHAR,
             // so assume max length for variable-length types (VARCHAR and VARBINARY).
-            expr.setValueSize(expr.getInBytes() ? voltType.getMaxLengthInBytes() : VoltType.MAX_VALUE_LENGTH_IN_CHARACTERS);
+            int size = expr.getInBytes() ?
+                    voltType.getMaxLengthInBytes() :
+                        VoltType.MAX_VALUE_LENGTH_IN_CHARACTERS;
+            expr.setValueSize(size);
             expr.setLeft(colExpr);
 
             // switch the new expression for CAST

--- a/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
@@ -259,7 +259,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
             if (canPadding && missingKeyType.isMaxValuePaddable()) {
                 ConstantValueExpression missingKey = new ConstantValueExpression();
                 missingKey.setValueType(missingKeyType);
-                missingKey.setValue(String.valueOf(VoltType.getPaddedMaxTypeValue(missingKeyType)));
+                missingKey.setValue(String.valueOf(missingKeyType.getMaxValueForKeyPadding()));
                 missingKey.setValueSize(missingKeyType.getLengthInBytesForFixedTypes());
                 endType = IndexLookupType.LTE;
                 endKeys.add(missingKey);

--- a/src/frontend/org/voltdb/types/GeographyValue.java
+++ b/src/frontend/org/voltdb/types/GeographyValue.java
@@ -48,7 +48,13 @@ public class GeographyValue {
      * The minimum-allowed length (in bytes) for a column with type GEOGRAPHY.
      * This is the length of a polygon with just three vertices.
      */
-    public static final int MIN_SERIALIZED_LENGTH = 155; // number of bytes need to store a triangle
+    public static final int MIN_SERIALIZED_LENGTH = 155; // number of bytes needed to store a triangle
+
+    /**
+     * The maximum-allowed length (in bytes) for a column with type GEOGRAPHY.
+     * This is the usual max column length.
+     */
+    public static final int MAX_SERIALIZED_LENGTH = 1048576;
 
     //
     // This is a list of loops.  Each loop must be in

--- a/src/frontend/org/voltdb/utils/VoltTypeUtil.java
+++ b/src/frontend/org/voltdb/utils/VoltTypeUtil.java
@@ -445,22 +445,6 @@ public abstract class VoltTypeUtil {
         return (ret);
     }
 
-    public static long getHashableLongFromObject(Object obj) {
-        if (obj == null || VoltType.isNullVoltType(obj)) {
-            return 0;
-        } else if (obj instanceof Long) {
-            return ((Long) obj).longValue();
-        } else if (obj instanceof Integer) {
-            return ((Integer)obj).intValue();
-        } else if (obj instanceof Short) {
-            return ((Short)obj).shortValue();
-        } else if (obj instanceof Byte) {
-            return ((Byte)obj).byteValue();
-        } else {
-            throw new RuntimeException(obj + " cannot be casted to a long");
-        }
-    }
-
     public static java.sql.Timestamp getSqlTimestampFromMicrosSinceEpoch(long timestamp) {
         java.sql.Timestamp result;
 

--- a/tests/frontend/org/voltdb/TestClientInterface.java
+++ b/tests/frontend/org/voltdb/TestClientInterface.java
@@ -392,7 +392,7 @@ public class TestClientInterface {
         assertEquals(1, parameters.length);
         assertEquals(3, parameters[0]);
         AdHocPlannedStatement[] statements = AdHocPlannedStmtBatch.planArrayFromBuffer(buf);
-        assertTrue(Arrays.equals(TheHashinator.valueToBytes(3), (byte[]) partitionParam));
+        assertTrue(Arrays.equals(VoltType.valueToBytes(3), (byte[]) partitionParam));
         assertEquals(1, statements.length);
         String sql = new String(statements[0].sql, Constants.UTF8ENCODING);
         assertEquals(query, sql);

--- a/tests/frontend/org/voltdb/TestParameterSet.java
+++ b/tests/frontend/org/voltdb/TestParameterSet.java
@@ -56,13 +56,13 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Date;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop_voltpatches.util.PureJavaCrc32C;
 import org.json_voltpatches.JSONException;
 import org.voltdb.types.TimestampType;
 import org.voltdb.types.VoltDecimalHelper;
+
+import junit.framework.TestCase;
 
 public class TestParameterSet extends TestCase {
     ParameterSet params;
@@ -413,7 +413,7 @@ public class TestParameterSet extends TestCase {
         ByteBuffer buf;
 
         Object[] psetObjs = new Object[] {
-                null, VoltType.INTEGER.getNullValue(), VoltType.DECIMAL.getNullValue(), // null values
+                null, VoltType.NULL_INTEGER, VoltType.NULL_DECIMAL, // null values
                 (byte)1, (short)2, (int)3, (long)4, 1.2f, 3.6d, // numbers
                 "This is spinal tap", "", // strings
                 "ABCDF012", new byte[] { 1, 3, 5 }, new byte[0], // binary

--- a/tests/frontend/org/voltdb/TestVoltTable.java
+++ b/tests/frontend/org/voltdb/TestVoltTable.java
@@ -648,7 +648,7 @@ public class TestVoltTable extends TestCase {
             for (int j = 0; j < types.length; ++j) {
                 VoltTable table = new VoltTable(new ColumnInfo("test_table",
                         types[i]));
-                table.addRow(types[j].getNullValue());
+                table.addRow(types[j].getNullValueForTest());
                 VoltTableRow row = table.fetchRow(0);
                 row.get(0, types[i]);
                 assertTrue("Value wasn't null", row.wasNull());

--- a/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
@@ -502,7 +502,7 @@ public class RegressionSuite extends TestCase {
             }
             else {
                 VoltType type = vt.getColumnType(i);
-                assertEquals(message + "expected null: ", Long.parseLong(type.getNullValue().toString()), actual);
+                assertEquals(message + "expected null: ", Long.parseLong(type.getNullValueForTest().toString()), actual);
             }
         }
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestComparisonOperatorsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestComparisonOperatorsSuite.java
@@ -370,7 +370,7 @@ public class TestComparisonOperatorsSuite  extends RegressionSuite {
         sql = "SELECT CASE WHEN ID > 11 THEN VB1 ELSE VB2 END FROM INLINED_VC_VB_TABLE WHERE ID = 72;";
         vt = cl.callProcedure("@AdHoc", sql).getResults()[0];
         vt.advanceRow();
-        assertTrue(VoltType.varbinaryToPrintableString(vt.getVarbinary(0)).contains("DEADBEEF"));
+        assertTrue(VoltTable.varbinaryToPrintableString(vt.getVarbinary(0)).contains("DEADBEEF"));
 
         cl.callProcedure("R1.insert", 3, "ORACLE",  8, 8.0, new Timestamp(1000000000000L));
         // Test nested case when

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -2049,7 +2049,7 @@ public class TestFunctionsSuite extends RegressionSuite {
         sql = "SELECT CAST(VB1 AS VARBINARY) FROM INLINED_VC_VB_TABLE WHERE ID = 22;";
         vt = client.callProcedure("@AdHoc", sql).getResults()[0];
         vt.advanceRow();
-        assertTrue(VoltType.varbinaryToPrintableString(vt.getVarbinary(0)).contains("DEADBEEF"));
+        assertTrue(VoltTable.varbinaryToPrintableString(vt.getVarbinary(0)).contains("DEADBEEF"));
     }
 
     private void subtestVarCharCasts(Client client) throws Exception

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
@@ -177,7 +177,7 @@ public class TestGeographyValueQueries extends RegressionSuite {
 
             // Insert a null by passing an instance of the null sigil
             validateTableOfScalarLongs(client, "delete from " + tbl, new long[] {1});
-            vt = client.callProcedure(tbl + ".Insert", 0, "null geog", VoltType.GEOGRAPHY.getNullValue()).getResults()[0];
+            vt = client.callProcedure(tbl + ".Insert", 0, "null geog", VoltType.NULL_GEOGRAPHY).getResults()[0];
             validateTableOfScalarLongs(vt, new long[] {1});
 
             vt = client.callProcedure("@AdHoc", "select poly from " + tbl).getResults()[0];
@@ -741,7 +741,7 @@ public class TestGeographyValueQueries extends RegressionSuite {
                 client.callProcedure("select_in_" + tbl,
                     (Object)(new Object[] {
                             BERMUDA_TRIANGLE_POLY,
-                            VoltType.GEOGRAPHY.getNullValue(),
+                            VoltType.NULL_GEOGRAPHY,
                             LOWELL_SQUARE_POLY}));
                 fail("Expected an exception to be thrown");
             }

--- a/tests/frontend/org/voltdb/regressionsuites/TestLoadingSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestLoadingSuite.java
@@ -25,10 +25,7 @@ package org.voltdb.regressionsuites;
 
 import java.io.IOException;
 
-import junit.framework.Test;
-
 import org.voltdb.BackendTarget;
-import org.voltdb.TheHashinator;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
@@ -36,6 +33,8 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
+
+import junit.framework.Test;
 
 public class TestLoadingSuite extends RegressionSuite {
 
@@ -73,7 +72,7 @@ public class TestLoadingSuite extends RegressionSuite {
         table = m_template.clone(100);
         table.addRow(1, 1, 1, "1", 1.0);
         table.addRow(2, 1, 2, "2", 2.0);
-        r = client.callProcedure("@LoadSinglepartitionTable", TheHashinator.valueToBytes(1),
+        r = client.callProcedure("@LoadSinglepartitionTable", VoltType.valueToBytes(1),
                 "PARTITIONED", upsertMode, table);
         assertEquals(ClientResponse.SUCCESS, r.getStatus());
         assertEquals(1, r.getResults().length);
@@ -82,7 +81,7 @@ public class TestLoadingSuite extends RegressionSuite {
 
         // test failure to load replicated table from SP proc
         try {
-            r = client.callProcedure("@LoadSinglepartitionTable", TheHashinator.valueToBytes(1),
+            r = client.callProcedure("@LoadSinglepartitionTable", VoltType.valueToBytes(1),
                     "REPLICATED", upsertMode, table);
             fail(); // prev stmt should throw exception
         } catch (ProcCallException e) {
@@ -95,7 +94,7 @@ public class TestLoadingSuite extends RegressionSuite {
         table.addRow(3, 2, 3, "3", 3.0);
         table.addRow(3, 2, 3, "3", 3.0);
         try {
-            r = client.callProcedure("@LoadSinglepartitionTable", TheHashinator.valueToBytes(2),
+            r = client.callProcedure("@LoadSinglepartitionTable", VoltType.valueToBytes(2),
                     "PARTITIONED", upsertMode, table);
             fail(); // prev stmt should throw exception
         } catch (ProcCallException e) {


### PR DESCRIPTION
VoltType-related refactoring to:
   migrate some static methods to more relevant classes.
   use the "smart enum" feature of java 7 to special-case behavior of specific VoltTypes and reduce reliance on switch statements (should make adding new types easier) -- the new model follows a kind of 80/20 rule -- VoltType provides a simple "usual" implementation of each function which only a FEW specific VoltTypes will need to override to implement special case behavior. This is more efficient and maintainable than lots of switch statements.
    better distinguish fixed and variable length types
    avoid boilerplate especially in initialization
    improve javadoc coverage