### PR TITLE
ENG-10064: Kafka importer UAC system test scenario fails with short row count

### DIFF
--- a/src/frontend/org/voltdb/InternalConnectionHandler.java
+++ b/src/frontend/org/voltdb/InternalConnectionHandler.java
@@ -198,7 +198,7 @@ public class InternalConnectionHandler {
         int prev = m_backpressureIndication.get();
         int delta = b ? 1 : -(prev > 1 ? prev >> 1 : 1);
         int next = prev + delta;
-        while (next >= 0 && next <= 7 && !m_backpressureIndication.compareAndSet(prev, next)) {
+        while (next >= 0 && next <= 8 && !m_backpressureIndication.compareAndSet(prev, next)) {
             prev = m_backpressureIndication.get();
             delta = b ? 1 : -(prev > 1 ? prev >> 1 : 1);
             next = prev + delta;
@@ -210,8 +210,8 @@ public class InternalConnectionHandler {
         final int count = m_backpressureIndication.get();
         if (count > 0) {
             try { // increase sleep time exponentially to a max of 128ms
-                if (count > 7) {
-                    Thread.sleep(128);
+                if (count > 8) {
+                    Thread.sleep(256);
                 } else {
                     Thread.sleep(1<<count);
                 }

--- a/tests/test_apps/kafkaimporter/client/kafkaimporter/MatchChecks.java
+++ b/tests/test_apps/kafkaimporter/client/kafkaimporter/MatchChecks.java
@@ -40,7 +40,7 @@ public class MatchChecks {
     protected static long getMirrorTableRowCount(boolean alltypes, Client client) {
         // check row count in mirror table -- the "master" of what should come back
         // eventually via import
-        String table = alltypes ? "KafkaMirrorTable1" : "KafkaMirrorTable2";
+        String table = alltypes ? "KafkaMirrorTable2" : "KafkaMirrorTable1";
         ClientResponse response = doAdHoc(client, "select count(*) from " + table);
         VoltTable[] countQueryResult = response.getResults();
         VoltTable data = countQueryResult[0];
@@ -150,6 +150,9 @@ public class MatchChecks {
         long importRowCount = 0;
         long importMax = 0;
         long importMin = 0;
+
+        // check row count in import table
+        // String table = alltypes ? "KafkaImportTable2" : "KafkaImportTable1";
 
         ClientResponse response = doAdHoc(client, "select count(key), min(key), max(key) from kafkaimporttable1");
         VoltTable countQueryResult = response.getResults()[0];


### PR DESCRIPTION
1. tweak to backpressure In InternalConnectionHandler to be less aggressive;
2. In kafka Importer,  wait for voltdb if observe large gap;
3. refine the KafkaImportBenchmark