### PR TITLE
ENG-10229: Break replication instead of crash on unexpected exceptions from the callbacks

### DIFF
--- a/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
+++ b/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -93,7 +94,14 @@ public class SynchronizedStatesManager {
     private final String m_ssmRootNode;
     private final String m_stateMachineRoot;
     private final String m_stateMachineMemberPath;
-    private final String m_memberId;
+    private String m_memberId;
+    private final String m_canonical_memberId;
+    private int m_resetCounter;
+    private int m_resetLimit;
+    private final int m_resetAllowance; // number of resets allowed within a reset clear threshold duration
+    private long m_lastResetTimeInMillis = -1L;
+
+    private static final long RESET_CLEAR_THRESHOLD = TimeUnit.DAYS.toMillis(1);
 
     private enum REQUEST_TYPE {
         INITIALIZING,
@@ -175,15 +183,16 @@ public class SynchronizedStatesManager {
      */
 
     public abstract class StateMachineInstance {
-        protected final String m_stateMachineId;
+        protected String m_stateMachineId;
+        private final String m_stateMachineName;
         private Set<String> m_knownMembers;
         private boolean m_membershipChangePending = false;
         private final String m_statePath;
         private final String m_lockPath;
         private final String m_barrierResultsPath;
-        private final String m_myResultPath;
+        private String m_myResultPath;
         private final String m_barrierParticipantsPath;
-        private final String m_myPartiticpantsPath;
+        private String m_myParticipantPath;
         private boolean m_stateChangeInitiator = false;
         private String m_ourDistributedLockName = null;
         private String m_lockWaitingOn = null;
@@ -196,6 +205,18 @@ public class SynchronizedStatesManager {
         private int m_currentParticipants = 0;
         private Set<String> m_memberResults = null;
         private int m_lastProposalVersion = 0;
+
+        private boolean m_initializationCompleted = false;
+
+        private boolean isInitializationCompleted() {
+            lockLocalState();
+            unlockLocalState();
+            return m_initializationCompleted;
+        }
+
+        public int getResetCounter() {
+            return m_resetCounter;
+        }
 
         private final Lock m_mutex = new ReentrantLock();
         private int m_mutexLockedCnt = 0;
@@ -267,7 +288,7 @@ public class SynchronizedStatesManager {
             public void process(final WatchedEvent event) {
                 try {
                     if (!m_done.get()) {
-                        m_shared_es.submit(HandlerForBarrierPartiticpantsEvent);
+                        m_shared_es.submit(HandlerForBarrierParticipantsEvent);
                     }
                 } catch (RejectedExecutionException e) {
                 }
@@ -307,13 +328,14 @@ public class SynchronizedStatesManager {
         public StateMachineInstance()
         {
             m_statePath = "MockInstanceStatePath";
-            m_stateMachineId = "MockInstanceId";
             m_barrierResultsPath = "MockBarrierResultsPath";
             m_myResultPath = "MockMyResultPath";
             m_barrierParticipantsPath = "MockParticipantsPath";
-            m_myPartiticpantsPath = "MockMyParticipantPath";
+            m_myParticipantPath = "MockMyParticipantPath";
             m_lockPath = "MockLockPath";
             m_log = null;
+            m_stateMachineId = "MockStateMachineId";
+            m_stateMachineName = "MockStateMachineName";
         }
 
         public StateMachineInstance(String instanceName, VoltLogger logger) throws RuntimeException {
@@ -321,14 +343,15 @@ public class SynchronizedStatesManager {
                 throw new RuntimeException("State machine name may not be named " + m_memberNode);
             }
             assert(!instanceName.equals(m_memberNode));
+            m_stateMachineName = instanceName;
             m_statePath = ZKUtil.joinZKPath(m_stateMachineRoot, instanceName);
             m_lockPath = ZKUtil.joinZKPath(m_statePath, "LOCK_CONTENDERS");
             m_barrierResultsPath = ZKUtil.joinZKPath(m_statePath, "BARRIER_RESULTS");
             m_myResultPath = ZKUtil.joinZKPath(m_barrierResultsPath, m_memberId);
             m_barrierParticipantsPath = ZKUtil.joinZKPath(m_statePath, "BARRIER_PARTICIPANTS");
-            m_myPartiticpantsPath = ZKUtil.joinZKPath(m_barrierParticipantsPath, m_memberId);
+            m_myParticipantPath = ZKUtil.joinZKPath(m_barrierParticipantsPath, m_memberId);
             m_log = logger;
-            m_stateMachineId = "SMI " + m_ssmRootNode + "/" + instanceName  + "/" + m_memberId;
+            m_stateMachineId = "SMI " + m_ssmRootNode + "/" + m_stateMachineName + "/" + m_memberId;
             m_log.debug(m_stateMachineId + " created.");
         }
 
@@ -341,6 +364,13 @@ public class SynchronizedStatesManager {
             registerStateMachine(this);
         }
 
+        /**
+         * Notify the derived class that the state machine instance is being reset,
+         * the derived class should reset its own specific states and provide a reset state
+         * @param isDirectVictim true if the reset is caused by callback exception in this instance
+         * @return a ByteBuffer encapsulating the reset state provided by the derived class
+         */
+        protected abstract ByteBuffer notifyOfStateMachineReset(boolean isDirectVictim);
 
         private void initializeStateMachine(Set<String> knownMembers) throws KeeperException, InterruptedException {
             addIfMissing(m_statePath, CreateMode.PERSISTENT, null);
@@ -380,10 +410,19 @@ public class SynchronizedStatesManager {
                 m_lockWaitingOn = "bogus"; // Avoids call to notifyDistributedLockWaiter
                 m_log.info(m_stateMachineId + ": Initialized (first member) with State " +
                         stateToString(m_synchronizedState.asReadOnlyBuffer()));
+                m_initializationCompleted = true;
                 cancelDistributedLock();
                 checkForBarrierParticipantsChange();
                 // Notify the derived object that we have a stable state
-                setInitialState(readOnlyResult);
+                try {
+                    setInitialState(readOnlyResult);
+                } catch (Exception e) {
+                    if (m_log.isDebugEnabled()) {
+                        m_log.debug("Error in StateMachineInstance callbacks.", e);
+                    }
+                    m_initializationCompleted = false;
+                    m_shared_es.submit(new CallbackExceptionHandler(this));
+                }
             }
             else {
                 // To get a stable result set, we need to get the lock for this state machine. If someone else has the
@@ -420,15 +459,52 @@ public class SynchronizedStatesManager {
          */
         private void disableMembership() throws InterruptedException {
             lockLocalState();
+            // put in two separate try-catch blocks so that both actions are attempted
             try {
-                m_zk.delete(m_myPartiticpantsPath, -1);
+                m_zk.delete(m_myParticipantPath, -1);
+            }
+            catch (KeeperException e) {
+            }
+            try {
                 if (m_ourDistributedLockName != null) {
                     m_zk.delete(m_ourDistributedLockName, -1);
                 }
             }
             catch (KeeperException e) {
             }
+            m_initializationCompleted = false;
             unlockLocalState();
+        }
+
+        private void reset(boolean isDirectVictim) {
+            ByteBuffer resetState = notifyOfStateMachineReset(isDirectVictim);
+            // if we are the direct victim, use the reset state as requested initial state
+            if (isDirectVictim) {
+                m_requestedInitialState = resetState;
+            }
+            // else simply use currently requested initial state or synchronized state as requested initial state
+            else {
+                if (m_requestedInitialState == null) {
+                    assert(m_synchronizedState != null);
+                    m_requestedInitialState = m_synchronizedState;
+                }
+            }
+            m_synchronizedState = null;
+
+            m_membershipChangePending = false;
+            m_stateChangeInitiator = false;
+            m_ourDistributedLockName = null;
+            m_lockWaitingOn = null;
+            m_holdingDistributedLock = false;
+            m_pendingProposal = null;
+            m_currentRequestType = REQUEST_TYPE.INITIALIZING;
+            m_memberResults = null;
+            m_lastProposalVersion = 0;
+            m_mutexLockedCnt = 0;
+
+            m_myResultPath = ZKUtil.joinZKPath(m_barrierResultsPath, m_memberId);
+            m_myParticipantPath = ZKUtil.joinZKPath(m_barrierParticipantsPath, m_memberId);
+            m_stateMachineId = "SMI " + m_ssmRootNode + "/" + m_stateMachineName + "/" + m_memberId;
         }
 
         private int getProposalVersion() {
@@ -445,7 +521,7 @@ public class SynchronizedStatesManager {
                 m_log.debug(m_stateMachineId + ": Received InterruptedException in getProposalVersion");
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in StateMachine.", true, e);
+                        "Unexpected failure in StateMachine.", true, e);
             }
             return proposalVersion;
         }
@@ -518,7 +594,7 @@ public class SynchronizedStatesManager {
                             else {
                                 // We track the number of people waiting on the results so we know when the result is stale and
                                 // the next lock holder can initiate a new state proposal.
-                                m_zk.create(m_myPartiticpantsPath, null, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+                                m_zk.create(m_myParticipantPath, null, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
 
                                 m_pendingProposal = existingAndProposedStates.m_proposal;
                                 ByteBuffer proposedState = m_pendingProposal.asReadOnlyBuffer();
@@ -535,10 +611,26 @@ public class SynchronizedStatesManager {
                                 }
                                 unlockLocalState();
                                 if (type == REQUEST_TYPE.STATE_CHANGE_REQUEST) {
-                                    stateChangeProposed(proposedState);
+                                    try {
+                                        stateChangeProposed(proposedState);
+                                    } catch (Exception e) {
+                                        if (m_log.isDebugEnabled()) {
+                                            m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                        }
+                                        m_initializationCompleted = false;
+                                        m_shared_es.submit(new CallbackExceptionHandler(this));
+                                    }
                                 }
                                 else {
-                                    taskRequested(proposedState);
+                                    try {
+                                        taskRequested(proposedState);
+                                    } catch (Exception e) {
+                                        if (m_log.isDebugEnabled()) {
+                                            m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                        }
+                                        m_initializationCompleted = false;
+                                        m_shared_es.submit(new CallbackExceptionHandler(this));
+                                    }
                                 }
                             }
                         }
@@ -552,7 +644,15 @@ public class SynchronizedStatesManager {
                             // provide a result.
                             ByteBuffer taskRequest = m_pendingProposal.asReadOnlyBuffer();
                             unlockLocalState();
-                            taskRequested(taskRequest);
+                            try {
+                                taskRequested(taskRequest);
+                            } catch (Exception e) {
+                                if (m_log.isDebugEnabled()) {
+                                    m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                }
+                                m_initializationCompleted = false;
+                                m_shared_es.submit(new CallbackExceptionHandler(this));
+                            }
                         }
                         else {
                             unlockLocalState();
@@ -586,7 +686,7 @@ public class SynchronizedStatesManager {
                 unlockLocalState();
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in StateMachine.", true, e);
+                        "Unexpected failure in StateMachine.", true, e);
             }
             assert(!debugIsLocalStateLocked());
         }
@@ -641,7 +741,7 @@ public class SynchronizedStatesManager {
                     }
                 }
                 // Remove ourselves from the participants list to unblock the next distributed lock waiter
-                m_zk.delete(m_myPartiticpantsPath, -1);
+                m_zk.delete(m_myParticipantPath, -1);
             } catch (KeeperException.SessionExpiredException e) {
                 results = new ArrayList<ByteBuffer>();
                 m_log.debug(m_stateMachineId + ": Received SessionExpiredException in getUncorrelatedResults");
@@ -653,7 +753,7 @@ public class SynchronizedStatesManager {
                 m_log.debug(m_stateMachineId + ": Received InterruptedException in getUncorrelatedResults");
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in StateMachine.", true, e);
+                        "Unexpected failure in StateMachine.", true, e);
             }
             return results;
         }
@@ -676,7 +776,7 @@ public class SynchronizedStatesManager {
                     }
                 }
                 // Remove ourselves from the participants list to unblock the next distributed lock waiter
-                m_zk.delete(m_myPartiticpantsPath, -1);
+                m_zk.delete(m_myParticipantPath, -1);
             } catch (KeeperException.SessionExpiredException e) {
                 results = new HashMap<String, ByteBuffer>();
                 m_log.debug(m_stateMachineId + ": Received SessionExpiredException in getCorrelatedResults");
@@ -688,7 +788,7 @@ public class SynchronizedStatesManager {
                 m_log.debug(m_stateMachineId + ": Received InterruptedException in getCorrelatedResults");
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in StateMachine.", true, e);
+                        "Unexpected failure in StateMachine.", true, e);
             }
             return results;
         }
@@ -753,7 +853,7 @@ public class SynchronizedStatesManager {
                     }
 
                     // Remove ourselves from the participants list to unblock the next distributed lock waiter
-                    m_zk.delete(m_myPartiticpantsPath, -1);
+                    m_zk.delete(m_myParticipantPath, -1);
                 } catch (KeeperException.SessionExpiredException e) {
                     m_log.debug(m_stateMachineId + ": Received SessionExpiredException in processResultQuorum");
                 } catch (KeeperException.ConnectionLossException e) {
@@ -762,7 +862,7 @@ public class SynchronizedStatesManager {
                     m_log.debug(m_stateMachineId + ": Received InterruptedException in processResultQuorum");
                 } catch (Exception e) {
                     org.voltdb.VoltDB.crashLocalVoltDB(
-                            "Unexepected failure in StateMachine.", true, e);
+                            "Unexpected failure in StateMachine.", true, e);
                 }
                 if (m_stateChangeInitiator) {
                     m_stateChangeInitiator = false;
@@ -775,12 +875,23 @@ public class SynchronizedStatesManager {
                     m_pendingProposal = null;
                     m_log.info(m_stateMachineId + ": Initialized (concensus) with State " +
                             stateToString(m_synchronizedState.asReadOnlyBuffer()));
+                    m_initializationCompleted = true;
                     unlockLocalState();
-                    setInitialState(readOnlyResult);
+                    try {
+                        setInitialState(readOnlyResult);
+                    } catch (Exception e) {
+                        if (m_log.isDebugEnabled()) {
+                            m_log.debug("Error in StateMachineInstance callbacks.", e);
+                        }
+                        m_initializationCompleted = false;
+                        m_shared_es.submit(new CallbackExceptionHandler(this));
+                    }
 
-                    // If we are ready to provide an initial state to the derived state machine, add us to
-                    // participants watcher so we can see the next request
-                    monitorParticipantChanges();
+                    if (m_initializationCompleted) {
+                        // If we are ready to provide an initial state to the derived state machine, add us to
+                        // participants watcher so we can see the next request
+                        monitorParticipantChanges();
+                    }
                 }
                 else {
                     unlockLocalState();
@@ -797,7 +908,7 @@ public class SynchronizedStatesManager {
                         // We don't have a result yet but it is available
                         RESULT_CONCENSUS result = resultsAgreeOnSuccess(memberList);
                         // Now that we have a result we can remove ourselves from the participants list.
-                        m_zk.delete(m_myPartiticpantsPath, -1);
+                        m_zk.delete(m_myParticipantPath, -1);
                         if (result == RESULT_CONCENSUS.AGREE) {
                             success = true;
                             m_synchronizedState = m_pendingProposal;
@@ -823,15 +934,26 @@ public class SynchronizedStatesManager {
                         m_log.debug(m_stateMachineId + ": Received InterruptedException in processResultQuorum");
                     } catch (Exception e) {
                         org.voltdb.VoltDB.crashLocalVoltDB(
-                                "Unexepected failure in StateMachine.", true, e);
+                                "Unexpected failure in StateMachine.", true, e);
                         success = false;
                     }
                     m_log.info(m_stateMachineId + ": Proposed state " + (success?"succeeded ":"failed ") +
                             stateToString(attemptedChange.asReadOnlyBuffer()));
                     unlockLocalState();
                     // Notify the derived state machine engine of the current state
-                    proposedStateResolved(initiator, attemptedChange, success);
-                    monitorParticipantChanges();
+                    try {
+                        proposedStateResolved(initiator, attemptedChange, success);
+                    } catch (Exception e) {
+                        if (m_log.isDebugEnabled()) {
+                            m_log.debug("Error in StateMachineInstance callbacks.", e);
+                        }
+                        m_initializationCompleted = false;
+                        m_shared_es.submit(new CallbackExceptionHandler(this));
+                    }
+
+                    if (m_initializationCompleted) {
+                        monitorParticipantChanges();
+                    }
                 }
                 else {
                     // Process the results of a TASK request
@@ -847,7 +969,15 @@ public class SynchronizedStatesManager {
                             cancelDistributedLock();
                         }
                         unlockLocalState();
-                        correlatedTaskCompleted(initiator, taskRequest, results);
+                        try {
+                            correlatedTaskCompleted(initiator, taskRequest, results);
+                        } catch (Exception e) {
+                            if (m_log.isDebugEnabled()) {
+                                m_log.debug("Error in StateMachineInstance callbacks.", e);
+                            }
+                            m_initializationCompleted = false;
+                            m_shared_es.submit(new CallbackExceptionHandler(this));
+                        }
                     }
                     else {
                         ArrayList<ByteBuffer> results = getUncorrelatedResults(taskRequest, memberList);
@@ -858,9 +988,20 @@ public class SynchronizedStatesManager {
                             cancelDistributedLock();
                         }
                         unlockLocalState();
-                        uncorrelatedTaskCompleted(initiator, taskRequest, results);
+                        try {
+                            uncorrelatedTaskCompleted(initiator, taskRequest, results);
+                        } catch (Exception e) {
+                            if (m_log.isDebugEnabled()) {
+                                m_log.debug("Error in StateMachineInstance callbacks.", e);
+                            }
+                            m_initializationCompleted = false;
+                            m_shared_es.submit(new CallbackExceptionHandler(this));
+                        }
                     }
-                    monitorParticipantChanges();
+
+                    if (m_initializationCompleted) {
+                        monitorParticipantChanges();
+                    }
                 }
             }
         }
@@ -887,7 +1028,7 @@ public class SynchronizedStatesManager {
                 m_log.debug(m_stateMachineId + ": Received InterruptedException in checkForBarrierResultsChanges");
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in StateMachine.", true, e);
+                        "Unexpected failure in StateMachine.", true, e);
                 membersWithResults = new TreeSet<String>();
             }
             if (Sets.difference(m_knownMembers, membersWithResults).isEmpty()) {
@@ -963,6 +1104,7 @@ public class SynchronizedStatesManager {
                     if (existingAndProposedStates.m_requestType != REQUEST_TYPE.INITIALIZING) {
                         staleTask = existingAndProposedStates.m_proposal.asReadOnlyBuffer();
                     }
+                    m_initializationCompleted = true;
                     cancelDistributedLock();
                     // Add an acceptable result so the next initializing member recognizes an immediate quorum.
                     m_lockWaitingOn = "bogus"; // Avoids call to notifyDistributedLockWaiter below
@@ -976,14 +1118,30 @@ public class SynchronizedStatesManager {
                 m_log.debug(m_stateMachineId + ": Received InterruptedException in initializeFromActiveCommunity");
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in StateMachine.", true, e);
+                        "Unexpected failure in StateMachine.", true, e);
             }
             if (readOnlyResult != null) {
                 // Notify the derived object that we have a stable state
-                setInitialState(readOnlyResult);
+                try {
+                    setInitialState(readOnlyResult);
+                } catch (Exception e) {
+                    if (m_log.isDebugEnabled()) {
+                        m_log.debug("Error in StateMachineInstance callbacks.", e);
+                    }
+                    m_initializationCompleted = false;
+                    m_shared_es.submit(new CallbackExceptionHandler(this));
+                }
             }
             if (staleTask != null) {
-                staleTaskRequestNotification(staleTask);
+                try {
+                    staleTaskRequestNotification(staleTask);
+                } catch (Exception e) {
+                    if (m_log.isDebugEnabled()) {
+                        m_log.debug("Error in StateMachineInstance callbacks.", e);
+                    }
+                    m_initializationCompleted = false;
+                    m_shared_es.submit(new CallbackExceptionHandler(this));
+                }
             }
         }
 
@@ -997,8 +1155,10 @@ public class SynchronizedStatesManager {
                     m_zk.delete(ZKUtil.joinZKPath(m_barrierResultsPath, resultNode), -1);
                 }
                 Stat newProposalStat = m_zk.setData(m_barrierResultsPath, proposal, -1);
-                m_zk.create(m_myPartiticpantsPath, null, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+                m_zk.create(m_myParticipantPath, null, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
                 newProposalVersion = newProposalStat.getVersion();
+                // force the participant count to be 1, so that lock notifications can be correctly guarded
+                m_currentParticipants = 1;
             } catch (KeeperException.SessionExpiredException e) {
                 m_log.debug(m_stateMachineId + ": Received SessionExpiredException in wakeCommunityWithProposal");
             } catch (KeeperException.ConnectionLossException e) {
@@ -1007,12 +1167,12 @@ public class SynchronizedStatesManager {
                 m_log.debug(m_stateMachineId + ": Received InterruptedException in wakeCommunityWithProposal");
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in StateMachine.", true, e);
+                        "Unexpected failure in StateMachine.", true, e);
             }
             return newProposalVersion;
         }
 
-        private final Runnable HandlerForBarrierPartiticpantsEvent = new Runnable() {
+        private final Runnable HandlerForBarrierParticipantsEvent = new Runnable() {
             @Override
             public void run() {
                 lockLocalStateForParticipantRunner();
@@ -1080,7 +1240,7 @@ public class SynchronizedStatesManager {
                         m_lockWaitingOn = "We died so we can't ever get the distributed lock";
                     } catch (Exception e) {
                         org.voltdb.VoltDB.crashLocalVoltDB(
-                                "Unexepected failure in StateMachine.", true, e);
+                                "Unexpected failure in StateMachine.", true, e);
                     }
                     if (m_lockWaitingOn.equals(m_ourDistributedLockName) && m_currentParticipants == 0) {
                         // There are no more members still processing the last result
@@ -1112,7 +1272,7 @@ public class SynchronizedStatesManager {
                 m_log.debug(m_stateMachineId + ": Received InterruptedException in cancelDistributedLock");
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in SynchronizedStatesManager.", true, e);
+                        "Unexpected failure in SynchronizedStatesManager.", true, e);
             }
             m_ourDistributedLockName = null;
             m_holdingDistributedLock = false;
@@ -1145,7 +1305,15 @@ public class SynchronizedStatesManager {
                 unlockLocalState();
             }
             if (notInitializing) {
-                membershipChanged(addedMembers, removedMembers);
+                try {
+                    membershipChanged(addedMembers, removedMembers);
+                } catch (Exception e) {
+                    if (m_log.isDebugEnabled()) {
+                        m_log.debug("Error in StateMachineInstance callbacks.", e);
+                    }
+                    m_initializationCompleted = false;
+                    m_shared_es.submit(new CallbackExceptionHandler(this));
+                }
             }
             assert(!debugIsLocalStateLocked());
         }
@@ -1164,7 +1332,7 @@ public class SynchronizedStatesManager {
                 m_log.debug(m_stateMachineId + ": Received InterruptedException in getLatestMembership");
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in SynchronizedStatesManager.", true, e);
+                        "Unexpected failure in SynchronizedStatesManager.", true, e);
             }
         }
 
@@ -1188,13 +1356,25 @@ public class SynchronizedStatesManager {
                 m_lockWaitingOn = null;
                 unlockLocalState();
                 // Notify the derived class that the lock is available
-                lockRequestCompleted();
+                try {
+                    lockRequestCompleted();
+                } catch (Exception e) {
+                    cancelLockRequest();
+                    if (m_log.isDebugEnabled()) {
+                        m_log.debug("Error in StateMachineInstance callbacks.", e);
+                    }
+                    m_initializationCompleted = false;
+                    m_shared_es.submit(new CallbackExceptionHandler(this));
+                }
             }
         }
 
         private boolean requestDistributedLock() {
             try {
-                assert(m_ourDistributedLockName == null);
+                if (m_ourDistributedLockName != null) {
+                    m_log.error(m_stateMachineId + ": Requested distributed lock before prior state change or task has been completed");
+                    return false;
+                }
                 assert(debugIsLocalStateLocked());
                 m_ourDistributedLockName = m_zk.create(ZKUtil.joinZKPath(m_lockPath, "lock_"), null,
                         Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
@@ -1217,7 +1397,7 @@ public class SynchronizedStatesManager {
                 m_log.debug(m_stateMachineId + ": Received InterruptedException in requestDistributedLock");
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in StateMachine.", true, e);
+                        "Unexpected failure in StateMachine.", true, e);
             }
             return false;
         }
@@ -1238,11 +1418,11 @@ public class SynchronizedStatesManager {
                 // and the call to checkForBarrierParticipantsChange, a second null result is assigned.
                 if (m_requestedInitialState == null || result != null) {
                     org.voltdb.VoltDB.crashLocalVoltDB(
-                            "Unexepected failure in StateMachine; Two results created for one proposal.", true, e);
+                            "Unexpected failure in StateMachine; Two results created for one proposal.", true, e);
                 }
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in StateMachine.", true, e);
+                        "Unexpected failure in StateMachine.", true, e);
             }
         }
 
@@ -1260,7 +1440,7 @@ public class SynchronizedStatesManager {
             else {
                 try {
                     // Since we don't care about the outcome remove ourself from the participant list
-                    m_zk.delete(m_myPartiticpantsPath, -1);
+                    m_zk.delete(m_myParticipantPath, -1);
                 } catch (KeeperException.SessionExpiredException e) {
                     m_log.debug(m_stateMachineId + ": Received SessionExpiredException in assignStateChangeAgreement");
                 } catch (KeeperException.ConnectionLossException e) {
@@ -1269,7 +1449,7 @@ public class SynchronizedStatesManager {
                     m_log.debug(m_stateMachineId + ": Received InterruptedException in assignStateChangeAgreement");
                 } catch (Exception e) {
                     org.voltdb.VoltDB.crashLocalVoltDB(
-                            "Unexepected failure in StateMachine.", true, e);
+                            "Unexpected failure in StateMachine.", true, e);
                 }
                 unlockLocalState();
             }
@@ -1282,7 +1462,7 @@ public class SynchronizedStatesManager {
         protected boolean isInitialized() {
             boolean initialized;
             lockLocalState();
-            initialized = m_requestedInitialState == null;
+            initialized = m_initializationCompleted && m_requestedInitialState == null;
             unlockLocalState();
             return initialized;
         }
@@ -1298,7 +1478,10 @@ public class SynchronizedStatesManager {
          */
         protected boolean requestLock() {
             lockLocalState();
-            boolean rslt = requestDistributedLock();
+            boolean rslt = false;
+            if (m_initializationCompleted) {
+                rslt = requestDistributedLock();
+            }
             unlockLocalState();
             return rslt;
         }
@@ -1310,8 +1493,10 @@ public class SynchronizedStatesManager {
          */
         protected void cancelLockRequest() {
             lockLocalState();
-            assert(m_pendingProposal == null);
-            cancelDistributedLock();
+            if (m_initializationCompleted) {
+                assert (m_pendingProposal == null);
+                cancelDistributedLock();
+            }
             unlockLocalState();
         }
 
@@ -1327,6 +1512,10 @@ public class SynchronizedStatesManager {
             assert(proposedState != null);
             assert(proposedState.remaining() < Short.MAX_VALUE);
             lockLocalState();
+            if (!m_initializationCompleted) {
+                unlockLocalState();
+                return;
+            }
             // Only the lock owner can initiate a barrier request
             assert(m_requestedInitialState == null);
             if (proposedState.position() == 0) {
@@ -1359,6 +1548,10 @@ public class SynchronizedStatesManager {
          */
         protected void requestedStateChangeAcceptable(boolean acceptable) {
             lockLocalState();
+            if (!m_initializationCompleted) {
+                unlockLocalState();
+                return;
+            }
             assert(!m_stateChangeInitiator);
             m_log.debug(m_stateMachineId + (acceptable?": Agrees with State proposal":
                     ": Disagrees with State proposal"));
@@ -1378,36 +1571,35 @@ public class SynchronizedStatesManager {
             assert(proposedTask != null);
             assert(proposedTask.remaining() < Short.MAX_VALUE);
             lockLocalState();
-            // Only the lock owner can initiate a barrier request
-            assert(m_requestedInitialState == null);
-            if (proposedTask.position() == 0) {
+            if (m_initializationCompleted) {
+                // Only the lock owner can initiate a barrier request
+                assert (m_requestedInitialState == null);
+                if (proposedTask.position() == 0) {
+                    m_pendingProposal = proposedTask;
+                } else {
+                    // Move to a new 0 aligned buffer
+                    m_pendingProposal = ByteBuffer.allocate(proposedTask.remaining());
+                    m_pendingProposal.put(proposedTask.array(),
+                            proposedTask.arrayOffset() + proposedTask.position(), proposedTask.remaining());
+                    m_pendingProposal.flip();
+                }
+                if (m_log.isDebugEnabled()) {
+                    if (m_pendingProposal.hasRemaining()) {
+                        m_log.debug(m_stateMachineId + ": Requested new Task " + taskToString(m_pendingProposal.asReadOnlyBuffer()));
+                    } else {
+                        m_log.debug(m_stateMachineId + ": Requested unspecified new Task");
+                    }
+                }
+                m_stateChangeInitiator = true;
+                m_currentRequestType = correlated ?
+                        REQUEST_TYPE.CORRELATED_COORDINATED_TASK :
+                        REQUEST_TYPE.UNCORRELATED_COORDINATED_TASK;
+                ByteBuffer taskProposal = buildProposal(m_currentRequestType,
+                        m_synchronizedState.asReadOnlyBuffer(), proposedTask.asReadOnlyBuffer());
                 m_pendingProposal = proposedTask;
+                // Since we don't update m_lastProposalVersion, we will wake ourselves up
+                wakeCommunityWithProposal(taskProposal.array());
             }
-            else {
-                // Move to a new 0 aligned buffer
-                m_pendingProposal = ByteBuffer.allocate(proposedTask.remaining());
-                m_pendingProposal.put(proposedTask.array(),
-                        proposedTask.arrayOffset()+proposedTask.position(), proposedTask.remaining());
-                m_pendingProposal.flip();
-            }
-            if (m_log.isDebugEnabled()) {
-                if (m_pendingProposal.hasRemaining()) {
-                    m_log.debug(m_stateMachineId + ": Requested new Task " + taskToString(m_pendingProposal.asReadOnlyBuffer()));
-                }
-                else {
-                    m_log.debug(m_stateMachineId + ": Requested unspecified new Task");
-
-                }
-            }
-            m_stateChangeInitiator = true;
-            m_currentRequestType = correlated ?
-                    REQUEST_TYPE.CORRELATED_COORDINATED_TASK :
-                    REQUEST_TYPE.UNCORRELATED_COORDINATED_TASK;
-            ByteBuffer taskProposal = buildProposal(m_currentRequestType,
-                    m_synchronizedState.asReadOnlyBuffer(), proposedTask.asReadOnlyBuffer());
-            m_pendingProposal = proposedTask;
-            // Since we don't update m_lastProposalVersion, we will wake ourselves up
-            wakeCommunityWithProposal(taskProposal.array());
             unlockLocalState();
         }
 
@@ -1429,6 +1621,10 @@ public class SynchronizedStatesManager {
         protected void requestedTaskComplete(ByteBuffer result)
         {
             lockLocalState();
+            if (!m_initializationCompleted) {
+                unlockLocalState();
+                return;
+            }
             assert(m_pendingProposal != null);
             if (m_log.isDebugEnabled()) {
                 if (result.hasRemaining()) {
@@ -1461,8 +1657,14 @@ public class SynchronizedStatesManager {
          * warning: The ByteBuffer taskRequest is not guaranteed to start at position 0 (avoid rewind, flip, ...)
          */
         protected ByteBuffer getCurrentState() {
+            ByteBuffer currentState;
             lockLocalState();
-            ByteBuffer currentState = m_synchronizedState.asReadOnlyBuffer();
+            if (m_initializationCompleted) {
+                currentState = m_synchronizedState.asReadOnlyBuffer();
+            }
+            else {
+                currentState = ByteBuffer.allocate(0);
+            }
             unlockLocalState();
             return currentState;
         }
@@ -1494,6 +1696,8 @@ public class SynchronizedStatesManager {
         }
 
         protected boolean holdingDistributedLock() {
+            lockLocalState();
+            unlockLocalState();
             return m_holdingDistributedLock;
         }
 
@@ -1517,9 +1721,17 @@ public class SynchronizedStatesManager {
         m_stateMachineRoot = "MockRootForSSM";
         m_stateMachineMemberPath = "MockRootMembershipNode";
         m_memberId = "MockMemberId";
+        m_canonical_memberId = "MockCanonicalMemberId";
+        m_resetAllowance = 5;
+        m_resetLimit = m_resetAllowance;
     }
 
     public SynchronizedStatesManager(ZooKeeper zk, String rootPath, String ssmNodeName, String memberId, int registeredInstances)
+            throws KeeperException, InterruptedException {
+        this(zk, rootPath, ssmNodeName, memberId, registeredInstances, 5); // default resetAllowance is 5
+    }
+
+    public SynchronizedStatesManager(ZooKeeper zk, String rootPath, String ssmNodeName, String memberId, int registeredInstances, int resetAllowance)
             throws KeeperException, InterruptedException {
         m_zk = zk;
         // We will not add ourselves as members in ZooKeeper until all StateMachineInstances have registered
@@ -1530,7 +1742,11 @@ public class SynchronizedStatesManager {
         numberOfInstances.putInt(registeredInstances);
         addIfMissing(m_stateMachineRoot, CreateMode.PERSISTENT, numberOfInstances.array());
         m_stateMachineMemberPath = ZKUtil.joinZKPath(m_stateMachineRoot, m_memberNode);
-        m_memberId = memberId;
+        m_canonical_memberId = memberId;
+        m_resetCounter = 0;
+        m_resetAllowance = resetAllowance;
+        m_resetLimit = m_resetAllowance;
+        m_memberId = m_canonical_memberId + "_v" + m_resetCounter;
     }
 
     public void ShutdownSynchronizedStatesManager() throws InterruptedException {
@@ -1548,27 +1764,23 @@ public class SynchronizedStatesManager {
         @Override
         public void run() {
             try {
+                m_done.set(true);
                 for (StateMachineInstance stateMachine : m_registeredStateMachines) {
                     stateMachine.disableMembership();
                 }
-                m_done.set(true);
                 m_zk.delete(ZKUtil.joinZKPath(m_stateMachineMemberPath, m_memberId), -1);
             } catch (KeeperException.SessionExpiredException e) {
                 // lost the full connection. some test cases do this...
                 // means zk shutdown without the elector being shutdown.
                 // ignore.
-                m_done.set(true);
             } catch (KeeperException.ConnectionLossException e) {
                 // lost the full connection. some test cases do this...
                 // means shutdown without the elector being
                 // shutdown; ignore.
-                m_done.set(true);
             } catch (InterruptedException e) {
-                m_done.set(true);
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in SynchronizedStatesManager.", true, e);
-                m_done.set(true);
+                        "Unexpected failure in SynchronizedStatesManager.", true, e);
             }
         }
     };
@@ -1589,7 +1801,7 @@ public class SynchronizedStatesManager {
             } catch (InterruptedException e) {
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in SynchronizedStatesManager.", true, e);
+                        "Unexpected failure in SynchronizedStatesManager.", true, e);
             }
         }
     };
@@ -1642,7 +1854,7 @@ public class SynchronizedStatesManager {
                 m_done.set(true);
             } catch (Exception e) {
                 org.voltdb.VoltDB.crashLocalVoltDB(
-                        "Unexepected failure in initializeInstances.", true, e);
+                        "Unexpected failure in initializeInstances.", true, e);
                 m_done.set(true);
             }
         }
@@ -1651,8 +1863,8 @@ public class SynchronizedStatesManager {
     private synchronized void registerStateMachine(StateMachineInstance machine) throws InterruptedException {
         assert(m_registeredStateMachineInstances < m_registeredStateMachines.length);
 
-        m_registeredStateMachines[m_registeredStateMachineInstances] = machine;
-        m_registeredStateMachineInstances++;
+        m_registeredStateMachines[m_registeredStateMachineInstances] = (machine);
+        ++m_registeredStateMachineInstances;
         if (m_registeredStateMachineInstances == m_registeredStateMachines.length) {
             if (machine.m_log.isDebugEnabled()) {
                 // lets make sure all the state machines are using unique paths
@@ -1672,6 +1884,52 @@ public class SynchronizedStatesManager {
             }
             catch (ExecutionException e) {
                 Throwables.propagate(e.getCause());
+            }
+        }
+    }
+
+    private class CallbackExceptionHandler implements Runnable {
+        final StateMachineInstance m_directVictim;
+
+        CallbackExceptionHandler(StateMachineInstance directVictim) {
+            m_directVictim = directVictim;
+        }
+
+        @Override
+        public void run() {
+            // if the direct victim has already been reset, ignore the stale callback exception handling task
+            if (!m_directVictim.isInitializationCompleted()) {
+                assert (m_registeredStateMachineInstances > 0 && m_registeredStateMachineInstances == m_registeredStateMachines.length);
+
+                disableInstances.run();
+
+                if (m_lastResetTimeInMillis == -1L) {
+                    m_lastResetTimeInMillis = System.currentTimeMillis();
+                } else {
+                    long currentTimeInMillis = System.currentTimeMillis();
+                    // if a full reset clear threshold duration has passed after last reset, bump the reset limit
+                    if (currentTimeInMillis - m_lastResetTimeInMillis >= RESET_CLEAR_THRESHOLD) {
+                        m_resetLimit = m_resetCounter + m_resetAllowance;
+                    }
+                    m_lastResetTimeInMillis = currentTimeInMillis;
+                }
+
+                ++m_resetCounter;
+                if (m_resetCounter > m_resetLimit) {
+                    return;
+                }
+
+                m_memberId = m_canonical_memberId + "_v" + m_resetCounter;
+                try {
+                    for (StateMachineInstance instance : m_registeredStateMachines) {
+                        instance.reset(instance == m_directVictim);
+                    }
+                } catch (Exception e) {
+                    return; // if something wrong happened in reset(), give up as if the reset limit is hit
+                }
+                m_done.set(false);
+
+                initializeInstances.run();
             }
         }
     }

--- a/tests/frontend/org/voltcore/zk/StateMachineSnipits.java
+++ b/tests/frontend/org/voltcore/zk/StateMachineSnipits.java
@@ -102,6 +102,11 @@ public class StateMachineSnipits extends ZKTestBase {
         }
 
         @Override
+        protected ByteBuffer notifyOfStateMachineReset(boolean isDirectVictim) {
+            return ByteBuffer.allocate(0);
+        }
+
+        @Override
         protected void setInitialState(ByteBuffer currentAgreedState)
         {
         }
@@ -198,6 +203,11 @@ public class StateMachineSnipits extends ZKTestBase {
         }
 
         @Override
+        protected ByteBuffer notifyOfStateMachineReset(boolean isDirectVictim) {
+            return ByteBuffer.allocate(0);
+        }
+
+        @Override
         protected void setInitialState(ByteBuffer currentAgreedState)
         {
             m_cb.membersAdded(getCurrentMembers());
@@ -245,6 +255,11 @@ public class StateMachineSnipits extends ZKTestBase {
 
         protected StateMachine(SynchronizedStatesManager ssm, String instanceName) {
             ssm.super(instanceName, log);
+        }
+
+        @Override
+        protected ByteBuffer notifyOfStateMachineReset(boolean isDirectVictim) {
+            return m_startingState;
         }
 
         @Override
@@ -345,6 +360,11 @@ public class StateMachineSnipits extends ZKTestBase {
 
         public Task(SynchronizedStatesManager ssm, String instanceName) {
             ssm.super(instanceName, log);
+        }
+
+        @Override
+        protected ByteBuffer notifyOfStateMachineReset(boolean isDirectVictim) {
+            return ByteBuffer.allocate(0);
         }
 
         @Override

--- a/tests/frontend/org/voltcore/zk/TestStateMachine.java
+++ b/tests/frontend/org/voltcore/zk/TestStateMachine.java
@@ -23,6 +23,7 @@
 
 package org.voltcore.zk;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -81,22 +82,29 @@ public class TestStateMachine extends ZKTestBase {
     }
 
     public void addStateMachinesFor(int Site) {
+        addStateMachinesFor(Site, false, false, false);
+    }
+
+    public void addStateMachinesFor(int Site, boolean g1BooleanBroken, boolean g2BooleanBroken, boolean g2ByteBroken) {
         String siteString = "zkClient" + Integer.toString(Site);
         try {
             // Create a SynchronizedStatesManager to manage a single BooleanStateMachine
             SynchronizedStatesManager ssm1 = new SynchronizedStatesManager(m_messengers.get(Site).getZK(),
                     stateMachineManagerRoot, "ssm1", siteString);
             m_stateMachineGroup1[Site] = ssm1;
-            BooleanStateMachine bsm1 = new BooleanStateMachine(ssm1, "bool");
+            BooleanStateMachine bsm1 = g1BooleanBroken ?
+                    new BrokenBooleanStateMachine(ssm1, "bool") : new BooleanStateMachine(ssm1, "bool");
             m_booleanStateMachinesForGroup1[Site] = bsm1;
 
             // Create a SynchronizedStatesManager to manage both a BooleanStateMachine and ByteStateMachine
             SynchronizedStatesManager ssm2 = new SynchronizedStatesManager(m_messengers.get(Site).getZK(),
                     stateMachineManagerRoot, "ssm2", siteString, stateMachines.values().length);
             m_stateMachineGroup2[Site] = ssm2;
-            BooleanStateMachine bsm2 = new BooleanStateMachine(ssm2, "bool");
+            BooleanStateMachine bsm2 = g2BooleanBroken ?
+                    new BrokenBooleanStateMachine(ssm2, "bool") : new BooleanStateMachine(ssm2, "bool");
             m_booleanStateMachinesForGroup2[Site] = bsm2;
-            ByteStateMachine msm2 = new ByteStateMachine(ssm2, "byte");
+            ByteStateMachine msm2 = g2ByteBroken ?
+                    new BrokenByteStateMachine(ssm2, "byte") : new ByteStateMachine(ssm2, "byte");
             m_byteStateMachinesForGroup2[Site] = msm2;
         }
         catch (KeeperException | InterruptedException e) {
@@ -171,11 +179,15 @@ public class TestStateMachine extends ZKTestBase {
         boolean ignoreProposal = false;
         ByteBuffer proposed;
         volatile boolean state;
-        boolean coorelatedTask = true;
+        boolean correlatedTask = true;
         final String taskString = "DO SOME WORK";
         String taskResultString = defaultTaskResult;
         volatile Map<String, ByteBuffer> correlatedResults;
         volatile List<ByteBuffer> uncorrelatedResults;
+
+        boolean notifiedOfReset = false;
+        boolean isDirectVictim;
+        volatile boolean staleTaskRequestProcessed = false;
 
         public boolean toBoolean(ByteBuffer buff) {
             byte[] b = new byte[buff.remaining()];
@@ -221,7 +233,7 @@ public class TestStateMachine extends ZKTestBase {
                 else {
                     assertTrue(startTask);
                     proposed = ByteBuffer.wrap(taskString.getBytes(Charsets.UTF_8));
-                    initiateCoordinatedTask(coorelatedTask, proposed);
+                    initiateCoordinatedTask(correlatedTask, proposed);
                     assertFalse("State machine local lock held after bool delayed task request", debugIsLocalStateLocked());
                 }
             }
@@ -298,7 +310,7 @@ public class TestStateMachine extends ZKTestBase {
             assertFalse("State machine local lock held after bool uncorrelated task completion", debugIsLocalStateLocked());
             assertTrue(taskRequest.equals(ByteBuffer.wrap(taskString.getBytes(Charsets.UTF_8))));
             assertTrue(ourTask == startTask);
-            coorelatedTask = true;
+            correlatedTask = true;
             startTask = false;
             acceptProposalOrTask = true;
             taskResultString = defaultTaskResult;
@@ -318,7 +330,7 @@ public class TestStateMachine extends ZKTestBase {
             startTask = true;
             if (requestLock()) {
                 proposed = ByteBuffer.wrap(taskString.getBytes(Charsets.UTF_8));
-                initiateCoordinatedTask(coorelatedTask, proposed);
+                initiateCoordinatedTask(correlatedTask, proposed);
                 assertFalse("State machine local lock held after bool task request", debugIsLocalStateLocked());
             }
         }
@@ -342,7 +354,124 @@ public class TestStateMachine extends ZKTestBase {
             task.get(b, 0, b.length);
             return new String(b);
         }
-    };
+
+        @Override
+        protected ByteBuffer notifyOfStateMachineReset(boolean isDirectVictim) {
+            this.isDirectVictim = isDirectVictim;
+            staleTaskRequestProcessed = false;
+            makeProposal = false;
+            startTask = false;
+            proposalsOrTasksCompleted = 0;
+            ourProposalOrTaskFinished = false;
+            acceptProposalOrTask = true;
+            justHoldTheLock = false;
+            ignoreProposal = false;
+            correlatedTask = true;
+
+            notifiedOfReset = true;
+
+            return bsm_states[0]; // FALSE as reset state
+        }
+    }
+
+    class BrokenBooleanStateMachine extends BooleanStateMachine {
+        String brokenCallbackName = "DEFAULT";
+
+        public BrokenBooleanStateMachine(SynchronizedStatesManager ssm, String instanceName) {
+            super(ssm, instanceName);
+        }
+
+        @Override
+        protected void setInitialState(ByteBuffer currentAgreedState) {
+            if (brokenCallbackName.equals("setInitialState")) {
+                throw new NullPointerException();
+            }
+            else {
+                super.setInitialState(currentAgreedState);
+            }
+        }
+
+        @Override
+        protected void taskRequested(ByteBuffer taskRequest) {
+            if (brokenCallbackName.equals("taskRequested")) {
+                throw new NullPointerException();
+            }
+            else {
+                super.taskRequested(taskRequest);
+            }
+        }
+
+        @Override
+        protected void correlatedTaskCompleted(boolean ourTask, ByteBuffer taskRequest, Map<String, ByteBuffer> results) {
+            if (brokenCallbackName.equals("correlatedTaskCompleted")) {
+                throw new NullPointerException();
+            }
+            else {
+                super.correlatedTaskCompleted(ourTask, taskRequest, results);
+            }
+        }
+
+        @Override
+        protected void uncorrelatedTaskCompleted(boolean ourTask, ByteBuffer taskRequest, List<ByteBuffer> results) {
+            if (brokenCallbackName.equals("uncorrelatedTaskCompleted")) {
+                throw new NullPointerException();
+            }
+            else {
+                super.uncorrelatedTaskCompleted(ourTask, taskRequest, results);
+            }
+        }
+
+        @Override
+        protected void lockRequestCompleted() {
+            if (brokenCallbackName.equals("lockRequestCompleted")) {
+                throw new NullPointerException();
+            }
+            else {
+                super.lockRequestCompleted();
+            }
+        }
+
+        @Override
+        protected void membershipChanged(Set<String> addedHosts, Set<String> removedHosts) {
+            if (brokenCallbackName.equals("membershipChanged")) {
+                throw new NullPointerException();
+            }
+            else {
+                super.membershipChanged(addedHosts, removedHosts);
+            }
+        }
+
+        @Override
+        protected void stateChangeProposed(ByteBuffer proposedState) {
+            if (brokenCallbackName.equals("stateChangeProposed")) {
+                throw new NullPointerException();
+            }
+            else {
+                super.stateChangeProposed(proposedState);
+            }
+        }
+
+        @Override
+        protected void staleTaskRequestNotification(ByteBuffer proposedTask) {
+            if (brokenCallbackName.equals("staleTaskRequestNotification")) {
+                throw new NullPointerException();
+            }
+            else {
+                super.staleTaskRequestNotification(proposedTask);
+                staleTaskRequestProcessed = true;
+            }
+        }
+
+        @Override
+        protected void proposedStateResolved(boolean ourProposal, ByteBuffer proposedState, boolean success) {
+            if (brokenCallbackName.equals("proposedStateResolved")) {
+                throw new NullPointerException();
+            }
+            else {
+                super.proposedStateResolved(ourProposal, proposedState, success);
+            }
+        }
+    }
 
     class ByteStateMachine extends SynchronizedStatesManager.StateMachineInstance {
         volatile boolean initialized = false;
@@ -355,11 +484,14 @@ public class TestStateMachine extends ZKTestBase {
         boolean ignoreProposal = false;
         ByteBuffer proposed;
         volatile byte state;
-        boolean coorelatedTask = true;
+        boolean correlatedTask = true;
         final String taskString = "DO SOME OTHER WORK";
         String taskResultString = defaultTaskResult;
         volatile Map<String, ByteBuffer> correlatedResults;
         volatile List<ByteBuffer> uncorrelatedResults;
+
+        boolean notifiedOfReset = false;
+        boolean isDirectVictim;
 
         public byte toByte(ByteBuffer buff) {
             return buff.get();
@@ -402,7 +534,7 @@ public class TestStateMachine extends ZKTestBase {
                 else {
                     assertTrue(startTask);
                     proposed = ByteBuffer.wrap(taskString.getBytes(Charsets.UTF_8));
-                    initiateCoordinatedTask(coorelatedTask, proposed);
+                    initiateCoordinatedTask(correlatedTask, proposed);
                     assertFalse("State machine local lock held after byte delayed task request", debugIsLocalStateLocked());
                 }
             }
@@ -460,7 +592,7 @@ public class TestStateMachine extends ZKTestBase {
             assertFalse("State machine local lock held after byte correlated task completion", debugIsLocalStateLocked());
             assertTrue(taskRequest.equals(ByteBuffer.wrap(taskString.getBytes(Charsets.UTF_8))));
             assertTrue(ourTask == startTask);
-            assertTrue(!ourTask || coorelatedTask);
+            assertTrue(!ourTask || correlatedTask);
             startTask = false;
             acceptProposalOrTask = true;
             taskResultString = defaultTaskResult;
@@ -478,8 +610,8 @@ public class TestStateMachine extends ZKTestBase {
             assertFalse("State machine local lock held after byte uncorrelated task completion", debugIsLocalStateLocked());
             assertTrue(taskRequest.equals(ByteBuffer.wrap(taskString.getBytes(Charsets.UTF_8))));
             assertTrue(ourTask == startTask);
-            assertFalse(ourTask || coorelatedTask);
-            coorelatedTask = true;
+            assertFalse(ourTask || correlatedTask);
+            correlatedTask = true;
             startTask = false;
             acceptProposalOrTask = true;
             taskResultString = defaultTaskResult;
@@ -499,7 +631,7 @@ public class TestStateMachine extends ZKTestBase {
             ourProposalOrTaskFinished = false;
             if (requestLock()) {
                 proposed = ByteBuffer.wrap(taskString.getBytes(Charsets.UTF_8));
-                initiateCoordinatedTask(coorelatedTask, proposed);
+                initiateCoordinatedTask(correlatedTask, proposed);
                 assertFalse("State machine local lock held after byte task request", debugIsLocalStateLocked());
             }
         }
@@ -521,7 +653,42 @@ public class TestStateMachine extends ZKTestBase {
             task.get(b, 0, b.length);
             return new String(b);
         }
-    };
+
+        @Override
+        protected ByteBuffer notifyOfStateMachineReset(boolean isDirectVictim) {
+            this.isDirectVictim = isDirectVictim;
+            makeProposal = false;
+            startTask = false;
+            proposalsOrTasksCompleted = 0;
+            ourProposalOrTaskFinished = false;
+            acceptProposalOrTask = true;
+            justHoldTheLock = false;
+            ignoreProposal = false;
+            correlatedTask = true;
+
+            notifiedOfReset = true;
+
+            return msm_states[0]; // 100 as reset state
+        }
+    }
+
+    class BrokenByteStateMachine extends ByteStateMachine {
+        String brokenCallbackName = "DEFAULT";
+
+        public BrokenByteStateMachine(SynchronizedStatesManager ssm, String instanceName) {
+            super(ssm, instanceName);
+        }
+
+        @Override
+        protected void stateChangeProposed(ByteBuffer proposedState) {
+            if (brokenCallbackName.equals("stateChangeProposed")) {
+                throw new NullPointerException();
+            }
+            else {
+                super.stateChangeProposed(proposedState);
+            }
+        }
+    }
 
     boolean boolProposalOrTaskFinished(BooleanStateMachine[] machines, int expectedCompletions) {
         for (BooleanStateMachine sm : machines) {
@@ -636,7 +803,6 @@ public class TestStateMachine extends ZKTestBase {
         return true;
     }
 
-
     @Test
     public void testSingleNodeStateChange() {
         log.info("Starting testSuccessfulStateChange");
@@ -666,7 +832,7 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(i0.state == newVal);
         }
         catch (InterruptedException e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -699,7 +865,7 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(i0.state == newVal);
         }
         catch (InterruptedException e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -734,7 +900,7 @@ public class TestStateMachine extends ZKTestBase {
             assertFalse(i0.state == newVal);
         }
         catch (InterruptedException e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -771,7 +937,7 @@ public class TestStateMachine extends ZKTestBase {
             assertFalse(i0.state == newVal);
         }
         catch (InterruptedException e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -803,7 +969,7 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(i0.state == newVal);
         }
         catch (InterruptedException e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -849,7 +1015,7 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
         }
         catch (InterruptedException e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -903,7 +1069,7 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(i0.state == newVal);
         }
         catch (InterruptedException e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -945,7 +1111,7 @@ public class TestStateMachine extends ZKTestBase {
             assertFalse(i1.justHoldTheLock);
         }
         catch (Exception e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -988,7 +1154,7 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(i0.state == newVal);
         }
         catch (Exception e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -1036,7 +1202,7 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(i2.state == rawByteStates[2]);
         }
         catch (Exception e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -1108,7 +1274,147 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(g1i0.state);
        }
         catch (Exception e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
+        }
+    }
+
+    @Test
+    public void testCallbackExceptionCorrectlyResetOtherStateMachines() {
+        log.info("Starting testCallbackExceptionCorrectlyResetOtherStateMachines");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, false, true, false);
+        for (int ii = 1; ii < NUM_AGREEMENT_SITES; ii++) {
+            addStateMachinesFor(ii);
+        }
+
+        try {
+            BrokenBooleanStateMachine g2i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup2[0];
+            g2i0.brokenCallbackName = "stateChangeProposed";
+            BooleanStateMachine g2i1 = m_booleanStateMachinesForGroup2[1];
+            ByteStateMachine g2j0 = m_byteStateMachinesForGroup2[0];
+            ByteStateMachine g2j1 = m_byteStateMachinesForGroup2[1];
+
+            // For any site all state machine instances must be registered before it participates with other sites
+            for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+                m_booleanStateMachinesForGroup2[ii].registerStateMachineWithManager(bsm_states[0]);
+                m_byteStateMachinesForGroup2[ii].registerStateMachineWithManager(msm_states[0]);
+            }
+
+            while (!boolsInitialized(m_booleanStateMachinesForGroup2)) {
+                Thread.sleep(500);
+            }
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup2));
+
+            while (!bytesInitialized(m_byteStateMachinesForGroup2)) {
+                Thread.sleep(500);
+            }
+            assertTrue(bytesSynchronized(m_byteStateMachinesForGroup2));
+
+            // StateMachine Group 2 is stable. Change some states in Group 2 and start up the Group 1
+            g2j0.switchState();     // set Group 2 Byte State to rawByteStates[1]
+            g2j1.switchState();     // set Group 2 Byte State to rawByteStates[2]
+            while (!byteProposalOrTaskFinished(m_byteStateMachinesForGroup2, 2) ||
+                    !bytesSynchronized(m_byteStateMachinesForGroup2)) {
+                Thread.sleep(500);
+            }
+            g2i1.switchState();     // set Group 2 Bool State to true, will trigger the reset
+
+            int waitLoop = 0;
+            for (; waitLoop < 5; waitLoop++) {
+                if (boolProposalOrTaskFinished(m_booleanStateMachinesForGroup2, 1) &&
+                        boolsSynchronized(m_booleanStateMachinesForGroup2)) {
+                    break;
+                }
+                Thread.sleep(500);
+            }
+            // i0 should have never stepped into proposedStateResolved because of the reset, so the actual
+            // completion count is 0, hence the timeout, but the state will be correctly switched after the reset
+            assertEquals(5, waitLoop);
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup2));
+            assertTrue(g2i0.state);
+            assertTrue(g2i0.notifiedOfReset);
+            assertEquals(1, g2i0.getResetCounter());
+            assertTrue(g2i0.isDirectVictim);
+
+            // Verify that the group2 byte state machine at site 0 was also reset, and reinitialized with correct state
+            assertTrue(bytesSynchronized(m_byteStateMachinesForGroup2));
+            assertEquals(rawByteStates[2], g2j0.state);
+            assertTrue(g2j0.notifiedOfReset);
+            assertEquals(1, g2j0.getResetCounter());
+            assertFalse(g2j0.isDirectVictim);
+        }
+        catch (Exception e) {
+            fail("Exception occurred during test.");
+        }
+    }
+
+    @Test
+    public void testHandleMultipleCallbackExceptionHandlerFromDifferentSMI() {
+        log.info("Starting testHandleMultipleCallbackExceptionHandlerFromDifferentSMI");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, false, true, true);
+        for (int ii = 1; ii < NUM_AGREEMENT_SITES; ii++) {
+            addStateMachinesFor(ii);
+        }
+
+        try {
+            BrokenBooleanStateMachine g2i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup2[0];
+            g2i0.brokenCallbackName = "stateChangeProposed";
+            BooleanStateMachine g2i1 = m_booleanStateMachinesForGroup2[1];
+            BrokenByteStateMachine g2j0 = (BrokenByteStateMachine) m_byteStateMachinesForGroup2[0];
+            g2j0.brokenCallbackName = "stateChangeProposed";
+            ByteStateMachine g2j1 = m_byteStateMachinesForGroup2[1];
+
+            // For any site all state machine instances must be registered before it participates with other sites
+            for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+                m_booleanStateMachinesForGroup2[ii].registerStateMachineWithManager(bsm_states[0]);
+                m_byteStateMachinesForGroup2[ii].registerStateMachineWithManager(msm_states[0]);
+            }
+
+            while (!boolsInitialized(m_booleanStateMachinesForGroup2)) {
+                Thread.sleep(500);
+            }
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup2));
+
+            while (!bytesInitialized(m_byteStateMachinesForGroup2)) {
+                Thread.sleep(500);
+            }
+            assertTrue(bytesSynchronized(m_byteStateMachinesForGroup2));
+
+            g2i1.switchState();     // set Group 2 Bool State to true, will trigger the reset
+            g2j1.switchState();     // set Group 2 Byte State to 110, will also trigger the reset
+
+            int waitLoop = 0;
+            for (; waitLoop < 5; waitLoop++) {
+                if (boolProposalOrTaskFinished(m_booleanStateMachinesForGroup2, 1) &&
+                        boolsSynchronized(m_booleanStateMachinesForGroup2)) {
+                    break;
+                }
+                Thread.sleep(500);
+            }
+            // i0 should have never stepped into proposedStateResolved because of the reset, so the actual
+            // completion count is 0, hence the timeout, but the state will be correctly switched after the reset
+            assertEquals(5, waitLoop);
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup2));
+            assertTrue(g2i0.state);
+            assertTrue(g2i0.notifiedOfReset);
+            assertEquals(2, g2i0.getResetCounter());
+            assertFalse(g2i0.isDirectVictim);
+
+            assertTrue(bytesSynchronized(m_byteStateMachinesForGroup2));
+            assertEquals(rawByteStates[1], g2j0.state);
+            assertTrue(g2j0.notifiedOfReset);
+            assertEquals(2, g2j0.getResetCounter());
+            assertTrue(g2j0.isDirectVictim);
+        }
+        catch (Exception e) {
+            fail("Exception occurred during test.");
         }
     }
 
@@ -1160,7 +1466,7 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(i1.state == newVal);
         }
         catch (Exception e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
@@ -1209,14 +1515,14 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(waitLoop < 10);
         }
         catch (Exception e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
 
     @Test
     public void testSuccessfulUncorrelatedWithStateChangeTask() {
-        log.info("Starting testSimpleTask");
+        log.info("Starting testSuccessfulUncorrelatedWithStateChangeTask");
         try {
             for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
                 registerGroup1BoolFor(ii);
@@ -1228,7 +1534,7 @@ public class TestStateMachine extends ZKTestBase {
             BooleanStateMachine i0 = m_booleanStateMachinesForGroup1[0];
             BooleanStateMachine i1 = m_booleanStateMachinesForGroup1[1];
             assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
-            i0.coorelatedTask = false;
+            i0.correlatedTask = false;
             i0.startTask();
             // after task add a usually contending state change
             i1.switchState();
@@ -1250,13 +1556,13 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(i0.state);
         }
         catch (InterruptedException e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
     @Test
     public void testSuccessfulCorrelatedTask() {
-        log.info("Starting testSimpleTask");
+        log.info("Starting testSuccessfulCorrelatedTask");
         try {
             for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
                 registerGroup1BoolFor(ii);
@@ -1267,7 +1573,7 @@ public class TestStateMachine extends ZKTestBase {
             }
             BooleanStateMachine i0 = m_booleanStateMachinesForGroup1[0];
             assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
-            i0.coorelatedTask = true;
+            i0.correlatedTask = true;
             i0.startTask();
 
             boolean taskCompleted = false;
@@ -1285,13 +1591,13 @@ public class TestStateMachine extends ZKTestBase {
             assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
         }
         catch (InterruptedException e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
     @Test
     public void testSingleTaskWithOneUniqueResult() {
-        log.info("Starting testSingleRejectedProposal");
+        log.info("Starting testSingleTaskWithOneUniqueResult");
         try {
             BooleanStateMachine i0 = m_booleanStateMachinesForGroup1[0];
             BooleanStateMachine i1 = m_booleanStateMachinesForGroup1[1];
@@ -1318,8 +1624,453 @@ public class TestStateMachine extends ZKTestBase {
             assertFalse(i0.state == newVal);
         }
         catch (InterruptedException e) {
-            fail("Exception occured during test.");
+            fail("Exception occurred during test.");
         }
     }
 
+    @Test
+    public void testResetIfExceptionInSetInitialState() {
+        log.info("Starting testResetIfExceptionInSetInitialState");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, true, false, false);
+        for (int ii = 1; ii < NUM_AGREEMENT_SITES; ii++) {
+            addStateMachinesFor(ii);
+        }
+
+        try {
+            BrokenBooleanStateMachine i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup1[0];
+            i0.brokenCallbackName = "setInitialState";
+            assertEquals(0, i0.getResetCounter());
+
+            for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+                registerGroup1BoolFor(ii);
+            }
+
+            int ii = 0;
+            for (; ii < 5; ii++) {
+                if (boolsInitialized(m_booleanStateMachinesForGroup1)) {
+                    break;
+                }
+                Thread.sleep(500);
+            }
+
+            // i0 should have never been initialized successfully
+            assertEquals(5, ii);
+
+            // i0 should have reached the reset limit
+            assertTrue(i0.notifiedOfReset);
+            assertEquals(6, i0.getResetCounter());
+        }
+        catch (InterruptedException e) {
+            fail("Exception occurred during test.");
+        }
+    }
+
+    @Test
+    public void testResetIfExceptionInTaskRequested() {
+        log.info("Starting testResetIfExceptionInTaskRequested");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, true, false, false);
+        for (int ii = 1; ii < NUM_AGREEMENT_SITES; ii++) {
+            addStateMachinesFor(ii);
+        }
+
+        try {
+            BrokenBooleanStateMachine i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup1[0];
+            BooleanStateMachine i1 = m_booleanStateMachinesForGroup1[1];
+            i0.brokenCallbackName = "taskRequested";
+            for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+                registerGroup1BoolFor(ii);
+            }
+
+            while (!boolsInitialized(m_booleanStateMachinesForGroup1)) {
+                Thread.sleep(500);
+            }
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+
+            assertEquals(0, i0.getResetCounter());
+
+            // let i1 start a task so that i0 will be notified via taskRequested()
+            i1.startTask();
+            i0.switchState();
+            int ii = 0;
+            for (; ii < 5; ii++) {
+                if (i0.ourProposalOrTaskFinished &&
+                        boolProposalOrTaskFinished(m_booleanStateMachinesForGroup1, 2)) {
+                    break;
+                }
+                Thread.sleep(500);
+            }
+
+            // i0 should have never incremented the completion count because it will be reset upon i1's task request
+            assertEquals(5, ii);
+
+            // i0's switch should fail because it won't have got the lock before being reset
+            // i0's state should have been reinitialized to false with consensus
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+            assertFalse(i0.state);
+            assertTrue(i0.notifiedOfReset);
+            assertEquals(1, i0.getResetCounter());
+        }
+        catch (InterruptedException e) {
+            fail("Exception occurred during test.");
+        }
+    }
+
+    @Test
+    public void testResetIfExceptionInCorrelatedTaskCompleted() {
+        log.info("Starting testResetIfExceptionInCorrelatedTaskCompleted");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, true, false, false);
+        for (int ii = 1; ii < NUM_AGREEMENT_SITES; ii++) {
+            addStateMachinesFor(ii);
+        }
+
+        try {
+            BrokenBooleanStateMachine i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup1[0];
+            BooleanStateMachine i1 = m_booleanStateMachinesForGroup1[1];
+            i0.brokenCallbackName = "correlatedTaskCompleted";
+            for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+                registerGroup1BoolFor(ii);
+            }
+
+            while (!boolsInitialized(m_booleanStateMachinesForGroup1)) {
+                Thread.sleep(500);
+            }
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+
+            assertEquals(0, i0.getResetCounter());
+
+            // let i1 start a correlated task so that i0 will be notified via correlatedTaskCompleted()
+            i1.startTask();
+            int ii = 0;
+            for (; ii < 5; ii++) {
+                if (boolProposalOrTaskFinished(m_booleanStateMachinesForGroup1, 1)) {
+                    break;
+                }
+                Thread.sleep(500);
+            }
+
+            // i0 should have never incremented the completion count because it will be reset upon i1's task completion notification
+            assertEquals(5, ii);
+
+            // i0's switch should fail and state should have been reinitialized to false with consensus
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+            assertFalse(i0.state);
+            assertTrue(i0.notifiedOfReset);
+            assertEquals(1, i0.getResetCounter());
+        }
+        catch (InterruptedException e) {
+            fail("Exception occurred during test.");
+        }
+    }
+
+    @Test
+    public void testResetIfExceptionInUncorrelatedTaskCompleted() {
+        log.info("Starting testResetIfExceptionInUncorrelatedTaskCompleted");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, true, false, false);
+        for (int ii = 1; ii < NUM_AGREEMENT_SITES; ii++) {
+            addStateMachinesFor(ii);
+        }
+
+        try {
+            BrokenBooleanStateMachine i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup1[0];
+            BooleanStateMachine i1 = m_booleanStateMachinesForGroup1[1];
+            i0.brokenCallbackName = "uncorrelatedTaskCompleted";
+            for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+                registerGroup1BoolFor(ii);
+            }
+
+            while (!boolsInitialized(m_booleanStateMachinesForGroup1)) {
+                Thread.sleep(500);
+            }
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+
+            assertEquals(0, i0.getResetCounter());
+
+            // let i1 start a correlated task so that i0 will be notified via uncorrelatedTaskCompleted()
+            i1.correlatedTask = false;
+            i1.startTask();
+            int ii = 0;
+            for (; ii < 5; ii++) {
+                if (boolProposalOrTaskFinished(m_booleanStateMachinesForGroup1, 1)) {
+                    break;
+                }
+                Thread.sleep(500);
+            }
+
+            // i0 should have never incremented the completion count because it will be reset upon i1's task completion notification
+            assertEquals(5, ii);
+
+            // i0's switch should fail and state should have been reinitialized to false with consensus
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+            assertFalse(i0.state);
+            assertTrue(i0.notifiedOfReset);
+            assertEquals(1, i0.getResetCounter());
+        }
+        catch (InterruptedException e) {
+            fail("Exception occurred during test.");
+        }
+    }
+
+    @Test
+    public void testResetIfExceptionInLockRequestCompleted() {
+        log.info("Starting testResetIfExceptionInLockRequestCompleted");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, true, false, false);
+        for (int ii = 1; ii < NUM_AGREEMENT_SITES; ii++) {
+            addStateMachinesFor(ii);
+        }
+
+        try {
+            BrokenBooleanStateMachine i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup1[0];
+            BooleanStateMachine i1 = m_booleanStateMachinesForGroup1[1];
+            i0.brokenCallbackName = "lockRequestCompleted";
+            for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+                registerGroup1BoolFor(ii);
+            }
+
+            while (!boolsInitialized(m_booleanStateMachinesForGroup1)) {
+                Thread.sleep(500);
+            }
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+
+            assertEquals(0, i0.getResetCounter());
+
+            // let i1 grab the lock first, so that i0 will be notified with lock via lockRequestCompleted()
+            i1.startTask();
+            i0.switchState();
+            int ii = 0;
+            for (; ii < 5; ii++) {
+                if (i0.ourProposalOrTaskFinished &&
+                        boolProposalOrTaskFinished(m_booleanStateMachinesForGroup1, 2)) {
+                    break;
+                }
+                Thread.sleep(500);
+            }
+
+            // i0 should have never incremented the completion count because it will never get the lock (broken callback)
+            assertEquals(5, ii);
+
+            // i0's switch should fail and state should have been reinitialized to false with consensus
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+            assertFalse(i0.state);
+            assertTrue(i0.notifiedOfReset);
+            assertEquals(1, i0.getResetCounter());
+        }
+        catch (InterruptedException e) {
+            fail("Exception occurred during test.");
+        }
+    }
+
+    @Test
+    public void testResetIfExceptionInMembershipChanged() {
+        log.info("Starting testResetIfExceptionInMembershipChanged");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, true, false, false);
+        for (int ii = 1; ii < NUM_AGREEMENT_SITES; ii++) {
+            addStateMachinesFor(ii);
+        }
+
+        try {
+            BrokenBooleanStateMachine i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup1[0];
+            assertEquals(0, i0.getResetCounter());
+
+            i0.brokenCallbackName = "membershipChanged";
+            for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+                // introduce some interval between member nodes being created in ZK
+                // so there will be several membership change notifications, hence several resets for i0
+                Thread.sleep(500);
+                registerGroup1BoolFor(ii);
+            }
+
+            while (!boolsInitialized(m_booleanStateMachinesForGroup1)) {
+                Thread.sleep(500);
+            }
+
+            // i0 will be reset whenever it is notified of membership changes (broken callback).
+            // After all other members have been initialized, i0 can be initialized to false with consensus
+            // properly (as there is no further membership change)
+            assertFalse(i0.state);
+            assertTrue(i0.notifiedOfReset);
+            assertTrue(i0.getResetCounter() > 0);
+        }
+        catch (InterruptedException e) {
+            fail("Exception occurred during test.");
+        }
+    }
+
+    @Test
+    public void testResetIfExceptionInStateChangeProposed() {
+        log.info("Starting testResetIfExceptionInStateChangeProposed");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, true, false, false);
+        for (int ii = 1; ii < NUM_AGREEMENT_SITES; ii++) {
+            addStateMachinesFor(ii);
+        }
+
+        try {
+            BrokenBooleanStateMachine i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup1[0];
+            BooleanStateMachine i1 = m_booleanStateMachinesForGroup1[1];
+            i0.brokenCallbackName = "stateChangeProposed";
+            for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+                registerGroup1BoolFor(ii);
+            }
+
+            while (!boolsInitialized(m_booleanStateMachinesForGroup1)) {
+                Thread.sleep(500);
+            }
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+
+            assertEquals(0, i0.getResetCounter());
+
+            i1.switchState();
+            int ii = 0;
+            for (; ii < 5; ii++) {
+                if (i1.ourProposalOrTaskFinished &&
+                        boolProposalOrTaskFinished(m_booleanStateMachinesForGroup1, 1)) {
+                    break;
+                }
+                Thread.sleep(500);
+            }
+
+            // i0 should have never stepped into proposedStateResolved because of the reset, so the actual
+            // completion count is 0, hence the timeout
+            assertEquals(5, ii);
+
+            // i1's switch should succeed because the old i0 is removed from members and the new i0 responded with NULL result,
+            // state should have been reset and reinitialized to true with consensus
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+            assertTrue(i0.state);
+            assertTrue(i0.notifiedOfReset);
+            assertEquals(1, i0.getResetCounter());
+        }
+        catch (InterruptedException e) {
+            fail("Exception occurred during test.");
+        }
+    }
+
+    @Test
+    public void testResetIfExceptionInStaleTaskRequestNotification() {
+        log.info("Starting testResetIfExceptionInStaleTaskRequestNotification");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, true, false, false);
+        addStateMachinesFor(1);
+
+        try {
+            BrokenBooleanStateMachine i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup1[0];
+            BooleanStateMachine i1 = m_booleanStateMachinesForGroup1[1];
+            i0.brokenCallbackName = "staleTaskRequestNotification";
+
+            assertEquals(0, i0.getResetCounter());
+
+            registerGroup1BoolFor(1);
+            i1.startTask(); // the task will be seen as a stale task when i0 is initializing
+            registerGroup1BoolFor(0);
+
+            while (!boolsInitialized(m_booleanStateMachinesForGroup1)) {
+                Thread.sleep(500);
+            }
+
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+
+            int ii = 0;
+            for (; ii < 5; ii++) {
+                // stale task request will never be processed because of the broken callback
+                if (i0.staleTaskRequestProcessed) {
+                    break;
+                }
+                Thread.sleep(500);
+            }
+
+            // i0 will always fail to initialize because of the stale task left by i1, hence the timeout
+            assertEquals(5, ii);
+
+            // state will remain false and the default reset limit 5 will be reached
+            assertFalse(i0.state);
+            assertTrue(i0.notifiedOfReset);
+            assertEquals(6, i0.getResetCounter());
+        }
+        catch (InterruptedException e) {
+            fail("Exception occurred during test.");
+        }
+    }
+
+    @Test
+    public void testResetIfExceptionInProposedStateResolved() {
+        log.info("Starting testResetIfExceptionInProposedStateResolved");
+
+        for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+            removeStateMachinesFor(ii);
+        }
+        addStateMachinesFor(0, true, false, false);
+        for (int ii = 1; ii < NUM_AGREEMENT_SITES; ii++) {
+            addStateMachinesFor(ii);
+        }
+
+        try {
+            BrokenBooleanStateMachine i0 = (BrokenBooleanStateMachine) m_booleanStateMachinesForGroup1[0];
+            BooleanStateMachine i1 = m_booleanStateMachinesForGroup1[1];
+            i0.brokenCallbackName = "proposedStateResolved";
+            for (int ii = 0; ii < NUM_AGREEMENT_SITES; ii++) {
+                registerGroup1BoolFor(ii);
+            }
+
+            while (!boolsInitialized(m_booleanStateMachinesForGroup1)) {
+                Thread.sleep(500);
+            }
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+
+            assertEquals(0, i0.getResetCounter());
+
+            // any instance can propose the change, here we use i1
+            i1.switchState();
+            int ii = 0;
+            for (; ii < 5; ii++) {
+                if (i1.ourProposalOrTaskFinished &&
+                        boolProposalOrTaskFinished(m_booleanStateMachinesForGroup1, 1)) {
+                    break;
+                }
+                Thread.sleep(500);
+            }
+
+            // i0 should have never incremented the completion count because proposedStateResolved()
+            // is broken, hence the timeout
+            assertEquals(5, ii);
+
+            // switch should succeed and state should have been reinitialized to true with consensus
+            assertTrue(boolsSynchronized(m_booleanStateMachinesForGroup1));
+            assertTrue(i0.state);
+            assertTrue(i0.notifiedOfReset);
+            assertEquals(1, i0.getResetCounter());
+        }
+        catch (InterruptedException e) {
+            fail("Exception occurred during test.");
+        }
+    }
 }


### PR DESCRIPTION
- Upon unexpected exceptions from the StateMachineInstance derived classes' callbacks, remove current instance from the community, initialize the instance with a different member id and triggers predefined reset actions to be executed.
- For DR Producer state machine, the reset action is to break replication so that the conversation on the victim producer node will be reset.
- If the replication mode is active-passive and sync snapshot provided by the victim producer node is still in progress, consumer cluster nodes will go down. In other cases, consumer cluster nodes will remain in RECEIVE state while keep failing to subscribe to the victim producer node because of conversation mismatch.
- In either case, subsystems other than DR in the producer cluster will remain functional.

Tests:
- Added tests in TestStateMachine that inject exception to different callbacks and make sure the state machine instance is gracefully reset.