### PR TITLE
Eng 10148 pause incompatible dr stream

### DIFF
--- a/src/ee/common/StreamBlock.h
+++ b/src/ee/common/StreamBlock.h
@@ -29,7 +29,7 @@ namespace voltdb
 {
     enum StreamBlockType {
         NORMAL_STREAM_BLOCK = 1,
-        LARGE_STREAM_BLOCK = 2
+        LARGE_STREAM_BLOCK = 2,
     };
     /**
      * A single data block with some buffer semantics.
@@ -50,7 +50,8 @@ namespace voltdb
               m_lastDRSequenceNumber(std::numeric_limits<int64_t>::max()),
               m_lastSpUniqueId(0),
               m_lastMpUniqueId(0),
-              m_type(voltdb::NORMAL_STREAM_BLOCK)
+              m_type(NORMAL_STREAM_BLOCK),
+              m_drEventType(voltdb::NOT_A_EVENT)
         {
         }
 
@@ -68,7 +69,8 @@ namespace voltdb
               m_lastDRSequenceNumber(other->m_lastDRSequenceNumber),
               m_lastSpUniqueId(other->m_lastSpUniqueId),
               m_lastMpUniqueId(other->m_lastMpUniqueId),
-              m_type(other->m_type)
+              m_type(other->m_type),
+              m_drEventType(other->m_drEventType)
         {
         }
 
@@ -159,6 +161,14 @@ namespace voltdb
             m_lastMpUniqueId = lastMpUniqueId;
         }
 
+        void markAsEventBuffer(DREventType type) {
+            m_drEventType = type;
+        }
+
+        DREventType drEventType() {
+            return m_drEventType;
+        }
+
         size_t updateRowCountForDR(size_t rowsToCommit) {
             m_rowCountForDR += rowsToCommit;
             return m_rowCountForDR;
@@ -228,6 +238,7 @@ namespace voltdb
         int64_t m_lastSpUniqueId;
         int64_t m_lastMpUniqueId;
         StreamBlockType m_type;
+        DREventType m_drEventType;
 
         friend class TupleStreamBase;
         friend class ExportTupleStream;

--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -483,7 +483,18 @@ enum TaskType {
     TASK_TYPE_GET_DR_TUPLESTREAM_STATE = 1,
     TASK_TYPE_SET_DR_SEQUENCE_NUMBERS = 2,
     TASK_TYPE_SET_DR_PROTOCOL_VERSION = 3,
-    TASK_TYPE_SP_JAVA_GET_DRID_TRACKER = 4      // not supported in EE
+    TASK_TYPE_SP_JAVA_GET_DRID_TRACKER = 4,      // not supported in EE
+    TASK_TYPE_SET_DRID_TRACKER = 5,              // not supported in EE
+    TASK_TYPE_GENERATE_DR_EVENT = 6
+};
+
+// ------------------------------------------------------------------
+// Types of DR in-band events
+// ------------------------------------------------------------------
+enum DREventType {
+    NOT_A_EVENT = 0,
+    POISON_PILL = 1,      // not supported in EE
+    CATALOG_UPDATE = 2,
 };
 
 

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -174,7 +174,7 @@ JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecuti
     m_pushDRBufferMID = m_jniEnv->GetStaticMethodID(
             m_partitionDRGatewayClass,
             "pushDRBuffer",
-            "(IJJJJLjava/nio/ByteBuffer;)J");
+            "(IJJJJILjava/nio/ByteBuffer;)J");
     if (m_pushDRBufferMID == NULL) {
         m_jniEnv->ExceptionDescribe();
         assert(m_pushDRBufferMID != NULL);
@@ -470,6 +470,7 @@ int64_t JNITopend::pushDRBuffer(int32_t partitionId, StreamBlock *block) {
                 block->lastDRSequenceNumber(),
                 block->lastSpUniqueId(),
                 block->lastMpUniqueId(),
+                block->drEventType(),
                 buffer);
         m_jniEnv->DeleteLocalRef(buffer);
     }

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1783,8 +1783,7 @@ void VoltDBEngine::updateHashinator(HashinatorType type, const char *config, int
     }
 }
 
-void VoltDBEngine::dispatchValidatePartitioningTask(const char *taskParams) {
-    ReferenceSerializeInputBE taskInfo(taskParams, std::numeric_limits<std::size_t>::max());
+void VoltDBEngine::dispatchValidatePartitioningTask(ReferenceSerializeInputBE &taskInfo) {
     std::vector<CatalogId> tableIds;
     const int32_t numTables = taskInfo.readInt();
     for (int ii = 0; ii < numTables; ii++) {
@@ -1792,7 +1791,7 @@ void VoltDBEngine::dispatchValidatePartitioningTask(const char *taskParams) {
     }
 
     HashinatorType type = static_cast<HashinatorType>(taskInfo.readInt());
-    const char *config = taskParams + (sizeof(int32_t) * 2) +  (sizeof(int64_t) * tableIds.size());
+    const char *config = taskInfo.getRawPointer();
     TheHashinator* hashinator;
     switch(type) {
         case HASHINATOR_LEGACY:
@@ -1867,16 +1866,15 @@ int64_t VoltDBEngine::applyBinaryLog(int64_t txnId,
     return rowCount;
 }
 
-void VoltDBEngine::executeTask(TaskType taskType, const char* taskParams) {
+void VoltDBEngine::executeTask(TaskType taskType, ReferenceSerializeInputBE &taskInfo) {
     switch (taskType) {
     case TASK_TYPE_VALIDATE_PARTITIONING:
-        dispatchValidatePartitioningTask(taskParams);
+        dispatchValidatePartitioningTask(taskInfo);
         break;
     case TASK_TYPE_GET_DR_TUPLESTREAM_STATE:
         collectDRTupleStreamStateInfo();
         break;
     case TASK_TYPE_SET_DR_SEQUENCE_NUMBERS: {
-        ReferenceSerializeInputBE taskInfo(taskParams, std::numeric_limits<std::size_t>::max());
         int64_t partitionSequenceNumber = taskInfo.readLong();
         int64_t mpSequenceNumber = taskInfo.readLong();
         if (partitionSequenceNumber >= 0) {
@@ -1889,7 +1887,6 @@ void VoltDBEngine::executeTask(TaskType taskType, const char* taskParams) {
         break;
     }
     case TASK_TYPE_SET_DR_PROTOCOL_VERSION: {
-        ReferenceSerializeInputBE taskInfo(taskParams, std::numeric_limits<std::size_t>::max());
         uint32_t drVersion = taskInfo.readInt();
         if (drVersion != DRTupleStream::PROTOCOL_VERSION) {
             m_executorContext->setDrStream(m_compatibleDRStream);
@@ -1904,6 +1901,21 @@ void VoltDBEngine::executeTask(TaskType taskType, const char* taskParams) {
         }
         m_drVersion = drVersion;
         m_resultOutput.writeInt(0);
+        break;
+    }
+    case TASK_TYPE_GENERATE_DR_EVENT: {
+        DREventType type = (DREventType)taskInfo.readInt();
+        int64_t uniqueId = taskInfo.readLong();
+        int64_t lastCommittedSpHandle = taskInfo.readLong();
+        int64_t spHandle = taskInfo.readLong();
+        ByteArray payloads = taskInfo.readBinaryString();
+
+        m_executorContext->drStream()->generateDREvent(type, lastCommittedSpHandle,
+                spHandle, uniqueId, payloads);
+        if (m_executorContext->drReplicatedStream()) {
+            m_executorContext->drReplicatedStream()->generateDREvent(type, lastCommittedSpHandle,
+                    spHandle, uniqueId, payloads);
+        }
         break;
     }
     default:

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1382,7 +1382,7 @@ void VoltDBEngine::tick(int64_t timeInMillis, int64_t lastCommittedSpHandle) {
     }
 }
 
-/** For now, bring the Export system to a steady state with no buffers with content */
+/** Bring the Export and DR system to a steady state with no pending committed data */
 void VoltDBEngine::quiesce(int64_t lastCommittedSpHandle) {
     m_executorContext->setupForQuiesce(lastCommittedSpHandle);
     BOOST_FOREACH (TablePair table, m_exportingTables) {

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -390,7 +390,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
          * Execute an arbitrary task represented by the task id and serialized parameters.
          * Returns serialized representation of the results
          */
-        void executeTask(TaskType taskType, const char* taskParams);
+        void executeTask(TaskType taskType, ReferenceSerializeInputBE &taskInfo);
 
         void rebuildTableCollections();
 
@@ -413,7 +413,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         /*
          * Tasks dispatched by executeTask
          */
-        void dispatchValidatePartitioningTask(const char *taskParams);
+        void dispatchValidatePartitioningTask(ReferenceSerializeInputBE &taskInfo);
 
         void collectDRTupleStreamStateInfo();
 

--- a/src/ee/storage/AbstractDRTupleStream.h
+++ b/src/ee/storage/AbstractDRTupleStream.h
@@ -94,6 +94,9 @@ public:
 
     virtual DRCommittedInfo getLastCommittedSequenceNumberAndUniqueIds() = 0;
 
+    virtual void generateDREvent(DREventType type, int64_t lastCommittedSpHandle, int64_t spHandle,
+                                 int64_t uniqueId, ByteArray payloads) = 0;
+
     bool m_enabled;
 protected:
     CatalogId m_partitionId;

--- a/src/ee/storage/AbstractDRTupleStream.h
+++ b/src/ee/storage/AbstractDRTupleStream.h
@@ -61,7 +61,6 @@ public:
     virtual size_t appendTuple(int64_t lastCommittedSpHandle,
                        char *tableHandle,
                        int partitionColumn,
-                       int64_t txnId,
                        int64_t spHandle,
                        int64_t uniqueId,
                        TableTuple &tuple,
@@ -74,7 +73,6 @@ public:
     virtual size_t appendUpdateRecord(int64_t lastCommittedSpHandle,
                        char *tableHandle,
                        int partitionColumn,
-                       int64_t txnId,
                        int64_t spHandle,
                        int64_t uniqueId,
                        TableTuple &oldTuple,
@@ -84,7 +82,6 @@ public:
                        char *tableHandle,
                        std::string tableName,
                        int partitionColumn,
-                       int64_t txnId,
                        int64_t spHandle,
                        int64_t uniqueId) = 0;
 

--- a/src/ee/storage/CompatibleDRTupleStream.cpp
+++ b/src/ee/storage/CompatibleDRTupleStream.cpp
@@ -52,7 +52,6 @@ size_t CompatibleDRTupleStream::truncateTable(int64_t lastCommittedSpHandle,
                                               char *tableHandle,
                                               std::string tableName,
                                               int partitionColumn,
-                                              int64_t txnId,
                                               int64_t spHandle,
                                               int64_t uniqueId) {
     size_t startingUso = m_uso;
@@ -60,7 +59,7 @@ size_t CompatibleDRTupleStream::truncateTable(int64_t lastCommittedSpHandle,
     //Drop the row, don't move the USO
     if (!m_enabled) return INVALID_DR_MARK;
 
-    transactionChecks(lastCommittedSpHandle, txnId, spHandle, uniqueId);
+    transactionChecks(lastCommittedSpHandle, spHandle, uniqueId);
 
     if (!m_currBlock) {
         extendBufferChain(m_defaultCapacity);
@@ -108,7 +107,6 @@ size_t CompatibleDRTupleStream::truncateTable(int64_t lastCommittedSpHandle,
 size_t CompatibleDRTupleStream::appendTuple(int64_t lastCommittedSpHandle,
                                               char *tableHandle,
                                               int partitionColumn,
-                                              int64_t txnId,
                                               int64_t spHandle,
                                               int64_t uniqueId,
                                               TableTuple &tuple,
@@ -123,7 +121,7 @@ size_t CompatibleDRTupleStream::appendTuple(int64_t lastCommittedSpHandle,
     size_t rowMetadataSz = 0;
     size_t tupleMaxLength = 0;
 
-    transactionChecks(lastCommittedSpHandle, txnId, spHandle, uniqueId);
+    transactionChecks(lastCommittedSpHandle, spHandle, uniqueId);
 
     // Compute the upper bound on bytes required to serialize tuple.
     // exportxxx: can memoize this calculation.
@@ -166,7 +164,6 @@ size_t CompatibleDRTupleStream::appendTuple(int64_t lastCommittedSpHandle,
 size_t CompatibleDRTupleStream::appendUpdateRecord(int64_t lastCommittedSpHandle,
                                                      char *tableHandle,
                                                      int partitionColumn,
-                                                     int64_t txnId,
                                                      int64_t spHandle,
                                                      int64_t uniqueId,
                                                      TableTuple &oldTuple,
@@ -182,7 +179,7 @@ size_t CompatibleDRTupleStream::appendUpdateRecord(int64_t lastCommittedSpHandle
     size_t newRowMetadataSz = 0;
     size_t maxLength = TXN_RECORD_HEADER_SIZE;
 
-    transactionChecks(lastCommittedSpHandle, txnId, spHandle, uniqueId);
+    transactionChecks(lastCommittedSpHandle, spHandle, uniqueId);
 
     DRRecordType type = DR_RECORD_UPDATE;
     maxLength += computeOffsets(type, oldTuple, oldRowHeaderSz, oldRowMetadataSz);
@@ -225,7 +222,7 @@ size_t CompatibleDRTupleStream::appendUpdateRecord(int64_t lastCommittedSpHandle
     return startingUso;
 }
 
-void CompatibleDRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, int64_t txnId, int64_t spHandle, int64_t uniqueId) {
+void CompatibleDRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId) {
     // Transaction IDs for transactions applied to this tuple stream
     // should always be moving forward in time.
     if (spHandle < m_openSpHandle) {
@@ -235,7 +232,7 @@ void CompatibleDRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, i
                 );
     }
 
-    commit(lastCommittedSpHandle, spHandle, txnId, uniqueId, false, false);
+    commit(lastCommittedSpHandle, spHandle, uniqueId, false, false);
     if (!m_opened) {
         beginTransaction(m_openSequenceNumber, uniqueId);
     }
@@ -453,22 +450,22 @@ int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionId,
         tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValueList[ii]));
 
         if (flagList[ii] == TXN_PAR_HASH_SPECIAL) {
-            stream.truncateTable(lastUID, tableHandle, "foobar", partitionId == 16383 ? -1 : 0, uid, uid, uid);
+            stream.truncateTable(lastUID, tableHandle, "foobar", partitionId == 16383 ? -1 : 0, uid, uid);
         }
 
         for (int zz = 0; zz < 5; zz++) {
-            stream.appendTuple(lastUID, tableHandle, partitionId == 16383 ? -1 : 0, uid, uid, uid, tuple, DR_RECORD_INSERT);
+            stream.appendTuple(lastUID, tableHandle, partitionId == 16383 ? -1 : 0, uid, uid, tuple, DR_RECORD_INSERT);
         }
 
         if (flagList[ii] == TXN_PAR_HASH_MULTI) {
             tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValueList[ii] + 1));
             for (int zz = 0; zz < 5; zz++) {
-                stream.appendTuple(lastUID, tableHandle,  partitionId == 16383 ? -1 : 0, uid, uid, uid, tuple, DR_RECORD_INSERT);
+                stream.appendTuple(lastUID, tableHandle,  partitionId == 16383 ? -1 : 0, uid, uid, tuple, DR_RECORD_INSERT);
             }
         }
         else if (flagList[ii] == TXN_PAR_HASH_SPECIAL) {
-            stream.truncateTable(lastUID, tableHandle, "foobar", partitionId == 16383 ? -1 : 0, uid, uid, uid);
-            stream.truncateTable(lastUID, tableHandle, "foobar", partitionId == 16383 ? -1 : 0, uid, uid, uid);
+            stream.truncateTable(lastUID, tableHandle, "foobar", partitionId == 16383 ? -1 : 0, uid, uid);
+            stream.truncateTable(lastUID, tableHandle, "foobar", partitionId == 16383 ? -1 : 0, uid, uid);
         }
 
         stream.endTransaction(uid);
@@ -478,7 +475,7 @@ int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionId,
     TupleSchema::freeTupleSchema(schema);
 
     int64_t committedUID = lastUID;
-    stream.commit(committedUID, committedUID, committedUID, committedUID, false, false);
+    stream.commit(committedUID, committedUID, committedUID, false, false);
 
     size_t headerSize = MAGIC_HEADER_SPACE_FOR_JAVA + MAGIC_DR_TRANSACTION_PADDING;
     const int32_t adjustedLength = static_cast<int32_t>(stream.m_currBlock->rawLength() - headerSize);

--- a/src/ee/storage/CompatibleDRTupleStream.h
+++ b/src/ee/storage/CompatibleDRTupleStream.h
@@ -81,6 +81,12 @@ public:
     virtual DRCommittedInfo getLastCommittedSequenceNumberAndUniqueIds() {
         return DRCommittedInfo(m_committedSequenceNumber, m_lastCommittedSpUniqueId, m_lastCommittedMpUniqueId);
     }
+
+    virtual void generateDREvent(DREventType type, int64_t lastCommittedSpHandle, int64_t spHandle,
+                                 int64_t uniqueId, ByteArray payloads) {
+        // This method is not supported in compatible stream
+    }
+
     static int32_t getTestDRBuffer(int32_t partitionId,
                                    std::vector<int32_t> partitionKeyValueList,
                                    std::vector<int32_t> flagList,

--- a/src/ee/storage/CompatibleDRTupleStream.h
+++ b/src/ee/storage/CompatibleDRTupleStream.h
@@ -47,7 +47,6 @@ public:
     virtual size_t appendTuple(int64_t lastCommittedSpHandle,
                        char *tableHandle,
                        int partitionColumn,
-                       int64_t txnId,
                        int64_t spHandle,
                        int64_t uniqueId,
                        TableTuple &tuple,
@@ -60,7 +59,6 @@ public:
     virtual size_t appendUpdateRecord(int64_t lastCommittedSpHandle,
                        char *tableHandle,
                        int partitionColumn,
-                       int64_t txnId,
                        int64_t spHandle,
                        int64_t uniqueId,
                        TableTuple &oldTuple,
@@ -70,7 +68,6 @@ public:
                        char *tableHandle,
                        std::string tableName,
                        int partitionColumn,
-                       int64_t txnId,
                        int64_t spHandle,
                        int64_t uniqueId);
 
@@ -89,7 +86,7 @@ public:
                                    std::vector<int32_t> flagList,
                                    char *out);
 private:
-    void transactionChecks(int64_t lastCommittedSpHandle, int64_t txnId, int64_t spHandle, int64_t uniqueId);
+    void transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId);
 
     void writeRowTuple(TableTuple& tuple,
             size_t rowHeaderSz,

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -52,7 +52,6 @@ public:
     virtual size_t appendTuple(int64_t lastCommittedSpHandle,
                        char *tableHandle,
                        int partitionColumn,
-                       int64_t txnId,
                        int64_t spHandle,
                        int64_t uniqueId,
                        TableTuple &tuple,
@@ -65,7 +64,6 @@ public:
     virtual size_t appendUpdateRecord(int64_t lastCommittedSpHandle,
                        char *tableHandle,
                        int partitionColumn,
-                       int64_t txnId,
                        int64_t spHandle,
                        int64_t uniqueId,
                        TableTuple &oldTuple,
@@ -75,7 +73,6 @@ public:
                        char *tableHandle,
                        std::string tableName,
                        int partitionColumn,
-                       int64_t txnId,
                        int64_t spHandle,
                        int64_t uniqueId);
 
@@ -96,7 +93,7 @@ public:
                                    char *out);
 
 private:
-    void transactionChecks(int64_t lastCommittedSpHandle, int64_t txnId, int64_t spHandle, int64_t uniqueId);
+    void transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId);
 
     void writeRowTuple(TableTuple& tuple,
             size_t rowHeaderSz,
@@ -139,7 +136,6 @@ public:
     size_t appendTuple(int64_t lastCommittedSpHandle,
                            char *tableHandle,
                            int partitionColumn,
-                           int64_t txnId,
                            int64_t spHandle,
                            int64_t uniqueId,
                            TableTuple &tuple,
@@ -155,7 +151,6 @@ public:
                        char *tableHandle,
                        std::string tableName,
                        int partitionColumn,
-                       int64_t txnId,
                        int64_t spHandle,
                        int64_t uniqueId) {
         return 0;

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -38,7 +38,7 @@ public:
     static const size_t HASH_DELIMITER_SIZE = 1 + 4;
 
     // Also update DRProducerProtocol.java if version changes
-    static const uint8_t PROTOCOL_VERSION = 4;
+    static const uint8_t PROTOCOL_VERSION = 5;
 
     DRTupleStream(int partitionId, int defaultBufferSize);
 
@@ -86,6 +86,9 @@ public:
     virtual DRCommittedInfo getLastCommittedSequenceNumberAndUniqueIds() {
         return DRCommittedInfo(m_committedSequenceNumber, m_lastCommittedSpUniqueId, m_lastCommittedMpUniqueId);
     }
+
+    virtual void generateDREvent(DREventType type, int64_t lastCommittedSpHandle, int64_t spHandle,
+                                 int64_t uniqueId, ByteArray catalogCommands);
 
     static int32_t getTestDRBuffer(int32_t partitionId,
                                    std::vector<int32_t> partitionKeyValueList,

--- a/src/ee/storage/ExportTupleStream.cpp
+++ b/src/ee/storage/ExportTupleStream.cpp
@@ -109,7 +109,7 @@ size_t ExportTupleStream::appendTuple(int64_t lastCommittedSpHandle,
     //Most of the transaction id info and unique id info supplied to commit
     //is nonsense since it isn't currently supplied with a transaction id
     //but it is fine since export isn't currently using the info
-    commit(lastCommittedSpHandle, spHandle, spHandle, uniqueId, false, false);
+    commit(lastCommittedSpHandle, spHandle, uniqueId, false, false);
 
     // Compute the upper bound on bytes required to serialize tuple.
     // exportxxx: can memoize this calculation.

--- a/src/ee/storage/TupleStreamBase.cpp
+++ b/src/ee/storage/TupleStreamBase.cpp
@@ -98,7 +98,7 @@ void TupleStreamBase::cleanupManagedBuffers()
  * This is the only function that should modify m_openSpHandle,
  * m_openTransactionUso.
  */
-void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHandle, int64_t txnId, int64_t uniqueId, bool sync, bool flush)
+void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHandle, int64_t uniqueId, bool sync, bool flush)
 {
     if (currentSpHandle < m_openSpHandle)
     {
@@ -116,9 +116,9 @@ void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHan
     if ((currentSpHandle == m_openSpHandle) &&
         (lastCommittedSpHandle == m_committedSpHandle))
     {
-        //std::cout << "Current spHandle(" << currentSpHandle << ") == m_openSpHandle(" << m_openSpHandle <<
-        //") && lastCommittedSpHandle(" << lastCommittedSpHandle << ") m_committedSpHandle(" <<
-        //m_committedSpHandle << ")" << std::endl;
+        std::cout << "Current spHandle(" << currentSpHandle << ") == m_openSpHandle(" << m_openSpHandle <<
+        ") && lastCommittedSpHandle(" << lastCommittedSpHandle << ") m_committedSpHandle(" <<
+        m_committedSpHandle << ")" << std::endl;
         if (sync) {
             pushExportBuffer(
                     NULL,
@@ -360,6 +360,6 @@ TupleStreamBase::periodicFlush(int64_t timeInMillis,
          * in calls to this procedure may be called right after
          * these.
          */
-        commit(lastCommittedSpHandle, maxSpHandle, maxSpHandle, std::numeric_limits<int64_t>::min(), timeInMillis < 0 ? true : false, true);
+        commit(lastCommittedSpHandle, maxSpHandle, std::numeric_limits<int64_t>::min(), timeInMillis < 0 ? true : false, true);
     }
 }

--- a/src/ee/storage/TupleStreamBase.cpp
+++ b/src/ee/storage/TupleStreamBase.cpp
@@ -98,7 +98,8 @@ void TupleStreamBase::cleanupManagedBuffers()
  * This is the only function that should modify m_openSpHandle,
  * m_openTransactionUso.
  */
-void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHandle, int64_t uniqueId, bool sync, bool flush)
+void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHandle, int64_t uniqueId,
+        bool sync, bool flush, DREventType eventType)
 {
     if (currentSpHandle < m_openSpHandle)
     {
@@ -116,9 +117,9 @@ void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHan
     if ((currentSpHandle == m_openSpHandle) &&
         (lastCommittedSpHandle == m_committedSpHandle))
     {
-        std::cout << "Current spHandle(" << currentSpHandle << ") == m_openSpHandle(" << m_openSpHandle <<
-        ") && lastCommittedSpHandle(" << lastCommittedSpHandle << ") m_committedSpHandle(" <<
-        m_committedSpHandle << ")" << std::endl;
+        //std::cout << "Current spHandle(" << currentSpHandle << ") == m_openSpHandle(" << m_openSpHandle <<
+        //") && lastCommittedSpHandle(" << lastCommittedSpHandle << ") m_committedSpHandle(" <<
+        //m_committedSpHandle << ")" << std::endl;
         if (sync) {
             pushExportBuffer(
                     NULL,
@@ -156,6 +157,17 @@ void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHan
         m_openSpHandle = currentSpHandle;
         m_openSequenceNumber++;
         m_openUniqueId = uniqueId;
+
+        if (eventType != NOT_A_EVENT) {
+            m_currBlock->startDRSequenceNumber(m_openSequenceNumber);
+            m_currBlock->recordCompletedSequenceNumForDR(m_openSequenceNumber);
+            if (UniqueId::isMpUniqueId(uniqueId)) {
+                m_currBlock->recordCompletedMpTxnForDR(uniqueId);
+            } else {
+                m_currBlock->recordCompletedSpTxnForDR(uniqueId);
+            }
+            m_currBlock->markAsEventBuffer(eventType);
+        }
 
         if (flush) {
             extendBufferChain(0);

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -77,7 +77,7 @@ public:
     virtual bool checkOpenTransaction(StreamBlock *sb, size_t minLength, size_t& blockSize, size_t& uso) { return false; }
 
     /** Send committed data to the top end. */
-    void commit(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t txnId, int64_t uniqueId, bool sync, bool flush);
+    void commit(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId, bool sync, bool flush);
 
     /** time interval between flushing partially filled buffers */
     int64_t m_flushInterval;

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -77,7 +77,8 @@ public:
     virtual bool checkOpenTransaction(StreamBlock *sb, size_t minLength, size_t& blockSize, size_t& uso) { return false; }
 
     /** Send committed data to the top end. */
-    void commit(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId, bool sync, bool flush);
+    void commit(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId, bool sync, bool flush,
+            DREventType type = NOT_A_EVENT);
 
     /** time interval between flushing partially filled buffers */
     int64_t m_flushInterval;

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -403,10 +403,10 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
     size_t drMark = INVALID_DR_MARK;
     if (drStream && !m_isMaterialized && m_drEnabled) {
         const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
-        const int64_t currentTxnId = ec->currentTxnId();
         const int64_t currentSpHandle = ec->currentSpHandle();
         const int64_t currentUniqueId = ec->currentUniqueId();
-        drMark = drStream->truncateTable(lastCommittedSpHandle, m_signature, m_name, m_partitionColumn, currentTxnId, currentSpHandle, currentUniqueId);
+        drMark = drStream->truncateTable(lastCommittedSpHandle, m_signature, m_name, m_partitionColumn,
+                                         currentSpHandle, currentUniqueId);
     }
 
     UndoQuantum *uq = ExecutorContext::currentUndoQuantum();
@@ -512,10 +512,10 @@ void PersistentTable::insertTupleCommon(TableTuple &source, TableTuple &target, 
     if (drStream && !m_isMaterialized && m_drEnabled && shouldDRStream) {
         ExecutorContext *ec = ExecutorContext::getExecutorContext();
         const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
-        const int64_t currentTxnId = ec->currentTxnId();
         const int64_t currentSpHandle = ec->currentSpHandle();
         const int64_t currentUniqueId = ec->currentUniqueId();
-        drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, m_partitionColumn, currentTxnId, currentSpHandle, currentUniqueId, target, DR_RECORD_INSERT);
+        drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, m_partitionColumn, currentSpHandle,
+                                       currentUniqueId, target, DR_RECORD_INSERT);
     }
 
     if (m_schema->getUninlinedObjectColumnCount() != 0) {
@@ -656,10 +656,10 @@ void PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUp
     if (drStream && !m_isMaterialized && m_drEnabled) {
         ExecutorContext *ec = ExecutorContext::getExecutorContext();
         const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
-        const int64_t currentTxnId = ec->currentTxnId();
         const int64_t currentSpHandle = ec->currentSpHandle();
         const int64_t currentUniqueId = ec->currentUniqueId();
-        drMark = drStream->appendUpdateRecord(lastCommittedSpHandle, m_signature, m_partitionColumn, currentTxnId, currentSpHandle, currentUniqueId, targetTupleToUpdate, sourceTupleWithNewValues);
+        drMark = drStream->appendUpdateRecord(lastCommittedSpHandle, m_signature, m_partitionColumn, currentSpHandle,
+                                              currentUniqueId, targetTupleToUpdate, sourceTupleWithNewValues);
     }
 
     if (m_tableStreamer != NULL) {
@@ -844,10 +844,10 @@ bool PersistentTable::deleteTuple(TableTuple &target, bool fallible) {
     size_t drMark = INVALID_DR_MARK;
     if (drStream && !m_isMaterialized && m_drEnabled) {
         const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
-        const int64_t currentTxnId = ec->currentTxnId();
         const int64_t currentSpHandle = ec->currentSpHandle();
         const int64_t currentUniqueId = ec->currentUniqueId();
-        drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, m_partitionColumn, currentTxnId, currentSpHandle, currentUniqueId, target, DR_RECORD_DELETE);
+        drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, m_partitionColumn, currentSpHandle,
+                                       currentUniqueId, target, DR_RECORD_DELETE);
     }
 
     // Just like insert, we want to remove this tuple from all of our indexes

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -1523,8 +1523,9 @@ void VoltDBIPC::executeTask(struct ipc_command *cmd) {
     try {
         execute_task *task = (execute_task*)cmd;
         voltdb::TaskType taskId = static_cast<voltdb::TaskType>(ntohll(task->taskId));
+        ReferenceSerializeInputBE input(task->task, MAX_MSG_SZ);
         m_engine->resetReusedResultOutputBuffer(1);
-        m_engine->executeTask(taskId, task->task);
+        m_engine->executeTask(taskId, input);
         int32_t responseLength = m_engine->getResultsSize();
         char *resultsBuffer = m_engine->getReusedResultBuffer();
         resultsBuffer[0] = kErrorCode_Success;

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1406,7 +1406,7 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExecu
 
         ReferenceSerializeInputBE input(engine->getParameterBuffer(), engine->getParameterBufferCapacity());
         TaskType taskId = static_cast<TaskType>(input.readLong());
-        engine->executeTask(taskId, engine->getParameterBuffer() + sizeof(int64_t));
+        engine->executeTask(taskId, input);
         return org_voltdb_jni_ExecutionEngine_ERRORCODE_SUCCESS;
     } catch (const SerializableEEException &e) {
         engine->resetReusedResultOutputBuffer();

--- a/src/frontend/org/voltdb/DRConsumerStatsBase.java
+++ b/src/frontend/org/voltdb/DRConsumerStatsBase.java
@@ -40,6 +40,7 @@ public class DRConsumerStatsBase {
         public static final String COVERING_HOST = "COVERING_HOST";
         public static final String LAST_RECEIVED_TIMESTAMP = "LAST_RECEIVED_TIMESTAMP";
         public static final String LAST_APPLIED_TIMESTAMP = "LAST_APPLIED_TIMESTAMP";
+        public static final String IS_PAUSED = "IS_PAUSED";
     }
 
     public static class DRConsumerNodeStatsBase extends StatsSource {
@@ -78,6 +79,7 @@ public class DRConsumerStatsBase {
             columns.add(new ColumnInfo(Columns.COVERING_HOST, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.LAST_RECEIVED_TIMESTAMP, VoltType.TIMESTAMP));
             columns.add(new ColumnInfo(Columns.LAST_APPLIED_TIMESTAMP, VoltType.TIMESTAMP));
+            columns.add(new ColumnInfo(Columns.IS_PAUSED, VoltType.STRING));
         }
 
         @Override

--- a/src/frontend/org/voltdb/PartitionDRGateway.java
+++ b/src/frontend/org/voltdb/PartitionDRGateway.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
+import org.voltdb.jni.ExecutionEngine.EventType;
 import org.voltdb.licensetool.LicenseApi;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
@@ -137,7 +138,7 @@ public class PartitionDRGateway implements DurableUniqueIdListener {
                                    StoredProcedureInvocation spi,
                                    ClientResponseImpl response) {}
     public long onBinaryDR(int partitionId, long startSequenceNumber, long lastSequenceNumber,
-            long lastSpUniqueId, long lastMpUniqueId, ByteBuffer buf) {
+            long lastSpUniqueId, long lastMpUniqueId, EventType eventType, ByteBuffer buf) {
         final BBContainer cont = DBBPool.wrapBB(buf);
         DBBPool.registerUnsafeMemory(cont.address());
         cont.discard();
@@ -161,12 +162,14 @@ public class PartitionDRGateway implements DurableUniqueIdListener {
             long lastSequenceNumber,
             long lastSpUniqueId,
             long lastMpUniqueId,
+            int eventType,
             ByteBuffer buf) {
         final PartitionDRGateway pdrg = m_partitionDRGateways.get(partitionId);
         if (pdrg == null) {
             VoltDB.crashLocalVoltDB("No PRDG when there should be", true, null);
         }
-        return pdrg.onBinaryDR(partitionId, startSequenceNumber, lastSequenceNumber, lastSpUniqueId, lastMpUniqueId, buf);
+        return pdrg.onBinaryDR(partitionId, startSequenceNumber, lastSequenceNumber,
+                lastSpUniqueId, lastMpUniqueId, EventType.values()[eventType], buf);
     }
 
     public void forceAllDRNodeBuffersToDisk(final boolean nofsync) {}

--- a/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
+++ b/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
@@ -69,7 +69,7 @@ public interface SystemProcedureExecutionContext {
     public void updateBackendLogLevels();
 
     public boolean updateCatalog(String catalogDiffCommands, CatalogContext context,
-            CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation);
+            CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation, long uniqueId, long spHandle);
 
     public TheHashinator getCurrentHashinator();
 

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -199,7 +199,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
     public void updateCatalog(String diffCmds, CatalogContext context, CatalogSpecificPlanner csp)
     {
         // note this will never require snapshot isolation because the MPI has no snapshot funtionality
-        m_executionSite.updateCatalog(diffCmds, context, csp, false, true);
+        m_executionSite.updateCatalog(diffCmds, context, csp, false, true, Long.MIN_VALUE, Long.MIN_VALUE);
         MpScheduler sched = (MpScheduler)m_scheduler;
         sched.updateCatalog(diffCmds, context, csp);
     }

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -208,7 +208,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
 
         @Override
         public boolean updateCatalog(String diffCmds, CatalogContext context,
-                CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation)
+                CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation, long uniqueId, long spHandle)
         {
             throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
         }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -85,6 +85,7 @@ import org.voltdb.dtxn.TransactionState;
 import org.voltdb.dtxn.UndoAction;
 import org.voltdb.exceptions.EEException;
 import org.voltdb.jni.ExecutionEngine;
+import org.voltdb.jni.ExecutionEngine.EventType;
 import org.voltdb.jni.ExecutionEngine.TaskType;
 import org.voltdb.jni.ExecutionEngineIPC;
 import org.voltdb.jni.ExecutionEngineJNI;
@@ -99,6 +100,7 @@ import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.LogKeys;
 import org.voltdb.utils.MinimumRatioMaintainer;
 
+import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.base.Preconditions;
 
 import vanilla.java.affinity.impl.PosixJNAAffinity;
@@ -370,9 +372,11 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
 
         @Override
         public boolean updateCatalog(String diffCmds, CatalogContext context,
-                CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation)
+                CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation,
+                long uniqueId, long spHandle)
         {
-            return Site.this.updateCatalog(diffCmds, context, csp, requiresSnapshotIsolation, false);
+            return Site.this.updateCatalog(diffCmds, context, csp, requiresSnapshotIsolation,
+                    false, uniqueId, spHandle);
         }
 
         @Override
@@ -1392,14 +1396,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
      * Update the catalog.  If we're the MPI, don't bother with the EE.
      */
     public boolean updateCatalog(String diffCmds, CatalogContext context, CatalogSpecificPlanner csp,
-            boolean requiresSnapshotIsolationboolean, boolean isMPI)
+            boolean requiresSnapshotIsolationboolean, boolean isMPI, long uniqueId, long spHandle)
     {
-        DRCatalogDiffEngine diffEngine = new DRCatalogDiffEngine(m_context.catalog, context.catalog);
-        boolean incompatibleCatalogChange = false;
-        if (!diffEngine.supported()) {
-            incompatibleCatalogChange = true;
-        }
-
         m_context = context;
         m_ee.setBatchTimeout(m_context.cluster.getDeployment().get("deployment").
                 getSystemsettings().get("systemsettings").getQuerytimeout());
@@ -1410,6 +1408,16 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             return true;
         }
 
+        boolean DRCatalogChange = false;
+        CatalogMap<Table> tables = m_context.catalog.getClusters().get("cluster").getDatabases().get("database").getTables();
+        for (Table t : tables) {
+            if (t.getIsdred()) {
+                DRCatalogChange |= diffCmds.contains("tables#" + t.getTypeName());
+                if (DRCatalogChange) {
+                    break;
+                }
+            }
+        }
         // if a snapshot is in process, wait for it to finish
         // don't bother if this isn't a schema change
         //
@@ -1430,6 +1438,11 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         //so export data for the old generation is pushed to Java.
         m_ee.quiesce(m_lastCommittedSpHandle);
         m_ee.updateCatalog(m_context.m_uniqueId, diffCmds);
+        if (DRCatalogChange) {
+            final Pair<Long, String> catalogCommands = DRCatalogDiffEngine.serializeCatalogCommandsForDr(m_context.catalog);
+            generateDREvent( EventType.CATALOG_UPDATE, uniqueId, m_lastCommittedSpHandle,
+                    spHandle, catalogCommands.getSecond().getBytes(Charsets.UTF_8));
+        }
 
         return true;
     }
@@ -1543,5 +1556,21 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         paramBuffer.putInt(drVersion);
         m_ee.executeTask(TaskType.SET_DR_PROTOCOL_VERSION, paramBuffer);
         hostLog.info("DR protocol version has been set to " + drVersion);
+    }
+
+    /**
+     * Generate a in-stream DR event which pushes an event buffer to topend
+     */
+    public void generateDREvent(EventType type, long uniqueId, long lastCommittedSpHandle,
+            long spHandle, byte[] payloads) {
+        m_ee.quiesce(lastCommittedSpHandle);
+        ByteBuffer paramBuffer = m_ee.getParamBufferForExecuteTask(32 + payloads.length);
+        paramBuffer.putInt(type.ordinal());
+        paramBuffer.putLong(uniqueId);
+        paramBuffer.putLong(lastCommittedSpHandle);
+        paramBuffer.putLong(spHandle);
+        paramBuffer.putInt(payloads.length);
+        paramBuffer.put(payloads);
+        m_ee.executeTask(TaskType.GENERATE_DR_EVENT, paramBuffer);
     }
 }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -75,6 +75,7 @@ import org.voltdb.VoltProcedure.VoltAbortException;
 import org.voltdb.VoltTable;
 import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Cluster;
+import org.voltdb.catalog.DRCatalogDiffEngine;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Deployment;
 import org.voltdb.catalog.Procedure;
@@ -1393,6 +1394,12 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     public boolean updateCatalog(String diffCmds, CatalogContext context, CatalogSpecificPlanner csp,
             boolean requiresSnapshotIsolationboolean, boolean isMPI)
     {
+        DRCatalogDiffEngine diffEngine = new DRCatalogDiffEngine(m_context.catalog, context.catalog);
+        boolean incompatibleCatalogChange = false;
+        if (!diffEngine.supported()) {
+            incompatibleCatalogChange = true;
+        }
+
         m_context = context;
         m_ee.setBatchTimeout(m_context.cluster.getDeployment().get("deployment").
                 getSystemsettings().get("systemsettings").getQuerytimeout());

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -61,13 +61,27 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         SET_DR_SEQUENCE_NUMBERS(2),
         SET_DR_PROTOCOL_VERSION(3),
         SP_JAVA_GET_DRID_TRACKER(4),
-        SET_DRID_TRACKER(5);
+        SET_DRID_TRACKER(5),
+        GENERATE_DR_EVENT(6);
 
         private TaskType(int taskId) {
             this.taskId = taskId;
         }
 
         public final int taskId;
+    }
+
+    // keep sync with DREventType in ee/src/common/types.h
+    public static enum EventType {
+        NOT_A_EVENT(0),
+        POISON_PILL(1),
+        CATALOG_UPDATE(2);
+
+        private EventType(int typeId) {
+            this.typeId = typeId;
+        }
+
+        public final int typeId;
     }
 
     // is the execution site dirty

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationCatalog.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationCatalog.java
@@ -283,7 +283,10 @@ public class UpdateApplicationCatalog extends VoltSystemProcedure {
                         catalogStuff.getDeploymentHash());
 
                 // update the local catalog.  Safe to do this thanks to the check to get into here.
-                context.updateCatalog(commands, p.getFirst(), p.getSecond(), requiresSnapshotIsolation);
+                long uniqueId = m_runner.getUniqueId();
+                long spHandle = m_runner.getTxnState().getNotice().getSpHandle();
+                context.updateCatalog(commands, p.getFirst(), p.getSecond(),
+                        requiresSnapshotIsolation, uniqueId, spHandle);
 
                 log.debug(String.format("Site %s completed catalog update with catalog hash %s, deployment hash %s%s.",
                         CoreUtils.hsIdToString(m_site.getCorrespondingSiteId()),

--- a/tests/ee/storage/DRTupleStream_test.cpp
+++ b/tests/ee/storage/DRTupleStream_test.cpp
@@ -122,7 +122,7 @@ public:
         currentSpHandle = addPartitionId(currentSpHandle);
         // append into the buffer
         return m_wrapper.appendTuple(lastCommittedSpHandle, tableHandle, 0, currentSpHandle,
-                               currentSpHandle, currentSpHandle, *m_tuple, type);
+                               currentSpHandle, *m_tuple, type);
     }
 
     virtual ~DRTupleStreamTest() {


### PR DESCRIPTION
The best order to review those changes is

Producer Side:
Site.java::updateCatalog() -> generatedDRCatalogChangeEvent() -> VoltDBEngine.cpp::VoltDBEngine::executeTask()->DRTupleStream.cpp::generateDRCatalogChangeEvent()->PartitionDRGatewayImpl.java:: onBinaryDR()->DRProducerConnectionInterface.java::prepareForDispatch()

Consumer Side:
AbstractDRPartitionReceiver.java::processBuffer()->preprocessBuffer() in both syncSnapshot and normal buffer receiver -> handleInbandDREvent()

Also, this patch includes removal of an unused parameter in generate DR log path, removal the old out-of-band CATALOG_UPDATE event.