### PR TITLE
Work around some ExpressionLike optimisations.

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLike.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLike.java
@@ -72,7 +72,6 @@ public final class ExpressionLike extends ExpressionLogical {
 
         this.nodes      = other.nodes;
         this.likeObject = other.likeObject;
-        this.noOptimisation = true;
     }
 
     @Override
@@ -234,7 +233,7 @@ public final class ExpressionLike extends ExpressionLogical {
             /*
              * Can guarantee this won't work with an escape in the EE
              */
-            if (nodes.length > 2) {
+            if (hasEscape()) {
                 throw new RuntimeException("Like with an escape is not supported in parameterized queries");
             }
             return;
@@ -303,7 +302,7 @@ public final class ExpressionLike extends ExpressionLogical {
                 /*
                  * Escape is not supported in the EE yet
                  */
-                if (nodes.length > 2) {
+                if (hasEscape()) {
                     throw new RuntimeException("Like with an escape is not supported unless it is prefix like");
                 }
                 return;
@@ -338,7 +337,7 @@ public final class ExpressionLike extends ExpressionLogical {
                 /*
                  * Escape is not supported in the EE yet
                  */
-                if (nodes.length > 2) {
+                if (hasEscape()) {
                     throw new RuntimeException("Like with an escape is not supported unless it is prefix like");
                 }
                 nodes        = new Expression[BINARY];
@@ -363,7 +362,7 @@ public final class ExpressionLike extends ExpressionLogical {
                 /*
                  * Escape is not supported in the EE yet
                  */
-                if (nodes.length > 2) {
+                if (hasEscape()) {
                     throw new RuntimeException("Like with an escape is not supported unless it is prefix like");
                 }
             }

--- a/tests/frontend/org/voltdb/planner/TestFunctions.java
+++ b/tests/frontend/org/voltdb/planner/TestFunctions.java
@@ -121,4 +121,8 @@ public class TestFunctions extends PlannerTestCase {
         failToCompile("select BIT_SHIFT_RIGHT(BIGINT_TYPE)from bit", errorMsg);
 
     }
+
+    public void testLikeNoopt() {
+        compile("select case when varchar_type like 'M%' then 1 end as m_state from bit;");
+    }
 }

--- a/tests/frontend/org/voltdb/planner/TestFunctions.java
+++ b/tests/frontend/org/voltdb/planner/TestFunctions.java
@@ -124,5 +124,6 @@ public class TestFunctions extends PlannerTestCase {
 
     public void testLikeNoopt() {
         compile("select case when varchar_type like 'M%' then 1 end as m_state from bit;");
+        compile("select case when varchar_type like '_%' then 1 end as m_state from bit;");
     }
 }


### PR DESCRIPTION
ExpressionLike is optimized at one point to change some cases to be
ordinary boolean expressions.  However, the logic for resolving
expression types was not updated to look for these boolean expressions,
and still expected operands to be string expressions.  The resulting
confusion caused unexpected HSQL parsing errors, and therefore planning
errors.

We currently do the computation in a slightly different order.  When the
optimization is done in HSQL, we set the types of the operands, and then
no further resolution is required.

https://issues.voltdb.com/browse/ENG-10016