### PR TITLE
Fix issue with materialized views and alter table

### DIFF
--- a/src/ee/storage/TableCatalogDelegate.hpp
+++ b/src/ee/storage/TableCatalogDelegate.hpp
@@ -73,10 +73,6 @@ class TableCatalogDelegate {
                              catalog::Table const &catalogTable,
                              std::map<std::string, TableCatalogDelegate*> const &tablesByName);
 
-    static void migrateChangedTuples(catalog::Table const &catalogTable,
-                                     voltdb::PersistentTable* existingTable,
-                                     voltdb::PersistentTable* newTable);
-
     static TupleSchema *createTupleSchema(catalog::Database const &catalogDatabase,
                                           catalog::Table const &catalogTable);
 


### PR DESCRIPTION
This was a bug in which we saw assertion failures when instantiating an index scan executor in the EE, because the required index seemed to be missing.

This issue happened because a materialized view had a "fallback executor vector" which was being instantiated from the catalog JSON while a schema change was in progress (add or drop column).  At this time, the TableCatalogDelegate pointed to the stale, existing table which had already had its indexes removed (and recreated on the new table).

The fix was to set the table referred to by the TableCatalogDelegate to the new table before migrating the views.

The first commit has the actual behavior-changing modifications that I made, and in the second commit I just moved some methods around for the sake of consistency with other functions in the file.