### PR TITLE
ENG-10135: DR small table truncation

### DIFF
--- a/src/ee/stats/StatsAgent.cpp
+++ b/src/ee/stats/StatsAgent.cpp
@@ -107,7 +107,7 @@ Table* StatsAgent::getStats(StatisticsSelectorType sst,
         m_statsTablesByStatsSelector[sst] = statsTable;
     }
 
-    statsTable->deleteAllTuples(false);
+    statsTable->deleteAllTuples(false, false);
 
     for (int ii = 0; ii < catalogIds.size(); ii++) {
         multimap<CatalogId, StatsSource*>::const_iterator iter;

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -401,28 +401,28 @@ bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, 
     }
 
     if (existingMetaTableForDelete.get()) {
-        existingMetaTableForDelete.get()->deleteAllTuples(true);
+        existingMetaTableForDelete.get()->deleteAllTuples(true, false);
     }
     if (existingTupleTableForDelete.get()) {
-        existingTupleTableForDelete.get()->deleteAllTuples(true);
+        existingTupleTableForDelete.get()->deleteAllTuples(true, false);
     }
     if (expectedMetaTableForDelete.get()) {
-        expectedMetaTableForDelete.get()->deleteAllTuples(true);
+        expectedMetaTableForDelete.get()->deleteAllTuples(true, false);
     }
     if (expectedTupleTableForDelete.get()) {
-        expectedTupleTableForDelete.get()->deleteAllTuples(true);
+        expectedTupleTableForDelete.get()->deleteAllTuples(true, false);
     }
     if (existingMetaTableForInsert.get()) {
-        existingMetaTableForInsert.get()->deleteAllTuples(true);
+        existingMetaTableForInsert.get()->deleteAllTuples(true, false);
     }
     if (existingTupleTableForInsert.get()) {
-        existingTupleTableForInsert.get()->deleteAllTuples(true);
+        existingTupleTableForInsert.get()->deleteAllTuples(true, false);
     }
     if (newMetaTableForInsert.get()) {
-        newMetaTableForInsert.get()->deleteAllTuples(true);
+        newMetaTableForInsert.get()->deleteAllTuples(true, false);
     }
     if (newTupleTableForInsert.get()) {
-        newTupleTableForInsert.get()->deleteAllTuples(true);
+        newTupleTableForInsert.get()->deleteAllTuples(true, false);
     }
 
     return true;

--- a/src/ee/storage/CompatibleBinaryLogSink.cpp
+++ b/src/ee/storage/CompatibleBinaryLogSink.cpp
@@ -429,28 +429,28 @@ bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, 
     }
 
     if (existingMetaTableForDelete.get()) {
-        existingMetaTableForDelete.get()->deleteAllTuples(true);
+        existingMetaTableForDelete.get()->deleteAllTuples(true, false);
     }
     if (existingTupleTableForDelete.get()) {
-        existingTupleTableForDelete.get()->deleteAllTuples(true);
+        existingTupleTableForDelete.get()->deleteAllTuples(true, false);
     }
     if (expectedMetaTableForDelete.get()) {
-        expectedMetaTableForDelete.get()->deleteAllTuples(true);
+        expectedMetaTableForDelete.get()->deleteAllTuples(true, false);
     }
     if (expectedTupleTableForDelete.get()) {
-        expectedTupleTableForDelete.get()->deleteAllTuples(true);
+        expectedTupleTableForDelete.get()->deleteAllTuples(true, false);
     }
     if (existingMetaTableForInsert.get()) {
-        existingMetaTableForInsert.get()->deleteAllTuples(true);
+        existingMetaTableForInsert.get()->deleteAllTuples(true, false);
     }
     if (existingTupleTableForInsert.get()) {
-        existingTupleTableForInsert.get()->deleteAllTuples(true);
+        existingTupleTableForInsert.get()->deleteAllTuples(true, false);
     }
     if (newMetaTableForInsert.get()) {
-        newMetaTableForInsert.get()->deleteAllTuples(true);
+        newMetaTableForInsert.get()->deleteAllTuples(true, false);
     }
     if (newTupleTableForInsert.get()) {
-        newTupleTableForInsert.get()->deleteAllTuples(true);
+        newTupleTableForInsert.get()->deleteAllTuples(true, false);
     }
 
     return true;

--- a/src/ee/storage/DRTupleStreamUndoAction.h
+++ b/src/ee/storage/DRTupleStreamUndoAction.h
@@ -1,0 +1,49 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DRTUPLESTREAMUNDOACTION_H
+#define DRTUPLESTREAMUNDOACTION_H
+
+#include "common/UndoAction.h"
+
+namespace voltdb {
+
+class DRTupleStreamUndoAction : public voltdb::UndoAction {
+public:
+DRTupleStreamUndoAction(AbstractDRTupleStream *stream, size_t mark, size_t cost)
+    : m_stream(stream), m_mark(mark), m_cost(cost)
+    {
+    }
+
+    void undo() {
+        if (m_stream) {
+            m_stream->rollbackTo(m_mark, m_cost);
+        }
+    }
+
+    void release() {
+    }
+
+private:
+    AbstractDRTupleStream *m_stream;
+    size_t m_mark;
+    size_t m_cost;
+};
+
+}
+
+#endif

--- a/src/ee/storage/PersistentTableUndoDeleteAction.h
+++ b/src/ee/storage/PersistentTableUndoDeleteAction.h
@@ -27,8 +27,8 @@ namespace voltdb {
 
 class PersistentTableUndoDeleteAction: public UndoAction {
 public:
-    inline PersistentTableUndoDeleteAction(char *deletedTuple, PersistentTableSurgeon *table, size_t drMark)
-        : m_tuple(deletedTuple), m_table(table), m_drMark(drMark)
+    inline PersistentTableUndoDeleteAction(char *deletedTuple, PersistentTableSurgeon *table)
+        : m_tuple(deletedTuple), m_table(table)
     {}
 
 private:
@@ -39,7 +39,6 @@ private:
      */
     virtual void undo() {
         m_table->insertTupleForUndo(m_tuple);
-        m_table->DRRollback(m_drMark, rowCostForDRRecord(DR_RECORD_DELETE));
     }
 
     /*
@@ -51,7 +50,6 @@ private:
 private:
     char *m_tuple;
     PersistentTableSurgeon *m_table;
-    size_t m_drMark;
 };
 
 }

--- a/src/ee/storage/PersistentTableUndoInsertAction.h
+++ b/src/ee/storage/PersistentTableUndoInsertAction.h
@@ -28,9 +28,8 @@ namespace voltdb {
 class PersistentTableUndoInsertAction: public voltdb::UndoAction {
 public:
     inline PersistentTableUndoInsertAction(char* insertedTuple,
-                                           voltdb::PersistentTableSurgeon *table,
-                                           size_t drMark)
-        : m_tuple(insertedTuple), m_table(table), m_drMark(drMark)
+                                           voltdb::PersistentTableSurgeon *table)
+        : m_tuple(insertedTuple), m_table(table)
     { }
 
     virtual ~PersistentTableUndoInsertAction() { }
@@ -40,7 +39,6 @@ public:
      */
     virtual void undo() {
         m_table->deleteTupleForUndo(m_tuple);
-        m_table->DRRollback(m_drMark, rowCostForDRRecord(DR_RECORD_INSERT));
     }
 
     /*
@@ -51,7 +49,6 @@ public:
 private:
     char* m_tuple;
     PersistentTableSurgeon *m_table;
-    size_t m_drMark;
 };
 
 }

--- a/src/ee/storage/PersistentTableUndoTruncateTableAction.h
+++ b/src/ee/storage/PersistentTableUndoTruncateTableAction.h
@@ -26,10 +26,8 @@ namespace voltdb {
 class PersistentTableUndoTruncateTableAction: public UndoAction {
 public:
     inline PersistentTableUndoTruncateTableAction(VoltDBEngine * engine, TableCatalogDelegate * tcd,
-            PersistentTable *originalTable, PersistentTable *emptyTable,
-            PersistentTableSurgeon *emptyTableSurgeon, size_t drMark)
-    :  m_engine(engine), m_tcd(tcd), m_originalTable(originalTable), m_emptyTable(emptyTable),
-       m_emptyTableSurgeon(emptyTableSurgeon), m_drMark(drMark)
+            PersistentTable *originalTable, PersistentTable *emptyTable)
+    :  m_engine(engine), m_tcd(tcd), m_originalTable(originalTable), m_emptyTable(emptyTable)
     {}
 
 private:
@@ -41,7 +39,6 @@ private:
      *
      */
     virtual void undo() {
-        m_emptyTableSurgeon->DRRollback(m_drMark, rowCostForDRRecord(DR_RECORD_TRUNCATE_TABLE));
         m_emptyTable->truncateTableForUndo(m_engine, m_tcd, m_originalTable);
     }
 
@@ -64,8 +61,6 @@ private:
     TableCatalogDelegate * m_tcd;
     PersistentTable *m_originalTable;
     PersistentTable *m_emptyTable;
-    PersistentTableSurgeon *m_emptyTableSurgeon;
-    size_t m_drMark;
 };
 
 }

--- a/src/ee/storage/PersistentTableUndoUpdateAction.h
+++ b/src/ee/storage/PersistentTableUndoUpdateAction.h
@@ -30,10 +30,10 @@ public:
 
     inline PersistentTableUndoUpdateAction(char* oldTuple, char* newTuple,
                                            std::vector<char*> const & oldObjects, std::vector<char*> const & newObjects,
-                                           PersistentTableSurgeon *table, bool revertIndexes, size_t drMark)
+                                           PersistentTableSurgeon *table, bool revertIndexes)
       : m_oldTuple(oldTuple), m_newTuple(newTuple),
         m_table(table), m_revertIndexes(revertIndexes),
-        m_oldUninlineableColumns(oldObjects), m_newUninlineableColumns(newObjects), m_drMark(drMark)
+        m_oldUninlineableColumns(oldObjects), m_newUninlineableColumns(newObjects)
     { }
 
     /*
@@ -45,7 +45,6 @@ public:
     {
         m_table->updateTupleForUndo(m_newTuple, m_oldTuple, m_revertIndexes);
         NValue::freeObjectsFromTupleStorage(m_newUninlineableColumns);
-        m_table->DRRollback(m_drMark, rowCostForDRRecord(DR_RECORD_UPDATE));
     }
 
     /*
@@ -64,7 +63,6 @@ private:
     bool const m_revertIndexes;
     std::vector<char*> const m_oldUninlineableColumns;
     std::vector<char*> const m_newUninlineableColumns;
-    size_t const m_drMark;
 };
 
 }

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -78,6 +78,7 @@
 #include "storage/PersistentTableUndoDeleteAction.h"
 #include "storage/PersistentTableUndoTruncateTableAction.h"
 #include "storage/PersistentTableUndoUpdateAction.h"
+#include "storage/DRTupleStreamUndoAction.h"
 #include "storage/ConstraintFailureException.h"
 #include "storage/TupleStreamException.h"
 #include "storage/CopyOnWriteContext.h"
@@ -253,12 +254,31 @@ void PersistentTable::nextFreeTuple(TableTuple *tuple) {
     }
 }
 
-void PersistentTable::deleteAllTuples(bool freeAllocatedStrings) {
+void PersistentTable::deleteAllTuples(bool freeAllocatedStrings, bool fallible) {
+    // Instead of recording each tuple deletion, log it as a table truncation DR.
+    ExecutorContext *ec = ExecutorContext::getExecutorContext();
+    AbstractDRTupleStream *drStream = getDRTupleStream(ec);
+    if (drStream && !m_isMaterialized && m_drEnabled) {
+        const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
+        const int64_t currentSpHandle = ec->currentSpHandle();
+        const int64_t currentUniqueId = ec->currentUniqueId();
+        size_t drMark = drStream->truncateTable(lastCommittedSpHandle, m_signature, m_name, m_partitionColumn, currentSpHandle, currentUniqueId);
+
+        UndoQuantum *uq = ExecutorContext::currentUndoQuantum();
+        if (uq && fallible) {
+            uq->registerUndoAction(new (*uq) DRTupleStreamUndoAction(drStream, drMark, rowCostForDRRecord(DR_RECORD_TRUNCATE_TABLE)));
+        }
+    }
+
+    // Temporarily disable DR binary logging so that it doesn't record the
+    // individual deletions below.
+    DRTupleStreamDisableGuard drGuard(ec, false);
+
     // nothing interesting
     TableIterator ti(this, m_data.begin());
     TableTuple tuple(m_schema);
     while (ti.next(tuple)) {
-        deleteTuple(tuple, true);
+        deleteTuple(tuple, fallible);
     }
 }
 
@@ -347,7 +367,7 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
         const double blockLoadFactor = m_data.begin().data()->loadFactor();
         if ((blockLoadFactor <= tableLFCutoffForTrunc) ||
             (m_views.size() > 0 && blockLoadFactor <= tableWithViewsLFCutoffForTrunc)) {
-            return deleteAllTuples(true);
+            return deleteAllTuples(true, fallible);
         }
     }
     //For MAT view dont optimize needs more work.
@@ -400,13 +420,17 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
 
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
     AbstractDRTupleStream *drStream = getDRTupleStream(ec);
-    size_t drMark = INVALID_DR_MARK;
     if (drStream && !m_isMaterialized && m_drEnabled) {
         const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
         const int64_t currentSpHandle = ec->currentSpHandle();
         const int64_t currentUniqueId = ec->currentUniqueId();
-        drMark = drStream->truncateTable(lastCommittedSpHandle, m_signature, m_name, m_partitionColumn,
-                                         currentSpHandle, currentUniqueId);
+        size_t drMark = drStream->truncateTable(lastCommittedSpHandle, m_signature, m_name, m_partitionColumn,
+                                                currentSpHandle, currentUniqueId);
+
+        UndoQuantum *uq = ExecutorContext::currentUndoQuantum();
+        if (uq && fallible) {
+            uq->registerUndoAction(new (*uq) DRTupleStreamUndoAction(drStream, drMark, rowCostForDRRecord(DR_RECORD_TRUNCATE_TABLE)));
+        }
     }
 
     UndoQuantum *uq = ExecutorContext::currentUndoQuantum();
@@ -419,7 +443,7 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
         emptyTable->m_tuplesPinnedByUndo = emptyTable->m_tupleCount;
         emptyTable->m_invisibleTuplesPendingDeleteCount = emptyTable->m_tupleCount;
         // Create and register an undo action.
-        uq->registerUndoAction(new (*uq) PersistentTableUndoTruncateTableAction(engine, tcd, this, emptyTable, &m_surgeon, drMark));
+        uq->registerUndoAction(new (*uq) PersistentTableUndoTruncateTableAction(engine, tcd, this, emptyTable));
     } else {
         if (fallible) {
             throwFatalException("Attempted to truncate table %s when there was no "
@@ -508,14 +532,18 @@ void PersistentTable::insertTupleCommon(TableTuple &source, TableTuple &target, 
     }
 
     AbstractDRTupleStream *drStream = getDRTupleStream(ec);
-    size_t drMark = INVALID_DR_MARK;
     if (drStream && !m_isMaterialized && m_drEnabled && shouldDRStream) {
         ExecutorContext *ec = ExecutorContext::getExecutorContext();
         const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
         const int64_t currentSpHandle = ec->currentSpHandle();
         const int64_t currentUniqueId = ec->currentUniqueId();
-        drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, m_partitionColumn, currentSpHandle,
-                                       currentUniqueId, target, DR_RECORD_INSERT);
+        size_t drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, m_partitionColumn, currentSpHandle,
+                                              currentUniqueId, target, DR_RECORD_INSERT);
+
+        UndoQuantum *uq = ExecutorContext::currentUndoQuantum();
+        if (uq && fallible) {
+            uq->registerUndoAction(new (*uq) DRTupleStreamUndoAction(drStream, drMark, rowCostForDRRecord(DR_RECORD_INSERT)));
+        }
     }
 
     if (m_schema->getUninlinedObjectColumnCount() != 0) {
@@ -540,8 +568,6 @@ void PersistentTable::insertTupleCommon(TableTuple &source, TableTuple &target, 
     TableTuple conflict(m_schema);
     tryInsertOnAllIndexes(&target, &conflict);
     if (!conflict.isNullTuple()) {
-        // Roll the DR stream back because the undo action is not registered
-        m_surgeon.DRRollback(drMark, rowCostForDRRecord(DR_RECORD_INSERT));
         throw ConstraintFailureException(this, source, conflict, CONSTRAINT_TYPE_UNIQUE);
     }
 
@@ -557,7 +583,7 @@ void PersistentTable::insertTupleCommon(TableTuple &source, TableTuple &target, 
             //* enable for debug */ std::cout << "DEBUG: inserting " << (void*)target.address()
             //* enable for debug */           << " { " << target.debugNoHeader() << " } "
             //* enable for debug */           << " copied to " << (void*)tupleData << std::endl;
-            uq->registerUndoAction(new (*uq) PersistentTableUndoInsertAction(tupleData, &m_surgeon, drMark));
+            uq->registerUndoAction(new (*uq) PersistentTableUndoInsertAction(tupleData, &m_surgeon));
         }
     }
 
@@ -652,14 +678,18 @@ void PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUp
     }
 
     AbstractDRTupleStream *drStream = getDRTupleStream(ec);
-    size_t drMark = INVALID_DR_MARK;
     if (drStream && !m_isMaterialized && m_drEnabled) {
         ExecutorContext *ec = ExecutorContext::getExecutorContext();
         const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
         const int64_t currentSpHandle = ec->currentSpHandle();
         const int64_t currentUniqueId = ec->currentUniqueId();
-        drMark = drStream->appendUpdateRecord(lastCommittedSpHandle, m_signature, m_partitionColumn, currentSpHandle,
-                                              currentUniqueId, targetTupleToUpdate, sourceTupleWithNewValues);
+        size_t drMark = drStream->appendUpdateRecord(lastCommittedSpHandle, m_signature, m_partitionColumn, currentSpHandle,
+                                                     currentUniqueId, targetTupleToUpdate, sourceTupleWithNewValues);
+
+        UndoQuantum *uq = ExecutorContext::currentUndoQuantum();
+        if (uq && fallible) {
+            uq->registerUndoAction(new (*uq) DRTupleStreamUndoAction(drStream, drMark, rowCostForDRRecord(DR_RECORD_UPDATE)));
+        }
     }
 
     if (m_tableStreamer != NULL) {
@@ -735,8 +765,7 @@ void PersistentTable::updateTupleWithSpecificIndexes(TableTuple &targetTupleToUp
         char* newTupleData = uq->allocatePooledCopy(targetTupleToUpdate.address(), tupleLength);
         uq->registerUndoAction(new (*uq) PersistentTableUndoUpdateAction(oldTupleData, newTupleData,
                                                                          oldObjects, newObjects,
-                                                                         &m_surgeon, someIndexGotUpdated,
-                                                                         drMark));
+                                                                         &m_surgeon, someIndexGotUpdated));
     } else {
         // This is normally handled by the Undo Action's release (i.e. when there IS an Undo Action)
         // -- though maybe even that case should delegate memory management back to the PersistentTable
@@ -841,13 +870,17 @@ bool PersistentTable::deleteTuple(TableTuple &target, bool fallible) {
     // be left forgotten in case this throws.
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
     AbstractDRTupleStream *drStream = getDRTupleStream(ec);
-    size_t drMark = INVALID_DR_MARK;
     if (drStream && !m_isMaterialized && m_drEnabled) {
         const int64_t lastCommittedSpHandle = ec->lastCommittedSpHandle();
         const int64_t currentSpHandle = ec->currentSpHandle();
         const int64_t currentUniqueId = ec->currentUniqueId();
-        drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, m_partitionColumn, currentSpHandle,
-                                       currentUniqueId, target, DR_RECORD_DELETE);
+        size_t drMark = drStream->appendTuple(lastCommittedSpHandle, m_signature, m_partitionColumn, currentSpHandle,
+                                              currentUniqueId, target, DR_RECORD_DELETE);
+
+        UndoQuantum *uq = ExecutorContext::currentUndoQuantum();
+        if (uq && fallible) {
+            uq->registerUndoAction(new (*uq) DRTupleStreamUndoAction(drStream, drMark, rowCostForDRRecord(DR_RECORD_DELETE)));
+        }
     }
 
     // Just like insert, we want to remove this tuple from all of our indexes
@@ -868,7 +901,7 @@ bool PersistentTable::deleteTuple(TableTuple &target, bool fallible) {
             m_tuplesPinnedByUndo++;
             ++m_invisibleTuplesPendingDeleteCount;
             // Create and register an undo action.
-            uq->registerUndoAction(new (*uq) PersistentTableUndoDeleteAction(target.address(), &m_surgeon, drMark), this);
+            uq->registerUndoAction(new (*uq) PersistentTableUndoDeleteAction(target.address(), &m_surgeon), this);
             return true;
         }
     }

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -138,7 +138,6 @@ public:
     void activateSnapshot();
     void printIndex(std::ostream &os, int32_t limit) const;
     ElasticHash generateTupleHash(TableTuple &tuple) const;
-    void DRRollback(size_t drMark, size_t drRowCost);
 
 private:
 
@@ -247,7 +246,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     // ------------------------------------------------------------------
     // GENERIC TABLE OPERATIONS
     // ------------------------------------------------------------------
-    virtual void deleteAllTuples(bool freeAllocatedStrings);
+    virtual void deleteAllTuples(bool freeAllocatedStrings, bool fallible = true);
 
     virtual void truncateTable(VoltDBEngine* engine, bool fallible = true);
     // The fallible flag is used to denote a change to a persistent table
@@ -884,19 +883,6 @@ PersistentTableSurgeon::getIndexTupleRangeIterator(const ElasticIndexHashRange &
     assert(m_table.m_schema != NULL);
     return boost::shared_ptr<ElasticIndexTupleRangeIterator>(
             new ElasticIndexTupleRangeIterator(*m_index, *m_table.m_schema, range));
-}
-
-inline void
-PersistentTableSurgeon::DRRollback(size_t drMark, size_t drRowCost) {
-    if (!m_table.m_isMaterialized && m_table.m_drEnabled) {
-        if (m_table.m_partitionColumn == -1) {
-            if (ExecutorContext::getExecutorContext()->drReplicatedStream()) {
-                ExecutorContext::getExecutorContext()->drReplicatedStream()->rollbackTo(drMark, drRowCost);
-            }
-        } else {
-            ExecutorContext::getExecutorContext()->drStream()->rollbackTo(drMark, drRowCost);
-        }
-    }
 }
 
 inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block)

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -183,7 +183,7 @@ TableIterator* StreamedTable::makeIterator() {
                                   "May not iterate a streamed table.");
 }
 
-void StreamedTable::deleteAllTuples(bool freeAllocatedStrings)
+void StreamedTable::deleteAllTuples(bool freeAllocatedStrings, bool fallible)
 {
     throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                   "May not delete all tuples of a streamed"

--- a/src/ee/storage/streamedtable.h
+++ b/src/ee/storage/streamedtable.h
@@ -73,7 +73,7 @@ class StreamedTable : public Table {
     // ------------------------------------------------------------------
     // GENERIC TABLE OPERATIONS
     // ------------------------------------------------------------------
-    virtual void deleteAllTuples(bool freeAllocatedStrings);
+    virtual void deleteAllTuples(bool freeAllocatedStrings, bool=true);
     // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
     // The bool argument is irrelevent to StreamedTable.
     virtual bool deleteTuple(TableTuple &tuple, bool=true);

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -125,7 +125,7 @@ class Table {
     // ------------------------------------------------------------------
     // OPERATIONS
     // ------------------------------------------------------------------
-    virtual void deleteAllTuples(bool freeAllocatedStrings) = 0;
+    virtual void deleteAllTuples(bool freeAllocatedStrings, bool fallible=true) = 0;
     // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
     // The fallible flag is used to denote a change to a persistent table
     // which is part of a long transaction that has been vetted and can

--- a/src/ee/storage/temptable.cpp
+++ b/src/ee/storage/temptable.cpp
@@ -64,7 +64,7 @@ TempTable::~TempTable() {}
 // ------------------------------------------------------------------
 // OPERATIONS
 // ------------------------------------------------------------------
-void TempTable::deleteAllTuples(bool freeAllocatedStrings) {
+void TempTable::deleteAllTuples(bool freeAllocatedStrings, bool) {
     deleteAllTuplesNonVirtual(freeAllocatedStrings);
 }
 

--- a/src/ee/storage/temptable.h
+++ b/src/ee/storage/temptable.h
@@ -102,7 +102,7 @@ class TempTable : public Table {
     // ------------------------------------------------------------------
     // GENERIC TABLE OPERATIONS
     // ------------------------------------------------------------------
-    virtual void deleteAllTuples(bool freeAllocatedStrings);
+    virtual void deleteAllTuples(bool freeAllocatedStrings, bool=true);
     // Deleting a tuple from temp table is not supported. use deleteAllTuples instead
     // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
     virtual bool deleteTuple(TableTuple &tuple, bool);

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -1994,6 +1994,30 @@ TEST_F(DRBinaryLogTest, DeleteOverBufferLimit) {
     ASSERT_TRUE(false);
 }
 
+TEST_F(DRBinaryLogTest, TruncateTable) {
+    createIndexes();
+    const int total = 150;
+    int spHandle = 1;
+
+    for (int i = 1; i <= total; i++, spHandle++) {
+        beginTxn(m_engine, spHandle, spHandle, spHandle-1, spHandle);
+        insertTuple(m_table, prepareTempTuple(m_table, 42, i, "349508345.34583", "a thing", "a totally different thing altogether", i));
+        endTxn(m_engine, true);
+    }
+
+    flushAndApply(spHandle - 1);
+    EXPECT_EQ(total, m_table->activeTupleCount());
+    EXPECT_EQ(total, m_tableReplica->activeTupleCount());
+
+    beginTxn(m_engine, spHandle, spHandle, spHandle-1, spHandle);
+    m_table->truncateTable(m_engine);
+    endTxn(m_engine, true);
+
+    flushAndApply(spHandle);
+    EXPECT_EQ(0, m_table->activeTupleCount());
+    EXPECT_EQ(0, m_tableReplica->activeTupleCount());
+}
+
 TEST_F(DRBinaryLogTest, IgnoreTableRowLimit) {
     m_tableReplica->setTupleLimit(100);
 


### PR DESCRIPTION
* An optimization that uses tuple-by-tuple deletion on tables with low number of rows instead table swapping for truncation caused DR to generate a large binary log, sometimes over the 45MB limit. I'm putting a guard around that to prevent it from generating DR delete records in the binary log when it should actually be a truncation record. Regardless of the optimization, it will always generate a single truncation record in the binary log.

* Provide some context when the DR buffer size limit is reached.