### PR TITLE
ENG-10316

### DIFF
--- a/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
+++ b/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
@@ -125,11 +125,10 @@ public class ExtensibleSnapshotDigestData {
                     JSONObject existingEntry = sequenceNumbers.getJSONObject(partitionIdString);
                     Long existingSequenceNumber = existingEntry.getLong("sequenceNumber");
                     if (!existingSequenceNumber.equals(partitionSequenceNumber)) {
-                        log.error("Found a mismatch in export sequence numbers while recording snapshot metadata " +
-                                " for partition " + partitionId +
+                        log.error("Found a mismatch in export sequence numbers of export table " + tableName +
+                                " while recording snapshot metadata for partition " + partitionId +
                                 " the sequence number should be the same at all replicas, but one had " +
-                                existingSequenceNumber
-                                + " and another had " + partitionSequenceNumber);
+                                existingSequenceNumber + " and the local node reported " + partitionSequenceNumber);
                     }
                     existingEntry.put(partitionIdString, Math.max(existingSequenceNumber, partitionSequenceNumber));
 


### PR DESCRIPTION
There is a suspicion that this output comes from replicated export tables (which may not have identical sequence numbers). Add table name to the error message to identify the table that has inconsistent sequence numbers.