### PR TITLE
Eng 8872 block changes

### DIFF
--- a/src/ee/storage/CopyOnWriteIterator.cpp
+++ b/src/ee/storage/CopyOnWriteIterator.cpp
@@ -69,6 +69,10 @@ bool CopyOnWriteIterator::needToDirtyTuple(char *tupleAddress) {
         return false;
     }
 
+    // code will be removed. Not for check-in: for debugging purpose only
+    if (m_currentBlock == NULL) {
+        StackTrace::printStackTrace();
+    }
     assert(m_currentBlock != NULL);
     /**
      * Now check where this is relative to the COWIterator.

--- a/src/ee/storage/CopyOnWriteIterator.cpp
+++ b/src/ee/storage/CopyOnWriteIterator.cpp
@@ -57,10 +57,6 @@ CopyOnWriteIterator::CopyOnWriteIterator(
  * it skiped a dirty tuple and didn't end up with the right found tuple count upon reaching the end.
  */
 bool CopyOnWriteIterator::needToDirtyTuple(char *tupleAddress) {
-    if (m_currentBlock == NULL) {
-        return false;
-    }
-
     /**
      * Find out which block the address is contained in. Lower bound returns the first entry
      * in the index >= the address. Unless the address happens to be equal then the block

--- a/src/ee/storage/CopyOnWriteIterator.cpp
+++ b/src/ee/storage/CopyOnWriteIterator.cpp
@@ -28,6 +28,7 @@ CopyOnWriteIterator::CopyOnWriteIterator(
         m_location(NULL),
         m_blockOffset(0),
         m_currentBlock(NULL),
+        m_emptyTable(false),
         m_skippedDirtyRows(0),
         m_skippedInactiveRows(0) {
 
@@ -36,6 +37,7 @@ CopyOnWriteIterator::CopyOnWriteIterator(
         // has empty tuple storage block associated with it. So no need
         // to set it up for snapshot
         m_blockIterator = m_end;
+        m_emptyTable = true;
         return;
     }
 
@@ -57,6 +59,12 @@ CopyOnWriteIterator::CopyOnWriteIterator(
  * it skiped a dirty tuple and didn't end up with the right found tuple count upon reaching the end.
  */
 bool CopyOnWriteIterator::needToDirtyTuple(char *tupleAddress) {
+    if (m_emptyTable) {
+        // snapshot was activated when the table was empty.
+        // Tuple is not in  snapshot region, don't care about this tuple
+        assert(m_currentBlock == NULL);
+        return false;
+    }
     /**
      * Find out which block the address is contained in. Lower bound returns the first entry
      * in the index >= the address. Unless the address happens to be equal then the block
@@ -69,11 +77,8 @@ bool CopyOnWriteIterator::needToDirtyTuple(char *tupleAddress) {
         return false;
     }
 
-    // code will be removed. Not for check-in: for debugging purpose only
-    if (m_currentBlock == NULL) {
-        StackTrace::printStackTrace();
-    }
     assert(m_currentBlock != NULL);
+
     /**
      * Now check where this is relative to the COWIterator.
      */

--- a/src/ee/storage/CopyOnWriteIterator.cpp
+++ b/src/ee/storage/CopyOnWriteIterator.cpp
@@ -28,7 +28,7 @@ CopyOnWriteIterator::CopyOnWriteIterator(
         m_location(NULL),
         m_blockOffset(0),
         m_currentBlock(NULL),
-        m_emptyTable(false),
+        m_tableEmpty(false),
         m_skippedDirtyRows(0),
         m_skippedInactiveRows(0) {
 
@@ -37,7 +37,7 @@ CopyOnWriteIterator::CopyOnWriteIterator(
         // has empty tuple storage block associated with it. So no need
         // to set it up for snapshot
         m_blockIterator = m_end;
-        m_emptyTable = true;
+        m_tableEmpty = true;
         return;
     }
 
@@ -59,7 +59,7 @@ CopyOnWriteIterator::CopyOnWriteIterator(
  * it skiped a dirty tuple and didn't end up with the right found tuple count upon reaching the end.
  */
 bool CopyOnWriteIterator::needToDirtyTuple(char *tupleAddress) {
-    if (m_emptyTable) {
+    if (m_tableEmpty) {
         // snapshot was activated when the table was empty.
         // Tuple is not in  snapshot region, don't care about this tuple
         assert(m_currentBlock == NULL);

--- a/src/ee/storage/CopyOnWriteIterator.cpp
+++ b/src/ee/storage/CopyOnWriteIterator.cpp
@@ -69,6 +69,7 @@ bool CopyOnWriteIterator::needToDirtyTuple(char *tupleAddress) {
         return false;
     }
 
+    assert(m_currentBlock != NULL);
     /**
      * Now check where this is relative to the COWIterator.
      */

--- a/src/ee/storage/CopyOnWriteIterator.h
+++ b/src/ee/storage/CopyOnWriteIterator.h
@@ -109,7 +109,7 @@ private:
     uint32_t m_blockOffset;
     TBPtr m_currentBlock;
     // flag to track if the snapshot was activated when the table was empty
-    bool m_emptyTable;
+    bool m_tableEmpty;
 public:
     int32_t m_skippedDirtyRows;
     int32_t m_skippedInactiveRows;

--- a/src/ee/storage/CopyOnWriteIterator.h
+++ b/src/ee/storage/CopyOnWriteIterator.h
@@ -108,6 +108,8 @@ private:
 
     uint32_t m_blockOffset;
     TBPtr m_currentBlock;
+    // flag to track if the snapshot was activated when the table was empty
+    bool m_emptyTable;
 public:
     int32_t m_skippedDirtyRows;
     int32_t m_skippedInactiveRows;

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -365,12 +365,12 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
         const double tableWithViewsLFCutoffForTrunc = 0.015416;
 
         const double blockLoadFactor = m_data.begin().data()->loadFactor();
-        if ((m_views.empty() && (blockLoadFactor <= tableWithNoViewLFCutoffForTrunc)) ||    // table with no view
-            (!m_views.empty() && (blockLoadFactor <= tableWithViewsLFCutoffForTrunc))) {    // table with views
+        if ((!m_views.empty() && (blockLoadFactor <= tableWithViewsLFCutoffForTrunc)) ||
+            (blockLoadFactor <= tableWithNoViewLFCutoffForTrunc)) {
             return deleteAllTuples(true, fallible);
         }
     }
-    // For MAT view don't optimize, needs more work.
+    // For MAT view don't optimize, needs more work - ENG-10323.
     if (isMaterialized()) {
         return deleteAllTuples(true);
     }

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -254,7 +254,7 @@ void PersistentTable::nextFreeTuple(TableTuple *tuple) {
     }
 }
 
-void PersistentTable::deleteAllTuples(bool freeAllocatedStrings, bool fallible) {
+void PersistentTable::deleteAllTuples(bool, bool fallible) {
     // Instead of recording each tuple deletion, log it as a table truncation DR.
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
     AbstractDRTupleStream *drStream = getDRTupleStream(ec);

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -246,7 +246,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     // ------------------------------------------------------------------
     // GENERIC TABLE OPERATIONS
     // ------------------------------------------------------------------
-    virtual void deleteAllTuples(bool freeAllocatedStrings, bool fallible = true);
+    virtual void deleteAllTuples(bool, bool fallible = true);
 
     virtual void truncateTable(VoltDBEngine* engine, bool fallible = true);
     // The fallible flag is used to denote a change to a persistent table

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -885,20 +885,6 @@ PersistentTableSurgeon::getIndexTupleRangeIterator(const ElasticIndexHashRange &
             new ElasticIndexTupleRangeIterator(*m_index, *m_table.m_schema, range));
 }
 
-
-inline void
-PersistentTableSurgeon::DRRollback(size_t drMark, size_t drRowCost) {
-    if (!m_table.m_isMaterialized && m_table.m_drEnabled) {
-        if (m_table.m_partitionColumn == -1) {
-            if (ExecutorContext::getExecutorContext()->drReplicatedStream()) {
-                ExecutorContext::getExecutorContext()->drReplicatedStream()->rollbackTo(drMark, drRowCost);
-            }
-        } else {
-            ExecutorContext::getExecutorContext()->drStream()->rollbackTo(drMark, drRowCost);
-        }
-    }
-}
-
 inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block, bool deleteLastEmptyBlock)
 {
     // May not delete an already deleted tuple.

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -599,7 +599,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
      * Normally this will return the tuple storage to the free list.
      * In the memcheck build it will return the storage to the heap.
      */
-    void deleteTupleStorage(TableTuple &tuple, TBPtr block = TBPtr(NULL));
+    void deleteTupleStorage(TableTuple &tuple, TBPtr block = TBPtr(NULL), bool deleteLastEmptyBlock = false);
 
     /*
      * Implemented by persistent table and called by Table::loadTuplesFrom
@@ -885,7 +885,21 @@ PersistentTableSurgeon::getIndexTupleRangeIterator(const ElasticIndexHashRange &
             new ElasticIndexTupleRangeIterator(*m_index, *m_table.m_schema, range));
 }
 
-inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block)
+
+inline void
+PersistentTableSurgeon::DRRollback(size_t drMark, size_t drRowCost) {
+    if (!m_table.m_isMaterialized && m_table.m_drEnabled) {
+        if (m_table.m_partitionColumn == -1) {
+            if (ExecutorContext::getExecutorContext()->drReplicatedStream()) {
+                ExecutorContext::getExecutorContext()->drReplicatedStream()->rollbackTo(drMark, drRowCost);
+            }
+        } else {
+            ExecutorContext::getExecutorContext()->drStream()->rollbackTo(drMark, drRowCost);
+        }
+    }
+}
+
+inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block, bool deleteLastEmptyBlock)
 {
     // May not delete an already deleted tuple.
     assert(tuple.isActive());
@@ -924,22 +938,27 @@ inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block)
             //std::cout << "Swapping block " << static_cast<void*>(block.get()) << " to bucket " << retval << std::endl;
             block->swapToBucket(m_blocksNotPendingSnapshotLoad[retval]);
         //Check if the block goes into the pending snapshot set of buckets
-        } else if (m_blocksPendingSnapshot.find(block) != m_blocksPendingSnapshot.end()) {
+        }
+        else if (m_blocksPendingSnapshot.find(block) != m_blocksPendingSnapshot.end()) {
             block->swapToBucket(m_blocksPendingSnapshotLoad[retval]);
-        } else {
+        }
+        else {
             //In this case the block is actively being snapshotted and isn't eligible for merge operations at all
             //do nothing, once the block is finished by the iterator, the iterator will return it
         }
     }
 
-    if (block->isEmpty()) {
+    if (block->isEmpty() && (m_data.size() > 1 || deleteLastEmptyBlock)) {
+        // Release the empty block unless it's the only remaining block and caller has requested not to do so.
+        // The intent of doing so is to avoid block allocation cost at time tuple insertion into the table
         m_data.erase(block->address());
         m_blocksWithSpace.erase(block);
         m_blocksNotPendingSnapshot.erase(block);
         assert(m_blocksPendingSnapshot.find(block) == m_blocksPendingSnapshot.end());
         //Eliminates circular reference
         block->swapToBucket(TBBucketPtr());
-    } else if (transitioningToBlockWithSpace) {
+    }
+    else if (transitioningToBlockWithSpace) {
         m_blocksWithSpace.insert(block);
     }
 }

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -92,6 +92,16 @@ Table* TableFactory::getPersistentTable(
     // initialize stats for the table
     configureStats(databaseId, name, table);
 
+    if (!exportOnly) {
+        // Allocate and assign the tuple storage block to the persistent table ahead of time instead
+        // of doing so at time of first tuple insertion. The intent of block allocation ahead of time
+        // is to avoid allocation cost at time of tuple insertion
+        PersistentTable *persistentTable = static_cast <PersistentTable*> (table);
+        TBPtr block = persistentTable->allocateNextBlock();
+        assert(block->hasFreeTuples());
+        persistentTable->m_blocksWithSpace.insert(block);
+    }
+
     return table;
 }
 

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -364,7 +364,7 @@ TEST_F(CompactionTest, BasicCompaction) {
         m_table->deleteTuple(tuple, true);
     }
     m_table->doForcedCompaction();
-    ASSERT_EQ( m_table->m_data.size(), 0);
+    ASSERT_EQ( m_table->m_data.size(), 1);
     ASSERT_EQ( m_table->activeTupleCount(), 0);
 }
 
@@ -507,7 +507,7 @@ TEST_F(CompactionTest, CompactionWithCopyOnWrite) {
 
     }
     m_table->doForcedCompaction();
-    ASSERT_EQ( m_table->m_data.size(), 0);
+    ASSERT_EQ( m_table->m_data.size(), 1);
     ASSERT_EQ( m_table->activeTupleCount(), 0);
     for (int ii = 0; ii < tupleCount; ii++) {
         ASSERT_TRUE(COWTuples.find(ii) != COWTuples.end());

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -287,18 +287,23 @@ TEST_F(PersistentTableTest, TruncateTableTest) {
     engine->loadCatalog(0, catalogPayload());
     PersistentTable *table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
     ASSERT_NE(NULL, table);
+    ASSERT_EQ(1, table->allocatedBlockCount());
 
+    beginWork();
     const int tuplesToInsert = 10;
     (void) tuplesToInsert;  // to make compiler happy
-    ASSERT_EQ(1, table->allocatedBlockCount());
     assert(tableutil::addRandomTuples(table, tuplesToInsert));
-    size_t blockCount = table->allocatedBlockCount();
+    commit();
 
+    size_t blockCount = table->allocatedBlockCount();
     table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
     ASSERT_NE(NULL, table);
     ASSERT_EQ(blockCount, table->allocatedBlockCount());
+
+    beginWork();
     assert(tableutil::addRandomTuples(table, tuplesToInsert));
     table->truncateTable(engine);
+    commit();
 
     // refresh table pointer by fetching the table from catalog as in truncate old table
     // gets replaced with new cloned empty table

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -37,7 +37,7 @@
 #include "storage/table.h"
 #include "storage/persistenttable.h"
 #include "storage/tablefactory.h"
-
+#include "storage/tableutil.h"
 
 using voltdb::ExecutorContext;
 using voltdb::NValue;
@@ -51,7 +51,7 @@ using voltdb::VALUE_TYPE_BIGINT;
 using voltdb::VALUE_TYPE_VARCHAR;
 using voltdb::ValueFactory;
 using voltdb::VoltDBEngine;
-
+using voltdb::tableutil;
 
 class PersistentTableTest : public Test {
 public:
@@ -280,6 +280,31 @@ TEST_F(PersistentTableTest, DRTimestampColumn) {
 
         ++i;
     }
+}
+
+TEST_F(PersistentTableTest, TruncateTableTest) {
+    VoltDBEngine* engine = getEngine();
+    engine->loadCatalog(0, catalogPayload());
+    PersistentTable *table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+
+    const int tuplesToInsert = 10;
+    (void) tuplesToInsert;  // to make compiler happy
+    ASSERT_EQ(1, table->allocatedBlockCount());
+    assert(tableutil::addRandomTuples(table, tuplesToInsert));
+    size_t blockCount = table->allocatedBlockCount();
+
+    table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+    ASSERT_EQ(blockCount, table->allocatedBlockCount());
+    assert(tableutil::addRandomTuples(table, tuplesToInsert));
+    table->truncateTable(engine);
+
+    // refresh table pointer by fetching the table from catalog as in truncate old table
+    // gets replaced with new cloned empty table
+    table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+    ASSERT_EQ(1, table->allocatedBlockCount());
 }
 
 int main() {

--- a/tests/frontend/org/voltdb/regressionsuites/TestJoinsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestJoinsSuite.java
@@ -533,7 +533,7 @@ public class TestJoinsSuite extends RegressionSuite {
         // R2 3rd joined with R3 null
         // R2 4th joined with R3 null
         VoltTable result = client.callProcedure(
-                "@AdHoc", "select * FROM R2 LEFT JOIN R3 ON R3.A = R2.A")
+                "@AdHoc", "select * FROM R2 LEFT JOIN R3 ON R3.A = R2.A order by R2.A")
                                  .getResults()[0];
         VoltTableRow row = result.fetchRow(2);
         assertEquals(3, row.getLong(1));
@@ -618,13 +618,17 @@ public class TestJoinsSuite extends RegressionSuite {
                 "@AdHoc", "select * FROM R3 RIGHT JOIN R2 ON R3.A = R2.A WHERE R3.A IS NULL")
                                  .getResults()[0];
         System.out.println(result.toString());
-        if ( ! isHSQL()) assertEquals(2, result.getRowCount()); //// PENDING HSQL flaw investigation
+        if ( ! isHSQL()) {
+            assertEquals(2, result.getRowCount()); //// PENDING HSQL flaw investigation
+        }
         // Same as above but with partitioned table
         result = client.callProcedure(
                 "@AdHoc", "select * FROM R3 RIGHT JOIN P2 ON R3.A = P2.A WHERE R3.A IS NULL")
                                  .getResults()[0];
         System.out.println(result.toString());
-        if ( ! isHSQL())  assertEquals(2, result.getRowCount()); //// PENDING HSQL flaw investigation
+        if ( ! isHSQL()) {
+            assertEquals(2, result.getRowCount()); //// PENDING HSQL flaw investigation
+        }
 
         // R2 1st eliminated by R2.C < 0
         // R2 2nd eliminated by R2.C < 0


### PR DESCRIPTION
- Update persistent table logic to allocate tuple storage block to table on table creation. Don't release the only remaining tuple storage block back to system during truncate or delete operation. This will prevent persistent table to request fresh tuple storage block on next row insertion into empty table. 
- Updated snapshot save logic so that when system is performing snapshot save, it takes into account the persistent table can contain empty tuple storage