### PR TITLE
Parse dates better in sqlcmd.

### DIFF
--- a/src/frontend/org/voltdb/ParameterConverter.java
+++ b/src/frontend/org/voltdb/ParameterConverter.java
@@ -415,7 +415,7 @@ public class ParameterConverter {
                     // Defer errors to the generic Exception throw below, if it's not the right format
                 }
                 try {
-                    return new TimestampType(timestring);
+                    return SQLParser.parseDate(timestring);
                 }
                 catch (IllegalArgumentException e) {
                     // Defer errors to the generic Exception throw below, if it's not the right format

--- a/tests/frontend/org/voltdb/types/TestDateParsing.java
+++ b/tests/frontend/org/voltdb/types/TestDateParsing.java
@@ -1,0 +1,133 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */package org.voltdb.types;
+
+import java.util.Calendar;
+
+import org.voltdb.parser.SQLParser;
+
+import junit.framework.TestCase;
+
+public class TestDateParsing extends TestCase {
+    private void validateCalendar(Calendar now,
+                                  int  year,
+                                  int  month,
+                                  int  dom,
+                                  int  hour,
+                                  int  minute,
+                                  int  second,
+                                  int  millis) {
+        assertEquals(year, now.get(Calendar.YEAR));
+        // Month is zero origin.
+        assertEquals("Month:",        month-1, now.get(Calendar.MONTH));
+        assertEquals("Day of Month:", dom, now.get(Calendar.DATE));
+        assertEquals("Hour:",         hour, now.get(Calendar.HOUR));
+        assertEquals("Minute:",       minute, now.get(Calendar.MINUTE));
+        assertEquals("Second:",       second, now.get(Calendar.SECOND));
+        // We assert that we use microseconds, but we really
+        // only get milliseconds.
+        assertEquals(millis, now.get(Calendar.MILLISECOND));
+    }
+
+    public void validateMicrosecondTime(long timestamp,
+                                        int  year,
+                                        int  month,
+                                        int  dom,
+                                        int  hour,
+                                        int  minute,
+                                        int  second,
+                                        int  fractionalMicroSeconds) {
+        long usec = timestamp % 1000000;
+        long seconds = timestamp / 1000000;
+        Calendar now = Calendar.getInstance();
+        now.setTimeInMillis(seconds * 1000);
+        validateCalendar(now, year, month, dom, hour, minute, second, 0);
+        assertEquals(fractionalMicroSeconds, usec);
+    }
+
+    public long parseDate(String dateString)  {
+        return SQLParser.parseDate(dateString).getTime();
+    }
+
+    public void parseDateFails(String dateString) {
+        try {
+            parseDate(dateString);
+            assertFalse("Expected a date parsing error.", true);
+        } catch (IllegalArgumentException ex) {
+            assertTrue(true);
+        }
+    }
+
+    public void testDateParsing() {
+        TimestampType timestamp;
+        timestamp = SQLParser.parseDate("2016-05-11 10:11:12.123");
+        validateMicrosecondTime(timestamp.getTime(), 2016, 05, 11, 10, 11, 12, 123000);
+
+        timestamp = SQLParser.parseDate("2016-05-11 10:11:12.12");
+        validateMicrosecondTime(timestamp.getTime(), 2016, 05, 11, 10, 11, 12, 120000);
+
+        timestamp = SQLParser.parseDate("2016-05-11 10:11:12.1");
+        validateMicrosecondTime(timestamp.getTime(), 2016, 05, 11, 10, 11, 12, 100000);
+
+        timestamp = SQLParser.parseDate("2016-05-11 10:11:12");
+        validateMicrosecondTime(timestamp.getTime(), 2016, 05, 11, 10, 11, 12, 0);
+
+        timestamp = SQLParser.parseDate("2016-05-11");
+        validateMicrosecondTime(timestamp.getTime(), 2016, 05, 11, 0, 0, 0, 0);
+
+        parseDateFails("20016-05-11");
+        parseDateFails("16-05-11");
+        // The month and day may only have 2 digits, not 1, and not
+        // more than one.
+        parseDateFails("2016-1-10");
+        parseDateFails("2016-100-10");
+        parseDateFails("2016-10-1");
+        parseDateFails("2016-10-100");
+        // The fractional seconds may have 1 through 6 digits but no more and no less.
+        parseDateFails("2016-10-11 10:10:10.123456789");
+        parseDateFails("2016-10-11 10:10:10.");
+        // Tab characters are right out.
+        parseDateFails("2016-10-11\t10:10:10.123456");
+        // Only one fractional seconds field.
+        parseDateFails("2016-10-11 10:10:10.123.456");
+    }
+}

--- a/tests/sqlcmd/baselines/simple/parsedates.errbaseline
+++ b/tests/sqlcmd/baselines/simple/parsedates.errbaseline
@@ -1,0 +1,10 @@
+Unexpected Ad Hoc Planning Error: java.lang.RuntimeException: Error compiling query: org.voltdb.VoltTypeException: tryToMakeCompatible: The provided value: (20150-11-11 10:10:10) of type: java.lang.String is not a match or is out of range for the target parameter type: org.voltdb.types.TimestampType (Stack trace has been written to the log.)
+Unexpected Ad Hoc Planning Error: java.lang.RuntimeException: Error compiling query: org.voltdb.VoltTypeException: tryToMakeCompatible: The provided value: (201-11-11 10:10:10) of type: java.lang.String is not a match or is out of range for the target parameter type: org.voltdb.types.TimestampType (Stack trace has been written to the log.)
+Unexpected Ad Hoc Planning Error: java.lang.RuntimeException: Error compiling query: org.voltdb.VoltTypeException: tryToMakeCompatible: The provided value: (2015-111-11 10:10:10) of type: java.lang.String is not a match or is out of range for the target parameter type: org.voltdb.types.TimestampType (Stack trace has been written to the log.)
+Unexpected Ad Hoc Planning Error: java.lang.RuntimeException: Error compiling query: org.voltdb.VoltTypeException: tryToMakeCompatible: The provided value: (2015-11-111 10:10:10) of type: java.lang.String is not a match or is out of range for the target parameter type: org.voltdb.types.TimestampType (Stack trace has been written to the log.)
+Unexpected Ad Hoc Planning Error: java.lang.RuntimeException: Error compiling query: org.voltdb.VoltTypeException: tryToMakeCompatible: The provided value: (2015-11-11 10:10:10.) of type: java.lang.String is not a match or is out of range for the target parameter type: org.voltdb.types.TimestampType (Stack trace has been written to the log.)
+Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]
+Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]
+Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]
+Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]
+Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]

--- a/tests/sqlcmd/baselines/simple/parsedates.outbaseline
+++ b/tests/sqlcmd/baselines/simple/parsedates.outbaseline
@@ -1,0 +1,99 @@
+
+drop table FOO if exists;
+Command succeeded.
+
+create table FOO ( a timestamp, source varchar);
+Command succeeded.
+
+insert into FOO values ('2015-11-11 10:11:12.123456', 'sql');
+(Returned 1 rows in #.##s)
+
+insert into FOO values ('2015-11-11 10:11:12.12345',  'sql');
+(Returned 1 rows in #.##s)
+
+insert into FOO values ('2015-11-11 10:11:12.1234',   'sql');
+(Returned 1 rows in #.##s)
+
+insert into FOO values ('2015-11-11 10:11:12.123',    'sql');
+(Returned 1 rows in #.##s)
+
+insert into FOO values ('2015-11-11 10:11:12.12',     'sql');
+(Returned 1 rows in #.##s)
+
+insert into FOO values ('2015-11-11 10:11:12.1',      'sql');
+(Returned 1 rows in #.##s)
+
+insert into FOO values ('2015-11-11 10:11:12',        'sql');
+(Returned 1 rows in #.##s)
+
+insert into FOO values ('2015-11-11',                 'sql');
+(Returned 1 rows in #.##s)
+
+insert into FOO values ('20150-11-11 10:10:10', 'sqlfail');
+
+insert into FOO values ('201-11-11 10:10:10',   'sqlfail');
+
+insert into FOO values ('2015-111-11 10:10:10', 'sqlfail');
+
+insert into FOO values ('2015-11-111 10:10:10', 'sqlfail');
+
+insert into FOO values ('2015-11-11 10:10:10.', 'sqlfail');
+
+exec FOO.insert '2015-11-11 10:11:12.123456' 'crud';
+(Returned 1 rows in #.##s)
+
+exec FOO.insert '2015-11-11 10:11:12.12345'  'crud';
+(Returned 1 rows in #.##s)
+
+exec FOO.insert '2015-11-11 10:11:12.1234'   'crud';
+(Returned 1 rows in #.##s)
+
+exec FOO.insert '2015-11-11 10:11:12.123'    'crud';
+(Returned 1 rows in #.##s)
+
+exec FOO.insert '2015-11-11 10:11:12.12'     'crud';
+(Returned 1 rows in #.##s)
+
+exec FOO.insert '2015-11-11 10:11:12.1'      'crud';
+(Returned 1 rows in #.##s)
+
+exec FOO.insert '2015-11-11 10:11:12'        'crud';
+(Returned 1 rows in #.##s)
+
+exec FOO.insert '2015-11-11'                 'crud';
+(Returned 1 rows in #.##s)
+
+exec FOO.insert '20150-11-11 10:10:10' 'crudfail';
+
+exec FOO.insert '201-11-11 10:10:10'   'crudfail';
+
+exec FOO.insert '2015-111-11 10:10:10' 'crudfail';
+
+exec FOO.insert '2015-11-111 10:10:10' 'crudfail';
+
+exec FOO.insert '2015-11-11 10:11:12.' 'crudfail';
+
+select * from FOO;
+A                           SOURCE 
+--------------------------- -------
+2015-11-11 10:11:12.123456  sql    
+2015-11-11 10:11:12.123450  sql    
+2015-11-11 10:11:12.123400  sql    
+2015-11-11 10:11:12.123000  sql    
+2015-11-11 10:11:12.120000  sql    
+2015-11-11 10:11:12.100000  sql    
+2015-11-11 10:11:12.000000  sql    
+2015-11-11 00:00:00.000000  sql    
+2015-11-11 10:11:12.123456  crud   
+2015-11-11 10:11:12.123450  crud   
+2015-11-11 10:11:12.123400  crud   
+2015-11-11 10:11:12.123000  crud   
+2015-11-11 10:11:12.120000  crud   
+2015-11-11 10:11:12.100000  crud   
+2015-11-11 10:11:12.000000  crud   
+2015-11-11 00:00:00.000000  crud   
+
+(Returned 16 rows in #.##s)
+
+drop table FOO if exists;
+Command succeeded.

--- a/tests/sqlcmd/scripts/simple/parsedates.config
+++ b/tests/sqlcmd/scripts/simple/parsedates.config
@@ -1,0 +1,1 @@
+--stop-on-error=false

--- a/tests/sqlcmd/scripts/simple/parsedates.in
+++ b/tests/sqlcmd/scripts/simple/parsedates.in
@@ -1,0 +1,40 @@
+drop table FOO if exists;
+create table FOO ( a timestamp, source varchar);
+insert into FOO values ('2015-11-11 10:11:12.123456', 'sql');
+insert into FOO values ('2015-11-11 10:11:12.12345',  'sql');
+insert into FOO values ('2015-11-11 10:11:12.1234',   'sql');
+insert into FOO values ('2015-11-11 10:11:12.123',    'sql');
+insert into FOO values ('2015-11-11 10:11:12.12',     'sql');
+insert into FOO values ('2015-11-11 10:11:12.1',      'sql');
+insert into FOO values ('2015-11-11 10:11:12',        'sql');
+insert into FOO values ('2015-11-11',                 'sql');
+
+-- Try some negative cases.
+insert into FOO values ('20150-11-11 10:10:10', 'sqlfail');
+insert into FOO values ('201-11-11 10:10:10',   'sqlfail');
+insert into FOO values ('2015-111-11 10:10:10', 'sqlfail');
+insert into FOO values ('2015-11-111 10:10:10', 'sqlfail');
+insert into FOO values ('2015-11-11 10:10:10.', 'sqlfail');
+
+-- Now try the same things as before, but with a CRUD procedure.
+-- This is problematic because sqlcmd tries to parse the datetime.
+exec FOO.insert '2015-11-11 10:11:12.123456' 'crud';
+exec FOO.insert '2015-11-11 10:11:12.12345'  'crud';
+exec FOO.insert '2015-11-11 10:11:12.1234'   'crud';
+exec FOO.insert '2015-11-11 10:11:12.123'    'crud';
+exec FOO.insert '2015-11-11 10:11:12.12'     'crud';
+exec FOO.insert '2015-11-11 10:11:12.1'      'crud';
+exec FOO.insert '2015-11-11 10:11:12'        'crud';
+exec FOO.insert '2015-11-11'                 'crud';
+
+-- Try some negative CRUD tests.
+exec FOO.insert '20150-11-11 10:10:10' 'crudfail';
+exec FOO.insert '201-11-11 10:10:10'   'crudfail';
+exec FOO.insert '2015-111-11 10:10:10' 'crudfail';
+exec FOO.insert '2015-11-111 10:10:10' 'crudfail';
+exec FOO.insert '2015-11-11 10:11:12.' 'crudfail';
+
+
+-- We should not see any with sqlfail or crudfail as sources.
+select * from FOO;
+drop table FOO if exists;

--- a/tests/sqlcmd/sqlcmdtest.py
+++ b/tests/sqlcmd/sqlcmdtest.py
@@ -91,7 +91,7 @@ def launch_and_wait_on_voltdb(reportout):
     # Launch a single local voltdb server to serve all scripted sqlcmd runs.
     # The scripts are expected to clean up after themselves  -- and/or defensively
     # drop and create all of their tables up front.
-    subprocess.Popen(['../../bin/voltdb', 'create'], shell=False)
+    subprocess.Popen(['../../bin/voltdb', 'create', '--force'], shell=False)
     # give server a little startup time.
     time.sleep(5)
 


### PR DESCRIPTION
The documented forms for VoltDB dates are 'yyyy-mm-dd HH:MM.sss',
'yyyy-MM-dd HH:MM' and 'yyyy-MM-dd'. The previous pattern did not
work for the latter two. This commit fixes this by trying all three
patterns. There seems to be no way to specify that a part of the
pattern is optional.

I changed the parsing strategy, and just use the one for TimestampType.
This
gives us microsecond granularity, which is what we seem to be
advertising,
and it parses all the formats we advertise.

In this commit I also added a fix to ENG-10369. It was really obvious,
and easier to fix it than to describe how to fix it in the ticket.

https://issues.voltdb.com/browse/ENG-10031