### PR TITLE
ENG-10431 Enable VoltDB build on Ubuntu 16.04 in backward compatible way

### DIFF
--- a/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathlimits.h
+++ b/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathlimits.h
@@ -190,13 +190,21 @@ DECL_UNSIGNED_INT_LIMITS(unsigned long long int)
   static bool IsPosInf(const Type x) { return _fpclass(x) == _FPCLASS_PINF; } \
   static bool IsNegInf(const Type x) { return _fpclass(x) == _FPCLASS_NINF; }
 #else
-  using namespace std;
+#if __cplusplus >= 201103L
+#define DECL_FP_LIMIT_FUNCS \
+  static bool IsFinite(const Type x) { return !std::isinf(x)  &&  !std::isnan(x); } \
+  static bool IsNaN(const Type x) { return std::isnan(x); } \
+  static bool IsInf(const Type x) { return std::isinf(x); } \
+  static bool IsPosInf(const Type x) { return std::isinf(x)  &&  x > 0; } \
+  static bool IsNegInf(const Type x) { return std::isinf(x)  &&  x < 0; }
+#else
 #define DECL_FP_LIMIT_FUNCS \
   static bool IsFinite(const Type x) { return !isinf(x)  &&  !isnan(x); } \
   static bool IsNaN(const Type x) { return isnan(x); } \
   static bool IsInf(const Type x) { return isinf(x); } \
   static bool IsPosInf(const Type x) { return isinf(x)  &&  x > 0; } \
   static bool IsNegInf(const Type x) { return isinf(x)  &&  x < 0; }
+#endif
 #endif
 
 /// We can't put floating-point constant values in the header here because

--- a/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathlimits.h
+++ b/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathlimits.h
@@ -190,6 +190,7 @@ DECL_UNSIGNED_INT_LIMITS(unsigned long long int)
   static bool IsPosInf(const Type x) { return _fpclass(x) == _FPCLASS_PINF; } \
   static bool IsNegInf(const Type x) { return _fpclass(x) == _FPCLASS_NINF; }
 #else
+  using namespace std;
 #define DECL_FP_LIMIT_FUNCS \
   static bool IsFinite(const Type x) { return !isinf(x)  &&  !isnan(x); } \
   static bool IsNaN(const Type x) { return isnan(x); } \

--- a/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathlimits.h
+++ b/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathlimits.h
@@ -182,7 +182,7 @@ DECL_UNSIGNED_INT_LIMITS(unsigned long long int)
 #undef DECL_INT_LIMIT_FUNCS
 
 /// ========================================================================= //
-#ifdef WIN32  // Lacks built-in std::isnan() and std::isinf()
+#ifdef WIN32  // Lacks built-in isnan() and isinf()
 #define DECL_FP_LIMIT_FUNCS \
   static bool IsFinite(const Type x) { return _finite(x); } \
   static bool IsNaN(const Type x) { return _isnan(x); } \
@@ -191,11 +191,11 @@ DECL_UNSIGNED_INT_LIMITS(unsigned long long int)
   static bool IsNegInf(const Type x) { return _fpclass(x) == _FPCLASS_NINF; }
 #else
 #define DECL_FP_LIMIT_FUNCS \
-  static bool IsFinite(const Type x) { return !std::isinf(x)  &&  !std::isnan(x); } \
-  static bool IsNaN(const Type x) { return std::isnan(x); } \
-  static bool IsInf(const Type x) { return std::isinf(x); } \
-  static bool IsPosInf(const Type x) { return std::isinf(x)  &&  x > 0; } \
-  static bool IsNegInf(const Type x) { return std::isinf(x)  &&  x < 0; }
+  static bool IsFinite(const Type x) { return !isinf(x)  &&  !isnan(x); } \
+  static bool IsNaN(const Type x) { return isnan(x); } \
+  static bool IsInf(const Type x) { return isinf(x); } \
+  static bool IsPosInf(const Type x) { return isinf(x)  &&  x > 0; } \
+  static bool IsNegInf(const Type x) { return isinf(x)  &&  x < 0; }
 #endif
 
 /// We can't put floating-point constant values in the header here because

--- a/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathlimits.h
+++ b/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathlimits.h
@@ -190,7 +190,7 @@ DECL_UNSIGNED_INT_LIMITS(unsigned long long int)
   static bool IsPosInf(const Type x) { return _fpclass(x) == _FPCLASS_PINF; } \
   static bool IsNegInf(const Type x) { return _fpclass(x) == _FPCLASS_NINF; }
 #else
-#if __cplusplus >= 201103L
+#if __GNUC__ > 4
 #define DECL_FP_LIMIT_FUNCS \
   static bool IsFinite(const Type x) { return !std::isinf(x)  &&  !std::isnan(x); } \
   static bool IsNaN(const Type x) { return std::isnan(x); } \

--- a/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathlimits.h
+++ b/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathlimits.h
@@ -182,7 +182,7 @@ DECL_UNSIGNED_INT_LIMITS(unsigned long long int)
 #undef DECL_INT_LIMIT_FUNCS
 
 /// ========================================================================= //
-#ifdef WIN32  // Lacks built-in isnan() and isinf()
+#ifdef WIN32  // Lacks built-in std::isnan() and std::isinf()
 #define DECL_FP_LIMIT_FUNCS \
   static bool IsFinite(const Type x) { return _finite(x); } \
   static bool IsNaN(const Type x) { return _isnan(x); } \
@@ -191,11 +191,11 @@ DECL_UNSIGNED_INT_LIMITS(unsigned long long int)
   static bool IsNegInf(const Type x) { return _fpclass(x) == _FPCLASS_NINF; }
 #else
 #define DECL_FP_LIMIT_FUNCS \
-  static bool IsFinite(const Type x) { return !isinf(x)  &&  !isnan(x); } \
-  static bool IsNaN(const Type x) { return isnan(x); } \
-  static bool IsInf(const Type x) { return isinf(x); } \
-  static bool IsPosInf(const Type x) { return isinf(x)  &&  x > 0; } \
-  static bool IsNegInf(const Type x) { return isinf(x)  &&  x < 0; }
+  static bool IsFinite(const Type x) { return !std::isinf(x)  &&  !std::isnan(x); } \
+  static bool IsNaN(const Type x) { return std::isnan(x); } \
+  static bool IsInf(const Type x) { return std::isinf(x); } \
+  static bool IsPosInf(const Type x) { return std::isinf(x)  &&  x > 0; } \
+  static bool IsNegInf(const Type x) { return std::isinf(x)  &&  x < 0; }
 #endif
 
 /// We can't put floating-point constant values in the header here because

--- a/third_party/cpp/google-s2-geometry/geometry/util/math/exactfloat/exactfloat.cc
+++ b/third_party/cpp/google-s2-geometry/geometry/util/math/exactfloat/exactfloat.cc
@@ -11,7 +11,14 @@ using std::max;
 using std::swap;
 using std::reverse;
 
-#if __cplusplus >= 201103L
+#if __GNUC__ > 4
+
+#define VALUE_TO_STRING(x) #x
+#define VALUE(x) VALUE_TO_STRING(x)
+#define VAR_NAME_VALUE(var) #var "="  VALUE(var)
+#pragma message(VAR_NAME_VALUE(__cplusplus))
+#pragma message(VAR_NAME_VALUE(__GNUC__))
+
 using std::isinf;
 using std::isnan;
 #endif

--- a/third_party/cpp/google-s2-geometry/geometry/util/math/exactfloat/exactfloat.cc
+++ b/third_party/cpp/google-s2-geometry/geometry/util/math/exactfloat/exactfloat.cc
@@ -10,6 +10,8 @@ using std::min;
 using std::max;
 using std::swap;
 using std::reverse;
+using std::isnan;
+using std::isinf;
 
 #include <limits>
 using std::numeric_limits;
@@ -88,9 +90,9 @@ static int BN_ext_count_low_zero_bits(const BIGNUM* bn) {
 ExactFloat::ExactFloat(double v) {
   BN_init(&bn_);
   sign_ = std::signbit(v) ? -1 : 1;
-  if (std::isnan(v)) {
+  if (isnan(v)) {
     set_nan();
-  } else if (std::isinf(v)) {
+  } else if (isinf(v)) {
     set_inf(sign_);
   } else {
     /// The following code is much simpler than messing about with bit masks,

--- a/third_party/cpp/google-s2-geometry/geometry/util/math/exactfloat/exactfloat.cc
+++ b/third_party/cpp/google-s2-geometry/geometry/util/math/exactfloat/exactfloat.cc
@@ -88,9 +88,9 @@ static int BN_ext_count_low_zero_bits(const BIGNUM* bn) {
 ExactFloat::ExactFloat(double v) {
   BN_init(&bn_);
   sign_ = std::signbit(v) ? -1 : 1;
-  if (isnan(v)) {
+  if (std::isnan(v)) {
     set_nan();
-  } else if (isinf(v)) {
+  } else if (std::isinf(v)) {
     set_inf(sign_);
   } else {
     /// The following code is much simpler than messing about with bit masks,

--- a/third_party/cpp/google-s2-geometry/geometry/util/math/exactfloat/exactfloat.cc
+++ b/third_party/cpp/google-s2-geometry/geometry/util/math/exactfloat/exactfloat.cc
@@ -12,13 +12,6 @@ using std::swap;
 using std::reverse;
 
 #if __GNUC__ > 4
-
-#define VALUE_TO_STRING(x) #x
-#define VALUE(x) VALUE_TO_STRING(x)
-#define VAR_NAME_VALUE(var) #var "="  VALUE(var)
-#pragma message(VAR_NAME_VALUE(__cplusplus))
-#pragma message(VAR_NAME_VALUE(__GNUC__))
-
 using std::isinf;
 using std::isnan;
 #endif

--- a/third_party/cpp/google-s2-geometry/geometry/util/math/exactfloat/exactfloat.cc
+++ b/third_party/cpp/google-s2-geometry/geometry/util/math/exactfloat/exactfloat.cc
@@ -10,8 +10,11 @@ using std::min;
 using std::max;
 using std::swap;
 using std::reverse;
-using std::isnan;
+
+#if __cplusplus >= 201103L
 using std::isinf;
+using std::isnan;
+#endif
 
 #include <limits>
 using std::numeric_limits;

--- a/third_party/cpp/google-s2-geometry/geometry/util/math/mathlimits.cc
+++ b/third_party/cpp/google-s2-geometry/geometry/util/math/mathlimits.cc
@@ -3,6 +3,9 @@
 ///
 ///
 
+using std::isinf;
+using std::isnan;
+
 #include "s2geo/util/math/mathlimits.h"
 
 #include "s2geo/base/integral_types.h"

--- a/third_party/cpp/google-s2-geometry/geometry/util/math/mathlimits.cc
+++ b/third_party/cpp/google-s2-geometry/geometry/util/math/mathlimits.cc
@@ -3,9 +3,6 @@
 ///
 ///
 
-using std::isinf;
-using std::isnan;
-
 #include "s2geo/util/math/mathlimits.h"
 
 #include "s2geo/base/integral_types.h"


### PR DESCRIPTION
Small set of changes so VoltDB community and/or pro will build and run on the newest Ubuntu, 16.04, while continuing to build and run on older CentOS/RHEL 6 and Ubuntu 12.04 without further source changes or preprocessor conditionals.

It's not necessarily a requirement to avoid preprocessor fencing but it keeps things simpler, though at the expense of a broad namespace "using".