### PR TITLE
ENG-10164: duplicate column bug

### DIFF
--- a/src/frontend/org/voltdb/planner/ParsedColInfo.java
+++ b/src/frontend/org/voltdb/planner/ParsedColInfo.java
@@ -47,6 +47,9 @@ public class ParsedColInfo implements Cloneable {
     /** Index of the column in its table.  This is used for MV sanity-checking */
     public int index = 0;
 
+    /** A differentiator used to tell apart column references when there are
+     * duplicate column names produced by the expansion of "*" that happens in HSQL.*/
+    public int differentiator = -1;
     //
     // Used in ParsedSelectStmt.m_displayColumns
     //
@@ -136,7 +139,7 @@ public class ParsedColInfo implements Cloneable {
 
     /** Return this as an instance of SchemaColumn */
     public SchemaColumn asSchemaColumn() {
-        return new SchemaColumn(tableName, tableAlias, columnName, alias, expression);
+        return new SchemaColumn(tableName, tableAlias, columnName, alias, expression, differentiator);
     }
 
     @Override

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -765,7 +765,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         // materialized views (which use the parsed select statement but
         // don't go through the planner pass that does more involved
         // column index resolution).
-        col.index = m_displayColumns.size();
+        col.index = index;
 
         insertAggExpressionsToAggResultColumns(m_aggregationList, col);
         if (m_aggregationList.size() >= 1) {
@@ -988,9 +988,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
             m_distinctGroupByColumns.add(pcol);
 
             // ParsedColInfo, TVE, SchemaColumn, NodeSchema ??? Could it be more complicated ???
-            SchemaColumn schema_col = new SchemaColumn(
-                    col.tableName, col.tableAlias, col.columnName, col.alias, tve, col.differentiator);
-            m_distinctProjectSchema.addColumn(schema_col);
+            m_distinctProjectSchema.addColumn(col.asSchemaColumn());
         }
 
         return groupbyElement;

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -466,7 +466,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
             if (hasComplexAgg()) {
                 expr = col.expression.replaceWithTVE(aggTableIndexMap, indexToColumnMap);
             }
-            SchemaColumn schema_col = new SchemaColumn(col.tableName, col.tableAlias, col.columnName, col.alias, expr);
+            SchemaColumn schema_col = new SchemaColumn(col.tableName, col.tableAlias, col.columnName, col.alias, expr, col.differentiator);
             m_projectSchema.addColumn(schema_col);
         }
 
@@ -689,12 +689,14 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
     }
 
     private void parseDisplayColumns(VoltXMLElement columnsNode, boolean isDistributed) {
+        int index = 0;
         for (VoltXMLElement child : columnsNode.children) {
-            parseDisplayColumn(child, isDistributed);
+            parseDisplayColumn(index, child, isDistributed);
+            ++index;
         }
     }
 
-    private void parseDisplayColumn(VoltXMLElement child, boolean isDistributed) {
+    private void parseDisplayColumn(int index, VoltXMLElement child, boolean isDistributed) {
         ParsedColInfo col = new ParsedColInfo();
         m_aggregationList.clear();
         AbstractExpression colExpr = parseExpressionTree(child);
@@ -779,6 +781,10 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
             }
         }
 
+        // The differentiator is used when ParsedColInfo is converted to
+        // a SchemaColumn object, to differentiate between columns that have the
+        // same name within a table (which can happen for subqueries or joins).
+        col.differentiator = index;
         m_displayColumns.add(col);
     }
 
@@ -983,7 +989,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
 
             // ParsedColInfo, TVE, SchemaColumn, NodeSchema ??? Could it be more complicated ???
             SchemaColumn schema_col = new SchemaColumn(
-                    col.tableName, col.tableAlias, col.columnName, col.alias, tve);
+                    col.tableName, col.tableAlias, col.columnName, col.alias, tve, col.differentiator);
             m_distinctProjectSchema.addColumn(schema_col);
         }
 

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -988,7 +988,8 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
             m_distinctGroupByColumns.add(pcol);
 
             // ParsedColInfo, TVE, SchemaColumn, NodeSchema ??? Could it be more complicated ???
-            m_distinctProjectSchema.addColumn(col.asSchemaColumn());
+            SchemaColumn schema_col = new SchemaColumn(col.tableName, col.tableAlias, col.columnName, col.alias, tve, col.differentiator);
+            m_distinctProjectSchema.addColumn(schema_col);
         }
 
         return groupbyElement;

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.voltcore.utils.Pair;
 import org.voltdb.catalog.Index;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.TupleValueExpression;
@@ -43,7 +44,7 @@ public class StmtSubqueryScan extends StmtTableScan {
     // Sub-Query
     private final AbstractParsedStmt m_subqueryStmt;
     private final ArrayList<SchemaColumn> m_outputColumnList = new ArrayList<>();
-    private final Map<String, Integer> m_outputColumnIndexMap = new HashMap<String, Integer>();
+    private final Map<Pair<String, Integer>, Integer> m_outputColumnIndexMap = new HashMap<>();
 
     private CompiledPlan m_bestCostPlan = null;
 
@@ -70,9 +71,9 @@ public class StmtSubqueryScan extends StmtTableScan {
         int i = 0;
         for (ParsedColInfo col: ((ParsedSelectStmt)subqueryStmt).displayColumns()) {
             String colAlias = col.alias == null? col.columnName : col.alias;
-            SchemaColumn scol = new SchemaColumn(col.tableName, col.tableAlias, col.columnName, col.alias, col.expression);
+            SchemaColumn scol = new SchemaColumn(col.tableName, col.tableAlias, col.columnName, col.alias, col.expression, col.differentiator);
             m_outputColumnList.add(scol);
-            m_outputColumnIndexMap.put(colAlias, i);
+            m_outputColumnIndexMap.put(Pair.of(colAlias, col.differentiator), i);
             i++;
         }
     }
@@ -266,7 +267,7 @@ public class StmtSubqueryScan extends StmtTableScan {
 
     @Override
     public void processTVE(TupleValueExpression expr, String columnName) {
-        Integer idx = m_outputColumnIndexMap.get(columnName);
+        Integer idx = m_outputColumnIndexMap.get(Pair.of(columnName, expr.getDifferentiator()));
         if (idx == null) {
             throw new PlanningErrorException("Mismatched columns " + columnName + " in subquery");
         }

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -71,7 +71,7 @@ public class StmtSubqueryScan extends StmtTableScan {
         int i = 0;
         for (ParsedColInfo col: ((ParsedSelectStmt)subqueryStmt).displayColumns()) {
             String colAlias = col.alias == null? col.columnName : col.alias;
-            SchemaColumn scol = new SchemaColumn(col.tableName, col.tableAlias, col.columnName, col.alias, col.expression, col.differentiator);
+            SchemaColumn scol = col.asSchemaColumn();
             m_outputColumnList.add(scol);
             m_outputColumnIndexMap.put(Pair.of(colAlias, col.differentiator), i);
             i++;

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtTableScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtTableScan.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.voltcore.utils.Pair;
 import org.voltdb.catalog.Index;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.plannodes.SchemaColumn;
@@ -42,7 +43,7 @@ public abstract class StmtTableScan {
 
     // Store a unique list of scan columns.
     protected List<SchemaColumn> m_scanColumnsList = new ArrayList<>();
-    protected Set<String> m_scanColumnNameSet = new HashSet<>();
+    protected Set<Pair<String, Integer>> m_scanColumnNameSet = new HashSet<>();
 
     // Partitioning column info
     protected List<SchemaColumn> m_partitioningColumns = null;
@@ -83,10 +84,11 @@ public abstract class StmtTableScan {
         processTVE(expr, columnName);
         expr.setOrigStmtId(m_stmtId);
 
-        if ( ! m_scanColumnNameSet.contains(columnName)) {
+        Pair<String, Integer> setItem = Pair.of(columnName, expr.getDifferentiator());
+        if ( ! m_scanColumnNameSet.contains(setItem)) {
             SchemaColumn scol = new SchemaColumn(getTableName(), m_tableAlias,
                     columnName, columnName, (TupleValueExpression) expr.clone());
-            m_scanColumnNameSet.add(columnName);
+            m_scanColumnNameSet.add(setItem);
             m_scanColumnsList.add(scol);
         }
     }

--- a/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
@@ -19,7 +19,6 @@ package org.voltdb.plannodes;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.TreeMap;
 
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
@@ -395,4 +394,23 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode {
         return collected;
     }
 
+    /**
+     * When a project node is added to the top of the plan, we need to adjust
+     * the differentiator field of TVEs to reflect differences in the scan
+     * schema vs the storage schema of a table, so that fields with duplicate names
+     * produced by expanding "SELECT *" can resolve correctly.
+     *
+     * We recurse until we find either a join node or a scan node.
+     *
+     * Resolution of columns produced by "SELECT *" is not a problem for joins because
+     * there is always a sequential scan at the top of plans that have this problem,
+     * so just return the passed-in differentiator here.
+     *
+     * @param  existing differentiator field of a TVE
+     * @return new differentiator value
+     */
+    @Override
+    public int adjustDifferentiatorField(int differentiator) {
+        return differentiator;
+    }
 }

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -1134,4 +1134,20 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         }
         return false;
     }
+
+    /**
+     * When a project node is added to the top of the plan, we need to adjust
+     * the differentiator field of TVEs to reflect differences in the scan
+     * schema vs the storage schema of a table, so that fields with duplicate names
+     * produced by expanding "SELECT *" can resolve correctly.
+     *
+     * We recurse until we find either a join node or a scan node.
+     *
+     * @param  existing differentiator field of a TVE
+     * @return new differentiator value
+     */
+    public int adjustDifferentiatorField(int differentiator) {
+        assert (m_children.size() == 1);
+        return m_children.get(0).adjustDifferentiatorField(differentiator);
+    }
 }

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -19,6 +19,7 @@ package org.voltdb.plannodes;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +56,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
     protected NodeSchema m_tableSchema = null;
     // Store the columns we use from this table as an internal schema
     protected NodeSchema m_tableScanSchema = new NodeSchema();
+    protected Map<Integer, Integer> m_differentiatorMap = new HashMap<>();
     protected AbstractExpression m_predicate;
 
     // The target table is the table that the plannode wants to perform some operation on.
@@ -158,7 +160,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         setSubQuery(tableScan instanceof StmtSubqueryScan);
         setTargetTableAlias(tableScan.getTableAlias());
         setTargetTableName(tableScan.getTableName());
-        Collection<SchemaColumn> scanColumns = tableScan.getScanColumns();
+        List<SchemaColumn> scanColumns = tableScan.getScanColumns();
         if (scanColumns != null && ! scanColumns.isEmpty()) {
             setScanColumns(scanColumns);
         }
@@ -186,12 +188,42 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         m_predicate = ExpressionUtil.cloneAndCombinePredicates(exps);
     }
 
-    protected void setScanColumns(Collection<SchemaColumn> scanColumns)
+    protected void setScanColumns(List<SchemaColumn> scanColumns)
     {
         assert(scanColumns != null);
+        int i = 0;
         for (SchemaColumn col : scanColumns) {
-            m_tableScanSchema.addColumn(col.clone());
+            TupleValueExpression tve = (TupleValueExpression)col.getExpression();
+            m_differentiatorMap.put(tve.getDifferentiator(), i);
+            SchemaColumn clonedCol = col.clone();
+            clonedCol.setDifferentiator(i);
+            m_tableScanSchema.addColumn(clonedCol);
+            ++i;
         }
+    }
+
+    /**
+     * When a project node is added to the top of the plan, we need to adjust
+     * the differentiator field of TVEs to reflect differences in the scan
+     * schema vs the storage schema of a table, so that fields with duplicate names
+     * produced by expanding "SELECT *" can resolve correctly.
+     *
+     * We recurse until we find either a join node or a scan node.
+     *
+     * For scan nodes, we need to reflect the difference between the
+     * storage order of columns produced by a subquery, and the columns
+     * that are actually projected (via an inlined project) from the scan,
+     * since unused columns are typically omitted from the output schema
+     * of the scan.
+     *
+     * @param  existing differentiator field of a TVE
+     * @return new differentiator value
+     */
+    @Override
+    public int adjustDifferentiatorField(int storageIndex) {
+        Integer scanIndex = m_differentiatorMap.get(storageIndex);
+        assert(scanIndex != null);
+        return scanIndex;
     }
 
     NodeSchema getTableSchema()
@@ -244,7 +276,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
                                                              m_targetTableAlias,
                                                              col.getTypeName(),
                                                              col.getTypeName(),
-                                                             tve));
+                                                             tve, col.getIndex()));
                 }
             }
         }
@@ -287,10 +319,13 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
             // before we stick them in the projection output
             List<TupleValueExpression> scan_tves =
                     new ArrayList<TupleValueExpression>();
+            int i = 0;
             for (SchemaColumn col : m_tableScanSchema.getColumns())
             {
                 assert(col.getExpression() instanceof TupleValueExpression);
+                col.setDifferentiator(i);
                 scan_tves.addAll(ExpressionUtil.getTupleValueExpressions(col.getExpression()));
+                ++i;
             }
             // and update their indexes against the table schema
             for (TupleValueExpression tve : scan_tves)

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -20,6 +20,7 @@ package org.voltdb.plannodes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -130,6 +131,7 @@ public class IndexScanPlanNode extends AbstractScanPlanNode {
         m_tableSchema = srcNode.m_tableSchema;
         m_predicate = srcNode.m_predicate;
         m_tableScanSchema = srcNode.m_tableScanSchema.clone();
+        m_differentiatorMap = new HashMap<>(srcNode.m_differentiatorMap);
         for (AbstractPlanNode inlineChild : srcNode.getInlinePlanNodes().values()) {
             addInlinePlanNode(inlineChild);
         }

--- a/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
@@ -101,9 +101,12 @@ public class ProjectionPlanNode extends AbstractPlanNode {
         // get all the TVEs in the output columns
         List<TupleValueExpression> output_tves =
             new ArrayList<TupleValueExpression>();
+        int i = 0;
         for (SchemaColumn col : m_outputSchema.getColumns())
         {
+            col.setDifferentiator(i);
             output_tves.addAll(ExpressionUtil.getTupleValueExpressions(col.getExpression()));
+            ++i;
         }
         // and update their indexes against the table schema
         for (TupleValueExpression tve : output_tves)

--- a/src/frontend/org/voltdb/plannodes/SchemaColumn.java
+++ b/src/frontend/org/voltdb/plannodes/SchemaColumn.java
@@ -41,6 +41,7 @@ public class SchemaColumn
     private String m_columnName;
     private String m_columnAlias;
     private AbstractExpression m_expression;
+    private int m_differentiator = -1;
 
     /**
      * Create a new SchemaColumn
@@ -75,6 +76,13 @@ public class SchemaColumn
         }
     }
 
+    public SchemaColumn(String tableName, String tableAlias, String columnName,
+            String columnAlias, AbstractExpression expression, int differentiator)
+    {
+        this(tableName, tableAlias, columnName, columnAlias, expression);
+        m_differentiator = differentiator;
+    }
+
     /**
      * Clone a schema column
      */
@@ -82,7 +90,7 @@ public class SchemaColumn
     protected SchemaColumn clone()
     {
         return new SchemaColumn(m_tableName, m_tableAlias, m_columnName, m_columnAlias,
-                                m_expression);
+                                m_expression, m_differentiator);
     }
 
     /**
@@ -105,7 +113,11 @@ public class SchemaColumn
         }
 
         SchemaColumn sc = (SchemaColumn) obj;
-        return compareNames(sc) == 0;
+        if (compareNames(sc) != 0) {
+            return false;
+        }
+
+        return getDifferentiator() == sc.getDifferentiator();
     }
 
     private int nullSafeStringCompareTo(String str1, String str2) {
@@ -172,6 +184,8 @@ public class SchemaColumn
         } else if (m_columnAlias != null && !m_columnAlias.equals("")) {
             result += m_columnAlias.hashCode();
         }
+
+        result += m_differentiator;
         return result;
     }
 
@@ -195,7 +209,7 @@ public class SchemaColumn
                     m_expression.getInBytes());
         }
         return new SchemaColumn(m_tableName, m_tableAlias, m_columnName, m_columnAlias,
-                                new_exp);
+                                new_exp, m_differentiator);
     }
 
     public String getTableName()
@@ -248,12 +262,21 @@ public class SchemaColumn
         return m_expression.getValueSize();
     }
 
+    /**
+     * Return the differentiator that can distinguish columns with the same name.
+     * This value is just the ordinal position of the SchemaColumn within its NodeSchema.
+     * @return  differentiator for this schema column
+     */
     public int getDifferentiator() {
-        if (m_expression instanceof TupleValueExpression) {
-            return ((TupleValueExpression)m_expression).getDifferentiator();
-        }
+        return m_differentiator;
+    }
 
-        return -1;
+    /**
+     * Set the differentiator value for this SchemaColumn.
+     * @param differentiator
+     */
+    public void setDifferentiator(int differentiator) {
+        m_differentiator = differentiator;
     }
 
     @Override
@@ -267,6 +290,7 @@ public class SchemaColumn
         sb.append("\tColumn Alias: ").append(m_columnAlias).append("\n");
         sb.append("\tColumn Type: ").append(getType()).append("\n");
         sb.append("\tColumn Size: ").append(getSize()).append("\n");
+        sb.append("\tDifferentiator: ").append(getDifferentiator()).append("\n");
         sb.append("\tExpression: ").append(m_expression.toString()).append("\n");
         return sb.toString();
     }

--- a/src/frontend/org/voltdb/plannodes/SendPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SendPlanNode.java
@@ -45,7 +45,7 @@ public class SendPlanNode extends AbstractPlanNode {
         assert(m_children.size() == 1);
         m_children.get(0).resolveColumnIndexes();
         NodeSchema input_schema = m_children.get(0).getOutputSchema();
-        assert (input_schema.equals(m_outputSchema));
+        assert (input_schema.equalsOnlyNames(m_outputSchema));
 
         for (SchemaColumn col : m_outputSchema.getColumns())
         {

--- a/tests/frontend/org/voltdb/planner/TestUnion.java
+++ b/tests/frontend/org/voltdb/planner/TestUnion.java
@@ -311,7 +311,16 @@ public class TestUnion extends PlannerTestCase {
             AbstractPlanNode pn = compile("(select B as B1, B as B2 from T2 UNION select B as B1, B as B2 from T2) order by B1 asc, B2 desc");
             pn = pn.getChild(0);
             String[] columnNames = {"B1", "B2"};
-            int[] idxs = {1, 1};
+            // We are selecting the same column twice from both sides of the union,
+            // so it doesn't matter if the column indices are 0 or 1 here.
+            int[] idxs = {0, 0};
+            checkOrderByNode(pn, columnNames, idxs);
+        }
+        {
+            AbstractPlanNode pn = compile("(select B as B1, B * -1 as B2 from T2 UNION select B as B1, B * -1 as B2 from T2) order by B1 asc, B2 desc");
+            pn = pn.getChild(0);
+            String[] columnNames = {"B1", "B2"};
+            int[] idxs = {0, 1};
             checkOrderByNode(pn, columnNames, idxs);
         }
         {


### PR DESCRIPTION
This set of changes follows through on implementing a "differentiator" field for various data structures in the planner that represent table columns.  They're really only used as a "tie breaker" for the case when there is a `SELECT *`, and the thing we're selecting from is a subquery.  (Note that HSQL treats parenthesized joins in the FROM clause as if they were subqueries.)