### PR TITLE
Change the misleading error message.

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
@@ -1691,7 +1691,7 @@ public class Expression {
                 // Going forward, it seems to make more sense to leverage the surviving VoltDB code path by hard-wiring here:
                 // valueType="BIGINT", value="1"/"0".
                 throw new org.hsqldb_voltpatches.HSQLInterface.HSQLParseException(
-                        "VoltDB does not support WHERE clauses containing only constants");
+                        "VoltDB does not support constant boolean values");
             }
 
             exp.attributes.put("valuetype", Types.getTypeName(dataType.typeCode));

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
@@ -1691,7 +1691,7 @@ public class Expression {
                 // Going forward, it seems to make more sense to leverage the surviving VoltDB code path by hard-wiring here:
                 // valueType="BIGINT", value="1"/"0".
                 throw new org.hsqldb_voltpatches.HSQLInterface.HSQLParseException(
-                        "VoltDB does not support constant boolean values");
+                        "VoltDB does not support constant Boolean values, like TRUE or FALSE");
             }
 
             exp.attributes.put("valuetype", Types.getTypeName(dataType.typeCode));

--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -823,7 +823,7 @@ public class TestAdHocQueries extends AdHocQueryTester {
                 fail("did not fail on static clause");
             }
             catch (ProcCallException pcex) {
-                assertTrue(pcex.getMessage().indexOf("does not support WHERE clauses containing only constants") > 0);
+                assertTrue(pcex.getMessage().indexOf("does not support constant Boolean values, like TRUE or FALSE") > 0);
             }
             adHocQuery = "ROLLBACK;";
             try {

--- a/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
@@ -758,10 +758,10 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
     }
 
     public void testConstantExpressionInWhereClause() {
-        failToCompile("select * from r1 where 3 > 1;", "VoltDB does not support WHERE clauses containing only constants");
+        failToCompile("select * from r1 where 3 > 1;", "VoltDB does not support constant Boolean values, like TRUE or FALSE");
 
         failToCompile("select a from r1 where exists " +
-                " (select max(c) from r2) and 3 > 1;", "VoltDB does not support WHERE clauses containing only constants");
+                " (select max(c) from r2) and 3 > 1;", "VoltDB does not support constant Boolean values, like TRUE or FALSE");
     }
 
     // HSQL failed to parse  these statement


### PR DESCRIPTION
VoltDB does not support WHERE clauses containing only constants
=====>
VoltDB does not support constant boolean values