### PR TITLE
ENG-10383: Support JSON Hashinator config

### DIFF
--- a/src/frontend/org/voltdb/ElasticHashinator.java
+++ b/src/frontend/org/voltdb/ElasticHashinator.java
@@ -65,8 +65,8 @@ public class ElasticHashinator extends TheHashinator {
         Integer.parseInt(System.getProperty("ELASTIC_TOTAL_TOKENS", "16384"));
 
     // JSON KEYS FOR SERIALIZATION
-    public static final String JSON_TOKENCOUNT_KEY = "tokencount";
-    public static final String JSON_TOKENPARTITION_KEY = "tokenpartition";
+    public static final String JSON_TOKENCOUNT_KEY = "count";
+    public static final String JSON_TOKENPARTITION_KEY = "map";
 
     /**
      * Tokens on the ring. A value hashes to a token if the token is the first value <=

--- a/src/frontend/org/voltdb/ElasticHashinator.java
+++ b/src/frontend/org/voltdb/ElasticHashinator.java
@@ -17,7 +17,11 @@
 package org.voltdb;
 
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.lang.Thread.State;
 import java.nio.ByteBuffer;
 import java.util.HashSet;
@@ -27,11 +31,17 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 import org.apache.cassandra_voltpatches.MurmurHash3;
+import org.json_voltpatches.JSONException;
+import org.json_voltpatches.JSONStringer;
 import org.voltcore.utils.Bits;
 import org.voltcore.utils.Pair;
 import org.voltdb.utils.CompressionService;
+
+import sun.misc.Cleaner;
 
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.base.Supplier;
@@ -41,8 +51,6 @@ import com.google_voltpatches.common.collect.ImmutableSortedSet;
 import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.collect.SortedMapDifference;
 import com.google_voltpatches.common.collect.UnmodifiableIterator;
-
-import sun.misc.Cleaner;
 
 /**
  * A hashinator that uses Murmur3_x64_128 to hash values and a consistent hash ring
@@ -55,6 +63,10 @@ public class ElasticHashinator extends TheHashinator {
 
     public static int DEFAULT_TOTAL_TOKENS =
         Integer.parseInt(System.getProperty("ELASTIC_TOTAL_TOKENS", "16384"));
+
+    // JSON KEYS FOR SERIALIZATION
+    public static final String JSON_TOKENCOUNT_KEY = "tokencount";
+    public static final String JSON_TOKENPARTITION_KEY = "tokenpartition";
 
     /**
      * Tokens on the ring. A value hashes to a token if the token is the first value <=
@@ -91,6 +103,19 @@ public class ElasticHashinator extends TheHashinator {
         @Override
         public Long get() {
             return TheHashinator.computeConfigurationSignature(m_configBytes.get());
+        }
+    });
+
+    private final Supplier<String> m_configJSON = Suppliers.memoize(new Supplier<String>() {
+        @Override
+        public String get() {
+            return toJSONString();
+        }
+    });
+    private final Supplier<byte[]> m_configJSONCompressed = Suppliers.memoize(new Supplier<byte[]>() {
+        @Override
+        public byte[] get() {
+            return toJSONStringCompressed();
         }
     });
 
@@ -196,6 +221,71 @@ public class ElasticHashinator extends TheHashinator {
             buf.putInt(pid);
         }
         return buf.array();
+    }
+
+    /**
+     * Serializes the configuration into JSON, also updates the currently cached m_configJSON.
+     * @return The JSONString of the current configuration.
+     */
+
+    private String toJSONString() {
+        JSONStringer js = new JSONStringer();
+        try {
+            js.object();
+            js.key(JSON_TOKENCOUNT_KEY).value(m_tokenCount);
+            js.key(JSON_TOKENPARTITION_KEY).object();
+            for (Map.Entry<Integer, Integer> entry : m_tokensMap.get().entrySet()) {
+                js.key(entry.getKey().toString()).value(entry.getValue());
+            }
+            js.endObject().endObject();
+        }catch (JSONException e) {
+            throw new RuntimeException("Failed to serialized Hashinator Configuration to JSON.", e);
+        }
+        return js.toString();
+    }
+
+    /**
+     * Serializes the configuration into JSON, also updates the currently cached m_configJSON.
+     * @return The JSONString of the current configuration.
+     */
+
+    private byte[] toJSONStringCompressed() {
+        String str = m_configJSON.get();
+        if (str == null || str.length() == 0) {
+            return new byte[0] ;
+        }
+        byte[] outStr;
+        try {
+            outStr = compressJSONString(str);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialized Hashinator Configuration to Compressed JSON .", e);
+        }
+        return outStr;
+    }
+
+    public static byte[] compressJSONString(String data) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream(data.length());
+        GZIPOutputStream gzip = new GZIPOutputStream(bos);
+        gzip.write(data.getBytes());
+        gzip.close();
+        byte[] compressed = bos.toByteArray();
+        bos.close();
+        return compressed;
+    }
+
+    public static String decompressJSONString(byte[] compressed) throws IOException {
+        ByteArrayInputStream bis = new ByteArrayInputStream(compressed);
+        GZIPInputStream gis = new GZIPInputStream(bis);
+        BufferedReader br = new BufferedReader(new InputStreamReader(gis, "UTF-8"));
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while((line = br.readLine()) != null) {
+            sb.append(line);
+        }
+        br.close();
+        gis.close();
+        bis.close();
+        return sb.toString();
     }
 
     /**
@@ -415,6 +505,26 @@ public class ElasticHashinator extends TheHashinator {
     public byte[] getConfigBytes()
     {
         return m_configBytes.get();
+    }
+
+    /**
+     * Returns raw config JSONString.
+     * @return config JSONString
+     */
+    @Override
+    public String getConfigJSON()
+    {
+        return m_configJSON.get();
+    }
+
+    /**
+     * Returns compressed config JSONString.
+     * @return config compressed JSONString
+     */
+    @Override
+    public byte[] getConfigJSONCompressed()
+    {
+        return m_configJSONCompressed.get();
     }
 
     /**

--- a/src/frontend/org/voltdb/ElasticHashinator.java
+++ b/src/frontend/org/voltdb/ElasticHashinator.java
@@ -262,9 +262,9 @@ public class ElasticHashinator extends TheHashinator {
 
     public static String decompressJSONString(byte[] compressed) throws IOException {
         ByteArrayOutputStream result = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
         try (ByteArrayInputStream bis = new ByteArrayInputStream(compressed);
                 GZIPInputStream gis = new GZIPInputStream(bis)) {
-            byte[] buffer = new byte[1024];
             int length;
             while ((length = gis.read(buffer)) != -1) {
                 result.write(buffer, 0, length);

--- a/src/frontend/org/voltdb/LegacyHashinator.java
+++ b/src/frontend/org/voltdb/LegacyHashinator.java
@@ -22,12 +22,15 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.json_voltpatches.JSONException;
+import org.json_voltpatches.JSONStringer;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.Pair;
 
 public class LegacyHashinator extends TheHashinator {
     private final int catalogPartitionCount;
     private final byte m_configBytes[];
+    private final String m_configJSON;
     private final long m_signature;
     @SuppressWarnings("unused")
     private static final VoltLogger hostLogger = new VoltLogger("HOST");
@@ -60,6 +63,12 @@ public class LegacyHashinator extends TheHashinator {
     public LegacyHashinator(byte configBytes[], boolean cooked) {
         catalogPartitionCount = ByteBuffer.wrap(configBytes).getInt();
         m_configBytes = Arrays.copyOf(configBytes, configBytes.length);
+        try {
+            m_configJSON = new JSONStringer().
+                    array().value(catalogPartitionCount).endArray().toString();
+        } catch (JSONException e) {
+            throw new RuntimeException("Failed to serialized Hashinator Configuration to JSON.", e);
+        }
         m_signature = TheHashinator.computeConfigurationSignature(m_configBytes);
     }
 
@@ -106,6 +115,16 @@ public class LegacyHashinator extends TheHashinator {
     public byte[] getConfigBytes()
     {
         return m_configBytes;
+    }
+
+    /**
+     * Returns raw config JSONString.
+     * @return config JSONString
+     */
+    @Override
+    public String getConfigJSON()
+    {
+        return m_configJSON;
     }
 
     @Override

--- a/src/frontend/org/voltdb/OpsAgent.java
+++ b/src/frontend/org/voltdb/OpsAgent.java
@@ -26,6 +26,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.BinaryPayloadMessage;
@@ -104,6 +105,14 @@ public abstract class OpsAgent
             this.c = c;
             this.clientData = clientData;
             this.request = request;
+        }
+
+        public boolean getInterval() {
+            try {
+                return request.getBoolean("interval");
+            } catch (JSONException e) {
+                return false;
+            }
         }
     }
 

--- a/src/frontend/org/voltdb/OpsAgent.java
+++ b/src/frontend/org/voltdb/OpsAgent.java
@@ -26,7 +26,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.BinaryPayloadMessage;
@@ -105,17 +104,6 @@ public abstract class OpsAgent
             this.c = c;
             this.clientData = clientData;
             this.request = request;
-        }
-
-        // hacky way to support two format of hashconfig using interval value
-        // return true if interval == true (delta-flag == 1), indicate sent compressed json
-        // otherwise return false, indicate sent original binary format
-        public boolean getConfigType() {
-            try {
-                return request.getBoolean("interval");
-            } catch (JSONException e) {
-                return false;
-            }
         }
     }
 

--- a/src/frontend/org/voltdb/OpsAgent.java
+++ b/src/frontend/org/voltdb/OpsAgent.java
@@ -107,7 +107,10 @@ public abstract class OpsAgent
             this.request = request;
         }
 
-        public boolean getInterval() {
+        // hacky way to support two format of hashconfig using interval value
+        // return true if interval == true (delta-flag == 1), indicate sent compressed json
+        // otherwise return false, indicate sent original binary format
+        public boolean getConfigType() {
             try {
                 return request.getBoolean("interval");
             } catch (JSONException e) {

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -313,12 +313,10 @@ public class StatsAgent extends OpsAgent
                     new VoltTable(
                             new VoltTable.ColumnInfo("HASHTYPE", VoltType.STRING),
                             new VoltTable.ColumnInfo("HASHCONFIG", VoltType.VARBINARY),
-                            new VoltTable.ColumnInfo("HASHCONFIGJSON", VoltType.STRING),
                             new VoltTable.ColumnInfo("HASHCONFIGJSONCompressed", VoltType.VARBINARY));
             tables[1] = vt;
             HashinatorConfig hashConfig = TheHashinator.getCurrentConfig();
             vt.addRow(hashConfig.type.toString(), hashConfig.configBytes,
-                    TheHashinator.getCurrentHashinator().getConfigJSON(),
                     TheHashinator.getCurrentHashinator().getConfigJSONCompressed());
         }
         psr.aggregateTables = tables;

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -312,12 +312,19 @@ public class StatsAgent extends OpsAgent
             VoltTable vt =
                     new VoltTable(
                             new VoltTable.ColumnInfo("HASHTYPE", VoltType.STRING),
-                            new VoltTable.ColumnInfo("HASHCONFIG", VoltType.VARBINARY),
-                            new VoltTable.ColumnInfo("HASHCONFIGJSONCompressed", VoltType.VARBINARY));
+                            new VoltTable.ColumnInfo("HASHCONFIG", VoltType.VARBINARY));
             tables[1] = vt;
             HashinatorConfig hashConfig = TheHashinator.getCurrentConfig();
-            vt.addRow(hashConfig.type.toString(), hashConfig.configBytes,
-                    TheHashinator.getCurrentHashinator().getConfigJSONCompressed());
+            // hacky way to support two format of hashconfig
+            // if interval == true (delta-flag == 1), sent compressed json
+            // otherwise sent original binary format
+            boolean interval = psr.getInterval();
+            if (!interval) {
+                vt.addRow(hashConfig.type.toString(), hashConfig.configBytes);
+            } else {
+                vt.addRow(hashConfig.type.toString(), TheHashinator.getCurrentHashinator().getConfigJSONCompressed());
+            }
+
         }
         psr.aggregateTables = tables;
 

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -312,10 +312,14 @@ public class StatsAgent extends OpsAgent
             VoltTable vt =
                     new VoltTable(
                             new VoltTable.ColumnInfo("HASHTYPE", VoltType.STRING),
-                            new VoltTable.ColumnInfo("HASHCONFIG", VoltType.VARBINARY));
+                            new VoltTable.ColumnInfo("HASHCONFIG", VoltType.VARBINARY),
+                            new VoltTable.ColumnInfo("HASHCONFIGJSON", VoltType.STRING),
+                            new VoltTable.ColumnInfo("HASHCONFIGJSONCompressed", VoltType.VARBINARY));
             tables[1] = vt;
             HashinatorConfig hashConfig = TheHashinator.getCurrentConfig();
-            vt.addRow(hashConfig.type.toString(), hashConfig.configBytes);
+            vt.addRow(hashConfig.type.toString(), hashConfig.configBytes,
+                    TheHashinator.getCurrentHashinator().getConfigJSON(),
+                    TheHashinator.getCurrentHashinator().getConfigJSONCompressed());
         }
         psr.aggregateTables = tables;
 

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -315,11 +315,8 @@ public class StatsAgent extends OpsAgent
                             new VoltTable.ColumnInfo("HASHCONFIG", VoltType.VARBINARY));
             tables[1] = vt;
             HashinatorConfig hashConfig = TheHashinator.getCurrentConfig();
-            // hacky way to support two format of hashconfig
-            // if interval == true (delta-flag == 1), sent compressed json
-            // otherwise sent original binary format
-            boolean interval = psr.getInterval();
-            if (!interval) {
+            boolean jsonConfig = psr.getConfigType();
+            if (!jsonConfig) {
                 vt.addRow(hashConfig.type.toString(), hashConfig.configBytes);
             } else {
                 vt.addRow(hashConfig.type.toString(), TheHashinator.getCurrentHashinator().getConfigJSONCompressed());

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -220,7 +220,11 @@ public class StatsAgent extends OpsAgent
                     clientHandle,
                     System.currentTimeMillis(),
                     obj);
-            collectTopoStats(psr);
+            // hacky way to support two format of hashconfig using interval value
+            // return true if interval == true (delta-flag == 1), indicate sent compressed json
+            // otherwise return false, indicate sent original binary format
+            boolean jsonConfig = obj.getBoolean("interval");
+            collectTopoStats(psr,jsonConfig);
             return;
         }
         else if (subselector.equalsIgnoreCase("PARTITIONCOUNT")) {
@@ -302,7 +306,7 @@ public class StatsAgent extends OpsAgent
         }
     }
 
-    private void collectTopoStats(PendingOpsRequest psr)
+    private void collectTopoStats(PendingOpsRequest psr, boolean jsonConfig)
     {
         VoltTable[] tables = null;
         VoltTable topoStats = getStatsAggregate(StatsSelector.TOPO, false, psr.startTime);
@@ -315,7 +319,6 @@ public class StatsAgent extends OpsAgent
                             new VoltTable.ColumnInfo("HASHCONFIG", VoltType.VARBINARY));
             tables[1] = vt;
             HashinatorConfig hashConfig = TheHashinator.getCurrentConfig();
-            boolean jsonConfig = psr.getConfigType();
             if (!jsonConfig) {
                 vt.addRow(hashConfig.type.toString(), hashConfig.configBytes);
             } else {

--- a/src/frontend/org/voltdb/TheHashinator.java
+++ b/src/frontend/org/voltdb/TheHashinator.java
@@ -77,6 +77,21 @@ public abstract class TheHashinator {
     public abstract byte[] getConfigBytes();
 
     /**
+     * Uncompressed configuration data accessor in JSONString.
+     * @return configuration data JSONString
+     */
+    public abstract String getConfigJSON();
+
+    /**
+     * Compressed configuration data accessor in JSONString.
+     * Default to providing raw bytes, e.g. for legacy
+     * @return configuration data in Compressed JSONString
+     */
+    public byte[] getConfigJSONCompressed(){
+        return getConfigBytes();
+    }
+
+    /**
      * A map to store hashinators, including older versions of hashinators.
      * During live rejoin sites will replay balance fragments in an order that results
      * in some sites skipping ahead to newer hashinators.

--- a/tests/frontend/org/voltdb/TestTheHashinator.java
+++ b/tests/frontend/org/voltdb/TestTheHashinator.java
@@ -931,11 +931,10 @@ public class TestTheHashinator {
     private void checkConfigJSON(ImmutableSortedMap<Integer, Integer> tokens,
                                     String JSON) throws JSONException {
         final JSONObject jsonData = new JSONObject(JSON);
-        assertEquals(tokens.size(), jsonData.getInt(ElasticHashinator.JSON_TOKENCOUNT_KEY));
-        final JSONObject tokenPartition = jsonData.getJSONObject(ElasticHashinator.JSON_TOKENPARTITION_KEY);
+        assertEquals(tokens.size(), jsonData.length());
         for (Map.Entry<Integer, Integer> entry: tokens.entrySet()) {
             assertEquals(entry.getValue().intValue(),
-                    tokenPartition.getInt(entry.getKey().toString()));
+                    jsonData.getInt(entry.getKey().toString()));
         }
     }
     @Test

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -362,16 +362,15 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         expectedSchema1[2] = new ColumnInfo("Leader", VoltType.STRING);
         VoltTable expectedTable1 = new VoltTable(expectedSchema1);
 
-        ColumnInfo[] expectedSchema2 = new ColumnInfo[3];
+        ColumnInfo[] expectedSchema2 = new ColumnInfo[2];
         expectedSchema2[0] = new ColumnInfo("HASHTYPE", VoltType.STRING);
         expectedSchema2[1] = new ColumnInfo("HASHCONFIG", VoltType.VARBINARY);
-        expectedSchema2[2] = new ColumnInfo("HASHCONFIGJSONCompressed", VoltType.VARBINARY);
         VoltTable expectedTable2 = new VoltTable(expectedSchema2);
 
         VoltTable[] results = null;
 
         //
-        // TOPO
+        // TOPO with interval set to 0, retrieving binary hash config
         //
         results = client.callProcedure("@Statistics", "TOPO", 0).getResults();
         // two aggregate tables returned
@@ -385,6 +384,30 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertEquals(PARTITIONS + 1, results[0].getRowCount());
         // Make sure we can find the MPI, at least
         boolean found = false;
+        while (topo.advanceRow()) {
+            if ((int)topo.getLong("Partition") == MpInitiator.MP_INIT_PID) {
+                found = true;
+            }
+        }
+        assertTrue(found);
+        // and only one row in the second table
+        assertEquals(1, results[1].getRowCount());
+
+        //
+        // TOPO with interval set to 1, for retrieving compressed json hash config
+        //
+        results = client.callProcedure("@Statistics", "TOPO", 1).getResults();
+        // two aggregate tables returned
+        assertEquals(2, results.length);
+        System.out.println("Test TOPO table: " + results[0].toString());
+        System.out.println("Test TOPO table: " + results[1].toString());
+        validateSchema(results[0], expectedTable1);
+        validateSchema(results[1], expectedTable2);
+        topo = results[0];
+        // Should have partitions + 1 rows in the first table
+        assertEquals(PARTITIONS + 1, results[0].getRowCount());
+        // Make sure we can find the MPI, at least
+        found = false;
         while (topo.advanceRow()) {
             if ((int)topo.getLong("Partition") == MpInitiator.MP_INIT_PID) {
                 found = true;

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import junit.framework.Test;
+
 import org.HdrHistogram_voltpatches.AbstractHistogram;
 import org.HdrHistogram_voltpatches.Histogram;
 import org.voltcore.utils.CompressionStrategySnappy;
@@ -41,8 +43,6 @@ import org.voltdb.client.ProcCallException;
 import org.voltdb.iv2.MpInitiator;
 import org.voltdb.regressionsuites.StatisticsTestSuiteBase;
 import org.voltdb_testprocs.regressionsuites.malicious.GoSleep;
-
-import junit.framework.Test;
 
 public class TestStatisticsSuite extends StatisticsTestSuiteBase {
 
@@ -362,9 +362,10 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         expectedSchema1[2] = new ColumnInfo("Leader", VoltType.STRING);
         VoltTable expectedTable1 = new VoltTable(expectedSchema1);
 
-        ColumnInfo[] expectedSchema2 = new ColumnInfo[2];
+        ColumnInfo[] expectedSchema2 = new ColumnInfo[3];
         expectedSchema2[0] = new ColumnInfo("HASHTYPE", VoltType.STRING);
         expectedSchema2[1] = new ColumnInfo("HASHCONFIG", VoltType.VARBINARY);
+        expectedSchema2[2] = new ColumnInfo("HASHCONFIGJSONCompressed", VoltType.VARBINARY);
         VoltTable expectedTable2 = new VoltTable(expectedSchema2);
 
         VoltTable[] results = null;


### PR DESCRIPTION
JSON Format for the hashinator config
{"count": 16384,
 "map": {"token1": partID1,
                     "token2": partID2,
                     ...}
 }

Compressing using GZIP

use "@Statsistics TOPO 1" for retrieving new format

checkForTopologyChanges in ClientIntface still using old binary format
