### PR TITLE
ENG-10453: Don't let work happen before partition detection kills nodes.

### DIFF
--- a/src/frontend/org/voltcore/agreement/AgreementSite.java
+++ b/src/frontend/org/voltcore/agreement/AgreementSite.java
@@ -612,15 +612,15 @@ public class AgreementSite implements org.apache.zookeeper_voltpatches.server.Zo
                     null);
         }
         Set<Long> unknownFaultedHosts = new TreeSet<>();
+
+        // This one line is a biggie. Gets agreement on what the post-fault cluster will be.
         Map<Long, Long> initiatorSafeInitPoint = m_meshArbiter.reconfigureOnFault(m_hsIds, faultMessage, unknownFaultedHosts);
-        Set<Long> failedSites;
-        if (!initiatorSafeInitPoint.isEmpty()) {
-            failedSites = initiatorSafeInitPoint.keySet();
-            handleSiteFaults(failedSites, initiatorSafeInitPoint);
-        } else if (unknownFaultedHosts.isEmpty()) {
+
+        ImmutableSet<Long> failedSites = ImmutableSet.copyOf(initiatorSafeInitPoint.keySet());
+
+        // check if nothing actually happened
+        if (initiatorSafeInitPoint.isEmpty() && unknownFaultedHosts.isEmpty()) {
             return;
-        } else {
-            failedSites = ImmutableSet.of();
         }
 
         ImmutableSet.Builder<Integer> failedHosts = ImmutableSet.builder();
@@ -633,6 +633,14 @@ public class AgreementSite implements org.apache.zookeeper_voltpatches.server.Zo
             failedHosts.add(CoreUtils.getHostIdFromHSId(hsId));
         }
         m_failedHostsCallback.disconnect(failedHosts.build());
+
+        // Handle the failed sites after the failedHostsCallback to ensure
+        // that partition detection is run first -- as this might release
+        // work back to a client waiting on a failure notice. That's unsafe
+        // if we partitioned.
+        if (!initiatorSafeInitPoint.isEmpty()) {
+            handleSiteFaults(failedSites, initiatorSafeInitPoint);
+        }
 
         m_hsIds.removeAll(failedSites);
     }

--- a/src/frontend/org/voltcore/agreement/MeshArbiter.java
+++ b/src/frontend/org/voltcore/agreement/MeshArbiter.java
@@ -85,7 +85,7 @@ public class MeshArbiter {
      */
     protected final Set<Long> m_failedSites = Sets.newTreeSet();
 
-    protected final Map<Long,SiteFailureForwardMessage> m_forwardCandidates = Maps.newHashMap();
+    protected final Map<Long, SiteFailureForwardMessage> m_forwardCandidates = Maps.newHashMap();
     /**
      * it builds mesh graphs, and determines the the kill set to resolve
      * an arbitration
@@ -265,12 +265,12 @@ public class MeshArbiter {
      *   indicate either a stale message, or that an agreement has not been
      *   reached
      */
-    public Map<Long,Long> reconfigureOnFault(Set<Long> hsIds, FaultMessage fm, Set<Long> unknownFaultedSites) {
+    public Map<Long, Long> reconfigureOnFault(Set<Long> hsIds, FaultMessage fm, Set<Long> unknownFaultedSites) {
         boolean proceed = false;
         do {
-            Discard ignoreIt = mayIgnore(hsIds,fm);
+            Discard ignoreIt = mayIgnore(hsIds, fm);
             if (Discard.DoNot == ignoreIt) {
-                m_inTrouble.put(fm.failedSite,fm.witnessed || fm.decided);
+                m_inTrouble.put(fm.failedSite, fm.witnessed || fm.decided);
                 m_recoveryLog.info("Agreement, Processing " + fm);
                 proceed = true;
             } else {
@@ -280,7 +280,7 @@ public class MeshArbiter {
             if (Discard.Unknown == ignoreIt) {
                 unknownFaultedSites.add(fm.failedSite);
             }
-            fm = (FaultMessage)m_mailbox.recv(justFailures);
+            fm = (FaultMessage) m_mailbox.recv(justFailures);
         } while (fm != null);
 
         if (!proceed) {
@@ -296,7 +296,7 @@ public class MeshArbiter {
         discoverGlobalFaultData_send(hsIds);
 
         if (discoverGlobalFaultData_rcv(hsIds)) {
-            Map<Long,Long> lastTxnIdByFailedSite = extractGlobalFaultData(hsIds);
+            Map<Long, Long> lastTxnIdByFailedSite = extractGlobalFaultData(hsIds);
             if (lastTxnIdByFailedSite.isEmpty()) {
                 return ImmutableMap.of();
             }
@@ -333,14 +333,14 @@ public class MeshArbiter {
      * @param decision map where the keys contain the kill sites
      *   and its values are their last known safe transaction ids
      */
-    protected void notifyOnKill(Set<Long> hsIds, Map<Long,Long> decision) {
+    protected void notifyOnKill(Set<Long> hsIds, Map<Long, Long> decision) {
 
         SiteFailureMessage.Builder sfmb = SiteFailureMessage.
                 builder()
                 .decisions(decision.keySet())
                 .failures(decision.keySet());
 
-        Set<Long> dests = Sets.filter(m_seeker.getSurvivors(),not(equalTo(m_hsId)));
+        Set<Long> dests = Sets.filter(m_seeker.getSurvivors(), not(equalTo(m_hsId)));
         if (dests.isEmpty()) return;
 
         sfmb.survivors(Sets.difference(m_seeker.getSurvivors(), decision.keySet()));
@@ -360,10 +360,10 @@ public class MeshArbiter {
         m_inTroubleCount = 0;
     }
 
-    protected Map<Long,Long> getSafeTxnIdsForSites(Set<Long> hsIds) {
-        ImmutableMap.Builder<Long,Long> safeb = ImmutableMap.builder();
+    protected Map<Long, Long> getSafeTxnIdsForSites(Set<Long> hsIds) {
+        ImmutableMap.Builder<Long, Long> safeb = ImmutableMap.builder();
         for (long h: Sets.filter(hsIds, not(equalTo(m_hsId)))) {
-            safeb.put(h,m_meshAide.getNewestSafeTransactionForInitiator(h));
+            safeb.put(h, m_meshAide.getNewestSafeTransactionForInitiator(h));
         }
         return safeb.build();
     }
@@ -376,7 +376,7 @@ public class MeshArbiter {
      * Sends all data all the time to avoid a need for request/response.
      */
     private void discoverGlobalFaultData_send(Set<Long> hsIds) {
-        Set<Long> dests = Sets.filter(m_seeker.getSurvivors(),not(equalTo(m_hsId)));
+        Set<Long> dests = Sets.filter(m_seeker.getSurvivors(), not(equalTo(m_hsId)));
 
         SiteFailureMessage.Builder msgBuilder = SiteFailureMessage.
                 builder()
@@ -395,7 +395,7 @@ public class MeshArbiter {
         m_recoveryLog.info("Agreement, Sending survivors " + sfm);
     }
 
-    protected void updateFailedSitesLedger(Set<Long> hsIds,SiteFailureMessage sfm) {
+    protected void updateFailedSitesLedger(Set<Long> hsIds, SiteFailureMessage sfm) {
         for (Map.Entry<Long, Long> e: sfm.m_safeTxnIds.entrySet()) {
 
             if(  !hsIds.contains(e.getKey())
@@ -452,7 +452,7 @@ public class MeshArbiter {
 
             } else if (m.getSubject() == Subject.SITE_FAILURE_UPDATE.getId()) {
 
-                SiteFailureMessage sfm = (SiteFailureMessage)m;
+                SiteFailureMessage sfm = (SiteFailureMessage) m;
 
                 if (  !m_seeker.getSurvivors().contains(m.m_sourceHSId)
                     || m_failedSites.contains(m.m_sourceHSId)
@@ -467,7 +467,7 @@ public class MeshArbiter {
 
             } else if (m.getSubject() == Subject.SITE_FAILURE_FORWARD.getId()) {
 
-                SiteFailureForwardMessage fsfm = (SiteFailureForwardMessage)m;
+                SiteFailureForwardMessage fsfm = (SiteFailureForwardMessage) m;
 
                 addForwardCandidate(fsfm);
 
@@ -487,9 +487,9 @@ public class MeshArbiter {
                  * If the fault distributor reports a new fault, ignore it if it is known , otherwise
                  * re-deliver the message to ourself and then abort so that the process can restart.
                  */
-                FaultMessage fm = (FaultMessage)m;
+                FaultMessage fm = (FaultMessage) m;
 
-                Discard ignoreIt = mayIgnore(hsIds,fm);
+                Discard ignoreIt = mayIgnore(hsIds, fm);
                 if (Discard.DoNot == ignoreIt) {
                     m_mailbox.deliverFront(m);
                     m_recoveryLog.info("Agreement, Detected a concurrent failure from FaultDistributor, new failed site "
@@ -512,7 +512,7 @@ public class MeshArbiter {
                     Map.Entry<Long, SiteFailureForwardMessage> e = itr.next();
                     Set<Long> unseenBy = m_seeker.forWhomSiteIsDead(e.getKey());
                     if (unseenBy.size() > 0) {
-                        m_mailbox.send(Longs.toArray(unseenBy),e.getValue());
+                        m_mailbox.send(Longs.toArray(unseenBy), e.getValue());
                         m_recoveryLog.info("Agreement, fowarding to "
                                 + CoreUtils.hsIdCollectionToString(unseenBy)
                                 + " " + e.getValue());
@@ -560,7 +560,7 @@ public class MeshArbiter {
         return missingMessages.isEmpty();
     }
 
-    private Map<Long,Long> extractGlobalFaultData(Set<Long> hsIds) {
+    private Map<Long, Long> extractGlobalFaultData(Set<Long> hsIds) {
 
         if (!haveNecessaryFaultInfo(m_seeker.getSurvivors(), false)) {
             VoltDB.crashLocalVoltDB("Error extracting fault data", true, null);

--- a/src/frontend/org/voltcore/messaging/ForeignHost.java
+++ b/src/frontend/org/voltcore/messaging/ForeignHost.java
@@ -24,10 +24,9 @@ import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-
-import com.google_voltpatches.common.base.Throwables;
 
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
@@ -41,6 +40,8 @@ import org.voltcore.utils.EstTime;
 import org.voltcore.utils.RateLimitedLogger;
 import org.voltdb.OperationMode;
 import org.voltdb.VoltDB;
+
+import com.google_voltpatches.common.base.Throwables;
 
 public class ForeignHost {
     private static final VoltLogger hostLog = new VoltLogger("HOST");
@@ -65,6 +66,10 @@ public class ForeignHost {
 
     private final AtomicInteger m_deadReportsCount = new AtomicInteger(0);
 
+    // used to immediately cut off reads from a foreign host
+    // great way to trigger a heartbeat timout / simulate a network partition
+    private AtomicBoolean m_linkCutForTest = new AtomicBoolean(false);
+
     public static final int POISON_PILL = -1;
 
     public static final int CRASH_ALL = 0;
@@ -81,6 +86,11 @@ public class ForeignHost {
 
         @Override
         public void handleMessage(ByteBuffer message, Connection c) throws IOException {
+            // if this link is "gone silent" for partition tests, just drop the message on the floor
+            if (m_linkCutForTest.get()) {
+                return;
+            }
+
             handleRead(message, c);
         }
 
@@ -408,5 +418,13 @@ public class ForeignHost {
     public void updateDeadHostTimeout(int timeout) {
         m_deadHostTimeout = timeout;
         setLogRate(timeout);
+    }
+
+    /**
+     * used to immediately cut off reads from a foreign host
+     * great way to trigger a heartbeat timout / simulate a network partition
+     */
+    void cutLink() {
+        m_linkCutForTest.set(true);
     }
 }

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -219,7 +219,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     // memoized InstanceId
     private InstanceId m_instanceId = null;
     private boolean m_shuttingDown = false;
-    private AtomicBoolean m_partitionDetectionEnabled = new AtomicBoolean(true); // default to true
+    // default to false for PD, so hopefully this gets set to true very quickly
+    private AtomicBoolean m_partitionDetectionEnabled = new AtomicBoolean(false);
     private boolean m_partitionDetected = false;
 
     private final Object m_mapLock = new Object();

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -877,10 +877,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
                         m_messenger,
                         m_configuredNumberOfPartitions,
                         m_catalogContext.getDeployment().getCluster().getKfactor(),
-                        m_catalogContext.cluster.getNetworkpartition(),
                         m_catalogContext.cluster.getFaultsnapshots().get("CLUSTER_PARTITION"),
-                        usingCommandLog,
-                        topo, m_MPI, kSafetyStats, expectSyncSnapshot);
+                        topo,
+                        m_MPI,
+                        kSafetyStats,
+                        expectSyncSnapshot
+                );
                 m_globalServiceElector.registerService(m_leaderAppointer);
             } catch (Exception e) {
                 Throwable toLog = e;

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -98,6 +98,7 @@ import org.voltdb.compiler.AsyncCompilerAgent;
 import org.voltdb.compiler.ClusterConfig;
 import org.voltdb.compiler.deploymentfile.DeploymentType;
 import org.voltdb.compiler.deploymentfile.HeartbeatType;
+import org.voltdb.compiler.deploymentfile.PartitionDetectionType;
 import org.voltdb.compiler.deploymentfile.PathsType;
 import org.voltdb.compiler.deploymentfile.SystemSettingsType;
 import org.voltdb.dtxn.InitiatorStats;
@@ -1529,6 +1530,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
                 m_messenger.setDeadHostTimeout(m_config.m_deadHostTimeoutMS);
             } else {
                 hostLog.info("Dead host timeout set to " + m_config.m_deadHostTimeoutMS + " milliseconds");
+            }
+
+            PartitionDetectionType pt = deployment.getPartitionDetection();
+            if (pt != null) {
+                m_config.m_partitionDetectionEnabled = pt.isEnabled();
+                m_messenger.setPartitionDetectionEnabled(m_config.m_partitionDetectionEnabled);
             }
 
             final String elasticSetting = deployment.getCluster().getElastic().trim().toUpperCase();

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -753,6 +753,11 @@ public class VoltDB {
             // slightly less important than death, this try/finally block protects code that
             // prints a message to stdout
             try {
+                // turn off client interface as fast as possible
+                // we don't expect this to ever fail, but if it does, skip to dying immediately
+                if (!instance().getClientInterface().ceaseAllPublicFacingTrafficImmediately()) {
+                    return; // this will jump to the finally block and die faster
+                }
 
                 // Even if the logger is null, don't stop.  We want to log the stack trace and
                 // any other pertinent information to a .dmp file for crash diagnosis
@@ -868,6 +873,11 @@ public class VoltDB {
         // end test code
 
         try {
+            // turn off client interface as fast as possible
+            // we don't expect this to ever fail, but if it does, skip to dying immediately
+            if (!instance().getClientInterface().ceaseAllPublicFacingTrafficImmediately()) {
+                return; // this will jump to the finally block and die faster
+            }
             // instruct the rest of the cluster to die
             instance().getHostMessenger().sendPoisonPill(errMsg);
             // give the pill a chance to make it through the network buffer

--- a/src/frontend/org/voltdb/iv2/DuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/DuplicateCounter.java
@@ -77,6 +77,7 @@ public class DuplicateCounter
     int updateReplicas(List<Long> replicas) {
         Set<Long> newSet = new HashSet<Long>(replicas);
         m_expectedHSIds.retainAll(newSet);
+        tmLog.info(String.format("*** RELEASING TXN %d", m_txnId));
         if (m_expectedHSIds.size() == 0) {
             return DONE;
         }

--- a/src/frontend/org/voltdb/iv2/LeaderAppointer.java
+++ b/src/frontend/org/voltdb/iv2/LeaderAppointer.java
@@ -17,8 +17,6 @@
 
 package org.voltdb.iv2;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -34,16 +32,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.zookeeper_voltpatches.CreateMode;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.WatchedEvent;
 import org.apache.zookeeper_voltpatches.Watcher;
-import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
-import org.json_voltpatches.JSONStringer;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.CoreUtils;
@@ -52,14 +47,10 @@ import org.voltcore.zk.BabySitter;
 import org.voltcore.zk.LeaderElector;
 import org.voltcore.zk.ZKUtil;
 import org.voltdb.Promotable;
-import org.voltdb.SnapshotFormat;
 import org.voltdb.TheHashinator;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
 import org.voltdb.catalog.SnapshotSchedule;
-import org.voltdb.client.ClientResponse;
-import org.voltdb.sysprocs.saverestore.SnapshotUtil;
-import org.voltdb.sysprocs.saverestore.SnapshotUtil.SnapshotResponseHandler;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableSortedSet;
@@ -83,7 +74,6 @@ public class LeaderAppointer implements Promotable
         DONE            // indicates normal running conditions, including repair
     }
 
-    private final HostMessenger m_hostMessenger;
     private final ZooKeeper m_zk;
     // This should only be accessed through getInitialPartitionCount() on cluster startup.
     private final int m_initialPartitionCount;
@@ -97,9 +87,6 @@ public class LeaderAppointer implements Promotable
     private final AtomicReference<AppointerState> m_state =
         new AtomicReference<AppointerState>(AppointerState.INIT);
     private SettableFuture<Object> m_startupLatch = null;
-    private final boolean m_partitionDetectionEnabled;
-    private boolean m_partitionDetected = false;
-    private boolean m_usingCommandLog = false;
     private final AtomicBoolean m_replayComplete = new AtomicBoolean(false);
     private final boolean m_expectingDrSnapshot;
     private final AtomicBoolean m_snapshotSyncComplete = new AtomicBoolean(false);
@@ -117,37 +104,6 @@ public class LeaderAppointer implements Promotable
     // handling of callbacks in LeaderAppointer.
     private final ExecutorService m_es =
         CoreUtils.getCachedSingleThreadExecutor("LeaderAppointer-Babysitters", 15000);
-    private final SnapshotSchedule m_partSnapshotSchedule;
-
-    private final SnapshotResponseHandler m_snapshotHandler =
-        new SnapshotResponseHandler() {
-            @Override
-            public void handleResponse(ClientResponse resp)
-            {
-                if (resp == null) {
-                    VoltDB.crashLocalVoltDB("Received a null response to a snapshot initiation request.  " +
-                            "This should be impossible.", true, null);
-                }
-                else if (resp.getStatus() != ClientResponse.SUCCESS) {
-                    tmLog.info("Failed to complete partition detection snapshot, status: " + resp.getStatus() +
-                            ", reason: " + resp.getStatusString());
-                    tmLog.info("Retrying partition detection snapshot...");
-                    SnapshotUtil.requestSnapshot(0L,
-                            m_partSnapshotSchedule.getPath(),
-                            m_partSnapshotSchedule.getPrefix() + System.currentTimeMillis(),
-                            true, SnapshotFormat.NATIVE, null, m_snapshotHandler,
-                            true);
-                }
-                else if (!SnapshotUtil.didSnapshotRequestSucceed(resp.getResults())) {
-                    VoltDB.crashGlobalVoltDB("Unable to complete partition detection snapshot: " +
-                        resp.getResults()[0], false, null);
-                }
-                else {
-                    VoltDB.crashGlobalVoltDB("Partition detection snapshot completed. Shutting down.",
-                            false, null);
-                }
-            }
-        };
 
     private class PartitionCallback extends BabySitter.Callback
     {
@@ -182,13 +138,13 @@ public class LeaderAppointer implements Promotable
             // compute previously unseen HSId set in the callback list
             Set<Long> newHSIds = new HashSet<Long>(updatedHSIds);
             newHSIds.removeAll(m_replicas);
-            tmLog.debug("Newly seen replicas: " + CoreUtils.hsIdCollectionToString(newHSIds));
+            tmLog.info("Newly seen replicas: " + CoreUtils.hsIdCollectionToString(newHSIds));
             // compute previously seen but now vanished from the callback list HSId set
             Set<Long> missingHSIds = new HashSet<Long>(m_replicas);
             missingHSIds.removeAll(updatedHSIds);
-            tmLog.debug("Newly dead replicas: " + CoreUtils.hsIdCollectionToString(missingHSIds));
+            tmLog.info("Newly dead replicas: " + CoreUtils.hsIdCollectionToString(missingHSIds));
 
-            tmLog.debug("Handling babysitter callback for partition " + m_partitionId + ": children: " +
+            tmLog.info("Handling babysitter callback for partition " + m_partitionId + ": children: " +
                     CoreUtils.hsIdCollectionToString(updatedHSIds));
             if (m_state.get() == AppointerState.CLUSTER_START) {
                 // We can't yet tolerate a host failure during startup.  Crash it all
@@ -236,10 +192,6 @@ public class LeaderAppointer implements Promotable
                 if (m_expectingDrSnapshot && m_snapshotSyncComplete.get() == false) {
                     VoltDB.crashGlobalVoltDB("Detected node failure during DR snapshot sync. Cluster will shut down.",
                                              false, null);
-                }
-                // Check to see if there's been a possible network partition and we're not already handling it
-                if (m_partitionDetectionEnabled && !m_partitionDetected) {
-                    doPartitionDetectionActivities(hostsOnRing);
                 }
                 // If we survived the above gauntlet of fail, appoint a new leader for this partition.
                 if (missingHSIds.contains(m_currentLeader)) {
@@ -309,14 +261,15 @@ public class LeaderAppointer implements Promotable
         }
     };
 
-    public LeaderAppointer(HostMessenger hm, int numberOfPartitions,
-            int kfactor, boolean partitionDetectionEnabled,
-            SnapshotSchedule partitionSnapshotSchedule,
-            boolean usingCommandLog,
-            JSONObject topology, MpInitiator mpi,
-            KSafetyStats stats, boolean expectingDrSnapshot)
+    public LeaderAppointer(HostMessenger hm,
+                           int numberOfPartitions,
+                           int kfactor,
+                           SnapshotSchedule partitionSnapshotSchedule,
+                           JSONObject topology,
+                           MpInitiator mpi,
+                           KSafetyStats stats,
+                           boolean expectingDrSnapshot)
     {
-        m_hostMessenger = hm;
         m_zk = hm.getZK();
         m_kfactor = kfactor;
         m_topo = topology;
@@ -326,18 +279,8 @@ public class LeaderAppointer implements Promotable
         m_partitionWatchers = new HashMap<Integer, BabySitter>();
         m_iv2appointees = new LeaderCache(m_zk, VoltZK.iv2appointees);
         m_iv2masters = new LeaderCache(m_zk, VoltZK.iv2masters, m_masterCallback);
-        m_partitionDetectionEnabled = partitionDetectionEnabled;
-        m_partSnapshotSchedule = partitionSnapshotSchedule;
-        m_usingCommandLog = usingCommandLog;
         m_stats = stats;
         m_expectingDrSnapshot = expectingDrSnapshot;
-        if (m_partitionDetectionEnabled) {
-            if (!testPartitionDetectionDirectory(m_partSnapshotSchedule))
-            {
-                VoltDB.crashLocalVoltDB("Unable to create partition detection snapshot directory at " +
-                        m_partSnapshotSchedule.getPath(), false, null);
-            }
-        }
     }
 
     @Override
@@ -401,7 +344,6 @@ public class LeaderAppointer implements Promotable
             // LeaderCache callback will count it down once it has seen all the
             // appointed leaders publish themselves as the actual leaders.
             m_startupLatch = SettableFuture.create();
-            writeKnownLiveNodes(new HashSet<Integer>(m_hostMessenger.getLiveHostIds()));
 
             // Theoretically, the whole try/catch block below can be removed because the leader
             // appointer now watches the parent dir for any new partitions. It doesn't have to
@@ -562,175 +504,6 @@ public class LeaderAppointer implements Promotable
             VoltDB.crashLocalVoltDB("Unable to appoint new master for partition " + partitionId, true, e);
         }
         return masterHSId;
-    }
-
-    private void writeKnownLiveNodes(Set<Integer> liveNodes)
-    {
-        try {
-            if (m_zk.exists(VoltZK.lastKnownLiveNodes, null) == null)
-            {
-                // VoltZK.createPersistentZKNodes should have done this
-                m_zk.create(VoltZK.lastKnownLiveNodes, null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-            }
-            JSONStringer stringer = new JSONStringer();
-            stringer.object();
-            stringer.key("liveNodes").array();
-            for (Integer node : liveNodes) {
-                stringer.value(node);
-            }
-            stringer.endArray();
-            stringer.endObject();
-            JSONObject obj = new JSONObject(stringer.toString());
-            tmLog.debug("Writing live nodes to ZK: " + obj.toString(4));
-            m_zk.setData(VoltZK.lastKnownLiveNodes, obj.toString(4).getBytes("UTF-8"), -1);
-        } catch (Exception e) {
-            VoltDB.crashLocalVoltDB("Unable to update known live nodes at ZK path: " +
-                    VoltZK.lastKnownLiveNodes, true, e);
-        }
-    }
-
-    private Set<Integer> readPriorKnownLiveNodes()
-    {
-        Set<Integer> nodes = new HashSet<Integer>();
-        try {
-            byte[] data = m_zk.getData(VoltZK.lastKnownLiveNodes, false, null);
-            String jsonString = new String(data, "UTF-8");
-            tmLog.debug("Read prior known live nodes: " + jsonString);
-            JSONObject jsObj = new JSONObject(jsonString);
-            JSONArray jsonNodes = jsObj.getJSONArray("liveNodes");
-            for (int ii = 0; ii < jsonNodes.length(); ii++) {
-                nodes.add(jsonNodes.getInt(ii));
-            }
-        } catch (Exception e) {
-            VoltDB.crashLocalVoltDB("Unable to read prior known live nodes at ZK path: " +
-                    VoltZK.lastKnownLiveNodes, true, e);
-        }
-        return nodes;
-    }
-
-    /*
-     * Check if the directory specified for the snapshot on partition detection
-     * exists, and has permissions set correctly.
-     */
-    private boolean testPartitionDetectionDirectory(SnapshotSchedule schedule) {
-        if (m_partitionDetectionEnabled) {
-            File partitionPath = new File(schedule.getPath());
-            if (!partitionPath.exists()) {
-                tmLog.error("Directory " + partitionPath + " for partition detection snapshots does not exist");
-                return false;
-            }
-            if (!partitionPath.isDirectory()) {
-                tmLog.error("Directory " + partitionPath + " for partition detection snapshots is not a directory");
-                return false;
-            }
-            File partitionPathFile = new File(partitionPath, Long.toString(System.currentTimeMillis()));
-            try {
-                partitionPathFile.createNewFile();
-                partitionPathFile.delete();
-            } catch (IOException e) {
-                tmLog.error(
-                        "Could not create a test file in " +
-                        partitionPath +
-                        " for partition detection snapshots");
-                e.printStackTrace();
-                return false;
-            }
-            return true;
-        } else {
-            return true;
-        }
-    }
-
-    /**
-     * Given a set of the known host IDs before a fault, and the known host IDs in the
-     * post-fault cluster, determine whether or not we think a network partition may have happened.
-     * NOTE: this assumes that we have already done the k-safety validation for every partition and already failed
-     * if we weren't a viable cluster.
-     * ALSO NOTE: not private so it may be unit-tested.
-     */
-    static boolean makePPDDecision(Set<Integer> previousHosts, Set<Integer> currentHosts)
-    {
-        // Real partition detection stuff would go here
-        // find the lowest hostId between the still-alive hosts and the
-        // failed hosts. Which set contains the lowest hostId?
-        int blessedHostId = Integer.MAX_VALUE;
-        boolean blessedHostIdInFailedSet = true;
-
-        // This should be all the pre-partition hosts IDs.  Any new host IDs
-        // (say, if this was triggered by rejoin), will be greater than any surviving
-        // host ID, so don't worry about including it in this search.
-        for (Integer hostId : previousHosts) {
-            if (hostId < blessedHostId) {
-                blessedHostId = hostId;
-            }
-        }
-
-        for (Integer hostId : currentHosts) {
-            if (hostId.equals(blessedHostId)) {
-                blessedHostId = hostId;
-                blessedHostIdInFailedSet = false;
-            }
-        }
-
-        // Evaluate PPD triggers.
-        boolean partitionDetectionTriggered = false;
-        // Exact 50-50 splits. The set with the lowest survivor host doesn't trigger PPD
-        // If the blessed host is in the failure set, this set is not blessed.
-        if (currentHosts.size() * 2 == previousHosts.size()) {
-            if (blessedHostIdInFailedSet) {
-                tmLog.info("Partition detection triggered for 50/50 cluster failure. " +
-                        "This survivor set is shutting down.");
-                partitionDetectionTriggered = true;
-            }
-            else {
-                tmLog.info("Partition detected for 50/50 failure. " +
-                        "This survivor set is continuing execution.");
-            }
-        }
-
-        // A strict, viable minority is always a partition.
-        if (currentHosts.size() * 2 < previousHosts.size()) {
-            tmLog.info("Partition detection triggered. " +
-                         "This minority survivor set is shutting down.");
-            partitionDetectionTriggered = true;
-        }
-
-        return partitionDetectionTriggered;
-    }
-
-    private void doPartitionDetectionActivities(Set<Integer> currentNodes)
-    {
-        // We should never re-enter here once we've decided we're partitioned and doomed
-        assert(!m_partitionDetected);
-
-        Set<Integer> currentHosts = new HashSet<Integer>(currentNodes);
-        Set<Integer> previousHosts = readPriorKnownLiveNodes();
-
-        boolean partitionDetectionTriggered = makePPDDecision(previousHosts, currentHosts);
-
-        if (partitionDetectionTriggered) {
-            m_partitionDetected = true;
-            if (m_usingCommandLog) {
-                // Just shut down immediately
-                VoltDB.crashGlobalVoltDB("Use of command logging detected, no additional database snapshot will " +
-                        "be generated.  Please use the 'recover' action to restore the database if necessary.",
-                        false, null);
-            }
-            else {
-                SnapshotUtil.requestSnapshot(0L,
-                        m_partSnapshotSchedule.getPath(),
-                        m_partSnapshotSchedule.getPrefix() + System.currentTimeMillis(),
-                        true, SnapshotFormat.NATIVE, null, m_snapshotHandler,
-                        true);
-            }
-        }
-        // If the cluster host set has changed, then write the new set to ZK
-        // NOTE: we don't want to update the known live nodes if we've decided that our subcluster is
-        // dying, otherwise a poorly timed subsequent failure might reverse this decision.  Any future promoted
-        // LeaderAppointer should make their partition detection decision based on the pre-partition cluster state.
-        else if (!currentHosts.equals(previousHosts)) {
-            writeKnownLiveNodes(currentNodes);
-        }
     }
 
     private boolean isClusterKSafe(Set<Integer> hostsOnRing)

--- a/src/frontend/org/voltdb/iv2/LeaderCache.java
+++ b/src/frontend/org/voltdb/iv2/LeaderCache.java
@@ -17,19 +17,17 @@
 
 package org.voltdb.iv2;
 
-import java.io.UnsupportedEncodingException;
-
 import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.Future;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.zookeeper_voltpatches.CreateMode;
 import org.apache.zookeeper_voltpatches.KeeperException;
@@ -41,8 +39,7 @@ import org.voltcore.utils.CoreUtils;
 import org.voltcore.zk.ZKUtil;
 import org.voltcore.zk.ZKUtil.ByteArrayCallback;
 
-import org.voltdb.VoltDB;
-
+import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
 
@@ -121,17 +118,13 @@ public class LeaderCache implements LeaderCacheReader, LeaderCacheWriter {
     @Override
     public void put(int partitionId, long HSId) throws KeeperException, InterruptedException {
         try {
-            try {
-                m_zk.create(ZKUtil.joinZKPath(m_rootNode, Integer.toString(partitionId)),
-                        Long.toString(HSId).getBytes("UTF-8"),
-                        Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-            } catch (KeeperException.NodeExistsException e) {
-                m_zk.setData(ZKUtil.joinZKPath(m_rootNode, Integer.toString(partitionId)),
-                        Long.toString(HSId).getBytes("UTF-8"), -1);
-            }
+            m_zk.create(ZKUtil.joinZKPath(m_rootNode, Integer.toString(partitionId)),
+                    Long.toString(HSId).getBytes(Charsets.UTF_8),
+                    Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         }
-        catch (UnsupportedEncodingException utf8) {
-            VoltDB.crashLocalVoltDB("Invalid string encoding: UTF-8", true, utf8);
+        catch (KeeperException.NodeExistsException e) {
+            m_zk.setData(ZKUtil.joinZKPath(m_rootNode, Integer.toString(partitionId)),
+                    Long.toString(HSId).getBytes(Charsets.UTF_8), -1);
         }
     }
 

--- a/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
+++ b/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
@@ -24,11 +24,14 @@
 package org.voltcore.messaging;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.After;
@@ -168,4 +171,55 @@ public class TestHostMessenger {
         hm3.waitForGroupJoin(2);
     }
 
+    @Test
+    public void testPartitionDetectionMinoritySet() throws Exception
+    {
+        Set<Integer> previous = new HashSet<Integer>();
+        Set<Integer> current = new HashSet<Integer>();
+
+        // current cluster has 2 hosts
+        current.add(0);
+        current.add(1);
+        // the pre-fail cluster had 5 hosts.
+        previous.addAll(current);
+        previous.add(2);
+        previous.add(3);
+        previous.add(4);
+        // this should trip partition detection
+        assertTrue(HostMessenger.makePPDDecision(previous, current));
+    }
+
+    @Test
+    public void testPartitionDetection5050KillBlessed() throws Exception
+    {
+        Set<Integer> previous = new HashSet<Integer>();
+        Set<Integer> current = new HashSet<Integer>();
+
+        // current cluster has 2 hosts
+        current.add(2);
+        current.add(3);
+        // the pre-fail cluster had 4 hosts and the lowest host ID
+        previous.addAll(current);
+        previous.add(0);
+        previous.add(1);
+        // this should trip partition detection
+        assertTrue(HostMessenger.makePPDDecision(previous, current));
+    }
+
+    @Test
+    public void testPartitionDetection5050KillNonBlessed() throws Exception
+    {
+        Set<Integer> previous = new HashSet<Integer>();
+        Set<Integer> current = new HashSet<Integer>();
+
+        // current cluster has 2 hosts
+        current.add(0);
+        current.add(1);
+        // the pre-fail cluster had 4 hosts but not the lowest host ID
+        previous.addAll(current);
+        previous.add(2);
+        previous.add(3);
+        // this should not trip partition detection
+        assertFalse(HostMessenger.makePPDDecision(previous, current));
+    }
 }

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -30,15 +30,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.google_voltpatches.common.collect.Maps;
-import com.google_voltpatches.common.collect.Sets;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONException;
@@ -55,6 +52,8 @@ import org.voltdb.VoltZK;
 import org.voltdb.compiler.ClusterConfig;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.Maps;
+import com.google_voltpatches.common.collect.Sets;
 
 public class TestLeaderAppointer extends ZKTestBase {
 
@@ -129,9 +128,8 @@ public class TestLeaderAppointer extends ZKTestBase {
     {
         KSafetyStats stats = new KSafetyStats();
         m_dut = new LeaderAppointer(m_hm, m_config.getPartitionCount(),
-                m_config.getReplicationFactor(), enablePPD,
-                null, false,
-                m_config.getTopology(m_hostGroups), m_mpi, stats, false);
+                m_config.getReplicationFactor(),
+                null, m_config.getTopology(m_hostGroups), m_mpi, stats, false);
         m_dut.onReplayCompletion();
     }
 
@@ -276,11 +274,14 @@ public class TestLeaderAppointer extends ZKTestBase {
         m_dut.shutdown();
         deleteReplica(0, m_cache.pointInTimeCache().get(0));
         // create a new appointer and start it up in the replay state
-        m_dut = new LeaderAppointer(m_hm, m_config.getPartitionCount(),
-                                    m_config.getReplicationFactor(), false,
-                                    null, false,
-                                    m_config.getTopology(m_hostGroups), m_mpi,
-                                    new KSafetyStats(), false);
+        m_dut = new LeaderAppointer(m_hm,
+                                    m_config.getPartitionCount(),
+                                    m_config.getReplicationFactor(),
+                                    null,
+                                    m_config.getTopology(m_hostGroups),
+                                    m_mpi,
+                                    new KSafetyStats(),
+                                    false);
         m_newAppointee.set(false);
         VoltDB.ignoreCrash = true;
         boolean threw = false;
@@ -419,58 +420,6 @@ public class TestLeaderAppointer extends ZKTestBase {
     }
 
     @Test
-    public void testPartitionDetectionMinoritySet() throws Exception
-    {
-        Set<Integer> previous = new HashSet<Integer>();
-        Set<Integer> current = new HashSet<Integer>();
-
-        // current cluster has 2 hosts
-        current.add(0);
-        current.add(1);
-        // the pre-fail cluster had 5 hosts.
-        previous.addAll(current);
-        previous.add(2);
-        previous.add(3);
-        previous.add(4);
-        // this should trip partition detection
-        assertTrue(LeaderAppointer.makePPDDecision(previous, current));
-    }
-
-    @Test
-    public void testPartitionDetection5050KillBlessed() throws Exception
-    {
-        Set<Integer> previous = new HashSet<Integer>();
-        Set<Integer> current = new HashSet<Integer>();
-
-        // current cluster has 2 hosts
-        current.add(2);
-        current.add(3);
-        // the pre-fail cluster had 4 hosts and the lowest host ID
-        previous.addAll(current);
-        previous.add(0);
-        previous.add(1);
-        // this should trip partition detection
-        assertTrue(LeaderAppointer.makePPDDecision(previous, current));
-    }
-
-    @Test
-    public void testPartitionDetection5050KillNonBlessed() throws Exception
-    {
-        Set<Integer> previous = new HashSet<Integer>();
-        Set<Integer> current = new HashSet<Integer>();
-
-        // current cluster has 2 hosts
-        current.add(0);
-        current.add(1);
-        // the pre-fail cluster had 4 hosts but not the lowest host ID
-        previous.addAll(current);
-        previous.add(2);
-        previous.add(3);
-        // this should not trip partition detection
-        assertFalse(LeaderAppointer.makePPDDecision(previous, current));
-    }
-
-    @Test
     public void testAddPartition() throws Exception
     {
         // run once to get to a startup state
@@ -572,11 +521,14 @@ public class TestLeaderAppointer extends ZKTestBase {
         m_dut.shutdown();
         deleteReplica(0, m_cache.pointInTimeCache().get(0));
         // create a new appointer and start it up with expectSyncSnapshot=true
-        m_dut = new LeaderAppointer(m_hm, m_config.getPartitionCount(),
-                                    m_config.getReplicationFactor(), false,
-                                    null, false,
-                                    m_config.getTopology(m_hostGroups), m_mpi,
-                                    new KSafetyStats(), true);
+        m_dut = new LeaderAppointer(m_hm,
+                                    m_config.getPartitionCount(),
+                                    m_config.getReplicationFactor(),
+                                    null,
+                                    m_config.getTopology(m_hostGroups),
+                                    m_mpi,
+                                    new KSafetyStats(),
+                                    true);
         m_dut.onReplayCompletion();
         m_newAppointee.set(false);
         VoltDB.ignoreCrash = true;

--- a/tests/frontend/org/voltdb/regressionsuites/TestStopNode2NK1PartitionDetectionOn.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestStopNode2NK1PartitionDetectionOn.java
@@ -26,14 +26,14 @@ package org.voltdb.regressionsuites;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
-import junit.framework.Test;
-
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcedureCallback;
 import org.voltdb.compiler.VoltProjectBuilder;
+
+import junit.framework.Test;
 
 public class TestStopNode2NK1PartitionDetectionOn extends RegressionSuite
 {
@@ -108,7 +108,7 @@ public class TestStopNode2NK1PartitionDetectionOn extends RegressionSuite
         //Lets tolerate 3 node failures.
         m_config = new LocalCluster("decimal-default.jar", 4, 2, 1, BackendTarget.NATIVE_EE_JNI);
         m_config.setHasLocalServer(true);
-        project.setPartitionDetectionSettings(TMPDIR, TESTNONCE);
+        project.setPartitionDetectionEnabled(true);
         success = m_config.compile(project);
         assertTrue(success);
 


### PR DESCRIPTION
1) Move partition detection into HostMessenger so it happens sooner.
2) Have CrashGlobal/LocalVoltDB kill the client connection ASAP.
3) Remove the partition snapshot feature.
4) Hopefully improve error messaging

I still need to add an error message if you start with partition snapshot settings set.