### PR TITLE
ENG-10463, make getTestDRBuffer flexible to generate binary log with …

### DIFF
--- a/src/ee/storage/CompatibleDRTupleStream.cpp
+++ b/src/ee/storage/CompatibleDRTupleStream.cpp
@@ -422,6 +422,7 @@ bool CompatibleDRTupleStream::checkOpenTransaction(StreamBlock* sb, size_t minLe
 int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionId,
     std::vector<int32_t> partitionKeyValueList,
     std::vector<int32_t> flagList,
+    long startSequenceNumber,
     char *outBytes) {
 
     CompatibleDRTupleStream stream(partitionId, 2 * 1024 * 1024 + MAGIC_HEADER_SPACE_FOR_JAVA + MAGIC_DR_TRANSACTION_PADDING); // 2MB
@@ -445,6 +446,7 @@ int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionId,
     TableTuple tuple(tupleMemory, schema);
 
     int64_t lastUID = UniqueId::makeIdFromComponents(-5, 0, partitionId);
+    stream.m_openSequenceNumber = startSequenceNumber - 1;
     for (int ii = 0; ii < flagList.size(); ii++) {
         int64_t uid = UniqueId::makeIdFromComponents(ii * 5, 0, (flagList[ii] == TXN_PAR_HASH_MULTI || flagList[ii] == TXN_PAR_HASH_SPECIAL) ? 16383 : partitionId);
         tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValueList[ii]));

--- a/src/ee/storage/CompatibleDRTupleStream.h
+++ b/src/ee/storage/CompatibleDRTupleStream.h
@@ -90,6 +90,7 @@ public:
     static int32_t getTestDRBuffer(int32_t partitionId,
                                    std::vector<int32_t> partitionKeyValueList,
                                    std::vector<int32_t> flagList,
+                                   long startSequenceNumber,
                                    char *out);
 private:
     void transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId);

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -551,7 +551,7 @@ void DRTupleStream::generateDREvent(DREventType type, int64_t lastCommittedSpHan
 
 int32_t DRTupleStream::getTestDRBuffer(int32_t partitionId,
     std::vector<int32_t> partitionKeyValueList,
-    std::vector<int32_t> flagList,
+    std::vector<int32_t> flagList, long startSequenceNumber,
     char *outBytes) {
 
     DRTupleStream stream(partitionId, 2 * 1024 * 1024 + MAGIC_HEADER_SPACE_FOR_JAVA + MAGIC_DR_TRANSACTION_PADDING); // 2MB
@@ -575,6 +575,8 @@ int32_t DRTupleStream::getTestDRBuffer(int32_t partitionId,
     TableTuple tuple(tupleMemory, schema);
 
     int64_t lastUID = UniqueId::makeIdFromComponents(-5, 0, partitionId);
+    // Override start sequence number
+    stream.m_openSequenceNumber = startSequenceNumber - 1;
     for (int ii = 0; ii < flagList.size(); ii++) {
         int64_t uid = UniqueId::makeIdFromComponents(ii * 5, 0, (flagList[ii] == TXN_PAR_HASH_MULTI || flagList[ii] == TXN_PAR_HASH_SPECIAL) ? 16383 : partitionId);
         tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValueList[ii]));

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -93,6 +93,7 @@ public:
     static int32_t getTestDRBuffer(int32_t partitionId,
                                    std::vector<int32_t> partitionKeyValueList,
                                    std::vector<int32_t> flagList,
+                                   long startSequenceNumber,
                                    char *out);
 
 private:

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1424,7 +1424,8 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExecu
  * Signature: (ZI[I[I)[B
  */
 SHAREDLIB_JNIEXPORT jbyteArray JNICALL Java_org_voltdb_jni_ExecutionEngine_getTestDRBuffer
-  (JNIEnv *env, jclass clazz, jboolean compatible, jint partitionId, jintArray partitionKeyValues, jintArray flags) {
+  (JNIEnv *env, jclass clazz, jboolean compatible, jint partitionId, jintArray partitionKeyValues, jintArray flags,
+          jlong startSequenceNumber) {
     try {
         jint *partitionKeyValuesJPtr = env->GetIntArrayElements(partitionKeyValues, NULL);
         int32_t *partitionKeyValuesPtr = reinterpret_cast<int32_t *>(partitionKeyValuesJPtr);
@@ -1442,9 +1443,11 @@ SHAREDLIB_JNIEXPORT jbyteArray JNICALL Java_org_voltdb_jni_ExecutionEngine_getTe
         char *output = new char[1024 * 256];
         int32_t length;
         if (compatible) {
-            length = CompatibleDRTupleStream::getTestDRBuffer(partitionId, partitionKeyValueList, flagList, output);
+            length = CompatibleDRTupleStream::getTestDRBuffer(partitionId, partitionKeyValueList, flagList,
+                    startSequenceNumber, output);
         } else {
-            length = DRTupleStream::getTestDRBuffer(partitionId, partitionKeyValueList, flagList, output);
+            length = DRTupleStream::getTestDRBuffer(partitionId, partitionKeyValueList, flagList,
+                    startSequenceNumber, output);
         }
         jbyteArray array = env->NewByteArray(length);
         jbyte *arrayBytes = env->GetByteArrayElements(array, NULL);

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -1033,9 +1033,11 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * @param partitionId producer partition ID
      * @param partitionKeyValues list of partition key value that specifies the desired partition key value of each txn
      * @param flags list of DRTxnPartitionHashFlags that specifies the desired type of each txn
+     * @param startSequenceNumber the starting sequence number of DR buffers
      * @return payload bytes (only txns with no InvocationBuffer header)
      */
-    public native static byte[] getTestDRBuffer(boolean compatible, int partitionId, int partitionKeyValues[], int flags[]);
+    public native static byte[] getTestDRBuffer(boolean compatible, int partitionId, int partitionKeyValues[], int flags[],
+            long startSequenceNumber);
 
     /**
      * Start collecting statistics (starts timer).


### PR DESCRIPTION
…any DR sequence number.

Change-Id: I92f7e616a4f22de96bf2b14c600446d0bd54b6b2