### PR TITLE
ENG-10421: allow multiple hosts trying to rejoin at the same time

### DIFF
--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -486,7 +486,12 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     /**
      * Start the host messenger and connect to the leader, or become the leader
      * if necessary.
-     * @param request    The requested action to send to other nodes when joining the mesh.
+     *
+     * @param request The requested action to send to other nodes when joining
+     * the mesh. This is opaque to the HostMessenger, it can be any
+     * string. HostMessenger will encode this in the request to join mesh to the
+     * live hosts. The live hosts can use this request string to make further
+     * decision on whether or not to accept the request.
      */
     public void start(String request) throws Exception {
         /*
@@ -679,9 +684,14 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
     }
 
-    /*
+    /**
      * Any node can serve a request to join. The coordination of generating a new host id
      * is done via ZK
+     *
+     * @param request The requested action from the rejoining host. This is
+     * opaque to the HostMessenger, it can be any string. The request string can
+     * be used to make further decision on whether or not to accept the request
+     * in the MembershipAcceptor.
      */
     @Override
     public void requestJoin(SocketChannel socket, InetSocketAddress listeningAddress, String request) throws Exception {

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -710,6 +710,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                     int read = socket.read(finishedJoining);
                     if (read == -1) {
                         m_networkLog.info("New connection was unable to establish mesh");
+                        socket.close();
                         return;
                     } else if (read < 1) {
                         Thread.sleep(5);
@@ -726,6 +727,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                 m_networkLog.error("Error joining new node", e);
                 addFailedHost(hostId);
                 removeForeignHost(hostId);
+                socket.close();
                 return;
             }
 

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -431,6 +431,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                     }
                 }
 
+                // notifying any watchers who are interested in failure -- used
+                // initially to do ZK cleanup when rejoining nodes die
                 if (m_hostWatcher != null) {
                     m_hostWatcher.hostsFailed(failedHostIds);
                 }

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -708,7 +708,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                 if (m_membershipAcceptor != null) {
                     shouldAcceptMember = m_membershipAcceptor.shouldAccept(hostId, request, errMsg);
                 } else {
-                    shouldAcceptMember = false;
+                    shouldAcceptMember = true;
                 }
 
                 /*

--- a/src/frontend/org/voltcore/messaging/SocketJoiner.java
+++ b/src/frontend/org/voltcore/messaging/SocketJoiner.java
@@ -707,7 +707,7 @@ public class SocketJoiner {
 
             /*
              * Notify the leader that we connected to the entire cluster, it will then go
-             * and queue a txn for our agreement site to join the lcuster
+             * and queue a txn for our agreement site to join the cluster
              */
             ByteBuffer joinCompleteBuffer = ByteBuffer.allocate(1);
             while (joinCompleteBuffer.hasRemaining()) {

--- a/src/frontend/org/voltcore/messaging/SocketJoiner.java
+++ b/src/frontend/org/voltcore/messaging/SocketJoiner.java
@@ -596,7 +596,7 @@ public class SocketJoiner {
             JSONObject jsonObj = readJSONObjFromWire(socket, remoteAddress);
 
             // check if the membership request is accepted
-            if (jsonObj.has("accepted") && !jsonObj.getBoolean("accepted")) {
+            if (!jsonObj.optBoolean("accepted", true)) {
                 socket.close();
                 throw new CoreUtils.RetryException(jsonObj.getString("reason"));
             }

--- a/src/frontend/org/voltcore/messaging/SocketJoiner.java
+++ b/src/frontend/org/voltcore/messaging/SocketJoiner.java
@@ -595,7 +595,7 @@ public class SocketJoiner {
             JSONObject jsonObj = readJSONObjFromWire(socket, remoteAddress);
 
             // check if the membership request is accepted
-            if (!jsonObj.getBoolean("accepted")) {
+            if (jsonObj.has("accepted") && !jsonObj.getBoolean("accepted")) {
                 socket.close();
                 throw new CoreUtils.RetryException(jsonObj.getString("reason"));
             }

--- a/src/frontend/org/voltcore/messaging/SocketJoiner.java
+++ b/src/frontend/org/voltcore/messaging/SocketJoiner.java
@@ -197,6 +197,9 @@ public class SocketJoiner {
                     try { Thread.sleep(TimeUnit.SECONDS.toMillis(retryInterval)); } catch (InterruptedException e1) {}
                     // exponential back off with a salt to avoid collision. Max is 5 minutes.
                     retryInterval = Math.min(retryInterval * 2, TimeUnit.MINUTES.toSeconds(5)) + salt.nextInt(30);
+                } catch (Exception e) {
+                    hostLog.error("Failed to establish socket mesh.", e);
+                    throw new RuntimeException(e);
                 }
             }
         }
@@ -506,7 +509,8 @@ public class SocketJoiner {
      * it must connect to the leader which will generate a host id and
      * advertise the rest of the cluster so that connectToPrimary can connect to it
      */
-    private void connectToPrimary() throws CoreUtils.RetryException {
+    private void connectToPrimary() throws Exception
+    {
         // collect clock skews from all nodes
         List<Long> skews = new ArrayList<Long>();
 
@@ -721,9 +725,6 @@ public class SocketJoiner {
             m_joinHandler.notifyOfHosts( m_localHostId, hostIds, hostSockets, listeningAddresses);
         } catch (ClosedByInterruptException e) {
             //This is how shutdown is done
-        } catch (Exception e) {
-            hostLog.error("Failed to establish socket mesh.", e);
-            throw new RuntimeException(e);
         }
     }
 

--- a/src/frontend/org/voltcore/messaging/SocketJoiner.java
+++ b/src/frontend/org/voltcore/messaging/SocketJoiner.java
@@ -185,7 +185,7 @@ public class SocketJoiner {
              * The request to join the cluster may be rejected, e.g. multiple hosts
              * rejoining at the same time. In this case, the code will retry.
              */
-            long retryInterval = 10;
+            long retryInterval = Integer.getInteger("MESH_JOIN_RETRY_INTERVAL", 10);
             final Random salt = new Random();
             while (true) {
                 try {
@@ -196,7 +196,8 @@ public class SocketJoiner {
                                            retryInterval, e.getMessage()));
                     try { Thread.sleep(TimeUnit.SECONDS.toMillis(retryInterval)); } catch (InterruptedException e1) {}
                     // exponential back off with a salt to avoid collision. Max is 5 minutes.
-                    retryInterval = Math.min(retryInterval * 2, TimeUnit.MINUTES.toSeconds(5)) + salt.nextInt(30);
+                    retryInterval = (Math.min(retryInterval * 2, TimeUnit.MINUTES.toSeconds(5)) +
+                                     salt.nextInt(Integer.getInteger("MESH_JOIN_RETRY_INTERVAL_SALT", 30)));
                 } catch (Exception e) {
                     hostLog.error("Failed to establish socket mesh.", e);
                     throw new RuntimeException(e);

--- a/src/frontend/org/voltcore/utils/CoreUtils.java
+++ b/src/frontend/org/voltcore/utils/CoreUtils.java
@@ -974,10 +974,13 @@ public class CoreUtils {
         return Math.max(1, Runtime.getRuntime().availableProcessors());
     }
 
-    public static final class RetryException extends RuntimeException {
+    public static final class RetryException extends Exception {
         public RetryException() {};
         public RetryException(Throwable cause) {
             super(cause);
+        }
+        public RetryException(String errMsg) {
+            super(errMsg);
         }
     }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1071,7 +1071,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     @Override
     public void hostsFailed(Set<Integer> failedHosts)
     {
-        scheduleWork(new Runnable() {
+        getSES(true).submit(new Runnable() {
             @Override
             public void run()
             {
@@ -1082,7 +1082,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     VoltZK.removeRejoinNodeIndicatorForHost(m_messenger.getZK(), hostId);
                 }
             }
-        }, 0, 0, TimeUnit.MILLISECONDS);
+        });
     }
 
     class DailyLogTask implements Runnable {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1038,6 +1038,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         }
     }
 
+    /**
+     * This is currently used to prevent simultaneous rejoins and rejoins during network partition.
+     * It returns true for non-rejoin cases.
+     */
     @Override
     public boolean shouldAccept(int hostId, String request, StringBuilder errMsg)
     {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -504,6 +504,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
             buildClusterMesh(isRejoin || m_joining);
 
+            // Create rejoin guard immediately after joining the mesh to prevent simultaneous rejoins
+            if (isRejoin) {
+                final String node = VoltZK.rejoinNodesBlockerHost+m_messenger.getHostId();
+                VoltZK.createRejoinNodeIndicator(m_messenger.getZK(),node);
+            }
+
             //Register dummy agents immediately
             m_opsRegistrar.registerMailboxes(m_messenger);
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2590,8 +2590,13 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             // so there is no need to wait for the truncation snapshot requested
             // above to finish.
             if (logRecoveryCompleted || m_joining) {
+                if (m_rejoining) {
+                    final String node = VoltZK.rejoinNodesBlockerHost + String.valueOf(m_myHostId);
+                    VoltZK.removeRejoinNodeIndicator(m_messenger.getZK(), node);
+                    m_rejoining = false;
+                }
+
                 String actionName = m_joining ? "join" : "rejoin";
-                m_rejoining = false;
                 m_joining = false;
                 consoleLog.info(String.format("Node %s completed", actionName));
             }

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -335,9 +335,10 @@ public class VoltZK {
                 return true;
             }
         } catch (KeeperException e) {
-            if (e.code() != KeeperException.Code.NONODE &&
-                e.code() != KeeperException.Code.BADVERSION) {
-                return false;
+            if (e.code() == KeeperException.Code.NONODE ||
+                e.code() == KeeperException.Code.BADVERSION) {
+                // Okay if the rejoin blocker for the given hostId is already gone.
+                return true;
             }
         } catch (InterruptedException e) {
             return false;

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -332,6 +332,7 @@ public class VoltZK {
             final int rejoiningHost = ByteBuffer.wrap(zk.getData(rejoinNodeBlocker, false, stat)).getInt();
             if (hostId == rejoiningHost) {
                 zk.delete(rejoinNodeBlocker, stat.getVersion());
+                return true;
             }
         } catch (KeeperException e) {
             if (e.code() != KeeperException.Code.NONODE &&
@@ -341,6 +342,6 @@ public class VoltZK {
         } catch (InterruptedException e) {
             return false;
         }
-        return true;
+        return false;
     }
 }

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -482,7 +482,7 @@ public class Cartographer extends StatsSource
                     }
                     // check if any node still in rejoin status
                     try {
-                        List<String> children = m_zk.getChildren(VoltZK.rejoinNodesBlocker, false);
+                        List<String> children = m_zk.getChildren(VoltZK.rejoinNodeBlocker, false);
                         if (!children.isEmpty())
                             return false;
                     } catch (KeeperException.NoNodeException ignore) {} // shouldn't happen

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.apache.zookeeper_voltpatches.data.Stat;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
@@ -482,9 +483,9 @@ public class Cartographer extends StatsSource
                     }
                     // check if any node still in rejoin status
                     try {
-                        List<String> children = m_zk.getChildren(VoltZK.rejoinNodeBlocker, false);
-                        if (!children.isEmpty())
+                        if (m_zk.exists(VoltZK.rejoinNodeBlocker, false) != null) {
                             return false;
+                        }
                     } catch (KeeperException.NoNodeException ignore) {} // shouldn't happen
                     //Otherwise we do check replicas for host
                     return doPartitionsHaveReplicas(hid);

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -187,8 +187,6 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
     public boolean startJoin(Database catalog) {
         m_catalog = catalog;
         boolean schemaHasNoTables = catalog.getTables().isEmpty();
-        final String node = VoltZK.rejoinNodesBlockerHost+m_hostId;
-        VoltZK.createRejoinNodeIndicator(m_messenger.getZK(),node);
         m_startTime = System.currentTimeMillis();
         if (m_liveRejoin) {
             long firstSite;

--- a/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
+++ b/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
@@ -64,7 +64,7 @@ public class TestHostMessenger {
         HostMessenger.Config config = new HostMessenger.Config();
         config.internalPort = config.internalPort + index;
         config.zkInterface = "127.0.0.1:" + (7181 + index);
-        HostMessenger hm = new HostMessenger(config, null);
+        HostMessenger hm = new HostMessenger(config, null, null);
         createdMessengers.add(hm);
         if (start) {
             hm.start(null);

--- a/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
+++ b/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
@@ -64,7 +64,7 @@ public class TestHostMessenger {
         HostMessenger.Config config = new HostMessenger.Config();
         config.internalPort = config.internalPort + index;
         config.zkInterface = "127.0.0.1:" + (7181 + index);
-        HostMessenger hm = new HostMessenger(config);
+        HostMessenger hm = new HostMessenger(config, null);
         createdMessengers.add(hm);
         if (start) {
             hm.start();

--- a/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
+++ b/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
@@ -67,7 +67,7 @@ public class TestHostMessenger {
         HostMessenger hm = new HostMessenger(config, null);
         createdMessengers.add(hm);
         if (start) {
-            hm.start();
+            hm.start(null);
         }
         return hm;
     }
@@ -105,7 +105,7 @@ public class TestHostMessenger {
             @Override
             public void run() {
                 try {
-                    hm2.start();
+                    hm2.start(null);
                 } catch (Exception e) {
                     e.printStackTrace();
                     exception.set(e);
@@ -116,7 +116,7 @@ public class TestHostMessenger {
             @Override
             public void run() {
                 try {
-                    hm3.start();
+                    hm3.start(null);
                 } catch (Exception e) {
                     e.printStackTrace();
                     exception.set(e);

--- a/tests/frontend/org/voltcore/messaging/TestMessaging.java
+++ b/tests/frontend/org/voltcore/messaging/TestMessaging.java
@@ -158,7 +158,7 @@ public class TestMessaging extends TestCase {
                         @Override
                         public void run() {
                             try {
-                                messenger.start();
+                                messenger.start(null);
                             } catch (Exception e) {
                                 e.printStackTrace();
                             }
@@ -303,9 +303,9 @@ public class TestMessaging extends TestCase {
 
     public void testSimple() throws Exception {
         HostMessenger msg1 = new HostMessenger(getConfig(), null);
-        msg1.start();
+        msg1.start(null);
         HostMessenger msg2 = new HostMessenger(getConfig(), null);
-        msg2.start();
+        msg2.start(null);
 
         System.out.println("Waiting for socketjoiners...");
         msg1.waitForGroupJoin(2);
@@ -361,11 +361,11 @@ public class TestMessaging extends TestCase {
 
     public void testMultiMailbox() throws Exception {
         HostMessenger msg1 = new HostMessenger(getConfig(), null);
-        msg1.start();
+        msg1.start(null);
         HostMessenger msg2 = new HostMessenger(getConfig(), null);
-        msg2.start();
+        msg2.start(null);
         HostMessenger msg3 = new HostMessenger(getConfig(), null);
-        msg3.start();
+        msg3.start(null);
 
         System.out.println("Waiting for socketjoiners...");
         msg1.waitForGroupJoin(3);
@@ -496,7 +496,7 @@ public class TestMessaging extends TestCase {
             try {
                 HostMessenger.Config config = new HostMessenger.Config(m_portGenerator);
                 HostMessenger msg = new HostMessenger(config, null);
-                msg.start();
+                msg.start(null);
                 m_ready.set(true);
                 msg.waitForGroupJoin(2);
             } catch (Exception e) {
@@ -515,9 +515,9 @@ public class TestMessaging extends TestCase {
         }
 
         HostMessenger msg1 = new HostMessenger(getConfig(), null);
-        msg1.start();
+        msg1.start(null);
         HostMessenger msg2 = new HostMessenger(getConfig(), null);
-        msg2.start();
+        msg2.start(null);
         System.out.println("Waiting for socketjoiners...");
         msg1.waitForGroupJoin(2);
         System.out.println("Finished socket joiner for msg1");

--- a/tests/frontend/org/voltcore/messaging/TestMessaging.java
+++ b/tests/frontend/org/voltcore/messaging/TestMessaging.java
@@ -151,7 +151,7 @@ public class TestMessaging extends TestCase {
                     }
                     System.out.printf("Host/Site %d/%d is creating a new HostMessenger.\n", hostId, mySiteId);
                     HostMessenger.Config config = new HostMessenger.Config(m_portGenerator);
-                    final HostMessenger messenger = new HostMessenger(config, null);
+                    final HostMessenger messenger = new HostMessenger(config, null, null);
                     currentMessenger = messenger;
                     messengers[hostId] = currentMessenger;
                     new Thread() {
@@ -302,9 +302,9 @@ public class TestMessaging extends TestCase {
     }
 
     public void testSimple() throws Exception {
-        HostMessenger msg1 = new HostMessenger(getConfig(), null);
+        HostMessenger msg1 = new HostMessenger(getConfig(), null, null);
         msg1.start(null);
-        HostMessenger msg2 = new HostMessenger(getConfig(), null);
+        HostMessenger msg2 = new HostMessenger(getConfig(), null, null);
         msg2.start(null);
 
         System.out.println("Waiting for socketjoiners...");
@@ -360,11 +360,11 @@ public class TestMessaging extends TestCase {
     }
 
     public void testMultiMailbox() throws Exception {
-        HostMessenger msg1 = new HostMessenger(getConfig(), null);
+        HostMessenger msg1 = new HostMessenger(getConfig(), null, null);
         msg1.start(null);
-        HostMessenger msg2 = new HostMessenger(getConfig(), null);
+        HostMessenger msg2 = new HostMessenger(getConfig(), null, null);
         msg2.start(null);
-        HostMessenger msg3 = new HostMessenger(getConfig(), null);
+        HostMessenger msg3 = new HostMessenger(getConfig(), null, null);
         msg3.start(null);
 
         System.out.println("Waiting for socketjoiners...");
@@ -495,7 +495,7 @@ public class TestMessaging extends TestCase {
         public void run() {
             try {
                 HostMessenger.Config config = new HostMessenger.Config(m_portGenerator);
-                HostMessenger msg = new HostMessenger(config, null);
+                HostMessenger msg = new HostMessenger(config, null, null);
                 msg.start(null);
                 m_ready.set(true);
                 msg.waitForGroupJoin(2);
@@ -514,9 +514,9 @@ public class TestMessaging extends TestCase {
             throw new RuntimeException(ex);
         }
 
-        HostMessenger msg1 = new HostMessenger(getConfig(), null);
+        HostMessenger msg1 = new HostMessenger(getConfig(), null, null);
         msg1.start(null);
-        HostMessenger msg2 = new HostMessenger(getConfig(), null);
+        HostMessenger msg2 = new HostMessenger(getConfig(), null, null);
         msg2.start(null);
         System.out.println("Waiting for socketjoiners...");
         msg1.waitForGroupJoin(2);

--- a/tests/frontend/org/voltcore/messaging/TestMessaging.java
+++ b/tests/frontend/org/voltcore/messaging/TestMessaging.java
@@ -151,7 +151,7 @@ public class TestMessaging extends TestCase {
                     }
                     System.out.printf("Host/Site %d/%d is creating a new HostMessenger.\n", hostId, mySiteId);
                     HostMessenger.Config config = new HostMessenger.Config(m_portGenerator);
-                    final HostMessenger messenger = new HostMessenger(config);
+                    final HostMessenger messenger = new HostMessenger(config, null);
                     currentMessenger = messenger;
                     messengers[hostId] = currentMessenger;
                     new Thread() {
@@ -302,9 +302,9 @@ public class TestMessaging extends TestCase {
     }
 
     public void testSimple() throws Exception {
-        HostMessenger msg1 = new HostMessenger(getConfig());
+        HostMessenger msg1 = new HostMessenger(getConfig(), null);
         msg1.start();
-        HostMessenger msg2 = new HostMessenger(getConfig());
+        HostMessenger msg2 = new HostMessenger(getConfig(), null);
         msg2.start();
 
         System.out.println("Waiting for socketjoiners...");
@@ -360,11 +360,11 @@ public class TestMessaging extends TestCase {
     }
 
     public void testMultiMailbox() throws Exception {
-        HostMessenger msg1 = new HostMessenger(getConfig());
+        HostMessenger msg1 = new HostMessenger(getConfig(), null);
         msg1.start();
-        HostMessenger msg2 = new HostMessenger(getConfig());
+        HostMessenger msg2 = new HostMessenger(getConfig(), null);
         msg2.start();
-        HostMessenger msg3 = new HostMessenger(getConfig());
+        HostMessenger msg3 = new HostMessenger(getConfig(), null);
         msg3.start();
 
         System.out.println("Waiting for socketjoiners...");
@@ -495,7 +495,7 @@ public class TestMessaging extends TestCase {
         public void run() {
             try {
                 HostMessenger.Config config = new HostMessenger.Config(m_portGenerator);
-                HostMessenger msg = new HostMessenger(config);
+                HostMessenger msg = new HostMessenger(config, null);
                 msg.start();
                 m_ready.set(true);
                 msg.waitForGroupJoin(2);
@@ -514,9 +514,9 @@ public class TestMessaging extends TestCase {
             throw new RuntimeException(ex);
         }
 
-        HostMessenger msg1 = new HostMessenger(getConfig());
+        HostMessenger msg1 = new HostMessenger(getConfig(), null);
         msg1.start();
-        HostMessenger msg2 = new HostMessenger(getConfig());
+        HostMessenger msg2 = new HostMessenger(getConfig(), null);
         msg2.start();
         System.out.println("Waiting for socketjoiners...");
         msg1.waitForGroupJoin(2);

--- a/tests/frontend/org/voltcore/zk/TestStateMachine.java
+++ b/tests/frontend/org/voltcore/zk/TestStateMachine.java
@@ -153,7 +153,7 @@ public class TestStateMachine extends ZKTestBase {
         m_siteIdToZKPort.put(site, clientPort);
         config.networkThreads = 1;
         config.coordinatorIp = new InetSocketAddress( recoverPort );
-        HostMessenger hm = new HostMessenger(config, null);
+        HostMessenger hm = new HostMessenger(config, null, null);
         hm.start(null);
         m_messengers.set(site, hm);
         addStateMachinesFor(site);

--- a/tests/frontend/org/voltcore/zk/TestStateMachine.java
+++ b/tests/frontend/org/voltcore/zk/TestStateMachine.java
@@ -153,7 +153,7 @@ public class TestStateMachine extends ZKTestBase {
         m_siteIdToZKPort.put(site, clientPort);
         config.networkThreads = 1;
         config.coordinatorIp = new InetSocketAddress( recoverPort );
-        HostMessenger hm = new HostMessenger(config);
+        HostMessenger hm = new HostMessenger(config, null);
         hm.start();
         m_messengers.set(site, hm);
         addStateMachinesFor(site);

--- a/tests/frontend/org/voltcore/zk/TestStateMachine.java
+++ b/tests/frontend/org/voltcore/zk/TestStateMachine.java
@@ -154,7 +154,7 @@ public class TestStateMachine extends ZKTestBase {
         config.networkThreads = 1;
         config.coordinatorIp = new InetSocketAddress( recoverPort );
         HostMessenger hm = new HostMessenger(config, null);
-        hm.start();
+        hm.start(null);
         m_messengers.set(site, hm);
         addStateMachinesFor(site);
     }

--- a/tests/frontend/org/voltcore/zk/TestZK.java
+++ b/tests/frontend/org/voltcore/zk/TestZK.java
@@ -79,7 +79,7 @@ public class TestZK extends ZKTestBase {
         m_siteIdToZKPort.put(site, clientPort);
         config.networkThreads = 1;
         config.coordinatorIp = new InetSocketAddress( recoverPort );
-        HostMessenger hm = new HostMessenger(config);
+        HostMessenger hm = new HostMessenger(config, null);
         hm.start();
         m_messengers.set(site, hm);
     }

--- a/tests/frontend/org/voltcore/zk/TestZK.java
+++ b/tests/frontend/org/voltcore/zk/TestZK.java
@@ -79,7 +79,7 @@ public class TestZK extends ZKTestBase {
         m_siteIdToZKPort.put(site, clientPort);
         config.networkThreads = 1;
         config.coordinatorIp = new InetSocketAddress( recoverPort );
-        HostMessenger hm = new HostMessenger(config, null);
+        HostMessenger hm = new HostMessenger(config, null, null);
         hm.start(null);
         m_messengers.set(site, hm);
     }

--- a/tests/frontend/org/voltcore/zk/TestZK.java
+++ b/tests/frontend/org/voltcore/zk/TestZK.java
@@ -80,7 +80,7 @@ public class TestZK extends ZKTestBase {
         config.networkThreads = 1;
         config.coordinatorIp = new InetSocketAddress( recoverPort );
         HostMessenger hm = new HostMessenger(config, null);
-        hm.start();
+        hm.start(null);
         m_messengers.set(site, hm);
     }
 

--- a/tests/frontend/org/voltcore/zk/ZKTestBase.java
+++ b/tests/frontend/org/voltcore/zk/ZKTestBase.java
@@ -58,7 +58,7 @@ public class ZKTestBase {
             config.zkInterface = "127.0.0.1:" + externalPort;
             m_siteIdToZKPort.put(ii, externalPort);
             config.networkThreads = 1;
-            HostMessenger hm = new HostMessenger(config, null);
+            HostMessenger hm = new HostMessenger(config, null, null);
             hm.start(null);
             m_messengers.add(hm);
         }

--- a/tests/frontend/org/voltcore/zk/ZKTestBase.java
+++ b/tests/frontend/org/voltcore/zk/ZKTestBase.java
@@ -35,7 +35,6 @@ import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.PortGenerator;
 
-import com.google_voltpatches.common.collect.ImmutableSet;
 import com.google_voltpatches.common.collect.Sets;
 
 /**
@@ -59,7 +58,7 @@ public class ZKTestBase {
             config.zkInterface = "127.0.0.1:" + externalPort;
             m_siteIdToZKPort.put(ii, externalPort);
             config.networkThreads = 1;
-            HostMessenger hm = new HostMessenger(config);
+            HostMessenger hm = new HostMessenger(config, null);
             hm.start();
             m_messengers.add(hm);
         }

--- a/tests/frontend/org/voltcore/zk/ZKTestBase.java
+++ b/tests/frontend/org/voltcore/zk/ZKTestBase.java
@@ -59,7 +59,7 @@ public class ZKTestBase {
             m_siteIdToZKPort.put(ii, externalPort);
             config.networkThreads = 1;
             HostMessenger hm = new HostMessenger(config, null);
-            hm.start();
+            hm.start(null);
             m_messengers.add(hm);
         }
     }

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -71,7 +71,7 @@ public class MockVoltDB implements VoltDBInterface
     final String m_clusterName = "cluster";
     final String m_databaseName = "database";
     StatsAgent m_statsAgent = null;
-    HostMessenger m_hostMessenger = new HostMessenger(new HostMessenger.Config(), null);
+    HostMessenger m_hostMessenger = new HostMessenger(new HostMessenger.Config(), null, null);
     private OperationMode m_mode = OperationMode.RUNNING;
     private volatile String m_localMetadata;
     final SnapshotCompletionMonitor m_snapshotCompletionMonitor = new SnapshotCompletionMonitor();

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -122,7 +122,7 @@ public class MockVoltDB implements VoltDBInterface
             assert(cluster != null);
 
             try {
-                m_hostMessenger.start();
+                m_hostMessenger.start(null);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -71,7 +71,7 @@ public class MockVoltDB implements VoltDBInterface
     final String m_clusterName = "cluster";
     final String m_databaseName = "database";
     StatsAgent m_statsAgent = null;
-    HostMessenger m_hostMessenger = new HostMessenger(new HostMessenger.Config());
+    HostMessenger m_hostMessenger = new HostMessenger(new HostMessenger.Config(), null);
     private OperationMode m_mode = OperationMode.RUNNING;
     private volatile String m_localMetadata;
     final SnapshotCompletionMonitor m_snapshotCompletionMonitor = new SnapshotCompletionMonitor();

--- a/tests/frontend/org/voltdb/TestVoltZK.java
+++ b/tests/frontend/org/voltdb/TestVoltZK.java
@@ -1,0 +1,73 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb;
+
+import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.voltcore.zk.ZKTestBase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestVoltZK extends ZKTestBase {
+    private ZooKeeper m_zk = null;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        VoltDB.ignoreCrash = false;
+        VoltDB.wasCrashCalled = false;
+        setUpZK(1);
+        m_zk = getClient(0);
+        VoltZK.createPersistentZKNodes(m_zk);
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        if (m_zk != null) {
+            m_zk.close();
+        }
+        tearDownZK();
+    }
+
+    @Test
+    public void testRejoinBlocker()
+    {
+        // Create a rejoin blocker for host 0
+        assertEquals(-1, VoltZK.createRejoinNodeIndicator(m_zk, 0));
+        // Try to create a blocker for host 1 while host 0 is still in progress, should fail
+        assertEquals(0, VoltZK.createRejoinNodeIndicator(m_zk, 1));
+        // Try removing the blocker for host 1, which doesn't hold the blocker, no-op
+        assertFalse(VoltZK.removeRejoinNodeIndicatorForHost(m_zk, 1));
+        // Remove host 0's blocker
+        assertTrue(VoltZK.removeRejoinNodeIndicatorForHost(m_zk, 0));
+        // Should be able to create another blocker now
+        assertEquals(-1, VoltZK.createRejoinNodeIndicator(m_zk, 2));
+        assertTrue(VoltZK.removeRejoinNodeIndicatorForHost(m_zk, 2));
+    }
+}

--- a/tests/frontend/org/voltdb/TestVoltZK.java
+++ b/tests/frontend/org/voltdb/TestVoltZK.java
@@ -69,5 +69,7 @@ public class TestVoltZK extends ZKTestBase {
         // Should be able to create another blocker now
         assertEquals(-1, VoltZK.createRejoinNodeIndicator(m_zk, 2));
         assertTrue(VoltZK.removeRejoinNodeIndicatorForHost(m_zk, 2));
+        // Removing the same hostId twice should be okay
+        assertTrue(VoltZK.removeRejoinNodeIndicatorForHost(m_zk, 2));
     }
 }


### PR DESCRIPTION
On startup, each node sends a request to rejoin the mesh to the live node. The live node will check if the request can be accepted at the moment. For example, we only allow one node to rejoin at a time. If more than one node tries to rejoin, the first rejoning node will atomically check and set the ZK blocker. Subsequent node will fail to do so and be rejected to join the mesh. They will retry after a while until they can succeed.