### PR TITLE
Tuple block changes for empty persistent table

### DIFF
--- a/src/ee/storage/CopyOnWriteIterator.h
+++ b/src/ee/storage/CopyOnWriteIterator.h
@@ -108,6 +108,8 @@ private:
 
     uint32_t m_blockOffset;
     TBPtr m_currentBlock;
+    // flag to track if the snapshot was activated when the table was empty
+    bool m_tableEmpty;
 public:
     int32_t m_skippedDirtyRows;
     int32_t m_skippedInactiveRows;

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -254,7 +254,7 @@ void PersistentTable::nextFreeTuple(TableTuple *tuple) {
     }
 }
 
-void PersistentTable::deleteAllTuples(bool freeAllocatedStrings, bool fallible) {
+void PersistentTable::deleteAllTuples(bool, bool fallible) {
     // Instead of recording each tuple deletion, log it as a table truncation DR.
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
     AbstractDRTupleStream *drStream = getDRTupleStream(ec);
@@ -360,17 +360,17 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
         // - tables with indexes
 
         // cut-off for table with no views
-        const double tableLFCutoffForTrunc = 0.105666;
+        const double tableWithNoViewLFCutoffForTrunc = 0.105666;
         //cut-off for table with views
         const double tableWithViewsLFCutoffForTrunc = 0.015416;
 
         const double blockLoadFactor = m_data.begin().data()->loadFactor();
-        if ((blockLoadFactor <= tableLFCutoffForTrunc) ||
-            (m_views.size() > 0 && blockLoadFactor <= tableWithViewsLFCutoffForTrunc)) {
+        if ((!m_views.empty() && (blockLoadFactor <= tableWithViewsLFCutoffForTrunc)) ||
+            (blockLoadFactor <= tableWithNoViewLFCutoffForTrunc)) {
             return deleteAllTuples(true, fallible);
         }
     }
-    //For MAT view dont optimize needs more work.
+    // For MAT view don't optimize, needs more work - ENG-10323.
     if (isMaterialized()) {
         return deleteAllTuples(true);
     }
@@ -967,7 +967,9 @@ void PersistentTable::deleteTupleFinalize(TableTuple &target)
  *  Indexes and views have been destroyed first.
  */
 void PersistentTable::deleteTupleForSchemaChange(TableTuple &target) {
-    deleteTupleStorage(target); // also frees object columns
+    TBPtr block = findBlock(target.address(), m_data, m_tableAllocationSize);
+    // free object columns along with empty tuple block storage
+    deleteTupleStorage(target, block, true);
 }
 
 /*
@@ -1707,7 +1709,19 @@ int64_t PersistentTable::validatePartitioning(TheHashinator *hashinator, int32_t
 }
 
 void PersistentTableSurgeon::activateSnapshot() {
-    //All blocks are now pending snapshot
+    TBMapI blockIterator = m_table.m_data.begin();
+
+    // Persistent table should have minimum of one block in it's block map.
+    assert(m_table.m_data.begin() != m_table.m_data.end());
+
+    if ((m_table.m_data.size() == 1) && blockIterator.data()->isEmpty()) {
+        assert(m_table.activeTupleCount() == 0);
+        // The single empty block in an empty table does not need to be considered as pending block
+        // for snapshot(load). CopyOnWriteIterator may not and need not expect empty blocks.
+        return;
+    }
+
+    // All blocks are now pending snapshot
     m_table.m_blocksPendingSnapshot.swap(m_table.m_blocksNotPendingSnapshot);
     m_table.m_blocksPendingSnapshotLoad.swap(m_table.m_blocksNotPendingSnapshotLoad);
     assert(m_table.m_blocksNotPendingSnapshot.empty());

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -246,7 +246,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
     // ------------------------------------------------------------------
     // GENERIC TABLE OPERATIONS
     // ------------------------------------------------------------------
-    virtual void deleteAllTuples(bool freeAllocatedStrings, bool fallible = true);
+    virtual void deleteAllTuples(bool, bool fallible = true);
 
     virtual void truncateTable(VoltDBEngine* engine, bool fallible = true);
     // The fallible flag is used to denote a change to a persistent table
@@ -599,7 +599,7 @@ class PersistentTable : public Table, public UndoQuantumReleaseInterest,
      * Normally this will return the tuple storage to the free list.
      * In the memcheck build it will return the storage to the heap.
      */
-    void deleteTupleStorage(TableTuple &tuple, TBPtr block = TBPtr(NULL));
+    void deleteTupleStorage(TableTuple &tuple, TBPtr block = TBPtr(NULL), bool deleteLastEmptyBlock = false);
 
     /*
      * Implemented by persistent table and called by Table::loadTuplesFrom
@@ -885,7 +885,7 @@ PersistentTableSurgeon::getIndexTupleRangeIterator(const ElasticIndexHashRange &
             new ElasticIndexTupleRangeIterator(*m_index, *m_table.m_schema, range));
 }
 
-inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block)
+inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block, bool deleteLastEmptyBlock)
 {
     // May not delete an already deleted tuple.
     assert(tuple.isActive());
@@ -924,22 +924,27 @@ inline void PersistentTable::deleteTupleStorage(TableTuple &tuple, TBPtr block)
             //std::cout << "Swapping block " << static_cast<void*>(block.get()) << " to bucket " << retval << std::endl;
             block->swapToBucket(m_blocksNotPendingSnapshotLoad[retval]);
         //Check if the block goes into the pending snapshot set of buckets
-        } else if (m_blocksPendingSnapshot.find(block) != m_blocksPendingSnapshot.end()) {
+        }
+        else if (m_blocksPendingSnapshot.find(block) != m_blocksPendingSnapshot.end()) {
             block->swapToBucket(m_blocksPendingSnapshotLoad[retval]);
-        } else {
+        }
+        else {
             //In this case the block is actively being snapshotted and isn't eligible for merge operations at all
             //do nothing, once the block is finished by the iterator, the iterator will return it
         }
     }
 
-    if (block->isEmpty()) {
+    if (block->isEmpty() && (m_data.size() > 1 || deleteLastEmptyBlock)) {
+        // Release the empty block unless it's the only remaining block and caller has requested not to do so.
+        // The intent of doing so is to avoid block allocation cost at time tuple insertion into the table
         m_data.erase(block->address());
         m_blocksWithSpace.erase(block);
         m_blocksNotPendingSnapshot.erase(block);
         assert(m_blocksPendingSnapshot.find(block) == m_blocksPendingSnapshot.end());
         //Eliminates circular reference
         block->swapToBucket(TBBucketPtr());
-    } else if (transitioningToBlockWithSpace) {
+    }
+    else if (transitioningToBlockWithSpace) {
         m_blocksWithSpace.insert(block);
     }
 }

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -92,6 +92,16 @@ Table* TableFactory::getPersistentTable(
     // initialize stats for the table
     configureStats(databaseId, name, table);
 
+    if (!exportOnly) {
+        // Allocate and assign the tuple storage block to the persistent table ahead of time instead
+        // of doing so at time of first tuple insertion. The intent of block allocation ahead of time
+        // is to avoid allocation cost at time of tuple insertion
+        PersistentTable *persistentTable = static_cast <PersistentTable*> (table);
+        TBPtr block = persistentTable->allocateNextBlock();
+        assert(block->hasFreeTuples());
+        persistentTable->m_blocksWithSpace.insert(block);
+    }
+
     return table;
 }
 

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -364,7 +364,7 @@ TEST_F(CompactionTest, BasicCompaction) {
         m_table->deleteTuple(tuple, true);
     }
     m_table->doForcedCompaction();
-    ASSERT_EQ( m_table->m_data.size(), 0);
+    ASSERT_EQ( m_table->m_data.size(), 1);
     ASSERT_EQ( m_table->activeTupleCount(), 0);
 }
 
@@ -507,7 +507,7 @@ TEST_F(CompactionTest, CompactionWithCopyOnWrite) {
 
     }
     m_table->doForcedCompaction();
-    ASSERT_EQ( m_table->m_data.size(), 0);
+    ASSERT_EQ( m_table->m_data.size(), 1);
     ASSERT_EQ( m_table->activeTupleCount(), 0);
     for (int ii = 0; ii < tupleCount; ii++) {
         ASSERT_TRUE(COWTuples.find(ii) != COWTuples.end());

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -37,7 +37,7 @@
 #include "storage/table.h"
 #include "storage/persistenttable.h"
 #include "storage/tablefactory.h"
-
+#include "storage/tableutil.h"
 
 using voltdb::ExecutorContext;
 using voltdb::NValue;
@@ -51,7 +51,7 @@ using voltdb::VALUE_TYPE_BIGINT;
 using voltdb::VALUE_TYPE_VARCHAR;
 using voltdb::ValueFactory;
 using voltdb::VoltDBEngine;
-
+using voltdb::tableutil;
 
 class PersistentTableTest : public Test {
 public:
@@ -280,6 +280,36 @@ TEST_F(PersistentTableTest, DRTimestampColumn) {
 
         ++i;
     }
+}
+
+TEST_F(PersistentTableTest, TruncateTableTest) {
+    VoltDBEngine* engine = getEngine();
+    engine->loadCatalog(0, catalogPayload());
+    PersistentTable *table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+    ASSERT_EQ(1, table->allocatedBlockCount());
+
+    beginWork();
+    const int tuplesToInsert = 10;
+    (void) tuplesToInsert;  // to make compiler happy
+    assert(tableutil::addRandomTuples(table, tuplesToInsert));
+    commit();
+
+    size_t blockCount = table->allocatedBlockCount();
+    table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+    ASSERT_EQ(blockCount, table->allocatedBlockCount());
+
+    beginWork();
+    assert(tableutil::addRandomTuples(table, tuplesToInsert));
+    table->truncateTable(engine);
+    commit();
+
+    // refresh table pointer by fetching the table from catalog as in truncate old table
+    // gets replaced with new cloned empty table
+    table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+    ASSERT_EQ(1, table->allocatedBlockCount());
 }
 
 int main() {

--- a/tests/frontend/org/voltdb/regressionsuites/TestJoinsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestJoinsSuite.java
@@ -533,7 +533,7 @@ public class TestJoinsSuite extends RegressionSuite {
         // R2 3rd joined with R3 null
         // R2 4th joined with R3 null
         VoltTable result = client.callProcedure(
-                "@AdHoc", "select * FROM R2 LEFT JOIN R3 ON R3.A = R2.A")
+                "@AdHoc", "select * FROM R2 LEFT JOIN R3 ON R3.A = R2.A order by R2.A")
                                  .getResults()[0];
         VoltTableRow row = result.fetchRow(2);
         assertEquals(3, row.getLong(1));
@@ -618,13 +618,17 @@ public class TestJoinsSuite extends RegressionSuite {
                 "@AdHoc", "select * FROM R3 RIGHT JOIN R2 ON R3.A = R2.A WHERE R3.A IS NULL")
                                  .getResults()[0];
         System.out.println(result.toString());
-        if ( ! isHSQL()) assertEquals(2, result.getRowCount()); //// PENDING HSQL flaw investigation
+        if ( ! isHSQL()) {
+            assertEquals(2, result.getRowCount()); //// PENDING HSQL flaw investigation
+        }
         // Same as above but with partitioned table
         result = client.callProcedure(
                 "@AdHoc", "select * FROM R3 RIGHT JOIN P2 ON R3.A = P2.A WHERE R3.A IS NULL")
                                  .getResults()[0];
         System.out.println(result.toString());
-        if ( ! isHSQL())  assertEquals(2, result.getRowCount()); //// PENDING HSQL flaw investigation
+        if ( ! isHSQL()) {
+            assertEquals(2, result.getRowCount()); //// PENDING HSQL flaw investigation
+        }
 
         // R2 1st eliminated by R2.C < 0
         // R2 2nd eliminated by R2.C < 0


### PR DESCRIPTION
- Updated persistent table logic to allocate tuple storage block to table on table creation. Don't release the only remaining tuple storage block back to system during truncate or delete operation. This will prevent persistent table to request fresh tuple storage block on next row insertion into empty table.
- Updated snapshot save logic so that when system is performing snapshot save, it takes into account the persistent table can contain empty tuple storage