### PR TITLE
ENG-10198: Generate DR sequence number for DR table changes and DR events all the time

### DIFF
--- a/src/ee/common/StreamBlock.h
+++ b/src/ee/common/StreamBlock.h
@@ -242,6 +242,7 @@ namespace voltdb
 
         friend class TupleStreamBase;
         friend class ExportTupleStream;
+        friend class AbstractDRTupleStream;
         friend class DRTupleStream;
         friend class CompatibleDRTupleStream;
     };

--- a/src/ee/storage/AbstractDRTupleStream.cpp
+++ b/src/ee/storage/AbstractDRTupleStream.cpp
@@ -24,16 +24,19 @@ using namespace voltdb;
 AbstractDRTupleStream::AbstractDRTupleStream(int partitionId, int defaultBufferSize)
         : TupleStreamBase(defaultBufferSize, MAGIC_DR_TRANSACTION_PADDING),
           m_enabled(true),
+          m_guarded(false),
+          m_openSequenceNumber(-1),
+          m_committedSequenceNumber(-1),
           m_partitionId(partitionId),
           m_secondaryCapacity(SECONDARY_BUFFER_SIZE),
           m_rowTarget(-1),
           m_opened(false),
-          m_txnRowCount(0) {
-
-}
+          m_txnRowCount(0)
+{}
 
 // for test purpose
-void AbstractDRTupleStream::setSecondaryCapacity(size_t capacity) {
+void AbstractDRTupleStream::setSecondaryCapacity(size_t capacity)
+{
     assert (capacity > 0);
     if (m_uso != 0 || m_openSpHandle != 0 ||
         m_openTransactionUso != 0 || m_committedSpHandle != 0)
@@ -44,7 +47,8 @@ void AbstractDRTupleStream::setSecondaryCapacity(size_t capacity) {
     m_secondaryCapacity = capacity;
 }
 
-void AbstractDRTupleStream::pushExportBuffer(StreamBlock *block, bool sync, bool endOfStream) {
+void AbstractDRTupleStream::pushExportBuffer(StreamBlock *block, bool sync, bool endOfStream)
+{
     if (sync) return;
     int64_t rowTarget = ExecutorContext::getExecutorContext()->getTopend()->pushDRBuffer(m_partitionId, block);
     if (rowTarget >= 0) {
@@ -54,8 +58,13 @@ void AbstractDRTupleStream::pushExportBuffer(StreamBlock *block, bool sync, bool
 
 // Set m_opened = false first otherwise checkOpenTransaction() may
 // consider the transaction being rolled back as open.
-void AbstractDRTupleStream::rollbackTo(size_t mark, size_t drRowCost) {
+void AbstractDRTupleStream::rollbackTo(size_t mark, size_t drRowCost)
+{
     if (mark == INVALID_DR_MARK) {
+        m_openSpHandle = m_committedSpHandle;
+        m_openUniqueId = m_committedUniqueId;
+        m_openSequenceNumber = m_committedSequenceNumber;
+        m_opened = false;
         return;
     }
     if (drRowCost <= m_txnRowCount) {
@@ -67,13 +76,84 @@ void AbstractDRTupleStream::rollbackTo(size_t mark, size_t drRowCost) {
     }
     if (mark == m_committedUso) {
         assert(m_txnRowCount == 0);
+        m_openSequenceNumber = m_committedSequenceNumber;
         m_opened = false;
     }
     TupleStreamBase::rollbackTo(mark, drRowCost);
 }
 
-void AbstractDRTupleStream::setLastCommittedSequenceNumber(int64_t sequenceNumber) {
+void
+AbstractDRTupleStream::periodicFlush(int64_t timeInMillis,
+                                     int64_t lastCommittedSpHandle)
+{
+    // negative timeInMillis instructs a mandatory flush
+    if (timeInMillis < 0 || (m_flushInterval > 0 && timeInMillis - m_lastFlush > m_flushInterval)) {
+        int64_t currentSpHandle = std::max(m_openSpHandle, lastCommittedSpHandle);
+        if (timeInMillis > 0) {
+            m_lastFlush = timeInMillis;
+        }
+
+        if (currentSpHandle < m_openSpHandle) {
+            throwFatalException(
+                    "Active transactions moving backwards: openSpHandle is %jd, while the current spHandle is %jd",
+                    (intmax_t)m_openSpHandle, (intmax_t)currentSpHandle
+                    );
+        }
+
+        // more data for an ongoing transaction with no new committed data
+        if ((currentSpHandle == m_openSpHandle) &&
+                (lastCommittedSpHandle == m_committedSpHandle)) {
+            extendBufferChain(0);
+            return;
+        }
+
+        // the open transaction should be committed
+        if (m_openSpHandle <= lastCommittedSpHandle) {
+            extendBufferChain(0);
+        }
+
+        pushPendingBlocks();
+    }
+}
+
+void AbstractDRTupleStream::setLastCommittedSequenceNumber(int64_t sequenceNumber)
+{
     assert(m_committedSequenceNumber <= m_openSequenceNumber);
     m_openSequenceNumber = sequenceNumber;
     m_committedSequenceNumber = sequenceNumber;
+}
+
+void AbstractDRTupleStream::handleOpenTransaction(StreamBlock *oldBlock)
+{
+    size_t uso = m_currBlock->uso();
+    size_t partialTxnLength = oldBlock->offset() - oldBlock->lastDRBeginTxnOffset();
+    ::memcpy(m_currBlock->mutableDataPtr(), oldBlock->mutableLastBeginTxnDataPtr(), partialTxnLength);
+    m_currBlock->startDRSequenceNumber(m_openSequenceNumber);
+    m_currBlock->recordLastBeginTxnOffset();
+    m_currBlock->consumed(partialTxnLength);
+    ::memset(oldBlock->mutableLastBeginTxnDataPtr(), 0, partialTxnLength);
+    oldBlock->truncateTo(uso);
+    oldBlock->clearLastBeginTxnOffset();
+    // If the whole previous block has been moved to new block, discards the empty one.
+    if (oldBlock->offset() == 0) {
+        m_pendingBlocks.pop_back();
+        discardBlock(oldBlock);
+    }
+}
+
+void AbstractDRTupleStream::openTransactionCommon(int64_t spHandle, int64_t uniqueId)
+{
+    m_openSpHandle = spHandle;
+    m_openUniqueId = uniqueId;
+
+    m_opened = true;
+}
+
+void AbstractDRTupleStream::commitTransactionCommon()
+{
+    m_committedSpHandle = m_openSpHandle;
+    m_committedUniqueId = m_openUniqueId;
+    m_committedSequenceNumber = m_openSequenceNumber;
+
+    m_opened = false;
 }

--- a/src/ee/storage/CompatibleDRTupleStream.h
+++ b/src/ee/storage/CompatibleDRTupleStream.h
@@ -71,19 +71,21 @@ public:
                        int64_t spHandle,
                        int64_t uniqueId);
 
-    virtual void beginTransaction(int64_t sequenceNumber, int64_t uniqueId);
+    virtual void beginTransaction(int64_t sequenceNumber, int64_t spHandle, int64_t uniqueId);
     // If a transaction didn't generate any binary log data, calling this
     // would be a no-op because it was never begun.
     virtual void endTransaction(int64_t uniqueId);
 
     virtual bool checkOpenTransaction(StreamBlock *sb, size_t minLength, size_t& blockSize, size_t& uso);
 
-    virtual DRCommittedInfo getLastCommittedSequenceNumberAndUniqueIds() {
+    virtual DRCommittedInfo getLastCommittedSequenceNumberAndUniqueIds()
+    {
         return DRCommittedInfo(m_committedSequenceNumber, m_lastCommittedSpUniqueId, m_lastCommittedMpUniqueId);
     }
 
     virtual void generateDREvent(DREventType type, int64_t lastCommittedSpHandle, int64_t spHandle,
-                                 int64_t uniqueId, ByteArray payloads) {
+                                 int64_t uniqueId, ByteArray payloads)
+    {
         // This method is not supported in compatible stream
     }
 

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -42,8 +42,7 @@ public:
 
     DRTupleStream(int partitionId, int defaultBufferSize);
 
-    virtual ~DRTupleStream() {
-    }
+    virtual ~DRTupleStream() {}
 
     /**
      * write an insert or delete record to the stream
@@ -76,14 +75,15 @@ public:
                        int64_t spHandle,
                        int64_t uniqueId);
 
-    virtual void beginTransaction(int64_t sequenceNumber, int64_t uniqueId);
+    virtual void beginTransaction(int64_t sequenceNumber, int64_t spHandle, int64_t uniqueId);
     // If a transaction didn't generate any binary log data, calling this
     // would be a no-op because it was never begun.
     virtual void endTransaction(int64_t uniqueId);
 
     virtual bool checkOpenTransaction(StreamBlock *sb, size_t minLength, size_t& blockSize, size_t& uso);
 
-    virtual DRCommittedInfo getLastCommittedSequenceNumberAndUniqueIds() {
+    virtual DRCommittedInfo getLastCommittedSequenceNumberAndUniqueIds()
+    {
         return DRCommittedInfo(m_committedSequenceNumber, m_lastCommittedSpUniqueId, m_lastCommittedMpUniqueId);
     }
 
@@ -143,7 +143,8 @@ public:
                            int64_t spHandle,
                            int64_t uniqueId,
                            TableTuple &tuple,
-                           DRRecordType type) {
+                           DRRecordType type)
+    {
         return 0;
     }
 
@@ -156,7 +157,8 @@ public:
                        std::string tableName,
                        int partitionColumn,
                        int64_t spHandle,
-                       int64_t uniqueId) {
+                       int64_t uniqueId)
+    {
         return 0;
     }
 };

--- a/src/ee/storage/TupleStreamBase.cpp
+++ b/src/ee/storage/TupleStreamBase.cpp
@@ -47,11 +47,9 @@ TupleStreamBase::TupleStreamBase(int defaultBufferSize, size_t extraHeaderSpace 
       // calls appendTupple with LONG_MIN transaction ids
       // this allows initial ticks to succeed after rejoins
       m_openSpHandle(0),
-      m_openSequenceNumber(-1),
       m_openUniqueId(0),
       m_openTransactionUso(0),
       m_committedSpHandle(0), m_committedUso(0),
-      m_committedSequenceNumber(-1),
       m_committedUniqueId(0),
       m_headerSpace(MAGIC_HEADER_SPACE_FOR_JAVA + extraHeaderSpace)
 {
@@ -99,10 +97,9 @@ void TupleStreamBase::cleanupManagedBuffers()
  * m_openTransactionUso.
  */
 void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHandle, int64_t uniqueId,
-        bool sync, bool flush, DREventType eventType)
+        bool sync, bool flush)
 {
-    if (currentSpHandle < m_openSpHandle)
-    {
+    if (currentSpHandle < m_openSpHandle) {
         throwFatalException(
                 "Active transactions moving backwards: openSpHandle is %jd, while the current spHandle is %jd",
                 (intmax_t)m_openSpHandle, (intmax_t)currentSpHandle
@@ -115,8 +112,7 @@ void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHan
 
     // more data for an ongoing transaction with no new committed data
     if ((currentSpHandle == m_openSpHandle) &&
-        (lastCommittedSpHandle == m_committedSpHandle))
-    {
+        (lastCommittedSpHandle == m_committedSpHandle)) {
         //std::cout << "Current spHandle(" << currentSpHandle << ") == m_openSpHandle(" << m_openSpHandle <<
         //") && lastCommittedSpHandle(" << lastCommittedSpHandle << ") m_committedSpHandle(" <<
         //m_committedSpHandle << ")" << std::endl;
@@ -140,8 +136,7 @@ void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHan
     // If last committed and current sphandle are the same
     // this isn't a new transaction, the block below handles it better
     // by ending the current open transaction and not starting a new one
-    if (m_openSpHandle < currentSpHandle && currentSpHandle != lastCommittedSpHandle)
-    {
+    if (m_openSpHandle < currentSpHandle && currentSpHandle != lastCommittedSpHandle) {
         if (uniqueId < 0) {
             throwFatalException(
                     "Received invalid uniqueId (%jd) with open spHandle %jd, currentSpHandle %jd, lastCommittedSpHandle %jd.",
@@ -150,24 +145,11 @@ void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHan
         //std::cout << "m_openSpHandle(" << m_openSpHandle << ") < currentSpHandle("
         //<< currentSpHandle << ")" << std::endl;
         m_committedUso = m_uso;
-        m_committedSequenceNumber = m_openSequenceNumber;
         m_committedUniqueId = m_openUniqueId;
         // Advance the tip to the new transaction.
         m_committedSpHandle = m_openSpHandle;
         m_openSpHandle = currentSpHandle;
-        m_openSequenceNumber++;
         m_openUniqueId = uniqueId;
-
-        if (eventType != NOT_A_EVENT) {
-            m_currBlock->startDRSequenceNumber(m_openSequenceNumber);
-            m_currBlock->recordCompletedSequenceNumForDR(m_openSequenceNumber);
-            if (UniqueId::isMpUniqueId(uniqueId)) {
-                m_currBlock->recordCompletedMpTxnForDR(uniqueId);
-            } else {
-                m_currBlock->recordCompletedSpTxnForDR(uniqueId);
-            }
-            m_currBlock->markAsEventBuffer(eventType);
-        }
 
         if (flush) {
             extendBufferChain(0);
@@ -177,11 +159,9 @@ void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHan
     // now check to see if the lastCommittedSpHandle tells us that our open
     // transaction should really be committed.  If so, update the
     // committed state.
-    if (m_openSpHandle <= lastCommittedSpHandle)
-    {
+    if (m_openSpHandle <= lastCommittedSpHandle) {
         //std::cout << "m_openSpHandle(" << m_openSpHandle << ") <= lastCommittedSpHandle(" <<
         //lastCommittedSpHandle << ")" << std::endl;
-        m_committedSequenceNumber = m_openSequenceNumber;
         m_committedUso = m_uso;
         m_committedSpHandle = m_openSpHandle;
         m_committedUniqueId = m_openUniqueId;
@@ -201,9 +181,9 @@ void TupleStreamBase::commit(int64_t lastCommittedSpHandle, int64_t currentSpHan
     }
 }
 
-void TupleStreamBase::pushPendingBlocks() {
-    while (!m_pendingBlocks.empty())
-    {
+void TupleStreamBase::pushPendingBlocks()
+{
+    while (!m_pendingBlocks.empty()) {
         StreamBlock* block = m_pendingBlocks.front();
         //std::cout << "m_committedUso(" << m_committedUso << "), block->uso() + block->offset() == "
         //<< (block->uso() + block->offset()) << std::endl;
@@ -270,7 +250,6 @@ void TupleStreamBase::rollbackTo(size_t mark, size_t)
         }
     }
     if (m_uso == m_committedUso) {
-        m_openSequenceNumber = m_committedSequenceNumber;
         m_openSpHandle = m_committedSpHandle;
         m_openUniqueId = m_committedUniqueId;
     }
@@ -280,7 +259,8 @@ void TupleStreamBase::rollbackTo(size_t mark, size_t)
  * Correctly release and delete a managed buffer that won't
  * be handed off
  */
-void TupleStreamBase::discardBlock(StreamBlock *sb) {
+void TupleStreamBase::discardBlock(StreamBlock *sb)
+{
     if (sb != NULL) {
         delete [] sb->rawPtr();
         delete sb;
@@ -330,21 +310,8 @@ void TupleStreamBase::extendBufferChain(size_t minLength)
     }
 
     if (openTransaction) {
-        size_t partialTxnLength = oldBlock->offset() - oldBlock->lastDRBeginTxnOffset();
-        ::memcpy(m_currBlock->mutableDataPtr(), oldBlock->mutableLastBeginTxnDataPtr(), partialTxnLength);
-        m_currBlock->startDRSequenceNumber(m_openSequenceNumber);
-        m_currBlock->recordLastBeginTxnOffset();
-        m_currBlock->consumed(partialTxnLength);
-        ::memset(oldBlock->mutableLastBeginTxnDataPtr(), 0, partialTxnLength);
-        oldBlock->truncateTo(uso);
-        oldBlock->clearLastBeginTxnOffset();
-        // If the whole previous block has been moved to new block, discards the empty one.
-        if (oldBlock->offset() == 0) {
-            m_pendingBlocks.pop_back();
-            discardBlock(oldBlock);
-        }
+        handleOpenTransaction(oldBlock);
     }
-
 
     pushPendingBlocks();
 }
@@ -356,7 +323,7 @@ void TupleStreamBase::extendBufferChain(size_t minLength)
  */
 void
 TupleStreamBase::periodicFlush(int64_t timeInMillis,
-                                  int64_t lastCommittedSpHandle)
+                               int64_t lastCommittedSpHandle)
 {
     // negative timeInMillis instructs a mandatory flush
     if (timeInMillis < 0 || (m_flushInterval > 0 && timeInMillis - m_lastFlush > m_flushInterval)) {

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -43,7 +43,8 @@ public:
 
     TupleStreamBase(int defaultBufferSizes, size_t extraHeaderSpace = 0);
 
-    virtual ~TupleStreamBase() {
+    virtual ~TupleStreamBase()
+    {
         cleanupManagedBuffers();
     }
 
@@ -59,7 +60,7 @@ public:
      * to test buffer rollover.
      */
     void setDefaultCapacity(size_t capacity);
-    virtual void setSecondaryCapacity(size_t capacity) {};
+    virtual void setSecondaryCapacity(size_t capacity) {}
 
     virtual void pushExportBuffer(StreamBlock *block, bool sync, bool endOfStream) = 0;
 
@@ -67,8 +68,8 @@ public:
     virtual void rollbackTo(size_t mark, size_t drRowCost);
 
     /** age out committed data */
-    void periodicFlush(int64_t timeInMillis,
-                       int64_t lastComittedSpHandle);
+    virtual void periodicFlush(int64_t timeInMillis,
+                               int64_t lastComittedSpHandle);
 
     virtual void extendBufferChain(size_t minLength);
     void pushPendingBlocks();
@@ -76,9 +77,10 @@ public:
 
     virtual bool checkOpenTransaction(StreamBlock *sb, size_t minLength, size_t& blockSize, size_t& uso) { return false; }
 
+    virtual void handleOpenTransaction(StreamBlock *oldBlock) {}
+
     /** Send committed data to the top end. */
-    void commit(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId, bool sync, bool flush,
-            DREventType type = NOT_A_EVENT);
+    void commit(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId, bool sync, bool flush);
 
     /** time interval between flushing partially filled buffers */
     int64_t m_flushInterval;
@@ -101,8 +103,6 @@ public:
     /** transaction id of the current (possibly uncommitted) transaction */
     int64_t m_openSpHandle;
 
-    int64_t m_openSequenceNumber;
-
     int64_t m_openUniqueId;
 
     /** Universal stream offset when current transaction was opened */
@@ -113,8 +113,6 @@ public:
 
     /** current committed uso */
     size_t m_committedUso;
-
-    int64_t m_committedSequenceNumber;
 
     int64_t m_committedUniqueId;
 


### PR DESCRIPTION
**Problem:**
1. Previously, DR sequence number is only generated for DR table changes when "listen" is set to true in the deployment file. This causes problem in recovery if the command log records corresponding to these unnumbered write transactions are not truncated before the cluster goes down. In this case, they will be newly numbered with the same DR sequence number as transactions after them, which may have already been received and recorded in the IdempotencyFilter in consumer cluster. Thus, when the command log replayed transactions hit the consumer cluster, the cluster will find two inconsistent transactions with the same DR sequence number and throw DR exception.
2. Because of the change, we cannot skip a write transaction immediately if "listen" is set to false since we need to increment the DR sequence number and update some states. However, it is the desired behavior if the DR table changes originated from remote cluster so that we don't do a circular replication.

**Solution:**
1. Move DR sequence number states from TupleStreamBase to AbstractDRTupleStream.
2. Get rid of calls to commit() in DRTupleStream related code, move transaction state update code to transactionChecks() and endTransaction(). Same for CompatibleDRTupleStream.
3. Adjust generateDREvent() to fit into the new design, also fix a bug of not updating the last committed uniqueIds for DR events.
4. AbstractDRTupleStream now overrides and has its own implementation of periodicFlush(), its flow is similar to commit() but greatly simplified. It basically pushes newly committed data to top end periodically.
5. A separate flag "m_guarded" is added to specifically guard the circular replication, while the existing "m_enabled" indicates if "listen" is set to true or not.