### PR TITLE
Remove underused expression tree search code.

### DIFF
--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -841,60 +841,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
     }
 
     public ArrayList<AbstractExpression> findBaseTVEs() {
-        return findAllSubexpressionsOfType(ExpressionType.VALUE_TUPLE);
-    }
-
-    /**
-     * @param type expression type to search for
-     * @return a list of contained expressions that are of the desired type
-     */
-    public ArrayList<AbstractExpression> findAllSubexpressionsOfType(ExpressionType type) {
-        ArrayList<AbstractExpression> collected = new ArrayList<AbstractExpression>();
-        findAllSubexpressionsOfType_recurse(type, collected);
-        return collected;
-    }
-
-    private void findAllSubexpressionsOfType_recurse(ExpressionType type,ArrayList<AbstractExpression> collected) {
-        if (getExpressionType() == type)
-            collected.add(this);
-
-        if (m_left != null) {
-            m_left.findAllSubexpressionsOfType_recurse(type, collected);
-        }
-        if (m_right != null) {
-            m_right.findAllSubexpressionsOfType_recurse(type, collected);
-        }
-        if (m_args != null) {
-        for (AbstractExpression argument : m_args) {
-            argument.findAllSubexpressionsOfType_recurse(type, collected);
-        }
-    }
-    }
-
-    /**
-     * @param type expression type to search for
-     * @return whether the expression or any contained expressions are of the desired type
-     */
-    public boolean hasAnySubexpressionOfType(ExpressionType type) {
-        if (getExpressionType() == type) {
-            return true;
-        }
-
-        if (m_left != null && m_left.hasAnySubexpressionOfType(type)) {
-            return true;
-        }
-
-        if (m_right != null && m_right.hasAnySubexpressionOfType(type)) {
-            return true;
-        }
-        if (m_args != null) {
-            for (AbstractExpression argument : m_args) {
-                if (argument.hasAnySubexpressionOfType(type)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return findAllSubexpressionsOfClass(TupleValueExpression.class);
     }
 
     /**
@@ -949,6 +896,10 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             }
         }
         return false;
+    }
+
+    public boolean hasTVE() {
+        return hasAnySubexpressionOfClass(TupleValueExpression.class);
     }
 
     /**

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -1375,20 +1375,6 @@ public abstract class AbstractParsedStmt {
         return subqueries;
     }
 
-    /*
-     *  Extract all subexpressions of a given type from this statement
-     */
-    public List<AbstractExpression> findAllSubexpressionsOfType(ExpressionType exprType) {
-        List<AbstractExpression> exprs = new ArrayList<AbstractExpression>();
-        if (m_joinTree != null) {
-            AbstractExpression treeExpr = m_joinTree.getAllFilters();
-            if (treeExpr != null) {
-                exprs.addAll(treeExpr.findAllSubexpressionsOfType(exprType));
-            }
-        }
-        return exprs;
-    }
-
     /// This is for use with integer-valued row count parameters, namely LIMITs and OFFSETs.
     /// It should be called (at least) once for each LIMIT or OFFSET parameter to establish that
     /// the parameter is being used in a BIGINT context.

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -1933,25 +1933,6 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         }
     }
 
-    @Override
-    public List<AbstractExpression> findAllSubexpressionsOfType(ExpressionType exprType) {
-        List<AbstractExpression> exprs = super.findAllSubexpressionsOfType(exprType);
-        if (m_having != null) {
-            exprs.addAll(m_having.findAllSubexpressionsOfType(exprType));
-        }
-        if (m_groupByExpressions != null) {
-            for (AbstractExpression groupByExpr : m_groupByExpressions.values()) {
-                exprs.addAll(groupByExpr.findAllSubexpressionsOfType(exprType));
-            }
-        }
-        for(ParsedColInfo col : m_displayColumns) {
-            if (col.expression != null) {
-                exprs.addAll(col.expression.findAllSubexpressionsOfType(exprType));
-            }
-        }
-        return exprs;
-    }
-
     /**
      * This functions tries to find all expression from the statement. For complex group by or complex aggregate,
      * we have a special function ParsedSelectStmt::placeTVEsinColumns() to replace the expression with TVE for

--- a/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
@@ -296,15 +296,6 @@ public class ParsedUnionStmt extends AbstractParsedStmt {
     }
 
     @Override
-    public List<AbstractExpression> findAllSubexpressionsOfType(ExpressionType exprType) {
-        List<AbstractExpression> exprs = new ArrayList<AbstractExpression>();
-        for (AbstractParsedStmt childStmt : m_children) {
-            exprs.addAll(childStmt.findAllSubexpressionsOfType(exprType));
-        }
-        return exprs;
-    }
-
-    @Override
     public Set<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
         Set<AbstractExpression> exprs = new HashSet<AbstractExpression>();
         for (AbstractParsedStmt childStmt : m_children) {

--- a/src/frontend/org/voltdb/planner/SubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SubPlanAssembler.java
@@ -456,7 +456,7 @@ public abstract class SubPlanAssembler {
                         // were based on constants and/or parameters.
                         for (AbstractExpression eq_comparator : retval.indexExprs) {
                             AbstractExpression otherExpr = eq_comparator.getRight();
-                            if (otherExpr.hasAnySubexpressionOfType(ExpressionType.VALUE_TUPLE)) {
+                            if (otherExpr.hasTVE()) {
                                 // Can't index this IN LIST filter without some kind of three-way NLIJ,
                                 // so, add it to the post-filters.
                                 AbstractExpression in_list_comparator = inListExpr.getOriginalFilter();
@@ -1194,7 +1194,7 @@ public abstract class SubPlanAssembler {
                                                              coveringExpr, coveringColId);
                 if (binding != null) {
                     if ( ! allowIndexedJoinFilters) {
-                        if (otherExpr.hasAnySubexpressionOfType(ExpressionType.VALUE_TUPLE)) {
+                        if (otherExpr.hasTVE()) {
                             // This filter can not be used with the index, possibly due to interactions
                             // wih IN LIST processing that would require a three-way NLIJ.
                             binding = null;
@@ -1240,7 +1240,7 @@ public abstract class SubPlanAssembler {
                         }
                     }
                     if (targetComparator == ExpressionType.COMPARE_IN) {
-                        if (otherExpr.hasAnySubexpressionOfType(ExpressionType.VALUE_TUPLE)) {
+                        if (otherExpr.hasTVE()) {
                             // This is a fancy edge case where the expression could only be indexed
                             // if it:
                             // A) does not reference the indexed table and
@@ -1293,7 +1293,7 @@ public abstract class SubPlanAssembler {
                                                              coveringExpr, coveringColId);
                 if (binding != null) {
                     if ( ! allowIndexedJoinFilters) {
-                        if (otherExpr.hasAnySubexpressionOfType(ExpressionType.VALUE_TUPLE)) {
+                        if (otherExpr.hasTVE()) {
                             // This filter can not be used with the index, probably due to interactions
                             // with IN LIST processing of another key component that would require a
                             // three-way NLIJ to be injected.


### PR DESCRIPTION
Eliminate code by standardizing on one way to search for subexpressions -- by java class rather than by ExpressionType tag.
These two search algorithms are theoretically not exactly equivalent in all cases, but they ARE equivalent in the ONE and ONLY oddball case we were using ExpressionType, namely for ExpressionType.VALUE_TUPLE. 

(this instanceof TupleValueExpression) === (m_expressionType == ExpressionType.VALUE_TUPLE)