### PR TITLE
ENG-10422 Add range checks to TRUNCATE to avoid boost exceptions

### DIFF
--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -147,7 +147,6 @@ std::string NValue::debug() const {
         buffer << getInteger();
         break;
     case VALUE_TYPE_BIGINT:
-    case VALUE_TYPE_TIMESTAMP:
         buffer << getBigInt();
         break;
     case VALUE_TYPE_DOUBLE:
@@ -176,6 +175,20 @@ std::string NValue::debug() const {
     case VALUE_TYPE_DECIMAL:
         buffer << createStringFromDecimal();
         break;
+    case VALUE_TYPE_TIMESTAMP: {
+        try {
+            std::stringstream ss;
+            streamTimestamp(ss);
+            buffer << ss.str();
+        }
+        catch (const SQLException &) {
+            buffer << "<out of range timestamp:" << getBigInt() << ">";
+        }
+        catch (...) {
+            buffer << "<exception when converting timestamp:" << getBigInt() << ">";
+        }
+        break;
+    }
     case VALUE_TYPE_POINT:
         buffer << getGeographyPointValue().toString();
         break;

--- a/src/ee/expressions/datefunctions.h
+++ b/src/ee/expressions/datefunctions.h
@@ -28,7 +28,9 @@
 #include "common/NValue.hpp"
 
 static const boost::posix_time::ptime EPOCH(boost::gregorian::date(1970,1,1));
-static const int64_t GREGORIAN_EPOCH = -12212553600000000;  // 1583-01-01 00:00:00
+static const int64_t GREGORIAN_EPOCH = -12212553600000000;  //  1583-01-01 00:00:00
+static const int64_t NYE9999         = 253402300799999999;  //  9999-12-31 23:59:59.999999
+
 static const int8_t QUARTER_START_MONTH_BY_MONTH[] = {
         /*[0] not used*/-1,  1, 1, 1,  4, 4, 4,  7, 7, 7,  10, 10, 10 };
 
@@ -53,42 +55,37 @@ static const int64_t PTIME_MIN_MILLISECOND_INTERVAL = -PTIME_MAX_MILLISECOND_INT
 static const int64_t PTIME_MAX_MICROSECOND_INTERVAL = PTIME_MAX_MILLISECOND_INTERVAL * 1000;
 static const int64_t PTIME_MIN_MICROSECOND_INTERVAL = -PTIME_MAX_MICROSECOND_INTERVAL;
 
+static inline void checkRangeOfEpochMicros(int64_t epochMicros) {
+    if (epochMicros < GREGORIAN_EPOCH || epochMicros > NYE9999) {
+        throw voltdb::SQLException(voltdb::SQLException::data_exception_numeric_value_out_of_range,
+                                   "Value out of range. Cannot convert dates prior to the year 1583 or after the year 9999");
+    }
+}
+
 /** Convert from epoch_micros to date **/
 static inline void micros_to_date(int64_t epoch_micros_in, boost::gregorian::date& date_out) {
-    if (epoch_micros_in < GREGORIAN_EPOCH) {
-        throw voltdb::SQLException(voltdb::SQLException::data_exception_numeric_value_out_of_range,
-                "Value out of range. Cannot convert dates prior to the year 1583");
-    }
+    checkRangeOfEpochMicros(epoch_micros_in);
     boost::posix_time::ptime input_ptime = EPOCH + boost::posix_time::microseconds(epoch_micros_in);
     date_out = input_ptime.date();
 }
 
 /** Convert from epoch_micros to time **/
 static inline void micros_to_time(int64_t epoch_micros_in, boost::posix_time::time_duration& time_out) {
-    if (epoch_micros_in < GREGORIAN_EPOCH) {
-        throw voltdb::SQLException(voltdb::SQLException::data_exception_numeric_value_out_of_range,
-                "Value out of range. Cannot convert dates prior to the year 1583");
-    }
+    checkRangeOfEpochMicros(epoch_micros_in);
     boost::posix_time::ptime input_ptime = EPOCH + boost::posix_time::microseconds(epoch_micros_in);
     time_out = input_ptime.time_of_day();
 }
 
 /** Convert from epoch_micros to ptime **/
 static inline void micros_to_ptime(int64_t epoch_micros_in, boost::posix_time::ptime& ptime_out) {
-    if (epoch_micros_in < GREGORIAN_EPOCH) {
-        throw voltdb::SQLException(voltdb::SQLException::data_exception_numeric_value_out_of_range,
-                "Value out of range. Cannot convert dates prior to the year 1583");
-        }
-        ptime_out = EPOCH + boost::posix_time::microseconds(epoch_micros_in);
+    checkRangeOfEpochMicros(epoch_micros_in);
+    ptime_out = EPOCH + boost::posix_time::microseconds(epoch_micros_in);
 }
 
 /** Convert from epoch_micros to date and time **/
 static inline void micros_to_date_and_time(int64_t epoch_micros_in, boost::gregorian::date& date_out,
-        boost::posix_time::time_duration& time_out) {
-    if (epoch_micros_in < GREGORIAN_EPOCH) {
-        throw voltdb::SQLException(voltdb::SQLException::data_exception_numeric_value_out_of_range,
-                "Value out of range. Cannot convert dates prior to the year 1583");
-    }
+                                           boost::posix_time::time_duration& time_out) {
+    checkRangeOfEpochMicros(epoch_micros_in);
     boost::posix_time::ptime input_ptime = EPOCH + boost::posix_time::microseconds(epoch_micros_in);
     date_out = input_ptime.date();
     time_out = input_ptime.time_of_day();
@@ -361,20 +358,40 @@ template<> inline NValue NValue::callUnary<FUNC_SINCE_EPOCH_MICROSECOND>() const
 
 /** implement the timestamp TO_TIMESTAMP from SECONDs function **/
 template<> inline NValue NValue::callUnary<FUNC_TO_TIMESTAMP_SECOND>() const {
+    static const int64_t MAX_SECONDS = std::numeric_limits<int64_t>::max() / 1000000;
+
     if (isNull()) {
         return *this;
     }
+
     int64_t seconds = castAsBigIntAndGetValue();
+    if (seconds > MAX_SECONDS || seconds < -MAX_SECONDS) {
+        // This would overflow the valid range of the 64-bit int storage, so decline to
+        // produce a result from this undefined behavior
+        std::string message = "Input to TO_TIMESTAMP would overflow TIMESTAMP data type";
+        throw SQLException(SQLException::data_exception_numeric_value_out_of_range, message);
+    }
+
     int64_t epoch_micros = seconds * 1000000;
     return getTimestampValue(epoch_micros);
 }
 
 /** implement the timestamp TO_TIMESTAMP from MILLISECONDs function **/
 template<> inline NValue NValue::callUnary<FUNC_TO_TIMESTAMP_MILLISECOND>() const {
+    static const int64_t MAX_MILLIS = std::numeric_limits<int64_t>::max() / 1000;
+
     if (isNull()) {
         return *this;
     }
+
     int64_t millis = castAsBigIntAndGetValue();
+    if (millis > MAX_MILLIS || millis < -MAX_MILLIS) {
+        // This would overflow the valid range of the 64-bit int storage, so decline to
+        // produce a result from this undefined behavior
+        std::string message = "Input to TO_TIMESTAMP would overflow TIMESTAMP data type";
+        throw SQLException(SQLException::data_exception_numeric_value_out_of_range, message.c_str());
+    }
+
     int64_t epoch_micros = millis * 1000;
     return getTimestampValue(epoch_micros);
 }
@@ -384,6 +401,7 @@ template<> inline NValue NValue::callUnary<FUNC_TO_TIMESTAMP_MICROSECOND>() cons
     if (isNull()) {
         return *this;
     }
+
     int64_t epoch_micros = castAsBigIntAndGetValue();
     return getTimestampValue(epoch_micros);
 }
@@ -526,6 +544,8 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_MILLISECOND>() const {
     }
 
     int64_t epoch_micros = getTimestamp();
+    checkRangeOfEpochMicros(epoch_micros);
+
     int64_t epoch_millis = static_cast<int64_t>(epoch_micros / 1000);
     if (epoch_micros < 0) {
         epoch_millis -= 1;
@@ -544,6 +564,8 @@ template<> inline NValue NValue::callUnary<FUNC_TRUNCATE_MICROSECOND>() const {
     }
 
     int64_t epoch_micros = getTimestamp();
+    checkRangeOfEpochMicros(epoch_micros);
+
     return getTimestampValue(epoch_micros);
 }
 

--- a/tests/ee/expressions/function_test.cpp
+++ b/tests/ee/expressions/function_test.cpp
@@ -49,7 +49,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 #include <iostream>
-#include <limits.h>
+#include <limits>
+#include <sstream>
 #include "harness.h"
 
 #include "expressions/abstractexpression.h"
@@ -96,12 +97,29 @@ struct FunctionTest : public Test {
         int testUnary(int operation, INPUT_TYPE input, OUTPUT_TYPE output, bool expect_null = false);
 
         /**
+         * Similar to the above function, but returns "success" if the function threw a
+         * SQLException with the given input.
+         */
+        template <typename INPUT_TYPE>
+        std::string testUnaryThrows(int operation, INPUT_TYPE input, const std::string& expectedMessage);
+
+        /**
          * A template for calling binary function call expressions.  For any C++
          * type T, define the function "NValue getSomeValue(T val)" to
          * convert the T value to an NValue below.
          */
         template <typename LEFT_INPUT_TYPE, typename RIGHT_INPUT_TYPE, typename OUTPUT_TYPE>
         int testBinary(int operation, LEFT_INPUT_TYPE left_input, RIGHT_INPUT_TYPE right_input, OUTPUT_TYPE output, bool expect_null = false);
+
+        /**
+         * Similar to the above function, but returns "success" if the function threw a
+         * SQLException with the given inputs.
+         */
+        template <typename LEFT_INPUT_TYPE, typename RIGHT_INPUT_TYPE>
+        std::string testBinaryThrows(int operation,
+                                     LEFT_INPUT_TYPE left_input,
+                                     RIGHT_INPUT_TYPE right_input,
+                                     const std::string& expectedMessage);
 
         /**
          * A template for calling ternary functions.  This follows the pattern
@@ -136,6 +154,19 @@ static NValue getSomeValue(const TTInt &val)
     return ValueFactory::getDecimalValueFromString(val.ToString());
 }
 
+static NValue& getSomeValue(NValue &val)
+{
+    return val;
+}
+
+// So that NValues can be dumped to stdout when
+// staticVerboseFlag is enabled below...
+std::ostream& operator<<(std::ostream& os, const NValue& val)
+{
+    os << val.debug();
+    return os;
+}
+
 /**
  * Test a unary function call expression.
  * @returns: -1 if the result of the function evaluation is less than the expected result.
@@ -146,6 +177,7 @@ static NValue getSomeValue(const TTInt &val)
 template <typename INPUT_TYPE, typename OUTPUT_TYPE>
 int FunctionTest::testUnary(int operation, INPUT_TYPE input, OUTPUT_TYPE output, bool expect_null) {
     if (staticVerboseFlag) {
+        std::cout << "\n *** *** ***\n";
         std::cout << "operation:     " << operation << std::endl;
         std::cout << "Operand:       " << input << std::endl;
         std::cout << "Expected out:  " << output << std::endl;
@@ -180,6 +212,34 @@ int FunctionTest::testUnary(int operation, INPUT_TYPE input, OUTPUT_TYPE output,
     expected.free();
     return cmpout;
 }
+
+template <typename INPUT_TYPE>
+std::string FunctionTest::testUnaryThrows(int operation,
+                                          INPUT_TYPE input,
+                                          const std::string& expectedMessage) {
+    std::string diagnostic = "success";
+    try {
+        testUnary(operation, input, -1);
+        diagnostic = "Failed to throw an exception";
+    }
+    catch (const SQLException& exc) {
+        if (exc.message().find(expectedMessage) == std::string::npos) {
+            diagnostic = "Expected message \"" + expectedMessage + "\", but found \"" +
+                exc.message() + "\"";
+        }
+    }
+    catch (...) {
+        diagnostic = "Caught some unexpected kind of exception";
+    }
+
+    if (diagnostic.compare("success") != 0) {
+        std::cerr << "\n***  " << diagnostic << "  ***\n";
+    }
+
+    return diagnostic;
+}
+
+
 /**
  * Test a binary function call expression.
  * @returns: -1 if the result of the function evaluation is less than the expected result.
@@ -228,6 +288,36 @@ int FunctionTest::testBinary(int operation, LEFT_INPUT_TYPE linput, RIGHT_INPUT_
     delete bin_exp;
     return cmpout;
 }
+
+template <typename LEFT_INPUT_TYPE, typename RIGHT_INPUT_TYPE>
+std::string FunctionTest::testBinaryThrows(int operation,
+                                           LEFT_INPUT_TYPE left_input,
+                                           RIGHT_INPUT_TYPE right_input,
+                                           const std::string& expectedMessage) {
+    std::string diagnostic = "success";
+    try {
+        testBinary(operation, left_input, right_input, -1);
+        diagnostic = "Failed to throw an exception";
+    }
+    catch (const SQLException& exc) {
+        if (exc.message().find(expectedMessage) == std::string::npos) {
+            diagnostic = "Expected message \"" + expectedMessage + "\", but found \"" +
+                exc.message() + "\"";
+        }
+    }
+    catch (...) {
+        diagnostic = "Caught some unexpected kind of exception";
+    }
+
+    if (diagnostic.compare("success") != 0) {
+        std::cerr << "\n***  " << diagnostic << "  ***\n";
+    }
+
+    return diagnostic;
+
+}
+
+
 
 /**
  * Test a ternary function call expression.
@@ -581,9 +671,295 @@ TEST_F(FunctionTest, RegularExpressionMatch) {
     ASSERT_EQ(testBinary(FUNC_VOLT_REGEXP_POSITION, testUTF8String, "[a-z]家", 0), 0);
 }
 
+static NValue timestampFromString(const std::string& dateString) {
+    return ValueFactory::getTimestampValue(NValue::parseTimestampString(dateString));
+}
+
+static const NValue nullTimestamp = ValueFactory::getTimestampValue(std::numeric_limits<int64_t>::min());
+static const NValue minInt64 = ValueFactory::getTimestampValue(std::numeric_limits<int64_t>::min() + 1);
+static const NValue tooSmallTimestamp = ValueFactory::getTimestampValue(GREGORIAN_EPOCH - 1);
+static const NValue minValidTimestamp = ValueFactory::getTimestampValue(GREGORIAN_EPOCH);
+static const NValue maxValidTimestamp = ValueFactory::getTimestampValue(NYE9999);
+static const NValue tooBigTimestamp = ValueFactory::getTimestampValue(NYE9999 + 1);
+static const NValue maxInt64 = ValueFactory::getTimestampValue(std::numeric_limits<int64_t>::max());
+
+static const std::string outOfRangeMessage = "Value out of range. Cannot convert dates prior to the year 1583 or after the year 9999";
+
+TEST_F(FunctionTest, DateFunctionsTruncate) {
+    std::vector<int> funcs {
+        FUNC_TRUNCATE_YEAR,
+        FUNC_TRUNCATE_QUARTER,
+        FUNC_TRUNCATE_MONTH,
+        FUNC_TRUNCATE_DAY,
+        FUNC_TRUNCATE_HOUR,
+        FUNC_TRUNCATE_MINUTE,
+        FUNC_TRUNCATE_SECOND,
+        FUNC_TRUNCATE_MILLISECOND,
+        FUNC_TRUNCATE_MICROSECOND
+    };
+
+    std::vector<string> maxExpected {
+        "9999-01-01",                 // year
+        "9999-10-01",                 // quarter
+        "9999-12-01",                 // month
+        "9999-12-31",                 // day
+        "9999-12-31 23:00:00.000000", // hour
+        "9999-12-31 23:59:00.000000", // minute
+        "9999-12-31 23:59:59.000000", // second
+        "9999-12-31 23:59:59.999000", // millisecond
+        "9999-12-31 23:59:59.999999"  // microsecond
+    };
+
+    int i = 0;
+    BOOST_FOREACH(int func, funcs) {
+        ASSERT_EQ(testUnary(func, nullTimestamp, nullTimestamp, true), 0);
+        ASSERT_EQ("success", testUnaryThrows(func, minInt64, outOfRangeMessage));
+        ASSERT_EQ("success", testUnaryThrows(func, tooSmallTimestamp, outOfRangeMessage));
+        ASSERT_EQ("success", testUnaryThrows(func, tooBigTimestamp, outOfRangeMessage));
+        ASSERT_EQ("success", testUnaryThrows(func, maxInt64, outOfRangeMessage));
+
+        // truncate on the min valid timestamp is always a no-op,
+        // except for bug ENG-10507, which is related to TRUNCATE MILLISECOND.
+        if (func != FUNC_TRUNCATE_MILLISECOND) {
+            ASSERT_EQ(testUnary(func, minValidTimestamp, minValidTimestamp), 0);
+        }
+        else {
+            ASSERT_EQ(testUnary(func, minValidTimestamp, minValidTimestamp), -1);
+        }
+
+        ASSERT_EQ(testUnary(func, maxValidTimestamp,
+                            timestampFromString(maxExpected[i])), 0);
+
+        ++i;
+    }
+}
+
+TEST_F(FunctionTest, DateFunctionsExtract) {
+
+    std::vector<int> funcs {
+        FUNC_EXTRACT_YEAR,
+        FUNC_EXTRACT_MONTH,
+        FUNC_EXTRACT_DAY,
+        FUNC_EXTRACT_DAY_OF_WEEK,
+        FUNC_EXTRACT_WEEKDAY,
+        FUNC_EXTRACT_WEEK_OF_YEAR,
+        FUNC_EXTRACT_DAY_OF_YEAR,
+        FUNC_EXTRACT_QUARTER,
+        FUNC_EXTRACT_HOUR,
+        FUNC_EXTRACT_MINUTE,
+        FUNC_EXTRACT_SECOND
+    };
+
+    std::vector<int> minExpected {
+        1583, // year
+        1,    // month
+        1,    // day
+        7,    // day of week: Saturday
+        5,    // weekday: Saturday
+        52,   // week of year (consistent with ISO-8601)
+        1,    // day of year
+        1,    // quarter
+        0,    // hour
+        0,    // minute
+        0     // second
+    };
+
+    std::vector<int> maxExpected {
+        9999, // year
+        12,   // month
+        31,   // day
+        6,    // day of week: Friday
+        4,    // weekday: Friday
+        52,   // week of year
+        365,  // day of year
+        4,    // quarter
+        23,   // hour
+        59,   // minute
+        -1    // second  (EXTRACT second produces a decimal, see below)
+    };
+
+    int i = 0;
+    BOOST_FOREACH(int func, funcs) {
+        ASSERT_EQ("success", testUnaryThrows(func, minInt64, outOfRangeMessage));
+        ASSERT_EQ("success", testUnaryThrows(func, tooSmallTimestamp, outOfRangeMessage));
+        ASSERT_EQ("success", testUnaryThrows(func, tooBigTimestamp, outOfRangeMessage));
+        ASSERT_EQ("success", testUnaryThrows(func, maxInt64, outOfRangeMessage));
+
+        ASSERT_EQ(testUnary(func, nullTimestamp, nullTimestamp, true), 0);
+
+        ASSERT_EQ(testUnary(func, minValidTimestamp, minExpected[i]), 0);
+
+        if (func != FUNC_EXTRACT_SECOND) {
+            ASSERT_EQ(testUnary(func, maxValidTimestamp, maxExpected[i]), 0);
+        }
+        else {
+            ASSERT_EQ(testUnary(func, maxValidTimestamp,
+                                ValueFactory::getDecimalValueFromString("59.999999")), 0);
+        }
+
+        ++i;
+    }
+}
+
+TEST_F(FunctionTest, DateFunctionsAdd) {
+    const std::string intervalTooLargeMsg = "interval is too large for DATEADD function";
+
+    std::vector<int> funcs {
+        FUNC_VOLT_DATEADD_YEAR,
+        FUNC_VOLT_DATEADD_QUARTER,
+        FUNC_VOLT_DATEADD_MONTH,
+        FUNC_VOLT_DATEADD_DAY,
+        FUNC_VOLT_DATEADD_HOUR,
+        FUNC_VOLT_DATEADD_MINUTE,
+        FUNC_VOLT_DATEADD_SECOND,
+        FUNC_VOLT_DATEADD_MILLISECOND,
+        FUNC_VOLT_DATEADD_MICROSECOND
+    };
+
+    std::vector<int64_t> maxIntervals {
+        PTIME_MAX_YEAR_INTERVAL,
+        PTIME_MAX_QUARTER_INTERVAL,
+        PTIME_MAX_MONTH_INTERVAL,
+        PTIME_MAX_DAY_INTERVAL,
+        PTIME_MAX_HOUR_INTERVAL,
+        PTIME_MAX_MINUTE_INTERVAL,
+        PTIME_MAX_SECOND_INTERVAL,
+        PTIME_MAX_MILLISECOND_INTERVAL,
+        PTIME_MAX_MICROSECOND_INTERVAL
+    };
+
+    std::vector<int64_t> minIntervals {
+        PTIME_MIN_YEAR_INTERVAL,
+        PTIME_MIN_QUARTER_INTERVAL,
+        PTIME_MIN_MONTH_INTERVAL,
+        PTIME_MIN_DAY_INTERVAL,
+        PTIME_MIN_HOUR_INTERVAL,
+        PTIME_MIN_MINUTE_INTERVAL,
+        PTIME_MIN_SECOND_INTERVAL,
+        PTIME_MIN_MILLISECOND_INTERVAL,
+        PTIME_MIN_MICROSECOND_INTERVAL
+    };
+
+    int i = 0;
+    BOOST_FOREACH(int func, funcs) {
+        // test null values
+        ASSERT_EQ(0, testBinary(func, 1, nullTimestamp, nullTimestamp, true));
+        ASSERT_EQ(0, testBinary(func, NValue::getNullValue(VALUE_TYPE_BIGINT),
+                                minValidTimestamp, nullTimestamp, true));
+
+        ASSERT_EQ("success", testBinaryThrows(func, 1, minInt64, outOfRangeMessage));
+        ASSERT_EQ("success", testBinaryThrows(func, 1, tooSmallTimestamp, outOfRangeMessage));
+        ASSERT_EQ("success", testBinaryThrows(func, 1, tooBigTimestamp, outOfRangeMessage));
+        ASSERT_EQ("success", testBinaryThrows(func, 1, maxInt64, outOfRangeMessage));
+
+        ASSERT_EQ("success", testBinaryThrows(func, maxIntervals[i] + 1,
+                                              minValidTimestamp, intervalTooLargeMsg));
+        ASSERT_EQ("success", testBinaryThrows(func, minIntervals[i] - 1,
+                                              maxValidTimestamp, intervalTooLargeMsg));
+
+        ASSERT_EQ(testBinary(func, 0, minValidTimestamp, minValidTimestamp), 0);
+        ASSERT_EQ(testBinary(func, 0, maxValidTimestamp, maxValidTimestamp), 0);
+
+        // This just asserts that if we add 1 unit (year, month, whatever)
+        // that the result is larger than the input.
+        ASSERT_EQ(testBinary(func, 1, minValidTimestamp, minValidTimestamp), 1);
+
+        // Likewise for subtracting a unit
+        ASSERT_EQ(testBinary(func, -1, maxValidTimestamp, maxValidTimestamp), -1);
+
+        ++i;
+    }
+}
+
+static const int64_t MIN_INT64 = std::numeric_limits<int64_t>::min() + 1;
+static const int64_t MAX_INT64 = std::numeric_limits<int64_t>::max();
+
+
+TEST_F(FunctionTest, DateFunctionsSinceEpoch) {
+    std::vector<int> funcs {
+        FUNC_SINCE_EPOCH_SECOND,
+        FUNC_SINCE_EPOCH_MILLISECOND,
+        FUNC_SINCE_EPOCH_MICROSECOND
+    };
+
+    std::vector<int> scale {
+        1000000,
+        1000,
+        1
+    };
+
+    int i = 0;
+    BOOST_FOREACH(int func, funcs) {
+        ASSERT_EQ(0, testUnary(func, nullTimestamp, nullTimestamp, true));
+
+        // SINCE_EPOCH does no range checking on timestamps, just simple division
+        // by 1, 1000 or 1000000.  Therefore it doesn't throw an exception for
+        // out of range values.
+
+        ASSERT_EQ(0, testUnary(func, minInt64, MIN_INT64 / scale[i]));
+        ASSERT_EQ(0, testUnary(func, tooSmallTimestamp, (GREGORIAN_EPOCH-1) / scale[i]));
+        ASSERT_EQ(0, testUnary(func, minValidTimestamp, GREGORIAN_EPOCH / scale[i]));
+        ASSERT_EQ(0, testUnary(func, maxValidTimestamp, NYE9999 / scale[i]));
+        ASSERT_EQ(0, testUnary(func, tooBigTimestamp, (NYE9999+1) / scale[i]));
+        ASSERT_EQ(0, testUnary(func, maxInt64, MAX_INT64 / scale[i]));
+
+        ++i;
+    }
+}
+
+TEST_F(FunctionTest, DateFunctionsToTimestamp) {
+    const std::string overflowMessage = "Input to TO_TIMESTAMP would overflow TIMESTAMP data type";
+
+    std::vector<int> funcs {
+        FUNC_TO_TIMESTAMP_SECOND,
+        FUNC_TO_TIMESTAMP_MILLISECOND,
+        FUNC_TO_TIMESTAMP_MICROSECOND
+    };
+
+    std::vector<int> scale {
+        1000000,
+        1000,
+        1
+    };
+
+    const NValue nullBigint = NValue::getNullValue(VALUE_TYPE_NULL);
+
+    int i = 0;
+    BOOST_FOREACH(int func, funcs) {
+        ASSERT_EQ(0, testUnary(func, nullBigint, nullTimestamp, true));
+
+        // These functions really just multiply their argument by a constant
+        // and produce a timestamp, so there are no range checks, except to avoid
+        // overflow of the 64-bit timestamp storage.
+
+        if (scale[i] != 1) {
+            ASSERT_EQ("success", testUnaryThrows(func, MIN_INT64, overflowMessage));
+            ASSERT_EQ("success", testUnaryThrows(func, (MIN_INT64 / scale[i]) - 1, overflowMessage));
+            ASSERT_EQ("success", testUnaryThrows(func, MAX_INT64, overflowMessage));
+            ASSERT_EQ("success", testUnaryThrows(func, (MAX_INT64 / scale[i]) + 1, overflowMessage));
+        }
+
+        const int64_t TRUNCATED_MIN_INT64 = (MIN_INT64 / scale[i]) * scale[i];
+        const int64_t TRUNCATED_MIN_VALID_TS = (GREGORIAN_EPOCH / scale[i]) * scale[i];
+        const int64_t TRUNCATED_MAX_VALID_TS = (NYE9999 / scale[i]) * scale[i];
+        const int64_t TRUNCATED_MAX_INT64 = (MAX_INT64 / scale[i]) * scale[i];
+
+        ASSERT_EQ(0, testUnary(func, MIN_INT64 / scale[i],
+                               ValueFactory::getTimestampValue(TRUNCATED_MIN_INT64)));
+        ASSERT_EQ(0, testUnary(func, GREGORIAN_EPOCH / scale[i],
+                               ValueFactory::getTimestampValue(TRUNCATED_MIN_VALID_TS)));
+        ASSERT_EQ(0, testUnary(func, NYE9999/ scale[i],
+                               ValueFactory::getTimestampValue(TRUNCATED_MAX_VALID_TS)));
+        ASSERT_EQ(0, testUnary(func, MAX_INT64 / scale[i],
+                               ValueFactory::getTimestampValue(TRUNCATED_MAX_INT64)));
+
+        ++i;
+    }
+}
+
 int main(int argc, char **argv) {
     for (argv++; *argv; argv++) {
-        if (strcmp(*argv, "--verbose")) {
+        if (strcmp(*argv, "--verbose") == 0) {
             staticVerboseFlag = true;
         } else {
             std::cerr << "Unknown command line parameter: " << *argv << std::endl;


### PR DESCRIPTION
Add EE unit tests for timestamp functions.

The functional changes here are just to avoid the boost exception produced with using the boost functions with years greater than 9999, and to avoid overflow of the int64_t storage for timestamps in the TO_TIMESTAMP method.

In particular, I didn't add code that would throw exceptions if out-of-range timestamps would be produced as output.  I wanted to avoid breaking existing apps as much as possible.  This issue can be addressed in the future ticket that will more properly guard against out-of-range timestamps.