### PR TITLE
Don't forget the conjuncts.

### DIFF
--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -154,7 +154,7 @@ class Table {
 
     /**
      * Includes tuples that are pending any kind of delete.
-     * Used by iterators to determine how many tupels to expect while scanning
+     * Used by iterators to determine how many tuples to expect while scanning
      */
     virtual int64_t activeTupleCount() const {
         return m_tupleCount;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
@@ -788,7 +788,7 @@ public class ExpressionColumn extends Expression {
 
             case OpTypes.DYNAMIC_PARAM :
                 sb.append("DYNAMIC PARAM: ");
-                sb.append(", TYPE = ").append(dataType.getNameString());
+                sb.append(", TYPE = ").append((dataType != null) ? dataType.getNameString() : "null");
                 break;
 
             case OpTypes.SEQUENCE :

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
@@ -492,17 +492,21 @@ final class RangeVariable {
 
             case OpTypes.GREATER :
             case OpTypes.GREATER_EQUAL :
-                indexCondition = e;
+            	indexCondition = makeConjunction(indexCondition, e);
                 break;
 
             case OpTypes.SMALLER :
             case OpTypes.SMALLER_EQUAL :
-                indexEndCondition = e;
+            	indexEndCondition = makeConjunction(indexEndCondition, e);
                 break;
 
             default :
                 Error.runtimeError(ErrorCode.U_S0500, "Expression");
         }
+    }
+
+    private static Expression makeConjunction(Expression existingExpr, Expression newExpr) {
+    	return (existingExpr == null) ? newExpr : new ExpressionLogical(OpTypes.AND, existingExpr, newExpr);
     }
 
     /**
@@ -1257,19 +1261,11 @@ final class RangeVariable {
         if (isJoinIndex == true) {
             joinCond = indexCondition;
             if (indexEndCondition != null) {
-                if (joinCond != null) {
-                    joinCond = new ExpressionLogical(OpTypes.AND, joinCond, indexEndCondition);
-                } else {
-                    joinCond = indexEndCondition;
-                }
+            	joinCond = makeConjunction(joinCond, indexEndCondition);
             }
             // then go to the nonIndexJoinCondition
             if (nonIndexJoinCondition != null) {
-                if (joinCond != null) {
-                    joinCond = new ExpressionLogical(OpTypes.AND, joinCond, nonIndexJoinCondition);
-                } else {
-                    joinCond = nonIndexJoinCondition;
-                }
+            	joinCond = makeConjunction(joinCond, nonIndexJoinCondition);
             }
             // then go to the nonIndexWhereCondition
             whereCond = nonIndexWhereCondition;
@@ -1278,19 +1274,11 @@ final class RangeVariable {
 
             whereCond = indexCondition;
             if (indexEndCondition != null) {
-                if (whereCond != null) {
-                    whereCond = new ExpressionLogical(OpTypes.AND, whereCond, indexEndCondition);
-                } else {
-                    whereCond = indexEndCondition;
-                }
+            	whereCond = makeConjunction(whereCond, indexEndCondition);
             }
             // then go to the nonIndexWhereCondition
             if (nonIndexWhereCondition != null) {
-                if (whereCond != null) {
-                    whereCond = new ExpressionLogical(OpTypes.AND, whereCond, nonIndexWhereCondition);
-                } else {
-                    whereCond = nonIndexWhereCondition;
-                }
+            	whereCond = makeConjunction(whereCond, nonIndexWhereCondition);
             }
 
         }

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexesSuite.java
@@ -1253,6 +1253,32 @@ public class TestIndexesSuite extends RegressionSuite {
         validateTableColumnOfScalarVarbinary(client, sql, new String[]{"0A0BCD", "0A0BEF"});
     }
 
+    public void testBooleanExpressions() throws Exception {
+        Client client = getClient();
+        VoltTable results;
+        client.callProcedure("BTEST_R2.insert", 16, -123, 3, 109, -92);
+        client.callProcedure("BTEST_R2.insert", 17, -123, 3, 109, 120);
+        client.callProcedure("BTEST_R2.insert", 18, -123, 3, 109, 91);
+        client.callProcedure("BTEST_R2.insert", 19, -123, 3, 109, 35);
+        // This is handy for debugging.
+        /*
+        results = client.callProcedure("@AdHoc", "select * from BTEST_R2;").getResults()[0];
+        System.out.println("BTEST_R2: " + results.toString());
+        results = client.callProcedure("@AdHoc", "select * from V_BTEST_R2_ABS;").getResults()[0];
+        System.out.println("V_BTEST_R2_ABS: " + results.toString());
+        //*/
+        String sql0 = "SELECT * FROM V_BTEST_R2_ABS WHERE V_SUM_RENT < 1000;";
+        String sql1 = "SELECT * FROM V_BTEST_R2_ABS WHERE V_SUM_RENT < 42;";
+        String sql2 = "SELECT * FROM V_BTEST_R2_ABS WHERE V_SUM_RENT < 42 AND V_SUM_RENT < 26661;";
+        // The rent field is 35.  So that's what we expect.
+        results = client.callProcedure("@AdHoc", sql0).getResults()[0];
+        assertEquals(1, results.getRowCount());
+        results = client.callProcedure("@AdHoc", sql1).getResults()[0];
+        assertEquals(0, results.getRowCount());
+        // Now, it can't be increased by conjoining another condition.
+        results = client.callProcedure("@AdHoc", sql2).getResults()[0];
+        assertEquals(0, results.getRowCount());
+    }
     //
     // JUnit / RegressionSuite boilerplate
     //

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/indexes/indexes-ddl.sql
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/indexes/indexes-ddl.sql
@@ -126,3 +126,24 @@ CREATE TABLE varbinaryTableTree (
 );
 CREATE INDEX varbinaryTableTree_INDEX_varb2 ON varbinaryTableTree(varb2);
 CREATE INDEX varbinaryTableTree_INDEX_varb512 ON varbinaryTableTree(varb512);
+
+-- ENG-10478
+-- Sometimes we mangle boolean expressions of the form "col < 42 and col < 26661"
+-- when "col" is the same table in both conjuncts.  See TestIndexesSuite.testBooleanExpressions.
+DROP VIEW V_BTEST_R2_ABS IF EXISTS;
+DROP TABLE BTEST_R2 IF EXISTS;
+CREATE TABLE BTEST_R2 (
+    ID          INTEGER NOT NULL, 
+    WAGE        SMALLINT, 
+    DEPT        SMALLINT, 
+    AGE         SMALLINT, 
+    RENT        SMALLINT, 
+    PRIMARY KEY (ID)
+);
+CREATE VIEW V_BTEST_R2_ABS 
+    (V_G1, V_G2, V_CNT, V_sum_age, V_sum_rent) 
+AS  SELECT ABS(wage), dept, count(*), sum(age), sum(rent)  
+        FROM BTEST_R2 
+        GROUP BY ABS(wage), dept;
+
+


### PR DESCRIPTION
In ENG-10478 we discovered that we sometimes could forget conjuncts in
where clauses. For example, in the select statement:

select * from SOMEVIEW where THERENT < 42 AND THERENT < 26000;

where SOMEVIEW is a view, we create an index on the view and use that to
help us evaluate the where expression. Since both conjuncts are tests
on the same column of SOMEVIEW, we can use one index to answer both
predicates. But unfortunately we lost the left hand conjunct, and only
used the right hand one.

Plus some other refactoring, spelling corrections and unit test
creation.

https://issues.voltdb.com/browse/ENG-10478