### PR TITLE
ENG-8154 precursor work to enabling all subqueries on replicated tables

### DIFF
--- a/src/frontend/org/voltdb/VoltTableRow.java
+++ b/src/frontend/org/voltdb/VoltTableRow.java
@@ -338,8 +338,12 @@ public abstract class VoltTableRow {
      * @see #wasNull()
      */
     public final long getLong(int columnIndex) {
-        if ((columnIndex >= getColumnCount()) || (columnIndex < 0)) {
-            throw new IndexOutOfBoundsException("Column index " + columnIndex + " is type greater than the number of columns");
+        if (columnIndex < 0) {
+            throw new IndexOutOfBoundsException("Column index " + columnIndex + " is negative");
+        }
+        if (columnIndex >= getColumnCount()) {
+            throw new IndexOutOfBoundsException("Column index " + columnIndex +
+                    " is beyond number of columns " + getColumnCount());
         }
         final VoltType type = getColumnType(columnIndex);
         if (m_activeRowIndex == INVALID_ROW_INDEX)

--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -2911,11 +2911,11 @@ public class DDLCompiler {
         // Now it safe to parse the expression tree
         AbstractExpression predicate = dummy.parseExpressionTree(predicateXML);
 
-        if (!predicate.findAllSubexpressionsOfClass(AggregateExpression.class).isEmpty()) {
+        if (predicate.hasAnySubexpressionOfClass(AggregateExpression.class)) {
             msg += "with aggregate expression(s) is not supported.";
             throw compiler.new VoltCompilerException(msg);
         }
-        if (!predicate.findAllSubexpressionsOfClass(AbstractSubqueryExpression.class).isEmpty()) {
+        if (predicate.hasAnySubexpressionOfClass(AbstractSubqueryExpression.class)) {
             msg += "with subquery expression(s) is not supported.";
             throw compiler.new VoltCompilerException(msg);
         }

--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.Stack;
 
 import org.voltdb.VoltType;
-import org.voltdb.catalog.Database;
 import org.voltdb.planner.PlanningErrorException;
 import org.voltdb.types.ExpressionType;
 
@@ -282,18 +281,6 @@ public abstract class ExpressionUtil {
     }
 
     /**
-     * A convenience wrapper around AbstractExpression.findAllExpressionsOfClass
-     * Recursively walk an expression and return a list of all the expressions
-     * of a given type it contains.
-     */
-    public static List<AbstractExpression> findAllExpressionsOfClass(AbstractExpression input, Class< ? extends AbstractExpression> aeClass) {
-        if (input == null) {
-            return new ArrayList<AbstractExpression>();
-        }
-        return input.findAllSubexpressionsOfClass(aeClass);
-    }
-
-    /**
      * Method to simplify an expression by eliminating identical subexpressions (same id)
      * If the expression is a logical conjunction of the form e1 AND e2 AND e3 AND e4,
      * and subexpression e1 is identical to the subexpression e2 the simplified expression is
@@ -450,40 +437,6 @@ public abstract class ExpressionUtil {
         return false;
     }
 
-    /**
-     * Resolve the column indexes from all subqueries that are part of this expression
-     * @param expr
-     * @param db
-     */
-    public static void resolveSubqueryExpressionColumnIndexes(AbstractExpression expr) {
-        if (expr == null) {
-            return;
-        }
-        List<AbstractExpression> subqueryExpressions = expr.findAllSubexpressionsOfClass(AbstractSubqueryExpression.class);
-        if (subqueryExpressions.isEmpty()) {
-            return;
-        }
-        for (AbstractExpression subqueryExpression : subqueryExpressions) {
-            assert(subqueryExpression instanceof AbstractSubqueryExpression);
-            ((AbstractSubqueryExpression) subqueryExpression).resolveColumnIndexes();
-        }
-    }
-
-    /**
-     * Generate the output schemas for the subquery expression nodes
-     * @param expr
-     * @param db
-     */
-    public static void generateSubqueryExpressionOutputSchema(AbstractExpression expr, Database db) {
-        if (expr == null) {
-            return;
-        }
-        List<AbstractExpression> subqueryExpressions = expr.findAllSubexpressionsOfClass(AbstractSubqueryExpression.class);
-        for (AbstractExpression subqueryExpression : subqueryExpressions) {
-            assert(subqueryExpression instanceof AbstractSubqueryExpression);
-            ((AbstractSubqueryExpression) subqueryExpression).generateOutputSchema(db);
-        }
-    }
     /**
      * Traverse this expression tree.  Where we find a SelectSubqueryExpression, wrap it
      * in a ScalarValueExpression if its parent is not one of:

--- a/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
@@ -37,7 +37,9 @@ public class ScalarValueExpression extends AbstractValueExpression {
     @Override
     public boolean equals(Object obj) {
         assert(m_left != null);
-        if (obj instanceof ScalarValueExpression == false) return false;
+        if (obj instanceof ScalarValueExpression == false) {
+            return false;
+        }
         ScalarValueExpression expr = (ScalarValueExpression) obj;
         return m_left.equals(expr.getLeft());
     }

--- a/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
@@ -250,17 +250,20 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
             AbstractExpression expr = entry.getValue();
             if (expr instanceof TupleValueExpression) {
                 TupleValueExpression tve = (TupleValueExpression) expr;
-                if(tve.getOrigStmtId() == parentStmt.m_stmtId) {
+                if (tve.getOrigStmtId() == parentStmt.m_stmtId) {
                     // TVE originates from the statement that this SubqueryExpression belongs to
                     addArgumentParameter(paramIdx, expr);
-                } else {
+                }
+                else {
                     // TVE originates from a statement above this parent. Move it up.
                     parentStmt.m_parameterTveMap.put(paramIdx, expr);
                 }
-            } else if (expr instanceof AggregateExpression) {
+            }
+            else if (expr instanceof AggregateExpression) {
                 // An aggregate expression is always from THIS parent statement.
                 addArgumentParameter(paramIdx, expr);
-            } else {
+            }
+            else {
                 // so far it should be either AggregateExpression or TupleValueExpression types
                 assert(false);
             }

--- a/src/frontend/org/voltdb/expressions/TupleValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/TupleValueExpression.java
@@ -72,26 +72,36 @@ public class TupleValueExpression extends AbstractValueExpression {
                                 String tableAlias,
                                 String columnName,
                                 String columnAlias,
-                                int columnIndex) {
+                                int columnIndex,
+                                int differentiator) {
         super(ExpressionType.VALUE_TUPLE);
         m_tableName = tableName;
         m_tableAlias = tableAlias;
         m_columnName = columnName;
         m_columnAlias = columnAlias;
         m_columnIndex = columnIndex;
+        m_differentiator = differentiator;
+    }
+
+    public TupleValueExpression(String tableName,
+            String tableAlias,
+            String columnName,
+            String columnAlias,
+            int columnIndex) {
+        this(tableName, tableAlias, columnName, columnAlias, columnIndex, -1);
     }
 
     public TupleValueExpression(String tableName,
                                 String tableAlias,
                                 String columnName,
                                 String columnAlias) {
-        this(tableName, tableAlias, columnName, columnAlias, -1);
+        this(tableName, tableAlias, columnName, columnAlias, -1, -1);
     }
 
     public TupleValueExpression(String tableName,
                                 String columnName,
                                 int columnIndex) {
-        this(tableName, null, columnName, null, columnIndex);
+        this(tableName, null, columnName, null, columnIndex, -1);
     }
 
     public TupleValueExpression() {

--- a/src/frontend/org/voltdb/planner/MaterializedViewFixInfo.java
+++ b/src/frontend/org/voltdb/planner/MaterializedViewFixInfo.java
@@ -34,7 +34,6 @@ import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.AggregateExpression;
 import org.voltdb.expressions.ExpressionUtil;
 import org.voltdb.expressions.TupleValueExpression;
-import org.voltdb.planner.ParsedColInfo;
 import org.voltdb.planner.parseinfo.BranchNode;
 import org.voltdb.planner.parseinfo.JoinNode;
 import org.voltdb.planner.parseinfo.StmtTableScan;
@@ -397,7 +396,7 @@ public class MaterializedViewFixInfo {
         List<AbstractExpression> exprs = ExpressionUtil.uncombine(filters);
 
         for (AbstractExpression expr: exprs) {
-            ArrayList<AbstractExpression> tves = expr.findBaseTVEs();
+            List<AbstractExpression> tves = expr.findAllTupleValueSubexpressions();
 
             boolean canPushdown = true;
 

--- a/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
@@ -232,9 +232,10 @@ public class ParsedInsertStmt extends AbstractParsedStmt {
         Set<AbstractExpression> exprs = super.findAllSubexpressionsOfClass(aeClass);
 
         for (AbstractExpression expr : m_columns.values()) {
-            if (expr != null) {
-                exprs.addAll(expr.findAllSubexpressionsOfClass(aeClass));
+            if (expr == null) {
+                continue;
             }
+            exprs.addAll(expr.findAllSubexpressionsOfClass(aeClass));
         }
 
         if (m_subquery != null) {

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -42,7 +42,6 @@ import org.voltdb.expressions.OperatorExpression;
 import org.voltdb.expressions.ParameterValueExpression;
 import org.voltdb.expressions.RowSubqueryExpression;
 import org.voltdb.expressions.ScalarValueExpression;
-import org.voltdb.expressions.SelectSubqueryExpression;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.planner.parseinfo.BranchNode;
 import org.voltdb.planner.parseinfo.JoinNode;
@@ -529,7 +528,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
     private void insertAggExpressionsToAggResultColumns (List<AbstractExpression> aggColumns, ParsedColInfo cookedCol) {
         for (AbstractExpression expr: aggColumns) {
             assert(expr instanceof AggregateExpression);
-            if (! expr.findAllSubexpressionsOfClass(SelectSubqueryExpression.class).isEmpty()) {
+            if (expr.hasSubquerySubexpression()) {
                 throw new PlanningErrorException(
                         "SQL Aggregate with subquery expression is not allowed.");
             }
@@ -605,8 +604,9 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
      * @param tveList
      */
     private void findAllTVEs(AbstractExpression expr, List<TupleValueExpression> tveList) {
-        if (!isNewtoColumnList(m_aggResultColumns, expr))
+        if (!isNewtoColumnList(m_aggResultColumns, expr)) {
             return;
+        }
         if (expr instanceof TupleValueExpression) {
             tveList.add((TupleValueExpression) expr.clone());
             return;
@@ -627,7 +627,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
     private void updateAvgExpressions () {
         List<AbstractExpression> optimalAvgAggs = new ArrayList<AbstractExpression>();
         Iterator<AbstractExpression> itr = m_aggregationList.iterator();
-        while(itr.hasNext()) {
+        while (itr.hasNext()) {
             AbstractExpression aggExpr = itr.next();
             assert(aggExpr instanceof AggregateExpression);
             if (aggExpr.getExpressionType() == ExpressionType.AGGREGATE_AVG) {
@@ -755,8 +755,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
             col.tableAlias = sve.getSubqueryScan().getTableAlias();
             col.expression = colExpr;
         }
-        else
-        {
+        else {
             col.expression = colExpr;
             // XXX hacky, assume all non-column refs come from a temp table
             col.tableName = "VOLT_TEMP_TABLE";
@@ -835,15 +834,14 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         }
 
         // find the matching columns in display list
-        for (int i = 0; i < m_displayColumns.size(); ++i) {
-            ParsedColInfo col = m_displayColumns.get(i);
-            if (col.expression.equals(groupbyCol.expression)) {
-                groupbyCol.alias = col.alias;
-                groupbyCol.groupByInDisplay = true;
-
-                col.groupBy = true;
-                break;
+        for (ParsedColInfo col : m_displayColumns) {
+            if (! col.expression.equals(groupbyCol.expression)) {
+                continue;
             }
+            groupbyCol.alias = col.alias;
+            groupbyCol.groupByInDisplay = true;
+            col.groupBy = true;
+            break;
         }
 
         m_groupByColumns.add(groupbyCol);
@@ -879,7 +877,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         assert(order_exp != null);
 
         // guards against subquery inside of order by clause
-        if (! order_exp.findAllSubexpressionsOfClass(SelectSubqueryExpression.class).isEmpty()) {
+        if (order_exp.hasSubquerySubexpression()) {
             throw new PlanningErrorException(
                     "ORDER BY clause with subquery expression is not allowed.");
         }
@@ -918,7 +916,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         assert(havingNode.children.size() == 1);
         m_having = parseConditionTree(havingNode.children.get(0));
         assert(m_having != null);
-        if (! m_having.findAllSubexpressionsOfClass(SelectSubqueryExpression.class).isEmpty()) {
+        if (m_having.hasSubquerySubexpression()) {
             throw new PlanningErrorException(
                     "SQL HAVING with subquery expression is not allowed.");
         }
@@ -1785,7 +1783,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
                 orderByAllBaseTVEs.add(orderByExpr);
             } else {
                 orderByNonTVEs.add(orderByExpr);
-                List<AbstractExpression> baseTVEs = orderByExpr.findBaseTVEs();
+                List<AbstractExpression> baseTVEs = orderByExpr.findAllTupleValueSubexpressions();
                 orderByNonTVEBaseTVEs.add(baseTVEs);
                 orderByAllBaseTVEs.addAll(baseTVEs);
             }
@@ -1795,7 +1793,7 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
 
         for (AbstractExpression candidateExpr : candidateExprHardCases)
         {
-            Collection<AbstractExpression> candidateBases = candidateExpr.findBaseTVEs();
+            Collection<AbstractExpression> candidateBases = candidateExpr.findAllTupleValueSubexpressions();
             if (orderByTVEs.containsAll(candidateBases)) {
                 continue;
             }
@@ -1950,30 +1948,77 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
     @Override
     public Set<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
         Set<AbstractExpression> exprs = super.findAllSubexpressionsOfClass(aeClass);
-        if (m_having != null) {
-            exprs.addAll(m_having.findAllSubexpressionsOfClass(aeClass));
-        }
-        if (m_groupByExpressions != null) {
-            for (AbstractExpression groupByExpr : m_groupByExpressions.values()) {
-                exprs.addAll(groupByExpr.findAllSubexpressionsOfClass(aeClass));
-            }
-        }
-        if (m_projectSchema != null) {
-            for(SchemaColumn col : m_projectSchema.getColumns()) {
-                if (col.getExpression() != null) {
-                    exprs.addAll(col.getExpression().findAllSubexpressionsOfClass(aeClass));
-                }
-            }
-        }
 
-        // m_having, m_groupByExpressions, m_projectSchema may contain the aggregation or group by expression that have
-        // been replaced with TVEs already. So check out the repository of the original expression in m_aggResultColumns.
-        for (ParsedColInfo col: m_aggResultColumns) {
-            if (col.expression != null) {
-                exprs.addAll(col.expression.findAllSubexpressionsOfClass(aeClass));
+        if (m_having != null) {
+            Collection<AbstractExpression> found =
+                    m_having.findAllSubexpressionsOfClass(aeClass);
+            if (! found.isEmpty()) {
+                exprs.addAll(found);
             }
+        }
+        addAllSubexpressionsOfClassFromColList(exprs, aeClass, m_groupByColumns);
+        if (m_projectSchema != null) {
+            addAllSubexpressionsOfClassFromNodeSchema(exprs, aeClass, m_projectSchema);
+        }
+        // m_having, m_groupByExpressions, m_projectSchema
+        // may contain the aggregation or group by expression that have been
+        // replaced with TVEs already.
+        // So look for the original expression in m_aggResultColumns.
+        addAllSubexpressionsOfClassFromColList(exprs, aeClass, m_aggResultColumns);
+
+        if (m_avgPushdownHaving != null &&
+                m_avgPushdownHaving != m_having) {
+            Collection<AbstractExpression> found =
+                    m_avgPushdownHaving.findAllSubexpressionsOfClass(aeClass);
+            if (! found.isEmpty()) {
+                exprs.addAll(found);
+            }
+        }
+        if (m_avgPushdownGroupByColumns != null && m_avgPushdownGroupByColumns != m_groupByColumns) {
+            addAllSubexpressionsOfClassFromColList(exprs, aeClass, m_avgPushdownGroupByColumns);
+        }
+        if (m_avgPushdownProjectSchema != null && m_avgPushdownProjectSchema != m_projectSchema) {
+            addAllSubexpressionsOfClassFromNodeSchema(exprs, aeClass, m_avgPushdownProjectSchema);
+        }
+        // m_avgPushdownHaving, m_avgPushdownGroupByColumns, m_avgPushdownProjectSchema
+        // may contain the aggregation or group by expression that have been
+        // replaced with TVEs already.
+        // So look for the original expression in m_avgPushdownAggResultColumns.
+        if (m_avgPushdownAggResultColumns != null && m_avgPushdownAggResultColumns != m_aggResultColumns) {
+            addAllSubexpressionsOfClassFromColList(exprs, aeClass, m_avgPushdownAggResultColumns);
         }
         return exprs;
+
+    }
+
+    private static void addAllSubexpressionsOfClassFromColList(Set<AbstractExpression> exprs,
+            Class<? extends AbstractExpression> aeClass, List<ParsedColInfo> colList) {
+        for (ParsedColInfo groupByCol : colList) {
+            AbstractExpression groupByExpr = groupByCol.expression;
+            if (groupByExpr == null) {
+                continue;
+            }
+            Collection<AbstractExpression> found = groupByExpr.findAllSubexpressionsOfClass(aeClass);
+            if (found.isEmpty()) {
+                continue;
+            }
+            exprs.addAll(found);
+        }
+    }
+
+    private static void addAllSubexpressionsOfClassFromNodeSchema(Set<AbstractExpression> exprs,
+            Class<? extends AbstractExpression> aeClass, NodeSchema colList) {
+        for (SchemaColumn col : colList.getColumns()) {
+            AbstractExpression colExpr = col.getExpression();
+            if (colExpr == null) {
+                continue;
+            }
+            Collection<AbstractExpression> found = colExpr.findAllSubexpressionsOfClass(aeClass);
+            if (found.isEmpty()) {
+                continue;
+            }
+            exprs.addAll(found);
+        }
     }
 
     @Override

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -38,7 +38,6 @@ import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Index;
 import org.voltdb.catalog.Table;
 import org.voltdb.expressions.AbstractExpression;
-import org.voltdb.expressions.AbstractSubqueryExpression;
 import org.voltdb.expressions.AggregateExpression;
 import org.voltdb.expressions.ConstantValueExpression;
 import org.voltdb.expressions.ExpressionUtil;
@@ -451,8 +450,7 @@ public class PlanAssembler {
         }
 
         // Get the best plans for the expression subqueries ( IN/EXISTS (SELECT...) )
-        Set<AbstractExpression> subqueryExprs = parsedStmt.findAllSubexpressionsOfClass(
-                SelectSubqueryExpression.class);
+        Set<AbstractExpression> subqueryExprs = parsedStmt.findSubquerySubexpressions();
         if ( ! subqueryExprs.isEmpty() ) {
             if (parsedStmt instanceof ParsedSelectStmt == false) {
                 m_recentErrorMsg = "Subquery expressions are only supported in SELECT statements";
@@ -478,7 +476,7 @@ public class PlanAssembler {
                         return null;
                     }
                 }
-             }
+            }
 
             if (!getBestCostPlanForExpressionSubQueries(subqueryExprs)) {
                 // There was at least one sub-query and we should have a compiled plan for it
@@ -606,9 +604,9 @@ public class PlanAssembler {
         int nextPlanId = m_planSelector.m_planId;
 
         for (AbstractExpression expr : subqueryExprs) {
+            assert(expr instanceof SelectSubqueryExpression);
             if (!(expr instanceof SelectSubqueryExpression)) {
-                // it can be IN (values)
-                continue;
+                continue; // DEAD CODE?
             }
             SelectSubqueryExpression subqueryExpr = (SelectSubqueryExpression) expr;
             StmtSubqueryScan subqueryScan = subqueryExpr.getSubqueryScan();
@@ -942,12 +940,10 @@ public class PlanAssembler {
         HashAggregatePlanNode mvReAggTemplate = m_parsedSelect.m_mvFixInfo.getReAggregationPlanNode();
         if (mvReAggTemplate != null) {
             reAggNode = new HashAggregatePlanNode(mvReAggTemplate);
-            List<AbstractExpression> subqueryExprs =
-                    ExpressionUtil.findAllExpressionsOfClass(reAggNode.getPostPredicate(),
-                    AbstractSubqueryExpression.class);
-            if ( ! subqueryExprs.isEmpty()) {
+            AbstractExpression postPredicate = reAggNode.getPostPredicate();
+            if (postPredicate != null && postPredicate.hasSubquerySubexpression()) {
                 // For now, this is just a special case violation of the limitation on
-                // use of expression subqueries in MP queries on partitioned data.
+                // use of subquery expressions in MP queries on partitioned data.
                 // That special case was going undetected when we didn't flag it here.
                 m_recentErrorMsg = IN_EXISTS_SCALAR_ERROR_MESSAGE;
                 return null;
@@ -2661,7 +2657,7 @@ public class PlanAssembler {
         for (ParsedColInfo col : orderBys) {
             AbstractExpression rootExpr = col.expression;
             // Fix ENG-3487: can't push down limits when results are ordered by aggregate values.
-            ArrayList<AbstractExpression> tves = rootExpr.findBaseTVEs();
+            Collection<AbstractExpression> tves = rootExpr.findAllTupleValueSubexpressions();
             for (AbstractExpression tve: tves) {
                 if  (((TupleValueExpression) tve).hasAggregate()) {
                     return true;

--- a/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
@@ -706,7 +706,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
         indexedExprs.addAll(endExprs);
         // Find an outer TVE by ignoring any TVEs based on the inner table.
         for (AbstractExpression indexed : indexedExprs) {
-            Collection<AbstractExpression> indexedTVEs = indexed.findBaseTVEs();
+            Collection<AbstractExpression> indexedTVEs = indexed.findAllTupleValueSubexpressions();
             for (AbstractExpression indexedTVExpr : indexedTVEs) {
                 if ( ! TupleValueExpression.isOperandDependentOnTable(indexedTVExpr, innerTableAlias)) {
                     return true;

--- a/src/frontend/org/voltdb/planner/SubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SubPlanAssembler.java
@@ -456,7 +456,7 @@ public abstract class SubPlanAssembler {
                         // were based on constants and/or parameters.
                         for (AbstractExpression eq_comparator : retval.indexExprs) {
                             AbstractExpression otherExpr = eq_comparator.getRight();
-                            if (otherExpr.hasTVE()) {
+                            if (otherExpr.hasTupleValueSubexpression()) {
                                 // Can't index this IN LIST filter without some kind of three-way NLIJ,
                                 // so, add it to the post-filters.
                                 AbstractExpression in_list_comparator = inListExpr.getOriginalFilter();
@@ -1178,7 +1178,7 @@ public abstract class SubPlanAssembler {
         for (AbstractExpression filter : filtersToCover) {
 
             // ENG-8203: Not going to try to use index with sub-query expression
-            if (filter.findAllSubexpressionsOfClass(AbstractSubqueryExpression.class).size() > 0) {
+            if (filter.hasSubquerySubexpression()) {
                 // Including RowSubqueryExpression and SelectSubqueryExpression
                 // SelectSubqueryExpression also can be scalar sub-query
                 continue;
@@ -1194,7 +1194,7 @@ public abstract class SubPlanAssembler {
                                                              coveringExpr, coveringColId);
                 if (binding != null) {
                     if ( ! allowIndexedJoinFilters) {
-                        if (otherExpr.hasTVE()) {
+                        if (otherExpr.hasTupleValueSubexpression()) {
                             // This filter can not be used with the index, possibly due to interactions
                             // wih IN LIST processing that would require a three-way NLIJ.
                             binding = null;
@@ -1240,7 +1240,7 @@ public abstract class SubPlanAssembler {
                         }
                     }
                     if (targetComparator == ExpressionType.COMPARE_IN) {
-                        if (otherExpr.hasTVE()) {
+                        if (otherExpr.hasTupleValueSubexpression()) {
                             // This is a fancy edge case where the expression could only be indexed
                             // if it:
                             // A) does not reference the indexed table and
@@ -1293,7 +1293,7 @@ public abstract class SubPlanAssembler {
                                                              coveringExpr, coveringColId);
                 if (binding != null) {
                     if ( ! allowIndexedJoinFilters) {
-                        if (otherExpr.hasTVE()) {
+                        if (otherExpr.hasTupleValueSubexpression()) {
                             // This filter can not be used with the index, probably due to interactions
                             // with IN LIST processing of another key component that would require a
                             // three-way NLIJ to be injected.

--- a/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexCounter.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexCounter.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import org.voltdb.catalog.Index;
 import org.voltdb.expressions.AbstractExpression;
-import org.voltdb.expressions.AggregateExpression;
 import org.voltdb.plannodes.AbstractPlanNode;
 import org.voltdb.plannodes.AbstractScanPlanNode;
 import org.voltdb.plannodes.AggregatePlanNode;
@@ -85,7 +84,7 @@ public class ReplaceWithIndexCounter extends MicroOptimization {
 
             AbstractExpression postPredicate = aggplan.getPostPredicate();
             if (postPredicate != null) {
-                List<AbstractExpression> aggList = postPredicate.findAllSubexpressionsOfClass(AggregateExpression.class);
+                List<AbstractExpression> aggList = postPredicate.findAllAggregateSubexpressions();
 
                 boolean allCountStar = true;
                 for (AbstractExpression expr: aggList) {

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -42,6 +42,8 @@ import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.AbstractSubqueryExpression;
+import org.voltdb.expressions.SelectSubqueryExpression;
+import org.voltdb.planner.CompiledPlan;
 import org.voltdb.planner.PlanStatistics;
 import org.voltdb.planner.StatsField;
 import org.voltdb.planner.parseinfo.StmtTableScan;
@@ -130,10 +132,25 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
     public int overrideId(int newId) {
         m_id = newId++;
         // Override subqueries ids
-        Collection<AbstractExpression> subqueries = findAllExpressionsOfClass(AbstractSubqueryExpression.class);
-        for (AbstractExpression subquery : subqueries) {
-            assert(subquery instanceof AbstractSubqueryExpression);
-            newId = ((AbstractSubqueryExpression) subquery).overrideSubqueryNodeIds(newId);
+        Collection<AbstractExpression> subqueries = findAllSubquerySubexpressions();
+        for (AbstractExpression expr : subqueries) {
+            assert(expr instanceof AbstractSubqueryExpression);
+            AbstractSubqueryExpression subquery = (AbstractSubqueryExpression) expr;
+            // overrideSubqueryNodeIds(newId) will get an NPE if the subquery
+            // has not been planned, presumably the effect of hitting a bug
+            // earlier in the planner. If that happens again, it MAY be useful
+            // to preempt those cases here and single-step through a replay of
+            // findAllSubquerySubexpressions. Determining where in the parent
+            // plan this subquery expression was found MAY provide a clue
+            // as to why the subquery was not planned. It has helped before.
+            //REDO to debug*/ if (subquery instanceof SelectSubqueryExpression) {
+            //REDO to debug*/     CompiledPlan subqueryPlan = ((SelectSubqueryExpression)subquery)
+            //REDO to debug*/             .getSubqueryScan().getBestCostPlan();
+            //REDO to debug*/     if (subqueryPlan == null) {
+            //REDO to debug*/         findAllSubquerySubexpressions();
+            //REDO to debug*/     }
+            //REDO to debug*/ }
+            newId = subquery.overrideSubqueryNodeIds(newId);
         }
         return newId;
     }
@@ -219,6 +236,14 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
      * FIXME: This needs to be reworked with generateOutputSchema to eliminate redundancies.
      */
     public abstract void resolveColumnIndexes();
+
+    protected void resolveSubqueryColumnIndexes() {
+        // Possible subquery expressions
+        Collection<AbstractExpression> exprs = findAllSubquerySubexpressions();
+        for (AbstractExpression expr: exprs) {
+            ((AbstractSubqueryExpression) expr).resolveColumnIndexes();
+        }
+    }
 
     public void validate() throws Exception {
         //
@@ -733,12 +758,18 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
             inlined.findAllNodesOfType_recurse(type, pnClass, collected, visited);
     }
 
+    final public Collection<AbstractExpression> findAllSubquerySubexpressions() {
+        Set<AbstractExpression> collected = new HashSet<AbstractExpression>();
+        findAllExpressionsOfClass(AbstractSubqueryExpression.class, collected);
+        return collected;
+    }
+
     /**
      * Collect a unique list of expressions of a given type that this node has including its inlined nodes
      * @param type expression type to search for
      * @return a collection(set) of expressions that this node has
      */
-    public Collection<AbstractExpression> findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
+    final private Collection<AbstractExpression> findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
         Set<AbstractExpression> collected = new HashSet<AbstractExpression>();
         findAllExpressionsOfClass(aeClass, collected);
         return collected;
@@ -748,8 +779,7 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         // Check the inlined plan nodes
         for (AbstractPlanNode inlineNode: getInlinePlanNodes().values()) {
             // For inline node we MUST go recursive to its children!!!!!
-            Collection<AbstractExpression> exprs = inlineNode.findAllExpressionsOfClass(aeClass);
-            collected.addAll(exprs);
+            inlineNode.findAllExpressionsOfClass(aeClass, collected);
         }
 
         // and the output column expressions if there were no projection
@@ -757,11 +787,14 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         if (schema != null) {
             for (SchemaColumn col : schema.getColumns()) {
                 AbstractExpression expr = col.getExpression();
-                if (expr != null) {
-                    List<AbstractExpression> exprs = expr.findAllSubexpressionsOfClass(
-                            aeClass);
-                    collected.addAll(exprs);
+                if (expr == null) {
+                    continue;
                 }
+                List<AbstractExpression> exprs = expr.findAllSubexpressionsOfClass(aeClass);
+                if (exprs.isEmpty()) {
+                    continue;
+                }
+                collected.addAll(exprs);
             }
         }
     }

--- a/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
@@ -20,6 +20,7 @@ package org.voltdb.plannodes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
@@ -101,12 +102,13 @@ public class AggregatePlanNode extends AbstractPlanNode {
         //
         if (m_aggregateTypes.size() != m_aggregateDistinct.size() ||
             m_aggregateDistinct.size() != m_aggregateExpressions.size() ||
-            m_aggregateExpressions.size() != m_aggregateOutputColumns.size())
-        {
+            m_aggregateExpressions.size() != m_aggregateOutputColumns.size()) {
             throw new Exception("ERROR: Mismatched number of aggregate expression column attributes for PlanNode '" + this + "'");
-        } else if (m_aggregateTypes.isEmpty()|| m_aggregateTypes.contains(ExpressionType.INVALID)) {
+        }
+        if (m_aggregateTypes.isEmpty()|| m_aggregateTypes.contains(ExpressionType.INVALID)) {
             throw new Exception("ERROR: Invalid Aggregate ExpressionType or No Aggregate Expression types for PlanNode '" + this + "'");
-        } else if (m_aggregateExpressions.isEmpty()) {
+        }
+        if (m_aggregateExpressions.isEmpty()) {
             throw new Exception("ERROR: No Aggregate Expressions for PlanNode '" + this + "'");
         }
     }
@@ -146,9 +148,11 @@ public class AggregatePlanNode extends AbstractPlanNode {
         if (!isTableNonDistinctCount()) {
             return false;
         }
+        AbstractExpression aggArgument = m_aggregateExpressions.get(0);
+        ExpressionType argumentType = aggArgument.getExpressionType();
         // Is the expression a constant?
-        return m_aggregateExpressions.get(0).getExpressionType().equals(ExpressionType.VALUE_PARAMETER) ||
-                m_aggregateExpressions.get(0).getExpressionType().equals(ExpressionType.VALUE_CONSTANT);
+        return argumentType.equals(ExpressionType.VALUE_PARAMETER) ||
+                argumentType.equals(ExpressionType.VALUE_CONSTANT);
     }
 
     public boolean isTableCountNonDistinctNullableColumn() {
@@ -156,7 +160,8 @@ public class AggregatePlanNode extends AbstractPlanNode {
             return false;
         }
         // Is the expression a column?
-        if (! m_aggregateExpressions.get(0).getExpressionType().equals(ExpressionType.VALUE_TUPLE)) {
+        AbstractExpression aggArgument = m_aggregateExpressions.get(0);
+        if (! aggArgument.getExpressionType().equals(ExpressionType.VALUE_TUPLE)) {
             return false;
         }
         // Need to go to its child node to see the table schema.
@@ -172,7 +177,7 @@ public class AggregatePlanNode extends AbstractPlanNode {
         }
         StmtTargetTableScan sttscan = (StmtTargetTableScan)asp.getTableScan();
         Table tbl = sttscan.getTargetTable();
-        TupleValueExpression tve = (TupleValueExpression)m_aggregateExpressions.get(0);
+        TupleValueExpression tve = (TupleValueExpression)aggArgument;
         String columnName = tve.getColumnName();
         Column col = tbl.getColumns().get(columnName);
         // Is the column nullable?
@@ -260,10 +265,12 @@ public class AggregatePlanNode extends AbstractPlanNode {
 
             assert(m_hasSignificantOutputSchema);
         }
-        // Possible subquery expressions
-        Collection<AbstractExpression> exprs = findAllExpressionsOfClass(AbstractSubqueryExpression.class);
-        for (AbstractExpression expr: exprs) {
-            ExpressionUtil.generateSubqueryExpressionOutputSchema(expr, db);
+
+        // Generate the output schema for subqueries
+        Collection<AbstractExpression> subqueryExpressions = findAllSubquerySubexpressions();
+        for (AbstractExpression subqueryExpression : subqueryExpressions) {
+            assert(subqueryExpression instanceof AbstractSubqueryExpression);
+            ((AbstractSubqueryExpression) subqueryExpression).generateOutputSchema(db);
         }
     }
 
@@ -297,8 +304,7 @@ public class AggregatePlanNode extends AbstractPlanNode {
                                                tve.getColumnName());
                 }
             }
-            else
-            {
+            else {
                 tve.setColumnIndex(index);
             }
         }
@@ -308,12 +314,10 @@ public class AggregatePlanNode extends AbstractPlanNode {
         // sure these should be TVEs in the long term.
         List<TupleValueExpression> agg_tves =
             new ArrayList<TupleValueExpression>();
-        for (AbstractExpression agg_exp : m_aggregateExpressions)
-        {
+        for (AbstractExpression agg_exp : m_aggregateExpressions) {
             agg_tves.addAll(ExpressionUtil.getTupleValueExpressions(agg_exp));
         }
-        for (TupleValueExpression tve : agg_tves)
-        {
+        for (TupleValueExpression tve : agg_tves) {
             int index = tve.resolveColumnIndexesUsingSchema(input_schema);
             tve.setColumnIndex(index);
         }
@@ -321,12 +325,10 @@ public class AggregatePlanNode extends AbstractPlanNode {
         // Aggregates also need to resolve indexes for group_by inputs
         List<TupleValueExpression> group_tves =
             new ArrayList<TupleValueExpression>();
-        for (AbstractExpression group_exp : m_groupByExpressions)
-        {
+        for (AbstractExpression group_exp : m_groupByExpressions) {
             group_tves.addAll(ExpressionUtil.getTupleValueExpressions(group_exp));
         }
-        for (TupleValueExpression tve : group_tves)
-        {
+        for (TupleValueExpression tve : group_tves) {
             int index = tve.resolveColumnIndexesUsingSchema(input_schema);
             tve.setColumnIndex(index);
         }
@@ -334,16 +336,20 @@ public class AggregatePlanNode extends AbstractPlanNode {
         // Post filter also needs to resolve indexes.
         List<TupleValueExpression> postFilter_tves =
                 ExpressionUtil.getTupleValueExpressions(m_postPredicate);
-        for (TupleValueExpression tve : postFilter_tves)
-        {
+        for (TupleValueExpression tve : postFilter_tves) {
             int index = m_outputSchema.getIndexOfTve(tve);
             tve.setColumnIndex(index);
         }
 
+        resolveSubqueryColumnIndexes();
+    }
+
+    @Override
+    protected void resolveSubqueryColumnIndexes() {
         // Possible subquery expressions
-        Collection<AbstractExpression> exprs = findAllExpressionsOfClass(AbstractSubqueryExpression.class);
+        Collection<AbstractExpression> exprs = findAllSubquerySubexpressions();
         for (AbstractExpression expr: exprs) {
-            ExpressionUtil.resolveSubqueryExpressionColumnIndexes(expr);
+            ((AbstractSubqueryExpression) expr).resolveColumnIndexes();
         }
     }
 
@@ -468,24 +474,26 @@ public class AggregatePlanNode extends AbstractPlanNode {
         }
 
         sb.append(aggType + " AGGREGATION ops: ");
+        String sep = "";
         int ii = 0;
         for (ExpressionType e : m_aggregateTypes) {
-            sb.append(e.symbol());
-            if (e != ExpressionType.AGGREGATE_COUNT_STAR) {
+            sb.append(sep).append(e.symbol());
+            sep = ", ";
+            if (e == ExpressionType.AGGREGATE_COUNT_STAR) {
+                sb.append("(*)");
+            }
+            else {
                 if (m_aggregateDistinct.get(ii) == 1) {
                     sb.append(" DISTINCT");
                 }
-                sb.append("(");
                 AbstractExpression ae = m_aggregateExpressions.get(ii);
-                if (ae != null) {
-                    sb.append(ae.explain(optionalTableName));
-                }
-                sb.append("), ");
+                assert(ae != null);
+                sb.append("(");
+                sb.append(ae.explain(optionalTableName));
+                sb.append(")");
             }
             ++ii;
         }
-        // trim the last ", " from the string
-        sb.setLength(sb.length() - 2);
         if (m_prePredicate != null) {
             sb.append(" ONLY IF " + m_prePredicate.explain(optionalTableName));
         }
@@ -548,18 +556,25 @@ public class AggregatePlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public Collection<AbstractExpression> findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        Collection<AbstractExpression> collected = super.findAllExpressionsOfClass(aeClass);
-
-        collected.addAll(ExpressionUtil.findAllExpressionsOfClass(m_prePredicate, aeClass));
-        collected.addAll(ExpressionUtil.findAllExpressionsOfClass(m_postPredicate, aeClass));
+    public void findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass, Set<AbstractExpression> collected) {
+        super.findAllExpressionsOfClass(aeClass, collected);
+        if (m_prePredicate != null) {
+            collected.addAll(m_prePredicate.findAllSubexpressionsOfClass(aeClass));
+        }
+        if (m_postPredicate != null) {
+            collected.addAll(m_postPredicate.findAllSubexpressionsOfClass(aeClass));
+        }
         for (AbstractExpression ae : m_aggregateExpressions) {
-            collected.addAll(ExpressionUtil.findAllExpressionsOfClass(ae, aeClass));
+            if (ae == null) {
+                // This is a place-holder for the "*" in "COUNT(*)".
+                // There are no subexpressions to find here.
+                continue;
+            }
+            collected.addAll(ae.findAllSubexpressionsOfClass(aeClass));
         }
         for (AbstractExpression ae : m_groupByExpressions) {
-            collected.addAll(ExpressionUtil.findAllExpressionsOfClass(ae, aeClass));
+            collected.addAll(ae.findAllSubexpressionsOfClass(aeClass));
         }
-        return collected;
     }
 
     @Override

--- a/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.hsqldb_voltpatches.HSQLInterface;
 import org.json_voltpatches.JSONException;
@@ -489,18 +490,18 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
     }
 
     @Override
-    public Collection<AbstractExpression> findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        Collection<AbstractExpression> collected = super.findAllExpressionsOfClass(aeClass);
-
-        collected.addAll(ExpressionUtil.findAllExpressionsOfClass(m_skip_null_predicate, aeClass));
+    public void findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass, Set<AbstractExpression> collected) {
+        super.findAllExpressionsOfClass(aeClass, collected);
+        if (m_skip_null_predicate != null) {
+            collected.addAll(m_skip_null_predicate.findAllSubexpressionsOfClass(aeClass));
+        }
         for (AbstractExpression ae : m_searchkeyExpressions) {
-            collected.addAll(ExpressionUtil.findAllExpressionsOfClass(ae, aeClass));
+            collected.addAll(ae.findAllSubexpressionsOfClass(aeClass));
         }
         if (m_bindings != null) {
             for (AbstractExpression ae : m_bindings) {
-                collected.addAll(ExpressionUtil.findAllExpressionsOfClass(ae, aeClass));
+                collected.addAll(ae.findAllSubexpressionsOfClass(aeClass));
             }
         }
-        return collected;
     }
 }

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -43,7 +43,6 @@ import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.ComparisonExpression;
 import org.voltdb.expressions.ExpressionUtil;
 import org.voltdb.expressions.OperatorExpression;
-import org.voltdb.expressions.ParameterValueExpression;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.planner.parseinfo.StmtTableScan;
 import org.voltdb.planner.parseinfo.StmtTargetTableScan;
@@ -950,7 +949,7 @@ public class IndexScanPlanNode extends AbstractScanPlanNode {
             m_eliminatedPostFilterExpressions.add((AbstractExpression)expr.clone());
             // Add eliminated PVEs to the bindings. They will be used by the PlannerTool to compare
             // bound plans in the cache
-            List<AbstractExpression> pves = expr.findAllSubexpressionsOfClass(ParameterValueExpression.class);
+            List<AbstractExpression> pves = expr.findAllParameterSubexpressions();
             m_bindings.addAll(pves);
         }
     }
@@ -983,16 +982,20 @@ public class IndexScanPlanNode extends AbstractScanPlanNode {
     }
 
     @Override
-    public Collection<AbstractExpression> findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        Collection<AbstractExpression> collected = super.findAllExpressionsOfClass(aeClass);
-
-        collected.addAll(ExpressionUtil.findAllExpressionsOfClass(m_endExpression, aeClass));
-        collected.addAll(ExpressionUtil.findAllExpressionsOfClass(m_initialExpression, aeClass));
-        collected.addAll(ExpressionUtil.findAllExpressionsOfClass(m_skip_null_predicate, aeClass));
-        for (AbstractExpression ae : m_searchkeyExpressions) {
-            collected.addAll(ExpressionUtil.findAllExpressionsOfClass(ae, aeClass));
+    public void findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass, Set<AbstractExpression> collected) {
+        super.findAllExpressionsOfClass(aeClass, collected);
+        if (m_endExpression != null) {
+            collected.addAll(m_endExpression.findAllSubexpressionsOfClass(aeClass));
         }
-        return collected;
+        if (m_initialExpression != null) {
+            collected.addAll(m_initialExpression.findAllSubexpressionsOfClass(aeClass));
+        }
+        if (m_skip_null_predicate != null) {
+            collected.addAll(m_skip_null_predicate.findAllSubexpressionsOfClass(aeClass));
+        }
+        for (AbstractExpression ae : m_searchkeyExpressions) {
+            collected.addAll(ae.findAllSubexpressionsOfClass(aeClass));
+        }
     }
 
 }

--- a/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
@@ -17,7 +17,7 @@
 
 package org.voltdb.plannodes;
 
-import java.util.Collection;
+import java.util.Set;
 
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
@@ -27,7 +27,6 @@ import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
 import org.voltdb.expressions.AbstractExpression;
-import org.voltdb.expressions.ExpressionUtil;
 import org.voltdb.expressions.ParameterValueExpression;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.expressions.VectorValueExpression;
@@ -158,11 +157,9 @@ public class MaterializedScanPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public Collection<AbstractExpression> findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        Collection<AbstractExpression> collected = super.findAllExpressionsOfClass(aeClass);
-
-        collected.addAll(ExpressionUtil.findAllExpressionsOfClass(m_tableData, aeClass));
-        return collected;
+    public void findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass, Set<AbstractExpression> collected) {
+        super.findAllExpressionsOfClass(aeClass, collected);
+        collected.addAll(m_tableData.findAllSubexpressionsOfClass(aeClass));
     }
 
 }

--- a/src/frontend/org/voltdb/plannodes/NodeSchema.java
+++ b/src/frontend/org/voltdb/plannodes/NodeSchema.java
@@ -25,7 +25,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.voltdb.expressions.TupleValueExpression;
-import org.voltdb.planner.PlanningErrorException;
 
 /**
  * This class encapsulates the representation and common operations for
@@ -233,13 +232,13 @@ public class NodeSchema
 
     public NodeSchema replaceTableClone(String tableAlias) {
         NodeSchema copy = new NodeSchema();
-        for (int i = 0; i < m_columns.size(); ++i)
-        {
+        for (int i = 0; i < m_columns.size(); ++i) {
             SchemaColumn col = m_columns.get(i);
             String colAlias = col.getColumnAlias();
+            int differentiator = col.getDifferentiator();
 
-            TupleValueExpression tve = new TupleValueExpression(tableAlias, tableAlias, colAlias, colAlias, i);
-            tve.setDifferentiator(col.getDifferentiator());
+            TupleValueExpression tve = new TupleValueExpression(
+                    tableAlias, tableAlias, colAlias, colAlias, i, differentiator);
             tve.setTypeSizeBytes(col.getType(), col.getSize(), col.getExpression().getInBytes());
             SchemaColumn sc = new SchemaColumn(tableAlias, tableAlias, colAlias, colAlias, tve, col.getDifferentiator());
             copy.addColumn(sc);

--- a/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
@@ -18,8 +18,8 @@
 package org.voltdb.plannodes;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
@@ -206,12 +206,11 @@ public class OrderByPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public Collection<AbstractExpression> findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        Collection<AbstractExpression> collected = super.findAllExpressionsOfClass(aeClass);
+    public void findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass, Set<AbstractExpression> collected) {
+        super.findAllExpressionsOfClass(aeClass, collected);
         for (AbstractExpression ae : m_sortExpressions) {
-            collected.addAll(ExpressionUtil.findAllExpressionsOfClass(ae, aeClass));
+            collected.addAll(ae.findAllSubexpressionsOfClass(aeClass));
         }
-        return collected;
     }
 
     @Override

--- a/src/frontend/org/voltdb/plannodes/PlanNodeTree.java
+++ b/src/frontend/org/voltdb/plannodes/PlanNodeTree.java
@@ -182,9 +182,7 @@ public class PlanNodeTree implements JSONString {
         if (predicate == null) {
             return;
         }
-        List<AbstractExpression> subquerysExprs = predicate.findAllSubexpressionsOfClass(
-                AbstractSubqueryExpression.class);
-
+        List<AbstractExpression> subquerysExprs = predicate.findAllSubquerySubexpressions();
         for (AbstractExpression expr : subquerysExprs) {
             assert(expr instanceof AbstractSubqueryExpression);
             AbstractSubqueryExpression subqueryExpr = (AbstractSubqueryExpression) expr;
@@ -280,8 +278,7 @@ public class PlanNodeTree implements JSONString {
      */
     private void extractSubqueries(AbstractPlanNode node)  throws Exception {
         assert(node != null);
-        Collection<AbstractExpression> subexprs =
-                node.findAllExpressionsOfClass(AbstractSubqueryExpression.class);
+        Collection<AbstractExpression> subexprs = node.findAllSubquerySubexpressions();
         for (AbstractExpression nextexpr : subexprs) {
             assert(nextexpr instanceof AbstractSubqueryExpression);
             AbstractSubqueryExpression subqueryExpr = (AbstractSubqueryExpression) nextexpr;

--- a/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
@@ -83,11 +83,8 @@ public class ProjectionPlanNode extends AbstractPlanNode {
         NodeSchema input_schema = m_children.get(0).getOutputSchema();
         resolveColumnIndexesUsingSchema(input_schema);
 
-        // Possible subquery expressions
-        Collection<AbstractExpression> exprs = findAllExpressionsOfClass(AbstractSubqueryExpression.class);
-        for (AbstractExpression expr: exprs) {
-            ExpressionUtil.resolveSubqueryExpressionColumnIndexes(expr);
-        }
+        // Resolve subquery expression indexes
+        resolveSubqueryColumnIndexes();
     }
 
     /**
@@ -154,12 +151,11 @@ public class ProjectionPlanNode extends AbstractPlanNode {
         m_hasSignificantOutputSchema = true;
 
         // Generate the output schema for subqueries
-        Collection<AbstractExpression> exprs = findAllExpressionsOfClass(AbstractSubqueryExpression.class);
-        for (AbstractExpression expr: exprs) {
-            ExpressionUtil.generateSubqueryExpressionOutputSchema(expr, db);
+        Collection<AbstractExpression> subqueryExpressions = findAllSubquerySubexpressions();
+        for (AbstractExpression subqueryExpression : subqueryExpressions) {
+            assert(subqueryExpression instanceof AbstractSubqueryExpression);
+            ((AbstractSubqueryExpression) subqueryExpression).generateOutputSchema(db);
         }
-
-        return;
     }
 
     @Override

--- a/tests/frontend/org/voltdb/planner/TestPlansGroupBy.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansGroupBy.java
@@ -649,7 +649,7 @@ public class TestPlansGroupBy extends PlannerTestCase {
              inline Serial AGGREGATION ops
               inline LIMIT 5
         */
-        String expectedStr = "  inline Serial AGGREGATION ops\n" +
+        String expectedStr = "  inline Serial AGGREGATION ops: \n" +
                              "   inline LIMIT 5";
         String explainPlan = "";
         for (AbstractPlanNode apn: pns) {

--- a/tests/frontend/org/voltdb/planner/TestPlansOrderBy.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansOrderBy.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.voltdb.expressions.AbstractExpression;
-import org.voltdb.expressions.ExpressionUtil;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.plannodes.AbstractPlanNode;
 import org.voltdb.plannodes.IndexScanPlanNode;
@@ -783,7 +782,7 @@ public class TestPlansOrderBy extends PlannerTestCase {
         int idx = 0;
         List<AbstractExpression> sesTves = new ArrayList<>();
         for (AbstractExpression se : ses) {
-            sesTves.addAll(ExpressionUtil.findAllExpressionsOfClass(se, TupleValueExpression.class));
+            sesTves.addAll(se.findAllTupleValueSubexpressions());
         }
         assertEquals(sortColumnIdx.length, sesTves.size());
         for (AbstractExpression seTve : sesTves) {


### PR DESCRIPTION
Mostly invisible changes for correctness and performance -- sometimes having an actual detectable behavior effect only later when partitioned table queries have replicated table subqueries:
Apply recursive expression searches more consistently and simplify their use and implementation
-- critical to later enabling edge cases of replicated table subqueries with partitioned tables in the parent query. This was especially true when it came to applying algorithms consistently between the structures representing a "normal case" parsed select stmt and the "avg push down special cases".
This should have been done from the start.

Integrate the new differentiator as a first class member of TVE rather than an apparent afterthought.

Normalize use of whitespace and braces.

Unrelated bugs found and fixed:
Fix some algorithmic glitches causing typos when explaining agg nodes.
Give a more accurate negative index diagnostic in VoltTableRow.