### PR TITLE
ENG-10543, fix the bug that may bypass the snapshot completion check …

### DIFF
--- a/src/frontend/org/voltdb/RestoreAgent.java
+++ b/src/frontend/org/voltdb/RestoreAgent.java
@@ -704,17 +704,17 @@ SnapshotCompletionInterest, Promotable
     {
         int partitionCount = -1;
         for (TableFiles tf : s.m_tableFiles.values()) {
-            if (tf.m_isReplicated) {
-                continue;
+            // Check if the snapshot is complete
+            if (tf.m_completed.stream().anyMatch(b->!b)) {
+                m_snapshotErrLogStr.append("\nRejected snapshot ")
+                                   .append(s.getNonce())
+                                   .append(" because it was not completed.");
+                return null;
             }
 
-            for (boolean completed : tf.m_completed) {
-                if (!completed) {
-                    m_snapshotErrLogStr.append("\nRejected snapshot ")
-                                    .append(s.getNonce())
-                                    .append(" because it was not completed.");
-                    return null;
-                }
+            // Replicated table doesn't check partition count
+            if (tf.m_isReplicated) {
+                continue;
             }
 
             // Everyone has to agree on the total partition count

--- a/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFile.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFile.java
@@ -324,7 +324,7 @@ public class TableSaveFile
         } catch (JSONException e) {
             throw new IOException(e);
         }
-            }
+    }
 
     public int[] getVersionNumber()
     {


### PR DESCRIPTION
…if there are replication tables only,

This will lead to the problem that in recover the restore agent choose the incomplete c/l snapshot to restore.

Change-Id: I8f3690f1f1f9898c467cdf619f7fbafb08a35d0a