### PR TITLE
ENG-10584: Fix NPE on node failure during initialization.

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1071,18 +1071,29 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     @Override
     public void hostsFailed(Set<Integer> failedHosts)
     {
-        getSES(true).submit(new Runnable() {
-            @Override
-            public void run()
-            {
-                // Cleanup the rejoin blocker in case the rejoining node failed.
-                // This has to run on a separate thread because the callback is
-                // invoked on the ZooKeeper server thread.
-                for (int hostId : failedHosts) {
-                    VoltZK.removeRejoinNodeIndicatorForHost(m_messenger.getZK(), hostId);
+        final ScheduledExecutorService es = getSES(true);
+        if (es != null) {
+            es.submit(new Runnable() {
+                @Override
+                public void run()
+                {
+                    // Cleanup the rejoin blocker in case the rejoining node failed.
+                    // This has to run on a separate thread because the callback is
+                    // invoked on the ZooKeeper server thread.
+                    //
+                    // I'm trying to be defensive to have this cleanup code run on
+                    // all live nodes. One of them will succeed in cleaning up the
+                    // rejoin ZK nodes. The others will just do nothing if the ZK
+                    // nodes are already gone. If this node is still initializing
+                    // when a rejoining node fails, there must be a live node that
+                    // can clean things up. It's okay to skip this if the executor
+                    // services are not set up yet.
+                    for (int hostId : failedHosts) {
+                        VoltZK.removeRejoinNodeIndicatorForHost(m_messenger.getZK(), hostId);
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     class DailyLogTask implements Runnable {


### PR DESCRIPTION
If a node fails when another node is still initializing, it may trigger an NPE in the callback on the initializing node because the executor services are not set up yet. Check for this case and avoid submitting any work on the initializing node in that case.