### PR TITLE
ENG-10486:

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1071,6 +1071,11 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     @Override
     public void hostsFailed(Set<Integer> failedHosts)
     {
+        Set<Integer> hostsOnRing = new HashSet<Integer>();
+        if (!m_leaderAppointer.isClusterKSafe(hostsOnRing)) {
+            VoltDB.crashGlobalVoltDB("Some partitions have no replicas.  Cluster has become unviable.",
+                    false, null);
+        }
         getSES(true).submit(new Runnable() {
             @Override
             public void run()

--- a/src/frontend/org/voltdb/iv2/LeaderAppointer.java
+++ b/src/frontend/org/voltdb/iv2/LeaderAppointer.java
@@ -506,7 +506,7 @@ public class LeaderAppointer implements Promotable
         return masterHSId;
     }
 
-    private boolean isClusterKSafe(Set<Integer> hostsOnRing)
+    public boolean isClusterKSafe(Set<Integer> hostsOnRing)
     {
         boolean retval = true;
         List<String> partitionDirs = null;


### PR DESCRIPTION
When a cluster is partitioned due to network failure, we would like to detect that the cluster is not KSafe (all partitions are present) before performing any partition repair process. This patch addresses this issue.