### PR TITLE
Add guards for windowed functions.

### DIFF
--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -93,6 +93,7 @@ import org.voltdb.utils.CatalogUtil;
  *
  */
 public class PlanAssembler {
+    public static boolean HANDLE_WINDOWED_OPERATORS = Boolean.valueOf(System.getProperty("org.voltdb.handlewindowedfunctions", "False"));
 
     // The convenience struct to accumulate results after parsing multiple statements
     private static class ParsedResultAccumulator {
@@ -2113,6 +2114,9 @@ public class PlanAssembler {
      * @return
      */
     private AbstractPlanNode handleWindowedOperators(AbstractPlanNode root) {
+        if ( ! HANDLE_WINDOWED_OPERATORS ) {
+            throw new PlanningErrorException("Windowed operators are not supported in this version of VoltDB.");
+        }
         // Get the windowed expression.  We need to set its output
         // schema from the display list.
         ParsedColInfo colInfo = m_parsedSelect.getWindowedColinfo();


### PR DESCRIPTION
We have added initial support for windowed aggregate functions.  The
planner can plan for them, but the EE cannot execute the resulting
plans.  This commit adds guards in the planner to keep these plans from
being generated.  It's possible to disable the guards in the server by
setting the system property org.voltdb.handlewindowedfunctions to true.

https://issues.voltdb.com/browse/ENG-10602