### PR TITLE
Cache an empty block in indices.

### DIFF
--- a/src/ee/structures/CompactingHashTable.h
+++ b/src/ee/structures/CompactingHashTable.h
@@ -122,6 +122,7 @@ namespace voltdb {
         KeyEqChecker m_keyEq;             // instance of the key eq checker
         DataEqChecker m_dataEq;           // instance of the value eq checker
 
+
     public:
 
         /**
@@ -177,6 +178,8 @@ namespace voltdb {
 
         /** verification for debugging and testing */
         bool verify();
+        /** Do we have a cached last buffer?  This is used in testing. */
+        bool hasCachedLastBuffer() const { return (m_allocator.hasCachedLastBuffer()); }
 
     protected:
         /** find, given a bucket/key */

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -236,6 +236,8 @@ public:
      */
     bool verify() const;
     bool verifyRank() const;
+    /** Do we have a cached last buffer?  This is used in testing. */
+    bool hasCachedLastBuffer() const { return (m_allocator.hasCachedLastBuffer()); }
 
 protected:
     // main internal functions

--- a/src/ee/structures/ContiguousAllocator.cpp
+++ b/src/ee/structures/ContiguousAllocator.cpp
@@ -22,7 +22,12 @@
 using namespace voltdb;
 
 ContiguousAllocator::ContiguousAllocator(int32_t allocSize, int32_t chunkSize)
-: m_count(0), m_allocSize(allocSize), m_chunkSize(chunkSize), m_tail(NULL), m_blockCount(0) {}
+    : m_count(0),
+      m_allocationSize(allocSize),
+      m_numberAllocationsPerBlock(chunkSize),
+      m_tail(NULL),
+      m_blockCount(0),
+      m_cachedBuffer(0) {}
 
 ContiguousAllocator::~ContiguousAllocator() {
     while (m_tail) {
@@ -30,22 +35,31 @@ ContiguousAllocator::~ContiguousAllocator() {
         free(m_tail);
         m_tail = buf;
     }
+    if (m_cachedBuffer != NULL) {
+        free(m_cachedBuffer);
+    }
 }
 
 void *ContiguousAllocator::alloc() {
     m_count++;
 
     // determine where in the current block the new alloc will go
-    int64_t blockOffset = (m_count - 1) % m_chunkSize;
+    int64_t blockOffset = (m_count - 1) % m_numberAllocationsPerBlock;
 
     // if a new block is needed...
     if (blockOffset == 0) {
-        void *memory = malloc(sizeof(Buffer) + m_allocSize * m_chunkSize);
+        void *memory;
+        if (m_cachedBuffer != NULL) {
+            memory = static_cast<void *>(m_cachedBuffer);
+            m_cachedBuffer = NULL;
+        } else {
+            memory = static_cast<void *>(malloc(sizeof(Buffer) + m_allocationSize * m_numberAllocationsPerBlock));
+        }
 
         Buffer *buf = reinterpret_cast<Buffer*>(memory);
 
         // for debugging
-        //memset(buf, 0, sizeof(sizeof(ChainedBuffer) + m_allocSize * m_chunkSize));
+        //memset(buf, 0, sizeof(sizeof(Buffer) + m_allocSize * m_chunkSize));
 
         buf->prev = m_tail;
         m_tail = buf;
@@ -53,7 +67,7 @@ void *ContiguousAllocator::alloc() {
     }
 
     // get a pointer to where the new alloc will live
-    void *retval = m_tail->data + (m_allocSize * blockOffset);
+    void *retval = m_tail->data + (m_allocationSize * blockOffset);
     assert(retval == last());
     return retval;
 }
@@ -63,8 +77,8 @@ void *ContiguousAllocator::last() const {
     assert(m_tail != NULL);
 
     // determine where in the current block the last alloc is
-    int64_t blockOffset = (m_count - 1) % m_chunkSize;
-    return m_tail->data + (m_allocSize * blockOffset);
+    int64_t blockOffset = (m_count - 1) % m_numberAllocationsPerBlock;
+    return m_tail->data + (m_allocationSize * blockOffset);
 }
 
 void ContiguousAllocator::trim() {
@@ -77,20 +91,24 @@ void ContiguousAllocator::trim() {
     m_count--;
 
     // determine where in the current block the last alloc is
-    int64_t blockOffset = m_count % m_chunkSize;
+    int64_t blockOffset = m_count % m_numberAllocationsPerBlock;
 
     // yay! kill a block
     if (blockOffset == 0) {
         Buffer *buf = m_tail->prev;
-        free(m_tail);
-        m_tail = buf;
         m_blockCount--;
+        if (m_blockCount == 0) {
+            m_cachedBuffer = m_tail;
+        } else {
+            free(m_tail);
+        }
+        m_tail = buf;
     }
 }
 
 size_t ContiguousAllocator::bytesAllocated() const {
     size_t total = static_cast<size_t>(m_blockCount) *
-        static_cast<size_t>(m_allocSize) *
-        static_cast<size_t>(m_chunkSize);
+        static_cast<size_t>(m_allocationSize) *
+        static_cast<size_t>(m_numberAllocationsPerBlock);
     return total;
 }

--- a/src/ee/structures/ContiguousAllocator.h
+++ b/src/ee/structures/ContiguousAllocator.h
@@ -23,40 +23,101 @@
 namespace voltdb {
 
 /**
- * Dead simple buffer chain that allocates fixed size buffers and
- * fixed size indivual allocations to consumers within those
- * buffers.
+ * This is a dead simple buffer chain that allocates fixed size buffers and
+ * parcels out smaller, fixed size individual allocations to consumers.  These
+ * allocations are carved out of the fixed size buffers.  Allocations
+ * are allocated and returned in LIFO order.  So, if an allocation is
+ * deleted from a data structure, the data from the most recent allocation
+ * must to be copied to the deleted allocation, so that the most recent
+ * allocation's data may be recovered.  The clients all do this.
+ *
+ * A *block* is a fixed size allocation, which has been obtained from
+ * malloc(3). These are chained together.  They are all the same size
+ * in bytes.  This size is set when the allocator is constructed.
+ *
+ * The head of the chain of blocks is the *tail block*.  Blocks which
+ * are not the tail block are completely full.
+ *
+ * An *allocation* is a hunk of memory which is returned to a client of this class.
+ * Its size is set when the allocator is constructed.
  *
  * Note, there are few checks here when running in release mode.
  */
 class ContiguousAllocator {
+    /*
+     * Each block is one of these.  Blocks are chained using the
+     * prev field.
+     */
     struct Buffer {
         Buffer *prev;
         char data[0];
     };
-
+    /** This is the total number of allocations in use in all blocks. */
     int64_t m_count;
-    int32_t m_allocSize;
-    int32_t m_chunkSize;
+    /** This is the size of a allocation for this allocator in bytes. */
+    const int32_t m_allocationSize;
+    /** This is the number of allocations in each block in this allocator. */
+    const int32_t m_numberAllocationsPerBlock;
+    /**
+     * This points to the tail buffer.  When m_count % m_chunkSize reaches
+     * zero and we want a new node we must allocate a new block.  The address
+     * of the last node is then m_tail->data + (m_count - 1) * m_allocSize.
+     */
     Buffer *m_tail;
+    /** This is the number of blocks in this allocation. */
     int32_t m_blockCount;
+    /**
+     * This is the last deleted block.  If all the allocations are
+     * returned, then we cached the last block here, to avoid thrashing
+     * the allocator.
+     */
+    Buffer *m_cachedBuffer;
 
 public:
+
     /**
      * @param allocSize is the size in bytes of individual allocations.
-     * @param chunkSize is the number of allocations per buffer (not bytes).
+     * @param chunkSize is the number of allocations per block (not bytes).
      */
     ContiguousAllocator(int32_t allocSize, int32_t chunkSize);
     ~ContiguousAllocator();
 
+    /**
+     * Return an allocation.
+     */
     void *alloc();
+
+    /**
+     * Return the address of the last allocation.   It is an error if this function
+     * is called when there are no used allocations.
+     */
     void *last() const;
+
+    /**
+     * Recover the last allocation.  The data in the last allocation must
+     * be copied someplace else or it will be lost.
+     */
     void trim();
+
+    /**
+     * Return the number of used allocations in this allocator.  This may
+     * be zero.
+     */
     int64_t count() const { return m_count; }
 
-    int32_t allocationSize() const { return m_allocSize; }
+    /**
+     * Return the size of an allocation.
+     */
+    int32_t allocationSize() const { return m_allocationSize; }
 
+    /**
+     * Return the number of bytes allocated to allocations.  This does not
+     * include overhead for the block chain pointers.
+     */
     size_t bytesAllocated() const;
+
+    /** Do we have a cached last buffer?  This is used in testing. */
+    bool hasCachedLastBuffer() const { return (m_cachedBuffer != NULL); }
 };
 
 } // namespace voltdb

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -121,7 +121,7 @@ public class PlannerTool {
         DatabaseEstimates estimates = new DatabaseEstimates();
         QueryPlanner planner = new QueryPlanner(
             sql, "PlannerTool", "PlannerToolProc", m_cluster, m_database,
-            partitioning, m_hsql, estimates, true,
+            partitioning, m_hsql, estimates, !VoltCompiler.DEBUG_MODE,
             AD_HOC_JOINED_TABLE_LIMIT, costModel, null, null, DeterminismMode.FASTER);
 
         CompiledPlan plan = null;
@@ -197,7 +197,7 @@ public class PlannerTool {
             DatabaseEstimates estimates = new DatabaseEstimates();
             QueryPlanner planner = new QueryPlanner(
                     sql, "PlannerTool", "PlannerToolProc", m_cluster, m_database,
-                    partitioning, m_hsql, estimates, true,
+                    partitioning, m_hsql, estimates, !VoltCompiler.DEBUG_MODE,
                     AD_HOC_JOINED_TABLE_LIMIT, costModel, null, null, DeterminismMode.FASTER);
 
             CompiledPlan plan = null;

--- a/tests/ee/structures/CompactingHashTest.cpp
+++ b/tests/ee/structures/CompactingHashTest.cpp
@@ -559,6 +559,7 @@ TEST_F(CompactingHashTest, Trivial) {
 
     // UNIQUE MAP
     voltdb::CompactingHashTable<uint64_t,uint64_t> m(true);
+    ASSERT_FALSE(m.hasCachedLastBuffer());
     success = (m.insert(two,two) == NULL);
     ASSERT_TRUE(success);
     success = (m.insert(one,one) == NULL);
@@ -572,13 +573,34 @@ TEST_F(CompactingHashTest, Trivial) {
     iter = m.find(two);
     ASSERT_FALSE(iter.isEnd());
     ASSERT_EQ(iter.key(), two);
-
     success = m.erase(iter);
     ASSERT_TRUE(success);
-    ASSERT_TRUE(m.verify());
     ASSERT_TRUE(m.size() == 2);
-
+    ASSERT_FALSE(m.hasCachedLastBuffer());
+    ASSERT_TRUE(m.verify());
     iter = m.find(two);
+    ASSERT_TRUE(iter.isEnd());
+
+    iter = m.find(one);
+    ASSERT_FALSE(iter.isEnd());
+    ASSERT_EQ(iter.key(), one);
+    success = m.erase(iter);
+    ASSERT_TRUE(success);
+    ASSERT_TRUE(m.size() == 1);
+    ASSERT_FALSE(m.hasCachedLastBuffer());
+    ASSERT_TRUE(m.verify());
+    iter = m.find(two);
+    ASSERT_TRUE(iter.isEnd());
+
+    iter = m.find(three);
+    ASSERT_FALSE(iter.isEnd());
+    ASSERT_EQ(iter.key(), three);
+    success = m.erase(iter);
+    ASSERT_TRUE(success);
+    ASSERT_TRUE(m.size() == 0);
+    ASSERT_TRUE(m.hasCachedLastBuffer());
+    ASSERT_TRUE(m.verify());
+    iter = m.find(three);
     ASSERT_TRUE(iter.isEnd());
 
     // MULTIMAP

--- a/tests/test_apps/insertdelete/README.md
+++ b/tests/test_apps/insertdelete/README.md
@@ -1,0 +1,25 @@
+# insertdelete test app #
+-------------------------
+
+This app tests a customer-inspired use case where the customer wanted something similar to a user-defined "temp table".  The tables beginning with the prefix "tmp_" are for this purpose.  The procedures insert records into 10 of these tables, then delete those same records by their IDs.  The end result is no change to the state of the tables, but along the way, the EE needed to do the inserts and deletes.
+
+
+While VoltDB can handle inserts and deletes very well, this is a special edge case where each insert is the first and only row in the table, and each delete is removing the last row from the table.  These operations used to incur performance penalties which cause this workload to be slower and perhaps less scalable than similar OLTP operations where the tables are not empty.  The client performs up to 2*K inserts, where K is a command line parameter.  The default value for K is 1.0e6.  The stored procedure makes K calls to insert into and delete from a table with inline storage only.  It can also make another K calls to a procedure that does the same for a table that includes a VARCHAR(150) as that may perform differently than a purely inline table.  The processing of inline or out-of-line data may be separately suppressed, to test inline-only performance or out-of-line only performance.
+
+Directions:
+    ./run.sh server        ## To start the server in one terminal window.
+    ./run.sh init          ## To initialize the database schema.
+    ./run.sh seed          ## This is optional, to seed the server's tables.
+    ./run.sh client [ ... args ... ] ## To run the test
+       The args here are:
+          --inline            Only test insertion/deletion of inline data
+          --outline           Only test insertion/deletion of out-of-line data
+          --numiters K        Insert and delete K records.
+
+For comparison, use the "seed" command to insert a set of rows into each table that will not be touched by the client.  Then run the client again, to see the difference when the tables are not empty.
+
+    ./run.sh init
+    ./run.sh seed
+    ./run.sh client [ ... args as above ... ]
+
+Tests should be run on how well the workload scales.  In the customer case that inspired this, a similar workload would hit maximum throughput with a small number of sitesperhost, and not scale up.

--- a/tests/test_apps/insertdelete/client/benchmark/Benchmark.java
+++ b/tests/test_apps/insertdelete/client/benchmark/Benchmark.java
@@ -1,0 +1,141 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package benchmark;
+
+import java.util.Random;
+import org.voltdb.*;
+import org.voltdb.client.*;
+
+public class Benchmark {
+
+    private Client client;
+    private Random rand = new Random();
+    private BenchmarkStats stats;
+
+
+    public Benchmark(String servers) throws Exception {
+        client = ClientFactory.createClient();
+        String[] serverArray = servers.split(",");
+        for (String server : serverArray) {
+            client.createConnection(server);
+        }
+        stats = new BenchmarkStats(client);
+    }
+
+
+    public void init() throws Exception {
+
+        // any initial setup can go here
+
+    }
+
+
+    public void runBenchmark(boolean inline, boolean outline, int numberIterations) throws Exception {
+
+        stats.startBenchmark();
+
+        for (int i=0; i < numberIterations; i++) {
+            int appid;
+            int deviceid;
+            if (outline) {
+                appid = rand.nextInt(50);
+                deviceid = rand.nextInt(1000000)+500; // add 500 to avoid low values that may be used for seed data
+                client.callProcedure(new BenchmarkCallback("InsertDeleteWithString"),
+                                     "InsertDeleteWithString",
+                                     appid,
+                                     deviceid,
+                                     "They’re selling postcards of the hanging. They’re painting the passports brown. The beauty parlor is filled with sailors. The circus is in town"
+                                     );
+            }
+
+            if (inline) {
+                appid = rand.nextInt(50);
+                deviceid = rand.nextInt(1000000)+500; // add 500 to avoid low values that may be used for seed data
+                client.callProcedure(new BenchmarkCallback("InsertDelete"),
+                                     "InsertDelete",
+                                     appid,
+                                     deviceid
+                                     );
+            }
+        }
+
+        stats.endBenchmark();
+
+        client.drain();
+        BenchmarkCallback.printAllResults();
+
+        client.close();
+    }
+
+
+    public static void main(String[] args) throws Exception {
+        boolean inline = true;
+        boolean outline = true;
+        String serverlist = "localhost";
+        int idx;
+        int numberIterations = 1000000;
+        for (idx = 0; idx < args.length && args[idx].startsWith("--"); idx += 1) {
+            String arg = args[idx];
+            if ("--inline".equals(arg)) {
+                inline = true;
+                outline = false;
+            } else if ("--outofline".equals(arg)) {
+                outline = true;
+                inline  = false;
+            } else if ("--numiters".equals(arg)) {
+                idx += 1;
+                arg = args[idx];
+                numberIterations = Integer.valueOf(arg);
+            } else {
+                System.err.printf("Benchmark: Unknown command line parameter %s\n", arg);
+                System.exit(100);
+            }
+        }
+        if (args.length > idx) {
+            serverlist = args[idx];
+        }
+        Benchmark benchmark = new Benchmark(serverlist);
+        benchmark.init();
+        benchmark.runBenchmark(inline, outline, numberIterations);
+    }
+}

--- a/tests/test_apps/insertdelete/client/benchmark/BenchmarkCallback.java
+++ b/tests/test_apps/insertdelete/client/benchmark/BenchmarkCallback.java
@@ -1,0 +1,114 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *//* This file is part of VoltDB.
+ * Copyright (C) 2008-2014 VoltDB Inc.
+ */
+package benchmark;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import com.google_voltpatches.common.collect.ConcurrentHashMultiset;
+import com.google_voltpatches.common.collect.Multiset;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.client.ProcedureCallback;
+
+public class BenchmarkCallback implements ProcedureCallback {
+
+    private static Multiset<String> stats = ConcurrentHashMultiset.create();
+    private static ConcurrentHashMap<String,Integer> procedures = new ConcurrentHashMap<String,Integer>();
+    String procedureName;
+    long maxErrors;
+
+    public static int count( String procedureName, String event ){
+        return stats.add(procedureName + event, 1);
+    }
+
+    public static int getCount( String procedureName, String event ){
+        return stats.count(procedureName + event);
+    }
+
+    public static void printProcedureResults(String procedureName) {
+        System.out.println("  " + procedureName);
+        System.out.println("        calls: " + getCount(procedureName,"call"));
+        System.out.println("      commits: " + getCount(procedureName,"commit"));
+        System.out.println("    rollbacks: " + getCount(procedureName,"rollback"));
+    }
+
+    public static void printAllResults() {
+        List<String> l = new ArrayList<String>(procedures.keySet());
+        Collections.sort(l);
+        for (String e : l) {
+            printProcedureResults(e);
+        }
+    }
+
+    public BenchmarkCallback(String procedure, long maxErrors) {
+        super();
+        this.procedureName = procedure;
+        this.maxErrors = maxErrors;
+    procedures.putIfAbsent(procedure,1);
+    }
+
+    public BenchmarkCallback(String procedure) {
+        this(procedure, 5l);
+    }
+
+    @Override
+    public void clientCallback(ClientResponse cr) {
+
+        count(procedureName,"call");
+
+        if (cr.getStatus() == ClientResponse.SUCCESS) {
+            count(procedureName,"commit");
+        } else {
+            long totalErrors = count(procedureName,"rollback");
+
+            if (totalErrors > maxErrors) {
+                System.err.println("exceeded " + maxErrors + " maximum database errors - exiting client");
+                System.exit(-1);
+            }
+
+            System.err.println("DATABASE ERROR: " + cr.getStatusString());
+        }
+    }
+}
+

--- a/tests/test_apps/insertdelete/client/benchmark/BenchmarkStats.java
+++ b/tests/test_apps/insertdelete/client/benchmark/BenchmarkStats.java
@@ -1,0 +1,140 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */package benchmark;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import org.voltdb.*;
+import org.voltdb.client.*;
+
+public class BenchmarkStats {
+
+    private Timer timer;
+    private Client client;
+    private long startTimeMillis;
+    // Statistics manager objects from the client
+    final ClientStatsContext periodicStatsContext;
+    final ClientStatsContext fullStatsContext;
+
+    public BenchmarkStats(Client client) {
+        this.client = client;
+        periodicStatsContext = client.createStatsContext();
+        fullStatsContext = client.createStatsContext();
+
+        // start benchmark
+
+    }
+
+    public void startBenchmark() {
+        fullStatsContext.fetchAndResetBaseline();
+        periodicStatsContext.fetchAndResetBaseline();
+        startTimeMillis = System.currentTimeMillis();
+        schedulePeriodicStats();
+    }
+
+    public void endBenchmark() throws Exception {
+        timer.cancel();
+        client.drain();
+        printResults();
+    }
+
+    public void schedulePeriodicStats() {
+        timer = new Timer();
+        TimerTask statsPrinting = new TimerTask() {
+                @Override
+                public void run() { printStatistics(); }
+            };
+        timer.scheduleAtFixedRate(statsPrinting,
+                                  5 * 1000,
+                                  5 * 1000);
+    }
+
+    public synchronized void printStatistics() {
+        ClientStats stats = periodicStatsContext.fetchAndResetBaseline().getStats();
+        long time = Math.round((stats.getEndTimestamp() - startTimeMillis) / 1000.0);
+
+        System.out.printf("%02d:%02d:%02d ", time / 3600, (time / 60) % 60, time % 60);
+        System.out.printf("Throughput %d/s, ", stats.getTxnThroughput());
+        System.out.printf("Aborts/Failures %d/%d",
+                          stats.getInvocationAborts(), stats.getInvocationErrors());
+        if(true) {
+            System.out.printf(", Avg/95%% Latency %.2f/%.2fms", stats.getAverageLatency(),
+                              stats.kPercentileLatencyAsDouble(0.95));
+        }
+        System.out.printf("\n");
+    }
+
+    public synchronized void printResults() throws Exception {
+        final String HORIZONTAL_RULE =
+            "----------" + "----------" + "----------" + "----------" +
+            "----------" + "----------" + "----------" + "----------" + "\n";
+
+        ClientStats stats = fullStatsContext.fetch().getStats();
+        // 3. Performance statistics
+        System.out.print(HORIZONTAL_RULE);
+        System.out.println(" Client Workload Statistics");
+        System.out.println(HORIZONTAL_RULE);
+
+        System.out.printf("Average throughput:            %,9d txns/sec\n", stats.getTxnThroughput());
+
+        System.out.printf("Average latency:               %,9.2f ms\n", stats.getAverageLatency());
+        System.out.printf("10th percentile latency:       %,9.2f ms\n", stats.kPercentileLatencyAsDouble(.1));
+        System.out.printf("25th percentile latency:       %,9.2f ms\n", stats.kPercentileLatencyAsDouble(.25));
+        System.out.printf("50th percentile latency:       %,9.2f ms\n", stats.kPercentileLatencyAsDouble(.5));
+        System.out.printf("75th percentile latency:       %,9.2f ms\n", stats.kPercentileLatencyAsDouble(.75));
+        System.out.printf("90th percentile latency:       %,9.2f ms\n", stats.kPercentileLatencyAsDouble(.9));
+        System.out.printf("95th percentile latency:       %,9.2f ms\n", stats.kPercentileLatencyAsDouble(.95));
+        System.out.printf("99th percentile latency:       %,9.2f ms\n", stats.kPercentileLatencyAsDouble(.99));
+        System.out.printf("99.5th percentile latency:     %,9.2f ms\n", stats.kPercentileLatencyAsDouble(.995));
+        System.out.printf("99.9th percentile latency:     %,9.2f ms\n", stats.kPercentileLatencyAsDouble(.999));
+
+        System.out.print("\n" + HORIZONTAL_RULE);
+        System.out.println(" System Server Statistics");
+        System.out.println(HORIZONTAL_RULE);
+        System.out.printf("Reported Internal Avg Latency: %,9.2f ms\n", stats.getAverageInternalLatency());
+
+        System.out.print("\n" + HORIZONTAL_RULE);
+        System.out.println(" Latency Histogram");
+        System.out.println(HORIZONTAL_RULE);
+        System.out.println(stats.latencyHistoReport());
+    }
+}

--- a/tests/test_apps/insertdelete/client/benchmark/SeedTables.java
+++ b/tests/test_apps/insertdelete/client/benchmark/SeedTables.java
@@ -1,0 +1,91 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package benchmark;
+
+import org.voltdb.*;
+import org.voltdb.client.*;
+
+public class SeedTables {
+
+    public static void main(String[] args) throws Exception {
+
+        /*
+         * Instantiate a client and connect to the database.
+         */
+        org.voltdb.client.Client myApp;
+        myApp = ClientFactory.createClient();
+        myApp.createConnection("localhost");
+
+
+        VoltTable p = myApp.callProcedure("@GetPartitionKeys","INTEGER").getResults()[0];
+        int i = 0;
+        while (p.advanceRow()) {
+            i++;
+            long id = p.getLong(0);
+            myApp.callProcedure("TMP_0.insert",0,id,0);
+            myApp.callProcedure("TMP_1.insert",0,id,0);
+            myApp.callProcedure("TMP_2.insert",0,id,0);
+            myApp.callProcedure("TMP_3.insert",0,id,0);
+            myApp.callProcedure("TMP_4.insert",0,id,0);
+            myApp.callProcedure("TMP_5.insert",0,id,0);
+            myApp.callProcedure("TMP_6.insert",0,id,0);
+            myApp.callProcedure("TMP_7.insert",0,id,0);
+            myApp.callProcedure("TMP_8.insert",0,id,0);
+            myApp.callProcedure("TMP_9.insert",0,id,0);
+
+            myApp.callProcedure("TMP_s0.insert",0,id,0,"FOO");
+            myApp.callProcedure("TMP_s1.insert",0,id,0,"FOO");
+            myApp.callProcedure("TMP_s2.insert",0,id,0,"FOO");
+            myApp.callProcedure("TMP_s3.insert",0,id,0,"FOO");
+            myApp.callProcedure("TMP_s4.insert",0,id,0,"FOO");
+            myApp.callProcedure("TMP_s5.insert",0,id,0,"FOO");
+            myApp.callProcedure("TMP_s6.insert",0,id,0,"FOO");
+            myApp.callProcedure("TMP_s7.insert",0,id,0,"FOO");
+            myApp.callProcedure("TMP_s8.insert",0,id,0,"FOO");
+            myApp.callProcedure("TMP_s9.insert",0,id,0,"FOO");
+
+        }
+        System.out.println("Finished seeding " + i + " partitions.");
+    }
+}

--- a/tests/test_apps/insertdelete/ddl.sql
+++ b/tests/test_apps/insertdelete/ddl.sql
@@ -1,0 +1,207 @@
+file -inlinebatch END_OF_BATCH
+
+DROP PROCEDURE InsertDelete IF EXISTS;
+DROP PROCEDURE InsertDeleteWithString IF EXISTS;
+DROP TABLE tmp_0 IF EXISTS;
+DROP TABLE tmp_1 IF EXISTS;
+DROP TABLE tmp_2 IF EXISTS;
+DROP TABLE tmp_3 IF EXISTS;
+DROP TABLE tmp_4 IF EXISTS;
+DROP TABLE tmp_5 IF EXISTS;
+DROP TABLE tmp_6 IF EXISTS;
+DROP TABLE tmp_7 IF EXISTS;
+DROP TABLE tmp_8 IF EXISTS;
+DROP TABLE tmp_9 IF EXISTS;
+DROP TABLE tmp_s0 IF EXISTS;
+DROP TABLE tmp_s1 IF EXISTS;
+DROP TABLE tmp_s2 IF EXISTS;
+DROP TABLE tmp_s3 IF EXISTS;
+DROP TABLE tmp_s4 IF EXISTS;
+DROP TABLE tmp_s5 IF EXISTS;
+DROP TABLE tmp_s6 IF EXISTS;
+DROP TABLE tmp_s7 IF EXISTS;
+DROP TABLE tmp_s8 IF EXISTS;
+DROP TABLE tmp_s9 IF EXISTS;
+
+END_OF_BATCH
+
+-- Update classes from jar so that server will know about classes but not procedures yet.
+LOAD CLASSES procs.jar;
+
+file -inlinebatch END_OF_BATCH
+
+CREATE TABLE tmp_0 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_0 ON COLUMN deviceid;
+
+CREATE TABLE tmp_1 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_1 ON COLUMN deviceid;
+
+CREATE TABLE tmp_2 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_2 ON COLUMN deviceid;
+
+CREATE TABLE tmp_3 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_3 ON COLUMN deviceid;
+
+CREATE TABLE tmp_4 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_4 ON COLUMN deviceid;
+
+CREATE TABLE tmp_5 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_5 ON COLUMN deviceid;
+
+CREATE TABLE tmp_6 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_6 ON COLUMN deviceid;
+
+CREATE TABLE tmp_7 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_7 ON COLUMN deviceid;
+
+CREATE TABLE tmp_8 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_8 ON COLUMN deviceid;
+
+CREATE TABLE tmp_9 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_9 ON COLUMN deviceid;
+
+-- tables with VARCHAR 16
+CREATE TABLE tmp_s0 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO',
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_s0 ON COLUMN deviceid;
+
+CREATE TABLE tmp_s1 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO',
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_s1 ON COLUMN deviceid;
+
+CREATE TABLE tmp_s2 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO',
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_s2 ON COLUMN deviceid;
+
+CREATE TABLE tmp_s3 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO',
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_s3 ON COLUMN deviceid;
+
+CREATE TABLE tmp_s4 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO',
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_s4 ON COLUMN deviceid;
+
+CREATE TABLE tmp_s5 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO',
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_s5 ON COLUMN deviceid;
+
+CREATE TABLE tmp_s6 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO',
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_s6 ON COLUMN deviceid;
+
+CREATE TABLE tmp_s7 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO',
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_s7 ON COLUMN deviceid;
+
+CREATE TABLE tmp_s8 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO',
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_s8 ON COLUMN deviceid;
+
+CREATE TABLE tmp_s9 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO',
+  PRIMARY KEY (deviceid, appid)
+);
+PARTITION TABLE tmp_s9 ON COLUMN deviceid;
+
+CREATE PROCEDURE PARTITION ON TABLE tmp_0 COLUMN deviceid PARAMETER 1 FROM CLASS procedures.InsertDelete;
+CREATE PROCEDURE PARTITION ON TABLE tmp_s0 COLUMN deviceid PARAMETER 1 FROM CLASS procedures.InsertDeleteWithString;
+
+END_OF_BATCH

--- a/tests/test_apps/insertdelete/ddl_noindices.sql
+++ b/tests/test_apps/insertdelete/ddl_noindices.sql
@@ -1,0 +1,167 @@
+file -inlinebatch END_OF_BATCH
+
+DROP PROCEDURE InsertDelete IF EXISTS;
+DROP PROCEDURE InsertDeleteWithString IF EXISTS;
+DROP TABLE tmp_0 IF EXISTS;
+DROP TABLE tmp_1 IF EXISTS;
+DROP TABLE tmp_2 IF EXISTS;
+DROP TABLE tmp_3 IF EXISTS;
+DROP TABLE tmp_4 IF EXISTS;
+DROP TABLE tmp_5 IF EXISTS;
+DROP TABLE tmp_6 IF EXISTS;
+DROP TABLE tmp_7 IF EXISTS;
+DROP TABLE tmp_8 IF EXISTS;
+DROP TABLE tmp_9 IF EXISTS;
+DROP TABLE tmp_s0 IF EXISTS;
+DROP TABLE tmp_s1 IF EXISTS;
+DROP TABLE tmp_s2 IF EXISTS;
+DROP TABLE tmp_s3 IF EXISTS;
+DROP TABLE tmp_s4 IF EXISTS;
+DROP TABLE tmp_s5 IF EXISTS;
+DROP TABLE tmp_s6 IF EXISTS;
+DROP TABLE tmp_s7 IF EXISTS;
+DROP TABLE tmp_s8 IF EXISTS;
+DROP TABLE tmp_s9 IF EXISTS;
+
+END_OF_BATCH
+
+-- Update classes from jar so that server will know about classes but not procedures yet.
+LOAD CLASSES procs.jar;
+
+file -inlinebatch END_OF_BATCH
+
+CREATE TABLE tmp_0 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW
+);
+
+CREATE TABLE tmp_1 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW
+);
+
+CREATE TABLE tmp_2 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW
+);
+
+CREATE TABLE tmp_3 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW
+);
+
+CREATE TABLE tmp_4 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW
+);
+
+CREATE TABLE tmp_5 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW
+);
+
+CREATE TABLE tmp_6 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW
+);
+
+CREATE TABLE tmp_7 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW
+);
+
+CREATE TABLE tmp_8 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW
+);
+
+CREATE TABLE tmp_9 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW
+);
+
+-- tables with VARCHAR 16
+CREATE TABLE tmp_s0 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO'
+);
+
+CREATE TABLE tmp_s1 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO'
+);
+
+CREATE TABLE tmp_s2 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO'
+);
+
+CREATE TABLE tmp_s3 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO'
+);
+
+CREATE TABLE tmp_s4 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO'
+);
+
+CREATE TABLE tmp_s5 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO'
+);
+
+CREATE TABLE tmp_s6 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO'
+);
+
+CREATE TABLE tmp_s7 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO'
+);
+
+CREATE TABLE tmp_s8 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO'
+);
+
+CREATE TABLE tmp_s9 (
+  appid            INTEGER      NOT NULL,
+  deviceid         BIGINT       NOT NULL,
+  ts               TIMESTAMP    DEFAULT NOW,
+  val              VARCHAR(150)  DEFAULT 'FOO'
+);
+
+CREATE PROCEDURE FROM CLASS procedures.InsertDelete;
+CREATE PROCEDURE FROM CLASS procedures.InsertDeleteWithString;
+
+END_OF_BATCH

--- a/tests/test_apps/insertdelete/procedures/InsertDelete.java
+++ b/tests/test_apps/insertdelete/procedures/InsertDelete.java
@@ -1,0 +1,98 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */package procedures;
+
+import org.voltdb.*;
+
+public class InsertDelete extends VoltProcedure {
+
+    public final SQLStmt insert0 = new SQLStmt("INSERT INTO tmp_0 (appid,deviceid) VALUES (?,?);");
+    public final SQLStmt insert1 = new SQLStmt("INSERT INTO tmp_1 (appid,deviceid) VALUES (?,?);");
+    public final SQLStmt insert2 = new SQLStmt("INSERT INTO tmp_2 (appid,deviceid) VALUES (?,?);");
+    public final SQLStmt insert3 = new SQLStmt("INSERT INTO tmp_3 (appid,deviceid) VALUES (?,?);");
+    public final SQLStmt insert4 = new SQLStmt("INSERT INTO tmp_4 (appid,deviceid) VALUES (?,?);");
+    public final SQLStmt insert5 = new SQLStmt("INSERT INTO tmp_5 (appid,deviceid) VALUES (?,?);");
+    public final SQLStmt insert6 = new SQLStmt("INSERT INTO tmp_6 (appid,deviceid) VALUES (?,?);");
+    public final SQLStmt insert7 = new SQLStmt("INSERT INTO tmp_7 (appid,deviceid) VALUES (?,?);");
+    public final SQLStmt insert8 = new SQLStmt("INSERT INTO tmp_8 (appid,deviceid) VALUES (?,?);");
+    public final SQLStmt insert9 = new SQLStmt("INSERT INTO tmp_9 (appid,deviceid) VALUES (?,?);");
+
+    public final SQLStmt delete0 = new SQLStmt("DELETE FROM tmp_0 WHERE deviceid = ?;");
+    public final SQLStmt delete1 = new SQLStmt("DELETE FROM tmp_1 WHERE deviceid = ?;");
+    public final SQLStmt delete2 = new SQLStmt("DELETE FROM tmp_2 WHERE deviceid = ?;");
+    public final SQLStmt delete3 = new SQLStmt("DELETE FROM tmp_3 WHERE deviceid = ?;");
+    public final SQLStmt delete4 = new SQLStmt("DELETE FROM tmp_4 WHERE deviceid = ?;");
+    public final SQLStmt delete5 = new SQLStmt("DELETE FROM tmp_5 WHERE deviceid = ?;");
+    public final SQLStmt delete6 = new SQLStmt("DELETE FROM tmp_6 WHERE deviceid = ?;");
+    public final SQLStmt delete7 = new SQLStmt("DELETE FROM tmp_7 WHERE deviceid = ?;");
+    public final SQLStmt delete8 = new SQLStmt("DELETE FROM tmp_8 WHERE deviceid = ?;");
+    public final SQLStmt delete9 = new SQLStmt("DELETE FROM tmp_9 WHERE deviceid = ?;");
+
+
+    public VoltTable[] run(int appid, long deviceid)
+        throws VoltAbortException {
+
+        voltQueueSQL(insert0,appid,deviceid);
+        voltQueueSQL(insert1,appid,deviceid);
+        voltQueueSQL(insert2,appid,deviceid);
+        voltQueueSQL(insert3,appid,deviceid);
+        voltQueueSQL(insert4,appid,deviceid);
+        voltQueueSQL(insert5,appid,deviceid);
+        voltQueueSQL(insert6,appid,deviceid);
+        voltQueueSQL(insert7,appid,deviceid);
+        voltQueueSQL(insert8,appid,deviceid);
+        voltQueueSQL(insert9,appid,deviceid);
+
+        voltQueueSQL(delete0,deviceid);
+        voltQueueSQL(delete1,deviceid);
+        voltQueueSQL(delete2,deviceid);
+        voltQueueSQL(delete3,deviceid);
+        voltQueueSQL(delete4,deviceid);
+        voltQueueSQL(delete5,deviceid);
+        voltQueueSQL(delete6,deviceid);
+        voltQueueSQL(delete7,deviceid);
+        voltQueueSQL(delete8,deviceid);
+        voltQueueSQL(delete9,deviceid);
+
+        return voltExecuteSQL();
+    }
+}

--- a/tests/test_apps/insertdelete/procedures/InsertDeleteWithString.java
+++ b/tests/test_apps/insertdelete/procedures/InsertDeleteWithString.java
@@ -1,0 +1,98 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */package procedures;
+
+import org.voltdb.*;
+
+public class InsertDeleteWithString extends VoltProcedure {
+
+    public final SQLStmt insert0 = new SQLStmt("INSERT INTO tmp_s0 (appid,deviceid,val) VALUES (?,?,?);");
+    public final SQLStmt insert1 = new SQLStmt("INSERT INTO tmp_s1 (appid,deviceid,val) VALUES (?,?,?);");
+    public final SQLStmt insert2 = new SQLStmt("INSERT INTO tmp_s2 (appid,deviceid,val) VALUES (?,?,?);");
+    public final SQLStmt insert3 = new SQLStmt("INSERT INTO tmp_s3 (appid,deviceid,val) VALUES (?,?,?);");
+    public final SQLStmt insert4 = new SQLStmt("INSERT INTO tmp_s4 (appid,deviceid,val) VALUES (?,?,?);");
+    public final SQLStmt insert5 = new SQLStmt("INSERT INTO tmp_s5 (appid,deviceid,val) VALUES (?,?,?);");
+    public final SQLStmt insert6 = new SQLStmt("INSERT INTO tmp_s6 (appid,deviceid,val) VALUES (?,?,?);");
+    public final SQLStmt insert7 = new SQLStmt("INSERT INTO tmp_s7 (appid,deviceid,val) VALUES (?,?,?);");
+    public final SQLStmt insert8 = new SQLStmt("INSERT INTO tmp_s8 (appid,deviceid,val) VALUES (?,?,?);");
+    public final SQLStmt insert9 = new SQLStmt("INSERT INTO tmp_s9 (appid,deviceid,val) VALUES (?,?,?);");
+
+    public final SQLStmt delete0 = new SQLStmt("DELETE FROM tmp_s0 WHERE deviceid = ?;");
+    public final SQLStmt delete1 = new SQLStmt("DELETE FROM tmp_s1 WHERE deviceid = ?;");
+    public final SQLStmt delete2 = new SQLStmt("DELETE FROM tmp_s2 WHERE deviceid = ?;");
+    public final SQLStmt delete3 = new SQLStmt("DELETE FROM tmp_s3 WHERE deviceid = ?;");
+    public final SQLStmt delete4 = new SQLStmt("DELETE FROM tmp_s4 WHERE deviceid = ?;");
+    public final SQLStmt delete5 = new SQLStmt("DELETE FROM tmp_s5 WHERE deviceid = ?;");
+    public final SQLStmt delete6 = new SQLStmt("DELETE FROM tmp_s6 WHERE deviceid = ?;");
+    public final SQLStmt delete7 = new SQLStmt("DELETE FROM tmp_s7 WHERE deviceid = ?;");
+    public final SQLStmt delete8 = new SQLStmt("DELETE FROM tmp_s8 WHERE deviceid = ?;");
+    public final SQLStmt delete9 = new SQLStmt("DELETE FROM tmp_s9 WHERE deviceid = ?;");
+
+
+    public VoltTable[] run(int appid, long deviceid, String val)
+        throws VoltAbortException {
+
+        voltQueueSQL(insert0,appid,deviceid,val);
+        voltQueueSQL(insert1,appid,deviceid,val);
+        voltQueueSQL(insert2,appid,deviceid,val);
+        voltQueueSQL(insert3,appid,deviceid,val);
+        voltQueueSQL(insert4,appid,deviceid,val);
+        voltQueueSQL(insert5,appid,deviceid,val);
+        voltQueueSQL(insert6,appid,deviceid,val);
+        voltQueueSQL(insert7,appid,deviceid,val);
+        voltQueueSQL(insert8,appid,deviceid,val);
+        voltQueueSQL(insert9,appid,deviceid,val);
+
+        voltQueueSQL(delete0,deviceid);
+        voltQueueSQL(delete1,deviceid);
+        voltQueueSQL(delete2,deviceid);
+        voltQueueSQL(delete3,deviceid);
+        voltQueueSQL(delete4,deviceid);
+        voltQueueSQL(delete5,deviceid);
+        voltQueueSQL(delete6,deviceid);
+        voltQueueSQL(delete7,deviceid);
+        voltQueueSQL(delete8,deviceid);
+        voltQueueSQL(delete9,deviceid);
+
+        return voltExecuteSQL();
+    }
+}

--- a/tests/test_apps/insertdelete/run.sh
+++ b/tests/test_apps/insertdelete/run.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+# leader host for startup purposes only
+# (once running, all nodes are the same -- no leaders)
+STARTUPLEADERHOST="localhost"
+# list of cluster nodes separated by commas in host:[port] format
+SERVERS="localhost"
+
+# find voltdb binaries
+if [ -e ../../bin/voltdb ]; then
+    # assume this is the examples folder for a kit
+    VOLTDB_BIN="$(dirname $(dirname $(pwd)))/bin"
+elif [ -n "$(which voltdb 2> /dev/null)" ]; then
+    # assume we're using voltdb from the path
+    VOLTDB_BIN=$(dirname "$(which voltdb)")
+else
+    echo "Unable to find VoltDB installation."
+    echo "Please add VoltDB's bin directory to your path."
+    exit -1
+fi
+
+# call script to set up paths, including
+# java classpaths and binary paths
+source $VOLTDB_BIN/voltenv
+
+# remove binaries, logs, runtime artifacts, etc... but keep the jars
+function clean() {
+    rm -rf voltdbroot log procedures/*.class client/benchmark/*.class
+}
+
+# remove everything from "clean" as well as the jarfiles
+function cleanall() {
+    clean
+    rm -rf procs.jar client.jar
+}
+
+
+# compile the source code for procedures and the client into jarfiles
+function jars() {
+    # compile java source
+    javac -classpath $APPCLASSPATH procedures/*.java
+    javac -classpath $CLIENTCLASSPATH client/benchmark/*.java
+    # build procedure and client jars
+    jar cf procs.jar -C . procedures
+    jar cf client.jar -C client benchmark
+    # remove compiled .class files
+    rm -rf procedures/*.class client/benchmark/*.class
+}
+
+# compile the procedure and client jarfiles if they don't exist
+function jars-ifneeded() {
+    if [ ! -e procs.jar ] || [ ! -e client.jar ]; then
+        jars;
+    fi
+}
+
+# run the voltdb server locally
+function server() {
+    # note: "create --force" will delete any existing data
+    # use "recover" to start from an existing voltdbroot folder with data
+    voltdb create --force -H $STARTUPLEADERHOST
+}
+
+# load schema and procedures
+function init() {
+    jars-ifneeded
+    sqlcmd < ddl.sql
+}
+
+# run this target to see what command line options the client offers
+function client-help() {
+    jars-ifneeded
+    java -classpath client.jar:$CLIENTCLASSPATH benchmark.Benchmark --help
+}
+
+# run the client that drives the example with some editable options
+# Here we run the tests with both inline and outofline data.
+function client() {
+    local DONE
+    local ARG
+    jars-ifneeded
+    java -classpath client.jar:$CLIENTCLASSPATH benchmark.Benchmark $INLINE $OUTLINE $NUMITERS $SERVERS
+}
+
+function seed() {
+    jars-ifneeded
+    java -classpath client.jar:$CLIENTCLASSPATH benchmark.SeedTables $SERVERS
+}
+
+
+function help() {
+    echo "Usage: ./run.sh {clean|cleanall|jars|server|init|client|client-help}"
+}
+
+# Run the targets pass on the command line
+# If no first arg, run server
+if [ -n "$1" ] ; then
+    CMD="$1"
+    shift
+fi
+while [ -z "$DONE" ] ; do
+    case "$1" in
+    --#)
+        shift;
+        ECHO=echo
+        ;;
+    --inline)
+        shift;
+        # Both --inline and --outline means nothing.
+        if [ -n "$OUTLINE" ] ; then
+            unset OUTLINE
+        else
+            INLINE="--inline"
+        fi
+        ;;
+    --outline)
+        shift;
+        # Both --inline and --outline means nothing.
+        if [ -n "$INLINE" ] ; then
+            unset INLINE
+        else
+            OUTLINE="--outline"
+        fi
+        ;;
+    --numiters)
+        shift;
+        NUMITERS="--numiters $1"
+        shift
+        ;;
+    "")
+        DONE=YES
+        ;;
+    *)
+	shift
+	CMD="$1"
+	shift
+        ;;
+    esac
+done
+
+if [ -z "$CMD" ]; then server; exit; fi
+echo "Performing $CMD"
+$CMD


### PR DESCRIPTION
Some rows add nodes to indices on the table of the row. When the last
row of a table is deleted, the nodes for that row are deleted. If we
delete a row and then add a row repeatedly we will thrash the allocator,
which is expensive.

This commit caches the last allocated block of nodes in the index'
allocator, and reuses it when another node is added to the index. This
costs some memory for empty tables, but is much faster.

https://issues.voltdb.com/browse/ENG-8872