### PR TITLE
ENG-10612: Fix ordering of read-only procedure when CL is on.

### DIFF
--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -64,6 +64,7 @@ import org.voltdb.SnapshotTableTask;
 import org.voltdb.StartAction;
 import org.voltdb.StatsAgent;
 import org.voltdb.StatsSelector;
+import org.voltdb.SystemProcedureCatalog;
 import org.voltdb.SystemProcedureExecutionContext;
 import org.voltdb.TableStats;
 import org.voltdb.TableStreamType;
@@ -884,8 +885,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         }
         else if (tibm instanceof Iv2InitiateTaskMessage) {
             Iv2InitiateTaskMessage itm = (Iv2InitiateTaskMessage) tibm;
-            //All durable sysprocs and non-sysprocs should not get filtered.
-            return !CatalogUtil.isDurableProc(itm.getStoredProcedureName());
+            final SystemProcedureCatalog.Config sysproc = SystemProcedureCatalog.listing.get(itm.getStoredProcedureName());
+            // All durable sysprocs and non-sysprocs should not get filtered.
+            return sysproc != null && !sysproc.isDurable();
         }
         return false;
     }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -555,10 +555,16 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
      */
     private void doLocalInitiateOffer(Iv2InitiateTaskMessage msg)
     {
+        /**
+         * A shortcut read is a read operation sent to any replica and completed with no
+         * confirmation or communication with other replicas. In a partition scenario, it's
+         * possible to read an unconfirmed transaction's writes that will be lost.
+         */
+        final boolean shortcutRead = msg.isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
         final String procedureName = msg.getStoredProcedureName();
         final SpProcedureTask task =
             new SpProcedureTask(m_mailbox, procedureName, m_pendingTasks, msg, m_drGateway);
-        if (!msg.isReadOnly()) {
+        if (!shortcutRead) {
             ListenableFuture<Object> durabilityBackpressureFuture =
                     m_cl.log(msg, msg.getSpHandle(), null, m_durabilityListener, task);
             //Durability future is always null for sync command logging
@@ -845,7 +851,15 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             // AND we've never seen anything for this transaction before.  We can't
             // actually log until we create a TransactionTask, though, so just keep track
             // of whether it needs to be done.
-            logThis = (msg.getInitiateTask() != null && !msg.getInitiateTask().isReadOnly());
+            if (msg.getInitiateTask() != null) {
+                /**
+                 * A shortcut read is a read operation sent to any replica and completed with no
+                 * confirmation or communication with other replicas. In a partition scenario, it's
+                 * possible to read an unconfirmed transaction's writes that will be lost.
+                 */
+                final boolean shortcutRead = msg.getInitiateTask().isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+                logThis = !shortcutRead;
+            }
         }
 
         // Check to see if this is the final task for this txn, and if so, if we can close it out early

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -59,9 +59,7 @@ public class TransactionTaskQueue
     {
         Iv2Trace.logTransactionTaskQueueOffer(task);
         TransactionState txnState = task.getTransactionState();
-        if (!txnState.isReadOnly()) {
-            m_maxTaskedSpHandle = Math.max(m_maxTaskedSpHandle, txnState.m_spHandle);
-        }
+        m_maxTaskedSpHandle = Math.max(m_maxTaskedSpHandle, txnState.m_spHandle);
         boolean retval = false;
         if (!m_backlog.isEmpty()) {
             /*

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2302,14 +2302,8 @@ public abstract class CatalogUtil {
      * @return true if proc is durable for non sys procs return true (durable)
      */
     public static boolean isDurableProc(String procName) {
-        //For sysprocs look at sysproc catalog.
-        if (procName.charAt(0) == '@') {
-            SystemProcedureCatalog.Config sysProc = SystemProcedureCatalog.listing.get(procName);
-            if (sysProc != null) {
-                return sysProc.isDurable();
-            }
-        }
-        return true;
+        SystemProcedureCatalog.Config sysProc = SystemProcedureCatalog.listing.get(procName);
+        return sysProc == null || sysProc.isDurable();
     }
 
     /**


### PR DESCRIPTION
When command logging is turned on, read-write transactions are passed to
the command logging thread. If read-only transactions are not done the
same way, they may be sequenced differently on different replicas,
resulting in hash mismatches. This only affects SAFE consistency level
because reads are sent to all replicas.

Also advance the last spHandle in the TransactionTaskQueue regardless of
the type of transaction. Reads can advance the spHandle in SAFE
consistency level.