### PR TITLE
ENG-10599: Print way more info on hash mismatch.

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -961,7 +961,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
 
             clientResponse.setClientHandle(clientData.m_clientHandle);
             clientResponse.setClusterRoundtrip((int)TimeUnit.NANOSECONDS.toMillis(delta));
-            clientResponse.setHash(null); // not part of wire protocol
+            clientResponse.setHashes(null); // not part of wire protocol
 
             return clientResponse.getSerializedSize() + 4;
         }

--- a/src/frontend/org/voltdb/ClientResponseImpl.java
+++ b/src/frontend/org/voltdb/ClientResponseImpl.java
@@ -43,7 +43,7 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
     private String appStatusString = null;
     private byte encodedAppStatusString[];
     private VoltTable[] results = new VoltTable[0];
-    private Integer m_hash = null;
+    private int[] m_hashes = null;
 
     private int clusterRoundTripTime = 0;
     private int clientRoundTripTime = 0;
@@ -109,8 +109,8 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
         this.setProperly = true;
     }
 
-    public void setHash(Integer hash) {
-        m_hash = hash;
+    public void setHashes(int[] hashes) {
+        m_hashes = hashes;
     }
 
     @Override
@@ -136,8 +136,8 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
         return clientHandle;
     }
 
-    public Integer getHash() {
-        return m_hash;
+    public int[] getHashes() {
+        return m_hashes;
     }
 
     public void initFromBuffer(ByteBuffer buf) throws IOException {
@@ -161,9 +161,13 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
             throw new RuntimeException("Use of deprecated exception in Client Response serialization.");
         }
         if ((presentFields & (1 << 4)) != 0) {
-            m_hash = buf.getInt();
+            int hashArrayLen = buf.getShort();
+            m_hashes = new int[hashArrayLen];
+            for (int i = 0; i < hashArrayLen; ++i) {
+                m_hashes[i] = buf.getInt();
+            }
         } else {
-            m_hash = null;
+            m_hashes = null;
         }
         int tableCount = buf.getShort();
         if (tableCount < 0) {
@@ -199,8 +203,9 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
             encodedStatusString = statusString.getBytes(Constants.UTF8ENCODING);
             msgsize += encodedStatusString.length + 4;
         }
-        if (m_hash != null) {
-            msgsize += 4;
+        if (m_hashes != null) {
+            msgsize += 2; // short array len
+            msgsize += m_hashes.length * 4; // array of ints
         }
         for (VoltTable vt : results) {
             msgsize += vt.getSerializedSize();
@@ -223,7 +228,7 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
         if (statusString != null) {
             presentFields |= 1 << 5;
         }
-        if (m_hash != null) {
+        if (m_hashes != null) {
             presentFields |= 1 << 4;
         }
         buf.put(presentFields);
@@ -238,8 +243,12 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
             buf.put(encodedAppStatusString);
         }
         buf.putInt(clusterRoundTripTime);
-        if (m_hash != null) {
-            buf.putInt(m_hash.intValue());
+        if (m_hashes != null) {
+            assert(m_hashes.length <= Short.MAX_VALUE) : "CRI hash array length overflow";
+            buf.putShort((short) m_hashes.length);
+            for (int hash : m_hashes) {
+                buf.putInt(hash);
+            }
         }
         buf.putShort((short) results.length);
         for (VoltTable vt : results)
@@ -335,23 +344,6 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
             e.printStackTrace();
             return 0;
         }
-    }
-
-    /**
-     * Take the perfectly good results and convert them to a single long value
-     * that stores the hash for determinism.
-     *
-     * This presumes the DR agent has no need for results. This probably saves
-     * some small amount of bandwidth. The other proposed idea was using the status
-     * string to hold the sql hash. Tossup... this seemed slightly more performant,
-     * but also a bit icky.
-     */
-    public void convertResultsToHashForDeterminism() {
-        int hash = m_hash == null ? 0 : m_hash;
-
-        VoltTable t = new VoltTable(new VoltTable.ColumnInfo("", VoltType.INTEGER));
-        t.addRow(hash);
-        results = new VoltTable[] { t };
     }
 
     public void dropResultTable() {

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -269,7 +269,12 @@ public class ProcedureRunner {
         Object[] paramList = paramListIn;
 
         // reset the hash of results for a new call
-        m_determinismHash.reset(m_systemProcedureContext.getCatalogVersion());
+        if (m_systemProcedureContext != null) {
+            m_determinismHash.reset(m_systemProcedureContext.getCatalogVersion());
+        }
+        else {
+            m_determinismHash.reset(0);
+        }
         assert(m_determinismHash.getHashes()[0] == 0);
 
         ClientResponseImpl retval = null;

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -33,7 +33,6 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.hadoop_voltpatches.util.PureJavaCrc32C;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.CatalogContext.ProcedurePartitionInfo;
@@ -56,6 +55,7 @@ import org.voltdb.exceptions.EEException;
 import org.voltdb.exceptions.SerializableException;
 import org.voltdb.exceptions.SpecifiedException;
 import org.voltdb.groovy.GroovyScriptProcedureDelegate;
+import org.voltdb.iv2.DeterminismHash;
 import org.voltdb.iv2.UniqueIdGenerator;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.planner.ActivePlanRepository;
@@ -138,7 +138,7 @@ public class ProcedureRunner {
     protected final static int AGG_DEPID = 1;
 
     // current hash of sql and params
-    protected final PureJavaCrc32C m_inputCRC = new PureJavaCrc32C();
+    protected final DeterminismHash m_determinismHash = new DeterminismHash();
 
     // running procedure info
     //  - track the current call to voltExecuteSQL for logging progress
@@ -170,8 +170,6 @@ public class ProcedureRunner {
                     SystemProcedureExecutionContext sysprocContext,
                     Procedure catProc,
                     CatalogSpecificPlanner csp) {
-        assert(m_inputCRC.getValue() == 0L);
-
         String language = catProc.getLanguage();
 
         if (language != null && !language.trim().isEmpty()) {
@@ -258,9 +256,6 @@ public class ProcedureRunner {
         assert(m_appStatusString == null);
         assert(m_cachedRNG == null);
 
-        // reset the hash of results
-        m_inputCRC.reset();
-
         // reset batch context info
         m_batchIndex = -1;
 
@@ -272,6 +267,10 @@ public class ProcedureRunner {
 
         // use local var to avoid warnings about reassigning method argument
         Object[] paramList = paramListIn;
+
+        // reset the hash of results for a new call
+        m_determinismHash.reset(m_systemProcedureContext.getCatalogVersion());
+        assert(m_determinismHash.getHashes()[0] == 0);
 
         ClientResponseImpl retval = null;
         // assert no sql is queued
@@ -419,15 +418,9 @@ public class ProcedureRunner {
                         m_statusString);
             }
 
-            int hash = (int) m_inputCRC.getValue();
-            if (ClientResponseImpl.isTransactionallySuccessful(retval.getStatus()) && (hash != 0)) {
-                retval.setHash(hash);
-            }
-            if ((m_txnState != null) && // may be null for tests
-                (m_txnState.getInvocation() != null) &&
-                (ProcedureInvocationType.isDeprecatedInternalDRType(m_txnState.getInvocation().getType())))
-            {
-                retval.convertResultsToHashForDeterminism();
+            int[] hashes = m_determinismHash.getHashes();
+            if (ClientResponseImpl.isTransactionallySuccessful(retval.getStatus()) && (hashes != null)) {
+                retval.setHashes(hashes);
             }
         }
         finally {
@@ -581,12 +574,12 @@ public class ProcedureRunner {
 
     private void updateCRC(QueuedSQL queuedSQL) {
         if (!queuedSQL.stmt.isReadOnly) {
-            m_inputCRC.update(queuedSQL.stmt.sqlCRC);
+            byte[] serializedParams = null;
             try {
                 ByteBuffer buf = ByteBuffer.allocate(queuedSQL.params.getSerializedSize());
                 queuedSQL.params.flattenToBuffer(buf);
                 buf.flip();
-                m_inputCRC.update(buf.array());
+                serializedParams = buf.array();
                 queuedSQL.serialization = buf;
             } catch (IOException e) {
                 log.error("Unable to compute CRC of parameters to " +
@@ -595,6 +588,7 @@ public class ProcedureRunner {
                 // presumably, this will fail deterministically at all replicas
                 // just log the error and hope people report it
             }
+            m_determinismHash.offerStatement(queuedSQL.stmt, serializedParams);
         }
     }
 
@@ -613,7 +607,7 @@ public class ProcedureRunner {
         if (log.isDebugEnabled()) {
             if (!queuedSQL.stmt.isReadOnly) {
                 log.debug("voltQueueSQL receives " + queuedSQL.stmt.getText() + " " + queuedSQL.params.toString() +
-                        " txnid: " + m_txnState.txnId + ", hash: " + (int)m_inputCRC.getValue() );
+                        " txnid: " + m_txnState.txnId + ", hash: " + stmt.sqlCRC );
             }
         }
     }

--- a/src/frontend/org/voltdb/SQLStmt.java
+++ b/src/frontend/org/voltdb/SQLStmt.java
@@ -17,8 +17,6 @@
 
 package org.voltdb;
 
-import java.nio.ByteBuffer;
-
 import org.apache.hadoop_voltpatches.util.PureJavaCrc32C;
 import org.voltdb.common.Constants;
 import org.voltdb.planner.ActivePlanRepository;
@@ -54,7 +52,7 @@ public class SQLStmt {
     String sqlTextStr;
     String joinOrder;
     // hash of the SQL string for determinism checks
-    byte[] sqlCRC;
+    int sqlCRC;
 
     byte statementParamJavaTypes[];
 
@@ -100,8 +98,7 @@ public class SQLStmt {
         // create a hash for determinism purposes
         PureJavaCrc32C crc = new PureJavaCrc32C();
         crc.update(sqlText);
-        // ugly hack to get bytes from an int
-        this.sqlCRC = ByteBuffer.allocate(4).putInt((int) crc.getValue()).array();
+        this.sqlCRC = (int) crc.getValue();
 
         inCatalog = true;
     }

--- a/src/frontend/org/voltdb/SQLStmtAdHocHelper.java
+++ b/src/frontend/org/voltdb/SQLStmtAdHocHelper.java
@@ -73,4 +73,8 @@ public class SQLStmtAdHocHelper {
         sqlStmt.sqlText = null;
         sqlStmt.sqlTextStr = sql;
     }
+    
+    public static int getHash(SQLStmt sqlStmt) {
+        return sqlStmt.sqlCRC;
+    }
 }

--- a/src/frontend/org/voltdb/SQLStmtAdHocHelper.java
+++ b/src/frontend/org/voltdb/SQLStmtAdHocHelper.java
@@ -73,7 +73,7 @@ public class SQLStmtAdHocHelper {
         sqlStmt.sqlText = null;
         sqlStmt.sqlTextStr = sql;
     }
-    
+
     public static int getHash(SQLStmt sqlStmt) {
         return sqlStmt.sqlCRC;
     }

--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -647,7 +647,7 @@ class Distributer {
                 m_rateLimiter.transactionResponseReceived(nowNanos, clusterRoundTrip, stuff.ignoreBackpressure);
                 updateStats(stuff.name, deltaNanos, clusterRoundTrip, abort, error, false);
                 response.setClientRoundtrip(deltaNanos);
-                assert(response.getHash() == null); // make sure it didn't sneak into wire protocol
+                assert(response.getHashes() == null) : "A determinism hash snuck into the client wire protocol";
                 try {
                     cb.clientCallback(response);
                 } catch (Exception e) {

--- a/src/frontend/org/voltdb/iv2/DeterminismHash.java
+++ b/src/frontend/org/voltdb/iv2/DeterminismHash.java
@@ -76,8 +76,9 @@ public class DeterminismHash {
      * hash for the first int value in the array.
      */
     public int[] getHashes() {
-        int[] retval = new int[m_stmtCount * 2 + HEADER_OFFSET];
-        System.arraycopy(m_hashes, 0, retval, HEADER_OFFSET, m_stmtCount * 2);
+        int includedStmts = Math.min(m_stmtCount, MAX_STATEMENTS_WITH_DETAIL);
+        int[] retval = new int[includedStmts * 2 + HEADER_OFFSET];
+        System.arraycopy(m_hashes, 0, retval, HEADER_OFFSET, includedStmts * 2);
 
         m_inputCRC.update(m_catalogVersion);
         m_inputCRC.update(m_stmtCount);

--- a/src/frontend/org/voltdb/iv2/DeterminismHash.java
+++ b/src/frontend/org/voltdb/iv2/DeterminismHash.java
@@ -1,0 +1,152 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.iv2;
+
+import org.apache.hadoop_voltpatches.util.PureJavaCrc32C;
+import org.voltcore.logging.VoltLogger;
+import org.voltdb.SQLStmt;
+import org.voltdb.SQLStmtAdHocHelper;
+
+/**
+ * This class expands the determinsim hash of yesteryear with an array
+ * of hashes. For speed and memory reasons, this class is a simple int
+ * array, even though it's really three ints and then an array of int pairs.
+ *
+ * The first int is an overall hash, equivalent to the old hash value, but
+ * also including the catalog version of the procedure.
+ *
+ * Then catalog version (not hashed), then the number of DML statements run
+ * by the proc (not hashed).
+ *
+ * Then a list of pairs, up to MAX_STATEMENTS_WITH_DETAIL long.
+ *  a) The hash of the SQL text
+ *  b) The hash of the parameter values for that SQL statement.
+ *
+ * This array is passed around in ClientResponseImpl internally, where we
+ * used to pass a single long.
+ *
+ * It is not yet used for replay or command logging.
+ *
+ * Use the static helper function in this class to check two arrays and print
+ * helpful output.
+ */
+public class DeterminismHash {
+
+    protected static final VoltLogger m_tmLog = new VoltLogger("TM");
+
+    // HEADER IS:
+    // 1) total hash
+    // 2) catalog version
+    // 3) statement count
+    public final static int HEADER_OFFSET = 3;
+
+    public final static int MAX_STATEMENTS_WITH_DETAIL = 256;
+
+    int m_catalogVersion = 0;
+    int m_stmtCount = 0;
+
+    final int[] m_hashes = new int[MAX_STATEMENTS_WITH_DETAIL];
+
+    protected final PureJavaCrc32C m_inputCRC = new PureJavaCrc32C();
+    protected final PureJavaCrc32C m_stmtParamCRC = new PureJavaCrc32C();
+
+    public void reset(int catalogVersion) {
+        m_catalogVersion = catalogVersion;
+        m_inputCRC.reset();
+        m_stmtCount = 0;
+    }
+
+    /**
+     * Serialize the running hashes to an array and complete the overall
+     * hash for the first int value in the array.
+     */
+    public int[] getHashes() {
+        int[] retval = new int[m_stmtCount * 2 + HEADER_OFFSET];
+        System.arraycopy(m_hashes, 0, retval, HEADER_OFFSET, m_stmtCount * 2);
+
+        m_inputCRC.update(m_catalogVersion);
+        m_inputCRC.update(m_stmtCount);
+
+        // no work done means 0 hash to convey that
+        if (m_stmtCount == 0) {
+            retval[0] = 0;
+        }
+        else {
+            retval[0] = (int) m_inputCRC.getValue();
+        }
+        retval[1] = m_catalogVersion;
+        retval[2] = m_stmtCount;
+        return retval;
+    }
+
+    /**
+     * Update the overall hash. Add a pair of ints to the array
+     * if the size isn't too large.
+     */
+    public void offerStatement(SQLStmt stmt, byte[] serializedParams) {
+        int stmtHash = SQLStmtAdHocHelper.getHash(stmt);
+
+        m_inputCRC.update(stmtHash);
+        m_inputCRC.update(serializedParams);
+        if (m_stmtCount < MAX_STATEMENTS_WITH_DETAIL) {
+            m_stmtParamCRC.reset();
+            m_stmtParamCRC.update(serializedParams);
+
+            m_hashes[m_stmtCount * 2] = stmtHash;
+            m_hashes[m_stmtCount * 2 + 1] = (int) m_stmtParamCRC.getValue();
+        }
+        m_stmtCount++;
+    }
+
+    /**
+     * Compare two hash arrays return true if the same.
+     *
+     * For now, just compares first integer value in array.
+     */
+    public static boolean compareHashes(int[] leftHashes, int[] rightHashes) {
+        assert(leftHashes != null);
+        assert(rightHashes != null);
+        assert(leftHashes.length >= 3);
+        assert(rightHashes.length >= 3);
+
+        return leftHashes[0] == rightHashes[0];
+    }
+
+    /**
+     * Log the contents of the hash array
+     */
+    public static String description(int[] hashes) {
+        assert(hashes != null);
+        assert(hashes.length >= 3);
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("Full Hash ").append(hashes[0]);
+        sb.append(", Catalog Version ").append(hashes[1]);
+        sb.append(", Statement Count ").append(hashes[2]);
+
+        int includedStmts = Math.min(hashes[2], MAX_STATEMENTS_WITH_DETAIL);
+        for (int i = 0; i < includedStmts; ++i) {
+            sb.append("\n  Ran Statement ").append(hashes[i * 2 + HEADER_OFFSET]);
+            sb.append(" with Parameters ").append(hashes[i * 2 + HEADER_OFFSET + 1]);
+        }
+        if (hashes[2] > MAX_STATEMENTS_WITH_DETAIL) {
+            sb.append("\n  Additional SQL statements truncated");
+        }
+        return sb.toString();
+    }
+}

--- a/src/frontend/org/voltdb/iv2/DeterminismHash.java
+++ b/src/frontend/org/voltdb/iv2/DeterminismHash.java
@@ -60,7 +60,7 @@ public class DeterminismHash {
     int m_catalogVersion = 0;
     int m_stmtCount = 0;
 
-    final int[] m_hashes = new int[MAX_STATEMENTS_WITH_DETAIL];
+    final int[] m_hashes = new int[MAX_STATEMENTS_WITH_DETAIL * 2 + HEADER_OFFSET];
 
     protected final PureJavaCrc32C m_inputCRC = new PureJavaCrc32C();
     protected final PureJavaCrc32C m_stmtParamCRC = new PureJavaCrc32C();

--- a/src/frontend/org/voltdb/iv2/ProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/ProcedureTask.java
@@ -115,7 +115,13 @@ abstract public class ProcedureTask extends TransactionTask
                 // execute the procedure
                 cr = runner.call(callerParams);
 
-                m_txnState.setHash(cr.getHash());
+                // pass in the first value in the hashes array if it's not null
+                Integer hash = null;
+                int[] hashes = cr.getHashes();
+                if (hashes != null && hashes.length > 0) {
+                    hash = hashes[0];
+                }
+                m_txnState.setHash(hash);
                 //Don't pay the cost of returning the result tables for a replicated write
                 //With reads don't apply the optimization just in case
                 //                    if (!task.shouldReturnResultTables() && !task.isReadOnly()) {

--- a/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
@@ -97,7 +97,10 @@ public class SysProcDuplicateCounter extends DuplicateCounter
             tables.add(dep);
         }
 
-        return checkCommon(hash, message.isRecovering(), null, message);
+        // needs to be a three long array to work
+        int[] hashes = new int[] { (int) hash, 0, 0 };
+
+        return checkCommon(hashes, message.isRecovering(), null, message);
     }
 
     @Override

--- a/src/frontend/org/voltdb/messaging/InitiateResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/InitiateResponseMessage.java
@@ -19,6 +19,7 @@ package org.voltdb.messaging;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+
 import org.voltcore.messaging.Subject;
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
@@ -27,6 +28,7 @@ import org.voltdb.ClientResponseImpl;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.VoltTable;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.iv2.DeterminismHash;
 
 /**
  * Message from an execution site to initiator with the final response for
@@ -271,6 +273,10 @@ public class InitiateResponseMessage extends VoltMessage {
             sb.append("\n  COMMIT");
         else
             sb.append("\n  ROLLBACK/ABORT, ");
+        int[] hashes = m_response.getHashes();
+        if (hashes != null) {
+            sb.append("\n RESPONSE HASH: ").append(DeterminismHash.description(hashes));
+        }
         sb.append("\n CLIENT RESPONSE: \n");
         sb.append(m_response.toJSONString());
 


### PR DESCRIPTION
This isn't really enough, but it's a lot more to go on.

Example output:

```
2016-06-15 21:12:14,483   FATAL [SP 0 Site - 0:0] TM: Stored procedure NonDeterministicSPProc generated different SQL queries at different partitions. Shutting down to preserve data integrity.
2016-06-15 21:12:14,483   ERROR [SP 0 Site - 0:0] TM: HASH MISMATCH COMPARING: 521055388 to -1169211678
PREV MESSAGE: INITITATE_RESPONSE FOR TXN 3619631923232768
 SP HANDLE: 3619631923232768
 INITIATOR HSID: 1:-4
 COORDINATOR HSID: 0:0
 CLIENT INTERFACE HANDLE: 0
 CLIENT CONNECTION ID: 2
 READ-ONLY: false
 RECOVERING: false
 MISPARTITIONED: false
  COMMIT
 RESPONSE HASH: Full Hash -1169211678, Catalog Version 0, Statement Count 1
  Ran Statement -595975625 with Parameters -612913751
 CLIENT RESPONSE: 
{"status":1,"appstatus":-128,"statusstring":null,"appstatusstring":null,"results":[{"status":-128,"schema":[{"name":"","type":6}],"data":[]}]}
CURR MESSAGE: INITITATE_RESPONSE FOR TXN 3619631923232768
 SP HANDLE: 3619631923232768
 INITIATOR HSID: 0:0
 COORDINATOR HSID: 0:0
 CLIENT INTERFACE HANDLE: 0
 CLIENT CONNECTION ID: 2
 READ-ONLY: false
 RECOVERING: false
 MISPARTITIONED: false
  COMMIT
 RESPONSE HASH: Full Hash 521055388, Catalog Version 0, Statement Count 1
  Ran Statement -595975625 with Parameters 689712810
 CLIENT RESPONSE: 
{"status":1,"appstatus":-128,"statusstring":null,"appstatusstring":null,"results":[{"status":-128,"schema":[{"name":"","type":6}],"data":[]}]}
```
