### PR TITLE
ENG-10486:

### DIFF
--- a/src/frontend/org/voltdb/utils/VoltFile.java
+++ b/src/frontend/org/voltdb/utils/VoltFile.java
@@ -16,14 +16,15 @@
  */
 package org.voltdb.utils;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.*;
-import java.nio.*;
-import java.nio.channels.*;
 
 /*
  * Extend the File class and override its constructors to allow a property to be specified
@@ -265,7 +266,15 @@ public class VoltFile extends File {
             return pathname;
         }
         if (pathname.contains(m_magic)) {
-            return pathname;
+            if (pathname.contains(m_voltFilePrefix.getAbsolutePath())) {
+                return pathname;
+            }
+            else {
+                int offset = pathname.indexOf(m_magic) + m_magic.length();
+                String relativePath = pathname.substring(offset);
+                // The this is probably a snapshot path and needs to be re-mapped to our snapshot dir
+                return m_voltFilePrefix.getAbsolutePath() + relativePath;
+            }
         }
 
         if (m_voltFilePrefix != null) {

--- a/src/frontend/org/voltdb/utils/VoltFile.java
+++ b/src/frontend/org/voltdb/utils/VoltFile.java
@@ -272,7 +272,8 @@ public class VoltFile extends File {
             else {
                 int offset = pathname.indexOf(m_magic) + m_magic.length();
                 String relativePath = pathname.substring(offset);
-                // The this is probably a snapshot path and needs to be re-mapped to our snapshot dir
+                // The this is probably a snapshot path and needs to be re-mapped to our snapshot
+                // directory because truncation snapshot requests specify absolute paths
                 return m_voltFilePrefix.getAbsolutePath() + relativePath;
             }
         }


### PR DESCRIPTION
When truncation snapshots are taken the absolute path is specififed. For LocalCluster, this means that all hosts will write their snapshots to the same directory rather than the directory designated as the root for each host. This works fine if each snapshot instance contains data for all partitions but if the cluster is multi-host and not k-safe, multiple snapshots are required to complete a RECOVER.

This patch alters VoltFile (which is already LocalCluster aware) to convert file and directory requests to a different host directory to the correct host directory.