### PR TITLE
Add time stamp validity functions

### DIFF
--- a/buildtools.py
+++ b/buildtools.py
@@ -649,7 +649,13 @@ def runTests(CTX):
                 if targetpath.find(test) != -1:
                     isValgrindTest = False;
             if CTX.PLATFORM == "Linux" and isValgrindTest:
-                process = Popen(executable="valgrind", args=["valgrind", "--leak-check=full", "--show-reachable=yes", "--error-exitcode=-1", targetpath], stderr=PIPE, bufsize=-1)
+                process = Popen(executable="valgrind", args=["valgrind", 
+							     "--leak-check=full", 
+							     "--show-reachable=yes",
+							     "--error-exitcode=-1",
+							     "--suppressions=" + os.path.join(TEST_PREFIX,
+											      "test_utils/vdbsuppressions.supp"),
+							     targetpath], stderr=PIPE, bufsize=-1)
                 #out = process.stdout.readlines()
                 allHeapBlocksFreed = False
                 otherValgrindError = True

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -1854,6 +1854,34 @@ private:
     }
 
 
+    int compareBooleanValue (const NValue &rhs) const {
+        assert(m_valueType == VALUE_TYPE_BOOLEAN);
+
+        // get the right hand side as an integer.
+        if (rhs.getValueType() == VALUE_TYPE_BOOLEAN) {
+            bool rhsValue = rhs.getBoolean();
+            bool lhsValue = getBoolean();
+            if (lhsValue == rhsValue) {
+                return 0;
+            }
+            // False < True.  So,
+            //    compare(False, True)  = 1
+            //    compare(True,  False) = -1
+            if (lhsValue) {
+                return -1;
+            }
+            return 1;
+        }
+        char message[128];
+        snprintf(message, 128,
+                 "Type %s cannot be cast for comparison to type %s",
+                 valueToString(rhs.getValueType()).c_str(),
+                 valueToString(getValueType()).c_str());
+         throw SQLException(SQLException::data_exception_most_specific_type_mismatch,
+                            message);
+         // Not reached
+    }
+
     int compareTimestamp (const NValue& rhs) const {
         assert(m_valueType == VALUE_TYPE_TIMESTAMP);
 
@@ -2607,6 +2635,8 @@ inline int NValue::compare_withoutNull(const NValue& rhs) const {
         return comparePointValue(rhs);
     case VALUE_TYPE_GEOGRAPHY:
         return compareGeographyValue(rhs);
+    case VALUE_TYPE_BOOLEAN:
+        return compareBooleanValue(rhs);
     default: {
         throwDynamicSQLException(
                 "non comparable types lhs '%s' rhs '%s'",

--- a/src/ee/expressions/datefunctions.h
+++ b/src/ee/expressions/datefunctions.h
@@ -863,4 +863,28 @@ template<> inline NValue NValue::call<FUNC_VOLT_DATEADD_MICROSECOND>(const std::
     }
 }
 
+const int64_t MIN_VALID_TIMESTAMP_VALUE = GREGORIAN_EPOCH;
+const int64_t MAX_VALID_TIMESTAMP_VALUE = NYE9999;
+
+inline bool timestampIsValid(int64_t ts) {
+    return (MIN_VALID_TIMESTAMP_VALUE <= ts) && (ts <= MAX_VALID_TIMESTAMP_VALUE);
+}
+
+template<> inline NValue NValue::callConstant<FUNC_VOLT_MIN_VALID_TIMESTAMP>() {
+    return getTimestampValue(MIN_VALID_TIMESTAMP_VALUE);
+}
+
+template<> inline NValue NValue::callConstant<FUNC_VOLT_MAX_VALID_TIMESTAMP>() {
+    return getTimestampValue(MAX_VALID_TIMESTAMP_VALUE);
+}
+
+template<> inline NValue NValue::callUnary<FUNC_VOLT_IS_VALID_TIMESTAMP>() const {
+    if (isNull()) {
+        return getNullValue();
+    }
+    int64_t timestamp_number = castAsBigIntAndGetValue();
+    return getBooleanValue(timestampIsValid(timestamp_number));
+}
+
+
 }

--- a/src/ee/expressions/functionexpression.cpp
+++ b/src/ee/expressions/functionexpression.cpp
@@ -206,6 +206,12 @@ ExpressionUtil::functionFactory(int functionId, const std::vector<AbstractExpres
         case FUNC_PI:
             ret = new ConstantFunctionExpression<FUNC_PI>();
             break;
+        case FUNC_VOLT_MIN_VALID_TIMESTAMP:
+            ret = new ConstantFunctionExpression<FUNC_VOLT_MIN_VALID_TIMESTAMP>();
+            break;
+        case FUNC_VOLT_MAX_VALID_TIMESTAMP:
+            ret = new ConstantFunctionExpression<FUNC_VOLT_MAX_VALID_TIMESTAMP>();
+            break;
         default:
             return NULL;
         }
@@ -390,6 +396,9 @@ ExpressionUtil::functionFactory(int functionId, const std::vector<AbstractExpres
             break;
         case FUNC_VOLT_STR:
             ret = new UnaryFunctionExpression<FUNC_VOLT_STR>((*arguments)[0]);
+            break;
+        case FUNC_VOLT_IS_VALID_TIMESTAMP:
+            ret = new UnaryFunctionExpression<FUNC_VOLT_IS_VALID_TIMESTAMP>((*arguments)[0]);
             break;
         default:
             return NULL;

--- a/src/ee/expressions/functionexpression.h
+++ b/src/ee/expressions/functionexpression.h
@@ -281,6 +281,9 @@ static const int FUNC_VOLT_DWITHIN                     = 21017;     // wrapper i
 static const int FUNC_VOLT_DWITHIN_POINT_POINT         = 21018;     // if two points are within certain distance of each other
 static const int FUNC_VOLT_DWITHIN_POLYGON_POINT       = 21019;     // if a polygon and a point are within certain distance of each other
 static const int FUNC_VOLT_VALIDPOLYGONFROMTEXT        = 21020;     // like polygonfromtext, but also validates the result
+static const int FUNC_VOLT_MIN_VALID_TIMESTAMP         = 21021;     // minimum valid timestamp
+static const int FUNC_VOLT_MAX_VALID_TIMESTAMP         = 21022;     // maximum valid timestamp
+static const int FUNC_VOLT_IS_VALID_TIMESTAMP          = 21023;     // is a timestamp valid
 
 // From Tokens.java.
 static const int SQL_TRIM_LEADING                     = 149;

--- a/src/frontend/org/voltdb/expressions/FunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/FunctionExpression.java
@@ -359,6 +359,10 @@ public class FunctionExpression extends AbstractExpression {
                 connector = ", ";
             }
             result += ")";
+        } else {
+        	// The two functions MIN_VALID_TIMESTAMP and MAX_VALID_TIMESTAMP
+        	// are nullary.  Others may be in the future.
+        	result += "()";
         }
         return result;
     }

--- a/src/frontend/org/voltdb/expressions/FunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/FunctionExpression.java
@@ -360,9 +360,9 @@ public class FunctionExpression extends AbstractExpression {
             }
             result += ")";
         } else {
-        	// The two functions MIN_VALID_TIMESTAMP and MAX_VALID_TIMESTAMP
-        	// are nullary.  Others may be in the future.
-        	result += "()";
+            // The two functions MIN_VALID_TIMESTAMP and MAX_VALID_TIMESTAMP
+            // are nullary.  Others may be in the future.
+            result += "()";
         }
         return result;
     }

--- a/src/frontend/org/voltdb/jdbc/JDBC4DatabaseMetaData.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4DatabaseMetaData.java
@@ -883,7 +883,8 @@ public class JDBC4DatabaseMetaData implements java.sql.DatabaseMetaData
     {
         checkClosed();
         return "CURRENT_TIMESTAMP,DATEADD,DAY,DAYOFMONTH,DAYOFWEEK,DAYOFYEAR,EXTRACT,FROM_UNIXTIME,HOUR," +
-               "MINUT,MONTH,NOW,QUARTER,SECOND,SINCE_EPOCH,TO_TIMESTAMP,TRUNCATE,WEEK,WEEKOFYEAR,"+
+        	   "IS_VALID_TIMESTAMP,MAX_VALID_TIMESTAMP,MIN_VALID_TIMESTAMP," +
+               "MINUTE,MONTH,NOW,QUARTER,SECOND,SINCE_EPOCH,TO_TIMESTAMP,TRUNCATE,WEEK,WEEKOFYEAR,"+
                "WEEKDAY,YEAR";
     }
 
@@ -1721,14 +1722,16 @@ public class JDBC4DatabaseMetaData implements java.sql.DatabaseMetaData
         }
     }
 
-    public ResultSet getPseudoColumns(String catalog, String schemaPattern,
+    @Override
+	public ResultSet getPseudoColumns(String catalog, String schemaPattern,
             String tableNamePattern, String columnNamePattern)
             throws SQLException {
         checkClosed();
         throw SQLError.noSupport();
     }
 
-    public boolean generatedKeyAlwaysReturned() throws SQLException {
+    @Override
+	public boolean generatedKeyAlwaysReturned() throws SQLException {
         throw SQLError.noSupport();
     }
 }

--- a/src/frontend/org/voltdb/jdbc/JDBC4DatabaseMetaData.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4DatabaseMetaData.java
@@ -883,7 +883,7 @@ public class JDBC4DatabaseMetaData implements java.sql.DatabaseMetaData
     {
         checkClosed();
         return "CURRENT_TIMESTAMP,DATEADD,DAY,DAYOFMONTH,DAYOFWEEK,DAYOFYEAR,EXTRACT,FROM_UNIXTIME,HOUR," +
-        	   "IS_VALID_TIMESTAMP,MAX_VALID_TIMESTAMP,MIN_VALID_TIMESTAMP," +
+               "IS_VALID_TIMESTAMP,MAX_VALID_TIMESTAMP,MIN_VALID_TIMESTAMP," +
                "MINUTE,MONTH,NOW,QUARTER,SECOND,SINCE_EPOCH,TO_TIMESTAMP,TRUNCATE,WEEK,WEEKOFYEAR,"+
                "WEEKDAY,YEAR";
     }
@@ -1723,7 +1723,7 @@ public class JDBC4DatabaseMetaData implements java.sql.DatabaseMetaData
     }
 
     @Override
-	public ResultSet getPseudoColumns(String catalog, String schemaPattern,
+    public ResultSet getPseudoColumns(String catalog, String schemaPattern,
             String tableNamePattern, String columnNamePattern)
             throws SQLException {
         checkClosed();
@@ -1731,7 +1731,7 @@ public class JDBC4DatabaseMetaData implements java.sql.DatabaseMetaData
     }
 
     @Override
-	public boolean generatedKeyAlwaysReturned() throws SQLException {
+    public boolean generatedKeyAlwaysReturned() throws SQLException {
         throw SQLError.noSupport();
     }
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
@@ -167,6 +167,9 @@ public class FunctionForVoltDB extends FunctionSQL {
         static final int FUNC_VOLT_DWITHIN_POINT_POINT          = 21018;    // if two points are within certain distance of each other
         static final int FUNC_VOLT_DWITHIN_POLYGON_POINT        = 21019;    // if a polygon and a point are within certain distance of each other
         static final int FUNC_VOLT_VALIDPOLYGONFROMTEXT         = 21020;    // list polygonFromText, but validates after construction
+        static final int FUNC_VOLT_MIN_VALID_TIMESTAMP          = 21021;    // Minimum valid timestamp.
+        static final int FUNC_VOLT_MAX_VALID_TIMESTAMP          = 21022;    // Maximum valid timestamp.
+        static final int FUNC_VOLT_IS_VALID_TIMESTAMP           = 21023;    // Is a timestamp value in range?
 
 
         /*
@@ -357,6 +360,16 @@ public class FunctionForVoltDB extends FunctionSQL {
             new FunctionId("validpolygonfromtext", Type.VOLT_GEOGRAPHY, FUNC_VOLT_VALIDPOLYGONFROMTEXT, -1,
                     new Type[] { Type.SQL_VARCHAR },
                     new short[] {  Tokens.OPENBRACKET, Tokens.QUESTION, Tokens.CLOSEBRACKET }),
+
+            new FunctionId("min_valid_timestamp", Type.SQL_TIMESTAMP, FUNC_VOLT_MIN_VALID_TIMESTAMP, -1,
+            		new Type[] {},
+            		new short[] { Tokens.OPENBRACKET, Tokens.CLOSEBRACKET }),
+            new FunctionId("max_valid_timestamp", Type.SQL_TIMESTAMP, FUNC_VOLT_MAX_VALID_TIMESTAMP, -1,
+            		new Type[] {},
+            		new short[] { Tokens.OPENBRACKET, Tokens.CLOSEBRACKET }),
+            new FunctionId("is_valid_timestamp", Type.SQL_BOOLEAN, FUNC_VOLT_IS_VALID_TIMESTAMP, -1,
+            		new Type[] { Type.SQL_TIMESTAMP },
+            		new short[] { Tokens.OPENBRACKET, Tokens.QUESTION, Tokens.CLOSEBRACKET }),
         };
 
         private static Map<String, FunctionId> by_LC_name = new HashMap<String, FunctionId>();

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
@@ -721,7 +721,11 @@ public class FunctionForVoltDB extends FunctionSQL {
             break;
         }
         default:
-            sb.append(nodes[0].getSQL());
+        	// If this is a nullary function, we don't want to
+        	// crash here.
+        	if (0 < nodes.length) {
+        		sb.append(nodes[0].getSQL());
+        	}
             break;
         }
         for (int ii = 1; ii < nodes.length; ii++) {

--- a/template.classpath
+++ b/template.classpath
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="src" path="src/frontend"/>
-    <classpathentry kind="src" path="tests/frontend"/>
-    <classpathentry kind="src" path="tests/testprocs"/>
-    <classpathentry kind="src" path="tests/hsqldb"/>
-    <classpathentry kind="src" path="src/hsqldb19b3"/>
-    <classpathentry kind="src" path="third_party/java/src"/>
-    <classpathentry kind="lib" path="lib/commons-lang3-3.0.jar"/>
-    <classpathentry kind="lib" path="lib/jline-2.10.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/hamcrest-all-1.3.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/ant-junit.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/ant-testability-explorer.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/ant.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/emma_ant.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/emma.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/japex.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/jcommon-1.0.16.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/jfreechart-1.0.13.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/junit-dep-4.10.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/pmd-4.2.5.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/testability-explorer.jar"/>
-    <classpathentry kind="lib" path="lib/log4j-1.2.16.jar"/>
-    <classpathentry kind="lib" path="lib/jetty-http-9.3.6.v20151106.jar"/>
-    <classpathentry kind="lib" path="lib/jetty-server-9.3.6.v20151106.jar"/>
-    <classpathentry kind="lib" path="lib/servlet-api-3.1.jar"/>
-    <classpathentry kind="lib" path="lib/jetty-util-9.3.6.v20151106.jar"/>
-    <classpathentry kind="lib" path="lib/jetty-continuation-9.3.6.v20151106.jar"/>
-    <classpathentry kind="lib" path="lib/jetty-io-9.3.6.v20151106.jar"/>
-    <classpathentry kind="lib" path="lib/slf4j-api-1.6.2.jar"/>
-    <classpathentry kind="lib" path="lib/slf4j-nop-1.6.2.jar"/>
-    <classpathentry kind="lib" path="lib/jna.jar"/>
-    <classpathentry kind="lib" path="lib/protobuf-java-2.5.0.jar"/>
-    <classpathentry kind="lib" path="lib/snappy-java-1.1.1.7.jar"/>
-    <classpathentry kind="lib" path="lib/jsch-0.1.51.jar"/>
-    <classpathentry kind="lib" path="lib/super-csv-2.1.0.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/mockito-all-1.10.19.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/objenesis-2.1.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/make-it-easy-3.1.0.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/javaee-api-7.0.jar"/>
-    <classpathentry kind="lib" path="lib/groovy-all-2.1.7-indy.jar"/>
-    <classpathentry kind="lib" path="lib/kafka-clients-0.8.2.1.jar"/>
-    <classpathentry kind="lib" path="lib/kafka_2.10-0.8.2.1.jar"/>
-    <classpathentry kind="lib" path="lib/lz4-1.2.0.jar"/>
-    <classpathentry kind="lib" path="lib/metrics-core-2.2.0.jar"/>
-    <classpathentry kind="lib" path="lib/scala-library-2.10.4.jar"/>
-    <classpathentry kind="lib" path="lib/jackson-core-asl-1.9.13.jar"/>
-    <classpathentry kind="lib" path="lib/jackson-mapper-asl-1.9.13.jar"/>
-    <classpathentry kind="lib" path="lib/felix.jar"/>
-    <classpathentry kind="lib" path="lib/httpclient-4.3.2.jar"/>
-    <classpathentry kind="lib" path="lib/httpcore-4.3.2.jar"/>
-    <classpathentry kind="lib" path="lib/commons-logging-1.1.3.jar"/>
-    <classpathentry kind="lib" path="lib/tomcat-jdbc.jar"/>
-    <classpathentry kind="lib" path="third_party/java/jars/amazon-kinesis-client-1.6.2.jar" />
-    <classpathentry kind="lib" path="third_party/java/jars/aws-java-sdk-1.10.72.jar" />
-    <classpathentry kind="lib" path="third_party/java/jars/jackson-dataformat-cbor-2.5.3.jar" />
-    <classpathentry kind="lib" path="third_party/java/jars/jackson-databind-2.5.3.jar" />
-    <classpathentry kind="lib" path="third_party/java/jars/jackson-core-2.5.3.jar" />
-    <classpathentry kind="lib" path="third_party/java/jars/jackson-annotations-2.5.0.jar" />
-    <classpathentry kind="lib" path="third_party/java/jars/joda-time-2.9.3.jar" />
-    <classpathentry kind="lib" path="third_party/java/jars/commons-lang-2.6.jar" />
-    <classpathentry kind="lib" path="third_party/java/jars/guava-18.0.jar" />
-    <classpathentry kind="lib" path="third_party/java/jars/protobuf-java-2.6.1.jar" />
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-        <attributes>
-            <attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="voltdb/voltdb"/>
-        </attributes>
-    </classpathentry>
-
-    <classpathentry kind="output" path="obj/eclipse"/>
+	<classpathentry kind="src" path="src/frontend"/>
+	<classpathentry kind="src" path="tests/frontend"/>
+	<classpathentry kind="src" path="tests/testprocs"/>
+	<classpathentry kind="src" path="tests/hsqldb"/>
+	<classpathentry kind="src" path="src/hsqldb19b3"/>
+	<classpathentry kind="src" path="third_party/java/src"/>
+	<classpathentry kind="lib" path="lib/commons-lang3-3.0.jar"/>
+	<classpathentry kind="lib" path="lib/jline-2.10.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/hamcrest-all-1.3.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/ant-junit.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/ant-testability-explorer.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/ant.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/emma_ant.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/emma.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/japex.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/jcommon-1.0.16.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/jfreechart-1.0.13.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/junit-dep-4.10.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/pmd-4.2.5.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/testability-explorer.jar"/>
+	<classpathentry kind="lib" path="lib/log4j-1.2.16.jar"/>
+	<classpathentry kind="lib" path="lib/jetty-http-9.3.6.v20151106.jar"/>
+	<classpathentry kind="lib" path="lib/jetty-server-9.3.6.v20151106.jar"/>
+	<classpathentry kind="lib" path="lib/servlet-api-3.1.jar"/>
+	<classpathentry kind="lib" path="lib/jetty-util-9.3.6.v20151106.jar"/>
+	<classpathentry kind="lib" path="lib/jetty-continuation-9.3.6.v20151106.jar"/>
+	<classpathentry kind="lib" path="lib/jetty-io-9.3.6.v20151106.jar"/>
+	<classpathentry kind="lib" path="lib/slf4j-api-1.6.2.jar"/>
+	<classpathentry kind="lib" path="lib/slf4j-nop-1.6.2.jar"/>
+	<classpathentry kind="lib" path="lib/jna.jar"/>
+	<classpathentry kind="lib" path="lib/protobuf-java-2.5.0.jar"/>
+	<classpathentry kind="lib" path="lib/snappy-java-1.1.1.7.jar"/>
+	<classpathentry kind="lib" path="lib/jsch-0.1.51.jar"/>
+	<classpathentry kind="lib" path="lib/super-csv-2.1.0.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/mockito-all-1.10.19.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/objenesis-2.1.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/make-it-easy-3.1.0.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/javaee-api-7.0.jar"/>
+	<classpathentry kind="lib" path="lib/groovy-all-2.1.7-indy.jar"/>
+	<classpathentry kind="lib" path="lib/kafka-clients-0.8.2.1.jar"/>
+	<classpathentry kind="lib" path="lib/kafka_2.10-0.8.2.1.jar"/>
+	<classpathentry kind="lib" path="lib/lz4-1.2.0.jar"/>
+	<classpathentry kind="lib" path="lib/metrics-core-2.2.0.jar"/>
+	<classpathentry kind="lib" path="lib/scala-library-2.10.4.jar"/>
+	<classpathentry kind="lib" path="lib/jackson-core-asl-1.9.13.jar"/>
+	<classpathentry kind="lib" path="lib/jackson-mapper-asl-1.9.13.jar"/>
+	<classpathentry kind="lib" path="lib/felix.jar"/>
+	<classpathentry kind="lib" path="lib/httpclient-4.3.2.jar"/>
+	<classpathentry kind="lib" path="lib/httpcore-4.3.2.jar"/>
+	<classpathentry kind="lib" path="lib/commons-logging-1.1.3.jar"/>
+	<classpathentry kind="lib" path="lib/tomcat-jdbc.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/amazon-kinesis-client-1.6.2.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/aws-java-sdk-1.10.72.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/jackson-dataformat-cbor-2.5.3.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/jackson-databind-2.5.3.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/jackson-core-2.5.3.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/jackson-annotations-2.5.0.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/joda-time-2.9.3.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/commons-lang-2.6.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/guava-18.0.jar"/>
+	<classpathentry kind="lib" path="third_party/java/jars/protobuf-java-2.6.1.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="voltdb/voltdb"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib/tomcat-juli.jar"/>
+	<classpathentry kind="output" path="obj/eclipse"/>
 </classpath>

--- a/tests/ee/test_utils/vdbsuppressions.supp
+++ b/tests/ee/test_utils/vdbsuppressions.supp
@@ -1,0 +1,12 @@
+{
+   stlvector
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/lib/x86_64-linux-gnu/ld-2.19.so
+}
+

--- a/tests/ee/test_utils/vdbsuppressions.supp
+++ b/tests/ee/test_utils/vdbsuppressions.supp
@@ -1,7 +1,6 @@
 {
    stlvector
    Memcheck:Leak
-   match-leak-kinds: reachable
    fun:malloc
    obj:/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22
    fun:call_init.part.0

--- a/tests/frontend/org/voltdb/fullddlfeatures/fullDDL.sql
+++ b/tests/frontend/org/voltdb/fullddlfeatures/fullDDL.sql
@@ -1148,6 +1148,11 @@ CREATE INDEX ENG_8168_INDEX_USES_YEAR ON T55 (YEAR(TS) - 1900);
 -- Wrap up with a minor variant of an index already tried to show that
 -- the previous line didn't corrupt catalog replay.
 CREATE INDEX ENG_8168_INDEX_USES_ABS_AGAIN ON T55 (ABS(BIG - 1));
+-- Verify that we can use MIN_VALID_TIMESTAMP and MAX_VALID_TIMESTAMP in indices
+CREATE INDEX ENG_10490_INDEX_USES_MIN_VALID_TIMESTAMP ON T55 
+        (SINCE_EPOCH(MICROS, TS)                     - SINCE_EPOCH(MICROS, MIN_VALID_TIMESTAMP()),
+         SINCE_EPOCH(MICROS, MAX_VALID_TIMESTAMP())  - SINCE_EPOCH(MICROS, TS))
+     WHERE IS_VALID_TIMESTAMP(TS);
 
 
 -- Test for polygon validity.


### PR DESCRIPTION
This commit adds the timestamp validity functions MIN_VALID_TIMESTAMP, MAX_VALID_TIMESTAMP and IS_VALID_TIMESTAMP.

Along with this we added a valgrind suppression file which suppresses false positive memory leak warnings.  We also added a boolean comparison in the EE.  This is necessary to test the results of boolean valued functions.  Finally, we added a testNullary() test operation in the EE tests.

https://issues.voltdb.com/browse/ENG-10559
