### PR TITLE
ENG-10373: Fix XDCR conflict log timestamps to be based on unix epoch

### DIFF
--- a/build.py
+++ b/build.py
@@ -448,6 +448,7 @@ if whichtests in ("${eetestsuite}", "common"):
      tupleschema_test
      undolog_test
      valuearray_test
+     uniqueid_test
     """
 
 if whichtests in ("${eetestsuite}", "execution"):

--- a/src/ee/common/UniqueId.hpp
+++ b/src/ee/common/UniqueId.hpp
@@ -23,12 +23,14 @@
 
 namespace voltdb
 {
+const static int64_t VOLT_EPOCH = 1199145600000000L;
+const static int64_t VOLT_EPOCH_IN_MILLIS = 1199145600000L;
+
 class UniqueId {
 public:
     const static int64_t TIMESTAMP_BITS = 40;
     const static int64_t COUNTER_BITS = 9;
     const static int64_t PARTITIONID_BITS = 14;
-    const static int64_t VOLT_EPOCH = 1199145600000L;
     const static int64_t TIMESTAMP_MAX_VALUE = (1L << TIMESTAMP_BITS) - 1L;
     const static int64_t COUNTER_MAX_VALUE = (1L << COUNTER_BITS) - 1L;
     const static int64_t TIMESTAMP_PLUS_COUNTER_MAX_VALUE = (1LL << (TIMESTAMP_BITS + COUNTER_BITS)) - 1LL;
@@ -37,8 +39,8 @@ public:
     const static int64_t MP_INIT_PID = PARTITION_ID_MASK;
 
     static UniqueId makeIdFromComponents(int64_t ts, int64_t seqNo, int64_t partitionId) {
-        // compute the time in millis since VOLT_EPOCH
-        int64_t uniqueId = ts - VOLT_EPOCH;
+        // compute the time in millis since VOLT_EPOCH_IN_MILLIS
+        int64_t uniqueId = ts - VOLT_EPOCH_IN_MILLIS;
         // verify all fields are the right size
         assert(uniqueId <= TIMESTAMP_MAX_VALUE);
         assert(seqNo <= COUNTER_MAX_VALUE);

--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -33,8 +33,6 @@ using namespace std;
 
 namespace voltdb {
 
-const int64_t VOLT_EPOCH = epoch_microseconds_from_components(2008);
-
 static pthread_key_t static_key;
 static pthread_once_t static_keyOnce = PTHREAD_ONCE_INIT;
 

--- a/src/ee/common/executorcontext.hpp
+++ b/src/ee/common/executorcontext.hpp
@@ -31,6 +31,7 @@
 namespace voltdb {
 
 extern const int64_t VOLT_EPOCH;
+extern const int64_t VOLT_EPOCH_IN_MILLIS;
 
 class AbstractExecutor;
 class AbstractDRTupleStream;
@@ -84,7 +85,7 @@ class ExecutorContext {
         m_txnId = txnId;
         m_lastCommittedSpHandle = lastCommittedSpHandle;
         m_uniqueId = uniqueId;
-        m_currentTxnTimestamp = (m_uniqueId >> 23) + VOLT_EPOCH;
+        m_currentTxnTimestamp = (m_uniqueId >> 23) + VOLT_EPOCH_IN_MILLIS;
         m_currentDRTimestamp = createDRTimestampHiddenValue(static_cast<int64_t>(m_drClusterId), m_uniqueId);
     }
 

--- a/tests/ee/common/uniqueid_test.cpp
+++ b/tests/ee/common/uniqueid_test.cpp
@@ -1,0 +1,73 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/* Copyright (C) 2008
+ * Evan Jones
+ * Massachusetts Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "harness.h"
+#include "common/UniqueId.hpp"
+
+using namespace std;
+using namespace voltdb;
+
+class UniqueIdTest : public Test {
+public:
+    UniqueIdTest() {}
+};
+
+TEST_F(UniqueIdTest, TimestampRoundtrip) {
+    int64_t ts = 1451606400000; // 2016-01-01 00:00:00
+    int64_t seqNo = 99;
+    int64_t partitionId = 3;
+    UniqueId uid = UniqueId::makeIdFromComponents(ts, seqNo, partitionId);
+
+    EXPECT_EQ(ts * 1000 + seqNo, UniqueId::timestampSinceUnixEpoch(uid));
+}
+
+int main() {
+    return TestSuite::globalInstance()->runAll();
+}


### PR DESCRIPTION
1. Add a constant VOLT_EPOCH_IN_MILLIS to denote volt epoch in unit of millisecond.
2. Fix the old VOLT_EPOCH constant in UniqueId.cpp to have the correct microsecond-unit volt epoch value.
3. Add a unit test to make sure microsecond-unit timestamp can be extracted from uniqueId correctly.