### PR TITLE
ENG-10354, fix NPE during elastic join.

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -1110,11 +1110,8 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                     Procedure procedure = null;
 
                     if (invocation != null) {
-                        procedure = catalogContext.procedures.get(invocation.getProcName());
-                        if (procedure == null) {
-                            procedure = SystemProcedureCatalog.listing.get(invocation.getProcName())
-                                                              .asCatalogProcedure();
-                        }
+                        procedure = getProcedureFromName(invocation.getProcName(), catalogContext);
+                        assert (procedure != null);
                     }
 
                     //Can be null on hangup


### PR DESCRIPTION
NPE is caused by using default CRUD procedure while elastic joining, CI fails to
lookup default procedure before it thinks this is a sysproc.

Change-Id: Ib82af94954cc63a4d5f6f53b805096ae6bbc18ac