### PR TITLE
ENG-10634: Fix handling of fast read invocation response.

### DIFF
--- a/src/frontend/org/voltdb/iv2/DuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/DuplicateCounter.java
@@ -82,7 +82,7 @@ public class DuplicateCounter
         String msg = String.format("HASH MISMATCH COMPARING: %d to %d\n"
                 + "REQUEST MESSAGE: %s\n"
                 + "PREV RESPONSE MESSAGE: %s\n"
-                + "CURR REsPONSE MESSAGE: %s\n",
+                + "CURR RESPONSE MESSAGE: %s\n",
                 hash,
                 m_responseHash,
                 m_openMessage.toString(),

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -680,15 +680,21 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     // Pass a response through the duplicate counters.
     public void handleInitiateResponseMessage(InitiateResponseMessage message)
     {
-        // All single-partition reads are short-circuit reads and will have no duplicate counter.
-        // SpScheduler will only see InitiateResponseMessages for SP transactions, so if it's
-        // read-only here, it's short-circuited.  Avoid all the lookup below.  Also, don't update
-        // the truncation handle, since it won't have meaning for anyone.
-        /*if (message.isReadOnly()) {
+        /**
+         * A shortcut read is a read operation sent to any replica and completed with no
+         * confirmation or communication with other replicas. In a partition scenario, it's
+         * possible to read an unconfirmed transaction's writes that will be lost.
+         */
+        boolean shortcutRead = message.isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+
+        // All short-circuit reads will have no duplicate counter.
+        // Avoid all the lookup below.
+        // Also, don't update the truncation handle, since it won't have meaning for anyone.
+        if (shortcutRead) {
             // the initiatorHSId is the ClientInterface mailbox. Yeah. I know.
             m_mailbox.send(message.getInitiatorHSId(), message);
             return;
-        }*/
+        }
 
         final long spHandle = message.getSpHandle();
         final DuplicateCounterKey dcKey = new DuplicateCounterKey(message.getTxnId(), spHandle);


### PR DESCRIPTION
The initiate response message was still looking for a duplicate counter, even if it was supposed to be a "fast" response. This was dumb oversight.

Also fix typo.

[http://ci/view/Branch-jobs/view/branch-ENG-10634-fastread-mismatch](http://ci/view/Branch-jobs/view/branch-ENG-10634-fastread-mismatch)