### PR TITLE
Limit 0 should really return 0 rows.

### DIFF
--- a/src/ee/executors/orderbyexecutor.cpp
+++ b/src/ee/executors/orderbyexecutor.cpp
@@ -131,49 +131,56 @@ OrderByExecutor::p_execute(const NValueArray &params)
     VOLT_TRACE("Input Table:\n '%s'", input_table->debug().c_str());
     TableIterator iterator = input_table->iterator();
     TableTuple tuple(input_table->schema());
-    vector<TableTuple> xs;
-    ProgressMonitorProxy pmp(m_engine, this);
-    while (iterator.next(tuple))
-    {
-        pmp.countdownProgress();
-        assert(tuple.isActive());
-        xs.push_back(tuple);
-    }
-    VOLT_TRACE("\n***** Input Table PreSort:\n '%s'",
-               input_table->debug().c_str());
+
+    // If limit == 0 we have no work here.  There's no need to sort anything,
+    // or to fetch the vector of tuples from the input.  If limit < 0 we
+    // need to do the loop below, though.  The only case where we can skip
+    // is if limit == 0.
+    if (limit != 0) {
+        vector<TableTuple> xs;
+        ProgressMonitorProxy pmp(m_engine, this);
+        while (iterator.next(tuple))
+        {
+            pmp.countdownProgress();
+            assert(tuple.isActive());
+            xs.push_back(tuple);
+        }
+        VOLT_TRACE("\n***** Input Table PreSort:\n '%s'",
+                   input_table->debug().c_str());
 
 
-    if (limit >= 0 && xs.begin() + limit + offset < xs.end()) {
-        // partial sort
-        partial_sort(xs.begin(), xs.begin() + limit + offset, xs.end(),
-                AbstractExecutor::TupleComparer(node->getSortExpressions(), node->getSortDirections()));
-    } else {
-        // full sort
-        sort(xs.begin(), xs.end(),
-                AbstractExecutor::TupleComparer(node->getSortExpressions(), node->getSortDirections()));
-    }
-
-    int tuple_ctr = 0;
-    int tuple_skipped = 0;
-    for (vector<TableTuple>::iterator it = xs.begin(); it != xs.end(); it++)
-    {
-        //
-        // Check if has gone past the offset
-        //
-        if (tuple_skipped < offset) {
-            tuple_skipped++;
-            continue;
+        if (limit >= 0 && xs.begin() + limit + offset < xs.end()) {
+            // partial sort
+            partial_sort(xs.begin(), xs.begin() + limit + offset, xs.end(),
+                    AbstractExecutor::TupleComparer(node->getSortExpressions(), node->getSortDirections()));
+        } else {
+            // full sort
+            sort(xs.begin(), xs.end(),
+                    AbstractExecutor::TupleComparer(node->getSortExpressions(), node->getSortDirections()));
         }
 
-        VOLT_TRACE("\n***** Input Table PostSort:\n '%s'",
-                   input_table->debug().c_str());
-        output_table->insertTupleNonVirtual(*it);
-        pmp.countdownProgress();
-        //
-        // Check whether we have gone past our limit
-        //
-        if (limit >= 0 && ++tuple_ctr >= limit) {
-            break;
+        int tuple_ctr = 0;
+        int tuple_skipped = 0;
+        // If (limit < 0), so we don't have a limit at all, then just compare
+        // the iterator with the end.  Otherwise check that the tuple_counter is
+        // not over the limit.
+        for (vector<TableTuple>::iterator it = xs.begin();
+             ((limit < 0) ? true : (tuple_ctr < limit)) && it != xs.end();
+             it++)
+        {
+            //
+            // Check if has gone past the offset
+            //
+            if (tuple_skipped < offset) {
+                tuple_skipped++;
+                continue;
+            }
+
+            VOLT_TRACE("\n***** Input Table PostSort:\n '%s'",
+                       input_table->debug().c_str());
+            output_table->insertTupleNonVirtual(*it);
+            pmp.countdownProgress();
+            tuple_ctr += 1;
         }
     }
     VOLT_TRACE("Result of OrderBy:\n '%s'", output_table->debug().c_str());

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -685,8 +685,12 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         }
 
         // limit and offset can't have both value and parameter
-        if (limitOffset.m_limit != -1) assert limitOffset.m_limitParameterId == -1 : "Parsed value and param. limit.";
-        if (limitOffset.m_offset != 0) assert limitOffset.m_offsetParameterId == -1 : "Parsed value and param. offset.";
+        if (limitOffset.m_limit != -1) {
+            assert limitOffset.m_limitParameterId == -1 : "Parsed value and param. limit.";
+        }
+        if (limitOffset.m_offset != 0) {
+            assert limitOffset.m_offsetParameterId == -1 : "Parsed value and param. offset.";
+        }
     }
 
     private void parseDisplayColumns(VoltXMLElement columnsNode, boolean isDistributed) {

--- a/tests/frontend/org/voltdb/regressionsuites/TestLimitOffsetSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestLimitOffsetSuite.java
@@ -118,7 +118,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         }
     }
 
-    public void notestBasicLimitOffsets() throws IOException, ProcCallException, InterruptedException
+    public void testBasicLimitOffsets() throws IOException, ProcCallException, InterruptedException
     {
         Client client = this.getClient();
         load(client);
@@ -188,7 +188,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         }
     }
 
-    public void notestDistinctLimitOffset() throws NoConnectionsException, IOException, ProcCallException
+    public void testDistinctLimitOffset() throws NoConnectionsException, IOException, ProcCallException
     {
         Client client = getClient();
         client.callProcedure("InsertA", 0, 1);
@@ -203,7 +203,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         assertEquals(0, result.getRowCount());
     }
 
-    public void notestENG3487() throws IOException, ProcCallException
+    public void testENG3487() throws IOException, ProcCallException
     {
         Client client = this.getClient();
 
@@ -226,7 +226,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
 
     }
 
-    public void notestENG1808() throws IOException, ProcCallException
+    public void testENG1808() throws IOException, ProcCallException
     {
         Client client = this.getClient();
 
@@ -237,7 +237,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         assertEquals(0, result.getRowCount());
     }
 
-    public void notestENG5156() throws IOException, ProcCallException {
+    public void testENG5156() throws IOException, ProcCallException {
         Client client = this.getClient();
         VoltTable result = null;
 
@@ -268,7 +268,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         validateTableOfLongs(result, new long[][] {{2,2}});
     }
 
-    public void notestENG6485() throws IOException, ProcCallException {
+    public void testENG6485() throws IOException, ProcCallException {
         Client client = this.getClient();
         VoltTable result = null;
 
@@ -315,7 +315,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
             fail("cannot get data from table c");
         }
     }
-    public void notestSubqueryLimit() throws Exception {
+    public void testSubqueryLimit() throws Exception {
         Client client = getClient();
 
         ClientResponse cr;

--- a/tests/frontend/org/voltdb/regressionsuites/TestLimitOffsetSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestLimitOffsetSuite.java
@@ -118,7 +118,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         }
     }
 
-    public void testBasicLimitOffsets() throws IOException, ProcCallException, InterruptedException
+    public void notestBasicLimitOffsets() throws IOException, ProcCallException, InterruptedException
     {
         Client client = this.getClient();
         load(client);
@@ -188,7 +188,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         }
     }
 
-    public void testDistinctLimitOffset() throws NoConnectionsException, IOException, ProcCallException
+    public void notestDistinctLimitOffset() throws NoConnectionsException, IOException, ProcCallException
     {
         Client client = getClient();
         client.callProcedure("InsertA", 0, 1);
@@ -203,7 +203,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         assertEquals(0, result.getRowCount());
     }
 
-    public void testENG3487() throws IOException, ProcCallException
+    public void notestENG3487() throws IOException, ProcCallException
     {
         Client client = this.getClient();
 
@@ -226,7 +226,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
 
     }
 
-    public void testENG1808() throws IOException, ProcCallException
+    public void notestENG1808() throws IOException, ProcCallException
     {
         Client client = this.getClient();
 
@@ -237,7 +237,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         assertEquals(0, result.getRowCount());
     }
 
-    public void testENG5156() throws IOException, ProcCallException {
+    public void notestENG5156() throws IOException, ProcCallException {
         Client client = this.getClient();
         VoltTable result = null;
 
@@ -268,7 +268,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         validateTableOfLongs(result, new long[][] {{2,2}});
     }
 
-    public void testENG6485() throws IOException, ProcCallException {
+    public void notestENG6485() throws IOException, ProcCallException {
         Client client = this.getClient();
         VoltTable result = null;
 
@@ -315,7 +315,7 @@ public class TestLimitOffsetSuite extends RegressionSuite {
             fail("cannot get data from table c");
         }
     }
-    public void testSubqueryLimit() throws Exception {
+    public void notestSubqueryLimit() throws Exception {
         Client client = getClient();
 
         ClientResponse cr;
@@ -349,6 +349,68 @@ public class TestLimitOffsetSuite extends RegressionSuite {
         tbl = cr.getResults()[0];
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
         validateTableOfLongs(tbl, new long[][]{{-3364L}, {-3364}, {11411}, {11411}});
+    }
+
+    public void testLimitZeroWithOrderBy() throws Exception {
+        Client client = getClient();
+        ClientResponse cr;
+        VoltTable vt;
+
+        // Check that limit 0 on a table with no indices or partitions
+        // works as expected, and that it doesn't break other limits.
+        cr = client.callProcedure("PLAINJANE.insert", 100, 101, 102);
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+        cr = client.callProcedure("PLAINJANE.insert", 200, 201, 202);
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+        cr = client.callProcedure("PLAINJANE.insert", 300, 301, 302);
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+        cr = client.callProcedure("PLAINJANE.insert", 400, 401, 402);
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+        cr = client.callProcedure("PLAINJANE.insert", 500, 501, 502);
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        for (int idx = 0; idx < 5; idx += 1) {
+            String sql = "SELECT * FROM PLAINJANE ORDER BY ID LIMIT " + idx + ";";
+            cr = client.callProcedure("@AdHoc", sql);
+            assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+            vt = cr.getResults()[0];
+            assertEquals(idx, vt.getRowCount());
+        }
+
+        // Check the same thing using a table with an index.  This is
+        // important since the plan may be different.  The order by
+        // node of the plan may be avoided by scanning the index.
+        cr = client.callProcedure("@AdHoc", "INSERT INTO R1 VALUES (8, 'nSAFoccWXxEGXR', -3364, 7.76005886643784892343e-01);");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        cr = client.callProcedure("@AdHoc", "INSERT INTO R1 VALUES (9, 'nSAFoccWXxEGXR', -3364, 8.65086522017155634678e-01);");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        cr = client.callProcedure("@AdHoc", "INSERT INTO R1 VALUES (10, 'nSAFoccWXxEGXR', 11411, 3.49977104648325210157e-01);");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        cr = client.callProcedure("@AdHoc", "INSERT INTO R1 VALUES (11, 'nSAFoccWXxEGXR', 11411, 4.96260220021031761561e-01);");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        cr = client.callProcedure("@AdHoc", "INSERT INTO R1 VALUES (12, 'ebWfhdmIZfYhRC', NULL, 3.94021683247165688257e-01);");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        cr = client.callProcedure("@AdHoc", "INSERT INTO R1 VALUES (13, 'ebWfhdmIZfYhRC', NULL, 2.97950296374613898820e-02);");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        cr = client.callProcedure("@AdHoc", "INSERT INTO R1 VALUES (14, 'ebWfhdmIZfYhRC', 23926, 8.56241324965489991605e-01);");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        cr = client.callProcedure("@AdHoc", "INSERT INTO R1 VALUES (15, 'ebWfhdmIZfYhRC', 23926, 3.61291695704730075889e-01); ");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        for (int idx = 0; idx < 5; idx += 1) {
+            String sql = "SELECT * FROM R1 ORDER BY ID LIMIT " + idx + ";";
+            cr = client.callProcedure("@AdHoc", sql);
+            assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+            vt = cr.getResults()[0];
+            assertEquals(idx, vt.getRowCount());
+        }
     }
 
     static public junit.framework.Test suite()

--- a/tests/frontend/org/voltdb/regressionsuites/testlimitoffset-ddl.sql
+++ b/tests/frontend/org/voltdb/regressionsuites/testlimitoffset-ddl.sql
@@ -48,3 +48,10 @@ CREATE TABLE R1 (
   PRIMARY KEY (ID)
 );
  
+-- This table has no key, no indices and no partition specification.
+CREATE TABLE PLAINJANE (
+  ID INTEGER,
+  A  INTEGER,
+  B  INTEGER
+);
+


### PR DESCRIPTION
The algorithm in the order by executor for limit nodes was incorrect.
This commit makes limit 0 do almost no work.  It was reading the input
table and sorting it.  The sort was a special case which only does a
partial sort, but copying the input table into a std::vector is
unnecessary and can't be zero cost.

https://issues.voltdb.com/browse/ENG-10559
