### PR TITLE
ENG-10641: Populate and use fragment parameters as before when replay…

### DIFF
--- a/src/ee/storage/BinaryLogSinkWrapper.cpp
+++ b/src/ee/storage/BinaryLogSinkWrapper.cpp
@@ -37,7 +37,7 @@ int64_t BinaryLogSinkWrapper::apply(const char* taskParams, boost::unordered_map
         pool->purge();
         const char* recordStart = taskInfo.getRawPointer();
         const uint8_t drVersion = taskInfo.readByte();
-        if (drVersion == DRTupleStream::PROTOCOL_VERSION) { // currently 4
+        if (drVersion == DRTupleStream::PROTOCOL_VERSION) {
             rowCount += m_sink.applyTxn(&taskInfo, tables, pool, engine, remoteClusterId,
                                         recordStart);
         } else if (drVersion == CompatibleDRTupleStream::COMPATIBLE_PROTOCOL_VERSION) {


### PR DESCRIPTION
…ing ApplyBinaryLogMP on cluster recover, use only invocation parameters for normal execution