### PR TITLE
Fixed a bug in SnapshotSaveAPI.java

### DIFF
--- a/src/frontend/org/voltdb/SnapshotSaveAPI.java
+++ b/src/frontend/org/voltdb/SnapshotSaveAPI.java
@@ -307,8 +307,8 @@ public class SnapshotSaveAPI
             earlyResultTable = result;
         }
 
-        // If earlyResultTable is set, return here
-        if (earlyResultTable != null) {
+        // If earlyResultTable is set and result table is empty, return here
+        if (earlyResultTable != null && result.getRowCount() == 0) {
             if (runPostTasks) {
                 // Need to run post-snapshot tasks before finishing
                 SnapshotSiteProcessor.runPostSnapshotTasks(context);


### PR DESCRIPTION
- Update startSnapshotting() to show the table name when doing 
voltadmin save --tables=replicated-table

When snapshotting replicated table only, there are chance that earlyResultTable != null while result table is not empty. It's because in this case the site who creates snapshot targets is not the same one who do the actual job.

Table name can be shown now.