### PR TITLE
ENG-10651: Reset DR applied tracker after command log replaying when r…

### DIFF
--- a/src/frontend/org/voltdb/RestoreAgent.java
+++ b/src/frontend/org/voltdb/RestoreAgent.java
@@ -105,6 +105,8 @@ SnapshotCompletionInterest, Promotable
     // Current state of the restore agent
     private volatile State m_state = State.RESTORE;
 
+    private static final int MAX_RESET_DR_APPLIED_TRACKER_TIMEOUT_MILLIS = 30000;
+
     // Restore adapter needs a completion functor.
     // Runnable here preferable to exposing all of RestoreAgent to RestoreAdapater.
     private final Runnable m_changeStateFunctor = new Runnable() {
@@ -1307,9 +1309,11 @@ SnapshotCompletionInterest, Promotable
                 ByteBuffer params = ByteBuffer.allocate(4);
                 params.putInt(ExecutionEngine.TaskType.RESET_DR_APPLIED_TRACKER.ordinal());
                 try {
-                    instance.getClientInterface().callExecuteTask(30000, params.array());
-                } catch (IOException | InterruptedException e) {
-                    e.printStackTrace();
+                    instance.getClientInterface().callExecuteTask(MAX_RESET_DR_APPLIED_TRACKER_TIMEOUT_MILLIS, params.array());
+                } catch (IOException e) {
+                    LOG.warn("Failed to reset DR applied tracker due to an IOException", e);
+                } catch (InterruptedException e) {
+                    LOG.warn("Failed to reset DR applied tracker due to an InterruptedException", e);
                 }
             }
         }

--- a/src/frontend/org/voltdb/RestoreAgent.java
+++ b/src/frontend/org/voltdb/RestoreAgent.java
@@ -22,6 +22,7 @@ import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -56,6 +57,7 @@ import org.voltdb.catalog.Procedure;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.common.Constants;
 import org.voltdb.dtxn.TransactionCreator;
+import org.voltdb.jni.ExecutionEngine;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil.Snapshot;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil.TableFiles;
@@ -1293,6 +1295,24 @@ SnapshotCompletionInterest, Promotable
         }
 
         changeState();
+
+        // ENG-10651: if the cluster is recovering and has completed replaying
+        // command log, check if it is recovered as a producer cluster for
+        // active-passive DR. If it is, the DR applied trackers in sites should
+        // be reset and cleared as they are no longer valid.
+        if (m_isLeader && m_action.doesRecover()) {
+            VoltDBInterface instance = VoltDB.instance();
+            if (!instance.getCatalogContext().database.getIsactiveactivedred() &&
+                instance.getReplicationRole() == ReplicationRole.NONE) {
+                ByteBuffer params = ByteBuffer.allocate(4);
+                params.putInt(ExecutionEngine.TaskType.RESET_DR_APPLIED_TRACKER.ordinal());
+                try {
+                    instance.getClientInterface().callExecuteTask(30000, params.array());
+                } catch (IOException | InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
 
         /*
          * ENG-1516: Use truncation snapshot to save the catalog if CL is

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -63,7 +63,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         SET_DR_PROTOCOL_VERSION(3),
         SP_JAVA_GET_DRID_TRACKER(4),
         SET_DRID_TRACKER(5),
-        GENERATE_DR_EVENT(6);
+        GENERATE_DR_EVENT(6),
+        RESET_DR_APPLIED_TRACKER(7);
 
         private TaskType(int taskId) {
             this.taskId = taskId;

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
@@ -130,6 +130,13 @@ public class ExecuteTask extends VoltSystemProcedure {
                 }
                 break;
             }
+            case RESET_DR_APPLIED_TRACKER:
+            {
+                result = new VoltTable(STATUS_SCHEMA);
+                result.addRow(STATUS_OK);
+                context.resetDrAppliedTracker();
+                break;
+            }
             default:
                 throw new VoltAbortException("Unable to find the task associated with the given task id");
             }


### PR DESCRIPTION
…recovering an old replica cluster to a new normal cluster

**Problem and solution:**
if the cluster is recovering and has completed replaying command log, check if it is recovered as a producer cluster for active-passive DR. If it is, the DR applied trackers in sites should be reset and cleared as they are no longer valid.

Added a new type of task in ExecuteTask system procedure, RESET_DR_APPLIED_TRACKER, which will clear the DR applied trackers on every site.