### PR TITLE
basic-upsert.sql: reduced the numbers added to the ID column (e.g.,

### DIFF
--- a/tests/scripts/examples/sql_coverage/basic-upsert.sql
+++ b/tests/scripts/examples/sql_coverage/basic-upsert.sql
@@ -27,7 +27,7 @@
 UPSERT INTO @dmltable               VALUES (@insertvals)
 UPSERT INTO @dmltable (@insertcols) VALUES (@insertvals)
 -- Confirm the values that were "upserted"
-SELECT * FROM @dmltable
+SELECT @star FROM @dmltable
 
 -- ... using a subset of columns
 UPSERT INTO @dmltable (_variable[id], _variable[@comparabletype])                             VALUES (_value[byte], @updatevalue)
@@ -36,7 +36,7 @@ UPSERT INTO @dmltable (_variable[id], _variable[@comparabletype], _variable[@com
 UPSERT INTO @dmltable (_variable[@comparabletype], _variable[id], _variable[@comparabletype]) VALUES (@updatevalue, _value[byte], @updatevalue)
 UPSERT INTO @dmltable (_variable[@comparabletype], _variable[@comparabletype], _variable[id]) VALUES (@updatevalue, @updatevalue, _value[byte])
 -- Confirm the values that were "upserted"
-SELECT * FROM @dmltable
+SELECT @star FROM @dmltable
 
 -- Tests of UPSERT INTO SELECT, using all columns (with and without a column list)
 UPSERT INTO @dmltable               SELECT @insertcols FROM @fromtables ORDER BY @idcol
@@ -46,29 +46,25 @@ UPSERT INTO @dmltable (@insertcols) SELECT @insertcols FROM @fromtables ORDER BY
 UPSERT INTO @dmltable               SELECT @star       FROM @fromtables ORDER BY @idcol
 UPSERT INTO @dmltable (@insertcols) SELECT @star       FROM @fromtables ORDER BY @idcol
 -- Confirm the values that were "upserted"
-SELECT * FROM @dmltable
+SELECT @star FROM @dmltable
 
 -- ... using a WHERE clause, with comparison ops (<, <=, =, >=, >)
 UPSERT INTO @dmltable               SELECT @insertcols FROM @fromtables WHERE @columnpredicate ORDER BY @idcol
 UPSERT INTO @dmltable (@insertcols) SELECT @insertcols FROM @fromtables WHERE @columnpredicate ORDER BY @idcol
 --- ... with logic operators (AND, OR) and comparison ops
--- Commenting these out, because they yield too many statements, which is slow,
--- and they don't add that much value:
---UPSERT INTO @dmltable               SELECT @insertcols FROM @fromtables WHERE (@updatecolumn @cmp @comparablevalue) _logicop @columnpredicate  ORDER BY @idcol
---UPSERT INTO @dmltable (@insertcols) SELECT @insertcols FROM @fromtables WHERE (@updatecolumn @cmp @comparablevalue) _logicop @columnpredicate  ORDER BY @idcol
+UPSERT INTO @dmltable               SELECT @insertcols FROM @fromtables WHERE (@updatecolumn @somecmp @comparablevalue) _logicop (@updatesource @somecmp @comparablevalue)  ORDER BY @idcol
+UPSERT INTO @dmltable (@insertcols) SELECT @insertcols FROM @fromtables WHERE (@updatecolumn @somecmp @comparablevalue) _logicop (@updatesource @somecmp @comparablevalue)  ORDER BY @idcol
 --- ... with arithmetic operators (+, -, *, /) and comparison ops
 UPSERT INTO @dmltable               SELECT @insertcols FROM @fromtables WHERE (_variable[@comparabletype] @aftermath) @cmp @comparableconstant ORDER BY @idcol
 UPSERT INTO @dmltable (@insertcols) SELECT @insertcols FROM @fromtables WHERE (_variable[@comparabletype] @aftermath) @cmp @comparableconstant ORDER BY @idcol
 -- Confirm the values that were "upserted"
-SELECT * FROM @dmltable
+SELECT @star FROM @dmltable
 
 -- ... using arithmetic (+, -, *, /) ops in the SELECT clause
-UPSERT INTO @dmltable (_variable[id], _variable[#c2 @comparabletype])                                 SELECT @idcol + 100, __[#c2] @plus10                   FROM @fromtables ORDER BY @idcol
-UPSERT INTO @dmltable (_variable[#c2 @comparabletype], _variable[id])                                 SELECT __[#c2] @plus10, @idcol + 200                   FROM @fromtables ORDER BY @idcol
-UPSERT INTO @dmltable (_variable[id], _variable[#c2 @comparabletype], _variable[#c3 @comparabletype]) SELECT @idcol + 1000, __[#c2] @plus10, __[#c3] @plus10 FROM @fromtables ORDER BY @idcol
--- TODO, see ENG-10458: Commenting these out, because they cause
--- "timeout: procedure call took longer than 5 seconds" errors:
---UPSERT INTO @dmltable (_variable[#c2 @comparabletype], _variable[id], _variable[#c3 @comparabletype]) SELECT __[#c2] @plus10, @idcol + 2000, __[#c3] @plus10 FROM @fromtables ORDER BY @idcol
---UPSERT INTO @dmltable (_variable[#c2 @comparabletype], _variable[#c3 @comparabletype], _variable[id]) SELECT __[#c2] @plus10, __[#c3] @plus10, @idcol + 3000 FROM @fromtables ORDER BY @idcol
+UPSERT INTO @dmltable (_variable[id], _variable[#c2 @comparabletype])                                 SELECT @idcol + 20, __[#c2] @plus10                  FROM @fromtables ORDER BY @idcol
+UPSERT INTO @dmltable (_variable[#c2 @comparabletype], _variable[id])                                 SELECT __[#c2] @plus10, @idcol + 30                  FROM @fromtables ORDER BY @idcol
+UPSERT INTO @dmltable (_variable[id], _variable[#c2 @comparabletype], _variable[#c3 @comparabletype]) SELECT @idcol + 40, __[#c2] @plus10, __[#c3] @plus10 FROM @fromtables ORDER BY @idcol
+UPSERT INTO @dmltable (_variable[#c2 @comparabletype], _variable[id], _variable[#c3 @comparabletype]) SELECT __[#c2] @plus10, @idcol + 50, __[#c3] @plus10 FROM @fromtables ORDER BY @idcol
+UPSERT INTO @dmltable (_variable[#c2 @comparabletype], _variable[#c3 @comparabletype], _variable[id]) SELECT __[#c2] @plus10, __[#c3] @plus10, @idcol + 60 FROM @fromtables ORDER BY @idcol
 -- Confirm the values that were "upserted"
-SELECT * FROM @dmltable
+SELECT @star FROM @dmltable

--- a/tests/scripts/sql_coverage_test.py
+++ b/tests/scripts/sql_coverage_test.py
@@ -89,10 +89,9 @@ def print_elapsed_seconds(message_end="", prev_time=-1,
     current system time and a previous time, which is either the specified
     'prev_time' or, if that is negative (or unspecified), the previous time
     at which this function was called. The printed message is preceded by
-    'message_begin' and followed by "seconds, " and 'message_end'; if the
-    elapsed time is greater than or equal to 60 seconds, it also includes the
-    minutes and seconds in parentheses, e.g., 61.9 seconds would be printed
-    as "61.9 seconds (01:02), ".
+    'message_begin' and followed by 'message_end'; the elapsed time is printed
+    in a minutes:seconds format, with the exact number of seconds in parentheses,
+    e.g., 61.9 seconds would be printed as "01:02 (61.9 seconds), ".
     """
 
     now = time.time()


### PR DESCRIPTION
changed '@idcol + 100' to '@idcol + 20'), which reduces the number of
rows created in each table (each UPSERT now does more updating and less
inserting), which solves the slow (PostgreSQL) query problem, so those
query templates are now uncommented. Also uncommented a couple of other
query templates, after tweaking them to generate fewer queries (e.g.,
changed '@cmp' to '@somecmp', and replaced '@columnpredicate' with a
clause using '@somecmp’). And changed 'SELECT *' queries to 'SELECT
@star' (which will make ENG-10464 easier).
sql_coverage_test.py: just fixed the comments for the
print_elapsed_seconds method.