### PR TITLE
ENG-10618: Fix mesh arbiter fault resolution algorithm.

### DIFF
--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -415,7 +415,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         if (makePPDDecision(m_localHostId, previousHosts, currentHosts, m_partitionDetectionEnabled.get())) {
             // record here so we can ensure this only happens once for this node
             m_partitionDetected = true;
-            VoltDB.crashGlobalVoltDB("Partition detection logic will stop this process to ensure against split brains.",
+            VoltDB.crashLocalVoltDB("Partition detection logic will stop this process to ensure against split brains.",
                         false, null);
         }
     }
@@ -1378,11 +1378,15 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     public void cutLink(int hostIdA, int hostIdB) {
         if (m_localHostId == hostIdA) {
             ForeignHost fh = m_foreignHosts.get(hostIdB);
-            fh.cutLink();
+            if (fh != null) {
+                fh.cutLink();
+            }
         }
         if (m_localHostId == hostIdB) {
             ForeignHost fh = m_foreignHosts.get(hostIdA);
-            fh.cutLink();
+            if (fh != null) {
+                fh.cutLink();
+            }
         }
     }
 


### PR DESCRIPTION
On single link failures, a host A may claim another host B is down
because host C witnessed the link failure between B and C. Same goes for
C. In this case, A has the freedom to go with either B or C. Both B and
C should wait until A makes the decision before they continue to make
theirs. Otherwise B and C may both think they still have A in their
subclusters and continue on because they are the majority.

Now it makes local decision, broadcast it and wait for decisions from all
survivors. If disagrees, kill that host's link and repeat the process.