### PR TITLE
ENG-10523: Recognize multi-partition binary log entries in the buffer splitter

### DIFF
--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -270,7 +270,7 @@ void ExecutorContext::checkTransactionForDR() {
             m_undoQuantum->registerUndoAction(
                     new (*m_undoQuantum) DRTupleStreamUndoAction(m_drStream,
                             m_drStream->m_committedUso,
-                            rowCostForDRRecord(DR_RECORD_BEGIN_TXN)));
+                            0));
             if (m_drReplicatedStream) {
                 m_drReplicatedStream->transactionChecks(m_lastCommittedSpHandle,
                         m_spHandle, m_uniqueId);
@@ -278,7 +278,7 @@ void ExecutorContext::checkTransactionForDR() {
                         new (*m_undoQuantum) DRTupleStreamUndoAction(
                                 m_drReplicatedStream,
                                 m_drReplicatedStream->m_committedUso,
-                                rowCostForDRRecord(DR_RECORD_BEGIN_TXN)));
+                                0));
             }
         }
     }

--- a/src/ee/storage/CompatibleDRTupleStream.cpp
+++ b/src/ee/storage/CompatibleDRTupleStream.cpp
@@ -488,7 +488,10 @@ int32_t CompatibleDRTupleStream::getTestDRBuffer(int32_t partitionId,
     // Override start sequence number
     stream.m_openSequenceNumber = startSequenceNumber - 1;
     for (int ii = 0; ii < flagList.size(); ii++) {
-        int64_t uid = UniqueId::makeIdFromComponents(ii * 5, 0, (flagList[ii] == TXN_PAR_HASH_MULTI || flagList[ii] == TXN_PAR_HASH_SPECIAL) ? 16383 : partitionId);
+        bool isMp = (flagList[ii] == TXN_PAR_HASH_MULTI && partitionKeyValueList[ii] != -1) ||
+                    flagList[ii] == TXN_PAR_HASH_SPECIAL ||
+                    (flagList[ii] == TXN_PAR_HASH_SINGLE && partitionKeyValueList[ii] == -1);
+        int64_t uid = UniqueId::makeIdFromComponents(ii * 5, 0, isMp ? 16383 : partitionId);
         tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValueList[ii]));
 
         if (flagList[ii] == TXN_PAR_HASH_SPECIAL) {

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -657,7 +657,10 @@ int32_t DRTupleStream::getTestDRBuffer(int32_t partitionId,
     // Override start sequence number
     stream.m_openSequenceNumber = startSequenceNumber - 1;
     for (int ii = 0; ii < flagList.size(); ii++) {
-        int64_t uid = UniqueId::makeIdFromComponents(ii * 5, 0, (flagList[ii] == TXN_PAR_HASH_MULTI || flagList[ii] == TXN_PAR_HASH_SPECIAL) ? 16383 : partitionId);
+        bool isMp = (flagList[ii] == TXN_PAR_HASH_MULTI && partitionKeyValueList[ii] != -1) ||
+                    flagList[ii] == TXN_PAR_HASH_SPECIAL ||
+                    (flagList[ii] == TXN_PAR_HASH_SINGLE && partitionKeyValueList[ii] == -1);
+        int64_t uid = UniqueId::makeIdFromComponents(ii * 5, 0, isMp ? 16383 : partitionId);
         tuple.setNValue(0, ValueFactory::getIntegerValue(partitionKeyValueList[ii]));
 
         if (flagList[ii] == TXN_PAR_HASH_SPECIAL) {

--- a/src/frontend/org/voltdb/PartitionDRGateway.java
+++ b/src/frontend/org/voltdb/PartitionDRGateway.java
@@ -41,6 +41,7 @@ public class PartitionDRGateway implements DurableUniqueIdListener {
         INSERT, DELETE, UPDATE, BEGIN_TXN, END_TXN, TRUNCATE_TABLE, DELETE_BY_INDEX, UPDATE_BY_INDEX, HASH_DELIMITER;
     }
 
+    // Keep sync with EE DRTxnPartitionHashFlag at types.h
     public enum DRTxnPartitionHashFlag {
         PLACEHOLDER,
         REPLICATED,
@@ -63,12 +64,19 @@ public class PartitionDRGateway implements DurableUniqueIdListener {
     // Keep sync with EE DRConflictType at types.h
     public static enum DRConflictType {
         NO_CONFLICT,
-        CONSTRIANT_VIOLATION,
+        CONSTRAINT_VIOLATION,
         EXPECTED_ROW_MISSING,
         EXPECTED_ROW_TIMESTAMP_MISMATCH
     }
 
     public static ImmutableMap<Integer, PartitionDRGateway> m_partitionDRGateways = ImmutableMap.of();
+
+    // all partial MP txns go into SP streams
+    public static final byte DR_NO_MP_START_PROTOCOL_VERSION = 3;
+    // all partial MP txns except those with table truncation record go to MP stream separately without coordination
+    public static final byte DR_UNCOORDINATED_MP_START_PROTOCOL_VERSION = 4;
+    // partial MP txns of the same MP txn coordinated and combined before going to MP stream
+    public static final byte DR_COORDINATED_MP_START_PROTOCOL_VERSION = 6;
 
     /**
      * Load the full subclass if it should, otherwise load the


### PR DESCRIPTION
1. Add check for MP single hash txn so that if the txn is not for local partition, it will be skipped.
2. For DR binary log record of DR_RECORD_TRUNCATE_TABLE type, ignore the value of skipRows because the hash for this type of record is just a placeholder and meaningless. Table truncation should always be executed.
3. Adjust the behavior of getTestDRBuffer() for both normal and compatible DR tuple stream. A partition key value of -1 for a SINGLE_HASH type txn will now instruct this test method to generate this txn as a MP txn for test purpose. A partition key value of -1 for a MULTI_HASH type txn will now instruct this test method to generate this txn as a SP txn (part of a run-everywhere txns group) for test purpose.
4. Add some version constants for binary log versions from which DR starts to support different transactionality guarantee levels on the consumer cluster. (All SP & No MP, Uncoordinated MP and coordinated MP)
5. Fix a typo for CONSTRAINT_VIOLATION.