### PR TITLE
ENG-9244: Partial snapshot missing replicated table name

### DIFF
--- a/src/frontend/org/voltdb/SnapshotSaveAPI.java
+++ b/src/frontend/org/voltdb/SnapshotSaveAPI.java
@@ -243,7 +243,10 @@ public class SnapshotSaveAPI
                             earlyResultTable.addRow(context.getHostId(), hostname,
                                     CoreUtils.getSiteIdFromHSId(context.getSiteId()), "SUCCESS", "");
                         } else {
-                            earlyResultTable = SnapshotUtil.constructNodeResultsTable();
+                        	//If doing snapshot for only replicated table(s), earlyResultTable here
+                        	//may not be empty even if the taskList of this site is null.
+                        	//In that case, snapshot result is preserved by earlyResultTable.
+                            earlyResultTable = result;
                         }
                     }
                     else {

--- a/src/frontend/org/voltdb/SnapshotSaveAPI.java
+++ b/src/frontend/org/voltdb/SnapshotSaveAPI.java
@@ -243,9 +243,9 @@ public class SnapshotSaveAPI
                             earlyResultTable.addRow(context.getHostId(), hostname,
                                     CoreUtils.getSiteIdFromHSId(context.getSiteId()), "SUCCESS", "");
                         } else {
-                        	//If doing snapshot for only replicated table(s), earlyResultTable here
-                        	//may not be empty even if the taskList of this site is null.
-                        	//In that case, snapshot result is preserved by earlyResultTable.
+                            //If doing snapshot for only replicated table(s), earlyResultTable here
+                            //may not be empty even if the taskList of this site is null.
+                            //In that case, snapshot result is preserved by earlyResultTable.
                             earlyResultTable = result;
                         }
                     }


### PR DESCRIPTION
Fix SnapshotSaveAPI/startSnapshotting() to show table name when doing partial snapshot only for replicated table(s).

Reason for previous problem: the site who created the snapshot taskList may empty the result table because its own taskList is null. Actual snapshot work is done by other site.
