### PR TITLE
Eng 10645 sqlcov limit0

### DIFF
--- a/tests/scripts/examples/sql_coverage/advanced-template.sql
+++ b/tests/scripts/examples/sql_coverage/advanced-template.sql
@@ -42,23 +42,23 @@ SELECT 1, @star FROM @fromtables A WHERE @columnpredicate
 SELECT 2, @star FROM @fromtables A WHERE @optionalfn(A._variable[#some numeric]) @somecmp (            A._variable[#other numeric]  _math 2)
 SELECT 3, @star FROM @fromtables A WHERE             A._variable[#some numeric]  @somecmp (@optionalfn(A._variable[#other numeric]) _math 3)
 
-SELECT @optionalfn(A._variable[#picked @columntype]) AS Q4 FROM @fromtables A ORDER BY @optionalfn(A.__[#picked]), 1 LIMIT _value[int:1,10]
+SELECT @optionalfn(A._variable[#picked @columntype]) AS Q4 FROM @fromtables A ORDER BY @optionalfn(A.__[#picked]), 1 LIMIT _value[int:0,10]
 
 -- Found eng-3191 (or similar, anyway) crashed (fixed, since?) with these statements:
 -- -- combine where and limit
--- SELECT @optionalfn(A._variable[#picked @columntype]) AS Q5 FROM @fromtables A WHERE  @optionalfn(A._variable[@comparabletype]) @somecmp @optionalfn(A._variable[@comparabletype]) ORDER BY @optionalfn(A.__[#picked]) LIMIT _value[int:1,100]
+-- SELECT @optionalfn(A._variable[#picked @columntype]) AS Q5 FROM @fromtables A WHERE  @optionalfn(A._variable[@comparabletype]) @somecmp @optionalfn(A._variable[@comparabletype]) ORDER BY @optionalfn(A.__[#picked]) LIMIT _value[int:0,100]
 -- -- combine where and offset
--- SELECT @optionalfn(A._variable[#picked @columntype]) AS Q6 FROM @fromtables A WHERE  @optionalfn(A._variable[@comparabletype]) @somecmp @optionalfn(A._variable[@comparabletype]) ORDER BY @optionalfn(A.__[#picked]) LIMIT _value[int:1,100] OFFSET _value[int:1,100]
+-- SELECT @optionalfn(A._variable[#picked @columntype]) AS Q6 FROM @fromtables A WHERE  @optionalfn(A._variable[@comparabletype]) @somecmp @optionalfn(A._variable[@comparabletype]) ORDER BY @optionalfn(A.__[#picked]) LIMIT _value[int:0,100] OFFSET _value[int:0,100]
 -- -- compare more columns
 -- SELECT @optionalfn(A._variable[@comparabletype]    ) AS Q7 FROM @fromtables A WHERE (@optionalfn(A._variable[@comparabletype]) @somecmp @optionalfn(A._variable[@comparabletype])) _logicop (@optionalfn(A._variable[@comparabletype]) @somecmp @optionalfn(A._variable[@comparabletype]))
 -- Now that eng-3191 is fixed, we keep them watered down to reduce the number of generated combinations:
 -- Even simplified like this, it crashes (or DID, anyway):
--- SELECT @optionalfn(A._variable[#picked            ]) AS Q5 FROM @fromtables A WHERE             (A._variable[@comparabletype]) @somecmp @optionalfn(A._variable[@comparabletype]) ORDER BY @optionalfn(A.__[#picked]) LIMIT _value[int:1,100]
+-- SELECT @optionalfn(A._variable[#picked            ]) AS Q5 FROM @fromtables A WHERE             (A._variable[@comparabletype]) @somecmp @optionalfn(A._variable[@comparabletype]) ORDER BY @optionalfn(A.__[#picked]) LIMIT _value[int:0,100]
 -- so, it was simplified even further
 -- combine where and limit
-   SELECT @optionalfn(A._variable[#picked @columntype]) AS Q5 FROM @fromtables A WHERE             (A.__[#picked]               ) @somecmp            (A._variable[@comparabletype]) ORDER BY 1                        LIMIT _value[int:1,100]
+   SELECT @optionalfn(A._variable[#picked @columntype]) AS Q5 FROM @fromtables A WHERE             (A.__[#picked]               ) @somecmp            (A._variable[@comparabletype]) ORDER BY 1                        LIMIT _value[int:0,100]
 -- combine where and offset
-   SELECT @optionalfn(A._variable[#picked @columntype]) AS Q6 FROM @fromtables A WHERE             (A._variable[@comparabletype]) @somecmp            (A.__[#picked]               ) ORDER BY 1                        LIMIT _value[int:1,100] OFFSET _value[int:1,100]
+   SELECT @optionalfn(A._variable[#picked @columntype]) AS Q6 FROM @fromtables A WHERE             (A._variable[@comparabletype]) @somecmp            (A.__[#picked]               ) ORDER BY 1                        LIMIT _value[int:0,100] OFFSET _value[int:0,100]
 -- compare more columns
    SELECT @optionalfn(A._variable[#picked @columntype]) AS Q7 FROM @fromtables A WHERE (           (A.__[#picked]               ) @somecmp            (A._variable[@comparabletype])) _logicop ( @columnpredicate )
 

--- a/tests/scripts/examples/sql_coverage/basic-select.sql
+++ b/tests/scripts/examples/sql_coverage/basic-select.sql
@@ -77,7 +77,8 @@ SELECT _variable[#grouped @columntype] B14 FROM @fromtables A GROUP BY __[#group
 {_optionallimitoffset |= "LIMIT _value[int:0,3]"}
 {_optionallimitoffset |= "LIMIT _value[int:0,3] OFFSET _value[int:0,3]"}
 -- include OFFSET without LIMIT, which works fine
-{_optionallimitoffset |= "                      OFFSET _value[int:0,3]"}
+-- Uncomment this, once ENG-10733 is fixed:
+--{_optionallimitoffset |= "                      OFFSET _value[int:0,3]"}
 
 -- test ORDER BY with optional LIMIT/OFFSET
 -- HSQL disagrees about ordering of NULLs descending, this only shows as an error on limit/offset queries,

--- a/tests/scripts/examples/sql_coverage/basic-select.sql
+++ b/tests/scripts/examples/sql_coverage/basic-select.sql
@@ -74,10 +74,10 @@ SELECT @star FROM @fromtables B13 WHERE (_variable[#arg @comparabletype] @cmp @c
 SELECT _variable[#grouped @columntype] B14 FROM @fromtables A GROUP BY __[#grouped]
 
 {_optionallimitoffset |= ""}
-{_optionallimitoffset |= "LIMIT _value[int:1,3]"}
-{_optionallimitoffset |= "LIMIT _value[int:1,3] OFFSET _value[int:1,3]"}
--- OFFSET without LIMIT not supported -- is that SQL standard?
---{_optionallimitoffset |= "                      OFFSET _value[int:1,3]"}
+{_optionallimitoffset |= "LIMIT _value[int:0,3]"}
+{_optionallimitoffset |= "LIMIT _value[int:0,3] OFFSET _value[int:0,3]"}
+-- include OFFSET without LIMIT, which works fine
+{_optionallimitoffset |= "                      OFFSET _value[int:0,3]"}
 
 -- test ORDER BY with optional LIMIT/OFFSET
 -- HSQL disagrees about ordering of NULLs descending, this only shows as an error on limit/offset queries,


### PR DESCRIPTION
Updated basic-select.sql, advanced-template.sql to include LIMIT 0 and OFFSET 0 as possible options, for various query templates.