### PR TITLE
Deployment file pretty print

### DIFF
--- a/src/frontend/org/voltdb/utils/HTTPAdminListener.java
+++ b/src/frontend/org/voltdb/utils/HTTPAdminListener.java
@@ -484,7 +484,7 @@ public class HTTPAdminListener {
                 if (baseRequest.getRequestURI().contains("/download")) {
                     //Deployment xml is text/xml
                     response.setContentType("text/xml;charset=utf-8");
-                    response.getWriter().write(new String(getDeploymentBytes()));
+                    response.getWriter().write(CatalogUtil.getDeployment(this.getDeployment(), true));
                 } else if (baseRequest.getRequestURI().contains("/users")) {
                     if (request.getMethod().equalsIgnoreCase("POST")) {
                         handleUpdateUser(jsonp, target, baseRequest, request, response, authResult);


### PR DESCRIPTION
Manually tested it by: 

* Starting a database with the new cli using 'start' without a deployment file and downloading a default deployment file through VMC (_which is a different default from the one in RealVoltDB but works the same_). 
* Making changes to the deployment through VMC to only some of the fields. 
* Catalog update through voltadmin and download new version on VMC. 

In all cases the file was indented and consistent with the change.