### PR TITLE
Add consumer cluster id to DRProducer stats

### DIFF
--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -28,7 +28,7 @@ public class DRProducerStatsBase {
 
     public static interface Columns {
         // column for both tables
-        public static final String CONSUMER_CLUSTER_ID = "CLUSTER_ID";
+        public static final String CONSUMER_CLUSTER_ID = "CONSUMER_CLUSTER_ID";
 
         // columns for the node-level table
         public static final String STATE = "STATE";
@@ -59,7 +59,7 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
-            columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.INTEGER));
+            columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
             columns.add(new ColumnInfo(Columns.STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.SYNC_SNAPSHOT_STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.ROWS_IN_SYNC_SNAPSHOT, VoltType.BIGINT));
@@ -82,7 +82,7 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
-            columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.INTEGER));
+            columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
             columns.add(new ColumnInfo(VoltSystemProcedure.CNAME_PARTITION_ID, VoltType.INTEGER));
             columns.add(new ColumnInfo(Columns.STREAM_TYPE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.TOTAL_BYTES, VoltType.BIGINT));

--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -26,8 +26,8 @@ import com.google_voltpatches.common.collect.ImmutableSet;
 
 public class DRProducerStatsBase {
 
-    //  DR_CONSUMER_CLUSTER_STATS property must equal "true"
-    private static boolean m_addConsumerStats = Boolean.getBoolean("DR_CONSUMER_CLUSTER_STATS");
+    //  DR_STATS_CONSUMER_CLUSTER_ID java property must equal "true"
+    private static boolean m_addConsumerIdStat = Boolean.getBoolean("DR_STATS_CONSUMER_CLUSTER_ID");
 
     public static interface Columns {
         // column for both tables
@@ -62,7 +62,7 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
-            if (m_addConsumerStats) {
+            if (m_addConsumerIdStat) {
                 columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
             }
             columns.add(new ColumnInfo(Columns.STATE, VoltType.STRING));
@@ -87,7 +87,7 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
-            if (m_addConsumerStats) {
+            if (m_addConsumerIdStat) {
                 columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
             }
             columns.add(new ColumnInfo(VoltSystemProcedure.CNAME_PARTITION_ID, VoltType.INTEGER));

--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -26,6 +26,9 @@ import com.google_voltpatches.common.collect.ImmutableSet;
 
 public class DRProducerStatsBase {
 
+    //  DR_CONSUMER_CLUSTER_STATS property must equal "true"
+    private static boolean m_addConsumerStats = Boolean.getBoolean("DR_CONSUMER_CLUSTER_STATS");
+
     public static interface Columns {
         // column for both tables
         public static final String CONSUMER_CLUSTER_ID = "CONSUMERCLUSTERID";
@@ -59,7 +62,9 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
-            columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
+            if (m_addConsumerStats) {
+                columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
+            }
             columns.add(new ColumnInfo(Columns.STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.SYNC_SNAPSHOT_STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.ROWS_IN_SYNC_SNAPSHOT, VoltType.BIGINT));
@@ -82,7 +87,9 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
-            columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
+            if (m_addConsumerStats) {
+                columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
+            }
             columns.add(new ColumnInfo(VoltSystemProcedure.CNAME_PARTITION_ID, VoltType.INTEGER));
             columns.add(new ColumnInfo(Columns.STREAM_TYPE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.TOTAL_BYTES, VoltType.BIGINT));

--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -28,7 +28,7 @@ public class DRProducerStatsBase {
 
     public static interface Columns {
         // column for both tables
-        public static final String CONSUMER_CLUSTER_ID = "CONSUMER_CLUSTER_ID";
+        public static final String CONSUMER_CLUSTER_ID = "CONSUMERCLUSTERID";
 
         // columns for the node-level table
         public static final String STATE = "STATE";

--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -27,6 +27,9 @@ import com.google_voltpatches.common.collect.ImmutableSet;
 public class DRProducerStatsBase {
 
     public static interface Columns {
+        // column for both tables
+        public static final String CONSUMER_CLUSTER_ID = "CLUSTER_ID";
+
         // columns for the node-level table
         public static final String STATE = "STATE";
         public static final String SYNC_SNAPSHOT_STATE = "SYNCSNAPSHOTSTATE";
@@ -56,6 +59,7 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
+            columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.INTEGER));
             columns.add(new ColumnInfo(Columns.STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.SYNC_SNAPSHOT_STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.ROWS_IN_SYNC_SNAPSHOT, VoltType.BIGINT));
@@ -78,6 +82,7 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
+            columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.INTEGER));
             columns.add(new ColumnInfo(VoltSystemProcedure.CNAME_PARTITION_ID, VoltType.INTEGER));
             columns.add(new ColumnInfo(Columns.STREAM_TYPE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.TOTAL_BYTES, VoltType.BIGINT));

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
@@ -27,14 +27,14 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.Test;
-
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
 import org.voltdb.client.Client;
 import org.voltdb.regressionsuites.StatisticsTestSuiteBase;
+
+import junit.framework.Test;
 
 public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
 
@@ -50,15 +50,16 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         System.out.println("\n\nTESTING DRNODE STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
-        ColumnInfo[] expectedSchema2 = new ColumnInfo[8];
+        ColumnInfo[] expectedSchema2 = new ColumnInfo[9];
         expectedSchema2[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
         expectedSchema2[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
         expectedSchema2[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedSchema2[3] = new ColumnInfo("STATE", VoltType.STRING);
-        expectedSchema2[4] = new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING);
-        expectedSchema2[5] = new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT);
-        expectedSchema2[6] = new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT);
-        expectedSchema2[7] = new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT);
+        expectedSchema2[3] = new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT);
+        expectedSchema2[4] = new ColumnInfo("STATE", VoltType.STRING);
+        expectedSchema2[5] = new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING);
+        expectedSchema2[6] = new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT);
+        expectedSchema2[7] = new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT);
+        expectedSchema2[8] = new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT);
         VoltTable expectedTable2 = new VoltTable(expectedSchema2);
 
         VoltTable[] results = null;
@@ -85,21 +86,22 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         System.out.println("\n\nTESTING DRPRODUCERPARTITION STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
-        ColumnInfo[] expectedSchema1 = new ColumnInfo[14];
+        ColumnInfo[] expectedSchema1 = new ColumnInfo[15];
         expectedSchema1[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
         expectedSchema1[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
         expectedSchema1[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedSchema1[3] = new ColumnInfo("PARTITION_ID", VoltType.INTEGER);
-        expectedSchema1[4] = new ColumnInfo("STREAMTYPE", VoltType.STRING);
-        expectedSchema1[5] = new ColumnInfo("TOTALBYTES", VoltType.BIGINT);
-        expectedSchema1[6] = new ColumnInfo("TOTALBYTESINMEMORY", VoltType.BIGINT);
-        expectedSchema1[7] = new ColumnInfo("TOTALBUFFERS", VoltType.BIGINT);
-        expectedSchema1[8] = new ColumnInfo("LASTQUEUEDDRID", VoltType.BIGINT);
-        expectedSchema1[9] = new ColumnInfo("LASTACKDRID", VoltType.BIGINT);
-        expectedSchema1[10] = new ColumnInfo("LASTQUEUEDTIMESTAMP", VoltType.TIMESTAMP);
-        expectedSchema1[11] = new ColumnInfo("LASTACKTIMESTAMP", VoltType.TIMESTAMP);
-        expectedSchema1[12] = new ColumnInfo("ISSYNCED", VoltType.STRING);
-        expectedSchema1[13] = new ColumnInfo("MODE", VoltType.STRING);
+        expectedSchema1[3] = new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT);
+        expectedSchema1[4] = new ColumnInfo("PARTITION_ID", VoltType.INTEGER);
+        expectedSchema1[5] = new ColumnInfo("STREAMTYPE", VoltType.STRING);
+        expectedSchema1[6] = new ColumnInfo("TOTALBYTES", VoltType.BIGINT);
+        expectedSchema1[7] = new ColumnInfo("TOTALBYTESINMEMORY", VoltType.BIGINT);
+        expectedSchema1[8] = new ColumnInfo("TOTALBUFFERS", VoltType.BIGINT);
+        expectedSchema1[9] = new ColumnInfo("LASTQUEUEDDRID", VoltType.BIGINT);
+        expectedSchema1[10] = new ColumnInfo("LASTACKDRID", VoltType.BIGINT);
+        expectedSchema1[11] = new ColumnInfo("LASTQUEUEDTIMESTAMP", VoltType.TIMESTAMP);
+        expectedSchema1[12] = new ColumnInfo("LASTACKTIMESTAMP", VoltType.TIMESTAMP);
+        expectedSchema1[13] = new ColumnInfo("ISSYNCED", VoltType.STRING);
+        expectedSchema1[14] = new ColumnInfo("MODE", VoltType.STRING);
         VoltTable expectedTable1 = new VoltTable(expectedSchema1);
 
         VoltTable[] results = null;
@@ -130,32 +132,34 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         System.out.println("\n\nTESTING DR STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
-        ColumnInfo[] expectedSchema1 = new ColumnInfo[14];
+        ColumnInfo[] expectedSchema1 = new ColumnInfo[15];
         expectedSchema1[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
         expectedSchema1[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
         expectedSchema1[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedSchema1[3] = new ColumnInfo("PARTITION_ID", VoltType.INTEGER);
-        expectedSchema1[4] = new ColumnInfo("STREAMTYPE", VoltType.STRING);
-        expectedSchema1[5] = new ColumnInfo("TOTALBYTES", VoltType.BIGINT);
-        expectedSchema1[6] = new ColumnInfo("TOTALBYTESINMEMORY", VoltType.BIGINT);
-        expectedSchema1[7] = new ColumnInfo("TOTALBUFFERS", VoltType.BIGINT);
-        expectedSchema1[8] = new ColumnInfo("LASTQUEUEDDRID", VoltType.BIGINT);
-        expectedSchema1[9] = new ColumnInfo("LASTACKDRID", VoltType.BIGINT);
-        expectedSchema1[10] = new ColumnInfo("LASTQUEUEDTIMESTAMP", VoltType.TIMESTAMP);
-        expectedSchema1[11] = new ColumnInfo("LASTACKTIMESTAMP", VoltType.TIMESTAMP);
-        expectedSchema1[12] = new ColumnInfo("ISSYNCED", VoltType.STRING);
-        expectedSchema1[13] = new ColumnInfo("MODE", VoltType.STRING);
+        expectedSchema1[3] = new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT);
+        expectedSchema1[4] = new ColumnInfo("PARTITION_ID", VoltType.INTEGER);
+        expectedSchema1[5] = new ColumnInfo("STREAMTYPE", VoltType.STRING);
+        expectedSchema1[6] = new ColumnInfo("TOTALBYTES", VoltType.BIGINT);
+        expectedSchema1[7] = new ColumnInfo("TOTALBYTESINMEMORY", VoltType.BIGINT);
+        expectedSchema1[8] = new ColumnInfo("TOTALBUFFERS", VoltType.BIGINT);
+        expectedSchema1[9] = new ColumnInfo("LASTQUEUEDDRID", VoltType.BIGINT);
+        expectedSchema1[10] = new ColumnInfo("LASTACKDRID", VoltType.BIGINT);
+        expectedSchema1[11] = new ColumnInfo("LASTQUEUEDTIMESTAMP", VoltType.TIMESTAMP);
+        expectedSchema1[12] = new ColumnInfo("LASTACKTIMESTAMP", VoltType.TIMESTAMP);
+        expectedSchema1[13] = new ColumnInfo("ISSYNCED", VoltType.STRING);
+        expectedSchema1[14] = new ColumnInfo("MODE", VoltType.STRING);
         VoltTable expectedTable1 = new VoltTable(expectedSchema1);
 
-        ColumnInfo[] expectedSchema2 = new ColumnInfo[8];
+        ColumnInfo[] expectedSchema2 = new ColumnInfo[9];
         expectedSchema2[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
         expectedSchema2[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
         expectedSchema2[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedSchema2[3] = new ColumnInfo("STATE", VoltType.STRING);
-        expectedSchema2[4] = new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING);
-        expectedSchema2[5] = new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT);
-        expectedSchema2[6] = new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT);
-        expectedSchema2[7] = new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT);
+        expectedSchema2[3] = new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT);
+        expectedSchema2[4] = new ColumnInfo("STATE", VoltType.STRING);
+        expectedSchema2[5] = new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING);
+        expectedSchema2[6] = new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT);
+        expectedSchema2[7] = new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT);
+        expectedSchema2[8] = new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT);
         VoltTable expectedTable2 = new VoltTable(expectedSchema2);
 
         VoltTable[] results = null;

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
@@ -27,14 +27,14 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import junit.framework.Test;
+
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
 import org.voltdb.client.Client;
 import org.voltdb.regressionsuites.StatisticsTestSuiteBase;
-
-import junit.framework.Test;
 
 public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
 
@@ -50,16 +50,16 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         System.out.println("\n\nTESTING DRNODE STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
-        ColumnInfo[] expectedSchema2 = new ColumnInfo[9];
+        ColumnInfo[] expectedSchema2 = new ColumnInfo[8];
+        assertEquals("Expected DRNodeStatistics schema length is 8", 8, expectedSchema2.length);
         expectedSchema2[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
         expectedSchema2[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
         expectedSchema2[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedSchema2[3] = new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT);
-        expectedSchema2[4] = new ColumnInfo("STATE", VoltType.STRING);
-        expectedSchema2[5] = new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING);
-        expectedSchema2[6] = new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT);
-        expectedSchema2[7] = new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT);
-        expectedSchema2[8] = new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT);
+        expectedSchema2[3] = new ColumnInfo("STATE", VoltType.STRING);
+        expectedSchema2[4] = new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING);
+        expectedSchema2[5] = new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT);
+        expectedSchema2[6] = new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT);
+        expectedSchema2[7] = new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT);
         VoltTable expectedTable2 = new VoltTable(expectedSchema2);
 
         VoltTable[] results = null;
@@ -86,22 +86,22 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         System.out.println("\n\nTESTING DRPRODUCERPARTITION STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
-        ColumnInfo[] expectedSchema1 = new ColumnInfo[15];
+        ColumnInfo[] expectedSchema1 = new ColumnInfo[14];
+        assertEquals("Expected DRPartitionStatistics schema length is 14", 14, expectedSchema1.length);
         expectedSchema1[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
         expectedSchema1[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
         expectedSchema1[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedSchema1[3] = new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT);
-        expectedSchema1[4] = new ColumnInfo("PARTITION_ID", VoltType.INTEGER);
-        expectedSchema1[5] = new ColumnInfo("STREAMTYPE", VoltType.STRING);
-        expectedSchema1[6] = new ColumnInfo("TOTALBYTES", VoltType.BIGINT);
-        expectedSchema1[7] = new ColumnInfo("TOTALBYTESINMEMORY", VoltType.BIGINT);
-        expectedSchema1[8] = new ColumnInfo("TOTALBUFFERS", VoltType.BIGINT);
-        expectedSchema1[9] = new ColumnInfo("LASTQUEUEDDRID", VoltType.BIGINT);
-        expectedSchema1[10] = new ColumnInfo("LASTACKDRID", VoltType.BIGINT);
-        expectedSchema1[11] = new ColumnInfo("LASTQUEUEDTIMESTAMP", VoltType.TIMESTAMP);
-        expectedSchema1[12] = new ColumnInfo("LASTACKTIMESTAMP", VoltType.TIMESTAMP);
-        expectedSchema1[13] = new ColumnInfo("ISSYNCED", VoltType.STRING);
-        expectedSchema1[14] = new ColumnInfo("MODE", VoltType.STRING);
+        expectedSchema1[3] = new ColumnInfo("PARTITION_ID", VoltType.INTEGER);
+        expectedSchema1[4] = new ColumnInfo("STREAMTYPE", VoltType.STRING);
+        expectedSchema1[5] = new ColumnInfo("TOTALBYTES", VoltType.BIGINT);
+        expectedSchema1[6] = new ColumnInfo("TOTALBYTESINMEMORY", VoltType.BIGINT);
+        expectedSchema1[7] = new ColumnInfo("TOTALBUFFERS", VoltType.BIGINT);
+        expectedSchema1[8] = new ColumnInfo("LASTQUEUEDDRID", VoltType.BIGINT);
+        expectedSchema1[9] = new ColumnInfo("LASTACKDRID", VoltType.BIGINT);
+        expectedSchema1[10] = new ColumnInfo("LASTQUEUEDTIMESTAMP", VoltType.TIMESTAMP);
+        expectedSchema1[11] = new ColumnInfo("LASTACKTIMESTAMP", VoltType.TIMESTAMP);
+        expectedSchema1[12] = new ColumnInfo("ISSYNCED", VoltType.STRING);
+        expectedSchema1[13] = new ColumnInfo("MODE", VoltType.STRING);
         VoltTable expectedTable1 = new VoltTable(expectedSchema1);
 
         VoltTable[] results = null;
@@ -132,34 +132,34 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         System.out.println("\n\nTESTING DR STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
-        ColumnInfo[] expectedSchema1 = new ColumnInfo[15];
+        ColumnInfo[] expectedSchema1 = new ColumnInfo[14];
+        assertEquals("Expected DRPartitionStatistics schema length is 14", 14, expectedSchema1.length);
         expectedSchema1[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
         expectedSchema1[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
         expectedSchema1[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedSchema1[3] = new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT);
-        expectedSchema1[4] = new ColumnInfo("PARTITION_ID", VoltType.INTEGER);
-        expectedSchema1[5] = new ColumnInfo("STREAMTYPE", VoltType.STRING);
-        expectedSchema1[6] = new ColumnInfo("TOTALBYTES", VoltType.BIGINT);
-        expectedSchema1[7] = new ColumnInfo("TOTALBYTESINMEMORY", VoltType.BIGINT);
-        expectedSchema1[8] = new ColumnInfo("TOTALBUFFERS", VoltType.BIGINT);
-        expectedSchema1[9] = new ColumnInfo("LASTQUEUEDDRID", VoltType.BIGINT);
-        expectedSchema1[10] = new ColumnInfo("LASTACKDRID", VoltType.BIGINT);
-        expectedSchema1[11] = new ColumnInfo("LASTQUEUEDTIMESTAMP", VoltType.TIMESTAMP);
-        expectedSchema1[12] = new ColumnInfo("LASTACKTIMESTAMP", VoltType.TIMESTAMP);
-        expectedSchema1[13] = new ColumnInfo("ISSYNCED", VoltType.STRING);
-        expectedSchema1[14] = new ColumnInfo("MODE", VoltType.STRING);
+        expectedSchema1[3] = new ColumnInfo("PARTITION_ID", VoltType.INTEGER);
+        expectedSchema1[4] = new ColumnInfo("STREAMTYPE", VoltType.STRING);
+        expectedSchema1[5] = new ColumnInfo("TOTALBYTES", VoltType.BIGINT);
+        expectedSchema1[6] = new ColumnInfo("TOTALBYTESINMEMORY", VoltType.BIGINT);
+        expectedSchema1[7] = new ColumnInfo("TOTALBUFFERS", VoltType.BIGINT);
+        expectedSchema1[8] = new ColumnInfo("LASTQUEUEDDRID", VoltType.BIGINT);
+        expectedSchema1[9] = new ColumnInfo("LASTACKDRID", VoltType.BIGINT);
+        expectedSchema1[10] = new ColumnInfo("LASTQUEUEDTIMESTAMP", VoltType.TIMESTAMP);
+        expectedSchema1[11] = new ColumnInfo("LASTACKTIMESTAMP", VoltType.TIMESTAMP);
+        expectedSchema1[12] = new ColumnInfo("ISSYNCED", VoltType.STRING);
+        expectedSchema1[13] = new ColumnInfo("MODE", VoltType.STRING);
         VoltTable expectedTable1 = new VoltTable(expectedSchema1);
 
-        ColumnInfo[] expectedSchema2 = new ColumnInfo[9];
+        ColumnInfo[] expectedSchema2 = new ColumnInfo[8];
+        assertEquals("Expected DRNodeStatistics schema length is 8", 8, expectedSchema2.length);
         expectedSchema2[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
         expectedSchema2[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
         expectedSchema2[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedSchema2[3] = new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT);
-        expectedSchema2[4] = new ColumnInfo("STATE", VoltType.STRING);
-        expectedSchema2[5] = new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING);
-        expectedSchema2[6] = new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT);
-        expectedSchema2[7] = new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT);
-        expectedSchema2[8] = new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT);
+        expectedSchema2[3] = new ColumnInfo("STATE", VoltType.STRING);
+        expectedSchema2[4] = new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING);
+        expectedSchema2[5] = new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT);
+        expectedSchema2[6] = new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT);
+        expectedSchema2[7] = new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT);
         VoltTable expectedTable2 = new VoltTable(expectedSchema2);
 
         VoltTable[] results = null;


### PR DESCRIPTION
Add a new column to the node level and partition level table that adds an entry for the consumer cluster id that the producer is connected to. The id is the integer id of the consumer specified in the deployment.

Andrew said that in the future it would be nice if the rows were in order by the consumer cluster id.