### PR TITLE
basic-select.sql: include tests of OFFSET without LIMIT, now that

### DIFF
--- a/tests/scripts/examples/sql_coverage/basic-select.sql
+++ b/tests/scripts/examples/sql_coverage/basic-select.sql
@@ -76,9 +76,8 @@ SELECT _variable[#grouped @columntype] B14 FROM @fromtables A GROUP BY __[#group
 {_optionallimitoffset |= ""}
 {_optionallimitoffset |= "LIMIT _value[int:0,3]"}
 {_optionallimitoffset |= "LIMIT _value[int:0,3] OFFSET _value[int:0,3]"}
--- include OFFSET without LIMIT, which works fine
--- Uncomment this, once ENG-10733 is fixed:
---{_optionallimitoffset |= "                      OFFSET _value[int:0,3]"}
+-- include OFFSET without LIMIT, which now works fine
+{_optionallimitoffset |= "                      OFFSET _value[int:0,3]"}
 
 -- test ORDER BY with optional LIMIT/OFFSET
 -- HSQL disagrees about ordering of NULLs descending, this only shows as an error on limit/offset queries,


### PR DESCRIPTION
ENG-10733 seems to be fixed (for materialized views).