### PR TITLE
Fix compilation errors on Ubuntu 16.04.

### DIFF
--- a/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathutil.h
+++ b/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/mathutil.h
@@ -451,6 +451,13 @@ class MathUtil {
     return bit_cast<double>(g_rep);
   }
 
+  /// Is a number a NaN?
+  /// We just defer to MathLimits<T>.
+  template <typename T>
+  static bool IsNaN(T x) {
+    return MathLimits<T>::IsNaN(x);
+  }
+
   /// Largest of two values.
   /// Works correctly for special floating point values.
   /// Note: 0.0 and -0.0 are not differentiated by Max (Max(0.0, -0.0) is -0.0),

--- a/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/matrix3x3-inl.h
+++ b/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/matrix3x3-inl.h
@@ -539,7 +539,7 @@ class Matrix3x3 {
   bool IsNaN() const {
     for ( int i = 0; i < 3; ++i ) {
       for ( int j = 0; j < 3; ++j ) {
-        if ( isnan(m_[i][j]) ) {
+        if ( MathUtil::IsNaN(m_[i][j]) ) {
           return true;
         }
       }

--- a/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/vector2-inl.h
+++ b/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/vector2-inl.h
@@ -317,7 +317,7 @@ void Vector2<VType>::Clear() {
 
 template <typename VType>
 bool Vector2<VType>::IsNaN() const {
-  return isnan(c_[0]) || isnan(c_[1]);
+  return MathUtil::IsNaN(c_[0]) || MathUtil::IsNaN(c_[1]);
 }
 
 template <typename VType>

--- a/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/vector3-inl.h
+++ b/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/vector3-inl.h
@@ -374,7 +374,7 @@ void Vector3<VType>::Clear() {
 
 template <typename VType>
 bool Vector3<VType>::IsNaN() const {
-  return isnan(c_[0]) || isnan(c_[1]) || isnan(c_[2]);
+  return MathUtil::IsNaN(c_[0]) || MathUtil::IsNaN(c_[1]) || MathUtil::IsNaN(c_[2]);
 }
 
 template <typename VType>

--- a/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/vector4-inl.h
+++ b/third_party/cpp/google-s2-geometry/geometry/include/s2geo/util/math/vector4-inl.h
@@ -374,7 +374,7 @@ void Vector4<VType>::Clear() {
 
 template <typename VType>
 bool Vector4<VType>::IsNaN() const {
-  return isnan(c_[0]) || isnan(c_[1]) || isnan(c_[2]) || isnan(c_[3]);
+  return MathUtil::IsNaN(c_[0]) || MathUtil::IsNaN(c_[1]) || MathUtil::IsNaN(c_[2]) || MathUtil::IsNaN(c_[3]);
 }
 
 template <typename VType>


### PR DESCRIPTION
The GCC version 5.4.0 compiler does not have a global definition of
isnan.  This function is in std::isnan and not global.  The C6, C7
and U14.04 compilers had these functions in the global namespace and
not in std::isnan.  So, we leverage some partial support for this in
the S2 library and expand coverage to other data types which need it.