### PR TITLE
Added a new valgrind suppression.

### DIFF
--- a/build.py
+++ b/build.py
@@ -439,6 +439,12 @@ if whichtests in ("${eetestsuite}", "logging"):
     logging_test
     """
 
+if whichtests in ("${eetestsuite}", "memleaktests"):
+   CTX.TESTS['memleaktests'] = """
+     definite_losses
+     indirect_losses
+     still_reachable_losses
+   """
 if whichtests in ("${eetestsuite}", "common"):
     CTX.TESTS['common'] = """
      debuglog_test

--- a/build.py
+++ b/build.py
@@ -558,6 +558,8 @@ elif CTX.PLATFORM == "Linux":
         if name == "processor":
             numHardwareThreads = numHardwareThreads + 1
 
+print("Making in directory \"%s\" with %d threads" 
+		% (CTX.OUTPUT_PREFIX, numHardwareThreads))
 retval = os.system("make --directory=%s -j%d" % (CTX.OUTPUT_PREFIX, numHardwareThreads))
 if retval != 0:
     sys.exit(-1)

--- a/build.py
+++ b/build.py
@@ -444,6 +444,8 @@ if whichtests in ("${eetestsuite}", "memleaktests"):
      definite_losses
      indirect_losses
      still_reachable_losses
+     possible_losses
+     rw_deleted
    """
 if whichtests in ("${eetestsuite}", "common"):
     CTX.TESTS['common'] = """

--- a/buildtools.py
+++ b/buildtools.py
@@ -618,6 +618,66 @@ def buildIPC(CTX):
     retval = os.system("make --directory=%s prod/voltdbipc -j4" % (CTX.OUTPUT_PREFIX))
     return retval
 
+class MemLeakError:
+    def __init__(self, bytes, blocks, errType, line):
+        self.bytes = bytes
+        self.blocks = blocks
+        self.errType = errType
+        self.line = line
+    def message(self):
+        return self.errType + '\n    ' + self.line
+
+class ValgrindError:
+    def __init__(self, errorCount, contextCount, errType, line):
+        self.errorCount = errorCount
+        self.contextCount = contextCount
+        self.line = line
+    def message(self):
+        return self.line
+
+class ErrorState:
+    def __init__(self, expectNoErrors):
+        self.expectErrors = not expectNoErrors
+        self.memLossPattern = re.compile(".*(?P<errorType>((definitely)|(possibly)|(indirectly))) lost: (?P<byteCount>\d*) bytes in (?P<blockCount>\d*) blocks");
+        self.stillReachablePattern = re.compile(".*still reachable: (?P<byteCount>\d*) bytes in (?P<blockCount>\d*) blocks");
+        self.errorPattern = re.compile(".*ERROR SUMMARY: (?P<errorCount>\d*) errors from (?P<errorContexts>\d*) contexts")
+        self.errorLines = []
+
+    def processErrorString(self, line):
+        m = self.memLossPattern.match(line)
+        if m:
+            bytes = int(m.group('byteCount'))
+            if bytes > 0:
+                blocks = int(m.group('blockCount'))
+                errtype = m.group("errorType")
+                self.errorLines += [MemLeakError(bytes, blocks, "Memory " + errtype + " Lost.", line)]
+            return
+        m = self.stillReachablePattern.match(line)
+        if m:
+            bytes = int(m.group('byteCount'))
+            if bytes > 0:
+                blocks = int(m.group('blockCount'))
+                errType = "Memory still reachable"
+                self.errorLines += [MemLeakError(bytes, blocks, "Memory " + errType + " Lost.", line)]
+            return
+        m = self.errorPattern.match(line)
+        if m:
+            errors = int(m.group('errorCount'))
+            if errors > 0:
+                contexts = int(m.group('errorContexts'))
+                errtype = 'other'
+                self.errorLines += [ValgrindError(errors, contexts, errtype, line)]
+                
+    def isExpectedState(self):
+        if self.expectErrors:
+            return (len(self.errorLines) > 0)
+        else:
+            return (len(self.errorLines) == 0)
+
+    def errorMessage(self):
+        return ("%d Valgrind Errors: \n" % len(self.errorLines)) \
+		+ "\n".join(map(lambda l: l.message(), self.errorLines))
+    
 def runTests(CTX):
     failedTests = []
 
@@ -631,11 +691,12 @@ def runTests(CTX):
     tests = []
     for dir in CTX.TESTS.keys():
         input = CTX.TESTS[dir].split()
-        tests += [TEST_PREFIX + "/" + dir + "/" + x for x in input]
+        tests += [(dir, TEST_PREFIX + "/" + dir + "/" + x) for x in input]
     successes = 0
     failures = 0
     noValgrindTests = [ "CompactionTest", "CopyOnWriteTest", "harness_test", "serializeio_test" ]
-    for test in tests:
+    for dir, test in tests:
+	expectNoMemLeaks = not (dir == "memleaktests")
         binname, objectname, sourcename = namesForTestCode(test)
         targetpath = OUTPUT_PREFIX + "/" + binname
         retval = 0
@@ -656,33 +717,13 @@ def runTests(CTX):
 							     "--suppressions=" + os.path.join(TEST_PREFIX,
 											      "test_utils/vdbsuppressions.supp"),
 							     targetpath], stderr=PIPE, bufsize=-1)
-                #out process= process.stdout.readlines()
-		noDefiniteLeaks = False
-		noPossibleLeaks = False
-		noIndirectLeaks = False
-                otherValgrindError = True
                 out_err = process.stderr.readlines()
                 retval = process.wait()
-                for str in out_err:
-		    if "definitely lost: 0 bytes in 0 blocks" in str:
-			noDefiniteLeaks = True
-		    elif "indirectly lost: 0 bytes in 0 blocks" in str:
-			noIndirectLeaks = True
-		    elif "possibly lost: 0 bytes in 0 blocks" in str:
-			noPossibleLeaks = True
-                    elif "ERROR SUMMARY: 0 errors from 0 contexts" in str:
-                        otherValgrindError = False
-		if not noDefiniteLeaks:
-		    print "Definite leaks found"
-		    retval = -1
-	        if not noPossibleLeaks:
-		    print "Possible leaks found."
-		    retval = -1
-                if not noIndirectLeaks:
-		    print "Indirect leaks found"
-		    retval = -1
-                if otherValgrindError:
-                    print "Valgrind reported errors..."
+                errorState = ErrorState(expectNoMemLeaks)
+                for line in out_err:
+                    errorState.processErrorString(line);
+                if not errorState.isExpectedState():
+                    print errorState.errorMessage()
                     retval = -1
                 if retval == -1:
                     for str in out_err:

--- a/tests/ee/common/nvalue_test.cpp
+++ b/tests/ee/common/nvalue_test.cpp
@@ -2976,12 +2976,12 @@ TEST_F(NValueTest, TestTimestampStringParse)
             cout << "Timestamp cast should have failed for string '" << trials[ii] << "'.\n";
             failed = true;
         } catch(SQLException& exc) {
-            const char* msg = exc.message().c_str();
+            string msg = exc.message();
             string to_find = "\'";
             to_find += trials[ii];
             to_find += "\'";
-            const char* found = strstr(msg, to_find.c_str());
-            if (found && found > msg && found[0] == '\'' && found[strlen(trials[ii])+1] == '\'') {
+            string::size_type found = msg.find(to_find);
+            if (found != string::npos && found > 0 && msg[found] == '\'' && msg[found + strlen(trials[ii]) + 1] == '\'') {
                 continue;
             }
             cout << "Timestamp cast exception message looks corrupted: '" << msg << "'.\n";

--- a/tests/ee/expressions/function_test.cpp
+++ b/tests/ee/expressions/function_test.cpp
@@ -72,6 +72,13 @@ using namespace voltdb;
 
 static bool staticVerboseFlag = false;
 
+namespace {
+bool findString(const std::string &string, std::string pattern) {
+    std::string::size_type found = string.find(pattern);
+    return (found != std::string::npos);
+}
+}
+
 struct FunctionTest : public Test {
         FunctionTest() :
                 Test(),
@@ -472,23 +479,21 @@ TEST_F(FunctionTest, NaturalLogTest) {
     ASSERT_EQ(testUnary(FUNC_LN, 1, 0),
               0);
 
-    bool sawExecption = false;
+    bool sawException = false;
     try {
         testUnary(FUNC_LN, -1, 0);
     } catch(SQLException &sqlExcp) {
-        const char *errMsg = sqlExcp.message().c_str();
-        sawExecption = (strncmp(errMsg, "Invalid result value (nan)", strlen(errMsg)) >= 0) ? true : false;
+	sawException = findString(sqlExcp.message(), "Invalid result value (nan)");
     }
-    ASSERT_EQ(sawExecption, true);
+    ASSERT_EQ(sawException, true);
 
-    sawExecption = false;
+    sawException = false;
     try {
         testUnary(FUNC_LN, 0, 0);
     } catch(SQLException &sqlExcp) {
-        const char *errMsg = sqlExcp.message().c_str();
-        sawExecption = (strncmp(errMsg, "Invalid result value (-inf)", strlen(errMsg)) >= 0)? true : false;
+	sawException = findString(sqlExcp.message(), "Invalid result value (-inf)");
     }
-    ASSERT_EQ(sawExecption, true);
+    ASSERT_EQ(sawException, true);
 }
 
 TEST_F(FunctionTest, NaturalLog10Test) {
@@ -496,34 +501,31 @@ TEST_F(FunctionTest, NaturalLog10Test) {
     ASSERT_EQ(testUnary(FUNC_LOG10, 100.0, 2.0), 0);
 
     //invalid parameter value
-    bool sawExecption = false;
+    bool sawException = false;
     try {
         testUnary(FUNC_LOG10, -100, 0);
     } catch(SQLException &sqlExcp) {
-        const char *errMsg = sqlExcp.message().c_str();
-        sawExecption = (strncmp(errMsg, "Invalid result value (nan)", strlen(errMsg)) >= 0) ? true : false;
+	sawException = findString(sqlExcp.message(), "Invalid result value (nan)");
     }
-    ASSERT_EQ(sawExecption, true);
+    ASSERT_EQ(sawException, true);
 
     //invalid parameter value
-    sawExecption = false;
+    sawException = false;
     try {
         testUnary(FUNC_LOG10, -1, 0);
     } catch(SQLException &sqlExcp) {
-        const char *errMsg = sqlExcp.message().c_str();
-        sawExecption = (strncmp(errMsg, "Invalid result value (nan)", strlen(errMsg)) >= 0) ? true : false;
+	sawException = findString(sqlExcp.message(), "Invalid result value (nan)");
     }
-    ASSERT_EQ(sawExecption, true);
+    ASSERT_EQ(sawException, true);
 
     //invalid parameter type
-    sawExecption = false;
+    sawException = false;
     try {
         testUnary(FUNC_LOG10, "100", 0);
     } catch(SQLException &sqlExcp) {
-        const char *errMsg = sqlExcp.message().c_str();
-        sawExecption = (strncmp(errMsg, "Invalid result value (nan)", strlen(errMsg)) >= 0) ? true : false;
+	sawException = findString(sqlExcp.message(), "Type VARCHAR can't be cast as FLOAT");
     }
-    ASSERT_EQ(sawExecption, true);
+    ASSERT_EQ(sawException, true);
 }
 
 TEST_F(FunctionTest, NaturalModTest) {
@@ -540,15 +542,14 @@ TEST_F(FunctionTest, NaturalModTest) {
     ASSERT_EQ(testBinary(FUNC_MOD, TTInt("-25.2"), TTInt("-7.4"), TTInt("-4.000000000000")), 0);
 
     //invalid parameter value
-    bool sawExecption = false;
+    bool sawException = false;
     try {
         testBinary(FUNC_MOD, "-100", 3, 1);
     } catch(SQLException &sqlExcp) {
-        const char *errMsg = sqlExcp.message().c_str();
-        sawExecption = (strncmp(errMsg,
-            "unsupported non-numeric type for SQL MOD function", strlen(errMsg)) >= 0) ? true : false;
+	sawException = findString(sqlExcp.message(), 
+                                  "unsupported non-numeric type for SQL MOD function");
     }
-    ASSERT_EQ(sawExecption, true);
+    ASSERT_EQ(sawException, true);
 }
 
 TEST_F(FunctionTest, HexTest) {

--- a/tests/ee/expressions/function_test.cpp
+++ b/tests/ee/expressions/function_test.cpp
@@ -483,7 +483,7 @@ TEST_F(FunctionTest, NaturalLogTest) {
     try {
         testUnary(FUNC_LN, -1, 0);
     } catch(SQLException &sqlExcp) {
-	sawException = findString(sqlExcp.message(), "Invalid result value (nan)");
+    sawException = findString(sqlExcp.message(), "Invalid result value (nan)");
     }
     ASSERT_EQ(sawException, true);
 
@@ -491,7 +491,7 @@ TEST_F(FunctionTest, NaturalLogTest) {
     try {
         testUnary(FUNC_LN, 0, 0);
     } catch(SQLException &sqlExcp) {
-	sawException = findString(sqlExcp.message(), "Invalid result value (-inf)");
+    sawException = findString(sqlExcp.message(), "Invalid result value (-inf)");
     }
     ASSERT_EQ(sawException, true);
 }
@@ -505,7 +505,7 @@ TEST_F(FunctionTest, NaturalLog10Test) {
     try {
         testUnary(FUNC_LOG10, -100, 0);
     } catch(SQLException &sqlExcp) {
-	sawException = findString(sqlExcp.message(), "Invalid result value (nan)");
+    sawException = findString(sqlExcp.message(), "Invalid result value (nan)");
     }
     ASSERT_EQ(sawException, true);
 
@@ -514,7 +514,7 @@ TEST_F(FunctionTest, NaturalLog10Test) {
     try {
         testUnary(FUNC_LOG10, -1, 0);
     } catch(SQLException &sqlExcp) {
-	sawException = findString(sqlExcp.message(), "Invalid result value (nan)");
+    sawException = findString(sqlExcp.message(), "Invalid result value (nan)");
     }
     ASSERT_EQ(sawException, true);
 
@@ -523,7 +523,7 @@ TEST_F(FunctionTest, NaturalLog10Test) {
     try {
         testUnary(FUNC_LOG10, "100", 0);
     } catch(SQLException &sqlExcp) {
-	sawException = findString(sqlExcp.message(), "Type VARCHAR can't be cast as FLOAT");
+    sawException = findString(sqlExcp.message(), "Type VARCHAR can't be cast as FLOAT");
     }
     ASSERT_EQ(sawException, true);
 }
@@ -546,7 +546,7 @@ TEST_F(FunctionTest, NaturalModTest) {
     try {
         testBinary(FUNC_MOD, "-100", 3, 1);
     } catch(SQLException &sqlExcp) {
-	sawException = findString(sqlExcp.message(), 
+    sawException = findString(sqlExcp.message(),
                                   "unsupported non-numeric type for SQL MOD function");
     }
     ASSERT_EQ(sawException, true);

--- a/tests/ee/memleaktests/definite_losses.cpp
+++ b/tests/ee/memleaktests/definite_losses.cpp
@@ -1,0 +1,70 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/* Copyright (C) 2008
+ * Evan Jones
+ * Massachusetts Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "harness.h"
+#include <string.h>
+
+/**
+ * This is a test for our handling of definite memory losses.  This
+ * tests the test harness more than the product.
+ */
+class DefiniteMemoryLoss : public Test {
+public:
+    DefiniteMemoryLoss() {}
+};
+
+TEST_F(DefiniteMemoryLoss, memLossTest) {
+    char *garbage = new char[128];
+    memset(garbage, 0, 128);
+}
+
+int main() {
+    return TestSuite::globalInstance()->runAll();
+}

--- a/tests/ee/memleaktests/indirect_losses.cpp
+++ b/tests/ee/memleaktests/indirect_losses.cpp
@@ -1,0 +1,89 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/* Copyright (C) 2008
+ * Evan Jones
+ * Massachusetts Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "harness.h"
+
+/**
+ * Nothing to see here.
+ */
+struct mystruct {
+  int           idx;
+};
+
+/**
+ * This is a memory leak.  We are testing for it.
+ */
+struct rootstruct {
+  mystruct      *ptr;
+  rootstruct() : ptr(0) {}
+  void init() {
+    ptr = new mystruct();
+  }
+};
+
+/**
+ * This is a test for our handling of indirect memory losses.  This
+ * tests the test harness more than the product.
+ */
+class IndirectMemoryLoss : public Test {
+public:
+    IndirectMemoryLoss() {}
+};
+
+TEST_F(IndirectMemoryLoss, memLossTest) {
+    rootstruct *p = new rootstruct();
+    p->init();
+    delete p;
+    // Note: p->ptr is leaked.  Will valgrind find it?
+}
+
+int main() {
+    return TestSuite::globalInstance()->runAll();
+}

--- a/tests/ee/memleaktests/possible_losses.cpp
+++ b/tests/ee/memleaktests/possible_losses.cpp
@@ -49,38 +49,27 @@
  */
 
 #include "harness.h"
+#include <string.h>
 
 /**
- * Nothing to see here.
- */
-struct mystruct {
-  int           idx;
-};
-
-/**
- * This is a memory leak.  We are testing for it.
- */
-struct rootstruct {
-  mystruct      *ptr;
-  rootstruct() : ptr(0) {}
-  void init() {
-    ptr = new mystruct();
-  }
-};
-
-/**
- * This is a test for our handling of indirect memory losses.  This
+ * This is a test for our handling of definite memory losses.  This
  * tests the test harness more than the product.
  */
-class IndirectMemoryLoss : public Test {
+class PossibleMemoryLoss : public Test {
 public:
-    IndirectMemoryLoss() {}
+    PossibleMemoryLoss() {}
 };
 
-TEST_F(IndirectMemoryLoss, memLossTest) {
-    rootstruct *p = new rootstruct();
-    p->init();
-    // Note: both p and p->ptr is leaked.  Will valgrind find it?
+namespace {
+char *garbage = 0;
+}
+
+TEST_F(PossibleMemoryLoss, memLossTest) {
+    // Allocate some memory, but
+    // point to the middle of it.
+    // Maybe this will fool valgrind.
+    garbage = new char[128];
+    garbage = garbage + 64;
 }
 
 int main() {

--- a/tests/ee/memleaktests/rw_deleted.cpp
+++ b/tests/ee/memleaktests/rw_deleted.cpp
@@ -49,38 +49,30 @@
  */
 
 #include "harness.h"
+#include <string.h>
 
 /**
- * Nothing to see here.
- */
-struct mystruct {
-  int           idx;
-};
-
-/**
- * This is a memory leak.  We are testing for it.
- */
-struct rootstruct {
-  mystruct      *ptr;
-  rootstruct() : ptr(0) {}
-  void init() {
-    ptr = new mystruct();
-  }
-};
-
-/**
- * This is a test for our handling of indirect memory losses.  This
+ * This is a test for our handling of definite memory losses.  This
  * tests the test harness more than the product.
  */
-class IndirectMemoryLoss : public Test {
+class ReadWriteErrors : public Test {
 public:
-    IndirectMemoryLoss() {}
+    ReadWriteErrors() {}
 };
 
-TEST_F(IndirectMemoryLoss, memLossTest) {
-    rootstruct *p = new rootstruct();
-    p->init();
-    // Note: both p and p->ptr is leaked.  Will valgrind find it?
+namespace {
+char *garbage = 0;
+}
+
+TEST_F(ReadWriteErrors, readWriteErrors) {
+    // Allocate some memory, but
+    // point to the middle of it.
+    // Maybe this will fool valgrind.
+    garbage = new char[128];
+    delete garbage;
+    char j = garbage[64];
+    memset(&garbage[64], 0, 1);
+    memset(&j, 0, sizeof(j));
 }
 
 int main() {

--- a/tests/ee/memleaktests/still_reachable_losses.cpp
+++ b/tests/ee/memleaktests/still_reachable_losses.cpp
@@ -1,0 +1,74 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/* Copyright (C) 2008
+ * Evan Jones
+ * Massachusetts Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "harness.h"
+#include <string.h>
+
+namespace {
+char *garbage = new char[128];
+};
+/**
+ * This is a test for our handling of indirect memory losses.  This
+ * tests the test harness more than the product.
+ */
+class StillReachableMemoryLeaks : public Test {
+public:
+    StillReachableMemoryLeaks() {}
+};
+
+TEST_F(StillReachableMemoryLeaks, memLossTest) {
+    // Note: <anon namespace>::garbage is leaked.
+    //       will valgrind find it?
+    memset(garbage, 0, 128);
+}
+
+int main() {
+    return TestSuite::globalInstance()->runAll();
+}

--- a/tests/ee/test_utils/vdbsuppressions.supp
+++ b/tests/ee/test_utils/vdbsuppressions.supp
@@ -9,3 +9,13 @@
    obj:/lib/x86_64-linux-gnu/ld-2.19.so
 }
 
+{
+   stl:u16.04
+   Memcheck:Leak
+   fun:malloc
+   obj:/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/lib/x86_64-linux-gnu/ld-2.23.so
+}


### PR DESCRIPTION
For Ubuntu 16.04 the old STL suppression does not work.  The library
version numbers are incorrect.  I also added a diagnostic to build.py
to show how many threads are used when making the EE and the EE tests.
