### PR TITLE
ignore being admin-mode being set through deployment when using new verbs 

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1637,8 +1637,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
         // log message unconditionally indicating that the provided host-count and admin-mode settings in
         // deployment, if any, will be ignored
-        consoleLog.info("Hostcount, admin-mode settings specified in the deployment file will be ignored");
-        hostLog.info("Hostcount, admin-mode settings specified in the deployment file will be ignored");
+        consoleLog.info("When using the INIT command, some deployment file settings (hostcount, voltdbroot path, "
+                + "and admin-mode) are ignored");
+        hostLog.info("When using the INIT command, some deployment file settings (hostcount, voltdbroot path, "
+                + "and admin-mode) are ignored");
 
         // see if you just can simply copy the deployment file
         if (writeGeneratedDF) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -298,6 +298,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     private final ListeningExecutorService m_es = CoreUtils.getCachedSingleThreadExecutor("StartAction ZK Watcher", 15000);
 
     private volatile boolean m_isRunning = false;
+    private boolean m_isRunningWithOldVerb = true;
+
+    @Override
+    public boolean isRunningWithOldVerbs() { return m_isRunningWithOldVerb; };
 
     @Override
     public boolean rejoining() { return m_rejoining; }
@@ -438,6 +442,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 System.exit(-1);
             }
 
+            m_isRunningWithOldVerb = config.m_startAction.isLegacy();
             readBuildInfo(config.m_isEnterprise ? "Enterprise Edition" : "Community Edition");
 
             // Replay command line args that we can see
@@ -1563,9 +1568,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 consoleLog.info("Ignoring voltdbroot \"" + deprootFN + "\"specified in the deployment file");
                 hostLog.info("Ignoring voltdbroot \"" + deprootFN + "\"specified in the deployment file");
             }
-            // if provided admin-mode settings in deployment are different than the default one, update
-            // admin mode settings to default and update flag to commit updated deployment
-            if(CatalogUtil.updateAdminModeToDefaultIfNotDefault(dt)) {
+            // if provided admin-mode start up is different than the default one, update amin-mode
+            // startup to null for default, which is admin-mode set to false in deployment, and
+            // flag updated to reflect rewrite the deployment instead of copy
+            if(dt.getAdminMode().isAdminstartup()) {
+                dt.getAdminMode().setAdminstartup(null);
+                dt.getAdminMode().setPort(null);
                writeGeneratedDF = true;
             }
         } catch (IOException e) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -301,13 +301,19 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     private boolean m_isRunningWithOldVerb = true;
 
     @Override
-    public boolean isRunningWithOldVerbs() { return m_isRunningWithOldVerb; };
+    public boolean isRunningWithOldVerbs() {
+        return m_isRunningWithOldVerb;
+     };
 
     @Override
-    public boolean rejoining() { return m_rejoining; }
+    public boolean rejoining() {
+        return m_rejoining;
+    }
 
     @Override
-    public boolean rejoinDataPending() { return m_rejoinDataPending; }
+    public boolean rejoinDataPending() {
+        return m_rejoinDataPending;
+    }
 
     @Override
     public boolean isMpSysprocSafeToExecute(long txnId)
@@ -1568,12 +1574,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 consoleLog.info("Ignoring voltdbroot \"" + deprootFN + "\"specified in the deployment file");
                 hostLog.info("Ignoring voltdbroot \"" + deprootFN + "\"specified in the deployment file");
             }
-            // if provided admin-mode start up is different than the default one, update amin-mode
-            // startup to null for default, which is admin-mode set to false in deployment, and
-            // flag updated to reflect rewrite the deployment instead of copy
+            // if provided admin-mode start up is set, update it to false and update
+            // the rewrite-flag reflect to rewrite the deployment instead of copy
             if(dt.getAdminMode().isAdminstartup()) {
-                dt.getAdminMode().setAdminstartup(null);
-                dt.getAdminMode().setPort(null);
+                dt.getAdminMode().setAdminstartup(false);
                writeGeneratedDF = true;
             }
         } catch (IOException e) {

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -45,6 +45,7 @@ public interface VoltDBInterface
     public void readBuildInfo(String editionTag);
 
     public CommandLog getCommandLog();
+    public boolean isRunningWithOldVerbs();
 
     /**
      * Initialize all the global components, then initialize all the m_sites.

--- a/src/frontend/org/voltdb/compiler/AsyncCompilerAgentHelper.java
+++ b/src/frontend/org/voltdb/compiler/AsyncCompilerAgentHelper.java
@@ -29,6 +29,7 @@ import org.voltdb.catalog.CatalogDiffEngine;
 import org.voltdb.common.Constants;
 import org.voltdb.compiler.ClassMatcher.ClassNameMatchStatus;
 import org.voltdb.compiler.VoltCompiler.VoltCompilerException;
+import org.voltdb.compiler.deploymentfile.DeploymentType;
 import org.voltdb.licensetool.LicenseApi;
 import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.Encoder;
@@ -200,16 +201,32 @@ public class AsyncCompilerAgentHelper
                 }
             }
 
-            result =
-                CatalogUtil.compileDeploymentString(newCatalog, deploymentString, false);
+            DeploymentType dt  = CatalogUtil.parseDeploymentFromString(deploymentString);
+            if (dt == null) {
+                retval.errorMsg = "Unable to update deployment configuration: Error parsing deployment string";
+                return retval;
+            }
+
+            result = CatalogUtil.compileDeployment(newCatalog, dt, false);
             if (result != null) {
                 retval.errorMsg = "Unable to update deployment configuration: " + result;
                 return retval;
             }
 
-            retval.deploymentString = deploymentString;
+            // ignore admin mode settings if operating with new start actions/verbs
+            if (!VoltDB.instance().isRunningWithOldVerbs() && dt.getAdminMode().isAdminstartup()) {
+                // set it to null, this will default to admin-mode startup to default which is false
+                dt.getAdminMode().setAdminstartup(null);
+                dt.getAdminMode().setPort(null);
+                retval.deploymentString = CatalogUtil.getDeployment(dt, true);
+            }
+            else {
+                retval.deploymentString = deploymentString;
+            }
+
+
             retval.deploymentHash =
-                CatalogUtil.makeDeploymentHash(deploymentString.getBytes(Constants.UTF8ENCODING));
+                CatalogUtil.makeDeploymentHash(retval.deploymentString.getBytes(Constants.UTF8ENCODING));
 
             // store the version of the catalog the diffs were created against.
             // verified when / if the update procedure runs in order to verify

--- a/src/frontend/org/voltdb/compiler/AsyncCompilerAgentHelper.java
+++ b/src/frontend/org/voltdb/compiler/AsyncCompilerAgentHelper.java
@@ -215,9 +215,9 @@ public class AsyncCompilerAgentHelper
 
             // ignore admin mode settings if operating with new start actions/verbs
             if (!VoltDB.instance().isRunningWithOldVerbs() && dt.getAdminMode().isAdminstartup()) {
-                // set it to null, this will default to admin-mode startup to default which is false
-                dt.getAdminMode().setAdminstartup(null);
-                dt.getAdminMode().setPort(null);
+                // set the admin-startup mode to false and fetch update the deployment string from
+                // updated deployment object
+                dt.getAdminMode().setAdminstartup(false);
                 retval.deploymentString = CatalogUtil.getDeployment(dt, true);
             }
             else {

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -1061,26 +1061,6 @@ public abstract class CatalogUtil {
     }
 
     /**
-     * Checks if the admin-mode settings in passed in deployment are default or not. If not,
-     * the admin mode settings are updated to default
-     * @param deployment Reference to root <deployment> element of deployment file to be validated.
-     * @return Returns true if the admin-mode setting was updated with defaults.
-     */
-    public static boolean updateAdminModeToDefaultIfNotDefault(DeploymentType dt) {
-        AdminModeType defaultAdminMode = new AdminModeType();
-        AdminModeType providedAdminMode = dt.getAdminMode();
-        // generated xml binding classes don't generate common functions
-        // like equals(), so compare the fields manually
-        if (providedAdminMode.getPort() == defaultAdminMode.getPort() &&
-                providedAdminMode.isAdminstartup() == defaultAdminMode.isAdminstartup()) {
-            return false;
-        }
-        // prune admin-mode from deployment by replacing admin mode with default
-        dt.setAdminMode(defaultAdminMode);
-        return true;
-    }
-
-    /**
      * Set cluster info in the catalog.
      * @param leader The leader hostname
      * @param catalog The catalog to be updated.

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -1061,6 +1061,26 @@ public abstract class CatalogUtil {
     }
 
     /**
+     * Checks if the admin-mode settings in passed in deployment are default or not. If not,
+     * the admin mode settings are updated to default
+     * @param deployment Reference to root <deployment> element of deployment file to be validated.
+     * @return Returns true if the admin-mode setting was updated with defaults.
+     */
+    public static boolean updateAdminModeToDefaultIfNotDefault(DeploymentType dt) {
+        AdminModeType defaultAdminMode = new AdminModeType();
+        AdminModeType providedAdminMode = dt.getAdminMode();
+        // generated xml binding classes don't generate common functions
+        // like equals(), so compare the fields manually
+        if (providedAdminMode.getPort() == defaultAdminMode.getPort() &&
+                providedAdminMode.isAdminstartup() == defaultAdminMode.isAdminstartup()) {
+            return false;
+        }
+        // prune admin-mode from deployment by replacing admin mode with default
+        dt.setAdminMode(defaultAdminMode);
+        return true;
+    }
+
+    /**
      * Set cluster info in the catalog.
      * @param leader The leader hostname
      * @param catalog The catalog to be updated.

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -356,6 +356,11 @@ public class MockVoltDB implements VoltDBInterface
     }
 
     @Override
+    public boolean isRunningWithOldVerbs() {
+        return voltconfig.m_startAction.isLegacy();
+    }
+
+    @Override
     public void initialize(Configuration config)
     {
         m_noLoadLib = config.m_noLoadLibVOLTDB;


### PR DESCRIPTION
Logic updates to ignore admin mode setting via deployment file during voldtb init if different than default.  

Changes have been tested for the following scenario:
- User provides no deployment, the default deployment gets used same as today
- User provides a valid deployment without admin mode settings, deployment file gets copied to voldbroot if voldbroot is not changing
- User provides a valid deployment with admin mode startup set to false, the same deployment file gets copied to voldbroot if voldbroot is not changing
- User provides a valid deployment with admin mode set or different admin port , newly generated deployment file with other default setting gets written to voldbroot similar to case if the voltdbroot directory was different.