### PR TITLE
Prevent voltdb to recover from a partial snapshot.

### DIFF
--- a/src/frontend/org/voltdb/RestoreAgent.java
+++ b/src/frontend/org/voltdb/RestoreAgent.java
@@ -833,7 +833,7 @@ SnapshotCompletionInterest, Promotable
             // Make sure this is not a partial snapshot.
             // Compare digestTableNames with all normal table names in catalog file.
             // A normal table is one that's NOT a materialized view, nor an export table.
-            Set<String> catalogNormalTableNames = CatalogUtil.getNormalTableNamesfromInMemoryJar(jarfile);
+            Set<String> catalogNormalTableNames = CatalogUtil.getNormalTableNamesFromInMemoryJar(jarfile);
             if (!catalogNormalTableNames.equals(digestTableNames)) {
                 m_snapshotErrLogStr.append("\nRejected snapshot ")
                                 .append(s.getNonce())

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2256,7 +2256,7 @@ public abstract class CatalogUtil {
      * @param InMemoryJarfile a in-memory catalog jar file
      * @return A set of normal table names
      */
-    public static Set<String> getNormalTableNamesfromInMemoryJar(InMemoryJarfile jarfile) {
+    public static Set<String> getNormalTableNamesFromInMemoryJar(InMemoryJarfile jarfile) {
         Set<String> tableNames = new HashSet<>();
         Catalog catalog = new Catalog();
         catalog.execute(getSerializedCatalogStringFromJar(jarfile));

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -35,6 +35,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -2247,6 +2248,26 @@ public abstract class CatalogUtil {
         stmt.setIndexesused(indexString);
 
         assert(tablesRead.size() == 0);
+    }
+
+    /**
+     * Get all normal table names from a in-memory catalog jar file.
+     * A normal table is one that's NOT a materialized view, nor an export table.
+     * @param InMemoryJarfile a in-memory catalog jar file
+     * @return A set of normal table names
+     */
+    public static Set<String> getNormalTableNamesfromInMemoryJar(InMemoryJarfile jarfile) {
+        Set<String> tableNames = new HashSet<>();
+        Catalog catalog = new Catalog();
+        catalog.execute(getSerializedCatalogStringFromJar(jarfile));
+        Database db = catalog.getClusters().get("cluster").getDatabases().get("database");
+        for (Table table : getNormalTables(db, true)) {
+            tableNames.add(table.getTypeName());
+        }
+        for (Table table : getNormalTables(db, false)) {
+            tableNames.add(table.getTypeName());
+        }
+        return tableNames;
     }
 
     /**

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -18,12 +18,12 @@
 package org.voltdb.utils;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.BindException;
 import java.net.ServerSocket;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -88,6 +88,7 @@ public class MiscUtils {
     /**
      * Serialize a file into bytes. Used to serialize catalog and deployment
      * file for UpdateApplicationCatalog on the client.
+     * Notice that if the file is larger than 2GB, readAllBytes() will throw a OutOfMemoryError.
      *
      * @param path
      * @return a byte array of the file
@@ -95,28 +96,7 @@ public class MiscUtils {
      *             If there are errors reading the file
      */
     public static byte[] fileToBytes(File path) throws IOException {
-        FileInputStream fin = null;
-        byte[] buffer = new byte[(int) path.length() + 1000];
-        int readBytes = 0;
-        int totalBytes = 0;
-        try {
-            fin = new FileInputStream(path);
-            while (readBytes >= 0) {
-                totalBytes += readBytes;
-                readBytes = fin.read(buffer, totalBytes, buffer.length - totalBytes - 1);
-            }
-        } catch(IOException ioe) {
-            throw new IOException("File " + path.getAbsolutePath() + " is empty");
-        } finally {
-            if (fin != null) {
-                try {
-                    fin.close();
-                }
-                catch (Exception e) {}
-            }
-        }
-        byte[] bytes = Arrays.copyOf(buffer, totalBytes);
-        return bytes;
+        return Files.readAllBytes(path.toPath());
     }
 
     /**

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -95,16 +95,28 @@ public class MiscUtils {
      *             If there are errors reading the file
      */
     public static byte[] fileToBytes(File path) throws IOException {
-        FileInputStream fin = new FileInputStream(path);
-        byte[] buffer = new byte[(int) fin.getChannel().size()];
+        FileInputStream fin = null;
+        byte[] buffer = new byte[(int) path.length() + 1000];
+        int readBytes = 0;
+        int totalBytes = 0;
         try {
-            if (fin.read(buffer) == -1) {
-                throw new IOException("File " + path.getAbsolutePath() + " is empty");
+            fin = new FileInputStream(path);
+            while (readBytes >= 0) {
+                totalBytes += readBytes;
+                readBytes = fin.read(buffer, totalBytes, buffer.length - totalBytes - 1);
             }
+        } catch(IOException ioe) {
+            throw new IOException("File " + path.getAbsolutePath() + " is empty");
         } finally {
-            fin.close();
+            if (fin != null) {
+                try {
+                    fin.close();
+                }
+                catch (Exception e) {}
+            }
         }
-        return buffer;
+        byte[] bytes = Arrays.copyOf(buffer, totalBytes);
+        return bytes;
     }
 
     /**

--- a/tests/frontend/org/voltdb/utils/TestCatalogUtil.java
+++ b/tests/frontend/org/voltdb/utils/TestCatalogUtil.java
@@ -27,8 +27,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Calendar;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 
 import org.voltcore.utils.Pair;
@@ -2035,5 +2037,29 @@ public class TestCatalogUtil extends TestCase {
         assertEquals(1, mapping.size());
         assertEquals(true, mapping.containsKey("B"));
         assertEquals(0, mapping.get("B").getIndex());
+    }
+
+    public void testGetNormalTableNamesFromInMemoryJar() throws Exception {
+        String schema = "CREATE TABLE NORMAL_A (C1 INTEGER NOT NULL, C2 TIMESTAMP NOT NULL);\n" +
+                "CREATE TABLE NORMAL_B (C1 BIGINT NOT NULL, C2 SMALLINT NOT NULL);\n" +
+                "CREATE TABLE NORMAL_C (C1 TINYINT NOT NULL, C2 VARCHAR(3) NOT NULL);\n" +
+                "CREATE VIEW VIEW_A (TOTAL_ROWS) AS SELECT COUNT(*) FROM NORMAL_A;\n" +
+                "CREATE STREAM EXPORT_A (C1 BIGINT NOT NULL, C2 SMALLINT NOT NULL);\n";
+        String testDir = BuildDirectoryUtils.getBuildDirectoryPath();
+        final File file = VoltFile.createTempFile("testGetNormalTableNamesFromInMemoryJar", ".jar", new File(testDir));
+
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        builder.addLiteralSchema(schema);
+        builder.compile(file.getPath());
+        byte[] bytes = MiscUtils.fileToBytes(file);
+        InMemoryJarfile jarfile = CatalogUtil.loadInMemoryJarFile(bytes);
+        file.delete();
+
+        Set<String> definedNormalTableNames = new HashSet<>();
+        definedNormalTableNames.add("NORMAL_A");
+        definedNormalTableNames.add("NORMAL_B");
+        definedNormalTableNames.add("NORMAL_C");
+        Set<String> returnedNormalTableNames = CatalogUtil.getNormalTableNamesFromInMemoryJar(jarfile);
+        assertEquals(definedNormalTableNames, returnedNormalTableNames);
     }
 }


### PR DESCRIPTION
Compare tables in snapshot digest file with tables in catalog jar. If there is a dismatch, ignore that snapshot.

- Create getNormalTableNamesfromInMemoryJar() in CatalogUtil, which returns all the normal table names in a catalog in-memory jar file.

- Call getNormalTableNamesfromInMemoryJar() in RestoreAgent to compare the table names in catalog with table names in digest.