### PR TITLE
ENG-10667: Backports of ENG-10389 and part of ENG-10453 to 5.9

### DIFF
--- a/src/frontend/org/voltcore/messaging/ForeignHost.java
+++ b/src/frontend/org/voltcore/messaging/ForeignHost.java
@@ -24,10 +24,9 @@ import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-
-import com.google_voltpatches.common.base.Throwables;
 
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
@@ -41,6 +40,8 @@ import org.voltcore.utils.EstTime;
 import org.voltcore.utils.RateLimitedLogger;
 import org.voltdb.OperationMode;
 import org.voltdb.VoltDB;
+
+import com.google_voltpatches.common.base.Throwables;
 
 public class ForeignHost {
     private static final VoltLogger hostLog = new VoltLogger("HOST");
@@ -64,6 +65,10 @@ public class ForeignHost {
 
     private final AtomicInteger m_deadReportsCount = new AtomicInteger(0);
 
+    // used to immediately cut off reads from a foreign host
+    // great way to trigger a heartbeat timout / simulate a network partition
+    private AtomicBoolean m_linkCutForTest = new AtomicBoolean(false);
+
     public static final int POISON_PILL = -1;
 
     public static final int CRASH_ALL = 0;
@@ -80,6 +85,10 @@ public class ForeignHost {
 
         @Override
         public void handleMessage(ByteBuffer message, Connection c) throws IOException {
+            // if this link is "gone silent" for partition tests, just drop the message on the floor
+            if (m_linkCutForTest.get()) {
+                return;
+            }
             handleRead(message, c);
         }
 
@@ -197,42 +206,45 @@ public class ForeignHost {
             return;
         }
 
-        m_network.enqueue(
-                new DeferredSerialization() {
-                    @Override
-                    public final void serialize(final ByteBuffer buf) throws IOException {
-                        buf.putInt(buf.capacity() - 4);
-                        buf.putLong(message.m_sourceHSId);
-                        buf.putInt(destinations.length);
-                        for (int ii = 0; ii < destinations.length; ii++) {
-                            buf.putLong(destinations[ii]);
+        // if this link is "gone silent" for partition tests, just drop the message on the floor
+        if (!m_linkCutForTest.get()) {
+            m_network.enqueue(
+                    new DeferredSerialization() {
+                        @Override
+                        public final void serialize(final ByteBuffer buf) throws IOException {
+                            buf.putInt(buf.capacity() - 4);
+                            buf.putLong(message.m_sourceHSId);
+                            buf.putInt(destinations.length);
+                            for (int ii = 0; ii < destinations.length; ii++) {
+                                buf.putLong(destinations[ii]);
+                            }
+                            message.flattenToBuffer(buf);
+                            buf.flip();
                         }
-                        message.flattenToBuffer(buf);
-                        buf.flip();
-                    }
 
-                    @Override
-                    public final void cancel() {
-                    /*
-                     * Can this be removed?
-                     */
-                    }
+                        @Override
+                        public final void cancel() {
+                        /*
+                         * Can this be removed?
+                         */
+                        }
 
-                    @Override
-                    public String toString() {
-                        return message.getClass().getName();
-                    }
+                        @Override
+                        public String toString() {
+                            return message.getClass().getName();
+                        }
 
-                    @Override
-                    public int getSerializedSize() {
-                        final int len = 4            /* length prefix */
-                                + 8            /* source hsid */
-                                + 4            /* destinationCount */
-                                + 8 * destinations.length  /* destination list */
-                                + message.getSerializedSize();
-                        return len;
-                    }
-                });
+                        @Override
+                        public int getSerializedSize() {
+                            final int len = 4            /* length prefix */
+                                    + 8            /* source hsid */
+                                    + 4            /* destinationCount */
+                                    + 8 * destinations.length  /* destination list */
+                                    + message.getSerializedSize();
+                            return len;
+                        }
+                    });
+        }
 
         long current_time = EstTime.currentTimeMillis();
         long current_delta = current_time - m_lastMessageMillis.get();
@@ -374,6 +386,11 @@ public class ForeignHost {
     }
 
     public void sendPoisonPill(String err, int cause) {
+        // if this link is "gone silent" for partition tests, just drop the message on the floor
+        if (m_linkCutForTest.get()) {
+            return;
+        }
+
         byte errBytes[];
         try {
             errBytes = err.getBytes("UTF-8");
@@ -394,5 +411,13 @@ public class ForeignHost {
 
     public void updateDeadHostTimeout(int timeout) {
         m_deadHostTimeout = timeout;
+    }
+
+    /**
+     * used to immediately cut off reads from a foreign host
+     * great way to trigger a heartbeat timeout / simulate a network partition
+     */
+    void cutLink() {
+        m_linkCutForTest.set(true);
     }
 }

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1180,4 +1180,18 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         return m_network.getIOStats(interval, picoNetworks);
     }
 
+    /**
+     * Cut the network connection between two hostids immediately
+     * Useful for simulating network partitions
+     */
+    public void cutLink(int hostIdA, int hostIdB) {
+        if (m_localHostId == hostIdA) {
+            ForeignHost fh = m_foreignHosts.get(hostIdB);
+            fh.cutLink();
+        }
+        if (m_localHostId == hostIdB) {
+            ForeignHost fh = m_foreignHosts.get(hostIdA);
+            fh.cutLink();
+        }
+    }
 }

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -79,6 +79,7 @@ import org.voltdb.AuthSystem.AuthProvider;
 import org.voltdb.AuthSystem.AuthUser;
 import org.voltdb.CatalogContext.ProcedurePartitionInfo;
 import org.voltdb.ClientInterfaceHandleManager.Iv2InFlight;
+import org.voltdb.Consistency.ReadLevel;
 import org.voltdb.SystemProcedureCatalog.Config;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.catalog.CatalogMap;
@@ -175,6 +176,9 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
 
     private final ClientAcceptor m_acceptor;
     private ClientAcceptor m_adminAcceptor;
+
+    // used to decide if we should shortcut reads
+    private final Consistency.ReadLevel m_defaultConsistencyReadLevel;
 
     private final SnapshotDaemon m_snapshotDaemon;
     private final SnapshotDaemonAdapter m_snapshotDaemonAdapter;
@@ -1063,6 +1067,12 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     {
         assert(!isSinglePartition || (partition >= 0));
         final ClientInterfaceHandleManager cihm = m_cihm.get(connectionId);
+        if (cihm == null) {
+            hostLog.warn("ClientInterface.createTransaction request rejected. "
+                    + "This is likely due to VoltDB ceasing client communication as it "
+                    + "shuts down.");
+            return false;
+        }
 
         Long initiatorHSId = null;
         boolean isShortCircuitRead = false;
@@ -1072,7 +1082,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
          * if there is, send it to the replica as a short circuit read
          */
         if (isSinglePartition && !isEveryPartition) {
-            if (isReadOnly) {
+            if (isReadOnly && (m_defaultConsistencyReadLevel == ReadLevel.FAST)) {
                 initiatorHSId = m_localReplicas.get(partition);
             }
             if (initiatorHSId != null) {
@@ -1220,6 +1230,9 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
         InternalClientResponseAdapter internalAdapter = new InternalClientResponseAdapter(INTERNAL_CID, "Internal");
         bindAdapter(internalAdapter, null, true);
         m_internalConnectionHandler = new InternalConnectionHandler(internalAdapter);
+
+        // try to get the global default setting for read consistency, but fall back to SAFE
+        m_defaultConsistencyReadLevel = VoltDB.Configuration.getDefaultReadConsistencyLevel();
     }
 
     public InternalConnectionHandler getInternalConnectionHandler() {
@@ -2011,13 +2024,21 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                         buf.capacity(),
                         nowNanos);
         if (!success) {
+            // COMMENT 1:
             // HACK: this return is for the DR agent so that it
             // will move along on duplicate replicated transactions
             // reported by the slave cluster.  We report "SUCCESS"
             // to keep the agent from choking.  ENG-2334
-            return new ClientResponseImpl(ClientResponseImpl.UNEXPECTED_FAILURE,
+
+            // COMMENT 2: ENG-10389-backport
+            // when VoltDB.crash... is called, we close off the client interface
+            // and it might not be possible to create new transactions.
+            // Return an error.
+            return new ClientResponseImpl(ClientResponseImpl.SERVER_UNAVAILABLE,
                     new VoltTable[0],
-                    ClientResponseImpl.IGNORED_TRANSACTION,
+                    "VoltDB failed to create the transaction internally.  It is possible this "
+                            + "was caused by a node failure or intentional shutdown. If the cluster recovers, "
+                            + "it should be safe to resend the work, as the work was never started.",
                     task.clientHandle);
         }
         return null;
@@ -3080,4 +3101,43 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
         return clientResponse;
     }
 
+    /**
+     * This is not designed to be a safe shutdown.
+     * This is designed to stop sending messages to clients as fast as possible.
+     * It is currently called from VoltDB.crash...
+     *
+     * Note: this really needs to work. We CAN'T respond back to the client anything
+     * after we've decided to crash or it might break some of our contracts.
+     *
+     * @return false if we can't be assured this safely worked
+     */
+    public boolean ceaseAllPublicFacingTrafficImmediately() {
+        try {
+            if (m_acceptor != null) {
+                // This call seems to block until the shutdown is done
+                // which is good becasue we assume there will be no new
+                // connections afterward
+                m_acceptor.shutdown();
+            }
+            if (m_adminAcceptor != null) {
+                m_adminAcceptor.shutdown();
+            }
+        }
+        catch (InterruptedException e) {
+            // this whole method is really a best effort kind of thing...
+            log.error(e);
+            // if we didn't succeed, let the caller know and take action
+            return false;
+        }
+        finally {
+            // this feels like an unclean thing to do... but should work
+            // for the purposes of cutting all responses right before we deliberatly
+            // end the process
+            // m_cihm itself is threadsafe, and the regular shutdown code won't
+            // care if it's empty... so... this.
+            m_cihm.clear();
+        }
+
+        return true;
+    }
 }

--- a/src/frontend/org/voltdb/Consistency.java
+++ b/src/frontend/org/voltdb/Consistency.java
@@ -1,0 +1,79 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb;
+
+import org.voltdb.compiler.deploymentfile.ReadlevelType;
+
+public abstract class Consistency {
+
+    public enum ReadLevel {
+        FAST (0),
+        SAFE (1);
+
+        private final int value;
+
+        /** Constructor for non-JDBC-visible types.
+         * This can safely stub out any attributes that are only used by jdbc. */
+        private ReadLevel(int value) {
+            this.value = value;
+        }
+
+        public int toInt() {
+            return value;
+        }
+
+        public static ReadLevel fromInt(int value) {
+            if (value == FAST.value) {
+                return FAST;
+            }
+            else if (value == SAFE.value) {
+                return SAFE;
+            }
+            else {
+                throw new IllegalArgumentException(
+                        String.format("No Consistency.ReadLevel with value: %d", value));
+            }
+        }
+
+        public static ReadLevel fromReadLevelType(ReadlevelType value) {
+            if (value == ReadlevelType.FAST) {
+                return FAST;
+            }
+            else if (value == ReadlevelType.SAFE) {
+                return SAFE;
+            }
+            else {
+                throw new IllegalArgumentException(
+                        String.format("No Consistency.ReadLevel with value: %s", value.toString()));
+            }
+        }
+
+        public ReadlevelType toReadLevelType() {
+            if (this == FAST) {
+                return ReadlevelType.FAST;
+            }
+            else if (this == SAFE) {
+                return ReadlevelType.SAFE;
+            }
+            else {
+                throw new IllegalArgumentException(
+                        String.format("No ReadlevelType mapping for Consistency.ReadLevel: %s", toString()));
+            }
+        }
+    }
+}

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -140,6 +140,9 @@ public class VoltDB {
         public int m_adminPort = -1;
         public String m_adminInterface = "";
 
+        /** consistency level for reads */
+        public Consistency.ReadLevel m_consistencyReadLevel = Consistency.ReadLevel.SAFE;
+
         /** port number to use to build intra-cluster mesh */
         public int m_internalPort = DEFAULT_INTERNAL_PORT;
         public String m_internalPortInterface = DEFAULT_INTERNAL_INTERFACE;
@@ -610,6 +613,15 @@ public class VoltDB {
             return testObj.getAbsolutePath() + File.separator + jarname;
         }
 
+        public static Consistency.ReadLevel getDefaultReadConsistencyLevel() {
+            // try to get the global default setting for read consistency, but fall back to SAFE
+            if ((VoltDB.instance() != null) && (VoltDB.instance().getConfig() != null)) {
+                return VoltDB.instance().getConfig().m_consistencyReadLevel;
+            }
+            else {
+                return Consistency.ReadLevel.SAFE;
+            }
+        }
     }
 
     /* helper functions to access current configuration values */
@@ -700,6 +712,23 @@ public class VoltDB {
         }
     }
 
+    /**
+     * turn off client interface as fast as possible
+     */
+    private static boolean turnOffClientInterface() {
+        // we don't expect this to ever fail, but if it does, skip to dying immediately
+        VoltDBInterface vdbInstance = instance();
+        if (vdbInstance != null) {
+            ClientInterface ci = vdbInstance.getClientInterface();
+            if (ci != null) {
+                if (!ci.ceaseAllPublicFacingTrafficImmediately()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     public static void crashLocalVoltDB(String errMsg) {
         crashLocalVoltDB(errMsg, false, null);
     }
@@ -738,6 +767,11 @@ public class VoltDB {
             // slightly less important than death, this try/finally block protects code that
             // prints a message to stdout
             try {
+                // turn off client interface as fast as possible
+                // we don't expect this to ever fail, but if it does, skip to dying immediately
+                if (!turnOffClientInterface()) {
+                    return; // this will jump to the finally block and die faster
+                }
 
                 // Even if the logger is null, don't stop.  We want to log the stack trace and
                 // any other pertinent information to a .dmp file for crash diagnosis
@@ -853,6 +887,12 @@ public class VoltDB {
         // end test code
 
         try {
+            // turn off client interface as fast as possible
+            // we don't expect this to ever fail, but if it does, skip to dying immediately
+            if (!turnOffClientInterface()) {
+                return; // this will jump to the finally block and die faster
+            }
+
             // instruct the rest of the cluster to die
             instance().getHostMessenger().sendPoisonPill(errMsg);
             // give the pill a chance to make it through the network buffer

--- a/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
+++ b/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
@@ -49,6 +49,7 @@
       <xs:element name="security" minOccurs='0' maxOccurs='1' type="securityType"/>
       <xs:element name="dr" minOccurs='0' maxOccurs='1' type="drType" />
       <xs:element name="import" minOccurs="0" maxOccurs="1" type="importType"/>
+      <xs:element name="consistency" minOccurs="0" type="consistencyType"/>
     </xs:all>
   </xs:complexType>
 
@@ -75,6 +76,18 @@
     <xs:attribute name="id" type="clusterIdType"/>
     <xs:attribute name="elastic" type="xs:string" default="enabled"/>
     <xs:attribute name="schema" type="schemaType" default="ddl"/>
+  </xs:complexType>
+  
+  <xs:simpleType name="readlevelType"> 
+    <xs:restriction base="xs:string"> 
+      <xs:enumeration value="fast"/>
+      <xs:enumeration value="safe"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <!-- <consistency> -->
+  <xs:complexType name="consistencyType">
+    <xs:attribute name="readlevel" type="readlevelType" default="safe"/>
   </xs:complexType>
 
   <!-- <paths> -->

--- a/src/frontend/org/voltdb/iv2/RepairLog.java
+++ b/src/frontend/org/voltdb/iv2/RepairLog.java
@@ -30,7 +30,10 @@ import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.DRLogSegmentId;
 import org.voltdb.StoredProcedureInvocation;
+import org.voltdb.Consistency;
+import org.voltdb.Consistency.ReadLevel;
 import org.voltdb.TheHashinator;
+import org.voltdb.VoltDB;
 import org.voltdb.messaging.CompleteTransactionMessage;
 import org.voltdb.messaging.DumpMessage;
 import org.voltdb.messaging.FragmentTaskMessage;
@@ -73,6 +76,9 @@ public class RepairLog
 
     // The HSID of this initiator, for logging purposes
     long m_HSId = Long.MIN_VALUE;
+
+    // used to decide if we should shortcut reads
+    private final Consistency.ReadLevel m_defaultConsistencyReadLevel;
 
     // want voltmessage as payload with message-independent metadata.
     static class Item
@@ -134,6 +140,8 @@ public class RepairLog
     {
         m_logSP = new ArrayDeque<Item>();
         m_logMP = new ArrayDeque<Item>();
+
+        m_defaultConsistencyReadLevel = VoltDB.Configuration.getDefaultReadConsistencyLevel();
     }
 
     // get the HSID for dump logging
@@ -158,11 +166,20 @@ public class RepairLog
     // the repairLog if the message includes a truncation hint.
     public void deliver(VoltMessage msg)
     {
+        /**
+         * Note: A shortcut read is a read operation sent to any replica and completed with no
+         * confirmation or communication with other replicas. In a partition scenario, it's
+         * possible to read an unconfirmed transaction's writes that will be lost.
+         */
+
         if (!m_isLeader && msg instanceof Iv2InitiateTaskMessage) {
             final Iv2InitiateTaskMessage m = (Iv2InitiateTaskMessage)msg;
+
+            boolean shortcutRead = m.isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+
             // We can't repair read-only SP transactions due to their short-circuited nature.
             // Just don't log them to the repair log.
-            if (!m.isReadOnly()) {
+            if (!shortcutRead) {
                 m_lastSpHandle = m.getSpHandle();
                 truncate(m.getTruncationHandle(), IS_SP);
                 m_logSP.add(new Item(IS_SP, m, m.getSpHandle(), m.getTxnId()));
@@ -178,7 +195,10 @@ public class RepairLog
             }
         } else if (msg instanceof FragmentTaskMessage) {
             final FragmentTaskMessage m = (FragmentTaskMessage) msg;
-            if (!m.isReadOnly()) {
+
+            boolean shortcutRead = m.isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+
+            if (!shortcutRead) {
                 truncate(m.getTruncationHandle(), IS_MP);
                 // only log the first fragment of a procedure (and handle 1st case)
                 if (m.getTxnId() > m_lastMpHandle || m_lastMpHandle == Long.MAX_VALUE) {
@@ -202,7 +222,10 @@ public class RepairLog
             // a CompleteTransactionMessage which indicates restart is not the end of the
             // transaction.  We don't want to log it in the repair log.
             CompleteTransactionMessage ctm = (CompleteTransactionMessage)msg;
-            if (!ctm.isReadOnly() && !ctm.isRestart()) {
+
+            boolean shortcutRead = ctm.isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+
+            if (!shortcutRead && !ctm.isRestart()) {
                 truncate(ctm.getTruncationHandle(), IS_MP);
                 m_logMP.add(new Item(IS_MP, ctm, ctm.getSpHandle(), ctm.getTxnId()));
                 //Restore will send a complete transaction message with a lower mp transaction id because

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -59,6 +59,7 @@ import org.voltdb.SnapshotTableTask;
 import org.voltdb.StartAction;
 import org.voltdb.StatsAgent;
 import org.voltdb.StatsSelector;
+import org.voltdb.SystemProcedureCatalog;
 import org.voltdb.SystemProcedureExecutionContext;
 import org.voltdb.TableStats;
 import org.voltdb.TableStreamType;
@@ -88,7 +89,6 @@ import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.rejoin.TaskLog;
 import org.voltdb.sysprocs.SysProcFragmentId;
-import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.LogKeys;
 import org.voltdb.utils.MinimumRatioMaintainer;
@@ -730,8 +730,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         }
         else if (tibm instanceof Iv2InitiateTaskMessage) {
             Iv2InitiateTaskMessage itm = (Iv2InitiateTaskMessage) tibm;
-            //All durable sysprocs and non-sysprocs should not get filtered.
-            return !CatalogUtil.isDurableProc(itm.getStoredProcedureName());
+            final SystemProcedureCatalog.Config sysproc = SystemProcedureCatalog.listing.get(itm.getStoredProcedureName());
+            // All durable sysprocs and non-sysprocs should not get filtered.
+            return sysproc != null && !sysproc.isDurable();
         }
         return false;
     }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -37,6 +37,8 @@ import org.voltcore.utils.CoreUtils;
 import org.voltdb.ClientResponseImpl;
 import org.voltdb.CommandLog;
 import org.voltdb.CommandLog.DurabilityListener;
+import org.voltdb.Consistency;
+import org.voltdb.Consistency.ReadLevel;
 import org.voltdb.PartitionDRGateway;
 import org.voltdb.SnapshotCompletionInterest;
 import org.voltdb.SnapshotCompletionMonitor;
@@ -148,6 +150,9 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     private CommandLog m_cl;
     private PartitionDRGateway m_drGateway = new PartitionDRGateway();
     private final SnapshotCompletionMonitor m_snapMonitor;
+    // used to decide if we should shortcut reads
+    private final Consistency.ReadLevel m_defaultConsistencyReadLevel;
+
     // Need to track when command log replay is complete (even if not performed) so that
     // we know when we can start writing viable replay sets to the fault log.
     boolean m_replayComplete = false;
@@ -166,6 +171,9 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         m_snapMonitor = snapMonitor;
         m_durabilityListener = new SpDurabilityListener(this, m_pendingTasks);
         m_uniqueIdGenerator = new UniqueIdGenerator(partitionId, 0);
+
+        // try to get the global default setting for read consistency, but fall back to SAFE
+        m_defaultConsistencyReadLevel = VoltDB.Configuration.getDefaultReadConsistencyLevel();
     }
 
     @Override
@@ -399,11 +407,18 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
                     "should never receive multi-partition initiations.");
         }
 
+        /**
+         * A shortcut read is a read operation sent to any replica and completed with no
+         * confirmation or communication with other replicas. In a partition scenario, it's
+         * possible to read an unconfirmed transaction's writes that will be lost.
+         */
+        boolean shortcutRead = message.isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+
         final String procedureName = message.getStoredProcedureName();
         long newSpHandle;
         long uniqueId = Long.MIN_VALUE;
         Iv2InitiateTaskMessage msg = message;
-        if (m_isLeader || message.isReadOnly()) {
+        if (m_isLeader || shortcutRead) {
             /*
              * A short circuit read is a read where the client interface is local to
              * this node. The CI will let a replica perform a read in this case and
@@ -445,7 +460,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             if (message.isForReplay()) {
                 newSpHandle = message.getTxnId();
                 setMaxSeenTxnId(newSpHandle);
-            } else if (m_isLeader && !message.isReadOnly()) {
+            } else if (m_isLeader && !shortcutRead) {
                 TxnEgo ego = advanceTxnEgo();
                 newSpHandle = ego.getTxnId();
                 uniqueId = m_uniqueIdGenerator.getNextUniqueId();
@@ -495,7 +510,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 
             //Don't replicate reads, this really assumes that DML validation
             //is going to be integrated soonish
-            if (m_isLeader && !msg.isReadOnly() && m_sendToHSIds.length > 0) {
+            if (m_isLeader && (!shortcutRead) && (m_sendToHSIds.length > 0)) {
                 Iv2InitiateTaskMessage replmsg =
                     new Iv2InitiateTaskMessage(m_mailbox.getHSId(),
                             m_mailbox.getHSId(),
@@ -540,10 +555,17 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
      */
     private void doLocalInitiateOffer(Iv2InitiateTaskMessage msg)
     {
+        /**
+         * A shortcut read is a read operation sent to any replica and completed with no
+         * confirmation or communication with other replicas. In a partition scenario, it's
+         * possible to read an unconfirmed transaction's writes that will be lost.
+         */
+        final boolean shortcutRead = msg.isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+
         final String procedureName = msg.getStoredProcedureName();
         final SpProcedureTask task =
             new SpProcedureTask(m_mailbox, procedureName, m_pendingTasks, msg, m_drGateway);
-        if (!msg.isReadOnly()) {
+        if (!shortcutRead) {
             ListenableFuture<Object> durabilityBackpressureFuture =
                     m_cl.log(msg, msg.getSpHandle(), null, m_durabilityListener, task);
             //Durability future is always null for sync command logging
@@ -655,11 +677,17 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     // Pass a response through the duplicate counters.
     public void handleInitiateResponseMessage(InitiateResponseMessage message)
     {
-        // All single-partition reads are short-circuit reads and will have no duplicate counter.
-        // SpScheduler will only see InitiateResponseMessages for SP transactions, so if it's
-        // read-only here, it's short-circuited.  Avoid all the lookup below.  Also, don't update
-        // the truncation handle, since it won't have meaning for anyone.
-        if (message.isReadOnly()) {
+        /**
+         * A shortcut read is a read operation sent to any replica and completed with no
+         * confirmation or communication with other replicas. In a partition scenario, it's
+         * possible to read an unconfirmed transaction's writes that will be lost.
+         */
+        boolean shortcutRead = message.isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+
+        // All short-circuit reads will have no duplicate counter.
+        // Avoid all the lookup below.
+        // Also, don't update the truncation handle, since it won't have meaning for anyone.
+        if (shortcutRead) {
             // the initiatorHSId is the ClientInterface mailbox. Yeah. I know.
             m_mailbox.send(message.getInitiatorHSId(), message);
             return;
@@ -736,6 +764,8 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     // doesn't matter, it isn't going to be used for anything.
     void handleFragmentTaskMessage(FragmentTaskMessage message)
     {
+        boolean shortcutRead = message.isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+
         FragmentTaskMessage msg = message;
         long newSpHandle;
         if (m_isLeader) {
@@ -745,7 +775,8 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             msg = new FragmentTaskMessage(message.getInitiatorHSId(),
                     message.getCoordinatorHSId(), message);
             //Not going to use the timestamp from the new Ego because the multi-part timestamp is what should be used
-            if (!message.isReadOnly()) {
+
+            if (!shortcutRead) {
                 TxnEgo ego = advanceTxnEgo();
                 newSpHandle = ego.getTxnId();
             } else {
@@ -765,7 +796,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
              * everywhere.
              * In that case don't propagate it to avoid a determinism check and extra messaging overhead
              */
-            if (m_sendToHSIds.length > 0 && (!msg.isReadOnly() || msg.isSysProcTask())) {
+            if (m_sendToHSIds.length > 0 && (!shortcutRead || msg.isSysProcTask())) {
                 FragmentTaskMessage replmsg =
                     new FragmentTaskMessage(m_mailbox.getHSId(),
                             m_mailbox.getHSId(), msg);
@@ -819,7 +850,15 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             // AND we've never seen anything for this transaction before.  We can't
             // actually log until we create a TransactionTask, though, so just keep track
             // of whether it needs to be done.
-            logThis = (msg.getInitiateTask() != null && !msg.getInitiateTask().isReadOnly());
+            if (msg.getInitiateTask() != null) {
+                /**
+                 * A shortcut read is a read operation sent to any replica and completed with no
+                 * confirmation or communication with other replicas. In a partition scenario, it's
+                 * possible to read an unconfirmed transaction's writes that will be lost.
+                 */
+                final boolean shortcutRead = msg.getInitiateTask().isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+                logThis = !shortcutRead;
+            }
         }
 
         // Check to see if this is the final task for this txn, and if so, if we can close it out early

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -59,9 +59,7 @@ public class TransactionTaskQueue
     {
         Iv2Trace.logTransactionTaskQueueOffer(task);
         TransactionState txnState = task.getTransactionState();
-        if (!txnState.isReadOnly()) {
-            m_maxTaskedSpHandle = Math.max(m_maxTaskedSpHandle, txnState.m_spHandle);
-        }
+        m_maxTaskedSpHandle = Math.max(m_maxTaskedSpHandle, txnState.m_spHandle);
         boolean retval = false;
         if (!m_backlog.isEmpty()) {
             /*

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2114,14 +2114,8 @@ public abstract class CatalogUtil {
      * @return true if proc is durable for non sys procs return true (durable)
      */
     public static boolean isDurableProc(String procName) {
-        //For sysprocs look at sysproc catalog.
-        if (procName.charAt(0) == '@') {
-            SystemProcedureCatalog.Config sysProc = SystemProcedureCatalog.listing.get(procName);
-            if (sysProc != null) {
-                return sysProc.isDurable();
-            }
-        }
-        return true;
+        SystemProcedureCatalog.Config sysProc = SystemProcedureCatalog.listing.get(procName);
+        return sysProc == null || sysProc.isDurable();
     }
 
     /**


### PR DESCRIPTION
Add FAST and SAFE read modes in deployment file.
Make SAFE default.
Cut off client networking at the beginning of crashLocal/GlobalVoltDB

Companion pull: https://github.com/VoltDB/pro/pull/1431