### PR TITLE
Eng 10654 fault logging

### DIFF
--- a/src/frontend/org/voltdb/CommandLog.java
+++ b/src/frontend/org/voltdb/CommandLog.java
@@ -73,7 +73,7 @@ public interface CommandLog {
     public abstract void shutdown() throws InterruptedException;
 
     /**
-     * IV2-only method.  Write this Iv2FaultLogEntry to the fault log portion of the command log.
+     * IV2-only method. Write this Iv2FaultLogEntry to the fault log portion of the command log.
      * @return a settable future that is set true after the entry has been written to disk.
      */
     public abstract SettableFuture<Boolean> logIv2Fault(long writerHSId, Set<Long> survivorHSId,

--- a/src/frontend/org/voltdb/CommandLog.java
+++ b/src/frontend/org/voltdb/CommandLog.java
@@ -24,6 +24,7 @@ import org.voltdb.iv2.TransactionTask;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
+import com.google_voltpatches.common.util.concurrent.SettableFuture;
 
 public interface CommandLog {
     /**
@@ -72,9 +73,10 @@ public interface CommandLog {
     public abstract void shutdown() throws InterruptedException;
 
     /**
-     * IV2-only method.  Write this Iv2FaultLogEntry to the fault log portion of the command log
+     * IV2-only method.  Write this Iv2FaultLogEntry to the fault log portion of the command log.
+     * @return a settable future that is set true after the entry has been written to disk.
      */
-    public abstract void logIv2Fault(long writerHSId, Set<Long> survivorHSId,
+    public abstract SettableFuture<Boolean> logIv2Fault(long writerHSId, Set<Long> survivorHSId,
             int partitionId, long spHandle);
 
     /**

--- a/src/frontend/org/voltdb/CommandLog.java
+++ b/src/frontend/org/voltdb/CommandLog.java
@@ -24,7 +24,6 @@ import org.voltdb.iv2.TransactionTask;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
-import com.google_voltpatches.common.util.concurrent.SettableFuture;
 
 public interface CommandLog {
     /**
@@ -73,10 +72,9 @@ public interface CommandLog {
     public abstract void shutdown() throws InterruptedException;
 
     /**
-     * IV2-only method.  Write this Iv2FaultLogEntry to the fault log portion of the command log.
-     * @return a settable future that is set true after the entry has been written to disk.
+     * IV2-only method.  Write this Iv2FaultLogEntry to the fault log portion of the command log
      */
-    public abstract SettableFuture<Boolean> logIv2Fault(long writerHSId, Set<Long> survivorHSId,
+    public abstract void logIv2Fault(long writerHSId, Set<Long> survivorHSId,
             int partitionId, long spHandle);
 
     /**

--- a/src/frontend/org/voltdb/DummyCommandLog.java
+++ b/src/frontend/org/voltdb/DummyCommandLog.java
@@ -58,9 +58,7 @@ public class DummyCommandLog implements CommandLog {
     @Override
     public SettableFuture<Boolean> logIv2Fault(long writerHSId, Set<Long> survivorHSId,
             int partitionId, long spHandle) {
-        SettableFuture<Boolean> written = SettableFuture.create();
-        written.set(false);
-        return written;
+        return null;
     }
 
     @Override

--- a/src/frontend/org/voltdb/DummyCommandLog.java
+++ b/src/frontend/org/voltdb/DummyCommandLog.java
@@ -58,7 +58,9 @@ public class DummyCommandLog implements CommandLog {
     @Override
     public SettableFuture<Boolean> logIv2Fault(long writerHSId, Set<Long> survivorHSId,
             int partitionId, long spHandle) {
-        return SettableFuture.create();
+        SettableFuture<Boolean> written = SettableFuture.create();
+        written.set(false);
+        return written;
     }
 
     @Override

--- a/src/frontend/org/voltdb/DummyCommandLog.java
+++ b/src/frontend/org/voltdb/DummyCommandLog.java
@@ -25,7 +25,6 @@ import org.voltdb.messaging.Iv2InitiateTaskMessage;
 
 import com.google_voltpatches.common.util.concurrent.Futures;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
-import com.google_voltpatches.common.util.concurrent.SettableFuture;
 
 public class DummyCommandLog implements CommandLog {
     @Override
@@ -56,9 +55,8 @@ public class DummyCommandLog implements CommandLog {
     }
 
     @Override
-    public SettableFuture<Boolean> logIv2Fault(long writerHSId, Set<Long> survivorHSId,
+    public void logIv2Fault(long writerHSId, Set<Long> survivorHSId,
             int partitionId, long spHandle) {
-        return SettableFuture.create();
     }
 
     @Override

--- a/src/frontend/org/voltdb/DummyCommandLog.java
+++ b/src/frontend/org/voltdb/DummyCommandLog.java
@@ -25,6 +25,7 @@ import org.voltdb.messaging.Iv2InitiateTaskMessage;
 
 import com.google_voltpatches.common.util.concurrent.Futures;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
+import com.google_voltpatches.common.util.concurrent.SettableFuture;
 
 public class DummyCommandLog implements CommandLog {
     @Override
@@ -55,8 +56,9 @@ public class DummyCommandLog implements CommandLog {
     }
 
     @Override
-    public void logIv2Fault(long writerHSId, Set<Long> survivorHSId,
+    public SettableFuture<Boolean> logIv2Fault(long writerHSId, Set<Long> survivorHSId,
             int partitionId, long spHandle) {
+        return SettableFuture.create();
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1089,15 +1089,22 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         if (m_replayComplete) {
             SettableFuture<Boolean> written = m_cl.logIv2Fault(m_mailbox.getHSId(),
                 new HashSet<Long>(m_replicaHSIds), m_partitionId, spHandle);
+
             boolean logWritten = false;
-            try {
-                logWritten = written.get();
-            } catch (InterruptedException e) {
-            } catch (ExecutionException e) {
-            } finally {
-                if (!logWritten){
-                    tmLog.warn("Fault Log not written for SP Handle: " + spHandle);
+
+            if (written != null) {
+                try {
+                    logWritten = written.get();
+                } catch (InterruptedException e) {
+                } catch (ExecutionException e) {
+                    if (tmLog.isDebugEnabled()) {
+                        tmLog.debug("Could not determine fault log state for partition: " + m_partitionId, e);
+                    }
                 }
+            }
+
+            if (!logWritten) {
+                tmLog.warn("Fault log not written for partition: " + m_partitionId);
             }
         }
     }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -29,7 +29,6 @@ import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
@@ -63,7 +62,6 @@ import org.voltdb.messaging.MultiPartitionParticipantMessage;
 import com.google_voltpatches.common.primitives.Ints;
 import com.google_voltpatches.common.primitives.Longs;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
-import com.google_voltpatches.common.util.concurrent.SettableFuture;
 
 public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 {
@@ -1087,18 +1085,8 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     void writeIv2ViableReplayEntryInternal(long spHandle)
     {
         if (m_replayComplete) {
-            SettableFuture<Boolean> written = m_cl.logIv2Fault(m_mailbox.getHSId(),
-                new HashSet<Long>(m_replicaHSIds), m_partitionId, spHandle);
-            boolean logWritten = false;
-            try {
-                logWritten = written.get();
-            } catch (InterruptedException e) {
-            } catch (ExecutionException e) {
-            } finally {
-                if (!logWritten){
-                    tmLog.warn("Fault Log not written for SP Handle: " + spHandle);
-                }
-            }
+            m_cl.logIv2Fault(m_mailbox.getHSId(), new HashSet<Long>(m_replicaHSIds), m_partitionId,
+                    spHandle);
         }
     }
 

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
@@ -62,6 +63,7 @@ import org.voltdb.messaging.MultiPartitionParticipantMessage;
 import com.google_voltpatches.common.primitives.Ints;
 import com.google_voltpatches.common.primitives.Longs;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
+import com.google_voltpatches.common.util.concurrent.SettableFuture;
 
 public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 {
@@ -1085,8 +1087,18 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     void writeIv2ViableReplayEntryInternal(long spHandle)
     {
         if (m_replayComplete) {
-            m_cl.logIv2Fault(m_mailbox.getHSId(), new HashSet<Long>(m_replicaHSIds), m_partitionId,
-                    spHandle);
+            SettableFuture<Boolean> written = m_cl.logIv2Fault(m_mailbox.getHSId(),
+                new HashSet<Long>(m_replicaHSIds), m_partitionId, spHandle);
+            boolean logWritten = false;
+            try {
+                logWritten = written.get();
+            } catch (InterruptedException e) {
+            } catch (ExecutionException e) {
+            } finally {
+                if (!logWritten){
+                    tmLog.warn("Fault Log not written for SP Handle: " + spHandle);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR proposes changing the method signature of Command Log's logIv2Fault method to return a settable future with parameter boolean. The calling thread can block on this future to wait to be told if the fault log was successfully written to disk or not. The status of the write is propagated from the FileWriter in the command log back to the SpScheduler so the caller can decide to block on it or not.

The two cases where blocking was added was:
1. The leader waits for their write to finish after it has commanded the other replicas to do so (updateReplicas)
2. The replicas wait for their write to finish but only when they get that message from the leader (handleIv2LogFaultMessage)

So these block in cases where fault logging races with starting to process transactions again