### PR TITLE
Fix ENG-10749, 10750

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
@@ -683,6 +683,7 @@ public class FunctionForVoltDB extends FunctionSQL {
                             catch (Exception e) {
                                 throw Error.error(ErrorCode.X_42561);
                             }
+                            nodes[i].valueData = paramTypes[i].castToType(session, nodes[i].valueData, nodes[i].dataType);
                             nodes[i].dataType = paramTypes[i];
                         }
                     } else if (paramTypes[i].isNumberType() && !nodes[i].dataType.isNumberType()) {

--- a/tests/frontend/org/voltdb/planner/TestFunctions.java
+++ b/tests/frontend/org/voltdb/planner/TestFunctions.java
@@ -126,4 +126,9 @@ public class TestFunctions extends PlannerTestCase {
         compile("select case when varchar_type like 'M%' then 1 end as m_state from bit;");
         compile("select case when varchar_type like '_%' then 1 end as m_state from bit;");
     }
+
+    public void testSerializeFunctionTimestampArgumentInPlan() {
+        // This test comes from ENG-10749 and ENG-10750
+        compile("SELECT SINCE_EPOCH(MICROSECOND, '1812-10-28 07:30:43') FROM ENG10749 WHERE '2080-05-24 11:18:38' <> TIME OR '4253-02-25 00:20:34' IS NULL;");
+    }
 }

--- a/tests/frontend/org/voltdb/planner/testplans-functions-ddl.sql
+++ b/tests/frontend/org/voltdb/planner/testplans-functions-ddl.sql
@@ -15,3 +15,7 @@ CREATE TABLE bit (
 CREATE INDEX bit_BITAND_IDX ON bit ( bitand(bigint_type, 3) );
 CREATE INDEX bit_BITOR_IDX  ON bit ( bitor(bigint_type, 3) );
 CREATE INDEX bit_BITXOR_IDX  ON bit ( bitxor(bigint_type, 3) );
+
+CREATE TABLE ENG10749 (
+    TIME TIMESTAMP
+);


### PR DESCRIPTION
I today found the two bugs are actually the same one.
The parameter problem, although the data type didn't show correct, does not affect the behavior of the EE. So I guess there are some other places in the code that can detect the DECIMAL and BIGINT type issue.

The real problem was serializing TIMESTAMP to JSON, I just added the code to make it support both long value string and date string.