### PR TITLE
ENG-10799: Don't set TxnEgo backward.

### DIFF
--- a/src/frontend/org/voltdb/iv2/Scheduler.java
+++ b/src/frontend/org/voltdb/iv2/Scheduler.java
@@ -117,7 +117,9 @@ abstract public class Scheduler implements InitiatorMessageHandler
                     "Received a transaction id at partition " + m_txnEgo.getPartitionId() +
                     " for partition " + ego.getPartitionId() + ". The partition ids should match.", true, null);
         }
-        m_txnEgo = ego;
+        if (m_txnEgo.getTxnId() < ego.getTxnId()) {
+            m_txnEgo = ego;
+        }
     }
 
     final protected TxnEgo advanceTxnEgo()


### PR DESCRIPTION
When setting the TxnEgo during leader promotion, recover, or snapshot
restore, only set it if it's moving into the future. Never set the
TxnEgo because that leads to duplicate txnIds down the road.