### PR TITLE
Eng 10775 full join postgres

### DIFF
--- a/tests/scripts/SQLCoverageReport.py
+++ b/tests/scripts/SQLCoverageReport.py
@@ -294,7 +294,8 @@ contain the SQL statements which caused different responses on both backends.
 
 def generate_html_reports(suite, seed, statements_path, cmpdb_path, jni_path,
                           output_dir, report_invalid, report_all, extra_stats='',
-                          cmpdb='HSqlDB', modified_sql_path=None, cntonly=False):
+                          cmpdb='HSqlDB', modified_sql_path=None, max_mismatches=0,
+                          cntonly=False):
     if output_dir != None and not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
@@ -385,7 +386,7 @@ def generate_html_reports(suite, seed, statements_path, cmpdb_path, jni_path,
     topLines = getTopSummaryLines(cmpdb, False)
     currentTime = datetime.datetime.now().strftime("%A, %B %d, %I:%M:%S %p")
     keyStats = createSummaryInHTML(count, failures, len(mismatches), len(voltdb_npes),
-                                   len(cmpdb_npes), extra_stats, seed)
+                                   len(cmpdb_npes), extra_stats, seed, max_mismatches)
     report = """
 <html>
 <head>
@@ -470,7 +471,8 @@ def getTopSummaryLines(cmpdb, includeAll=True):
     topLines += "</tr>"
     return topLines
 
-def createSummaryInHTML(count, failures, misses, voltdb_npes, cmpdb_npes, extra_stats, seed):
+def createSummaryInHTML(count, failures, misses, voltdb_npes, cmpdb_npes,
+                        extra_stats, seed, max_misses=0):
     passed = count - (failures + misses)
     passed_ps = fail_ps = cell4misPct = cell4misCnt = color = None
     count_color = fail_color = ""
@@ -491,6 +493,8 @@ def createSummaryInHTML(count, failures, misses, voltdb_npes, cmpdb_npes, extra_
         cell4misCnt = "<td align=right>0</td>"
     else:
         color = "#FF0000" # red
+        if misses <= max_misses:
+            color = "#FFA500" # orange
         mis_ps = "{0:.2f}".format((misses/float(max(count, 1))) * 100)
         cell4misPct = "<td align=right bgcolor=" + color + ">" + mis_ps + "%</td>"
         cell4misCnt = "<td align=right bgcolor=" + color + ">" + str(misses) + "</td>"
@@ -554,7 +558,8 @@ h2 {text-transform: uppercase}
 <tr><td align=right bgcolor=#FF0000>Red</td><td>table elements indicate a test failure(s), due to a mismatch between VoltDB and %s results, a crash,
                                                    or an NPE in VoltDB (or, an <i>extremely</i> slow test suite).</td></tr>
 <tr><td align=right bgcolor=#FFA500>Orange</td><td>table elements indicate a strong warning, for something that should be looked into (e.g. a pattern
-                                                   that generated no SQL queries, an NPE in %s, or a <i>very</i> slow test suite), but no test failures.</td></tr>
+                                                   that generated no SQL queries, an NPE in %s, or a <i>very</i> slow test suite), but no test failures
+                                                   (or only "known" failures).</td></tr>
 <tr><td align=right bgcolor=#FFFF00>Yellow</td><td>table elements indicate a mild warning, for something you might want to improve (e.g. a pattern
                                                    that generated a very large number of SQL queries, or a somewhat slow test suite).</td></tr>
 <tr><td align=right bgcolor=#D3D3D3>Gray</td><td>table elements indicate data that was not computed, due to a crash.</td></tr>

--- a/tests/scripts/examples/sql_coverage/join-template.sql
+++ b/tests/scripts/examples/sql_coverage/join-template.sql
@@ -48,6 +48,7 @@ SELECT LHS41.@idcol, LHS41.@numcol FROM @fromtables LHS41 @jointype JOIN @fromta
 -- Uncomment after ENG-9367 is fixed (??):
 --SELECT       @idcol,       @numcol FROM @fromtables LHS42 @jointype JOIN @fromtables MHS ON  LHS42.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON LHS42.@numcol = RHS.@numcol
 
-SELECT *                           FROM @fromtables LHS43 @jointype JOIN @fromtables MHS ON  LHS43.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON LHS43.@numcol _cmp 45;
-SELECT *                           FROM @fromtables LHS44 @jointype JOIN @fromtables MHS ON  LHS44.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON MHS.@numcol _cmp 45;
-SELECT *                           FROM @fromtables LHS45 @jointype JOIN @fromtables MHS ON  LHS45.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON RHS.@numcol _cmp 45;
+--TODO: uncomment these when/if we can figure out a way to have them pass on PostgreSQL, or only run on HSQL; see ENG-10775
+--SELECT *                           FROM @fromtables LHS43 @jointype JOIN @fromtables MHS ON  LHS43.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON LHS43.@numcol _cmp 45;
+--SELECT *                           FROM @fromtables LHS44 @jointype JOIN @fromtables MHS ON  LHS44.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON MHS.@numcol _cmp 45;
+--SELECT *                           FROM @fromtables LHS45 @jointype JOIN @fromtables MHS ON  LHS45.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON RHS.@numcol _cmp 45;

--- a/tests/scripts/examples/sql_coverage/join-template.sql
+++ b/tests/scripts/examples/sql_coverage/join-template.sql
@@ -48,7 +48,6 @@ SELECT LHS41.@idcol, LHS41.@numcol FROM @fromtables LHS41 @jointype JOIN @fromta
 -- Uncomment after ENG-9367 is fixed (??):
 --SELECT       @idcol,       @numcol FROM @fromtables LHS42 @jointype JOIN @fromtables MHS ON  LHS42.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON LHS42.@numcol = RHS.@numcol
 
---TODO: uncomment these when/if we can figure out a way to have them pass on PostgreSQL, or only run on HSQL; see ENG-10775
---SELECT *                           FROM @fromtables LHS43 @jointype JOIN @fromtables MHS ON  LHS43.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON LHS43.@numcol _cmp 45;
---SELECT *                           FROM @fromtables LHS44 @jointype JOIN @fromtables MHS ON  LHS44.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON MHS.@numcol _cmp 45;
---SELECT *                           FROM @fromtables LHS45 @jointype JOIN @fromtables MHS ON  LHS45.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON RHS.@numcol _cmp 45;
+SELECT *                           FROM @fromtables LHS43 @jointype JOIN @fromtables MHS ON  LHS43.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON LHS43.@numcol _cmp 45;
+SELECT *                           FROM @fromtables LHS44 @jointype JOIN @fromtables MHS ON  LHS44.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON MHS.@numcol _cmp 45;
+SELECT *                           FROM @fromtables LHS45 @jointype JOIN @fromtables MHS ON  LHS45.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON RHS.@numcol _cmp 45;

--- a/tests/scripts/examples/sql_coverage/normalizer.py
+++ b/tests/scripts/examples/sql_coverage/normalizer.py
@@ -47,9 +47,9 @@ def safecmp(x, y):
 
 def compare_results(suite, seed, statements_path, hsql_path, jni_path,
                     output_dir, report_invalid, report_all, extra_stats,
-                    comparison_database, modified_sql_path):
+                    comparison_database, modified_sql_path, max_mismatches=0):
     """Just calls SQLCoverageReport.generate_html_reports(...).
     """
     return generate_html_reports(suite, seed, statements_path, hsql_path, jni_path,
                                  output_dir, report_invalid, report_all, extra_stats,
-                                 comparison_database, modified_sql_path)
+                                 comparison_database, modified_sql_path, max_mismatches)

--- a/tests/scripts/examples/sql_coverage/not-a-normalizer.py
+++ b/tests/scripts/examples/sql_coverage/not-a-normalizer.py
@@ -40,9 +40,10 @@ def normalize(table, sql):
 
 def compare_results(suite, seed, statements_path, hsql_path, jni_path,
                     output_dir, report_invalid, report_all, extra_stats,
-                    comparison_database, modified_sql_path):
+                    comparison_database, modified_sql_path, max_mismatches=0):
     """Just calls SQLCoverageReport.generate_html_reports(...).
     """
     return generate_html_reports(suite, seed, statements_path, hsql_path, jni_path,
                                  output_dir, report_invalid, report_all, extra_stats,
-                                 comparison_database, modified_sql_path, True)
+                                 comparison_database, modified_sql_path, max_mismatches,
+                                 True)

--- a/tests/scripts/sql_coverage_test.py
+++ b/tests/scripts/sql_coverage_test.py
@@ -209,6 +209,31 @@ def run_once(name, command, statements_path, results_path, submit_verbosely, tes
     else:
         return 0
 
+def get_max_mismatches(comparison_database, suite_name):
+    """Returns the maximum number of acceptable mismatches, i.e., the number of
+    'known' failures for VoltDB to match the results of the comparison database
+    (HSQL or PostgreSQL), which is normally zero; however, there are sometimes
+    a few exceptions, e.g., for queries that are not supported by PostgreSQL.
+    """
+    max_mismatches = 0
+
+    # Kludge to not fail for known issues, when running against PostgreSQL
+    # (or the PostGIS extension of PostgreSQL)
+    if comparison_database.startswith('Post'):
+        # Known failures in the basic-joins test suite, and in the basic-index-joins,
+        # and basic-compoundex-joins "extended" test suites (see ENG-10775)
+        if (config_name == 'basic-joins' or config_name == 'basic-index-joins' or
+              config_name == 'basic-compoundex-joins'):
+            max_mismatches = 4620
+        # Known failures in the numeric-decimals and numeric-ints "extended"
+        # test suites (see ENG-10546)
+        elif config_name == 'numeric-decimals':
+            max_mismatches = 1180
+        elif config_name == 'numeric-ints':
+            max_mismatches = 2820
+
+    return max_mismatches
+
 def run_config(suite_name, config, basedir, output_dir, random_seed,
                report_invalid, report_all, generate_only, subversion_generation,
                submit_verbosely, ascii_only, args, testConfigKit):
@@ -346,13 +371,14 @@ def run_config(suite_name, config, basedir, output_dir, random_seed,
                  get_time_html_table_element(voltdb_time) +
                  get_time_html_table_element(cmpdb_time) )
     extraStats = get_numerical_html_table_element(num_crashes, error_above=0) + someStats
+    max_mismatches = get_max_mismatches(comparison_database, suite_name)
 
     global compare_results
     try:
         compare_results = imp.load_source("normalizer", config["normalizer"]).compare_results
         success = compare_results(suite_name, random_seed, statements_path, cmpdb_path,
                                   jni_path, output_dir, report_invalid, report_all, extraStats,
-                                  comparison_database, modified_sql_path)
+                                  comparison_database, modified_sql_path, max_mismatches)
     except:
         print >> sys.stderr, "Compare (VoltDB & " + comparison_database + ") results crashed!"
         traceback.print_exc()
@@ -744,22 +770,9 @@ if __name__ == "__main__":
         statistics[config_name] = result["keyStats"]
         statistics["seed"] = seed
 
-        max_mismatches = 0
-        # Kludge to not fail for known issues, when running against PostgreSQL
-        # (or the PostGIS extension of PostgreSQL), in either the basic-joins
-        # test suite, the basic-index-joins, and basic-compoundex-joins
-        # "extended" test suites (see ENG-10775); or, in the numeric-decimals
-        # and numeric-ints "extended" test suites (see ENG-10546)
-        if comparison_database.startswith('Post'):
-            if (config_name == 'basic-joins' or config_name == 'basic-index-joins' or
-                  config_name == 'basic-compoundex-joins'):
-                max_mismatches = 4620
-            elif config_name == 'numeric-decimals':
-                max_mismatches = 1180
-            elif config_name == 'numeric-ints':
-                max_mismatches = 2820
-        # End of kludge; the following is the normal behavior:
-        if result["mis"] > max_mismatches:
+        # The maximum number of acceptable mismatches is normally zero, except
+        # for certain rare cases involving known errors in PostgreSQL
+        if result["mis"] > get_max_mismatches(comparison_database, config_name):
             success = False
 
     # Write the summary

--- a/tests/scripts/sql_coverage_test.py
+++ b/tests/scripts/sql_coverage_test.py
@@ -378,7 +378,7 @@ def run_config(suite_name, config, basedir, output_dir, random_seed,
         compare_results = imp.load_source("normalizer", config["normalizer"]).compare_results
         success = compare_results(suite_name, random_seed, statements_path, cmpdb_path,
                                   jni_path, output_dir, report_invalid, report_all, extraStats,
-                                  comparison_database, modified_sql_path, max_mismatches)
+                                  comparison_database, modified_sql_path)
     except:
         print >> sys.stderr, "Compare (VoltDB & " + comparison_database + ") results crashed!"
         traceback.print_exc()


### PR DESCRIPTION
Added a get_max_mismatches method, and use it to determine whether the tests have failed; and apply this to the current 'known' failures in the basic-joins, basic-index-joins, basic-compoundex-joins, numeric-decimals & numeric-ints test suites (all of these only on PostgreSQL).