### PR TITLE
ENG-10896: Only register undo action for BEGINTXN when one has been written to the stream

### DIFF
--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -264,21 +264,25 @@ void ExecutorContext::setDrReplicatedStream(AbstractDRTupleStream *drReplicatedS
  */
 void ExecutorContext::checkTransactionForDR() {
     if (UniqueId::isMpUniqueId(m_uniqueId) && m_undoQuantum != NULL) {
-        if (dynamic_cast<DRTupleStream *>(m_drStream)) {
-            m_drStream->transactionChecks(m_lastCommittedSpHandle, m_spHandle,
-                    m_uniqueId);
-            m_undoQuantum->registerUndoAction(
-                    new (*m_undoQuantum) DRTupleStreamUndoAction(m_drStream,
-                            m_drStream->m_committedUso,
-                            0));
-            if (m_drReplicatedStream) {
-                m_drReplicatedStream->transactionChecks(m_lastCommittedSpHandle,
-                        m_spHandle, m_uniqueId);
+        if (m_drStream) {
+            if (m_drStream->transactionChecks(m_lastCommittedSpHandle,
+                        m_spHandle, m_uniqueId))
+            {
                 m_undoQuantum->registerUndoAction(
-                        new (*m_undoQuantum) DRTupleStreamUndoAction(
-                                m_drReplicatedStream,
-                                m_drReplicatedStream->m_committedUso,
+                        new (*m_undoQuantum) DRTupleStreamUndoAction(m_drStream,
+                                m_drStream->m_committedUso,
                                 0));
+            }
+            if (m_drReplicatedStream) {
+                if (m_drReplicatedStream->transactionChecks(m_lastCommittedSpHandle,
+                            m_spHandle, m_uniqueId))
+                {
+                    m_undoQuantum->registerUndoAction(
+                            new (*m_undoQuantum) DRTupleStreamUndoAction(
+                                    m_drReplicatedStream,
+                                    m_drReplicatedStream->m_committedUso,
+                                    0));
+                }
             }
         }
     }

--- a/src/ee/storage/AbstractDRTupleStream.h
+++ b/src/ee/storage/AbstractDRTupleStream.h
@@ -121,7 +121,8 @@ protected:
     size_t m_txnRowCount;
 
 private:
-    virtual void transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId) = 0;
+    // return true if stream state was switched from close to open
+    virtual bool transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId) = 0;
 };
 
 class DRTupleStreamDisableGuard {

--- a/src/ee/storage/CompatibleDRTupleStream.cpp
+++ b/src/ee/storage/CompatibleDRTupleStream.cpp
@@ -230,7 +230,7 @@ size_t CompatibleDRTupleStream::appendUpdateRecord(int64_t lastCommittedSpHandle
     return startingUso;
 }
 
-void CompatibleDRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId)
+bool CompatibleDRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId)
 {
     // Transaction IDs for transactions applied to this tuple stream
     // should always be moving forward in time.
@@ -241,6 +241,7 @@ void CompatibleDRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, i
                 );
     }
 
+    bool switchedToOpen = false;
     if (!m_opened) {
         ++m_openSequenceNumber;
 
@@ -250,8 +251,10 @@ void CompatibleDRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, i
         else {
             openTransactionCommon(spHandle, uniqueId);
         }
+        switchedToOpen = true;
     }
     assert(m_opened);
+    return switchedToOpen;
 }
 
 void CompatibleDRTupleStream::writeRowTuple(TableTuple& tuple,

--- a/src/ee/storage/CompatibleDRTupleStream.h
+++ b/src/ee/storage/CompatibleDRTupleStream.h
@@ -95,7 +95,7 @@ public:
                                    long startSequenceNumber,
                                    char *out);
 private:
-    void transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId);
+    bool transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId);
 
     void writeRowTuple(TableTuple& tuple,
             size_t rowHeaderSz,

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -324,7 +324,7 @@ size_t DRTupleStream::appendUpdateRecord(int64_t lastCommittedSpHandle,
     return startingUso;
 }
 
-void DRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId)
+bool DRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId)
 {
     // Transaction IDs for transactions applied to this tuple stream
     // should always be moving forward in time.
@@ -335,6 +335,7 @@ void DRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, int64_t spH
                 );
     }
 
+    bool switchedToOpen = false;
     if (!m_opened) {
         ++m_openSequenceNumber;
 
@@ -344,8 +345,10 @@ void DRTupleStream::transactionChecks(int64_t lastCommittedSpHandle, int64_t spH
         else {
             openTransactionCommon(spHandle, uniqueId);
         }
+        switchedToOpen = true;
     }
     assert(m_opened);
+    return switchedToOpen;
 }
 
 void DRTupleStream::writeRowTuple(TableTuple& tuple,

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -97,7 +97,7 @@ public:
                                    char *out);
 
 private:
-    void transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId);
+    bool transactionChecks(int64_t lastCommittedSpHandle, int64_t spHandle, int64_t uniqueId);
 
     void writeRowTuple(TableTuple& tuple,
             size_t rowHeaderSz,


### PR DESCRIPTION
Make transactionChecks() return a bool indicating if stream state was switched from close to open in this function call.

Register an undo action for BEGINTXN only if it has been written to stream (i.e. transactionChecks() returns true)