### PR TITLE
allow inherited SQLStmts and Multiple inheritance

### DIFF
--- a/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
+++ b/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
@@ -101,7 +101,7 @@ public abstract class ProcedureCompiler implements GroovyCodeBlockConstants {
         Field[] fields = procClass.getDeclaredFields();
         for (Field f : fields) {
             // skip non SQL fields
-            if (f.getType() != SQLStmt.class)
+            if (!SQLStmt.class.isAssignableFrom(f.getType()))
                 continue;
 
             int modifiers = f.getModifiers();
@@ -144,6 +144,15 @@ public abstract class ProcedureCompiler implements GroovyCodeBlockConstants {
         if (superClass != null) {
             Map<String, SQLStmt> superStmts = getValidSQLStmts(compiler, procName, superClass, procInstance, false);
             for (Entry<String, SQLStmt> e : superStmts.entrySet()) {
+                if (retval.containsKey(e.getKey()) == false)
+                    retval.put(e.getKey(), e.getValue());
+            }
+        }
+        
+        Class<?> interfaces[] = procClass.getInterfaces();
+        for (Class<?> aninterface : interfaces ){
+        	Map<String, SQLStmt> interfaceStmts = getValidSQLStmts(compiler, procName, aninterface, procInstance, false);
+            for (Entry<String, SQLStmt> e : interfaceStmts.entrySet()) {
                 if (retval.containsKey(e.getKey()) == false)
                     retval.put(e.getKey(), e.getValue());
             }


### PR DESCRIPTION
- Allow extending SQLStmt so that a method that expects a specific SQLStmt as input can force compile time validation to avoid the wrong SQLStmt being passed in. 
- Also check interfaces for SQLStmts, this allows using multiple inheritance through interfaces with default implementations to avoid one enormous superclass when many stored procedures share some logic but not all stored procedures share the same methods.

To use the multiple inheritance part you need to define the SLQStmts in the interface as statics, I haven't thoroughly tested yet if this has undesirable effects. 