### PR TITLE
Fix ENG-10916

### DIFF
--- a/src/ee/storage/MaterializedViewTriggerForInsert.cpp
+++ b/src/ee/storage/MaterializedViewTriggerForInsert.cpp
@@ -63,15 +63,6 @@ MaterializedViewTriggerForInsert::MaterializedViewTriggerForInsert(PersistentTab
 
     allocateBackedTuples();
 
-    /* If there is no group by column and the target table is still empty
-     * even after catching up with pre-existing source tuples, we should initialize the
-     * target table with a row of default values.
-     * COUNT() functions should have value 0, other aggregation functions should have value NULL.
-     * See ENG-7872
-     */
-    if (m_groupByColumnCount == 0 && m_target->isPersistentTableEmpty()) {
-        initializeTupleHavingNoGroupBy();
-    }
     VOLT_TRACE("Finished MaterializedViewTriggerForInsert initialization...");
 }
 

--- a/src/ee/storage/MaterializedViewTriggerForWrite.cpp
+++ b/src/ee/storage/MaterializedViewTriggerForWrite.cpp
@@ -44,9 +44,7 @@ MaterializedViewTriggerForWrite::MaterializedViewTriggerForWrite(PersistentTable
 
     // Catch up on pre-existing source tuples UNLESS target tuples have already been migrated in.
     if (m_target->isPersistentTableEmpty()) {
-        /* If there is no group by column and the target table is still empty
-         * even after catching up with pre-existing source tuples, we should initialize the
-         * target table with a row of default values.
+        /* If there is no group by column, a special initialization is required.
          * COUNT() functions should have value 0, other aggregation functions should have value NULL.
          * See ENG-7872
          */

--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -507,7 +507,7 @@ static void migrateChangedTuples(catalog::Table const &catalogTable,
     // leaves any dependent materialized view tables untouched/intact
     // (technically, temporarily out of synch with the shrinking table).
     // But the normal "insertPersistentTuple" used here on the new table tries to populate any dependent
-    // serialized views.
+    // materialized views.
     // Rather than empty the surviving view tables, and transfer them to the new table to be re-populated "retail",
     // transfer them "wholesale" post-migration.
 


### PR DESCRIPTION
Streams support views as long as the partition column is part of the view. However, for view definitions without any group by columns, there is no way you could have a partition column in the view. (aggregation on a partition column does not count!)

That is, **you cannot define a view without a group by column on a streamed table**.

There was an initializeTupleHavingNoGroupBy() function in the persistent view logic to handle the initialization for views without group-by column because there will always be one row even the source table is empty. This call was persistent view specific when I fist added it in ENG-7872 last year.

During a recent refactoring of the old code, we pulled this logic from persistent view to a common code path shared by both types of views. This accidentally invalidated a logic the persistent view had for triggering the data catching-up process.

This fix put the logic back to track. Related tests will be checked in along with ENG-10867 to avoid conflicts.