### PR TITLE
versioncheck.config: added the '--stop-on-error=false' option (to the

### DIFF
--- a/tests/sqlcmd/baselines/ddl/load_remove_classes.outbaseline
+++ b/tests/sqlcmd/baselines/ddl/load_remove_classes.outbaseline
@@ -17,6 +17,15 @@ Command succeeded.
 drop table dropable if exists;
 Command succeeded.
 
+drop table my_table_1 if exists;
+Command succeeded.
+
+drop table my_table_2 if exists;
+Command succeeded.
+
+drop table my_table_3 if exists;
+Command succeeded.
+
 drop table prefixes if exists;
 Command succeeded.
 

--- a/tests/sqlcmd/baselines/simple/versioncheck.outbaseline
+++ b/tests/sqlcmd/baselines/simple/versioncheck.outbaseline
@@ -1,4 +1,3 @@
-WARN: Strict java memory checking is enabled, don't do release builds or performance runs with this enabled. Invoke "ant clean" and "ant -Djmemcheck=NO_MEMCHECK" to disable.
 
 drop table t if exists;
 Command succeeded.
@@ -93,3 +92,269 @@ c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and
 c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and 
 c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and 
 c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0 and c > 0;
+
+create table t2 ( c integer, d varchar(4), e varchar(4) );
+Command succeeded.
+
+exec T.insert 1,'a';
+(Returned 1 rows in #.##s)
+
+execute T.insert 2 ab;
+(Returned 1 rows in #.##s)
+
+exec T.insert 3 'abc';
+(Returned 1 rows in #.##s)
+
+execute T.insert,4,abcd;
+(Returned 1 rows in #.##s)
+
+ exec T.insert 11, 'a';
+(Returned 1 rows in #.##s)
+
+  execute T.insert 12 ab;
+(Returned 1 rows in #.##s)
+
+exec    T.insert 13 , 'abc';
+(Returned 1 rows in #.##s)
+
+execute  T.insert  ,  14  ,  abcd;
+(Returned 1 rows in #.##s)
+
+	exec T.insert 21, 'a';
+(Returned 1 rows in #.##s)
+
+  execute T.insert	22	ab;
+(Returned 1 rows in #.##s)
+
+exec 	  T.insert 23	,	'abc';
+(Returned 1 rows in #.##s)
+
+execute		T.insert		,		24		,		abcd;
+(Returned 1 rows in #.##s)
+
+exec    T.insert 31,  'a z';
+(Returned 1 rows in #.##s)
+
+execute T.insert 32   ' ab';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 33 , 'abc ';
+(Returned 1 rows in #.##s)
+
+ exec   T.insert 41,  'a;z';
+(Returned 1 rows in #.##s)
+
+execute T.insert 42   ';ab';
+(Returned 1 rows in #.##s)
+
+EXEC    T.insert 43 , 'abc;';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 51,  'a,z';
+(Returned 1 rows in #.##s)
+
+execute T.insert 52   ',ab';
+(Returned 1 rows in #.##s)
+
+EXECUTE T.insert 53 , 'abc,';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 61,  ' ,;';
+(Returned 1 rows in #.##s)
+
+execute T.insert 62   '; ,';
+(Returned 1 rows in #.##s)
+
+EXECUTE T.insert 63 , ';,  ';
+(Returned 1 rows in #.##s)
+
+EXECUTE T.insert 71 ,
+ ';,  ';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 81,  'x''';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 82,  '''y';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 83,  '''z''';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 84,  ''' ''';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 85,  '" "';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 86,  ''' "';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 87,  ''' "';
+(Returned 1 rows in #.##s)
+
+exec    T2.insert 88,  ''' '  ' ''';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 91,  '( )';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 92,  ')';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 93,  '"(';
+(Returned 1 rows in #.##s)
+
+exec    T.insert 94,  '''()';
+(Returned 1 rows in #.##s)
+
+exec    T2.insert 95,  '('  ')';
+(Returned 1 rows in #.##s)
+
+exec p 'abc'    'abd';
+C   D    
+--- -----
+  3 abc  
+  4 abcd 
+ 13 abc  
+ 14 abcd 
+ 23 abc  
+ 24 abcd 
+ 33 abc  
+ 43 abc; 
+ 53 abc, 
+
+(Returned 9 rows in #.##s)
+
+exec p 'abc'    'abd''';
+C   D    
+--- -----
+  3 abc  
+  4 abcd 
+ 13 abc  
+ 14 abcd 
+ 23 abc  
+ 24 abcd 
+ 33 abc  
+ 43 abc; 
+ 53 abc, 
+
+(Returned 9 rows in #.##s)
+
+exec p ''' abc' 'abd ''';
+C   D    
+--- -----
+  1 a    
+  2 ab   
+  3 abc  
+  4 abcd 
+ 11 a    
+ 12 ab   
+ 13 abc  
+ 14 abcd 
+ 21 a    
+ 22 ab   
+ 23 abc  
+ 24 abcd 
+ 31 a z  
+ 33 abc  
+ 41 a;z  
+ 42 ;ab  
+ 43 abc; 
+ 51 a,z  
+ 52 ,ab  
+ 53 abc, 
+ 62 ; ,  
+ 63 ;,   
+ 71 ;,   
+ 82 'y   
+ 83 'z'  
+ 91 ( )  
+ 92 )    
+ 94 '()  
+
+(Returned 28 rows in #.##s)
+
+exec p '((' '))';
+C   D 
+--- --
+ 92 ) 
+
+(Returned 1 rows in #.##s)
+
+exec p ( );
+C   D   
+--- ----
+ 91 ( ) 
+ 92 )   
+
+(Returned 2 rows in #.##s)
+
+exec max_predicates 90;
+C1 
+---
+  4
+
+(Returned 1 rows in #.##s)
+
+select * from t order by c;
+C   D    
+--- -----
+  1 a    
+  2 ab   
+  3 abc  
+  4 abcd 
+ 11 a    
+ 12 ab   
+ 13 abc  
+ 14 abcd 
+ 21 a    
+ 22 ab   
+ 23 abc  
+ 24 abcd 
+ 31 a z  
+ 32  ab  
+ 33 abc  
+ 41 a;z  
+ 42 ;ab  
+ 43 abc; 
+ 51 a,z  
+ 52 ,ab  
+ 53 abc, 
+ 61  ,;  
+ 62 ; ,  
+ 63 ;,   
+ 71 ;,   
+ 81 x'   
+ 82 'y   
+ 83 'z'  
+ 84 ' '  
+ 85 " "  
+ 86 ' "  
+ 87 ' "  
+ 91 ( )  
+ 92 )    
+ 93 "(   
+ 94 '()  
+
+(Returned 36 rows in #.##s)
+
+select * from t2 order by c;
+C   D   E  
+--- --- ---
+ 88 '    ' 
+ 95 (   )  
+
+(Returned 2 rows in #.##s)
+
+drop table t2;
+Command succeeded.
+
+drop procedure max_predicates;
+Command succeeded.
+
+drop procedure p;
+Command succeeded.
+
+drop table t;
+Command succeeded.

--- a/tests/sqlcmd/scripts/ddl/load_remove_classes.in
+++ b/tests/sqlcmd/scripts/ddl/load_remove_classes.in
@@ -5,6 +5,9 @@ drop table t if exists;
 drop table t2 if exists;
 drop table addable if exists;
 drop table dropable if exists;
+drop table my_table_1 if exists;
+drop table my_table_2 if exists;
+drop table my_table_3 if exists;
 drop table prefixes if exists;
 drop table raw if exists;
 

--- a/tests/sqlcmd/scripts/simple/versioncheck.config
+++ b/tests/sqlcmd/scripts/simple/versioncheck.config
@@ -1,1 +1,2 @@
 --no-version-check
+--stop-on-error=false


### PR DESCRIPTION
'--no-version-check' option), so that the test script will run to the end, even after the expected error, and therefore will clean up after itself, deleting the tables & procedures it creates (which were causing other tests to fail); hence, had to add additional text to versioncheck.outbaseline, for the part after the error; also, deleted the initial WARN, which gets "cleaned" away (which was causing this test to fail).
load_remove_classes.in: also, added drop (if exists) for the my_table_1, my_table_2 & my_table_3 tables, which theoretically could cause this test to fail (though I've not seen this happen); and added corresponding text to load_remove_classes.outbaseline.