### PR TITLE
ENG-10472: Advance the SPI truncation point when transaction is done.

### DIFF
--- a/src/frontend/org/voltdb/iv2/DuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/DuplicateCounter.java
@@ -26,6 +26,7 @@ import org.voltcore.utils.CoreUtils;
 import org.voltdb.ClientResponseImpl;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.VoltTable;
+import org.voltdb.messaging.CompleteTransactionResponseMessage;
 import org.voltdb.messaging.FragmentResponseMessage;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.messaging.InitiateResponseMessage;
@@ -178,6 +179,11 @@ public class DuplicateCounter
     }
 
     int offer(FragmentResponseMessage message)
+    {
+        return checkCommon(0, message.isRecovering(), null, message);
+    }
+
+    int offer(CompleteTransactionResponseMessage message)
     {
         return checkCommon(0, message.isRecovering(), null, message);
     }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -845,7 +845,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                 // Only complete transactions that are open...
                 if (global_replay_mpTxn != null) {
                     CompleteTransactionMessage m = (CompleteTransactionMessage)tibm;
-                    CompleteTransactionTask t = new CompleteTransactionTask(global_replay_mpTxn,
+                    CompleteTransactionTask t = new CompleteTransactionTask(m_initiatorMailbox, global_replay_mpTxn,
                             null, m, m_drGateway);
                     if (!m.isRestart()) {
                         global_replay_mpTxn = null;

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1292,7 +1292,11 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
                 synchronized (m_lock) {
                     if (m_lastSentTruncationHandle < m_repairLogTruncationHandle) {
                         m_lastSentTruncationHandle = m_repairLogTruncationHandle;
-                        m_mailbox.send(m_sendToHSIds, new RepairLogTruncationMessage(m_repairLogTruncationHandle));
+                        final RepairLogTruncationMessage truncMsg = new RepairLogTruncationMessage(m_repairLogTruncationHandle);
+                        // Also keep the local repair log's truncation point up-to-date
+                        // so that it can trigger the callbacks.
+                        m_mailbox.deliver(truncMsg);
+                        m_mailbox.send(m_sendToHSIds, truncMsg);
                     }
                 }
             }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -240,6 +240,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         for (DuplicateCounterKey key : doneCounters) {
             DuplicateCounter counter = m_duplicateCounters.remove(key);
             VoltMessage resp = counter.getLastResponse();
+            setRepairLogTruncationHandle(key.m_spHandle);
             if (resp != null) {
                 // MPI is tracking deps per partition HSID.  We need to make
                 // sure we write ours into the message getting sent to the MPI

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -727,6 +727,9 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         }
         else {
             // the initiatorHSId is the ClientInterface mailbox. Yeah. I know.
+            if (!message.isReadOnly()) {
+                setRepairLogTruncationHandle(spHandle);
+            }
             m_mailbox.send(message.getInitiatorHSId(), message);
         }
     }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1058,13 +1058,15 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 
         if (txnDone) {
             m_outstandingTxns.remove(msg.getTxnId());
-
-            // Set the truncation handle here instead of when processing
-            // FragmentResponseMessage to avoid letting replicas think a
-            // fragment is done before the MP txn is fully committed.
-            assert txn == null || txn.isDone();
             m_duplicateCounters.remove(duplicateCounterKey);
-            setRepairLogTruncationHandle(msg.getSpHandle());
+
+            if (txn != null) {
+                // Set the truncation handle here instead of when processing
+                // FragmentResponseMessage to avoid letting replicas think a
+                // fragment is done before the MP txn is fully committed.
+                assert txn.isDone();
+                setRepairLogTruncationHandle(txn.m_spHandle);
+            }
         }
 
         // The CompleteTransactionResponseMessage ends at the SPI. It is not

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -978,7 +978,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             int result = counter.offer(message);
             if (result == DuplicateCounter.DONE) {
                 if (txn != null && txn.isDone()) {
-                    setRepairLogTruncationHandle(message.getSpHandle());
+                    setRepairLogTruncationHandle(txn.m_spHandle);
                 }
 
                 m_duplicateCounters.remove(new DuplicateCounterKey(message.getTxnId(), message.getSpHandle()));
@@ -995,7 +995,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             return;
         } else {
             if (txn != null && txn.isDone()) {
-                setRepairLogTruncationHandle(message.getSpHandle());
+                setRepairLogTruncationHandle(txn.m_spHandle);
             }
         }
 

--- a/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
+++ b/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
@@ -79,9 +79,9 @@ public class CompleteTransactionMessage extends TransactionInfoBaseMessage
         setBit(ISRESTART, isRestart);
     }
 
-    public CompleteTransactionMessage(CompleteTransactionMessage msg)
+    public CompleteTransactionMessage(long initiatorHSId, long coordinatorHSId, CompleteTransactionMessage msg)
     {
-        super(msg.getInitiatorHSId(), msg.getCoordinatorHSId(), msg);
+        super(initiatorHSId, coordinatorHSId, msg);
         m_hash = msg.m_hash;
         m_flags = msg.m_flags;
     }

--- a/src/frontend/org/voltdb/messaging/CompleteTransactionResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/CompleteTransactionResponseMessage.java
@@ -27,6 +27,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
 {
     long m_txnId;
     long m_spHandle;
+    long m_spiHSId;
     boolean m_isRestart;
     boolean m_isRecovering = false;
 
@@ -40,6 +41,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
         m_txnId = msg.getTxnId();
         m_spHandle = msg.getSpHandle();
         m_isRestart = msg.isRestart();
+        m_spiHSId = msg.getCoordinatorHSId();
     }
 
     public long getTxnId()
@@ -50,6 +52,11 @@ public class CompleteTransactionResponseMessage extends VoltMessage
     public long getSpHandle()
     {
         return m_spHandle;
+    }
+
+    public long getSPIHSId()
+    {
+        return m_spiHSId;
     }
 
     public boolean isRestart()
@@ -71,7 +78,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
     public int getSerializedSize()
     {
         int msgsize = super.getSerializedSize();
-        msgsize += 8 + 8 + 1 + 1;
+        msgsize += 8 + 8 + 8 + 1 + 1;
         return msgsize;
     }
 
@@ -81,6 +88,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
         buf.put(VoltDbMessageFactory.COMPLETE_TRANSACTION_RESPONSE_ID);
         buf.putLong(m_txnId);
         buf.putLong(m_spHandle);
+        buf.putLong(m_spiHSId);
         buf.put((byte) (m_isRestart ? 1 : 0));
         buf.put((byte) (m_isRecovering ? 1 : 0));
         assert(buf.capacity() == buf.position());
@@ -92,6 +100,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
     {
         m_txnId = buf.getLong();
         m_spHandle = buf.getLong();
+        m_spiHSId = buf.getLong();
         m_isRestart = buf.get() == 1;
         m_isRecovering = buf.get() == 1;
         assert(buf.capacity() == buf.position());
@@ -106,6 +115,8 @@ public class CompleteTransactionResponseMessage extends VoltMessage
         sb.append(TxnEgo.txnIdToString(m_txnId));
         sb.append(" SPHANDLE: ");
         sb.append(TxnEgo.txnIdToString(m_spHandle));
+        sb.append(" SPI ");
+        sb.append(CoreUtils.hsIdToString(m_spiHSId));
         sb.append(" ISRESTART: ");
         sb.append(m_isRestart);
         sb.append(" RECOVERING ");

--- a/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
+++ b/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
@@ -108,7 +108,7 @@ public class TestTransactionTaskQueue extends TestCase
         CompleteTransactionMessage msg = mock(CompleteTransactionMessage.class);
         when(msg.getTxnId()).thenReturn(mpTxnId);
         CompleteTransactionTask task =
-            new CompleteTransactionTask(txn, queue, msg, null);
+            new CompleteTransactionTask(mock(InitiatorMailbox.class), txn, queue, msg, null);
         return task;
     }
 

--- a/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
+++ b/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
@@ -386,12 +386,13 @@ public class TestVoltMessageSerialization extends TestCase {
                                            true, false, true);
 
         CompleteTransactionResponseMessage ctrm =
-            new CompleteTransactionResponseMessage(ctm, Long.MAX_VALUE - 4);
+            new CompleteTransactionResponseMessage(ctm);
 
         CompleteTransactionResponseMessage ctrm2 =
             (CompleteTransactionResponseMessage) checkVoltMessage(ctrm);
-        assertEquals(ctrm.getExecutionSiteId(), ctrm.getExecutionSiteId());
         assertEquals(ctrm.getTxnId(), ctrm2.getTxnId());
+        assertEquals(ctrm.getSpHandle(), ctrm2.getSpHandle());
+        assertEquals(ctrm.isRestart(), ctrm2.isRestart());
     }
 
     public void testIv2RepairLogRequestMessage() throws IOException


### PR DESCRIPTION
CompleteTransactionMessage needs to send a response to the SPI to
reliably track MP transaction commit point. Otherwise, it may be racing
with the execution of the FragmentTasks and SpProcedureTasks before the
MP.