### PR TITLE
ENG-10951: failed assertions in debug build

### DIFF
--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -773,7 +773,7 @@ inline void TableTuple::copyForPersistentUpdate(const TableTuple &source,
                                                 std::vector<char*> &oldObjects, std::vector<char*> &newObjects)
 {
     assert(m_schema);
-    assert(m_schema == source.m_schema);
+    assert(m_schema->equals(source.m_schema));
     const int columnCount = m_schema->columnCount();
     const uint16_t uninlineableObjectColumnCount = m_schema->getUninlinedObjectColumnCount();
     /*

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/SetFunction.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/SetFunction.java
@@ -31,6 +31,7 @@
 
 package org.hsqldb_voltpatches;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
@@ -42,8 +43,6 @@ import org.hsqldb_voltpatches.types.IntervalSecondData;
 import org.hsqldb_voltpatches.types.IntervalType;
 import org.hsqldb_voltpatches.types.NumberType;
 import org.hsqldb_voltpatches.types.Type;
-
-import java.io.Serializable;
 
 /**
  * Implementation of SQL set functions (currently only aggregate functions).
@@ -380,7 +379,7 @@ public class SetFunction implements Serializable {
     static Type getType(int setType, Type type) {
 
         if (setType == OpTypes.COUNT) {
-            return Type.SQL_INTEGER;
+            return Type.SQL_BIGINT;
         }
 
         // A VoltDB extension to handle aggfnc(*) syntax errors.
@@ -590,8 +589,8 @@ public class SetFunction implements Serializable {
         }
 
         return sample ? (n == 1) ? null    // NULL (not NaN) is correct in this case
-                                 : new Double(vk / (double) (n - 1))
-                      : new Double(vk / (double) (n));
+                                 : new Double(vk / (n - 1))
+                      : new Double(vk / (n));
     }
 
     private Number getStdDev() {
@@ -601,8 +600,8 @@ public class SetFunction implements Serializable {
         }
 
         return sample ? (n == 1) ? null    // NULL (not NaN) is correct in this case
-                                 : new Double(Math.sqrt(vk / (double) (n - 1)))
-                      : new Double(Math.sqrt(vk / (double) (n)));
+                                 : new Double(Math.sqrt(vk / (n - 1)))
+                      : new Double(Math.sqrt(vk / (n)));
     }
 
     // end statistics support


### PR DESCRIPTION
In the backend there was an index on a COUNT(*) field of a MV.  The component type for the index was INTEGER, but we expected BIGINT.  I made HSQL set the output type of COUNT(*) to be BIGINT always.

I also loosened an equality check in `copyForPersistentUpdate`.  We were expecting the same instance of `TupleSchema` when copying tuples, but they really only need to be equivalent.  In particular, if we are copying into a tuple backed by `StandAloneTupleStorage`, the schema instance will never be the same as some persistent table, since the stand alone class allocates its own copy.