### PR TITLE
Eng 10740 planner perf

### DIFF
--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -66,8 +66,6 @@ import org.voltdb.compiler.VoltCompiler.ProcedureDescriptor;
 import org.voltdb.compiler.VoltCompiler.VoltCompilerException;
 import org.voltdb.compilereport.TableAnnotation;
 import org.voltdb.expressions.AbstractExpression;
-import org.voltdb.expressions.AbstractSubqueryExpression;
-import org.voltdb.expressions.AggregateExpression;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.groovy.GroovyCodeBlockCompiler;
 import org.voltdb.parser.HSQLLexer;
@@ -2447,7 +2445,7 @@ public class DDLCompiler {
         assert(tableName != null);
         String msg = "Partial index \"" + indexName + "\" ";
 
-        // Make sure all column expressions refer the index table
+        // Make sure all column expressions refer to the index table
         List<VoltXMLElement> columnRefs= predicateXML.findChildrenRecursively("columnref");
         for (VoltXMLElement columnRef : columnRefs) {
             String columnRefTableName = columnRef.attributes.get("table");
@@ -2459,11 +2457,11 @@ public class DDLCompiler {
         // Now it safe to parse the expression tree
         AbstractExpression predicate = dummy.parseExpressionTree(predicateXML);
 
-        if (predicate.hasAnySubexpressionOfClass(AggregateExpression.class)) {
+        if (predicate.hasAggregateSubexpression()) {
             msg += "with aggregate expression(s) is not supported.";
             throw compiler.new VoltCompilerException(msg);
         }
-        if (predicate.hasAnySubexpressionOfClass(AbstractSubqueryExpression.class)) {
+        if (predicate.hasSubquerySubexpression()) {
             msg += "with subquery expression(s) is not supported.";
             throw compiler.new VoltCompilerException(msg);
         }

--- a/src/frontend/org/voltdb/compiler/MaterializedViewProcessor.java
+++ b/src/frontend/org/voltdb/compiler/MaterializedViewProcessor.java
@@ -884,7 +884,7 @@ public class MaterializedViewProcessor {
                     if (!encodedPredicate.isEmpty()) {
                         String predicate = Encoder.hexDecodeToString(encodedPredicate);
                         AbstractExpression matViewPredicate = AbstractExpression.fromJSONString(predicate, tableScan);
-                        coveringExprs.addAll(ExpressionUtil.uncombineAny(matViewPredicate));
+                        coveringExprs.addAll(ExpressionUtil.uncombineConjunctions(matViewPredicate));
                     }
                 } catch (JSONException e) {
                     e.printStackTrace();

--- a/src/frontend/org/voltdb/expressions/ConjunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/ConjunctionExpression.java
@@ -21,19 +21,20 @@ import org.voltdb.VoltType;
 import org.voltdb.types.ExpressionType;
 
 public class ConjunctionExpression extends AbstractExpression {
-    public ConjunctionExpression(ExpressionType type) {
-        super(type);
-        setValueType(VoltType.BOOLEAN);
-    }
     public ConjunctionExpression(ExpressionType type, AbstractExpression left, AbstractExpression right) {
         super(type, left, right);
+        assert(left != null);
+        assert(right != null);
         setValueType(VoltType.BOOLEAN);
+        setValueSize(m_valueType.getLengthInBytesForFixedTypes());
     }
     public ConjunctionExpression() {
         //
         // This is needed for serialization
         //
         super();
+        setValueType(VoltType.BOOLEAN);
+        setValueSize(m_valueType.getLengthInBytesForFixedTypes());
     }
 
     @Override
@@ -45,17 +46,8 @@ public class ConjunctionExpression extends AbstractExpression {
     public void finalizeValueTypes()
     {
         finalizeChildValueTypes();
-        //
-        // IMPORTANT:
-        // We are not handling the case where one of types is NULL. That is because we
-        // are only dealing with what the *output* type should be, not what the actual
-        // value is at execution time. There will need to be special handling code
-        // over on the ExecutionEngine to handle special cases for conjunctions with NULLs
-        // Therefore, it is safe to assume that the output is always going to be an
-        // integer (for booleans)
-        //
-        m_valueType = VoltType.BOOLEAN;
-        m_valueSize = m_valueType.getLengthInBytesForFixedTypes();
+        assert(m_valueType == VoltType.BOOLEAN);
+        assert(m_valueSize == m_valueType.getLengthInBytesForFixedTypes());
     }
 
     @Override

--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -22,14 +22,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
 import org.voltdb.VoltType;
-import org.voltdb.planner.PlanningErrorException;
 import org.voltdb.types.ExpressionType;
 
 /**
@@ -37,12 +34,23 @@ import org.voltdb.types.ExpressionType;
  */
 public abstract class ExpressionUtil {
 
-    public static void finalizeValueTypes(AbstractExpression exp)
-    {
+    /**
+     * Make a final pass over the abstract expression tree, first specializing
+     * the types of certain operands based on the types of their sibling
+     * operands and then finalizing types to be specific enough to be
+     * acceptable to the EE.
+     * @param exp expression tree whose value types may still need refinement.
+     */
+    public static void finalizeValueTypes(AbstractExpression exp) {
         exp.normalizeOperandTypes_recurse();
         exp.finalizeValueTypes();
     }
 
+    /**
+     * Combine a list of source predicate expressions into a single AND-tree
+     * expression containing clones of the source predicates.
+     * @param colExps
+     */
     @SafeVarargs
     public static AbstractExpression cloneAndCombinePredicates(Collection<AbstractExpression>... colExps) {
         Stack<AbstractExpression> stack = new Stack<AbstractExpression>();
@@ -57,11 +65,23 @@ public abstract class ExpressionUtil {
         if (stack.isEmpty()) {
             return null;
         }
-        return combineStack(stack);
+        return combinePredicateStack(stack);
     }
 
     /**
-     *
+     * Combine two predicate arguments with AND into a single predicate
+     * @param left
+     * @param right
+     * @return Both expressions passed in combined by an And conjunction.
+     */
+    public static AbstractExpression combinePredicates(AbstractExpression left, AbstractExpression right) {
+        AbstractExpression retval = new ConjunctionExpression(ExpressionType.CONJUNCTION_AND, left, right);
+        // Simplify combined expression if possible
+        return evaluateExpression(retval);
+    }
+
+    /**
+     * Combine one or more lists of predicate expressions into a single AND-tree expression.
      * @param colExps
      */
     @SafeVarargs
@@ -75,40 +95,25 @@ public abstract class ExpressionUtil {
         if (stack.isEmpty()) {
             return null;
         }
-        return combineStack(stack);
+        return combinePredicateStack(stack);
     }
 
-    private static AbstractExpression combineStack(Stack<AbstractExpression> stack) {
+    private static AbstractExpression combinePredicateStack(Stack<AbstractExpression> stack) {
         // TODO: This code probably doesn't need to go through all this trouble to create AND trees
         // like "((D and C) and B) and A)" from the list "[A, B, C, D]".
-        // There is an easier algorithm that does not require stacking intermediate results.
-        // Even better, it would be easier here to generate "(D and (C and (B and A)))"
-        // which would also short-circuit slightly faster in the executor.
+        // It might be better to generate "(D and (C and (B and A)))"
+        // which would short-circuit slightly faster in the executor.
         // NOTE: Any change to the structure of the trees produced by this algorithm should be
-        // reflected in the algorithm used to reverse the process in uncombine(AbstractExpression expr).
+        // reflected in the algorithm used to reverse the process in uncombinePredicate(AbstractExpression expr).
 
         AbstractExpression ret = null;
-        while (stack.size() > 1) {
+        while (stack.size() > 0) {
             AbstractExpression child_exp = stack.pop();
-            //
-            // If our return node is null, then we need to make a new one
-            //
             if (ret == null) {
-                ret = new ConjunctionExpression(ExpressionType.CONJUNCTION_AND);
-                ret.setLeft(child_exp);
-            //
-            // Check whether we can add it to the right side
-            //
-            } else if (ret.getRight() == null) {
-                ret.setRight(child_exp);
-                stack.push(ret);
-                ret = null;
+                ret = child_exp;
+                continue;
             }
-        }
-        if (ret == null) {
-            ret = stack.pop();
-        } else {
-            ret.setRight(stack.pop());
+            ret = new ConjunctionExpression(ExpressionType.CONJUNCTION_AND, ret, child_exp);
         }
         // Simplify combined expression if possible
         return ExpressionUtil.evaluateExpression(ret);
@@ -123,26 +128,19 @@ public abstract class ExpressionUtil {
      * @param expr
      * @return
      */
-    public static List<AbstractExpression> uncombinePredicate(AbstractExpression expr)
-    {
+    public static List<AbstractExpression> uncombinePredicate(AbstractExpression expr) {
+        List<AbstractExpression> result = new ArrayList<AbstractExpression>();
         if (expr == null) {
-            return new ArrayList<AbstractExpression>();
+            return result;
         }
-        if (expr instanceof ConjunctionExpression) {
-            ConjunctionExpression conj = (ConjunctionExpression)expr;
-            if (conj.getExpressionType() == ExpressionType.CONJUNCTION_AND) {
-                // Calculate the list for the tree or leaf on the left.
-                List<AbstractExpression> branch = uncombinePredicate(conj.getLeft());
-                // Insert the leaf on the right at the head of that list
-                branch.add(0, conj.getRight());
-                return branch;
-            }
-            // Any other kind of conjunction must have been a leaf. Fall through.
+        while (expr.getExpressionType() == ExpressionType.CONJUNCTION_AND) {
+            // Append the leaf on the right to the list.
+            result.add(expr.getRight());
+            // "Tail recurse" on the tree or leaf on the left.
+            expr = expr.getLeft();
         }
-        // At the left-most leaf, start a new list.
-        List<AbstractExpression> leaf = new ArrayList<AbstractExpression>();
-        leaf.add(expr);
-        return leaf;
+        result.add(expr);
+        return result;
     }
 
     /**
@@ -155,8 +153,7 @@ public abstract class ExpressionUtil {
      * @return a Collection containing expr or if expr is a conjunction, its top-level non-conjunction
      * child expressions.
      */
-    public static Collection<AbstractExpression> uncombineAny(AbstractExpression expr)
-    {
+    public static Collection<AbstractExpression> uncombineConjunctions(AbstractExpression expr) {
         ArrayDeque<AbstractExpression> out = new ArrayDeque<AbstractExpression>();
         if (expr != null) {
             ArrayDeque<AbstractExpression> in = new ArrayDeque<AbstractExpression>();
@@ -177,25 +174,6 @@ public abstract class ExpressionUtil {
         return out;
     }
 
-    public static boolean isColumnEquivalenceFilter(AbstractExpression expr) {
-        // Ignore expressions that are not of COMPARE_EQUAL type
-        if (expr.getExpressionType() != ExpressionType.COMPARE_EQUAL) {
-            return false;
-        }
-        AbstractExpression leftExpr = expr.getLeft();
-        AbstractExpression rightExpr = expr.getRight();
-        // Can't use an expression that is based on a column value but is not just a simple column value.
-        if ( ( ! (leftExpr instanceof TupleValueExpression)) &&
-                leftExpr.hasAnySubexpressionOfClass(TupleValueExpression.class) ) {
-            return false;
-        }
-        if ( ( ! (rightExpr instanceof TupleValueExpression)) &&
-                rightExpr.hasAnySubexpressionOfClass(TupleValueExpression.class) ) {
-            return false;
-        }
-        return true;
-    }
-
     /**
      * Find any listed expressions that qualify as potential partitioning where filters,
      * which is to say are equality comparisons with a TupleValueExpression on at least one side,
@@ -205,12 +183,10 @@ public abstract class ExpressionUtil {
      * @param the running result
      * @return a Collection containing the qualifying filter expressions.
      */
-    public static void
-    collectPartitioningFilters(Collection<AbstractExpression> filterList,
-                               HashMap<AbstractExpression, Set<AbstractExpression> > equivalenceSet)
-    {
+    public static void collectPartitioningFilters(Collection<AbstractExpression> filterList,
+            HashMap<AbstractExpression, Set<AbstractExpression> > equivalenceSet) {
         for (AbstractExpression expr : filterList) {
-            if ( ! isColumnEquivalenceFilter(expr)) {
+            if ( ! expr.isColumnEquivalenceFilter()) {
                 continue;
             }
             AbstractExpression leftExpr = expr.getLeft();
@@ -228,14 +204,16 @@ public abstract class ExpressionUtil {
                     // Add new leftExpr into existing rightExpr's eqSet.
                     equivalenceSet.put(leftExpr, eqSet2);
                     eqSet2.add(leftExpr);
-                } else {
+                }
+                else {
                     // Merge eqSets, re-mapping all the rightExpr's equivalents into leftExpr's eqset.
                     for (AbstractExpression eqMember : eqSet2) {
                         eqSet1.add(eqMember);
                         equivalenceSet.put(eqMember, eqSet1);
                     }
                 }
-            } else {
+            }
+            else {
                 if (eqSet1 == null) {
                     // Both leftExpr and rightExpr are new -- add leftExpr to the new eqSet first.
                     eqSet1 = new HashSet<AbstractExpression>();
@@ -247,320 +225,6 @@ public abstract class ExpressionUtil {
                 eqSet1.add(rightExpr);
             }
         }
-    }
-
-    /**
-     *
-     * @param left
-     * @param right
-     * @return Both expressions passed in combined by an And conjunction.
-     */
-    public static AbstractExpression combine(AbstractExpression left, AbstractExpression right) {
-        AbstractExpression retval = new ConjunctionExpression(ExpressionType.CONJUNCTION_AND, left, right);
-        // Simplify combined expression if possible
-        return ExpressionUtil.evaluateExpression(retval);
-    }
-
-    /**
-     * Recursively walk an expression and return a list of all the tuple
-     * value expressions it contains.
-     */
-    public static List<TupleValueExpression>
-    getTupleValueExpressions(AbstractExpression input)
-    {
-        ArrayList<TupleValueExpression> tves =
-            new ArrayList<TupleValueExpression>();
-        // recursive stopping steps
-        if (input == null)
-        {
-            return tves;
-        } else if (input instanceof TupleValueExpression) {
-            tves.add((TupleValueExpression) input);
-            return tves;
-        }
-
-        // recursive calls
-        tves.addAll(getTupleValueExpressions(input.m_left));
-        tves.addAll(getTupleValueExpressions(input.m_right));
-        if (input.m_args != null) {
-            for (AbstractExpression argument : input.m_args) {
-                tves.addAll(getTupleValueExpressions(argument));
-            }
-        }
-        return tves;
-    }
-
-    /**
-     * Method to simplify an expression by eliminating identical subexpressions (same id)
-     * If the expression is a logical conjunction of the form e1 AND e2 AND e3 AND e4,
-     * and subexpression e1 is identical to the subexpression e2 the simplified expression is
-     * e1 AND e3 AND e4.
-     *
-     * @param expr to simplify
-     * @return simplified expression.
-     */
-    public static AbstractExpression eliminateDuplicates(Collection<AbstractExpression> exprList) {
-        // Eliminate duplicates by building the map of expression's ids, values.
-        Map<String, AbstractExpression> subExprMap = new HashMap<String, AbstractExpression>();
-        for (AbstractExpression subExpr : exprList) {
-            subExprMap.put(subExpr.m_id, subExpr);
-        }
-        // Now reconstruct the expression
-        return ExpressionUtil.combinePredicates(subExprMap.values());
-    }
-
-    /**
-     *  A condition is null-rejected for a given table in the following cases:
-     *      If it is of the form A IS NOT NULL, where A is an attribute of any of the inner tables
-     *      If it is a predicate containing a reference to an inner table that evaluates to UNKNOWN
-     *          when one of its arguments is NULL
-     *      If it is a conjunction containing a null-rejected condition as a conjunct
-     *      If it is a disjunction of null-rejected conditions
-     *
-     * @param expr
-     * @param tableAlias
-     * @return
-     */
-    public static boolean isNullRejectingExpression(AbstractExpression expr, String tableAlias) {
-        ExpressionType exprType = expr.getExpressionType();
-        if (exprType == ExpressionType.CONJUNCTION_AND) {
-            assert(expr.m_left != null && expr.m_right != null);
-            return isNullRejectingExpression(expr.m_left, tableAlias) || isNullRejectingExpression(expr.m_right, tableAlias);
-        }
-        if (exprType == ExpressionType.CONJUNCTION_OR) {
-            assert(expr.m_left != null && expr.m_right != null);
-            return isNullRejectingExpression(expr.m_left, tableAlias) && isNullRejectingExpression(expr.m_right, tableAlias);
-        }
-        if (exprType == ExpressionType.COMPARE_NOTDISTINCT) {
-            return false;
-        }
-        if (exprType == ExpressionType.OPERATOR_NOT) {
-            assert(expr.m_left != null);
-            // "NOT ( P and Q )" is as null-rejecting as "NOT P or NOT Q"
-            // "NOT ( P or Q )" is as null-rejecting as "NOT P and NOT Q"
-            // Handling AND and OR expressions requires a "negated" flag to the recursion that tweaks
-            // (switches?) the handling of ANDs and ORs to enforce the above equivalences.
-            if (expr.m_left.getExpressionType() == ExpressionType.OPERATOR_IS_NULL) {
-                return containsMatchingTVE(expr, tableAlias);
-            }
-            if (expr.m_left.getExpressionType() == ExpressionType.CONJUNCTION_AND ||
-                    expr.m_left.getExpressionType() == ExpressionType.CONJUNCTION_OR) {
-                assert(expr.m_left.m_left != null && expr.m_left.m_right != null);
-                // Need to test for an existing child NOT and skip it.
-                // e.g. NOT (P AND NOT Q) --> (NOT P) OR NOT NOT Q --> (NOT P) OR Q
-                AbstractExpression tempLeft = null;
-                if (expr.m_left.m_left.getExpressionType() != ExpressionType.OPERATOR_NOT) {
-                    tempLeft = new OperatorExpression(ExpressionType.OPERATOR_NOT, expr.m_left.m_left, null);
-                }
-                else {
-                    assert(expr.m_left.m_left.m_left != null);
-                    tempLeft = expr.m_left.m_left.m_left;
-                }
-                AbstractExpression tempRight = null;
-                if (expr.m_left.m_right.getExpressionType() != ExpressionType.OPERATOR_NOT) {
-                    tempRight = new OperatorExpression(ExpressionType.OPERATOR_NOT, expr.m_left.m_right, null);
-                }
-                else {
-                    assert(expr.m_left.m_right.m_left != null);
-                    tempRight = expr.m_left.m_right.m_left;
-                }
-                ExpressionType type = (expr.m_left.getExpressionType() == ExpressionType.CONJUNCTION_AND) ?
-                        ExpressionType.CONJUNCTION_OR : ExpressionType.CONJUNCTION_AND;
-                AbstractExpression tempExpr = new OperatorExpression(type, tempLeft, tempRight);
-                return isNullRejectingExpression(tempExpr, tableAlias);
-            }
-            if (expr.m_left.getExpressionType() == ExpressionType.OPERATOR_NOT) {
-                // It's probably safe to assume that HSQL will have stripped out other double negatives,
-                // (like "NOT T.c IS NOT NULL"). Yet, we could also handle them here
-                assert(expr.m_left.m_left != null);
-                return isNullRejectingExpression(expr.m_left.m_left, tableAlias);
-            }
-            return isNullRejectingExpression(expr.m_left, tableAlias);
-        }
-        if (exprType == ExpressionType.OPERATOR_IS_NULL) {
-            // IS NOT NULL is NULL rejecting -- IS NULL is not
-            return false;
-        }
-        if (expr.hasAnySubexpressionOfClass(OperatorExpression.class)) {
-            // COALESCE expression is a sub-expression
-            // For example, COALESCE (C1, C2) > 0
-            List<OperatorExpression> coalesceExprs = expr.findAllSubexpressionsOfClass(OperatorExpression.class);
-            for (OperatorExpression coalesceExpr : coalesceExprs) {
-                if ((coalesceExpr.getExpressionType() == ExpressionType.OPERATOR_ALTERNATIVE) &&
-                    containsMatchingTVE(coalesceExpr, tableAlias)) {
-                    // This table is part of the COALESCE expression - not NULL-rejecting
-                    return false;
-                }
-            }
-            // If we get there it means that the tableAlias is not part of any of COALESCE expression
-            // still need to check the catch all case
-        }
-        // @TODO ENG_3038 Is it safe to assume for the rest of the expressions that if
-        // it contains a TVE with the matching table name then it is NULL rejection expression?
-        // Presently, yes, logical expressions are not expected to appear inside other
-        // generalized expressions, so since the handling of other kinds of expressions
-        // is pretty much "containsMatchingTVE", this fallback should be safe.
-        // The only planned developments that might contradict this restriction (AFAIK --paul)
-        // would be support for standard pseudo-functions that take logical condition arguments.
-        // These should probably be supported as special non-functions/operations for a number
-        // of reasons and may need special casing here.
-        return containsMatchingTVE(expr, tableAlias);
-    }
-
-    /**
-     *  Given two equal length lists of the expressions build a combined equivalence expression
-     *  (le1, le2,..., leN) (re1, re2,..., reN) =>
-     *  (le1=re1) AND (le2=re2) AND .... AND (leN=reN)
-     *
-     * @param leftExprs
-     * @param rightExprs
-     * @return AbstractExpression
-     */
-    public static AbstractExpression buildEquavalenceExpression(Collection<AbstractExpression> leftExprs, Collection<AbstractExpression> rightExprs) {
-        assert(leftExprs.size() == rightExprs.size());
-        Iterator<AbstractExpression> leftIt = leftExprs.iterator();
-        Iterator<AbstractExpression> rightIt = rightExprs.iterator();
-        AbstractExpression result = null;
-        while (leftIt.hasNext() && rightIt.hasNext()) {
-            AbstractExpression leftExpr = leftIt.next();
-            AbstractExpression rightExpr = rightIt.next();
-            AbstractExpression eqaulityExpr = new ComparisonExpression(ExpressionType.COMPARE_EQUAL, leftExpr, rightExpr);
-            if (result == null) {
-                result = eqaulityExpr;
-            } else {
-                result = new ConjunctionExpression(ExpressionType.CONJUNCTION_AND, result, eqaulityExpr);
-            }
-        }
-        return result;
-    }
-
-    /**
-     *  Return true/false whether an expression contains any aggregate expression
-     *
-     * @param expr
-     * @return true is expression contains an aggregate subexpression
-     */
-    public static boolean containsAggregateExpression(AbstractExpression expr) {
-        AbstractExpression.SubexprFinderPredicate pred = new AbstractExpression.SubexprFinderPredicate() {
-            @Override
-            public boolean matches(AbstractExpression expr) {
-                return expr.getExpressionType().isAggregateExpression();
-            }
-        };
-        return expr.hasAnySubexpressionWithPredicate(pred);
-    }
-
-    private static boolean containsMatchingTVE(AbstractExpression expr, String tableAlias) {
-        assert(expr != null);
-        List<TupleValueExpression> tves = getTupleValueExpressions(expr);
-        for (TupleValueExpression tve : tves) {
-            if (tve.m_tableAlias != null) {
-                if (tve.m_tableAlias.equals(tableAlias)) {
-                    return true;
-                }
-            } else if (tve.m_tableName.equals(tableAlias)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Traverse this expression tree.  Where we find a SelectSubqueryExpression, wrap it
-     * in a ScalarValueExpression if its parent is not one of:
-     * - comparison (=, !=, <, etc)
-     * - operator exists
-     * @param expr   - the expression that may contain subqueries that need to be wrapped
-     * @return the expression with subqueries wrapped where needed
-     */
-    public static AbstractExpression wrapScalarSubqueries(AbstractExpression expr) {
-        return wrapScalarSubqueriesHelper(null, expr);
-    }
-
-    private static AbstractExpression wrapScalarSubqueriesHelper(AbstractExpression parentExpr, AbstractExpression expr) {
-
-        // Bottom-up recursion.  Proceed to the children first.
-        AbstractExpression leftChild = expr.getLeft();
-        if (leftChild != null) {
-            AbstractExpression newLeft = wrapScalarSubqueriesHelper(expr, leftChild);
-            if (newLeft != leftChild) {
-                expr.setLeft(newLeft);
-            }
-        }
-
-        AbstractExpression rightChild = expr.getRight();
-        if (rightChild != null) {
-            AbstractExpression newRight = wrapScalarSubqueriesHelper(expr, rightChild);
-            if (newRight != rightChild) {
-                expr.setRight(newRight);
-            }
-        }
-
-        // Let's not forget the args, which may also contain subqueries.
-        List<AbstractExpression> args = expr.getArgs();
-        if (args != null) {
-            for (int i = 0; i < args.size(); ++i) {
-                AbstractExpression arg = args.get(i);
-                AbstractExpression newArg = wrapScalarSubqueriesHelper(expr, arg);
-                if (newArg != arg) {
-                    expr.setArgAtIndex(i, newArg);
-                }
-            }
-        }
-
-        if (expr instanceof SelectSubqueryExpression
-                && subqueryRequiresScalarValueExpressionFromContext(parentExpr)) {
-            expr = addScalarValueExpression((SelectSubqueryExpression)expr);
-        }
-        return expr;
-    }
-
-    /**
-     * Return true if we must insert a ScalarValueExpression between a subquery
-     * and its parent expression.
-     * @param parentExpr  the parent expression of a subquery
-     * @return true if the parent expression is not a comparison, EXISTS operator, or
-     *   a scalar value expression
-     */
-    private static boolean subqueryRequiresScalarValueExpressionFromContext(AbstractExpression parentExpr) {
-        if (parentExpr == null) {
-            // No context: we are a top-level expression.  E.g, an item on the
-            // select list.  In this case, assume the expression must be scalar.
-            return true;
-        }
-
-        // Exists and comparison operators can handle non-scalar subqueries.
-        if (parentExpr.getExpressionType() == ExpressionType.OPERATOR_EXISTS
-                || parentExpr instanceof ComparisonExpression) {
-            return false;
-        }
-
-        // There is already a ScalarValueExpression above the subquery.
-        if (parentExpr instanceof ScalarValueExpression) {
-            return false;
-        }
-
-        // By default, assume that the subquery must produce a single value.
-        return true;
-    }
-
-    /**
-     * Add a ScalarValueExpression on top of the SubqueryExpression
-     * @param expr - subquery expression
-     * @return ScalarValueExpression
-     */
-    private static AbstractExpression addScalarValueExpression(SelectSubqueryExpression expr) {
-        if (expr.getSubqueryScan().getOutputSchema().size() != 1) {
-            throw new PlanningErrorException("Scalar subquery can have only one output column");
-        }
-
-        expr.changeToScalarExprType();
-
-        AbstractExpression scalarExpr = new ScalarValueExpression();
-        scalarExpr.setLeft(expr);
-        scalarExpr.setValueType(expr.getValueType());
-        scalarExpr.setValueSize(expr.getValueSize());
-        return scalarExpr;
     }
 
     /**
@@ -583,51 +247,60 @@ public abstract class ExpressionUtil {
             if (ExpressionType.VALUE_CONSTANT == expr.getLeft().getExpressionType()) {
                 if (ConstantValueExpression.isBooleanTrue(expr.getLeft())) {
                     return expr.getRight();
-                } else {
+                }
+                else {
                     return expr.getLeft();
                 }
             }
             if (ExpressionType.VALUE_CONSTANT == expr.getRight().getExpressionType()) {
                 if (ConstantValueExpression.isBooleanTrue(expr.getRight())) {
                     return expr.getLeft();
-                } else {
+                }
+                else {
                     return expr.getRight();
                 }
             }
-        } else if (ExpressionType.CONJUNCTION_OR == expr.getExpressionType()) {
+        }
+        else if (ExpressionType.CONJUNCTION_OR == expr.getExpressionType()) {
             if (ExpressionType.VALUE_CONSTANT == expr.getLeft().getExpressionType()) {
                 if (ConstantValueExpression.isBooleanTrue(expr.getLeft())) {
                     return expr.getLeft();
-                } else {
+                }
+                else {
                     return expr.getRight();
                 }
             }
             if (ExpressionType.VALUE_CONSTANT == expr.getRight().getExpressionType()) {
                 if (ConstantValueExpression.isBooleanTrue(expr.getRight())) {
                     return expr.getRight();
-                } else {
+                }
+                else {
                     return expr.getLeft();
                 }
             }
-        } else if (ExpressionType.OPERATOR_NOT == expr.getExpressionType()) {
+        }
+        else if (ExpressionType.OPERATOR_NOT == expr.getExpressionType()) {
             AbstractExpression leftExpr = expr.getLeft();
             // function expressions can also return boolean. So the left child expression
             // can be expression which are not constant value expressions, so don't
             // evaluate every left child expr as constant value expression
-            if ((VoltType.BOOLEAN == leftExpr.getValueType()) &&
-                    (leftExpr instanceof ConstantValueExpression)) {
+            assert(VoltType.BOOLEAN == leftExpr.getValueType());
+            if (leftExpr instanceof ConstantValueExpression) {
                 if (ConstantValueExpression.isBooleanTrue(leftExpr)) {
                     return ConstantValueExpression.getFalse();
-                } else {
+                }
+                else {
                     return ConstantValueExpression.getTrue();
                 }
-            } else if (ExpressionType.OPERATOR_NOT == leftExpr.getExpressionType()) {
+            }
+            if (ExpressionType.OPERATOR_NOT == leftExpr.getExpressionType()) {
                 return leftExpr.getLeft();
-            } else if (ExpressionType.CONJUNCTION_OR == leftExpr.getExpressionType()) {
+            }
+            if (ExpressionType.CONJUNCTION_OR == leftExpr.getExpressionType()) {
                 // NOT (.. OR .. OR ..) => NOT(..) AND NOT(..) AND NOT(..)
                 AbstractExpression l = new OperatorExpression(ExpressionType.OPERATOR_NOT, leftExpr.getLeft(), null);
                 AbstractExpression r = new OperatorExpression(ExpressionType.OPERATOR_NOT, leftExpr.getRight(), null);
-                leftExpr = new OperatorExpression(ExpressionType.CONJUNCTION_AND, l, r);
+                leftExpr = new ConjunctionExpression(ExpressionType.CONJUNCTION_AND, l, r);
                 return evaluateExpression(leftExpr);
             }
             // NOT (expr1 AND expr2) => (NOT expr1) || (NOT expr2)

--- a/src/frontend/org/voltdb/expressions/InComparisonExpression.java
+++ b/src/frontend/org/voltdb/expressions/InComparisonExpression.java
@@ -42,7 +42,8 @@ public class InComparisonExpression extends ComparisonExpression {
         //
         if (m_left == null) {
             throw new Exception("ERROR: The left node for '" + this + "' is NULL");
-        } else if (m_right == null) {
+        }
+        if (m_right == null) {
             throw new Exception("ERROR: The right node for '" + this + "' is NULL");
         }
 
@@ -53,8 +54,7 @@ public class InComparisonExpression extends ComparisonExpression {
     }
 
     @Override
-    public void finalizeValueTypes()
-    {
+    public void finalizeValueTypes() {
         // First, make sure this node and its children have valid types.
         // This ignores the overall element type of the rhs.
         super.finalizeValueTypes();

--- a/src/frontend/org/voltdb/expressions/OperatorExpression.java
+++ b/src/frontend/org/voltdb/expressions/OperatorExpression.java
@@ -36,10 +36,6 @@ import org.voltdb.utils.VoltTypeUtil;
  *   - alternative (unsupported?)
  */
 public class OperatorExpression extends AbstractExpression {
-    public OperatorExpression(ExpressionType type) {
-        super(type);
-    }
-
     public OperatorExpression(ExpressionType type, AbstractExpression left, AbstractExpression right) {
         super(type, left, right);
     }

--- a/src/frontend/org/voltdb/expressions/WindowedExpression.java
+++ b/src/frontend/org/voltdb/expressions/WindowedExpression.java
@@ -198,8 +198,9 @@ public class WindowedExpression extends AbstractExpression {
      * partition by and order by lists.
      */
     @Override
-    public <aeClass> List<aeClass> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        List<aeClass> list = super.findAllSubexpressionsOfClass(aeClass);
+    public <T extends AbstractExpression> List<T> findAllSubexpressionsOfClass(
+            Class< ? extends AbstractExpression> aeClass) {
+        List<T> list = super.findAllSubexpressionsOfClass(aeClass);
         for (AbstractExpression pbexpr : m_partitionByExpressions) {
             list.addAll(pbexpr.findAllSubexpressionsOfClass(aeClass));
         }

--- a/src/frontend/org/voltdb/planner/AccessPath.java
+++ b/src/frontend/org/voltdb/planner/AccessPath.java
@@ -18,6 +18,7 @@
 package org.voltdb.planner;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.voltdb.catalog.Index;
 import org.voltdb.expressions.AbstractExpression;
@@ -38,10 +39,22 @@ public class AccessPath {
     final ArrayList<AbstractExpression> initialExpr = new ArrayList<AbstractExpression>();
     final ArrayList<AbstractExpression> indexExprs = new ArrayList<AbstractExpression>();
     final ArrayList<AbstractExpression> endExprs = new ArrayList<AbstractExpression>();
-    final ArrayList<AbstractExpression> otherExprs = new ArrayList<AbstractExpression>();
-    final ArrayList<AbstractExpression> joinExprs = new ArrayList<AbstractExpression>();
+    final ArrayList<AbstractExpression> otherExprs;
+    final ArrayList<AbstractExpression> joinExprs;
     final ArrayList<AbstractExpression> bindings = new ArrayList<AbstractExpression>();
     final ArrayList<AbstractExpression> eliminatedPostExprs = new ArrayList<AbstractExpression>();
+
+    AccessPath() {
+        otherExprs = new ArrayList<>();
+        joinExprs = new ArrayList<>();
+    }
+
+    AccessPath(List<AbstractExpression> filterExprs, List<AbstractExpression> joinExprs2) {
+        otherExprs = (filterExprs == null) ? new ArrayList<>() :
+            new ArrayList<>(filterExprs);
+        joinExprs = (joinExprs2 == null) ? new ArrayList<>() :
+            new ArrayList<>(joinExprs2);
+    }
 
     @Override
     public String toString() {

--- a/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
@@ -228,9 +228,8 @@ public class ParsedInsertStmt extends AbstractParsedStmt {
     }
 
     @Override
-    public Set<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        Set<AbstractExpression> exprs = super.findAllSubexpressionsOfClass(aeClass);
-
+    public <T extends AbstractExpression> Set<T> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
+        Set<T> exprs = super.findAllSubexpressionsOfClass(aeClass);
         for (AbstractExpression expr : m_columns.values()) {
             if (expr == null) {
                 continue;

--- a/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
@@ -374,8 +374,9 @@ public class ParsedUnionStmt extends AbstractParsedStmt {
     }
 
     @Override
-    public Set<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        Set<AbstractExpression> exprs = new HashSet<AbstractExpression>();
+    public <T extends AbstractExpression> Set<T> findAllSubexpressionsOfClass(
+            Class< ? extends AbstractExpression> aeClass) {
+        Set<T> exprs = new HashSet<>();
         for (AbstractParsedStmt childStmt : m_children) {
             exprs.addAll(childStmt.findAllSubexpressionsOfClass(aeClass));
         }

--- a/src/frontend/org/voltdb/planner/ParsedUpdateStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedUpdateStmt.java
@@ -76,8 +76,9 @@ public class ParsedUpdateStmt extends AbstractParsedStmt {
     }
 
     @Override
-    public Set<AbstractExpression> findAllSubexpressionsOfClass(Class< ? extends AbstractExpression> aeClass) {
-        Set<AbstractExpression> exprs = super.findAllSubexpressionsOfClass(aeClass);
+    public <T extends AbstractExpression> Set<T> findAllSubexpressionsOfClass(
+            Class< ? extends AbstractExpression> aeClass) {
+        Set<T> exprs = super.findAllSubexpressionsOfClass(aeClass);
 
         for (AbstractExpression expr : columns.values()) {
             if (expr != null) {

--- a/src/frontend/org/voltdb/planner/WriterSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/WriterSubPlanAssembler.java
@@ -70,7 +70,8 @@ public class WriterSubPlanAssembler extends SubPlanAssembler {
             // only once on the node.
             JoinNode tableNode = (JoinNode) m_parsedStmt.m_joinTree.clone();
             // Analyze join conditions
-            tableNode.analyzeJoinExpressions(m_parsedStmt.m_noTableSelectionList);
+            tableNode.analyzeJoinExpressions(m_parsedStmt.m_noTableSelectionList,
+                    m_parsedStmt.m_tableList.size());
             // these just shouldn't happen right?
             assert(m_parsedStmt.m_noTableSelectionList.size() == 0);
 
@@ -86,7 +87,6 @@ public class WriterSubPlanAssembler extends SubPlanAssembler {
 
             for (AccessPath path : tableNode.m_accessPaths) {
                 tableNode.m_currentAccessPath = path;
-
                 AbstractPlanNode plan = getAccessPlanForTable(tableNode);
                 m_plans.add(plan);
             }

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -274,8 +274,7 @@ public class StmtSubqueryScan extends StmtTableScan {
         SchemaColumn schemaCol = m_outputColumnList.get(idx.intValue());
 
         expr.setColumnIndex(idx.intValue());
-        expr.setTypeSizeBytes(schemaCol.getType(), schemaCol.getSize(),
-                schemaCol.getExpression().getInBytes());
+        expr.setTypeSizeAndInBytes(schemaCol.getExpression());
 
     }
 

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtTargetTableScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtTargetTableScan.java
@@ -87,7 +87,7 @@ public class StmtTargetTableScan extends StmtTableScan {
 
         TupleValueExpression tve = new TupleValueExpression(
                 tbName, m_tableAlias, colName, colName, partitionCol.getIndex());
-        tve.setTypeSizeBytes(partitionCol.getType(), partitionCol.getSize(), partitionCol.getInbytes());
+        tve.setTypeSizeAndInBytes(partitionCol);
 
         SchemaColumn scol = new SchemaColumn(tbName, m_tableAlias, colName, colName, tve);
         m_partitioningColumns = new ArrayList<SchemaColumn>();

--- a/src/frontend/org/voltdb/planner/parseinfo/SubqueryLeafNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/SubqueryLeafNode.java
@@ -82,9 +82,9 @@ public class SubqueryLeafNode extends JoinNode{
     public String getTableAlias() { return m_subqueryScan.getTableAlias(); }
 
     @Override
-    public void analyzeJoinExpressions(List<AbstractExpression> noneList) {
-        m_joinInnerList.addAll(ExpressionUtil.uncombineAny(getJoinExpression()));
-        m_whereInnerList.addAll(ExpressionUtil.uncombineAny(getWhereExpression()));
+    public void analyzeJoinExpressions(List<AbstractExpression> noneList, int stmtScanCount) {
+        m_joinInnerList.addAll(ExpressionUtil.uncombineConjunctions(getJoinExpression()));
+        m_whereInnerList.addAll(ExpressionUtil.uncombineConjunctions(getWhereExpression()));
     }
 
     @Override

--- a/src/frontend/org/voltdb/planner/parseinfo/TableLeafNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/TableLeafNode.java
@@ -72,9 +72,9 @@ public class TableLeafNode extends JoinNode {
     @Override public String getTableAlias() { return m_tableScan.getTableAlias(); }
 
     @Override
-    public void analyzeJoinExpressions(List<AbstractExpression> noneList) {
-        m_joinInnerList.addAll(ExpressionUtil.uncombineAny(getJoinExpression()));
-        m_whereInnerList.addAll(ExpressionUtil.uncombineAny(getWhereExpression()));
+    public void analyzeJoinExpressions(List<AbstractExpression> noneList, int stmtScanCount) {
+        m_joinInnerList.addAll(ExpressionUtil.uncombineConjunctions(getJoinExpression()));
+        m_whereInnerList.addAll(ExpressionUtil.uncombineConjunctions(getWhereExpression()));
     }
 
     @Override

--- a/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
@@ -90,14 +90,12 @@ public abstract class AbstractOperationPlanNode extends AbstractPlanNode {
         assert(m_children.size() == 1 ||
                ((this instanceof DeletePlanNode) &&
                 (((DeletePlanNode)this).m_truncate)));
-        if (m_children.size() == 1)
-        {
+        if (m_children.size() == 1) {
             m_children.get(0).generateOutputSchema(db);
         }
         // Our output schema isn't ever going to change, only generate this once
-        if (m_outputSchema == null)
-        {
-            m_outputSchema = new NodeSchema();
+        if (m_outputSchema == null) {
+            m_outputSchema = new NodeSchema(1);
             // If there is a child node, its output schema will depend on that.
             // If not, mark this flag true to get initialized in EE.
             m_hasSignificantOutputSchema = m_children.size() == 0 ? true : false;

--- a/src/frontend/org/voltdb/plannodes/AbstractReceivePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractReceivePlanNode.java
@@ -76,20 +76,17 @@ public abstract class AbstractReceivePlanNode extends AbstractPlanNode {
         return true;
     }
 
-    protected void resolveColumnIndexes(NodeSchema outputSchema)
-    {
+    protected void resolveColumnIndexes(NodeSchema outputSchema) {
         // Need to order and resolve indexes of output columns
         assert(m_children.size() == 1);
         m_children.get(0).resolveColumnIndexes();
         NodeSchema input_schema = m_children.get(0).getOutputSchema();
         assert (input_schema.equals(outputSchema));
-        for (SchemaColumn col : outputSchema.getColumns())
-        {
+        for (SchemaColumn col : outputSchema.getColumns()) {
             // At this point, they'd better all be TVEs.
             assert(col.getExpression() instanceof TupleValueExpression);
             TupleValueExpression tve = (TupleValueExpression)col.getExpression();
-            int index = tve.resolveColumnIndexesUsingSchema(input_schema);
-            tve.setColumnIndex(index);
+            tve.resolveColumnIndexUsingSchema(input_schema);
         }
         // output schema for ReceivePlanNode should never be re-sorted
     }

--- a/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
@@ -104,7 +104,6 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
 
         m_estimatedOutputTupleCount = 1;
         m_tableSchema = isp.m_tableSchema;
-        m_tableScanSchema = isp.m_tableScanSchema.clone();
 
         m_targetIndexName = isp.m_targetIndexName;
 
@@ -490,7 +489,9 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
     }
 
     @Override
-    public void findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass, Set<AbstractExpression> collected) {
+    public <T extends AbstractExpression> void findAllExpressionsOfClass(
+            Class< ? extends AbstractExpression> aeClass,
+            Set<T> collected) {
         super.findAllExpressionsOfClass(aeClass, collected);
         if (m_skip_null_predicate != null) {
             collected.addAll(m_skip_null_predicate.findAllSubexpressionsOfClass(aeClass));

--- a/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
@@ -132,19 +132,16 @@ public class LimitPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void resolveColumnIndexes()
-    {
+    public void resolveColumnIndexes() {
         // Need to order and resolve indexes of output columns
         assert(m_children.size() == 1);
         m_children.get(0).resolveColumnIndexes();
         NodeSchema input_schema = m_children.get(0).getOutputSchema();
-        for (SchemaColumn col : m_outputSchema.getColumns())
-        {
+        for (SchemaColumn col : m_outputSchema.getColumns()) {
             // At this point, they'd better all be TVEs.
             assert(col.getExpression() instanceof TupleValueExpression);
             TupleValueExpression tve = (TupleValueExpression)col.getExpression();
-            int index = tve.resolveColumnIndexesUsingSchema(input_schema);
-            tve.setColumnIndex(index);
+            tve.resolveColumnIndexUsingSchema(input_schema);
         }
         m_outputSchema.sortByTveIndex();
     }

--- a/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
@@ -65,8 +65,7 @@ public class MaterializedScanPlanNode extends AbstractPlanNode {
         assert(tableData instanceof VectorValueExpression || tableData instanceof ParameterValueExpression);
         m_tableData = tableData;
 
-        m_outputExpression.setTypeSizeBytes(m_tableData.getValueType(), m_tableData.getValueSize(),
-                m_tableData.getInBytes());
+        m_outputExpression.setTypeSizeAndInBytes(m_tableData);
     }
 
     public void setSortDirection(SortDirectionType direction) {
@@ -112,7 +111,7 @@ public class MaterializedScanPlanNode extends AbstractPlanNode {
         m_hasSignificantOutputSchema = true;
         // fill in the table schema if we haven't already
         if (m_outputSchema == null) {
-            m_outputSchema = new NodeSchema();
+            m_outputSchema = new NodeSchema(1);
             // must produce a tuple value expression for the one column.
             m_outputSchema.addColumn(
                 new SchemaColumn(m_outputExpression.getTableName(),
@@ -157,7 +156,7 @@ public class MaterializedScanPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass, Set<AbstractExpression> collected) {
+    public <T extends AbstractExpression> void findAllExpressionsOfClass(Class< ? extends AbstractExpression> aeClass, Set<T> collected) {
         super.findAllExpressionsOfClass(aeClass, collected);
         collected.addAll(m_tableData.findAllSubexpressionsOfClass(aeClass));
     }

--- a/src/frontend/org/voltdb/plannodes/MergeReceivePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MergeReceivePlanNode.java
@@ -103,10 +103,10 @@ public class MergeReceivePlanNode extends AbstractReceivePlanNode {
     public void loadFromJSONObject( JSONObject jobj, Database db ) throws JSONException {
         helpLoadFromJSONObject(jobj, db);
         if (jobj.has(Members.OUTPUT_SCHEMA_PRE_AGG.name())) {
-            m_outputSchemaPreInlineAgg = new NodeSchema();
             m_hasSignificantOutputSchema = true;
             JSONArray jarray = jobj.getJSONArray( Members.OUTPUT_SCHEMA_PRE_AGG.name() );
             int size = jarray.length();
+            m_outputSchemaPreInlineAgg = new NodeSchema(size);
             for( int i = 0; i < size; i++ ) {
                 m_outputSchemaPreInlineAgg.addColumn( SchemaColumn.fromJSONObject(jarray.getJSONObject(i)) );
             }

--- a/src/frontend/org/voltdb/plannodes/PartitionByPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/PartitionByPlanNode.java
@@ -35,21 +35,13 @@ import org.voltdb.types.PlanNodeType;
  * Note that this is a trivial kind of an AggregatePlanNode.
  */
 public class PartitionByPlanNode extends AggregatePlanNode {
-    private enum Members {
-        ORDER_BY_EXPRS
-    };
-
     @Override
-    public void generateOutputSchema(Database db)
-    {
-        if (m_outputSchema == null) {
-            m_outputSchema = new NodeSchema();
-        } else {
-            assert(getOutputSchema().size() == 0);
-        }
+    public void generateOutputSchema(Database db) {
         assert(m_children.size() == 1);
         m_children.get(0).generateOutputSchema(db);
         NodeSchema inputSchema = m_children.get(0).getOutputSchema();
+        List<SchemaColumn> inputColumns = inputSchema.getColumns();
+        m_outputSchema = new NodeSchema(1 + inputColumns.size());
         // We already created the TVE for this expression.
         TupleValueExpression tve = m_windowedExpression.getDisplayListExpression();
         SchemaColumn aggCol = new SchemaColumn(tve.getTableName(),
@@ -57,10 +49,10 @@ public class PartitionByPlanNode extends AggregatePlanNode {
                                                tve.getColumnName(),
                                                tve.getColumnAlias(),
                                                tve);
-        getOutputSchema().addColumn(aggCol);
+        m_outputSchema.addColumn(aggCol);
         // Just copy the input columns to the output schema.
         for (SchemaColumn col : inputSchema.getColumns()) {
-            getOutputSchema().addColumn(col.clone());
+            m_outputSchema.addColumn(col.clone());
         }
         m_hasSignificantOutputSchema = true;
     }

--- a/src/frontend/org/voltdb/plannodes/PlanNodeTree.java
+++ b/src/frontend/org/voltdb/plannodes/PlanNodeTree.java
@@ -31,6 +31,7 @@ import org.json_voltpatches.JSONStringer;
 import org.voltdb.catalog.Database;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.AbstractSubqueryExpression;
+import org.voltdb.expressions.SelectSubqueryExpression;
 import org.voltdb.types.PlanNodeType;
 
 /**
@@ -182,10 +183,8 @@ public class PlanNodeTree implements JSONString {
         if (predicate == null) {
             return;
         }
-        List<AbstractExpression> subquerysExprs = predicate.findAllSubquerySubexpressions();
-        for (AbstractExpression expr : subquerysExprs) {
-            assert(expr instanceof AbstractSubqueryExpression);
-            AbstractSubqueryExpression subqueryExpr = (AbstractSubqueryExpression) expr;
+        List<SelectSubqueryExpression> subquerysExprs = predicate.findAllSubquerySubexpressions();
+        for (SelectSubqueryExpression subqueryExpr : subquerysExprs) {
             int subqueryId = subqueryExpr.getSubqueryId();
             int subqueryNodeId = subqueryExpr.getSubqueryNodeId();
             List<AbstractPlanNode> subqueryNodes = m_planNodesListMap.get(subqueryId);
@@ -278,10 +277,8 @@ public class PlanNodeTree implements JSONString {
      */
     private void extractSubqueries(AbstractPlanNode node)  throws Exception {
         assert(node != null);
-        Collection<AbstractExpression> subexprs = node.findAllSubquerySubexpressions();
-        for (AbstractExpression nextexpr : subexprs) {
-            assert(nextexpr instanceof AbstractSubqueryExpression);
-            AbstractSubqueryExpression subqueryExpr = (AbstractSubqueryExpression) nextexpr;
+        Collection<AbstractSubqueryExpression> subexprs = node.findAllSubquerySubexpressions();
+        for (AbstractSubqueryExpression subqueryExpr : subexprs) {
             int stmtId = subqueryExpr.getSubqueryId();
             List<AbstractPlanNode> planNodes = new ArrayList<AbstractPlanNode>();
             assert(!m_planNodesListMap.containsKey(stmtId));

--- a/src/frontend/org/voltdb/plannodes/SchemaColumn.java
+++ b/src/frontend/org/voltdb/plannodes/SchemaColumn.java
@@ -20,7 +20,6 @@ package org.voltdb.plannodes;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
-import org.voltdb.VoltType;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.TupleValueExpression;
 
@@ -87,8 +86,7 @@ public class SchemaColumn
      * Clone a schema column
      */
     @Override
-    protected SchemaColumn clone()
-    {
+    protected SchemaColumn clone() {
         return new SchemaColumn(m_tableName, m_tableAlias, m_columnName, m_columnAlias,
                                 m_expression, m_differentiator);
     }
@@ -117,7 +115,7 @@ public class SchemaColumn
             return false;
         }
 
-        return getDifferentiator() == sc.getDifferentiator();
+        return m_differentiator == sc.m_differentiator;
     }
 
     private int nullSafeStringCompareTo(String str1, String str2) {
@@ -197,16 +195,13 @@ public class SchemaColumn
     public SchemaColumn copyAndReplaceWithTVE()
     {
         TupleValueExpression new_exp = null;
-        if (m_expression instanceof TupleValueExpression)
-        {
+        if (m_expression instanceof TupleValueExpression) {
             new_exp = (TupleValueExpression) m_expression.clone();
         }
-        else
-        {
+        else {
             new_exp = new TupleValueExpression(m_tableName, m_tableAlias, m_columnName, m_columnAlias);
             // XXX not sure this is right
-            new_exp.setTypeSizeBytes(m_expression.getValueType(), m_expression.getValueSize(),
-                    m_expression.getInBytes());
+            new_exp.setTypeSizeAndInBytes(m_expression);
         }
         return new SchemaColumn(m_tableName, m_tableAlias, m_columnName, m_columnAlias,
                                 new_exp, m_differentiator);
@@ -252,16 +247,6 @@ public class SchemaColumn
         return m_expression;
     }
 
-    public VoltType getType()
-    {
-        return m_expression.getValueType();
-    }
-
-    public int getSize()
-    {
-        return m_expression.getValueSize();
-    }
-
     /**
      * Return the differentiator that can distinguish columns with the same name.
      * This value is just the ordinal position of the SchemaColumn within its NodeSchema.
@@ -288,9 +273,7 @@ public class SchemaColumn
         sb.append("\tTable Alias: ").append(m_tableAlias).append("\n");
         sb.append("\tColumn Name: ").append(m_columnName).append("\n");
         sb.append("\tColumn Alias: ").append(m_columnAlias).append("\n");
-        sb.append("\tColumn Type: ").append(getType()).append("\n");
-        sb.append("\tColumn Size: ").append(getSize()).append("\n");
-        sb.append("\tDifferentiator: ").append(getDifferentiator()).append("\n");
+        sb.append("\tDifferentiator: ").append(m_differentiator).append("\n");
         sb.append("\tExpression: ").append(m_expression.toString()).append("\n");
         return sb.toString();
     }
@@ -304,8 +287,7 @@ public class SchemaColumn
         // a result set that has all the aliases that may have been specified
         // by the user (thanks to chains of setOutputTable(getInputTable))
         if (finalOutput) {
-            if (getColumnAlias() != null && !getColumnAlias().equals(""))
-            {
+            if (getColumnAlias() != null && !getColumnAlias().equals("")) {
                 stringer.key(Members.COLUMN_NAME.name()).value(getColumnAlias());
             }
             else if (getColumnName() != null) {

--- a/src/frontend/org/voltdb/plannodes/SendPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SendPlanNode.java
@@ -39,21 +39,19 @@ public class SendPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void resolveColumnIndexes()
-    {
+    public void resolveColumnIndexes() {
         // Need to order and resolve indexes of output columns
         assert(m_children.size() == 1);
-        m_children.get(0).resolveColumnIndexes();
-        NodeSchema input_schema = m_children.get(0).getOutputSchema();
+        AbstractPlanNode child = m_children.get(0);
+        child.resolveColumnIndexes();
+        NodeSchema input_schema = child.getOutputSchema();
         assert (input_schema.equalsOnlyNames(m_outputSchema));
 
-        for (SchemaColumn col : m_outputSchema.getColumns())
-        {
+        for (SchemaColumn col : m_outputSchema.getColumns()) {
             // At this point, they'd better all be TVEs.
             assert(col.getExpression() instanceof TupleValueExpression);
             TupleValueExpression tve = (TupleValueExpression)col.getExpression();
-            int index = tve.resolveColumnIndexesUsingSchema(input_schema);
-            tve.setColumnIndex(index);
+            tve.resolveColumnIndexUsingSchema(input_schema);
         }
         // output schema for SendPlanNode should not ever be changed
     }

--- a/src/frontend/org/voltdb/plannodes/TupleScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/TupleScanPlanNode.java
@@ -66,7 +66,7 @@ public class TupleScanPlanNode extends AbstractScanPlanNode {
     @Override
     public void generateOutputSchema(Database db) {
         if (m_tableSchema == null) {
-            m_tableSchema = new NodeSchema();
+            m_tableSchema = new NodeSchema(m_columnList.size());
             int columnIdx = 1;
             for (AbstractExpression colExpr : m_columnList) {
                 assert(colExpr instanceof ParameterValueExpression);
@@ -75,8 +75,7 @@ public class TupleScanPlanNode extends AbstractScanPlanNode {
                 String columnName = "C" + Integer.toString(columnIdx);
                 TupleValueExpression tve = new TupleValueExpression(
                         m_targetTableName, m_targetTableAlias, columnName, columnName, columnIdx);
-
-                tve.setTypeSizeBytes(pve.getValueType(), pve.getValueSize(), pve.getInBytes());
+                tve.setTypeSizeAndInBytes(pve);
                 m_tableSchema.addColumn(new SchemaColumn(m_targetTableName,
                         m_targetTableAlias,
                         columnName,
@@ -96,8 +95,7 @@ public class TupleScanPlanNode extends AbstractScanPlanNode {
             // At this point, they'd better all be TVEs.
             assert(col.getExpression() instanceof TupleValueExpression);
             TupleValueExpression tve = (TupleValueExpression)col.getExpression();
-            int index = tve.resolveColumnIndexesUsingSchema(m_tableSchema);
-            tve.setColumnIndex(index);
+            tve.resolveColumnIndexUsingSchema(m_tableSchema);
         }
         m_outputSchema.sortByTveIndex();
     }

--- a/src/frontend/org/voltdb/plannodes/UnionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/UnionPlanNode.java
@@ -91,7 +91,8 @@ public class UnionPlanNode extends AbstractPlanNode {
                 throw new RuntimeException("Column number mismatch detected in rows of UNION");
             }
             for (int j = 0; j < outputColumns.size(); ++j) {
-                if (outputColumns.get(j).getType() != columns.get(j).getType()) {
+                if (outputColumns.get(j).getExpression().getValueType() !=
+                        columns.get(j).getExpression().getValueType()) {
                     throw new PlanningErrorException("Incompatible data types in UNION");
                 }
             }

--- a/src/frontend/org/voltdb/utils/VoltTypeUtil.java
+++ b/src/frontend/org/voltdb/utils/VoltTypeUtil.java
@@ -157,22 +157,19 @@ public abstract class VoltTypeUtil {
         }
         // Check for NULL first, if either type is NULL the output is always NULL
         // XXX do we need to actually check for all NULL_foo types here?
-        else if (left == VoltType.NULL || right == VoltType.NULL)
-        {
+        else if (left == VoltType.NULL || right == VoltType.NULL) {
             return VoltType.NULL;
         }
         //
         // No mixing of strings and numbers
         //
         else if ((left == VoltType.STRING && right != VoltType.STRING) ||
-                (left != VoltType.STRING && right == VoltType.STRING))
-        {
+                (left != VoltType.STRING && right == VoltType.STRING)) {
             throw new VoltTypeException(String.format(VoltTypeCastErrorMessage, left, right));
         }
         // No mixing of numbers and non-numbers
         else if ((left.isNumber() && !right.isNumber()) ||
-                 (right.isNumber() && !left.isNumber()))
-        {
+                 (right.isNumber() && !left.isNumber())) {
             throw new VoltTypeException(String.format(VoltTypeCastErrorMessage, left, right));
         }
         //
@@ -194,8 +191,7 @@ public abstract class VoltTypeUtil {
             //
             // If any one of the types is the current cast type, we'll use that
             //
-            if (left == cast_type || right == cast_type)
-            {
+            if (left == cast_type || right == cast_type) {
                 return cast_type;
             }
         }
@@ -203,8 +199,7 @@ public abstract class VoltTypeUtil {
         // If we have INT types smaller than BIGINT
         // promote the output up to BIGINT
         if ((left == VoltType.INTEGER || left == VoltType.SMALLINT || left == VoltType.TINYINT) &&
-                (right == VoltType.INTEGER || right == VoltType.SMALLINT || right == VoltType.TINYINT))
-        {
+                (right == VoltType.INTEGER || right == VoltType.SMALLINT || right == VoltType.TINYINT)) {
             return VoltType.BIGINT;
         }
 

--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -616,7 +616,7 @@ public class TestAdHocQueries extends AdHocQueryTester {
             fail("Query was expected to generate stack overflow error");
         }
         catch (Exception exception) {
-            System.out.println(exception.getMessage());
+            //* enable to debug */ System.out.println(exception.getMessage());
             String expectedMsg;
             expectedMsg = "Encountered stack overflow error. " +
                           "Try reducing the number of predicate expressions in the query.";

--- a/tests/frontend/org/voltdb/planner/TestIndexReverseScan.java
+++ b/tests/frontend/org/voltdb/planner/TestIndexReverseScan.java
@@ -48,7 +48,7 @@ public class TestIndexReverseScan extends PlannerTestCase {
     String sql;
 
 
-    public void testLegancyTests()
+    public void testLegacyTests()
     {
         sql = "select a from t where a = ? and b < ?";
         checkReverseScan("COVER2_TREE", IndexLookupType.LT, 2, 1, 1, SortDirectionType.INVALID);
@@ -74,7 +74,7 @@ public class TestIndexReverseScan extends PlannerTestCase {
 
     }
 
-    public void testLegancyTests_NonOptimizable()
+    public void testLegacyTests_NonOptimizable()
     {
         // ORDER BY ASC: do not do reverse scan optimization
         sql = "select a, b from t where a = ? and c = ? and b < ? order by b;";
@@ -479,7 +479,7 @@ public class TestIndexReverseScan extends PlannerTestCase {
             SortDirectionType sortType, boolean needOrderby) {
 
         AbstractPlanNode pn = compile(sql);
-        System.out.println(pn.toExplainPlanString());
+        //*enable to debug*/ System.out.println(pn.toExplainPlanString());
 
         assertTrue(pn instanceof SendPlanNode);
         pn = pn.getChild(0);
@@ -523,7 +523,7 @@ public class TestIndexReverseScan extends PlannerTestCase {
     private void checkForwardScan(String indexName, IndexLookupType lookupType,
             int searchKeys, int endKeys, int predicates, SortDirectionType sortType, boolean needOrderby) {
         AbstractPlanNode pn = compile(sql);
-        System.out.println(pn.toExplainPlanString());
+        //*enable to debug*/ System.out.println(pn.toExplainPlanString());
 
         assertTrue(pn instanceof SendPlanNode);
         pn = pn.getChild(0);

--- a/tests/frontend/org/voltdb/planner/TestIndexSelection.java
+++ b/tests/frontend/org/voltdb/planner/TestIndexSelection.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.hsqldb_voltpatches.HSQLInterface;
 import org.json_voltpatches.JSONException;
 import org.voltdb.expressions.AbstractExpression;
-import org.voltdb.expressions.ExpressionUtil;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.plannodes.AbstractPlanNode;
 import org.voltdb.plannodes.IndexCountPlanNode;
@@ -743,7 +742,7 @@ public class TestIndexSelection extends PlannerTestCase {
         IndexScanPlanNode ipn = (IndexScanPlanNode) pn;
         AbstractExpression pred = ipn.getPredicate();
         assertTrue(pred != null);
-        List<TupleValueExpression> tves = ExpressionUtil.getTupleValueExpressions(pred);
+        List<TupleValueExpression> tves = pred.findAllTupleValueSubexpressions();
         for (TupleValueExpression tve : tves) {
             boolean match = false;
             for (String column: columns) {
@@ -763,7 +762,7 @@ public class TestIndexSelection extends PlannerTestCase {
         IndexScanPlanNode ipn = (IndexScanPlanNode) pn;
         AbstractExpression pred = ipn.getPredicate();
         assertTrue(pred != null);
-        List<TupleValueExpression> tves = ExpressionUtil.getTupleValueExpressions(pred);
+        List<TupleValueExpression> tves = pred.findAllTupleValueSubexpressions();
         for (TupleValueExpression tve : tves) {
             for (String column: columns) {
                 assertTrue(!tve.getColumnName().equals(column));

--- a/tests/frontend/org/voltdb/planner/TestParsedStatements.java
+++ b/tests/frontend/org/voltdb/planner/TestParsedStatements.java
@@ -87,7 +87,8 @@ public class TestParsedStatements extends TestCase {
         // analyze expressions
         // except for "insert" statements that currently do without a joinTree.
         if (parsedStmt.m_joinTree != null) {
-            parsedStmt.m_joinTree.analyzeJoinExpressions(parsedStmt.m_noTableSelectionList);
+            parsedStmt.m_joinTree.analyzeJoinExpressions(parsedStmt.m_noTableSelectionList,
+                    parsedStmt.m_tableList.size());
         }
         // output a description of the parsed stmt
         BuildDirectoryUtils.writeFile("statement-hsql-parsed", stmtName + ".txt", parsedStmt.toString(), true);

--- a/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
@@ -852,8 +852,8 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         for (int i = 0; i < scs.size(); ++i) {
             SchemaColumn col = scs.get(i);
             assertEquals(columns[i], col.getColumnName());
-            assertEquals(4, col.getSize());
-            assertEquals(VoltType.INTEGER, col.getType());
+            assertEquals(4, col.getExpression().getValueSize());
+            assertEquals(VoltType.INTEGER, col.getExpression().getValueType());
             assertTrue(col.getExpression() instanceof TupleValueExpression);
             assertTrue(((TupleValueExpression)col.getExpression()).getColumnIndex() != -1);
         }

--- a/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
@@ -2324,7 +2324,7 @@ public class TestPlansSubQueries extends PlannerTestCase {
         String sql = "select C1 from ( select cast(a as varchar), c as c1 from r5 ) as SQ where SQ.C1 < 0;";
     AbstractPlanNode pn = compile(sql);
     assertNotNull(pn);
-    VoltType vt = pn.getOutputSchema().getColumns().get(0).getType();
+    VoltType vt = pn.getOutputSchema().getColumns().get(0).getExpression().getValueType();
     assert(VoltType.INTEGER.equals(vt));
     }
 }

--- a/tests/frontend/org/voltdb/plannodes/MockPlanNode.java
+++ b/tests/frontend/org/voltdb/plannodes/MockPlanNode.java
@@ -34,8 +34,7 @@ public class MockPlanNode extends AbstractPlanNode
     String[] m_columnNames;
     boolean m_isOrderDeterministic = false;
 
-    MockPlanNode(String tableName, String[] columnNames)
-    {
+    MockPlanNode(String tableName, String[] columnNames) {
         super();
         m_nondeterminismDetail = "no ordering was asserted for Mock Plan Node";
         m_tableName = tableName;
@@ -43,12 +42,10 @@ public class MockPlanNode extends AbstractPlanNode
     }
 
     @Override
-    public void generateOutputSchema(Database db)
-    {
-        m_outputSchema = new NodeSchema();
+    public void generateOutputSchema(Database db) {
+        m_outputSchema = new NodeSchema(m_columnNames.length);
         m_hasSignificantOutputSchema = true;
-        for (int i = 0; i < m_columnNames.length; ++i)
-        {
+        for (int i = 0; i < m_columnNames.length; ++i) {
             TupleValueExpression tve = new TupleValueExpression(m_tableName,
                                                                 m_tableName,
                                                                 m_columnNames[i],
@@ -63,21 +60,13 @@ public class MockPlanNode extends AbstractPlanNode
     }
 
     @Override
-    public PlanNodeType getPlanNodeType()
-    {
-        return null;
-    }
+    public PlanNodeType getPlanNodeType() { return null; }
 
     @Override
-    public void resolveColumnIndexes()
-    {
-
-    }
+    public void resolveColumnIndexes() { }
 
     @Override
-    protected String explainPlanForNode(String indent) {
-        return "MOCK";
-    }
+    protected String explainPlanForNode(String indent) { return "MOCK"; }
 
     /**
      * Accessor for flag marking the plan as guaranteeing an identical result/effect

--- a/tests/frontend/org/voltdb/plannodes/TestScanPlanNode.java
+++ b/tests/frontend/org/voltdb/plannodes/TestScanPlanNode.java
@@ -126,7 +126,7 @@ public class TestScanPlanNode extends TestCase
         // be the tuple address, the second one a parameter expression, next
         // will be a constant, and the other will be a more complex expression
         // that uses some TVEs.
-        NodeSchema proj_schema = new NodeSchema();
+        NodeSchema proj_schema = new NodeSchema(4);
         String[] cols = new String[4];
 
         TupleAddressExpression col1_exp = new TupleAddressExpression();
@@ -181,15 +181,12 @@ public class TestScanPlanNode extends TestCase
         dut.generateOutputSchema(m_voltdb.getDatabase());
         NodeSchema dut_schema = dut.getOutputSchema();
         System.out.println(dut_schema.toString());
-        for (int i = 0; i < cols.length; i++)
-        {
+        for (int i = 0; i < cols.length; i++) {
             SchemaColumn col = null;
-            if (i == 0)
-            {
+            if (i == 0) {
                 col = dut_schema.find("", "", cols[i], cols[i]);
             }
-            else
-            {
+            else {
                 col = dut_schema.find(TABLE1, TABLE1, cols[i], cols[i]);
             }
             assertNotNull(col);

--- a/tests/test_apps/adhocbenchmark/run.sh
+++ b/tests/test_apps/adhocbenchmark/run.sh
@@ -89,7 +89,7 @@ function _benchmark() {
         ${APPNAME}.Benchmark \
         --displayinterval=5 \
         --servers=localhost \
-        --configfile=cachefriendlyconfig.xml \
+        --configfile=config.xml \
         --warmup=5 \
         --duration=60 \
         --test=$1 \


### PR DESCRIPTION
Code reductions:
    encapsulate inside AbstractExpression.java former ExpressionUtil methods that take an obvious this-like AbstractExpression argument. 
    encapsulate inside AbstractExpression.java most recursive expression tree searches with specific target Expression classes and optional caller-specific filters.
  use java generics to avoid the need to downcast the results of the recursive searches in the callers.
  encapsulate copying TVE value type/size settings from SchemaColumns, ColInfos, TVEs, and other expressions.
  encapsulate resetting of TVE column indexes.

Code optimizations:
    use a short-circuiting "has any" AbstractExpression tree search method instead of calling isEmpty() on the results of a "find all" method that collects all possible matches for nothing.
   eliminate some redundant attribute settings in clone methods (which still profile as rather expensive).
   eliminate ArrayList resizing by pre-allocating at least enough elements (when known).
   eliminate temporary ArrayLists that just addAll their contents to another ArrayList, when we can pre-allocate and directly fill the final ArrayList.
  eliminate some extraneous cloning where the original object is about to become unreachable.

Other simplifications:
  avoid potentially confusing edge case mismatches between an AbstractExpression's class and its ExpressionType -- like
 `new OperatorExpression(COMPARE_EQUAL, ...` instead of the canonical
 `new ComparisonExpression(COMPARE_EQUAL, ...`
