### PR TITLE
Use rack aware algorithm for rejoin

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -62,6 +62,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google_voltpatches.common.collect.HashMultimap;
 import org.apache.cassandra_voltpatches.GCInspector;
 import org.apache.log4j.Appender;
 import org.apache.log4j.DailyRollingFileAppender;
@@ -780,17 +781,18 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             VoltZK.createStartActionNode(m_messenger.getZK(), m_messenger.getHostId(), m_config.m_startAction);
             validateStartAction();
 
-            Map<Integer, String> hostGroups = null;
-
-            final int numberOfNodes = readDeploymentAndCreateStarterCatalogContext(config);
+            final int numberOfNodes;
+            if (!isRejoin && !m_joining) {
+                numberOfNodes = readDeploymentAndCreateStarterCatalogContext(config);
+            } else {
+                numberOfNodes = m_messenger.getLiveHostIds().size();
+            }
             if (config.m_isEnterprise && m_config.m_startAction.doesRequireEmptyDirectories()
                     && !config.m_forceVoltdbCreate) {
                     managedPathsEmptyCheck(config);
             }
 
-            if (!isRejoin && !m_joining) {
-                hostGroups = m_messenger.waitForGroupJoin(numberOfNodes);
-            }
+            final Map<Integer, String> hostGroups = m_messenger.waitForGroupJoin(numberOfNodes);
             if (m_messenger.isPaused() || m_config.m_isPaused) {
                 setStartMode(OperationMode.PAUSED);
                 setMode(OperationMode.PAUSED);
@@ -899,19 +901,17 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 m_configuredReplicationFactor = clusterConfig.getReplicationFactor();
                 m_cartographer = new Cartographer(m_messenger, m_configuredReplicationFactor,
                         m_catalogContext.cluster.getNetworkpartition());
-                List<Integer> partitions = null;
+                List<Integer> partitions;
                 if (isRejoin) {
                     m_configuredNumberOfPartitions = m_cartographer.getPartitionCount();
-                    partitions = m_cartographer.getIv2PartitionsToReplace(m_configuredReplicationFactor,
-                                                                          clusterConfig.getSitesPerHost());
+                    partitions = ClusterConfig.partitionsForHost(topo, m_messenger.getHostId());
                     if (partitions.size() == 0) {
                         VoltDB.crashLocalVoltDB("The VoltDB cluster already has enough nodes to satisfy " +
                                 "the requested k-safety factor of " +
                                 m_configuredReplicationFactor + ".\n" +
                                 "No more nodes can join.", false, null);
                     }
-                }
-                else {
+                } else {
                     m_configuredNumberOfPartitions = clusterConfig.getPartitionCount();
                     partitions = ClusterConfig.partitionsForHost(topo, m_messenger.getHostId());
                 }
@@ -1559,28 +1559,29 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                                    JoinCoordinator joinCoordinator)
     {
         JSONObject topo = null;
+        int sitesperhost = m_catalogContext.getDeployment().getCluster().getSitesperhost();
+        int kfactor = m_catalogContext.getDeployment().getCluster().getKfactor();
         if (startAction == StartAction.JOIN) {
             assert(joinCoordinator != null);
             topo = joinCoordinator.getTopology();
         }
-        else if (!startAction.doesRejoin()) {
-            int sitesperhost = m_catalogContext.getDeployment().getCluster().getSitesperhost();
-            int hostcount = m_clusterSettings.get().hostcount();
-            int kfactor = m_catalogContext.getDeployment().getCluster().getKfactor();
+        else {
+            final Set<Integer> liveHostIds = m_messenger.getLiveHostIds();
+            Preconditions.checkArgument(hostGroups.keySet().equals(liveHostIds));
+            int hostcount = liveHostIds.size();
             ClusterConfig clusterConfig = new ClusterConfig(hostcount, sitesperhost, kfactor);
             if (!clusterConfig.validate()) {
                 VoltDB.crashLocalVoltDB(clusterConfig.getErrorMsg(), false, null);
             }
-            topo = registerClusterConfig(clusterConfig, hostGroups);
-        }
-        else {
-            Stat stat = new Stat();
+
             try {
-                topo =
-                    new JSONObject(new String(m_messenger.getZK().getData(VoltZK.topology, false, stat), "UTF-8"));
+                topo = clusterConfig.getTopology(hostGroups, HashMultimap.create(), new HashMap<>());
+            } catch (Exception e) {
+                VoltDB.crashLocalVoltDB("Unable to calculate topology", false, e);
             }
-            catch (Exception e) {
-                VoltDB.crashLocalVoltDB("Unable to get topology from ZK", true, e);
+
+            if (!startAction.doesRejoin()) {
+                topo = registerClusterConfig(topo);
             }
         }
         return topo;
@@ -1601,16 +1602,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         return initiators;
     }
 
-    private JSONObject registerClusterConfig(ClusterConfig config, Map<Integer, String> hostGroups)
+    private JSONObject registerClusterConfig(JSONObject topo)
     {
         // First, race to write the topology to ZK using Highlander rules
         // (In the end, there can be only one)
-        JSONObject topo = null;
         try
         {
-            final Set<Integer> liveHostIds = m_messenger.getLiveHostIds();
-            Preconditions.checkArgument(hostGroups.keySet().equals(liveHostIds));
-            topo = config.getTopology(hostGroups);
             byte[] payload = topo.toString(4).getBytes("UTF-8");
             m_messenger.getZK().create(VoltZK.topology, payload,
                     Ids.OPEN_ACL_UNSAFE,

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -62,7 +62,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.google_voltpatches.common.collect.HashMultimap;
 import org.apache.cassandra_voltpatches.GCInspector;
 import org.apache.log4j.Appender;
 import org.apache.log4j.DailyRollingFileAppender;
@@ -893,14 +892,14 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
              * Ning: topology may not reflect the true partitions in the cluster during join. So if another node
              * is trying to rejoin, it should rely on the cartographer's view to pick the partitions to replace.
              */
+            m_configuredReplicationFactor = m_catalogContext.getDeployment().getCluster().getKfactor();
+            m_cartographer = new Cartographer(m_messenger, m_configuredReplicationFactor,
+                                              m_catalogContext.cluster.getNetworkpartition());
             JSONObject topo = getTopology(config.m_startAction, hostGroups, m_joinCoordinator);
             m_partitionsToSitesAtStartupForExportInit = new ArrayList<>();
             try {
                 // IV2 mailbox stuff
                 ClusterConfig clusterConfig = new ClusterConfig(topo);
-                m_configuredReplicationFactor = clusterConfig.getReplicationFactor();
-                m_cartographer = new Cartographer(m_messenger, m_configuredReplicationFactor,
-                        m_catalogContext.cluster.getNetworkpartition());
                 List<Integer> partitions;
                 if (isRejoin) {
                     m_configuredNumberOfPartitions = m_cartographer.getPartitionCount();
@@ -1575,7 +1574,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
 
             try {
-                topo = clusterConfig.getTopology(hostGroups, HashMultimap.create(), new HashMap<>());
+                topo = clusterConfig.getTopology(hostGroups,
+                                                 m_cartographer.getReplicasForPartitions(m_cartographer.getPartitions()),
+                                                 m_cartographer.getHSIdsForSinglePartitionMasters());
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("Unable to calculate topology", false, e);
             }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1567,7 +1567,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             Preconditions.checkArgument(hostGroups.keySet().equals(liveHostIds));
             int hostcount = liveHostIds.size();
             ClusterConfig clusterConfig = new ClusterConfig(hostcount, sitesperhost, kfactor);
-            if (!clusterConfig.validate()) {
+            if (!startAction.doesRejoin() && !clusterConfig.validate()) {
                 VoltDB.crashLocalVoltDB(clusterConfig.getErrorMsg(), false, null);
             }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -62,6 +62,8 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google_voltpatches.common.collect.HashMultimap;
+import com.google_voltpatches.common.collect.Multimap;
 import org.apache.cassandra_voltpatches.GCInspector;
 import org.apache.log4j.Appender;
 import org.apache.log4j.DailyRollingFileAppender;
@@ -780,12 +782,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             VoltZK.createStartActionNode(m_messenger.getZK(), m_messenger.getHostId(), m_config.m_startAction);
             validateStartAction();
 
-            final int numberOfNodes;
-            if (!isRejoin && !m_joining) {
-                numberOfNodes = readDeploymentAndCreateStarterCatalogContext(config);
-            } else {
-                numberOfNodes = m_messenger.getLiveHostIds().size();
-            }
+            readDeploymentAndCreateStarterCatalogContext(config);
+            final int numberOfNodes = m_messenger.getLiveHostIds().size();
             if (config.m_isEnterprise && m_config.m_startAction.doesRequireEmptyDirectories()
                     && !config.m_forceVoltdbCreate) {
                     managedPathsEmptyCheck(config);
@@ -1574,9 +1572,11 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
 
             try {
-                topo = clusterConfig.getTopology(hostGroups,
-                                                 m_cartographer.getReplicasForPartitions(m_cartographer.getPartitions()),
-                                                 m_cartographer.getHSIdsForSinglePartitionMasters());
+                final Multimap<Integer, Long> replicas = m_cartographer.getReplicasForPartitions(m_cartographer.getPartitions());
+                final Map<Integer, Long> masters = m_cartographer.getHSIdsForSinglePartitionMasters();
+                replicas.removeAll(MpInitiator.MP_INIT_PID);
+                masters.remove(MpInitiator.MP_INIT_PID);
+                topo = clusterConfig.getTopology(hostGroups, replicas, masters);
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("Unable to calculate topology", false, e);
             }
@@ -1816,7 +1816,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         }
     }
 
-    int readDeploymentAndCreateStarterCatalogContext(VoltDB.Configuration config) {
+    void readDeploymentAndCreateStarterCatalogContext(VoltDB.Configuration config) {
         /*
          * Debate with the cluster what the deployment file should be
          */
@@ -2039,8 +2039,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                             null,
                             deploymentBytes,
                             0);
-
-            return m_clusterSettings.get().hostcount();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -238,7 +238,7 @@ public class Cartographer extends StatsSource
      */
     public Map<Integer, Long> getHSIdsForSinglePartitionMasters()
     {
-        return m_iv2Masters.pointInTimeCache();
+        return new HashMap<>(m_iv2Masters.pointInTimeCache());
     }
 
     /**

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -32,6 +32,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import com.google_voltpatches.common.collect.HashMultimap;
+import com.google_voltpatches.common.collect.Multimap;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONException;
@@ -232,6 +234,14 @@ public class Cartographer extends StatsSource
     }
 
     /**
+     * Get the HSID of all the partition masters
+     */
+    public Map<Integer, Long> getHSIdsForSinglePartitionMasters()
+    {
+        return m_iv2Masters.pointInTimeCache();
+    }
+
+    /**
      * Get the HSID of the single partition master for the specified partition ID
      */
     public long getHSIdForSinglePartitionMaster(int partitionId)
@@ -318,8 +328,8 @@ public class Cartographer extends StatsSource
     /**
      * Given a set of partition IDs, return a map of partition to a list of HSIDs of all the sites with copies of each partition
      */
-    public Map<Integer, List<Long>> getReplicasForPartitions(Collection<Integer> partitions) {
-        Map<Integer, List<Long>> retval = new HashMap<Integer, List<Long>>();
+    public Multimap<Integer, Long> getReplicasForPartitions(Collection<Integer> partitions) {
+        Multimap<Integer, Long> retval = HashMultimap.create();
         List<Pair<Integer,ZKUtil.ChildrenCallback>> callbacks = new ArrayList<Pair<Integer, ZKUtil.ChildrenCallback>>();
 
         for (Integer partition : partitions) {
@@ -333,11 +343,9 @@ public class Cartographer extends StatsSource
             final Integer partition = p.getFirst();
             try {
                 List<String> children = p.getSecond().getChildren();
-                List<Long> sites = new ArrayList<Long>();
                 for (String child : children) {
-                    sites.add(Long.valueOf(child.split("_")[0]));
+                    retval.put(partition, Long.valueOf(child.split("_")[0]));
                 }
-                retval.put(partition, sites);
             } catch (KeeperException.NoNodeException e) {
                 //This can happen when a partition is being removed from the system
             } catch (KeeperException ke) {
@@ -370,41 +378,6 @@ public class Cartographer extends StatsSource
             keys.add(entry.getKey());
         }
         return keys;
-    }
-
-    /**
-     * Given the current state of the cluster, compute the partitions which should be replicated on a single new host.
-     * Break this method out to be static and testable independent of ZK, JSON, other ugh.
-     */
-    static public List<Integer> computeReplacementPartitions(Map<Integer, Integer> repsPerPart, int kfactor,
-                                                             int sitesPerHost)
-    {
-        List<Integer> partitions = new ArrayList<Integer>();
-        List<Integer> partSortedByRep = sortKeysByValue(repsPerPart);
-        for (int i = 0; i < partSortedByRep.size(); i++) {
-            int leastReplicatedPart = partSortedByRep.get(i);
-            if (repsPerPart.get(leastReplicatedPart) < kfactor + 1) {
-                partitions.add(leastReplicatedPart);
-                if (partitions.size() == sitesPerHost) {
-                    break;
-                }
-            }
-        }
-        return partitions;
-    }
-
-    public List<Integer> getIv2PartitionsToReplace(int kfactor, int sitesPerHost)
-        throws JSONException
-    {
-        List<Integer> partitions = getPartitions();
-        hostLog.info("Computing partitions to replace.  Total partitions: " + partitions);
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        for (int pid : partitions) {
-            repsPerPart.put(pid, getReplicaCountForPartition(pid));
-        }
-        List<Integer> partitionsToReplace = computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        hostLog.info("IV2 Sites will replicate the following partitions: " + partitionsToReplace);
-        return partitionsToReplace;
     }
 
     /**
@@ -441,14 +414,10 @@ public class Cartographer extends StatsSource
     {
         List<MailboxNodeContent> sitesList = new ArrayList<MailboxNodeContent>();
         final Set<Integer> iv2MastersKeySet = m_iv2Masters.pointInTimeCache().keySet();
-        Map<Integer, List<Long>> hsidsForPartMap = getReplicasForPartitions(iv2MastersKeySet);
-        for (Map.Entry<Integer, List<Long>> entry : hsidsForPartMap.entrySet()) {
-            Integer partId = entry.getKey();
-            List<Long> hsidsForPart = entry.getValue();
-            for (long hsid : hsidsForPart) {
-                MailboxNodeContent mnc = new MailboxNodeContent(hsid, partId);
-                sitesList.add(mnc);
-            }
+        Multimap<Integer, Long> hsidsForPartMap = getReplicasForPartitions(iv2MastersKeySet);
+        for (Map.Entry<Integer, Long> entry : hsidsForPartMap.entries()) {
+            MailboxNodeContent mnc = new MailboxNodeContent(entry.getValue(), entry.getKey());
+            sitesList.add(mnc);
         }
         return sitesList;
     }

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -679,7 +679,7 @@ public class MiscUtils {
      * Zip the two lists up into a multimap
      * @return null if one of the lists is empty
      */
-    public static <K, V> Multimap<K, V> zipToMap(List<K> keys, List<V> values)
+    public static <K, V> Multimap<K, V> zipToMap(Collection<K> keys, Collection<V> values)
     {
         if (keys.isEmpty() || values.isEmpty()) {
             return null;
@@ -695,7 +695,7 @@ public class MiscUtils {
 
         // In case there are more values than keys, assign the rest of the
         // values to the first key
-        K firstKey = keys.get(0);
+        K firstKey = keys.iterator().next();
         while (valueIter.hasNext()) {
             result.put(firstKey, valueIter.next());
         }

--- a/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
@@ -23,10 +23,13 @@
 package org.voltdb.compiler;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.HashMultimap;
 import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.collect.Multimap;
@@ -36,6 +39,7 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 
 import junit.framework.TestCase;
+import org.voltcore.utils.CoreUtils;
 import org.voltdb.VoltDB;
 
 public class TestClusterCompiler extends TestCase
@@ -47,7 +51,7 @@ public class TestClusterCompiler extends TestCase
         topology.put(0, "0");
         topology.put(1, "0");
         topology.put(2, "0");
-        JSONObject obj = config.getTopology(topology);
+        JSONObject obj = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         config.validate();
         System.out.println(obj.toString(4));
         JSONArray partitions = obj.getJSONArray("partitions");
@@ -99,7 +103,7 @@ public class TestClusterCompiler extends TestCase
         ClusterConfig config = new ClusterConfig(1, 6, 0);
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(1, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(0, topo.getInt("kfactor"));
@@ -116,7 +120,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(0, topo.getInt("kfactor"));
@@ -135,7 +139,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(1, topo.getInt("kfactor"));
@@ -152,7 +156,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(1, topo.getInt("kfactor"));
@@ -163,6 +167,197 @@ public class TestClusterCompiler extends TestCase
             ClusterConfig.addHosts(3, topo);
             fail("Shouldn't allow adding more than ksafe + 1 node");
         } catch (AssertionError e) {}
+    }
+
+    public void testRejoinOneNode() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology =
+        ImmutableMap.of(0, "0",
+                        1, "0");
+        killAndRejoinNodes(topology, 1, 1);
+    }
+
+    public void testRejoinTwoNodes() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology =
+        ImmutableMap.of(0, "0",
+                        1, "1",
+                        2, "2");
+        killAndRejoinNodes(topology, 2, 2);
+    }
+
+    public void testRejoinTwoNodesToTwo() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
+                                                 .put(0, "0")
+                                                 .put(1, "0")
+                                                 .put(2, "1")
+                                                 .put(3, "1")
+                                                 .put(4, "2")
+                                                 .put(5, "2")
+                                                 .build();
+        killAndRejoinNodes(topology, 1, 2);
+    }
+
+    public void testRejoinThreeNodesToFour() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
+                                                 .put(0, "0")
+                                                 .put(1, "0")
+                                                 .put(2, "0")
+                                                 .put(3, "0")
+                                                 .put(4, "1")
+                                                 .put(5, "1")
+                                                 .put(6, "1")
+                                                 .build();
+        killAndRejoinNodes(topology, 2, 3);
+    }
+
+    private static void killAndRejoinNodes(ImmutableMap<Integer, String> fullHostGroup, int kfactor, int nodesToKill)
+    throws JSONException
+    {
+        final int maxSph = 20;
+        for (int sph = 1; sph < maxSph; sph++) {
+            final Map<Integer, String> rejoinHostGroup = new HashMap<>(fullHostGroup);
+            final ClusterConfig initialConfig = new ClusterConfig(rejoinHostGroup.size(), sph, kfactor);
+            if (!initialConfig.validate()) {
+                // Invalid config, skip
+                continue;
+            }
+            final JSONObject initialTopo = initialConfig.getTopology(rejoinHostGroup, HashMultimap.create(), new HashMap<>());
+
+            final Multimap<Integer, Integer> partitionToHosts = HashMultimap.create();
+            final Multimap<Integer, Integer> hostPartitions = HashMultimap.create();
+            final Multimap<Integer, Integer> hostMasters = HashMultimap.create();
+            for (int hostId : rejoinHostGroup.keySet()) {
+                for (int pid : ClusterConfig.partitionsForHost(initialTopo, hostId)) {
+                    partitionToHosts.put(pid, hostId);
+                }
+                hostPartitions.putAll(hostId, ClusterConfig.partitionsForHost(initialTopo, hostId));
+                hostMasters.putAll(hostId, ClusterConfig.partitionsForHost(initialTopo, hostId, true));
+            }
+
+            // Pick nodes to kill from different groups. if this is
+            // not a valid topology for multiple rejoins in different
+            // groups, the returned set will be empty.
+            final Set<Integer> hostIdsToKill = pickNodesInDiffGroupsToKill(fullHostGroup, hostPartitions, kfactor, nodesToKill);
+            if (hostIdsToKill.isEmpty()) {
+                System.out.println("Not a valid topology for multi node rejoin, skipping. Sites per host " + sph);
+                continue;
+            }
+            System.out.println("Running config: sites " + sph + ", host partitions: " + hostPartitions +
+                               ", nodes to kill: " + hostIdsToKill);
+
+            // Remove all partitions and masters from the failed nodes, migrate masters to remaining nodes
+            final Multimap<Integer, Integer> expectedRejoinHostPartitions = HashMultimap.create();
+            final HashSet<Integer> liveHosts = new HashSet<>(hostPartitions.keySet());
+            final Map<Integer, String> rejoinHostGroups = new HashMap<>();
+            for (int toKill : hostIdsToKill) {
+                liveHosts.remove(toKill);
+                for (int masterToRedistribute : hostMasters.get(toKill)) {
+                    for (int hostCandidate : partitionToHosts.get(masterToRedistribute)) {
+                        if (hostCandidate != toKill && liveHosts.contains(hostCandidate)) {
+                            hostMasters.put(hostCandidate, masterToRedistribute);
+                            break;
+                        }
+                    }
+                }
+                expectedRejoinHostPartitions.putAll(toKill, hostPartitions.removeAll(toKill));
+                hostMasters.removeAll(toKill);
+                rejoinHostGroups.put(toKill, rejoinHostGroup.remove(toKill));
+            }
+
+            // Fake partition to HSID mappings
+            Multimap<Integer, Long> replicas = HashMultimap.create();
+            for (Map.Entry<Integer, Integer> e : hostPartitions.entries()) {
+                replicas.put(e.getValue(), CoreUtils.getHSIdFromHostAndSite(e.getKey(), e.getValue()));
+            }
+            Map<Integer, Long> masters = new HashMap<>();
+            for (Map.Entry<Integer, Integer> e : hostMasters.entries()) {
+                masters.put(e.getValue(), CoreUtils.getHSIdFromHostAndSite(e.getKey(), e.getValue()));
+            }
+
+            // Rejoin one node at a time and verify that they have the correct partitions
+            for (Map.Entry<Integer, String> rejoin : rejoinHostGroups.entrySet()) {
+                System.out.println("Rejoining " + rejoin.getKey() + " in group " + rejoin.getValue());
+                rejoinHostGroup.put(rejoin.getKey(), rejoin.getValue());
+                final JSONObject rejoinTopo = initialConfig.getTopology(rejoinHostGroup, replicas, masters);
+                final List<Integer> partitionsOnRejoinHost = ClusterConfig.partitionsForHost(rejoinTopo, rejoin.getKey());
+
+                // Verify rejoined host first. Partitions on rejoined host should have
+                // at least one replica in a different group.
+                if (fullHostGroup.values().stream().distinct().count() > 1) {
+                    for (int partitionOnRejoined : partitionsOnRejoinHost) {
+                        final String rejoinedHostGroup = rejoin.getValue();
+                        boolean foundHostInOtherGroup = false;
+                        for (long hsId : replicas.get(partitionOnRejoined)) {
+                            if (!rejoinHostGroup.get(CoreUtils.getHostIdFromHSId(hsId)).equals(rejoinedHostGroup)) {
+                                foundHostInOtherGroup = true;
+                                break;
+                            }
+                        }
+                        assertTrue("Host " + rejoin.getKey() + " partition " + partitionOnRejoined + " rejoined: " +
+                                   partitionsOnRejoinHost + " current " + replicas,
+                                   foundHostInOtherGroup);
+                    }
+                }
+                assertTrue(ClusterConfig.partitionsForHost(rejoinTopo, rejoin.getKey(), true).isEmpty()); // No master on rejoined host
+
+                // Verify existing hosts remain the same
+                for (Map.Entry<Integer, Collection<Integer>> e : hostPartitions.asMap().entrySet()) {
+                    assertEquals(e.getValue(), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, e.getKey())));
+                    assertEquals(hostMasters.get(e.getKey()), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, e.getKey(), true)));
+                }
+
+                // Now add the rejoined host to the live host maps
+                hostPartitions.putAll(rejoin.getKey(), partitionsOnRejoinHost);
+                for (int pid : partitionsOnRejoinHost) {
+                    replicas.put(pid, CoreUtils.getHSIdFromHostAndSite(rejoin.getKey(), pid));
+                }
+            }
+        }
+    }
+
+    private static Set<Integer> pickNodesInDiffGroupsToKill(ImmutableMap<Integer, String> topo,
+                                                            Multimap<Integer, Integer> hostPartitions,
+                                                            int kfactor,
+                                                            int nodesToKill)
+    {
+        for (Set<Integer> perm : Sets.powerSet(topo.keySet())) {
+            // Skip permutation size not equal to the node count to kill
+            if (perm.size() != nodesToKill) {
+                continue;
+            }
+            // If the nodes in the list share the group, skip
+            if (perm.stream().map(topo::get).distinct().count() != nodesToKill) {
+                continue;
+            }
+
+            // Count the occurrences of each partition in the candidate nodes
+            Map<Integer, Integer> partitionOccurrances = new HashMap<>();
+            perm.stream().map(hostPartitions::get).forEach(s -> s.forEach(a -> {
+                if (partitionOccurrances.containsKey(a)) {
+                    partitionOccurrances.put(a, partitionOccurrances.get(a) + 1);
+                } else {
+                    partitionOccurrances.put(a, 1);
+                }
+            }));
+
+            // If a partition appears k+1 times in the candidate nodes, killing
+            // them will take the cluster down, so skip this set of candidate nodes
+            boolean skip = false;
+            for (int count : partitionOccurrances.values()) {
+                if (count > kfactor) {
+                    skip = true;
+                }
+            }
+            if (skip) {
+                continue;
+            }
+
+            return new HashSet<>(perm);
+        }
+        return new HashSet<>();
     }
 
     public void testFourNodesOneGroups() throws JSONException
@@ -213,7 +408,7 @@ public class TestClusterCompiler extends TestCase
         hostGroups.put(3, "1");
         hostGroups.put(4, "2");
         hostGroups.put(5, "2");
-        runConfigAndVerifyTopology(hostGroups, 2);
+        runConfigAndVerifyTopology(hostGroups, 1);
     }
 
     public void testFiveNodesTwoGroups() throws JSONException
@@ -262,6 +457,15 @@ public class TestClusterCompiler extends TestCase
         runConfigAndVerifyTopology(hostGroups, 2);
     }
 
+    public void testFiftNodesInThreeGroups() throws JSONException
+    {
+        Map<Integer, String> hostGroups = Maps.newHashMap();
+        for (int i = 0; i < 50; i++) {
+            hostGroups.put(i, String.valueOf(i % 3));
+        }
+        runConfigAndVerifyTopology(hostGroups, 2);
+    }
+
     private static void runConfigAndVerifyTopology(Map<Integer, String> hostGroups, int kfactor) throws JSONException
     {
         final int maxSites = 20;
@@ -273,9 +477,9 @@ public class TestClusterCompiler extends TestCase
 
         for (int sites = 1; sites <= maxSites; sites++) {
             final ClusterConfig config = new ClusterConfig(hostGroups.size(), sites, kfactor);
-            System.out.println("Running config " + sites + " sitesperhost, k=" + kfactor);
+            System.out.println("Running config " + hostGroups.size() + " hosts, " + sites + " sitesperhost, k=" + kfactor);
             if (config.validate()) {
-                final JSONObject topo = config.getTopology(hostGroups);
+                final JSONObject topo = config.getTopology(hostGroups, HashMultimap.create(), new HashMap<>());
                 verifyTopology(hostGroups, topo);
             } else {
                 System.out.println(config.getErrorMsg());
@@ -320,17 +524,11 @@ public class TestClusterCompiler extends TestCase
             assertEquals(nodesWithMaxMasterCount, masterCountToHost.get(maxMasterCount).size());
         }
 
-        for (Map.Entry<String, Collection<Integer>> ghEntry : groupHosts.asMap().entrySet()) {
-            if (ghEntry.getValue().size() * sitesPerHost < partitionCount) {
-                // Non-optimal topology, no need to verify the rest
-                System.out.println("Group " + ghEntry.getKey() + " only has " + ghEntry.getValue().size() + " hosts");
-                return;
-            }
-        }
-
         // Each group should have at least one copy of all the partitions
-        for (Collection<Integer> partitions : groupPartitions.asMap().values()) {
-            assertEquals(partitionCount, Sets.newHashSet(partitions).size());
+        for (Map.Entry<String, Collection<Integer>> groupAndPids : groupPartitions.asMap().entrySet()) {
+            assertEquals(groupPartitions.toString(),
+                         Math.min(partitionCount, groupHosts.get(groupAndPids.getKey()).size() * sitesPerHost),
+                         Sets.newHashSet(groupAndPids.getValue()).size());
         }
     }
 }

--- a/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
@@ -279,10 +279,11 @@ public class TestClusterCompiler extends TestCase
 
             // Rejoin one node at a time and verify that they have the correct partitions
             for (Map.Entry<Integer, String> rejoin : rejoinHostGroups.entrySet()) {
-                System.out.println("Rejoining " + rejoin.getKey() + " in group " + rejoin.getValue());
-                rejoinHostGroup.put(rejoin.getKey(), rejoin.getValue());
+                final int rejoinHostId = rejoin.getKey() + fullHostGroup.size();
+                System.out.println("Rejoining " + rejoin.getKey() + " as " + rejoinHostId + " in group " + rejoin.getValue());
+                rejoinHostGroup.put(rejoinHostId, rejoin.getValue());
                 final JSONObject rejoinTopo = initialConfig.getTopology(rejoinHostGroup, replicas, masters);
-                final List<Integer> partitionsOnRejoinHost = ClusterConfig.partitionsForHost(rejoinTopo, rejoin.getKey());
+                final List<Integer> partitionsOnRejoinHost = ClusterConfig.partitionsForHost(rejoinTopo, rejoinHostId);
 
                 // Verify rejoined host first. Partitions on rejoined host should have
                 // at least one replica in a different group.
@@ -301,18 +302,22 @@ public class TestClusterCompiler extends TestCase
                                    foundHostInOtherGroup);
                     }
                 }
-                assertTrue(ClusterConfig.partitionsForHost(rejoinTopo, rejoin.getKey(), true).isEmpty()); // No master on rejoined host
+                assertTrue(ClusterConfig.partitionsForHost(rejoinTopo, rejoinHostId, true).isEmpty()); // No master on rejoined host
 
                 // Verify existing hosts remain the same
                 for (Map.Entry<Integer, Collection<Integer>> e : hostPartitions.asMap().entrySet()) {
-                    assertEquals(e.getValue(), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, e.getKey())));
-                    assertEquals(hostMasters.get(e.getKey()), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, e.getKey(), true)));
+                    int hostId = e.getKey();
+                    if (rejoinHostGroups.containsKey(e.getKey())) {
+                        hostId = e.getKey() + fullHostGroup.size();
+                    }
+                    assertEquals("host " + hostId + " key " + e.getKey(), e.getValue(), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, hostId)));
+                    assertEquals(hostMasters.get(e.getKey()), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, hostId, true)));
                 }
 
                 // Now add the rejoined host to the live host maps
                 hostPartitions.putAll(rejoin.getKey(), partitionsOnRejoinHost);
                 for (int pid : partitionsOnRejoinHost) {
-                    replicas.put(pid, CoreUtils.getHSIdFromHostAndSite(rejoin.getKey(), pid));
+                    replicas.put(pid, CoreUtils.getHSIdFromHostAndSite(rejoinHostId, pid));
                 }
             }
         }

--- a/tests/frontend/org/voltdb/iv2/TestCartographer.java
+++ b/tests/frontend/org/voltdb/iv2/TestCartographer.java
@@ -80,65 +80,6 @@ public class TestCartographer extends ZKTestBase {
     }
 
     @Test
-    public void testReplicateLeastReplicated()
-    {
-        // Gin up our fake replication counts to leave the last partition needing two replicas
-        // 5 hosts, 3 sites/host, k=2 is 15 sites, 5 partitions.
-        // Need 2 hosts dead, so 6 missing replicas, last one needs to miss 2
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        repsPerPart.put(0, 2);
-        repsPerPart.put(1, 2);
-        repsPerPart.put(2, 2);
-        repsPerPart.put(3, 2);
-        repsPerPart.put(4, 1);
-        int kfactor = 2;
-        int numberOfPartitions = 5;
-        int sitesPerHost = 3;
-
-        List<Integer> firstRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(3, firstRejoin.size());
-        assertEquals((Integer)4, firstRejoin.get(0));
-        assertEquals((Integer)0, firstRejoin.get(1));
-        assertEquals((Integer)1, firstRejoin.get(2));
-        // add to each of the repsPerPart from the firstRejoin results
-        for (int partition : firstRejoin) {
-            repsPerPart.put(partition, repsPerPart.get(partition) + 1);
-        }
-
-        // now do it again and make sure we fully replicate
-        List<Integer> secondRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(3, secondRejoin.size());
-        assertEquals((Integer)2, secondRejoin.get(0));
-        assertEquals((Integer)3, secondRejoin.get(1));
-        assertEquals((Integer)4, secondRejoin.get(2));
-    }
-
-    @Test
-    public void testNoOverReplication()
-    {
-        // We'll set things up to only require one more replica and then offer up a host with more sites
-        // than we need.  This particular case could never happen but should test the logic correctly.
-        // Also, test that we don't replicate the same partition twice on the same host again.
-        int kfactor = 2;
-        int numberOfPartitions = 5;
-        int sitesPerHost = 3;
-
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        repsPerPart.put(0, 3);
-        repsPerPart.put(1, 3);
-        repsPerPart.put(2, 3);
-        repsPerPart.put(3, 3);
-        repsPerPart.put(4, 1);
-
-        List<Integer> firstRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(1, firstRejoin.size());
-        assertEquals((Integer)4, firstRejoin.get(0));
-    }
-
-    @Test
     public void testSPMasterChange() throws Exception
     {
         ZooKeeper zk = getClient(0);

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -30,12 +30,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google_voltpatches.common.collect.HashMultimap;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONException;
@@ -128,8 +130,8 @@ public class TestLeaderAppointer extends ZKTestBase {
     {
         KSafetyStats stats = new KSafetyStats();
         m_dut = new LeaderAppointer(m_hm, m_config.getPartitionCount(),
-                m_config.getReplicationFactor(),
-                null, m_config.getTopology(m_hostGroups), m_mpi, stats, false);
+                                    m_config.getReplicationFactor(),
+                                    null, m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()), m_mpi, stats, false);
         m_dut.onReplayCompletion();
     }
 
@@ -278,7 +280,7 @@ public class TestLeaderAppointer extends ZKTestBase {
                                     m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(),
                                     null,
-                                    m_config.getTopology(m_hostGroups),
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
                                     m_mpi,
                                     new KSafetyStats(),
                                     false);
@@ -525,7 +527,7 @@ public class TestLeaderAppointer extends ZKTestBase {
                                     m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(),
                                     null,
-                                    m_config.getTopology(m_hostGroups),
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
                                     m_mpi,
                                     new KSafetyStats(),
                                     true);


### PR DESCRIPTION
- Fixed a bug in the original rack-aware algorithm to cover more cases.
- Rejoining node calls rack-aware algorithm similar to when create is called.

Since there's significant change to the algorithm, reviewing the diff in ClusterConfig may not be straightforward. It's easier to read the new algorithm directly. I suggest start from there and review the changes in the other files afterwards.
