### PR TITLE
Fix an NPE bug for explanations of plans with windowed RANK().

### DIFF
--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -728,7 +728,9 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
                                                  JSONObject               jobj) throws JSONException {
         if (jobj.has(AbstractExpression.SortMembers.SORT_COLUMNS.name())) {
             sortExpressions.clear();
-            sortDirections.clear();
+            if (sortDirections != null) {
+                sortDirections.clear();
+            }
             JSONArray jarray = jobj.getJSONArray(SortMembers.SORT_COLUMNS.name());
             int size = jarray.length();
             for (int ii = 0; ii < size; ii += 1) {

--- a/src/frontend/org/voltdb/expressions/WindowedExpression.java
+++ b/src/frontend/org/voltdb/expressions/WindowedExpression.java
@@ -137,50 +137,6 @@ public class WindowedExpression extends AbstractExpression {
     }
 
     @Override
-    protected void loadFromJSONObject(JSONObject jobj) throws JSONException {
-        assert(false);
-        super.loadFromJSONObject(jobj);
-        m_partitionByExpressions.clear();
-
-        /*
-         * Load the array of partition expressions.  The AbstractExpression class
-         * has a useful routine to do just this for us.
-         */
-        AbstractExpression.loadFromJSONArrayChild(m_partitionByExpressions, jobj, Members.PARTITION_BY_EXPRESSIONS.name(), null);
-
-        /*
-         * Unfortunately we cannot use AbstractExpression.loadFromJSONArrayChild here,
-         * as we need to get a sort expression and a sort order for each column.
-         */
-        AbstractExpression.loadSortListFromJSONArray(m_orderByExpressions, m_orderByDirections, jobj);
-    }
-
-    @Override
-    public void toJSONString(JSONStringer stringer) throws JSONException {
-        assert(false);
-        super.toJSONString(stringer);
-        assert (m_orderByExpressions.size() == m_orderByDirections.size());
-        // Be careful.  This node may have changed to be a
-        // non-windowed expression.  Don't serialize the partition by and sort
-        // expressions unless we are really a windowed expression.
-        if (getExpressionType().getExpressionClass() == WindowedExpression.class) {
-            /*
-             * Serialize the partition expressions.  The orderby
-             * expressions which are not redundant with the PartitionBy
-             * expressions will be serialized in the orderby node which preceeds
-             * the PartitionByPlanNode.
-             */
-            stringer.key(Members.PARTITION_BY_EXPRESSIONS.name()).array();
-            for (int idx = 0; idx < m_partitionByExpressions.size(); idx += 1) {
-                stringer.object();
-                m_partitionByExpressions.get(idx).toJSONString(stringer);
-                stringer.endObject();
-            }
-            stringer.endArray();
-        }
-    }
-
-    @Override
     public void finalizeValueTypes() {
         m_valueType = VoltType.BIGINT;
         m_valueSize = VoltType.BIGINT.getLengthInBytesForFixedTypes();

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowedAggregateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowedAggregateSuite.java
@@ -160,7 +160,6 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
     }
 
     public void testRank_UNIQUE() throws NoConnectionsException, IOException, ProcCallException {
-        System.out.println("STARTING xin......");
         Client client = getClient();
         VoltTable vt = null;
 
@@ -190,7 +189,6 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
     // NON-UNIQUE RANK SCAN TEST
     //
     public void testRank_NON_UNIQUE() throws NoConnectionsException, IOException, ProcCallException {
-        System.out.println("STARTING xin......");
         Client client = getClient();
         VoltTable vt = null;
 
@@ -478,6 +476,28 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
             assertEquals(msg, expected[rowIdx][colB],    vt.getLong(1));
             assertEquals(msg, expected[rowIdx][colC],    vt.getLong(2));
             assertEquals(msg, expected[rowIdx][colR_A],  vt.getLong(3));
+        }
+    }
+
+    /*
+     * This test just makes sure that we can execute the @Explain
+     * sysproc on a windowed aggregate.  At one time this failed due to
+     * an NPE.  When deserializing a JSON string the resulting plan is not
+     * the same as the original plan.  We don't serialize sort orders
+     * for windowed aggregates.
+     */
+    public void testExplainPlan() throws Exception {
+        Client client = getClient();
+        String sql = "select rank() over ( partition by A, B order by C ) from T;";
+
+        ClientResponse cr;
+        try {
+            cr = client.callProcedure("@Explain", sql);
+            assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+            VoltTable vt = cr.getResults()[0];
+            assertTrue(true);
+        } catch (Exception ex) {
+            fail("Exception on @Explain of windowed expression");
         }
     }
 


### PR DESCRIPTION
We don't serialize sort directions in windowed RANK() expressions.  So,
when we deserialize plans with PartitionByPlanNodes we pass in a null in
the parameter which holds the list of sort directions.  We needed to be
more careful about testing for this null.

Also, some dead code was eliminated, and some spurious debug printing in
tests was deleted.
