### PR TITLE
ENG-10972: Resolve column indices for ORDER BY expressions of windowed aggregates

### DIFF
--- a/src/frontend/org/voltdb/expressions/WindowedExpression.java
+++ b/src/frontend/org/voltdb/expressions/WindowedExpression.java
@@ -17,12 +17,8 @@
 package org.voltdb.expressions;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
-import org.json_voltpatches.JSONException;
-import org.json_voltpatches.JSONObject;
-import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
 import org.voltdb.types.ExpressionType;
 import org.voltdb.types.SortDirectionType;
@@ -53,6 +49,13 @@ public class WindowedExpression extends AbstractExpression {
     private List<AbstractExpression> m_partitionByExpressions = new ArrayList<>();
     private List<AbstractExpression> m_orderByExpressions = new ArrayList<>();
     private List<SortDirectionType>  m_orderByDirections = new ArrayList<>();
+
+    // This object is not in the display list.  It's squirreled away in the ParsedSelectStatment.  But
+    // the display list has a TVE which references the column which holds the values this aggregate
+    // expression will compute.  This field holds this TVE.
+    private TupleValueExpression m_displayListExpression;
+
+    private int m_xmlID = -1;
 
     public WindowedExpression() {
         //
@@ -118,22 +121,6 @@ public class WindowedExpression extends AbstractExpression {
         hash += m_orderByExpressions.hashCode();
         hash += m_partitionByExpressions.hashCode();
         return hash;
-    }
-
-    private Collection<? extends AbstractExpression> copyPartitionByExpressions() {
-        List<AbstractExpression> copy = new ArrayList<>();
-        for (AbstractExpression ae : m_partitionByExpressions) {
-            copy.add((AbstractExpression)ae.clone());
-        }
-        return copy;
-    }
-
-    private Collection<? extends AbstractExpression> copyOrderByExpressions() {
-        List<AbstractExpression> copy = new ArrayList<>();
-        for (AbstractExpression ae : m_orderByExpressions) {
-            copy.add((AbstractExpression)ae.clone());
-        }
-        return copy;
     }
 
     @Override
@@ -209,11 +196,6 @@ public class WindowedExpression extends AbstractExpression {
         return -1;
     }
 
-    // This object is not in the display list.  It's squirreled away in the ParsedSelectStatment.  But
-    // the display list has a TVE which references the column which holds the values this aggregate
-    // expression will compute.  This field holds this TVE.
-    private TupleValueExpression m_displayListExpression;
-
     public final TupleValueExpression getDisplayListExpression() {
         return m_displayListExpression;
     }
@@ -221,8 +203,6 @@ public class WindowedExpression extends AbstractExpression {
     public final void setDisplayListExpression(TupleValueExpression displayListExpression) {
         m_displayListExpression = displayListExpression;
     }
-
-    private int m_xmlID = -1;
 
     /**
      * When a VoltXMLElement is translated to an expression, we remember the

--- a/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
@@ -472,19 +472,25 @@ public class AggregatePlanNode extends AbstractPlanNode {
         }
     }
 
+    private static String planNodeTypeToAggDescString(PlanNodeType nodeType) {
+        switch (nodeType) {
+        case AGGREGATE:
+            return "Serial";
+        case PARTIALAGGREGATE:
+            return "Partial";
+        case PARTITIONBY:
+            return "Windowed";
+        default:
+            assert(nodeType == PlanNodeType.HASHAGGREGATE);
+            return "Hash";
+        }
+    }
+
     @Override
     protected String explainPlanForNode(String indent) {
         StringBuilder sb = new StringBuilder();
         String optionalTableName = "*NO MATCH -- USE ALL TABLE NAMES*";
-        String aggType = "Hash";
-        if (getPlanNodeType() == PlanNodeType.AGGREGATE) {
-            aggType = "Serial";
-        } else if (getPlanNodeType() == PlanNodeType.PARTIALAGGREGATE) {
-            aggType = "Partial";
-        } else {
-            assert(getPlanNodeType() == PlanNodeType.HASHAGGREGATE
-                    || getPlanNodeType() == PlanNodeType.PARTITIONBY);
-        }
+        String aggType = planNodeTypeToAggDescString(getPlanNodeType());
 
         sb.append(aggType + " AGGREGATION ops: ");
         String sep = "";

--- a/src/frontend/org/voltdb/plannodes/PartitionByPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/PartitionByPlanNode.java
@@ -161,10 +161,12 @@ public class PartitionByPlanNode extends AggregatePlanNode {
 
         NodeSchema inputSchema = m_children.get(0).getOutputSchema();
 
-        List<TupleValueExpression> TVEs = ExpressionUtil.getTupleValueExpressions(m_windowedExpression.getOrderByExpressions().get(0));
-        for (TupleValueExpression tve : TVEs) {
-            int index = tve.resolveColumnIndexesUsingSchema(inputSchema);
-            tve.setColumnIndex(index);
+        for (AbstractExpression obExpr : m_windowedExpression.getOrderByExpressions()) {
+            List<TupleValueExpression> TVEs = ExpressionUtil.getTupleValueExpressions(obExpr);
+            for (TupleValueExpression tve : TVEs) {
+                int index = tve.resolveColumnIndexesUsingSchema(inputSchema);
+                tve.setColumnIndex(index);
+            }
         }
     }
 }

--- a/src/frontend/org/voltdb/plannodes/PartitionByPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/PartitionByPlanNode.java
@@ -23,6 +23,7 @@ import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.catalog.Database;
 import org.voltdb.expressions.AbstractExpression;
+import org.voltdb.expressions.ExpressionUtil;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.expressions.WindowedExpression;
 import org.voltdb.types.PlanNodeType;
@@ -38,6 +39,10 @@ public class PartitionByPlanNode extends AggregatePlanNode {
     private enum Members {
         ORDER_BY_EXPRS
     };
+
+    // This member is not serialized to JSON but the ORDER BY expressions,
+    // which it contains, are serialized
+    private WindowedExpression     m_windowedExpression = null;
 
     @Override
     public void generateOutputSchema(Database db)
@@ -150,5 +155,16 @@ public class PartitionByPlanNode extends AggregatePlanNode {
         return answer;
     }
 
-    private WindowedExpression     m_windowedExpression = null;
+    @Override
+    public void resolveColumnIndexes() {
+        super.resolveColumnIndexes();
+
+        NodeSchema inputSchema = m_children.get(0).getOutputSchema();
+
+        List<TupleValueExpression> TVEs = ExpressionUtil.getTupleValueExpressions(m_windowedExpression.getOrderByExpressions().get(0));
+        for (TupleValueExpression tve : TVEs) {
+            int index = tve.resolveColumnIndexesUsingSchema(inputSchema);
+            tve.setColumnIndex(index);
+        }
+    }
 }

--- a/tests/frontend/org/voltdb/planner/TestWindowedFunctions.java
+++ b/tests/frontend/org/voltdb/planner/TestWindowedFunctions.java
@@ -330,6 +330,15 @@ public class TestWindowedFunctions extends PlannerTestCase {
                       "Column \"A\" is ambiguous.  It\'s in tables: ALPHA, BBB");
     }
 
+    public void testExplainPlanText() {
+        String windowedQuery = "SELECT RANK() OVER (PARTITION BY A ORDER BY B DESC) FROM AAA;";
+        AbstractPlanNode plan = compile(windowedQuery);
+        String explainPlanText = plan.toExplainPlanString();
+        String expected = "Windowed AGGREGATION ops: RANK()";
+        assertTrue("Expected to find \"" + expected + "\" in explain plan text, but did not:\n"
+                + explainPlanText, explainPlanText.contains(expected));
+    }
+
     @Override
     protected void setUp() throws Exception {
         setupSchema(true, TestWindowedFunctions.class.getResource("testplans-windowingfunctions-ddl.sql"), "testwindowfunctions");

--- a/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
@@ -887,6 +887,8 @@ public class RegressionSuite extends TestCase {
                                                       Object[] expectedRow,
                                                       VoltTable actualRow,
                                                       double epsilon) {
+        assertEquals("Actual row has wrong number of columns",
+                expectedRow.length, actualRow.getColumnCount());
         for (int i = 0; i < expectedRow.length; ++i) {
             String msg = "Row " + row + ", col " + i + ": ";
             Object expectedObj = expectedRow[i];

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowedAggregateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowedAggregateSuite.java
@@ -602,18 +602,19 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
             config = new LocalCluster("test-windowed-rank.jar", 1, 1, 0, BackendTarget.NATIVE_EE_JNI);
             setupSchema(project);
             success = config.compile(project);
+            assertTrue(success);
+            builder.addServerConfig(config);
 
             project = new VoltProjectBuilder();
             config = new LocalCluster("test-windowed-rank.jar", 3, 1, 0, BackendTarget.NATIVE_EE_JNI);
             setupSchema(project);
             success = config.compile(project);
+            assertTrue(success);
+            builder.addServerConfig(config);
         }
         catch (IOException excp) {
             fail();
         }
-
-        assertTrue(success);
-        builder.addServerConfig(config);
 
         return builder;
     }


### PR DESCRIPTION
I added a resolveColumnIndices method to `PartitionByPlanNode`.  I also moved some member variables to the top of classes.  This conventions seems to actually be followed pretty consistently within our code base, so I thought it would be good to follow the trend.