### PR TITLE
use deep copy in toString function to avoid data changing for negativ…

### DIFF
--- a/src/frontend/org/voltdb/types/TimestampType.java
+++ b/src/frontend/org/voltdb/types/TimestampType.java
@@ -148,7 +148,7 @@ public class TimestampType implements JSONString, Comparable<TimestampType> {
     @Override
     public String toString() {
         SimpleDateFormat sdf = new SimpleDateFormat(Constants.ODBC_DATE_FORMAT_STRING);
-        Date dateToMillis = m_date;
+        Date dateToMillis = (Date) m_date.clone(); // deep copy as we change it later
         short usecs = m_usecs;
         if (usecs < 0) {
             // Negative usecs can occur for dates before 1970.

--- a/tests/frontend/org/voltdb/TestVoltType.java
+++ b/tests/frontend/org/voltdb/TestVoltType.java
@@ -268,6 +268,20 @@ public class TestVoltType extends TestCase {
         fail();
     }
 
+    public void testTimestampToStringBeforeEpoch() {
+        long micros = -48932323284323L;
+        TimestampType beforeEpoch = new TimestampType(micros);
+        assertEquals("1968-06-13 11:41:16.715677", beforeEpoch.toString());
+        assertEquals(micros, beforeEpoch.getTime());
+
+        // test Long.MIN as NULL_TimestampType
+        // NULL_TimestampType is translated to VoltType.NULL_BIGINT in
+        // @see org.voltdb.ParameterSet#flattenToBuffer()
+        beforeEpoch = new TimestampType(VoltType.NULL_BIGINT);
+        assertEquals("290303-12-10 14:59:05.224192", beforeEpoch.toString());
+        assertEquals(VoltType.NULL_BIGINT, beforeEpoch.getTime());
+    }
+
     public void testTimestampStringRoundTrip() {
         String[] date_str = {"1900-01-01",
                              "2000-02-03",


### PR DESCRIPTION
…e timestamp before epoch