### PR TITLE
Table partitioning and window partitioning must match.

### DIFF
--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -551,7 +551,7 @@ public abstract class AbstractParsedStmt {
                     return we.getDisplayListExpression();
                 }
             }
-            throw new PlanningErrorException("Windowed expressions can only appear in the select list.");
+            throw new PlanningErrorException("Windowed RANK() expressions can only appear in the selection list of a query or subquery.");
         }
         // Parse individual rank expressions
         List<AbstractExpression> partitionbyExprs = new ArrayList<>();

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -300,6 +300,9 @@ public class PlanAssembler {
             if (isPartitionColumnInGroupbyList(m_parsedSelect.m_groupByColumns)) {
                 m_parsedSelect.setHasPartitionColumnInGroupby();
             }
+            if (isPartitionColumnInWindowedAggregatePartitionByList()) {
+                m_parsedSelect.setHasPartitionColumnInWindowedAggregate();
+            }
 
             // FIXME: is the following scheme/comment obsolete?
             // FIXME: turn it on when we are able to push down DISTINCT
@@ -366,6 +369,12 @@ public class PlanAssembler {
             m_partitioning.analyzeForMultiPartitionAccess(parsedStmt.allScans(), valueEquivalence);
         }
         m_subAssembler = new WriterSubPlanAssembler(m_catalogDb, parsedStmt, m_partitioning);
+    }
+
+    private boolean isPartitionColumnInWindowedAggregatePartitionByList() {
+        assert (m_parsedSelect != null);
+
+        return (m_parsedSelect.isPartitionColumnInWindowedAggregatePartitionByList());
     }
 
     private static void failIfNonDeterministicDml(AbstractParsedStmt parsedStmt, CompiledPlan plan) {
@@ -2955,7 +2964,7 @@ public class PlanAssembler {
         }
 
         // The JOIN expressions (ON) are only applicable to the INNER node of an outer join.
-        List<AbstractExpression> exprsForInnerNode = new ArrayList<AbstractExpression>(exprs);
+        List<AbstractExpression> exprsForInnerNode = new ArrayList<>(exprs);
         if (leftNode.getJoinExpression() != null) {
             exprsForInnerNode.add(leftNode.getJoinExpression());
         }

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -124,7 +124,7 @@ public class StmtSubqueryScan extends StmtTableScan {
                     }
                 }
                 if (values == null) {
-                    values = new HashSet<AbstractExpression>();
+                    values = new HashSet<>();
                 }
             }
             updateEqualSets(values, valueEquivalence, eqSets, tveKey, spExpr);
@@ -228,7 +228,7 @@ public class StmtSubqueryScan extends StmtTableScan {
     }
 
     public List<StmtTargetTableScan> getAllTargetTables() {
-        List <StmtTargetTableScan> stmtTables = new ArrayList<StmtTargetTableScan>();
+        List <StmtTargetTableScan> stmtTables = new ArrayList<>();
         for (StmtTableScan tableScan : m_subqueryStmt.allScans()) {
             if (tableScan instanceof StmtTargetTableScan) {
                 stmtTables.add((StmtTargetTableScan)tableScan);
@@ -242,7 +242,7 @@ public class StmtSubqueryScan extends StmtTableScan {
         return stmtTables;
     }
 
-    static final List<Index> noIndexesSupportedOnSubqueryScans = new ArrayList<Index>();
+    static final List<Index> noIndexesSupportedOnSubqueryScans = new ArrayList<>();
     @Override
     public List<Index> getIndexes() {
         return noIndexesSupportedOnSubqueryScans;
@@ -347,6 +347,9 @@ public class StmtSubqueryScan extends StmtTableScan {
             if (! selectStmt.hasPartitionColumnInGroupby()) {
                 return false;
             }
+        }
+        if ( ! selectStmt.hasPartitionColumnInWindowedExpression()) {
+            return false;
         }
         // Now. If this sub-query joins with a partitioned table in the parent statement,
         // push the join down by removing the send/receive plan node pair.

--- a/tests/frontend/org/voltdb/planner/TestWindowedFunctions.java
+++ b/tests/frontend/org/voltdb/planner/TestWindowedFunctions.java
@@ -214,6 +214,52 @@ public class TestWindowedFunctions extends PlannerTestCase {
         validateQueryWithSubquery(windowedQuery);
         windowedQuery = "SELECT BBB.B, RANK() OVER (PARTITION BY ALPHA.A ORDER BY BBB.B ) AS ARANK FROM (select A, B, C from AAA where A < B) ALPHA, BBB WHERE ALPHA.C <> BBB.C;";
         validateQueryWithSubquery(windowedQuery);
+
+        // Test with windowed aggregates in the subquery itself.
+
+        // First, use a windowed PARTITION BY which is a table partition column. The PARTITION BY node can then be
+        // distributed.  So, we expect 0 coordinator partition by plan nodes and 1 distributed partition by plan nodes.
+        windowedQuery = "SELECT * FROM ( SELECT A, B, C, RANK() OVER (PARTITION BY A ORDER BY B) FROM AAA_PA) ARANK;";
+        validateQueryWithSubqueryWithWindowedAggregate(windowedQuery, 0, 1);
+
+        // Now, use a windowed PARTITION BY which is not in a table partition column.  The partition by
+        // node can no longer be distributed.  So we expect it to show up in the coordinator fragment.
+        windowedQuery = "SELECT * FROM ( SELECT A, B, C, RANK() OVER (PARTITION BY B ORDER BY A) FROM AAA_PA ) ARANK;";
+        validateQueryWithSubqueryWithWindowedAggregate(windowedQuery, 1, 0);
+
+        // Test that putting a windowed aggregate in the outer selection list gets about the
+        // same answers.  The outer windowed aggregate adds 1 to all the PB counts on the
+        // coordinator fragment.
+        windowedQuery = "SELECT *, RANK() OVER (PARTITION BY A ORDER BY B) FROM ( SELECT A, B, C, RANK() OVER (PARTITION BY A ORDER BY B) FROM AAA_PA) ARANK;";
+        validateQueryWithSubqueryWithWindowedAggregate(windowedQuery, 1, 1);
+
+        // Now, use a window partition by which is not in the table partition column.  The partition by
+        // node can no longer be distributed.  So we expect it to show up in the coordinator fragment.
+        windowedQuery = "SELECT *, RANK() OVER (PARTITION BY B ORDER BY A) FROM ( SELECT A, B, C, RANK() OVER (PARTITION BY B ORDER BY A) FROM AAA_PA ) ARANK;";
+        validateQueryWithSubqueryWithWindowedAggregate(windowedQuery, 2, 0);
+    }
+
+    private void validateQueryWithSubqueryWithWindowedAggregate(String windowedQuery, int numCoordinatorPartitionBys, int numDistributedPartitionBys) {
+        List<AbstractPlanNode> nodes = compileToFragments(windowedQuery);
+
+        assertEquals(2, nodes.size());
+        assertTrue(nodes.get(0) instanceof SendPlanNode);
+        int numCoordPBNodes = countPBNodes(nodes.get(0));
+        int numDistPBNodes  = countPBNodes(nodes.get(1));
+
+        assertEquals(numCoordinatorPartitionBys, numCoordPBNodes);
+        assertEquals(numDistributedPartitionBys, numDistPBNodes);
+    }
+
+    private int countPBNodes(AbstractPlanNode node) {
+        int answer = 0;
+        while (node.getChildCount() > 0) {
+            if (node instanceof PartitionByPlanNode) {
+                answer += 1;
+            }
+            node = node.getChild(0);
+        }
+        return answer;
     }
 
     /**
@@ -306,20 +352,19 @@ public class TestWindowedFunctions extends PlannerTestCase {
 
     public void testRankFailures() {
         failToCompile("SELECT RANK() OVER (PARTITION BY A ORDER BY B ) FROM AAA GROUP BY A;",
-                      "Use of both windowed operations and GROUP BY is not supported.");
+                      "Use of both windowed RANK() and GROUP BY in a single query is not supported.");
         failToCompile("SELECT RANK() OVER (PARTITION BY A ORDER BY B ) AS R1, " +
                       "       RANK() OVER (PARTITION BY B ORDER BY A ) AS R2  " +
                       "FROM AAA;",
-                      "At most one windowed display column is supported.");
+                      "Only one windowed RANK() expression may appear in a selection list.");
         failToCompile("SELECT RANK() OVER (PARTITION BY A ORDER BY A, B) FROM AAA;",
-                      "Aggregate windowed expressions with range " +
-                      "window frame units can have only one order by expression.");
+                      "Windowed RANK() expressions can have only one ORDER BY expression in their window.");
+
         failToCompile("SELECT RANK() OVER (PARTITION BY A ORDER BY CAST(A AS FLOAT)) FROM AAA;",
-                      "Aggregate windowed expressions with RANGE " +
-                      "window frame units can have only integer or TIMESTAMP value types.");
-        // Windowed expressions can only appear in the display list.
+                      "Windowed RANK() expressions can have only integer or TIMESTAMP value types in the ORDER BY expression of their window.");
+        // Windowed expressions can only appear in the selection list.
         failToCompile("SELECT A, B, C FROM AAA WHERE RANK() OVER (PARTITION BY A ORDER BY B) < 3;",
-                      "Windowed expressions can only appear in the select list.");
+                      "Windowed RANK() expressions can only appear in the selection list of a query or subquery.");
 
         // Detect that PARTITION BY A is ambiguous when A names multiple columns.
         // Queries like this passed at one point in development, ignoring the subquery


### PR DESCRIPTION
Table partitioning and window partitioning are related.  If a query has
a windowed aggregate with a PARTTION BY expression which is a reference
to a table partition column, then the PartitionByPlanNode from the
windowed aggregate expression can be pushed down to a distributed
fragment.  Otherwise, the PartionByPlanNode needs to be executed on the
coordinator fragment.

This commit implements this properly.