### PR TITLE
ENG-11029: Planner assertions for some seemingly innocuous RANK queries

### DIFF
--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -585,7 +585,11 @@ public abstract class AbstractParsedStmt {
             }
         }
 
+        String columnName = WINDOWED_AGGREGATE_COLUMN_NAME;
         String alias      = WINDOWED_AGGREGATE_COLUMN_NAME;
+        if (exprNode.attributes.containsKey("alias")) {
+            alias = exprNode.attributes.get("alias");
+        }
         WindowedExpression rankExpr = new WindowedExpression(ExpressionType.AGGREGATE_WINDOWED_RANK,
                                                              partitionbyExprs,
                                                              orderbyExprs,

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -584,11 +584,8 @@ public abstract class AbstractParsedStmt {
                 throw new PlanningErrorException("invalid RANK expression found: " + ele.name);
             }
         }
-        String columnName = WINDOWED_AGGREGATE_COLUMN_NAME;
+
         String alias      = WINDOWED_AGGREGATE_COLUMN_NAME;
-        if (exprNode.attributes.containsKey("alias")) {
-            alias = exprNode.attributes.get("alias");
-        }
         WindowedExpression rankExpr = new WindowedExpression(ExpressionType.AGGREGATE_WINDOWED_RANK,
                                                              partitionbyExprs,
                                                              orderbyExprs,

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -1702,6 +1702,13 @@ public class PlanAssembler {
         // Adjust the differentiator fields of TVEs, since they need to reflect
         // the inlined projection node in scan nodes.
         for (TupleValueExpression tve : allTves) {
+            if (tve.getTableAlias().equals(AbstractParsedStmt.TEMP_TABLE_NAME)) {
+                // Some nodes generate columns that are not from any table
+                // e.g., PartitionByPlanNode has a RANK column.  These do not need
+                // to have their differentiator updated, since its only used for
+                // disambiguation in some combinations of "SELECT *" and subqueries.
+                continue;
+            }
             tve.setDifferentiator(rootNode.adjustDifferentiatorField(tve.getColumnIndex()));
         }
         projectionNode.setOutputSchemaWithoutClone(proj_schema);

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -1703,8 +1703,7 @@ public class PlanAssembler {
         // the inlined projection node in scan nodes.
         for (TupleValueExpression tve : allTves) {
             if (tve.getTableAlias().equals(AbstractParsedStmt.TEMP_TABLE_NAME)
-                    && tve.getColumnName().equals(AbstractParsedStmt.WINDOWED_AGGREGATE_COLUMN_NAME)
-                    && rootNode instanceof PartitionByPlanNode) {
+                && rootNode instanceof PartitionByPlanNode) {
                 // PartitionByPlanNode can have an internally generated RANK column.  These do not need
                 // to have their differentiator updated, since its only used for disambiguation in some
                 // combinations of "SELECT *" and subqueries.  In fact attempting to adjust this

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -1702,11 +1702,14 @@ public class PlanAssembler {
         // Adjust the differentiator fields of TVEs, since they need to reflect
         // the inlined projection node in scan nodes.
         for (TupleValueExpression tve : allTves) {
-            if (tve.getTableAlias().equals(AbstractParsedStmt.TEMP_TABLE_NAME)) {
-                // Some nodes generate columns that are not from any table
-                // e.g., PartitionByPlanNode has a RANK column.  These do not need
-                // to have their differentiator updated, since its only used for
-                // disambiguation in some combinations of "SELECT *" and subqueries.
+            if (tve.getTableAlias().equals(AbstractParsedStmt.TEMP_TABLE_NAME)
+                    && tve.getColumnName().equals(AbstractParsedStmt.WINDOWED_AGGREGATE_COLUMN_NAME)
+                    && rootNode instanceof PartitionByPlanNode) {
+                // PartitionByPlanNode can have an internally generated RANK column.  These do not need
+                // to have their differentiator updated, since its only used for disambiguation in some
+                // combinations of "SELECT *" and subqueries.  In fact attempting to adjust this
+                // special column will cause failed assertions.
+                // (ENG-11029)
                 continue;
             }
             tve.setDifferentiator(rootNode.adjustDifferentiatorField(tve.getColumnIndex()));

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowedAggregateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowedAggregateSuite.java
@@ -624,8 +624,7 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
                 + "  BIG, "
                 + "  RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) RANK, "
                 + "  SMALL "
-                + "FROM P1_ENG_11029 "
-                + "ORDER BY ID;").getResults()[0];
+                + "FROM P1_ENG_11029").getResults()[0];
         assertContentOfTable(new Object [][] {
             {100, 1, 10},
             {101, 2, 10},
@@ -638,8 +637,7 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
                 + "  TINY, "
                 + "  SMALL, "
                 + "  RANK() OVER (PARTITION BY SMALL ORDER BY TINY ) RANK "
-                + "FROM P1_ENG_11029 "
-                + "ORDER BY ID;").getResults()[0];
+                + "FROM P1_ENG_11029").getResults()[0];
         assertContentOfTable(new Object [][] {
             {1, 10, 1},
             {1, 10, 1},
@@ -651,8 +649,7 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
                 "SELECT "
                 + "  BIG, "
                 + "  RANK() OVER (PARTITION BY TINY ORDER BY SMALL) RANK "
-                + "FROM P1_ENG_11029 "
-                + "ORDER BY ID;").getResults()[0];
+                + "FROM P1_ENG_11029").getResults()[0];
         assertContentOfTable(new Object [][] {
             {100, 1},
             {101, 1},

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowedAggregateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowedAggregateSuite.java
@@ -152,6 +152,15 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
                 + "  PRIMARY KEY (ID, TINY)"
                 + ");"
                 + "PARTITION TABLE P2 ON COLUMN TINY;"
+
+                + "CREATE TABLE P1_ENG_11029 ("
+                + "        ID INTEGER NOT NULL,"
+                + "        TINY TINYINT NOT NULL,"
+                + "        SMALL SMALLINT NOT NULL,"
+                + "        BIG BIGINT NOT NULL,"
+                + "        PRIMARY KEY (ID)"
+                + ");"
+                + "PARTITION TABLE P1_ENG_11029 ON COLUMN ID;"
                 ;
         project.addLiteralSchema(literalSchema);
         project.setUseDDLSchema(true);
@@ -588,6 +597,68 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
                 + "FROM P1_ENG_10972;").getResults()[0];
         assertContentOfTable(new Object[][] {
             {2.0, 1}}, vt);
+    }
+
+    public void testEng11029() throws Exception {
+        // Regression test for ENG-11029
+        Client client = getClient();
+
+        //        CREATE TABLE P1_ENG_11029 (
+        //                ID INTEGER NOT NULL,
+        //                TINY TINYINT NOT NULL,
+        //                SMALL SMALLINT NOT NULL,
+        //                BIG BIGINT NOT NULL,
+        //                PRIMARY KEY (ID)
+        //        );
+        //
+        //        PARTITION TABLE P1_ENG_11029 ON COLUMN ID;
+
+        client.callProcedure("P1_ENG_11029.Insert", 0, 1, 10, 100);
+        client.callProcedure("P1_ENG_11029.Insert", 1, 1, 10, 101);
+        client.callProcedure("P1_ENG_11029.Insert", 2, 2, 12, 102);
+        client.callProcedure("P1_ENG_11029.Insert", 3, 2, 12, 103);
+
+        VoltTable vt;
+        vt = client.callProcedure("@AdHoc",
+                "SELECT "
+                + "  BIG, "
+                + "  RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) RANK, "
+                + "  SMALL "
+                + "FROM P1_ENG_11029 "
+                + "ORDER BY ID;").getResults()[0];
+        assertContentOfTable(new Object [][] {
+            {100, 1, 10},
+            {101, 2, 10},
+            {102, 1, 12},
+            {103, 2, 12}
+        }, vt);
+
+        vt = client.callProcedure("@AdHoc",
+                "SELECT "
+                + "  TINY, "
+                + "  SMALL, "
+                + "  RANK() OVER (PARTITION BY SMALL ORDER BY TINY ) RANK "
+                + "FROM P1_ENG_11029 "
+                + "ORDER BY ID;").getResults()[0];
+        assertContentOfTable(new Object [][] {
+            {1, 10, 1},
+            {1, 10, 1},
+            {2, 12, 1},
+            {2, 12, 1}
+        }, vt);
+
+        vt = client.callProcedure("@AdHoc",
+                "SELECT "
+                + "  BIG, "
+                + "  RANK() OVER (PARTITION BY TINY ORDER BY SMALL) RANK "
+                + "FROM P1_ENG_11029 "
+                + "ORDER BY ID;").getResults()[0];
+        assertContentOfTable(new Object [][] {
+            {100, 1},
+            {101, 1},
+            {102, 1},
+            {103, 1}
+        }, vt);
     }
 
     static public junit.framework.Test suite() {


### PR DESCRIPTION
The issue here is with the generation of the synthesized RANK column produced by PartitionByPlanNode.  When we need to add an extra projection to the plan, we need to update the "differentiator" field of TVEs in order to help us disambiguate columns in some obscure cases.  The code that does this adjustment is confused by synthesized columns.

The fix here was just to avoid doing the differentiator adjustment for synthesized columns, which consistently have the table alias `VOLT_TEMP_TABLE`.

I think that we didn't find this before because we happened to have combinations of column indexes such that things happened to work.

We are close to shipping 6.6, but this seems like it could make RANK very difficult to use for some tables, and this change seems pretty safe to make.
