### PR TITLE
Fix TestWindowedAggregateSuite test failures.

### DIFF
--- a/src/frontend/org/voltdb/expressions/TupleValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/TupleValueExpression.java
@@ -53,6 +53,7 @@ public class TupleValueExpression extends AbstractValueExpression {
     // have two columns named "C".  HSQL is able to tell these apart, so we use the
     // "index" field produced by voltXML as a differentiator between identical columns.
     private int m_differentiator = -1;
+    private boolean m_needsDifferentiation = true;
 
     private boolean m_hasAggregate = false;
     /** The statement id this TVE refers to */
@@ -451,6 +452,14 @@ public class TupleValueExpression extends AbstractValueExpression {
         } else {
             return "<none>";
         }
+    }
+
+    public final boolean needsDifferentiation() {
+        return m_needsDifferentiation;
+    }
+
+    public final void setNeedsNoDifferentiation() {
+        m_needsDifferentiation = false;
     }
 
     @Override

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -604,6 +604,8 @@ public abstract class AbstractParsedStmt {
         tve.setColumnIndex(offset);
         tve.setValueType(rankExpr.getValueType());
         tve.setValueSize(rankExpr.getValueSize());
+        // This tve does not ever need a differentiator.
+        tve.setNeedsNoDifferentiation();
         rankExpr.setDisplayListExpression(tve);
         return tve;
     }

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -1702,13 +1702,14 @@ public class PlanAssembler {
         // Adjust the differentiator fields of TVEs, since they need to reflect
         // the inlined projection node in scan nodes.
         for (TupleValueExpression tve : allTves) {
-            if (tve.getTableAlias().equals(AbstractParsedStmt.TEMP_TABLE_NAME)
-                && rootNode instanceof PartitionByPlanNode) {
-                // PartitionByPlanNode can have an internally generated RANK column.  These do not need
+            if ( ! tve.needsDifferentiation() ) {
+                // PartitionByPlanNode and a following OrderByPlanNode
+                // can have an internally generated RANK column.  These do not need
                 // to have their differentiator updated, since its only used for disambiguation in some
                 // combinations of "SELECT *" and subqueries.  In fact attempting to adjust this
-                // special column will cause failed assertions.
-                // (ENG-11029)
+                // special column will cause failed assertions.  The tve for this expression
+                // will be marked as not needing differentiation, so we just ignore
+                // it here.
                 continue;
             }
             tve.setDifferentiator(rootNode.adjustDifferentiatorField(tve.getColumnIndex()));

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowedAggregateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowedAggregateSuite.java
@@ -528,9 +528,16 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
 
         String sql;
 
-        sql = "SELECT *, RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) RANK FROM (SELECT *, RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) SUBRANK FROM P2 W09) SUB;";
+        sql = "SELECT *, RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) SRANK "
+                + "FROM ( SELECT *, RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) SUBRANK FROM P2 W09) SUB "
+                + "ORDER BY ID, TINY, SMALL, BIG, SRANK;"
+                ;
         validateSubqueryWithWindowedAggregate(client, sql);
-        sql = "SELECT *, RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) RANK FROM (SELECT *, RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) SUBRANK FROM P2 W09) SUB;";
+
+        sql = "SELECT *, RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) SRANK "
+               + "FROM (SELECT *, RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) SUBRANK FROM P2 W09) SUB "
+               + "ORDER BY ID, TINY, SMALL, BIG, SRANK;"
+               ;
         validateSubqueryWithWindowedAggregate(client, sql);
     }
 
@@ -581,7 +588,7 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
         client.callProcedure("@AdHoc", "INSERT INTO P1_ENG_10972 VALUES (0, 'BS', NULL, 2.0);");
         client.callProcedure("@AdHoc", "INSERT INTO P1_ENG_10972 VALUES (1, 'DS', NULL, 2.0);");
         vt = client.callProcedure("@AdHoc",
-                "SELECT RANK() OVER (PARTITION BY ID ORDER BY ABS(NUM) ) RANK "
+                "SELECT RANK() OVER (PARTITION BY ID ORDER BY ABS(NUM) ) SRANK "
                 + "FROM P1_ENG_10972;").getResults()[0];
         assertContentOfTable(new Object[][] {
             {1},
@@ -591,10 +598,11 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
 
         client.callProcedure("@AdHoc", "INSERT INTO P1_ENG_10972 VALUES (0, 'BS', NULL, 2.0);");
 
-        client.callProcedure("@AdHoc", "SELECT ID, VCHAR, NUM, RATIO, RANK() OVER (PARTITION BY ID ORDER BY ABS(NUM) ) RANK FROM P1_ENG_10972;");
+        client.callProcedure("@AdHoc", "SELECT ID, VCHAR, NUM, RATIO, RANK() OVER (PARTITION BY ID ORDER BY ABS(NUM) ) SRANK FROM P1_ENG_10972;");
         vt = client.callProcedure("@AdHoc",
-                "SELECT RATIO, RANK() OVER (PARTITION BY ID ORDER BY ABS(NUM) ) RANK "
-                + "FROM P1_ENG_10972;").getResults()[0];
+                "SELECT RATIO, RANK() OVER (PARTITION BY ID ORDER BY ABS(NUM) ) SRANK "
+                 + "FROM P1_ENG_10972 "
+                 + "ORDER BY RATIO, SRANK;").getResults()[0];
         assertContentOfTable(new Object[][] {
             {2.0, 1}}, vt);
     }
@@ -622,9 +630,10 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
         vt = client.callProcedure("@AdHoc",
                 "SELECT "
                 + "  BIG, "
-                + "  RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) RANK, "
+                + "  RANK() OVER (PARTITION BY SMALL ORDER BY BIG ) SRANK, "
                 + "  SMALL "
-                + "FROM P1_ENG_11029").getResults()[0];
+                + "FROM P1_ENG_11029 "
+                + "ORDER BY BIG, SRANK, SMALL;").getResults()[0];
         assertContentOfTable(new Object [][] {
             {100, 1, 10},
             {101, 2, 10},
@@ -636,8 +645,9 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
                 "SELECT "
                 + "  TINY, "
                 + "  SMALL, "
-                + "  RANK() OVER (PARTITION BY SMALL ORDER BY TINY ) RANK "
-                + "FROM P1_ENG_11029").getResults()[0];
+                + "  RANK() OVER (PARTITION BY SMALL ORDER BY TINY ) SRANK "
+                + "FROM P1_ENG_11029 "
+                + "ORDER BY TINY, SMALL, SRANK;").getResults()[0];
         assertContentOfTable(new Object [][] {
             {1, 10, 1},
             {1, 10, 1},
@@ -648,8 +658,9 @@ public class TestWindowedAggregateSuite extends RegressionSuite {
         vt = client.callProcedure("@AdHoc",
                 "SELECT "
                 + "  BIG, "
-                + "  RANK() OVER (PARTITION BY TINY ORDER BY SMALL) RANK "
-                + "FROM P1_ENG_11029").getResults()[0];
+                + "  RANK() OVER (PARTITION BY TINY ORDER BY SMALL) SRANK "
+                + "FROM P1_ENG_11029 "
+                + "ORDER BY BIG, SRANK;").getResults()[0];
         assertContentOfTable(new Object [][] {
             {100, 1},
             {101, 1},


### PR DESCRIPTION
The test point testEng11029 was failing.  It needed an order by clause
to make it deterministic.  But there was also a problem in fixing up TVE
differentiators.  PartitionByPlanNodes and OrderByPlanNodes following
PartitionByPlanNodes will contain a column which does not have a
differentiator.  We fix this in general by marking the TVE for the rank
expression with a flag saying it does not need its differentiator value
updated.