### PR TITLE
Eng 10980 sqlcov rank failures

### DIFF
--- a/tests/scripts/examples/sql_coverage/analytic-template.sql
+++ b/tests/scripts/examples/sql_coverage/analytic-template.sql
@@ -26,18 +26,22 @@ INSERT INTO @dmltable VALUES (@insertvals)
 {@orderbyclause = "ORDER BY _orderbycolumnorexpr _sortorder"}
 
 -- Test the RANK (Window / SQL Analytic) function
-SELECT               @star,  RANK() OVER (PARTITION BY __[#ord]                                    @orderbyclause) RANK            FROM @fromtables W01
--- TODO: some failures here, due to ENG-10972:
-SELECT            __[#ord],  RANK() OVER (PARTITION BY _variable[#part]                            @orderbyclause) RANK, __[#part] FROM @fromtables W02
-SELECT __[#ord], __[#part],  RANK() OVER (PARTITION BY _variable[#part]                            @orderbyclause) RANK            FROM @fromtables W03
--- TODO: some failures here, due to ENG-10973:
-SELECT       _columnorexpr,  RANK() OVER (PARTITION BY _variable[#part]                            @orderbyclause) RANK            FROM @fromtables W04
-SELECT                       RANK() OVER (PARTITION BY _columnorexpr                               @orderbyclause) RANK, @star     FROM @fromtables W05
-SELECT               @star,  RANK() OVER (PARTITION BY _columnorexpr, _columnorexpr                @orderbyclause) RANK            FROM @fromtables W06
-SELECT                       RANK() OVER (PARTITION BY _columnorexpr, _columnorexpr, _columnorexpr @orderbyclause) RANK, @star     FROM @fromtables W07
+-- ... without PARTITION BY clause:
+SELECT               @star,  RANK() OVER (                                                         @orderbyclause) RANK            FROM @fromtables W01
+SELECT                       RANK() OVER (                                                         @orderbyclause) RANK, @star     FROM @fromtables W02
+-- ... with PARTITION BY clause:
+SELECT               @star,  RANK() OVER (PARTITION BY __[#ord]                                    @orderbyclause) RANK            FROM @fromtables W03
+SELECT            __[#ord],  RANK() OVER (PARTITION BY _variable[#part]                            @orderbyclause) RANK, __[#part] FROM @fromtables W04
+SELECT __[#ord], __[#part],  RANK() OVER (PARTITION BY _variable[#part]                            @orderbyclause) RANK            FROM @fromtables W05
+SELECT       _columnorexpr,  RANK() OVER (PARTITION BY _variable[#part]                            @orderbyclause) RANK            FROM @fromtables W06
+SELECT                       RANK() OVER (PARTITION BY _columnorexpr                               @orderbyclause) RANK, @star     FROM @fromtables W07
+SELECT               @star,  RANK() OVER (PARTITION BY _columnorexpr, _columnorexpr                @orderbyclause) RANK            FROM @fromtables W08
+SELECT                       RANK() OVER (PARTITION BY _columnorexpr, _columnorexpr, _columnorexpr @orderbyclause) RANK, @star     FROM @fromtables W09
 
 -- Test the RANK function used in a sub-query
--- TODO: some failures here, due to ENG-10953:
-SELECT * FROM (SELECT @star, RANK() OVER (PARTITION BY _columnorexpr                               @orderbyclause) SUBRANK         FROM @fromtables W08) SUB
+SELECT * FROM (SELECT @star, RANK() OVER (PARTITION BY _columnorexpr                               @orderbyclause) SUBRANK         FROM @fromtables W10) SUB
 SELECT                 *,    RANK() OVER (PARTITION BY _variable[#part]                            @orderbyclause) RANK            FROM \
-             (SELECT @star,  RANK() OVER (PARTITION BY _variable[#part]                            @orderbyclause) SUBRANK         FROM @fromtables W09) SUB
+             (SELECT @star,  RANK() OVER (PARTITION BY _variable[#part]                            @orderbyclause) SUBRANK         FROM @fromtables W11) SUB
+-- ... without PARTITION BY clause:
+SELECT                 *,    RANK() OVER (                                                         @orderbyclause) RANK            FROM \
+             (SELECT @star,  RANK() OVER (                                                         @orderbyclause) SUBRANK         FROM @fromtables W12) SUB

--- a/tests/scripts/sql_coverage_test.py
+++ b/tests/scripts/sql_coverage_test.py
@@ -232,22 +232,6 @@ def get_max_mismatches(comparison_database, suite_name):
         # Known failures in the numeric-decimals "extended" test suite (see ENG-10546)
         elif config_name == 'numeric-decimals':
             max_mismatches = 300
-        # Known failures in the various "analytic" test suites, for testing the
-        # RANK function (see ENG-10953, ENG-10972, ENG-10973)
-        elif config_name == 'analytic':
-            max_mismatches = 186
-        elif config_name == 'analytic-ints':
-            max_mismatches = 312
-        elif config_name == 'analytic-strings':
-            max_mismatches = 45
-        elif config_name == 'analytic-timestamp':
-            max_mismatches = 144
-        elif config_name == 'analytic-decimal':
-            max_mismatches = 96
-        elif config_name == 'analytic-geo-point':
-            max_mismatches = 78
-        elif config_name == 'analytic-geo-polygon':
-            max_mismatches = 78
 
     return max_mismatches
 


### PR DESCRIPTION
Removes the kludge that expected certain tests of RANK to fail, since the relevant bugs are now fixed; and adds tests of RANK without a PARTITION BY clause - now targeted to merge onto the release-6.6.x branch.