### PR TITLE
ENG-11048: Fix issue with wrong answers when deleting tuples from MV source tables

### DIFF
--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -991,13 +991,15 @@ void PersistentTable::deleteTuple(TableTuple &target, bool fallible) {
     // handle any materialized views, insert the tuple into delta table,
     // then hide the tuple from the scan temporarily.
     insertTupleIntoDeltaTable(target, fallible);
-    BOOST_FOREACH (auto viewHandler, m_viewHandlers) {
-        viewHandler->handleTupleDelete(this, fallible);
-    }
-
-    // This is for single table view.
     {
         SetAndRestorePendingDeleteFlag setPending(target);
+
+        // for multi-table views
+        BOOST_FOREACH (auto viewHandler, m_viewHandlers) {
+            viewHandler->handleTupleDelete(this, fallible);
+        }
+
+        // This is for single table view.
         for (int i = 0; i < m_views.size(); i++) {
             m_views[i]->processTupleDelete(target, fallible);
         }

--- a/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewSuite.java
@@ -1640,16 +1640,14 @@ public class TestMaterializedViewSuite extends RegressionSuite {
             verifyViewOnJoinQueryResult(client);
         }
 
-// This part of the test commented out until ENG-11048 is fixed
-//
-//        // -- 5 -- Test deleting the data from the source tables.
-//
-//        Collections.shuffle(dataList1);
-//        System.out.println("Now testing deleting data from the join query view source table.");
-//        for (int i=0; i<dataList1.size(); i++) {
-//            deleteRow(client, dataList1.get(i));
-//            verifyViewOnJoinQueryResult(client);
-//        }
+        // -- 5 -- Test deleting the data from the source tables.
+
+        Collections.shuffle(dataList1);
+        System.out.println("Now testing deleting data from the join query view source table.");
+        for (int i=0; i<dataList1.size(); i++) {
+            deleteRow(client, dataList1.get(i));
+            verifyViewOnJoinQueryResult(client);
+        }
     }
 
     public void testEng11024() throws Exception {


### PR DESCRIPTION
This is analogous to similar issues we saw with MIN/MAX and update.  Here is that change, which is already merged:

https://github.com/VoltDB/voltdb/pull/3864/commits/6ab93a73aa23b9bf2c4030c8eca74847a2260e16