### PR TITLE
ENG-11056: Fix logic error in MaterializedViewHandler

### DIFF
--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -131,7 +131,7 @@ std::string NValue::debug() const {
     std::ostringstream buffer;
     std::string out_val;
     const char* ptr;
-    int64_t addr;
+
     buffer << getTypeName(type) << "::";
     switch (type) {
     case VALUE_TYPE_BOOLEAN:
@@ -156,20 +156,18 @@ std::string NValue::debug() const {
     {
         int32_t length;
         ptr = getObject_withoutNull(&length);
-        addr = reinterpret_cast<int64_t>(ptr);
         out_val = std::string(ptr, length);
         buffer << "[" << length << "]";
-        buffer << "\"" << out_val << "\"[@" << addr << "]";
+        buffer << "\"" << out_val << "\"[@" << static_cast<const void*>(ptr) << "]";
         break;
     }
     case VALUE_TYPE_VARBINARY:
     {
         int32_t length;
         ptr = getObject_withoutNull(&length);
-        addr = reinterpret_cast<int64_t>(ptr);
         out_val = std::string(ptr, length);
         buffer << "[" << length << "]";
-        buffer << "-bin[@" << addr << "]";
+        buffer << "-bin[@" << static_cast<const void*>(ptr) << "]";
         break;
     }
     case VALUE_TYPE_DECIMAL:

--- a/src/ee/common/tabletuple.cpp
+++ b/src/ee/common/tabletuple.cpp
@@ -91,10 +91,7 @@ std::string TableTuple::debug(const std::string& tableName) const {
         }
     }
 
-
-
-    uint64_t addressNum = (uint64_t)address();
-    buffer << " @" << addressNum;
+    buffer << " @" << static_cast<const void*>(address());
 
     std::string ret(buffer.str());
     return ret;

--- a/src/ee/storage/MaterializedViewHandler.cpp
+++ b/src/ee/storage/MaterializedViewHandler.cpp
@@ -381,11 +381,13 @@ namespace voltdb {
             if (existingCount.compare(deltaCount) == 0 && m_groupByColumnCount > 0) {
                 m_destTable->deleteTuple(m_existingTuple, fallible);
             }
-            mergeTupleForDelete(deltaTuple);
-            // Shouldn't need to update group-key-only indexes such as the primary key
-            // since their keys shouldn't ever change, but do update other indexes.
-            m_destTable->updateTupleWithSpecificIndexes(m_existingTuple, m_updatedTuple,
-                                                        m_updatableIndexList, fallible);
+            else {
+                mergeTupleForDelete(deltaTuple);
+                // Shouldn't need to update group-key-only indexes such as the primary key
+                // since their keys shouldn't ever change, but do update other indexes.
+                m_destTable->updateTupleWithSpecificIndexes(m_existingTuple, m_updatedTuple,
+                                                            m_updatableIndexList, fallible);
+            }
         }
         ec->cleanupExecutorsForSubquery(executorList);
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewSuite.java
@@ -1463,7 +1463,6 @@ public class TestMaterializedViewSuite extends RegressionSuite {
         assertTablesAreEqual(prefix + "QTYPERPRODUCT: ", tresult, vresult, EPSILON);
     }
 
-    // This test disabled pending fix for
     public void testViewOnJoinQuery() throws IOException, ProcCallException
     {
         Client client = getClient();
@@ -1569,6 +1568,9 @@ public class TestMaterializedViewSuite extends RegressionSuite {
         // have the full coverage of all the cases because we are inserting and deleting
         // all the rows. The cases updating values of all kinds of aggregations will be
         // tested in one row or another.
+        //
+        // For more deterministic debugging, consider doing this:
+        // Collections.reverse(dataList1);
         Collections.shuffle(dataList1);
         System.out.println("Now testing inserting data to the join query view source table.");
         for (int i=0; i<dataList1.size(); i++) {
@@ -1641,7 +1643,9 @@ public class TestMaterializedViewSuite extends RegressionSuite {
         }
 
         // -- 5 -- Test deleting the data from the source tables.
-
+        //
+        // For more deterministic debugging, consider doing this:
+        // Collections.reverse(dataList1);
         Collections.shuffle(dataList1);
         System.out.println("Now testing deleting data from the join query view source table.");
         for (int i=0; i<dataList1.size(); i++) {

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/TruncateMatViewDataMP.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/TruncateMatViewDataMP.java
@@ -133,13 +133,11 @@ public class TruncateMatViewDataMP extends VoltProcedure {
         voltQueueSQL(validateview14); // ("SELECT COUNT(*) FROM VENG6511expR;");
         voltQueueSQL(validateview15); // ("SELECT COUNT(*) FROM VENG6511expLR;");
         voltQueueSQL(validateview16); // ("SELECT COUNT(*) FROM VENG6511C;");
-        // TODO: It is very strange that validateview 17-21 fails but the view tables seem to be empty.
-        //       Disabling those checks for now.
-        // voltQueueSQL(validateview17); // ("SELECT COUNT(*) FROM ORDER_COUNT_NOPCOL;");
-        // voltQueueSQL(validateview18); // ("SELECT * FROM ORDER_COUNT_GLOBAL;");
-        // voltQueueSQL(validateview19); // ("SELECT COUNT(*) FROM ORDER_DETAIL_NOPCOL;");
-        // voltQueueSQL(validateview20); // ("SELECT COUNT(*) FROM ORDER_DETAIL_WITHPCOL;");
-        // voltQueueSQL(validateview21); // ("SELECT COUNT(*) FROM ORDER2016;");
+        voltQueueSQL(validateview17); // ("SELECT COUNT(*) FROM ORDER_COUNT_NOPCOL;");
+        voltQueueSQL(validateview18); // ("SELECT * FROM ORDER_COUNT_GLOBAL;");
+        voltQueueSQL(validateview19); // ("SELECT COUNT(*) FROM ORDER_DETAIL_NOPCOL;");
+        voltQueueSQL(validateview20); // ("SELECT COUNT(*) FROM ORDER_DETAIL_WITHPCOL;");
+        voltQueueSQL(validateview21); // ("SELECT COUNT(*) FROM ORDER2016;");
         voltQueueSQL(validateview22); // ("SELECT * FROM MATPEOPLE_COUNT;");
         voltQueueSQL(validateview23); // ("SELECT * FROM MATPEOPLE_CONDITIONAL_COUNT;");
         voltQueueSQL(validateview24); // ("SELECT NUM FROM MATPEOPLE_CONDITIONAL_COUNT_SUM;");


### PR DESCRIPTION
The symptom was that a view appeared to be nonempty even when all data was deleted from its source tables.  That is, until the transaction is committed.  After the current quantum is released, the view appears empty as it should.

This happened because logic in `handleTupleForDelete` was first deleting the tuple and then updating it.  We should do one or the other but not both.  The processing of updating the tuple changed the "pending delete" bit, such that it was visible again.  But once the transaction committed, the release of the undo action made the view appear empty again.
