### PR TITLE
ENG-10358, don't add a pending delete tuple back to elastic index dur…

### DIFF
--- a/src/ee/storage/ElasticContext.cpp
+++ b/src/ee/storage/ElasticContext.cpp
@@ -250,13 +250,14 @@ void ElasticContext::notifyTupleMovement(TBPtr sourceBlock,
                                          TableTuple &targetTuple)
 {
     if (m_indexActive) {
-        StreamPredicateList &predicates = getPredicates();
-        assert(predicates.size() > 0);
         if (m_surgeon.indexHas(sourceTuple)) {
             m_surgeon.indexRemove(sourceTuple);
-        }
-        if (predicates[0].eval(&targetTuple).isTrue()) {
-            m_surgeon.indexAdd(targetTuple);
+            // If the tuple is pending delete, it's held on by COW but
+            // shouldn't be accessible anymore. So don't add it back to
+            // elastic index.
+            if (!targetTuple.isPendingDelete()) {
+                m_surgeon.indexAdd(targetTuple);
+            }
         }
     }
 }


### PR DESCRIPTION
…ing force compaction.

If a tuple is marked as pending delete, it means COW context holds on it and no one can access it anyone.
So it should not be added back to elastic index.

Change-Id: I6ea3599b9a07e4b8221b3573231cb1c7bdfefc6a