### PR TITLE
Eng 11005 portremap

### DIFF
--- a/lib/python/voltcli/verbs.py
+++ b/lib/python/voltcli/verbs.py
@@ -439,7 +439,7 @@ class ServerBundle(JavaBundle):
         if self.is_legacy_verb and self.default_host:
             verb.add_options(cli.StringOption('-H', '--host', 'host',
                 'HOST[:PORT] (default HOST=localhost, PORT=3021)',
-                default='localhost:3021'))
+                default=' '))
         elif self.is_legacy_verb:
             verb.add_options(cli.StringOption('-H', '--host', 'host',
                 'HOST[:PORT] host must be specified (default HOST=localhost, PORT=3021)'))

--- a/lib/python/voltcli/voltdb.d/start.py
+++ b/lib/python/voltcli/voltdb.d/start.py
@@ -34,7 +34,7 @@ server_list_help = ('{hostname-or-ip[,...]}, '
     options = (
         VOLT.StringListOption('-H', '--host', 'server_list', server_list_help, default = ''),
         VOLT.IntegerOption('-c', '--count', 'hostcount', 'number of hosts in the cluster'),
-        VOLT.IntegerOption(None,'--portremap', 'remap_increment', 'Increment all port numbers by the specified value'),
+        VOLT.IntegerOption(None,'--remap', 'remap_increment', 'Increment all port numbers by the specified value'),
         VOLT.StringOption('-D', '--dir', 'directory_spec', voltdbroot_help, default = None),
         VOLT.BooleanOption('-r', '--replica', 'replica', 'start replica cluster', default = False),
         VOLT.BooleanOption('-A', '--add', 'enableadd', 'allows the server to elastically expand the cluster if the cluster is already complete', default = False),

--- a/lib/python/voltcli/voltdb.d/start.py
+++ b/lib/python/voltcli/voltdb.d/start.py
@@ -34,6 +34,7 @@ server_list_help = ('{hostname-or-ip[,...]}, '
     options = (
         VOLT.StringListOption('-H', '--host', 'server_list', server_list_help, default = ''),
         VOLT.IntegerOption('-c', '--count', 'hostcount', 'number of hosts in the cluster'),
+        VOLT.IntegerOption(None,'--portremap', 'remap_increment', 'Increment all port numbers by the specified value'),
         VOLT.StringOption('-D', '--dir', 'directory_spec', voltdbroot_help, default = None),
         VOLT.BooleanOption('-r', '--replica', 'replica', 'start replica cluster', default = False),
         VOLT.BooleanOption('-A', '--add', 'enableadd', 'allows the server to elastically expand the cluster if the cluster is already complete', default = False),
@@ -48,6 +49,8 @@ def start(runner):
     runner.args.extend(['mesh', ','.join(runner.opts.server_list)])
     if runner.opts.hostcount:
         runner.args.extend(['hostcount', runner.opts.hostcount])
+    if runner.opts.remap_increment:
+        runner.args.extend(['remap', runner.opts.remap_increment])
     if runner.opts.enableadd:
         runner.args.extend(['enableadd'])
     runner.go()

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -677,6 +677,18 @@ public class VoltDB {
                 referToDocAndExit();
             }
 
+                    // For a single node cluster, make sure the port and host matches
+                    // what the user set as the internal port.
+            if (m_internalPort != org.voltcore.common.Constants.DEFAULT_INTERNAL_PORT &&
+               (m_leader == null || m_leader.trim().isEmpty() ) ) {
+                 m_leader = "localhost:" + Integer.toString(m_internalPort);
+            }
+            if (m_startAction == StartAction.PROBE &&
+                (m_meshBrokers == null || m_meshBrokers.trim().isEmpty()) &&
+                (m_hostCount == UNDEFINED || m_hostCount == 1) &&
+                m_internalPort != org.voltcore.common.Constants.DEFAULT_INTERNAL_PORT) {
+                m_meshBrokers = "localhost:" + Integer.toString(m_internalPort);
+            }
 
             // ENG-3035 Warn if 'recover' action has a catalog since we won't
             // be using it. Only cover the 'recover' action since 'start' sometimes


### PR DESCRIPTION
This pull request includes two changes:

ENG-11005 -- a voltdb start argument that remaps all ports. The argument name is --remap

Change to default behavior is you start a one node cluster (either with create or start) that it uses the specified internal port (rather than the default internal port).  This means that if you change the internal port, eith with --internal or --remap, and there is only one node in the cluster, you no logner need to also specify --host with the new port number.
