### PR TITLE
simpler serializing anticipating LRR serializer integration

### DIFF
--- a/buildtools.py
+++ b/buildtools.py
@@ -505,7 +505,10 @@ def buildMakefile(CTX):
     makefile.write("\t$(AR) $(ARFLAGS) $@ $?\n")
     harness_source = TEST_PREFIX + "/harness.cpp"
     makefile.write("objects/harness.o: $(ROOTDIR)/" + harness_source + "\n")
-    makefile.write("\t$(CCACHE) $(COMPILE.cpp) -MMD -MP -o $@ $^\n")
+    # The dependency magic injects harness.h et. al. into the dependencies of
+    # harness.o. So, it's a good idea to explicitly repeat the source path on
+    # the compiler command line rather than trying to pick it up with $^.
+    makefile.write("\t$(CCACHE) $(COMPILE.cpp) -MMD -MP -o $@ $(ROOTDIR)/" + harness_source + "\n")
     makefile.write("-include %s\n" % "objects/harness.d")
     makefile.write("\n")
     cleanobjs += ["objects/volt.a", "objects/harness.o", "objects/harness.d"]

--- a/src/ee/common/ExportSerializeIo.h
+++ b/src/ee/common/ExportSerializeIo.h
@@ -46,269 +46,98 @@
 #ifndef NATIVEEXPORTSERIALIZEIO_H
 #define NATIVEEXPORTSERIALIZEIO_H
 
+#include "serializeio.h"
+
 #include <cassert>
-#include <cstring>
 #include <limits>
-#include <stdint.h>
 #include <string>
 
 namespace voltdb {
 
 /*
  * This file defines a crude Export serialization interface.
- * The idea is that other code could implement these method
- * names and duck-type their way to a different Export
- * serialization .. maybe doing some dynamic symbol finding
- * for a pluggable Export serializer. It's a work in progress.
- *
- * This doesn't derive from serializeio to avoid making the
- * the serialize IO baseclass functions all virtual.
+ * It could be much simplified if the SerializeOutput implementation
+ * in serializeio.h was an Endian-aware template.
  */
 
-class ExportSerializeInput {
+class ExportSerializeOutput : public SerializeOutput {
   public:
-
-    ExportSerializeInput(const void* data, size_t length)
+    ExportSerializeOutput(void *buffer, size_t capacity)
     {
-        current_ = reinterpret_cast<const char*>(data);
-        end_ = current_ + length;
+        initialize(buffer, capacity);
     }
 
+    ~ExportSerializeOutput() { }
 
-    virtual ~ExportSerializeInput() {};
-
-    inline char readChar() {
-        return readPrimitive<char>();
-    }
-
-    inline int8_t readByte() {
-        return readPrimitive<int8_t>();
-    }
-
-    inline int16_t readShort() {
-        return readPrimitive<int16_t>();
-    }
-
-    inline int32_t readInt() {
-        return readPrimitive<int32_t>();
-    }
-
-    inline bool readBool() {
-        return readByte();
-    }
-
-    inline char readEnumInSingleByte() {
-        return readByte();
-    }
-
-    inline int64_t readLong() {
-        return readPrimitive<int64_t>();
-    }
-
-    inline float readFloat() {
-        int32_t value = readPrimitive<int32_t>();
-        float retval;
-        memcpy(&retval, &value, sizeof(retval));
-        return retval;
-    }
-
-    inline double readDouble() {
-        int64_t value = readPrimitive<int64_t>();
-        double retval;
-        memcpy(&retval, &value, sizeof(retval));
-        return retval;
-    }
-
-    /** Returns a pointer to the internal data buffer, advancing the read position by length. */
-    const void* getRawPointer(size_t length) {
-        const void* result = current_;
-        current_ += length;
-        assert(current_ <= end_);
-        return result;
-    }
-
-    /** Copy a string from the buffer. */
-    inline std::string readTextString() {
-        int32_t stringLength = readInt();
-        assert(stringLength >= 0);
-        return std::string(reinterpret_cast<const char*>(getRawPointer(stringLength)),
-                stringLength);
-    };
-
-    /** Copy the next length bytes from the buffer to destination. */
-    inline void readBytes(void* destination, size_t length) {
-        ::memcpy(destination, getRawPointer(length), length);
-    };
-
-    /** Move the read position back by bytes. Warning: this method is
-    currently unverified and could result in reading before the
-    beginning of the buffer. */
-    // TODO(evanj): Change the implementation to validate this?
-    void unread(size_t bytes) {
-        current_ -= bytes;
-    }
-
-private:
-    template <typename T>
-    T readPrimitive() {
-        T value;
-        ::memcpy(&value, current_, sizeof(value));
-        current_ += sizeof(value);
-        return value;
-    }
-
-    // Current read position.
-    const char* current_;
-
-    // End of the buffer. Valid byte range: current_ <= validPointer < end_.
-    const char* end_;
-
-    // No implicit copies
-    ExportSerializeInput(const ExportSerializeInput&);
-    ExportSerializeInput& operator=(const ExportSerializeInput&);
-};
-
-class ExportSerializeOutput {
-  public:
-    ExportSerializeOutput(void *buffer, size_t capacity) :
-        buffer_(NULL), position_(0), capacity_(0)
-    {
-        buffer_ = reinterpret_cast<char*>(buffer);
-        assert(position_ <= capacity);
-        capacity_ = capacity;
-    }
-
-    virtual ~ExportSerializeOutput() {
-        // the serialization wrapper never owns its data buffer
-    };
-
-    /** Returns a pointer to the beginning of the buffer, for reading the serialized data. */
-    const char* data() const { return buffer_; }
-
-    /** Returns the number of bytes written in to the buffer. */
-    size_t size() const { return position_; }
-
-    // functions for serialization
-    inline void writeChar(char value) {
+    void writeShort(int16_t value) {
         writePrimitive(value);
     }
 
-    inline void writeByte(int8_t value) {
+    void writeInt(int32_t value) {
         writePrimitive(value);
     }
 
-    inline void writeShort(int16_t value) {
-        writePrimitive(static_cast<uint16_t>(value));
-    }
-
-    inline void writeInt(int32_t value) {
-        writePrimitive(value);
-    }
-
-    inline void writeBool(bool value) {
+    void writeBool(bool value) {
         writeByte(value ? int8_t(1) : int8_t(0));
     };
 
-    inline void writeLong(int64_t value) {
+    void writeLong(int64_t value) {
         writePrimitive(value);
     }
 
-    inline void writeFloat(float value) {
-        int32_t data;
-        memcpy(&data, &value, sizeof(data));
-        writePrimitive(data);
+    void writeFloat(float value) {
+        writePrimitive(value);
     }
 
-    inline void writeDouble(double value) {
-        int64_t data;
-        memcpy(&data, &value, sizeof(data));
-        writePrimitive(data);
+    void writeDouble(double value) {
+        writePrimitive(value);
     }
 
-    inline void writeEnumInSingleByte(int value) {
+    void writeEnumInSingleByte(int value) {
         assert(std::numeric_limits<int8_t>::min() <= value &&
                 value <= std::numeric_limits<int8_t>::max());
         writeByte(static_cast<int8_t>(value));
     }
 
-    // this explicitly accepts char* and length (or ByteArray)
+    // this explicitly accepts char* and length
     // as std::string's implicit construction is unsafe!
-    inline void writeBinaryString(const void* value, size_t length) {
-        int32_t stringLength = static_cast<int32_t>(length);
-        assureExpand(length + sizeof(stringLength));
-
-        char* current = buffer_ + position_;
-        memcpy(current, &stringLength, sizeof(stringLength));
-        current += sizeof(stringLength);
-        memcpy(current, value, length);
-        position_ += sizeof(stringLength) + length;
+    void writeBinaryString(const void* value, size_t length) {
+        int32_t intLength = static_cast<int32_t>(length);
+        writePrimitive(intLength);
+        assureExpand(length);
+        writeBytes(value, length);
     }
 
-    inline void writeTextString(const std::string &value) {
+    void writeTextString(const std::string &value) {
         writeBinaryString(value.data(), value.size());
     }
 
-    inline void writeBytes(const void *value, size_t length) {
-        assureExpand(length);
-        memcpy(buffer_ + position_, value, length);
-        position_ += length;
-    }
-
-    inline void writeZeros(size_t length) {
-        assureExpand(length);
-        memset(buffer_ + position_, 0, length);
-        position_ += length;
-    }
-
-    /** Reserves length bytes of space for writing. Returns the offset to the bytes. */
-    size_t reserveBytes(size_t length) {
-        assureExpand(length);
-        size_t offset = position_;
-        position_ += length;
-        return offset;
-    }
-
-    std::size_t position() {
-        return position_;
-    }
-
-    void position(std::size_t pos) {
-        position_ = pos;
+    // Wrapping this method exposes it as public.
+    void setPosition(size_t position) {
+        SerializeOutput::setPosition(position);
     }
 
 private:
     template <typename T>
     void writePrimitive(T value) {
         assureExpand(sizeof(value));
-        memcpy(buffer_ + position_, &value, sizeof(value));
-        position_ += sizeof(value);
+        writeBytes(&value, sizeof(value));
     }
 
-    template <typename T>
-    size_t writePrimitiveAt(size_t position, T value) {
-        return writeBytesAt(position, &value, sizeof(value));
+    void assureExpand(size_t next_write) {
+        assert(remaining() >= next_write);
+        // TODO: die, otherwise
     }
 
-    inline void assureExpand(size_t next_write) {
-        size_t minimum_desired = position_ + next_write;
-        if (minimum_desired > capacity_) {
-            // TODO: die
-        }
-        assert(capacity_ >= minimum_desired);
+    virtual void expand(size_t minimum_desired) {
+        assert(false);
+        // TODO: die
     }
-
-    // Beginning of the buffer.
-    char* buffer_;
 
     // No implicit copies
     ExportSerializeOutput(const ExportSerializeOutput&);
     ExportSerializeOutput& operator=(const ExportSerializeOutput&);
 
-protected:
-    // Current write position in the buffer.
-    size_t position_;
-    // Total bytes this buffer can contain.
-    size_t capacity_;
 };
 
 }

--- a/src/ee/common/serializeio.cpp
+++ b/src/ee/common/serializeio.cpp
@@ -41,8 +41,7 @@ void FallbackSerializeOutput::expand(size_t minimum_desired) {
     ExecutorContext::getExecutorContext()->getTopend()->fallbackToEEAllocatedBuffer(fallbackBuffer_, maxAllocationSize);
 }
 
-template<voltdb::Endianess E>
-std::string SerializeInput<E>::fullBufferStringRep() {
+template <class E> std::string SerializeInput<E>::fullBufferStringRep() {
     std::stringstream message(std::stringstream::in
                               | std::stringstream::out);
 

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -933,7 +933,7 @@ inline void TableTuple::deserializeFromDR(voltdb::SerializeInputLE &tupleIn,  Po
             setNValue(j, value);
         } else {
             char *dataPtr = getWritableDataPtr(columnInfo);
-            NValue::deserializeFrom<TUPLE_SERIALIZATION_DR, BYTE_ORDER_LITTLE_ENDIAN>(
+            NValue::deserializeFromDR(
                     tupleIn, dataPool, dataPtr,
                     columnInfo->getVoltType(), columnInfo->inlined,
                     static_cast<int32_t>(columnInfo->length), columnInfo->inBytes);
@@ -944,7 +944,7 @@ inline void TableTuple::deserializeFromDR(voltdb::SerializeInputLE &tupleIn,  Po
     for (int i = 0; i < hiddenColumnCount; i++) {
         const TupleSchema::ColumnInfo * hiddenColumnInfo = m_schema->getHiddenColumnInfo(i);
         char *dataPtr = getWritableDataPtr(hiddenColumnInfo);
-        NValue::deserializeFrom<TUPLE_SERIALIZATION_DR, BYTE_ORDER_LITTLE_ENDIAN>(
+        NValue::deserializeFromDR(
                             tupleIn, dataPool, dataPtr,
                             hiddenColumnInfo->getVoltType(), hiddenColumnInfo->inlined,
                             static_cast<int32_t>(hiddenColumnInfo->length), hiddenColumnInfo->inBytes);

--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -549,16 +549,6 @@ inline size_t rowCostForDRRecord(DRRecordType type) {
 }
 
 // ------------------------------------------------------------------
-// Tuple serialization formats
-// ------------------------------------------------------------------
-enum TupleSerializationFormat { TUPLE_SERIALIZATION_NATIVE = 0, TUPLE_SERIALIZATION_DR = 1 };
-
-// ------------------------------------------------------------------
-// Endianess
-// ------------------------------------------------------------------
-enum Endianess { BYTE_ORDER_BIG_ENDIAN = 0, BYTE_ORDER_LITTLE_ENDIAN = 1 };
-
-// ------------------------------------------------------------------
 // Types of DR conflict (keep sync with DRConflictType at PartitionDRGateway.java)
 // ------------------------------------------------------------------
 enum DRConflictType {

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -525,7 +525,7 @@ void DRTupleStream::endTransaction(int64_t uniqueId)
     int32_t txnLength = m_uso - m_beginTxnUso;
     ExportSerializeOutput extraio(m_currBlock->mutableDataPtr() - txnLength,
                                   txnLength);
-    extraio.position(BEGIN_RECORD_HEADER_SIZE);
+    extraio.setPosition(BEGIN_RECORD_HEADER_SIZE);
     extraio.writeByte(static_cast<int8_t>(m_hashFlag));
     extraio.writeInt(txnLength);
     // if it is the replicated stream or first record is TRUNCATE_TABLE
@@ -535,7 +535,7 @@ void DRTupleStream::endTransaction(int64_t uniqueId)
     uint32_t crc = vdbcrc::crc32cInit();
     crc = vdbcrc::crc32c(crc, m_currBlock->mutableDataPtr() - txnLength, txnLength - 4);
     crc = vdbcrc::crc32cFinish(crc);
-    extraio.position(txnLength - 4);
+    extraio.setPosition(txnLength - 4);
     extraio.writeInt(crc);
 
     m_committedUso = m_uso;

--- a/tests/ee/common/nvalue_test.cpp
+++ b/tests/ee/common/nvalue_test.cpp
@@ -1961,7 +1961,7 @@ TEST_F(NValueTest, SerializeToExport)
 
     // a plenty-large-buffer(tm)
     char buf[1024];
-    ExportSerializeInput sin(buf, 1024);
+    ReferenceSerializeInputLE sin(buf, 1024);
     ExportSerializeOutput out(buf, 1024);
 
     // tinyint
@@ -1970,21 +1970,21 @@ TEST_F(NValueTest, SerializeToExport)
     EXPECT_EQ(1, out.position());
     EXPECT_EQ(-50, sin.readByte());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     nv = ValueFactory::getTinyIntValue(0);
     nv.serializeToExport_withoutNull(out);
     EXPECT_EQ(1, out.position());
     EXPECT_EQ(0, sin.readByte());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     nv = ValueFactory::getTinyIntValue(50);
     nv.serializeToExport_withoutNull(out);
     EXPECT_EQ(1, out.position());
     EXPECT_EQ(50, sin.readByte());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     // smallint
     nv = ValueFactory::getSmallIntValue(-128);
@@ -1992,21 +1992,21 @@ TEST_F(NValueTest, SerializeToExport)
     EXPECT_EQ(2, out.position());
     EXPECT_EQ(-128, sin.readShort());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     nv = ValueFactory::getSmallIntValue(0);
     nv.serializeToExport_withoutNull(out);
     EXPECT_EQ(2, out.position());
     EXPECT_EQ(0, sin.readShort());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     nv = ValueFactory::getSmallIntValue(128);
     nv.serializeToExport_withoutNull(out);
     EXPECT_EQ(2, out.position());
     EXPECT_EQ(128, sin.readShort());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     // int
     nv = ValueFactory::getIntegerValue(-4999999);
@@ -2014,21 +2014,21 @@ TEST_F(NValueTest, SerializeToExport)
     EXPECT_EQ(4, out.position());
     EXPECT_EQ(-4999999, sin.readInt());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     nv = ValueFactory::getIntegerValue(0);
     nv.serializeToExport_withoutNull(out);
     EXPECT_EQ(4, out.position());
     EXPECT_EQ(0, sin.readInt());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     nv = ValueFactory::getIntegerValue(128);
     nv.serializeToExport_withoutNull(out);
     EXPECT_EQ(4, out.position());
     EXPECT_EQ(128, sin.readInt());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     // bigint
     nv = ValueFactory::getBigIntValue(-4999999);
@@ -2036,21 +2036,21 @@ TEST_F(NValueTest, SerializeToExport)
     EXPECT_EQ(8, out.position());
     EXPECT_EQ(-4999999, sin.readLong());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     nv = ValueFactory::getBigIntValue(0);
     nv.serializeToExport_withoutNull(out);
     EXPECT_EQ(8, out.position());
     EXPECT_EQ(0, sin.readLong());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     nv = ValueFactory::getBigIntValue(128);
     nv.serializeToExport_withoutNull(out);
     EXPECT_EQ(8, out.position());
     EXPECT_EQ(128, sin.readLong());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     // timestamp
     nv = ValueFactory::getTimestampValue(99999999);
@@ -2058,7 +2058,7 @@ TEST_F(NValueTest, SerializeToExport)
     EXPECT_EQ(8, out.position());
     EXPECT_EQ(99999999, sin.readLong());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     // double
     nv = ValueFactory::getDoubleValue(-5.5555);
@@ -2066,21 +2066,21 @@ TEST_F(NValueTest, SerializeToExport)
     EXPECT_EQ(8, out.position());
     EXPECT_EQ(-5.5555, sin.readDouble());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     nv = ValueFactory::getDoubleValue(0.0);
     nv.serializeToExport_withoutNull(out);
     EXPECT_EQ(8, out.position());
     EXPECT_EQ(0.0, sin.readDouble());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     nv = ValueFactory::getDoubleValue(128.256);
     nv.serializeToExport_withoutNull(out);
     EXPECT_EQ(8, out.position());
     EXPECT_EQ(128.256, sin.readDouble());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     // varchar
     nv = ValueFactory::getStringValue("ABCDEFabcdef");
@@ -2101,7 +2101,7 @@ TEST_F(NValueTest, SerializeToExport)
     EXPECT_EQ('e', sin.readChar());
     EXPECT_EQ('f', sin.readChar());
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 
     // decimal
     nv = ValueFactory::getDecimalValueFromString("-1234567890.456123000000");
@@ -2117,7 +2117,7 @@ TEST_F(NValueTest, SerializeToExport)
     EXPECT_EQ(low, val.table[1]);
     EXPECT_EQ(high, val.table[0]);
     sin.unread(out.position());
-    out.position(0);
+    out.setPosition(0);
 }
 
 TEST_F(NValueTest, TestLike)

--- a/tests/ee/common/serializeio_test.cpp
+++ b/tests/ee/common/serializeio_test.cpp
@@ -104,10 +104,6 @@ TEST_F(SerializeIOTest, ReadWrite) {
 
     ReferenceSerializeInputBE in(out.data(), out.size());
     readTestSuite(&in);
-
-    CopySerializeInputBE in2(out.data(), out.size());
-    memset(const_cast<char*>(out.data()), 0, out.size());
-    readTestSuite(&in2);
 }
 
 TEST_F(SerializeIOTest, Unread) {

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -60,9 +60,9 @@ const int CLUSTER_ID_REPLICA = 2;
 const int BUFFER_SIZE = 4096;
 const int LARGE_BUFFER_SIZE = 32768;
 
-static bool s_mulitPartitionFlag = false;
+static bool s_multiPartitionFlag = false;
 static int64_t addPartitionId(int64_t value) {
-    return s_mulitPartitionFlag ? ((value << 14) | 16383) : ((value << 14) | 42);
+    return s_multiPartitionFlag ? ((value << 14) | 16383) : ((value << 14) | 42);
 }
 
 class MockExportTupleStream : public ExportTupleStream {
@@ -448,10 +448,10 @@ public:
         return std::make_pair(data, startPos);
     }
 
-    CopySerializeInputLE* getDRTaskInfo() {
+    ReferenceSerializeInputLE* getDRTaskInfo() {
         DRStreamData data = getDRStreamData();
         const char* taskParams = &data.first[data.second];
-        return new CopySerializeInputLE(taskParams + 4,
+        return new ReferenceSerializeInputLE(taskParams + 4,
                 ntohl(*reinterpret_cast<const int32_t*>(taskParams)));
     }
 
@@ -2071,7 +2071,7 @@ TEST_F(DRBinaryLogTest, MultiPartNoDataChange) {
     ASSERT_FALSE(flush(98));
     ASSERT_EQ(0, m_topend.blocks.size());
 
-    s_mulitPartitionFlag = true;
+    s_multiPartitionFlag = true;
 
     beginTxn(m_engine, 99, 99, 98, 70);
     endTxn(m_engine, true);
@@ -2081,7 +2081,7 @@ TEST_F(DRBinaryLogTest, MultiPartNoDataChange) {
     EXPECT_EQ(0, m_tableReplica->activeTupleCount());
     ASSERT_EQ(2, m_topend.blocks.size());
 
-    std::unique_ptr<CopySerializeInputLE> taskInfo(getDRTaskInfo());
+    std::unique_ptr<ReferenceSerializeInputLE> taskInfo(getDRTaskInfo());
     taskInfo->readByte(); // DR version
     DRRecordType type = static_cast<DRRecordType>(taskInfo->readByte());
     ASSERT_EQ(DR_RECORD_BEGIN_TXN, type);
@@ -2117,7 +2117,7 @@ TEST_F(DRBinaryLogTest, MultiPartNoDataChange) {
     ASSERT_EQ(INT64_MAX, m_undoToken);
     m_undoToken = prevUndoToken;
 
-    s_mulitPartitionFlag = false;
+    s_multiPartitionFlag = false;
 }
 
 int main() {

--- a/tests/ee/storage/tabletuple_export_test.cpp
+++ b/tests/ee/storage/tabletuple_export_test.cpp
@@ -329,7 +329,7 @@ TableTupleExportTest::serElSize(std::vector<uint16_t> &keep_offsets,
 void
 TableTupleExportTest::verSer(int cnt, char *data)
 {
-    ExportSerializeInput sin(data, 2048);
+    ReferenceSerializeInputLE sin(data, 2048);
 
     if (cnt-- >= 0)
     {


### PR DESCRIPTION
Gutted ExportSerializeIo because its input serializer was not really needed and its output serializer had so much redundancy with the generic SerializeOutput base class -- from which it now inherits.
The export output serializer may go away or become trivial if/when we templatize the generic SerializeOutput class for endianness -- endian differences are the REAL novel feature of export serialization.

In NValue.hpp and tabletuple.h and serializeio.h, got rid of the clumsy explicit enum-based templating.
Some of this was replaced with dedicated functions for DR and non-DR that delegate to template code (only) for truly common functionality.
This allowed template functions to be called more cleanly with implied argument-driven parameterization.

In serializeio.h, I replaced the input serializers' use of explicit branching based on a dumb Endianess enum with a one-liner delegating to a smart Endian class parameter. The parameter classes use template and overload methods to encapsulate any required optional byte re-ordering.
As I just mentioned, the same kind of templating should probably be done (trivially) for the output serializers so that export output can be brought more fully into the fold.
I got rid of some unused virtual functions and the virtuality of some functions that are called only on known leaf types -- there are still a few slightly trickier cases to fix here involving optional output buffer expansion.
I got rid of some class specializations (and unit testing thereof) that weren't adding value.
