### PR TITLE
Eng 10539 optimize fragment result processing

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -523,7 +523,7 @@ int VoltDBEngine::executePlanFragment(int64_t planfragmentId,
     // the result buffer
     if (last) {
         m_resultOutput.writeBoolAt(m_startOfResultBuffer, m_dirtyFragmentBatch);
-        m_resultOutput.writeIntAt(m_startOfResultBuffer, static_cast<int32_t>(m_resultOutput.position() - m_startOfResultBuffer) - sizeof(int32_t) - sizeof(int8_t) + 1);
+        m_resultOutput.writeIntAt(m_startOfResultBuffer+1, static_cast<int32_t>(m_resultOutput.position() - m_startOfResultBuffer) - sizeof(int32_t) - sizeof(int8_t));
     }
 
     return ENGINE_ERRORCODE_SUCCESS;

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -522,8 +522,8 @@ int VoltDBEngine::executePlanFragment(int64_t planfragmentId,
     // write dirty-ness of the batch and number of dependencies output to the FRONT of
     // the result buffer
     if (last) {
-        m_resultOutput.writeIntAt(m_startOfResultBuffer, static_cast<int32_t>(m_resultOutput.position() - m_startOfResultBuffer) - sizeof(int32_t) - sizeof(int8_t));
-        m_resultOutput.writeBoolAt(m_startOfResultBuffer + sizeof(int32_t), m_dirtyFragmentBatch);
+        m_resultOutput.writeBoolAt(m_startOfResultBuffer, m_dirtyFragmentBatch);
+        m_resultOutput.writeIntAt(m_startOfResultBuffer, static_cast<int32_t>(m_resultOutput.position() - m_startOfResultBuffer) - sizeof(int32_t) - sizeof(int8_t) + 1);
     }
 
     return ENGINE_ERRORCODE_SUCCESS;
@@ -1444,7 +1444,8 @@ int32_t VoltDBEngine::getPerFragmentStatsSize() const {
 
 void VoltDBEngine::setBuffers(char* parameterBuffer, int parameterBufferCapacity,
         char* perFragmentStatsBuffer, int perFragmentStatsBufferCapacity,
-        char* resultBuffer, int resultBufferCapacity,
+        char *firstResultBuffer, int firstResultBufferCapacity,
+        char *finalResultBuffer, int finalResultBufferCapacity,
         char* exceptionBuffer, int exceptionBufferCapacity) {
     m_parameterBuffer = parameterBuffer;
     m_parameterBufferCapacity = parameterBufferCapacity;
@@ -1452,8 +1453,11 @@ void VoltDBEngine::setBuffers(char* parameterBuffer, int parameterBufferCapacity
     m_perFragmentStatsBuffer = perFragmentStatsBuffer;
     m_perFragmentStatsBufferCapacity = perFragmentStatsBufferCapacity;
 
-    m_reusedResultBuffer = resultBuffer;
-    m_reusedResultCapacity = resultBufferCapacity;
+    m_firstReusedResultBuffer = firstResultBuffer;
+    m_firstReusedResultCapacity = firstResultBufferCapacity;
+
+    m_finalReusedResultBuffer = finalResultBuffer;
+    m_finalReusedResultCapacity = finalResultBufferCapacity;
 
     m_exceptionBuffer = exceptionBuffer;
     m_exceptionBufferCapacity = exceptionBufferCapacity;

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1445,8 +1445,8 @@ int32_t VoltDBEngine::getPerFragmentStatsSize() const {
 void VoltDBEngine::setBuffers(char* parameterBuffer, int parameterBufferCapacity,
         char* perFragmentStatsBuffer, int perFragmentStatsBufferCapacity,
         char *firstResultBuffer, int firstResultBufferCapacity,
-        char *finalResultBuffer, int finalResultBufferCapacity,
-        char* exceptionBuffer, int exceptionBufferCapacity) {
+        char *nextResultBuffer, int nextResultBufferCapacity,
+        char *exceptionBuffer, int exceptionBufferCapacity) {
     m_parameterBuffer = parameterBuffer;
     m_parameterBufferCapacity = parameterBufferCapacity;
 
@@ -1456,8 +1456,8 @@ void VoltDBEngine::setBuffers(char* parameterBuffer, int parameterBufferCapacity
     m_firstReusedResultBuffer = firstResultBuffer;
     m_firstReusedResultCapacity = firstResultBufferCapacity;
 
-    m_finalReusedResultBuffer = finalResultBuffer;
-    m_finalReusedResultCapacity = finalResultBufferCapacity;
+    m_nextReusedResultBuffer = nextResultBuffer;
+    m_nextReusedResultCapacity = nextResultBufferCapacity;
 
     m_exceptionBuffer = exceptionBuffer;
     m_exceptionBufferCapacity = exceptionBufferCapacity;

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -252,20 +252,20 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         /**
          * Reset the result buffer (use the nextResultBuffer by default)
          */
-        void resetReusedResultOutputBuffer(const size_t headerSize = 0, const int batchIndex = 1) {
+        void resetReusedResultOutputBuffer(const size_t startingPosition = 0, const int batchIndex = 1) {
             if (batchIndex == 0) {
                 m_resultOutput.initializeWithPosition(m_firstReusedResultBuffer,
                                                       m_firstReusedResultCapacity,
-                                                      headerSize);
+                                                      startingPosition);
             }
             else {
                 m_resultOutput.initializeWithPosition(m_nextReusedResultBuffer,
                                                       m_nextReusedResultCapacity,
-                                                      headerSize);
+                                                      startingPosition);
             }
             m_exceptionOutput.initializeWithPosition(m_exceptionBuffer,
                                                      m_exceptionBufferCapacity,
-                                                     headerSize);
+                                                     startingPosition);
             *reinterpret_cast<int32_t*>(m_exceptionBuffer) =
                     voltdb::VOLT_EE_EXCEPTION_TYPE_NONE;
 

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -250,17 +250,17 @@ class __attribute__((visibility("default"))) VoltDBEngine {
                        bool shouldDRStream);
 
         /**
-         * Reset the result buffer (use the final one by default in case the first is still in use)
+         * Reset the result buffer (use the nextResultBuffer by default)
          */
-        void resetReusedResultOutputBuffer(const size_t headerSize = 0, const int bufferHint = 1) {
-            if (bufferHint == 0) {
+        void resetReusedResultOutputBuffer(const size_t headerSize = 0, const int batchIndex = 1) {
+            if (batchIndex == 0) {
                 m_resultOutput.initializeWithPosition(m_firstReusedResultBuffer,
                                                       m_firstReusedResultCapacity,
                                                       headerSize);
             }
             else {
-                m_resultOutput.initializeWithPosition(m_finalReusedResultBuffer,
-                                                      m_finalReusedResultCapacity,
+                m_resultOutput.initializeWithPosition(m_nextReusedResultBuffer,
+                                                      m_nextReusedResultCapacity,
                                                       headerSize);
             }
             m_exceptionOutput.initializeWithPosition(m_exceptionBuffer,
@@ -294,7 +294,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         void setBuffers(char *parameter_buffer, int m_parameterBuffercapacity,
                 char* perFragmentStatsBuffer, int perFragmentStatsBufferCapacity,
                 char *firstResultBuffer, int firstResultBufferCapacity,
-                char *finalResultBuffer, int finalResultBufferCapacity,
+                char *nextResultBuffer, int nextResultBufferCapacity,
                 char *exceptionBuffer, int exceptionBufferCapacity);
 
         const char* getParameterBuffer() const { return m_parameterBuffer; }
@@ -313,10 +313,10 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         int getResultsSize() const;
 
         /** Returns the buffer for receiving result tables from EE. */
-        char* getReusedResultBuffer() const { return m_finalReusedResultBuffer; }
+        char* getReusedResultBuffer() const { return m_nextReusedResultBuffer; }
 
         /** Returns the size of buffer for receiving result tables from EE. */
-        int getReusedResultBufferCapacity() const { return m_finalReusedResultCapacity; }
+        int getReusedResultBufferCapacity() const { return m_nextReusedResultCapacity; }
 
         int getPerFragmentStatsSize() const;
         char* getPerFragmentStatsBuffer() const { return m_perFragmentStatsBuffer; }
@@ -640,10 +640,10 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         int m_firstReusedResultCapacity;
 
         /** buffer object to receive final result tables from EE. */
-        char* m_finalReusedResultBuffer;
+        char* m_nextReusedResultBuffer;
 
         /** size of m_finalReusedResultBuffer. */
-        int m_finalReusedResultCapacity;
+        int m_nextReusedResultCapacity;
 
         // arrays to hold fragment ids and dep ids from java
         // n.b. these are 8k each, should be boost shared arrays?

--- a/src/ee/structures/ContiguousAllocator.cpp
+++ b/src/ee/structures/ContiguousAllocator.cpp
@@ -21,10 +21,12 @@
 
 using namespace voltdb;
 
+#define ALLOCATOR_BLOCKSIZE 2097152
+
 ContiguousAllocator::ContiguousAllocator(int32_t allocSize, int32_t chunkSize)
     : m_count(0),
       m_allocationSize(allocSize),
-      m_numberAllocationsPerBlock(chunkSize),
+      m_numberAllocationsPerBlock((ALLOCATOR_BLOCKSIZE - sizeof(Buffer)) / allocSize),
       m_tail(NULL),
       m_blockCount(0),
       m_cachedBuffer(0) {}
@@ -32,11 +34,11 @@ ContiguousAllocator::ContiguousAllocator(int32_t allocSize, int32_t chunkSize)
 ContiguousAllocator::~ContiguousAllocator() {
     while (m_tail) {
         Buffer *buf = m_tail->prev;
-        free(m_tail);
+        ThreadLocalPool::freeExactSizedObject(ALLOCATOR_BLOCKSIZE, m_tail);
         m_tail = buf;
     }
     if (m_cachedBuffer != NULL) {
-        free(m_cachedBuffer);
+        ThreadLocalPool::freeExactSizedObject(ALLOCATOR_BLOCKSIZE, m_cachedBuffer);
     }
 }
 
@@ -53,7 +55,7 @@ void *ContiguousAllocator::alloc() {
             memory = static_cast<void *>(m_cachedBuffer);
             m_cachedBuffer = NULL;
         } else {
-            memory = static_cast<void *>(malloc(sizeof(Buffer) + m_allocationSize * m_numberAllocationsPerBlock));
+            memory = static_cast<void *>(ThreadLocalPool::allocateExactSizedObject(ALLOCATOR_BLOCKSIZE));
         }
 
         Buffer *buf = reinterpret_cast<Buffer*>(memory);
@@ -97,10 +99,10 @@ void ContiguousAllocator::trim() {
     if (blockOffset == 0) {
         Buffer *buf = m_tail->prev;
         m_blockCount--;
-        if (m_blockCount == 0) {
+        if (m_cachedBuffer == NULL) {
             m_cachedBuffer = m_tail;
         } else {
-            free(m_tail);
+            ThreadLocalPool::freeExactSizedObject(ALLOCATOR_BLOCKSIZE, m_tail);
         }
         m_tail = buf;
     }

--- a/src/ee/structures/ContiguousAllocator.h
+++ b/src/ee/structures/ContiguousAllocator.h
@@ -19,7 +19,6 @@
 #define CONTIGUOUSALLOCATOR_H_
 
 #include <cstdlib>
-#include "common/ThreadLocalPool.h"
 
 namespace voltdb {
 
@@ -73,9 +72,6 @@ class ContiguousAllocator {
      * the allocator.
      */
     Buffer *m_cachedBuffer;
-
-private:
-    ThreadLocalPool m_tlPool;
 
 public:
 

--- a/src/ee/structures/ContiguousAllocator.h
+++ b/src/ee/structures/ContiguousAllocator.h
@@ -19,6 +19,7 @@
 #define CONTIGUOUSALLOCATOR_H_
 
 #include <cstdlib>
+#include "common/ThreadLocalPool.h"
 
 namespace voltdb {
 
@@ -72,6 +73,9 @@ class ContiguousAllocator {
      * the allocator.
      */
     Buffer *m_cachedBuffer;
+
+private:
+    ThreadLocalPool m_tlPool;
 
 public:
 

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -792,7 +792,7 @@ void VoltDBIPC::executePlanFragments(struct ipc_command *cmd) {
     ReferenceSerializeInputBE serialize_in(offset, sz);
 
     // and reset to space for the results output
-    m_engine->resetReusedResultOutputBuffer(1); // 1 byte to add status code
+    m_engine->resetReusedResultOutputBuffer(1, 1); // 1 byte to add status code
     m_engine->resetPerFragmentStatsOutputBuffer(queryCommand->perFragmentTimingEnabled);
 
     try {
@@ -1580,7 +1580,7 @@ void VoltDBIPC::executeTask(struct ipc_command *cmd) {
         execute_task *task = (execute_task*)cmd;
         voltdb::TaskType taskId = static_cast<voltdb::TaskType>(ntohll(task->taskId));
         ReferenceSerializeInputBE input(task->task, MAX_MSG_SZ);
-        m_engine->resetReusedResultOutputBuffer(1);
+        m_engine->resetReusedResultOutputBuffer(1, 1);
         m_engine->executeTask(taskId, input);
         int32_t responseLength = m_engine->getResultsSize();
         char *resultsBuffer = m_engine->getReusedResultBuffer();
@@ -1594,7 +1594,7 @@ void VoltDBIPC::executeTask(struct ipc_command *cmd) {
 void VoltDBIPC::applyBinaryLog(struct ipc_command *cmd) {
     try {
         apply_binary_log *params = (apply_binary_log*)cmd;
-        m_engine->resetReusedResultOutputBuffer(1);
+        m_engine->resetReusedResultOutputBuffer(1, 1);
         int64_t rows = m_engine->applyBinaryLog(ntohll(params->txnId),
                                         ntohll(params->spHandle),
                                         ntohll(params->lastCommittedSpHandle),

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -198,8 +198,7 @@ private:
 
     int m_fd;
     char *m_perFragmentStatsBuffer;
-    char *m_firstReusedResultBuffer;
-    char *m_finalReusedResultBuffer;
+    char *m_reusedResultBuffer;
     char *m_exceptionBuffer;
     bool m_terminate;
 
@@ -402,13 +401,8 @@ VoltDBIPC::VoltDBIPC(int fd) : m_fd(fd) {
     currentVolt = this;
     m_engine = NULL;
     m_counter = 0;
-<<<<<<< HEAD
     m_reusedResultBuffer = NULL;
     m_perFragmentStatsBuffer = NULL;
-=======
-    m_firstReusedResultBuffer = NULL;
-    m_finalReusedResultBuffer = NULL;
->>>>>>> ENG-10539:
     m_tupleBuffer = NULL;
     m_tupleBufferSize = 0;
     m_terminate = false;
@@ -423,13 +417,8 @@ VoltDBIPC::~VoltDBIPC() {
     // throw "Conditional jump or move depends on uninitialised value(s)" error.
     if (m_engine != NULL) {
         delete m_engine;
-<<<<<<< HEAD
         delete [] m_reusedResultBuffer;
         delete [] m_perFragmentStatsBuffer;
-=======
-        delete [] m_firstReusedResultBuffer;
-        delete [] m_finalReusedResultBuffer;
->>>>>>> ENG-10539:
         delete [] m_tupleBuffer;
         delete [] m_exceptionBuffer;
     }
@@ -645,25 +634,15 @@ int8_t VoltDBIPC::initialize(struct ipc_command *cmd) {
     try {
         m_engine = new VoltDBEngine(this, new voltdb::StdoutLogProxy());
         m_engine->getLogManager()->setLogLevels(cs->logLevels);
-<<<<<<< HEAD
         m_reusedResultBuffer = new char[MAX_MSG_SZ];
         m_perFragmentStatsBuffer = new char[MAX_MSG_SZ];
         std::memset(m_reusedResultBuffer, 0, MAX_MSG_SZ);
         m_exceptionBuffer = new char[MAX_MSG_SZ];
-        m_engine->setBuffers(NULL, 0, m_perFragmentStatsBuffer, MAX_MSG_SZ,
-                                      m_reusedResultBuffer, MAX_MSG_SZ,
-                                      m_exceptionBuffer, MAX_MSG_SZ);
-=======
-        m_firstReusedResultBuffer = new char[MAX_MSG_SZ];
-        std::memset(m_firstReusedResultBuffer, 0, MAX_MSG_SZ);
-        m_finalReusedResultBuffer = new char[MAX_MSG_SZ];
-        std::memset(m_finalReusedResultBuffer, 0, MAX_MSG_SZ);
-        m_exceptionBuffer = new char[MAX_MSG_SZ];
         m_engine->setBuffers(NULL, 0,
-                             m_firstReusedResultBuffer, MAX_MSG_SZ,
-                             m_finalReusedResultBuffer, MAX_MSG_SZ,
+                             m_perFragmentStatsBuffer, MAX_MSG_SZ,
+                             NULL, 0,
+                             m_reusedResultBuffer, MAX_MSG_SZ,
                              m_exceptionBuffer, MAX_MSG_SZ);
->>>>>>> ENG-10539:
         // The tuple buffer gets expanded (doubled) as needed, but never compacted.
         m_tupleBufferSize = MAX_MSG_SZ;
         m_tupleBuffer = new char[m_tupleBufferSize];
@@ -1181,42 +1160,42 @@ void VoltDBIPC::crashVoltDB(voltdb::FatalException e) {
                     filenameLength);
 
     //status code
-    m_finalReusedResultBuffer[0] = static_cast<char>(kErrorCode_CrashVoltDB);
+    m_reusedResultBuffer[0] = static_cast<char>(kErrorCode_CrashVoltDB);
     size_t position = 1;
 
     //overall message length, not included in messageLength
-    *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[position]) = htonl(messageLength);
+    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[position]) = htonl(messageLength);
     position += sizeof(int32_t);
 
     //reason string
-    *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[position]) = htonl(reasonLength);
+    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[position]) = htonl(reasonLength);
     position += sizeof(int32_t);
-    memcpy( &m_finalReusedResultBuffer[position], reasonBytes, reasonLength);
+    memcpy( &m_reusedResultBuffer[position], reasonBytes, reasonLength);
     position += reasonLength;
 
     //filename string
-    *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[position]) = htonl(filenameLength);
+    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[position]) = htonl(filenameLength);
     position += sizeof(int32_t);
-    memcpy( &m_finalReusedResultBuffer[position], e.m_filename, filenameLength);
+    memcpy( &m_reusedResultBuffer[position], e.m_filename, filenameLength);
     position += filenameLength;
 
     //lineno
-    *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[position]) = htonl(lineno);
+    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[position]) = htonl(lineno);
     position += sizeof(int32_t);
 
     //number of traces
-    *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[position]) = htonl(numTraces);
+    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[position]) = htonl(numTraces);
     position += sizeof(int32_t);
 
     for (int ii = 0; ii < static_cast<int>(e.m_traces.size()); ii++) {
         int32_t traceLength = static_cast<int32_t>(strlen(e.m_traces[ii].c_str()));
-        *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[position]) = htonl(traceLength);
+        *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[position]) = htonl(traceLength);
         position += sizeof(int32_t);
-        memcpy( &m_finalReusedResultBuffer[position], e.m_traces[ii].c_str(), traceLength);
+        memcpy( &m_reusedResultBuffer[position], e.m_traces[ii].c_str(), traceLength);
         position += traceLength;
     }
 
-    writeOrDie(m_fd,  (unsigned char*)m_finalReusedResultBuffer, 5 + messageLength);
+    writeOrDie(m_fd,  (unsigned char*)m_reusedResultBuffer, 5 + messageLength);
     exit(-1);
 }
 
@@ -1341,7 +1320,7 @@ void VoltDBIPC::tableStreamSerializeMore(struct ipc_command *cmd) {
         ReferenceSerializeInputBE in2(inptr, sz);
         // 1 byte status and 4 byte count
         size_t offset = 5;
-        ReferenceSerializeOutput out1(m_finalReusedResultBuffer, MAX_MSG_SZ);
+        ReferenceSerializeOutput out1(m_reusedResultBuffer, MAX_MSG_SZ);
         out1.writeInt(bufferCount);
         for (size_t i = 0; i < bufferCount; i++) {
             in2.readLong(); in2.readInt(); // skip address and offset, used for jni only
@@ -1355,7 +1334,7 @@ void VoltDBIPC::tableStreamSerializeMore(struct ipc_command *cmd) {
         }
 
         // Perform table stream serialization.
-        ReferenceSerializeInputBE out2(m_finalReusedResultBuffer, MAX_MSG_SZ);
+        ReferenceSerializeInputBE out2(m_reusedResultBuffer, MAX_MSG_SZ);
         std::vector<int> positions;
         int64_t remaining = m_engine->tableStreamSerializeMore(tableId, streamType, out2, positions);
 
@@ -1534,11 +1513,11 @@ void VoltDBIPC::threadLocalPoolAllocations() {
 }
 
 int64_t VoltDBIPC::getQueuedExportBytes(int32_t partitionId, std::string signature) {
-    m_finalReusedResultBuffer[0] = kErrorCode_getQueuedExportBytes;
-    *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[1]) = htonl(partitionId);
-    *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[5]) = htonl(static_cast<int32_t>(signature.size()));
-    ::memcpy( &m_finalReusedResultBuffer[9], signature.c_str(), signature.size());
-    writeOrDie(m_fd, (unsigned char*)m_finalReusedResultBuffer, 9 + signature.size());
+    m_reusedResultBuffer[0] = kErrorCode_getQueuedExportBytes;
+    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[1]) = htonl(partitionId);
+    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[5]) = htonl(static_cast<int32_t>(signature.size()));
+    ::memcpy( &m_reusedResultBuffer[9], signature.c_str(), signature.size());
+    writeOrDie(m_fd, (unsigned char*)m_reusedResultBuffer, 9 + signature.size());
 
     int64_t netval;
     ssize_t bytes = read(m_fd, &netval, sizeof(int64_t));
@@ -1561,38 +1540,38 @@ void VoltDBIPC::pushExportBuffer(
         bool sync,
         bool endOfStream) {
     int32_t index = 0;
-    m_finalReusedResultBuffer[index++] = kErrorCode_pushExportBuffer;
-    *reinterpret_cast<int64_t*>(&m_finalReusedResultBuffer[index]) = htonll(exportGeneration);
+    m_reusedResultBuffer[index++] = kErrorCode_pushExportBuffer;
+    *reinterpret_cast<int64_t*>(&m_reusedResultBuffer[index]) = htonll(exportGeneration);
     index += 8;
-    *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[index]) = htonl(partitionId);
+    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonl(partitionId);
     index += 4;
-    *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[index]) = htonl(static_cast<int32_t>(signature.size()));
+    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonl(static_cast<int32_t>(signature.size()));
     index += 4;
-    ::memcpy( &m_finalReusedResultBuffer[index], signature.c_str(), signature.size());
+    ::memcpy( &m_reusedResultBuffer[index], signature.c_str(), signature.size());
     index += static_cast<int32_t>(signature.size());
     if (block != NULL) {
-        *reinterpret_cast<int64_t*>(&m_finalReusedResultBuffer[index]) = htonll(block->uso());
+        *reinterpret_cast<int64_t*>(&m_reusedResultBuffer[index]) = htonll(block->uso());
     } else {
-        *reinterpret_cast<int64_t*>(&m_finalReusedResultBuffer[index]) = 0;
+        *reinterpret_cast<int64_t*>(&m_reusedResultBuffer[index]) = 0;
     }
     index += 8;
-    *reinterpret_cast<int8_t*>(&m_finalReusedResultBuffer[index++]) =
+    *reinterpret_cast<int8_t*>(&m_reusedResultBuffer[index++]) =
         sync ?
             static_cast<int8_t>(1) : static_cast<int8_t>(0);
-    *reinterpret_cast<int8_t*>(&m_finalReusedResultBuffer[index++]) =
+    *reinterpret_cast<int8_t*>(&m_reusedResultBuffer[index++]) =
         endOfStream ?
             static_cast<int8_t>(1) : static_cast<int8_t>(0);
     if (block != NULL) {
-        *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[index]) = htonl(block->rawLength());
-        writeOrDie(m_fd, (unsigned char*)m_finalReusedResultBuffer, index + 4);
+        *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonl(block->rawLength());
+        writeOrDie(m_fd, (unsigned char*)m_reusedResultBuffer, index + 4);
         // Memset the first 8 bytes to initialize the MAGIC_HEADER_SPACE_FOR_JAVA
         ::memset(block->rawPtr(), 0, 8);
         writeOrDie(m_fd, (unsigned char*)block->rawPtr(), block->rawLength());
         // Need the delete in the if statement for valgrind
         delete [] block->rawPtr();
     } else {
-        *reinterpret_cast<int32_t*>(&m_finalReusedResultBuffer[index]) = htonl(0);
-        writeOrDie(m_fd, (unsigned char*)m_finalReusedResultBuffer, index + 4);
+        *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonl(0);
+        writeOrDie(m_fd, (unsigned char*)m_reusedResultBuffer, index + 4);
     }
 }
 

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -580,8 +580,8 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExecu
     Topend *topend = static_cast<JNITopend*>(engine->getTopend())->updateJNIEnv(env);
     try {
         updateJNILogProxy(engine); //JNIEnv pointer can change between calls, must be updated
-        engine->resetReusedResultOutputBuffer(0, batch_index);
         engine->resetPerFragmentStatsOutputBuffer();
+        engine->resetReusedResultOutputBuffer(0, batch_index);
         static_cast<JNITopend*>(engine->getTopend())->updateJNIEnv(env);
 
         // fragment info

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -495,8 +495,8 @@ int deserializeParameterSet(const char* serialized_parameterset, jint serialized
  * @param per_fragment_stats_buffer_size size of the buffer
  * @param first_result_buffer direct byte buffer to be set
  * @param first_result_buffer_size size of the buffer
- * @param final_result_buffer direct byte buffer to be set
- * @param final_result_buffer_size size of the buffer
+ * @param next_result_buffer direct byte buffer to be set
+ * @param next_result_buffer_size size of the buffer
  * @param exception_buffer direct byte buffer to be set
  * @param exception_buffer_size size of the buffer
  * @return error code
@@ -505,7 +505,7 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeSetBu
   (JNIEnv *env, jobject obj, jlong engine_ptr, jobject parameter_buffer, jint parameter_buffer_size,
    jobject per_fragment_stats_buffer, jint per_fragment_stats_buffer_size,
    jobject first_result_buffer, jint first_result_buffer_size,
-   jobject final_result_buffer, jint final_result_buffer_size,
+   jobject next_result_buffer, jint next_result_buffer_size,
    jobject exception_buffer, jint exception_buffer_size)
 {
     VOLT_DEBUG("nativeSetBuffers() start");
@@ -529,9 +529,9 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeSetBu
                 env->GetDirectBufferAddress(first_result_buffer));
         int firstReusedResultBufferCapacity = first_result_buffer_size;
 
-        char *finalReusedResultBuffer = reinterpret_cast<char*>(
-                env->GetDirectBufferAddress(final_result_buffer));
-        int finalReusedResultBufferCapacity = final_result_buffer_size;
+        char *nextReusedResultBuffer = reinterpret_cast<char*>(
+                env->GetDirectBufferAddress(next_result_buffer));
+        int nextReusedResultBufferCapacity = next_result_buffer_size;
 
         char *exceptionBuffer = reinterpret_cast<char*>(
                  env->GetDirectBufferAddress(exception_buffer));
@@ -540,7 +540,7 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeSetBu
         engine->setBuffers(parameterBuffer, parameterBufferCapacity,
                 perFragmentStatsBuffer, perFragmentStatsBufferCapacity,
                 firstReusedResultBuffer, firstReusedResultBufferCapacity,
-                finalReusedResultBuffer, finalReusedResultBufferCapacity,
+                nextReusedResultBuffer, nextReusedResultBufferCapacity,
                 exceptionBuffer, exceptionBufferCapacity);
     } catch (const FatalException &e) {
         topend->crashVoltDB(e);
@@ -561,7 +561,7 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExecu
 (JNIEnv *env,
         jobject obj,
         jlong engine_ptr,
-        jint buffer_hint,
+        jint batch_index,
         jint num_fragments,
         jlongArray plan_fragment_ids,
         jlongArray input_dep_ids,
@@ -580,12 +580,8 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExecu
     Topend *topend = static_cast<JNITopend*>(engine->getTopend())->updateJNIEnv(env);
     try {
         updateJNILogProxy(engine); //JNIEnv pointer can change between calls, must be updated
-<<<<<<< HEAD
-        engine->resetReusedResultOutputBuffer();
+        engine->resetReusedResultOutputBuffer(0, batch_index);
         engine->resetPerFragmentStatsOutputBuffer();
-=======
-        engine->resetReusedResultOutputBuffer(0, buffer_hint);
->>>>>>> ENG-10539:
         static_cast<JNITopend*>(engine->getTopend())->updateJNIEnv(env);
 
         // fragment info

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -490,20 +490,22 @@ int deserializeParameterSet(const char* serialized_parameterset, jint serialized
  * cost of GetDirectBufferAddress().
  * @param engine_ptr the VoltDBEngine pointer
  * @param parameter_buffer direct byte buffer to be set
- * @param parameter_buffer_size size of the buffer
+ * @param m_parameterBuffersize size of the buffer
  * @param per_fragment_stats_buffer direct byte buffer to be set
  * @param per_fragment_stats_buffer_size size of the buffer
- * @param result_buffer direct byte buffer to be set
- * @param result_buffer_size size of the buffer
+ * @param first_result_buffer direct byte buffer to be set
+ * @param first_result_buffer_size size of the buffer
+ * @param final_result_buffer direct byte buffer to be set
+ * @param final_result_buffer_size size of the buffer
  * @param exception_buffer direct byte buffer to be set
  * @param exception_buffer_size size of the buffer
  * @return error code
 */
 SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeSetBuffers
-  (JNIEnv *env, jobject obj, jlong engine_ptr,
-   jobject parameter_buffer, jint parameter_buffer_size,
+  (JNIEnv *env, jobject obj, jlong engine_ptr, jobject parameter_buffer, jint parameter_buffer_size,
    jobject per_fragment_stats_buffer, jint per_fragment_stats_buffer_size,
-   jobject result_buffer, jint result_buffer_size,
+   jobject first_result_buffer, jint first_result_buffer_size,
+   jobject final_result_buffer, jint final_result_buffer_size,
    jobject exception_buffer, jint exception_buffer_size)
 {
     VOLT_DEBUG("nativeSetBuffers() start");
@@ -523,18 +525,23 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeSetBu
                 env->GetDirectBufferAddress(per_fragment_stats_buffer));
         int perFragmentStatsBufferCapacity = per_fragment_stats_buffer_size;
 
-        char *reusedResultBuffer = reinterpret_cast<char*>(
-                env->GetDirectBufferAddress(result_buffer));
-        int reusedResultBufferCapacity = result_buffer_size;
+        char *firstReusedResultBuffer = reinterpret_cast<char*>(
+                env->GetDirectBufferAddress(first_result_buffer));
+        int firstReusedResultBufferCapacity = first_result_buffer_size;
+
+        char *finalReusedResultBuffer = reinterpret_cast<char*>(
+                env->GetDirectBufferAddress(final_result_buffer));
+        int finalReusedResultBufferCapacity = final_result_buffer_size;
 
         char *exceptionBuffer = reinterpret_cast<char*>(
                  env->GetDirectBufferAddress(exception_buffer));
         int exceptionBufferCapacity = exception_buffer_size;
 
         engine->setBuffers(parameterBuffer, parameterBufferCapacity,
-            perFragmentStatsBuffer, perFragmentStatsBufferCapacity,
-            reusedResultBuffer, reusedResultBufferCapacity,
-            exceptionBuffer, exceptionBufferCapacity);
+                perFragmentStatsBuffer, perFragmentStatsBufferCapacity,
+                firstReusedResultBuffer, firstReusedResultBufferCapacity,
+                finalReusedResultBuffer, finalReusedResultBufferCapacity,
+                exceptionBuffer, exceptionBufferCapacity);
     } catch (const FatalException &e) {
         topend->crashVoltDB(e);
     }
@@ -554,6 +561,7 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExecu
 (JNIEnv *env,
         jobject obj,
         jlong engine_ptr,
+        jint buffer_hint,
         jint num_fragments,
         jlongArray plan_fragment_ids,
         jlongArray input_dep_ids,
@@ -572,8 +580,12 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExecu
     Topend *topend = static_cast<JNITopend*>(engine->getTopend())->updateJNIEnv(env);
     try {
         updateJNILogProxy(engine); //JNIEnv pointer can change between calls, must be updated
+<<<<<<< HEAD
         engine->resetReusedResultOutputBuffer();
         engine->resetPerFragmentStatsOutputBuffer();
+=======
+        engine->resetReusedResultOutputBuffer(0, buffer_hint);
+>>>>>>> ENG-10539:
         static_cast<JNITopend*>(engine->getTopend())->updateJNIEnv(env);
 
         // fragment info

--- a/src/frontend/org/voltdb/GcStats.java
+++ b/src/frontend/org/voltdb/GcStats.java
@@ -1,0 +1,118 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import org.voltdb.VoltTable.ColumnInfo;
+
+public class GcStats extends StatsSource {
+
+    private int m_lastNewGenGcCount = 0;
+    private int m_totalNewGenGcCount = 0;
+    private int m_lastNewGenGcTime = 0;
+    private int m_totalNewGenGcTime = 0;
+
+    private int m_lastOldGenGcCount = 0;
+    private int m_totalOldGenGcCount = 0;
+    private int m_lastOldGenGcTime = 0;
+    private int m_totalOldGenGcTime = 0;
+
+    private boolean m_intervalCollection = false;
+
+    public GcStats() {
+        super(false);
+    }
+
+    public synchronized void gcInspectorReport(boolean youngGenGC, int gcCount, long avgGcTime) {
+        if (youngGenGC) {
+            m_lastNewGenGcCount += gcCount;
+            m_lastNewGenGcTime += avgGcTime;
+        }
+        else {
+            m_lastOldGenGcCount += gcCount;
+            m_lastOldGenGcTime += avgGcTime;
+        }
+    }
+
+    @Override
+    protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
+        m_intervalCollection = interval;
+        return new Iterator<Object>() {
+            boolean returnRow = true;
+
+            @Override
+            public boolean hasNext() {
+                return returnRow;
+            }
+
+            @Override
+            public Object next() {
+                if (returnRow) {
+                    returnRow = false;
+                    return new Object();
+                } else {
+                    return null;
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    protected void populateColumnSchema(ArrayList<ColumnInfo> columns) {
+        super.populateColumnSchema(columns);
+        columns.add(new VoltTable.ColumnInfo("NEWGEN_GC_COUNT", VoltType.INTEGER));
+        columns.add(new VoltTable.ColumnInfo("NEWGEN_AVG_GC_TIME", VoltType.BIGINT));
+        columns.add(new VoltTable.ColumnInfo("OLDGEN_GC_COUNT", VoltType.INTEGER));
+        columns.add(new VoltTable.ColumnInfo("OLDGEN_AVG_GC_TIME", VoltType.BIGINT));
+    }
+
+    @Override
+    protected synchronized void updateStatsRow(Object rowKey, Object[] rowValues) {
+        if (m_intervalCollection) {
+            rowValues[columnNameToIndex.get("NEWGEN_GC_COUNT")] = m_lastNewGenGcCount;
+            rowValues[columnNameToIndex.get("NEWGEN_AVG_GC_TIME")] = m_lastNewGenGcCount > 0 ? m_lastNewGenGcTime / m_lastNewGenGcCount : 0;
+            rowValues[columnNameToIndex.get("OLDGEN_GC_COUNT")] = m_lastOldGenGcCount;
+            rowValues[columnNameToIndex.get("OLDGEN_AVG_GC_TIME")] = m_lastOldGenGcCount > 0 ? m_lastOldGenGcTime / m_lastOldGenGcCount : 0;
+            m_totalNewGenGcCount += m_lastNewGenGcCount;
+            m_lastNewGenGcCount = 0;
+            m_totalOldGenGcCount += m_lastOldGenGcCount;
+            m_lastOldGenGcCount = 0;
+            m_totalNewGenGcTime += m_lastNewGenGcTime;
+            m_lastNewGenGcTime = 0;
+            m_totalOldGenGcTime += m_lastOldGenGcCount;
+            m_lastOldGenGcCount = 0;
+        }
+        else {
+            int totalNewGcCount = m_totalNewGenGcCount + m_lastNewGenGcCount;
+            int totalOldGcCount = m_totalOldGenGcCount + m_lastOldGenGcCount;
+            rowValues[columnNameToIndex.get("NEWGEN_GC_COUNT")] = totalNewGcCount;
+            rowValues[columnNameToIndex.get("NEWGEN_AVG_GC_TIME")] = totalNewGcCount > 0 ? (m_totalNewGenGcTime + m_lastNewGenGcTime) / totalNewGcCount : 0;
+            rowValues[columnNameToIndex.get("OLDGEN_GC_COUNT")] = totalOldGcCount;
+            rowValues[columnNameToIndex.get("OLDGEN_AVG_GC_TIME")] = totalOldGcCount > 0 ? (m_totalOldGenGcTime + m_lastOldGenGcTime) / totalOldGcCount : 0;
+        }
+        super.updateStatsRow(rowKey, rowValues);
+    }
+
+}

--- a/src/frontend/org/voltdb/HybridCrc32.java
+++ b/src/frontend/org/voltdb/HybridCrc32.java
@@ -1,0 +1,83 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb;
+
+import java.nio.ByteBuffer;
+import java.util.zip.CRC32;
+
+import org.apache.hadoop_voltpatches.util.PureJavaCrc32C;
+
+public class HybridCrc32 extends PureJavaCrc32C {
+    private static final int NATIVE_REDIRECT_SIZE = 150;
+
+
+    public void update(byte[] b) {
+        if (b.length > NATIVE_REDIRECT_SIZE) {
+            CRC32 nativeCRC = new CRC32();
+            nativeCRC.update(b, 0, b.length);
+            int crc = (int) nativeCRC.getValue();
+            update(crc);
+        }
+        else {
+            super.update(b, 0, b.length);
+        }
+    }
+
+    public void update(ByteBuffer b) {
+        if (b.remaining() > NATIVE_REDIRECT_SIZE) {
+          CRC32 nativeCRC = new CRC32();
+          nativeCRC.update(b);
+          update((int) nativeCRC.getValue());
+          return;
+        }
+        int len = b.remaining();
+        int localCrc = crc;
+        while(len > 7) {
+          int c0 = b.get() ^ localCrc;
+          int c1 = b.get() ^ (localCrc >>>= 8);
+          int c2 = b.get() ^ (localCrc >>>= 8);
+          int c3 = b.get() ^ (localCrc >>>= 8);
+          localCrc = (T8_7[c0 & 0xff] ^ T8_6[c1 & 0xff])
+              ^ (T8_5[c2 & 0xff] ^ T8_4[c3 & 0xff]);
+
+          localCrc ^= (T8_3[b.get() & 0xff] ^ T8_2[b.get() & 0xff])
+               ^ (T8_1[b.get() & 0xff] ^ T8_0[b.get() & 0xff]);
+
+          len -= 8;
+        }
+        while(len > 0) {
+          localCrc = (localCrc >>> 8) ^ T8_0[(localCrc ^ b.get()) & 0xff];
+          len--;
+        }
+
+        // Publish crc out to object
+        crc = localCrc;
+    }
+
+    public void update(byte[] b, int off, int len) {
+        if (len > NATIVE_REDIRECT_SIZE) {
+            CRC32 nativeCRC = new CRC32();
+            nativeCRC.update(b, off, len);
+            update((int) nativeCRC.getValue());
+        }
+        else {
+            super.update(b, off, len);
+        }
+    }
+
+}

--- a/src/frontend/org/voltdb/HybridCrc32.java
+++ b/src/frontend/org/voltdb/HybridCrc32.java
@@ -80,4 +80,11 @@ public class HybridCrc32 extends PureJavaCrc32C {
         }
     }
 
+    public void updateFromPosition(int off, ByteBuffer b) {
+        b.limit(b.position());
+        b.position(off);
+        update(b);
+        assert(b.remaining() == 0);
+        b.limit(b.capacity());
+    }
 }

--- a/src/frontend/org/voltdb/ParameterConverter.java
+++ b/src/frontend/org/voltdb/ParameterConverter.java
@@ -561,12 +561,17 @@ public class ParameterConverter {
                     Exception e = new RuntimeException("VoltTable arrays with non-zero length cannot contain null values.");
                     throw new InvocationTargetException(e);
                 }
+                // Make sure this table does not use an ee cache buffer
+                table.convertToHeapBuffer();
             }
 
             return retval;
         }
         if (result instanceof VoltTable) {
-            return new VoltTable[] { (VoltTable) result };
+            VoltTable vt = (VoltTable) result;
+            // Make sure this table does not use an ee cache buffer
+            vt.convertToHeapBuffer();
+            return new VoltTable[] { vt };
         }
         if (result instanceof Long) {
             VoltTable t = new VoltTable(new VoltTable.ColumnInfo("", VoltType.BIGINT));

--- a/src/frontend/org/voltdb/PrivateVoltTableFactory.java
+++ b/src/frontend/org/voltdb/PrivateVoltTableFactory.java
@@ -42,6 +42,12 @@ public abstract class PrivateVoltTableFactory {
         return vt;
     }
 
+    public static VoltTable createVoltTableFromByteArray(byte[] backingBuff, int position, int len) {
+        VoltTable vt = new VoltTable();
+        vt.initFromByteArray(backingBuff, position, len);
+        return vt;
+    }
+
     /**
      * End users should not call this method.
      * Obtain a reference to the table's underlying buffer.

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
-import java.util.zip.CRC32;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
@@ -141,7 +140,7 @@ public class ProcedureRunner {
     protected final static int AGG_DEPID = 1;
 
     // current hash of sql and params
-    protected final CRC32 m_inputCRC = new CRC32();
+    protected final HybridCrc32 m_inputCRC = new HybridCrc32();
 
     // running procedure info
     //  - track the current call to voltExecuteSQL for logging progress

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -442,11 +442,13 @@ public class ProcedureRunner {
                                 m_cachedSingleStmt.stmt,
                                 m_cachedSingleStmt.params,
                                 m_cachedSingleStmt.stmt.statementParamTypes);
+                        table.convertToHeapBuffer();
                         results = new VoltTable[] { table };
                     }
                     else {
                         m_batch.add(m_cachedSingleStmt);
                         results = voltExecuteSQL(true);
+                        results = convertTablesToHeapBuffers(results);
                     }
                 }
                 catch (SerializableException ex) {
@@ -1349,6 +1351,14 @@ public class ProcedureRunner {
                appStatusString,
                new VoltTable[0],
                "VOLTDB ERROR: " + msg);
+   }
+
+   final private VoltTable[] convertTablesToHeapBuffers(VoltTable[] results) {
+       for (VoltTable table : results) {
+           // Make sure this table does not use an ee cache buffer
+           table.convertToHeapBuffer();
+       }
+       return results;
    }
 
    VoltTable[] executeQueriesInIndividualBatches(List<QueuedSQL> batch, boolean finalTask) {

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -647,6 +647,12 @@ public class ProcedureRunner {
         return m_site.getCorrespondingClusterId();
     }
 
+    private void updateCRC(QueuedSQL queuedSQL) {
+        if (!queuedSQL.stmt.isReadOnly) {
+            m_inputCRC.update(queuedSQL.stmt.sqlCRC);
+        }
+    }
+
     public void voltQueueSQL(final SQLStmt stmt, Expectation expectation, Object... args) {
         if (stmt == null) {
             throw new IllegalArgumentException("SQLStmt parameter to voltQueueSQL(..) was null.");
@@ -656,6 +662,7 @@ public class ProcedureRunner {
         queuedSQL.params = getCleanParams(stmt, true, args);
         queuedSQL.stmt = stmt;
 
+        updateCRC(queuedSQL);
         m_batch.add(queuedSQL);
     }
 
@@ -730,6 +737,7 @@ public class ProcedureRunner {
             }
             queuedSQL.params = getCleanParams(queuedSQL.stmt, false, argumentParams);
 
+            updateCRC(queuedSQL);
             m_batch.add(queuedSQL);
         }
         catch (Exception e) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -240,6 +240,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     private IOStats m_ioStats = null;
     private MemoryStats m_memoryStats = null;
     private CpuStats m_cpuStats = null;
+    private GcStats m_gcStats = null;
     private CommandLogStats m_commandLogStats = null;
     private DRRoleStats m_drRoleStats = null;
     private StatsManager m_statsManager = null;
@@ -1268,7 +1269,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_cpuStats = new CpuStats();
             getStatsAgent().registerStatsSource(StatsSelector.CPU,
                     0, m_cpuStats);
-
+            m_gcStats = new GcStats();
+            getStatsAgent().registerStatsSource(StatsSelector.GC,
+                    0, m_gcStats);
             // ENG-6321
             m_commandLogStats = new CommandLogStats(m_commandLog);
             getStatsAgent().registerStatsSource(StatsSelector.COMMANDLOG, 0, m_commandLogStats);
@@ -2073,7 +2076,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         EnterpriseMaintenance em = EnterpriseMaintenance.get();
         if (em != null) { em.setupMaintenaceTasks(); }
 
-        GCInspector.instance.start(m_periodicPriorityWorkThread);
+        GCInspector.instance.start(m_periodicPriorityWorkThread, m_gcStats);
     }
 
     private void startHealthMonitor() {

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -20,7 +20,6 @@ package org.voltdb;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
-import java.util.zip.CRC32;
 
 import org.voltcore.utils.Pair;
 import org.voltdb.VoltProcedure.VoltAbortException;
@@ -115,7 +114,7 @@ public interface SiteProcedureConnection {
             long[] inputDepIds,
             Object[] parameterSets,
             boolean[] isWriteFrag,
-            CRC32 writeCRC,
+            HybridCrc32 writeCRC,
             String[] sqlTexts,
             long txnId,
             long spHandle,

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -20,6 +20,7 @@ package org.voltdb;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
+import java.util.zip.CRC32;
 
 import org.voltcore.utils.Pair;
 import org.voltdb.VoltProcedure.VoltAbortException;
@@ -113,6 +114,8 @@ public interface SiteProcedureConnection {
             long[] planFragmentIds,
             long[] inputDepIds,
             Object[] parameterSets,
+            boolean[] isWriteFrag,
+            CRC32 writeCRC,
             String[] sqlTexts,
             long txnId,
             long spHandle,

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -27,6 +27,7 @@ import org.voltdb.dtxn.TransactionState;
 import org.voltdb.dtxn.UndoAction;
 import org.voltdb.exceptions.EEException;
 import org.voltdb.iv2.JoinProducerBase;
+import org.voltdb.messaging.FastDeserializer;
 
 /**
  * VoltProcedures invoke SiteProcedureConnection methods to
@@ -107,7 +108,7 @@ public interface SiteProcedureConnection {
      * Note: it's ok to pass null for inputDepIds if the fragments
      * have no dependencies.
      */
-    public VoltTable[] executePlanFragments(
+    public FastDeserializer executePlanFragments(
             int numFragmentIds,
             long[] planFragmentIds,
             long[] inputDepIds,
@@ -118,6 +119,12 @@ public interface SiteProcedureConnection {
             long uniqueId,
             boolean readOnly,
             boolean traceOn) throws EEException;
+
+    /**
+     * Allows caller to determine that a 50MB temporary (deallocated on next call) buffer
+     * was used to generate the EE result table.
+     */
+    public boolean usingFallbackBuffer();
 
     /**
      * Let the EE know which batch of sql is running so it can include this

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -565,6 +565,9 @@ public class StatsAgent extends OpsAgent
         case DRROLE:
             stats = collectStats(StatsSelector.DRROLE, false);
             break;
+        case GC:
+            stats = collectStats(StatsSelector.GC, interval);
+            break;
         default:
             // Should have been successfully groomed in collectStatsImpl().  Log something
             // for our information but let the null check below return harmlessly

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -54,7 +54,8 @@ public enum StatsSelector {
     TOPO,           // return leader and site info for iv2
     REBALANCE,      // return elastic rebalance progress
     KSAFETY,        // return ksafety coverage information
-    CPU,            // Return CPU Stats
+    CPU,            // return CPU Stats
+    GC,             // return GC Stats
 
     COMMANDLOG,     // return number of outstanding bytes and txns on this node
     IMPORTER

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1894,6 +1894,14 @@ public final class VoltTable extends VoltTableRow implements JSONString {
         buf.put(dup);
     }
 
+    public byte[] buildReusableDependenyResult() {
+        ByteBuffer dup = m_buffer.duplicate();
+        ByteBuffer responseBuf = ByteBuffer.allocate(dup.limit());
+        dup.position(0);
+        responseBuf.put(dup);
+        return responseBuf.array();
+    }
+
     private void initFromRawBuffer() {
         m_buffer.position(m_buffer.limit());
 

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1929,7 +1929,6 @@ public final class VoltTable extends VoltTableRow implements JSONString {
             ByteBuffer heapBuffer = ByteBuffer.allocate(m_buffer.limit());
             m_buffer.position(0);
             heapBuffer.put(m_buffer);
-            heapBuffer.position(heapBuffer.limit());
             m_buffer = heapBuffer;
         }
     }

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1897,9 +1897,9 @@ public final class VoltTable extends VoltTableRow implements JSONString {
     private void initFromRawBuffer() {
         m_buffer.position(m_buffer.limit());
 
-        // rowstart represents and offset to the start of row data,
-        //  but the serialization is the non-inclusive length of the header,
-        //  so add two bytes.
+        // m_rowStart represents an offset to the start of row data,
+        // but the serialization is the non-inclusive length of the header,
+        // so add 4 bytes.
         m_rowStart = m_buffer.getInt(0) + 4;
 
         m_colCount = m_buffer.getShort(5);
@@ -1915,9 +1915,9 @@ public final class VoltTable extends VoltTableRow implements JSONString {
 
     public final void convertToHeapBuffer() {
         if (m_buffer.isDirect()) {
-            // Either this was allocated by the stored procedure as a direct buffer cached
-            // from the EE. If the second, we need to make a copy so the EE can reuse the
-            // buffer fir the next stored procedure.
+            // Either this was allocated by the stored procedure as a direct buffer or this
+            // is cached from the EE. If the second, we need to make a copy so the EE can
+            // reuse the buffer for the next stored procedure.
             ByteBuffer heapBuffer = ByteBuffer.allocate(m_buffer.limit());
             m_buffer.position(0);
             heapBuffer.put(m_buffer);

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1915,11 +1915,13 @@ public final class VoltTable extends VoltTableRow implements JSONString {
 
     public final void convertToHeapBuffer() {
         if (m_buffer.isDirect()) {
+            // Either this was allocated by the stored procedure as a direct buffer cached
+            // from the EE. If the second, we need to make a copy so the EE can reuse the
+            // buffer fir the next stored procedure.
             ByteBuffer heapBuffer = ByteBuffer.allocate(m_buffer.limit());
             m_buffer.position(0);
             heapBuffer.put(m_buffer);
             heapBuffer.position(heapBuffer.limit());
-            m_buffer = heapBuffer.asReadOnlyBuffer();
         }
     }
 

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1922,6 +1922,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
             m_buffer.position(0);
             heapBuffer.put(m_buffer);
             heapBuffer.position(heapBuffer.limit());
+            m_buffer = heapBuffer;
         }
     }
 

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1894,6 +1894,35 @@ public final class VoltTable extends VoltTableRow implements JSONString {
         buf.put(dup);
     }
 
+    private void initFromRawBuffer() {
+        m_buffer.position(m_buffer.limit());
+
+        // rowstart represents and offset to the start of row data,
+        //  but the serialization is the non-inclusive length of the header,
+        //  so add two bytes.
+        m_rowStart = m_buffer.getInt(0) + 4;
+
+        m_colCount = m_buffer.getShort(5);
+        m_rowCount = m_buffer.getInt(m_rowStart);
+
+        assert(verifyTableInvariants());
+    }
+
+    void initFromByteArray(byte[] byteArray, int position, int len) {
+        m_buffer = ByteBuffer.wrap(byteArray, position, len).asReadOnlyBuffer();
+        initFromRawBuffer();
+    }
+
+    public final void convertToHeapBuffer() {
+        if (m_buffer.isDirect()) {
+            ByteBuffer heapBuffer = ByteBuffer.allocate(m_buffer.limit());
+            m_buffer.position(0);
+            heapBuffer.put(m_buffer);
+            heapBuffer.position(heapBuffer.limit());
+            m_buffer = heapBuffer.asReadOnlyBuffer();
+        }
+    }
+
     void initFromBuffer(ByteBuffer buf) {
         // Note: some of the snapshot and save/restore code makes assumptions
         // about the binary layout of tables.
@@ -1908,18 +1937,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
         m_buffer = buf.slice().asReadOnlyBuffer();
         buf.limit(startLimit);
         buf.position(buf.position() + len);
-
-        m_buffer.position(m_buffer.limit());
-
-        // rowstart represents and offset to the start of row data,
-        //  but the serialization is the non-inclusive length of the header,
-        //  so add two bytes.
-        m_rowStart = m_buffer.getInt(0) + 4;
-
-        m_colCount = m_buffer.getShort(5);
-        m_rowCount = m_buffer.getInt(m_rowStart);
-
-        assert(verifyTableInvariants());
+        initFromRawBuffer();
     }
 
     /**

--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -317,6 +317,8 @@ public class FragmentTask extends TransactionTask
                         new long[] { fragmentId },
                         new long [] { inputDepId },
                         new ParameterSet[] { params },
+                        new boolean[] { false },
+                        null,
                         stmtText == null ? null : new String[] { stmtText },
                         m_txnState.txnId,
                         m_txnState.m_spHandle,

--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -324,7 +324,7 @@ public class FragmentTask extends TransactionTask
                         new long[] { fragmentId },
                         new long [] { inputDepId },
                         new ParameterSet[] { params },
-                        new boolean[] { false },
+                        new boolean[] { false },    // FragmentTasks don't generate statement hashes
                         null,
                         stmtText == null ? null : new String[] { stmtText },
                         m_txnState.txnId,

--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -22,8 +22,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.voltcore.logging.Level;
+import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
+import org.voltdb.DependencyPair;
 import org.voltdb.ParameterSet;
 import org.voltdb.ProcedureRunner;
 import org.voltdb.SiteProcedureConnection;
@@ -34,6 +36,8 @@ import org.voltdb.client.BatchTimeoutOverrideType;
 import org.voltdb.exceptions.EEException;
 import org.voltdb.exceptions.InterruptException;
 import org.voltdb.exceptions.SQLException;
+import org.voltdb.jni.ExecutionEngine;
+import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.messaging.FragmentResponseMessage;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.planner.ActivePlanRepository;
@@ -46,6 +50,9 @@ import org.voltdb.utils.VoltTrace;
 
 public class FragmentTask extends TransactionTask
 {
+    /** java.util.logging logger. */
+    private static final VoltLogger LOG = new VoltLogger("HOST");
+
     final Mailbox m_initiator;
     final FragmentTaskMessage m_fragmentMsg;
     final Map<Integer, List<VoltTable>> m_inputDeps;
@@ -183,7 +190,7 @@ public class FragmentTask extends TransactionTask
         depTable.setStatusCode(VoltTableUtil.NULL_DEPENDENCY_STATUS);
         for (int frag = 0; frag < m_fragmentMsg.getFragmentCount(); frag++) {
             final int outputDepId = m_fragmentMsg.getOutputDepId(frag);
-            response.addDependency(outputDepId, depTable);
+            response.addDependency(new DependencyPair.TableDependencyPair(outputDepId, depTable));
         }
 
         deliverResponse(response);
@@ -245,8 +252,7 @@ public class FragmentTask extends TransactionTask
 
         if (m_fragmentMsg.isEmptyForRestart()) {
             int outputDepId = m_fragmentMsg.getOutputDepId(0);
-            currentFragResponse.addDependency(outputDepId,
-                    new VoltTable(new ColumnInfo[] {new ColumnInfo("UNUSED", VoltType.INTEGER)}, 1));
+            currentFragResponse.addDependency(new DependencyPair.TableDependencyPair(outputDepId, m_dummyResult));
             return currentFragResponse;
         }
 
@@ -285,6 +291,7 @@ public class FragmentTask extends TransactionTask
              */
             VoltTable dependency = null;
             try {
+                FastDeserializer fragResult;
                 fragmentPlan = m_fragmentMsg.getFragmentPlan(frag);
                 String stmtText = null;
 
@@ -305,7 +312,7 @@ public class FragmentTask extends TransactionTask
                 // set up the batch context for the fragment set
                 siteConnection.setBatch(m_fragmentMsg.getCurrentBatchIndex());
 
-                dependency = siteConnection.executePlanFragments(
+                fragResult = siteConnection.executePlanFragments(
                         1,
                         new long[] { fragmentId },
                         new long [] { inputDepId },
@@ -315,21 +322,40 @@ public class FragmentTask extends TransactionTask
                         m_txnState.m_spHandle,
                         m_txnState.uniqueId,
                         m_txnState.isReadOnly(),
-                        VoltTrace.log(VoltTrace.Category.EE) != null)[0];
+                        VoltTrace.log(VoltTrace.Category.EE) != null);
+
+                // get a copy of the result buffers from the cache buffer so we can post the
+                // fragment response to the network
+                final int tableSize;
+                final byte fullBacking[];
+                try {
+                    // read the complete size of the buffer used
+                    fragResult.readInt();
+                    // read number of dependencies (1)
+                    fragResult.readInt();
+                    // read the dependencyId() -1;
+                    fragResult.readInt();
+                    tableSize = fragResult.readInt();
+                    fullBacking = new byte[tableSize];
+                    // get a copy of the buffer
+                    fragResult.readFully(fullBacking);
+                } catch (final IOException ex) {
+                    LOG.error("Failed to deserialze result table" + ex);
+                    throw new EEException(ExecutionEngine.ERRORCODE_WRONG_SERIALIZED_BYTES);
+                }
 
                 if (hostLog.isTraceEnabled()) {
                     hostLog.l7dlog(Level.TRACE,
                        LogKeys.org_voltdb_ExecutionSite_SendingDependency.name(),
                        new Object[] { outputDepId }, null);
                 }
-                currentFragResponse.addDependency(outputDepId, dependency);
+                currentFragResponse.addDependency(new DependencyPair.BufferDependencyPair(outputDepId, fullBacking, 0, tableSize));
             } catch (final EEException e) {
                 hostLog.l7dlog( Level.TRACE, LogKeys.host_ExecutionSite_ExceptionExecutingPF.name(), new Object[] { Encoder.hexEncode(planHash) }, e);
                 currentFragResponse.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, e);
                 if (currentFragResponse.getTableCount() == 0) {
                     // Make sure the response has at least 1 result with a valid DependencyId
-                    currentFragResponse.addDependency(outputDepId,
-                            new VoltTable(new ColumnInfo[] {new ColumnInfo("UNUSED", VoltType.INTEGER)}, 1));
+                    currentFragResponse.addDependency(new DependencyPair.TableDependencyPair(outputDepId, m_dummyResult));
                 }
                 break;
             } catch (final SQLException e) {
@@ -337,8 +363,7 @@ public class FragmentTask extends TransactionTask
                 currentFragResponse.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, e);
                 if (currentFragResponse.getTableCount() == 0) {
                     // Make sure the response has at least 1 result with a valid DependencyId
-                    currentFragResponse.addDependency(outputDepId,
-                            new VoltTable(new ColumnInfo[] {new ColumnInfo("UNUSED", VoltType.INTEGER)}, 1));
+                    currentFragResponse.addDependency(new DependencyPair.TableDependencyPair(outputDepId, m_dummyResult));
                 }
                 break;
             }
@@ -347,8 +372,7 @@ public class FragmentTask extends TransactionTask
                 currentFragResponse.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, e);
                 if (currentFragResponse.getTableCount() == 0) {
                     // Make sure the response has at least 1 result with a valid DependencyId
-                    currentFragResponse.addDependency(outputDepId,
-                            new VoltTable(new ColumnInfo[] {new ColumnInfo("UNUSED", VoltType.INTEGER)}, 1));
+                    currentFragResponse.addDependency(new DependencyPair.TableDependencyPair(outputDepId, m_dummyResult));
                 }
                 break;
             }

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -20,7 +20,6 @@ package org.voltdb.iv2;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
-import java.util.zip.CRC32;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
@@ -33,6 +32,7 @@ import org.voltdb.DRConsumerDrIdTracker;
 import org.voltdb.DRIdempotencyResult;
 import org.voltdb.DependencyPair;
 import org.voltdb.HsqlBackend;
+import org.voltdb.HybridCrc32;
 import org.voltdb.LoadedProcedureSet;
 import org.voltdb.NonVoltDBBackend;
 import org.voltdb.ParameterSet;
@@ -578,7 +578,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
             long[] inputDepIds,
             Object[] parameterSets,
             boolean[] isWriteFrag,
-            CRC32 writeCRC,
+            HybridCrc32 writeCRC,
             String[] sqlTexts,
             long txnId,
             long spHandle,

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -20,6 +20,7 @@ package org.voltdb.iv2;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
+import java.util.zip.CRC32;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
@@ -576,6 +577,8 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
             long[] planFragmentIds,
             long[] inputDepIds,
             Object[] parameterSets,
+            boolean[] isWriteFrag,
+            CRC32 writeCRC,
             String[] sqlTexts,
             long txnId,
             long spHandle,

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -58,6 +58,7 @@ import org.voltdb.dtxn.UndoAction;
 import org.voltdb.exceptions.EEException;
 import org.voltdb.settings.ClusterSettings;
 import org.voltdb.settings.NodeSettings;
+import org.voltdb.messaging.FastDeserializer;
 
 /**
  * An implementation of Site which provides only the functionality
@@ -570,7 +571,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     }
 
     @Override
-    public VoltTable[] executePlanFragments(
+    public FastDeserializer executePlanFragments(
             int numFragmentIds,
             long[] planFragmentIds,
             long[] inputDepIds,
@@ -584,6 +585,11 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
             throws EEException
     {
         throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
+    }
+
+    @Override
+    public boolean usingFallbackBuffer() {
+        return false;
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -29,7 +29,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.zip.CRC32;
 
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
@@ -47,6 +46,7 @@ import org.voltdb.DRLogSegmentId;
 import org.voltdb.DependencyPair;
 import org.voltdb.ExtensibleSnapshotDigestData;
 import org.voltdb.HsqlBackend;
+import org.voltdb.HybridCrc32;
 import org.voltdb.IndexStats;
 import org.voltdb.LoadedProcedureSet;
 import org.voltdb.MemoryStats;
@@ -1435,7 +1435,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             long[] inputDepIds,
             Object[] parameterSets,
             boolean[] isWriteFrag,
-            CRC32 writeCRC,
+            HybridCrc32 writeCRC,
             String[] sqlTexts,
             long txnId,
             long spHandle,

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1176,6 +1176,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     @Override
     public TupleStreamStateInfo getDRTupleStreamStateInfo()
     {
+        // Set the psetBuffer buffer capacity and clear the buffer
+        m_ee.getParamBufferForExecuteTask(0);
         ByteBuffer resultBuffer = ByteBuffer.wrap(m_ee.executeTask(TaskType.GET_DR_TUPLESTREAM_STATE, ByteBuffer.allocate(0)));
         long partitionSequenceNumber = resultBuffer.getLong();
         long partitionSpUniqueId = resultBuffer.getLong();

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -29,6 +29,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.CRC32;
 
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
@@ -1431,6 +1432,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             long[] planFragmentIds,
             long[] inputDepIds,
             Object[] parameterSets,
+            boolean[] isWriteFrag,
+            CRC32 writeCRC,
             String[] sqlTexts,
             long txnId,
             long spHandle,
@@ -1444,6 +1447,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                 planFragmentIds,
                 inputDepIds,
                 parameterSets,
+                isWriteFrag,
+                writeCRC,
                 sqlTexts,
                 txnId,
                 spHandle,

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -93,6 +93,7 @@ import org.voltdb.jni.ExecutionEngineIPC;
 import org.voltdb.jni.ExecutionEngineJNI;
 import org.voltdb.jni.MockExecutionEngine;
 import org.voltdb.messaging.CompleteTransactionMessage;
+import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.rejoin.TaskLog;
@@ -104,10 +105,10 @@ import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.LogKeys;
 import org.voltdb.utils.MinimumRatioMaintainer;
 
+import vanilla.java.affinity.impl.PosixJNAAffinity;
+
 import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.base.Preconditions;
-
-import vanilla.java.affinity.impl.PosixJNAAffinity;
 
 public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConnection
 {
@@ -1425,17 +1426,18 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
-    public VoltTable[] executePlanFragments(int numFragmentIds,
-                                            long[] planFragmentIds,
-                                            long[] inputDepIds,
-                                            Object[] parameterSets,
-                                            String[] sqlTexts,
-                                            long txnId,
-                                            long spHandle,
-                                            long uniqueId,
-                                            boolean readOnly,
-                                            boolean traceOn)
-            throws EEException
+    public FastDeserializer executePlanFragments(
+            int numFragmentIds,
+            long[] planFragmentIds,
+            long[] inputDepIds,
+            Object[] parameterSets,
+            String[] sqlTexts,
+            long txnId,
+            long spHandle,
+            long uniqueId,
+            boolean readOnly,
+            boolean traceOn)
+                    throws EEException
     {
         return m_ee.executePlanFragments(
                 numFragmentIds,
@@ -1449,6 +1451,11 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                 uniqueId,
                 readOnly ? Long.MAX_VALUE : getNextUndoTokenBroken(),
                 traceOn);
+    }
+
+    @Override
+    public boolean usingFallbackBuffer() {
+        return m_ee.usingFallbackBuffer();
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.voltcore.messaging.VoltMessage;
+import org.voltdb.DependencyPair;
 import org.voltdb.VoltTable;
 import org.voltdb.messaging.FragmentResponseMessage;
 import org.voltdb.utils.MiscUtils;
@@ -111,7 +112,7 @@ public class SysProcDuplicateCounter extends DuplicateCounter
         // union up all the deps we've collected and jam them in
         for (Entry<Integer, List<VoltTable>> dep : m_alldeps.entrySet()) {
             VoltTable grouped = VoltTableUtil.unionTables(dep.getValue());
-            unioned.addDependency(dep.getKey(), grouped);
+            unioned.addDependency(new DependencyPair.TableDependencyPair(dep.getKey(), grouped));
         }
         return unioned;
     }

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -35,8 +35,12 @@ public abstract class TransactionTask extends SiteTasker
     protected static final VoltLogger execLog = new VoltLogger("EXEC");
     protected static final VoltLogger hostLog = new VoltLogger("HOST");
 
-    protected static final VoltTable m_dummyResult =
-            new VoltTable(new ColumnInfo[] {new ColumnInfo("UNUSED", VoltType.INTEGER)}, 1);
+    protected static final byte[] m_rawDummyResult;
+
+    static {
+        VoltTable dummyResult = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
+        m_rawDummyResult = dummyResult.buildReusableDependenyResult();
+    }
 
     final protected TransactionState m_txnState;
     final protected TransactionTaskQueue m_queue;

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -17,19 +17,26 @@
 
 package org.voltdb.iv2;
 
-import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.VoltDB;
+import org.voltdb.VoltTable;
+import org.voltdb.VoltTable.ColumnInfo;
+import org.voltdb.VoltType;
 import org.voltdb.dtxn.TransactionState;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.utils.VoltTrace;
+
+import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 
 public abstract class TransactionTask extends SiteTasker
 {
     protected static final VoltLogger execLog = new VoltLogger("EXEC");
     protected static final VoltLogger hostLog = new VoltLogger("HOST");
+
+    protected static final VoltTable m_dummyResult =
+            new VoltTable(new ColumnInfo[] {new ColumnInfo("UNUSED", VoltType.INTEGER)}, 1);
 
     final protected TransactionState m_txnState;
     final protected TransactionTaskQueue m_queue;

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -24,13 +24,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.zip.CRC32;
 
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.Pair;
+import org.voltdb.HybridCrc32;
 import org.voltdb.PlannerStatsCollector;
 import org.voltdb.PlannerStatsCollector.CacheUse;
 import org.voltdb.PrivateVoltTableFactory;
@@ -631,7 +631,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             long[] inputDepIds,
             Object[] parameterSets,
             boolean[] isWriteFrag,
-            CRC32 writeCRC,
+            HybridCrc32 writeCRC,
             String[] sqlTexts,
             long txnId,
             long spHandle,
@@ -693,7 +693,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             long[] inputDepIds,
             Object[] parameterSets,
             boolean[] isWriteFrag,
-            CRC32 writeCRC,
+            HybridCrc32 writeCRC,
             long txnId,
             long spHandle,
             long lastCommittedSpHandle,

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -658,7 +658,6 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
                 }
             }
 
-            int bufferHint = Math.min(m_currentBatchIndex,1);
             FastDeserializer results = coreExecutePlanFragments(m_currentBatchIndex, numFragmentIds, planFragmentIds,
                     inputDepIds, parameterSets, isWriteFrag, writeCRC, txnId, spHandle, lastCommittedSpHandle,
                     uniqueId, undoQuantumToken, traceOn);

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.zip.CRC32;
 
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
@@ -629,6 +630,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             long[] planFragmentIds,
             long[] inputDepIds,
             Object[] parameterSets,
+            boolean[] isWriteFrag,
+            CRC32 writeCRC,
             String[] sqlTexts,
             long txnId,
             long spHandle,
@@ -656,8 +659,9 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             }
 
             int bufferHint = Math.min(m_currentBatchIndex,1);
-            FastDeserializer results = coreExecutePlanFragments(bufferHint, numFragmentIds, planFragmentIds, inputDepIds,
-                    parameterSets, txnId, spHandle, lastCommittedSpHandle, uniqueId, undoQuantumToken, traceOn);
+            FastDeserializer results = coreExecutePlanFragments(bufferHint, numFragmentIds, planFragmentIds,
+                    inputDepIds, parameterSets, isWriteFrag, writeCRC, txnId, spHandle, lastCommittedSpHandle,
+                    uniqueId, undoQuantumToken, traceOn);
 
             if (traceOn) {
                 final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPSITE);
@@ -688,6 +692,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             long[] planFragmentIds,
             long[] inputDepIds,
             Object[] parameterSets,
+            boolean[] isWriteFrag,
+            CRC32 writeCRC,
             long txnId,
             long spHandle,
             long lastCommittedSpHandle,

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -659,7 +659,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             }
 
             int bufferHint = Math.min(m_currentBatchIndex,1);
-            FastDeserializer results = coreExecutePlanFragments(bufferHint, numFragmentIds, planFragmentIds,
+            FastDeserializer results = coreExecutePlanFragments(m_currentBatchIndex, numFragmentIds, planFragmentIds,
                     inputDepIds, parameterSets, isWriteFrag, writeCRC, txnId, spHandle, lastCommittedSpHandle,
                     uniqueId, undoQuantumToken, traceOn);
 
@@ -687,7 +687,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
     }
 
     protected abstract FastDeserializer coreExecutePlanFragments(
-            int bufferHint,
+            int batchIndex,
             int numFragmentIds,
             long[] planFragmentIds,
             long[] inputDepIds,
@@ -953,7 +953,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      */
     protected native int nativeExecutePlanFragments(
             long pointer,
-            int bufferHint,
+            int batchIndex,
             int numFragments,
             long[] planFragmentIds,
             long[] inputDepIds,

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -27,11 +27,11 @@ import java.nio.channels.SocketChannel;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.zip.CRC32;
 
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
 import org.voltdb.BackendTarget;
+import org.voltdb.HybridCrc32;
 import org.voltdb.ParameterSet;
 import org.voltdb.PrivateVoltTableFactory;
 import org.voltdb.StatsSelector;
@@ -926,7 +926,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             long[] inputDepIdsIn,
             final Object[] parameterSets,
             boolean[] isWriteFrag,
-            CRC32 writeCRC,
+            HybridCrc32 writeCRC,
             final long txnId,
             final long spHandle,
             final long lastCommittedSpHandle,
@@ -1002,7 +1002,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             final long[] inputDepIds,
             final Object[] parameterSets,
             boolean[] isWriteFrag,
-            CRC32 writeCRC,
+            HybridCrc32 writeCRC,
             final long txnId,
             final long spHandle,
             final long lastCommittedSpHandle,

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -937,26 +937,20 @@ public class ExecutionEngineIPC extends ExecutionEngine {
         final FastSerializer fser = new FastSerializer();
         try {
             for (int i = 0; i < numFragmentIds; ++i) {
+                Object params = parameterSets[i];
                 // pset can be ByteBuffer or ParameterSet instance
-                if (parameterSets[i] instanceof ByteBuffer) {
-                    ByteBuffer buf = (ByteBuffer) parameterSets[i];
-                    int paramStart = buf.position();
-                    fser.write((ByteBuffer) parameterSets[i]);
-                    if (isWriteFrag[i]) {
-                        buf.position(paramStart);
-                        writeCRC.update(buf);
-                    }
+                int paramStart = fser.getPosition();
+                if (params instanceof ByteBuffer) {
+                    ByteBuffer buf = (ByteBuffer) params;
+                    fser.write(buf);
                 }
                 else {
-                    ParameterSet pset = (ParameterSet) parameterSets[i];
-                    ByteBuffer buf = ByteBuffer.allocate(pset.getSerializedSize());
-                    pset.flattenToBuffer(buf);
-                    buf.flip();
-                    fser.write(buf);
-                    if (isWriteFrag[i]) {
-                        buf.position(0);
-                        writeCRC.update(buf);
-                    }
+                    ParameterSet pset = (ParameterSet) params;
+                    fser.writeParameterSet(pset);
+                }
+                if (isWriteFrag[i]) {
+                    fser.setPosition(paramStart);
+                    writeCRC.update(fser.getBuffer());
                 }
             }
         } catch (final IOException exception) {

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -550,9 +550,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             }
             dirtyBytes.flip();
             // check if anything was changed
-            final boolean dirty  = dirtyBytes.get() > 0;
-            if (dirty)
-                m_dirty = true;
+            m_dirty |= dirtyBytes.get() > 0;
 
             final ByteBuffer resultTablesLengthBytes = ByteBuffer.allocate(4);
             //resultTablesLengthBytes.order(ByteOrder.LITTLE_ENDIAN);
@@ -569,8 +567,9 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                 return resultTablesLengthBytes;
 
             final ByteBuffer resultTablesBuffer = ByteBuffer
-                    .allocate(resultTablesLength);
+                    .allocate(resultTablesLength+4);
             //resultTablesBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            resultTablesBuffer.putInt(resultTablesLength);
             while (resultTablesBuffer.hasRemaining()) {
                 int read = m_socketChannel.read(resultTablesBuffer);
                 if (read == -1) {
@@ -949,8 +948,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                     fser.writeParameterSet(pset);
                 }
                 if (isWriteFrag[i]) {
-                    fser.setPosition(paramStart);
-                    writeCRC.update(fser.getBuffer());
+                    writeCRC.updateFromPosition(paramStart, fser.getContainerNoFlip().b());
                 }
             }
         } catch (final IOException exception) {

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -194,13 +194,6 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
         m_psetBufferC = DBBPool.allocateDirect(size);
         m_psetBuffer = m_psetBufferC.b();
-        int errorCode = nativeSetBuffers(pointer, m_psetBuffer,
-                m_psetBuffer.capacity(),
-                perFragmentStatsBuffer, perFragmentStatsBuffer.capacity(),
-                m_firstDeserializer.buffer(), m_firstDeserializer.buffer().capacity(),
-                m_nextDeserializer.buffer(), m_nextDeserializer.buffer().capacity(),
-                m_exceptionBuffer, m_exceptionBuffer.capacity());
-        checkErrorCode(errorCode);
     }
 
     final void setupPerFragmentStatsBuffer(int size) {
@@ -223,6 +216,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
             // The last request was a batch that was greater than max network buffer size,
             // so let's not hang on to all that memory
             setupPsetBuffer(MAX_PSETBUFFER_SIZE);
+            updateEEBufferPointers();
         }
         else {
             m_psetBuffer.clear();

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -727,7 +727,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     @Override
     public byte[] executeTask(TaskType taskType, ByteBuffer task) throws EEException {
         try {
-            clearPsetAndEnsureCapacity(8);
+            assert(m_psetBuffer.limit() >= 8);
             m_psetBuffer.putLong(0, taskType.taskId);
 
             //Clear is destructive, do it before the native call

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -219,7 +219,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
             setupPsetBuffer(size);
             updateEEBufferPointers();
         }
-        else if (size < MAX_PSETBUFFER_SIZE && m_psetBuffer.capacity() > MAX_PSETBUFFER_SIZE) {
+        else if (m_psetBuffer.capacity() > MAX_PSETBUFFER_SIZE && size < MAX_PSETBUFFER_SIZE) {
             // The last request was a batch that was greater than max network buffer size,
             // so let's not hang on to all that memory
             setupPsetBuffer(MAX_PSETBUFFER_SIZE);
@@ -387,12 +387,13 @@ public class ExecutionEngineJNI extends ExecutionEngine {
         clearPsetAndEnsureCapacity(allPsetSize);
         for (int i = 0; i < batchSize; ++i) {
             int paramStart = m_psetBuffer.position();
-            if (parameterSets[i] instanceof ByteBuffer) {
-                ByteBuffer buf = (ByteBuffer) parameterSets[i];
+            Object param = parameterSets[i];
+            if (param instanceof ByteBuffer) {
+                ByteBuffer buf = (ByteBuffer) param;
                 m_psetBuffer.put(buf);
             }
             else {
-                ParameterSet pset = (ParameterSet) parameterSets[i];
+                ParameterSet pset = (ParameterSet) param;
                 try {
                     pset.flattenToBuffer(m_psetBuffer);
                 }
@@ -408,7 +409,6 @@ public class ExecutionEngineJNI extends ExecutionEngine {
                 m_psetBuffer.position(paramStart);
                 writeCRC.update(m_psetBuffer);
                 assert(m_psetBuffer.remaining() == 0);
-                m_psetBuffer.limit(allPsetSize);
             }
         }
         // checkMaxFsSize();

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -86,8 +86,9 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
     /** Create a ByteBuffer (in a container) for serializing arguments to C++. Use a direct
     ByteBuffer as it will be passed directly to the C++ code. */
-    private BBContainer psetBufferC = null;
-    private ByteBuffer psetBuffer = null;
+    private static final int MAX_PSETBUFFER_SIZE = 50 * 1024 * 1024; // 50MB
+    private BBContainer m_psetBufferC = null;
+    private ByteBuffer m_psetBuffer = null;
 
     /** Create a ByteBuffer (in a container) for the C++ side to share time measurements and
         the success / fail status for fragments in a batch. */
@@ -177,7 +178,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
     final void updateEEBufferPointers() {
         int errorCode = nativeSetBuffers(pointer,
-                psetBuffer, psetBuffer.capacity(),
+                m_psetBuffer, m_psetBuffer.capacity(),
                 perFragmentStatsBuffer, perFragmentStatsBuffer.capacity(),
                 m_firstDeserializer.buffer(), m_firstDeserializer.buffer().capacity(),
                 m_nextDeserializer.buffer(), m_nextDeserializer.buffer().capacity(),
@@ -186,15 +187,15 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     }
 
     final void setupPsetBuffer(int size) {
-        if (psetBuffer != null) {
-            psetBufferC.discard();
-            psetBuffer = null;
+        if (m_psetBuffer != null) {
+            m_psetBufferC.discard();
+            m_psetBuffer = null;
         }
 
-        psetBufferC = DBBPool.allocateDirect(size);
-        psetBuffer = psetBufferC.b();
-        int errorCode = nativeSetBuffers(pointer, psetBuffer,
-                psetBuffer.capacity(),
+        m_psetBufferC = DBBPool.allocateDirect(size);
+        m_psetBuffer = m_psetBufferC.b();
+        int errorCode = nativeSetBuffers(pointer, m_psetBuffer,
+                m_psetBuffer.capacity(),
                 perFragmentStatsBuffer, perFragmentStatsBuffer.capacity(),
                 m_firstDeserializer.buffer(), m_firstDeserializer.buffer().capacity(),
                 m_nextDeserializer.buffer(), m_nextDeserializer.buffer().capacity(),
@@ -213,13 +214,18 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     }
 
     final void clearPsetAndEnsureCapacity(int size) {
-        assert(psetBuffer != null);
-        if (size > psetBuffer.capacity()) {
+        assert(m_psetBuffer != null);
+        if (size > m_psetBuffer.capacity()) {
             setupPsetBuffer(size);
             updateEEBufferPointers();
         }
+        else if (size < MAX_PSETBUFFER_SIZE && m_psetBuffer.capacity() > MAX_PSETBUFFER_SIZE) {
+            // The last request was a batch that was greater than max network buffer size,
+            // so let's not hang on to all that memory
+            setupPsetBuffer(MAX_PSETBUFFER_SIZE);
+        }
         else {
-            psetBuffer.clear();
+            m_psetBuffer.clear();
         }
     }
 
@@ -274,8 +280,8 @@ public class ExecutionEngineJNI extends ExecutionEngine {
         m_nextDeserializerBufferOrigin.discard();
         m_exceptionBuffer = null;
         m_exceptionBufferOrigin.discard();
-        psetBufferC.discard();
-        psetBuffer = null;
+        m_psetBufferC.discard();
+        m_psetBuffer = null;
         perFragmentStatsBufferC.discard();
         perFragmentStatsBuffer = null;
         LOG.trace("Released Execution Engine.");
@@ -378,15 +384,15 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
         clearPsetAndEnsureCapacity(allPsetSize);
         for (int i = 0; i < batchSize; ++i) {
-            int paramStart = psetBuffer.position();
+            int paramStart = m_psetBuffer.position();
             if (parameterSets[i] instanceof ByteBuffer) {
                 ByteBuffer buf = (ByteBuffer) parameterSets[i];
-                psetBuffer.put(buf);
+                m_psetBuffer.put(buf);
             }
             else {
                 ParameterSet pset = (ParameterSet) parameterSets[i];
                 try {
-                    pset.flattenToBuffer(psetBuffer);
+                    pset.flattenToBuffer(m_psetBuffer);
                 }
                 catch (final IOException exception) {
                     throw new RuntimeException("Error serializing parameters for SQL batch element: " +
@@ -396,11 +402,11 @@ public class ExecutionEngineJNI extends ExecutionEngine {
                 }
             }
             if (isWriteFrag[i]) {
-                psetBuffer.limit(psetBuffer.position());
-                psetBuffer.position(paramStart);
-                writeCRC.update(psetBuffer);
-                assert(psetBuffer.remaining() == 0);
-                psetBuffer.limit(allPsetSize);
+                m_psetBuffer.limit(m_psetBuffer.position());
+                m_psetBuffer.position(paramStart);
+                writeCRC.update(m_psetBuffer);
+                assert(m_psetBuffer.remaining() == 0);
+                m_psetBuffer.limit(allPsetSize);
             }
         }
         // checkMaxFsSize();
@@ -427,8 +433,8 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
         try {
             checkErrorCode(errorCode);
-            m_usingFallbackBuffer = m_fallbackBuffer == null;
-            FastDeserializer fds = m_usingFallbackBuffer ? targetDeserializer : new FastDeserializer(m_fallbackBuffer);
+            m_usingFallbackBuffer = m_fallbackBuffer != null;
+            FastDeserializer fds = m_usingFallbackBuffer ? new FastDeserializer(m_fallbackBuffer) : targetDeserializer;
             assert(fds != null);
             try {
                 // check if anything was changed
@@ -664,7 +670,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
         // serialize the param set
         clearPsetAndEnsureCapacity(parameterSet.getSerializedSize());
         try {
-            parameterSet.flattenToBuffer(psetBuffer);
+            parameterSet.flattenToBuffer(m_psetBuffer);
         } catch (final IOException exception) {
             throw new RuntimeException(exception); // can't happen
         }
@@ -681,7 +687,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
             // serialize the param set
             clearPsetAndEnsureCapacity(parameterSet.getSerializedSize());
             try {
-                parameterSet.flattenToBuffer(psetBuffer);
+                parameterSet.flattenToBuffer(m_psetBuffer);
             } catch (final IOException exception) {
                 throw new RuntimeException(exception); // can't happen
             }
@@ -719,7 +725,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     @Override
     public byte[] executeTask(TaskType taskType, ByteBuffer task) throws EEException {
         try {
-            psetBuffer.putLong(0, taskType.taskId);
+            m_psetBuffer.putLong(0, taskType.taskId);
 
             //Clear is destructive, do it before the native call
             m_nextDeserializer.clear();
@@ -735,7 +741,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     @Override
     public ByteBuffer getParamBufferForExecuteTask(int requiredCapacity) {
         clearPsetAndEnsureCapacity(8 + requiredCapacity);
-        psetBuffer.position(8);
-        return psetBuffer;
+        m_psetBuffer.position(8);
+        return m_psetBuffer;
     }
 }

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -399,11 +399,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
                 }
             }
             if (isWriteFrag[i]) {
-                m_psetBuffer.limit(m_psetBuffer.position());
-                m_psetBuffer.position(paramStart);
-                writeCRC.update(m_psetBuffer);
-                assert(m_psetBuffer.remaining() == 0);
-                m_psetBuffer.limit(m_psetBuffer.capacity());
+                writeCRC.updateFromPosition(paramStart, m_psetBuffer);
             }
         }
         // checkMaxFsSize();
@@ -435,11 +431,9 @@ public class ExecutionEngineJNI extends ExecutionEngine {
             assert(fds != null);
             try {
                 // check if anything was changed
-                final boolean dirty = fds.readBoolean();
-                if (dirty)
-                    m_dirty = true;
+                m_dirty |= fds.readBoolean();
             } catch (final IOException ex) {
-                LOG.error("Failed to deserialze result table" + ex);
+                LOG.error("Failed to deserialize result table" + ex);
                 throw new EEException(ERRORCODE_WRONG_SERIALIZED_BYTES);
             }
 

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -280,6 +280,8 @@ public class ExecutionEngineJNI extends ExecutionEngine {
         m_nextDeserializerBufferOrigin.discard();
         m_exceptionBuffer = null;
         m_exceptionBufferOrigin.discard();
+        m_emptyDeserializer = null;
+        m_emptyDeserializerBuffer.discard();
         m_psetBufferC.discard();
         m_psetBuffer = null;
         perFragmentStatsBufferC.discard();
@@ -725,6 +727,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     @Override
     public byte[] executeTask(TaskType taskType, ByteBuffer task) throws EEException {
         try {
+            clearPsetAndEnsureCapacity(8);
             m_psetBuffer.putLong(0, taskType.taskId);
 
             //Clear is destructive, do it before the native call

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -20,12 +20,12 @@ package org.voltdb.jni;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.zip.CRC32;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
+import org.voltdb.HybridCrc32;
 import org.voltdb.ParameterSet;
 import org.voltdb.PrivateVoltTableFactory;
 import org.voltdb.StatsSelector;
@@ -354,7 +354,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
             final long[] inputDepIds,
             final Object[] parameterSets,
             boolean[] isWriteFrag,
-            CRC32 writeCRC,
+            HybridCrc32 writeCRC,
             final long txnId,
             final long spHandle,
             final long lastCommittedSpHandle,
@@ -409,6 +409,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
                 m_psetBuffer.position(paramStart);
                 writeCRC.update(m_psetBuffer);
                 assert(m_psetBuffer.remaining() == 0);
+                m_psetBuffer.limit(m_psetBuffer.capacity());
             }
         }
         // checkMaxFsSize();

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -33,6 +33,7 @@ import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
 import org.voltdb.exceptions.EEException;
 import org.voltdb.exceptions.SQLException;
+import org.voltdb.messaging.FastDeserializer;
 
 public class MockExecutionEngine extends ExecutionEngine {
 
@@ -44,7 +45,8 @@ public class MockExecutionEngine extends ExecutionEngine {
     }
 
     @Override
-    protected VoltTable[] coreExecutePlanFragments(
+    protected FastDeserializer coreExecutePlanFragments(
+            final int bufferHint,
             final int numFragmentIds,
             final long[] planFragmentIds,
             final long[] inputDepIds,
@@ -116,7 +118,9 @@ public class MockExecutionEngine extends ExecutionEngine {
                   new VoltTable.ColumnInfo("foo", VoltType.INTEGER)
         });
         vt.addRow(Integer.valueOf(1));
-        return new VoltTable[] { vt };
+        ByteBuffer buf = ByteBuffer.allocate(vt.getSerializedSize());
+        vt.flattenToBuffer(buf);
+        return new FastDeserializer(buf);
     }
 
     @Override

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.zip.CRC32;
 
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
@@ -51,6 +52,8 @@ public class MockExecutionEngine extends ExecutionEngine {
             final long[] planFragmentIds,
             final long[] inputDepIds,
             final Object[] parameterSets,
+            final boolean[] isWriteFrag,
+            final CRC32 writeCRC,
             final long txnId,
             final long spHandle,
             final long lastCommittedSpHandle,

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -22,10 +22,10 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.zip.CRC32;
 
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
+import org.voltdb.HybridCrc32;
 import org.voltdb.ParameterSet;
 import org.voltdb.StatsSelector;
 import org.voltdb.TableStreamType;
@@ -53,7 +53,7 @@ public class MockExecutionEngine extends ExecutionEngine {
             final long[] inputDepIds,
             final Object[] parameterSets,
             final boolean[] isWriteFrag,
-            final CRC32 writeCRC,
+            final HybridCrc32 writeCRC,
             final long txnId,
             final long spHandle,
             final long lastCommittedSpHandle,

--- a/src/frontend/org/voltdb/messaging/FastSerializer.java
+++ b/src/frontend/org/voltdb/messaging/FastSerializer.java
@@ -193,8 +193,6 @@ public class FastSerializer implements DataOutput {
      * to the shared buffer when the parameter buffer grows.
      */
     public BBContainer getContainerNoFlip() {
-        assert(isDirect == true);
-        assert(buffer.b().isDirect());
         return buffer;
     }
 

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
@@ -183,9 +183,10 @@ public class ExecuteTask extends VoltSystemProcedure {
             default:
                 throw new VoltAbortException("Unable to find the task associated with the given task id");
             }
-            return new DependencyPair(DEP_executeTask, result);
+            return new DependencyPair.TableDependencyPair(DEP_executeTask, result);
         } else if (fragmentId == SysProcFragmentId.PF_executeTaskAggregate) {
-            return new DependencyPair(DEP_executeTaskAggregate, VoltTableUtil.unionTables(dependencies.get(DEP_executeTask)));
+            VoltTable unionTable = VoltTableUtil.unionTables(dependencies.get(DEP_executeTask));
+            return new DependencyPair.TableDependencyPair(DEP_executeTaskAggregate, unionTable);
         }
         assert false;
         return null;

--- a/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
+++ b/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
@@ -98,7 +98,7 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
                 // report -1 rows inserted, though this might be false
                 result.addRow(-1);
             }
-            return new DependencyPair(DEP_distribute, result);
+            return new DependencyPair.TableDependencyPair(DEP_distribute, result);
 
         } else if (fragmentId == SysProcFragmentId.PF_aggregate) {
             long[] modifiedTuples = new long[context.getNumberOfPartitions()];
@@ -128,7 +128,7 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
                 rowsModified += l;
 
             result.addRow(rowsModified);
-            return new DependencyPair(DEP_aggregate, result);
+            return new DependencyPair.TableDependencyPair(DEP_aggregate, result);
         }
 
         // must handle every dependency id.

--- a/src/frontend/org/voltdb/sysprocs/PrepareShutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/PrepareShutdown.java
@@ -73,7 +73,7 @@ public class PrepareShutdown extends Pause {
                     LOG.debug("@PrepareShutdown returning sigil " + ll(m_stat.getMzxid()));
                 }
             }
-            return new DependencyPair(DEP_prepareShutdown, t);
+            return new DependencyPair.TableDependencyPair(DEP_prepareShutdown, t);
 
         } else if (fragmentId == PF_prepareShutdownAggregate) {
 
@@ -89,7 +89,7 @@ public class PrepareShutdown extends Pause {
                 t.addRow(zktxnid);
             }
 
-            return new DependencyPair(DEP_prepareShutdonwAggregate, t);
+            return new DependencyPair.TableDependencyPair(DEP_prepareShutdonwAggregate, t);
 
         } else {
 

--- a/src/frontend/org/voltdb/sysprocs/Quiesce.java
+++ b/src/frontend/org/voltdb/sysprocs/Quiesce.java
@@ -59,12 +59,12 @@ public class Quiesce extends VoltSystemProcedure {
                 context.getSiteProcedureConnection().quiesce();
                 VoltTable results = new VoltTable(new ColumnInfo("id", VoltType.BIGINT));
                 results.addRow(context.getSiteId());
-                return new DependencyPair(DEP_SITES, results);
+                return new DependencyPair.TableDependencyPair(DEP_SITES, results);
             }
             else if (fragmentId == SysProcFragmentId.PF_quiesce_processed_sites) {
                 VoltTable dummy = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
                 dummy.addRow(VoltSystemProcedure.STATUS_OK);
-                return new DependencyPair(DEP_PROCESSED_SITES, dummy);
+                return new DependencyPair.TableDependencyPair(DEP_PROCESSED_SITES, dummy);
             }
         }
         catch (Exception ex) {

--- a/src/frontend/org/voltdb/sysprocs/Shutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/Shutdown.java
@@ -81,12 +81,12 @@ public class Shutdown extends VoltSystemProcedure {
                 m_failsafe.start();
                 new VoltLogger("HOST").warn("VoltDB shutdown operation requested and in progress.  Cluster will terminate shortly.");
             }
-            return new DependencyPair(DEP_shutdownSync,
-                    new VoltTable(new ColumnInfo[] { new ColumnInfo("HA", VoltType.STRING) } ));
+            VoltTable rslt = new VoltTable(new ColumnInfo[] { new ColumnInfo("HA", VoltType.STRING) });
+            return new DependencyPair.TableDependencyPair(DEP_shutdownSync, rslt);
         }
         else if (fragmentId == SysProcFragmentId.PF_shutdownSyncDone) {
-            return new DependencyPair(DEP_shutdownSyncDone,
-                    new VoltTable(new ColumnInfo[] { new ColumnInfo("HA", VoltType.STRING) } ));
+            VoltTable rslt = new VoltTable(new ColumnInfo[] { new ColumnInfo("HA", VoltType.STRING) });
+            return new DependencyPair.TableDependencyPair(DEP_shutdownSyncDone, rslt);
         }
         else if (fragmentId == SysProcFragmentId.PF_shutdownCommand) {
             Thread shutdownThread = new Thread() {

--- a/src/frontend/org/voltdb/sysprocs/SystemInformation.java
+++ b/src/frontend/org/voltdb/sysprocs/SystemInformation.java
@@ -123,12 +123,12 @@ public class SystemInformation extends VoltSystemProcedure
                                        new ColumnInfo("KEY", VoltType.STRING),
                                        new ColumnInfo("VALUE", VoltType.STRING));
             }
-            return new DependencyPair(DEP_DISTRIBUTE, result);
+            return new DependencyPair.TableDependencyPair(DEP_DISTRIBUTE, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_systemInformationOverviewAggregate)
         {
             VoltTable result = VoltTableUtil.unionTables(dependencies.get(DEP_DISTRIBUTE));
-            return new DependencyPair(DEP_AGGREGATE, result);
+            return new DependencyPair.TableDependencyPair(DEP_AGGREGATE, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_systemInformationDeployment)
         {
@@ -144,7 +144,7 @@ public class SystemInformation extends VoltSystemProcedure
             {
                 result = new VoltTable(clusterInfoSchema);
             }
-            return new DependencyPair(DEP_systemInformationDeployment, result);
+            return new DependencyPair.TableDependencyPair(DEP_systemInformationDeployment, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_systemInformationAggregate)
         {
@@ -183,7 +183,7 @@ public class SystemInformation extends VoltSystemProcedure
                     }
                 }
             }
-            return new DependencyPair(DEP_systemInformationAggregate, result);
+            return new DependencyPair.TableDependencyPair(DEP_systemInformationAggregate, result);
         }
         assert(false);
         return null;

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationCatalog.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationCatalog.java
@@ -254,7 +254,7 @@ public class UpdateApplicationCatalog extends VoltSystemProcedure {
 
             // Don't actually care about the returned table, just need to send something
             // back to the MPI scoreboard
-            DependencyPair success = new DependencyPair(DEP_updateCatalogSync,
+            DependencyPair success = new DependencyPair.TableDependencyPair(DEP_updateCatalogSync,
                     new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
 
             if ( ! context.isLowestSiteId()) {
@@ -329,7 +329,7 @@ public class UpdateApplicationCatalog extends VoltSystemProcedure {
             // back to the MPI scoreboard
             log.info("Site " + CoreUtils.hsIdToString(m_site.getCorrespondingSiteId()) +
                     " acknowledged data and catalog prechecks.");
-            return new DependencyPair(DEP_updateCatalogSyncAggregate,
+            return new DependencyPair.TableDependencyPair(DEP_updateCatalogSyncAggregate,
                     new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
         }
         else if (fragmentId == SysProcFragmentId.PF_updateCatalog) {
@@ -402,11 +402,11 @@ public class UpdateApplicationCatalog extends VoltSystemProcedure {
 
             VoltTable result = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
             result.addRow(VoltSystemProcedure.STATUS_OK);
-            return new DependencyPair(DEP_updateCatalog, result);
+            return new DependencyPair.TableDependencyPair(DEP_updateCatalog, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_updateCatalogAggregate) {
             VoltTable result = VoltTableUtil.unionTables(dependencies.get(DEP_updateCatalog));
-            return new DependencyPair(DEP_updateCatalogAggregate, result);
+            return new DependencyPair.TableDependencyPair(DEP_updateCatalogAggregate, result);
         }
         else {
             VoltDB.crashLocalVoltDB(

--- a/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
@@ -93,7 +93,7 @@ public class UpdateSettings extends VoltSystemProcedure {
 
         if (fragmentId == SysProcFragmentId.PF_updateSettingsBarrier) {
 
-            DependencyPair success = new DependencyPair(DEP_updateSettingsBarrier,
+            DependencyPair success = new DependencyPair.TableDependencyPair(DEP_updateSettingsBarrier,
                     new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
             if (log.isInfoEnabled()) {
                 log.info("Site " + CoreUtils.hsIdToString(m_site.getCorrespondingSiteId()) +
@@ -117,7 +117,7 @@ public class UpdateSettings extends VoltSystemProcedure {
                 throw new SettingsException(msg, e);
             }
             log.info("Saved new cluster settings state");
-            return new DependencyPair(DEP_updateSettingsBarrierAggregate,
+            return new DependencyPair.TableDependencyPair(DEP_updateSettingsBarrierAggregate,
                     getVersionResponse(stat.getVersion()));
 
         } else if (fragmentId == SysProcFragmentId.PF_updateSettings) {
@@ -134,12 +134,12 @@ public class UpdateSettings extends VoltSystemProcedure {
 
             VoltTable result = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
             result.addRow(VoltSystemProcedure.STATUS_OK);
-            return new DependencyPair(DEP_updateSettings, result);
+            return new DependencyPair.TableDependencyPair(DEP_updateSettings, result);
 
         } else if (fragmentId == SysProcFragmentId.PF_updateSettingsAggregate) {
 
             VoltTable result = VoltTableUtil.unionTables(dependencies.get(DEP_updateSettings));
-            return new DependencyPair(DEP_updateSettingsAggregate, result);
+            return new DependencyPair.TableDependencyPair(DEP_updateSettingsAggregate, result);
 
         } else {
             VoltDB.crashLocalVoltDB(

--- a/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
+++ b/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
@@ -93,13 +93,13 @@ public class ValidatePartitioning extends VoltSystemProcedure {
             for (int ii = 0; ii < tableNames.size(); ii++) {
                 results.addRow(context.getHostId(), CoreUtils.getSiteIdFromHSId(context.getSiteId()), context.getPartitionId(), tableNames.get(ii), mispartitionedCounts[ii]);
             }
-            return new DependencyPair( DEP_validatePartitioning, results);
+            return new DependencyPair.TableDependencyPair( DEP_validatePartitioning, results);
 
         } else if (fragmentId == SysProcFragmentId.PF_validatePartitioningResults) {
 
             assert (dependencies.size() > 0);
             final VoltTable results = VoltTableUtil.unionTables(dependencies.get(DEP_validatePartitioning));
-            return new DependencyPair( DEP_validatePartitioningResults, results);
+            return new DependencyPair.TableDependencyPair( DEP_validatePartitioningResults, results);
 
         } else if (fragmentId == SysProcFragmentId.PF_matchesHashinator) {
 
@@ -119,13 +119,13 @@ public class ValidatePartitioning extends VoltSystemProcedure {
                     context.getPartitionId(),
                     givenConfigurationSignature == TheHashinator.getConfigurationSignature() ? (byte)1 : (byte)0);
 
-            return new DependencyPair(DEP_matchesHashinator, matchesHashinator);
+            return new DependencyPair.TableDependencyPair(DEP_matchesHashinator, matchesHashinator);
 
         } else if (fragmentId == SysProcFragmentId.PF_matchesHashinatorResults) {
 
             assert (dependencies.size() > 0);
             final VoltTable results = VoltTableUtil.unionTables(dependencies.get(DEP_matchesHashinator));
-            return new DependencyPair( DEP_matchesHashinatorResults, results);
+            return new DependencyPair.TableDependencyPair( DEP_matchesHashinatorResults, results);
 
         }
         assert (false);

--- a/tests/ee/execution/add_drop_table.cpp
+++ b/tests/ee/execution/add_drop_table.cpp
@@ -49,6 +49,7 @@ class AddDropTableTest : public Test {
         m_exceptionBuffer = new char[4096];
         m_engine->setBuffers(NULL, 0,
                              NULL, 0,
+                             NULL, 0,
                              m_resultBuffer, 1024 * 1024 * 2,
                              m_exceptionBuffer, 4096);
 

--- a/tests/ee/indexes/index_test.cpp
+++ b/tests/ee/indexes/index_test.cpp
@@ -175,7 +175,7 @@ public:
 
         m_engine = new VoltDBEngine();
         m_exceptionBuffer = new char[4096];
-        m_engine->setBuffers(NULL, 0, NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
+        m_engine->setBuffers(NULL, 0, NULL, 0, NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
         int partitionCount = 1;
         m_engine->initialize(0, 0, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false);
         m_engine->updateHashinator(HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
@@ -311,7 +311,7 @@ public:
         indexes.push_back(index);
         m_engine = new VoltDBEngine();
         m_exceptionBuffer = new char[4096];
-        m_engine->setBuffers(NULL, 0, NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
+        m_engine->setBuffers(NULL, 0, NULL, 0, NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
         int partitionCount = 1;
         m_engine->initialize(0, 0, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false);
         m_engine->updateHashinator(HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);

--- a/tests/ee/storage/constraint_test.cpp
+++ b/tests/ee/storage/constraint_test.cpp
@@ -79,7 +79,7 @@ public:
     ConstraintTest() : table(NULL) {
         this->database_id = 1000;
         m_exceptionBuffer = new char[4096];
-        m_engine.setBuffers(NULL, 0, NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
+        m_engine.setBuffers(NULL, 0, NULL, 0, NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
         m_engine.resetReusedResultOutputBuffer();
         int partitionCount = 1;
         m_engine.initialize(0, 0, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false);

--- a/tests/ee/test_utils/plan_testing_baseclass.h
+++ b/tests/ee/test_utils/plan_testing_baseclass.h
@@ -139,6 +139,7 @@ public:
         m_exception_buffer.reset(new char[m_smallBufferSize]);
         m_engine->setBuffers(m_parameter_buffer.get(), m_smallBufferSize,
                              m_per_fragment_stats_buffer.get(), m_smallBufferSize,
+                             NULL, 0,
                              m_result_buffer.get(), m_resultBufferSize,
                              m_exception_buffer.get(), m_smallBufferSize);
         m_engine->resetReusedResultOutputBuffer();

--- a/tests/frontend/org/voltdb/TestAdhocAlterTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocAlterTable.java
@@ -1099,7 +1099,7 @@ public class TestAdhocAlterTable extends AdhocDDLTestBase {
 
             // Check that the unique absolute value constraint applies
             m_client.callProcedure("FOO.insert", 1, 1, 1, 1);
-            boolean threw = true;
+            boolean threw = false;
             try {
                 m_client.callProcedure("FOO.insert", -1, -1, -1, -1);
             }

--- a/tests/frontend/org/voltdb/TestTwoSitePlans.java
+++ b/tests/frontend/org/voltdb/TestTwoSitePlans.java
@@ -197,6 +197,8 @@ public class TestTwoSitePlans extends TestCase {
                 new long[] { CatalogUtil.getUniqueIdForFragment(insertFrag) },
                 null,
                 new ParameterSet[] { params },
+                new boolean[] { false },
+                null,
                 new String[] { selectStmt.getSqltext() },
                 1,
                 1,
@@ -215,6 +217,8 @@ public class TestTwoSitePlans extends TestCase {
                 new long[] { CatalogUtil.getUniqueIdForFragment(insertFrag) },
                 null,
                 new ParameterSet[] { params },
+                new boolean[] { false },
+                null,
                 new String[] { insertStmt.getSqltext() },
                 2,
                 2,
@@ -237,6 +241,8 @@ public class TestTwoSitePlans extends TestCase {
                 new long[] { CatalogUtil.getUniqueIdForFragment(selectBottomFrag) },
                 null,
                 new ParameterSet[] { params },
+                new boolean[] { false },
+                null,
                 new String[] { selectStmt.getSqltext() },
                 3, 3, 2, 42, Long.MAX_VALUE, false);
         VoltTable dependency1 = null;
@@ -256,6 +262,8 @@ public class TestTwoSitePlans extends TestCase {
                 new long[] { CatalogUtil.getUniqueIdForFragment(selectBottomFrag) },
                 null,
                 new ParameterSet[] { params },
+                new boolean[] { false },
+                null,
                 new String[] { selectStmt.getSqltext() },
                 3, 3, 2, 42, Long.MAX_VALUE, false);
         VoltTable dependency2 = null;
@@ -278,6 +286,8 @@ public class TestTwoSitePlans extends TestCase {
                 new long[] { CatalogUtil.getUniqueIdForFragment(selectTopFrag) },
                 new long[] { outDepId },
                 new ParameterSet[] { params },
+                new boolean[] { false },
+                null,
                 new String[] { selectStmt.getSqltext() },
                 3, 3, 2, 42, Long.MAX_VALUE, false);
 

--- a/tests/frontend/org/voltdb/TestTwoSitePlans.java
+++ b/tests/frontend/org/voltdb/TestTwoSitePlans.java
@@ -42,6 +42,7 @@ import org.voltdb.catalog.Statement;
 import org.voltdb.dtxn.DtxnConstants;
 import org.voltdb.jni.ExecutionEngine;
 import org.voltdb.jni.ExecutionEngineJNI;
+import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.planner.ActivePlanRepository;
 import org.voltdb.utils.BuildDirectoryUtils;
 import org.voltdb.utils.CatalogUtil;
@@ -191,8 +192,7 @@ public class TestTwoSitePlans extends TestCase {
 
         // insert some data
         ParameterSet params = ParameterSet.fromArrayNoCopy(1L, 1L, 1L);
-
-        VoltTable[] results = ee2.executePlanFragments(
+        FastDeserializer fragResult2 = ee2.executePlanFragments(
                 1,
                 new long[] { CatalogUtil.getUniqueIdForFragment(insertFrag) },
                 null,
@@ -203,12 +203,14 @@ public class TestTwoSitePlans extends TestCase {
                 0,
                 42,
                 Long.MAX_VALUE, false);
-        assert(results.length == 1);
+        // ignore totalsize field in message
+        fragResult2.readInt();
+        VoltTable[] results = TableHelper.convertBackedBufferToTables(fragResult2.buffer(), 1);
         assert(results[0].asScalarLong() == 1L);
 
         params = ParameterSet.fromArrayNoCopy(2L, 2L, 2L);
 
-        results = ee1.executePlanFragments(
+        FastDeserializer fragResult1 = ee1.executePlanFragments(
                 1,
                 new long[] { CatalogUtil.getUniqueIdForFragment(insertFrag) },
                 null,
@@ -219,7 +221,10 @@ public class TestTwoSitePlans extends TestCase {
                 1,
                 42,
                 Long.MAX_VALUE, false);
-        assert(results.length == 1);
+        // ignore totalsize field in message
+        fragResult1.readInt();
+        results = TableHelper.convertBackedBufferToTables(fragResult1.buffer(), 1);
+        assert (fragResult1.buffer() != fragResult2.buffer());
         assert(results[0].asScalarLong() == 1L);
     }
 
@@ -227,28 +232,38 @@ public class TestTwoSitePlans extends TestCase {
         ParameterSet params = ParameterSet.emptyParameterSet();
 
         int outDepId = 1 | DtxnConstants.MULTIPARTITION_DEPENDENCY;
-        VoltTable dependency1 = ee1.executePlanFragments(
+        FastDeserializer fragResult1 = ee1.executePlanFragments(
                 1,
                 new long[] { CatalogUtil.getUniqueIdForFragment(selectBottomFrag) },
                 null,
                 new ParameterSet[] { params },
                 new String[] { selectStmt.getSqltext() },
-                3, 3, 2, 42, Long.MAX_VALUE, false)[0];
+                3, 3, 2, 42, Long.MAX_VALUE, false);
+        VoltTable dependency1 = null;
         try {
+            // ignore totalsize field in message
+            fragResult1.readInt();
+
+            dependency1 = TableHelper.convertBackedBufferToTables(fragResult1.buffer(), 1)[0];
             System.out.println(dependency1.toString());
         } catch (Exception e) {
             e.printStackTrace();
         }
         assertTrue(dependency1 != null);
 
-        VoltTable dependency2 = ee2.executePlanFragments(
+        FastDeserializer fragResult2 = ee2.executePlanFragments(
                 1,
                 new long[] { CatalogUtil.getUniqueIdForFragment(selectBottomFrag) },
                 null,
                 new ParameterSet[] { params },
                 new String[] { selectStmt.getSqltext() },
-                3, 3, 2, 42, Long.MAX_VALUE, false)[0];
+                3, 3, 2, 42, Long.MAX_VALUE, false);
+        VoltTable dependency2 = null;
         try {
+            // ignore totalsize field in message
+            fragResult2.readInt();
+
+            dependency2 = TableHelper.convertBackedBufferToTables(fragResult2.buffer(), 1)[0];
             System.out.println(dependency2.toString());
         } catch (Exception e) {
             e.printStackTrace();
@@ -258,14 +273,21 @@ public class TestTwoSitePlans extends TestCase {
         ee1.stashDependency(outDepId, dependency1);
         ee1.stashDependency(outDepId, dependency2);
 
-        dependency1 = ee1.executePlanFragments(
+        FastDeserializer fragResult3 = ee1.executePlanFragments(
                 1,
                 new long[] { CatalogUtil.getUniqueIdForFragment(selectTopFrag) },
                 new long[] { outDepId },
                 new ParameterSet[] { params },
                 new String[] { selectStmt.getSqltext() },
-                3, 3, 2, 42, Long.MAX_VALUE, false)[0];
+                3, 3, 2, 42, Long.MAX_VALUE, false);
+
+        // The underlying buffers are being reused
+        assert(fragResult1.buffer() == fragResult3.buffer());
         try {
+            // ignore totalsize field in message
+            fragResult3.readInt();
+
+            dependency1 = TableHelper.convertBackedBufferToTables(fragResult3.buffer(), 1)[0];
             System.out.println("Final Result");
             System.out.println(dependency1.toString());
         } catch (Exception e) {

--- a/tests/frontend/org/voltdb/iv2/TestMpTransactionState.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpTransactionState.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.messaging.VoltMessage;
+import org.voltdb.DependencyPair;
 import org.voltdb.ParameterSet;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.StoredProcedureInvocation;
@@ -133,15 +134,15 @@ public class TestMpTransactionState extends TestCase
                 if (rollback && i == (remoteHSIds.length - 1)) {
                     resp.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR,
                                    new EEException(1234));
-                    resp.addDependency(distributedOutputDepIds.get(0),
-                            new VoltTable(new ColumnInfo[] {new ColumnInfo("UNUSED", VoltType.INTEGER)}, 1));
+                    resp.addDependency(new DependencyPair.TableDependencyPair(distributedOutputDepIds.get(0),
+                            new VoltTable(new ColumnInfo[] {new ColumnInfo("UNUSED", VoltType.INTEGER)}, 1)));
                 }
                 else {
                     resp.setStatus(FragmentResponseMessage.SUCCESS, null);
                     for (int j = 0; j < distributedOutputDepIds.size(); j++) {
-                        resp.addDependency(distributedOutputDepIds.get(j),
+                        resp.addDependency(new DependencyPair.TableDependencyPair(distributedOutputDepIds.get(j),
                                            new VoltTable(new VoltTable.ColumnInfo("BOGO",
-                                                                                  VoltType.BIGINT)));
+                                                                                  VoltType.BIGINT))));
                     }
                 }
                 System.out.println("RESPONSE: " + resp);
@@ -173,9 +174,9 @@ public class TestMpTransactionState extends TestCase
         resp.m_sourceHSId = buddyHSId;
         resp.setStatus(FragmentResponseMessage.SUCCESS, null);
         for (int j = 0; j < batchSize ; j++) {
-            resp.addDependency(depsToResumeList.get(j),
+            resp.addDependency(new DependencyPair.TableDependencyPair(depsToResumeList.get(j),
                                new VoltTable(new VoltTable.ColumnInfo("BOGO",
-                                                                      VoltType.BIGINT)));
+                                                                      VoltType.BIGINT))));
         }
         System.out.println("BORROW RESPONSE: " + resp);
         plan.generatedResponses.add(resp);

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -439,6 +439,8 @@ public class TestFragmentProgressUpdate extends TestCase {
         long[] fragIds = new long[numFragsToExecute];
         ParameterSet[] paramSets = new ParameterSet[numFragsToExecute];
         String[] sqlTexts = new String[numFragsToExecute];
+        boolean[] writeFrags = new boolean[numFragsToExecute];
+        for (boolean writeFrag : writeFrags) { writeFrag = false; }
         createExecutionEngineInputs(stmtName, fragIds, paramSets, sqlTexts);
 
         // Replace the normal logger with a mocked one, so we can verify the message
@@ -478,7 +480,7 @@ public class TestFragmentProgressUpdate extends TestCase {
                     fragIds,
                     null,
                     paramSets,
-                    new boolean[] { false },
+                    writeFrags,
                     null,
                     sqlTexts,
                     3, 3, 2, 42,

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -25,6 +25,7 @@ package org.voltdb.jni;
 
 import static org.mockito.Matchers.contains;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 
@@ -49,7 +50,6 @@ import org.voltdb.catalog.Statement;
 import org.voltdb.planner.ActivePlanRepository;
 import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.Encoder;
-import static org.mockito.Mockito.verify;
 
 public class TestFragmentProgressUpdate extends TestCase {
 
@@ -132,6 +132,8 @@ public class TestFragmentProgressUpdate extends TestCase {
                 new long[] { CatalogUtil.getUniqueIdForFragment(selectBottomFrag) },
                 null,
                 new ParameterSet[] { params },
+                new boolean[] { false },
+                null,
                 new String[] { selectStmt.getSqltext() },
                 3, 3, 2, 42, Long.MAX_VALUE, false);
         // Like many fully successful operations, a single row fetch counts as 2 logical row operations,
@@ -185,6 +187,8 @@ public class TestFragmentProgressUpdate extends TestCase {
                 new long[] { CatalogUtil.getUniqueIdForFragment(selectBottomFrag) },
                 null,
                 new ParameterSet[] { params },
+                new boolean[] { false },
+                null,
                 new String[] { selectStmt.getSqltext() },
                 3, 3, 2, 42, Long.MAX_VALUE, false);
 
@@ -221,6 +225,8 @@ public class TestFragmentProgressUpdate extends TestCase {
                 new long[] { CatalogUtil.getUniqueIdForFragment(deleteBottomFrag) },
                 null,
                 new ParameterSet[] { params },
+                new boolean[] { false },
+                null,
                 new String[] { deleteStmt.getSqltext() },
                 3, 3, 2, 42, WRITE_TOKEN, false);
 
@@ -236,6 +242,8 @@ public class TestFragmentProgressUpdate extends TestCase {
                 new long[] { CatalogUtil.getUniqueIdForFragment(selectBottomFrag) },
                 null,
                 new ParameterSet[] { params },
+                new boolean[] { false },
+                null,
                 new String[] { selectStmt.getSqltext() },
                 3, 3, 2, 42, Long.MAX_VALUE, false);
         assertTrue(m_ee.m_callsFromEE > 2);
@@ -291,6 +299,8 @@ public class TestFragmentProgressUpdate extends TestCase {
                 new long[] { CatalogUtil.getUniqueIdForFragment(selectBottomFrag) },
                 null,
                 new ParameterSet[] { params },
+                new boolean[] { false },
+                null,
                 new String[] { selectStmt.getSqltext() },
                 3, 3, 2, 42, READ_ONLY_TOKEN, false);
 
@@ -468,6 +478,8 @@ public class TestFragmentProgressUpdate extends TestCase {
                     fragIds,
                     null,
                     paramSets,
+                    new boolean[] { false },
+                    null,
                     sqlTexts,
                     3, 3, 2, 42,
                     readOnly ? READ_ONLY_TOKEN : WRITE_TOKEN, false);

--- a/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
+++ b/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
@@ -33,6 +33,7 @@ import org.voltcore.messaging.HeartbeatResponseMessage;
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.Pair;
 import org.voltdb.ClientResponseImpl;
+import org.voltdb.DependencyPair;
 import org.voltdb.ParameterSet;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.VoltTable;
@@ -317,7 +318,7 @@ public class TestVoltMessageSerialization extends TestCase {
 
         FragmentResponseMessage fr = new FragmentResponseMessage(ft, 23);
         fr.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, new EEException(1));
-        fr.addDependency(99, table);
+        fr.addDependency(new DependencyPair.TableDependencyPair(99, table));
 
         FragmentResponseMessage fr2 = (FragmentResponseMessage) checkVoltMessage(fr);
 

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -600,6 +600,7 @@ public class LocalCluster extends VoltServerConfig {
         m_cmdLines.add(cmdln);
         if (isNewCli) {
             cmdln.m_startAction = StartAction.PROBE;
+            cmdln.enableAdd(action == StartAction.JOIN);
             cmdln.m_hostCount = m_hostCount;
             String hostIdStr = cmdln.getJavaProperty(clusterHostIdProperty);
             String root = m_hostRoots.get(hostIdStr);

--- a/tests/frontend/org/voltdb/regressionsuites/TestBigBatchAndFallbackBufferResults.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestBigBatchAndFallbackBufferResults.java
@@ -48,6 +48,9 @@ public class TestBigBatchAndFallbackBufferResults extends RegressionSuite {
 
     private void processBigMultiQueryProc(Client client, int returnBuffer, int checkMiddle, int useFinal,
             int firstMod, int secondMod, int thirdMod) throws NoConnectionsException, IOException, ProcCallException {
+        String reqStr = returnBuffer + ", " + checkMiddle + ", " + useFinal + " using ( " +
+                firstMod + ":" + secondMod + ":" + thirdMod +")";
+        System.out.println("requesting: " + reqStr);
         ClientResponse cr = client.callProcedure("SPMultiStatementQuery", 0, returnBuffer, checkMiddle, useFinal, firstMod, secondMod, thirdMod);
         assertTrue(cr.getStatus() == ClientResponse.SUCCESS);
         VoltTable vt = cr.getResults()[0];

--- a/tests/frontend/org/voltdb/regressionsuites/TestBigBatchAndFallbackBufferResults.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestBigBatchAndFallbackBufferResults.java
@@ -1,0 +1,207 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.voltdb.regressionsuites;
+
+import java.io.IOException;
+
+import org.voltdb.BackendTarget;
+import org.voltdb.VoltTable;
+import org.voltdb.client.Client;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.client.NoConnectionsException;
+import org.voltdb.client.ProcCallException;
+import org.voltdb.compiler.VoltProjectBuilder;
+
+/*
+ * This set of tests is verifies the results of Queries performed in different batches
+ * to ensure no data loss irrespective of whether the first, final or fallback buffers are
+ * used between the EE and the procedure runner.
+ */
+
+public class TestBigBatchAndFallbackBufferResults extends RegressionSuite {
+
+    private void populateTable(Client client, int rowCount) throws NoConnectionsException, IOException, ProcCallException {
+        ClientResponse cr = client.callProcedure("SPPopulatePartitionTable", 0, rowCount);
+        assertTrue(cr.getStatus() == ClientResponse.SUCCESS);
+        assertTrue(cr.getResults()[0].asScalarLong() == 0);
+   }
+
+    private void processBigMultiQueryProc(Client client, int returnBuffer, int checkMiddle, int useFinal,
+            int firstMod, int secondMod, int thirdMod) throws NoConnectionsException, IOException, ProcCallException {
+        ClientResponse cr = client.callProcedure("SPMultiStatementQuery", 0, returnBuffer, checkMiddle, useFinal, firstMod, secondMod, thirdMod);
+        assertTrue(cr.getStatus() == ClientResponse.SUCCESS);
+        VoltTable vt = cr.getResults()[0];
+        vt.advanceRow();
+        Long val = vt.getLong("id");
+        switch (returnBuffer) {
+        case RETURN_FIRST:
+            assertTrue(val == firstMod);
+            break;
+        case RETURN_MIDDLE:
+            assertTrue(val == secondMod);
+            break;
+        case RETURN_LAST:
+            assertTrue(val == thirdMod);
+            break;
+        default:
+            assertTrue(false);
+        }
+    }
+
+    private static final int RETURN_FIRST = 1;
+    private static final int RETURN_MIDDLE = 2;
+    private static final int RETURN_LAST = 3;
+    private static final int PERFORM_MIDDLE_QUERY = 1;
+    private static final int SKIP_MIDDLE_QUERY = 0;
+    private static final int USE_FINAL_OPTION = 1;
+    private static final int NO_FINAL_OPTION = 0;
+    //10485743
+    public void testQueryIsolation() throws IOException, ProcCallException {
+        System.out.println("test testSimpleQuery...");
+        Client client = getClient();
+        // Note that because there are 300 rows in the table and each row is slightly over 1MB a MOD
+        // value of 6 or lower will return 50+ rows which will exceed the max result buffer limit
+        // Therefore a MOD value of < 7 for the middle query will fail if that query is executed.
+        // In addition, a MOD value of 31 or more will ensure that the buffer is less than the 10MB,
+        // ensuring that the fallback buffer is not used at all.
+        populateTable(client, 300);
+
+        // Test first buffers
+        processBigMultiQueryProc(client, RETURN_FIRST, SKIP_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 1, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, SKIP_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 1, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, SKIP_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 1, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, SKIP_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 1, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, SKIP_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 1, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, SKIP_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 1, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, SKIP_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 1, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, SKIP_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 1, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 8, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 8, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 8, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 8, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 8, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 8, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 8, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 8, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 32, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 32, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 32, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 32, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 32, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 32, 33);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 32, 9);
+        processBigMultiQueryProc(client, RETURN_FIRST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 32, 33);
+
+        // Test second buffer values
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 8, 9);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 8, 33);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 8, 9);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 8, 33);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 8, 9);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 8, 33);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 8, 9);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 8, 33);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 32, 9);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 32, 33);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 32, 9);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 32, 33);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 32, 9);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 32, 33);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 32, 9);
+        processBigMultiQueryProc(client, RETURN_MIDDLE, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 32, 33);
+
+        // Test third buffer values
+        processBigMultiQueryProc(client, RETURN_LAST, SKIP_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 1, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, SKIP_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 1, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, SKIP_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 1, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, SKIP_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 1, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, SKIP_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 1, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, SKIP_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 1, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, SKIP_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 1, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, SKIP_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 1, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 8, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 8, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 8, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 8, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 8, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 8, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 8, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 8, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 32, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 7, 32, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 32, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, USE_FINAL_OPTION, 31, 32, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 32, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 7, 32, 33);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 32, 9);
+        processBigMultiQueryProc(client, RETURN_LAST, PERFORM_MIDDLE_QUERY, NO_FINAL_OPTION, 31, 32, 33);
+    }
+
+    public TestBigBatchAndFallbackBufferResults(String name) {
+        super(name);
+    }
+
+    static final Class<?>[] PROCEDURES = {
+        org.voltdb_testprocs.regressionsuites.fallbackbuffers.SPPopulatePartitionTable.class,
+        org.voltdb_testprocs.regressionsuites.fallbackbuffers.SPMultiStatementQuery.class,
+        };
+
+    static public junit.framework.Test suite() {
+        VoltServerConfig config = null;
+        MultiConfigSuiteBuilder builder = new MultiConfigSuiteBuilder(
+                TestBigBatchAndFallbackBufferResults.class);
+        VoltProjectBuilder project = new VoltProjectBuilder();
+
+        project.addProcedures(PROCEDURES);
+        final String literalSchema =
+                "CREATE TABLE p1 ( "
+                + "id INTEGER DEFAULT 0 NOT NULL assumeunique, "
+                + "num INTEGER DEFAULT 0 NOT NULL, "
+                + "str VARCHAR(1048576 BYTES), "
+                + "PRIMARY KEY (id, num) ); " +
+
+                "PARTITION TABLE p1 ON COLUMN num; " +
+                ""
+                ;
+        try {
+            project.addLiteralSchema(literalSchema);
+        } catch (IOException e) {
+            assertFalse(true);
+        }
+
+        boolean success;
+
+        config = new LocalCluster("catchexceptions-onesite.jar", 1, 1, 0, BackendTarget.NATIVE_EE_JNI);
+        success = config.compile(project);
+        assertTrue(success);
+        builder.addServerConfig(config);
+
+        // Cluster
+//        config = new LocalCluster("catchexceptions-onesite.jar", 2, 3, 1, BackendTarget.NATIVE_EE_JNI);
+//        success = config.compile(project);
+//        assertTrue(success);
+//        builder.addServerConfig(config);
+
+        return builder;
+    }
+}

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fallbackbuffers/SPMultiStatementQuery.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fallbackbuffers/SPMultiStatementQuery.java
@@ -1,0 +1,103 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.regressionsuites.fallbackbuffers;
+
+import org.voltdb.ProcInfo;
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertFalse;
+
+
+@ProcInfo
+(
+    singlePartition = true,
+    partitionInfo = "P1.NUM: 0"
+)
+
+public class SPMultiStatementQuery extends VoltProcedure {
+
+    public final SQLStmt query = new SQLStmt("select * from P1 where MOD(id, ?) = 0");
+
+    private boolean isTrue(int value) {
+        return value == 0 ? false: true;
+    }
+
+    private void checkBuffer(ByteBuffer buf, boolean mayBeDirect, boolean isFinal) {
+        if (isFinal) {
+            assertTrue(buf.isDirect());
+        }
+        else if (buf.capacity() > 10 * 1024 * 1024) {
+            assertFalse(buf.isDirect());
+        }
+        else {
+            assertTrue(mayBeDirect == buf.isDirect());
+        }
+    }
+
+    // use a partition key here to put all data insert into one partition
+    public VoltTable[] run(int partitionKey,
+            int returnBuffer, int checkMiddle, int useFinal,
+            int firstMod, int secondMod, int thirdMod) {
+        VoltTable[] result = null;
+
+        voltQueueSQL(query, firstMod);
+        VoltTable[] t1 = voltExecuteSQL();
+        checkBuffer(t1[0].getBuffer(), true, false);
+
+        VoltTable[] t2 = null;
+        if (isTrue(checkMiddle)) {
+            voltQueueSQL(query, secondMod);
+            t2 = voltExecuteSQL();
+            checkBuffer(t2[0].getBuffer(), false, false);
+        }
+
+        voltQueueSQL(query, thirdMod);
+        VoltTable[] t3;
+        if (isTrue(useFinal)) {
+            t3 = voltExecuteSQL(true);
+            checkBuffer(t3[0].getBuffer(), true, true);
+        }
+        else {
+            t3 = voltExecuteSQL();
+            checkBuffer(t3[0].getBuffer(), false, false);
+        }
+
+        if (returnBuffer == 1) {
+            result = t1;
+        }
+        else if (returnBuffer == 2){
+            result = t2;
+        }
+        else {
+            result = t3;
+        }
+        return result;
+    }
+}

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fallbackbuffers/SPPopulatePartitionTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fallbackbuffers/SPPopulatePartitionTable.java
@@ -1,0 +1,68 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.regressionsuites.fallbackbuffers;
+
+import java.util.Arrays;
+
+import org.voltdb.ProcInfo;
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+
+@ProcInfo
+(
+    singlePartition = true,
+    partitionInfo = "P1.NUM: 0"
+)
+
+public class SPPopulatePartitionTable extends VoltProcedure {
+
+    static {
+        final int ARRAY_SIZE = 1048576;
+        char[] genArray = new char[ARRAY_SIZE];
+        Arrays.fill(genArray, '1');
+        generatedStr = new String(genArray);
+    }
+
+    private static final String generatedStr;
+
+    public final SQLStmt insertP1 = new SQLStmt("insert into P1 (ID, str) values (?, ?)");
+
+    // use a partition key here to put all data insert into one partition
+    public long run(int partitionKey, int rowCount) {
+        int result = 0;
+
+        // VoltDB break large batch with 200 units
+        // 300 here will be be broke into two batches at least
+        try {
+            for (int i = 1; i <= rowCount; i++) {
+                voltQueueSQL(insertP1, i, generatedStr);
+            }
+            voltExecuteSQL();
+        } catch (Exception e) {
+            result = -1;
+        }
+
+        return result;
+    }
+}

--- a/third_party/java/src/org/apache/cassandra_voltpatches/GCInspector.java
+++ b/third_party/java/src/org/apache/cassandra_voltpatches/GCInspector.java
@@ -32,6 +32,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import org.voltcore.logging.VoltLogger;
+import org.voltdb.GcStats;
 
 import com.google_voltpatches.common.collect.ImmutableSet;
 
@@ -48,6 +49,7 @@ public class GCInspector
 
     final List<GarbageCollectorMXBean> beans = new ArrayList<GarbageCollectorMXBean>();
     final MemoryMXBean membean = ManagementFactory.getMemoryMXBean();
+    private GcStats m_voltGcStats = null;
 
     public GCInspector()
     {
@@ -67,11 +69,12 @@ public class GCInspector
         }
     }
 
-    public void start(ScheduledThreadPoolExecutor stpe)
+    public void start(ScheduledThreadPoolExecutor stpe, GcStats gcStats)
     {
         // don't bother starting a thread that will do nothing.
         if (beans.size() == 0)
             return;
+        m_voltGcStats = gcStats;
         Runnable t = new Runnable()
         {
             @Override
@@ -83,6 +86,10 @@ public class GCInspector
         stpe.scheduleAtFixedRate(t, INTERVAL_IN_MS, INTERVAL_IN_MS, TimeUnit.MILLISECONDS);
     }
 
+    private static final ImmutableSet<String> newGenGCs =
+            ImmutableSet.of(
+                    "ParNew",
+                    "G1 Young Generation");
     private static final ImmutableSet<String> oldGenGCs =
             ImmutableSet.of(
                     "ConcurrentMarkSweep",
@@ -128,14 +135,19 @@ public class GCInspector
             }
 
             // if we just finished a full collection and we're still using a lot of memory, log
+            if (newGenGCs.contains(gc.getName()))
+            {
+                m_voltGcStats.gcInspectorReport(true, (int)(count - previousCount), duration);
+            }
             if (oldGenGCs.contains(gc.getName()))
             {
+                m_voltGcStats.gcInspectorReport(false, (int)(count - previousCount), duration);
                 if (memoryUsed > .5 * memoryMax)
                 {
                     double usage = (double) memoryUsed / memoryMax;
 
                     String usageStr = String.format("%.2f", usage * 100);
-                    String memoryMaxStr = String.format("%.2f", (double) memoryMax / 1_048_576);  //2^20 Bytes 
+                    String memoryMaxStr = String.format("%.2f", (double) memoryMax / 1_048_576);  //2^20 Bytes
 
                     if (.5 <= usage && usage < .6)
                     {
@@ -146,21 +158,6 @@ public class GCInspector
                     }
                 }
             }
-        }
-    }
-
-    public static void main(String args[]) throws Exception {
-        ArrayList<byte[]> stuff = new ArrayList<byte[]>();
-        GCInspector.instance.start(new ScheduledThreadPoolExecutor(1));
-        int allocations = 3000;
-        for (int ii = 0; ii < allocations; ii++) {
-            for (int zz = 0; zz < 1024; zz++) {
-                stuff.add(new byte[1024]);
-            }
-        }
-        Random r = new Random();
-        while (true) {
-            stuff.set(r.nextInt(stuff.size()), new byte[1024]);
         }
     }
 }

--- a/third_party/java/src/org/apache/hadoop_voltpatches/util/PureJavaCrc32C.java
+++ b/third_party/java/src/org/apache/hadoop_voltpatches/util/PureJavaCrc32C.java
@@ -30,7 +30,7 @@ import java.util.zip.Checksum;
 public class PureJavaCrc32C implements Checksum {
 
   /** the current CRC value, bit-flipped */
-  private int crc;
+  protected int crc;
 
   /** Create a new PureJavaCrc32 object. */
   public PureJavaCrc32C() {
@@ -86,7 +86,7 @@ public class PureJavaCrc32C implements Checksum {
   // java -cp build/test/classes/:build/classes/ \
   //   org.apache.hadoop.util.TestPureJavaCrc32\$Table 82F63B78
 
-  static final int[] T8_0 = new int[] {
+  protected static final int[] T8_0 = new int[] {
     0x00000000, 0xF26B8303, 0xE13B70F7, 0x1350F3F4,
     0xC79A971F, 0x35F1141C, 0x26A1E7E8, 0xD4CA64EB,
     0x8AD958CF, 0x78B2DBCC, 0x6BE22838, 0x9989AB3B,
@@ -152,7 +152,7 @@ public class PureJavaCrc32C implements Checksum {
     0x79B737BA, 0x8BDCB4B9, 0x988C474D, 0x6AE7C44E,
     0xBE2DA0A5, 0x4C4623A6, 0x5F16D052, 0xAD7D5351
   };
-  static final int[] T8_1 = new int[] {
+  protected static final int[] T8_1 = new int[] {
     0x00000000, 0x13A29877, 0x274530EE, 0x34E7A899,
     0x4E8A61DC, 0x5D28F9AB, 0x69CF5132, 0x7A6DC945,
     0x9D14C3B8, 0x8EB65BCF, 0xBA51F356, 0xA9F36B21,
@@ -218,7 +218,7 @@ public class PureJavaCrc32C implements Checksum {
     0xD98EEDC6, 0xCA2C75B1, 0xFECBDD28, 0xED69455F,
     0x97048C1A, 0x84A6146D, 0xB041BCF4, 0xA3E32483
   };
-  static final int[] T8_2 = new int[] {
+  protected static final int[] T8_2 = new int[] {
     0x00000000, 0xA541927E, 0x4F6F520D, 0xEA2EC073,
     0x9EDEA41A, 0x3B9F3664, 0xD1B1F617, 0x74F06469,
     0x38513EC5, 0x9D10ACBB, 0x773E6CC8, 0xD27FFEB6,
@@ -284,7 +284,7 @@ public class PureJavaCrc32C implements Checksum {
     0xE5F54FC1, 0x40B4DDBF, 0xAA9A1DCC, 0x0FDB8FB2,
     0x7B2BEBDB, 0xDE6A79A5, 0x3444B9D6, 0x91052BA8
   };
-  static final int[] T8_3 = new int[] {
+  protected static final int[] T8_3 = new int[] {
     0x00000000, 0xDD45AAB8, 0xBF672381, 0x62228939,
     0x7B2231F3, 0xA6679B4B, 0xC4451272, 0x1900B8CA,
     0xF64463E6, 0x2B01C95E, 0x49234067, 0x9466EADF,
@@ -350,7 +350,7 @@ public class PureJavaCrc32C implements Checksum {
     0x31035088, 0xEC46FA30, 0x8E647309, 0x5321D9B1,
     0x4A21617B, 0x9764CBC3, 0xF54642FA, 0x2803E842
   };
-  static final int[] T8_4 = new int[] {
+  protected static final int[] T8_4 = new int[] {
     0x00000000, 0x38116FAC, 0x7022DF58, 0x4833B0F4,
     0xE045BEB0, 0xD854D11C, 0x906761E8, 0xA8760E44,
     0xC5670B91, 0xFD76643D, 0xB545D4C9, 0x8D54BB65,
@@ -416,7 +416,7 @@ public class PureJavaCrc32C implements Checksum {
     0x081E60E7, 0x300F0F4B, 0x783CBFBF, 0x402DD013,
     0xE85BDE57, 0xD04AB1FB, 0x9879010F, 0xA0686EA3
   };
-  static final int[] T8_5 = new int[] {
+  protected static final int[] T8_5 = new int[] {
     0x00000000, 0xEF306B19, 0xDB8CA0C3, 0x34BCCBDA,
     0xB2F53777, 0x5DC55C6E, 0x697997B4, 0x8649FCAD,
     0x6006181F, 0x8F367306, 0xBB8AB8DC, 0x54BAD3C5,
@@ -482,7 +482,7 @@ public class PureJavaCrc32C implements Checksum {
     0x37F2D291, 0xD8C2B988, 0xEC7E7252, 0x034E194B,
     0x8507E5E6, 0x6A378EFF, 0x5E8B4525, 0xB1BB2E3C
   };
-  static final int[] T8_6 = new int[] {
+  protected static final int[] T8_6 = new int[] {
     0x00000000, 0x68032CC8, 0xD0065990, 0xB8057558,
     0xA5E0C5D1, 0xCDE3E919, 0x75E69C41, 0x1DE5B089,
     0x4E2DFD53, 0x262ED19B, 0x9E2BA4C3, 0xF628880B,
@@ -548,7 +548,7 @@ public class PureJavaCrc32C implements Checksum {
     0x60F48DC6, 0x08F7A10E, 0xB0F2D456, 0xD8F1F89E,
     0xC5144817, 0xAD1764DF, 0x15121187, 0x7D113D4F
   };
-  static final int[] T8_7 = new int[] {
+  protected static final int[] T8_7 = new int[] {
     0x00000000, 0x493C7D27, 0x9278FA4E, 0xDB448769,
     0x211D826D, 0x6821FF4A, 0xB3657823, 0xFA590504,
     0x423B04DA, 0x0B0779FD, 0xD043FE94, 0x997F83B3,


### PR DESCRIPTION
Added an extra cache buffer between the EE and Volt that is used to supply results. One result buffer is used for the first batch result. The second buffer is used for all other results. If final is set or this is the first result, result buffer will not be copied into a heap byte buffer. Instead the volt tables are created directly on top of the result buffer. All non-final batches after the first batch are still copied.

Note that if any of the tables in the first batch result or the final batch result are returned by the stored procedure, they will be copied into a heap buffer as part of the response generation.

In addition, the conversion of the result to a volt table is deferred until we determine whether the batch is for the procedure runner or for a fragment result. This avoids the unnecessary generation of a VoltTable for Fragment Results.

Also changed the allocator for the index to use fixed size buffers (same size as table blocks) and vary the number of indexes per buffer. Also allocate from the thread local buffer pool rather than the shared heap. Finally change index to hang on to the last deleted buffer rather than returning all buffers and keeping the first buffer of the index. This avoids poor performance when the table size varies by a single row  (add one, delete one, add one, delete one) that happens to fall on an index buffer boundary.
