### PR TITLE
ENG-11184: Advance spHandle for CompleteTransactionMessage on recover.

### DIFF
--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1011,9 +1011,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             msg = new CompleteTransactionMessage(m_mailbox.getHSId(), m_mailbox.getHSId(), message);
             // Set the spHandle so that on repair the new master will set the max seen spHandle
             // correctly
-            if (!msg.isForReplay()) {
-                advanceTxnEgo();
-            }
+            advanceTxnEgo();
             msg.setSpHandle(getCurrentTxnId());
 
             if (m_sendToHSIds.length > 0 && !msg.isReadOnly()) {


### PR DESCRIPTION
We are duplicate counting the CompleteTransactionMessage for tracking
the locally executed spHandle in SpScheduler. Since the duplicate
counter key is the (txnId, spHandle) pair, if the
CompleteTransactionMessage shares the same spHandle with its last
fragment, such as in the case of an early abort triggered by other
partitions, it will result in duplicate counter collision. We always
increment the spHandle except for command log replay for the
CompleteTransactionMessage. Making it advance the spHandle for replay as
well.