### PR TITLE
ENG-11089, add buddy group support upon the rack aware group

### DIFF
--- a/lib/python/voltcli/verbs.py
+++ b/lib/python/voltcli/verbs.py
@@ -436,7 +436,7 @@ class ServerBundle(JavaBundle):
             cli.StringOption('-g', '--placement-group', 'placementgroup',
                              'placement group',
                              default = '0'))
-        verb.add_options( cli.StringOption('-b', '--buddy-group', 'buddygroup', 'buddy group', default = '0'))
+        verb.add_options( cli.StringOption('-u', '--buddy-group', 'buddygroup', 'buddy group', default = '0'))
         if self.is_legacy_verb and self.default_host:
             verb.add_options(cli.StringOption('-H', '--host', 'host',
                 'HOST[:PORT] (default HOST=localhost, PORT=3021)',

--- a/lib/python/voltcli/verbs.py
+++ b/lib/python/voltcli/verbs.py
@@ -436,6 +436,7 @@ class ServerBundle(JavaBundle):
             cli.StringOption('-g', '--placement-group', 'placementgroup',
                              'placement group',
                              default = '0'))
+        verb.add_options( cli.StringOption('-b', '--buddy-group', 'buddygroup', 'buddy group', default = '0'))
         if self.is_legacy_verb and self.default_host:
             verb.add_options(cli.StringOption('-H', '--host', 'host',
                 'HOST[:PORT] (default HOST=localhost, PORT=3021)',
@@ -514,6 +515,8 @@ class ServerBundle(JavaBundle):
             final_args.extend(['deployment', runner.opts.deployment])
         if runner.opts.placementgroup:
             final_args.extend(['placementgroup', runner.opts.placementgroup])
+        if runner.opts.buddygroup:
+            final_args.extend(['buddygroup', runner.opts.buddygroup])
         if self.is_legacy_verb and runner.opts.host:
             final_args.extend(['host', runner.opts.host])
         elif not self.subcommand in ('initialize', 'probe'):

--- a/lib/python/voltcli/verbs.py
+++ b/lib/python/voltcli/verbs.py
@@ -436,7 +436,6 @@ class ServerBundle(JavaBundle):
             cli.StringOption('-g', '--placement-group', 'placementgroup',
                              'placement group',
                              default = '0'))
-        verb.add_options( cli.StringOption('-u', '--buddy-group', 'buddygroup', 'buddy group', default = '0'))
         if self.is_legacy_verb and self.default_host:
             verb.add_options(cli.StringOption('-H', '--host', 'host',
                 'HOST[:PORT] (default HOST=localhost, PORT=3021)',
@@ -515,8 +514,6 @@ class ServerBundle(JavaBundle):
             final_args.extend(['deployment', runner.opts.deployment])
         if runner.opts.placementgroup:
             final_args.extend(['placementgroup', runner.opts.placementgroup])
-        if runner.opts.buddygroup:
-            final_args.extend(['buddygroup', runner.opts.buddygroup])
         if self.is_legacy_verb and runner.opts.host:
             final_args.extend(['host', runner.opts.host])
         elif not self.subcommand in ('initialize', 'probe'):

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -66,6 +66,7 @@ import org.voltcore.utils.PortGenerator;
 import org.voltcore.utils.ShutdownHooks;
 import org.voltcore.zk.CoreZK;
 import org.voltcore.zk.ZKUtil;
+import org.voltdb.compiler.ClusterConfig.ExtensibleGroupTag;
 import org.voltdb.probe.MeshProber;
 
 import com.google_voltpatches.common.base.Preconditions;
@@ -122,13 +123,15 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         private static final String INTERNAL_INTERFACE = "internalinterface";
         private static final String ZK_INTERFACE = "zkinterface";
         private static final String COORDINATOR_IP = "coordinatorip";
-        private static final String GROUP = "group";
+        private static final String RACK_AWARENESS_GROUP = "rackawarenessgroup";
+        private static final String BUDDY_GROUP = "buddygroup";
 
         public InetSocketAddress coordinatorIp;
         public String zkInterface = "127.0.0.1:7181";
         public String internalInterface = "";
         public int internalPort = 3021;
-        public String group = "0";
+        public String rackAwarenessgroup = "0";
+        public String buddyGroup = "0";
         public int deadHostTimeout = Constants.DEFAULT_HEARTBEAT_TIMEOUT_SECONDS * 1000;
         public long backwardsTimeForgivenessWindow = 1000 * 60 * 60 * 24 * 7;
         public VoltMessageFactory factory = new VoltMessageFactory();
@@ -212,7 +215,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
             JSONStringer js = new JSONStringer();
             try {
                 js.object();
-                js.key(GROUP).value(group);
+                js.key(RACK_AWARENESS_GROUP).value(rackAwarenessgroup);
+                js.key(BUDDY_GROUP).value(buddyGroup);
                 js.key(COORDINATOR_IP).value(coordinatorIp.toString());
                 js.key(ZK_INTERFACE).value(zkInterface);
                 js.key(INTERNAL_INTERFACE).value(internalInterface);
@@ -237,14 +241,17 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     private static class HostInfo {
 
         private final static String HOST_IP = "hostIp";
-        private final static String GROUP = "group";
+        private final static String RACK_AWARENESS_GROUP = "rackAwarenessGroup";
+        private final static String BUDDY_GROUP = "buddyGroup";
 
         final String m_hostIp;
-        final String m_group;
+        final String m_rackAwarenessGroup;
+        final String m_buddyGroup;
 
-        public HostInfo(String hostIp, String group) {
+        public HostInfo(String hostIp, String rackAwarenessGroup, String buddyGroup) {
             m_hostIp = hostIp;
-            m_group = group;
+            m_rackAwarenessGroup = rackAwarenessGroup;
+            m_buddyGroup = buddyGroup;
         }
 
         public byte[] toBytes() throws JSONException
@@ -252,7 +259,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
             final JSONStringer js = new JSONStringer();
             js.object();
             js.key(HOST_IP).value(m_hostIp);
-            js.key(GROUP).value(m_group);
+            js.key(RACK_AWARENESS_GROUP).value(m_rackAwarenessGroup);
+            js.key(BUDDY_GROUP).value(m_buddyGroup);
             js.endObject();
             return js.toString().getBytes(StandardCharsets.UTF_8);
         }
@@ -260,7 +268,9 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         public static HostInfo fromBytes(byte[] bytes) throws JSONException
         {
             final JSONObject obj = new JSONObject(new String(bytes, StandardCharsets.UTF_8));
-            return new HostInfo(obj.getString(HOST_IP), obj.getString(GROUP));
+            return new HostInfo(obj.getString(HOST_IP),
+                                obj.getString(RACK_AWARENESS_GROUP),
+                                obj.getString(BUDDY_GROUP));
         }
     }
 
@@ -649,7 +659,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
              * Store all the hosts and host ids here so that waitForGroupJoin
              * knows the size of the mesh. This part only registers this host
              */
-            final HostInfo hostInfo = new HostInfo(m_config.coordinatorIp.toString(), m_config.group);
+            final HostInfo hostInfo = new HostInfo(m_config.coordinatorIp.toString(),
+                    m_config.rackAwarenessgroup, m_config.buddyGroup);
             m_zk.create(CoreZK.hosts_host + selectedHostId, hostInfo.toBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
         }
         zkInitBarrier.countDown();
@@ -1003,10 +1014,10 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         HostInfo hostInfo;
         if (m_config.internalInterface.isEmpty()) {
             hostInfo = new HostInfo(new InetSocketAddress(m_joiner.m_reportedInternalInterface, m_config.internalPort).toString(),
-                                    m_config.group);
+                                    m_config.rackAwarenessgroup, m_config.buddyGroup);
         } else {
             hostInfo = new HostInfo(new InetSocketAddress(m_config.internalInterface, m_config.internalPort).toString(),
-                                    m_config.group);
+                                    m_config.rackAwarenessgroup, m_config.buddyGroup);
         }
 
         m_zk.create(CoreZK.hosts_host + getHostId(), hostInfo.toBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
@@ -1015,8 +1026,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     /**
      * Wait until all the nodes have built a mesh.
      */
-    public Map<Integer, String> waitForGroupJoin(int expectedHosts) {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
+    public Map<Integer, ExtensibleGroupTag> waitForGroupJoin(int expectedHosts) {
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
 
         try {
             while (true) {
@@ -1027,7 +1038,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                 for (String child : children) {
                     final HostInfo info = HostInfo.fromBytes(m_zk.getData(ZKUtil.joinZKPath(CoreZK.hosts, child), false, null));
                     // HostInfo ZK node name has the form "host#", hence the offset of 4 to skip the "host".
-                    hostGroups.put(Integer.parseInt(child.substring(child.indexOf("host") + 4)), info.m_group);
+                    ExtensibleGroupTag groupTag = new ExtensibleGroupTag(info.m_rackAwarenessGroup, info.m_buddyGroup);
+                    hostGroups.put(Integer.parseInt(child.substring(child.indexOf("host") + 4)), groupTag);
                 }
 
                 /*

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1073,6 +1073,21 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         return hostGroups;
     }
 
+    public Map<Integer, ExtensibleGroupTag> getGroupTags()
+            throws KeeperException, InterruptedException, JSONException
+    {
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
+        final List<String> children = m_zk.getChildren(CoreZK.hosts, false);
+
+        for (String child : children) {
+            final HostInfo info = HostInfo.fromBytes(m_zk.getData(ZKUtil.joinZKPath(CoreZK.hosts, child), false, null));
+            // HostInfo ZK node name has the form "host#", hence the offset of 4 to skip the "host".
+            ExtensibleGroupTag groupTag = new ExtensibleGroupTag(info.m_rackAwarenessGroup, info.m_buddyGroup);
+            hostGroups.put(Integer.parseInt(child.substring(child.indexOf("host") + 4)), groupTag);
+        }
+        return hostGroups;
+    }
+
     /**
      * Rewrite the calculated buddy group tag into cluster
      */

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1577,7 +1577,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             Preconditions.checkArgument(hostGroups.keySet().equals(liveHostIds));
             int hostcount = liveHostIds.size();
             ClusterConfig clusterConfig = new ClusterConfig(hostcount, sitesperhost, kfactor);
-            if (!clusterConfig.validate()) {
+            if (!startAction.doesRejoin() && !clusterConfig.validate()) {
                 VoltDB.crashLocalVoltDB(clusterConfig.getErrorMsg(), false, null);
             }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -158,6 +158,7 @@ import com.google_voltpatches.common.base.Supplier;
 import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.Lists;
 import com.google_voltpatches.common.collect.Multimap;
 import com.google_voltpatches.common.net.HostAndPort;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
@@ -1586,7 +1587,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 final Map<Integer, Long> masters = m_cartographer.getHSIdsForSinglePartitionMasters();
                 replicas.removeAll(MpInitiator.MP_INIT_PID);
                 masters.remove(MpInitiator.MP_INIT_PID);
-                topo = clusterConfig.getTopology(hostGroups, replicas, masters);
+                topo = clusterConfig.getTopology(hostGroups, replicas, masters, Lists.newArrayList());
                 m_messenger.registerGroupTags(hostGroups);
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("Unable to calculate topology", false, e);

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1587,6 +1587,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 replicas.removeAll(MpInitiator.MP_INIT_PID);
                 masters.remove(MpInitiator.MP_INIT_PID);
                 topo = clusterConfig.getTopology(hostGroups, replicas, masters);
+                m_messenger.registerGroupTags(hostGroups);
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("Unable to calculate topology", false, e);
             }
@@ -1594,6 +1595,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             if (!startAction.doesRejoin()) {
                 topo = registerClusterConfig(topo);
             }
+
         }
         return topo;
     }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2365,9 +2365,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         if (m_config.m_placementGroup != null) {
             hmconfig.rackAwarenessgroup = m_config.m_placementGroup;
         }
-        if (m_config.m_buddyGroup != null) {
-            hmconfig.buddyGroup = m_config.m_buddyGroup;
-        }
+        // default buddy group, clusterConfig will calculate the right group
+        // once all hosts is in cluster
+        hmconfig.buddyGroup = "0";
         hmconfig.internalPort = m_config.m_internalPort;
         hmconfig.internalInterface = m_config.m_internalInterface;
         hmconfig.zkInterface = m_config.m_zkInterface;

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -252,6 +252,9 @@ public class VoltDB {
         /** Placement group */
         public String m_placementGroup = null;
 
+        /** Buddy group */
+        public String m_buddyGroup = null;
+
         public boolean m_isPaused = false;
 
         private final static void referToDocAndExit() {
@@ -587,6 +590,8 @@ public class VoltDB {
                     m_buildStringOverrideForTest = args[++i].trim();
                 else if (arg.equalsIgnoreCase("placementgroup"))
                     m_placementGroup = args[++i].trim();
+                else if (arg.equalsIgnoreCase("buddygroup"))
+                    m_buddyGroup = args[++i].trim();
                 else if (arg.equalsIgnoreCase("force")) {
                     m_forceVoltdbCreate = true;
                 } else if (arg.equalsIgnoreCase("paused")) {

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -235,9 +235,9 @@ public class VoltDB {
         /** true if we're running the rejoin tests. Not used in production. */
         public boolean m_isRejoinTest = false;
 
-        public final Queue<String> m_networkCoreBindings = new ArrayDeque<String>();
-        public final Queue<String> m_computationCoreBindings = new ArrayDeque<String>();
-        public final Queue<String> m_executionCoreBindings = new ArrayDeque<String>();
+        public final Queue<String> m_networkCoreBindings = new ArrayDeque<>();
+        public final Queue<String> m_computationCoreBindings = new ArrayDeque<>();
+        public final Queue<String> m_executionCoreBindings = new ArrayDeque<>();
         public String m_commandLogBinding = null;
 
         /**
@@ -251,9 +251,6 @@ public class VoltDB {
 
         /** Placement group */
         public String m_placementGroup = null;
-
-        /** Buddy group */
-        public String m_buddyGroup = null;
 
         public boolean m_isPaused = false;
 
@@ -590,8 +587,6 @@ public class VoltDB {
                     m_buildStringOverrideForTest = args[++i].trim();
                 else if (arg.equalsIgnoreCase("placementgroup"))
                     m_placementGroup = args[++i].trim();
-                else if (arg.equalsIgnoreCase("buddygroup"))
-                    m_buddyGroup = args[++i].trim();
                 else if (arg.equalsIgnoreCase("force")) {
                     m_forceVoltdbCreate = true;
                 } else if (arg.equalsIgnoreCase("paused")) {
@@ -981,7 +976,7 @@ public class VoltDB {
      */
     public static void printStackTraces(PrintWriter writer, List<String> currentStacktrace) {
         if (currentStacktrace == null) {
-            currentStacktrace = new ArrayList<String>();
+            currentStacktrace = new ArrayList<>();
         }
 
         Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
@@ -1072,7 +1067,7 @@ public class VoltDB {
 
                 // Even if the logger is null, don't stop.  We want to log the stack trace and
                 // any other pertinent information to a .dmp file for crash diagnosis
-                List<String> currentStacktrace = new ArrayList<String>();
+                List<String> currentStacktrace = new ArrayList<>();
                 currentStacktrace.add("Stack trace from crashLocalVoltDB() method:");
 
                 // Create a special dump file to hold the stack trace

--- a/src/frontend/org/voltdb/compiler/ClusterConfig.java
+++ b/src/frontend/org/voltdb/compiler/ClusterConfig.java
@@ -687,7 +687,7 @@ public class ClusterConfig
             int sitesPerHost,
             int partitionCount)
     {
-        Map<String, Integer> sizingPlan = Maps.newHashMap();
+        Map<String, Integer> sizingPlan = Maps.newTreeMap();
         // see what's the best sizing of buddy group
         int optimalBuddyGroups = hostCount / (m_replicationFactor + 1);
         int remainder = hostCount % optimalBuddyGroups;
@@ -696,7 +696,7 @@ public class ClusterConfig
             sizingPlan.put(String.valueOf(groupId), size);
         }
 
-        Map<String, Set<Integer>> buddyGroupToHostIds = Maps.newHashMap();
+        Map<String, Set<Integer>> buddyGroupToHostIds = Maps.newTreeMap();
         // buddy these nodes up based on rack aware topology
         boolean singleRackGroup = rackAwareGroups.values().stream().distinct().count() == 1;
         if (singleRackGroup) {

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -238,7 +238,7 @@ public class Cartographer extends StatsSource
      */
     public Map<Integer, Long> getHSIdsForSinglePartitionMasters()
     {
-        return m_iv2Masters.pointInTimeCache();
+        return new HashMap<>(m_iv2Masters.pointInTimeCache());
     }
 
     /**

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -32,6 +32,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import com.google_voltpatches.common.collect.HashMultimap;
+import com.google_voltpatches.common.collect.Multimap;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONException;
@@ -232,6 +234,14 @@ public class Cartographer extends StatsSource
     }
 
     /**
+     * Get the HSID of all the partition masters
+     */
+    public Map<Integer, Long> getHSIdsForSinglePartitionMasters()
+    {
+        return m_iv2Masters.pointInTimeCache();
+    }
+
+    /**
      * Get the HSID of the single partition master for the specified partition ID
      */
     public long getHSIdForSinglePartitionMaster(int partitionId)
@@ -318,8 +328,8 @@ public class Cartographer extends StatsSource
     /**
      * Given a set of partition IDs, return a map of partition to a list of HSIDs of all the sites with copies of each partition
      */
-    public Map<Integer, List<Long>> getReplicasForPartitions(Collection<Integer> partitions) {
-        Map<Integer, List<Long>> retval = new HashMap<Integer, List<Long>>();
+    public Multimap<Integer, Long> getReplicasForPartitions(Collection<Integer> partitions) {
+        Multimap<Integer, Long> retval = HashMultimap.create();
         List<Pair<Integer,ZKUtil.ChildrenCallback>> callbacks = new ArrayList<Pair<Integer, ZKUtil.ChildrenCallback>>();
 
         for (Integer partition : partitions) {
@@ -333,11 +343,9 @@ public class Cartographer extends StatsSource
             final Integer partition = p.getFirst();
             try {
                 List<String> children = p.getSecond().getChildren();
-                List<Long> sites = new ArrayList<Long>();
                 for (String child : children) {
-                    sites.add(Long.valueOf(child.split("_")[0]));
+                    retval.put(partition, Long.valueOf(child.split("_")[0]));
                 }
-                retval.put(partition, sites);
             } catch (KeeperException.NoNodeException e) {
                 //This can happen when a partition is being removed from the system
             } catch (KeeperException ke) {
@@ -370,41 +378,6 @@ public class Cartographer extends StatsSource
             keys.add(entry.getKey());
         }
         return keys;
-    }
-
-    /**
-     * Given the current state of the cluster, compute the partitions which should be replicated on a single new host.
-     * Break this method out to be static and testable independent of ZK, JSON, other ugh.
-     */
-    static public List<Integer> computeReplacementPartitions(Map<Integer, Integer> repsPerPart, int kfactor,
-                                                             int sitesPerHost)
-    {
-        List<Integer> partitions = new ArrayList<Integer>();
-        List<Integer> partSortedByRep = sortKeysByValue(repsPerPart);
-        for (int i = 0; i < partSortedByRep.size(); i++) {
-            int leastReplicatedPart = partSortedByRep.get(i);
-            if (repsPerPart.get(leastReplicatedPart) < kfactor + 1) {
-                partitions.add(leastReplicatedPart);
-                if (partitions.size() == sitesPerHost) {
-                    break;
-                }
-            }
-        }
-        return partitions;
-    }
-
-    public List<Integer> getIv2PartitionsToReplace(int kfactor, int sitesPerHost)
-        throws JSONException
-    {
-        List<Integer> partitions = getPartitions();
-        hostLog.info("Computing partitions to replace.  Total partitions: " + partitions);
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        for (int pid : partitions) {
-            repsPerPart.put(pid, getReplicaCountForPartition(pid));
-        }
-        List<Integer> partitionsToReplace = computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        hostLog.info("IV2 Sites will replicate the following partitions: " + partitionsToReplace);
-        return partitionsToReplace;
     }
 
     /**
@@ -441,14 +414,10 @@ public class Cartographer extends StatsSource
     {
         List<MailboxNodeContent> sitesList = new ArrayList<MailboxNodeContent>();
         final Set<Integer> iv2MastersKeySet = m_iv2Masters.pointInTimeCache().keySet();
-        Map<Integer, List<Long>> hsidsForPartMap = getReplicasForPartitions(iv2MastersKeySet);
-        for (Map.Entry<Integer, List<Long>> entry : hsidsForPartMap.entrySet()) {
-            Integer partId = entry.getKey();
-            List<Long> hsidsForPart = entry.getValue();
-            for (long hsid : hsidsForPart) {
-                MailboxNodeContent mnc = new MailboxNodeContent(hsid, partId);
-                sitesList.add(mnc);
-            }
+        Multimap<Integer, Long> hsidsForPartMap = getReplicasForPartitions(iv2MastersKeySet);
+        for (Map.Entry<Integer, Long> entry : hsidsForPartMap.entries()) {
+            MailboxNodeContent mnc = new MailboxNodeContent(entry.getValue(), entry.getKey());
+            sitesList.add(mnc);
         }
         return sitesList;
     }

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -679,7 +679,7 @@ public class MiscUtils {
      * Zip the two lists up into a multimap
      * @return null if one of the lists is empty
      */
-    public static <K, V> Multimap<K, V> zipToMap(List<K> keys, List<V> values)
+    public static <K, V> Multimap<K, V> zipToMap(Collection<K> keys, Collection<V> values)
     {
         if (keys.isEmpty() || values.isEmpty()) {
             return null;
@@ -695,7 +695,7 @@ public class MiscUtils {
 
         // In case there are more values than keys, assign the rest of the
         // values to the first key
-        K firstKey = keys.get(0);
+        K firstKey = keys.iterator().next();
         while (valueIter.hasNext()) {
             result.put(firstKey, valueIter.next());
         }

--- a/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
@@ -29,28 +29,30 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.google_voltpatches.common.collect.ImmutableMap;
-import com.google_voltpatches.common.collect.HashMultimap;
-import com.google_voltpatches.common.collect.Maps;
-import com.google_voltpatches.common.collect.Multimap;
-import com.google_voltpatches.common.collect.Sets;
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
-
-import junit.framework.TestCase;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.VoltDB;
+import org.voltdb.compiler.ClusterConfig.ExtensibleGroupTag;
+
+import com.google_voltpatches.common.collect.HashMultimap;
+import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.Maps;
+import com.google_voltpatches.common.collect.Multimap;
+import com.google_voltpatches.common.collect.Sets;
+
+import junit.framework.TestCase;
 
 public class TestClusterCompiler extends TestCase
 {
     public void testNonZeroReplicationFactor() throws Exception
     {
         ClusterConfig config = new ClusterConfig(3, 1, 2);
-        Map<Integer, String> topology = Maps.newHashMap();
-        topology.put(0, "0");
-        topology.put(1, "0");
-        topology.put(2, "0");
+        Map<Integer, ExtensibleGroupTag> topology = Maps.newHashMap();
+        topology.put(0, new ExtensibleGroupTag("0", "0"));
+        topology.put(1, new ExtensibleGroupTag("0", "0"));
+        topology.put(2, new ExtensibleGroupTag("0", "0"));
         JSONObject obj = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         config.validate();
         System.out.println(obj.toString(4));
@@ -101,8 +103,8 @@ public class TestClusterCompiler extends TestCase
     public void testAddHostToNonKsafe() throws JSONException
     {
         ClusterConfig config = new ClusterConfig(1, 6, 0);
-        Map<Integer, String> topology = Maps.newHashMap();
-        topology.put(0, "0");
+        Map<Integer, ExtensibleGroupTag> topology = Maps.newHashMap();
+        topology.put(0, new ExtensibleGroupTag("0", "0"));
         JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(1, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
@@ -117,9 +119,9 @@ public class TestClusterCompiler extends TestCase
     public void testAddHostsToNonKsafe() throws JSONException
     {
         ClusterConfig config = new ClusterConfig(2, 6, 0);
-        Map<Integer, String> topology = Maps.newHashMap();
-        topology.put(0, "0");
-        topology.put(1, "0");
+        Map<Integer, ExtensibleGroupTag> topology = Maps.newHashMap();
+        topology.put(0, new ExtensibleGroupTag("0", "0"));
+        topology.put(1, new ExtensibleGroupTag("0", "0"));
         JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
@@ -136,9 +138,9 @@ public class TestClusterCompiler extends TestCase
     public void testAddHostsToKsafe() throws JSONException
     {
         ClusterConfig config = new ClusterConfig(2, 6, 1);
-        Map<Integer, String> topology = Maps.newHashMap();
-        topology.put(0, "0");
-        topology.put(1, "0");
+        Map<Integer, ExtensibleGroupTag> topology = Maps.newHashMap();
+        topology.put(0, new ExtensibleGroupTag("0", "0"));
+        topology.put(1, new ExtensibleGroupTag("0", "0"));
         JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
@@ -153,9 +155,9 @@ public class TestClusterCompiler extends TestCase
     public void testAddMoreThanKsafeHosts() throws JSONException
     {
         ClusterConfig config = new ClusterConfig(2, 6, 1);
-        Map<Integer, String> topology = Maps.newHashMap();
-        topology.put(0, "0");
-        topology.put(1, "0");
+        Map<Integer, ExtensibleGroupTag> topology = Maps.newHashMap();
+        topology.put(0, new ExtensibleGroupTag("0", "0"));
+        topology.put(1, new ExtensibleGroupTag("0", "0"));
         JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
@@ -171,54 +173,54 @@ public class TestClusterCompiler extends TestCase
 
     public void testRejoinOneNode() throws JSONException
     {
-        ImmutableMap<Integer, String> topology =
-        ImmutableMap.of(0, "0",
-                        1, "0");
+        ImmutableMap<Integer, ExtensibleGroupTag> topology =
+        ImmutableMap.of(0, new ExtensibleGroupTag("0", "0"),
+                        1, new ExtensibleGroupTag("0", "0"));
         killAndRejoinNodes(topology, 1, 1);
     }
 
     public void testRejoinTwoNodes() throws JSONException
     {
-        ImmutableMap<Integer, String> topology =
-        ImmutableMap.of(0, "0",
-                        1, "1",
-                        2, "2");
+        ImmutableMap<Integer, ExtensibleGroupTag> topology =
+        ImmutableMap.of(0, new ExtensibleGroupTag("0", "0"),
+                        1, new ExtensibleGroupTag("1", "0"),
+                        2, new ExtensibleGroupTag("2", "0"));
         killAndRejoinNodes(topology, 2, 2);
     }
 
     public void testRejoinTwoNodesToTwo() throws JSONException
     {
-        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
-                                                 .put(0, "0")
-                                                 .put(1, "0")
-                                                 .put(2, "1")
-                                                 .put(3, "1")
-                                                 .put(4, "2")
-                                                 .put(5, "2")
+        ImmutableMap<Integer, ExtensibleGroupTag> topology = new ImmutableMap.Builder<Integer, ExtensibleGroupTag>()
+                                                 .put(0, new ExtensibleGroupTag("0", "0"))
+                                                 .put(1, new ExtensibleGroupTag("0", "0"))
+                                                 .put(2, new ExtensibleGroupTag("1", "0"))
+                                                 .put(3, new ExtensibleGroupTag("1", "0"))
+                                                 .put(4, new ExtensibleGroupTag("2", "0"))
+                                                 .put(5, new ExtensibleGroupTag("2", "0"))
                                                  .build();
         killAndRejoinNodes(topology, 1, 2);
     }
 
     public void testRejoinThreeNodesToFour() throws JSONException
     {
-        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
-                                                 .put(0, "0")
-                                                 .put(1, "0")
-                                                 .put(2, "0")
-                                                 .put(3, "0")
-                                                 .put(4, "1")
-                                                 .put(5, "1")
-                                                 .put(6, "1")
+        ImmutableMap<Integer, ExtensibleGroupTag> topology = new ImmutableMap.Builder<Integer, ExtensibleGroupTag>()
+                                                 .put(0, new ExtensibleGroupTag("0", "0"))
+                                                 .put(1, new ExtensibleGroupTag("0", "0"))
+                                                 .put(2, new ExtensibleGroupTag("0", "0"))
+                                                 .put(3, new ExtensibleGroupTag("0", "0"))
+                                                 .put(4, new ExtensibleGroupTag("1", "0"))
+                                                 .put(5, new ExtensibleGroupTag("1", "0"))
+                                                 .put(6, new ExtensibleGroupTag("1", "0"))
                                                  .build();
         killAndRejoinNodes(topology, 2, 3);
     }
 
-    private static void killAndRejoinNodes(ImmutableMap<Integer, String> fullHostGroup, int kfactor, int nodesToKill)
+    private static void killAndRejoinNodes(ImmutableMap<Integer, ExtensibleGroupTag> fullHostGroup, int kfactor, int nodesToKill)
     throws JSONException
     {
         final int maxSph = 20;
         for (int sph = 1; sph < maxSph; sph++) {
-            final Map<Integer, String> rejoinHostGroup = new HashMap<>(fullHostGroup);
+            final Map<Integer, ExtensibleGroupTag> rejoinHostGroup = new HashMap<>(fullHostGroup);
             final ClusterConfig initialConfig = new ClusterConfig(rejoinHostGroup.size(), sph, kfactor);
             if (!initialConfig.validate()) {
                 // Invalid config, skip
@@ -251,7 +253,7 @@ public class TestClusterCompiler extends TestCase
             // Remove all partitions and masters from the failed nodes, migrate masters to remaining nodes
             final Multimap<Integer, Integer> expectedRejoinHostPartitions = HashMultimap.create();
             final HashSet<Integer> liveHosts = new HashSet<>(hostPartitions.keySet());
-            final Map<Integer, String> rejoinHostGroups = new HashMap<>();
+            final Map<Integer, ExtensibleGroupTag> rejoinHostGroups = new HashMap<>();
             for (int toKill : hostIdsToKill) {
                 liveHosts.remove(toKill);
                 for (int masterToRedistribute : hostMasters.get(toKill)) {
@@ -278,7 +280,7 @@ public class TestClusterCompiler extends TestCase
             }
 
             // Rejoin one node at a time and verify that they have the correct partitions
-            for (Map.Entry<Integer, String> rejoin : rejoinHostGroups.entrySet()) {
+            for (Map.Entry<Integer, ExtensibleGroupTag> rejoin : rejoinHostGroups.entrySet()) {
                 System.out.println("Rejoining " + rejoin.getKey() + " in group " + rejoin.getValue());
                 rejoinHostGroup.put(rejoin.getKey(), rejoin.getValue());
                 final JSONObject rejoinTopo = initialConfig.getTopology(rejoinHostGroup, replicas, masters);
@@ -288,7 +290,7 @@ public class TestClusterCompiler extends TestCase
                 // at least one replica in a different group.
                 if (fullHostGroup.values().stream().distinct().count() > 1) {
                     for (int partitionOnRejoined : partitionsOnRejoinHost) {
-                        final String rejoinedHostGroup = rejoin.getValue();
+                        final ExtensibleGroupTag rejoinedHostGroup = rejoin.getValue();
                         boolean foundHostInOtherGroup = false;
                         for (long hsId : replicas.get(partitionOnRejoined)) {
                             if (!rejoinHostGroup.get(CoreUtils.getHostIdFromHSId(hsId)).equals(rejoinedHostGroup)) {
@@ -318,7 +320,7 @@ public class TestClusterCompiler extends TestCase
         }
     }
 
-    private static Set<Integer> pickNodesInDiffGroupsToKill(ImmutableMap<Integer, String> topo,
+    private static Set<Integer> pickNodesInDiffGroupsToKill(ImmutableMap<Integer, ExtensibleGroupTag> topo,
                                                             Multimap<Integer, Integer> hostPartitions,
                                                             int kfactor,
                                                             int nodesToKill)
@@ -362,111 +364,111 @@ public class TestClusterCompiler extends TestCase
 
     public void testFourNodesOneGroups() throws JSONException
     {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "0");
-        hostGroups.put(3, "0");
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(1, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(2, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(3, new ExtensibleGroupTag("0", "0"));
         runConfigAndVerifyTopology(hostGroups, 1);
     }
 
     public void testFourNodesTwoGroups() throws JSONException
     {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "1");
-        hostGroups.put(3, "1");
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(1, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(2, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(3, new ExtensibleGroupTag("1", "0"));
         runConfigAndVerifyTopology(hostGroups, 1);
     }
 
     public void testFourNodesTwoGroupsNonoptimal() throws JSONException
     {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "0");
-        hostGroups.put(3, "1");
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(1, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(2, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(3, new ExtensibleGroupTag("1", "0"));
         runConfigAndVerifyTopology(hostGroups, 1);
     }
 
     public void testThreeNodesThreeGroups() throws JSONException
     {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "1");
-        hostGroups.put(2, "2");
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(1, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(2, new ExtensibleGroupTag("2", "0"));
         runConfigAndVerifyTopology(hostGroups, 2);
     }
 
     public void testSixNodesThreeGroups() throws JSONException
     {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "1");
-        hostGroups.put(3, "1");
-        hostGroups.put(4, "2");
-        hostGroups.put(5, "2");
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(1, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(2, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(3, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(4, new ExtensibleGroupTag("2", "0"));
+        hostGroups.put(5, new ExtensibleGroupTag("2", "0"));
         runConfigAndVerifyTopology(hostGroups, 1);
     }
 
     public void testFiveNodesTwoGroups() throws JSONException
     {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "1");
-        hostGroups.put(3, "1");
-        hostGroups.put(4, "1");
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(1, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(2, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(3, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(4, new ExtensibleGroupTag("1", "0"));
         runConfigAndVerifyTopology(hostGroups, 2);
     }
 
     public void testEightNodesTwoLevelsOfGroups() throws JSONException
     {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0.0");
-        hostGroups.put(1, "0.0");
-        hostGroups.put(2, "0.1");
-        hostGroups.put(3, "0.1");
-        hostGroups.put(4, "1.0");
-        hostGroups.put(5, "1.0");
-        hostGroups.put(6, "1.1");
-        hostGroups.put(7, "1.1");
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, new ExtensibleGroupTag("0.0", "0"));
+        hostGroups.put(1, new ExtensibleGroupTag("0.0", "0"));
+        hostGroups.put(2, new ExtensibleGroupTag("0.1", "0"));
+        hostGroups.put(3, new ExtensibleGroupTag("0.1", "0"));
+        hostGroups.put(4, new ExtensibleGroupTag("1.0", "0"));
+        hostGroups.put(5, new ExtensibleGroupTag("1.0", "0"));
+        hostGroups.put(6, new ExtensibleGroupTag("1.1", "0"));
+        hostGroups.put(7, new ExtensibleGroupTag("1.1", "0"));
         runConfigAndVerifyTopology(hostGroups, 3);
     }
 
     public void testFifteenNodesTwoGroups() throws JSONException
     {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "0");
-        hostGroups.put(3, "0");
-        hostGroups.put(4, "0");
-        hostGroups.put(5, "0");
-        hostGroups.put(6, "0");
-        hostGroups.put(7, "0");
-        hostGroups.put(8, "1");
-        hostGroups.put(9, "1");
-        hostGroups.put(10, "1");
-        hostGroups.put(11, "1");
-        hostGroups.put(12, "1");
-        hostGroups.put(13, "1");
-        hostGroups.put(14, "1");
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(1, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(2, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(3, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(4, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(5, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(6, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(7, new ExtensibleGroupTag("0", "0"));
+        hostGroups.put(8, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(9, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(10, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(11, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(12, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(13, new ExtensibleGroupTag("1", "0"));
+        hostGroups.put(14, new ExtensibleGroupTag("1", "0"));
         runConfigAndVerifyTopology(hostGroups, 2);
     }
 
     public void testFiftNodesInThreeGroups() throws JSONException
     {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
+        Map<Integer, ExtensibleGroupTag> hostGroups = Maps.newHashMap();
         for (int i = 0; i < 50; i++) {
-            hostGroups.put(i, String.valueOf(i % 3));
+            hostGroups.put(i, new ExtensibleGroupTag(String.valueOf(i % 3), "0"));
         }
         runConfigAndVerifyTopology(hostGroups, 2);
     }
 
-    private static void runConfigAndVerifyTopology(Map<Integer, String> hostGroups, int kfactor) throws JSONException
+    private static void runConfigAndVerifyTopology(Map<Integer, ExtensibleGroupTag> hostGroups, int kfactor) throws JSONException
     {
         final int maxSites = 20;
         int invalidConfigCount = 0;
@@ -490,7 +492,8 @@ public class TestClusterCompiler extends TestCase
         assertEquals(expectedInvalidConfigs, invalidConfigCount);
     }
 
-    private static void verifyTopology(Map<Integer, String> hostGroups, JSONObject topo) throws JSONException
+    // TODO: add buddy group verification
+    private static void verifyTopology(Map<Integer, ExtensibleGroupTag> hostGroups, JSONObject topo) throws JSONException
     {
         final int hostCount = new ClusterConfig(topo).getHostCount();
         final int sitesPerHost = new ClusterConfig(topo).getSitesPerHost();
@@ -500,9 +503,11 @@ public class TestClusterCompiler extends TestCase
         final int nodesWithMaxMasterCount = partitionCount % hostCount;
 
         Multimap<Integer, Integer> masterCountToHost = HashMultimap.create();
-        Multimap<String, Integer> groupHosts = HashMultimap.create();
-        Multimap<String, Integer> groupPartitions = HashMultimap.create();
-        for (Map.Entry<Integer, String> entry : hostGroups.entrySet()) {
+        Multimap<String, Integer> raGroupHosts = HashMultimap.create();
+        Multimap<String, Integer> buddyGroupHosts = HashMultimap.create();
+        Multimap<String, Integer> raGroupPartitions = HashMultimap.create();
+        Multimap<String, Integer> buddyGroupPartitions = HashMultimap.create();
+        for (Map.Entry<Integer, ExtensibleGroupTag> entry : hostGroups.entrySet()) {
             final List<Integer> hostPartitions = ClusterConfig.partitionsForHost(topo, entry.getKey());
             final List<Integer> hostMasters = ClusterConfig.partitionsForHost(topo, entry.getKey(), true);
             assertEquals(sitesPerHost, hostPartitions.size());
@@ -510,8 +515,8 @@ public class TestClusterCompiler extends TestCase
             assertEquals(hostPartitions.size(), Sets.newHashSet(hostPartitions).size());
 
             masterCountToHost.put(hostMasters.size(), entry.getKey());
-            groupHosts.put(entry.getValue(), entry.getKey());
-            groupPartitions.putAll(entry.getValue(), hostPartitions);
+            raGroupHosts.put(entry.getValue().m_rackAwarenessGroup, entry.getKey());
+            raGroupPartitions.putAll(entry.getValue().m_rackAwarenessGroup, hostPartitions);
         }
 
         // Make sure master partitions are spread out
@@ -525,9 +530,9 @@ public class TestClusterCompiler extends TestCase
         }
 
         // Each group should have at least one copy of all the partitions
-        for (Map.Entry<String, Collection<Integer>> groupAndPids : groupPartitions.asMap().entrySet()) {
-            assertEquals(groupPartitions.toString(),
-                         Math.min(partitionCount, groupHosts.get(groupAndPids.getKey()).size() * sitesPerHost),
+        for (Map.Entry<String, Collection<Integer>> groupAndPids : raGroupPartitions.asMap().entrySet()) {
+            assertEquals(raGroupPartitions.toString(),
+                         Math.min(partitionCount, raGroupHosts.get(groupAndPids.getKey()).size() * sitesPerHost),
                          Sets.newHashSet(groupAndPids.getValue()).size());
         }
     }

--- a/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
@@ -23,10 +23,13 @@
 package org.voltdb.compiler;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.HashMultimap;
 import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.collect.Multimap;
@@ -36,6 +39,7 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 
 import junit.framework.TestCase;
+import org.voltcore.utils.CoreUtils;
 import org.voltdb.VoltDB;
 
 public class TestClusterCompiler extends TestCase
@@ -47,7 +51,7 @@ public class TestClusterCompiler extends TestCase
         topology.put(0, "0");
         topology.put(1, "0");
         topology.put(2, "0");
-        JSONObject obj = config.getTopology(topology);
+        JSONObject obj = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         config.validate();
         System.out.println(obj.toString(4));
         JSONArray partitions = obj.getJSONArray("partitions");
@@ -99,7 +103,7 @@ public class TestClusterCompiler extends TestCase
         ClusterConfig config = new ClusterConfig(1, 6, 0);
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(1, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(0, topo.getInt("kfactor"));
@@ -116,7 +120,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(0, topo.getInt("kfactor"));
@@ -135,7 +139,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(1, topo.getInt("kfactor"));
@@ -152,7 +156,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(1, topo.getInt("kfactor"));
@@ -163,6 +167,197 @@ public class TestClusterCompiler extends TestCase
             ClusterConfig.addHosts(3, topo);
             fail("Shouldn't allow adding more than ksafe + 1 node");
         } catch (AssertionError e) {}
+    }
+
+    public void testRejoinOneNode() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology =
+        ImmutableMap.of(0, "0",
+                        1, "0");
+        killAndRejoinNodes(topology, 1, 1);
+    }
+
+    public void testRejoinTwoNodes() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology =
+        ImmutableMap.of(0, "0",
+                        1, "1",
+                        2, "2");
+        killAndRejoinNodes(topology, 2, 2);
+    }
+
+    public void testRejoinTwoNodesToTwo() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
+                                                 .put(0, "0")
+                                                 .put(1, "0")
+                                                 .put(2, "1")
+                                                 .put(3, "1")
+                                                 .put(4, "2")
+                                                 .put(5, "2")
+                                                 .build();
+        killAndRejoinNodes(topology, 1, 2);
+    }
+
+    public void testRejoinThreeNodesToFour() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
+                                                 .put(0, "0")
+                                                 .put(1, "0")
+                                                 .put(2, "0")
+                                                 .put(3, "0")
+                                                 .put(4, "1")
+                                                 .put(5, "1")
+                                                 .put(6, "1")
+                                                 .build();
+        killAndRejoinNodes(topology, 2, 3);
+    }
+
+    private static void killAndRejoinNodes(ImmutableMap<Integer, String> fullHostGroup, int kfactor, int nodesToKill)
+    throws JSONException
+    {
+        final int maxSph = 20;
+        for (int sph = 1; sph < maxSph; sph++) {
+            final Map<Integer, String> rejoinHostGroup = new HashMap<>(fullHostGroup);
+            final ClusterConfig initialConfig = new ClusterConfig(rejoinHostGroup.size(), sph, kfactor);
+            if (!initialConfig.validate()) {
+                // Invalid config, skip
+                continue;
+            }
+            final JSONObject initialTopo = initialConfig.getTopology(rejoinHostGroup, HashMultimap.create(), new HashMap<>());
+
+            final Multimap<Integer, Integer> partitionToHosts = HashMultimap.create();
+            final Multimap<Integer, Integer> hostPartitions = HashMultimap.create();
+            final Multimap<Integer, Integer> hostMasters = HashMultimap.create();
+            for (int hostId : rejoinHostGroup.keySet()) {
+                for (int pid : ClusterConfig.partitionsForHost(initialTopo, hostId)) {
+                    partitionToHosts.put(pid, hostId);
+                }
+                hostPartitions.putAll(hostId, ClusterConfig.partitionsForHost(initialTopo, hostId));
+                hostMasters.putAll(hostId, ClusterConfig.partitionsForHost(initialTopo, hostId, true));
+            }
+
+            // Pick nodes to kill from different groups. if this is
+            // not a valid topology for multiple rejoins in different
+            // groups, the returned set will be empty.
+            final Set<Integer> hostIdsToKill = pickNodesInDiffGroupsToKill(fullHostGroup, hostPartitions, kfactor, nodesToKill);
+            if (hostIdsToKill.isEmpty()) {
+                System.out.println("Not a valid topology for multi node rejoin, skipping. Sites per host " + sph);
+                continue;
+            }
+            System.out.println("Running config: sites " + sph + ", host partitions: " + hostPartitions +
+                               ", nodes to kill: " + hostIdsToKill);
+
+            // Remove all partitions and masters from the failed nodes, migrate masters to remaining nodes
+            final Multimap<Integer, Integer> expectedRejoinHostPartitions = HashMultimap.create();
+            final HashSet<Integer> liveHosts = new HashSet<>(hostPartitions.keySet());
+            final Map<Integer, String> rejoinHostGroups = new HashMap<>();
+            for (int toKill : hostIdsToKill) {
+                liveHosts.remove(toKill);
+                for (int masterToRedistribute : hostMasters.get(toKill)) {
+                    for (int hostCandidate : partitionToHosts.get(masterToRedistribute)) {
+                        if (hostCandidate != toKill && liveHosts.contains(hostCandidate)) {
+                            hostMasters.put(hostCandidate, masterToRedistribute);
+                            break;
+                        }
+                    }
+                }
+                expectedRejoinHostPartitions.putAll(toKill, hostPartitions.removeAll(toKill));
+                hostMasters.removeAll(toKill);
+                rejoinHostGroups.put(toKill, rejoinHostGroup.remove(toKill));
+            }
+
+            // Fake partition to HSID mappings
+            Multimap<Integer, Long> replicas = HashMultimap.create();
+            for (Map.Entry<Integer, Integer> e : hostPartitions.entries()) {
+                replicas.put(e.getValue(), CoreUtils.getHSIdFromHostAndSite(e.getKey(), e.getValue()));
+            }
+            Map<Integer, Long> masters = new HashMap<>();
+            for (Map.Entry<Integer, Integer> e : hostMasters.entries()) {
+                masters.put(e.getValue(), CoreUtils.getHSIdFromHostAndSite(e.getKey(), e.getValue()));
+            }
+
+            // Rejoin one node at a time and verify that they have the correct partitions
+            for (Map.Entry<Integer, String> rejoin : rejoinHostGroups.entrySet()) {
+                System.out.println("Rejoining " + rejoin.getKey() + " in group " + rejoin.getValue());
+                rejoinHostGroup.put(rejoin.getKey(), rejoin.getValue());
+                final JSONObject rejoinTopo = initialConfig.getTopology(rejoinHostGroup, replicas, masters);
+                final List<Integer> partitionsOnRejoinHost = ClusterConfig.partitionsForHost(rejoinTopo, rejoin.getKey());
+
+                // Verify rejoined host first. Partitions on rejoined host should have
+                // at least one replica in a different group.
+                if (fullHostGroup.values().stream().distinct().count() > 1) {
+                    for (int partitionOnRejoined : partitionsOnRejoinHost) {
+                        final String rejoinedHostGroup = rejoin.getValue();
+                        boolean foundHostInOtherGroup = false;
+                        for (long hsId : replicas.get(partitionOnRejoined)) {
+                            if (!rejoinHostGroup.get(CoreUtils.getHostIdFromHSId(hsId)).equals(rejoinedHostGroup)) {
+                                foundHostInOtherGroup = true;
+                                break;
+                            }
+                        }
+                        assertTrue("Host " + rejoin.getKey() + " partition " + partitionOnRejoined + " rejoined: " +
+                                   partitionsOnRejoinHost + " current " + replicas,
+                                   foundHostInOtherGroup);
+                    }
+                }
+                assertTrue(ClusterConfig.partitionsForHost(rejoinTopo, rejoin.getKey(), true).isEmpty()); // No master on rejoined host
+
+                // Verify existing hosts remain the same
+                for (Map.Entry<Integer, Collection<Integer>> e : hostPartitions.asMap().entrySet()) {
+                    assertEquals(e.getValue(), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, e.getKey())));
+                    assertEquals(hostMasters.get(e.getKey()), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, e.getKey(), true)));
+                }
+
+                // Now add the rejoined host to the live host maps
+                hostPartitions.putAll(rejoin.getKey(), partitionsOnRejoinHost);
+                for (int pid : partitionsOnRejoinHost) {
+                    replicas.put(pid, CoreUtils.getHSIdFromHostAndSite(rejoin.getKey(), pid));
+                }
+            }
+        }
+    }
+
+    private static Set<Integer> pickNodesInDiffGroupsToKill(ImmutableMap<Integer, String> topo,
+                                                            Multimap<Integer, Integer> hostPartitions,
+                                                            int kfactor,
+                                                            int nodesToKill)
+    {
+        for (Set<Integer> perm : Sets.powerSet(topo.keySet())) {
+            // Skip permutation size not equal to the node count to kill
+            if (perm.size() != nodesToKill) {
+                continue;
+            }
+            // If the nodes in the list share the group, skip
+            if (perm.stream().map(topo::get).distinct().count() != nodesToKill) {
+                continue;
+            }
+
+            // Count the occurrences of each partition in the candidate nodes
+            Map<Integer, Integer> partitionOccurrances = new HashMap<>();
+            perm.stream().map(hostPartitions::get).forEach(s -> s.forEach(a -> {
+                if (partitionOccurrances.containsKey(a)) {
+                    partitionOccurrances.put(a, partitionOccurrances.get(a) + 1);
+                } else {
+                    partitionOccurrances.put(a, 1);
+                }
+            }));
+
+            // If a partition appears k+1 times in the candidate nodes, killing
+            // them will take the cluster down, so skip this set of candidate nodes
+            boolean skip = false;
+            for (int count : partitionOccurrances.values()) {
+                if (count > kfactor) {
+                    skip = true;
+                }
+            }
+            if (skip) {
+                continue;
+            }
+
+            return new HashSet<>(perm);
+        }
+        return new HashSet<>();
     }
 
     public void testFourNodesOneGroups() throws JSONException
@@ -213,7 +408,7 @@ public class TestClusterCompiler extends TestCase
         hostGroups.put(3, "1");
         hostGroups.put(4, "2");
         hostGroups.put(5, "2");
-        runConfigAndVerifyTopology(hostGroups, 2);
+        runConfigAndVerifyTopology(hostGroups, 1);
     }
 
     public void testFiveNodesTwoGroups() throws JSONException
@@ -262,6 +457,15 @@ public class TestClusterCompiler extends TestCase
         runConfigAndVerifyTopology(hostGroups, 2);
     }
 
+    public void testFiftNodesInThreeGroups() throws JSONException
+    {
+        Map<Integer, String> hostGroups = Maps.newHashMap();
+        for (int i = 0; i < 50; i++) {
+            hostGroups.put(i, String.valueOf(i % 3));
+        }
+        runConfigAndVerifyTopology(hostGroups, 2);
+    }
+
     private static void runConfigAndVerifyTopology(Map<Integer, String> hostGroups, int kfactor) throws JSONException
     {
         final int maxSites = 20;
@@ -273,9 +477,9 @@ public class TestClusterCompiler extends TestCase
 
         for (int sites = 1; sites <= maxSites; sites++) {
             final ClusterConfig config = new ClusterConfig(hostGroups.size(), sites, kfactor);
-            System.out.println("Running config " + sites + " sitesperhost, k=" + kfactor);
+            System.out.println("Running config " + hostGroups.size() + " hosts, " + sites + " sitesperhost, k=" + kfactor);
             if (config.validate()) {
-                final JSONObject topo = config.getTopology(hostGroups);
+                final JSONObject topo = config.getTopology(hostGroups, HashMultimap.create(), new HashMap<>());
                 verifyTopology(hostGroups, topo);
             } else {
                 System.out.println(config.getErrorMsg());
@@ -320,17 +524,11 @@ public class TestClusterCompiler extends TestCase
             assertEquals(nodesWithMaxMasterCount, masterCountToHost.get(maxMasterCount).size());
         }
 
-        for (Map.Entry<String, Collection<Integer>> ghEntry : groupHosts.asMap().entrySet()) {
-            if (ghEntry.getValue().size() * sitesPerHost < partitionCount) {
-                // Non-optimal topology, no need to verify the rest
-                System.out.println("Group " + ghEntry.getKey() + " only has " + ghEntry.getValue().size() + " hosts");
-                return;
-            }
-        }
-
         // Each group should have at least one copy of all the partitions
-        for (Collection<Integer> partitions : groupPartitions.asMap().values()) {
-            assertEquals(partitionCount, Sets.newHashSet(partitions).size());
+        for (Map.Entry<String, Collection<Integer>> groupAndPids : groupPartitions.asMap().entrySet()) {
+            assertEquals(groupPartitions.toString(),
+                         Math.min(partitionCount, groupHosts.get(groupAndPids.getKey()).size() * sitesPerHost),
+                         Sets.newHashSet(groupAndPids.getValue()).size());
         }
     }
 }

--- a/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
@@ -22,6 +22,7 @@
  */
 package org.voltdb.compiler;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -55,7 +56,7 @@ public class TestClusterCompiler extends TestCase
         topology.put(0, new ExtensibleGroupTag("0", "0"));
         topology.put(1, new ExtensibleGroupTag("0", "0"));
         topology.put(2, new ExtensibleGroupTag("0", "0"));
-        JSONObject obj = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
+        JSONObject obj = config.getTopology(topology, HashMultimap.create(), new HashMap<>(), new ArrayList<>());
         config.validate();
         System.out.println(obj.toString(4));
         JSONArray partitions = obj.getJSONArray("partitions");
@@ -107,7 +108,7 @@ public class TestClusterCompiler extends TestCase
         ClusterConfig config = new ClusterConfig(1, 6, 0);
         Map<Integer, ExtensibleGroupTag> topology = Maps.newHashMap();
         topology.put(0, new ExtensibleGroupTag("0", "0"));
-        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>(), new ArrayList<>());
         assertEquals(1, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(0, topo.getInt("kfactor"));
@@ -124,7 +125,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, ExtensibleGroupTag> topology = Maps.newHashMap();
         topology.put(0, new ExtensibleGroupTag("0", "0"));
         topology.put(1, new ExtensibleGroupTag("0", "0"));
-        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>(), new ArrayList<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(0, topo.getInt("kfactor"));
@@ -143,7 +144,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, ExtensibleGroupTag> topology = Maps.newHashMap();
         topology.put(0, new ExtensibleGroupTag("0", "0"));
         topology.put(1, new ExtensibleGroupTag("0", "0"));
-        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>(), new ArrayList<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(1, topo.getInt("kfactor"));
@@ -160,7 +161,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, ExtensibleGroupTag> topology = Maps.newHashMap();
         topology.put(0, new ExtensibleGroupTag("0", "0"));
         topology.put(1, new ExtensibleGroupTag("0", "0"));
-        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>(), new ArrayList<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(1, topo.getInt("kfactor"));
@@ -228,7 +229,7 @@ public class TestClusterCompiler extends TestCase
                 // Invalid config, skip
                 continue;
             }
-            final JSONObject initialTopo = initialConfig.getTopology(rejoinHostGroup, HashMultimap.create(), new HashMap<>());
+            final JSONObject initialTopo = initialConfig.getTopology(rejoinHostGroup, HashMultimap.create(), new HashMap<>(), new ArrayList<>());
 
             final Multimap<Integer, Integer> partitionToHosts = HashMultimap.create();
             final Multimap<Integer, Integer> hostPartitions = HashMultimap.create();
@@ -286,7 +287,7 @@ public class TestClusterCompiler extends TestCase
                 final int rejoinHostId = rejoin.getKey() + fullHostGroup.size();
                 System.out.println("Rejoining H" + rejoin.getKey() + " as H" + rejoinHostId + " in group " + rejoin.getValue().m_rackAwarenessGroup);
                 rejoinHostGroup.put(rejoinHostId, rejoin.getValue());
-                final JSONObject rejoinTopo = initialConfig.getTopology(rejoinHostGroup, replicas, masters);
+                final JSONObject rejoinTopo = initialConfig.getTopology(rejoinHostGroup, replicas, masters, new ArrayList<>());
                 final List<Integer> partitionsOnRejoinHost = ClusterConfig.partitionsForHost(rejoinTopo, rejoinHostId);
 
                 // Verify rejoined host first. Partitions on rejoined host should have
@@ -549,7 +550,7 @@ public class TestClusterCompiler extends TestCase
             final ClusterConfig config = new ClusterConfig(hostGroups.size(), sites, kfactor);
             System.out.println("Running config " + hostGroups.size() + " hosts, " + sites + " sitesperhost, k=" + kfactor);
             if (config.validate()) {
-                final JSONObject topo = config.getTopology(hostGroups, HashMultimap.create(), new HashMap<>());
+                final JSONObject topo = config.getTopology(hostGroups, HashMultimap.create(), new HashMap<>(), new ArrayList<>());
                 verifyTopology(hostGroups, topo);
             } else {
                 System.out.println(config.getErrorMsg());

--- a/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
@@ -194,11 +194,11 @@ public class TestClusterCompiler extends TestCase
     {
         ImmutableMap<Integer, ExtensibleGroupTag> topology = new ImmutableMap.Builder<Integer, ExtensibleGroupTag>()
                                                  .put(0, new ExtensibleGroupTag("0", "0"))
-                                                 .put(1, new ExtensibleGroupTag("0", "0"))
-                                                 .put(2, new ExtensibleGroupTag("1", "0"))
-                                                 .put(3, new ExtensibleGroupTag("1", "0"))
+                                                 .put(1, new ExtensibleGroupTag("0", "1"))
+                                                 .put(2, new ExtensibleGroupTag("1", "1"))
+                                                 .put(3, new ExtensibleGroupTag("1", "2"))
                                                  .put(4, new ExtensibleGroupTag("2", "0"))
-                                                 .put(5, new ExtensibleGroupTag("2", "0"))
+                                                 .put(5, new ExtensibleGroupTag("2", "2"))
                                                  .build();
         killAndRejoinNodes(topology, 1, 2);
     }
@@ -207,12 +207,12 @@ public class TestClusterCompiler extends TestCase
     {
         ImmutableMap<Integer, ExtensibleGroupTag> topology = new ImmutableMap.Builder<Integer, ExtensibleGroupTag>()
                                                  .put(0, new ExtensibleGroupTag("0", "0"))
-                                                 .put(1, new ExtensibleGroupTag("0", "0"))
+                                                 .put(1, new ExtensibleGroupTag("0", "1"))
                                                  .put(2, new ExtensibleGroupTag("0", "0"))
                                                  .put(3, new ExtensibleGroupTag("0", "0"))
                                                  .put(4, new ExtensibleGroupTag("1", "0"))
-                                                 .put(5, new ExtensibleGroupTag("1", "0"))
-                                                 .put(6, new ExtensibleGroupTag("1", "0"))
+                                                 .put(5, new ExtensibleGroupTag("1", "1"))
+                                                 .put(6, new ExtensibleGroupTag("1", "1"))
                                                  .build();
         killAndRejoinNodes(topology, 2, 3);
     }

--- a/tests/frontend/org/voltdb/iv2/TestCartographer.java
+++ b/tests/frontend/org/voltdb/iv2/TestCartographer.java
@@ -80,65 +80,6 @@ public class TestCartographer extends ZKTestBase {
     }
 
     @Test
-    public void testReplicateLeastReplicated()
-    {
-        // Gin up our fake replication counts to leave the last partition needing two replicas
-        // 5 hosts, 3 sites/host, k=2 is 15 sites, 5 partitions.
-        // Need 2 hosts dead, so 6 missing replicas, last one needs to miss 2
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        repsPerPart.put(0, 2);
-        repsPerPart.put(1, 2);
-        repsPerPart.put(2, 2);
-        repsPerPart.put(3, 2);
-        repsPerPart.put(4, 1);
-        int kfactor = 2;
-        int numberOfPartitions = 5;
-        int sitesPerHost = 3;
-
-        List<Integer> firstRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(3, firstRejoin.size());
-        assertEquals((Integer)4, firstRejoin.get(0));
-        assertEquals((Integer)0, firstRejoin.get(1));
-        assertEquals((Integer)1, firstRejoin.get(2));
-        // add to each of the repsPerPart from the firstRejoin results
-        for (int partition : firstRejoin) {
-            repsPerPart.put(partition, repsPerPart.get(partition) + 1);
-        }
-
-        // now do it again and make sure we fully replicate
-        List<Integer> secondRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(3, secondRejoin.size());
-        assertEquals((Integer)2, secondRejoin.get(0));
-        assertEquals((Integer)3, secondRejoin.get(1));
-        assertEquals((Integer)4, secondRejoin.get(2));
-    }
-
-    @Test
-    public void testNoOverReplication()
-    {
-        // We'll set things up to only require one more replica and then offer up a host with more sites
-        // than we need.  This particular case could never happen but should test the logic correctly.
-        // Also, test that we don't replicate the same partition twice on the same host again.
-        int kfactor = 2;
-        int numberOfPartitions = 5;
-        int sitesPerHost = 3;
-
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        repsPerPart.put(0, 3);
-        repsPerPart.put(1, 3);
-        repsPerPart.put(2, 3);
-        repsPerPart.put(3, 3);
-        repsPerPart.put(4, 1);
-
-        List<Integer> firstRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(1, firstRejoin.size());
-        assertEquals((Integer)4, firstRejoin.get(0));
-    }
-
-    @Test
     public void testSPMasterChange() throws Exception
     {
         ZooKeeper zk = getClient(0);

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.google_voltpatches.common.collect.HashMultimap;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONException;
@@ -52,7 +51,9 @@ import org.voltdb.TheHashinator;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
 import org.voltdb.compiler.ClusterConfig;
+import org.voltdb.compiler.ClusterConfig.ExtensibleGroupTag;
 
+import com.google_voltpatches.common.collect.HashMultimap;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.collect.Sets;
@@ -62,7 +63,7 @@ public class TestLeaderAppointer extends ZKTestBase {
     private final int NUM_AGREEMENT_SITES = 1;
     private ClusterConfig m_config = null;
     private Set<Integer> m_hostIds;
-    private Map<Integer, String> m_hostGroups;
+    private Map<Integer, ExtensibleGroupTag> m_hostGroups;
     private MpInitiator m_mpi = null;
     private HostMessenger m_hm = null;
     private ZooKeeper m_zk = null;
@@ -116,7 +117,7 @@ public class TestLeaderAppointer extends ZKTestBase {
         m_hostGroups = Maps.newHashMap();
         for (int i = 0; i < hostCount; i++) {
             m_hostIds.add(i);
-            m_hostGroups.put(i, "0");
+            m_hostGroups.put(i, new ExtensibleGroupTag("0", "0"));
         }
         when(m_hm.getLiveHostIds()).thenReturn(m_hostIds);
         m_mpi = mock(MpInitiator.class);

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -30,12 +30,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google_voltpatches.common.collect.HashMultimap;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONException;
@@ -128,8 +130,8 @@ public class TestLeaderAppointer extends ZKTestBase {
     {
         KSafetyStats stats = new KSafetyStats();
         m_dut = new LeaderAppointer(m_hm, m_config.getPartitionCount(),
-                m_config.getReplicationFactor(),
-                null, m_config.getTopology(m_hostGroups), m_mpi, stats, false);
+                                    m_config.getReplicationFactor(),
+                                    null, m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()), m_mpi, stats, false);
         m_dut.onReplayCompletion();
     }
 
@@ -278,7 +280,7 @@ public class TestLeaderAppointer extends ZKTestBase {
                                     m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(),
                                     null,
-                                    m_config.getTopology(m_hostGroups),
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
                                     m_mpi,
                                     new KSafetyStats(),
                                     false);
@@ -525,7 +527,7 @@ public class TestLeaderAppointer extends ZKTestBase {
                                     m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(),
                                     null,
-                                    m_config.getTopology(m_hostGroups),
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
                                     m_mpi,
                                     new KSafetyStats(),
                                     true);

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -132,7 +133,7 @@ public class TestLeaderAppointer extends ZKTestBase {
         KSafetyStats stats = new KSafetyStats();
         m_dut = new LeaderAppointer(m_hm, m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(),
-                                    null, m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()), m_mpi, stats, false);
+                                    null, m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>(), new ArrayList<>()), m_mpi, stats, false);
         m_dut.onReplayCompletion();
     }
 
@@ -281,7 +282,7 @@ public class TestLeaderAppointer extends ZKTestBase {
                                     m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(),
                                     null,
-                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>(), new ArrayList<>()),
                                     m_mpi,
                                     new KSafetyStats(),
                                     false);
@@ -528,7 +529,7 @@ public class TestLeaderAppointer extends ZKTestBase {
                                     m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(),
                                     null,
-                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>(), new ArrayList<>()),
                                     m_mpi,
                                     new KSafetyStats(),
                                     true);


### PR DESCRIPTION
This patch contains a serial of things. Because I started the innovation week work of supporting buddy group from @nshi's work-in-progress branch, so it inevitable includes both changes from me and @nshi. 

The first three commits are from https://github.com/VoltDB/voltdb/pull/3837

The other commits from me is adding buddy group to existing rack aware grouping algorithm, it supports both the normal case and rejoin case.

The companion pro pull request is https://github.com/VoltDB/pro/pull/1502
