### PR TITLE
Eng-11183 Fix problem of voltadmin using 'hostname' to connect to issue a stop node.

### DIFF
--- a/lib/python/voltcli/voltadmin.d/stop.py
+++ b/lib/python/voltcli/voltadmin.d/stop.py
@@ -33,14 +33,11 @@ class Host(dict):
 
     def get_admininterface(self):
         """
-        Return the likely admininterface. The precedence rules are the order that
-        we're checking.
-        Implementation note: ipaddress will be set to externalinterface, if set
-        Otherwise it may be any interface.
+        Return the likely admininterface. 
+        Implementation note: Currently, ipaddress will be set to externalinterface
+        if set by user, otherwise server selects any interface.
         """
 
-        if 'publicinterface' in self and self['publicinterface']:
-            return self['publicinterface']
         if 'admininterface' in self and self['admininterface']:
             return self['admininterface']
         if 'ipaddress' in self and self['ipaddress']:


### PR DESCRIPTION
Fixes issue where 'hostname' is selected for connection during call to voltadmin stop.   It selects admininterface, if specified.  Otherwise it selects ipaddress.