### PR TITLE
ENG-11152

### DIFF
--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -100,10 +100,10 @@ import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.LogKeys;
 import org.voltdb.utils.MinimumRatioMaintainer;
 
+import vanilla.java.affinity.impl.PosixJNAAffinity;
+
 import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.base.Preconditions;
-
-import vanilla.java.affinity.impl.PosixJNAAffinity;
 
 public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConnection
 {
@@ -1481,6 +1481,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                 }
                 foundSinglepartTxnId = true;
                 m_initiatorMailbox.setMaxLastSeenTxnId(txnId);
+                setSpHandleForSnapshotDigest(txnId);
             }
             if (!skipMultiPart && TxnEgo.getPartitionId(txnId) == MpInitiator.MP_INIT_PID) {
                 if (foundMultipartTxnId) {


### PR DESCRIPTION
Currently the digest in all snapshots tracks the last TxnId for all partitions, even partitions invalid ones resulting from the restoring a snapshot from a different topology. Since UniqueIds are our time based reference for avoiding duplicate transactions, this artifact is no longer required. For now, we still store "legacy" TxnIds in snapshots. However these values are only preserved from a Recover.

From this point on, only Recover will populate the TxnId from a snapshot. Further, since DR state (including ClusterCreateTime) should not be populated either on from the restore path, this patch prevents this as well.