### PR TITLE
ENG-11185: patch 1

### DIFF
--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -248,7 +248,10 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             final TransactionState txn = m_outstandingTxns.get(key.m_txnId);
             if (txn == null || txn.isDone()) {
                 m_outstandingTxns.remove(key.m_txnId);
-                setRepairLogTruncationHandle(key.m_spHandle);
+                // for MP write txns, we should use it's first SpHandle in the TransactionState
+                // for SP write txns, we can just use the SpHandle from the DuplicateCounterKey
+                long m_safeSpHandle = txn == null ? key.m_spHandle: txn.m_spHandle;
+                setRepairLogTruncationHandle(m_safeSpHandle);
             }
 
             VoltMessage resp = counter.getLastResponse();


### PR DESCRIPTION
Promotion Related Changes:
1. Remove Complete Transaction Response Message Duplicate Counter, and swollen its repair truncation message on leader; 

2. Repaired MP transaction should use SpHandle from TransactionState other than its newest message SpHandle;

Once a while, I saw a similar truncation handle going backwards during process of rejoin, which seems to be a separate problem. Still working on this issue. 