### PR TITLE
ENG-11233: Change throwing exception case to debug logging case

### DIFF
--- a/src/frontend/org/voltdb/iv2/RepairLog.java
+++ b/src/frontend/org/voltdb/iv2/RepairLog.java
@@ -183,19 +183,18 @@ public class RepairLog
             // transaction.  We don't want to log it in the repair log.
             CompleteTransactionMessage ctm = (CompleteTransactionMessage)msg;
             // We can't repair read only SP transactions. Just don't log them to the repair log.
-            if (ctm.isReadOnly()) {
+            // Restart transaction do not need to be repaired here, don't log them as well.
+            if (ctm.isReadOnly() || ctm.isRestart()) {
                 return;
             }
 
-            if (!ctm.isRestart()) {
-                truncate(ctm.getTruncationHandle(), IS_MP);
-                m_logMP.add(new Item(IS_MP, ctm, ctm.getSpHandle(), ctm.getTxnId()));
-                //Restore will send a complete transaction message with a lower mp transaction id because
-                //the restore transaction precedes the loading of the right mp transaction id from the snapshot
-                //Hence Math.max
-                m_lastMpHandle = Math.max(m_lastMpHandle, ctm.getTxnId());
-                m_lastSpHandle = ctm.getSpHandle();
-            }
+            truncate(ctm.getTruncationHandle(), IS_MP);
+            m_logMP.add(new Item(IS_MP, ctm, ctm.getSpHandle(), ctm.getTxnId()));
+            //Restore will send a complete transaction message with a lower mp transaction id because
+            //the restore transaction precedes the loading of the right mp transaction id from the snapshot
+            //Hence Math.max
+            m_lastMpHandle = Math.max(m_lastMpHandle, ctm.getTxnId());
+            m_lastSpHandle = ctm.getSpHandle();
         }
         else if (msg instanceof DumpMessage) {
             String who = CoreUtils.hsIdToString(m_HSId);

--- a/src/frontend/org/voltdb/iv2/RepairLog.java
+++ b/src/frontend/org/voltdb/iv2/RepairLog.java
@@ -278,7 +278,9 @@ public class RepairLog
         Collections.sort(items, m_handleComparator);
 
         int ofTotal = items.size() + 1;
-        tmLog.debug("Responding with " + ofTotal + " repair log parts.");
+        if (tmLog.isDebugEnabled()) {
+            tmLog.debug("Responding with " + ofTotal + " repair log parts.");
+        }
         List<Iv2RepairLogResponseMessage> responses =
             new LinkedList<Iv2RepairLogResponseMessage>();
 

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1283,8 +1283,10 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         } else {
             // As far as I know, they are cases that will move truncation handle backwards.
             // These include node failures (promotion phase) and node rejoin (early rejoin phase).
-            tmLog.debug("Updating truncation point from " + TxnEgo.txnIdToString(m_repairLogTruncationHandle) +
-                    "to" + TxnEgo.txnIdToString(newHandle));
+            if (tmLog.isDebugEnabled()) {
+                tmLog.debug("Updating truncation point from " + TxnEgo.txnIdToString(m_repairLogTruncationHandle) +
+                        "to" + TxnEgo.txnIdToString(newHandle));
+            }
         }
     }
 

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1267,12 +1267,6 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 
     private void setRepairLogTruncationHandle(long newHandle)
     {
-        if (newHandle < m_repairLogTruncationHandle) {
-            throw new RuntimeException("Updating truncation point from " +
-                    TxnEgo.txnIdToString(m_repairLogTruncationHandle) +
-                    "to" + TxnEgo.txnIdToString(newHandle));
-        }
-
         if (newHandle > m_repairLogTruncationHandle) {
             m_repairLogTruncationHandle = newHandle;
 
@@ -1286,6 +1280,11 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
                 m_bufferedReadLog.releaseBufferedReads(m_mailbox, m_repairLogTruncationHandle);
             }
             scheduleRepairLogTruncateMsg();
+        } else {
+            // As far as I know, they are cases that will move truncation handle backwards.
+            // These include node failures (promotion phase) and node rejoin (early rejoin phase).
+            tmLog.debug("Updating truncation point from " + TxnEgo.txnIdToString(m_repairLogTruncationHandle) +
+                    "to" + TxnEgo.txnIdToString(newHandle));
         }
     }
 


### PR DESCRIPTION
Local repair log truncation handle is possible to move backwards. Instead of throwing runtime exception, we can debug logging it. Possible cases are added, like node failure and node rejoin. All of them are related to MP transaction CompleteTransactionResponseMessage with following SP write transaction during leader promotion or early rejoin phase (runForRejoin).