### PR TITLE
ENG-11231 skip live client stats collection for schema restore.

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -130,6 +130,8 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     public static final long INTERNAL_CID               = Long.MIN_VALUE + 5;
     public static final long EXECUTE_TASK_CID           = Long.MIN_VALUE + 6;
     public static final long DR_DISPATCHER_CID          = Long.MIN_VALUE + 7;
+    public static final long RESTORE_SCHEMAS_CID        = Long.MIN_VALUE + 8;
+
     // Leave CL_REPLAY_BASE_CID at the end, it uses this as a base and generates more cids
     // PerPartition cids
     private static long setBaseValue(int offset) { return offset << 14; }

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -46,7 +46,6 @@ import org.voltcore.messaging.HostMessenger;
 import org.voltcore.messaging.LocalObjectMessage;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.network.Connection;
-import org.voltcore.network.VoltProtocolHandler;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.EstTime;
 import org.voltcore.utils.RateLimitedLogger;
@@ -958,9 +957,8 @@ public final class InvocationDispatcher {
             catalogUpdateTask.setProcName("@UpdateApplicationCatalog");
             catalogUpdateTask.setParams(catalog,dep);
 
-            final long alternateConnectionId = ClientInterface.RESTORE_SCHEMAS_CID;
             final SimpleClientResponseAdapter alternateAdapter = new SimpleClientResponseAdapter(
-                    alternateConnectionId, "Empty database snapshot restore catalog update"
+                    ClientInterface.RESTORE_SCHEMAS_CID, "Empty database snapshot restore catalog update"
                     );
             final InvocationClientHandler alternateHandler = new InvocationClientHandler() {
                 @Override
@@ -969,7 +967,7 @@ public final class InvocationDispatcher {
                 }
                 @Override
                 public long connectionId() {
-                    return alternateConnectionId;
+                    return ClientInterface.RESTORE_SCHEMAS_CID;
                 }
             };
 

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -958,7 +958,7 @@ public final class InvocationDispatcher {
             catalogUpdateTask.setProcName("@UpdateApplicationCatalog");
             catalogUpdateTask.setParams(catalog,dep);
 
-            final long alternateConnectionId = VoltProtocolHandler.getNextConnectionId();
+            final long alternateConnectionId = ClientInterface.RESTORE_SCHEMAS_CID;
             final SimpleClientResponseAdapter alternateAdapter = new SimpleClientResponseAdapter(
                     alternateConnectionId, "Empty database snapshot restore catalog update"
                     );

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -957,6 +957,8 @@ public final class InvocationDispatcher {
             catalogUpdateTask.setProcName("@UpdateApplicationCatalog");
             catalogUpdateTask.setParams(catalog,dep);
 
+            //A connection with positive id will be thrown into live client statistics. The connection does not support stats.
+            //Thus make the connection id as a negative constant to skip the stats collection.
             final SimpleClientResponseAdapter alternateAdapter = new SimpleClientResponseAdapter(
                     ClientInterface.RESTORE_SCHEMAS_CID, "Empty database snapshot restore catalog update"
                     );


### PR DESCRIPTION
A connection with positive id in schema restore will be thrown into  live client statistics. However, the connection (SimpleClientResponseAdapter) does not support stats.  Thus make the connection id as a negative constant to skip the stats collection.