### PR TITLE
ENG-11180: avoid crash when create view is long-running

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -139,7 +139,7 @@ typedef boost::multi_index::multi_index_container<
 class EnginePlanSet : public PlanSet { };
 
 VoltDBEngine::VoltDBEngine(Topend *topend, LogProxy *logProxy)
-    : m_currentIndexInBatch(0),
+    : m_currentIndexInBatch(-1),
       m_tuplesProcessedInBatch(0),
       m_tuplesProcessedInFragment(0),
       m_tuplesProcessedSinceReport(0),

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -423,6 +423,8 @@ int VoltDBEngine::executePlanFragments(int32_t numFragments,
         m_stringPool.purge();
     }
 
+    m_currentIndexInBatch = -1;
+
     return failures;
 }
 
@@ -2063,16 +2065,18 @@ void VoltDBEngine::executePurgeFragment(PersistentTable* table) {
 
 static std::string dummy_last_accessed_plan_node_name("no plan node in progress");
 
-void VoltDBEngine::reportProgressToTopend() {
-    assert(m_currExecutorVec);
+void VoltDBEngine::reportProgressToTopend(const TempTableLimits *limits) {
+
+    int64_t allocated = limits != NULL ? limits->getAllocated() : -1;
+    int64_t peak = limits != NULL ? limits->getPeakMemoryInBytes() : -1;
 
     //Update stats in java and let java determine if we should cancel this query.
     m_tuplesProcessedInFragment += m_tuplesProcessedSinceReport;
     int64_t tupleReportThreshold = m_topend->fragmentProgressUpdate(m_currentIndexInBatch,
                                         m_lastAccessedPlanNodeType,
                                         m_tuplesProcessedInBatch + m_tuplesProcessedInFragment,
-                                        m_currExecutorVec->limits().getAllocated(),
-                                        m_currExecutorVec->limits().getPeakMemoryInBytes());
+                                        allocated,
+                                        peak);
     m_tuplesProcessedSinceReport = 0;
 
     if (tupleReportThreshold < 0) {

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -188,8 +188,10 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         // Executors can call this to note a certain number of tuples have been
         // scanned or processed.index
         inline int64_t pullTuplesRemainingUntilProgressReport(PlanNodeType planNodeType);
-        inline int64_t pushTuplesProcessedForProgressMonitoring(int64_t tuplesProcessed);
-        inline void pushFinalTuplesProcessedForProgressMonitoring(int64_t tuplesProcessed);
+        inline int64_t pushTuplesProcessedForProgressMonitoring(const TempTableLimits* limits,
+                                                                int64_t tuplesProcessed);
+        inline void pushFinalTuplesProcessedForProgressMonitoring(const TempTableLimits* limits,
+                                                                  int64_t tuplesProcessed);
 
         // If an insert will fail due to row limit constraint and user
         // has defined a delete action to make space, this method
@@ -458,7 +460,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         /**
          * Call into the topend with information about how executing a plan fragment is going.
          */
-        void reportProgressToTopend();
+        void reportProgressToTopend(const TempTableLimits* limits);
 
         /**
          * Execute a single plan fragment.
@@ -668,19 +670,21 @@ inline int64_t VoltDBEngine::pullTuplesRemainingUntilProgressReport(PlanNodeType
     return m_tupleReportThreshold - m_tuplesProcessedSinceReport;
 }
 
-inline int64_t VoltDBEngine::pushTuplesProcessedForProgressMonitoring(int64_t tuplesProcessed)
+inline int64_t VoltDBEngine::pushTuplesProcessedForProgressMonitoring(const TempTableLimits* limits,
+                                                                      int64_t tuplesProcessed)
 {
     m_tuplesProcessedSinceReport += tuplesProcessed;
     if (m_tuplesProcessedSinceReport >= m_tupleReportThreshold) {
-        reportProgressToTopend();
+        reportProgressToTopend(limits);
     }
     return m_tupleReportThreshold; // size of next batch
 }
 
-inline void VoltDBEngine::pushFinalTuplesProcessedForProgressMonitoring(int64_t tuplesProcessed)
+inline void VoltDBEngine::pushFinalTuplesProcessedForProgressMonitoring(const TempTableLimits *limits,
+                                                                        int64_t tuplesProcessed)
 {
     try {
-        pushTuplesProcessedForProgressMonitoring(tuplesProcessed);
+        pushTuplesProcessedForProgressMonitoring(limits, tuplesProcessed);
     } catch(const SerializableEEException &e) {
         e.serialize(getExceptionOutputSerializer());
     }

--- a/src/ee/executors/abstractexecutor.h
+++ b/src/ee/executors/abstractexecutor.h
@@ -75,6 +75,12 @@ class AbstractExecutor {
     /** Invoke a plannode's associated executor */
     bool execute(const NValueArray& params);
 
+    /** The temp output table for this executor.  May be null for a
+     *  SEND node! */
+    const TempTable* getTempOutputTable() const {
+        return m_tmpOutputTable;
+    }
+
     /**
      * Returns the plannode that generated this executor.
      */

--- a/src/ee/storage/temptable.h
+++ b/src/ee/storage/temptable.h
@@ -138,9 +138,9 @@ class TempTable : public Table {
     // ------------------------------------------------------------------
     virtual std::string tableType() const;
     virtual voltdb::TableStats* getTableStats();
-
-    // ptr to global integer tracking temp table memory allocated per frag
-    TempTableLimits* m_limits;
+    const TempTableLimits* getTempTableLimits() const {
+        return m_limits;
+    }
 
   protected:
     // can not use this constructor to coerce a cast
@@ -165,6 +165,9 @@ class TempTable : public Table {
   private:
     // pointers to chunks of data. Specific to table impl. Don't leak this type.
     std::vector<TBPtr> m_data;
+
+    // ptr to global integer tracking temp table memory allocated per frag
+    TempTableLimits* m_limits;
 };
 
 inline void TempTable::insertTempTupleDeepCopy(const TableTuple &source, Pool *pool) {

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -86,6 +86,16 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         public final int typeId;
     }
 
+    public static enum FragmentContext {
+        UNKNOWN,
+        RO_BATCH,
+        RW_BATCH,
+        CATALOG_UPDATE,
+        CATALOG_LOAD
+    }
+
+    private FragmentContext m_fragmentContext = FragmentContext.UNKNOWN;
+
     // is the execution site dirty
     protected boolean m_dirty;
 
@@ -127,7 +137,6 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
 
     String m_currentProcedureName = null;
     int m_currentBatchIndex = 0;
-    private boolean m_readOnly;
     private long m_startTime;
     private long m_lastMsgTime;
     private long m_logDuration = INITIAL_LOG_DURATION;
@@ -158,7 +167,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
     }
 
     private boolean shouldTimedOut (long latency) {
-        if (m_readOnly
+        if (m_fragmentContext == FragmentContext.RO_BATCH
                 && m_batchTimeout > NO_BATCH_TIMEOUT_VALUE
                 && m_batchTimeout < latency) {
             return true;
@@ -232,7 +241,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
 
     private class DependencyTracker {
         private final HashMap<Integer, ArrayDeque<VoltTable>> m_depsById =
-            new HashMap<Integer, ArrayDeque<VoltTable>>();
+            new HashMap<>();
 
         private final VoltLogger hostLog = new VoltLogger("HOST");
 
@@ -244,7 +253,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         void addDependency(final int depId, final VoltTable vt) {
             ArrayDeque<VoltTable> deque = m_depsById.get(depId);
             if (deque == null) {
-                deque = new ArrayDeque<VoltTable>();
+                deque = new ArrayDeque<>();
                 m_depsById.put(depId, deque);
             }
             deque.add(vt);
@@ -261,7 +270,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
                 // create a new list of references to the workunit's table
                 // to avoid any changes to the WorkUnit's list. But do not
                 // copy the table data.
-                final ArrayDeque<VoltTable> deque = new ArrayDeque<VoltTable>();
+                final ArrayDeque<VoltTable> deque = new ArrayDeque<>();
                 for (VoltTable depTable : e.getValue()) {
                     // A joining node will respond with a table that has this status code
                     if (depTable.getStatusCode() != VoltTableUtil.NULL_DEPENDENCY_STATUS) {
@@ -404,7 +413,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             // The callback was triggered earlier than we were ready to log.
             // If this keeps happening, it might makes sense to ramp up the threshold
             // to lower the callback frequency to something closer to the log duration
-            // (== the desired log message fequency).
+            // (== the desired log message frequency).
             // That probably involves keeping more stats to estimate the recent tuple processing rate.
             // Such a calibration should probably wait until the next "full batch" and NOT immediately
             // reflected in the current return value which effects the remaining processing of the
@@ -431,43 +440,58 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
 
     private String getLongRunningQueriesMessage(int indexFromFragmentTask,
             long latency, int planNodeTypeAsInt, boolean timeout) {
-        String status = timeout ? "timed out at" : "taking a long time to execute -- at least";
-        String msg = String.format(
-                "Procedure %s is %s " +
-                        "%.2f seconds spent accessing " +
-                        "%d tuples. Current plan fragment " +
-                        "%s in call " +
-                        "%d to voltExecuteSQL on site " +
-                        "%s. Current temp table uses " +
-                        "%d bytes memory, and the peak usage of memory for temp table is " +
-                        "%d bytes.",
-                        m_currentProcedureName,
-                        status,
-                        latency / 1000.0,
-                        m_lastTuplesAccessed,
-                        PlanNodeType.get(planNodeTypeAsInt).name(),
-                        m_currentBatchIndex,
-                        CoreUtils.hsIdToString(m_siteId),
-                        m_currMemoryInBytes,
-                        m_peakMemoryInBytes);
+        StringBuilder sb = new StringBuilder();
+
+        // First describe what is taking a long time.
+        switch (m_fragmentContext) {
+        default:
+        case RO_BATCH:
+        case RW_BATCH:
+            sb.append("Procedure " + m_currentProcedureName);
+            break;
+
+        case CATALOG_UPDATE:
+            sb.append("Catalog update");
+            break;
+
+        case CATALOG_LOAD:
+            sb.append("Catalog load");
+            break;
+        }
+
+        // Timing out (canceling) versus just reporting something taking a long time
+        sb.append(timeout ? " is timed out at " : " is taking a long time to execute -- at least ");
+        sb.append(String.format("%.2f seconds spent accessing %d tuples. ",
+                latency / 1000.0, m_lastTuplesAccessed));
+
+        // Type of plan node executing, and index in batch in known.
+        sb.append("Current plan fragment " + PlanNodeType.get(planNodeTypeAsInt).name());
+        if (indexFromFragmentTask >= 0) {
+            sb.append(" in call " + m_currentBatchIndex + " to voltExecuteSQL");
+        }
+        sb.append(" on site " + CoreUtils.hsIdToString(m_siteId) + ". ");
+
+        if (m_currMemoryInBytes > 0 && m_peakMemoryInBytes > 0) {
+            sb.append("Current temp table uses " + m_currMemoryInBytes + " bytes memory,"
+                    + " and the peak usage of memory for temp table is " + m_peakMemoryInBytes + " bytes.");
+        }
 
         if (m_sqlTexts != null
                 && indexFromFragmentTask >= 0
                 && indexFromFragmentTask < m_sqlTexts.length) {
-            msg += "  Executing SQL statement is \"" + m_sqlTexts[indexFromFragmentTask] + "\".";
+            sb.append(" Executing SQL statement is \"" + m_sqlTexts[indexFromFragmentTask] + "\".");
         }
         else if (m_sqlTexts == null) {
             // Can this happen?
-            msg += "  SQL statement text is not available.";
+            sb.append(" SQL statement text is not available.");
         }
         else {
             // For some reason, the current index in the fragment task message isn't a valid
             // index into the m_sqlTexts array.  We don't expect this to happen,
             // but let's dump something useful if it does.  (See ENG-7610)
-            StringBuffer sb = new StringBuffer();
-            sb.append("  Unable to report specific SQL statement text for "
-                    + "fragment task message index " + indexFromFragmentTask + ".  ");
-            sb.append("It MAY be one of these " + m_sqlTexts.length + " items: ");
+            sb.append(" Unable to report specific SQL statement text for "
+                    + "fragment task message index " + indexFromFragmentTask + ".");
+            sb.append(" It MAY be one of these " + m_sqlTexts.length + " items: ");
             for (int i = 0; i < m_sqlTexts.length; ++i) {
                 if (m_sqlTexts[i] != null) {
                     sb.append("\"" + m_sqlTexts[i] + "\"");
@@ -480,11 +504,9 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
                     sb.append(", ");
                 }
             }
-
-            msg += sb.toString();
         }
 
-        return msg;
+        return sb.toString();
     }
 
     /**
@@ -536,15 +558,35 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         }
     }
 
+    /** Pass the catalog to the engine */
     public void loadCatalog(long timestamp, String serializedCatalog) {
-        loadCatalog(timestamp, getStringBytes(serializedCatalog));
+        try {
+            m_startTime = 0;
+            m_logDuration = INITIAL_LOG_DURATION;
+            m_fragmentContext = FragmentContext.CATALOG_LOAD;
+            coreLoadCatalog(timestamp, getStringBytes(serializedCatalog));
+        }
+        finally {
+            m_fragmentContext = FragmentContext.UNKNOWN;
+        }
     }
 
-    /** Pass the catalog to the engine */
-    protected abstract void loadCatalog(final long timestamp, final byte[] catalogBytes) throws EEException;
+    protected abstract void coreLoadCatalog(final long timestamp, final byte[] catalogBytes) throws EEException;
 
     /** Pass diffs to apply to the EE's catalog to update it */
-    public abstract void updateCatalog(final long timestamp, final String diffCommands) throws EEException;
+    public final void updateCatalog(final long timestamp, final String diffCommands) throws EEException {
+        try {
+            m_startTime = 0;
+            m_logDuration = INITIAL_LOG_DURATION;
+            m_fragmentContext = FragmentContext.CATALOG_UPDATE;
+            coreUpdateCatalog(timestamp, diffCommands);
+        }
+        finally {
+            m_fragmentContext = FragmentContext.UNKNOWN;
+        }
+    }
+
+    protected abstract void coreUpdateCatalog(final long timestamp, final String diffCommands) throws EEException;
 
     public void setBatch(int batchIndex) {
         m_currentBatchIndex = batchIndex;
@@ -568,7 +610,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
     {
         try {
             // For now, re-transform undoQuantumToken to readOnly. Redundancy work in site.executePlanFragments()
-            m_readOnly = (undoQuantumToken == Long.MAX_VALUE) ? true : false;
+            m_fragmentContext = (undoQuantumToken == Long.MAX_VALUE) ? FragmentContext.RO_BATCH : FragmentContext.RW_BATCH;
 
             // reset context for progress updates
             m_startTime = 0;
@@ -588,6 +630,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             m_cacheMisses = 0;
 
             m_sqlTexts = null;
+
+            m_fragmentContext = FragmentContext.UNKNOWN;
         }
     }
 

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -461,19 +461,19 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
 
         // Timing out (canceling) versus just reporting something taking a long time
         sb.append(timeout ? " is timed out at " : " is taking a long time to execute -- at least ");
-        sb.append(String.format("%.2f seconds spent accessing %d tuples. ",
+        sb.append(String.format("%.2f seconds spent accessing %d tuples.",
                 latency / 1000.0, m_lastTuplesAccessed));
 
-        // Type of plan node executing, and index in batch in known.
-        sb.append("Current plan fragment " + PlanNodeType.get(planNodeTypeAsInt).name());
+        // Type of plan node executing, and index in batch if known.
+        sb.append(" Current plan fragment " + PlanNodeType.get(planNodeTypeAsInt).name());
         if (indexFromFragmentTask >= 0) {
             sb.append(" in call " + m_currentBatchIndex + " to voltExecuteSQL");
         }
-        sb.append(" on site " + CoreUtils.hsIdToString(m_siteId) + ". ");
+        sb.append(" on site " + CoreUtils.hsIdToString(m_siteId) + ".");
 
         if (m_currMemoryInBytes > 0 && m_peakMemoryInBytes > 0) {
-            sb.append("Current temp table uses " + m_currMemoryInBytes + " bytes memory,"
-                    + " and the peak usage of memory for temp table is " + m_peakMemoryInBytes + " bytes.");
+            sb.append(" Current temp table uses " + m_currMemoryInBytes + " bytes memory,"
+                    + " and the peak usage of memory for temp tables is " + m_peakMemoryInBytes + " bytes.");
         }
 
         if (m_sqlTexts != null

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -727,7 +727,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
 
     /** write the catalog as a UTF-8 byte string via connection */
     @Override
-    protected void loadCatalog(final long timestamp, final byte[] catalogBytes) throws EEException {
+    protected void coreLoadCatalog(final long timestamp, final byte[] catalogBytes) throws EEException {
         int result = ExecutionEngine.ERRORCODE_ERROR;
         m_data.clear();
 
@@ -752,7 +752,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
 
     /** write the diffs as a UTF-8 byte string via connection */
     @Override
-    public void updateCatalog(final long timestamp, final String catalogDiffs) throws EEException {
+    public void coreUpdateCatalog(final long timestamp, final String catalogDiffs) throws EEException {
         int result = ExecutionEngine.ERRORCODE_ERROR;
         m_data.clear();
 

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -226,7 +226,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
      *  catalog.
      */
     @Override
-    protected void loadCatalog(long timestamp, final byte[] catalogBytes) throws EEException {
+    protected void coreLoadCatalog(long timestamp, final byte[] catalogBytes) throws EEException {
         LOG.trace("Loading Application Catalog...");
         int errorCode = 0;
         errorCode = nativeLoadCatalog(pointer, timestamp, catalogBytes);
@@ -239,7 +239,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
      * engine's catalog.
      */
     @Override
-    public void updateCatalog(long timestamp, final String catalogDiffs) throws EEException {
+    public void coreUpdateCatalog(long timestamp, final String catalogDiffs) throws EEException {
         LOG.trace("Loading Application Catalog...");
         int errorCode = 0;
         errorCode = nativeUpdateCatalog(pointer, timestamp, getStringBytes(catalogDiffs));

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -125,11 +125,11 @@ public class MockExecutionEngine extends ExecutionEngine {
     }
 
     @Override
-    public void loadCatalog(final long txnId, final byte[] catalogBytes) throws EEException {
+    public void coreLoadCatalog(final long txnId, final byte[] catalogBytes) throws EEException {
     }
 
     @Override
-    public void updateCatalog(final long txnId, final String catalogDiffs) throws EEException {
+    public void coreUpdateCatalog(final long txnId, final String catalogDiffs) throws EEException {
     }
 
     @Override

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -493,7 +493,7 @@ public class TestFragmentProgressUpdate extends TestCase {
             break;
         case STATEMENT_LIST:
             expectedSqlTextMsg = "Unable to report specific SQL statement text "
-                    + "for fragment task message index " + (numFragsToExecute - 1) + ".  "
+                    + "for fragment task message index " + (numFragsToExecute - 1) + ". "
                     + "It MAY be one of these " + (numFragsToExecute - 1) + " items: "
                     + "\"SELECT W_ID FROM WAREHOUSE LIMIT 1;\", ";
             break;


### PR DESCRIPTION
This does some refactoring of the JNI layer on the Java side to keep track of whether we're executing a RO procedure, a RW one, or a catalog update, and modifies the long running query message to suit.

On the EE side I had to bypass using the "current fragment" as tracked by the VoltDBEngine, since we don't set it for catalog updates.  The only reason we needed it is for reporting usage of temp table memory, so I made it so we stored this info in the monitor proxy.

These changes make use of a refactoring (soon to be merged) that I did here:
https://github.com/VoltDB/voltdb/pull/3958
which is why I've made this pull request against that branch.