### PR TITLE
ENG-11229: fixing unit test for NEW_CLI=false in TestRejoinEndToEnd, …

### DIFF
--- a/src/frontend/org/voltdb/utils/CommandLine.java
+++ b/src/frontend/org/voltdb/utils/CommandLine.java
@@ -653,7 +653,7 @@ public class CommandLine extends VoltDB.Configuration
 
         cmdline.add("host");
         if (!m_coordinators.isEmpty()) {
-            cmdline.add(m_coordinators.first());
+            cmdline.add(Joiner.on(',').skipNulls().join(m_coordinators));
         } else {
             cmdline.add(m_leader);
         }

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -1668,7 +1668,7 @@ public class LocalCluster implements VoltServerConfig {
         cl.m_zkInterface = config.m_zkInterface;
         cl.m_internalPort = config.m_internalPort;
         cl.m_leader = config.m_leader;
-        cl.m_coordinators = ImmutableSortedSet.copyOf(cl.m_coordinators);
+        cl.m_coordinators = ImmutableSortedSet.copyOf(config.m_coordinators);
     }
 
     public static boolean isMemcheckDefined() {


### PR DESCRIPTION
…TestExportSuiteReplicatedSocketExport, TestDR2EndToEnd

also on pro side: https://github.com/VoltDB/pro/pull/1518