### PR TITLE
ENG-11110: Add a dummy transaction task message at the end of SP lead…

### DIFF
--- a/src/frontend/org/voltdb/iv2/DummyTransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/DummyTransactionTask.java
@@ -1,0 +1,66 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb.iv2;
+
+import java.io.IOException;
+
+import org.voltcore.messaging.Mailbox;
+import org.voltdb.SiteProcedureConnection;
+import org.voltdb.dtxn.TransactionState;
+import org.voltdb.messaging.DummyTransactionResponseMessage;
+import org.voltdb.rejoin.TaskLog;
+
+/**
+ * This dummy transaction task is a SP read only transaction that will be put into transaction task queue.
+ * And it will be duplicated to followers as well. This task acts as a synchronization transaction on all
+ * partition replicas like normal SP write transaction.
+ */
+public class DummyTransactionTask extends TransactionTask {
+    final Mailbox m_initiator;
+
+    public DummyTransactionTask(Mailbox initiator,
+            TransactionState txnState, TransactionTaskQueue queue) {
+        super(txnState, queue);
+        m_initiator = initiator;
+    }
+
+    private void generateDummyResponse() {
+        doCommonSPICompleteActions();
+        DummyTransactionResponseMessage response = new DummyTransactionResponseMessage(this);
+        response.m_sourceHSId = m_initiator.getHSId();
+        m_initiator.deliver(response);
+    }
+
+    @Override
+    public void run(SiteProcedureConnection siteConnection) {
+        generateDummyResponse();
+    }
+
+    @Override
+    public void runFromTaskLog(SiteProcedureConnection siteConnection) {
+        generateDummyResponse();
+    }
+
+    @Override
+    public void runForRejoin(SiteProcedureConnection siteConnection, TaskLog rejoinTaskLog) throws IOException {
+        generateDummyResponse();
+    }
+
+    public long getSPIHSId() {
+        return m_txnState.initiatorHSId;
+    }
+}

--- a/src/frontend/org/voltdb/iv2/DuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/DuplicateCounter.java
@@ -27,6 +27,7 @@ import org.voltdb.ClientResponseImpl;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.VoltTable;
 import org.voltdb.messaging.CompleteTransactionResponseMessage;
+import org.voltdb.messaging.DummyTransactionResponseMessage;
 import org.voltdb.messaging.FragmentResponseMessage;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.messaging.InitiateResponseMessage;
@@ -186,6 +187,11 @@ public class DuplicateCounter
     int offer(CompleteTransactionResponseMessage message)
     {
         return checkCommon(0, message.isRecovering(), null, message);
+    }
+
+    int offer(DummyTransactionResponseMessage message)
+    {
+        return checkCommon(0, false, null, message);
     }
 
     VoltMessage getLastResponse()

--- a/src/frontend/org/voltdb/iv2/Iv2Trace.java
+++ b/src/frontend/org/voltdb/iv2/Iv2Trace.java
@@ -25,6 +25,9 @@ import org.voltcore.utils.CoreUtils;
 import org.voltdb.ClientInterfaceHandleManager;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.messaging.CompleteTransactionMessage;
+import org.voltdb.messaging.CompleteTransactionResponseMessage;
+import org.voltdb.messaging.DummyTransactionResponseMessage;
+import org.voltdb.messaging.DummyTransactionTaskMessage;
 import org.voltdb.messaging.FragmentResponseMessage;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.messaging.InitiateResponseMessage;
@@ -141,6 +144,26 @@ public class Iv2Trace
                             txnIdToString(fresp.getSpHandle()),
                             fragStatusToString(fresp.getStatusCode())));
             }
+            else if (msg instanceof CompleteTransactionResponseMessage) {
+                CompleteTransactionResponseMessage cresp = (CompleteTransactionResponseMessage)msg;
+                String logmsg = "rxCompRsp %s from %s txnId %s spHandle %s SPI %s restart %s recovering %s";
+                iv2log.trace(String.format(logmsg, CoreUtils.hsIdToString(localHSId),
+                            CoreUtils.hsIdToString(cresp.m_sourceHSId),
+                            txnIdToString(cresp.getTxnId()),
+                            txnIdToString(cresp.getSpHandle()),
+                            txnIdToString(cresp.getSPIHSId()),
+                            cresp.isRestart(),
+                            cresp.isRecovering()));
+            }
+            else if (msg instanceof DummyTransactionResponseMessage) {
+                DummyTransactionResponseMessage dresp = (DummyTransactionResponseMessage)msg;
+                String logmsg = "rxDummyRsp %s from %s to %s for txnId %s";
+                iv2log.trace(String.format(logmsg, CoreUtils.hsIdToString(localHSId),
+                            CoreUtils.hsIdToString(dresp.m_sourceHSId),
+                            txnIdToString(dresp.getSPIHSId()),
+                            txnIdToString(dresp.getTxnId())
+                            ));
+            }
         }
     }
 
@@ -208,6 +231,17 @@ public class Iv2Trace
                         txnIdToString(ctask.getTxnId()),
                         ctask.isRollback() ? "ROLLBACK" : "COMMIT",
                         ctask.isRestart() ? "RESTART" : ""));
+        }
+    }
+
+    public static void logDummyTransactionTaskMessage(DummyTransactionTaskMessage dtask, long localHSId)
+    {
+        if (IV2_TRACE_ENABLED) {
+            String logmsg = "rxDummyTxnMsg %s from %s txnId %s spHandle %s";
+            iv2log.trace(String.format(logmsg, CoreUtils.hsIdToString(localHSId),
+                        CoreUtils.hsIdToString(dtask.m_sourceHSId),
+                        txnIdToString(dtask.getTxnId()),
+                        txnIdToString(dtask.getSpHandle())));
         }
     }
 

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -40,7 +40,6 @@ import org.voltdb.VoltZK;
 import org.voltdb.export.ExportManager;
 import org.voltdb.iv2.RepairAlgo.RepairResult;
 import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
-import org.voltdb.messaging.DummyTransactionTaskMessage;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
 
@@ -176,14 +175,6 @@ public class SpInitiator extends BaseInitiator implements Promotable
                     LeaderCacheWriter iv2masters = new LeaderCache(m_messenger.getZK(),
                             m_zkMailboxNode);
                     iv2masters.put(m_partitionId, m_initiatorMailbox.getHSId());
-
-                    // After SP leader promotion, a DummyTransactionTaskMessage is generated from the new leader.
-                    // This READ ONLY message will serve as a synchronization point on all replicas of this
-                    // partition, like normal SP write transaction that has to finish executing on all replicas.
-                    // In this way, the leader can make sure all replicas have finished replaying
-                    // all their repair logs entries.
-                    // From now on, the new leader is safe to accept new transactions. See ENG-11110.
-                    m_initiatorMailbox.deliver(new DummyTransactionTaskMessage());
                 }
                 else {
                     // The only known reason to fail is a failed replica during

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -185,6 +185,15 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     {
         super.setLeaderState(isLeader);
         m_snapMonitor.addInterest(this);
+
+        // After SP leader promotion, a DummyTransactionTaskMessage is generated from the new leader.
+        // This READ ONLY message will serve as a synchronization point on all replicas of this
+        // partition, like normal SP write transaction that has to finish executing on all replicas.
+        // In this way, the leader can make sure all replicas have finished replaying
+        // all their repair logs entries.
+        // From now on, the new leader is safe to accept new transactions. See ENG-11110.
+        // Deliver here is to make sure it's the first message on the new leader.
+        deliver(new DummyTransactionTaskMessage());
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -53,6 +53,8 @@ import org.voltdb.iv2.SiteTasker.SiteTaskerRunnable;
 import org.voltdb.messaging.BorrowTaskMessage;
 import org.voltdb.messaging.CompleteTransactionMessage;
 import org.voltdb.messaging.CompleteTransactionResponseMessage;
+import org.voltdb.messaging.DummyTransactionResponseMessage;
+import org.voltdb.messaging.DummyTransactionTaskMessage;
 import org.voltdb.messaging.DumpMessage;
 import org.voltdb.messaging.FragmentResponseMessage;
 import org.voltdb.messaging.FragmentTaskMessage;
@@ -399,6 +401,12 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         }
         else if (message instanceof DumpMessage) {
             handleDumpMessage();
+        }
+        else if (message instanceof DummyTransactionTaskMessage) {
+            handleDummyTransactionTaskMessage((DummyTransactionTaskMessage) message);
+        }
+        else if (message instanceof DummyTransactionResponseMessage) {
+            handleDummyTransactionResponseMessage((DummyTransactionResponseMessage)message);
         }
         else {
             throw new RuntimeException("UNKNOWN MESSAGE TYPE, BOOM!");
@@ -1142,6 +1150,67 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             }
         }
     }
+
+    private void handleDummyTransactionTaskMessage(DummyTransactionTaskMessage message)
+    {
+        DummyTransactionTaskMessage msg = message;
+        if (m_isLeader) {
+            TxnEgo ego = advanceTxnEgo();
+            long newSpHandle = ego.getTxnId();
+
+            msg = new DummyTransactionTaskMessage(m_mailbox.getHSId(), newSpHandle);
+
+            if (m_sendToHSIds.length > 0) {
+                m_mailbox.send(m_sendToHSIds, msg);
+
+                DuplicateCounter counter = new DuplicateCounter(
+                        HostMessenger.VALHALLA,
+                        msg.getTxnId(),
+                        m_replicaHSIds,
+                        msg);
+                safeAddToDuplicateCounterMap(new DuplicateCounterKey(msg.getTxnId(), newSpHandle), counter);
+            }
+        } else {
+            setMaxSeenTxnId(msg.getSpHandle());
+        }
+        Iv2Trace.logDummyTransactionTaskMessage(msg, m_mailbox.getHSId());
+
+        DummyTransactionTask task = new DummyTransactionTask(m_mailbox,
+                new SpTransactionState(msg), m_pendingTasks);
+        // This read only DummyTransactionTask is to help flushing the task queue,
+        // including tasks in command log queue as well.
+        ListenableFuture<Object> durabilityBackpressureFuture =
+                m_cl.log(null, msg.getSpHandle(), null,  m_durabilityListener, task);
+        // Durability future is always null for sync command logging
+        // the transaction will be delivered again by the CL for execution once durable
+        // Async command logging has to offer the task immediately with a Future for backpressure
+        if (m_cl.canOfferTask()) {
+            assert durabilityBackpressureFuture != null;
+            m_pendingTasks.offer(task.setDurabilityBackpressureFuture(durabilityBackpressureFuture));
+        }
+    }
+
+    private void handleDummyTransactionResponseMessage(DummyTransactionResponseMessage message) {
+        final long spHandle = message.getSpHandle();
+        final DuplicateCounterKey dcKey = new DuplicateCounterKey(message.getTxnId(), spHandle);
+        DuplicateCounter counter = m_duplicateCounters.get(dcKey);
+        if (counter == null) {
+            // this will be on SPI without k-safety or replica only with k-safety
+            setRepairLogTruncationHandle(spHandle);
+            if (!m_isLeader) {
+                m_mailbox.send(message.getSPIHSId(), message);
+            }
+            return;
+        }
+
+        int result = counter.offer(message);
+        if (result == DuplicateCounter.DONE) {
+            // DummyTransactionResponseMessage ends on SPI
+            m_duplicateCounters.remove(dcKey);
+            setRepairLogTruncationHandle(spHandle);
+        }
+    }
+
 
     @Override
     public void setCommandLog(CommandLog cl) {

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1157,8 +1157,9 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         if (m_isLeader) {
             TxnEgo ego = advanceTxnEgo();
             long newSpHandle = ego.getTxnId();
-
-            msg = new DummyTransactionTaskMessage(m_mailbox.getHSId(), newSpHandle);
+            // this uniqueId is needed as the command log tracks it (uniqueId has to advance)
+            long uniqueId = m_uniqueIdGenerator.getNextUniqueId();
+            msg = new DummyTransactionTaskMessage(m_mailbox.getHSId(), newSpHandle, uniqueId);
 
             if (m_sendToHSIds.length > 0) {
                 m_mailbox.send(m_sendToHSIds, msg);

--- a/src/frontend/org/voltdb/messaging/DummyTransactionResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/DummyTransactionResponseMessage.java
@@ -1,0 +1,107 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.messaging;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.voltcore.messaging.Subject;
+import org.voltcore.messaging.VoltMessage;
+import org.voltcore.utils.CoreUtils;
+import org.voltdb.iv2.DummyTransactionTask;
+import org.voltdb.iv2.TxnEgo;
+
+/**
+ * Message from an execution site to initiator for DummyTransaction
+ */
+public class DummyTransactionResponseMessage extends VoltMessage {
+    private long m_txnId;
+    private long m_spHandle;
+    private long m_spiHSId;
+
+    /** Empty constructor for de-serialization */
+    public DummyTransactionResponseMessage()
+    {
+        m_spiHSId = -1;
+        m_subject = Subject.DEFAULT.getId();
+    }
+
+    /**
+     * IV2 constructor
+     */
+    public DummyTransactionResponseMessage(DummyTransactionTask task) {
+        m_txnId = task.getTxnId();
+        m_spHandle = task.getSpHandle();
+        m_spiHSId = task.getSPIHSId();
+        m_subject = Subject.DEFAULT.getId();
+    }
+
+    public long getTxnId() {
+        return m_txnId;
+    }
+
+    public long getSpHandle() {
+        return m_spHandle;
+    }
+
+    public long getSPIHSId() {
+        return m_spiHSId;
+    }
+
+    @Override
+    public int getSerializedSize()
+    {
+        int msgsize = super.getSerializedSize();
+        msgsize += 8 // txnId
+            + 8 // m_spHandle
+            + 8 // SPI HSId
+            ;
+        return msgsize;
+    }
+
+    @Override
+    public void flattenToBuffer(ByteBuffer buf) throws IOException
+    {
+        buf.put(VoltDbMessageFactory.DUMMY_TRANSACTION_RESPONSE_ID);
+        buf.putLong(m_txnId);
+        buf.putLong(m_spHandle);
+        buf.putLong(m_spiHSId);
+        assert(buf.capacity() == buf.position());
+        buf.limit(buf.position());
+    }
+
+    @Override
+    public void initFromBuffer(ByteBuffer buf) throws IOException
+    {
+        m_txnId = buf.getLong();
+        m_spHandle = buf.getLong();
+        m_spiHSId = buf.getLong();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("DUMMY_TRANSACTION_RESPONSE (FROM ");
+        sb.append(CoreUtils.hsIdToString(m_sourceHSId));
+        sb.append(" FOR TXN ").append(TxnEgo.txnIdToString(m_txnId)).append(")");
+        sb.append(" SPI HSID: ").append(CoreUtils.hsIdToString(m_spiHSId));
+
+        return sb.toString();
+    }
+}

--- a/src/frontend/org/voltdb/messaging/DummyTransactionTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/DummyTransactionTaskMessage.java
@@ -1,0 +1,74 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.messaging;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.voltcore.messaging.TransactionInfoBaseMessage;
+import org.voltcore.utils.CoreUtils;
+import org.voltdb.iv2.TxnEgo;
+
+/**
+ * Message issued from an initiator just after newly leader promotion, helping flushing
+ * the transaction task queue on all partition replicas.
+ */
+public class DummyTransactionTaskMessage extends TransactionInfoBaseMessage
+{
+    public DummyTransactionTaskMessage()
+    {
+        super();
+        m_isReadOnly = true;
+        m_isForReplay = false;
+    }
+
+    public DummyTransactionTaskMessage (long initiatorHSId, long txnId) {
+        super(initiatorHSId, initiatorHSId, txnId, txnId, true, false);
+        m_isReadOnly = true;
+        m_isForReplay = false;
+        setSpHandle(txnId);
+    }
+
+    @Override
+    public boolean isSinglePartition() {
+        return true;
+    }
+
+    @Override
+    public void flattenToBuffer(ByteBuffer buf) throws IOException
+    {
+        buf.put(VoltDbMessageFactory.DUMMY_TRANSACTION_TASK_ID);
+        super.flattenToBuffer(buf);
+
+        assert(buf.capacity() == buf.position());
+        buf.limit(buf.position());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("DummyTaskMessage (FROM ");
+        sb.append(CoreUtils.hsIdToString(m_sourceHSId));
+        sb.append(" TO ");
+        sb.append(CoreUtils.hsIdToString(getCoordinatorHSId()));
+        sb.append(") FOR TXN ").append(TxnEgo.txnIdToString(m_txnId));
+        sb.append("SP HANDLE: ").append(TxnEgo.txnIdToString(getSpHandle())).append("\n");
+        return sb.toString();
+    }
+}

--- a/src/frontend/org/voltdb/messaging/DummyTransactionTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/DummyTransactionTaskMessage.java
@@ -37,8 +37,8 @@ public class DummyTransactionTaskMessage extends TransactionInfoBaseMessage
         m_isForReplay = false;
     }
 
-    public DummyTransactionTaskMessage (long initiatorHSId, long txnId) {
-        super(initiatorHSId, initiatorHSId, txnId, txnId, true, false);
+    public DummyTransactionTaskMessage (long initiatorHSId, long txnId, long uniqueId) {
+        super(initiatorHSId, initiatorHSId, txnId, uniqueId, true, false);
         m_isReadOnly = true;
         m_isForReplay = false;
         setSpHandle(txnId);

--- a/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
+++ b/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
@@ -49,6 +49,8 @@ public class VoltDbMessageFactory extends VoltMessageFactory
     final public static byte IV2_REPAIR_LOG_TRUNCATION = VOLTCORE_MESSAGE_ID_MAX + 23;
     final public static byte DR2_MULTIPART_TASK_ID = VOLTCORE_MESSAGE_ID_MAX + 24;
     final public static byte DR2_MULTIPART_RESPONSE_ID = VOLTCORE_MESSAGE_ID_MAX + 25;
+    final public static byte DUMMY_TRANSACTION_TASK_ID = VOLTCORE_MESSAGE_ID_MAX + 26;
+    final public static byte DUMMY_TRANSACTION_RESPONSE_ID = VOLTCORE_MESSAGE_ID_MAX + 27;
 
     /**
      * Overridden by subclasses to create message types unknown by voltcore
@@ -136,6 +138,12 @@ public class VoltDbMessageFactory extends VoltMessageFactory
             break;
         case DR2_MULTIPART_RESPONSE_ID:
             message = new Dr2MultipartResponseMessage();
+            break;
+        case DUMMY_TRANSACTION_TASK_ID:
+            message = new DummyTransactionTaskMessage();
+            break;
+        case DUMMY_TRANSACTION_RESPONSE_ID:
+            message = new DummyTransactionResponseMessage();
             break;
         default:
             message = null;


### PR DESCRIPTION
…er promotion. The request will be duplicated to replicas like a SP write. It does not do anything useful work, but as a signal to flush everyone's transaction queue before the newly promoted leader starting to run new transactions.