### PR TITLE
grammar.sql: added IS NOT DISTINCT FROM to the list of comparison

### DIFF
--- a/tests/scripts/examples/sql_coverage/grammar.sql
+++ b/tests/scripts/examples/sql_coverage/grammar.sql
@@ -68,6 +68,8 @@
 {_cmp |= ">"}
 {_cmp |= "<="}
 {_cmp |= ">="}
+-- TODO: should change NOT to _maybe, once this works fully
+{_cmp |= "IS NOT DISTINCT FROM"}
 
 -- A smaller list of comparison operators, used to reduce the
 -- explosion of generated queries that result from 7 _cmp values

--- a/tests/scripts/sql_coverage_test.py
+++ b/tests/scripts/sql_coverage_test.py
@@ -228,17 +228,17 @@ def get_max_mismatches(comparison_database, suite_name):
         # and basic-compoundex-joins "extended" test suites (see ENG-10775)
         if (config_name == 'basic-joins' or config_name == 'basic-index-joins' or
               config_name == 'basic-compoundex-joins'):
-            max_mismatches = 4620
+            max_mismatches = 5280
         # Known failures in the numeric-decimals "extended" test suite (see ENG-10546)
         elif config_name == 'numeric-decimals':
             max_mismatches = 300
         # Known failures in the joined-matview-* test suites ...
         # Failures in joined-matview-default-full due to ENG-11086
         elif config_name == 'joined-matview-default-full':
-            max_mismatches = 992
+            max_mismatches = 1056
         # Failures in joined-matview-int due to ENG-11196 & (mainly) ENG-11086
         elif config_name == 'joined-matview-int':
-            max_mismatches = 31352
+            max_mismatches = 46438
 
     return max_mismatches
 


### PR DESCRIPTION
operators.

PostgreSQLBackend.java: subtle change to one regex expression, to make
sure that it does not confuse the FROM in IS [NOT] DISTINCT FROM with
the FROM in SELECT ... FROM T1 ... (otherwise, such confusion causes
UPSERT statements to be translated into invalid INSERT / ON CONFLICT DO
statements); and corrected a couple of nearby comments.