### PR TITLE
ENG-10626: One-to-many active-passive DR happy path, rejoin, recover

### DIFF
--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -38,7 +38,7 @@ public:
     static const size_t HASH_DELIMITER_SIZE = 1 + 4;
 
     // Also update DRProducerProtocol.java if version changes
-    static const uint8_t PROTOCOL_VERSION = 6;
+    static const uint8_t PROTOCOL_VERSION = 7;
 
     DRTupleStream(int partitionId, int defaultBufferSize);
 

--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -26,9 +26,6 @@ import com.google_voltpatches.common.collect.ImmutableSet;
 
 public class DRProducerStatsBase {
 
-    //  DR_STATS_CONSUMER_CLUSTER_ID java property must equal "true"
-    private static boolean m_addConsumerIdStat = Boolean.getBoolean("DR_STATS_CONSUMER_CLUSTER_ID");
-
     public static interface Columns {
         // column for both tables
         public static final String CONSUMER_CLUSTER_ID = "CONSUMERCLUSTERID";
@@ -62,9 +59,7 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
-            if (m_addConsumerIdStat) {
-                columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
-            }
+            columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
             columns.add(new ColumnInfo(Columns.STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.SYNC_SNAPSHOT_STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.ROWS_IN_SYNC_SNAPSHOT, VoltType.BIGINT));
@@ -87,9 +82,7 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
-            if (m_addConsumerIdStat) {
-                columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
-            }
+            columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
             columns.add(new ColumnInfo(VoltSystemProcedure.CNAME_PARTITION_ID, VoltType.INTEGER));
             columns.add(new ColumnInfo(Columns.STREAM_TYPE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.TOTAL_BYTES, VoltType.BIGINT));

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -78,6 +78,12 @@ public interface BinaryDeque {
      */
     public BinaryDequeReader openForRead(String cursorId) throws IOException;
 
+    /**
+     * Close a BinaryDequeReader for reader, also close the SegmentReader for the segment if it is reading one
+     * @param cursorId a String identifying the cursor.
+     * @throws IOException on any errors trying to close the SegmentReader if it is the last one for the segment
+     */
+    public void closeCursor(String cursorId);
 
     /**
      * Persist all objects in the queue to the backing store

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.DeferredSerialization;
+import org.voltcore.utils.Pair;
 
 /**
  * Specialized deque interface for storing binary objects. Objects can be provided as a buffer chain
@@ -102,8 +103,7 @@ public interface BinaryDeque {
 
     public boolean initializedFromExistingFiles();
 
-    public long sizeInBytes() throws IOException;
-    public int getNumObjects() throws IOException;
+    public Pair<Integer, Long> getBufferCountAndSize() throws IOException;
 
     public void closeAndDelete() throws IOException;
 

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -75,9 +75,6 @@ public class PBDRegularSegment extends PBDSegment {
     public void reset()
     {
         m_syncedSinceLastEdit = false;
-        for (SegmentReader reader : m_readCursors.values()) {
-            reader.resetReader();
-        }
         if (m_tmpHeaderBuf != null) {
             m_tmpHeaderBuf.discard();
             m_tmpHeaderBuf = null;

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -733,7 +733,6 @@ public class PersistentBinaryDeque implements BinaryDeque {
     }
 
     @Override
-    //TODO: Should we get rid of persisted cursors on close?
     public synchronized void close() throws IOException {
         if (m_closed) {
             return;
@@ -743,6 +742,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         for (PBDSegment segment : m_segments.values()) {
             segment.close();
         }
+        m_segments.clear();
         m_closed = true;
     }
 
@@ -772,13 +772,17 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
     @Override
     public synchronized void closeAndDelete() throws IOException {
-        if (m_closed) return;
-        m_closed = true;
+        if (m_closed) {
+            return;
+        }
+        m_readCursors.clear();
+
         for (PBDSegment qs : m_segments.values()) {
             m_usageSpecificLog.debug("Segment " + qs.file() + " has been closed and deleted due to delete all");
             closeAndDeleteSegment(qs);
         }
         m_segments.clear();
+        m_closed = true;
     }
 
     public static class ByteBufferTruncatorResponse extends TruncatorResponse {

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -677,6 +677,18 @@ public class PersistentBinaryDeque implements BinaryDeque {
         return reader;
     }
 
+    @Override
+    public synchronized void closeCursor(String cursorId) {
+        ReadCursor reader = m_readCursors.remove(cursorId);
+        if (reader != null && reader.m_segment != null) {
+            try {
+                reader.m_segment.getReader(cursorId).close();
+            } catch (IOException e) {
+                // TODO ignore this for now, it is just the segment file failed to be closed
+            }
+        }
+    }
+
     private boolean canDeleteSegment(PBDSegment segment) throws IOException {
         for (ReadCursor cursor : m_readCursors.values()) {
             if (cursor.m_segment != null && (cursor.m_segment.segmentId() >= segment.segmentId())) {

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -34,6 +34,7 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.DeferredSerialization;
+import org.voltcore.utils.Pair;
 import org.voltdb.EELibraryLoader;
 import org.voltdb.utils.BinaryDeque.TruncatorResponse.Status;
 import org.voltdb.utils.PBDSegment.PBDSegmentReader;
@@ -757,6 +758,16 @@ public class PersistentBinaryDeque implements BinaryDeque {
             size += segment.size();
         }
         return size;
+    }
+
+    public synchronized Pair<Integer, Long> getBufferCountAndSize() throws IOException {
+        int count = 0;
+        long size = 0;
+        for (PBDSegment segment : m_segments.values()) {
+            count += segment.getNumEntries();
+            size += segment.size();
+        }
+        return Pair.of(count, size);
     }
 
     @Override

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -16,11 +16,9 @@
  */
 package org.voltdb.utils;
 
-import java.io.EOFException;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -222,20 +220,11 @@ public class PersistentBinaryDeque implements BinaryDeque {
                                 return;
                             }
                             if (canDeleteSegment(segment)) {
-                                // Remove this segment and segments with a smaller sequence number if there are any
-                                Iterator<Map.Entry<Long, PBDSegment>> iter = m_segments.entrySet().iterator();
-                                while (iter.hasNext()) {
-                                    Map.Entry<Long, PBDSegment> entry = iter.next();
-                                    if (entry.getKey() > segment.segmentId()) {
-                                        break;
-                                    }
-                                    PBDSegment segmentToDelete = entry.getValue();
-                                    if (m_usageSpecificLog.isDebugEnabled()) {
-                                        m_usageSpecificLog.debug("Segment " + segmentToDelete.file() + " has been closed and deleted after discarding last buffer");
-                                    }
-                                    closeAndDeleteSegment(segmentToDelete);
-                                    iter.remove();
+                                m_segments.remove(segment.segmentId());
+                                if (m_usageSpecificLog.isDebugEnabled()) {
+                                    m_usageSpecificLog.debug("Segment " + segment.file() + " has been closed and deleted after discarding last buffer");
                                 }
+                                closeAndDeleteSegment(segment);
                             }
                         } catch (IOException e) {
                             LOG.error("Exception closing and deleting PBD segment", e);
@@ -526,6 +515,23 @@ public class PersistentBinaryDeque implements BinaryDeque {
         return (entry!=null) ? entry.getValue() : null;
     }
 
+    private void closeAndDeleteSegmentsBefore(long segmentId, String reason) throws IOException {
+        // Remove this segment and segments with a smaller sequence number if there are any
+        Iterator<Map.Entry<Long, PBDSegment>> iter = m_segments.entrySet().iterator();
+        while (iter.hasNext()) {
+            Map.Entry<Long, PBDSegment> entry = iter.next();
+            if (entry.getKey() > segmentId) {
+                break;
+            }
+            PBDSegment segmentToDelete = entry.getValue();
+            if (m_usageSpecificLog.isDebugEnabled()) {
+                m_usageSpecificLog.debug("Segment " + segmentToDelete.file() + " has been closed and deleted " + reason);
+            }
+            closeAndDeleteSegment(segmentToDelete);
+            iter.remove();
+        }
+    }
+
     @Override
     public synchronized void offer(BBContainer object) throws IOException {
         offer(object, true);
@@ -575,14 +581,11 @@ public class PersistentBinaryDeque implements BinaryDeque {
     private PBDSegment addSegment(PBDSegment tail) throws IOException {
         //Check to see if the tail is completely consumed so we can close and delete it
         if (tail.hasAllFinishedReading() && canDeleteSegment(tail)) {
-            // Remove all segments as the last segment can be deleted
-            for (PBDSegment segmentToDelete : m_segments.values()) {
-                if (m_usageSpecificLog.isDebugEnabled()) {
-                    m_usageSpecificLog.debug("Segment " + segmentToDelete.file() + " has been closed and deleted because of empty queue");
-                }
-                closeAndDeleteSegment(segmentToDelete);
+            pollLastSegment();
+            if (m_usageSpecificLog.isDebugEnabled()) {
+                m_usageSpecificLog.debug("Segment " + tail.file() + " has been closed and deleted because of empty queue");
             }
-            m_segments.clear();
+            closeAndDeleteSegment(tail);
         }
         Long nextIndex = tail.segmentId() + 1;
         tail = newSegment(nextIndex, new VoltFile(m_path, m_nonce + "." + nextIndex + ".pbd"));
@@ -692,13 +695,41 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
     @Override
     public synchronized void closeCursor(String cursorId) {
+        if (m_closed) {
+            return;
+        }
         ReadCursor reader = m_readCursors.remove(cursorId);
         if (reader != null && reader.m_segment != null) {
             try {
                 reader.m_segment.getReader(cursorId).close();
-            } catch (IOException e) {
+            }
+            catch (IOException e) {
                 // TODO ignore this for now, it is just the segment file failed to be closed
             }
+        }
+        // check all segments from latest to oldest (excluding the last write segment) to see if they can be deleted
+        // in a separate try catch block because these two are independent
+        // We need this only in closeCursor() now, which is currently only used when removing snapshot placeholder
+        // cursor in one-to-many DR, this extra check is needed because other normal cursors may have read past some
+        // segments, leaving them hold only by the placeholder cursor, since we won't have triggers to check deletion
+        // eligibility for these segments anymore, the check needs to take place here to prevent leaking of segments
+        // file
+        try {
+            boolean isLastSegment = true;
+            for (PBDSegment segment : m_segments.descendingMap().values()) {
+                // skip the last segment
+                if (isLastSegment) {
+                    isLastSegment = false;
+                    continue;
+                }
+                if (canDeleteSegment(segment)) {
+                    closeAndDeleteSegmentsBefore(segment.segmentId(), "because of close of cursor");
+                    break;
+                }
+            }
+        }
+        catch (IOException e) {
+            LOG.error("Exception closing and deleting PBD segment", e);
         }
     }
 
@@ -711,7 +742,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
                     segmentReader = segment.openForRead(cursor.m_cursorId);
                 }
 
-                if (!segmentReader.allReadAndDiscarded()) return false;
+                if (!segmentReader.allReadAndDiscarded()) {
+                    return false;
+                }
             } else { // this cursor hasn't reached this segment yet
                 return false;
             }
@@ -742,24 +775,10 @@ public class PersistentBinaryDeque implements BinaryDeque {
         for (PBDSegment segment : m_segments.values()) {
             segment.close();
         }
-        m_segments.clear();
         m_closed = true;
     }
 
-    /*
-     * Don't use size in bytes to determine empty, could potentially
-     * diverge from object count on crash or power failure
-     * although incredibly unlikely
-     */
     @Override
-    public synchronized long sizeInBytes() throws IOException {
-        long size = 0;
-        for (PBDSegment segment : m_segments.values()) {
-            size += segment.size();
-        }
-        return size;
-    }
-
     public synchronized Pair<Integer, Long> getBufferCountAndSize() throws IOException {
         int count = 0;
         long size = 0;
@@ -830,16 +849,6 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
     public static TruncatorResponse fullTruncateResponse() {
         return new TruncatorResponse(Status.FULL_TRUNCATE);
-    }
-
-    @Override
-    public synchronized int getNumObjects() throws IOException {
-        int numObjects = 0;
-        for (PBDSegment segment : m_segments.values()) {
-            numObjects += segment.getNumEntries();
-        }
-
-        return numObjects;
     }
 
     @Override


### PR DESCRIPTION
This PR will include happy path, rejoin/recover handling. The DR reset functionality for individual and all conversations and the conversation collision handling which is dependent on this functionality will be addressed in another ticket and PR.

Changes in community repo:
- Add closeCursor() interface for BinaryDeque, for snapshot placeholder cursor in the case of snapshot discard and for the normal cursor in the case of conversation reset.
- Since snapshot placeholder cursor can prevent several PBD files from being deleted, after it goes away, a relatively new PBD file may be the first one eligible to be deleted. When this happens, PBD files older than this one should be deleted as well. Update the behavior in all 3 places that PBD file gets deleted, also update the m_segments map correspondingly.
- There were two synchronized functions for PBD buffer count and size separately, but there are cases where they are used together to initialize a DRPartitionStreamReader instance. Add a single synchronized function to return a pair of count and size.
- Bump the protocol version from 6 to 7 (an integration branch may be needed to avoid increasing the version prematurely, considering incorporating other associated tickets into this version)
- Remove the flag so that consumer cluster id is always in DR stats table.
