### PR TITLE
ENG-11275 block transactions during shutdown

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2683,6 +2683,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         synchronized(m_startAndStopLock) {
             boolean did_it = false;
             if (m_mode != OperationMode.SHUTTINGDOWN) {
+                //block all traffic other than some Sysprocs which are allowed during shutting down.
+                setShuttingdown(true);
                 did_it = true;
                 m_mode = OperationMode.SHUTTINGDOWN;
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2683,7 +2683,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         synchronized(m_startAndStopLock) {
             boolean did_it = false;
             if (m_mode != OperationMode.SHUTTINGDOWN) {
-                //block all traffic other than some Sysprocs which are allowed during shutting down.
+                //block all transactions other than some sysprocs, the same ones allowed in prepare shutting down process
                 setShuttingdown(true);
                 did_it = true;
                 m_mode = OperationMode.SHUTTINGDOWN;

--- a/src/frontend/org/voltdb/sysprocs/Shutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/Shutdown.java
@@ -121,6 +121,9 @@ public class Shutdown extends VoltSystemProcedure {
      * @return Never returned, no he never returned...
      */
     public VoltTable[] run(SystemProcedureExecutionContext ctx) {
+
+        //block all traffic now
+        VoltDB.instance().setShuttingdown(true);
         SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_shutdownSync;

--- a/src/frontend/org/voltdb/sysprocs/Shutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/Shutdown.java
@@ -121,9 +121,6 @@ public class Shutdown extends VoltSystemProcedure {
      * @return Never returned, no he never returned...
      */
     public VoltTable[] run(SystemProcedureExecutionContext ctx) {
-
-        //block all traffic now
-        VoltDB.instance().setShuttingdown(true);
         SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_shutdownSync;


### PR DESCRIPTION
When a cluster in PAUSED mode is force-shutdown, the cluster will be set to SHUTTINGDOWN mode. There may be a window before the cluster process is killed within which transactions can go through.