### PR TITLE
Eng 10842 mixed sph

### DIFF
--- a/lib/python/voltcli/voltdb.d/start.py
+++ b/lib/python/voltcli/voltdb.d/start.py
@@ -37,6 +37,7 @@ server_list_help = ('{hostname-or-ip[,...]}, '
         VOLT.StringOption('-D', '--dir', 'directory_spec', voltdbroot_help, default = None),
         VOLT.BooleanOption('-r', '--replica', 'replica', 'start replica cluster', default = False),
         VOLT.BooleanOption('-A', '--add', 'enableadd', 'allows the server to elastically expand the cluster if the cluster is already complete', default = False),
+        VOLT.IntegerOption('-s', '--sitesperhost', 'sitesperhost', None),
     ),
     description = 'Starts a database, which has been initialized.'
 )
@@ -48,6 +49,8 @@ def start(runner):
     runner.args.extend(['mesh', ','.join(runner.opts.server_list)])
     if runner.opts.hostcount:
         runner.args.extend(['hostcount', runner.opts.hostcount])
+    if runner.opts.sitesperhost:
+        runner.args.extend(['sitesperhost', runner.opts.sitesperhost])
     if runner.opts.enableadd:
         runner.args.extend(['enableadd'])
     runner.go()

--- a/src/catgen/spec.txt
+++ b/src/catgen/spec.txt
@@ -22,7 +22,6 @@ end
 
 begin Deployment javaonly         "Run-time deployment settings"
   int kfactor                     "The required k-safety factor"
-  int sitesperhost                "The number of execution sites per host"
   Systemsettings* systemsettings  "Values from the systemsettings element"
 end
 

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -1072,12 +1072,10 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
             CatalogContext context,
             ReplicationRole replicationRole,
             Cartographer cartographer,
-            int partitionCount,
             InetAddress clientIntf,
             int clientPort,
             InetAddress adminIntf,
-            int adminPort,
-            long timestampTestingSalt) throws Exception {
+            int adminPort) throws Exception {
 
         /*
          * Construct the runnables so they have access to the list of connections

--- a/src/frontend/org/voltdb/SnapshotSaveAPI.java
+++ b/src/frontend/org/voltdb/SnapshotSaveAPI.java
@@ -115,7 +115,10 @@ public class SnapshotSaveAPI
     {
         TRACE_LOG.trace("Creating snapshot target and handing to EEs");
         final VoltTable result = SnapshotUtil.constructNodeResultsTable();
-        final int numLocalSites = context.getCluster().getDeployment().get("deployment").getSitesperhost();
+        final int numLocalSites = VoltDB.instance().getHostMessenger().getLocalSitesCount();
+        if (numLocalSites == VoltDB.UNDEFINED) {
+            throw new RuntimeException("Failed to get number of local sites for host" + VoltDB.instance().getHostMessenger().getHostId());
+        }
         JSONObject jsData = null;
         if (data != null && !data.isEmpty()) {
             try {

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -296,6 +296,9 @@ public class VoltDB {
         /** number of hosts that participate in a VoltDB cluster */
         public int m_hostCount = UNDEFINED;
 
+        /** not sites per host actually, number of local sites in this node */
+        public int m_sitesperhost = UNDEFINED;
+
         /** allow elastic joins */
         public boolean m_enableAdd = false;
 
@@ -443,6 +446,8 @@ public class VoltDB {
                     m_meshBrokers = sbld.toString();
                 } else if (arg.equals("hostcount")) {
                     m_hostCount = Integer.parseInt(args[++i].trim());
+                } else if (arg.equals("sitesperhost")){
+                    m_sitesperhost = Integer.parseInt(args[++i].trim());
                 } else if (arg.equals("publicinterface")) {
                     m_publicInterface = args[++i].trim();
                 } else if (arg.startsWith("publicinterface ")) {

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -56,6 +56,8 @@ public class VoltZK {
     public static final String operationMode = "/db/operation_mode";
     public static final String exportGenerations = "/db/export_generations";
     public static final String importerBase = "/db/import";
+    // This node is used for keeping local sites count under its path individually
+    public static final String sitesPerHost = "/db/sitesperhost";
 
     /*
      * Processes that want to block catalog updates create children here

--- a/src/frontend/org/voltdb/compiler/ClusterConfig.java
+++ b/src/frontend/org/voltdb/compiler/ClusterConfig.java
@@ -29,19 +29,20 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
-import com.google_voltpatches.common.collect.Lists;
-import com.google_voltpatches.common.collect.Maps;
-import com.google_voltpatches.common.collect.Sets;
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltcore.logging.VoltLogger;
 import org.voltdb.VoltDB;
-
-import com.google_voltpatches.common.collect.Multimap;
 import org.voltdb.utils.MiscUtils;
+
+import com.google_voltpatches.common.collect.Lists;
+import com.google_voltpatches.common.collect.Maps;
+import com.google_voltpatches.common.collect.Multimap;
+import com.google_voltpatches.common.collect.Sets;
 
 public class ClusterConfig
 {
@@ -124,10 +125,31 @@ public class ClusterConfig
         }
     }
 
-    public ClusterConfig(int hostCount, int sitesPerHost, int replicationFactor)
+    /**
+     * Add new sitesperhost mapping to the toplogy
+     * @param topo              The topology that will be added to.
+     * @param joinedHostIds     Host ids that are elastically joining into cluster.
+     * @param sphMap            A map of host ids to their sitesperhost setting
+     * @throws JSONException
+     */
+    public static void addSitesPerHosts(JSONObject topo,
+                                        Collection<Integer> joinedHostIds,
+                                        Map<Integer, Integer> sphMap)
+        throws JSONException
+    {
+        JSONArray hostIdToSph = topo.getJSONArray("host_id_to_sph");
+        for (Integer hostId : joinedHostIds) {
+            JSONObject sphObj = new JSONObject();
+            sphObj.put("host_id", hostId);
+            sphObj.put("sites_per_host", sphMap.get(hostId));
+            hostIdToSph.put(sphObj);
+        }
+    }
+
+    public ClusterConfig(int hostCount, Map<Integer, Integer> sitesPerHostMap, int replicationFactor)
     {
         m_hostCount = hostCount;
-        m_sitesPerHost = sitesPerHost;
+        m_sitesPerHostMap = sitesPerHostMap;
         m_replicationFactor = replicationFactor;
         m_errorMsg = "Config is unvalidated";
     }
@@ -138,7 +160,14 @@ public class ClusterConfig
     public ClusterConfig(JSONObject topo) throws JSONException
     {
         m_hostCount = topo.getInt("hostcount");
-        m_sitesPerHost = topo.getInt("sites_per_host");
+        m_sitesPerHostMap = Maps.newHashMap();
+        JSONArray sphMap = topo.getJSONArray("host_id_to_sph");
+        for (int i = 0; i < sphMap.length(); i++) {
+            JSONObject entry = sphMap.getJSONObject(i);
+            int hostId = entry.getInt("host_id");
+            int sph = entry.getInt("sites_per_host");
+            m_sitesPerHostMap.put(hostId, sph);
+        }
         m_replicationFactor = topo.getInt("kfactor");
         m_errorMsg = "Config is unvalidated";
     }
@@ -148,9 +177,9 @@ public class ClusterConfig
         return m_hostCount;
     }
 
-    public int getSitesPerHost()
+    public Map<Integer, Integer> getSitesPerHostMap()
     {
-        return m_sitesPerHost;
+        return m_sitesPerHostMap;
     }
 
     public int getReplicationFactor()
@@ -158,9 +187,17 @@ public class ClusterConfig
         return m_replicationFactor;
     }
 
+    public int getTotalSitesCount() {
+        int totalSites = 0;
+        for (Map.Entry<Integer, Integer> entry : m_sitesPerHostMap.entrySet()) {
+            totalSites += entry.getValue();
+        }
+        return totalSites;
+    }
+
     public int getPartitionCount()
     {
-        return (m_hostCount * m_sitesPerHost) / (m_replicationFactor + 1);
+        return getTotalSitesCount() / (m_replicationFactor + 1);
     }
 
     public String getErrorMsg()
@@ -175,10 +212,11 @@ public class ClusterConfig
             m_errorMsg = "The number of hosts must be > 0.";
             return false;
         }
-        if (m_sitesPerHost <= 0)
-        {
-            m_errorMsg = "The number of sites per host must be > 0.";
-            return false;
+        for (Map.Entry<Integer, Integer> entry : m_sitesPerHostMap.entrySet()) {
+            if (entry.getValue() <= 0) {
+                m_errorMsg = "The number of sites per host must be > 0.";
+                return false;
+            }
         }
         if (m_hostCount <= m_replicationFactor)
         {
@@ -192,10 +230,10 @@ public class ClusterConfig
                                        m_replicationFactor);
             return false;
         }
-        if ((m_hostCount * m_sitesPerHost) % (m_replicationFactor + 1) > 0)
+        if (getTotalSitesCount() % (m_replicationFactor + 1) > 0)
         {
             m_errorMsg = "The cluster has more hosts and sites per hosts than required for the " +
-                "requested k-safety value. The number of total sites (sitesPerHost * hostCount) must be a " +
+                "requested k-safety value. The number of total sites must be a " +
                 "whole multiple of the number of copies of the database (k-safety + 1)";
             return false;
         }
@@ -488,9 +526,18 @@ public class ClusterConfig
             List<Integer> hostIds,
             int hostCount,
             int partitionCount,
-            int sitesPerHost) throws JSONException{
+            Map<Integer, Integer> sitesPerHostMap) throws JSONException{
         // add all the sites
         int partitionCounter = -1;
+
+        // build the assignment map, each entry has the lower bound of partition range as key,
+        // the host id as value.
+        TreeMap<Integer, Integer> sitesToHostId = Maps.newTreeMap();
+        int sitesCounter = 0;
+        for (Map.Entry<Integer, Integer> entry : sitesPerHostMap.entrySet()) {
+            sitesToHostId.put(sitesCounter, entry.getKey());
+            sitesCounter += entry.getValue();
+        }
 
         HashMap<Integer, ArrayList<Integer>> partToHosts =
             new HashMap<Integer, ArrayList<Integer>>();
@@ -499,12 +546,11 @@ public class ClusterConfig
             ArrayList<Integer> hosts = new ArrayList<Integer>();
             partToHosts.put(i, hosts);
         }
-        for (int i = 0; i < sitesPerHost * hostCount; i++) {
-
+        for (int i = 0; i < getTotalSitesCount(); i++) {
             // serially assign partitions to execution sites.
             int partition = (++partitionCounter) % partitionCount;
-            int hostForSite = hostIds.get(i / sitesPerHost);
-            partToHosts.get(partition).add(hostForSite);
+            int hostId = sitesToHostId.get(sitesToHostId.floorKey(i));
+            partToHosts.get(partition).add(hostId);
         }
 
         // We need to sort the hostID lists for each partition so that
@@ -513,11 +559,22 @@ public class ClusterConfig
             Collections.sort(e.getValue());
         }
 
+        if (!checkKSafetyConstraint(partToHosts, m_replicationFactor  + 1)) {
+            VoltDB.crashLocalVoltDB("Unable to find feasible partition replica assignment for the specified configuration");
+        }
+
         JSONStringer stringer = new JSONStringer();
         stringer.object();
         stringer.key("hostcount").value(m_hostCount);
         stringer.key("kfactor").value(getReplicationFactor());
-        stringer.key("sites_per_host").value(sitesPerHost);
+        stringer.key("host_id_to_sph").array();
+        for (Map.Entry<Integer, Integer> entry : sitesPerHostMap.entrySet()) {
+            stringer.object();
+            stringer.key("host_id").value(entry.getKey());
+            stringer.key("sites_per_host").value(entry.getValue());
+            stringer.endObject();
+        }
+        stringer.endArray();
         stringer.key("partitions").array();
         for (int part = 0; part < partitionCount; part++)
         {
@@ -542,6 +599,17 @@ public class ClusterConfig
     }
 
     /**
+     * Each partition should has K different replica
+     */
+    public static boolean checkKSafetyConstraint(
+            HashMap<Integer, ArrayList<Integer>> partToHosts,
+            int kfactor)
+    {
+        return partToHosts.entrySet().stream().allMatch(
+                v -> kfactor == Sets.newHashSet(v.getValue()).size());
+    }
+
+    /**
      * Placement strategy that attempts to distribute replicas across different
      * groups and also involve multiple nodes in replication so that the socket
      * between nodes is not a bottleneck.
@@ -554,7 +622,7 @@ public class ClusterConfig
     JSONObject groupAwarePlacementStrategy(
             Map<Integer, String> hostGroups,
             int partitionCount,
-            int sitesPerHost) throws JSONException {
+            Map<Integer, Integer> sitesPerHostMap) throws JSONException {
         final PhysicalTopology phys = new PhysicalTopology(hostGroups);
         final List<Node> allNodes = MiscUtils.zip(phys.getAllHosts());
 
@@ -593,7 +661,7 @@ public class ClusterConfig
                 while (needed-- > 0 && groupIter.hasNext()) {
                     final Deque<Node> nextGroup = groupIter.next();
                     for (Node nextNode : nextGroup) {
-                        if (nextNode.partitionCount() < sitesPerHost) {
+                        if (nextNode.partitionCount() < sitesPerHostMap.get(nextNode.m_hostId)) {
                             assert p.m_master != nextNode;
                             assert !nextNode.m_replicaPartitions.contains(p);
                             firstReplicaNodes.add(nextNode);
@@ -602,7 +670,7 @@ public class ClusterConfig
                     }
                 }
 
-                assignReplicas(sitesPerHost, phys, p, firstReplicaNodes);
+                assignReplicas(sitesPerHostMap, phys, p, firstReplicaNodes);
             }
 
             // Step 3. Assign the remaining replicas. Make sure each partition
@@ -613,7 +681,7 @@ public class ClusterConfig
                     nodesLeft.remove(p.m_master);
                     final List<Node> sortedNodesLeft =
                         MiscUtils.zip(sortByConnectionsToNode(p.m_master, Collections.singletonList(nodesLeft)));
-                    assignReplicas(sitesPerHost, phys, p, sortedNodesLeft);
+                    assignReplicas(sitesPerHostMap, phys, p, sortedNodesLeft);
                 }
             }
         }
@@ -621,7 +689,7 @@ public class ClusterConfig
         // Sanity check to make sure each node has enough partitions and each
         // partition has enough replicas.
         for (Node n : allNodes) {
-            if (n.partitionCount() != sitesPerHost) {
+            if (n.partitionCount() != sitesPerHostMap.get(n.m_hostId)) {
                 throw new RuntimeException("Unable to assign partitions using the new placement algorithm");
             }
         }
@@ -635,7 +703,14 @@ public class ClusterConfig
         stringer.object();
         stringer.key("hostcount").value(m_hostCount);
         stringer.key("kfactor").value(getReplicationFactor());
-        stringer.key("sites_per_host").value(sitesPerHost);
+        stringer.key("host_id_to_sph").array();
+        for (Map.Entry<Integer, Integer> entry : sitesPerHostMap.entrySet()) {
+            stringer.object();
+            stringer.key("host_id").value(entry.getKey());
+            stringer.key("sites_per_host").value(entry.getValue());
+            stringer.endObject();
+        }
+        stringer.endArray();
         stringer.key("partitions").array();
         for (int part = 0; part < partitionCount; part++)
         {
@@ -664,12 +739,12 @@ public class ClusterConfig
      * first few. If there are less, the given partition will not be fully
      * replicated.
      */
-    private static void assignReplicas(int sitesPerHost, PhysicalTopology phys, Partition p, Collection<Node> nodes) {
+    private static void assignReplicas(Map<Integer, Integer> sitesPerHostMap, PhysicalTopology phys, Partition p, Collection<Node> nodes) {
         final Iterator<Node> nodeIter = nodes.iterator();
         while (p.m_neededReplicas > 0 && nodeIter.hasNext()) {
             final Node replica = nodeIter.next();
 
-            if (replica.partitionCount() == sitesPerHost) {
+            if (replica.partitionCount() == sitesPerHostMap.get(replica.m_hostId)) {
                 phys.m_root.removeHost(replica);
                 continue;
             }
@@ -740,7 +815,7 @@ public class ClusterConfig
     {
         int hostCount = getHostCount();
         int partitionCount = getPartitionCount();
-        int sitesPerHost = getSitesPerHost();
+        Map<Integer, Integer> sitesPerHostMap = getSitesPerHostMap();
 
         if (hostCount != hostGroups.size()) {
             throw new RuntimeException("Provided " + hostGroups.size() + " host ids when host count is " + hostCount);
@@ -749,15 +824,15 @@ public class ClusterConfig
         JSONObject topo;
         if (Boolean.valueOf(System.getenv("VOLT_REPLICA_FALLBACK"))) {
             topo = fallbackPlacementStrategy(Lists.newArrayList(hostGroups.keySet()),
-                                             hostCount, partitionCount, sitesPerHost);
+                                             hostCount, partitionCount, sitesPerHostMap);
         } else {
             try {
-                topo = groupAwarePlacementStrategy(hostGroups, partitionCount, sitesPerHost);
+                topo = groupAwarePlacementStrategy(hostGroups, partitionCount, sitesPerHostMap);
             } catch (Exception e) {
                 hostLog.error("Unable to use optimal replica placement strategy. " +
                               "Falling back to a less optimal strategy that may result in worse performance");
                 topo = fallbackPlacementStrategy(Lists.newArrayList(hostGroups.keySet()),
-                                                 hostCount, partitionCount, sitesPerHost);
+                                                 hostCount, partitionCount, sitesPerHostMap);
             }
         }
 
@@ -766,7 +841,7 @@ public class ClusterConfig
     }
 
     private final int m_hostCount;
-    private final int m_sitesPerHost;
+    private final Map<Integer, Integer> m_sitesPerHostMap;
     private final int m_replicationFactor;
 
     private String m_errorMsg;

--- a/src/frontend/org/voltdb/compiler/ClusterConfig.java
+++ b/src/frontend/org/voltdb/compiler/ClusterConfig.java
@@ -546,7 +546,8 @@ public class ClusterConfig
             ArrayList<Integer> hosts = new ArrayList<Integer>();
             partToHosts.put(i, hosts);
         }
-        for (int i = 0; i < getTotalSitesCount(); i++) {
+        int totalSitesCount = getTotalSitesCount();
+        for (int i = 0; i < totalSitesCount; i++) {
             // serially assign partitions to execution sites.
             int partition = (++partitionCounter) % partitionCount;
             int hostId = sitesToHostId.get(sitesToHostId.floorKey(i));
@@ -599,14 +600,14 @@ public class ClusterConfig
     }
 
     /**
-     * Each partition should has K different replica
+     * Each partition should has K+1 replicas
      */
     public static boolean checkKSafetyConstraint(
             HashMap<Integer, ArrayList<Integer>> partToHosts,
-            int kfactor)
+            int replicasCount)
     {
         return partToHosts.entrySet().stream().allMatch(
-                v -> kfactor == Sets.newHashSet(v.getValue()).size());
+                v -> replicasCount == Sets.newHashSet(v.getValue()).size());
     }
 
     /**

--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -676,7 +676,10 @@ public class VoltCompiler {
             Deployment deployment = catalogContext != null ? catalogContext.cluster.getDeployment().get("deployment") : null;
             int hostcount = clusterSettings != null ? clusterSettings.hostcount() : 1;
             int kfactor = deployment != null ? deployment.getKfactor() : 0;
-            int sitesPerHost = deployment != null ? deployment.getSitesperhost() : 8;
+            int sitesPerHost = 8;
+            if  (voltdb != null && voltdb.getHostMessenger() != null) {
+                sitesPerHost = voltdb.getHostMessenger().getLocalSitesCount();
+            }
             boolean isPro = MiscUtils.isPro();
 
             long minHeapRqt = RealVoltDB.computeMinimumHeapRqt(isPro, tableCount, sitesPerHost, kfactor);

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -53,6 +53,7 @@ import org.voltdb.VoltZK;
 import org.voltdb.VoltZK.MailboxType;
 import org.voltdb.compiler.ClusterConfig;
 
+import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.collect.ImmutableMap;
 
 /**
@@ -396,6 +397,7 @@ public class Cartographer extends StatsSource
     public List<Integer> getIv2PartitionsToReplace(int kfactor, int sitesPerHost)
         throws JSONException
     {
+        Preconditions.checkArgument(sitesPerHost != VoltDB.UNDEFINED);
         List<Integer> partitions = getPartitions();
         hostLog.info("Computing partitions to replace.  Total partitions: " + partitions);
         Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();

--- a/src/frontend/org/voltdb/iv2/LeaderAppointer.java
+++ b/src/frontend/org/voltdb/iv2/LeaderAppointer.java
@@ -163,6 +163,7 @@ public class LeaderAppointer implements Promotable
                         int pid = aPartition.getInt("partition_id");
                         if (pid == m_partitionId) {
                             replicaCount = aPartition.getJSONArray("replicas").length();
+                            break;
                         }
                     }
                 } catch (JSONException e) {
@@ -470,6 +471,7 @@ public class LeaderAppointer implements Promotable
                     int pid = aPartition.getInt("partition_id");
                     if (pid == partitionId) {
                         masterHostId = aPartition.getInt("master");
+                        break;
                     }
                 }
             }

--- a/src/frontend/org/voltdb/sysprocs/SystemInformation.java
+++ b/src/frontend/org/voltdb/sysprocs/SystemInformation.java
@@ -459,7 +459,7 @@ public class SystemInformation extends VoltSystemProcedure
         Deployment deploy = cluster.getDeployment().get("deployment");
         results.addRow("hostcount", Integer.toString(clusterSettings.hostcount()));
         results.addRow("kfactor", Integer.toString(deploy.getKfactor()));
-        results.addRow("sitesperhost", Integer.toString(deploy.getSitesperhost()));
+        results.addRow("sitesperhost", Integer.toString(VoltDB.instance().getHostMessenger().getLocalSitesCount()));
 
         String http_enabled = "false";
         int http_port = VoltDB.instance().getConfig().m_httpPort;

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -1097,13 +1097,11 @@ public abstract class CatalogUtil {
      */
     private static void setClusterInfo(Catalog catalog, DeploymentType deployment) {
         ClusterType cluster = deployment.getCluster();
-        int sitesPerHost = cluster.getSitesperhost();
         int kFactor = cluster.getKfactor();
 
         Cluster catCluster = catalog.getClusters().get("cluster");
         // copy the deployment info that is currently not recorded anywhere else
         Deployment catDeploy = catCluster.getDeployment().get("deployment");
-        catDeploy.setSitesperhost(sitesPerHost);
         catDeploy.setKfactor(kFactor);
         // copy partition detection configuration from xml to catalog
         String defaultPPDPrefix = "partition_detection";

--- a/src/frontend/org/voltdb/utils/CommandLine.java
+++ b/src/frontend/org/voltdb/utils/CommandLine.java
@@ -759,6 +759,11 @@ public class CommandLine extends VoltDB.Configuration
             cmdline.add("paused");
         }
 
+        if (m_sitesperhost != VoltDB.UNDEFINED) {
+            cmdline.add("sitesperhost");
+            cmdline.add(Integer.toString(m_sitesperhost));
+        }
+
         //Add mesh and hostcount for probe only.
         if (m_startAction == StartAction.PROBE) {
             cmdline.add("mesh"); cmdline.add(Joiner.on(',').skipNulls().join(m_coordinators));

--- a/tests/frontend/org/voltdb/TestMixedSitesPerHostCluster.java
+++ b/tests/frontend/org/voltdb/TestMixedSitesPerHostCluster.java
@@ -1,0 +1,194 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.voltdb.VoltDB.Configuration;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.regressionsuites.LocalCluster;
+import org.voltdb.utils.MiscUtils;
+
+import com.google_voltpatches.common.collect.Maps;
+
+public class TestMixedSitesPerHostCluster {
+    static final int K = MiscUtils.isPro() ? 1 : 0;
+
+    static final String JAR_NAME = "mixed.jar";
+    static final VoltProjectBuilder m_builder = new VoltProjectBuilder();
+
+    private class MixedSitesPerHostCluster {
+        LocalCluster m_cluster = null;
+
+        MixedSitesPerHostCluster(Map<Integer, Integer> sphMap) {
+            assert(sphMap != null);
+            assertFalse(sphMap.isEmpty());
+
+            m_cluster = new LocalCluster(
+                    JAR_NAME,
+                    2,
+                    sphMap.size(),
+                    K,
+                    BackendTarget.NATIVE_EE_JNI);
+            m_cluster.setOverridesForSitesperhost(sphMap);
+            m_cluster.setHasLocalServer(false);
+            m_cluster.setDeploymentAndVoltDBRoot(
+                    m_builder.getPathToDeployment(),
+                    m_builder.getPathToVoltRoot().getAbsolutePath());
+        }
+
+        boolean start() {
+            m_cluster.startUp();
+
+            return true;
+        }
+
+        boolean killAndRejoin(int hostId, Map<Integer, Integer> sphMap) {
+            try {
+                m_cluster.killSingleHost(hostId);
+                // just set the override for the last host
+                m_cluster.setOverridesForSitesperhost(sphMap);
+                return m_cluster.recoverOne(hostId, 0, "");
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+                return false;
+            }
+        }
+
+        void shutdown() throws InterruptedException {
+            if (m_cluster != null) {
+                m_cluster.shutDown();
+            }
+        }
+    }
+
+    @BeforeClass
+    public static void compileCatalog() throws IOException {
+        // just use it to fool VoltDB compiler, use overrides CLI option to provide actual sitesperhost
+        final int fakeSph = 2;
+        final int hostCount = 3;
+        m_builder.addLiteralSchema("CREATE TABLE V0 (id BIGINT);");
+        m_builder.configureLogging(null, null, false, false, 200, Integer.MAX_VALUE, null);
+        assertTrue(m_builder.compile(Configuration.getPathToCatalogForTest(JAR_NAME), fakeSph, hostCount, K));
+    }
+
+    @Test
+    public void testSameSitesPerHost() throws InterruptedException {
+        MixedSitesPerHostCluster cluster = null;
+
+        // Same sitesperhost across cluster, should work
+        Map<Integer, Integer> sameSphMap = Maps.newHashMap();
+        sameSphMap.put(0, 2);
+        sameSphMap.put(1, 2);
+        sameSphMap.put(2, 2);
+        cluster = new MixedSitesPerHostCluster(sameSphMap);
+
+        assertTrue(cluster.start());
+        cluster.shutdown();
+    }
+
+    @Test
+    public void testMixedSitesPerHostOptimal() throws InterruptedException {
+        MixedSitesPerHostCluster cluster = null;
+
+        // Mixed sitesperhost, optimal, should work
+        Map<Integer, Integer> mixedSphMap = Maps.newHashMap();
+        mixedSphMap.put(0, 2);
+        mixedSphMap.put(1, 6);
+        mixedSphMap.put(2, 4);
+        cluster = new MixedSitesPerHostCluster(mixedSphMap);
+        assertTrue(cluster.start());
+        cluster.shutdown();
+    }
+
+    @Test
+    public void testMixedSitesPerHostSubOptimal() throws InterruptedException {
+        if (!MiscUtils.isPro()) { return; } // join tests are pro only
+
+        MixedSitesPerHostCluster cluster = null;
+
+        // Mixed sitesperhost, suboptimal, shouldn't allow to start
+        Map<Integer, Integer> subOptimalSphMap = Maps.newHashMap();
+        subOptimalSphMap.put(0, 2);
+        subOptimalSphMap.put(1, 6);
+        subOptimalSphMap.put(2, 3);
+        cluster = new MixedSitesPerHostCluster(subOptimalSphMap);
+        try {
+            cluster.start();
+            fail();
+        }
+        catch (RuntimeException e) {}
+        finally {
+            cluster.shutdown();
+        }
+    }
+
+    @Test
+    public void testSameSitesPerHostJoins() throws InterruptedException {
+        if (!MiscUtils.isPro()) { return; } // join tests are pro only
+
+        MixedSitesPerHostCluster cluster = null;
+
+        // test same sitesperhost rejoins
+        Map<Integer, Integer> sameSphMap = Maps.newHashMap();
+        sameSphMap.put(0, 2);
+        sameSphMap.put(1, 2);
+        sameSphMap.put(2, 2);
+        cluster = new MixedSitesPerHostCluster(sameSphMap);
+        assertTrue(cluster.start());
+
+        assertTrue(cluster.killAndRejoin(0, sameSphMap));
+        assertTrue(cluster.killAndRejoin(1, sameSphMap));
+        assertTrue(cluster.killAndRejoin(2, sameSphMap));
+        cluster.shutdown();
+    }
+
+    @Test
+    public void testMixedSitesPerHostJoins() throws InterruptedException {
+        if (!MiscUtils.isPro()) { return; } // join tests are pro only
+
+        MixedSitesPerHostCluster cluster = null;
+        // test mixed sitesperhost rejoins
+        Map<Integer, Integer> mixedSphMap = Maps.newHashMap();
+        mixedSphMap.put(0, 6);
+        mixedSphMap.put(1, 1);
+        mixedSphMap.put(2, 5);
+        cluster = new MixedSitesPerHostCluster(mixedSphMap);
+
+        assertTrue(cluster.start());
+
+        assertTrue(cluster.killAndRejoin(0, mixedSphMap));
+        assertTrue(cluster.killAndRejoin(1, mixedSphMap));
+        assertTrue(cluster.killAndRejoin(2, mixedSphMap));
+        cluster.shutdown();
+    }
+}

--- a/tests/frontend/org/voltdb/TestMixedSitesPerHostCluster.java
+++ b/tests/frontend/org/voltdb/TestMixedSitesPerHostCluster.java
@@ -146,7 +146,9 @@ public class TestMixedSitesPerHostCluster {
             cluster.start();
             fail();
         }
-        catch (RuntimeException e) {}
+        catch (RuntimeException e) {
+            assertTrue(e.getMessage().endsWith("external processes failed to start"));
+        }
         finally {
             cluster.shutdown();
         }

--- a/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
@@ -27,22 +27,27 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.json_voltpatches.JSONArray;
+import org.json_voltpatches.JSONException;
+import org.json_voltpatches.JSONObject;
+import org.voltdb.VoltDB;
+
 import com.google_voltpatches.common.collect.HashMultimap;
 import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.collect.Multimap;
 import com.google_voltpatches.common.collect.Sets;
-import org.json_voltpatches.JSONArray;
-import org.json_voltpatches.JSONException;
-import org.json_voltpatches.JSONObject;
 
 import junit.framework.TestCase;
-import org.voltdb.VoltDB;
 
 public class TestClusterCompiler extends TestCase
 {
     public void testNonZeroReplicationFactor() throws Exception
     {
-        ClusterConfig config = new ClusterConfig(3, 1, 2);
+        Map<Integer, Integer> sphMap = Maps.newHashMap();
+        sphMap.put(0, 1);
+        sphMap.put(1, 1);
+        sphMap.put(2, 1);
+        ClusterConfig config = new ClusterConfig(3, sphMap, 2);
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
@@ -77,7 +82,10 @@ public class TestClusterCompiler extends TestCase
     {
         // 2 hosts, 6 sites per host, 2 copies of each partition.
         // there are sufficient execution sites, but insufficient hosts
-        ClusterConfig config = new ClusterConfig(2, 6, 2);
+        Map<Integer, Integer> sphMap = Maps.newHashMap();
+        sphMap.put(0, 6);
+        sphMap.put(1, 6);
+        ClusterConfig config = new ClusterConfig(2, sphMap, 2);
         try
         {
             if (!config.validate()) {
@@ -96,12 +104,22 @@ public class TestClusterCompiler extends TestCase
 
     public void testAddHostToNonKsafe() throws JSONException
     {
-        ClusterConfig config = new ClusterConfig(1, 6, 0);
+        Map<Integer, Integer> sphMap = Maps.newHashMap();
+        sphMap.put(0, 6);
+        ClusterConfig config = new ClusterConfig(1, sphMap, 0);
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         JSONObject topo = config.getTopology(topology);
         assertEquals(1, topo.getInt("hostcount"));
-        assertEquals(6, topo.getInt("sites_per_host"));
+        int size = topo.getJSONArray("host_id_to_sph").length();
+        assertEquals(sphMap.size(), size);
+        for (int ii = 0; ii < size; ii++) {
+            JSONObject sphObj = topo.getJSONArray("host_id_to_sph").getJSONObject(ii);
+            int hostId = sphObj.getInt("host_id");
+            int sph = sphObj.getInt("sites_per_host");
+            assertTrue(sphMap.containsKey(hostId));
+            assertTrue(sphMap.get(hostId) == sph);
+        }
         assertEquals(0, topo.getInt("kfactor"));
         assertEquals(6, topo.getJSONArray("partitions").length());
 
@@ -112,13 +130,24 @@ public class TestClusterCompiler extends TestCase
 
     public void testAddHostsToNonKsafe() throws JSONException
     {
-        ClusterConfig config = new ClusterConfig(2, 6, 0);
+        Map<Integer, Integer> sphMap = Maps.newHashMap();
+        sphMap.put(0, 6);
+        sphMap.put(1, 6);
+        ClusterConfig config = new ClusterConfig(2, sphMap, 0);
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
         JSONObject topo = config.getTopology(topology);
         assertEquals(2, topo.getInt("hostcount"));
-        assertEquals(6, topo.getInt("sites_per_host"));
+        int size = topo.getJSONArray("host_id_to_sph").length();
+        assertEquals(sphMap.size(), size);
+        for (int ii = 0; ii < size; ii++) {
+            JSONObject sphObj = topo.getJSONArray("host_id_to_sph").getJSONObject(ii);
+            int hostId = sphObj.getInt("host_id");
+            int sph = sphObj.getInt("sites_per_host");
+            assertTrue(sphMap.containsKey(hostId));
+            assertTrue(sphMap.get(hostId) == sph);
+        }
         assertEquals(0, topo.getInt("kfactor"));
         assertEquals(12, topo.getJSONArray("partitions").length());
 
@@ -131,13 +160,24 @@ public class TestClusterCompiler extends TestCase
 
     public void testAddHostsToKsafe() throws JSONException
     {
-        ClusterConfig config = new ClusterConfig(2, 6, 1);
+        Map<Integer, Integer> sphMap = Maps.newHashMap();
+        sphMap.put(0, 6);
+        sphMap.put(1, 6);
+        ClusterConfig config = new ClusterConfig(2, sphMap, 1);
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
         JSONObject topo = config.getTopology(topology);
         assertEquals(2, topo.getInt("hostcount"));
-        assertEquals(6, topo.getInt("sites_per_host"));
+        int size = topo.getJSONArray("host_id_to_sph").length();
+        assertEquals(sphMap.size(), size);
+        for (int ii = 0; ii < size; ii++) {
+            JSONObject sphObj = topo.getJSONArray("host_id_to_sph").getJSONObject(ii);
+            int hostId = sphObj.getInt("host_id");
+            int sph = sphObj.getInt("sites_per_host");
+            assertTrue(sphMap.containsKey(hostId));
+            assertTrue(sphMap.get(hostId) == sph);
+        }
         assertEquals(1, topo.getInt("kfactor"));
         assertEquals(6, topo.getJSONArray("partitions").length());
 
@@ -148,13 +188,24 @@ public class TestClusterCompiler extends TestCase
 
     public void testAddMoreThanKsafeHosts() throws JSONException
     {
-        ClusterConfig config = new ClusterConfig(2, 6, 1);
+        Map<Integer, Integer> sphMap = Maps.newHashMap();
+        sphMap.put(0, 6);
+        sphMap.put(1, 6);
+        ClusterConfig config = new ClusterConfig(2, sphMap, 1);
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
         JSONObject topo = config.getTopology(topology);
         assertEquals(2, topo.getInt("hostcount"));
-        assertEquals(6, topo.getInt("sites_per_host"));
+        int size = topo.getJSONArray("host_id_to_sph").length();
+        assertEquals(sphMap.size(), size);
+        for (int ii = 0; ii < size; ii++) {
+            JSONObject sphObj = topo.getJSONArray("host_id_to_sph").getJSONObject(ii);
+            int hostId = sphObj.getInt("host_id");
+            int sph = sphObj.getInt("sites_per_host");
+            assertTrue(sphMap.containsKey(hostId));
+            assertTrue(sphMap.get(hostId) == sph);
+        }
         assertEquals(1, topo.getInt("kfactor"));
         assertEquals(6, topo.getJSONArray("partitions").length());
 
@@ -272,7 +323,11 @@ public class TestClusterCompiler extends TestCase
         }
 
         for (int sites = 1; sites <= maxSites; sites++) {
-            final ClusterConfig config = new ClusterConfig(hostGroups.size(), sites, kfactor);
+            Map<Integer, Integer> sphMap = Maps.newHashMap();
+            for (int host = 0; host < hostGroups.size(); host++) {
+                sphMap.put(host, sites);
+            }
+            final ClusterConfig config = new ClusterConfig(hostGroups.size(), sphMap, kfactor);
             System.out.println("Running config " + sites + " sitesperhost, k=" + kfactor);
             if (config.validate()) {
                 final JSONObject topo = config.getTopology(hostGroups);
@@ -289,7 +344,7 @@ public class TestClusterCompiler extends TestCase
     private static void verifyTopology(Map<Integer, String> hostGroups, JSONObject topo) throws JSONException
     {
         final int hostCount = new ClusterConfig(topo).getHostCount();
-        final int sitesPerHost = new ClusterConfig(topo).getSitesPerHost();
+        final Map<Integer, Integer> sitesPerHostMap = new ClusterConfig(topo).getSitesPerHostMap();
         final int partitionCount = new ClusterConfig(topo).getPartitionCount();
         final int minMasterCount = partitionCount / hostCount;
         final int maxMasterCount = minMasterCount + 1;
@@ -301,6 +356,8 @@ public class TestClusterCompiler extends TestCase
         for (Map.Entry<Integer, String> entry : hostGroups.entrySet()) {
             final List<Integer> hostPartitions = ClusterConfig.partitionsForHost(topo, entry.getKey());
             final List<Integer> hostMasters = ClusterConfig.partitionsForHost(topo, entry.getKey(), true);
+            assertNotNull(sitesPerHostMap.get(entry.getKey()));
+            int sitesPerHost = sitesPerHostMap.get(entry.getKey());
             assertEquals(sitesPerHost, hostPartitions.size());
             // Make sure a host only has unique partitions
             assertEquals(hostPartitions.size(), Sets.newHashSet(hostPartitions).size());
@@ -321,7 +378,11 @@ public class TestClusterCompiler extends TestCase
         }
 
         for (Map.Entry<String, Collection<Integer>> ghEntry : groupHosts.asMap().entrySet()) {
-            if (ghEntry.getValue().size() * sitesPerHost < partitionCount) {
+            int sitesCount = 0;
+            for(Integer hostId : ghEntry.getValue()) {
+                sitesCount += sitesPerHostMap.get(hostId);
+            }
+            if (sitesCount < partitionCount) {
                 // Non-optimal topology, no need to verify the rest
                 System.out.println("Group " + ghEntry.getKey() + " only has " + ghEntry.getValue().size() + " hosts");
                 return;

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -65,6 +65,8 @@ import org.voltdb.utils.BuildDirectoryUtils;
 import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.MiscUtils;
 
+import com.google.common.collect.Maps;
+
 import junit.framework.TestCase;
 
 public class TestVoltCompiler extends TestCase {
@@ -728,11 +730,14 @@ public class TestVoltCompiler extends TestCase {
 
     public void testBadClusterConfig() throws IOException {
         // check no hosts
-        ClusterConfig cluster_config = new ClusterConfig(0, 1, 0);
+        Map<Integer, Integer> emptySphMap = Maps.newHashMap();
+        ClusterConfig cluster_config = new ClusterConfig(0, emptySphMap, 0);
         assertFalse(cluster_config.validate());
 
         // check no sites-per-hosts
-        cluster_config = new ClusterConfig(1, 0, 0);
+        Map<Integer, Integer> zeroSphMap = Maps.newHashMap();
+        zeroSphMap.put(0, 0);
+        cluster_config = new ClusterConfig(1, zeroSphMap, 0);
         assertFalse(cluster_config.validate());
     }
 

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -108,7 +108,11 @@ public class TestLeaderAppointer extends ZKTestBase {
         when(m_hm.getZK()).thenReturn(m_zk);
         VoltZK.createPersistentZKNodes(m_zk);
 
-        m_config = new ClusterConfig(hostCount, sitesPerHost, replicationFactor);
+        Map<Integer, Integer> sphMap = Maps.newHashMap();
+        for (int hostId = 0; hostId < hostCount; hostId++) {
+            sphMap.put(hostId, sitesPerHost);
+        }
+        m_config = new ClusterConfig(hostCount, sphMap, replicationFactor);
         TheHashinator.initialize(TheHashinator.getConfiguredHashinatorClass(), TheHashinator.getConfigureBytes(m_config.getPartitionCount()));
         m_hostIds = Sets.newTreeSet();
         m_hostGroups = Maps.newHashMap();

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -45,6 +45,7 @@ import org.voltdb.utils.CommandLine;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltFile;
 
+import com.google.common.collect.Maps;
 import com.google_voltpatches.common.collect.ImmutableSortedSet;
 
 /**
@@ -138,6 +139,7 @@ public class LocalCluster implements VoltServerConfig {
     private String[] m_buildStringOverrides = null;
 
     private String[] m_modeOverrides = null;
+    private Map<Integer, Integer> m_sitesperhostOverrides = null;
 
     // The base command line - each process copies and customizes this.
     // Each local cluster process has a CommandLine instance configured
@@ -270,6 +272,10 @@ public class LocalCluster implements VoltServerConfig {
 
         m_siteCount = siteCount;
         m_hostCount = hostCount;
+        m_sitesperhostOverrides = Maps.newHashMap();
+        for (int hostId = 0; hostId < hostCount; hostId++) {
+            m_sitesperhostOverrides.put(hostId, m_siteCount);
+        }
         templateCmdLine.hostCount(hostCount);
         templateCmdLine.setNewCli(isNewCli);
         if (kfactor > 0 && !MiscUtils.isPro()) {
@@ -541,6 +547,11 @@ public class LocalCluster implements VoltServerConfig {
         if ((m_modeOverrides != null) && (m_modeOverrides.length > hostId)) {
             assert(m_modeOverrides[hostId] != null);
             cmdln.m_modeOverrideForTest = m_modeOverrides[hostId];
+        }
+
+        if ((m_sitesperhostOverrides != null) && (m_sitesperhostOverrides.size() > hostId)) {
+            assert(m_sitesperhostOverrides.containsKey(hostId));
+            cmdln.m_sitesperhost = m_sitesperhostOverrides.get(hostId);
         }
 
         // for debug, dump the command line to a unique file.
@@ -998,6 +1009,12 @@ public class LocalCluster implements VoltServerConfig {
                 cmdln.m_modeOverrideForTest = m_modeOverrides[hostId];
             }
 
+            if ((m_sitesperhostOverrides != null) && (m_sitesperhostOverrides.size() > hostId)) {
+                assert(m_sitesperhostOverrides.containsKey(hostId));
+                cmdln.m_sitesperhost = m_sitesperhostOverrides.get(hostId);
+            }
+
+
             m_cmdLines.add(cmdln);
             m_procBuilder.command().clear();
             List<String> cmdlnList = cmdln.createCommandLine();
@@ -1206,6 +1223,12 @@ public class LocalCluster implements VoltServerConfig {
                 }
             }
             //Rejoin does not do paused mode.
+
+            //Rejoin mixed sitesperhost
+            if ((m_sitesperhostOverrides != null) && (m_sitesperhostOverrides.size() > hostId)) {
+                assert(m_sitesperhostOverrides.containsKey(hostId));
+                rejoinCmdLn.m_sitesperhost = m_sitesperhostOverrides.get(hostId);
+            }
 
             List<String> rejoinCmdLnStr = rejoinCmdLn.createCommandLine();
             String cmdLineFull = "Rejoin cmd line:";
@@ -1632,6 +1655,13 @@ public class LocalCluster implements VoltServerConfig {
         assert(modes != null);
 
         m_modeOverrides = modes;
+    }
+
+    public void setOverridesForSitesperhost(Map<Integer, Integer> sphMap) {
+        assert(sphMap != null);
+        assert(!sphMap.isEmpty());
+
+        m_sitesperhostOverrides = sphMap;
     }
 
     @Override


### PR DESCRIPTION
This patch provides VoltDB the ability to start with mixed sitesperhost settings. By using the hidden option `-s` or `--sitesperhost` the user can overrides the `sitesperhost` field in deployment file for each host.

The Pro-side pull request is https://github.com/VoltDB/pro/pull/1534