### PR TITLE
ENG-11286: Reads should use the most recent scheduled write SpHandle,…

### DIFF
--- a/src/frontend/org/voltdb/iv2/BufferedReadLog.java
+++ b/src/frontend/org/voltdb/iv2/BufferedReadLog.java
@@ -120,11 +120,15 @@ public class BufferedReadLog
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("BufferedReadLog contents:");
-        Iterator<Item> itr = m_bufferedReads.iterator();
-        for(int i = 0; itr.hasNext(); i++)  {
-            sb.append("           ").append(i).append(":").append(itr.next().toString()).append("\n");
+        sb.append("BufferedReadLog size:").append(m_bufferedReads.size());
+        if (m_bufferedReads.size() > 0) {
+            sb.append(", contents:\n");
+            Iterator<Item> itr = m_bufferedReads.iterator();
+            for(int i = 0; itr.hasNext(); i++)  {
+                sb.append("BufferedReadLog entry[").append(i).append("]:").append(itr.next().toString()).append("\n");
+            }
         }
+
         return sb.toString();
     }
 }


### PR DESCRIPTION
… which advanced by multi-fragments MP write once only per transaction. BorrowTaskMessage is an SP read only message that got executed locally. The max SpHandle in the task queue counts multi-fragment write transaction multiples times per transaction. This change will use the max txn SpHandle will only counts MP write transaction one time. Having a larger SpHandle for read only message may lead its response sink in the BufferReadLog forever.