### PR TITLE
ENG-11228 junit leak

### DIFF
--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -405,10 +405,12 @@ VoltDBIPC::VoltDBIPC(int fd) : m_fd(fd) {
 }
 
 VoltDBIPC::~VoltDBIPC() {
-    delete m_engine;
-    delete [] m_reusedResultBuffer;
-    delete [] m_tupleBuffer;
-    delete [] m_exceptionBuffer;
+    if (m_engine != NULL) {
+        delete m_engine;
+        delete [] m_reusedResultBuffer;
+        delete [] m_tupleBuffer;
+        delete [] m_exceptionBuffer;
+    }
 }
 
 bool VoltDBIPC::execute(struct ipc_command *cmd) {

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -405,6 +405,10 @@ VoltDBIPC::VoltDBIPC(int fd) : m_fd(fd) {
 }
 
 VoltDBIPC::~VoltDBIPC() {
+    // If m_engine is NULL, the voltdbipc process did not even
+    // receive an initialize command and all those buffer pointers remain NULL.
+    // Attempting to release those NULL buffer pointers will cause valgrind to
+    // throw "Conditional jump or move depends on uninitialised value(s)" error.
     if (m_engine != NULL) {
         delete m_engine;
         delete [] m_reusedResultBuffer;

--- a/tests/frontend/org/voltdb/TestAdhocCreateDropJavaProc.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateDropJavaProc.java
@@ -159,9 +159,11 @@ public class TestAdhocCreateDropJavaProc extends AdhocDDLTestBase {
             }
             resp = m_client.callProcedure("@SystemCatalog", "CLASSES");
             assertEquals(0, resp.getResults()[0].getRowCount()); // no classes in catalog
+            m_client.close();
+            cluster.shutDown();
         }
-        finally {
-            teardownSystem();
+        catch (Exception e) {
+            e.printStackTrace();
         }
     }
 
@@ -223,9 +225,11 @@ public class TestAdhocCreateDropJavaProc extends AdhocDDLTestBase {
                 fail("Should be able to call fully consistent procedure");
             }
             assertEquals(10L, resp.getResults()[0].asScalarLong());
+            m_client.close();
+            cluster.shutDown();
         }
-        finally {
-            teardownSystem();
+        catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/EEProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/EEProcess.java
@@ -314,6 +314,9 @@ public class EEProcess {
         }
     }
 
+    // In some tests there is no client initiated and the IPC server will hang
+    // waiting for the incoming messages.
+    // Push EOFs to IPC processes in this case can help end the hanging situation.
     private void signalShutDown() {
         Socket ipcSocket;
         PrintWriter ipcWriter;
@@ -330,9 +333,7 @@ public class EEProcess {
                 ipcWriter.close();
                 ipcSocket.close();
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        } catch (IOException e) {}
     }
 
     public void waitForShutdown() throws InterruptedException {

--- a/tests/frontend/org/voltdb/regressionsuites/EEProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/EEProcess.java
@@ -321,13 +321,17 @@ public class EEProcess {
         Socket ipcSocket;
         PrintWriter ipcWriter;
         try {
+            // Need to send as many EOFs as m_siteCount.
             for (int i=0; i<m_siteCount; i++) {
+                // The connection will be closed once an EOF is sent.
+                // So we need to re-open the connection if we want to send another EOF.
                 ipcSocket = new Socket("localhost", m_port);
                 if (! ipcSocket.isConnected()) {
                     ipcSocket.close();
                     return;
                 }
                 ipcWriter = new PrintWriter(ipcSocket.getOutputStream());
+                // 0x04 is the code for EOF.
                 ipcWriter.write("\004");
                 ipcWriter.flush();
                 ipcWriter.close();

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -1417,11 +1418,12 @@ public class LocalCluster implements VoltServerConfig {
 
         if (templateCmdLine.target() == BackendTarget.NATIVE_EE_VALGRIND_IPC) {
             if (!EEProcess.m_valgrindErrors.isEmpty()) {
-                String failString = "";
-                for (final String error : EEProcess.m_valgrindErrors) {
-                    failString = failString + "\n" + error;
+                StringBuilder failString = new StringBuilder();
+                final Iterator<String> iter = EEProcess.m_valgrindErrors.iterator();
+                while (iter.hasNext()) {
+                    failString.append("\n" + iter.next());
                 }
-                org.junit.Assert.fail(failString);
+                org.junit.Assert.fail(failString.toString());
             }
         }
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestHttpPort.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestHttpPort.java
@@ -40,6 +40,7 @@ public class TestHttpPort extends TestCase {
     PortListener ncprocess;
     PipeToFile pf;
     int rport;
+    LocalCluster config;
 
     public TestHttpPort(String name) {
         super(name);
@@ -61,7 +62,7 @@ public class TestHttpPort extends TestCase {
             String catalogJar = "dummy.jar";
             builder.setHTTPDPort(rport);
 
-            LocalCluster config = new LocalCluster(catalogJar, 2, 1, 0, BackendTarget.NATIVE_EE_JNI);
+            config = new LocalCluster(catalogJar, 2, 1, 0, BackendTarget.NATIVE_EE_JNI);
 
             config.portGenerator.enablePortProvider();
             config.portGenerator.pprovider.setHttp(rport);
@@ -90,6 +91,7 @@ public class TestHttpPort extends TestCase {
         if (ncprocess != null) {
             ncprocess.close();
         }
+        config.shutDown();
     }
 
     /*

--- a/tests/frontend/org/voltdb/regressionsuites/TestSecurityNoAdminUser.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSecurityNoAdminUser.java
@@ -27,16 +27,15 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.security.SecureRandom;
-
-import static junit.framework.Assert.fail;
-import junit.framework.TestCase;
 
 import org.voltdb.BackendTarget;
 import org.voltdb.compiler.VoltProjectBuilder;
 
+import junit.framework.TestCase;
+
 public class TestSecurityNoAdminUser extends TestCase {
 
+    LocalCluster config;
     PipeToFile pf;
 
     public TestSecurityNoAdminUser(String name) {
@@ -52,7 +51,7 @@ public class TestSecurityNoAdminUser extends TestCase {
             builder.setSecurityEnabled(true, false);
             String catalogJar = "dummy.jar";
 
-            LocalCluster config = new LocalCluster(catalogJar, 2, 1, 0, BackendTarget.NATIVE_EE_JNI);
+            config = new LocalCluster(catalogJar, 2, 1, 0, BackendTarget.NATIVE_EE_JNI);
 
             config.setHasLocalServer(false);
             //We expect it to crash
@@ -68,6 +67,11 @@ public class TestSecurityNoAdminUser extends TestCase {
             fail(ex.getMessage());
         } finally {
         }
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        config.shutDown();
     }
 
     /*

--- a/tests/frontend/org/voltdb/utils/TestCollector.java
+++ b/tests/frontend/org/voltdb/utils/TestCollector.java
@@ -49,6 +49,7 @@ import java.util.zip.ZipFile;
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.voltcore.utils.CoreUtils;
@@ -104,6 +105,12 @@ public class TestCollector {
         listener = cluster.getListenerAddresses().get(0);
         client = ClientFactory.createClient();
         client.createConnection(listener);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.close();
+        cluster.shutDown();
     }
 
     private ZipFile collect(String voltDbRootPath, boolean skipHeapDump, int days) throws Exception {


### PR DESCRIPTION
This pull request fixed two things:
* Memory leaks because of not having the cluster `shutDown()` call in the following tests:
>org.voltdb.TestAdhocCreateDropJavaProc
org.voltdb.regressionsuites.TestCreateForceFlag
org.voltdb.regressionsuites.TestHttpPort
org.voltdb.regressionsuites.TestSecurityNoAdminUser
org.voltdb.utils.TestCollector

* When no client is initiated to connect to the external IPC process in a junit test, `EEProcess` will hang because `voltdbipc` is waiting for incoming commands and cannot be terminated gracefully.