### PR TITLE
ENG-11286:BorrowTask, ultimately FragmentTask or SysprocFragmentTas, …

### DIFF
--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -52,6 +52,8 @@ public class SysprocFragmentTask extends TransactionTask
     final FragmentTaskMessage m_fragmentMsg;
     Map<Integer, List<VoltTable>> m_inputDeps;
 
+    boolean m_respBufferable = true;
+
     // This constructor is used during live rejoin log replay.
     SysprocFragmentTask(Mailbox mailbox,
                         FragmentTaskMessage message,
@@ -74,6 +76,10 @@ public class SysprocFragmentTask extends TransactionTask
             m_inputDeps = new HashMap<Integer, List<VoltTable>>();
         }
         assert(m_fragmentMsg.isSysProcTask());
+
+        if (txnState != null && !txnState.isReadOnly()) {
+            m_respBufferable = false;
+        }
     }
 
     /**
@@ -95,8 +101,12 @@ public class SysprocFragmentTask extends TransactionTask
             final int outputDepId = m_fragmentMsg.getOutputDepId(frag);
             response.addDependency(outputDepId, depTable);
         }
-
+        response.setRespBufferable(m_respBufferable);
         m_initiator.deliver(response);
+    }
+
+    public void setResponseNotBufferable() {
+        m_respBufferable = false;
     }
 
     @Override
@@ -126,6 +136,7 @@ public class SysprocFragmentTask extends TransactionTask
 
         final FragmentResponseMessage response = processFragmentTask(siteConnection);
         response.m_sourceHSId = m_initiator.getHSId();
+        response.setRespBufferable(m_respBufferable);
         m_initiator.deliver(response);
     }
 

--- a/src/frontend/org/voltdb/messaging/FragmentResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/FragmentResponseMessage.java
@@ -50,6 +50,10 @@ public class FragmentResponseMessage extends VoltMessage {
     // Not currently used; leaving it in for now
     boolean m_dirty = true;
     boolean m_recovering = false;
+    // a flag to decide whether to buffer this response or not
+    // it does not need to send over network, because it's only set to be false
+    // for BorrowTask which executes locally.
+    // Writes are always false and the flag is not used.
     boolean m_respBufferable = true;
     // WHA?  Why do we have a separate dependency count when
     // the array lists will tell you their lengths?  Doesn't look like
@@ -178,7 +182,6 @@ public class FragmentResponseMessage extends VoltMessage {
             + 1 // status byte
             + 1 // dirty flag
             + 1 // node recovering flag
-            + 1 // response bufferable flag
             + 2; // dependency count
 
         // one int per dependency ID
@@ -217,7 +220,6 @@ public class FragmentResponseMessage extends VoltMessage {
         buf.put(m_status);
         buf.put((byte) (m_dirty ? 1 : 0));
         buf.put((byte) (m_recovering ? 1 : 0));
-        buf.put((byte) (m_respBufferable ? 1 : 0));
         buf.putShort(m_dependencyCount);
         for (int i = 0; i < m_dependencyCount; i++)
             buf.putInt(m_dependencyIds.get(i));
@@ -252,7 +254,6 @@ public class FragmentResponseMessage extends VoltMessage {
         m_status = buf.get();
         m_dirty = buf.get() == 0 ? false : true;
         m_recovering = buf.get() == 0 ? false : true;
-        m_respBufferable = buf.get() == 0 ? false : true;
         m_dependencyCount = buf.getShort();
         for (int i = 0; i < m_dependencyCount; i++)
             m_dependencyIds.add(buf.getInt());

--- a/src/frontend/org/voltdb/messaging/FragmentResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/FragmentResponseMessage.java
@@ -50,6 +50,7 @@ public class FragmentResponseMessage extends VoltMessage {
     // Not currently used; leaving it in for now
     boolean m_dirty = true;
     boolean m_recovering = false;
+    boolean m_respBufferable = true;
     // WHA?  Why do we have a separate dependency count when
     // the array lists will tell you their lengths?  Doesn't look like
     // we do anything else with this value other than track the length
@@ -85,6 +86,7 @@ public class FragmentResponseMessage extends VoltMessage {
         m_status = resp.m_status;
         m_dirty = resp.m_dirty;
         m_recovering = resp.m_recovering;
+        m_respBufferable = resp.m_respBufferable;
         m_exception = resp.m_exception;
         m_subject = Subject.DEFAULT.getId();
     }
@@ -136,6 +138,14 @@ public class FragmentResponseMessage extends VoltMessage {
         return m_spHandle;
     }
 
+    public boolean getRespBufferable() {
+        return m_respBufferable;
+    }
+
+    public void setRespBufferable(boolean respBufferable) {
+        m_respBufferable = respBufferable;
+    }
+
     public byte getStatusCode() {
         return m_status;
     }
@@ -168,6 +178,7 @@ public class FragmentResponseMessage extends VoltMessage {
             + 1 // status byte
             + 1 // dirty flag
             + 1 // node recovering flag
+            + 1 // response bufferable flag
             + 2; // dependency count
 
         // one int per dependency ID
@@ -206,6 +217,7 @@ public class FragmentResponseMessage extends VoltMessage {
         buf.put(m_status);
         buf.put((byte) (m_dirty ? 1 : 0));
         buf.put((byte) (m_recovering ? 1 : 0));
+        buf.put((byte) (m_respBufferable ? 1 : 0));
         buf.putShort(m_dependencyCount);
         for (int i = 0; i < m_dependencyCount; i++)
             buf.putInt(m_dependencyIds.get(i));
@@ -240,6 +252,7 @@ public class FragmentResponseMessage extends VoltMessage {
         m_status = buf.get();
         m_dirty = buf.get() == 0 ? false : true;
         m_recovering = buf.get() == 0 ? false : true;
+        m_respBufferable = buf.get() == 0 ? false : true;
         m_dependencyCount = buf.getShort();
         for (int i = 0; i < m_dependencyCount; i++)
             m_dependencyIds.add(buf.getInt());
@@ -279,6 +292,11 @@ public class FragmentResponseMessage extends VoltMessage {
             sb.append("\n  DIRTY");
         else
             sb.append("\n  PRISTINE");
+
+        if (m_respBufferable)
+            sb.append("\n  BUFFERABLE");
+        else
+            sb.append("\n  NOT BUFFERABLE");
 
         for (int i = 0; i < m_dependencyCount; i++) {
             sb.append("\n  DEP ").append(m_dependencyIds.get(i));


### PR DESCRIPTION
… is an read only task embedded in an MP transaction. Its response is a FragmentResponseMessage that should not ever be buffered on SpScheduler. The response used to not differentiate BorrowTask with FragmentTask/SysprocFragmentTask, so SpScheduler can not decide whether it should buffer the response or not. The commit addresses this issue by adding response bufferable flag into FragmentTask/SysprocFragmentTask and FragmentResponseMessage.