### PR TITLE
ENG-11286: Newly rejoined replica may receive a CompleteTransactionMe…

### DIFF
--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1059,6 +1059,14 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             final CompleteTransactionTask task =
                 new CompleteTransactionTask(m_mailbox, txn, m_pendingTasks, msg, m_drGateway);
             queueOrOfferMPTask(task);
+        } else {
+            // Generate a dummy response message when this site has not seen previous FragmentTaskMessage,
+            // the leader may have started to wait for replicas' response messages.
+            // This can happen in the early phase of site rejoin before replica receiving the snapshot initiation,
+            // it also means this CompleteTransactionMessage message will be dropped because it's after snapshot.
+            final CompleteTransactionResponseMessage resp = new CompleteTransactionResponseMessage(msg);
+            resp.m_sourceHSId = m_mailbox.getHSId();
+            handleCompleteTransactionResponseMessage(resp);
         }
     }
 


### PR DESCRIPTION
…ssage without seeing FragmentTaskMessage from its leader, leading not creating CompleteTransactionTask. The leader may hence start to wait for replica's CompleteTransactionResponseMessage and deadlock the MP transaction in this way. This fix is to generate a dummy CompleteTransactionResponseMessage without going into the site task queue.