### PR TITLE
ENG-11015: Add initial SPI migration system procedure to move SP init…

### DIFF
--- a/src/frontend/org/voltcore/zk/ZKUtil.java
+++ b/src/frontend/org/voltcore/zk/ZKUtil.java
@@ -84,6 +84,34 @@ public class ZKUtil {
         return path;
     }
 
+    private static final String BALANCE_SPI_SUFFIX = "_BALANCE_SPI_REQUEST";
+
+    /**
+     * Generate a HSID string with BALANCE_SPI_SUFFIX information.
+     * When this string is updated, we can tell the reason why HSID is changed.
+     */
+    public static String suffixHSIdsWithBalanceSPIRequest(Long HSId) {
+        return Long.toString(HSId) + BALANCE_SPI_SUFFIX;
+    }
+
+    /**
+     * Is the data string hsid written because of balance SPI request?
+     */
+    public static boolean isHSIdFromBalanceSPIRequest(String hsid) {
+        return hsid.endsWith(BALANCE_SPI_SUFFIX);
+    }
+
+    /**
+     * Given a data string, figure out what's the long HSID number. Usually the data string
+     * is read from the zookeeper node.
+     */
+    public static long getHSId(String hsid) {
+        if (isHSIdFromBalanceSPIRequest(hsid)) {
+            return Long.parseLong(hsid.substring(0, hsid.length() - BALANCE_SPI_SUFFIX.length()));
+        }
+        return Long.parseLong(hsid);
+    }
+
     public static File getUploadAsTempFile( ZooKeeper zk, String path, String prefix) throws Exception {
         byte data[] = retrieveChunksAsBytes(zk, path, prefix, false).getFirst();
         File tempFile = File.createTempFile("foo", "bar");

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -155,6 +155,7 @@ public class SystemProcedureCatalog {
         builder.put("@SystemInformation",       new Config("org.voltdb.sysprocs.SystemInformation",        false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,    false));
         builder.put("@UpdateLogging",           new Config("org.voltdb.sysprocs.UpdateLogging",            false, false, true,  0,    VoltType.INVALID,   false, false, true,  true,      false,    false));
         builder.put("@BalancePartitions",       new Config("org.voltdb.sysprocs.BalancePartitions",        false, false, false, 0,    VoltType.INVALID,   true,  true,  true,  false,     true,     false));
+        builder.put("@BalanceSPI",              new Config("org.voltdb.sysprocs.BalanceSPI",               true,  true,  false, 0,    VoltType.BIGINT,    true,  true,  true,  false,     true,     false));
         builder.put("@UpdateApplicationCatalog",new Config("org.voltdb.sysprocs.UpdateApplicationCatalog", false, false, false, 0,    VoltType.INVALID,   false, false, false, true,      true,     false));
         builder.put("@LoadMultipartitionTable", new Config("org.voltdb.sysprocs.LoadMultipartitionTable",  false, false, false, 0,    VoltType.INVALID,   false, false, false, false,     true,     false));
         builder.put("@LoadSinglepartitionTable",new Config("org.voltdb.sysprocs.LoadSinglepartitionTable", true,  false, false, 0,    VoltType.VARBINARY, false, false, false, false,     true,     false));

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -102,6 +102,54 @@ public class VoltZK {
     public static final String leaders_globalservice = "/db/leaders/globalservice";
     public static final String lastKnownLiveNodes = "/db/lastKnownLiveNodes";
 
+    public static final String debugLeadersInfo(ZooKeeper zk) {
+        StringBuilder build = new StringBuilder();
+        build.append(printZKDir(zk, iv2masters));
+        build.append(printZKDir(zk, iv2appointees));
+        build.append(printZKDir(zk, iv2mpi));
+        build.append(printZKDir(zk, leaders));
+        build.append(printZKDir(zk, leaders_initiators));
+        build.append(printZKDir(zk, leaders_globalservice));
+        build.append(printZKDir(zk, lastKnownLiveNodes));
+
+        return build.toString();
+    }
+
+    private static final String printZKDir(ZooKeeper zk, String dir) {
+        StringBuilder build = new StringBuilder();
+        build.append("zookeeper ").append(dir).append(": ");
+        try {
+            List<String> keys = zk.getChildren(dir, null);
+            boolean isData = true;
+            for (String key: keys) {
+                String path = ZKUtil.joinZKPath(dir, key);
+                byte[] arr = zk.getData(path, null, null);
+
+                if (arr != null) {
+                    String data = new String(arr, "UTF-8");
+                    build.append(key).append(" -> ").append(data).append(",");
+                } else {
+                    // path may be a dir instead
+                    isData = false;
+                    List<String> children = zk.getChildren(path, null);
+                    if (children != null) {
+                        build.append("\n").append(printZKDir(zk, path));
+                    }
+                }
+            }
+            if (isData) {
+                build.append("\n");
+            }
+        } catch (KeeperException e) {
+            build.append(e.getMessage());
+        } catch (InterruptedException e) {
+            build.append(e.getMessage());
+        } catch (UnsupportedEncodingException e) {
+            build.append(e.getMessage());
+        }
+        return build.toString();
+}
+
     // flag of initialization process complete
     public static final String init_completed = "/db/init_completed";
 

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -321,10 +321,10 @@ public class ExportManager
      * @param partitionId
      */
     synchronized public void acceptMastership(int partitionId) {
-        Preconditions.checkArgument(
-                m_masterOfPartitions.add(partitionId),
-                "can't acquire mastership twice for partition id: " + partitionId
-                );
+        // can't acquire mastership twice for the same partition id
+        if (! m_masterOfPartitions.add(partitionId)) {
+            return;
+        }
         exportLog.info("ExportManager accepting mastership for partition " + partitionId);
         /*
          * Only the first generation will have a processor which

--- a/src/frontend/org/voltdb/iv2/LeaderCacheWriter.java
+++ b/src/frontend/org/voltdb/iv2/LeaderCacheWriter.java
@@ -25,5 +25,6 @@ import org.apache.zookeeper_voltpatches.KeeperException;
  */
 public interface LeaderCacheWriter {
     public void put(int partitionId, long HSId) throws KeeperException, InterruptedException;
+    public void put(int partitionId, String HSIdStr) throws KeeperException, InterruptedException;
 }
 

--- a/src/frontend/org/voltdb/iv2/Scheduler.java
+++ b/src/frontend/org/voltdb/iv2/Scheduler.java
@@ -76,7 +76,7 @@ abstract public class Scheduler implements InitiatorMessageHandler
     final protected SiteTaskerQueue m_tasks;
     protected Mailbox m_mailbox;
     protected boolean m_isLeader = false;
-    private TxnEgo m_txnEgo;
+    protected TxnEgo m_txnEgo;
     final protected int m_partitionId;
 
     // helper class to put command log work in order
@@ -142,6 +142,10 @@ abstract public class Scheduler implements InitiatorMessageHandler
     public void setLeaderState(boolean isLeader)
     {
         m_isLeader = isLeader;
+    }
+
+    public boolean isLeader() {
+        return m_isLeader;
     }
 
     public SiteTaskerQueue getQueue()

--- a/src/frontend/org/voltdb/messaging/BalanceSPIMessage.java
+++ b/src/frontend/org/voltdb/messaging/BalanceSPIMessage.java
@@ -1,0 +1,71 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.messaging;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.voltcore.messaging.VoltMessage;
+
+/**
+ * Sent from SPIs to one replica when @BalanceSPI is called.
+ */
+public class BalanceSPIMessage extends VoltMessage {
+    protected int m_partitionId;
+    protected long m_newLeaderHSId;
+
+    public BalanceSPIMessage() {}
+
+    public BalanceSPIMessage(int pid, long hsid) {
+        m_partitionId = pid;
+        m_newLeaderHSId = hsid;
+    }
+
+    public int getParititionId() {
+        return m_partitionId;
+    }
+
+    public long getNewLeaderHSId() {
+        return m_newLeaderHSId;
+    }
+
+
+    @Override
+    public int getSerializedSize()
+    {
+        return super.getSerializedSize() + 4 + 8;
+    }
+
+    @Override
+    protected void initFromBuffer(ByteBuffer buf) throws IOException
+    {
+        m_partitionId = buf.getInt();
+        m_newLeaderHSId = buf.getLong();
+        assert(buf.capacity() == buf.position());
+    }
+
+    @Override
+    public void flattenToBuffer(ByteBuffer buf) throws IOException
+    {
+        buf.put(VoltDbMessageFactory.BalanceSPI_ID);
+        buf.putInt(m_partitionId);
+        buf.putLong(m_newLeaderHSId);
+        assert(buf.capacity() == buf.position());
+        buf.limit(buf.position());
+    }
+}

--- a/src/frontend/org/voltdb/messaging/BalanceSPIResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/BalanceSPIResponseMessage.java
@@ -1,0 +1,51 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.messaging;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.voltcore.messaging.VoltMessage;
+
+/**
+ * Sent from SPIs to one replica when @BalanceSPI is called.
+ */
+public class BalanceSPIResponseMessage extends VoltMessage {
+
+    public BalanceSPIResponseMessage() {}
+
+    @Override
+    public int getSerializedSize()
+    {
+        return super.getSerializedSize();
+    }
+
+    @Override
+    protected void initFromBuffer(ByteBuffer buf) throws IOException
+    {
+        assert(buf.capacity() == buf.position());
+    }
+
+    @Override
+    public void flattenToBuffer(ByteBuffer buf) throws IOException
+    {
+        buf.put(VoltDbMessageFactory.BalanceSPI_RESPONSE_ID);
+        assert(buf.capacity() == buf.position());
+        buf.limit(buf.position());
+    }
+}

--- a/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
+++ b/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
@@ -51,6 +51,9 @@ public class VoltDbMessageFactory extends VoltMessageFactory
     final public static byte DR2_MULTIPART_RESPONSE_ID = VOLTCORE_MESSAGE_ID_MAX + 25;
     final public static byte DUMMY_TRANSACTION_TASK_ID = VOLTCORE_MESSAGE_ID_MAX + 26;
     final public static byte DUMMY_TRANSACTION_RESPONSE_ID = VOLTCORE_MESSAGE_ID_MAX + 27;
+    final public static byte BalanceSPI_ID = VOLTCORE_MESSAGE_ID_MAX + 28;
+    final public static byte BalanceSPI_RESPONSE_ID = VOLTCORE_MESSAGE_ID_MAX + 29;
+
 
     /**
      * Overridden by subclasses to create message types unknown by voltcore
@@ -144,6 +147,12 @@ public class VoltDbMessageFactory extends VoltMessageFactory
             break;
         case DUMMY_TRANSACTION_RESPONSE_ID:
             message = new DummyTransactionResponseMessage();
+            break;
+        case BalanceSPI_ID:
+            message = new BalanceSPIMessage();
+            break;
+        case BalanceSPI_RESPONSE_ID:
+            message = new BalanceSPIResponseMessage();
             break;
         default:
             message = null;

--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -48,6 +48,10 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jline.console.CursorBuffer;
+import jline.console.KeyMap;
+import jline.console.history.FileHistory;
+
 import org.voltdb.CLIConfig;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
@@ -64,10 +68,6 @@ import org.voltdb.parser.SQLParser.FileOption;
 import org.voltdb.parser.SQLParser.ParseRecallResults;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
-
-import jline.console.CursorBuffer;
-import jline.console.KeyMap;
-import jline.console.history.FileHistory;
 
 public class SQLCommand
 {
@@ -974,6 +974,8 @@ public class SQLCommand
                 ImmutableMap.<Integer, List<String>>builder().put( 0, new ArrayList<String>()).build());
         Procedures.put("@ResetDR",
                 ImmutableMap.<Integer, List<String>>builder().put( 0, new ArrayList<String>()).build());
+        Procedures.put("@BalanceSPI",
+                ImmutableMap.<Integer, List<String>>builder().put( 4, Arrays.asList("int","int","int","int")).build());
     }
 
     private static Client getClient(ClientConfig config, String[] servers, int port) throws Exception

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -50,6 +50,7 @@ import org.voltdb.TheHashinator;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
 import org.voltdb.compiler.ClusterConfig;
+import org.voltdb.iv2.LeaderCache.LeaderCallBackInfo;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.Maps;
@@ -72,7 +73,7 @@ public class TestLeaderAppointer extends ZKTestBase {
     LeaderCache.Callback m_changeCallback = new LeaderCache.Callback()
     {
         @Override
-        public void run(ImmutableMap<Integer, Long> cache) {
+        public void run(ImmutableMap<Integer, LeaderCallBackInfo> cache) {
             m_newAppointee.set(true);
         }
     };

--- a/tests/frontend/org/voltdb/iv2/TestLeaderCache.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderCache.java
@@ -22,7 +22,9 @@
  */
 package org.voltdb.iv2;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import static org.junit.Assert.assertEquals;
 
@@ -35,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.voltcore.zk.ZKTestBase;
+import org.voltdb.iv2.LeaderCache.LeaderCallBackInfo;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
 
@@ -46,9 +49,14 @@ public class TestLeaderCache extends ZKTestBase {
     {
         volatile ImmutableMap<Integer, Long> m_cache = null;
 
-        public void run(ImmutableMap<Integer, Long> cache)
+        @Override
+        public void run(ImmutableMap<Integer, LeaderCallBackInfo> cache)
         {
-            m_cache = cache;
+            HashMap<Integer, Long> cacheCopy = new HashMap<Integer, Long>();
+            for (Entry<Integer, LeaderCallBackInfo> e : cache.entrySet()) {
+                cacheCopy.put(e.getKey(), e.getValue().m_HSID);
+            }
+            m_cache = ImmutableMap.copyOf(cacheCopy);
         }
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -1819,4 +1819,9 @@ public class LocalCluster implements VoltServerConfig {
     public int getLogicalPartitionCount() {
         return (m_siteCount * m_hostCount) / (m_kfactor + 1);
     }
+
+    @Override
+    public int getKfactor() {
+        return m_kfactor;
+    }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/LocalSingleProcessServer.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalSingleProcessServer.java
@@ -259,4 +259,9 @@ public abstract class LocalSingleProcessServer implements VoltServerConfig {
     public int getLogicalPartitionCount() {
         return 1;
     }
+
+    @Override
+    public int getKfactor() {
+        return 0;
+    }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/VoltServerConfig.java
+++ b/tests/frontend/org/voltdb/regressionsuites/VoltServerConfig.java
@@ -164,4 +164,6 @@ public interface VoltServerConfig {
      * @return the number of logical partitions in this configuration
      * I.e. (sitesPerHost * numHosts) when K safetey is zero. */
     public int getLogicalPartitionCount();
+
+    public int getKfactor();
 }


### PR DESCRIPTION
…iator from one HSID to another HSID

This is the initial happy path of SPI migration, does not handle any miss-routed transactions yet. The UI in SQLCMD is just for demo purpose. And the system procedure UI is still not final yet. Instead of using HSID, I use host id, site id separately for demo purpose. 

The design is included in ticket. There is a pro request as well: https://github.com/VoltDB/pro/pull/1550
