### PR TITLE
ENG-11372: fix an issue of a possible read only MP deadlock when sync cmdlog is on.

### DIFF
--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -884,9 +884,11 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             // AND we've never seen anything for this transaction before.  We can't
             // actually log until we create a TransactionTask, though, so just keep track
             // of whether it needs to be done.
-            if (msg.getInitiateTask() != null) {
-                logThis = !msg.getInitiateTask().isReadOnly();
-            }
+
+            // Like SP, we should log writes and safe reads.
+            // Fast reads can be directly put on the task queue.
+            boolean shortcutRead = msg.isReadOnly() && (m_defaultConsistencyReadLevel == ReadLevel.FAST);
+            logThis = !shortcutRead;
         }
 
         // Check to see if this is the final task for this txn, and if so, if we can close it out early


### PR DESCRIPTION
The MP safe reads jumped the transaction task queue when sync command logging is on, and these reads are buffered without returning to MPI. This commit asks MP safe reads to go though the command logging queue to get guarranteed order
