### PR TITLE
ENG-11392 let DR consumer complete transactions before shutting down

### DIFF
--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -208,3 +208,17 @@ def check_importer(runner):
         if outstanding == 0:
             return
         time.sleep(1)
+
+def check_dr_consumer(runner):
+     while True:
+        resp = get_stats(runner, 'DRCONSUMER')
+        outstanding = 0
+        if len(resp.table(1).tuples()) == 0:
+            return
+        for r in resp.table(1).tuples():
+            if r[7] <> r[8]:
+                outstanding += 1
+                runner.info('DR Consumer-partition %d on host %d has outstanding transactions to be applied.' %(r[4], r[1]))
+        if outstanding == 0:
+            return
+        time.sleep(2)

--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -218,7 +218,7 @@ def check_dr_consumer(runner):
         for r in resp.table(1).tuples():
             if r[7] <> r[8]:
                 outstanding += 1
-                runner.info('DR Consumer-partition %d on host %d has outstanding transactions to be applied.' %(r[4], r[1]))
+                runner.info('Partition %d on host %d has outstanding DR consumer transactions.' %(r[4], r[1]))
         if outstanding == 0:
             return
         time.sleep(2)

--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -215,10 +215,14 @@ def check_dr_consumer(runner):
         outstanding = 0
         if len(resp.table(1).tuples()) == 0:
             return
+        # DR consumer stats
+        # column 7: The timestamp of the last transaction received from the producer for the partition
+        # column 8: The timestamp of the last transaction successfully applied to this partition on the consumer
+        # If the two timestamps are the same, all the transactions have been applied for the partition.
         for r in resp.table(1).tuples():
             if r[7] <> r[8]:
                 outstanding += 1
                 runner.info('Partition %d on host %d has outstanding DR consumer transactions.' %(r[4], r[1]))
         if outstanding == 0:
             return
-        time.sleep(2)
+        time.sleep(1)

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -44,13 +44,13 @@ def shutdown(runner):
             status = runner.call_proc('@Quiesce', [], []).table(0).tuple(0).column_integer(0)
             if status <> 0:
                 runner.abort('The cluster has failed to be quiesce with status: %d' % status)
-            runner.info('Completing outstanding export and DR transactions...')
+            runner.info('Completing outstanding export and DR producer transactions...')
             checkstats.check_export_dr(runner)
             runner.info('Completing outstanding client transactions.')
             checkstats.check_clients(runner)
             runner.info('Completing outstanding importer requests.')
             checkstats.check_importer(runner)
-            runner.info('Waiting for DR consumer to apply all the transactions.')
+            runner.info('Completing outstanding DR consumer transactions...')
             checkstats.check_dr_consumer(runner)
             runner.info('Cluster is ready for shutdown')
             if runner.opts.save:

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -50,6 +50,8 @@ def shutdown(runner):
             checkstats.check_clients(runner)
             runner.info('Completing outstanding importer requests.')
             checkstats.check_importer(runner)
+            runner.info('Waiting for DR consumer to apply all the transactions.')
+            checkstats.check_dr_consumer(runner)
             runner.info('Cluster is ready for shutdown')
             if runner.opts.save:
                columns = [VOLT.FastSerializer.VOLTTYPE_BIGINT]


### PR DESCRIPTION
In graceful shutdown, check DR consumer stats. Let consumer apply all transactions before shutdown is issued.