### PR TITLE
Eng 10740 json perf

### DIFF
--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -216,16 +216,16 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
             JSONStringer js = new JSONStringer();
             try {
                 js.object();
-                js.key(GROUP).value(group);
-                js.key(COORDINATOR_IP).value(coordinatorIp.toString());
-                js.key(ZK_INTERFACE).value(zkInterface);
-                js.key(INTERNAL_INTERFACE).value(internalInterface);
-                js.key(INTERNAL_PORT).value(internalPort);
-                js.key(DEAD_HOST_TIMEOUT).value(deadHostTimeout);
-                js.key(BACKWARDS_TIME_FORGIVENESS_WINDOW).value(backwardsTimeForgivenessWindow);
-                js.key(NETWORK_THREADS).value(networkThreads);
+                js.keySymbolValuePair(GROUP, group);
+                js.keySymbolValuePair(COORDINATOR_IP, coordinatorIp.toString());
+                js.keySymbolValuePair(ZK_INTERFACE, zkInterface);
+                js.keySymbolValuePair(INTERNAL_INTERFACE, internalInterface);
+                js.keySymbolValuePair(INTERNAL_PORT, internalPort);
+                js.keySymbolValuePair(DEAD_HOST_TIMEOUT, deadHostTimeout);
+                js.keySymbolValuePair(BACKWARDS_TIME_FORGIVENESS_WINDOW, backwardsTimeForgivenessWindow);
+                js.keySymbolValuePair(NETWORK_THREADS, networkThreads);
                 js.key(ACCEPTOR).value(acceptor);
-                js.key(LOCAL_SITES_COUNT).value(localSitesCount);
+                js.keySymbolValuePair(LOCAL_SITES_COUNT, localSitesCount);
                 js.endObject();
 
                 return js.toString();
@@ -259,9 +259,9 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         {
             final JSONStringer js = new JSONStringer();
             js.object();
-            js.key(HOST_IP).value(m_hostIp);
-            js.key(GROUP).value(m_group);
-            js.key(LOCAL_SITES_COUNT).value(m_localSitesCount);
+            js.keySymbolValuePair(HOST_IP, m_hostIp);
+            js.keySymbolValuePair(GROUP, m_group);
+            js.keySymbolValuePair(LOCAL_SITES_COUNT, m_localSitesCount);
             js.endObject();
             return js.toString().getBytes(StandardCharsets.UTF_8);
         }
@@ -879,45 +879,48 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
 
         JSONObject jsObj = new JSONObject();
 
-        jsObj.put("accepted", decision.accepted);
+        jsObj.put(SocketJoiner.ACCEPTED, decision.accepted);
         if (decision.accepted) {
             /*
              * Tell the new node what its host id is
              */
-            jsObj.put("newHostId", hostId);
+            jsObj.put(SocketJoiner.NEW_HOST_ID, hostId);
 
             /*
              * Echo back the address that the node connected from
              */
-            jsObj.put("reportedAddress",
+            jsObj.put(SocketJoiner.REPORTED_ADDRESS,
                       ((InetSocketAddress) socket.socket().getRemoteSocketAddress()).getAddress().getHostAddress());
 
             /*
-             * Create an array containing an ad for every node including this one
+             * Create an array containing an id for every node including this one
              * even though the connection has already been made
              */
             JSONArray jsArray = new JSONArray();
             JSONObject hostObj = new JSONObject();
-            hostObj.put("hostId", getHostId());
-            hostObj.put("address",
+            hostObj.put(SocketJoiner.HOST_ID, getHostId());
+            hostObj.put(SocketJoiner.ADDRESS,
                         m_config.internalInterface.isEmpty() ?
-                        socket.socket().getLocalAddress().getHostAddress() : m_config.internalInterface);
-            hostObj.put("port", m_config.internalPort);
+                        socket.socket().getLocalAddress().getHostAddress() :
+                        m_config.internalInterface);
+            hostObj.put(SocketJoiner.PORT, m_config.internalPort);
             jsArray.put(hostObj);
             for (Map.Entry<Integer, ForeignHost> entry : m_foreignHosts.entrySet()) {
                 if (entry.getValue() == null) continue;
                 int hsId = entry.getKey();
                 ForeignHost fh = entry.getValue();
                 hostObj = new JSONObject();
-                hostObj.put("hostId", hsId);
-                hostObj.put("address", fh.m_listeningAddress.getAddress().getHostAddress());
-                hostObj.put("port", fh.m_listeningAddress.getPort());
+                hostObj.put(SocketJoiner.HOST_ID, hsId);
+                hostObj.put(SocketJoiner.ADDRESS,
+                        fh.m_listeningAddress.getAddress().getHostAddress());
+                hostObj.put(SocketJoiner.PORT, fh.m_listeningAddress.getPort());
                 jsArray.put(hostObj);
             }
-            jsObj.put("hosts", jsArray);
-        } else {
-            jsObj.put("reason", decision.errMsg);
-            jsObj.put("mayRetry", decision.mayRetry);
+            jsObj.put(SocketJoiner.HOSTS, jsArray);
+        }
+        else {
+            jsObj.put(SocketJoiner.REASON, decision.errMsg);
+            jsObj.put(SocketJoiner.MAY_RETRY, decision.mayRetry);
         }
 
         byte messageBytes[] = jsObj.toString(4).getBytes("UTF-8");

--- a/src/frontend/org/voltcore/messaging/SocketJoiner.java
+++ b/src/frontend/org/voltcore/messaging/SocketJoiner.java
@@ -66,20 +66,19 @@ import com.google_voltpatches.common.net.HostAndPort;
  * before accepting new connections
  */
 public class SocketJoiner {
-
-    private static final String HOSTS = "hosts";
-    private static final String REPORTED_ADDRESS = "reportedAddress";
-    private static final String NEW_HOST_ID = "newHostId";
-    private static final String REASON = "reason";
-    private static final String MAY_RETRY = "mayRetry";
-    private static final String ACCEPTED = "accepted";
+    static final String HOSTS = "hosts";
+    static final String REPORTED_ADDRESS = "reportedAddress";
+    static final String NEW_HOST_ID = "newHostId";
+    static final String REASON = "reason";
+    static final String MAY_RETRY = "mayRetry";
+    static final String ACCEPTED = "accepted";
     private static final String MAY_EXCHANGE_TS = "mayExchangeTs";
     private static final String TYPE = "type";
     private static final String PUBLISH_HOSTID = "PUBLISH_HOSTID";
     private static final String REQUEST_HOSTID = "REQUEST_HOSTID";
-    private static final String HOST_ID = "hostId";
-    private static final String PORT = "port";
-    private static final String ADDRESS = "address";
+    static final String HOST_ID = "hostId";
+    static final String PORT = "port";
+    static final String ADDRESS = "address";
     private static final String VERSION_COMPATIBLE = "versionCompatible";
     private static final String BUILD_STRING = "buildString";
     public  static final String VERSION_STRING = "versionString";

--- a/src/frontend/org/voltcore/utils/InstanceId.java
+++ b/src/frontend/org/voltcore/utils/InstanceId.java
@@ -78,8 +78,8 @@ public class InstanceId
     {
         JSONStringer stringer = new JSONStringer();
         stringer.object();
-        stringer.key("coord").value(m_coord);
-        stringer.key("timestamp").value(m_timestamp);
+        stringer.keySymbolValuePair("coord", m_coord);
+        stringer.keySymbolValuePair("timestamp", m_timestamp);
         stringer.endObject();
         return new JSONObject(stringer.toString());
     }

--- a/src/frontend/org/voltdb/ClientResponseImpl.java
+++ b/src/frontend/org/voltdb/ClientResponseImpl.java
@@ -297,14 +297,10 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
         try {
             js.object();
 
-            js.key(JSON_STATUS_KEY);
-            js.value(status);
-            js.key(JSON_APPSTATUS_KEY);
-            js.value(appStatus);
-            js.key(JSON_STATUSSTRING_KEY);
-            js.value(statusString);
-            js.key(JSON_APPSTATUSSTRING_KEY);
-            js.value(appStatusString);
+            js.keySymbolValuePair(JSON_STATUS_KEY, status);
+            js.keySymbolValuePair(JSON_APPSTATUS_KEY, appStatus);
+            js.keySymbolValuePair(JSON_STATUSSTRING_KEY, statusString);
+            js.keySymbolValuePair(JSON_APPSTATUSSTRING_KEY, appStatusString);
             js.key(JSON_RESULTS_KEY);
             js.array();
             for (VoltTable o : results) {
@@ -316,7 +312,7 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
         }
         catch (JSONException e) {
             e.printStackTrace();
-            throw new RuntimeException("Failed to serialized a parameter set to JSON.", e);
+            throw new RuntimeException("Failed to serialize a parameter set to JSON.", e);
         }
         return js.toString();
     }

--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -197,21 +197,21 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
         byte jsonBytes[] = null;
         try {
             stringer.object();
-            stringer.key("txnId").value(txnId);
-            stringer.key("hostId").value(hostId);
-            stringer.key("hostname").value(hostname);
-            stringer.key("clusterName").value(clusterName);
-            stringer.key("databaseName").value(databaseName);
-            stringer.key("tableName").value(tableName.toUpperCase());
-            stringer.key("isReplicated").value(isReplicated);
-            stringer.key("isCompressed").value(true);
-            stringer.key("checksumType").value("CRC32C");
-            stringer.key("timestamp").value(timestamp);
+            stringer.keySymbolValuePair("txnId", txnId);
+            stringer.keySymbolValuePair("hostId", hostId);
+            stringer.keySymbolValuePair("hostname", hostname);
+            stringer.keySymbolValuePair("clusterName", clusterName);
+            stringer.keySymbolValuePair("databaseName", databaseName);
+            stringer.keySymbolValuePair("tableName", tableName.toUpperCase());
+            stringer.keySymbolValuePair("isReplicated", isReplicated);
+            stringer.keySymbolValuePair("isCompressed", true);
+            stringer.keySymbolValuePair("checksumType", "CRC32C");
+            stringer.keySymbolValuePair("timestamp", timestamp);
             /*
              * The timestamp string is for human consumption, automated stuff should use
              * the actual timestamp
              */
-            stringer.key("timestampString").value(SnapshotUtil.formatHumanReadableDate(timestamp));
+            stringer.keySymbolValuePair("timestampString", SnapshotUtil.formatHumanReadableDate(timestamp));
             if (!isReplicated) {
                 stringer.key("partitionIds").array();
                 for (int partitionId : partitionIds) {
@@ -219,7 +219,7 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
                 }
                 stringer.endArray();
 
-                stringer.key("numPartitions").value(numPartitions);
+                stringer.keySymbolValuePair("numPartitions", numPartitions);
             }
             stringer.endObject();
             String jsonString = stringer.toString();

--- a/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
+++ b/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
@@ -76,14 +76,14 @@ public class ExtensibleSnapshotDigestData {
             for (Map.Entry<String, Map<Integer, Pair<Long, Long>>> entry : m_exportSequenceNumbers.entrySet()) {
                 stringer.object();
 
-                stringer.key("exportTableName").value(entry.getKey());
+                stringer.keySymbolValuePair("exportTableName", entry.getKey());
 
                 stringer.key("sequenceNumberPerPartition").array();
                 for (Map.Entry<Integer, Pair<Long,Long>> sequenceNumber : entry.getValue().entrySet()) {
                     stringer.object();
-                    stringer.key("partition").value(sequenceNumber.getKey());
+                    stringer.keySymbolValuePair("partition", sequenceNumber.getKey());
                     //First value is the ack offset which matters for pauseless rejoin, but not persistence
-                    stringer.key("exportSequenceNumber").value(sequenceNumber.getValue().getSecond());
+                    stringer.keySymbolValuePair("exportSequenceNumber", sequenceNumber.getValue().getSecond());
                     stringer.endObject();
                 }
                 stringer.endArray();
@@ -167,13 +167,13 @@ public class ExtensibleSnapshotDigestData {
                 stringer.key(e.getKey().toString());
                 stringer.object();
                 if (e.getKey() != MpInitiator.MP_INIT_PID) {
-                    stringer.key("sequenceNumber").value(e.getValue().partitionInfo.drId);
-                    stringer.key("spUniqueId").value(e.getValue().partitionInfo.spUniqueId);
-                    stringer.key("mpUniqueId").value(e.getValue().partitionInfo.mpUniqueId);
+                    stringer.keySymbolValuePair("sequenceNumber", e.getValue().partitionInfo.drId);
+                    stringer.keySymbolValuePair("spUniqueId", e.getValue().partitionInfo.spUniqueId);
+                    stringer.keySymbolValuePair("mpUniqueId", e.getValue().partitionInfo.mpUniqueId);
                 } else {
-                    stringer.key("sequenceNumber").value(e.getValue().replicatedInfo.drId);
-                    stringer.key("spUniqueId").value(e.getValue().replicatedInfo.spUniqueId);
-                    stringer.key("mpUniqueId").value(e.getValue().replicatedInfo.mpUniqueId);
+                    stringer.keySymbolValuePair("sequenceNumber", e.getValue().replicatedInfo.drId);
+                    stringer.keySymbolValuePair("spUniqueId", e.getValue().replicatedInfo.spUniqueId);
+                    stringer.keySymbolValuePair("mpUniqueId", e.getValue().replicatedInfo.mpUniqueId);
                 }
                 stringer.endObject();
             }
@@ -282,11 +282,11 @@ public class ExtensibleSnapshotDigestData {
     private void writeDRStateToSnapshot(JSONStringer stringer) throws IOException {
         try {
             long clusterCreateTime = VoltDB.instance().getClusterCreateTime();
-            stringer.key("clusterCreateTime").value(clusterCreateTime);
+            stringer.keySymbolValuePair("clusterCreateTime", clusterCreateTime);
 
             Iterator<Entry<Integer, TupleStreamStateInfo>> iter = m_drTupleStreamInfo.entrySet().iterator();
             if (iter.hasNext()) {
-                stringer.key("drVersion").value(iter.next().getValue().drVersion);
+                stringer.keySymbolValuePair("drVersion", iter.next().getValue().drVersion);
             }
             writeDRTupleStreamInfoToSnapshot(stringer);
             stringer.key("drMixedClusterSizeConsumerState");

--- a/src/frontend/org/voltdb/Inits.java
+++ b/src/frontend/org/voltdb/Inits.java
@@ -594,8 +594,8 @@ public class Inits {
             try {
                 JSONStringer js = new JSONStringer();
                 js.object();
-                js.key("role").value(m_config.m_replicationRole.ordinal());
-                js.key("active").value(m_rvdb.getReplicationActive());
+                js.keySymbolValuePair("role", m_config.m_replicationRole.ordinal());
+                js.keySymbolValuePair("active", m_rvdb.getReplicationActive());
                 js.endObject();
 
                 ZooKeeper zk = m_rvdb.getHostMessenger().getZK();

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -1245,12 +1245,12 @@ public final class InvocationDispatcher {
         try {
             JSONWriter jss = new JSONStringer()
                     .object()
-                    .key(SnapshotUtil.JSON_URIPATH).value("file://" + paths.resolve(paths.getSnapshoth()).getPath())
-                    .key(SnapshotUtil.JSON_NONCE).value(SnapshotUtil.getShutdownSaveNonce(zkTxnId))
-                    .key(SnapshotUtil.JSON_TERMINUS).value(zkTxnId)
-                    .key(SnapshotUtil.JSON_BLOCK).value(true)
-                    .key(SnapshotUtil.JSON_PATH_TYPE).value(SnapshotPathType.SNAP_AUTO.toString())
-                    .key(SnapshotUtil.JSON_FORMAT).value(SnapshotFormat.NATIVE.toString())
+                    .keySymbolValuePair(SnapshotUtil.JSON_URIPATH, "file://" + paths.resolve(paths.getSnapshoth()).getPath())
+                    .keySymbolValuePair(SnapshotUtil.JSON_NONCE, SnapshotUtil.getShutdownSaveNonce(zkTxnId))
+                    .keySymbolValuePair(SnapshotUtil.JSON_TERMINUS, zkTxnId)
+                    .keySymbolValuePair(SnapshotUtil.JSON_BLOCK, true)
+                    .keySymbolValuePair(SnapshotUtil.JSON_PATH_TYPE, SnapshotPathType.SNAP_AUTO.toString())
+                    .keySymbolValuePair(SnapshotUtil.JSON_FORMAT, SnapshotFormat.NATIVE.toString())
                     .endObject();
             snapshotJson = jss.toString();
         } catch (JSONException e) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1487,8 +1487,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 JSONStringer stringer = new JSONStringer();
                 stringer.object();
 
-                stringer.key("workingDir").value(System.getProperty("user.dir"));
-                stringer.key("pid").value(CLibrary.getpid());
+                stringer.keySymbolValuePair("workingDir", System.getProperty("user.dir"));
+                stringer.keySymbolValuePair("pid", CLibrary.getpid());
 
                 stringer.key("log4jDst").array();
                 Enumeration<?> appenders = Logger.getRootLogger().getAllAppenders();
@@ -1496,9 +1496,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     Appender appender = (Appender) appenders.nextElement();
                     if (appender instanceof FileAppender){
                         stringer.object();
-                        stringer.key("path").value(new File(((FileAppender) appender).getFile()).getCanonicalPath());
+                        stringer.keySymbolValuePair("path", new File(((FileAppender) appender).getFile()).getCanonicalPath());
                         if (appender instanceof DailyRollingFileAppender) {
-                            stringer.key("format").value(((DailyRollingFileAppender)appender).getDatePattern());
+                            stringer.keySymbolValuePair("format", ((DailyRollingFileAppender)appender).getDatePattern());
                         }
                         stringer.endObject();
                     }
@@ -1512,9 +1512,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                         Appender appender = (Appender) appenders.nextElement();
                         if (appender instanceof FileAppender){
                             stringer.object();
-                            stringer.key("path").value(new File(((FileAppender) appender).getFile()).getCanonicalPath());
+                            stringer.keySymbolValuePair("path", new File(((FileAppender) appender).getFile()).getCanonicalPath());
                             if (appender instanceof DailyRollingFileAppender) {
-                                stringer.key("format").value(((DailyRollingFileAppender)appender).getDatePattern());
+                                stringer.keySymbolValuePair("format", ((DailyRollingFileAppender)appender).getDatePattern());
                             }
                             stringer.endObject();
                         }
@@ -2321,20 +2321,20 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             } else {
                 stringer.endArray();
             }
-            stringer.key("clientPort").value(m_config.m_port);
-            stringer.key("clientInterface").value(m_config.m_clientInterface);
-            stringer.key("adminPort").value(m_config.m_adminPort);
-            stringer.key("adminInterface").value(m_config.m_adminInterface);
-            stringer.key("httpPort").value(m_config.m_httpPort);
-            stringer.key("httpInterface").value(m_config.m_httpPortInterface);
-            stringer.key("internalPort").value(m_config.m_internalPort);
-            stringer.key("internalInterface").value(m_config.m_internalInterface);
+            stringer.keySymbolValuePair("clientPort", m_config.m_port);
+            stringer.keySymbolValuePair("clientInterface", m_config.m_clientInterface);
+            stringer.keySymbolValuePair("adminPort", m_config.m_adminPort);
+            stringer.keySymbolValuePair("adminInterface", m_config.m_adminInterface);
+            stringer.keySymbolValuePair("httpPort", m_config.m_httpPort);
+            stringer.keySymbolValuePair("httpInterface", m_config.m_httpPortInterface);
+            stringer.keySymbolValuePair("internalPort", m_config.m_internalPort);
+            stringer.keySymbolValuePair("internalInterface", m_config.m_internalInterface);
             String[] zkInterface = m_config.m_zkInterface.split(":");
-            stringer.key("zkPort").value(zkInterface[1]);
-            stringer.key("zkInterface").value(zkInterface[0]);
-            stringer.key("drPort").value(VoltDB.getReplicationPort(m_catalogContext.cluster.getDrproducerport()));
-            stringer.key("drInterface").value(VoltDB.getDefaultReplicationInterface());
-            stringer.key("publicInterface").value(m_config.m_publicInterface);
+            stringer.keySymbolValuePair("zkPort", zkInterface[1]);
+            stringer.keySymbolValuePair("zkInterface", zkInterface[0]);
+            stringer.keySymbolValuePair("drPort", VoltDB.getReplicationPort(m_catalogContext.cluster.getDrproducerport()));
+            stringer.keySymbolValuePair("drInterface", VoltDB.getDefaultReplicationInterface());
+            stringer.keySymbolValuePair("publicInterface", m_config.m_publicInterface);
             stringer.endObject();
             JSONObject obj = new JSONObject(stringer.toString());
             // possibly atomic swap from null to realz
@@ -3631,8 +3631,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 JSONStringer js = new JSONStringer();
                 js.object();
                 // Replication role should the be same across the cluster
-                js.key("role").value(getReplicationRole().ordinal());
-                js.key("active").value(m_replicationActive.get());
+                js.keySymbolValuePair("role", getReplicationRole().ordinal());
+                js.keySymbolValuePair("active", m_replicationActive.get());
                 js.endObject();
 
                 getHostMessenger().getZK().setData(VoltZK.replicationconfig,

--- a/src/frontend/org/voltdb/RestoreAgent.java
+++ b/src/frontend/org/voltdb/RestoreAgent.java
@@ -319,18 +319,18 @@ SnapshotCompletionInterest, Promotable
             JSONStringer stringer = new JSONStringer();
             try {
                 stringer.object();
-                stringer.key("txnId").value(txnId);
-                stringer.key("path").value(path);
-                stringer.key(SnapshotUtil.JSON_PATH_TYPE).value(pathType.name());
-                stringer.key("nonce").value(nonce);
-                stringer.key("partitionCount").value(partitionCount);
-                stringer.key("newPartitionCount").value(newPartitionCount);
-                stringer.key("catalogCrc").value(catalogCrc);
-                stringer.key("hostId").value(hostId);
+                stringer.keySymbolValuePair("txnId", txnId);
+                stringer.keySymbolValuePair("path", path);
+                stringer.keySymbolValuePair(SnapshotUtil.JSON_PATH_TYPE, pathType.name());
+                stringer.keySymbolValuePair("nonce", nonce);
+                stringer.keySymbolValuePair("partitionCount", partitionCount);
+                stringer.keySymbolValuePair("newPartitionCount", newPartitionCount);
+                stringer.keySymbolValuePair("catalogCrc", catalogCrc);
+                stringer.keySymbolValuePair("hostId", hostId);
                 stringer.key("tables").array();
                 for (Entry<String, Set<Integer>> p : partitions.entrySet()) {
                     stringer.object();
-                    stringer.key("name").value(p.getKey());
+                    stringer.keySymbolValuePair("name", p.getKey());
                     stringer.key("partitions").array();
                     for (int pid : p.getValue()) {
                         stringer.value(pid);
@@ -344,7 +344,7 @@ SnapshotCompletionInterest, Promotable
                     stringer.key(e.getKey().toString()).value(e.getValue());
                 }
                 stringer.endObject(); // partitionToTxnId
-                stringer.key("instanceId").value(instanceId.serializeToJSONObject());
+                stringer.key("instanceId").value( instanceId.serializeToJSONObject());
                 stringer.key("digestTables").array();
                 for (String digestTable : digestTables) {
                     stringer.value(digestTable);
@@ -1216,10 +1216,10 @@ SnapshotCompletionInterest, Promotable
             stringer.object();
             // optional max value.
             if (max != null) {
-                stringer.key("max").value(max);
+                stringer.keySymbolValuePair("max", max);
             }
             // 1 means recover, 0 means to create new DB
-            stringer.key("action").value(m_action.ordinal());
+            stringer.keySymbolValuePair("action", m_action.ordinal());
             stringer.key("snapInfos").array();
             for (SnapshotInfo snapshot : snapshots) {
                 stringer.value(snapshot.toJSONObject());

--- a/src/frontend/org/voltdb/SnapshotCompletionMonitor.java
+++ b/src/frontend/org/voltdb/SnapshotCompletionMonitor.java
@@ -179,11 +179,13 @@ public class SnapshotCompletionMonitor {
             final JSONObject exportSequenceJSON = jsonObj.getJSONObject("exportSequenceNumbers");
             final ImmutableMap.Builder<String, Map<Integer, Pair<Long, Long>>> builder =
                     ImmutableMap.builder();
+            @SuppressWarnings("unchecked")
             final Iterator<String> tableKeys = exportSequenceJSON.keys();
             while (tableKeys.hasNext()) {
                 final String tableName = tableKeys.next();
                 final JSONObject tableSequenceNumbers = exportSequenceJSON.getJSONObject(tableName);
                 ImmutableMap.Builder<Integer, Pair<Long, Long>> tableBuilder = ImmutableMap.builder();
+                @SuppressWarnings("unchecked")
                 final Iterator<String> partitionKeys = tableSequenceNumbers.keys();
                 while (partitionKeys.hasNext()) {
                     final String partitionString = partitionKeys.next();

--- a/src/frontend/org/voltdb/SnapshotCompletionMonitor.java
+++ b/src/frontend/org/voltdb/SnapshotCompletionMonitor.java
@@ -179,13 +179,11 @@ public class SnapshotCompletionMonitor {
             final JSONObject exportSequenceJSON = jsonObj.getJSONObject("exportSequenceNumbers");
             final ImmutableMap.Builder<String, Map<Integer, Pair<Long, Long>>> builder =
                     ImmutableMap.builder();
-            @SuppressWarnings("unchecked")
             final Iterator<String> tableKeys = exportSequenceJSON.keys();
             while (tableKeys.hasNext()) {
                 final String tableName = tableKeys.next();
                 final JSONObject tableSequenceNumbers = exportSequenceJSON.getJSONObject(tableName);
                 ImmutableMap.Builder<Integer, Pair<Long, Long>> tableBuilder = ImmutableMap.builder();
-                @SuppressWarnings("unchecked")
                 final Iterator<String> partitionKeys = tableSequenceNumbers.keys();
                 while (partitionKeys.hasNext()) {
                     final String partitionString = partitionKeys.next();

--- a/src/frontend/org/voltdb/SnapshotSaveAPI.java
+++ b/src/frontend/org/voltdb/SnapshotSaveAPI.java
@@ -394,14 +394,14 @@ public class SnapshotSaveAPI
         try {
             JSONStringer stringer = new JSONStringer();
             stringer.object();
-            stringer.key("txnId").value(txnId);
-            stringer.key("isTruncation").value(isTruncation);
-            stringer.key("didSucceed").value(false);
-            stringer.key("hostCount").value(-1);
-            stringer.key(SnapshotUtil.JSON_PATH).value(path);
-            stringer.key(SnapshotUtil.JSON_PATH_TYPE).value(pathType);
-            stringer.key(SnapshotUtil.JSON_NONCE).value(nonce);
-            stringer.key("truncReqId").value(truncReqId);
+            stringer.keySymbolValuePair("txnId", txnId);
+            stringer.keySymbolValuePair("isTruncation", isTruncation);
+            stringer.keySymbolValuePair("didSucceed", false);
+            stringer.keySymbolValuePair("hostCount", -1);
+            stringer.keySymbolValuePair(SnapshotUtil.JSON_PATH, path);
+            stringer.keySymbolValuePair(SnapshotUtil.JSON_PATH_TYPE, pathType);
+            stringer.keySymbolValuePair(SnapshotUtil.JSON_NONCE, nonce);
+            stringer.keySymbolValuePair("truncReqId", truncReqId);
             stringer.key("exportSequenceNumbers").object().endObject();
             stringer.endObject();
             JSONObject jsonObj = new JSONObject(stringer.toString());

--- a/src/frontend/org/voltdb/StoredProcedureInvocation.java
+++ b/src/frontend/org/voltdb/StoredProcedureInvocation.java
@@ -550,16 +550,13 @@ public class StoredProcedureInvocation implements JSONString {
         JSONStringer js = new JSONStringer();
         try {
             js.object();
-            js.key("proc_name");
-            js.value(procName);
-            js.key("client_handle");
-            js.value(clientHandle);
+            js.keySymbolValuePair("proc_name", procName);
+            js.keySymbolValuePair("client_handle", clientHandle);
             // @ApplyBinaryLog is exempted because it's often
             // got a large binary payload and this is annoying for testing
             // also users shouldn't ever directly call it
             if (!procName.startsWith("@ApplyBinaryLog")) {
-                js.key("parameters");
-                js.value(params.get());
+                js.key("parameters").value(params.get());
             }
             js.endObject();
         }

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1561,14 +1561,14 @@ public final class VoltTable extends VoltTableRow implements JSONString {
             js.object();
 
             // status code (1 byte)
-            js.key(JSON_STATUS_KEY).value(getStatusCode());
+            js.keySymbolValuePair(JSON_STATUS_KEY, getStatusCode());
 
             // column schema
             js.key(JSON_SCHEMA_KEY).array();
             for (int i = 0; i < getColumnCount(); i++) {
                 js.object();
-                js.key(JSON_NAME_KEY).value(getColumnName(i));
-                js.key(JSON_TYPE_KEY).value(getColumnType(i).getValue());
+                js.keySymbolValuePair(JSON_NAME_KEY, getColumnName(i));
+                js.keySymbolValuePair(JSON_TYPE_KEY, getColumnType(i).getValue());
                 js.endObject();
             }
             js.endArray();

--- a/src/frontend/org/voltdb/compiler/ClusterConfig.java
+++ b/src/frontend/org/voltdb/compiler/ClusterConfig.java
@@ -566,13 +566,13 @@ public class ClusterConfig
 
         JSONStringer stringer = new JSONStringer();
         stringer.object();
-        stringer.key("hostcount").value(m_hostCount);
-        stringer.key("kfactor").value(getReplicationFactor());
+        stringer.keySymbolValuePair("hostcount", m_hostCount);
+        stringer.keySymbolValuePair("kfactor", getReplicationFactor());
         stringer.key("host_id_to_sph").array();
         for (Map.Entry<Integer, Integer> entry : sitesPerHostMap.entrySet()) {
             stringer.object();
-            stringer.key("host_id").value(entry.getKey());
-            stringer.key("sites_per_host").value(entry.getValue());
+            stringer.keySymbolValuePair("host_id", entry.getKey());
+            stringer.keySymbolValuePair("sites_per_host", entry.getValue());
             stringer.endObject();
         }
         stringer.endArray();
@@ -580,12 +580,12 @@ public class ClusterConfig
         for (int part = 0; part < partitionCount; part++)
         {
             stringer.object();
-            stringer.key("partition_id").value(part);
+            stringer.keySymbolValuePair("partition_id", part);
             // This two-line magic deterministically spreads the partition leaders
             // evenly across the cluster at startup.
             int index = part % (getReplicationFactor() + 1);
             int master = partToHosts.get(part).get(index);
-            stringer.key("master").value(master);
+            stringer.keySymbolValuePair("master", master);
             stringer.key("replicas").array();
             for (int host_pos : partToHosts.get(part)) {
                 stringer.value(host_pos);
@@ -702,13 +702,13 @@ public class ClusterConfig
 
         JSONStringer stringer = new JSONStringer();
         stringer.object();
-        stringer.key("hostcount").value(m_hostCount);
-        stringer.key("kfactor").value(getReplicationFactor());
+        stringer.keySymbolValuePair("hostcount", m_hostCount);
+        stringer.keySymbolValuePair("kfactor", getReplicationFactor());
         stringer.key("host_id_to_sph").array();
         for (Map.Entry<Integer, Integer> entry : sitesPerHostMap.entrySet()) {
             stringer.object();
-            stringer.key("host_id").value(entry.getKey());
-            stringer.key("sites_per_host").value(entry.getValue());
+            stringer.keySymbolValuePair("host_id", entry.getKey());
+            stringer.keySymbolValuePair("sites_per_host", entry.getValue());
             stringer.endObject();
         }
         stringer.endArray();
@@ -716,8 +716,8 @@ public class ClusterConfig
         for (int part = 0; part < partitionCount; part++)
         {
             stringer.object();
-            stringer.key("partition_id").value(part);
-            stringer.key("master").value(partitions.get(part).m_master.m_hostId);
+            stringer.keySymbolValuePair("partition_id", part);
+            stringer.keySymbolValuePair("master", partitions.get(part).m_master.m_hostId);
             stringer.key("replicas").array();
             for (Node n : partitions.get(part).m_replicas) {
                 stringer.value(n.m_hostId);

--- a/src/frontend/org/voltdb/exceptions/SerializableException.java
+++ b/src/frontend/org/voltdb/exceptions/SerializableException.java
@@ -223,10 +223,8 @@ public class SerializableException extends VoltProcedure.VoltAbortException impl
             JSONStringer js = new JSONStringer();
 
             js.object();
-            js.key("type");
-            js.value(getExceptionType().ordinal());
-            js.key("message");
-            js.value(m_message);
+            js.keySymbolValuePair("type", getExceptionType().ordinal());
+            js.keySymbolValuePair("message", m_message);
             js.endObject();
 
             return js.toString();

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -17,6 +17,8 @@
 
 package org.voltdb.export;
 
+import static com.google_voltpatches.common.base.Preconditions.checkNotNull;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -60,7 +62,6 @@ import com.google_voltpatches.common.util.concurrent.Futures;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
 import com.google_voltpatches.common.util.concurrent.SettableFuture;
-import static com.google_voltpatches.common.base.Preconditions.checkNotNull;
 
 /**
  *  Allows an ExportDataProcessor to access underlying table queues
@@ -201,7 +202,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         try {
             JSONStringer stringer = new JSONStringer();
             stringer.object();
-            stringer.key("database").value(m_database);
+            stringer.keySymbolValuePair("database", m_database);
             writeAdvertisementTo(stringer);
             stringer.endObject();
             JSONObject jsObj = new JSONObject(stringer.toString());
@@ -360,23 +361,23 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     }
 
     public final void writeAdvertisementTo(JSONStringer stringer) throws JSONException {
-        stringer.key("adVersion").value(0);
-        stringer.key("generation").value(m_generation);
-        stringer.key("partitionId").value(getPartitionId());
-        stringer.key("signature").value(m_signature);
-        stringer.key("tableName").value(getTableName());
-        stringer.key("startTime").value(ManagementFactory.getRuntimeMXBean().getStartTime());
+        stringer.keySymbolValuePair("adVersion", 0);
+        stringer.keySymbolValuePair("generation", m_generation);
+        stringer.keySymbolValuePair("partitionId", getPartitionId());
+        stringer.keySymbolValuePair("signature", m_signature);
+        stringer.keySymbolValuePair("tableName", getTableName());
+        stringer.keySymbolValuePair("startTime", ManagementFactory.getRuntimeMXBean().getStartTime());
         stringer.key("columns").array();
         for (int ii=0; ii < m_columnNames.size(); ++ii) {
             stringer.object();
-            stringer.key("name").value(m_columnNames.get(ii));
-            stringer.key("type").value(m_columnTypes.get(ii));
-            stringer.key("length").value(m_columnLengths.get(ii));
+            stringer.keySymbolValuePair("name", m_columnNames.get(ii));
+            stringer.keySymbolValuePair("type", m_columnTypes.get(ii));
+            stringer.keySymbolValuePair("length", m_columnLengths.get(ii));
             stringer.endObject();
         }
         stringer.endArray();
-        stringer.key("format").value(ExportFormat.FOURDOTFOUR.toString());
-        stringer.key("partitionColumnName").value(m_partitionColumnName);
+        stringer.keySymbolValuePair("format", ExportFormat.FOURDOTFOUR.toString());
+        stringer.keySymbolValuePair("partitionColumnName", m_partitionColumnName);
     }
 
     /**

--- a/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
@@ -144,8 +144,8 @@ public abstract class AbstractSubqueryExpression extends AbstractExpression {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.SUBQUERY_ID.name()).value(m_subqueryId);
-        stringer.key(Members.SUBQUERY_ROOT_NODE_ID.name()).value(m_subqueryNodeId);
+        stringer.keySymbolValuePair(Members.SUBQUERY_ID.name(), m_subqueryId);
+        stringer.keySymbolValuePair(Members.SUBQUERY_ROOT_NODE_ID.name(), m_subqueryNodeId);
         // Output the correlated parameter ids that originates at this subquery immediate
         // parent and need to be set before the evaluation
         if (!m_parameterIdxList.isEmpty()) {
@@ -159,11 +159,10 @@ public abstract class AbstractSubqueryExpression extends AbstractExpression {
 
     @Override
     protected void loadFromJSONObject(JSONObject obj) throws JSONException {
-        super.loadFromJSONObject(obj);
         m_subqueryId = obj.getInt(Members.SUBQUERY_ID.name());
         m_subqueryNodeId = obj.getInt(Members.SUBQUERY_ROOT_NODE_ID.name());
-        if (obj.has(AbstractExpression.Members.VALUE_TYPE.name())) {
-            m_valueType = VoltType.get((byte) obj.getInt(AbstractExpression.Members.VALUE_TYPE.name()));
+        if (obj.has(AbstractExpression.Members.VALUE_TYPE)) {
+            m_valueType = VoltType.get((byte) obj.getInt(AbstractExpression.Members.VALUE_TYPE));
             m_valueSize = m_valueType.getLengthInBytesForFixedTypes();
         }
         if (obj.has(Members.PARAM_IDX.name())) {

--- a/src/frontend/org/voltdb/expressions/ComparisonExpression.java
+++ b/src/frontend/org/voltdb/expressions/ComparisonExpression.java
@@ -32,8 +32,8 @@ import org.voltdb.types.QuantifierType;
  */
 public class ComparisonExpression extends AbstractExpression {
 
-    public enum Members {
-        QUANTIFIER;
+    private static class Members {
+        private static final String QUANTIFIER = "QUANTIFIER";
     }
 
     private QuantifierType m_quantifier = QuantifierType.NONE;
@@ -83,19 +83,19 @@ public class ComparisonExpression extends AbstractExpression {
 
     @Override
     protected void loadFromJSONObject(JSONObject obj) throws JSONException {
-        super.loadFromJSONObject(obj);
-       if (obj.has(Members.QUANTIFIER.name())) {
-           m_quantifier = QuantifierType.get(obj.getInt(Members.QUANTIFIER.name()));
-       } else {
-           m_quantifier = QuantifierType.NONE;
-       }
+        if (obj.has(Members.QUANTIFIER)) {
+            m_quantifier = QuantifierType.get(obj.getInt(Members.QUANTIFIER));
+        }
+        else {
+            m_quantifier = QuantifierType.NONE;
+        }
     }
 
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
         if (m_quantifier != QuantifierType.NONE) {
-            stringer.key(Members.QUANTIFIER.name()).value(m_quantifier.getValue());
+            stringer.keySymbolValuePair(Members.QUANTIFIER, m_quantifier.getValue());
         }
     }
 

--- a/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
@@ -112,14 +112,12 @@ public class ConstantValueExpression extends AbstractValueExpression {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.ISNULL.name());
-        stringer.value(m_isNull);
+        stringer.keySymbolValuePair(Members.ISNULL.name(), m_isNull);
         stringer.key(Members.VALUE.name());
-        if (m_isNull)
-        {
+        if (m_isNull) {
             stringer.value("NULL");
+            return;
         }
-        else
         {
             switch (m_valueType)
             {

--- a/src/frontend/org/voltdb/expressions/FunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/FunctionExpression.java
@@ -203,13 +203,13 @@ public class FunctionExpression extends AbstractExpression {
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
         assert(m_name != null);
-        stringer.key(Members.NAME.name()).value(m_name);
-        stringer.key(Members.FUNCTION_ID.name()).value(m_functionId);
+        stringer.keySymbolValuePair(Members.NAME.name(), m_name);
+        stringer.keySymbolValuePair(Members.FUNCTION_ID.name(), m_functionId);
         if (m_impliedArgument != null) {
-            stringer.key(Members.IMPLIED_ARGUMENT.name()).value(m_impliedArgument);
+            stringer.keySymbolValuePair(Members.IMPLIED_ARGUMENT.name(), m_impliedArgument);
         }
         if (m_resultTypeParameterIndex != NOT_PARAMETERIZED) {
-            stringer.key(Members.RESULT_TYPE_PARAM_IDX.name()).value(m_resultTypeParameterIndex);
+            stringer.keySymbolValuePair(Members.RESULT_TYPE_PARAM_IDX.name(), m_resultTypeParameterIndex);
         }
     }
 

--- a/src/frontend/org/voltdb/expressions/HashRangeExpression.java
+++ b/src/frontend/org/voltdb/expressions/HashRangeExpression.java
@@ -135,12 +135,12 @@ public class HashRangeExpression extends AbstractValueExpression {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.HASH_COLUMN.name()).value(m_hashColumn);
+        stringer.keySymbolValuePair(Members.HASH_COLUMN.name(), m_hashColumn);
         stringer.key(Members.RANGES.name()).array();
         for (Map.Entry<Integer, Integer> e : m_ranges.entrySet()) {
             stringer.object();
-            stringer.key(Members.RANGE_START.name()).value(e.getKey().intValue());
-            stringer.key(Members.RANGE_END.name()).value(e.getValue().intValue());
+            stringer.keySymbolValuePair(Members.RANGE_START.name(), e.getKey().intValue());
+            stringer.keySymbolValuePair(Members.RANGE_END.name(), e.getValue().intValue());
             stringer.endObject();
         }
         stringer.endArray();

--- a/src/frontend/org/voltdb/expressions/ParameterValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ParameterValueExpression.java
@@ -94,7 +94,7 @@ public class ParameterValueExpression extends AbstractValueExpression {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.PARAM_IDX.name()).value(m_paramIndex);
+        stringer.keySymbolValuePair(Members.PARAM_IDX.name(), m_paramIndex);
     }
 
     @Override

--- a/src/frontend/org/voltdb/expressions/TupleValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/TupleValueExpression.java
@@ -33,9 +33,10 @@ import org.voltdb.types.ExpressionType;
  */
 public class TupleValueExpression extends AbstractValueExpression {
 
-    public enum Members {
-        COLUMN_IDX,
-        TABLE_IDX,  // for JOIN queries only, 0 for outer table, 1 for inner table
+    private static class Members {
+        static final String COLUMN_IDX = "COLUMN_IDX";
+        // used for JOIN queries only, 0 for outer table, 1 for inner table
+        static final String TABLE_IDX = "TABLE_IDX";
     }
 
     private int m_columnIndex = -1;
@@ -358,18 +359,18 @@ public class TupleValueExpression extends AbstractValueExpression {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.COLUMN_IDX.name()).value(m_columnIndex);
+        stringer.keySymbolValuePair(Members.COLUMN_IDX, m_columnIndex);
         if (m_tableIdx > 0) {
-            stringer.key(Members.TABLE_IDX.name()).value(m_tableIdx);
+            stringer.keySymbolValuePair(Members.TABLE_IDX, m_tableIdx);
         }
     }
 
     @Override
     protected void loadFromJSONObject(JSONObject obj, StmtTableScan tableScan)
             throws JSONException {
-        m_columnIndex = obj.getInt(Members.COLUMN_IDX.name());
-        if (obj.has(Members.TABLE_IDX.name())) {
-            m_tableIdx = obj.getInt(Members.TABLE_IDX.name());
+        m_columnIndex = obj.getInt(Members.COLUMN_IDX);
+        if (obj.has(Members.TABLE_IDX)) {
+            m_tableIdx = obj.getInt(Members.TABLE_IDX);
         }
         if (tableScan != null) {
             m_tableAlias = tableScan.getTableAlias();

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -88,8 +88,8 @@ public class Cartographer extends StatsSource
         try {
             JSONStringer stringer = new JSONStringer();
             stringer.object();
-            stringer.key(JSON_PARTITION_ID).value(partitionId);
-            stringer.key(JSON_INITIATOR_HSID).value(hsId);
+            stringer.keySymbolValuePair(JSON_PARTITION_ID, partitionId);
+            stringer.keySymbolValuePair(JSON_INITIATOR_HSID, hsId);
             stringer.endObject();
             BinaryPayloadMessage bpm = new BinaryPayloadMessage(new byte[0], stringer.toString().getBytes("UTF-8"));
             int hostId = m_hostMessenger.getHostId();
@@ -210,7 +210,7 @@ public class Cartographer extends StatsSource
             sites.add(leader);
         }
         else {
-            leader = m_iv2Masters.pointInTimeCache().get((Integer)rowKey);
+            leader = m_iv2Masters.pointInTimeCache().get(rowKey);
             sites.addAll(getReplicasForPartition((Integer)rowKey));
         }
 

--- a/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
@@ -297,10 +297,9 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void toJSONString(JSONStringer stringer) throws JSONException
-    {
+    public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.JOIN_TYPE.name()).value(m_joinType.toString());
+        stringer.keySymbolValuePair(Members.JOIN_TYPE.name(), m_joinType.toString());
         stringer.key(Members.PRE_JOIN_PREDICATE.name()).value(m_preJoinPredicate);
         stringer.key(Members.JOIN_PREDICATE.name()).value(m_joinPredicate);
         stringer.key(Members.WHERE_PREDICATE.name()).value(m_wherePredicate);

--- a/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
@@ -131,7 +131,7 @@ public abstract class AbstractOperationPlanNode extends AbstractPlanNode {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.TARGET_TABLE_NAME).value(m_targetTableName);
+        stringer.keySymbolValuePair(Members.TARGET_TABLE_NAME, m_targetTableName);
     }
 
     @Override

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -915,8 +915,8 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
     }
 
     public void toJSONString(JSONStringer stringer) throws JSONException {
-        stringer.key(Members.ID.name()).value(m_id);
-        stringer.key(Members.PLAN_NODE_TYPE.name()).value(getPlanNodeType().toString());
+        stringer.keySymbolValuePair(Members.ID.name(), m_id);
+        stringer.keySymbolValuePair(Members.PLAN_NODE_TYPE.name(), getPlanNodeType().toString());
 
         if (m_inlineNodes.size() > 0) {
             PlanNodeType types[] = new PlanNodeType[m_inlineNodes.size()];

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -445,15 +445,15 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
 
         if (m_predicate != null) {
             if (ConstantValueExpression.isBooleanFalse(m_predicate)) {
-                stringer.key(Members.PREDICATE_FALSE.name()).value("TRUE");
+                stringer.keySymbolValuePair(Members.PREDICATE_FALSE.name(), "TRUE");
             }
             stringer.key(Members.PREDICATE.name());
             stringer.value(m_predicate);
         }
-        stringer.key(Members.TARGET_TABLE_NAME.name()).value(m_targetTableName);
-        stringer.key(Members.TARGET_TABLE_ALIAS.name()).value(m_targetTableAlias);
+        stringer.keySymbolValuePair(Members.TARGET_TABLE_NAME.name(), m_targetTableName);
+        stringer.keySymbolValuePair(Members.TARGET_TABLE_ALIAS.name(), m_targetTableAlias);
         if (m_isSubQuery) {
-            stringer.key(Members.SUBQUERY_INDICATOR.name()).value("TRUE");
+            stringer.keySymbolValuePair(Members.SUBQUERY_INDICATOR.name(), "TRUE");
         }
     }
 

--- a/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
@@ -409,9 +409,9 @@ public class AggregatePlanNode extends AbstractPlanNode {
         stringer.array();
         for (int ii = 0; ii < m_aggregateTypes.size(); ii++) {
             stringer.object();
-            stringer.key(Members.AGGREGATE_TYPE.name()).value(m_aggregateTypes.get(ii).name());
-            stringer.key(Members.AGGREGATE_DISTINCT.name()).value(m_aggregateDistinct.get(ii));
-            stringer.key(Members.AGGREGATE_OUTPUT_COLUMN.name()).value(m_aggregateOutputColumns.get(ii));
+            stringer.keySymbolValuePair(Members.AGGREGATE_TYPE.name(), m_aggregateTypes.get(ii).name());
+            stringer.keySymbolValuePair(Members.AGGREGATE_DISTINCT.name(), m_aggregateDistinct.get(ii));
+            stringer.keySymbolValuePair(Members.AGGREGATE_OUTPUT_COLUMN.name(), m_aggregateOutputColumns.get(ii));
             AbstractExpression ae = m_aggregateExpressions.get(ii);
             if (ae != null) {
                 stringer.key(Members.AGGREGATE_EXPRESSION.name());

--- a/src/frontend/org/voltdb/plannodes/DeletePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/DeletePlanNode.java
@@ -51,7 +51,7 @@ public class DeletePlanNode extends AbstractOperationPlanNode {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.TRUNCATE.name()).value(m_truncate);
+        stringer.keySymbolValuePair(Members.TRUNCATE.name(), m_truncate);
     }
 
     @Override

--- a/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
@@ -344,9 +344,9 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.LOOKUP_TYPE.name()).value(m_lookupType.toString());
-        stringer.key(Members.END_TYPE.name()).value(m_endType.toString());
-        stringer.key(Members.TARGET_INDEX_NAME.name()).value(m_targetIndexName);
+        stringer.keySymbolValuePair(Members.LOOKUP_TYPE.name(), m_lookupType.toString());
+        stringer.keySymbolValuePair(Members.END_TYPE.name(), m_endType.toString());
+        stringer.keySymbolValuePair(Members.TARGET_INDEX_NAME.name(), m_targetIndexName);
 
         stringer.key(Members.ENDKEY_EXPRESSIONS.name());
         if ( m_endkeyExpressions.isEmpty()) {

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -708,12 +708,12 @@ public class IndexScanPlanNode extends AbstractScanPlanNode {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.LOOKUP_TYPE.name()).value(m_lookupType.toString());
-        stringer.key(Members.SORT_DIRECTION.name()).value(m_sortDirection.toString());
+        stringer.keySymbolValuePair(Members.LOOKUP_TYPE.name(), m_lookupType.toString());
+        stringer.keySymbolValuePair(Members.SORT_DIRECTION.name(), m_sortDirection.toString());
         if (m_purpose != FOR_SCANNING_PERFORMANCE_OR_ORDERING) {
-            stringer.key(Members.PURPOSE.name()).value(m_purpose);
+            stringer.keySymbolValuePair(Members.PURPOSE.name(), m_purpose);
         }
-        stringer.key(Members.TARGET_INDEX_NAME.name()).value(m_targetIndexName);
+        stringer.keySymbolValuePair(Members.TARGET_INDEX_NAME.name(), m_targetIndexName);
         if (m_searchkeyExpressions.size() > 0) {
             stringer.key(Members.SEARCHKEY_EXPRESSIONS.name()).array(m_searchkeyExpressions);
         }

--- a/src/frontend/org/voltdb/plannodes/InsertPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/InsertPlanNode.java
@@ -83,7 +83,7 @@ public class InsertPlanNode extends AbstractOperationPlanNode {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.MULTI_PARTITION.name()).value(m_multiPartition);
+        stringer.keySymbolValuePair(Members.MULTI_PARTITION.name(), m_multiPartition);
         stringer.key(Members.FIELD_MAP.name()).array();
         for (int i : m_fieldMap) {
             stringer.value(i);
@@ -91,11 +91,11 @@ public class InsertPlanNode extends AbstractOperationPlanNode {
         stringer.endArray();
 
         if (m_isUpsert) {
-            stringer.key(Members.UPSERT.name()).value(true);
+            stringer.keySymbolValuePair(Members.UPSERT.name(), true);
         }
 
         if (m_sourceIsPartitioned) {
-            stringer.key(Members.SOURCE_IS_PARTITIONED.name()).value(true);
+            stringer.keySymbolValuePair(Members.SOURCE_IS_PARTITIONED.name(), true);
         }
     }
 

--- a/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
@@ -116,10 +116,10 @@ public class LimitPlanNode extends AbstractPlanNode {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.OFFSET.name()).value(m_offset);
-        stringer.key(Members.LIMIT.name()).value(m_limit);
-        stringer.key(Members.OFFSET_PARAM_IDX.name()).value(m_offsetParameterId);
-        stringer.key(Members.LIMIT_PARAM_IDX.name()).value(m_limitParameterId);
+        stringer.keySymbolValuePair(Members.OFFSET.name(), m_offset);
+        stringer.keySymbolValuePair(Members.LIMIT.name(), m_limit);
+        stringer.keySymbolValuePair(Members.OFFSET_PARAM_IDX.name(), m_offsetParameterId);
+        stringer.keySymbolValuePair(Members.LIMIT_PARAM_IDX.name(), m_limitParameterId);
         stringer.key(Members.LIMIT_EXPRESSION.name()).value(m_limitExpression);
     }
 

--- a/src/frontend/org/voltdb/plannodes/MaterializePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializePlanNode.java
@@ -26,10 +26,8 @@ import org.voltdb.types.PlanNodeType;
 public class MaterializePlanNode extends ProjectionPlanNode {
 
     public enum Members {
-        BATCHED;
+        BATCHED; // OBSOLETE
     }
-
-    protected boolean m_batched = false;
 
     public MaterializePlanNode() {
         super();
@@ -46,17 +44,8 @@ public class MaterializePlanNode extends ProjectionPlanNode {
         return PlanNodeType.MATERIALIZE;
     }
 
-    public void setBatched(boolean batched) {
-        m_batched = batched;
-    }
-
-    public boolean isBatched() {
-        return m_batched;
-    }
-
     @Override
-    public void generateOutputSchema(Database db)
-    {
+    public void generateOutputSchema(Database db) {
         // MaterializePlanNodes have no children
         assert(m_children.size() == 0);
         // MaterializePlanNode's output schema is pre-determined, don't touch
@@ -64,8 +53,7 @@ public class MaterializePlanNode extends ProjectionPlanNode {
     }
 
     @Override
-    public void resolveColumnIndexes()
-    {
+    public void resolveColumnIndexes() {
         // MaterializePlanNodes have no children
         assert(m_children.size() == 0);
     }
@@ -73,13 +61,14 @@ public class MaterializePlanNode extends ProjectionPlanNode {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.BATCHED.name()).value(m_batched);
+        stringer.keySymbolValuePair(Members.BATCHED.name(), false);
     }
 
     @Override
-    public void loadFromJSONObject( JSONObject jobj, Database db ) throws JSONException {
+    public void loadFromJSONObject(JSONObject jobj, Database db)
+            throws JSONException {
         super.loadFromJSONObject(jobj, db);
-        m_batched = jobj.getBoolean( Members.BATCHED.name() );
+        assert( ! jobj.getBoolean(Members.BATCHED.name()));
     }
 
     @Override

--- a/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
@@ -140,7 +140,7 @@ public class MaterializedScanPlanNode extends AbstractPlanNode {
         stringer.endObject();
 
         if (m_sortDirection == SortDirectionType.DESC) {
-            stringer.key(Members.SORT_DIRECTION.name()).value(m_sortDirection.toString());
+            stringer.keySymbolValuePair(Members.SORT_DIRECTION.name(), m_sortDirection.toString());
         }
     }
 

--- a/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
@@ -251,20 +251,21 @@ public class NestLoopIndexPlanNode extends AbstractJoinPlanNode {
     }
 
     @Override
-    public void toJSONString(JSONStringer stringer) throws JSONException
-    {
+    public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
         if (m_sortDirection != SortDirectionType.INVALID) {
-            stringer.key(Members.SORT_DIRECTION.name()).value(m_sortDirection.toString());
+            stringer.keySymbolValuePair(Members.SORT_DIRECTION.name(),
+                    m_sortDirection.toString());
         }
     }
 
     @Override
-    public void loadFromJSONObject( JSONObject jobj, Database db ) throws JSONException
-    {
+    public void loadFromJSONObject(JSONObject jobj, Database db)
+            throws JSONException {
         super.loadFromJSONObject(jobj, db);
-        if (!jobj.isNull(Members.SORT_DIRECTION.name())) {
-            m_sortDirection = SortDirectionType.get( jobj.getString( Members.SORT_DIRECTION.name() ) );
+        if ( ! jobj.isNull(Members.SORT_DIRECTION.name())) {
+            m_sortDirection = SortDirectionType.get(
+                    jobj.getString(Members.SORT_DIRECTION.name()));
         }
     }
 }

--- a/src/frontend/org/voltdb/plannodes/PlanNodeTree.java
+++ b/src/frontend/org/voltdb/plannodes/PlanNodeTree.java
@@ -100,7 +100,7 @@ public class PlanNodeTree implements JSONString {
             stringer.key(Members.PLAN_NODES_LISTS).array();
             for (Map.Entry<Integer, List<AbstractPlanNode>> planNodes : m_planNodesListMap.entrySet()) {
                 stringer.object();
-                stringer.key(Members.STATEMENT_ID).value(planNodes.getKey());
+                stringer.keySymbolValuePair(Members.STATEMENT_ID, planNodes.getKey());
                 stringer.key(Members.PLAN_NODES).array(planNodes.getValue());
                 stringer.endObject();
             }

--- a/src/frontend/org/voltdb/plannodes/SchemaColumn.java
+++ b/src/frontend/org/voltdb/plannodes/SchemaColumn.java
@@ -31,8 +31,8 @@ import org.voltdb.expressions.TupleValueExpression;
  */
 public class SchemaColumn {
     private static class Members {
-        public static final String COLUMN_NAME = "COLUMN_NAME";
-        public static final String EXPRESSION = "EXPRESSION";
+        static final String COLUMN_NAME = "COLUMN_NAME";
+        static final String EXPRESSION = "EXPRESSION";
     }
 
     private String m_tableName;
@@ -268,17 +268,15 @@ public class SchemaColumn {
         // a result set that has all the aliases that may have been specified
         // by the user (thanks to chains of setOutputTable(getInputTable))
         if (finalOutput) {
-            if (getColumnAlias() != null && !getColumnAlias().equals("")) {
-                stringer.key(Members.COLUMN_NAME).value(getColumnAlias());
+            String columnName = getColumnAlias();
+            if (columnName == null || columnName.equals("")) {
+                columnName = getColumnName();
             }
-            else if (getColumnName() != null) {
-                stringer.key(Members.COLUMN_NAME).value(getColumnName());
-            }
+            stringer.keySymbolValuePair(Members.COLUMN_NAME, columnName);
         }
 
         if (m_expression != null) {
-            stringer.key(Members.EXPRESSION);
-            stringer.object();
+            stringer.key(Members.EXPRESSION).object();
             m_expression.toJSONString(stringer);
             stringer.endObject();
         }
@@ -293,7 +291,7 @@ public class SchemaColumn {
         String columnName = null;
         String columnAlias = null;
         AbstractExpression expression = null;
-        if( ! jobj.isNull(Members.COLUMN_NAME)){
+        if ( ! jobj.isNull(Members.COLUMN_NAME)){
             columnName = jobj.getString(Members.COLUMN_NAME);
         }
         expression = AbstractExpression.fromJSONChild(jobj, Members.EXPRESSION);

--- a/src/frontend/org/voltdb/plannodes/UnionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/UnionPlanNode.java
@@ -120,7 +120,7 @@ public class UnionPlanNode extends AbstractPlanNode {
     @Override
     public void toJSONString(JSONStringer stringer) throws JSONException {
         super.toJSONString(stringer);
-        stringer.key(Members.UNION_TYPE.name()).value(m_unionType.name());
+        stringer.keySymbolValuePair(Members.UNION_TYPE.name(), m_unionType.name());
     }
 
     @Override

--- a/src/frontend/org/voltdb/probe/MeshProber.java
+++ b/src/frontend/org/voltdb/probe/MeshProber.java
@@ -650,17 +650,17 @@ public class MeshProber implements JoinAcceptor {
             jw.value(coordinator);
         }
         jw.endArray();
-        jw.key(ENTERPRISE).value(m_enterprise);
-        jw.key(START_ACTION).value(m_startAction.name());
-        jw.key(BARE).value(m_bare);
-        jw.key(CONFIG_HASH).value(m_configHash.toString());
-        jw.key(MESH_HASH).value(m_meshHash.toString());
-        jw.key(HOST_COUNT).value(m_hostCountSupplier.get());
-        jw.key(K_FACTOR).value(m_kFactor);
-        jw.key(PAUSED).value(m_paused);
-        jw.key(ADD_ALLOWED).value(m_addAllowed);
-        jw.key(SAFE_MODE).value(m_safeMode);
-        jw.key(TERMINUS_NONCE).value(m_terminusNonce);
+        jw.keySymbolValuePair(ENTERPRISE, m_enterprise);
+        jw.keySymbolValuePair(START_ACTION, m_startAction.name());
+        jw.keySymbolValuePair(BARE, m_bare);
+        jw.keySymbolValuePair(CONFIG_HASH, m_configHash.toString());
+        jw.keySymbolValuePair(MESH_HASH, m_meshHash.toString());
+        jw.keySymbolValuePair(HOST_COUNT, m_hostCountSupplier.get());
+        jw.keySymbolValuePair(K_FACTOR, m_kFactor);
+        jw.keySymbolValuePair(PAUSED, m_paused);
+        jw.keySymbolValuePair(ADD_ALLOWED, m_addAllowed);
+        jw.keySymbolValuePair(SAFE_MODE, m_safeMode);
+        jw.keySymbolValuePair(TERMINUS_NONCE, m_terminusNonce);
         jw.endObject();
     }
 

--- a/src/frontend/org/voltdb/sysprocs/BalancePartitionsRequest.java
+++ b/src/frontend/org/voltdb/sysprocs/BalancePartitionsRequest.java
@@ -17,15 +17,16 @@
 
 package org.voltdb.sysprocs;
 
-import com.google_voltpatches.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.List;
+
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONString;
 import org.json_voltpatches.JSONStringer;
 
-import java.util.Collection;
-import java.util.List;
+import com.google_voltpatches.common.collect.ImmutableList;
 
 public class BalancePartitionsRequest implements JSONString {
     public static class PartitionPair {
@@ -73,8 +74,7 @@ public class BalancePartitionsRequest implements JSONString {
     }
 
     @Override
-    public String toJSONString()
-    {
+    public String toJSONString() {
         JSONStringer stringer = new JSONStringer();
 
         try {
@@ -84,10 +84,10 @@ public class BalancePartitionsRequest implements JSONString {
             for (PartitionPair pair : partitionPairs) {
                 stringer.object();
 
-                stringer.key("srcPartition").value(pair.srcPartition);
-                stringer.key("destPartition").value(pair.destPartition);
-                stringer.key("rangeStart").value(pair.rangeStart);
-                stringer.key("rangeEnd").value(pair.rangeEnd);
+                stringer.keySymbolValuePair("srcPartition", pair.srcPartition);
+                stringer.keySymbolValuePair("destPartition", pair.destPartition);
+                stringer.keySymbolValuePair("rangeStart", pair.rangeStart);
+                stringer.keySymbolValuePair("rangeEnd", pair.rangeEnd);
 
                 stringer.endObject();
             }
@@ -96,7 +96,8 @@ public class BalancePartitionsRequest implements JSONString {
             stringer.endObject();
 
             return stringer.toString();
-        } catch (JSONException e) {
+        }
+        catch (JSONException e) {
             return null;
         }
     }

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask_SP.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask_SP.java
@@ -17,8 +17,6 @@
 
 package org.voltdb.sysprocs;
 
-import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,7 +25,6 @@ import org.json_voltpatches.JSONStringer;
 import org.voltcore.utils.Pair;
 import org.voltdb.DRConsumerDrIdTracker;
 import org.voltdb.DependencyPair;
-import org.voltdb.ExtensibleSnapshotDigestData;
 import org.voltdb.ParameterSet;
 import org.voltdb.SystemProcedureExecutionContext;
 import org.voltdb.VoltSystemProcedure;
@@ -80,8 +77,8 @@ public class ExecuteTask_SP extends VoltSystemProcedure {
     throws JSONException {
         JSONStringer stringer = new JSONStringer();
         stringer.object();
-        stringer.key("lastConsumerSpUniqueId").value(lastConsumerUniqueIds.getFirst());
-        stringer.key("lastConsumerMpUniqueId").value(lastConsumerUniqueIds.getSecond());
+        stringer.keySymbolValuePair("lastConsumerSpUniqueId", lastConsumerUniqueIds.getFirst());
+        stringer.keySymbolValuePair("lastConsumerMpUniqueId", lastConsumerUniqueIds.getSecond());
         stringer.key("trackers").object();
         if (allProducerTrackers != null) {
             for (Map.Entry<Integer, Map<Integer, DRConsumerDrIdTracker>> clusterTrackers : allProducerTrackers.entrySet()) {

--- a/src/frontend/org/voltdb/sysprocs/Promote.java
+++ b/src/frontend/org/voltdb/sysprocs/Promote.java
@@ -56,9 +56,9 @@ public class Promote extends VoltSystemProcedure {
         if (ctx.isLowestSiteId()) {
             JSONStringer js = new JSONStringer();
             js.object();
-            js.key("role").value(ReplicationRole.NONE.ordinal());
+            js.keySymbolValuePair("role", ReplicationRole.NONE.ordinal());
             // Replication active state should the be same across the cluster
-            js.key("active").value(VoltDB.instance().getReplicationActive());
+            js.keySymbolValuePair("active", VoltDB.instance().getReplicationActive());
             js.endObject();
 
             VoltDB.instance().getHostMessenger().getZK().setData(

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotPredicates.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotPredicates.java
@@ -24,7 +24,6 @@ import java.util.List;
 import org.json_voltpatches.JSONStringer;
 import org.voltcore.utils.Pair;
 import org.voltdb.VoltDB;
-import org.voltdb.catalog.Table;
 import org.voltdb.expressions.AbstractExpression;
 
 import com.google_voltpatches.common.base.Charsets;
@@ -57,7 +56,7 @@ public class SnapshotPredicates {
                 final AbstractExpression predicate = p.getFirst();
                 JSONStringer stringer = new JSONStringer();
                 stringer.object();
-                stringer.key("triggersDelete").value(p.getSecond());
+                stringer.keySymbolValuePair("triggersDelete", p.getSecond());
                 // If the predicate is null, EE will serialize all rows to the corresponding data
                 // target. It's the same as passing an always-true expression,
                 // but without the overhead of the evaluating the expression. This avoids the

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
@@ -180,12 +180,12 @@ public class SnapshotUtil {
             JSONStringer stringer = new JSONStringer();
             try {
                 stringer.object();
-                stringer.key("version").value(1);
-                stringer.key("clusterid").value(clusterId);
-                stringer.key("txnId").value(txnId);
-                stringer.key("timestamp").value(timestamp);
-                stringer.key("timestampString").value(SnapshotUtil.formatHumanReadableDate(timestamp));
-                stringer.key("newPartitionCount").value(newPartitionCount);
+                stringer.keySymbolValuePair("version", 1);
+                stringer.keySymbolValuePair("clusterid", clusterId);
+                stringer.keySymbolValuePair("txnId", txnId);
+                stringer.keySymbolValuePair("timestamp", timestamp);
+                stringer.keySymbolValuePair("timestampString", SnapshotUtil.formatHumanReadableDate(timestamp));
+                stringer.keySymbolValuePair("newPartitionCount", newPartitionCount);
                 stringer.key("tables").array();
                 for (int ii = 0; ii < tables.size(); ii++) {
                     stringer.value(tables.get(ii).getTypeName());
@@ -198,12 +198,13 @@ public class SnapshotUtil {
                 }
                 stringer.endObject();
 
-                stringer.key("catalogCRC").value(catalogCRC);
+                stringer.keySymbolValuePair("catalogCRC", catalogCRC);
                 stringer.key("instanceId").value(instanceId.serializeToJSONObject());
 
                 extraSnapshotData.writeToSnapshotDigest(stringer);
                 stringer.endObject();
-            } catch (JSONException e) {
+            }
+            catch (JSONException e) {
                 throw new IOException(e);
             }
 
@@ -223,18 +224,22 @@ public class SnapshotUtil {
                 public void run() {
                     try {
                         fos.getChannel().force(true);
-                    } catch (IOException e) {
+                    }
+                    catch (IOException e) {
                         throw new RuntimeException(e);
-                    } finally {
+                    }
+                    finally {
                         try {
                             fos.close();
-                        } catch (IOException e) {
+                        }
+                        catch (IOException e) {
                             throw new RuntimeException(e);
                         }
                     }
                 }
             };
-        } finally {
+        }
+        finally {
             if (!success) {
                 f.delete();
             }

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotRequestConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotRequestConfig.java
@@ -17,10 +17,11 @@
 
 package org.voltdb.sysprocs.saverestore;
 
-import com.google_voltpatches.common.collect.ArrayListMultimap;
-import com.google_voltpatches.common.collect.ImmutableList;
-import com.google_voltpatches.common.collect.ImmutableMultimap;
-import com.google_voltpatches.common.collect.Multimap;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
@@ -28,10 +29,10 @@ import org.json_voltpatches.JSONStringer;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Table;
 
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import com.google_voltpatches.common.collect.ArrayListMultimap;
+import com.google_voltpatches.common.collect.ImmutableList;
+import com.google_voltpatches.common.collect.ImmutableMultimap;
+import com.google_voltpatches.common.collect.Multimap;
 
 public class StreamSnapshotRequestConfig extends SnapshotRequestConfig {
 
@@ -120,7 +121,6 @@ public class StreamSnapshotRequestConfig extends SnapshotRequestConfig {
         if (jsData != null) {
             try {
                 JSONObject sp = jsData.getJSONObject("streamPairs");
-                @SuppressWarnings("unchecked")
                 Iterator<String> it = sp.keys();
                 while (it.hasNext()) {
                     String key = it.next();
@@ -144,13 +144,13 @@ public class StreamSnapshotRequestConfig extends SnapshotRequestConfig {
     {
         super.toJSONString(stringer);
 
-        stringer.key("shouldTruncate").value(shouldTruncate);
+        stringer.keySymbolValuePair("shouldTruncate", shouldTruncate);
         stringer.key("streams").array();
 
         for (Stream stream : streams) {
             stringer.object();
 
-            stringer.key("newPartition").value(stream.newPartition == null ?
+            stringer.keySymbolValuePair("newPartition", stream.newPartition == null ?
                                                null : Integer.toString(stream.newPartition));
 
             stringer.key("streamPairs").object();

--- a/src/frontend/org/voltdb/utils/Collector.java
+++ b/src/frontend/org/voltdb/utils/Collector.java
@@ -185,16 +185,16 @@ public class Collector {
                 JSONStringer stringer = new JSONStringer();
 
                 stringer.object();
-                stringer.key("server").value(m_config.prefix);
+                stringer.keySymbolValuePair("server", m_config.prefix);
                 stringer.key("files").array();
                 for (String path: collectionFilesList) {
                     stringer.object();
-                    stringer.key("filename").value(path);
+                    stringer.keySymbolValuePair("filename", path);
                     if (Arrays.asList(cmdFilenames).contains(path.split(" ")[0])) {
-                        stringer.key("size").value(0);
+                        stringer.keySymbolValuePair("size", 0);
                     }
                     else {
-                        stringer.key("size").value(new File(path).length());
+                        stringer.keySymbolValuePair("size", new File(path).length());
                     }
                     stringer.endObject();
                 }

--- a/tests/test_apps/adhocbenchmark/run.sh
+++ b/tests/test_apps/adhocbenchmark/run.sh
@@ -89,7 +89,7 @@ function _benchmark() {
         ${APPNAME}.Benchmark \
         --displayinterval=5 \
         --servers=localhost \
-        --configfile=cachefriendlyconfig.xml \
+        --configfile=config.xml \
         --warmup=5 \
         --duration=60 \
         --test=$1 \

--- a/third_party/java/src/org/json_voltpatches/JSONObject.java
+++ b/third_party/java/src/org/json_voltpatches/JSONObject.java
@@ -134,7 +134,7 @@ public class JSONObject {
     /**
      * The map where the JSONObject's properties are kept.
      */
-    private final Map<String, Object> map = new HashMap<>();
+    private final Map<String, Object> m_map = new HashMap<>();
 
 
     /**
@@ -243,7 +243,7 @@ public class JSONObject {
             return;
         }
         for (Entry<String, Object> entry : map.entrySet()) {
-            this.map.put(entry.getKey(), wrap(entry.getValue()));
+            m_map.put(entry.getKey(), wrap(entry.getValue()));
         }
     }
 
@@ -428,11 +428,13 @@ public class JSONObject {
                 ((String)o).equalsIgnoreCase("false"))) {
             return false;
         }
+
         if (o.equals(Boolean.TRUE) ||
                 (o instanceof String &&
                 ((String)o).equalsIgnoreCase("true"))) {
             return true;
         }
+
         throw new JSONException("JSONObject[" + quote(key) +
                 "] is not a Boolean.");
     }
@@ -549,7 +551,7 @@ public class JSONObject {
         if (length == 0) {
             return null;
         }
-        String[] names = jo.map.keySet().toArray(new String[length]);
+        String[] names = jo.m_map.keySet().toArray(new String[length]);
         return names;
     }
 
@@ -595,7 +597,7 @@ public class JSONObject {
      * @return      true if the key exists in the JSONObject.
      */
     public boolean has(String key) {
-        return this.map.containsKey(key);
+        return m_map.containsKey(key);
     }
 
 
@@ -650,7 +652,7 @@ public class JSONObject {
      * @return An iterator of the keys.
      */
     public Iterator<String> keys() {
-        return this.map.keySet().iterator();
+        return m_map.keySet().iterator();
     }
 
 
@@ -660,7 +662,7 @@ public class JSONObject {
      * @return The number of keys in the JSONObject.
      */
     public int length() {
-        return this.map.size();
+        return m_map.size();
     }
 
 
@@ -672,7 +674,7 @@ public class JSONObject {
      */
     public JSONArray names() {
         JSONArray ja = new JSONArray();
-        for (String key : this.map.keySet()) {
+        for (String key : m_map.keySet()) {
             ja.put(key);
         }
         return ja.length() == 0 ? null : ja;
@@ -712,7 +714,7 @@ public class JSONObject {
      * @return      An object which is the value, or null if there is no value.
      */
     public Object opt(String key) {
-        return key == null ? null : this.map.get(key);
+        return key == null ? null : m_map.get(key);
     }
 
 
@@ -942,7 +944,7 @@ public class JSONObject {
                         }
 
                         Object result = method.invoke(bean, (Object[])null);
-                        map.put(key, wrap(result));
+                        m_map.put(key, wrap(result));
                     }
                 }
             }
@@ -961,7 +963,10 @@ public class JSONObject {
      * @throws JSONException If the key is null.
      */
     public JSONObject put(String key, boolean value) throws JSONException {
-        put(key, value ? Boolean.TRUE : Boolean.FALSE);
+        if (key == null) {
+            throw new JSONException("Null key.");
+        }
+        m_map.put(key, value);
         return this;
     }
 
@@ -1053,7 +1058,7 @@ public class JSONObject {
         }
         if (value != null) {
             testValidity(value);
-            this.map.put(key, value);
+            m_map.put(key, value);
         }
         else {
             remove(key);
@@ -1098,42 +1103,73 @@ public class JSONObject {
         return this;
     }
 
-
-    /**
-     * Produce a string in double quotes with backslash sequences in all the
-     * right places. A backslash will be inserted within </, allowing JSON
-     * text to be delivered in HTML. In JSON text, a string cannot contain a
-     * control character or an unescaped quote or backslash.
-     * @param string A String
-     * @return  A String correctly formatted for insertion in a JSON text.
-     */
-    public static String quote(String string) {
-        if (string == null || string.length() == 0) {
-            return "\"\"";
+    public static String quotable(String string) {
+        if (string == null) {
+            return "";
         }
-
-        char         b;
-        char         c = 0;
+        char         prior = 0;
+        char         current = 0;
         int          i;
         int          len = string.length();
-        StringBuffer sb = new StringBuffer(len + 4);
-        String       t;
 
-        sb.append('"');
-        for (i = 0; i < len; i += 1) {
-            b = c;
-            c = string.charAt(i);
-            switch (c) {
+        // Optimize for the common cases where string contains only
+        // simple text characters -- no escape characters needed --
+        // or at least a long initial run of simple text characters.
+        for (i = 0; i < len; ++i) {
+            prior = current;
+            current = string.charAt(i);
+            if (current < ' ' || (current >= '\u0080' && current < '\u00a0') ||
+                    (current >= '\u2000' && current < '\u2100')) {
+                break;
+            }
+            if (current == '/') {
+                if (prior == '<') {
+                    break;
+                }
+                continue;
+            }
+            switch (current) {
+            default:
+                continue;
+            case '\\':
+            case '"':
+            case '\b':
+            case '\t':
+            case '\n':
+            case '\f':
+            case '\r':
+            }
+            break;
+        }
+
+        if (i == len) {
+            // a string of all simple characters can be
+            // written as is.
+            return string;
+        }
+
+        StringBuilder sb = new StringBuilder(len + 2);
+
+        if (i > 0) {
+            // a non-zero prefix of simple characters can be
+            // appended in bulk.
+            sb.append(string.substring(0, i));
+        }
+        current = prior;
+        for (; i < len; ++i) {
+            prior = current;
+            current = string.charAt(i);
+            switch (current) {
             case '\\':
             case '"':
                 sb.append('\\');
-                sb.append(c);
+                sb.append(current);
                 break;
             case '/':
-                if (b == '<') {
+                if (prior == '<') {
                     sb.append('\\');
                 }
-                sb.append(c);
+                sb.append(current);
                 break;
             case '\b':
                 sb.append("\\b");
@@ -1151,18 +1187,31 @@ public class JSONObject {
                 sb.append("\\r");
                 break;
             default:
-                if (c < ' ' || (c >= '\u0080' && c < '\u00a0') ||
-                               (c >= '\u2000' && c < '\u2100')) {
-                    t = "000" + Integer.toHexString(c);
+                if (current < ' ' || (current >= '\u0080' && current < '\u00a0') ||
+                               (current >= '\u2000' && current < '\u2100')) {
+                    String t = "000" + Integer.toHexString(current);
                     sb.append("\\u" + t.substring(t.length() - 4));
-                } else {
-                    sb.append(c);
+                }
+                else {
+                    sb.append(current);
                 }
             }
         }
-        sb.append('"');
         return sb.toString();
     }
+
+    /**
+     * Produce a string in double quotes with backslash sequences in all the
+     * right places. A backslash will be inserted within </, allowing JSON
+     * text to be delivered in HTML. In JSON text, a string cannot contain a
+     * control character or an unescaped quote or backslash.
+     * @param string A String
+     * @return the string correctly formatted inside double quotes
+     * for insertion in a JSON text.
+     */
+    public static String quote(String string) {
+        return "\"" + quotable(string) + "\"";
+}
 
     /**
      * Remove a name and its value, if present.
@@ -1171,7 +1220,7 @@ public class JSONObject {
      * or null if there was no value.
      */
     public Object remove(String key) {
-        return this.map.remove(key);
+        return m_map.remove(key);
     }
 
     /**
@@ -1181,7 +1230,7 @@ public class JSONObject {
      * @return An ordered set of the keys.
      */
     public Set<String> sortedKeySet() {
-        return new TreeSet<String>(this.map.keySet());
+        return new TreeSet<>(m_map.keySet());
     }
 
     /**
@@ -1310,17 +1359,19 @@ public class JSONObject {
     @Override
     public String toString() {
         try {
-            Iterator<String> keys = keys();
-            StringBuffer sb = new StringBuffer("{");
-
-            while (keys.hasNext()) {
-                if (sb.length() > 1) {
-                    sb.append(',');
-                }
-                Object o = keys.next();
-                sb.append(quote(o.toString()));
-                sb.append(':');
-                sb.append(valueToString(this.map.get(o)));
+            if (m_map.isEmpty()) {
+                return "{}";
+            }
+            StringBuffer sb = new StringBuffer();
+            // This prefix value applies to the first key only
+            String keyprefix = "{\"";
+            for (String key : m_map.keySet()) {
+                sb.append(keyprefix);
+                sb.append(quotable(key));
+                sb.append("\":");
+                sb.append(valueToString(m_map.get(key)));
+                // This prefix value applies to all subsequent keys
+                keyprefix = ",\"";
             }
             sb.append('}');
             return sb.toString();
@@ -1362,43 +1413,37 @@ public class JSONObject {
      * @throws JSONException If the object contains an invalid number.
      */
     String toString(int indentFactor, int indent) throws JSONException {
-        int j;
         int n = length();
         if (n == 0) {
             return "{}";
         }
-        Iterator<String> keys = sortedKeys();
-        StringBuffer sb = new StringBuffer("{");
-        int          newindent = indent + indentFactor;
-        Object       o;
+        Set<Entry<String, Object> > entries = m_map.entrySet();
         if (n == 1) {
-            o = keys.next();
-            sb.append(quote(o.toString()));
-            sb.append(": ");
-            sb.append(valueToString(this.map.get(o), indentFactor,
-                    indent));
-        } else {
-            while (keys.hasNext()) {
-                o = keys.next();
-                if (sb.length() > 1) {
-                    sb.append(",\n");
-                } else {
-                    sb.append('\n');
-                }
-                for (j = 0; j < newindent; j += 1) {
-                    sb.append(' ');
-                }
-                sb.append(quote(o.toString()));
-                sb.append(": ");
-                sb.append(valueToString(this.map.get(o), indentFactor,
-                        newindent));
+            Entry<String, Object> entry = entries.iterator().next();
+            return "{\"" + entry.getKey() + "\": " +
+                    valueToString(entry.getValue(), indentFactor, indent) +
+                    "}";
+        }
+
+        StringBuffer sb = new StringBuffer();
+        int newindent = indent + indentFactor;
+        // This prefix value applies to the first key only
+        String keyprefix = "{\n";
+        for (String key : sortedKeySet()) {
+            sb.append(keyprefix);
+            for (int j = 0; j < newindent; j += 1) {
+                sb.append(' ');
             }
-            if (sb.length() > 1) {
-                sb.append('\n');
-                for (j = 0; j < indent; j += 1) {
-                    sb.append(' ');
-                }
-            }
+            sb.append('"');
+            sb.append(quotable(key));
+            sb.append("\": ");
+            sb.append(valueToString(m_map.get(key), indentFactor, newindent));
+            // This prefix value applies to all subsequent keys
+            keyprefix = ",\n";
+        }
+        sb.append('\n');
+        for (int j = 0; j < indent; j += 1) {
+            sb.append(' ');
         }
         sb.append('}');
         return sb.toString();
@@ -1579,18 +1624,17 @@ public class JSONObject {
       */
      public Writer write(Writer writer) throws JSONException {
         try {
-            boolean  b = false;
-            Iterator<String> keys = keys();
-            writer.write('{');
-
-            while (keys.hasNext()) {
-                if (b) {
-                    writer.write(',');
-                }
-                Object k = keys.next();
-                writer.write(quote(k.toString()));
-                writer.write(':');
-                Object v = this.map.get(k);
+            if (m_map.isEmpty()) {
+                writer.write("{}");
+                return writer;
+            }
+            // This prefix value applies to the first key only
+            String keyprefix = "{\"";
+            for (Entry<String, Object> entry : m_map.entrySet()) {
+                writer.write(keyprefix);
+                writer.write(quotable(entry.getKey()));
+                writer.write("\":");
+                Object v = entry.getValue();
                 if (v instanceof JSONObject) {
                     ((JSONObject)v).write(writer);
                 }
@@ -1600,7 +1644,8 @@ public class JSONObject {
                 else {
                     writer.write(valueToString(v));
                 }
-                b = true;
+                // This prefix value applies to all subsequent keys
+                keyprefix = ",\"";
             }
             writer.write('}');
             return writer;


### PR DESCRIPTION
Reduce the StringBuffer overhead for the most common cases of JSON serializing strings that contain no or few special characters. 

Replace the idiom `stringer.key(HARD_CODED_SYMBOL).value(...)` with a new call `stringer.keySymbolValuePair(HARD_CODED_SYMBOL, ...)` that leaves it to the caller to assure that the key value is unique to this JSON object and contains no special characters. This drastically reduces serialization times.

The functional changes and widespread adaptation to the faster API are committed separately from an initial work-alike refactoring and cleanup of the JSON support code internals. You can review them separately if it helps.