### PR TITLE
analytic-template.sql: added COUNT(*) and COUNT(_columnorexpr) to the

### DIFF
--- a/tests/scripts/examples/sql_coverage/analytic-template.sql
+++ b/tests/scripts/examples/sql_coverage/analytic-template.sql
@@ -18,32 +18,38 @@
 DELETE FROM @dmltable
 INSERT INTO @dmltable VALUES (@insertvals)
 
--- Define expressions and clauses used to test analytic functions, such as RANK, below
+-- Define expressions and clauses used to test windowed analytic functions (such as RANK)
 {_columnorexpr |= "_variable"}
 {_columnorexpr |= "@onefun(_variable[@comparabletype])@plus10"}
 {_orderbycolumnorexpr |= "_variable[#ord @rankorderbytype]"}
 {_orderbycolumnorexpr |= "@onefun(_variable[#ord @rankorderbytype])@plus10"}
 {@orderbyclause = "ORDER BY _orderbycolumnorexpr _sortorder"}
-{_analyticfunc |= "RANK"}
-{_analyticfunc |= "DENSE_RANK"}
+{_maybeorderby |= ""}
+{_maybeorderby |= "@orderbyclause"}
+
+-- Define the actual windowed analytic functions being tested (such as RANK), with arguments, if any
+{_analyticfunc |= "RANK()"}
+{_analyticfunc |= "DENSE_RANK()"}
+{_analyticfunc |= "COUNT(*)"}
+{_analyticfunc |= "COUNT(_columnorexpr)"}
 
 -- Test SQL Analytic (Window) functions, such as RANK
 -- ... without PARTITION BY clause:
-SELECT               @star,  _analyticfunc() OVER (                                                         @orderbyclause) FUNC            FROM @fromtables W01
-SELECT                       _analyticfunc() OVER (                                                         @orderbyclause) FUNC, @star     FROM @fromtables W02
+SELECT               @star,  _analyticfunc OVER (                                                        @orderbyclause) FUNC            FROM @fromtables W01
+SELECT                       _analyticfunc OVER (                                                        @orderbyclause) FUNC, @star     FROM @fromtables W02
 -- ... with PARTITION BY clause:
-SELECT               @star,  _analyticfunc() OVER (PARTITION BY __[#ord]                                    @orderbyclause) FUNC            FROM @fromtables W03
-SELECT            __[#ord],  _analyticfunc() OVER (PARTITION BY _variable[#part]                            @orderbyclause) FUNC, __[#part] FROM @fromtables W04
-SELECT __[#ord], __[#part],  _analyticfunc() OVER (PARTITION BY _variable[#part]                            @orderbyclause) FUNC            FROM @fromtables W05
-SELECT       _columnorexpr,  _analyticfunc() OVER (PARTITION BY _variable[#part]                            @orderbyclause) FUNC            FROM @fromtables W06
-SELECT                       _analyticfunc() OVER (PARTITION BY _columnorexpr                               @orderbyclause) FUNC, @star     FROM @fromtables W07
-SELECT               @star,  _analyticfunc() OVER (PARTITION BY _columnorexpr, _columnorexpr                @orderbyclause) FUNC            FROM @fromtables W08
-SELECT                       _analyticfunc() OVER (PARTITION BY _columnorexpr, _columnorexpr, _columnorexpr @orderbyclause) FUNC, @star     FROM @fromtables W09
+SELECT               @star,  _analyticfunc OVER (PARTITION BY __[#ord]                                   @orderbyclause) FUNC            FROM @fromtables W03
+SELECT            __[#ord],  _analyticfunc OVER (PARTITION BY _variable[#part]                           @orderbyclause) FUNC, __[#part] FROM @fromtables W04
+SELECT __[#ord], __[#part],  _analyticfunc OVER (PARTITION BY _variable[#part]                           @orderbyclause) FUNC            FROM @fromtables W05
+SELECT       _columnorexpr,  _analyticfunc OVER (PARTITION BY _variable                                   _maybeorderby) FUNC            FROM @fromtables W06
+SELECT                       _analyticfunc OVER (PARTITION BY _columnorexpr                               _maybeorderby) FUNC, @star     FROM @fromtables W07
+SELECT               @star,  _analyticfunc OVER (PARTITION BY _columnorexpr, _columnorexpr                _maybeorderby) FUNC            FROM @fromtables W08
+SELECT                       _analyticfunc OVER (PARTITION BY _columnorexpr, _columnorexpr, _columnorexpr _maybeorderby) FUNC, @star     FROM @fromtables W09
 
 -- Test a SQL Analytic (Window) function used in a sub-query
-SELECT * FROM (SELECT @star, _analyticfunc() OVER (PARTITION BY _columnorexpr                               @orderbyclause) SUBFUNC         FROM @fromtables W10) SUB
-SELECT                 *,    _analyticfunc() OVER (PARTITION BY _variable[#part]                            @orderbyclause) FUNC            FROM \
-             (SELECT @star,  _analyticfunc() OVER (PARTITION BY _variable[#part]                            @orderbyclause) SUBFUNC         FROM @fromtables W11) SUB
+SELECT * FROM (SELECT @star, _analyticfunc OVER (PARTITION BY _columnorexpr                               _maybeorderby) SUBFUNC         FROM @fromtables W10) SUB
+SELECT                 *,    _analyticfunc OVER (PARTITION BY _variable[#part]                            _maybeorderby) FUNC            FROM \
+             (SELECT @star,  _analyticfunc OVER (PARTITION BY _variable[#part]                            _maybeorderby) SUBFUNC         FROM @fromtables W11) SUB
 -- ... without PARTITION BY clause:
-SELECT                 *,    _analyticfunc() OVER (                                                         @orderbyclause) FUNC            FROM \
-             (SELECT @star,  _analyticfunc() OVER (                                                         @orderbyclause) SUBFUNC         FROM @fromtables W12) SUB
+SELECT                 *,    _analyticfunc OVER (                                                        @orderbyclause) FUNC            FROM \
+             (SELECT @star,  _analyticfunc OVER (                                                        @orderbyclause) SUBFUNC         FROM @fromtables W12) SUB


### PR DESCRIPTION
list of analytic functions to be tested; and modified some (though not all) of the query templates to have optional ORDER BY clauses, since the old analytic functions (RANK, DENSE_RANK) always require an ORDER BY clause, but this new one does not. (Also tweaked the definition of _analyticfunc to include the parentheses, to support this; plus improved comments and spacing.)