### PR TITLE
ENG-11280: Abort rejoin if another node fails before rejoin completes.

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1363,6 +1363,15 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     for (int hostId : failedHosts) {
                         CoreZK.removeRejoinNodeIndicatorForHost(m_messenger.getZK(), hostId);
                     }
+
+                    // If the current node hasn't finished rejoin when another
+                    // node fails, fail this node to prevent locking up the
+                    // system.
+                    if (m_rejoining) {
+                        VoltDB.crashLocalVoltDB("Another node failed before this node could finish rejoining. " +
+                                                "As a result, the rejoin operation has been canceled. " +
+                                                "Please try again.");
+                    }
                 }
             });
         }


### PR DESCRIPTION
If the last rejoin truncation snapshot fails to finish due to a node
failure, the rejoining node would not notice that and hung the
system. Now the rejoining node detects node failures before rejoin fully
completes and aborts rejoin in that case.