### PR TITLE
ENG-10294 part 1 EE supports SWAP TABLES

### DIFF
--- a/build.py
+++ b/build.py
@@ -301,6 +301,7 @@ CTX.INPUT['executors'] = """
  receiveexecutor.cpp
  sendexecutor.cpp
  seqscanexecutor.cpp
+ swaptablesexecutor.cpp
  tablecountexecutor.cpp
  tuplescanexecutor.cpp
  unionexecutor.cpp
@@ -347,6 +348,7 @@ CTX.INPUT['plannodes'] = """
  SchemaColumn.cpp
  sendnode.cpp
  seqscannode.cpp
+ swaptablesnode.cpp
  tuplescannode.cpp
  unionnode.cpp
  updatenode.cpp

--- a/src/catgen/spec.txt
+++ b/src/catgen/spec.txt
@@ -147,6 +147,7 @@ end
 begin MaterializedViewInfo          "Information used to build and update a materialized view"
   Table? dest                       "The table which will be updated when the source table is updated"
   ColumnRef* groupbycols            "The columns involved in the group by of the aggregation"
+  string statementsql               "The view definition's SELECT statement text"
   string predicate                  "A filtering predicate"
   string groupbyExpressionsJson     "A serialized representation of the groupby expression trees"
   string aggregationExpressionsJson "A serialized representation of the aggregation expression trees"

--- a/src/ee/common/types.cpp
+++ b/src/ee/common/types.cpp
@@ -415,6 +415,9 @@ string planNodeToString(PlanNodeType type)
     case PLAN_NODE_TYPE_DELETE: {
         return "DELETE";
     }
+    case PLAN_NODE_TYPE_SWAPTABLES: {
+        return "SWAPTABLES";
+    }
     case PLAN_NODE_TYPE_SEND: {
         return "SEND";
     }
@@ -483,6 +486,8 @@ PlanNodeType stringToPlanNode(string str )
         return PLAN_NODE_TYPE_INSERT;
     } else if (str == "DELETE") {
         return PLAN_NODE_TYPE_DELETE;
+    } else if (str == "SWAPTABLES") {
+        return PLAN_NODE_TYPE_SWAPTABLES;
     } else if (str == "SEND") {
         return PLAN_NODE_TYPE_SEND;
     } else if (str == "RECEIVE") {

--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -199,6 +199,7 @@ enum PlanNodeType {
     PLAN_NODE_TYPE_INSERT           = 31,
     PLAN_NODE_TYPE_DELETE           = 32,
     // PLAN_NODE_TYPE_UPSERT           = 33, // RESERVED, but not used in the EE
+    PLAN_NODE_TYPE_SWAPTABLES       = 34,
 
     //
     // Communication Nodes
@@ -441,7 +442,7 @@ inline bool tableStreamTypeIsValid(TableStreamType streamType) {
     return streamType != TABLE_STREAM_NONE;
 }
 
-inline bool tableStreamTypeAppliesToPreTruncateTable(TableStreamType streamType) {
+inline bool tableStreamTypeAppliesToPreSwapTable(TableStreamType streamType) {
     return streamType == TABLE_STREAM_ELASTIC_INDEX;
 }
 

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1763,16 +1763,16 @@ int64_t VoltDBEngine::tableStreamSerializeMore(
             table->decrementRefcount();
         }
     }
-    else if (tableStreamTypeAppliesToPreTruncateTable(streamType)) {
+    else if (tableStreamTypeAppliesToPreSwapTable(streamType)) {
         Table* found = getTable(tableId);
         if (found == NULL) {
             return TABLE_STREAM_SERIALIZATION_ERROR;
         }
 
-        PersistentTable * currentTable = dynamic_cast<PersistentTable*>(found);
+        PersistentTable* currentTable = dynamic_cast<PersistentTable*>(found);
         assert(currentTable != NULL);
         // The ongoing TABLE STREAM needs the original table from the first table truncate.
-        PersistentTable * originalTable = currentTable->currentPreTruncateTable();
+        PersistentTable* originalTable = currentTable->currentPreSwapTable();
 
         VOLT_DEBUG("tableStreamSerializeMore: type %s, rewinds to the table before the first truncate",
                 tableStreamTypeToString(streamType).c_str());
@@ -1781,7 +1781,7 @@ int64_t VoltDBEngine::tableStreamSerializeMore(
         if (remaining <= 0) {
             // The on going TABLE STREAM of the original table before the first table truncate has finished.
             // Reset all the previous table pointers to be NULL.
-            currentTable->unsetPreTruncateTable();
+            currentTable->unsetPreSwapTable();
             VOLT_DEBUG("tableStreamSerializeMore: type %s, null the previous truncate table pointer",
                     tableStreamTypeToString(streamType).c_str());
         }

--- a/src/ee/executors/executorfactory.cpp
+++ b/src/ee/executors/executorfactory.cpp
@@ -66,15 +66,11 @@
 #include "executors/receiveexecutor.h"
 #include "executors/sendexecutor.h"
 #include "executors/seqscanexecutor.h"
+#include "executors/swaptablesexecutor.h"
 #include "executors/tuplescanexecutor.h"
 #include "executors/unionexecutor.h"
 #include "executors/updateexecutor.h"
 #include "executors/partitionbyexecutor.h"
-
-#include "plannodes/abstractplannode.h"
-
-
-#include <cassert>
 
 namespace voltdb {
 
@@ -103,6 +99,7 @@ AbstractExecutor* getNewExecutor(VoltDBEngine *engine,
     case PLAN_NODE_TYPE_RECEIVE: return new ReceiveExecutor(engine, abstract_node);
     case PLAN_NODE_TYPE_SEND: return new SendExecutor(engine, abstract_node);
     case PLAN_NODE_TYPE_SEQSCAN: return new SeqScanExecutor(engine, abstract_node);
+    case PLAN_NODE_TYPE_SWAPTABLES: return new SwapTablesExecutor(engine, abstract_node);
     case PLAN_NODE_TYPE_TABLECOUNT: return new TableCountExecutor(engine, abstract_node);
     case PLAN_NODE_TYPE_TUPLESCAN: return new TupleScanExecutor(engine, abstract_node);
     case PLAN_NODE_TYPE_UNION: return new UnionExecutor(engine, abstract_node);

--- a/src/ee/executors/swaptablesexecutor.cpp
+++ b/src/ee/executors/swaptablesexecutor.cpp
@@ -1,0 +1,109 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* Copyright (C) 2008 by H-Store Project
+ * Brown University
+ * Massachusetts Institute of Technology
+ * Yale University
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "swaptablesexecutor.h"
+
+#include "plannodes/swaptablesnode.h"
+//#include "storage/temptable.h"
+#include "storage/persistenttable.h"
+
+using namespace std;
+using namespace voltdb;
+
+bool SwapTablesExecutor::p_init(AbstractPlanNode *abstract_node, TempTableLimits* limits)
+{
+    VOLT_TRACE("init SwapTable Executor");
+#ifndef NDEBUG
+    SwapTablesPlanNode* node = dynamic_cast<SwapTablesPlanNode*>(m_abstractNode);
+    assert(node);
+    assert(node->getTargetTable1());
+    assert(node->getTargetTable2());
+    assert(node->getInputTableCount() == 0);
+#endif
+
+    setDMLCountOutputTable(limits);
+    return true;
+}
+
+bool SwapTablesExecutor::p_execute(const NValueArray &params) {
+    // target tables should be persistent tables
+    // update target table references from table delegates
+    SwapTablesPlanNode* node = static_cast<SwapTablesPlanNode*>(m_abstractNode);
+    assert(dynamic_cast<SwapTablesPlanNode*>(m_abstractNode));
+    PersistentTable* targetTable1 = node->getTargetTable1();
+    assert(targetTable1);
+    PersistentTable* targetTable2 = node->getTargetTable2();
+    assert(targetTable2);
+
+    int64_t modified_tuples = 0;
+
+    VOLT_TRACE("swap tables %s and %s",
+               targetTable1->name().c_str(),
+               targetTable2->name().c_str());
+    // count the active tuples in both tables as modified
+    modified_tuples = targetTable1->visibleTupleCount() +
+            targetTable2->visibleTupleCount();
+
+    VOLT_TRACE("Swap Tables: %s with %d active, %d visible, %d allocated"
+               " and %s with %d active, %d visible, %d allocated",
+               targetTable1->name().c_str(),
+               (int)targetTable1->activeTupleCount(),
+               (int)targetTable1->visibleTupleCount(),
+               (int)targetTable1->allocatedTupleCount(),
+               targetTable2->name().c_str(),
+               (int)targetTable2->activeTupleCount(),
+               (int)targetTable2->visibleTupleCount(),
+               (int)targetTable2->allocatedTupleCount());
+
+    // Swap the table catalog delegates and corresponding indexes and views.
+    targetTable1->swapTable(targetTable2, m_engine);
+
+    TableTuple& count_tuple = m_tmpOutputTable->tempTuple();
+    count_tuple.setNValue(0, ValueFactory::getBigIntValue(modified_tuples));
+    // try to put the tuple into the output table
+    m_tmpOutputTable->insertTempTuple(count_tuple);
+    m_engine->addToTuplesModified(modified_tuples);
+    return true;
+}

--- a/src/ee/executors/swaptablesexecutor.h
+++ b/src/ee/executors/swaptablesexecutor.h
@@ -1,0 +1,66 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* Copyright (C) 2008 by H-Store Project
+ * Brown University
+ * Massachusetts Institute of Technology
+ * Yale University
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef HSTORESWAPTABLESEXECUTOR_H
+#define HSTORESWAPTABLESEXECUTOR_H
+
+#include "executors/abstractexecutor.h"
+
+namespace voltdb {
+
+class SwapTablesExecutor : public AbstractExecutor {
+public:
+    SwapTablesExecutor(VoltDBEngine* engine, AbstractPlanNode* abstractNode)
+      : AbstractExecutor(engine, abstractNode)
+    { }
+
+private:
+    bool p_init(AbstractPlanNode*, TempTableLimits* limits);
+    bool p_execute(const NValueArray &params);
+};
+
+}
+
+#endif

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -392,6 +392,11 @@ public:
     bool checkForIndexChange(const TableTuple *lhs, const TableTuple *rhs) const;
 
     /**
+     * @return a compact definition of the index for swappability checking.
+     */
+    TableIndexScheme const& getScheme() const { return m_scheme; }
+
+    /**
      * Currently, UniqueIndex is just a TableIndex with additional checks.
      * We might have to make a different class in future for maximizing
      * performance of UniqueIndex.

--- a/src/ee/plannodes/abstractplannode.cpp
+++ b/src/ee/plannodes/abstractplannode.cpp
@@ -321,8 +321,22 @@ void AbstractPlanNode::loadIntArrayFromJSONObject(const char* label,
 {
     if (obj.hasNonNullKey(label)) {
         PlannerDomValue intArray = obj.valueForKey(label);
-        for (int i = 0; i < intArray.arrayLen(); i++) {
+        int len = intArray.arrayLen();
+        for (int i = 0; i < len; ++i) {
             result.push_back(intArray.valueAtIndex(i).asInt());
+        }
+    }
+}
+
+void AbstractPlanNode::loadStringArrayFromJSONObject(const char* label,
+                                                     PlannerDomValue obj,
+                                                     std::vector<std::string>& result)
+{
+    if (obj.hasNonNullKey(label)) {
+        PlannerDomValue stringArray = obj.valueForKey(label);
+        int len = stringArray.arrayLen();
+        for (int i = 0; i < len; ++i) {
+            result.push_back(stringArray.valueAtIndex(i).asStr());
         }
     }
 }

--- a/src/ee/plannodes/abstractplannode.h
+++ b/src/ee/plannodes/abstractplannode.h
@@ -216,7 +216,13 @@ protected:
     // and by AbstractJoinPlanNode::loadFromJSONObject for its pre-agg output tuple.
     static TupleSchema* generateTupleSchema(const std::vector<SchemaColumn*>& outputSchema);
 
-    static void loadIntArrayFromJSONObject(const char* label, PlannerDomValue obj, std::vector<int>& ary);
+    static void loadIntArrayFromJSONObject(const char* label,
+                                           PlannerDomValue obj,
+                                           std::vector<int>& ary);
+
+    static void loadStringArrayFromJSONObject(const char* label,
+                                              PlannerDomValue obj,
+                                              std::vector<std::string>& ary);
 
     static AbstractExpression* loadExpressionFromJSONObject(const char* label,
                                                             PlannerDomValue obj);

--- a/src/ee/plannodes/plannodeutil.cpp
+++ b/src/ee/plannodes/plannodeutil.cpp
@@ -64,6 +64,7 @@
 #include "plannodes/receivenode.h"
 #include "plannodes/sendnode.h"
 #include "plannodes/seqscannode.h"
+#include "plannodes/swaptablesnode.h"
 #include "plannodes/tuplescannode.h"
 #include "plannodes/unionnode.h"
 #include "plannodes/updatenode.h"
@@ -146,6 +147,12 @@ voltdb::AbstractPlanNode* getEmptyPlanNode(voltdb::PlanNodeType type) {
         // ------------------------------------------------------------------
         case (voltdb::PLAN_NODE_TYPE_DELETE):
             ret = new voltdb::DeletePlanNode();
+            break;
+        // ------------------------------------------------------------------
+        // SwapTables
+        // ------------------------------------------------------------------
+        case (voltdb::PLAN_NODE_TYPE_SWAPTABLES):
+            ret = new voltdb::SwapTablesPlanNode();
             break;
         // ------------------------------------------------------------------
         // Aggregate

--- a/src/ee/plannodes/swaptablesnode.cpp
+++ b/src/ee/plannodes/swaptablesnode.cpp
@@ -1,0 +1,116 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* Copyright (C) 2008 by H-Store Project
+ * Brown University
+ * Massachusetts Institute of Technology
+ * Yale University
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "swaptablesnode.h"
+
+#include "common/executorcontext.hpp"
+#include "storage/TableCatalogDelegate.hpp"
+
+namespace voltdb {
+
+SwapTablesPlanNode::~SwapTablesPlanNode() { }
+
+PlanNodeType SwapTablesPlanNode::getPlanNodeType() const { return PLAN_NODE_TYPE_SWAPTABLES; }
+
+PersistentTable* SwapTablesPlanNode::getTargetTable1() const {
+    if (m_tcd == NULL) {
+        return NULL;
+    }
+    return m_tcd->getPersistentTable();
+}
+
+PersistentTable* SwapTablesPlanNode::getTargetTable2() const {
+    if (m_otherTcd == NULL) {
+        return NULL;
+    }
+    return m_otherTcd->getPersistentTable();
+}
+
+static std::string commaJoined(const std::vector<std::string>& array) {
+    std::ostringstream buffer;
+    const char* prefix = "";
+    int len = array.size();
+    for (int i = 0; i < len; ++i) {
+        buffer << prefix << array[i];
+        prefix = ",";
+    }
+    return buffer.str();
+}
+
+std::string SwapTablesPlanNode::debugInfo(const std::string &spacer) const {
+    std::ostringstream buffer;
+    buffer << spacer << "OtherTargetTable[" << m_otherTargetTableName << "]\n";
+    buffer << spacer << "INDEXES_TO_SWAP1[" << commaJoined(m_indexesToSwap) << "]\n";
+    buffer << spacer << "INDEXES_TO_SWAP2[" << commaJoined(m_otherIndexesToSwap) << "]\n";
+    buffer << spacer << "INDEXES_TO_REBUILD1[" << commaJoined(m_indexesToRebuild) << "]\n";
+    buffer << spacer << "INDEXES_TO_REBUILD2[" << commaJoined(m_otherIndexesToRebuild) << "]\n";
+    buffer << spacer << "VIEWS_TO_SWAP1[" << commaJoined(m_viewsToSwap) << "]\n";
+    buffer << spacer << "VIEWS_TO_SWAP2[" << commaJoined(m_otherViewsToSwap) << "]\n";
+    buffer << spacer << "VIEWS_TO_REBUILD1[" << commaJoined(m_viewsToRebuild) << "]\n";
+    buffer << spacer << "VIEWS_TO_REBUILD2[" << commaJoined(m_otherViewsToRebuild) << "]\n";
+    return buffer.str();
+}
+
+void SwapTablesPlanNode::loadFromJSONObject(PlannerDomValue obj) {
+    AbstractOperationPlanNode::loadFromJSONObject(obj);
+    m_otherTargetTableName = obj.valueForKey("OTHER_TARGET_TABLE_NAME").asStr();
+    VoltDBEngine* engine = ExecutorContext::getEngine();
+    m_otherTcd = engine->getTableDelegate(m_otherTargetTableName);
+    if ( ! m_otherTcd) {
+        VOLT_ERROR("Failed to retrieve second target table from execution engine for PlanNode '%s'",
+                   debug().c_str());
+        //TODO: throw something
+    }
+
+    loadStringArrayFromJSONObject("INDEXES_TO_SWAP1", obj, m_indexesToSwap);
+    loadStringArrayFromJSONObject("INDEXES_TO_SWAP2", obj, m_otherIndexesToSwap);
+    loadStringArrayFromJSONObject("INDEXES_TO_REBUILD1", obj, m_indexesToRebuild);
+    loadStringArrayFromJSONObject("INDEXES_TO_REBUILD2", obj, m_otherIndexesToRebuild);
+    loadStringArrayFromJSONObject("VIEWS_TO_SWAP1", obj, m_viewsToSwap);
+    loadStringArrayFromJSONObject("VIEWS_TO_SWAP2", obj, m_otherViewsToSwap);
+    loadStringArrayFromJSONObject("VIEWS_TO_REBUILD1", obj, m_viewsToRebuild);
+    loadStringArrayFromJSONObject("VIEWS_TO_REBUILD2", obj, m_otherViewsToRebuild);
+}
+
+} // namespace voltdb

--- a/src/ee/plannodes/swaptablesnode.h
+++ b/src/ee/plannodes/swaptablesnode.h
@@ -1,0 +1,122 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* Copyright (C) 2008 by H-Store Project
+ * Brown University
+ * Massachusetts Institute of Technology
+ * Yale University
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef HSTORESWAPTABLESNODE_H
+#define HSTORESWAPTABLESNODE_H
+
+#include "abstractoperationnode.h"
+
+namespace voltdb {
+class PersistentTable;
+
+/**
+ * A mostly self-sufficient plan for swapping the content of two identically
+ * shaped and indexed tables, such as would be required to implement a
+ * hypothetical extended SQL "SWAP TABLE A B;" statement.
+ */
+class SwapTablesPlanNode : public AbstractOperationPlanNode {
+public:
+    SwapTablesPlanNode() : AbstractOperationPlanNode()
+        , m_otherTcd(NULL)
+        , m_otherTargetTableName("NOT SPECIFIED")
+    { }
+
+    virtual ~SwapTablesPlanNode();
+    virtual PlanNodeType getPlanNodeType() const;
+    virtual std::string debugInfo(const std::string &spacer) const;
+
+    PersistentTable* getTargetTable1() const;
+    PersistentTable* getTargetTable2() const;
+    void setOtherTargetTableDelegate(TableCatalogDelegate * tcd) { m_tcd = tcd; }
+    const std::string& getOtherTargetTableName() const { return m_otherTargetTableName; }
+
+    std::vector<std::string> const& indexesToSwap() {
+        return m_indexesToSwap;
+    }
+    std::vector<std::string> const& otherIndexesToSwap() {
+        return m_otherIndexesToSwap;
+    }
+    std::vector<std::string> const& indexesToRebuild() {
+        return m_indexesToRebuild;
+    }
+    std::vector<std::string> const& otherIndexesToRebuild() {
+        return m_otherIndexesToRebuild;
+    }
+    std::vector<std::string> const& viewsToSwap() {
+        return m_viewsToSwap;
+    }
+    std::vector<std::string> const& otherViewsToSwap() {
+        return m_otherViewsToSwap;
+    }
+    std::vector<std::string> const& viewsToRebuild() {
+        return m_viewsToRebuild;
+    }
+    std::vector<std::string> const& otherViewsToRebuild() {
+        return m_otherViewsToRebuild;
+    }
+
+protected:
+     virtual void loadFromJSONObject(PlannerDomValue obj);
+
+     // Other Target Table
+     // These tables are different from the input and the output tables
+     // The plannode can read in tuples from the input table(s) and apply them to the target table
+     // The results of the operations will be written to the the output table
+     TableCatalogDelegate * m_otherTcd;
+     std::string m_otherTargetTableName;
+
+     std::vector<std::string> m_indexesToSwap;
+     std::vector<std::string> m_otherIndexesToSwap;
+     std::vector<std::string> m_indexesToRebuild;
+     std::vector<std::string> m_otherIndexesToRebuild;
+     std::vector<std::string> m_viewsToSwap;
+     std::vector<std::string> m_otherViewsToSwap;
+     std::vector<std::string> m_viewsToRebuild;
+     std::vector<std::string> m_otherViewsToRebuild;
+};
+
+} // namepace voltdb
+
+#endif

--- a/src/ee/storage/MaterializedViewHandler.h
+++ b/src/ee/storage/MaterializedViewHandler.h
@@ -89,6 +89,22 @@ public:
     void handleTupleInsert(PersistentTable *sourceTable, bool fallible);
     void handleTupleDelete(PersistentTable *sourceTable, bool fallible);
 
+    void swapPlans(MaterializedViewHandler* otherView) {
+        auto createQueryExecutorVector = m_createQueryExecutorVector;
+        m_createQueryExecutorVector = otherView->m_createQueryExecutorVector;
+        otherView->m_createQueryExecutorVector = createQueryExecutorVector;
+
+        auto createQuerySQL = m_createQuerySQL;
+        m_createQuerySQL = otherView->m_createQuerySQL;
+        otherView->m_createQuerySQL = createQuerySQL;
+
+        auto minMaxExecutorVectors = m_minMaxExecutorVectors;
+        m_minMaxExecutorVectors = otherView->m_minMaxExecutorVectors;
+        otherView->m_minMaxExecutorVectors = minMaxExecutorVectors;
+    }
+
+    std::string getSwappableSQL(PersistentTable* sourceTable) const;
+
 private:
     std::vector<PersistentTable*> m_sourceTables;
     PersistentTable *m_destTable;
@@ -96,6 +112,8 @@ private:
     TableIndex *m_index;
     // Vector of query plans (executors) for every min/max column.
     std::vector<boost::shared_ptr<ExecutorVector>> m_minMaxExecutorVectors;
+    // The text of the view definition query.
+    std::string m_createQuerySQL;
     // The executor vector for the view definition query.
     boost::shared_ptr<ExecutorVector> m_createQueryExecutorVector;
     const int m_groupByColumnCount;

--- a/src/ee/storage/MaterializedViewTriggerForWrite.cpp
+++ b/src/ee/storage/MaterializedViewTriggerForWrite.cpp
@@ -17,6 +17,7 @@
 #include "MaterializedViewTriggerForWrite.h"
 
 #include "persistenttable.h"
+#include "MaterializedViewUtil.h"
 
 #include "catalog/indexref.h"
 #include "catalog/planfragment.h"
@@ -38,6 +39,8 @@ MaterializedViewTriggerForWrite::MaterializedViewTriggerForWrite(PersistentTable
     : MaterializedViewTriggerForInsert(destTable, mvInfo)
     , m_srcPersistentTable(srcTable)
     , m_minMaxSearchKeyBackingStoreSize(0)
+    , m_swappableSQL(MaterializedViewUtil::sourceTableDidact(
+              mvInfo->statementsql(), srcTable->name()))
 {
     // set up mechanisms for min/max recalculation
     setupMinMaxRecalculation(mvInfo->indexForMinMax(), mvInfo->fallbackQueryStmts());

--- a/src/ee/storage/MaterializedViewTriggerForWrite.h
+++ b/src/ee/storage/MaterializedViewTriggerForWrite.h
@@ -52,6 +52,13 @@ public:
                                  mvInfo->fallbackQueryStmts());
     }
 
+    void swapPlans(MaterializedViewTriggerForWrite* otherView) {
+        auto fallbackExecutorVectors = m_fallbackExecutorVectors;
+        m_fallbackExecutorVectors = otherView->m_fallbackExecutorVectors;
+        otherView->m_fallbackExecutorVectors = fallbackExecutorVectors;
+    }
+
+    std::string getSwappableSQL() const { return m_swappableSQL; }
 
 private:
     MaterializedViewTriggerForWrite(PersistentTable *srcTable,
@@ -87,7 +94,10 @@ private:
     boost::shared_array<char> m_minMaxSearchKeyBackingStore;
     size_t m_minMaxSearchKeyBackingStoreSize;
     // the index on srcTable which can be used to find each fallback min or max column.
-    std::vector<TableIndex *> m_indexForMinMax;
+    std::vector<TableIndex*> m_indexForMinMax;
+    // The view's defining select statement with the table name elided to allow
+    // matching with another table's identically defined view.
+    std::string m_swappableSQL;
     // Executor vectors to be executed when fallback on min/max value is needed (ENG-8641).
     std::vector<boost::shared_ptr<ExecutorVector> > m_fallbackExecutorVectors;
     std::vector<bool> m_usePlanForAgg;

--- a/src/ee/storage/MaterializedViewUtil.h
+++ b/src/ee/storage/MaterializedViewUtil.h
@@ -1,0 +1,64 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MATERIALIZEDVIEWUTIL_H
+#define MATERIALIZEDVIEWUTIL_H
+
+namespace voltdb {
+
+struct MaterializedViewUtil {
+    static std::string sourceTableDidact(std::string const& statementSQL,
+            std::string const& tableName) {
+        std::string result = statementSQL;
+        // This dummy head start string should be no longer than the minimum
+        // allowed from the SELECT to the FROM in materialized view definitions.
+        // Aside from a small performance boost, starting after 0 also makes it
+        // safe to do a one-character look-behind to check that we are not
+        // matching the table name to the middle of some other symbol.
+        static const size_t HEAD_START = strlen("select count(*) from");
+        static const string TRACER("@");
+        static const string SYMBOL_CHARS(
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz");
+        size_t length = tableName.size();
+        size_t pos = HEAD_START;
+        while ((pos = result.find(tableName, pos+1)) != std::string::npos) {
+            if (result.find_first_of(SYMBOL_CHARS, pos-1) == 0) {
+                // False positive -- the table name symbol was not preceded
+                // by a proper symbol separator in the statement -- it matched
+                // only a piece of a longer symbol.
+                // E.g. for "SELECT ... FROM DEPT ... GROUP BY DEPT.HEADOFDEPT"
+                // we want "SELECT ... FROM @ ... GROUP BY @.HEADOFDEPT"
+                // and not "SELECT ... FROM @ ... GROUP BY @.HEADOF@"
+                continue;
+            }
+            if (result.find_first_of(SYMBOL_CHARS, pos + length) == pos + length) {
+                // False positive -- the table name symbol was not terminated
+                // in the statement -- it matched a prefix of another symbol.
+                // E.g. for "SELECT ... FROM DEPT ... GROUP BY DEPT_ID".
+                // we want "SELECT ... FROM @ ... GROUP BY DEPT_ID"
+                // and not "SELECT ... FROM @ ... GROUP BY @_ID"
+                continue;
+            }
+            result = result.replace(pos, length, TRACER);
+        }
+        return result;
+    }
+};
+
+}// namespace voltdb
+
+#endif // MATERIALIZEDVIEWUTIL_H

--- a/src/ee/storage/PersistentTableUndoSwapTableAction.h
+++ b/src/ee/storage/PersistentTableUndoSwapTableAction.h
@@ -1,0 +1,58 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef PERSISTENTTABLEUNDOSWAPTABLEACTION_H_
+#define PERSISTENTTABLEUNDOSWAPTABLEACTION_H_
+
+#include "common/UndoAction.h"
+#include "storage/persistenttable.h"
+
+namespace voltdb {
+
+class PersistentTableUndoSwapTableAction: public UndoAction {
+public:
+    inline PersistentTableUndoSwapTableAction(
+            PersistentTable *originalTable,
+            PersistentTable *otherTable)
+    : m_originalTable(originalTable)
+    , m_otherTable(otherTable)
+    {}
+
+private:
+    virtual ~PersistentTableUndoSwapTableAction() {}
+
+    /*
+     * Undo whatever this undo action was created to undo.
+     * In this case, swap the tables back to their original state.
+     */
+    virtual void undo() {
+        VoltDBEngine* engine = ExecutorContext::getEngine();
+        m_originalTable->swapTable(m_otherTable, engine, false);
+    }
+
+    /*
+     * Release any resources held by the undo action. It will not need to be undone.
+     */
+    virtual void release() { }
+
+private:
+    PersistentTable *m_originalTable;
+    PersistentTable *m_otherTable;
+};
+
+}// namespace voltdb
+
+#endif /* PERSISTENTTABLEUNDOSWAPTABLEACTION_H_ */

--- a/src/ee/storage/PersistentTableUndoTruncateTableAction.h
+++ b/src/ee/storage/PersistentTableUndoTruncateTableAction.h
@@ -25,27 +25,30 @@ namespace voltdb {
 
 class PersistentTableUndoTruncateTableAction: public UndoAction {
 public:
-    inline PersistentTableUndoTruncateTableAction(VoltDBEngine * engine, TableCatalogDelegate * tcd,
+    inline PersistentTableUndoTruncateTableAction(TableCatalogDelegate * tcd,
             PersistentTable *originalTable, PersistentTable *emptyTable)
-    :  m_engine(engine), m_tcd(tcd), m_originalTable(originalTable), m_emptyTable(emptyTable)
+        : m_tcd(tcd)
+        , m_originalTable(originalTable)
+        , m_emptyTable(emptyTable)
     {}
 
 private:
     virtual ~PersistentTableUndoTruncateTableAction() {}
 
     /*
-     * Undo whatever this undo action was created to undo. In this case delete the newly constructed table,
+     * Undo whatever this undo action was created to undo.
+     *  In this case delete the newly constructed table,
      * and assign the table delegate with the original table.
      *
      */
     virtual void undo() {
-        m_emptyTable->truncateTableForUndo(m_engine, m_tcd, m_originalTable);
+        m_emptyTable->truncateTableForUndo(m_tcd, m_originalTable);
     }
 
     /*
-     * Release any resources held by the undo action. It will not need to be undone in the future.
-     * In this case delete all tuples from indexes, views and free the strings associated with each
-     * tuple in the original table.
+     * Release any resources held by the undo action. It will not need to be undone.
+     * In this case delete all tuples from indexes, views and free the strings
+     * associated with each tuple in the original table.
      */
     virtual void release() {
         //It's very important not to add anything else to this release method
@@ -57,12 +60,11 @@ private:
     }
 
 private:
-    VoltDBEngine * m_engine;
     TableCatalogDelegate * m_tcd;
     PersistentTable *m_originalTable;
     PersistentTable *m_emptyTable;
 };
 
-}
+}// namespace voltdb
 
 #endif /* PERSISTENTTABLEUNDOTRUNCATETABLEACTION_H_ */

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -21,37 +21,27 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <vector>
-#include <string>
-
-#include "boost/scoped_ptr.hpp"
-
 #include "harness.h"
 #include "test_utils/ScopedTupleSchema.hpp"
 
 #include "common/tabletuple.h"
-#include "common/types.h"
 #include "common/TupleSchemaBuilder.h"
+#include "common/types.h"
 #include "common/ValueFactory.hpp"
+
 #include "execution/VoltDBEngine.h"
-#include "storage/table.h"
+
+#include "indexes/tableindex.h"
+
 #include "storage/persistenttable.h"
+#include "storage/table.h"
+#include "storage/TableCatalogDelegate.hpp"
 #include "storage/tablefactory.h"
 #include "storage/tableutil.h"
 
-using voltdb::ExecutorContext;
-using voltdb::NValue;
-using voltdb::PersistentTable;
-using voltdb::Table;
-using voltdb::TableFactory;
-using voltdb::TableIterator;
-using voltdb::TableTuple;
-using voltdb::TupleSchemaBuilder;
-using voltdb::VALUE_TYPE_BIGINT;
-using voltdb::VALUE_TYPE_VARCHAR;
-using voltdb::ValueFactory;
-using voltdb::VoltDBEngine;
-using voltdb::tableutil;
+#include "boost/scoped_ptr.hpp"
+
+using namespace voltdb;
 
 class PersistentTableTest : public Test {
 public:
@@ -162,8 +152,72 @@ protected:
             "set $PREV oncommit \"\"\n"
             "set $PREV index /clusters#cluster/databases#database/tables#T/indexes#VOLTDB_AUTOGEN_IDX_PK_T_PK\n"
             "set $PREV foreignkeytable null\n"
+
+            "add /clusters#cluster/databases#database tables X\n"
+            "set /clusters#cluster/databases#database/tables#X isreplicated true\n"
+            "set $PREV partitioncolumn null\n"
+            "set $PREV estimatedtuplecount 0\n"
+            "set $PREV materializer null\n"
+            "set $PREV signature \"X|bv\"\n"
+            "set $PREV tuplelimit 2147483647\n"
+            "set $PREV isDRed true\n"
+            "add /clusters#cluster/databases#database/tables#X columns DATA\n"
+            "set /clusters#cluster/databases#database/tables#X/columns#DATA index 1\n"
+            "set $PREV type 9\n"
+            "set $PREV size 256\n"
+            "set $PREV nullable true\n"
+            "set $PREV name \"DATA\"\n"
+            "set $PREV defaultvalue null\n"
+            "set $PREV defaulttype 0\n"
+            "set $PREV matview null\n"
+            "set $PREV aggregatetype 0\n"
+            "set $PREV matviewsource null\n"
+            "set $PREV inbytes false\n"
+            "add /clusters#cluster/databases#database/tables#X columns PK\n"
+            "set /clusters#cluster/databases#database/tables#X/columns#PK index 0\n"
+            "set $PREV type 6\n"
+            "set $PREV size 8\n"
+            "set $PREV nullable false\n"
+            "set $PREV name \"PK\"\n"
+            "set $PREV defaultvalue null\n"
+            "set $PREV defaulttype 0\n"
+            "set $PREV matview null\n"
+            "set $PREV aggregatetype 0\n"
+            "set $PREV matviewsource null\n"
+            "set $PREV inbytes false\n"
+            "add /clusters#cluster/databases#database/tables#X indexes VOLTDB_AUTOGEN_IDX_PK_X_PK\n"
+            "set /clusters#cluster/databases#database/tables#X/indexes#VOLTDB_AUTOGEN_IDX_PK_X_PK unique true\n"
+            "set $PREV assumeUnique false\n"
+            "set $PREV countable true\n"
+            "set $PREV type 1\n"
+            "set $PREV expressionsjson \"\"\n"
+            "set $PREV predicatejson \"\"\n"
+            "add /clusters#cluster/databases#database/tables#X/indexes#VOLTDB_AUTOGEN_IDX_PK_X_PK columns PK\n"
+            "set /clusters#cluster/databases#database/tables#X/indexes#VOLTDB_AUTOGEN_IDX_PK_X_PK/columns#PK index 0\n"
+            "set $PREV column /clusters#cluster/databases#database/tables#X/columns#PK\n"
+            "add /clusters#cluster/databases#database/tables#X constraints VOLTDB_AUTOGEN_IDX_PK_X_PK\n"
+            "set /clusters#cluster/databases#database/tables#X/constraints#VOLTDB_AUTOGEN_IDX_PK_X_PK type 4\n"
+            "set $PREV oncommit \"\"\n"
+            "set $PREV index /clusters#cluster/databases#database/tables#X/indexes#VOLTDB_AUTOGEN_IDX_PK_X_PK\n"
+            "set $PREV foreignkeytable null\n"
             "");
         return payload;
+    }
+
+    void validateCounts(PersistentTable* table, PersistentTable* dupTable,
+                        size_t nTuples, size_t nDupTuples, size_t nIndexes) {
+        validateCounts(table, nTuples, nIndexes);
+        validateCounts(dupTable, nDupTuples, nIndexes);
+    }
+
+    void validateCounts(PersistentTable* table, size_t nTuples, size_t nIndexes) {
+        TableIterator iterator = table->iterator();
+        ASSERT_EQ(nTuples > 0, iterator.hasNext());
+        ASSERT_EQ(nTuples, table->activeTupleCount());
+        ASSERT_EQ(nIndexes, table->indexCount());
+        BOOST_FOREACH(TableIndex* index, table->allIndexes()) {
+            ASSERT_EQ(nTuples, index->getSize());
+        }
     }
 
 private:
@@ -283,6 +337,7 @@ TEST_F(PersistentTableTest, DRTimestampColumn) {
 }
 
 TEST_F(PersistentTableTest, TruncateTableTest) {
+    bool added;
     VoltDBEngine* engine = getEngine();
     engine->loadCatalog(0, catalogPayload());
     PersistentTable *table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
@@ -291,8 +346,8 @@ TEST_F(PersistentTableTest, TruncateTableTest) {
 
     beginWork();
     const int tuplesToInsert = 10;
-    (void) tuplesToInsert;  // to make compiler happy
-    assert(tableutil::addRandomTuples(table, tuplesToInsert));
+    added = tableutil::addRandomTuples(table, tuplesToInsert);
+    assert(added);
     commit();
 
     size_t blockCount = table->allocatedBlockCount();
@@ -301,7 +356,8 @@ TEST_F(PersistentTableTest, TruncateTableTest) {
     ASSERT_EQ(blockCount, table->allocatedBlockCount());
 
     beginWork();
-    assert(tableutil::addRandomTuples(table, tuplesToInsert));
+    added = tableutil::addRandomTuples(table, tuplesToInsert);
+    assert(added);
     table->truncateTable(engine);
     commit();
 
@@ -310,6 +366,182 @@ TEST_F(PersistentTableTest, TruncateTableTest) {
     table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
     ASSERT_NE(NULL, table);
     ASSERT_EQ(1, table->allocatedBlockCount());
+}
+
+TEST_F(PersistentTableTest, SwapTablesTest) {
+    bool added;
+    PersistentTable *namedTable;
+    VoltDBEngine* engine = getEngine();
+    engine->loadCatalog(0, catalogPayload());
+    PersistentTable *table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
+    ASSERT_NE(NULL, table);
+
+    PersistentTable *dupTable = dynamic_cast<PersistentTable*>(engine->getTable("X"));
+    ASSERT_NE(NULL, dupTable);
+
+    //
+    // Swap empty tables.
+    //
+
+    beginWork();
+    table->swapTable(dupTable, engine);
+
+    namedTable = dynamic_cast<PersistentTable*>(engine->getTableDelegate("T")->getTable());
+    ASSERT_EQ(namedTable, dupTable);
+    namedTable = dynamic_cast<PersistentTable*>(engine->getTableDelegate("X")->getTable());
+    ASSERT_EQ(namedTable, table);
+    // Refresh the local pointers to reflect the updated table name associations.
+    table = dupTable;
+    dupTable = namedTable;
+
+    // Validate the post-swap state of tables AND indexes.
+    validateCounts(table, dupTable, 0, 0, 1);
+
+    commit();
+
+    //
+    // Swap a table with an empty table.
+    //
+
+    const int tuplesToInsert = 10;
+
+    beginWork();
+    added = tableutil::addRandomTuples(table, tuplesToInsert);
+    assert(added);
+
+    // Validate the pre-swap state of tables AND indexes.
+    validateCounts(table, dupTable, tuplesToInsert, 0, 1);
+
+    table->swapTable(dupTable, engine);
+
+    namedTable = dynamic_cast<PersistentTable*>(engine->getTableDelegate("T")->getTable());
+    ASSERT_EQ(namedTable, dupTable);
+    namedTable = dynamic_cast<PersistentTable*>(engine->getTableDelegate("X")->getTable());
+    ASSERT_EQ(namedTable, table);
+    // Refresh the local pointers to reflect the updated table name associations.
+    table = dupTable;
+    dupTable = namedTable;
+
+    // Validate the post-swap state of tables AND indexes.
+
+    // After the swap, the first table should be empty.
+    // After the swap, the second table should be populated.
+    validateCounts(table, dupTable, 0, tuplesToInsert, 1);
+
+    commit();
+
+    //
+    // Swap with data in both tables.
+    //
+
+    beginWork();
+
+    // Populate the empty table currently swapped to table
+    added = tableutil::addRandomTuples(table, tuplesToInsert*3);
+    assert(added);
+
+    // Validate the pre-swap state of tables AND indexes.
+    validateCounts(table, dupTable, tuplesToInsert*3, tuplesToInsert, 1);
+
+
+    table->swapTable(dupTable, engine);
+
+    namedTable = dynamic_cast<PersistentTable*>(engine->getTableDelegate("T")->getTable());
+    ASSERT_EQ(namedTable, dupTable);
+    namedTable = dynamic_cast<PersistentTable*>(engine->getTableDelegate("X")->getTable());
+    ASSERT_EQ(namedTable, table);
+    // Refresh the local pointers to reflect the updated table name associations.
+    table = dupTable;
+    dupTable = namedTable;
+
+    // Validate the post-swap state of tables AND indexes.
+
+    // After the swap, the first table should contain the original population.
+    // After the swap, the second table should contain the second population.
+    validateCounts(table, dupTable, tuplesToInsert, tuplesToInsert*3, 1);
+
+    commit();
+
+    // swap and then undo to swap back.
+    beginWork();
+
+    table->swapTable(dupTable, engine);
+
+    namedTable = dynamic_cast<PersistentTable*>(engine->getTableDelegate("T")->getTable());
+    ASSERT_EQ(namedTable, dupTable);
+    namedTable = dynamic_cast<PersistentTable*>(engine->getTableDelegate("X")->getTable());
+    ASSERT_EQ(namedTable, table);
+    // Refresh the local pointers to reflect the updated table name associations.
+    table = dupTable;
+    dupTable = namedTable;
+
+    // Validate the post-swap state of tables AND indexes.
+
+    // After the swap, the first table should contain the second population.
+    // After the swap, the second table should contain the original population.
+    validateCounts(table, dupTable, tuplesToInsert*3, tuplesToInsert, 1);
+
+    rollback();
+
+    beginWork();
+
+    // Validate the pre-swap state of the rolled back tables AND indexes.
+
+    namedTable = dynamic_cast<PersistentTable*>(engine->getTableDelegate("T")->getTable());
+    ASSERT_EQ(namedTable, dupTable);
+    namedTable = dynamic_cast<PersistentTable*>(engine->getTableDelegate("X")->getTable());
+    ASSERT_EQ(namedTable, table);
+    // Refresh the local pointers to reflect the updated table name associations.
+    table = dupTable;
+    dupTable = namedTable;
+
+    // After the rollback, the first table should contain the original population.
+    // After the rollback, the second table should contain the second population.
+    validateCounts(table, dupTable, tuplesToInsert, tuplesToInsert*3, 1);
+
+    // Test explicit do and undo within the same eventually aborted transaction.
+    table->swapTable(dupTable, engine);
+    dupTable->swapTable(table, engine);
+
+    // Validate the pre-swap state of the twice-swapped tables AND indexes.
+    // After the do+undo, the first table should contain the original population.
+    // After the do+undo, the second table should contain the second population.
+    validateCounts(table, dupTable, tuplesToInsert, tuplesToInsert*3, 1);
+
+    rollback();
+
+    beginWork();
+
+    // Validate the pre-swap state of the rolled back tables AND indexes.
+
+    // After the rollback, the first table should contain the original population.
+    // After the rollback, the second table should contain the second population.
+    validateCounts(table, dupTable, tuplesToInsert, tuplesToInsert*3, 1);
+
+    // Test explicit do and undo within the same eventually committed transaction.
+    table->swapTable(dupTable, engine);
+    dupTable->swapTable(table, engine);
+
+    // Validate the pre-swap state of the rolled back tables AND indexes.
+    // After the do+undo, the first table should contain the original population.
+    // After the do+undo, the second table should contain the second population.
+    validateCounts(table, dupTable, tuplesToInsert, tuplesToInsert*3, 1);
+
+    commit();
+
+    beginWork();
+
+    // Validate the pre-swap state of the twice-swapped tables AND indexes.
+
+    // After the commit, the first table should contain the original population.
+    // After the commit, the second table should contain the second population.
+    validateCounts(table, dupTable, tuplesToInsert, tuplesToInsert*3, 1);
+
+    rollback();
+
+    //TODO: exercise combo transactions involving swaps and truncates, and swaps and writes
+    // with and without rollbacks.
+
 }
 
 int main() {


### PR DESCRIPTION
Also tweaked truncate table to simplify its undo action and to share (renamed) its underlying mechanism for dealing with streaming in progress against past state of the table(s) (such as snapshotting).

Error handling is still a little bit stubbed with some asserts where there should be runtime errors.

Handling of SWAP TABLES when the tables have different index or view definitions is guarded against and stubbed for now -- not sure how soon we'll get around to phasing in at least edge cases like that.