### PR TITLE
ENG-11471: skip pip install if the module already installed

### DIFF
--- a/lib/python/vdm/server/venv_starter.py
+++ b/lib/python/vdm/server/venv_starter.py
@@ -176,7 +176,7 @@ def install_required_packages(pip=''):
         for package_name in packages:
             if package_name != '' and '#' not in package_name:
                 if package_name not in sys.modules:
-                    run_cmd(pip, '--quiet', 'install', os.path.join(G.base_dir, 'third_party/python/packages', package_name))
+                    run_cmd(pip, '--quiet', 'install', '--user', os.path.join(G.base_dir, 'third_party/python/packages', package_name))
     else:
         if pip == '':
             info('Installing the python dependencies.')
@@ -187,8 +187,7 @@ def install_required_packages(pip=''):
         for package_name in packages:
             if package_name != '' and '#' not in package_name:
                 if package_name not in sys.modules:
-                    run_cmd(pip, '--quiet', 'install', package_name)
-        # run_cmd(pip, '--quiet', 'install', '-r', packages)
+                    run_cmd(pip, '--quiet', 'install', '--user', package_name)
 
 def create_data_config_path(path, con_path):
     org_wd = os.getcwd()

--- a/lib/python/vdm/server/venv_starter.py
+++ b/lib/python/vdm/server/venv_starter.py
@@ -175,7 +175,8 @@ def install_required_packages(pip=''):
 
         for package_name in packages:
             if package_name != '' and '#' not in package_name:
-                run_cmd(pip, '--quiet', 'install', os.path.join(G.base_dir, 'third_party/python/packages', package_name))
+                if package_name not in sys.modules:
+                    run_cmd(pip, '--quiet', 'install', os.path.join(G.base_dir, 'third_party/python/packages', package_name))
     else:
         if pip == '':
             info('Installing the python dependencies.')
@@ -183,7 +184,11 @@ def install_required_packages(pip=''):
             packages = os.path.join(G.base_dir, 'lib/python/vdm/requirements.txt')
         else:
             packages = os.path.join(G.base_dir, 'lib/python/vdm/requirements_python_2.6.txt')
-        run_cmd(pip, '--quiet', 'install', '-r', packages)
+        for package_name in packages:
+            if package_name != '' and '#' not in package_name:
+                if package_name not in sys.modules:
+                    run_cmd(pip, '--quiet', 'install', package_name)
+        # run_cmd(pip, '--quiet', 'install', '-r', packages)
 
 def create_data_config_path(path, con_path):
     org_wd = os.getcwd()

--- a/lib/python/vdm/server/venv_starter.py
+++ b/lib/python/vdm/server/venv_starter.py
@@ -181,12 +181,14 @@ def install_required_packages(pip=''):
         if pip == '':
             info('Installing the python dependencies.')
         if sys.version_info[:2] >= (2, 7):
-            packages = os.path.join(G.base_dir, 'lib/python/vdm/requirements.txt')
+            packages = [line.rstrip('\n') for line in open(os.path.join(G.base_dir, 'lib/python/vdm/requirements.txt'))]
         else:
-            packages = os.path.join(G.base_dir, 'lib/python/vdm/requirements_python_2.6.txt')
+            packages = [line.rstrip('\n') for line in open(os.path.join(G.base_dir, 'lib/python/vdm/requirements_python_2.6.txt'))]
+
         for package_name in packages:
             if package_name != '' and '#' not in package_name:
                 if package_name not in sys.modules:
+                    print "pip --quiet install --user", package_name
                     run_cmd(pip, '--quiet', 'install', '--user', package_name)
 
 def create_data_config_path(path, con_path):


### PR DESCRIPTION
It seems venv_start always try to install required packages. We should skip that if already system wide installed (by root).