### PR TITLE
ENG-11480 add timeout for DR consumer stats

### DIFF
--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -252,8 +252,8 @@ def check_dr_consumer(runner):
         if outstanding == 0:
             return
         timelast = time.time() - start
-        #if the DR consumer stats are not cleaned in 15 min, return and warn user
-        if timelast > 900 :
+        #if the DR consumer stats are not cleaned in 2 seconds, return and warn user
+        if timelast > 2 :
             raise TimeoutException('There are outstanding DR consumer transactions to be drained.')
         time.sleep(1)
 

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -51,7 +51,7 @@ def shutdown(runner):
             runner.info('All transactions have been made durable.')
             if runner.opts.save:
                columns = [VOLT.FastSerializer.VOLTTYPE_BIGINT]
-               shutdown_params =  [zk_pause_txnid]
+               shutdown_params = [zk_pause_txnid]
                #save option, check more stats
                try:
                    checkstats.check_dr_consumer(runner)

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -57,7 +57,7 @@ def shutdown(runner):
                    checkstats.check_dr_consumer(runner)
                except TimeoutException as error:
                    runner.warning(error.message)
-                   runner.warning('The snapshot saved may not contain all the data')
+                   runner.warning('The snapshot saved may not contain all the data.')
                runner.info('Starting resolution of external commitments...')
                checkstats.check_exporter(runner)
                checkstats.check_dr_producer(runner)

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -16,6 +16,7 @@
 import time
 import signal
 from voltcli import checkstats
+from voltcli.checkstats import TimeoutException
 
 @VOLT.Command(
     bundles = VOLT.AdminBundle(),
@@ -52,7 +53,11 @@ def shutdown(runner):
                columns = [VOLT.FastSerializer.VOLTTYPE_BIGINT]
                shutdown_params =  [zk_pause_txnid]
                #save option, check more stats
-               checkstats.check_dr_consumer(runner)
+               try:
+                   checkstats.check_dr_consumer(runner)
+               except TimeoutException as error:
+                   runner.warning(error.message)
+                   runner.warning('The snapshot saved may not contain all the data')
                runner.info('Starting resolution of external commitments...')
                checkstats.check_exporter(runner)
                checkstats.check_dr_producer(runner)


### PR DESCRIPTION
The DR consumer stats checking will be timeout and warning will be presented to users.