### PR TITLE
ENG-10316:

### DIFF
--- a/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
+++ b/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
@@ -213,7 +213,7 @@ public class ExtensibleSnapshotDigestData {
                 if (partitionStateInfo.drId > existingStateInfo.getLong("sequenceNumber")) {
                     addEntry = true;
                 }
-                log.error("Found a mismatch in dr sequence numbers for partition " + partitionId +
+                log.debug("Found a mismatch in dr sequence numbers for partition " + partitionId +
                         " the DRId should be the same at all replicas, but one node had " +
                         DRLogSegmentId.getDebugStringFromDRId(existingStateInfo.getLong("sequenceNumber")) +
                         " and the local node reported " + DRLogSegmentId.getDebugStringFromDRId(partitionStateInfo.drId));

--- a/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
+++ b/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
@@ -210,7 +210,9 @@ public class ExtensibleSnapshotDigestData {
                 addEntry = true;
             }
             else if (partitionStateInfo.drId != existingStateInfo.getLong("sequenceNumber")) {
-                addEntry = true;
+                if (partitionStateInfo.drId > existingStateInfo.getLong("sequenceNumber")) {
+                    addEntry = true;
+                }
                 log.error("Found a mismatch in dr sequence numbers for partition " + partitionId +
                         " the DRId should be the same at all replicas, but one node had " +
                         DRLogSegmentId.getDebugStringFromDRId(existingStateInfo.getLong("sequenceNumber")) +


### PR DESCRIPTION
When dr Squence numbers were inconsistent, we were logging the inconsistency as an error and always using the last value but we should only ever update the entry if the value is higher as originally implemented before the extra logging.