### PR TITLE
Do all-at-once deallocation of relocatables at transaction boundaries

### DIFF
--- a/build.py
+++ b/build.py
@@ -538,11 +538,12 @@ if whichtests in ("${eetestsuite}", "storage"):
 
 if whichtests in ("${eetestsuite}", "structures"):
     CTX.TESTS['structures'] = """
-     CompactingMapTest
-     CompactingMapIndexCountTest
      CompactingHashTest
-     CompactingPoolTest
      CompactingMapBenchmark
+     CompactingMapIndexCountTest
+     CompactingMapTest
+     CompactingPoolTest
+     CompactingSetTest
     """
 
 if whichtests in ("${eetestsuite}", "plannodes"):

--- a/src/ee/common/ThreadLocalPool.cpp
+++ b/src/ee/common/ThreadLocalPool.cpp
@@ -408,7 +408,7 @@ ScopedPoolDeferredReleaseMode::~ScopedPoolDeferredReleaseMode() {
         entry.second->freePendingAllocations(pendingReleaseSet);
     }
     assert (pendingReleaseSet.empty());
-    getPerThreadPools()->setRelocatablePoolReleaseMode(DEFERRED_RELEASE);
+    getPerThreadPools()->setRelocatablePoolReleaseMode(IMMEDIATE_RELEASE);
 }
 
 }

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -141,10 +141,10 @@ public:
 struct ScopedPoolDeferredReleaseMode {
     ScopedPoolDeferredReleaseMode();
     ~ScopedPoolDeferredReleaseMode();
+private:
+    bool m_origMode;
 };
 
 }
-
-
 
 #endif /* THREADLOCALPOOL_H_ */

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -143,36 +143,6 @@ struct ScopedPoolDeferredReleaseMode {
     ~ScopedPoolDeferredReleaseMode();
 };
 
-
-typedef std::pair<int32_t, void*> SizePtrPair;
-
-struct SizePtrPairComparator {
-    int operator() (const SizePtrPair& v1, const SizePtrPair& v2) const {
-
-        if (v1.first < v2.first) {
-            return -1;
-        }
-
-        if (v1.first > v2.first) {
-            return 1;
-        }
-
-        const char* cv1 = static_cast<const char*>(v1.second);
-        const char* cv2 = static_cast<const char*>(v2.second);
-        if (cv1 < cv2) {
-            return -1;
-        }
-
-        if (cv1 > cv2) {
-            return 1;
-        }
-
-        return 0;
-    }
-};
-
-typedef CompactingSet<SizePtrPair, SizePtrPairComparator> SizePtrPairSet;
-
 }
 
 

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -21,6 +21,8 @@
 #include "boost/pool/pool.hpp"
 #include "boost/shared_ptr.hpp"
 
+#include "structures/CompactingSet.h"
+
 namespace voltdb {
 
 /**
@@ -141,6 +143,38 @@ struct ScopedPoolDeferredReleaseMode {
     ~ScopedPoolDeferredReleaseMode();
 };
 
+
+typedef std::pair<int32_t, void*> SizePtrPair;
+
+struct SizePtrPairComparator {
+    int operator() (const SizePtrPair& v1, const SizePtrPair& v2) const {
+
+        if (v1.first < v2.first) {
+            return -1;
+        }
+
+        if (v1.first > v2.first) {
+            return 1;
+        }
+
+        const char* cv1 = static_cast<const char*>(v1.second);
+        const char* cv2 = static_cast<const char*>(v2.second);
+        if (cv1 < cv2) {
+            return -1;
+        }
+
+        if (cv1 > cv2) {
+            return 1;
+        }
+
+        return 0;
+    }
+};
+
+typedef CompactingSet<SizePtrPair, SizePtrPairComparator> SizePtrPairSet;
+
 }
+
+
 
 #endif /* THREADLOCALPOOL_H_ */

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -359,7 +359,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
 
         void releaseUndoToken(int64_t undoToken)
         {
-            ScopedDeferredReleaseMode sdrm;
+            ScopedPoolDeferredReleaseMode spdrm;
 
             if (m_currentUndoQuantum != NULL && m_currentUndoQuantum->getUndoToken() == undoToken) {
                 m_currentUndoQuantum = NULL;
@@ -377,7 +377,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
 
         void undoUndoToken(int64_t undoToken)
         {
-            ScopedDeferredReleaseMode sdrm;
+            ScopedPoolDeferredReleaseMode spdrm;
 
             m_currentUndoQuantum = NULL;
             m_executorContext->setupForPlanFragments(NULL);

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -359,6 +359,8 @@ class __attribute__((visibility("default"))) VoltDBEngine {
 
         void releaseUndoToken(int64_t undoToken)
         {
+            ScopedDeferredReleaseMode sdrm;
+
             if (m_currentUndoQuantum != NULL && m_currentUndoQuantum->getUndoToken() == undoToken) {
                 m_currentUndoQuantum = NULL;
                 m_executorContext->setupForPlanFragments(NULL);
@@ -375,6 +377,8 @@ class __attribute__((visibility("default"))) VoltDBEngine {
 
         void undoUndoToken(int64_t undoToken)
         {
+            ScopedDeferredReleaseMode sdrm;
+
             m_currentUndoQuantum = NULL;
             m_executorContext->setupForPlanFragments(NULL);
             m_undoLog.undo(undoToken);

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -20,7 +20,7 @@
 
 #include "ContiguousAllocator.h"
 
-#include <cstdlib>
+#include <cstdio>
 #include <stdint.h>
 #include <utility>
 #include <limits>

--- a/src/ee/structures/CompactingPool.h
+++ b/src/ee/structures/CompactingPool.h
@@ -171,6 +171,10 @@ class CompactingPool
     std::size_t getBytesAllocated() const
     { return m_allocator.bytesAllocated(); }
 
+    int64_t allocationCount() const {
+        return m_allocator.count();
+    }
+
     static int32_t FIXED_OVERHEAD_PER_ENTRY()
     { return static_cast<int32_t>(sizeof(Relocatable)); }
 

--- a/src/ee/structures/CompactingPool.h
+++ b/src/ee/structures/CompactingPool.h
@@ -153,7 +153,7 @@ class CompactingPool
     void freePendingAllocations(SizePtrPairSet& pendingReleaseSet)
     {
         const int32_t elemSize = elementSize();
-        SizePtrPair lowerKey = SizePtrPair(elemSize, NULL);
+        SizePtrPair lowerKey = SizePtrPair(elemSize, static_cast<void*>(NULL));
         while (true) {
             trimAllocationsPendingRelease(elemSize, pendingReleaseSet);
 

--- a/src/ee/structures/CompactingPool.h
+++ b/src/ee/structures/CompactingPool.h
@@ -153,7 +153,7 @@ class CompactingPool
     void freePendingAllocations(SizePtrPairSet& pendingReleaseSet)
     {
         const int32_t elemSize = elementSize();
-        SizePtrPair lowerKey = SizePtrPair(elemSize, 0);
+        SizePtrPair lowerKey = SizePtrPair(elemSize, NULL);
         while (true) {
             trimAllocationsPendingRelease(elemSize, pendingReleaseSet);
 

--- a/src/ee/structures/CompactingSet.h
+++ b/src/ee/structures/CompactingSet.h
@@ -56,6 +56,9 @@ public:
 
     inline iterator begin() { return m_map.begin(); }
 
+    inline iterator lowerBound(const Key& key) { return m_map.lowerBound(key); }
+    inline iterator upperBound(const Key& key) { return m_map.upperBound(key); }
+
 private:
     // unimplemented copy ctor and assignment operator
     CompactingSet(const CompactingSet<Key, Compare> &);

--- a/src/ee/structures/CompactingSet.h
+++ b/src/ee/structures/CompactingSet.h
@@ -67,17 +67,6 @@ private:
     tree_type m_map;
 };
 
-/**
- * A simple comparator that works for any kind of pointer.
- */
-struct PointerComparator {
-    int operator()(const void* v1, const void* v2) const {
-        // C++ does not like it if you try to subtract void pointers,
-        // because the size of void is ambiguous
-        return static_cast<const char*>(v1) - static_cast<const char*>(v2);
-    }
-};
-
 } // namespace voltdb
 
 #endif // COMPACTINGSET_H_

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -114,6 +114,13 @@ protected:
         m_engine->getStringPool()->purge();
     }
 
+    // SET DR = ACTIVE;
+    // CREATE TABLE T (
+    //   PK BIGINT NOT NULL,
+    //   DATA VARCHAR(256),
+    //   PRIMARY KEY (PK)
+    // );
+    // DR TABLE T;
     static const std::string& catalogPayload() {
         static const std::string payload(
             "add / clusters cluster\n"
@@ -174,6 +181,13 @@ protected:
         return payload;
     }
 
+    // CREATE TABLE TEST_TABLE (
+    //   ID BIGINT,
+    //   STR1 VARCHAR(4096),
+    //   STR2 VARCHAR(8192),
+    //   STR3 VARCHAR(10240),
+    //   PRIMARY KEY (id)
+    // );
     static const std::string& catalogPayloadForTableWithManyObjects() {
         static const std::string payload =
             "add / clusters cluster\n"

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -21,6 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <iostream>
 #include <vector>
 #include <string>
 
@@ -28,6 +29,7 @@
 
 #include "harness.h"
 #include "test_utils/ScopedTupleSchema.hpp"
+#include "test_utils/SimpleTimer.hpp"
 
 #include "common/tabletuple.h"
 #include "common/types.h"
@@ -46,12 +48,14 @@ using voltdb::Table;
 using voltdb::TableFactory;
 using voltdb::TableIterator;
 using voltdb::TableTuple;
+using voltdb::TupleSchema;
 using voltdb::TupleSchemaBuilder;
 using voltdb::VALUE_TYPE_BIGINT;
 using voltdb::VALUE_TYPE_VARCHAR;
 using voltdb::ValueFactory;
 using voltdb::VoltDBEngine;
 using voltdb::tableutil;
+
 
 class PersistentTableTest : public Test {
 public:
@@ -60,6 +64,8 @@ public:
         , m_undoToken(0)
         , m_uniqueId(0)
     {
+        std::srand(888);
+
         m_engine->initialize(1,     // clusterIndex
                              1,     // siteId
                              0,     // partitionId
@@ -98,12 +104,14 @@ protected:
         m_engine->releaseUndoToken(m_undoToken);
         ++m_undoToken;
         m_engine->setUndoToken(m_undoToken);
+        m_engine->getStringPool()->purge();
     }
 
     void rollback() {
         m_engine->undoUndoToken(m_undoToken);
         ++m_undoToken;
         m_engine->setUndoToken(m_undoToken);
+        m_engine->getStringPool()->purge();
     }
 
     static const std::string& catalogPayload() {
@@ -166,6 +174,119 @@ protected:
         return payload;
     }
 
+    static const std::string& catalogPayloadForTableWithManyObjects() {
+        static const std::string payload =
+            "add / clusters cluster\n"
+            "set /clusters#cluster localepoch 1199145600\n"
+            "set $PREV securityEnabled false\n"
+            "set $PREV httpdportno 0\n"
+            "set $PREV jsonapi false\n"
+            "set $PREV networkpartition false\n"
+            "set $PREV voltRoot \"\"\n"
+            "set $PREV exportOverflow \"\"\n"
+            "set $PREV drOverflow \"\"\n"
+            "set $PREV adminport 0\n"
+            "set $PREV adminstartup false\n"
+            "set $PREV heartbeatTimeout 0\n"
+            "set $PREV useddlschema false\n"
+            "set $PREV drConsumerEnabled false\n"
+            "set $PREV drProducerEnabled false\n"
+            "set $PREV drClusterId 0\n"
+            "set $PREV drProducerPort 0\n"
+            "set $PREV drMasterHost \"\"\n"
+            "set $PREV drFlushInterval 0\n"
+            "add /clusters#cluster databases database\n"
+            "set /clusters#cluster/databases#database schema \"eJxtjDsOwzAMQ/eexiZt0lqTNvc/UmmgQwpk0IfiE0VDU91DEy29Czp/+zQ95nW/Yqk00KJLTn0c5eat38mBK+6R38IZJwkGezZtV9TaE4uDjUXhzuGBW+zh8MfxgevJw04NWTxeX5X3LS8=\"\n"
+            "set $PREV isActiveActiveDRed false\n"
+            "set $PREV securityprovider \"\"\n"
+            "add /clusters#cluster/databases#database groups administrator\n"
+            "set /clusters#cluster/databases#database/groups#administrator admin true\n"
+            "set $PREV defaultproc true\n"
+            "set $PREV defaultprocread true\n"
+            "set $PREV sql true\n"
+            "set $PREV sqlread true\n"
+            "set $PREV allproc true\n"
+            "add /clusters#cluster/databases#database groups user\n"
+            "set /clusters#cluster/databases#database/groups#user admin false\n"
+            "set $PREV defaultproc true\n"
+            "set $PREV defaultprocread true\n"
+            "set $PREV sql true\n"
+            "set $PREV sqlread true\n"
+            "set $PREV allproc true\n"
+            "add /clusters#cluster/databases#database tables TEST_TABLE\n"
+            "set /clusters#cluster/databases#database/tables#TEST_TABLE isreplicated true\n"
+            "set $PREV partitioncolumn null\n"
+            "set $PREV estimatedtuplecount 0\n"
+            "set $PREV materializer null\n"
+            "set $PREV signature \"TEST_TABLE|bvvv\"\n"
+            "set $PREV tuplelimit 2147483647\n"
+            "set $PREV isDRed false\n"
+            "add /clusters#cluster/databases#database/tables#TEST_TABLE columns ID\n"
+            "set /clusters#cluster/databases#database/tables#TEST_TABLE/columns#ID index 0\n"
+            "set $PREV type 6\n"
+            "set $PREV size 8\n"
+            "set $PREV nullable true\n"
+            "set $PREV name \"ID\"\n"
+            "set $PREV defaultvalue null\n"
+            "set $PREV defaulttype 0\n"
+            "set $PREV matview null\n"
+            "set $PREV aggregatetype 0\n"
+            "set $PREV matviewsource null\n"
+            "set $PREV inbytes false\n"
+            "add /clusters#cluster/databases#database/tables#TEST_TABLE columns STR1\n"
+            "set /clusters#cluster/databases#database/tables#TEST_TABLE/columns#STR1 index 1\n"
+            "set $PREV type 9\n"
+            "set $PREV size 4096\n"
+            "set $PREV nullable true\n"
+            "set $PREV name \"STR1\"\n"
+            "set $PREV defaultvalue null\n"
+            "set $PREV defaulttype 0\n"
+            "set $PREV matview null\n"
+            "set $PREV aggregatetype 0\n"
+            "set $PREV matviewsource null\n"
+            "set $PREV inbytes false\n"
+            "add /clusters#cluster/databases#database/tables#TEST_TABLE columns STR2\n"
+            "set /clusters#cluster/databases#database/tables#TEST_TABLE/columns#STR2 index 2\n"
+            "set $PREV type 9\n"
+            "set $PREV size 8192\n"
+            "set $PREV nullable true\n"
+            "set $PREV name \"STR2\"\n"
+            "set $PREV defaultvalue null\n"
+            "set $PREV defaulttype 0\n"
+            "set $PREV matview null\n"
+            "set $PREV aggregatetype 0\n"
+            "set $PREV matviewsource null\n"
+            "set $PREV inbytes false\n"
+            "add /clusters#cluster/databases#database/tables#TEST_TABLE columns STR3\n"
+            "set /clusters#cluster/databases#database/tables#TEST_TABLE/columns#STR3 index 3\n"
+            "set $PREV type 9\n"
+            "set $PREV size 10240\n"
+            "set $PREV nullable true\n"
+            "set $PREV name \"STR3\"\n"
+            "set $PREV defaultvalue null\n"
+            "set $PREV defaulttype 0\n"
+            "set $PREV matview null\n"
+            "set $PREV aggregatetype 0\n"
+            "set $PREV matviewsource null\n"
+            "set $PREV inbytes false\n"
+            "add /clusters#cluster/databases#database/tables#TEST_TABLE indexes VOLTDB_AUTOGEN_IDX_PK_TEST_TABLE_ID\n"
+            "set /clusters#cluster/databases#database/tables#TEST_TABLE/indexes#VOLTDB_AUTOGEN_IDX_PK_TEST_TABLE_ID unique true\n"
+            "set $PREV assumeUnique false\n"
+            "set $PREV countable true\n"
+            "set $PREV type 1\n"
+            "set $PREV expressionsjson \"\"\n"
+            "set $PREV predicatejson \"\"\n"
+            "add /clusters#cluster/databases#database/tables#TEST_TABLE/indexes#VOLTDB_AUTOGEN_IDX_PK_TEST_TABLE_ID columns ID\n"
+            "set /clusters#cluster/databases#database/tables#TEST_TABLE/indexes#VOLTDB_AUTOGEN_IDX_PK_TEST_TABLE_ID/columns#ID index 0\n"
+            "set $PREV column /clusters#cluster/databases#database/tables#TEST_TABLE/columns#ID\n"
+            "add /clusters#cluster/databases#database/tables#TEST_TABLE constraints VOLTDB_AUTOGEN_IDX_PK_TEST_TABLE_ID\n"
+            "set /clusters#cluster/databases#database/tables#TEST_TABLE/constraints#VOLTDB_AUTOGEN_IDX_PK_TEST_TABLE_ID type 4\n"
+            "set $PREV oncommit \"\"\n"
+            "set $PREV index /clusters#cluster/databases#database/tables#TEST_TABLE/indexes#VOLTDB_AUTOGEN_IDX_PK_TEST_TABLE_ID\n"
+            "set $PREV foreignkeytable null\n";
+        return payload;
+    }
+
 private:
     boost::scoped_ptr<VoltDBEngine> m_engine;
     int64_t m_undoToken;
@@ -189,16 +310,18 @@ TEST_F(PersistentTableTest, DRTimestampColumn) {
     voltdb::StandAloneTupleStorage storage(schema);
     TableTuple &srcTuple = const_cast<TableTuple&>(storage.tuple());
 
-    NValue bigintNValues[] = {
+    std::vector<NValue> bigintNValues {
         ValueFactory::getBigIntValue(1900),
         ValueFactory::getBigIntValue(1901),
         ValueFactory::getBigIntValue(1902)
     };
 
-    NValue stringNValues[] = {
-        ValueFactory::getTempStringValue("Je me souviens"),
-        ValueFactory::getTempStringValue("Ut Incepit Fidelis Sic Permanet"),
-        ValueFactory::getTempStringValue("Splendor sine occasu")
+    // These cannot be temp strings, since we need to commit transactions
+    // in this test.
+    std::vector<NValue> stringNValues {
+        ValueFactory::getStringValue("Je me souviens"),
+        ValueFactory::getStringValue("Ut Incepit Fidelis Sic Permanet"),
+        ValueFactory::getStringValue("Splendor sine occasu")
     };
 
     // Let's do some inserts into the table.
@@ -280,6 +403,10 @@ TEST_F(PersistentTableTest, DRTimestampColumn) {
 
         ++i;
     }
+
+    BOOST_FOREACH(NValue& nval, stringNValues) {
+        nval.free();
+    }
 }
 
 TEST_F(PersistentTableTest, TruncateTableTest) {
@@ -310,6 +437,79 @@ TEST_F(PersistentTableTest, TruncateTableTest) {
     table = dynamic_cast<PersistentTable*>(engine->getTable("T"));
     ASSERT_NE(NULL, table);
     ASSERT_EQ(1, table->allocatedBlockCount());
+}
+
+/**
+ * This test creates a table with several non-inline string columns,
+ * and fills it with data.  Then it updates the table a bunch of times,
+ * creating and deleting non-inline string column values.
+ * Finally, it truncates the table.
+ *
+ * For each operation, print out how long it took.
+ *
+ * The purpose of this test is measure performance of the truncation
+ * operation, which must free all the allocated strings.
+ */
+TEST_F(PersistentTableTest, TruncateTableWithManyObjects) {
+
+    getEngine()->loadCatalog(0, catalogPayloadForTableWithManyObjects());
+    PersistentTable *table = dynamic_cast<PersistentTable*>(
+        getEngine()->getTable("TEST_TABLE"));
+    ASSERT_NE(NULL, table);
+
+    const int NUMROWS = 10000;
+    const TupleSchema* schema = table->schema();
+    std::vector<uint32_t> varcharColLengths {
+        schema->getColumnInfo(1)->length,
+        schema->getColumnInfo(2)->length,
+        schema->getColumnInfo(3)->length
+    };
+
+    std::cout << "\n           Loading table...";
+    SimpleTimer timer;
+    TableTuple tempTuple = table->tempTuple();
+    for (int i = 0; i < NUMROWS; ++i) {
+        char fillChar = (i % 26) + 'A';
+
+        tempTuple.setNValue(0, ValueFactory::getIntegerValue(i));
+        tempTuple.setNValue(1, ValueFactory::getTempStringValue(std::string(varcharColLengths[0], fillChar)));
+        tempTuple.setNValue(2, ValueFactory::getTempStringValue(std::string(varcharColLengths[1], fillChar)));
+        tempTuple.setNValue(3, ValueFactory::getTempStringValue(std::string(varcharColLengths[2], fillChar)));
+
+        table->insertTuple(tempTuple);
+        commit();
+    }
+
+    std::cout << "  " << timer.elapsedAsString() << "\n";
+
+    std::cout << "           Updating tuples...";
+    timer.reset();
+    for (int i = 0; i < NUMROWS; ++i) {
+        char fillChar = (i % 26) + 'a';
+
+        int64_t whichRow = std::rand() % NUMROWS;
+        tempTuple.setNValue(0, ValueFactory::getIntegerValue(whichRow));
+        tempTuple.setNValue(1, ValueFactory::getTempStringValue(std::string(varcharColLengths[0], fillChar)));
+        tempTuple.setNValue(2, ValueFactory::getTempStringValue(std::string(varcharColLengths[1], fillChar)));
+        tempTuple.setNValue(3, ValueFactory::getTempStringValue(std::string(varcharColLengths[2], fillChar)));
+
+        TableTuple tupleToUpdate = table->lookupTupleByValues(tempTuple);
+        ASSERT_FALSE(tupleToUpdate.isNullTuple());
+
+        beginWork();
+        table->updateTuple(tupleToUpdate, tempTuple);
+        commit();
+    }
+    std::cout << "  " << timer.elapsedAsString() << "\n";
+
+    std::cout << "           Truncating table...";
+    timer.reset();
+    beginWork();
+    table->truncateTable(getEngine(), true);
+    commit();
+    std::cout << "  " << timer.elapsedAsString() << "\n";
+
+    std::cout << "           ";
 }
 
 int main() {

--- a/tests/ee/structures/CompactingPoolTest.cpp
+++ b/tests/ee/structures/CompactingPoolTest.cpp
@@ -53,7 +53,8 @@ TEST_F(CompactingPoolTest, basic_ops)
     char* elem = reinterpret_cast<char*>(dut.malloc(&elem));
     EXPECT_EQ((size + CompactingPool::FIXED_OVERHEAD_PER_ENTRY())* num_elements,
             dut.getBytesAllocated());
-    dut.free(elem);
+    dut.markAllocationAsPendingRelease(elem);
+    dut.freePendingAllocations();
     EXPECT_EQ(0, dut.getBytesAllocated());
 
     // fill up a buffer + 1, then free something in the middle and
@@ -66,7 +67,8 @@ TEST_F(CompactingPoolTest, basic_ops)
     EXPECT_EQ(2, *reinterpret_cast<int8_t*>(elems[2]));
     EXPECT_EQ((size + CompactingPool::FIXED_OVERHEAD_PER_ENTRY()) * num_elements * 2,
             dut.getBytesAllocated());
-    dut.free(elems[2]);
+    dut.markAllocationAsPendingRelease(elems[2]);
+    dut.freePendingAllocations();
     // 2 should now have the last element, filled with num_elements
     EXPECT_EQ(num_elements, *reinterpret_cast<int8_t*>(elems[2]));
     // and we should have shrunk back to 1 buffer
@@ -77,7 +79,8 @@ TEST_F(CompactingPoolTest, basic_ops)
     elems[num_elements + 1] = reinterpret_cast<char*>(dut.malloc(&(elems[num_elements + 1])));
     EXPECT_EQ((size + CompactingPool::FIXED_OVERHEAD_PER_ENTRY()) * num_elements * 2,
             dut.getBytesAllocated());
-    dut.free(elems[num_elements + 1]);
+    dut.markAllocationAsPendingRelease(elems[num_elements + 1]);
+    dut.freePendingAllocations();
     EXPECT_EQ((size + CompactingPool::FIXED_OVERHEAD_PER_ENTRY()) * num_elements,
             dut.getBytesAllocated());
 }
@@ -109,8 +112,9 @@ TEST_F(CompactingPoolTest, bytes_allocated_test)
         // bonus extra hack test.  If we keep freeing the first
         // element, it should get compacted into and we can free it
         // again!
-        dut.free(elems[0]);
+        dut.markAllocationAsPendingRelease(elems[0]);
     }
+    dut.freePendingAllocations();
 }
 
 int main() {

--- a/tests/ee/structures/CompactingPoolTest.cpp
+++ b/tests/ee/structures/CompactingPoolTest.cpp
@@ -117,6 +117,9 @@ TEST_F(CompactingPoolTest, bytes_allocated_test)
     dut.freePendingAllocations();
 }
 
+TEST_F(CompactingPoolTest, deferred_release) {
+}
+
 int main() {
     return TestSuite::globalInstance()->runAll();
 }

--- a/tests/ee/structures/CompactingPoolTest.cpp
+++ b/tests/ee/structures/CompactingPoolTest.cpp
@@ -53,8 +53,7 @@ TEST_F(CompactingPoolTest, basic_ops)
     char* elem = reinterpret_cast<char*>(dut.malloc(&elem));
     EXPECT_EQ((size + CompactingPool::FIXED_OVERHEAD_PER_ENTRY())* num_elements,
             dut.getBytesAllocated());
-    dut.markAllocationAsPendingRelease(elem);
-    dut.freePendingAllocations();
+    dut.free(elem);
     EXPECT_EQ(0, dut.getBytesAllocated());
 
     // fill up a buffer + 1, then free something in the middle and
@@ -67,8 +66,7 @@ TEST_F(CompactingPoolTest, basic_ops)
     EXPECT_EQ(2, *reinterpret_cast<int8_t*>(elems[2]));
     EXPECT_EQ((size + CompactingPool::FIXED_OVERHEAD_PER_ENTRY()) * num_elements * 2,
             dut.getBytesAllocated());
-    dut.markAllocationAsPendingRelease(elems[2]);
-    dut.freePendingAllocations();
+    dut.free(elems[2]);
     // 2 should now have the last element, filled with num_elements
     EXPECT_EQ(num_elements, *reinterpret_cast<int8_t*>(elems[2]));
     // and we should have shrunk back to 1 buffer
@@ -79,8 +77,7 @@ TEST_F(CompactingPoolTest, basic_ops)
     elems[num_elements + 1] = reinterpret_cast<char*>(dut.malloc(&(elems[num_elements + 1])));
     EXPECT_EQ((size + CompactingPool::FIXED_OVERHEAD_PER_ENTRY()) * num_elements * 2,
             dut.getBytesAllocated());
-    dut.markAllocationAsPendingRelease(elems[num_elements + 1]);
-    dut.freePendingAllocations();
+    dut.free(elems[num_elements + 1]);
     EXPECT_EQ((size + CompactingPool::FIXED_OVERHEAD_PER_ENTRY()) * num_elements,
             dut.getBytesAllocated());
 }
@@ -112,9 +109,8 @@ TEST_F(CompactingPoolTest, bytes_allocated_test)
         // bonus extra hack test.  If we keep freeing the first
         // element, it should get compacted into and we can free it
         // again!
-        dut.markAllocationAsPendingRelease(elems[0]);
+        dut.free(elems[0]);
     }
-    dut.freePendingAllocations();
 }
 
 TEST_F(CompactingPoolTest, deferred_release) {

--- a/tests/ee/structures/CompactingSetTest.cpp
+++ b/tests/ee/structures/CompactingSetTest.cpp
@@ -31,7 +31,6 @@
 #include "common/ThreadLocalPool.h"
 
 using voltdb::CompactingSet;
-using voltdb::PointerComparator;
 using voltdb::SizePtrPair;
 using voltdb::SizePtrPairComparator;
 
@@ -43,6 +42,24 @@ public:
     ~CompactingSetTest() {
     }
 };
+
+/**
+ * A simple comparator that works for any kind of pointer.
+ */
+struct PointerComparator {
+    int operator()(const void* v1, const void* v2) const {
+        if (v1 < v2) {
+            return -1;
+        }
+
+        if (v1 > v2) {
+            return 1;
+        }
+
+        return 0;
+    }
+};
+
 
 TEST_F(CompactingSetTest, Simple) {
     CompactingSet<int*, PointerComparator> mySet;
@@ -115,8 +132,8 @@ TEST_F(CompactingSetTest, RangeScan) {
     }
 
     BOOST_FOREACH(int32_t size, std::vector<int32_t>({2, 4, 8})) {
-        SizePtrPair lowerKey(size, 0);
-        SizePtrPair upperKey(size + 1, 0);
+        SizePtrPair lowerKey(size, static_cast<void*>(NULL));
+        SizePtrPair upperKey(size + 1, static_cast<void*>(NULL));
 
         auto myIt = mySet.lowerBound(lowerKey);
         auto stdIt = stdSet.lower_bound(lowerKey);

--- a/tests/ee/structures/CompactingSetTest.cpp
+++ b/tests/ee/structures/CompactingSetTest.cpp
@@ -1,0 +1,95 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <cstdlib>
+#include <set>
+
+#include "boost/foreach.hpp"
+#include "harness.h"
+#include "structures/CompactingSet.h"
+
+using voltdb::CompactingSet;
+
+class CompactingSetTest : public Test {
+public:
+    CompactingSetTest() {
+    }
+
+    ~CompactingSetTest() {
+    }
+};
+
+TEST_F(CompactingSetTest, Simple) {
+    CompactingSet<int*> mySet;
+    std::set<int*> stdSet;
+
+    ASSERT_TRUE(mySet.empty());
+    ASSERT_EQ(0, mySet.size());
+
+    const int UB = 1000;
+    for (int i = 0; i < UB; ++i) {
+        int *val = new int(rand());
+        auto itBoolPair = stdSet.insert(val);
+        bool  b = mySet.insert(val);
+        ASSERT_EQ(itBoolPair.second, b);
+    }
+
+    ASSERT_FALSE(mySet.empty());
+    ASSERT_EQ(stdSet.size(), mySet.size());
+
+    // If you try to insert a duplicate value, insert should return false.
+    ASSERT_FALSE(mySet.insert(*(stdSet.begin())));
+
+    BOOST_FOREACH(int* val, stdSet) {
+        ASSERT_TRUE(mySet.exists(val));
+        auto it = mySet.find(val);
+        ASSERT_EQ(val, it.key());
+    }
+
+    auto it = mySet.begin();
+    while (! it.isEnd()) {
+        auto stdIt = stdSet.find(it.key());
+        ASSERT_EQ(*stdIt, it.key());
+        it.moveNext();
+    }
+
+    // Delete all the elements (this also prevents a leak in memcheck mode)
+    while (mySet.size() > 0) {
+        auto it = mySet.begin();
+        int *v = it.key();
+
+        ASSERT_EQ(1, stdSet.erase(v));
+        ASSERT_TRUE(mySet.erase(v));
+
+        delete v;
+    }
+
+    ASSERT_TRUE(mySet.empty());
+    ASSERT_EQ(0, mySet.size());
+}
+
+
+int main() {
+    ::srand(777);
+    return TestSuite::globalInstance()->runAll();
+}

--- a/tests/ee/structures/CompactingSetTest.cpp
+++ b/tests/ee/structures/CompactingSetTest.cpp
@@ -26,6 +26,7 @@
 
 #include "boost/foreach.hpp"
 #include "harness.h"
+#include "structures/CompactingPool.h"
 #include "structures/CompactingSet.h"
 #include "common/ThreadLocalPool.h"
 

--- a/tests/ee/test_utils/SimpleTimer.hpp
+++ b/tests/ee/test_utils/SimpleTimer.hpp
@@ -34,7 +34,6 @@
 struct SimpleTimer {
 
     typedef std::chrono::microseconds microseconds;
-    typedef std::chrono::high_resolution_clock::time_point time_point;
 
     /**
      * Construct a SimpleTimer with a start time of right now.
@@ -74,8 +73,7 @@ struct SimpleTimer {
     }
 
 private:
-    time_point m_start;
-
+    std::chrono::high_resolution_clock::time_point m_start;
 };
 
 #endif // TESTS_EE_TEST_UTILS_SIMPLETIMER_HPP

--- a/tests/ee/test_utils/SimpleTimer.hpp
+++ b/tests/ee/test_utils/SimpleTimer.hpp
@@ -1,0 +1,81 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+
+#ifndef TESTS_EE_TEST_UTILS_SIMPLETIMER_HPP
+#define TESTS_EE_TEST_UTILS_SIMPLETIMER_HPP
+
+#include <chrono>
+
+/**
+ * A simple class for timing various operations in EE unit tests.
+ */
+struct SimpleTimer {
+
+    typedef std::chrono::microseconds microseconds;
+    typedef std::chrono::high_resolution_clock::time_point time_point;
+
+    /**
+     * Construct a SimpleTimer with a start time of right now.
+     */
+    SimpleTimer()
+        : m_start(std::chrono::high_resolution_clock::now())
+    {
+    }
+
+    /**
+     * Return the elapsed time (since construction or since last call to reset())
+     * as a string.
+     */
+    std::string elapsedAsString() {
+        std::ostringstream oss;
+        auto end = std::chrono::high_resolution_clock::now();
+        auto elapsed = std::chrono::duration_cast<microseconds>(end - m_start);
+        auto micros = elapsed.count();
+        if (micros > 1000000) {
+            oss <<  (micros / 1000000.0) << " s";
+        }
+        else if (micros > 1000) {
+            oss <<  (micros / 1000.0) << " ms";
+        }
+        else {
+            oss <<  micros << " us";
+        }
+
+        return oss.str();
+    }
+
+    /**
+     * Reset the start time of this timer to the current time.
+     */
+    void reset() {
+        m_start = std::chrono::high_resolution_clock::now();
+    }
+
+private:
+    time_point m_start;
+
+};
+
+#endif // TESTS_EE_TEST_UTILS_SIMPLETIMER_HPP


### PR DESCRIPTION
A user noticed that TRUNCATE TABLE could take a long time to commit if the table contained a lot of string data.  I found that this lag was due to releasing memory for string data managed by ContiguousAllocator.  It's normally a hole-filling-allocator, but when many objects are released at the same time, we might be doing a lot of memcpys for things that may be deleted anyway.

These changes make it so we defer actual deallocation at transaction end until we know all the items that will be deallocated, and then we can avoid doing any needless copying.

This does not eliminate the problem, but is a significant improvement.