### PR TITLE
Added new stored procedures: TRURSwapTables.java, TRUPSwapTablesSP.java,

### DIFF
--- a/tests/test_apps/txnid-selfcheck2/README
+++ b/tests/test_apps/txnid-selfcheck2/README
@@ -26,18 +26,18 @@ The following is a list of features this app has:
 - An export table in the DDL with inserts that shadow inserts to persistent tables
 - The app also starts 2 Threads (MP & SP) to do Load*Table transactions. Load*Table
   transaction threads launch CopyAndDelete tasks which periodically copies data
-  from Load*Table assigned table to diff tables to sprinkle in other tranasactions.
+  from Load*Table assigned table to diff tables to sprinkle in other transactions.
 
 If a transaction is run out of order, missing or run twice, these mechanisms
 should fail. This failure should be detected by:
   - Validating data in the transaction.
   - Validating data at the client logic.
-  - The determisim checks built into VoltDB.
+  - The determinism checks built into VoltDB.
 Procedures returning GRACEFUL FAILURE or USER_ABORT are treated as terminal failures.
 Other exceptions/errors may be logged and then the client will continue if possible.
 Some threads like the adhoc, read, or loader threads may just stop on failure,
 leaving the primary write transactions still running.
 
-Valid total simulaneous thread counts for clients is 127. To run two clients at once,
+Valid total simultaneous thread counts for clients is 127. To run two clients at once,
 set an offset using the command line arguments so two clients don't claim the same
 range of [0,127].

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/Benchmark.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/Benchmark.java
@@ -166,6 +166,9 @@ public class Benchmark {
         @Option(desc = "Allow set ratio of mp to sp workload.")
         float mpratio = (float)0.20;
 
+        @Option(desc = "Allow set ratio of swap to truncate table workload.")
+        float swapratio = (float)0.50;
+
         @Option(desc = "Allow set ratio of upsert to insert workload.")
         float upsertratio = (float)0.50;
 
@@ -668,13 +671,13 @@ public class Benchmark {
 
         if (!config.disabledThreads.contains("partTrunclt")) {
             partTrunclt = new TruncateTableLoader(client, "trup",
-                (config.partfillerrowmb * 1024 * 1024) / config.fillerrowsize, config.fillerrowsize, 50, permits, config.mpratio);
+                    (config.partfillerrowmb * 1024 * 1024) / config.fillerrowsize, config.fillerrowsize, 50, permits, config.mpratio, config.swapratio);
             partTrunclt.start();
         }
         replTrunclt = null;
         if (config.mpratio > 0.0 && !config.disabledThreads.contains("replTrunclt")) {
             replTrunclt = new TruncateTableLoader(client, "trur",
-                    (config.replfillerrowmb * 1024 * 1024) / config.fillerrowsize, config.fillerrowsize, 3, permits, config.mpratio);
+                    (config.replfillerrowmb * 1024 * 1024) / config.fillerrowsize, config.fillerrowsize, 3, permits, config.mpratio, config.swapratio);
             replTrunclt.start();
         }
 

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl-nocat.sql
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl-nocat.sql
@@ -245,6 +245,40 @@ CREATE TABLE trup
 );
 PARTITION TABLE trup ON COLUMN p;
 
+CREATE TABLE swapr
+(
+  p          bigint             NOT NULL
+, id         bigint             NOT NULL
+, value      varbinary(1048576) NOT NULL
+, CONSTRAINT PK_id_sr PRIMARY KEY (p,id)
+);
+
+CREATE TABLE swapp
+(
+  p          bigint             NOT NULL
+, id         bigint             NOT NULL
+, value      varbinary(1048576) NOT NULL
+, CONSTRAINT PK_id_sp PRIMARY KEY (p,id)
+);
+PARTITION TABLE swapp ON COLUMN p;
+
+-- TODO: remove these, after SWAP TABLES actually works
+CREATE TABLE tempr
+(
+  p          bigint             NOT NULL
+, id         bigint             NOT NULL
+, value      varbinary(1048576) NOT NULL
+, CONSTRAINT PK_id_tempr PRIMARY KEY (p,id)
+);
+CREATE TABLE tempp
+(
+  p          bigint             NOT NULL
+, id         bigint             NOT NULL
+, value      varbinary(1048576) NOT NULL
+, CONSTRAINT PK_id_tempp PRIMARY KEY (p,id)
+);
+PARTITION TABLE tempp ON COLUMN p;
+
 CREATE TABLE capr
 (
   p          bigint             NOT NULL
@@ -308,12 +342,16 @@ CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.DeleteOnlyLoadTableSP;
 PARTITION PROCEDURE DeleteOnlyLoadTableSP ON TABLE loadp COLUMN cid;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.DeleteOnlyLoadTableMP;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRUPTableInsert;
-PARTITION PROCEDURE TRUPTableInsert ON TABLE bigp COLUMN p;
+PARTITION PROCEDURE TRUPTableInsert ON TABLE trup COLUMN p;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRURTableInsert;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRUPTruncateTableSP;
 PARTITION PROCEDURE TRUPTruncateTableSP ON TABLE trup COLUMN p;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRUPTruncateTableMP;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRURTruncateTable;
+CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRUPSwapTablesSP;
+PARTITION PROCEDURE TRUPSwapTablesSP ON TABLE trup COLUMN p;
+CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRUPSwapTablesMP;
+CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRURSwapTables;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRUPScanAggTableSP;
 PARTITION PROCEDURE TRUPScanAggTableSP ON TABLE trup COLUMN p;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRUPScanAggTableMP;

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl-nocat.sql
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl-nocat.sql
@@ -262,23 +262,6 @@ CREATE TABLE swapp
 );
 PARTITION TABLE swapp ON COLUMN p;
 
--- TODO: remove these, after SWAP TABLES actually works
-CREATE TABLE tempr
-(
-  p          bigint             NOT NULL
-, id         bigint             NOT NULL
-, value      varbinary(1048576) NOT NULL
-, CONSTRAINT PK_id_tempr PRIMARY KEY (p,id)
-);
-CREATE TABLE tempp
-(
-  p          bigint             NOT NULL
-, id         bigint             NOT NULL
-, value      varbinary(1048576) NOT NULL
-, CONSTRAINT PK_id_tempp PRIMARY KEY (p,id)
-);
-PARTITION TABLE tempp ON COLUMN p;
-
 CREATE TABLE capr
 (
   p          bigint             NOT NULL

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl.sql
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl.sql
@@ -303,7 +303,7 @@ CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.DeleteOnlyLoadTableSP;
 PARTITION PROCEDURE DeleteOnlyLoadTableSP ON TABLE loadp COLUMN cid;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.DeleteOnlyLoadTableMP;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRUPTableInsert;
-PARTITION PROCEDURE TRUPTableInsert ON TABLE bigp COLUMN p;
+PARTITION PROCEDURE TRUPTableInsert ON TABLE trup COLUMN p;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRURTableInsert;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.TRUPTruncateTableSP;
 PARTITION PROCEDURE TRUPTruncateTableSP ON TABLE trup COLUMN p;

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPSwapTablesMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPSwapTablesMP.java
@@ -34,17 +34,7 @@ public class TRUPSwapTablesMP extends VoltProcedure {
     final SQLStmt count_swap = new SQLStmt("select count(*) from swapp;");
     final SQLStmt scancount_tru = new SQLStmt("select count(*) from trup where p >= 0;");
     final SQLStmt scancount_swap = new SQLStmt("select count(*) from swapp where p >= 0;");
-    // TODO: uncomment this, after SWAP TABLES actually works
-    //final SQLStmt swap = new SQLStmt("swap tables trup swapp;");
-
-    // TODO: remove these, after SWAP TABLES actually works
-    final SQLStmt swap0 = new SQLStmt("truncate table tempp;");
-    final SQLStmt swap1 = new SQLStmt("insert into tempp select * from trup;");
-    final SQLStmt swap2 = new SQLStmt("truncate table trup;");
-    final SQLStmt swap3 = new SQLStmt("insert into trup select * from swapp;");
-    final SQLStmt swap4 = new SQLStmt("truncate table swapp;");
-    final SQLStmt swap5 = new SQLStmt("insert into swapp select * from tempp;");
-    final SQLStmt swap6 = new SQLStmt("select count(*) from tempp;");
+    final SQLStmt swap = new SQLStmt("swap tables trup swapp;");
 
     public VoltTable[] run(long p, byte shouldRollback) {
 
@@ -53,22 +43,7 @@ public class TRUPSwapTablesMP extends VoltProcedure {
         voltQueueSQL(count_swap);
         voltQueueSQL(scancount_tru);
         voltQueueSQL(scancount_swap);
-        // TODO: uncomment this, after SWAP TABLES actually works
-        //voltQueueSQL(swap);
-
-        // TODO: remove these, after SWAP TABLES actually works
-        voltQueueSQL(swap6);
-        voltQueueSQL(swap0);
-        voltQueueSQL(swap6);
-        voltQueueSQL(swap1);
-        voltQueueSQL(swap2);
-        voltQueueSQL(swap3);
-        voltQueueSQL(swap4);
-        voltQueueSQL(swap5);
-        voltQueueSQL(swap6);
-        voltQueueSQL(swap0);
-        voltQueueSQL(swap6);
-
+        voltQueueSQL(swap);
         voltQueueSQL(count_tru);
         voltQueueSQL(count_swap);
         voltQueueSQL(scancount_tru);
@@ -82,15 +57,15 @@ public class TRUPSwapTablesMP extends VoltProcedure {
         data = results[1];
         row = data.fetchRow(0);
         long swapCountBefore = row.getLong(0);
-        data = results[15];  // TODO: [5], not [11], after SWAP TABLES actually works
+        data = results[5];
         row = data.fetchRow(0);
         long truCountAfter = row.getLong(0);
-        data = results[16];  // TODO: [6], not [12], after SWAP TABLES actually works
+        data = results[6];
         row = data.fetchRow(0);
         long swapCountAfter = row.getLong(0);
         if (truCountBefore != swapCountAfter || swapCountBefore != truCountAfter) {
             throw new VoltAbortException("after swap (opt) counts (" + truCountAfter + "," + swapCountAfter
-                    + ") do not match those before (" + truCountBefore + "," + swapCountBefore + ")");
+                    + ") do not match reverse of those before (" + truCountBefore + "," + swapCountBefore + ")");
         }
 
         // Check that the partial (scan) counts of the two tables have been swapped
@@ -100,37 +75,16 @@ public class TRUPSwapTablesMP extends VoltProcedure {
         data = results[3];
         row = data.fetchRow(0);
         long swapScanCountBefore = row.getLong(0);
-        data = results[17];  // TODO: [7], not [13], after SWAP TABLES actually works
+        data = results[7];
         row = data.fetchRow(0);
         long truScanCountAfter = row.getLong(0);
-        data = results[18];  // TODO: [8], not [14], after SWAP TABLES actually works
+        data = results[8];
         row = data.fetchRow(0);
         long swapScanCountAfter = row.getLong(0);
         if (truScanCountBefore != swapScanCountAfter || swapScanCountBefore != truScanCountAfter) {
             throw new VoltAbortException("after swap (scan) counts (" + truScanCountAfter + "," + swapScanCountAfter
-                    + ") do not match those before (" + truScanCountBefore + "," + swapScanCountBefore + ")");
+                    + ") do not match reverse of those before (" + truScanCountBefore + "," + swapScanCountBefore + ")");
         }
-
-        // TODO: temp debug print:
-        data = results[4];
-        row = data.fetchRow(0);
-        long countTemp0 = row.getLong(0);
-        data = results[6];
-        row = data.fetchRow(0);
-        long countTemp1 = row.getLong(0);
-        data = results[12];
-        row = data.fetchRow(0);
-        long countTemp2 = row.getLong(0);
-        data = results[14];
-        row = data.fetchRow(0);
-        long countTemp3 = row.getLong(0);
-        System.out.println("In TRUPSwapTablesMP: shouldRollback: " + shouldRollback
-                + "\n  truCountBefore: " + truCountBefore + " swapCountBefore: " + swapCountBefore
-                + "; truCountAfter: " + truCountAfter + " swapCountAfter: " + swapCountAfter
-                + "\n  truScanCountBefore: " + truScanCountBefore + " swapScanCountBefore: " + swapScanCountBefore
-                + "; truScanCountAfter: " + truScanCountAfter + " swapScanCountAfter: " + swapScanCountAfter
-                + "\n  countTemp0: " + countTemp0 + " countTemp1: " + countTemp1
-                + "; countTemp2: " + countTemp2 + " countTemp3: " + countTemp3);
 
         if (shouldRollback != 0) {
             throw new VoltAbortException("EXPECTED ROLLBACK");

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPSwapTablesMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPSwapTablesMP.java
@@ -1,0 +1,140 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package txnIdSelfCheck.procedures;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+import org.voltdb.VoltTableRow;
+import org.voltdb.VoltProcedure.VoltAbortException;
+
+public class TRUPSwapTablesMP extends VoltProcedure {
+    final SQLStmt count_tru = new SQLStmt("select count(*) from trup;");
+    final SQLStmt count_swap = new SQLStmt("select count(*) from swapp;");
+    final SQLStmt scancount_tru = new SQLStmt("select count(*) from trup where p >= 0;");
+    final SQLStmt scancount_swap = new SQLStmt("select count(*) from swapp where p >= 0;");
+    // TODO: uncomment this, after SWAP TABLES actually works
+    //final SQLStmt swap = new SQLStmt("swap tables trup swapp;");
+
+    // TODO: remove these, after SWAP TABLES actually works
+    final SQLStmt swap0 = new SQLStmt("truncate table tempp;");
+    final SQLStmt swap1 = new SQLStmt("insert into tempp select * from trup;");
+    final SQLStmt swap2 = new SQLStmt("truncate table trup;");
+    final SQLStmt swap3 = new SQLStmt("insert into trup select * from swapp;");
+    final SQLStmt swap4 = new SQLStmt("truncate table swapp;");
+    final SQLStmt swap5 = new SQLStmt("insert into swapp select * from tempp;");
+    final SQLStmt swap6 = new SQLStmt("select count(*) from tempp;");
+
+    public VoltTable[] run(long p, byte shouldRollback) {
+
+        // Execute the SWAP TABLES query, with SELECT COUNT(*) queries before and after
+        voltQueueSQL(count_tru);
+        voltQueueSQL(count_swap);
+        voltQueueSQL(scancount_tru);
+        voltQueueSQL(scancount_swap);
+        // TODO: uncomment this, after SWAP TABLES actually works
+        //voltQueueSQL(swap);
+
+        // TODO: remove these, after SWAP TABLES actually works
+        voltQueueSQL(swap6);
+        voltQueueSQL(swap0);
+        voltQueueSQL(swap6);
+        voltQueueSQL(swap1);
+        voltQueueSQL(swap2);
+        voltQueueSQL(swap3);
+        voltQueueSQL(swap4);
+        voltQueueSQL(swap5);
+        voltQueueSQL(swap6);
+        voltQueueSQL(swap0);
+        voltQueueSQL(swap6);
+
+        voltQueueSQL(count_tru);
+        voltQueueSQL(count_swap);
+        voltQueueSQL(scancount_tru);
+        voltQueueSQL(scancount_swap);
+        VoltTable[] results = voltExecuteSQL(true);
+
+        // Check that the total (opt) counts of the two tables have been swapped
+        VoltTable data = results[0];
+        VoltTableRow row = data.fetchRow(0);
+        long truCountBefore = row.getLong(0);
+        data = results[1];
+        row = data.fetchRow(0);
+        long swapCountBefore = row.getLong(0);
+        data = results[15];  // TODO: [5], not [11], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long truCountAfter = row.getLong(0);
+        data = results[16];  // TODO: [6], not [12], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long swapCountAfter = row.getLong(0);
+        if (truCountBefore != swapCountAfter || swapCountBefore != truCountAfter) {
+            throw new VoltAbortException("after swap (opt) counts (" + truCountAfter + "," + swapCountAfter
+                    + ") do not match those before (" + truCountBefore + "," + swapCountBefore + ")");
+        }
+
+        // Check that the partial (scan) counts of the two tables have been swapped
+        data = results[2];
+        row = data.fetchRow(0);
+        long truScanCountBefore = row.getLong(0);
+        data = results[3];
+        row = data.fetchRow(0);
+        long swapScanCountBefore = row.getLong(0);
+        data = results[17];  // TODO: [7], not [13], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long truScanCountAfter = row.getLong(0);
+        data = results[18];  // TODO: [8], not [14], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long swapScanCountAfter = row.getLong(0);
+        if (truScanCountBefore != swapScanCountAfter || swapScanCountBefore != truScanCountAfter) {
+            throw new VoltAbortException("after swap (scan) counts (" + truScanCountAfter + "," + swapScanCountAfter
+                    + ") do not match those before (" + truScanCountBefore + "," + swapScanCountBefore + ")");
+        }
+
+        // TODO: temp debug print:
+        data = results[4];
+        row = data.fetchRow(0);
+        long countTemp0 = row.getLong(0);
+        data = results[6];
+        row = data.fetchRow(0);
+        long countTemp1 = row.getLong(0);
+        data = results[12];
+        row = data.fetchRow(0);
+        long countTemp2 = row.getLong(0);
+        data = results[14];
+        row = data.fetchRow(0);
+        long countTemp3 = row.getLong(0);
+        System.out.println("In TRUPSwapTablesMP: shouldRollback: " + shouldRollback
+                + "\n  truCountBefore: " + truCountBefore + " swapCountBefore: " + swapCountBefore
+                + "; truCountAfter: " + truCountAfter + " swapCountAfter: " + swapCountAfter
+                + "\n  truScanCountBefore: " + truScanCountBefore + " swapScanCountBefore: " + swapScanCountBefore
+                + "; truScanCountAfter: " + truScanCountAfter + " swapScanCountAfter: " + swapScanCountAfter
+                + "\n  countTemp0: " + countTemp0 + " countTemp1: " + countTemp1
+                + "; countTemp2: " + countTemp2 + " countTemp3: " + countTemp3);
+
+        if (shouldRollback != 0) {
+            throw new VoltAbortException("EXPECTED ROLLBACK");
+        }
+        return results;
+    }
+}

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPSwapTablesSP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPSwapTablesSP.java
@@ -1,0 +1,140 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package txnIdSelfCheck.procedures;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+import org.voltdb.VoltTableRow;
+import org.voltdb.VoltProcedure.VoltAbortException;
+
+public class TRUPSwapTablesSP extends VoltProcedure {
+    final SQLStmt count_tru = new SQLStmt("select count(*) from trup;");
+    final SQLStmt count_swap = new SQLStmt("select count(*) from swapp;");
+    final SQLStmt scancount_tru = new SQLStmt("select count(*) from trup where p >= 0;");
+    final SQLStmt scancount_swap = new SQLStmt("select count(*) from swapp where p >= 0;");
+    // TODO: uncomment this, after SWAP TABLES actually works
+    //final SQLStmt swap = new SQLStmt("swap tables trup swapp;");
+
+    // TODO: remove these, after SWAP TABLES actually works
+    final SQLStmt swap0 = new SQLStmt("truncate table tempp;");
+    final SQLStmt swap1 = new SQLStmt("insert into tempp select * from trup;");
+    final SQLStmt swap2 = new SQLStmt("truncate table trup;");
+    final SQLStmt swap3 = new SQLStmt("insert into trup select * from swapp;");
+    final SQLStmt swap4 = new SQLStmt("truncate table swapp;");
+    final SQLStmt swap5 = new SQLStmt("insert into swapp select * from tempp;");
+    final SQLStmt swap6 = new SQLStmt("select count(*) from tempp;");
+
+    public VoltTable[] run(long p, byte shouldRollback) {
+
+        // Execute the SWAP TABLES query, with SELECT COUNT(*) queries before and after
+        voltQueueSQL(count_tru);
+        voltQueueSQL(count_swap);
+        voltQueueSQL(scancount_tru);
+        voltQueueSQL(scancount_swap);
+        // TODO: uncomment this, after SWAP TABLES actually works
+        //voltQueueSQL(swap);
+
+        // TODO: remove these, after SWAP TABLES actually works
+        voltQueueSQL(swap6);
+        voltQueueSQL(swap0);
+        voltQueueSQL(swap6);
+        voltQueueSQL(swap1);
+        voltQueueSQL(swap2);
+        voltQueueSQL(swap3);
+        voltQueueSQL(swap4);
+        voltQueueSQL(swap5);
+        voltQueueSQL(swap6);
+        voltQueueSQL(swap0);
+        voltQueueSQL(swap6);
+
+        voltQueueSQL(count_tru);
+        voltQueueSQL(count_swap);
+        voltQueueSQL(scancount_tru);
+        voltQueueSQL(scancount_swap);
+        VoltTable[] results = voltExecuteSQL(true);
+
+        // Check that the total (opt) counts of the two tables have been swapped
+        VoltTable data = results[0];
+        VoltTableRow row = data.fetchRow(0);
+        long truCountBefore = row.getLong(0);
+        data = results[1];
+        row = data.fetchRow(0);
+        long swapCountBefore = row.getLong(0);
+        data = results[15];  // TODO: [5], not [11], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long truCountAfter = row.getLong(0);
+        data = results[16];  // TODO: [6], not [12], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long swapCountAfter = row.getLong(0);
+        if (truCountBefore != swapCountAfter || swapCountBefore != truCountAfter) {
+            throw new VoltAbortException("after swap (opt) counts (" + truCountAfter + "," + swapCountAfter
+                    + ") do not match those before (" + truCountBefore + "," + swapCountBefore + ")");
+        }
+
+        // Check that the partial (scan) counts of the two tables have been swapped
+        data = results[2];
+        row = data.fetchRow(0);
+        long truScanCountBefore = row.getLong(0);
+        data = results[3];
+        row = data.fetchRow(0);
+        long swapScanCountBefore = row.getLong(0);
+        data = results[17];  // TODO: [7], not [13], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long truScanCountAfter = row.getLong(0);
+        data = results[18];  // TODO: [8], not [14], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long swapScanCountAfter = row.getLong(0);
+        if (truScanCountBefore != swapScanCountAfter || swapScanCountBefore != truScanCountAfter) {
+            throw new VoltAbortException("after swap (scan) counts (" + truScanCountAfter + "," + swapScanCountAfter
+                    + ") do not match those before (" + truScanCountBefore + "," + swapScanCountBefore + ")");
+        }
+
+        // TODO: temp debug print:
+        data = results[4];
+        row = data.fetchRow(0);
+        long countTemp0 = row.getLong(0);
+        data = results[6];
+        row = data.fetchRow(0);
+        long countTemp1 = row.getLong(0);
+        data = results[12];
+        row = data.fetchRow(0);
+        long countTemp2 = row.getLong(0);
+        data = results[14];
+        row = data.fetchRow(0);
+        long countTemp3 = row.getLong(0);
+        System.out.println("In TRUPSwapTablesSP: shouldRollback: " + shouldRollback
+                + "\n  truCountBefore: " + truCountBefore + " swapCountBefore: " + swapCountBefore
+                + "; truCountAfter: " + truCountAfter + " swapCountAfter: " + swapCountAfter
+                + "\n  truScanCountBefore: " + truScanCountBefore + " swapScanCountBefore: " + swapScanCountBefore
+                + "; truScanCountAfter: " + truScanCountAfter + " swapScanCountAfter: " + swapScanCountAfter
+                + "\n  countTemp0: " + countTemp0 + " countTemp1: " + countTemp1
+                + "; countTemp2: " + countTemp2 + " countTemp3: " + countTemp3);
+
+        if (shouldRollback != 0) {
+            throw new VoltAbortException("EXPECTED ROLLBACK");
+        }
+        return results;
+    }
+}

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPSwapTablesSP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPSwapTablesSP.java
@@ -34,17 +34,7 @@ public class TRUPSwapTablesSP extends VoltProcedure {
     final SQLStmt count_swap = new SQLStmt("select count(*) from swapp;");
     final SQLStmt scancount_tru = new SQLStmt("select count(*) from trup where p >= 0;");
     final SQLStmt scancount_swap = new SQLStmt("select count(*) from swapp where p >= 0;");
-    // TODO: uncomment this, after SWAP TABLES actually works
-    //final SQLStmt swap = new SQLStmt("swap tables trup swapp;");
-
-    // TODO: remove these, after SWAP TABLES actually works
-    final SQLStmt swap0 = new SQLStmt("truncate table tempp;");
-    final SQLStmt swap1 = new SQLStmt("insert into tempp select * from trup;");
-    final SQLStmt swap2 = new SQLStmt("truncate table trup;");
-    final SQLStmt swap3 = new SQLStmt("insert into trup select * from swapp;");
-    final SQLStmt swap4 = new SQLStmt("truncate table swapp;");
-    final SQLStmt swap5 = new SQLStmt("insert into swapp select * from tempp;");
-    final SQLStmt swap6 = new SQLStmt("select count(*) from tempp;");
+    final SQLStmt swap = new SQLStmt("swap tables trup swapp;");
 
     public VoltTable[] run(long p, byte shouldRollback) {
 
@@ -53,22 +43,7 @@ public class TRUPSwapTablesSP extends VoltProcedure {
         voltQueueSQL(count_swap);
         voltQueueSQL(scancount_tru);
         voltQueueSQL(scancount_swap);
-        // TODO: uncomment this, after SWAP TABLES actually works
-        //voltQueueSQL(swap);
-
-        // TODO: remove these, after SWAP TABLES actually works
-        voltQueueSQL(swap6);
-        voltQueueSQL(swap0);
-        voltQueueSQL(swap6);
-        voltQueueSQL(swap1);
-        voltQueueSQL(swap2);
-        voltQueueSQL(swap3);
-        voltQueueSQL(swap4);
-        voltQueueSQL(swap5);
-        voltQueueSQL(swap6);
-        voltQueueSQL(swap0);
-        voltQueueSQL(swap6);
-
+        voltQueueSQL(swap);
         voltQueueSQL(count_tru);
         voltQueueSQL(count_swap);
         voltQueueSQL(scancount_tru);
@@ -82,15 +57,15 @@ public class TRUPSwapTablesSP extends VoltProcedure {
         data = results[1];
         row = data.fetchRow(0);
         long swapCountBefore = row.getLong(0);
-        data = results[15];  // TODO: [5], not [11], after SWAP TABLES actually works
+        data = results[5];
         row = data.fetchRow(0);
         long truCountAfter = row.getLong(0);
-        data = results[16];  // TODO: [6], not [12], after SWAP TABLES actually works
+        data = results[6];
         row = data.fetchRow(0);
         long swapCountAfter = row.getLong(0);
         if (truCountBefore != swapCountAfter || swapCountBefore != truCountAfter) {
             throw new VoltAbortException("after swap (opt) counts (" + truCountAfter + "," + swapCountAfter
-                    + ") do not match those before (" + truCountBefore + "," + swapCountBefore + ")");
+                    + ") do not match reverse of those before (" + truCountBefore + "," + swapCountBefore + ")");
         }
 
         // Check that the partial (scan) counts of the two tables have been swapped
@@ -100,37 +75,16 @@ public class TRUPSwapTablesSP extends VoltProcedure {
         data = results[3];
         row = data.fetchRow(0);
         long swapScanCountBefore = row.getLong(0);
-        data = results[17];  // TODO: [7], not [13], after SWAP TABLES actually works
+        data = results[7];
         row = data.fetchRow(0);
         long truScanCountAfter = row.getLong(0);
-        data = results[18];  // TODO: [8], not [14], after SWAP TABLES actually works
+        data = results[8];
         row = data.fetchRow(0);
         long swapScanCountAfter = row.getLong(0);
         if (truScanCountBefore != swapScanCountAfter || swapScanCountBefore != truScanCountAfter) {
             throw new VoltAbortException("after swap (scan) counts (" + truScanCountAfter + "," + swapScanCountAfter
-                    + ") do not match those before (" + truScanCountBefore + "," + swapScanCountBefore + ")");
+                    + ") do not match reverse of those before (" + truScanCountBefore + "," + swapScanCountBefore + ")");
         }
-
-        // TODO: temp debug print:
-        data = results[4];
-        row = data.fetchRow(0);
-        long countTemp0 = row.getLong(0);
-        data = results[6];
-        row = data.fetchRow(0);
-        long countTemp1 = row.getLong(0);
-        data = results[12];
-        row = data.fetchRow(0);
-        long countTemp2 = row.getLong(0);
-        data = results[14];
-        row = data.fetchRow(0);
-        long countTemp3 = row.getLong(0);
-        System.out.println("In TRUPSwapTablesSP: shouldRollback: " + shouldRollback
-                + "\n  truCountBefore: " + truCountBefore + " swapCountBefore: " + swapCountBefore
-                + "; truCountAfter: " + truCountAfter + " swapCountAfter: " + swapCountAfter
-                + "\n  truScanCountBefore: " + truScanCountBefore + " swapScanCountBefore: " + swapScanCountBefore
-                + "; truScanCountAfter: " + truScanCountAfter + " swapScanCountAfter: " + swapScanCountAfter
-                + "\n  countTemp0: " + countTemp0 + " countTemp1: " + countTemp1
-                + "; countTemp2: " + countTemp2 + " countTemp3: " + countTemp3);
 
         if (shouldRollback != 0) {
             throw new VoltAbortException("EXPECTED ROLLBACK");

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURSwapTables.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURSwapTables.java
@@ -34,17 +34,7 @@ public class TRURSwapTables extends VoltProcedure {
     final SQLStmt count_swap = new SQLStmt("select count(*) from swapr;");
     final SQLStmt scancount_tru = new SQLStmt("select count(*) from trur where p >= 0;");
     final SQLStmt scancount_swap = new SQLStmt("select count(*) from swapr where p >= 0;");
-    // TODO: uncomment this, after SWAP TABLES actually works
-    //final SQLStmt swap = new SQLStmt("swap tables trur swapr;");
-
-    // TODO: remove these, after SWAP TABLES actually works
-    final SQLStmt swap0 = new SQLStmt("truncate table tempr;");
-    final SQLStmt swap1 = new SQLStmt("insert into tempr select * from trur;");
-    final SQLStmt swap2 = new SQLStmt("truncate table trur;");
-    final SQLStmt swap3 = new SQLStmt("insert into trur select * from swapr;");
-    final SQLStmt swap4 = new SQLStmt("truncate table swapr;");
-    final SQLStmt swap5 = new SQLStmt("insert into swapr select * from tempr;");
-    final SQLStmt swap6 = new SQLStmt("select count(*) from tempr;");
+    final SQLStmt swap = new SQLStmt("swap tables trur swapr;");
 
     public VoltTable[] run(long p, byte shouldRollback) {
 
@@ -53,22 +43,7 @@ public class TRURSwapTables extends VoltProcedure {
         voltQueueSQL(count_swap);
         voltQueueSQL(scancount_tru);
         voltQueueSQL(scancount_swap);
-        // TODO: uncomment this, after SWAP TABLES actually works
-        //voltQueueSQL(swap);
-
-        // TODO: remove these, after SWAP TABLES actually works
-        voltQueueSQL(swap6);
-        voltQueueSQL(swap0);
-        voltQueueSQL(swap6);
-        voltQueueSQL(swap1);
-        voltQueueSQL(swap2);
-        voltQueueSQL(swap3);
-        voltQueueSQL(swap4);
-        voltQueueSQL(swap5);
-        voltQueueSQL(swap6);
-        voltQueueSQL(swap0);
-        voltQueueSQL(swap6);
-
+        voltQueueSQL(swap);
         voltQueueSQL(count_tru);
         voltQueueSQL(count_swap);
         voltQueueSQL(scancount_tru);
@@ -82,15 +57,15 @@ public class TRURSwapTables extends VoltProcedure {
         data = results[1];
         row = data.fetchRow(0);
         long swapCountBefore = row.getLong(0);
-        data = results[15];  // TODO: [5], not [11], after SWAP TABLES actually works
+        data = results[5];
         row = data.fetchRow(0);
         long truCountAfter = row.getLong(0);
-        data = results[16];  // TODO: [6], not [12], after SWAP TABLES actually works
+        data = results[6];
         row = data.fetchRow(0);
         long swapCountAfter = row.getLong(0);
         if (truCountBefore != swapCountAfter || swapCountBefore != truCountAfter) {
             throw new VoltAbortException("after swap (opt) counts (" + truCountAfter + "," + swapCountAfter
-                    + ") do not match those before (" + truCountBefore + "," + swapCountBefore + ")");
+                    + ") do not match reverse of those before (" + truCountBefore + "," + swapCountBefore + ")");
         }
 
         // Check that the partial (scan) counts of the two tables have been swapped
@@ -100,37 +75,16 @@ public class TRURSwapTables extends VoltProcedure {
         data = results[3];
         row = data.fetchRow(0);
         long swapScanCountBefore = row.getLong(0);
-        data = results[17];  // TODO: [7], not [13], after SWAP TABLES actually works
+        data = results[7];
         row = data.fetchRow(0);
         long truScanCountAfter = row.getLong(0);
-        data = results[18];  // TODO: [8], not [14], after SWAP TABLES actually works
+        data = results[8];
         row = data.fetchRow(0);
         long swapScanCountAfter = row.getLong(0);
         if (truScanCountBefore != swapScanCountAfter || swapScanCountBefore != truScanCountAfter) {
             throw new VoltAbortException("after swap (scan) counts (" + truScanCountAfter + "," + swapScanCountAfter
-                    + ") do not match those before (" + truScanCountBefore + "," + swapScanCountBefore + ")");
+                    + ") do not match reverse of those before (" + truScanCountBefore + "," + swapScanCountBefore + ")");
         }
-
-        // TODO: temp debug print:
-        data = results[4];
-        row = data.fetchRow(0);
-        long countTemp0 = row.getLong(0);
-        data = results[6];
-        row = data.fetchRow(0);
-        long countTemp1 = row.getLong(0);
-        data = results[12];
-        row = data.fetchRow(0);
-        long countTemp2 = row.getLong(0);
-        data = results[14];
-        row = data.fetchRow(0);
-        long countTemp3 = row.getLong(0);
-        System.out.println("In TRURSwapTables: shouldRollback: " + shouldRollback
-                + "\n  truCountBefore: " + truCountBefore + " swapCountBefore: " + swapCountBefore
-                + "; truCountAfter: " + truCountAfter + " swapCountAfter: " + swapCountAfter
-                + "\n  truScanCountBefore: " + truScanCountBefore + " swapScanCountBefore: " + swapScanCountBefore
-                + "; truScanCountAfter: " + truScanCountAfter + " swapScanCountAfter: " + swapScanCountAfter
-                + "\n  countTemp0: " + countTemp0 + " countTemp1: " + countTemp1
-                + "; countTemp2: " + countTemp2 + " countTemp3: " + countTemp3);
 
         if (shouldRollback != 0) {
             throw new VoltAbortException("EXPECTED ROLLBACK");

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURSwapTables.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURSwapTables.java
@@ -1,0 +1,140 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package txnIdSelfCheck.procedures;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+import org.voltdb.VoltTableRow;
+import org.voltdb.VoltProcedure.VoltAbortException;
+
+public class TRURSwapTables extends VoltProcedure {
+    final SQLStmt count_tru = new SQLStmt("select count(*) from trur;");
+    final SQLStmt count_swap = new SQLStmt("select count(*) from swapr;");
+    final SQLStmt scancount_tru = new SQLStmt("select count(*) from trur where p >= 0;");
+    final SQLStmt scancount_swap = new SQLStmt("select count(*) from swapr where p >= 0;");
+    // TODO: uncomment this, after SWAP TABLES actually works
+    //final SQLStmt swap = new SQLStmt("swap tables trur swapr;");
+
+    // TODO: remove these, after SWAP TABLES actually works
+    final SQLStmt swap0 = new SQLStmt("truncate table tempr;");
+    final SQLStmt swap1 = new SQLStmt("insert into tempr select * from trur;");
+    final SQLStmt swap2 = new SQLStmt("truncate table trur;");
+    final SQLStmt swap3 = new SQLStmt("insert into trur select * from swapr;");
+    final SQLStmt swap4 = new SQLStmt("truncate table swapr;");
+    final SQLStmt swap5 = new SQLStmt("insert into swapr select * from tempr;");
+    final SQLStmt swap6 = new SQLStmt("select count(*) from tempr;");
+
+    public VoltTable[] run(long p, byte shouldRollback) {
+
+        // Execute the SWAP TABLES query, with SELECT COUNT(*) queries before and after
+        voltQueueSQL(count_tru);
+        voltQueueSQL(count_swap);
+        voltQueueSQL(scancount_tru);
+        voltQueueSQL(scancount_swap);
+        // TODO: uncomment this, after SWAP TABLES actually works
+        //voltQueueSQL(swap);
+
+        // TODO: remove these, after SWAP TABLES actually works
+        voltQueueSQL(swap6);
+        voltQueueSQL(swap0);
+        voltQueueSQL(swap6);
+        voltQueueSQL(swap1);
+        voltQueueSQL(swap2);
+        voltQueueSQL(swap3);
+        voltQueueSQL(swap4);
+        voltQueueSQL(swap5);
+        voltQueueSQL(swap6);
+        voltQueueSQL(swap0);
+        voltQueueSQL(swap6);
+
+        voltQueueSQL(count_tru);
+        voltQueueSQL(count_swap);
+        voltQueueSQL(scancount_tru);
+        voltQueueSQL(scancount_swap);
+        VoltTable[] results = voltExecuteSQL(true);
+
+        // Check that the total (opt) counts of the two tables have been swapped
+        VoltTable data = results[0];
+        VoltTableRow row = data.fetchRow(0);
+        long truCountBefore = row.getLong(0);
+        data = results[1];
+        row = data.fetchRow(0);
+        long swapCountBefore = row.getLong(0);
+        data = results[15];  // TODO: [5], not [11], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long truCountAfter = row.getLong(0);
+        data = results[16];  // TODO: [6], not [12], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long swapCountAfter = row.getLong(0);
+        if (truCountBefore != swapCountAfter || swapCountBefore != truCountAfter) {
+            throw new VoltAbortException("after swap (opt) counts (" + truCountAfter + "," + swapCountAfter
+                    + ") do not match those before (" + truCountBefore + "," + swapCountBefore + ")");
+        }
+
+        // Check that the partial (scan) counts of the two tables have been swapped
+        data = results[2];
+        row = data.fetchRow(0);
+        long truScanCountBefore = row.getLong(0);
+        data = results[3];
+        row = data.fetchRow(0);
+        long swapScanCountBefore = row.getLong(0);
+        data = results[17];  // TODO: [7], not [13], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long truScanCountAfter = row.getLong(0);
+        data = results[18];  // TODO: [8], not [14], after SWAP TABLES actually works
+        row = data.fetchRow(0);
+        long swapScanCountAfter = row.getLong(0);
+        if (truScanCountBefore != swapScanCountAfter || swapScanCountBefore != truScanCountAfter) {
+            throw new VoltAbortException("after swap (scan) counts (" + truScanCountAfter + "," + swapScanCountAfter
+                    + ") do not match those before (" + truScanCountBefore + "," + swapScanCountBefore + ")");
+        }
+
+        // TODO: temp debug print:
+        data = results[4];
+        row = data.fetchRow(0);
+        long countTemp0 = row.getLong(0);
+        data = results[6];
+        row = data.fetchRow(0);
+        long countTemp1 = row.getLong(0);
+        data = results[12];
+        row = data.fetchRow(0);
+        long countTemp2 = row.getLong(0);
+        data = results[14];
+        row = data.fetchRow(0);
+        long countTemp3 = row.getLong(0);
+        System.out.println("In TRURSwapTables: shouldRollback: " + shouldRollback
+                + "\n  truCountBefore: " + truCountBefore + " swapCountBefore: " + swapCountBefore
+                + "; truCountAfter: " + truCountAfter + " swapCountAfter: " + swapCountAfter
+                + "\n  truScanCountBefore: " + truScanCountBefore + " swapScanCountBefore: " + swapScanCountBefore
+                + "; truScanCountAfter: " + truScanCountAfter + " swapScanCountAfter: " + swapScanCountAfter
+                + "\n  countTemp0: " + countTemp0 + " countTemp1: " + countTemp1
+                + "; countTemp2: " + countTemp2 + " countTemp3: " + countTemp3);
+
+        if (shouldRollback != 0) {
+            throw new VoltAbortException("EXPECTED ROLLBACK");
+        }
+        return results;
+    }
+}


### PR DESCRIPTION
TRUPSwapTablesMP.java, which perform a SWAP TABLES (in a replicated, partitioned SP, and partitioned MP context, respectively). Also added these to ddl-nocat.sql, along with definitions of related tables SWAPR & SWAPP (& corrected partitioning of TRUPTableInsert, to use the correct table - TRUP, not BIGP).
TruncateTableLoader.java: in the run() method, added 2 Swap Tables calls, which may or may not occur (randomly), before and after the Truncate; added a swapRatio arg to the constructor, which is used to determine how often those Swap Tables calls occur; added an isStatusSuccess method, to simplify old and new repetitive code.
Benchmark.java: added new swapratio option definition, and added it to arg list in call of new TruncateTableLoader(...).
README: just corrected spelling mistakes.