### PR TITLE
ENG-11434 voltadmin shutdown/pause timeout

### DIFF
--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -137,8 +137,7 @@ def dr_producer_stats(runner, partition_min_host, partition_min, partition_max):
         else:
             last_acked = r[9]
 
-        #The partition is in the initial state. no stats updated yet-no transactions are queued and acknowledged 
-        #thus no need to track. 
+        # Initial state, no transactions are queued and acknowledged.
         if last_queued == -1 and last_acked == -1:
             continue
 

--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -83,13 +83,7 @@ def check_dr_producer(runner):
 def monitorDRProducerStatisticsProgress(lastPartitionMin, lastPartitionMax, currentPartitionMin,
                              currentPartitionMax, lastUpdatedTime, runner):
     currentTime = time.time()
-    #no timeout check
-    timeout = -1;
-    if runner.opts.timeout:
-        timeout = (runner.opts.timeout) * 60
-
-    if timeout == -1:
-        return currentTime
+    timeout = (runner.opts.timeout) * 60
     #any stats progress?
     partitionMinProgressed = cmp(lastPartitionMin, currentPartitionMin)
     partitionMaxprogressed = cmp(lastPartitionMax, currentPartitionMax)
@@ -351,15 +345,7 @@ def check_command_log(runner):
 
 def monitorStatisticsProgress(lastUpdatedParams, currentParams, lastUpdatedTime, runner, component):
     currentTime = time.time()
-
-    timeout = -1;
-    if runner.opts.timeout:
-        timeout = (runner.opts.timeout) * 60
-
-    #no timeout check
-    if timeout == -1:
-        return currentTime
-
+    timeout = (runner.opts.timeout) * 60
     statsProgressed = True
     if isinstance(lastUpdatedParams, dict):
         statsProgressed = (cmp(lastUpdatedParams,currentParams) <> 0)

--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -137,10 +137,10 @@ def dr_producer_stats(runner, partition_min_host, partition_min, partition_max):
             last_acked = -1
         else:
             last_acked = r[9]
-        
+
         if last_queued == -1 and last_acked == -1:
             continue
-        
+
         # check TOTALBYTES
         if r[5] > 0:
             # track the highest seen drId for each partition. use last queued to get the upper bound

--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -137,6 +137,8 @@ def dr_producer_stats(runner, partition_min_host, partition_min, partition_max):
         else:
             last_acked = r[9]
 
+        #The partition is in the initial state. no stats updated yet-no transactions are queued and acknowledged 
+        #thus no need to track. 
         if last_queued == -1 and last_acked == -1:
             continue
 

--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -94,8 +94,8 @@ def monitorDRProducerStatisticsProgress(lastPartitionMin, lastPartitionMax, curr
     timeSinceLastUpdate = currentTime - lastUpdatedTime
     #stats timeout
     if timeSinceLastUpdate > timeout:
-         msg = "The cluster has not drained any transactions for DRPRODUCER in last %d minutes. There are outstanding transactions."
-         raise StatisticsProcedureException( msg % (runner.opts.timeout), 1)
+         msg = "The cluster has not drained any transactions for DRPRODUCER in last %d seconds. There are outstanding transactions."
+         raise StatisticsProcedureException( msg % (timeout), 1)
     #stats has not been moved but not timeout yet
     return lastUpdatedTime
 
@@ -362,8 +362,8 @@ def monitorStatisticsProgress(lastUpdatedParams, currentParams, lastUpdatedTime,
 
     #stats timeout
     if timeSinceLastUpdate > timeout:
-         msg = "The cluster has not drained any transactions for %s in last %d minutes. There are outstanding transactions."
-         raise StatisticsProcedureException( msg % (component, runner.opts.timeout), 1)
+         msg = "The cluster has not drained any transactions for %s in last %d seconds. There are outstanding transactions."
+         raise StatisticsProcedureException( msg % (component, timeout), 1)
 
     #not timeout yet
     return lastUpdatedTime

--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -137,6 +137,10 @@ def dr_producer_stats(runner, partition_min_host, partition_min, partition_max):
             last_acked = -1
         else:
             last_acked = r[9]
+        
+        if last_queued == -1 and last_acked == -1:
+            continue
+        
         # check TOTALBYTES
         if r[5] > 0:
             # track the highest seen drId for each partition. use last queued to get the upper bound

--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -83,7 +83,7 @@ def check_dr_producer(runner):
 def monitorDRProducerStatisticsProgress(lastPartitionMin, lastPartitionMax, currentPartitionMin,
                              currentPartitionMax, lastUpdatedTime, runner):
     currentTime = time.time()
-    timeout = (runner.opts.timeout) * 60
+    timeout = runner.opts.timeout
     #any stats progress?
     partitionMinProgressed = cmp(lastPartitionMin, currentPartitionMin)
     partitionMaxprogressed = cmp(lastPartitionMax, currentPartitionMax)
@@ -346,7 +346,7 @@ def check_command_log(runner):
 
 def monitorStatisticsProgress(lastUpdatedParams, currentParams, lastUpdatedTime, runner, component):
     currentTime = time.time()
-    timeout = (runner.opts.timeout) * 60
+    timeout = runner.opts.timeout
     statsProgressed = True
     if isinstance(lastUpdatedParams, dict):
         statsProgressed = (cmp(lastUpdatedParams,currentParams) <> 0)

--- a/lib/python/voltcli/voltadmin.d/pause.py
+++ b/lib/python/voltcli/voltadmin.d/pause.py
@@ -25,10 +25,13 @@ from voltcli.checkstats import StatisticsProcedureException
         VOLT.BooleanOption('-w', '--wait', 'waiting',
                            'wait for all DR and Export transactions to be externally processed',
                            default = False),
-        VOLT.IntegerOption('-t', '--timeout', 'timeout', 'The timeout value in minute if @Statistics is not progressing.', default = 2),
+        VOLT.IntegerOption('-t', '--timeout', 'timeout', 'The timeout value in minutes if @Statistics is not progressing.', default = 2),
     )
 )
 def pause(runner):
+    if runner.opts.timeout and runner.opts.timeout < 0:
+        runner.abort_with_help('You cannot specify timeout less than zero minutes.')
+
     #Check the STATUS column. runner.call_proc() detects and aborts on errors.
     status = runner.call_proc('@Pause', [], []).table(0).tuple(0).column_integer(0)
     if status <> 0:

--- a/lib/python/voltcli/voltadmin.d/pause.py
+++ b/lib/python/voltcli/voltadmin.d/pause.py
@@ -36,17 +36,14 @@ def pause(runner):
         return
     runner.info('The cluster is paused.')
     if runner.opts.waiting:
-        timeout = -1;
-        if runner.opts.timeout:
-            timeout = (runner.opts.timeout) * 60
         status = runner.call_proc('@Quiesce', [], []).table(0).tuple(0).column_integer(0)
         if status <> 0:
             runner.error('The cluster has failed to quiesce with status: %d' % status)
             return
         runner.info('The cluster is quiesced.')
         try:
-            checkstats.check_exporter(runner, timeout)
-            checkstats.check_dr_producer(runner, timeout)
+            checkstats.check_exporter(runner)
+            checkstats.check_dr_producer(runner)
         except StatisticsProcedureException as proex:
             runner.info('The pause process has stopped. The cluster is in a paused state.')
             runner.error(proex.message)

--- a/lib/python/voltcli/voltadmin.d/pause.py
+++ b/lib/python/voltcli/voltadmin.d/pause.py
@@ -25,12 +25,12 @@ from voltcli.checkstats import StatisticsProcedureException
         VOLT.BooleanOption('-w', '--wait', 'waiting',
                            'wait for all DR and Export transactions to be externally processed',
                            default = False),
-        VOLT.IntegerOption('-t', '--timeout', 'timeout', 'The timeout value in minutes if @Statistics is not progressing.', default = 2),
+        VOLT.IntegerOption('-t', '--timeout', 'timeout', 'The timeout value in seconds if @Statistics is not progressing.', default = 120),
     )
 )
 def pause(runner):
-    if runner.opts.timeout and runner.opts.timeout < 0:
-        runner.abort_with_help('You cannot specify timeout less than zero minutes.')
+    if runner.opts.timeout <= 0:
+        runner.abort_with_help('The timeout value must be more than zero seconds.')
 
     #Check the STATUS column. runner.call_proc() detects and aborts on errors.
     status = runner.call_proc('@Pause', [], []).table(0).tuple(0).column_integer(0)

--- a/lib/python/voltcli/voltadmin.d/pause.py
+++ b/lib/python/voltcli/voltadmin.d/pause.py
@@ -13,9 +13,10 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
-
+import sys
 import time
 from voltcli import checkstats
+from voltcli.checkstats import StatisticsProcedureException
 
 @VOLT.Command(
     bundles = VOLT.AdminBundle(),
@@ -23,7 +24,8 @@ from voltcli import checkstats
     options = (
         VOLT.BooleanOption('-w', '--wait', 'waiting',
                            'wait for all DR and Export transactions to be externally processed',
-                           default = False)
+                           default = False),
+        VOLT.IntegerOption('-t', '--timeout', 'timeout', 'The timeout value in minute if @Statistics is not progressing.', default = 2),
     )
 )
 def pause(runner):
@@ -34,14 +36,22 @@ def pause(runner):
         return
     runner.info('The cluster is paused.')
     if runner.opts.waiting:
+        timeout = -1;
+        if runner.opts.timeout:
+            timeout = (runner.opts.timeout) * 60
         status = runner.call_proc('@Quiesce', [], []).table(0).tuple(0).column_integer(0)
         if status <> 0:
             runner.error('The cluster has failed to quiesce with status: %d' % status)
             return
         runner.info('The cluster is quiesced.')
         try:
-            checkstats.check_exporter(runner)
-            checkstats.check_dr_producer(runner)
+            checkstats.check_exporter(runner, timeout)
+            checkstats.check_dr_producer(runner, timeout)
+        except StatisticsProcedureException as proex:
+            runner.info('The pause process has stopped. The cluster is in a paused state.')
+            runner.error(proex.message)
+            runner.info('Transactions may not be completely drained. You may continue monitoring the outstanding transactions with @Statistics')
+            sys.exit(1)
         except (KeyboardInterrupt, SystemExit):
             runner.info('The pause process has stopped. The cluster is in a paused state.')
             runner.abort('Transactions may not be completely drained. You may continue monitoring the outstanding transactions with @Statistics')

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -37,7 +37,7 @@ def shutdown(runner):
     runner.info('Cluster shutdown in progress.')
     timeout = -1;
     if runner.opts.timeout:
-        timeout = (runner.opts.timeout) * 60 * 1000
+        timeout = (runner.opts.timeout) * 60
 
     if not runner.opts.forcing:
         try:

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -25,14 +25,14 @@ from voltcli.checkstats import StatisticsProcedureException
     options = (
         VOLT.BooleanOption('-f', '--force', 'forcing', 'immediate shutdown', default = False),
         VOLT.BooleanOption('-s', '--save', 'save', 'snapshot database contents', default = False),
-        VOLT.IntegerOption('-t', '--timeout', 'timeout', 'The timeout value in minutes if @Statistics is not progressing.', default = 2),
+        VOLT.IntegerOption('-t', '--timeout', 'timeout', 'The timeout value in seconds if @Statistics is not progressing.', default = 120),
     )
 )
 def shutdown(runner):
     if runner.opts.forcing and runner.opts.save:
        runner.abort_with_help('You cannot specify both --force and --save options.')
-    if runner.opts.timeout and runner.opts.timeout < 0:
-        runner.abort_with_help('You cannot specify timeout less than zero minutes.')
+    if runner.opts.timeout <= 0:
+        runner.abort_with_help('The timeout value must be more than zero seconds.')
     shutdown_params = []
     columns = []
     zk_pause_txnid = 0

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -35,10 +35,6 @@ def shutdown(runner):
     columns = []
     zk_pause_txnid = 0
     runner.info('Cluster shutdown in progress.')
-    timeout = -1;
-    if runner.opts.timeout:
-        timeout = (runner.opts.timeout) * 60
-
     if not runner.opts.forcing:
         try:
             runner.info('Preparing for shutdown...')
@@ -51,18 +47,18 @@ def shutdown(runner):
             status = runner.call_proc('@Quiesce', [], []).table(0).tuple(0).column_integer(0)
             if status <> 0:
                 runner.abort('The cluster has failed to be quiesce with status: %d' % status)
-            checkstats.check_clients(runner, timeout)
-            checkstats.check_importer(runner, timeout)
-            checkstats.check_command_log(runner, timeout)
+            checkstats.check_clients(runner)
+            checkstats.check_importer(runner)
+            checkstats.check_command_log(runner)
             runner.info('All transactions have been made durable.')
             if runner.opts.save:
                columns = [VOLT.FastSerializer.VOLTTYPE_BIGINT]
                shutdown_params =  [zk_pause_txnid]
                #save option, check more stats
-               checkstats.check_dr_consumer(runner, timeout)
+               checkstats.check_dr_consumer(runner)
                runner.info('Starting resolution of external commitments...')
-               checkstats.check_exporter(runner, timeout)
-               checkstats.check_dr_producer(runner, timeout)
+               checkstats.check_exporter(runner)
+               checkstats.check_dr_producer(runner)
                runner.info('Saving a final snapshot, The cluster will shutdown after the snapshot is finished...')
             else:
                 runner.info('Shutting down the cluster...')

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -17,7 +17,6 @@ import time
 import signal
 from voltcli import checkstats
 from voltcli.checkstats import StatisticsProcedureException
-from voltcli.checkstats import StatisticsTimeoutException
 
 @VOLT.Command(
     bundles = VOLT.AdminBundle(),
@@ -68,10 +67,8 @@ def shutdown(runner):
                 runner.info('Shutting down the cluster...')
         except StatisticsProcedureException as proex:
              runner.info('The cluster shutdown process has stopped. The cluster is still in a paused state.')
-             runner.abort(proex.message)
-        except StatisticsTimeoutException as toex:
-             runner.info('The cluster shutdown process has stopped. The cluster is still in a paused state.')
-             runner.abort(toex.message)
+             runner.info(proex.message)
+             runner.abort('You may shutdown the cluster with the "voltadmin shutdown --force" command, or continue to wait with "voltadmin shutdown".')
         except (KeyboardInterrupt, SystemExit):
             runner.info('The cluster shutdown process has stopped. The cluster is still in a paused state.')
             runner.abort('You may shutdown the cluster with the "voltadmin shutdown --force" command, or continue to wait with "voltadmin shutdown".')

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -25,12 +25,14 @@ from voltcli.checkstats import StatisticsProcedureException
     options = (
         VOLT.BooleanOption('-f', '--force', 'forcing', 'immediate shutdown', default = False),
         VOLT.BooleanOption('-s', '--save', 'save', 'snapshot database contents', default = False),
-        VOLT.IntegerOption('-t', '--timeout', 'timeout', 'The timeout value in minute if @Statistics is not progressing.', default = 2),
+        VOLT.IntegerOption('-t', '--timeout', 'timeout', 'The timeout value in minutes if @Statistics is not progressing.', default = 2),
     )
 )
 def shutdown(runner):
     if runner.opts.forcing and runner.opts.save:
        runner.abort_with_help('You cannot specify both --force and --save options.')
+    if runner.opts.timeout and runner.opts.timeout < 0:
+        runner.abort_with_help('You cannot specify timeout less than zero minutes.')
     shutdown_params = []
     columns = []
     zk_pause_txnid = 0

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+import sys
 import time
 import signal
 from voltcli import checkstats
@@ -67,8 +68,9 @@ def shutdown(runner):
                 runner.info('Shutting down the cluster...')
         except StatisticsProcedureException as proex:
              runner.info('The cluster shutdown process has stopped. The cluster is still in a paused state.')
-             runner.info(proex.message)
-             runner.abort('You may shutdown the cluster with the "voltadmin shutdown --force" command, or continue to wait with "voltadmin shutdown".')
+             runner.error(proex.message)
+             runner.info('You may shutdown the cluster with the "voltadmin shutdown --force" command, or continue to wait with "voltadmin shutdown".')
+             sys.exit(1)
         except (KeyboardInterrupt, SystemExit):
             runner.info('The cluster shutdown process has stopped. The cluster is still in a paused state.')
             runner.abort('You may shutdown the cluster with the "voltadmin shutdown --force" command, or continue to wait with "voltadmin shutdown".')


### PR DESCRIPTION
added a mechanism to monitor the draining of outstanding transactions.  The command will be timed out if no transactions have been drained within timeout period after the last successfully drained transaction.