### PR TITLE
ENG-11447: Refactor DR producer initialization sequence.

### DIFF
--- a/src/frontend/org/voltdb/PartitionDRGateway.java
+++ b/src/frontend/org/voltdb/PartitionDRGateway.java
@@ -169,7 +169,7 @@ public class PartitionDRGateway implements DurableUniqueIdListener {
             ByteBuffer buf) {
         final PartitionDRGateway pdrg = m_partitionDRGateways.get(partitionId);
         if (pdrg == null) {
-            VoltDB.crashLocalVoltDB("No PRDG when there should be", true, null);
+            return -1;
         }
         return pdrg.onBinaryDR(partitionId, startSequenceNumber, lastSequenceNumber,
                 lastSpUniqueId, lastMpUniqueId, EventType.values()[eventType], buf);

--- a/src/frontend/org/voltdb/ProducerDRGateway.java
+++ b/src/frontend/org/voltdb/ProducerDRGateway.java
@@ -17,19 +17,21 @@
 
 package org.voltdb;
 
+import java.io.IOException;
 import java.util.Map;
 
 public interface ProducerDRGateway {
 
-    /*
-     * Ensure that all enabled DR Producer Hosts have agreed on the PBD file name
+    /**
+     * Start the main thread and the state machine, wait until all nodes converge on the initial state.
+     * @throws IOException
      */
-    public abstract void blockOnDRStateConvergence();
+    public void startAndWaitForGlobalAgreement() throws IOException;
 
     /**
      * Start listening on the ports
      */
-    public abstract void initialize(boolean drProducerEnabled, int listenPort, String portInterface);
+    public abstract void startListening(boolean drProducerEnabled, int listenPort, String portInterface) throws IOException;
 
     /**
      * @return true if bindPorts has been called.

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -64,6 +64,11 @@ public interface SiteProcedureConnection {
     public int getCorrespondingClusterId();
 
     /**
+     * Get the DR gateway
+     */
+    public PartitionDRGateway getDRGateway();
+
+    /**
      * Log settings changed. Signal EE to update log level.
      */
     public void updateBackendLogLevels();

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -29,7 +29,6 @@ import org.voltdb.CatalogSpecificPlanner;
 import org.voltdb.CommandLog;
 import org.voltdb.LoadedProcedureSet;
 import org.voltdb.MemoryStats;
-import org.voltdb.PartitionDRGateway;
 import org.voltdb.ProcedureRunnerFactory;
 import org.voltdb.StartAction;
 import org.voltdb.StarvationTracker;
@@ -129,8 +128,7 @@ public abstract class BaseInitiator implements Initiator
                           MemoryStats memStats,
                           CommandLog cl,
                           String coreBindIds,
-                          PartitionDRGateway drGateway,
-                          PartitionDRGateway mpDrGateway)
+                          boolean hasMPDRGateway)
         throws KeeperException, ExecutionException, InterruptedException
     {
             int snapshotPriority = 6;
@@ -162,8 +160,7 @@ public abstract class BaseInitiator implements Initiator
                                        memStats,
                                        coreBindIds,
                                        taskLog,
-                                       drGateway,
-                                       mpDrGateway);
+                                       hasMPDRGateway);
             ProcedureRunnerFactory prf = new ProcedureRunnerFactory();
             prf.configure(m_executionSite, m_executionSite.m_sysprocContext);
 

--- a/src/frontend/org/voltdb/iv2/Initiator.java
+++ b/src/frontend/org/voltdb/iv2/Initiator.java
@@ -41,15 +41,20 @@ public interface Initiator
     public void configure(BackendTarget backend,
                           CatalogContext catalogContext,
                           String serializedCatalog,
-                          int kfactor, CatalogSpecificPlanner csp,
+                          CatalogSpecificPlanner csp,
                           int numberOfPartitions,
                           StartAction startAction,
                           StatsAgent agent,
                           MemoryStats memStats,
                           CommandLog cl,
-                          ProducerDRGateway nodeDRGateway,
-                          boolean createMpDRGateway, String coreBindIds)
+                          String coreBindIds,
+                          boolean hasMPDRGateway)
         throws KeeperException, InterruptedException, ExecutionException;
+
+    /** Create DR gateway */
+    public void initDRGateway(StartAction startAction,
+                              ProducerDRGateway nodeDRGateway,
+                              boolean createMpDRGateway);
 
     /** Shutdown an Initiator and its sub-components. */
     public void shutdown();

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -67,14 +67,14 @@ public class MpInitiator extends BaseInitiator implements Promotable
     public void configure(BackendTarget backend,
                           CatalogContext catalogContext,
                           String serializedCatalog,
-                          int kfactor, CatalogSpecificPlanner csp,
+                          CatalogSpecificPlanner csp,
                           int numberOfPartitions,
                           StartAction startAction,
                           StatsAgent agent,
                           MemoryStats memStats,
                           CommandLog cl,
-                          ProducerDRGateway drGateway,
-                          boolean createMpDRGateway, String coreBindIds)
+                          String coreBindIds,
+                          boolean hasMPDRGateway)
         throws KeeperException, InterruptedException, ExecutionException
     {
         // note the mp initiator always uses a non-ipc site, even though it's never used for anything
@@ -83,8 +83,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
         }
 
         super.configureCommon(backend, catalogContext, serializedCatalog,
-                csp, numberOfPartitions, startAction, null, null, cl, coreBindIds,
-                null, null);
+                csp, numberOfPartitions, startAction, null, null, cl, coreBindIds, false);
         // Hacky
         MpScheduler sched = (MpScheduler)m_scheduler;
         MpRoSitePool sitePool = new MpRoSitePool(m_initiatorMailbox.getHSId(),
@@ -100,6 +99,12 @@ public class MpInitiator extends BaseInitiator implements Promotable
         LeaderElector.createParticipantNode(m_messenger.getZK(),
                 LeaderElector.electionDirForPartition(VoltZK.leaders_initiators, m_partitionId),
                 Long.toString(getInitiatorHSId()), null);
+    }
+
+    @Override
+    public void initDRGateway(StartAction startAction, ProducerDRGateway nodeDRGateway, boolean createMpDRGateway)
+    {
+        // No-op on MPI
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -35,6 +35,7 @@ import org.voltdb.HsqlBackend;
 import org.voltdb.LoadedProcedureSet;
 import org.voltdb.NonVoltDBBackend;
 import org.voltdb.ParameterSet;
+import org.voltdb.PartitionDRGateway;
 import org.voltdb.PostGISBackend;
 import org.voltdb.PostgreSQLBackend;
 import org.voltdb.ProcedureRunner;
@@ -422,6 +423,12 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     public int getCorrespondingClusterId()
     {
         return m_context.cluster.getDrclusterid();
+    }
+
+    @Override
+    public PartitionDRGateway getDRGateway()
+    {
+        throw new UnsupportedOperationException("RO MP Site doesn't have DR gateway");
     }
 
     @Override

--- a/tests/frontend/org/voltdb/iv2/TestDurabilityListener.java
+++ b/tests/frontend/org/voltdb/iv2/TestDurabilityListener.java
@@ -256,6 +256,6 @@ public class TestDurabilityListener {
         final Iv2InitiateTaskMessage msg = new Iv2InitiateTaskMessage(0, 0, 0, 0, uniqId,
                                                                       false, isSp, new StoredProcedureInvocation(),
                                                                       0, 0, false);
-        return new SpProcedureTask(null, "Hello", taskQueue, msg, null);
+        return new SpProcedureTask(null, "Hello", taskQueue, msg);
     }
 }

--- a/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
+++ b/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
@@ -63,7 +63,7 @@ public class TestTransactionTaskQueue extends TestCase
         when(mbox.getHSId()).thenReturn(1337l);
 
         SpProcedureTask task =
-            new SpProcedureTask(mbox, "TestProc", queue, init, null);
+            new SpProcedureTask(mbox, "TestProc", queue, init);
         return task;
     }
 
@@ -108,7 +108,7 @@ public class TestTransactionTaskQueue extends TestCase
         CompleteTransactionMessage msg = mock(CompleteTransactionMessage.class);
         when(msg.getTxnId()).thenReturn(mpTxnId);
         CompleteTransactionTask task =
-            new CompleteTransactionTask(mock(InitiatorMailbox.class), txn, queue, msg, null);
+            new CompleteTransactionTask(mock(InitiatorMailbox.class), txn, queue, msg);
         return task;
     }
 


### PR DESCRIPTION
- Instead of creating the DR gateways when the initiators are
  constructed, which is way early than when the DR producer is ready to
  do anything, I moved them out of the initiator constructor and create
  them when the DR producer is ready.

- The SpScheduler really doesn't care about the DR gateway. Only the
  transactions care about it when they are run on the site. So I removed
  the reference to the DR gateway from SpScheduler and created a getter
  in the Site so that transactions can have access to it.