### PR TITLE
ENG-11573 populate joined table view on snapshot restore

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1386,7 +1386,7 @@ template<class TABLE> void VoltDBEngine::initMaterializedViews(catalog::Table *c
             // the uninstallation of the previous (if exists) handler.
             MaterializedViewHandler *handler = new MaterializedViewHandler(destTable, mvHandlerInfo, this);
             if (destTable->isPersistentTableEmpty()) {
-                handler->catchUpWithExistingData(this, false);
+                handler->catchUpWithExistingData(false);
             }
         }
     }

--- a/src/ee/storage/MaterializedViewHandler.cpp
+++ b/src/ee/storage/MaterializedViewHandler.cpp
@@ -166,9 +166,9 @@ namespace voltdb {
     // to catch up with the existing data.
     //TODO: *non-grouped views could instead set up a hard-coded initial
     // row as they do in the single-table case to avoid querying empty tables.
-    void MaterializedViewHandler::catchUpWithExistingData(VoltDBEngine *engine, bool fallible) {
+    void MaterializedViewHandler::catchUpWithExistingData(bool fallible) {
         ExecutorContext* ec = ExecutorContext::getExecutorContext();
-        UniqueTempTableResult viewContent = engine->executePlanFragment(m_createQueryExecutorVector.get());
+        UniqueTempTableResult viewContent = ec->getEngine()->executePlanFragment(m_createQueryExecutorVector.get());
         TableIterator ti = viewContent->iterator();
         TableTuple tuple(viewContent->schema());
         while (ti.next(tuple)) {

--- a/src/ee/storage/MaterializedViewHandler.h
+++ b/src/ee/storage/MaterializedViewHandler.h
@@ -68,7 +68,7 @@ public:
     // This must be done outside of the constructor, since the
     // catching up executes a plan fragment which may throw an
     // exception.
-    void catchUpWithExistingData(VoltDBEngine* engine, bool fallible);
+    void catchUpWithExistingData(bool fallible);
 
     PersistentTable *destTable() const { return m_destTable; }
     /* A view handler becomes dirty (and needs to be recreated) when:

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1364,6 +1364,7 @@ void PersistentTable::processLoadedTuple(TableTuple &tuple,
                                          size_t &tupleCountPosition,
                                          bool shouldDRStreamRows) {
     try {
+        insertTupleIntoDeltaTable(tuple, true);
         insertTupleCommon(tuple, tuple, true, shouldDRStreamRows);
     }
     catch (ConstraintFailureException &e) {

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -493,7 +493,7 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
                                                                           mvHandlerInfo,
                                                                           engine);
         if (populateInitialTuple) {
-            newHandler->catchUpWithExistingData(engine, fallible);
+            newHandler->catchUpWithExistingData(fallible);
         }
     }
 
@@ -2009,8 +2009,8 @@ void PersistentTable::polluteViews() {
     // use the current table as one of their sources need to be updated.
     //   If the current table is a view target table, we need to refresh the list
     // of tracked indices so that the data in the table and its indices can be in sync.
-    BOOST_FOREACH (auto mvHanlder, m_viewHandlers) {
-        mvHanlder->pollute();
+    BOOST_FOREACH (auto mvHandler, m_viewHandlers) {
+        mvHandler->pollute();
     }
     if (m_mvHandler) {
         m_mvHandler->pollute();

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -620,13 +620,6 @@ void PersistentTable::insertPersistentTuple(TableTuple &source, bool fallible, b
     target.copyForPersistentInsert(source); // tuple in freelist must be already cleared
 
     try {
-        // Insert the tuple into the delta table first.
-        //
-        // (Note: we may hit a NOT NULL constraint violation,
-        // in which case, we want to clean up by calling
-        // deleteTupleStorage, below)
-        insertTupleIntoDeltaTable(source, fallible);
-
         insertTupleCommon(source, target, fallible);
     }
     catch (ConstraintFailureException &e) {
@@ -711,6 +704,13 @@ void PersistentTable::insertTupleCommon(TableTuple &source, TableTuple &target,
             uq->registerUndoAction(new (*uq) PersistentTableUndoInsertAction(tupleData, &m_surgeon));
         }
     }
+
+    // Insert the tuple into the delta table first.
+    //
+    // (Note: we may hit a NOT NULL constraint violation,
+    // in which case, we want to clean up by calling
+    // deleteTupleStorage, below)
+    insertTupleIntoDeltaTable(source, fallible);
 
     BOOST_FOREACH (auto viewHandler, m_viewHandlers) {
         viewHandler->handleTupleInsert(this, fallible);
@@ -1364,7 +1364,6 @@ void PersistentTable::processLoadedTuple(TableTuple &tuple,
                                          size_t &tupleCountPosition,
                                          bool shouldDRStreamRows) {
     try {
-        insertTupleIntoDeltaTable(tuple, true);
         insertTupleCommon(tuple, tuple, true, shouldDRStreamRows);
     }
     catch (ConstraintFailureException &e) {


### PR DESCRIPTION
When tuples are inserted into a base table of a multi-table view, the normal code path is:
`PersistentTable::insertTuple()` => `PersistentTable::insertPersistentTuple()` => `PersistentTable::insertTupleCommon()`

The function call to insert the new tuple into the delta table is in `PersistentTable::insertPersistentTuple()`. 

However, on snapshot restore, `PersistentTable::processLoadedTuple()` directly call `PersistentTable::insertTupleCommon()`, so the new tuple is not inserted into the delta table for view mantainence.

This pull request fixed the bug by adding a `insertTupleIntoDeltaTable()` call in `PersistentTable::processLoadedTuple()`.

The regression test will be added to the pro repository.