### PR TITLE
ENG-11447: Initialize the DR producer before CL replay on recover.

### DIFF
--- a/src/frontend/org/voltdb/ProducerDRGateway.java
+++ b/src/frontend/org/voltdb/ProducerDRGateway.java
@@ -29,6 +29,14 @@ public interface ProducerDRGateway {
     public void startAndWaitForGlobalAgreement() throws IOException;
 
     /**
+     * Truncate the DR log using the snapshot restore truncation point cached
+     * earlier. This is called on recover before the command log replay starts
+     * to drop all binary logs generated after the snapshot. Command log replay
+     * will recreate those binary logs.
+     */
+    public void truncateDRLog();
+
+    /**
      * Start listening on the ports
      */
     public abstract void startListening(boolean drProducerEnabled, int listenPort, String portInterface) throws IOException;
@@ -55,7 +63,7 @@ public interface ProducerDRGateway {
 
     public abstract int getDRClusterId();
 
-    public void truncateDRLogsForRestore(Map<Integer, Long> sequenceNumbers);
+    public void cacheSnapshotRestoreTruncationPoint(Map<Integer, Long> sequenceNumbers);
 
     /**
      * Clear all queued DR buffers for a master, useful when the replica goes away


### PR DESCRIPTION
My previous patch delayed the initialization of the DR producer until
replay finishes, which lost all replayed transactions' binary logs. I'm
initializing the producer right before replay starts now.