### PR TITLE
ENG-11616 delay param between node startup

### DIFF
--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -119,6 +119,12 @@ public class LocalCluster extends VoltServerConfig {
     ArrayList<CommandLine> m_cmdLines = null;
     ServerThread m_localServer = null;
     ProcessBuilder m_procBuilder;
+
+    //wait before next node is started up in millisecond
+    //to help matching the host id on the real cluster with the host id on the local
+    //cluster
+    private long m_deplayBetweenNodeStartup = 0;
+
     private final ArrayList<EEProcess> m_eeProcs = new ArrayList<EEProcess>();
     //This is additional process invironment variables that can be passed.
     // This is used to pass JMX port. Any additional use cases can use this too.
@@ -749,6 +755,13 @@ public class LocalCluster extends VoltServerConfig {
                 }
 
                 startOne(i, clearLocalDataDirectories, role, StartAction.CREATE, true, placementGroup);
+                //wait before next one
+                if (m_deplayBetweenNodeStartup > 0) {
+                    try {
+                        Thread.sleep(m_deplayBetweenNodeStartup);
+                    } catch (InterruptedException e) {
+                    }
+                }
             }
             catch (IOException ioe) {
                 throw new RuntimeException(ioe);
@@ -1920,5 +1933,9 @@ public class LocalCluster extends VoltServerConfig {
         else {
             valgrindOutputFile.delete();
         }
+    }
+
+    public void setDeplayBetweenNodeStartup(long deplayBetweenNodeStartup) {
+        m_deplayBetweenNodeStartup = deplayBetweenNodeStartup;
     }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -1204,6 +1204,12 @@ public class LocalCluster extends VoltServerConfig {
                     initLocalServer(entry.getKey(), true);
                 }
                 startOne(entry.getKey(), true, ReplicationRole.NONE, StartAction.JOIN, false, entry.getValue());
+                if (m_deplayBetweenNodeStartup > 0) {
+                    try {
+                        Thread.sleep(m_deplayBetweenNodeStartup);
+                    } catch (InterruptedException e) {
+                    }
+                }
             }
             catch (IOException ioe) {
                 throw new RuntimeException(ioe);

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -123,7 +123,7 @@ public class LocalCluster extends VoltServerConfig {
     //wait before next node is started up in millisecond
     //to help matching the host id on the real cluster with the host id on the local
     //cluster
-    private long m_deplayBetweenNodeStartup = 0;
+    private long m_deplayBetweenNodeStartupMS = 0;
 
     private final ArrayList<EEProcess> m_eeProcs = new ArrayList<EEProcess>();
     //This is additional process invironment variables that can be passed.
@@ -756,9 +756,9 @@ public class LocalCluster extends VoltServerConfig {
 
                 startOne(i, clearLocalDataDirectories, role, StartAction.CREATE, true, placementGroup);
                 //wait before next one
-                if (m_deplayBetweenNodeStartup > 0) {
+                if (m_deplayBetweenNodeStartupMS > 0) {
                     try {
-                        Thread.sleep(m_deplayBetweenNodeStartup);
+                        Thread.sleep(m_deplayBetweenNodeStartupMS);
                     } catch (InterruptedException e) {
                     }
                 }
@@ -1204,9 +1204,9 @@ public class LocalCluster extends VoltServerConfig {
                     initLocalServer(entry.getKey(), true);
                 }
                 startOne(entry.getKey(), true, ReplicationRole.NONE, StartAction.JOIN, false, entry.getValue());
-                if (m_deplayBetweenNodeStartup > 0) {
+                if (m_deplayBetweenNodeStartupMS > 0) {
                     try {
-                        Thread.sleep(m_deplayBetweenNodeStartup);
+                        Thread.sleep(m_deplayBetweenNodeStartupMS);
                     } catch (InterruptedException e) {
                     }
                 }
@@ -1942,6 +1942,6 @@ public class LocalCluster extends VoltServerConfig {
     }
 
     public void setDeplayBetweenNodeStartup(long deplayBetweenNodeStartup) {
-        m_deplayBetweenNodeStartup = deplayBetweenNodeStartup;
+        m_deplayBetweenNodeStartupMS = deplayBetweenNodeStartup;
     }
 }


### PR DESCRIPTION
Add an optional delay between the node startup to help matching the host ids cached on LocalCluster to those in real cluster.