### PR TITLE
11625ENG-11625:

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -36,7 +36,9 @@ public interface ConsumerDRGateway extends Promotable {
 
     DRConsumerMpCoordinator getDRConsumerMpCoordinator();
 
-    void queueStartCursors(byte clusterId, long clusterCreationId, List<String> clusterNodeInfo);
-    void startConsumerDispatcher(byte producerClusterId, List<String> clusterNodeInfo);
+    void clusterUnrecoverable(byte clusterId, Throwable t);
 
+    void queueStartCursors(byte clusterId, long clusterCreationId, List<String> clusterNodeInfo);
+
+    void startConsumerDispatcher(byte producerClusterId, List<String> clusterNodeInfo);
 }

--- a/src/frontend/org/voltdb/DRConsumerMpCoordinator.java
+++ b/src/frontend/org/voltdb/DRConsumerMpCoordinator.java
@@ -27,7 +27,7 @@ public interface DRConsumerMpCoordinator {
 
     void deliver(Dr2MultipartResponseMessage message);
 
-    void processClientResponse(int handle, ClientResponse response);
+    void processClientResponse(byte producerClusterId, ClientResponse response);
 
     void becomeLeader();
 

--- a/src/frontend/org/voltdb/messaging/Dr2MultipartResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/Dr2MultipartResponseMessage.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 public class Dr2MultipartResponseMessage extends VoltMessage {
 
     private boolean m_drain;
+    private byte m_producerClusterId;
     private int m_producerPID;
     private ClientResponseImpl m_response;
 
@@ -33,18 +34,24 @@ public class Dr2MultipartResponseMessage extends VoltMessage {
         super();
     }
 
-    public Dr2MultipartResponseMessage(int producerPID, ClientResponseImpl response)  {
+    public Dr2MultipartResponseMessage(byte producerClusterId, int producerPID, ClientResponseImpl response)  {
         m_drain = false;
+        m_producerClusterId = producerClusterId;
         m_producerPID = producerPID;
         m_response = response;
     }
 
-    public static Dr2MultipartResponseMessage createDrainMessage(int producerPID) {
+    public static Dr2MultipartResponseMessage createDrainMessage(byte producerClusterId, int producerPID) {
         final Dr2MultipartResponseMessage msg = new Dr2MultipartResponseMessage();
         msg.m_drain = true;
+        msg.m_producerClusterId = producerClusterId;
         msg.m_producerPID = producerPID;
         msg.m_response = null;
         return msg;
+    }
+
+    public byte getProducerClusterId() {
+        return m_producerClusterId;
     }
 
     public int getProducerPID() {
@@ -62,6 +69,7 @@ public class Dr2MultipartResponseMessage extends VoltMessage {
     @Override
     protected void initFromBuffer(ByteBuffer buf) throws IOException {
         m_drain = buf.get() == 1;
+        m_producerClusterId = buf.get();
         m_producerPID = buf.getInt();
         if (buf.remaining() > 0) {
             m_response = new ClientResponseImpl();
@@ -73,6 +81,7 @@ public class Dr2MultipartResponseMessage extends VoltMessage {
     public void flattenToBuffer(ByteBuffer buf) throws IOException {
         buf.put(VoltDbMessageFactory.DR2_MULTIPART_RESPONSE_ID);
         buf.put((byte) (m_drain ? 1 : 0));
+        buf.put(m_producerClusterId);
         buf.putInt(m_producerPID);
 
         if (!m_drain) {
@@ -87,6 +96,7 @@ public class Dr2MultipartResponseMessage extends VoltMessage {
     public int getSerializedSize() {
         int size = super.getSerializedSize()
                    + 1  // drain or not
+                   + 1  // producer cluster ID
                    + 4; // producer partition ID
         if (!m_drain) {
             size += m_response.getSerializedSize();

--- a/src/frontend/org/voltdb/messaging/Dr2MultipartTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/Dr2MultipartTaskMessage.java
@@ -27,6 +27,8 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
 
     private int m_producerPID;
     private boolean m_drain;
+    private byte m_producerClusterId;
+    private short m_producerPartitionCnt;
 
     private long m_lastExecutedMPUniqueID;
 
@@ -36,16 +38,21 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
         super();
     }
 
-    public Dr2MultipartTaskMessage(StoredProcedureInvocation invocation, long lastExecutedMPUniqueID) {
+    public Dr2MultipartTaskMessage(StoredProcedureInvocation invocation, byte producerClusterId,
+            short producerPartitionCnt, long lastExecutedMPUniqueID) {
         m_invocation = invocation;
+        m_producerClusterId = producerClusterId;
+        m_producerPartitionCnt = producerPartitionCnt;
         m_lastExecutedMPUniqueID = lastExecutedMPUniqueID;
         m_producerPID = -1;
         m_drain = false;
     }
 
-    public static Dr2MultipartTaskMessage createDrainMessage(int producerPID) {
+    public static Dr2MultipartTaskMessage createDrainMessage(byte producerClusterId, int producerPID) {
         final Dr2MultipartTaskMessage msg = new Dr2MultipartTaskMessage();
         msg.m_producerPID = producerPID;
+        msg.m_producerClusterId = producerClusterId;
+        msg.m_producerPartitionCnt = -1;
         msg.m_drain = true;
         msg.m_invocation = null;
         msg.m_lastExecutedMPUniqueID = Long.MIN_VALUE;
@@ -64,6 +71,14 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
         return m_drain;
     }
 
+    public byte getProducerClusterId() {
+        return m_producerClusterId;
+    }
+
+    public short getProducerPartitionCnt() {
+        return m_producerPartitionCnt;
+    }
+
     public int getProducerPID() {
         return m_producerPID;
     }
@@ -72,6 +87,8 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
     protected void initFromBuffer(ByteBuffer buf) throws IOException {
         m_producerPID = buf.getInt();
         m_drain = buf.get() == 1;
+        m_producerClusterId = buf.get();
+        m_producerPartitionCnt = buf.getShort();
         m_lastExecutedMPUniqueID = buf.getLong();
         if (buf.remaining() > 0) {
             m_invocation = new StoredProcedureInvocation();
@@ -86,6 +103,8 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
         buf.put(VoltDbMessageFactory.DR2_MULTIPART_TASK_ID);
         buf.putInt(m_producerPID);
         buf.put((byte) (m_drain ? 1 : 0));
+        buf.put(m_producerClusterId);
+        buf.putShort(m_producerPartitionCnt);
         buf.putLong(m_lastExecutedMPUniqueID);
 
         if (m_invocation != null) {
@@ -101,6 +120,8 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
         int size = super.getSerializedSize()
                    + 4  // producer partition ID
                    + 1  // is drain or not
+                   + 1  // producer clusterId
+                   + 2  // producer partition count
                    + 8; // last executed MP unique ID
         if (m_invocation != null) {
             size += m_invocation.getSerializedSize();


### PR DESCRIPTION
Add clusterId to DR MpCoordinator messages so we don't need an MpCoordinator (and executor thread) per dispatcher in mult-cluster XDCR.