### PR TITLE
ENG-11447: Extract DRConflictManager interface from PartitionDRGateway.

### DIFF
--- a/src/frontend/org/voltdb/DRConflictManager.java
+++ b/src/frontend/org/voltdb/DRConflictManager.java
@@ -1,0 +1,38 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb;
+
+import java.nio.ByteBuffer;
+
+public interface DRConflictManager {
+    public int resolveConflict(int partitionId,
+                               int remoteClusterId,
+                               long remoteTimestamp,
+                               String tableName,
+                               PartitionDRGateway.DRRecordType action,
+                               PartitionDRGateway.DRConflictType deleteConflictType,
+                               ByteBuffer existingMetaTableForDelete,
+                               ByteBuffer existingTupleTableForDelete,
+                               ByteBuffer expectedMetaTableForDelete,
+                               ByteBuffer expectedTupleTableForDelete,
+                               PartitionDRGateway.DRConflictType insertConflictType,
+                               ByteBuffer existingMetaTableForInsert,
+                               ByteBuffer existingTupleTableForInsert,
+                               ByteBuffer newMetaTableForInsert,
+                               ByteBuffer newTupleTableForInsert);
+}

--- a/src/frontend/org/voltdb/PartitionDRGateway.java
+++ b/src/frontend/org/voltdb/PartitionDRGateway.java
@@ -28,6 +28,7 @@ import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
 import org.voltdb.jni.ExecutionEngine.EventType;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
+import org.voltdb.utils.MiscUtils;
 
 /**
  * Stub class that provides a gateway to the DRProducer when
@@ -69,6 +70,20 @@ public class PartitionDRGateway implements DurableUniqueIdListener {
     }
 
     public static ImmutableMap<Integer, PartitionDRGateway> m_partitionDRGateways = ImmutableMap.of();
+    public static final DRConflictManager m_conflictManager;
+    static {
+        if (MiscUtils.isPro()) {
+            DRConflictManager tmpObj = null;
+            try {
+                Class<?> klass = Class.forName("org.voltdb.dr2.DRConflictManagerImpl");
+                Constructor<?> constructor = klass.getConstructor();
+                tmpObj = (DRConflictManager) constructor.newInstance();
+            } catch (Exception e) {}
+            m_conflictManager = tmpObj;
+        } else {
+            m_conflictManager = null;
+        }
+    }
 
     // all partial MP txns go into SP streams
     public static final byte DR_NO_MP_START_PROTOCOL_VERSION = 3;
@@ -151,14 +166,6 @@ public class PartitionDRGateway implements DurableUniqueIdListener {
     @Override
     public void lastUniqueIdsMadeDurable(long spUniqueId, long mpUniqueId) {}
 
-    public int processDRConflict(int partitionId, int remoteClusterId, long remoteTimestamp, String tableName, DRRecordType action,
-                                 DRConflictType deleteConflict, ByteBuffer existingMetaTableForDelete, ByteBuffer existingTupleTableForDelete,
-                                 ByteBuffer expectedMetaTableForDelete, ByteBuffer expectedTupleTableForDelete,
-                                 DRConflictType insertConflict, ByteBuffer existingMetaTableForInsert, ByteBuffer existingTupleTableForInsert,
-                                 ByteBuffer newMetaTableForInsert, ByteBuffer newTupleTableForInsert) {
-        return 0;
-    }
-
     public static long pushDRBuffer(
             int partitionId,
             long startSequenceNumber,
@@ -182,15 +189,17 @@ public class PartitionDRGateway implements DurableUniqueIdListener {
                                        ByteBuffer expectedMetaTableForDelete, ByteBuffer expectedTupleTableForDelete,
                                        int insertConflict, ByteBuffer existingMetaTableForInsert, ByteBuffer existingTupleTableForInsert,
                                        ByteBuffer newMetaTableForInsert, ByteBuffer newTupleTableForInsert) {
-        final PartitionDRGateway pdrg = m_partitionDRGateways.get(partitionId);
-        if (pdrg == null) {
-            VoltDB.crashLocalVoltDB("No PRDG when there should be", true, null);
-        }
-
-        return pdrg.processDRConflict(partitionId, remoteClusterId, remoteTimestamp, tableName, DRRecordType.values()[action],
-                DRConflictType.values()[deleteConflict], existingMetaTableForDelete, existingTupleTableForDelete,
-                expectedMetaTableForDelete, expectedTupleTableForDelete,
-                DRConflictType.values()[insertConflict], existingMetaTableForInsert, existingTupleTableForInsert,
-                newMetaTableForInsert, newTupleTableForInsert);
+        assert m_conflictManager != null : "Community edition should not have any conflicts";
+        return m_conflictManager.resolveConflict(partitionId,
+                                                 remoteClusterId,
+                                                 remoteTimestamp,
+                                                 tableName,
+                                                 DRRecordType.values()[action],
+                                                 DRConflictType.values()[deleteConflict],
+                                                 existingMetaTableForDelete, existingTupleTableForDelete,
+                                                 expectedMetaTableForDelete, expectedTupleTableForDelete,
+                                                 DRConflictType.values()[insertConflict],
+                                                 existingMetaTableForInsert, existingTupleTableForInsert,
+                                                 newMetaTableForInsert, newTupleTableForInsert);
     }
 }


### PR DESCRIPTION
So that the conflict manager can exist without the dependency on PDRG.