### PR TITLE
Eng-11644 Fix up some HSQLDB tests that were taking 2 min. to timeout the getClient() call

### DIFF
--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -2900,12 +2900,13 @@ public class TestFunctionsSuite extends RegressionSuite {
     // Unicode character to UTF8 string character
     public void testChar() throws NoConnectionsException, IOException, ProcCallException {
         System.out.println("STARTING test CHAR");
-        Client client = getClient();
-        ClientResponse cr;
-        VoltTable result;
 
         // Hsql has wrong answers.
         if (isHSQL()) return;
+
+        Client client = getClient();
+        ClientResponse cr;
+        VoltTable result;
 
         cr = client.callProcedure("P1.insert", 1, "Xin@VoltDB", 1, 1.0, new Timestamp(1000000000000L));
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -2902,7 +2902,9 @@ public class TestFunctionsSuite extends RegressionSuite {
         System.out.println("STARTING test CHAR");
 
         // Hsql has wrong answers.
-        if (isHSQL()) return;
+        if (isHSQL()) {
+            return;
+        }
 
         Client client = getClient();
         ClientResponse cr;

--- a/tests/frontend/org/voltdb/regressionsuites/TestPartialIndexesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestPartialIndexesSuite.java
@@ -25,8 +25,6 @@ package org.voltdb.regressionsuites;
 
 import java.io.IOException;
 
-import junit.framework.Test;
-
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.client.Client;
@@ -34,6 +32,8 @@ import org.voltdb.client.ClientResponse;
 import org.voltdb.client.NoConnectionsException;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
+
+import junit.framework.Test;
 
 public class TestPartialIndexesSuite extends RegressionSuite {
 
@@ -55,11 +55,6 @@ public class TestPartialIndexesSuite extends RegressionSuite {
 
     public void testPartialUniqueIndex() throws Exception {
         Client client = getClient();
-
-        if (isHSQL()) {
-            // HSQL doesn't support partial indexes
-            return;
-        }
 
         // CREATE UNIQUE INDEX r1_pidx_1 ON R1 (a) where b is not null;
         // CREATE UNIQUE INDEX r1_pidx_hash_1 ON R1 (c) where b is not null;
@@ -229,10 +224,6 @@ public class TestPartialIndexesSuite extends RegressionSuite {
     public void testPartitionPartialUniqueIndex() throws Exception {
         Client client = getClient();
 
-        if (isHSQL()) {
-            // HSQL doesn't support partial indexes
-            return;
-        }
         // CREATE UNIQUE INDEX p1_pidx_1 ON P1 (a) where b is not null;
         for (String tb : partitioned_tbs) {
             emptyTable(client, tb);
@@ -340,11 +331,6 @@ public class TestPartialIndexesSuite extends RegressionSuite {
 
     public void testPartialIndex() throws Exception {
         Client client = getClient();
-
-        if (isHSQL()) {
-            // HSQL doesn't support partial indexes
-            return;
-        }
 
         // CREATE INDEX r1_pidx_2 ON R1 (d) where a > 0;
         // CREATE INDEX r1_pidx_hash_2 ON R1 (d) where a < 0;
@@ -508,9 +494,9 @@ public class TestPartialIndexesSuite extends RegressionSuite {
         builder.addServerConfig(config);
 
         // HSQLDB
-        config = new LocalCluster("testpartialindexes-cluster.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
-        if (!config.compile(project)) fail();
-        builder.addServerConfig(config);
+        //config = new LocalCluster("testpartialindexes-cluster.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
+        //if (!config.compile(project)) fail();
+        //builder.addServerConfig(config);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestPartialIndexesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestPartialIndexesSuite.java
@@ -437,10 +437,6 @@ public class TestPartialIndexesSuite extends RegressionSuite {
     }
 
     public void testPartialIndexPlanCache() throws Exception {
-        if (isHSQL()) {
-            // HSQL doesn't support partial indexes
-            return;
-        }
         Client client = getClient();
 
         //CREATE INDEX r1_pidx_2 ON R1 (d) where a > 0;
@@ -493,7 +489,7 @@ public class TestPartialIndexesSuite extends RegressionSuite {
         if (!config.compile(project)) fail();
         builder.addServerConfig(config);
 
-        // HSQLDB
+        // HSQLDB does not support partial indexes. If it ever does, here's the code to run it.
         //config = new LocalCluster("testpartialindexes-cluster.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
         //if (!config.compile(project)) fail();
         //builder.addServerConfig(config);

--- a/tests/frontend/org/voltdb/regressionsuites/TestProcedureAPISuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestProcedureAPISuite.java
@@ -155,11 +155,11 @@ public class TestProcedureAPISuite extends RegressionSuite {
     }
 
     public void testMultiPartitionCURRENT_TIMESTAMP() throws IOException, ProcCallException {
-
-        if (!isHSQL()) {
-            Client client = getClient();
-            client.callProcedure(CurrentTimestampProcedure.class.getSimpleName());
+        if (isHSQL()) {
+            return;
         }
+        Client client = getClient();
+        client.callProcedure(CurrentTimestampProcedure.class.getSimpleName());
     }
 
     /**

--- a/tests/frontend/org/voltdb/regressionsuites/TestProcedureAPISuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestProcedureAPISuite.java
@@ -157,7 +157,7 @@ public class TestProcedureAPISuite extends RegressionSuite {
     public void testMultiPartitionCURRENT_TIMESTAMP() throws IOException, ProcCallException {
 
         if (!isHSQL()) {
-        	Client client = getClient();
+            Client client = getClient();
             client.callProcedure(CurrentTimestampProcedure.class.getSimpleName());
         }
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestProcedureAPISuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestProcedureAPISuite.java
@@ -28,8 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import junit.framework.Test;
-
 import org.voltdb.BackendTarget;
 import org.voltdb.client.Client;
 import org.voltdb.client.NoConnectionsException;
@@ -41,6 +39,8 @@ import org.voltdb_testprocs.regressionsuites.CurrentTimestampProcedure;
 import org.voltdb_testprocs.regressionsuites.LastBatchLie;
 import org.voltdb_testprocs.regressionsuites.VariableBatchSizeMP;
 import org.voltdb_testprocs.regressionsuites.VariableBatchSizeSP;
+
+import junit.framework.Test;
 
 public class TestProcedureAPISuite extends RegressionSuite {
 
@@ -155,8 +155,9 @@ public class TestProcedureAPISuite extends RegressionSuite {
     }
 
     public void testMultiPartitionCURRENT_TIMESTAMP() throws IOException, ProcCallException {
-        Client client = getClient();
+
         if (!isHSQL()) {
+        	Client client = getClient();
             client.callProcedure(CurrentTimestampProcedure.class.getSimpleName());
         }
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
@@ -26,8 +26,6 @@ package org.voltdb.regressionsuites;
 import java.io.IOException;
 import java.util.UUID;
 
-import junit.framework.Test;
-
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
@@ -39,6 +37,8 @@ import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb_testprocs.regressionsuites.sqlfeatureprocs.BatchedMultiPartitionTest;
 import org.voltdb_testprocs.regressionsuites.sqlfeatureprocs.PopulateTruncateTable;
 import org.voltdb_testprocs.regressionsuites.sqlfeatureprocs.TruncateTable;
+
+import junit.framework.Test;
 
 public class TestSQLFeaturesNewSuite extends RegressionSuite {
     // procedures used by these tests
@@ -156,12 +156,13 @@ public class TestSQLFeaturesNewSuite extends RegressionSuite {
 
     public void testTableLimitAndPercentage() throws Exception {
         System.out.println("STARTING TABLE LIMIT AND PERCENTAGE FULL TEST......");
-        Client client = getClient();
-        VoltTable vt = null;
+
         if(isHSQL()) {
             return;
         }
 
+        Client client = getClient();
+        VoltTable vt = null;
         // When table limit feature is fully supported, there needs to be more test cases.
         // generalize this test within a loop, maybe.
         // Test max row 0


### PR DESCRIPTION
Six tests were calling getClient() prior to checking isHSQL(), resulting in the tests waiting on
the getClient() timeout rather than quickly returning with a PASS for testcases that the HSQL
backend can't run.