### PR TITLE
ENG-11382: Fix DR sync snapshot node failure check after promotion.

### DIFF
--- a/src/frontend/org/voltdb/iv2/LeaderAppointer.java
+++ b/src/frontend/org/voltdb/iv2/LeaderAppointer.java
@@ -48,6 +48,7 @@ import org.voltcore.zk.BabySitter;
 import org.voltcore.zk.LeaderElector;
 import org.voltcore.zk.ZKUtil;
 import org.voltdb.Promotable;
+import org.voltdb.ReplicationRole;
 import org.voltdb.TheHashinator;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
@@ -190,8 +191,10 @@ public class LeaderAppointer implements Promotable
                     VoltDB.crashGlobalVoltDB("Detected node failure during command log replay. Cluster will shut down.",
                                              false, null);
                 }
-                // If we are a DR replica and starting from a snapshot, check if that has completed
-                if (m_expectingDrSnapshot && m_snapshotSyncComplete.get() == false) {
+                // If we are still a DR replica (not promoted) and starting from a snapshot,
+                // check if that has completed
+                if (VoltDB.instance().getReplicationRole() == ReplicationRole.REPLICA &&
+                    m_expectingDrSnapshot && m_snapshotSyncComplete.get() == false) {
                     VoltDB.crashGlobalVoltDB("Detected node failure before DR sync snapshot completes. Cluster will shut down.",
                                              false, null);
                 }

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -25,10 +25,7 @@ package org.voltdb.iv2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Map;
@@ -47,8 +44,11 @@ import org.voltcore.zk.LeaderElector;
 import org.voltcore.zk.ZKTestBase;
 import org.voltcore.zk.ZKUtil;
 import org.voltdb.AbstractTopology;
+import org.voltdb.MockVoltDB;
+import org.voltdb.ReplicationRole;
 import org.voltdb.TheHashinator;
 import org.voltdb.VoltDB;
+import org.voltdb.VoltDBInterface;
 import org.voltdb.VoltZK;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
@@ -503,6 +503,10 @@ public class TestLeaderAppointer extends ZKTestBase {
     @Test
     public void testFailureDuringSyncSnapshot() throws Exception
     {
+        final VoltDBInterface mVolt = mock(VoltDBInterface.class);
+        doReturn(ReplicationRole.REPLICA).when(mVolt).getReplicationRole();
+        VoltDB.replaceVoltDBInstanceForTest(mVolt);
+
         configure(2, 2, 1, false);
         Thread dutthread = new Thread() {
             @Override
@@ -547,5 +551,11 @@ public class TestLeaderAppointer extends ZKTestBase {
         }
         assertTrue(threw);
         assertTrue(VoltDB.wasCrashCalled);
+
+        // Promote the replica to a master before sync snapshot, failure should not crash now.
+        doReturn(ReplicationRole.NONE).when(mVolt).getReplicationRole();
+        VoltDB.wasCrashCalled = false;
+        m_dut.acceptPromotion();
+        assertFalse(VoltDB.wasCrashCalled);
     }
 }


### PR DESCRIPTION
If a replica cluster is promoted before a sync snapshot took place, the
cluster should not crash if a node failure is detected.