### PR TITLE
ENG-11661 use test switch to speedup unit test

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1750,7 +1750,7 @@ TEST CASES
             <env key="VOLT_ENABLEIV2" value="${enableiv2}" />
             <!-- Leave breadcrumbs so we can figure out deep in the bowels of VoltDB if
                  this is a test -->
-            <env key="VOLT_JUSTATEST" value="YESYESYES" />
+            <env key="VOLT_JUSTATEST" value="true" />
             <!-- Following two env vars are used by Java code
                  when running ant check -Dbuild=memcheck
                  The voltdbipc client is used in concert with valgrind

--- a/src/frontend/org/voltcore/utils/CoreUtils.java
+++ b/src/frontend/org/voltcore/utils/CoreUtils.java
@@ -1198,4 +1198,17 @@ public class CoreUtils {
             log.fatal("Unable to list ports in use at this time.");
         }
     }
+
+    // Utility method to figure out if this is a test case.  Various junit targets in
+    // build.xml set a environment variable to give us a hint
+    public static boolean isJunitTest() {
+
+        //check os environment variable
+        if ("true".equalsIgnoreCase(System.getenv().get("VOLT_JUSTATEST")) ){
+            return true;
+        }
+
+        //check system variable
+        return "true".equalsIgnoreCase(System.getProperty("VOLT_JUSTATEST"));
+    }
 }

--- a/src/frontend/org/voltcore/utils/CoreUtils.java
+++ b/src/frontend/org/voltcore/utils/CoreUtils.java
@@ -1204,7 +1204,7 @@ public class CoreUtils {
     public static boolean isJunitTest() {
 
         //check os environment variable
-        if ("true".equalsIgnoreCase(System.getenv().get("VOLT_JUSTATEST")) ){
+        if ("true".equalsIgnoreCase(System.getenv().get("VOLT_JUSTATEST"))){
             return true;
         }
 

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -40,6 +40,7 @@ import org.voltcore.logging.VoltLog4jLogger;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.network.ReverseDNSCache;
+import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.EstTimeUpdater;
 import org.voltcore.utils.OnDemandBinaryLogger;
 import org.voltcore.utils.PortGenerator;
@@ -90,22 +91,6 @@ public class VoltDB {
     public static final String DEFAULT_CLUSTER_NAME = "database";
     public static final String DBROOT = Constants.DBROOT;
     public static final String MODULE_CACHE = ".bundles-cache";
-
-    // Utility to try to figure out if this is a test case.  Various junit targets in
-    // build.xml set this environment variable to give us a hint
-    public static boolean isThisATest()
-    {
-        String test = System.getenv().get("VOLT_JUSTATEST");
-        if (test == null) {
-            test = System.getProperty("VOLT_JUSTATEST");
-        }
-        if (test != null && test.equalsIgnoreCase("YESYESYES")) {
-            return true;
-        }
-        else {
-            return false;
-        }
-    }
 
     // The name of the SQLStmt implied by a statement procedure's sql statement.
     public static final String ANON_STMT_NAME = "sql";
@@ -940,7 +925,7 @@ public class VoltDB {
      * human readable stack traces for all java threads in the current process.
      */
     public static void dropStackTrace(String message) {
-        if (VoltDB.isThisATest()) {
+        if (CoreUtils.isJunitTest()) {
             VoltLogger log = new VoltLogger("HOST");
             log.warn("Declining to drop a stack trace during a junit test.");
             return;
@@ -1080,7 +1065,7 @@ public class VoltDB {
         if (ignoreCrash) {
             throw new AssertionError("Faux crash of VoltDB successful.");
         }
-        if (VoltDB.isThisATest()) {
+        if (CoreUtils.isJunitTest()) {
             VoltLogger log = new VoltLogger("HOST");
             log.warn("Declining to drop a crash file during a junit test.");
         }
@@ -1332,7 +1317,7 @@ public class VoltDB {
     }
 
     public static void exit(int status) {
-        if (isThisATest() || ignoreCrash) {
+        if (CoreUtils.isJunitTest() || ignoreCrash) {
             throw new SimulatedExitException(status);
         }
         System.exit(status);

--- a/src/frontend/org/voltdb/client/ClientImpl.java
+++ b/src/frontend/org/voltdb/client/ClientImpl.java
@@ -39,7 +39,6 @@ import java.util.logging.Logger;
 
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.ClientResponseImpl;
-import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.client.HashinatorLite.HashinatorLiteType;
 import org.voltdb.client.VoltBulkLoader.BulkLoaderFailureCallBack;
@@ -623,7 +622,7 @@ public final class ClientImpl implements Client {
 
         if (m_ex != null) {
             m_ex.shutdown();
-            if (VoltDB.isThisATest()) {
+            if (ClientUtils.isThisATest()) {
                 m_ex.awaitTermination(1, TimeUnit.SECONDS);
             } else {
                 m_ex.awaitTermination(365, TimeUnit.DAYS);

--- a/src/frontend/org/voltdb/client/ClientImpl.java
+++ b/src/frontend/org/voltdb/client/ClientImpl.java
@@ -622,7 +622,7 @@ public final class ClientImpl implements Client {
 
         if (m_ex != null) {
             m_ex.shutdown();
-            if (ClientUtils.isThisATest()) {
+            if (CoreUtils.isJunitTest()) {
                 m_ex.awaitTermination(1, TimeUnit.SECONDS);
             } else {
                 m_ex.awaitTermination(365, TimeUnit.DAYS);

--- a/src/frontend/org/voltdb/client/ClientImpl.java
+++ b/src/frontend/org/voltdb/client/ClientImpl.java
@@ -39,6 +39,7 @@ import java.util.logging.Logger;
 
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.ClientResponseImpl;
+import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.client.HashinatorLite.HashinatorLiteType;
 import org.voltdb.client.VoltBulkLoader.BulkLoaderFailureCallBack;
@@ -622,7 +623,11 @@ public final class ClientImpl implements Client {
 
         if (m_ex != null) {
             m_ex.shutdown();
-            m_ex.awaitTermination(1, TimeUnit.SECONDS);
+            if (VoltDB.isThisATest()) {
+                m_ex.awaitTermination(1, TimeUnit.SECONDS);
+            } else {
+                m_ex.awaitTermination(365, TimeUnit.DAYS);
+            }
         }
         m_distributer.shutdown();
         ClientFactory.decreaseClientNum();

--- a/src/frontend/org/voltdb/client/ClientImpl.java
+++ b/src/frontend/org/voltdb/client/ClientImpl.java
@@ -622,7 +622,7 @@ public final class ClientImpl implements Client {
 
         if (m_ex != null) {
             m_ex.shutdown();
-            m_ex.awaitTermination(365, TimeUnit.DAYS);
+            m_ex.awaitTermination(1, TimeUnit.SECONDS);
         }
         m_distributer.shutdown();
         ClientFactory.decreaseClientNum();

--- a/src/frontend/org/voltdb/client/ClientUtils.java
+++ b/src/frontend/org/voltdb/client/ClientUtils.java
@@ -91,14 +91,4 @@ public class ClientUtils {
         }
         return buffer;
     }
-
-    // Utility to try to figure out if this is a test case.  Various junit targets in
-    // build.xml set this environment variable to give us a hint
-    public static boolean isThisATest() {
-        String test = System.getenv().get("VOLT_JUSTATEST");
-        if (test == null) {
-            test = System.getProperty("VOLT_JUSTATEST");
-        }
-        return ("YESYESYES".equalsIgnoreCase(test));
-    }
 }

--- a/src/frontend/org/voltdb/client/ClientUtils.java
+++ b/src/frontend/org/voltdb/client/ClientUtils.java
@@ -91,4 +91,14 @@ public class ClientUtils {
         }
         return buffer;
     }
+
+    // Utility to try to figure out if this is a test case.  Various junit targets in
+    // build.xml set this environment variable to give us a hint
+    public static boolean isThisATest() {
+        String test = System.getenv().get("VOLT_JUSTATEST");
+        if (test == null) {
+            test = System.getProperty("VOLT_JUSTATEST");
+        }
+        return ("YESYESYES".equalsIgnoreCase(test));
+    }
 }

--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -1215,7 +1215,7 @@ class Distributer {
         // stop the old proc call reaper
         m_timeoutReaperHandle.cancel(false);
         m_ex.shutdown();
-        m_ex.awaitTermination(365, TimeUnit.DAYS);
+        m_ex.awaitTermination(1, TimeUnit.SECONDS);
 
         m_network.shutdown();
     }

--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -62,6 +62,7 @@ import org.voltcore.network.VoltProtocolHandler;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
 import org.voltdb.ClientResponseImpl;
+import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.client.ClientStatusListenerExt.DisconnectCause;
 import org.voltdb.client.HashinatorLite.HashinatorLiteType;
@@ -1215,7 +1216,11 @@ class Distributer {
         // stop the old proc call reaper
         m_timeoutReaperHandle.cancel(false);
         m_ex.shutdown();
-        m_ex.awaitTermination(1, TimeUnit.SECONDS);
+        if (VoltDB.isThisATest()) {
+            m_ex.awaitTermination(1, TimeUnit.SECONDS);
+        } else {
+            m_ex.awaitTermination(365, TimeUnit.DAYS);
+        }
 
         m_network.shutdown();
     }

--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -62,7 +62,6 @@ import org.voltcore.network.VoltProtocolHandler;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
 import org.voltdb.ClientResponseImpl;
-import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.client.ClientStatusListenerExt.DisconnectCause;
 import org.voltdb.client.HashinatorLite.HashinatorLiteType;
@@ -1216,7 +1215,7 @@ class Distributer {
         // stop the old proc call reaper
         m_timeoutReaperHandle.cancel(false);
         m_ex.shutdown();
-        if (VoltDB.isThisATest()) {
+        if (ClientUtils.isThisATest()) {
             m_ex.awaitTermination(1, TimeUnit.SECONDS);
         } else {
             m_ex.awaitTermination(365, TimeUnit.DAYS);

--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -1215,7 +1215,7 @@ class Distributer {
         // stop the old proc call reaper
         m_timeoutReaperHandle.cancel(false);
         m_ex.shutdown();
-        if (ClientUtils.isThisATest()) {
+        if (CoreUtils.isJunitTest()) {
             m_ex.awaitTermination(1, TimeUnit.SECONDS);
         } else {
             m_ex.awaitTermination(365, TimeUnit.DAYS);


### PR DESCRIPTION
use env variable VOLT_JUSTATEST in the build as a switch to speed up unit tests. 