### PR TITLE
ENG-11647: Pre-populate site trackers for consumer clusters requested in snapshot request and start cursor request

### DIFF
--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -496,7 +496,9 @@ enum TaskType {
     TASK_TYPE_SP_JAVA_GET_DRID_TRACKER = 4,      // not supported in EE
     TASK_TYPE_SET_DRID_TRACKER = 5,              // not supported in EE
     TASK_TYPE_GENERATE_DR_EVENT = 6,
-    TASK_TYPE_RESET_DR_APPLIED_TRACKER = 7       // not supported in EE
+    TASK_TYPE_RESET_DR_APPLIED_TRACKER = 7,      // not supported in EE
+    TASK_TYPE_SET_MERGED_DRID_TRACKER = 8,       // not supported in EE
+    TASK_TYPE_INIT_DRID_TRACKER = 9,             // not supported in EE
 };
 
 // ------------------------------------------------------------------

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -1867,23 +1867,9 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
      * @throws IOException
      * @throws InterruptedException
      */
-    public ClientResponse callExecuteTask(long timeoutMS, byte[] params ) throws IOException, InterruptedException {
-        final String procedureName = "@ExecuteTask";
-        Config procedureConfig = SystemProcedureCatalog.listing.get(procedureName);
-        Procedure proc = procedureConfig.asCatalogProcedure();
-        StoredProcedureInvocation spi = new StoredProcedureInvocation();
-        spi.setProcName(procedureName);
-        spi.setParams(params);
+    public ClientResponse callExecuteTask(long timeoutMS, byte[] params) throws IOException, InterruptedException {
         SimpleClientResponseAdapter.SyncCallback syncCb = new SimpleClientResponseAdapter.SyncCallback();
-        spi.setClientHandle(m_executeTaskAdpater.registerCallback(syncCb));
-        if (spi.getSerializedParams() == null) {
-            spi = MiscUtils.roundTripForCL(spi);
-        }
-        createTransaction(m_executeTaskAdpater.connectionId(), spi,
-                proc.getReadonly(), proc.getSinglepartition(), proc.getEverysite(),
-                0 /* Can provide anything for multi-part */,
-                spi.getSerializedSize(), System.nanoTime());
-
+        callExecuteTaskAsync(syncCb, params);
         return syncCb.getResponse(timeoutMS);
     }
 
@@ -1907,11 +1893,12 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
         if (spi.getSerializedParams() == null) {
             spi = MiscUtils.roundTripForCL(spi);
         }
-        createTransaction(m_executeTaskAdpater.connectionId(), spi,
-                proc.getReadonly(), proc.getSinglepartition(), proc.getEverysite(),
-                0 /* Can provide anything for multi-part */,
-                spi.getSerializedSize(), System.nanoTime());
-
+        synchronized (m_executeTaskAdpater) {
+            createTransaction(m_executeTaskAdpater.connectionId(), spi,
+                    proc.getReadonly(), proc.getSinglepartition(), proc.getEverysite(),
+                    0 /* Can provide anything for multi-part */,
+                    spi.getSerializedSize(), System.nanoTime());
+        }
     }
 
     /**

--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -39,9 +39,9 @@ public interface ConsumerDRGateway extends Promotable {
 
     void clusterUnrecoverable(byte clusterId, Throwable t);
 
-    void queueStartCursors(byte clusterId, long clusterCreationId, List<String> clusterNodeInfo);
+    void queueStartCursors(byte producerClusterId, long producerClusterCreationId, List<String> producerHosts, int producerClusterPartitionCount);
 
-    void startConsumerDispatcher(byte producerClusterId, List<String> clusterNodeInfo, boolean awaitProducerSnapshot);
+    void startConsumerDispatcher(byte producerClusterId, List<String> producerHosts, boolean awaitProducerSnapshot);
 
     void addLocallyLedPartition(int partitionId);
 }

--- a/src/frontend/org/voltdb/ProducerDRGateway.java
+++ b/src/frontend/org/voltdb/ProducerDRGateway.java
@@ -105,9 +105,10 @@ public interface ProducerDRGateway {
      * When the process is complete, the passed in handler will be notified of the status.
      *
      * @param requestedCursors the clusters for which cursors must be started
+     * @param leaderClusterId ID of the cluster that needs to be marked as the snapshot source
      * @param handler callback to notify the status of the operation
      */
-    public void startCursor(final List<DRAgent.ClusterInfo> requestedCursors, final DRProducerResponseHandler handler);
+    public void startCursor(final List<DRAgent.ClusterInfo> requestedCursors, final byte leaderClusterId, final DRProducerResponseHandler handler);
 
     /**
      * Get the DR producer node stats. This method may block because the task

--- a/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
+++ b/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
@@ -104,6 +104,8 @@ public interface SystemProcedureExecutionContext {
 
     public void resetDrAppliedTracker();
 
+    public void initDRAppliedTracker(Map<Byte, Integer> clusterIdToPartitionCountMap);
+
     public Map<Integer, Map<Integer, DRConsumerDrIdTracker>> getDrAppliedTrackers();
 
     public Pair<Long, Long> getDrLastAppliedUniqueIds();

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -288,6 +288,11 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
         }
 
         @Override
+        public void initDRAppliedTracker(Map<Byte, Integer> clusterIdToPartitionCountMap) {
+            throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
+        }
+
+        @Override
         public Map<Integer, Map<Integer, DRConsumerDrIdTracker>> getDrAppliedTrackers()
         {
             throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -544,6 +544,27 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         }
 
         @Override
+        public void initDRAppliedTracker(Map<Byte, Integer> clusterIdToPartitionCountMap) {
+            for (Map.Entry<Byte, Integer> entry : clusterIdToPartitionCountMap.entrySet()) {
+                int producerClusterId = entry.getKey();
+                if (m_maxSeenDrLogsBySrcPartition.containsKey(producerClusterId)) {
+                    continue;
+                }
+                int producerPartitionCount = entry.getValue();
+                assert(producerPartitionCount != -1);
+                Map<Integer, DRConsumerDrIdTracker> clusterSources = new HashMap<>();
+                for (int i = 0; i < producerPartitionCount; i++) {
+                    DRConsumerDrIdTracker tracker =
+                            DRConsumerDrIdTracker.createPartitionTracker(
+                                    DRLogSegmentId.makeEmptyDRId(producerClusterId),
+                                    Long.MIN_VALUE, Long.MIN_VALUE, i);
+                    clusterSources.put(i, tracker);
+                }
+                m_maxSeenDrLogsBySrcPartition.put(producerClusterId, clusterSources);
+            }
+        }
+
+        @Override
         public Map<Integer, Map<Integer, DRConsumerDrIdTracker>> getDrAppliedTrackers()
         {
             if (drLog.isTraceEnabled()) {

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -65,7 +65,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         SET_DRID_TRACKER_START(5),
         GENERATE_DR_EVENT(6),
         RESET_DR_APPLIED_TRACKER(7),
-        SET_MERGED_DRID_TRACKER(8);
+        SET_MERGED_DRID_TRACKER(8),
+        INIT_DRID_TRACKER(9);
 
         private TaskType(int taskId) {
             this.taskId = taskId;

--- a/src/frontend/org/voltdb/pmsg/DRAgent.java
+++ b/src/frontend/org/voltdb/pmsg/DRAgent.java
@@ -1105,6 +1105,16 @@ public final class DRAgent {
      * </pre>
      */
     org.voltdb.pmsg.DRAgent.NodeInfoOrBuilder getNodeInfoOrBuilder();
+
+    // optional int32 globalPartitionCount = 3;
+    /**
+     * <code>optional int32 globalPartitionCount = 3;</code>
+     */
+    boolean hasGlobalPartitionCount();
+    /**
+     * <code>optional int32 globalPartitionCount = 3;</code>
+     */
+    int getGlobalPartitionCount();
   }
   /**
    * Protobuf type {@code pmsg.SnapshotReq}
@@ -1173,6 +1183,11 @@ public final class DRAgent {
                 nodeInfo_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              globalPartitionCount_ = input.readInt32();
               break;
             }
           }
@@ -1295,9 +1310,26 @@ public final class DRAgent {
       return nodeInfo_;
     }
 
+    // optional int32 globalPartitionCount = 3;
+    public static final int GLOBALPARTITIONCOUNT_FIELD_NUMBER = 3;
+    private int globalPartitionCount_;
+    /**
+     * <code>optional int32 globalPartitionCount = 3;</code>
+     */
+    public boolean hasGlobalPartitionCount() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional int32 globalPartitionCount = 3;</code>
+     */
+    public int getGlobalPartitionCount() {
+      return globalPartitionCount_;
+    }
+
     private void initFields() {
       nonce_ = "";
       nodeInfo_ = org.voltdb.pmsg.DRAgent.NodeInfo.getDefaultInstance();
+      globalPartitionCount_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1317,6 +1349,9 @@ public final class DRAgent {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeMessage(2, nodeInfo_);
       }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeInt32(3, globalPartitionCount_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -1333,6 +1368,10 @@ public final class DRAgent {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, nodeInfo_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(3, globalPartitionCount_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -1459,6 +1498,8 @@ public final class DRAgent {
           nodeInfoBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
+        globalPartitionCount_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -1499,6 +1540,10 @@ public final class DRAgent {
         } else {
           result.nodeInfo_ = nodeInfoBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.globalPartitionCount_ = globalPartitionCount_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1522,6 +1567,9 @@ public final class DRAgent {
         }
         if (other.hasNodeInfo()) {
           mergeNodeInfo(other.getNodeInfo());
+        }
+        if (other.hasGlobalPartitionCount()) {
+          setGlobalPartitionCount(other.getGlobalPartitionCount());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -1784,6 +1832,39 @@ public final class DRAgent {
           nodeInfo_ = null;
         }
         return nodeInfoBuilder_;
+      }
+
+      // optional int32 globalPartitionCount = 3;
+      private int globalPartitionCount_ ;
+      /**
+       * <code>optional int32 globalPartitionCount = 3;</code>
+       */
+      public boolean hasGlobalPartitionCount() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional int32 globalPartitionCount = 3;</code>
+       */
+      public int getGlobalPartitionCount() {
+        return globalPartitionCount_;
+      }
+      /**
+       * <code>optional int32 globalPartitionCount = 3;</code>
+       */
+      public Builder setGlobalPartitionCount(int value) {
+        bitField0_ |= 0x00000004;
+        globalPartitionCount_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 globalPartitionCount = 3;</code>
+       */
+      public Builder clearGlobalPartitionCount() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        globalPartitionCount_ = 0;
+        onChanged();
+        return this;
       }
 
       // @@protoc_insertion_point(builder_scope:pmsg.SnapshotReq)
@@ -17025,67 +17106,68 @@ public final class DRAgent {
       "\n\rdragent.proto\022\004pmsg\"\'\n\004UUID\022\020\n\010instanc" +
       "e\030\001 \002(\006\022\r\n\005count\030\002 \002(\006\"M\n\003Ack\022\023\n\013partiti" +
       "onId\030\001 \001(\005\022\021\n\ttimestamp\030\002 \001(\006\022\036\n\026average" +
-      "RowLatencyNanos\030\003 \001(\006\">\n\013SnapshotReq\022\r\n\005" +
+      "RowLatencyNanos\030\003 \001(\006\"\\\n\013SnapshotReq\022\r\n\005" +
       "nonce\030\001 \001(\t\022 \n\010nodeInfo\030\002 \001(\0132\016.pmsg.Nod" +
-      "eInfo\"/\n\005Reset\022\023\n\013partitionId\030\001 \001(\005\022\021\n\tt" +
-      "imestamp\030\002 \001(\006\"\034\n\005Pause\022\023\n\013partitionId\030\001" +
-      " \001(\005\"k\n\007Connect\022\021\n\tclusterId\030\001 \001(\005\022\031\n\021cl" +
-      "usterCreationId\030\002 \001(\006\022\027\n\017protocolVersion" +
-      "\030\003 \001(\005\022\031\n\021clusterRecoveryId\030\004 \001(\006\"t\n\tSub",
-      "scribe\022\023\n\013partitionId\030\001 \001(\005\022\021\n\ttimestamp" +
-      "\030\002 \001(\006\022\022\n\nisCovering\030\003 \001(\010\022\030\n\020rewindToUn" +
-      "iqueId\030\004 \001(\006\022\021\n\tisSyncing\030\005 \001(\010\"#\n\005Query" +
-      "\022\032\n\013includeMesh\030\001 \001(\010:\005false\"5\n\013StartCur" +
-      "sor\022&\n\013clusterInfo\030\001 \003(\0132\021.pmsg.ClusterI" +
-      "nfo\"\231\004\n\010Response\022\026\n\002id\030\001 \002(\0132\n.pmsg.UUID" +
-      "\022,\n\004mode\030\002 \001(\0162\036.pmsg.Response.Replicati" +
-      "onMode\022\031\n\021snapshotTimestamp\030\003 \001(\006\022\026\n\016ins" +
-      "tanceIdHash\030\004 \001(\006\022\017\n\007version\030\005 \001(\t\022 \n\010no" +
-      "deInfo\030\006 \003(\0132\016.pmsg.NodeInfo\022\034\n\024globalPa",
-      "rtitionCount\030\007 \001(\005\022*\n\rpartitionInfo\030\010 \003(" +
-      "\0132\023.pmsg.PartitionInfo\022\021\n\006status\030\t \001(\005:\001" +
-      "0\022%\n\004type\030\n \001(\0162\027.pmsg.CtrlEnvelope.Type" +
-      "\022\022\n\ncatalogCRC\030\013 \001(\006\022\030\n\020catalogSignature" +
-      "\030\014 \001(\t\022\024\n\014failureCause\030\r \001(\t\022\025\n\risEndOfS" +
-      "tream\030\016 \001(\010\022\027\n\017protocolVersion\030\017 \001(\005\"i\n\017" +
-      "ReplicationMode\022\010\n\004IDLE\020\001\022\026\n\022SYNCING_REP" +
-      "LICATED\020\002\022\027\n\023SYNCING_PARTITIONED\020\003\022\n\n\006AC" +
-      "TIVE\020\004\022\017\n\013UNAVAILABLE\020\005\"\377\001\n\021CtrlProtoRes" +
-      "ponse\022\026\n\002id\030\001 \002(\0132\n.pmsg.UUID\022%\n\004type\030\002 ",
-      "\001(\0162\027.pmsg.CtrlEnvelope.Type\022\021\n\006status\030\003" +
-      " \001(\005:\0010\022\024\n\014failureCause\030\004 \001(\t\022.\n\017connect" +
-      "Response\030\005 \001(\0132\025.pmsg.ConnectResponse\022*\n" +
-      "\rqueryResponse\030\006 \001(\0132\023.pmsg.QueryRespons" +
-      "e\022&\n\013ackResponse\030\007 \001(\0132\021.pmsg.AckRespons" +
-      "e\"$\n\013AckResponse\022\025\n\risEndOfStream\030\001 \001(\010\"" +
-      "\200\001\n\017ConnectResponse\022\022\n\ncatalogCRC\030\001 \001(\006\022" +
-      "\030\n\020catalogSignature\030\002 \001(\t\022\027\n\017protocolVer" +
-      "sion\030\003 \001(\005\022&\n\013clusterInfo\030\004 \003(\0132\021.pmsg.C" +
-      "lusterInfo\"S\n\rQueryResponse\022\032\n\013includeMe",
-      "sh\030\001 \001(\010:\005false\022&\n\013clusterInfo\030\002 \003(\0132\021.p" +
-      "msg.ClusterInfo\"\315\001\n\013ClusterInfo\022\021\n\tclust" +
-      "erId\030\001 \002(\005\022\022\n\ncreationId\030\002 \002(\006\022\022\n\nrecove" +
-      "ryId\030\003 \001(\006\022\027\n\017protocolVersion\030\004 \001(\005\022\034\n\024g" +
-      "lobalPartitionCount\030\005 \001(\005\022 \n\010nodeInfo\030\006 " +
-      "\003(\0132\016.pmsg.NodeInfo\022*\n\rpartitionInfo\030\007 \003" +
-      "(\0132\023.pmsg.PartitionInfo\":\n\010NodeInfo\022\020\n\010h" +
-      "ostname\030\001 \001(\t\022\016\n\006drport\030\002 \001(\005\022\014\n\004isUp\030\003 " +
-      "\001(\010\":\n\rPartitionInfo\022\023\n\013partitionId\030\001 \001(" +
-      "\005\022\024\n\014nextUniqueId\030\n \001(\003\"\222\004\n\014CtrlEnvelope",
-      "\022%\n\004type\030\001 \002(\0162\027.pmsg.CtrlEnvelope.Type\022" +
-      "\026\n\002id\030\002 \002(\0132\n.pmsg.UUID\022\026\n\003ack\030\003 \001(\0132\t.p" +
-      "msg.Ack\022\032\n\005reset\030\004 \001(\0132\013.pmsg.Reset\022\032\n\005p" +
-      "ause\030\005 \001(\0132\013.pmsg.Pause\022 \n\010response\030\006 \001(" +
-      "\0132\016.pmsg.Response\022&\n\013snapshotReq\030\007 \001(\0132\021" +
-      ".pmsg.SnapshotReq\022\"\n\tsubscribe\030\010 \001(\0132\017.p" +
-      "msg.Subscribe\022\036\n\007connect\030\n \001(\0132\r.pmsg.Co" +
-      "nnect\022\032\n\005query\030\013 \001(\0132\013.pmsg.Query\022&\n\013sta" +
-      "rtCursor\030\014 \001(\0132\021.pmsg.StartCursor\"\240\001\n\004Ty" +
-      "pe\022\007\n\003ACK\020\001\022\t\n\005RESET\020\002\022\t\n\005PAUSE\020\003\022\t\n\005QUE",
-      "RY\020\004\022\014\n\010RESPONSE\020\005\022\020\n\014SNAPSHOT_REQ\020\006\022\021\n\r" +
-      "SNAPSHOT_TERM\020\007\022\r\n\tSTOP_SYNC\020\010\022\013\n\007CONNEC" +
-      "T\020\t\022\r\n\tSUBSCRIBE\020\n\022\020\n\014START_CURSOR\020\013B\032\n\017" +
-      "org.voltdb.pmsgB\007DRAgent"
+      "eInfo\022\034\n\024globalPartitionCount\030\003 \001(\005\"/\n\005R" +
+      "eset\022\023\n\013partitionId\030\001 \001(\005\022\021\n\ttimestamp\030\002" +
+      " \001(\006\"\034\n\005Pause\022\023\n\013partitionId\030\001 \001(\005\"k\n\007Co" +
+      "nnect\022\021\n\tclusterId\030\001 \001(\005\022\031\n\021clusterCreat" +
+      "ionId\030\002 \001(\006\022\027\n\017protocolVersion\030\003 \001(\005\022\031\n\021",
+      "clusterRecoveryId\030\004 \001(\006\"t\n\tSubscribe\022\023\n\013" +
+      "partitionId\030\001 \001(\005\022\021\n\ttimestamp\030\002 \001(\006\022\022\n\n" +
+      "isCovering\030\003 \001(\010\022\030\n\020rewindToUniqueId\030\004 \001" +
+      "(\006\022\021\n\tisSyncing\030\005 \001(\010\"#\n\005Query\022\032\n\013includ" +
+      "eMesh\030\001 \001(\010:\005false\"5\n\013StartCursor\022&\n\013clu" +
+      "sterInfo\030\001 \003(\0132\021.pmsg.ClusterInfo\"\231\004\n\010Re" +
+      "sponse\022\026\n\002id\030\001 \002(\0132\n.pmsg.UUID\022,\n\004mode\030\002" +
+      " \001(\0162\036.pmsg.Response.ReplicationMode\022\031\n\021" +
+      "snapshotTimestamp\030\003 \001(\006\022\026\n\016instanceIdHas" +
+      "h\030\004 \001(\006\022\017\n\007version\030\005 \001(\t\022 \n\010nodeInfo\030\006 \003",
+      "(\0132\016.pmsg.NodeInfo\022\034\n\024globalPartitionCou" +
+      "nt\030\007 \001(\005\022*\n\rpartitionInfo\030\010 \003(\0132\023.pmsg.P" +
+      "artitionInfo\022\021\n\006status\030\t \001(\005:\0010\022%\n\004type\030" +
+      "\n \001(\0162\027.pmsg.CtrlEnvelope.Type\022\022\n\ncatalo" +
+      "gCRC\030\013 \001(\006\022\030\n\020catalogSignature\030\014 \001(\t\022\024\n\014" +
+      "failureCause\030\r \001(\t\022\025\n\risEndOfStream\030\016 \001(" +
+      "\010\022\027\n\017protocolVersion\030\017 \001(\005\"i\n\017Replicatio" +
+      "nMode\022\010\n\004IDLE\020\001\022\026\n\022SYNCING_REPLICATED\020\002\022" +
+      "\027\n\023SYNCING_PARTITIONED\020\003\022\n\n\006ACTIVE\020\004\022\017\n\013" +
+      "UNAVAILABLE\020\005\"\377\001\n\021CtrlProtoResponse\022\026\n\002i",
+      "d\030\001 \002(\0132\n.pmsg.UUID\022%\n\004type\030\002 \001(\0162\027.pmsg" +
+      ".CtrlEnvelope.Type\022\021\n\006status\030\003 \001(\005:\0010\022\024\n" +
+      "\014failureCause\030\004 \001(\t\022.\n\017connectResponse\030\005" +
+      " \001(\0132\025.pmsg.ConnectResponse\022*\n\rqueryResp" +
+      "onse\030\006 \001(\0132\023.pmsg.QueryResponse\022&\n\013ackRe" +
+      "sponse\030\007 \001(\0132\021.pmsg.AckResponse\"$\n\013AckRe" +
+      "sponse\022\025\n\risEndOfStream\030\001 \001(\010\"\200\001\n\017Connec" +
+      "tResponse\022\022\n\ncatalogCRC\030\001 \001(\006\022\030\n\020catalog" +
+      "Signature\030\002 \001(\t\022\027\n\017protocolVersion\030\003 \001(\005" +
+      "\022&\n\013clusterInfo\030\004 \003(\0132\021.pmsg.ClusterInfo",
+      "\"S\n\rQueryResponse\022\032\n\013includeMesh\030\001 \001(\010:\005" +
+      "false\022&\n\013clusterInfo\030\002 \003(\0132\021.pmsg.Cluste" +
+      "rInfo\"\315\001\n\013ClusterInfo\022\021\n\tclusterId\030\001 \002(\005" +
+      "\022\022\n\ncreationId\030\002 \002(\006\022\022\n\nrecoveryId\030\003 \001(\006" +
+      "\022\027\n\017protocolVersion\030\004 \001(\005\022\034\n\024globalParti" +
+      "tionCount\030\005 \001(\005\022 \n\010nodeInfo\030\006 \003(\0132\016.pmsg" +
+      ".NodeInfo\022*\n\rpartitionInfo\030\007 \003(\0132\023.pmsg." +
+      "PartitionInfo\":\n\010NodeInfo\022\020\n\010hostname\030\001 " +
+      "\001(\t\022\016\n\006drport\030\002 \001(\005\022\014\n\004isUp\030\003 \001(\010\":\n\rPar" +
+      "titionInfo\022\023\n\013partitionId\030\001 \001(\005\022\024\n\014nextU",
+      "niqueId\030\n \001(\003\"\222\004\n\014CtrlEnvelope\022%\n\004type\030\001" +
+      " \002(\0162\027.pmsg.CtrlEnvelope.Type\022\026\n\002id\030\002 \002(" +
+      "\0132\n.pmsg.UUID\022\026\n\003ack\030\003 \001(\0132\t.pmsg.Ack\022\032\n" +
+      "\005reset\030\004 \001(\0132\013.pmsg.Reset\022\032\n\005pause\030\005 \001(\013" +
+      "2\013.pmsg.Pause\022 \n\010response\030\006 \001(\0132\016.pmsg.R" +
+      "esponse\022&\n\013snapshotReq\030\007 \001(\0132\021.pmsg.Snap" +
+      "shotReq\022\"\n\tsubscribe\030\010 \001(\0132\017.pmsg.Subscr" +
+      "ibe\022\036\n\007connect\030\n \001(\0132\r.pmsg.Connect\022\032\n\005q" +
+      "uery\030\013 \001(\0132\013.pmsg.Query\022&\n\013startCursor\030\014" +
+      " \001(\0132\021.pmsg.StartCursor\"\240\001\n\004Type\022\007\n\003ACK\020",
+      "\001\022\t\n\005RESET\020\002\022\t\n\005PAUSE\020\003\022\t\n\005QUERY\020\004\022\014\n\010RE" +
+      "SPONSE\020\005\022\020\n\014SNAPSHOT_REQ\020\006\022\021\n\rSNAPSHOT_T" +
+      "ERM\020\007\022\r\n\tSTOP_SYNC\020\010\022\013\n\007CONNECT\020\t\022\r\n\tSUB" +
+      "SCRIBE\020\n\022\020\n\014START_CURSOR\020\013B\032\n\017org.voltdb" +
+      ".pmsgB\007DRAgent"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -17109,7 +17191,7 @@ public final class DRAgent {
           internal_static_pmsg_SnapshotReq_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_pmsg_SnapshotReq_descriptor,
-              new java.lang.String[] { "Nonce", "NodeInfo", });
+              new java.lang.String[] { "Nonce", "NodeInfo", "GlobalPartitionCount", });
           internal_static_pmsg_Reset_descriptor =
             getDescriptor().getMessageTypes().get(3);
           internal_static_pmsg_Reset_fieldAccessorTable = new

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
@@ -163,6 +163,23 @@ public class ExecuteTask extends VoltSystemProcedure {
                 }
                 break;
             }
+            case INIT_DRID_TRACKER:
+            {
+                result = new VoltTable(STATUS_SCHEMA);
+                try {
+                    byte[] paramBuf = new byte[buffer.remaining()];
+                    buffer.get(paramBuf);
+                    ByteArrayInputStream bais = new ByteArrayInputStream(paramBuf);
+                    ObjectInputStream ois = new ObjectInputStream(bais);
+                    Map<Byte, Integer> clusterIdToPartitionCountMap = (Map<Byte, Integer>)ois.readObject();
+                    context.initDRAppliedTracker(clusterIdToPartitionCountMap);
+                    result.addRow(STATUS_OK);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    result.addRow("FAILURE");
+                }
+                break;
+            }
             default:
                 throw new VoltAbortException("Unable to find the task associated with the given task id");
             }

--- a/src/protobuf/dragent.proto
+++ b/src/protobuf/dragent.proto
@@ -20,6 +20,7 @@ message SnapshotReq {
     // The node sending this snapshot request. It includes the DR interface and
     // port that he remote clusters can use to connect back.
     optional NodeInfo nodeInfo = 2;
+    optional int32 globalPartitionCount = 3;
 }
 
 message Reset {


### PR DESCRIPTION
1. Add a new ExecuteTask task type INIT_DRID_TRACKER which is used to populating empty trackers in XDCR
2. Add partition count in snapshot request protobuf, include partition count in snapshot requests and start cursor requests (they are not really used for now, will remove them if not needed)