### PR TITLE
ENG-11352:

### DIFF
--- a/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
+++ b/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
@@ -75,7 +75,9 @@ public class SpDurabilityListener implements DurabilityListener {
 
         @Override
         public void addTask(TransactionTask task) {
-            setLastDurableUniqueId(task.m_txnState.uniqueId);
+            if (!task.m_txnState.isReadOnly()) {
+                setLastDurableUniqueId(task.m_txnState.uniqueId);
+            }
         }
 
         @Override
@@ -133,6 +135,11 @@ public class SpDurabilityListener implements DurabilityListener {
         public void addTask(TransactionTask task) {
             m_pendingTransactions.add(task);
             super.addTask(task);
+        }
+
+        @Override
+        public boolean isChanged() {
+            return !m_pendingTransactions.isEmpty();
         }
 
         @Override


### PR DESCRIPTION
Read-only transactions use UniqueIds for access to Time but the UniqueId is not in fact unique nor is it continuously advancing relative to other transactions. Because we only want durability notifications for write transactions, we need to avoid updating UniqueIds for read-only transactions.

Because of read-write ordering issues identified by Jepsen Synchronous command logging does track read-only transactions. Therefore, even for a read-only workload, the durability listener must still be called to queue the read-only transactions to the Site thread.