### PR TITLE
ENG-11693: DRROLE for multi-cluster XDCR

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -18,6 +18,7 @@
 package org.voltdb;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 // Interface through which the outside world can interact with the consumer side
@@ -32,7 +33,7 @@ public interface ConsumerDRGateway extends Promotable {
      */
     void updateCatalog(CatalogContext catalog, String newConnectionSource);
 
-    DRRoleStats.State getState();
+    Map<Byte, DRRoleStats.State> getStates();
 
     void initialize(boolean resumeReplication);
 

--- a/src/frontend/org/voltdb/DRConsumerStatsBase.java
+++ b/src/frontend/org/voltdb/DRConsumerStatsBase.java
@@ -29,6 +29,7 @@ public class DRConsumerStatsBase {
     public static interface Columns {
         // shared columns
         public static final String CLUSTER_ID = "CLUSTER_ID";
+        public static final String PRODUCER_CLUSTER_ID = "PRODUCER_CLUSTER_ID";
 
         // columns for the node-level table
         public static final String STATE = "STATE";
@@ -53,6 +54,7 @@ public class DRConsumerStatsBase {
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
             columns.add(new ColumnInfo(Columns.CLUSTER_ID, VoltType.INTEGER));
+            columns.add(new ColumnInfo(Columns.PRODUCER_CLUSTER_ID, VoltType.INTEGER));
             columns.add(new ColumnInfo(Columns.STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.REPLICATION_RATE_1M, VoltType.BIGINT));
             columns.add(new ColumnInfo(Columns.REPLICATION_RATE_5M, VoltType.BIGINT));
@@ -74,6 +76,7 @@ public class DRConsumerStatsBase {
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
             columns.add(new ColumnInfo(Columns.CLUSTER_ID, VoltType.INTEGER));
+            columns.add(new ColumnInfo(Columns.PRODUCER_CLUSTER_ID, VoltType.INTEGER));
             columns.add(new ColumnInfo(VoltSystemProcedure.CNAME_PARTITION_ID, VoltType.INTEGER));
             columns.add(new ColumnInfo(Columns.IS_COVERED, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.COVERING_HOST, VoltType.STRING));

--- a/src/frontend/org/voltdb/DRProducerNodeStats.java
+++ b/src/frontend/org/voltdb/DRProducerNodeStats.java
@@ -18,6 +18,13 @@
 package org.voltdb;
 
 public class DRProducerNodeStats {
+    public static final DRProducerNodeStats DISABLED_NODE_STATS =
+        new DRProducerNodeStats((short) -1, DRRoleStats.State.DISABLED, "",
+                                -1, -1, 0);
+    public static final DRProducerNodeStats PENDING_NODE_STATS =
+        new DRProducerNodeStats((short) -1, DRRoleStats.State.PENDING, "",
+                                -1, -1, 0);
+
     public final short consumerClusterId;
     public final DRRoleStats.State state;
     public String syncSnapshotState;

--- a/src/frontend/org/voltdb/DRProducerNodeStats.java
+++ b/src/frontend/org/voltdb/DRProducerNodeStats.java
@@ -19,10 +19,10 @@ package org.voltdb;
 
 public class DRProducerNodeStats {
     public static final DRProducerNodeStats DISABLED_NODE_STATS =
-        new DRProducerNodeStats((short) -1, DRRoleStats.State.DISABLED, "",
+        new DRProducerNodeStats((short) -1, DRRoleStats.State.DISABLED, "NONE",
                                 -1, -1, 0);
     public static final DRProducerNodeStats PENDING_NODE_STATS =
-        new DRProducerNodeStats((short) -1, DRRoleStats.State.PENDING, "",
+        new DRProducerNodeStats((short) -1, DRRoleStats.State.PENDING, "NONE",
                                 -1, -1, 0);
 
     public final short consumerClusterId;

--- a/src/frontend/org/voltdb/DRProducerNodeStats.java
+++ b/src/frontend/org/voltdb/DRProducerNodeStats.java
@@ -21,9 +21,6 @@ public class DRProducerNodeStats {
     public static final DRProducerNodeStats DISABLED_NODE_STATS =
         new DRProducerNodeStats((short) -1, DRRoleStats.State.DISABLED, "NONE",
                                 -1, -1, 0);
-    public static final DRProducerNodeStats PENDING_NODE_STATS =
-        new DRProducerNodeStats((short) -1, DRRoleStats.State.PENDING, "NONE",
-                                -1, -1, 0);
 
     public final short consumerClusterId;
     public final DRRoleStats.State state;

--- a/src/frontend/org/voltdb/DRProducerNodeStats.java
+++ b/src/frontend/org/voltdb/DRProducerNodeStats.java
@@ -19,9 +19,10 @@ package org.voltdb;
 
 public class DRProducerNodeStats {
     public static final DRProducerNodeStats DISABLED_NODE_STATS =
-        new DRProducerNodeStats((short) -1, DRRoleStats.State.DISABLED, "NONE",
+        new DRProducerNodeStats((byte) -1, (byte) -1, DRRoleStats.State.DISABLED, "NONE",
                                 -1, -1, 0);
 
+    public final short clusterId;
     public final short consumerClusterId;
     public final DRRoleStats.State state;
     public String syncSnapshotState;
@@ -29,13 +30,14 @@ public class DRProducerNodeStats {
     public final long rowsAckedForSyncSnapshot;
     public final long queueDepth;
 
-    public DRProducerNodeStats(
-                              short consumerClusterId,
-                              DRRoleStats.State state,
-                              String syncSnapshotState,
-                              long rowsInSyncSnapshot,
-                              long rowsAckedForSyncSnapshot,
-                              long queueDepth) {
+    public DRProducerNodeStats(short clusterId,
+                               short consumerClusterId,
+                               DRRoleStats.State state,
+                               String syncSnapshotState,
+                               long rowsInSyncSnapshot,
+                               long rowsAckedForSyncSnapshot,
+                               long queueDepth) {
+        this.clusterId = clusterId;
         this.consumerClusterId = consumerClusterId;
         this.state = state;
         this.syncSnapshotState = syncSnapshotState;

--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -28,6 +28,7 @@ public class DRProducerStatsBase {
 
     public static interface Columns {
         // column for both tables
+        public static final String CLUSTER_ID = "CLUSTERID";
         public static final String CONSUMER_CLUSTER_ID = "CONSUMERCLUSTERID";
 
         // columns for the node-level table
@@ -59,6 +60,7 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
+            columns.add(new ColumnInfo(Columns.CLUSTER_ID, VoltType.SMALLINT));
             columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
             columns.add(new ColumnInfo(Columns.STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.SYNC_SNAPSHOT_STATE, VoltType.STRING));
@@ -82,6 +84,7 @@ public class DRProducerStatsBase {
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
             super.populateColumnSchema(columns);
+            columns.add(new ColumnInfo(Columns.CLUSTER_ID, VoltType.SMALLINT));
             columns.add(new ColumnInfo(Columns.CONSUMER_CLUSTER_ID, VoltType.SMALLINT));
             columns.add(new ColumnInfo(VoltSystemProcedure.CNAME_PARTITION_ID, VoltType.INTEGER));
             columns.add(new ColumnInfo(Columns.STREAM_TYPE, VoltType.STRING));

--- a/src/frontend/org/voltdb/DRRoleStats.java
+++ b/src/frontend/org/voltdb/DRRoleStats.java
@@ -17,7 +17,11 @@
 
 package org.voltdb;
 
+import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.Sets;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
@@ -79,65 +83,56 @@ public class DRRoleStats extends StatsSource {
     @Override
     protected void updateStatsRow(Object rowKey, Object[] rowValues)
     {
-        final ProducerDRGateway producer = m_vdb.getNodeDRGateway();
-        final DRProducerNodeStats producerStats;
-        if (producer != null) {
-            producerStats = producer.getNodeDRStats();
-        } else {
-            producerStats = null;
-        }
-
-        final Role role = getRole(producerStats);
-        State state = State.DISABLED;
-
-        if (role == Role.XDCR || role == Role.MASTER) {
-            if (producerStats != null) {
-                state = state.and(producerStats.state);
-            }
-        }
-
-        if (role == Role.XDCR || role == Role.REPLICA) {
-            final ConsumerDRGateway consumer = m_vdb.getConsumerDRGateway();
-            if (consumer != null) {
-                state = state.and(consumer.getState());
-            }
-        }
+        @SuppressWarnings("unchecked") Map.Entry<Byte, State> state = (Map.Entry<Byte, State>) rowKey;
+        final Role role = getRole(state.getValue());
 
         rowValues[columnNameToIndex.get(CN_ROLE)] = role.name();
-        rowValues[columnNameToIndex.get(CN_STATE)] = state.name();
-        rowValues[columnNameToIndex.get(CN_REMOTE_CLUSTER_ID)] = -1; // reserved for multi-cluster XDCR
+        rowValues[columnNameToIndex.get(CN_STATE)] = state.getValue().name();
+        rowValues[columnNameToIndex.get(CN_REMOTE_CLUSTER_ID)] = state.getKey();
     }
 
     @Override
     protected Iterator<Object> getStatsRowKeyIterator(boolean interval)
     {
-        return new Iterator<Object>() {
-            boolean returnRow = true;
+        final ProducerDRGateway producer = m_vdb.getNodeDRGateway();
+        final Map<Byte, DRProducerNodeStats> producerStats;
+        if (producer != null) {
+            producerStats = producer.getNodeDRStats();
+        } else {
+            producerStats = ImmutableMap.of((byte) -1, DRProducerNodeStats.DISABLED_NODE_STATS);
+        }
 
+        final ConsumerDRGateway consumer = m_vdb.getConsumerDRGateway();
+        final Map<Byte, State> consumerStates;
+        if (consumer != null) {
+            consumerStates = consumer.getStates();
+        } else {
+            consumerStates = ImmutableMap.of((byte) -1, State.DISABLED);
+        }
+
+        final Map<Byte, State> states = mergeProducerConsumerStates(producerStats, consumerStates);
+
+        final Iterator<Map.Entry<Byte, State>> iter = states.entrySet().iterator();
+        return new Iterator<Object>() {
             @Override
             public boolean hasNext()
             {
-                return returnRow;
+                return iter.hasNext();
             }
 
             @Override
             public Object next()
             {
-                if (returnRow) {
-                    returnRow = false;
-                    return new Object();
-                } else {
-                    return null;
-                }
+                return iter.next();
             }
         };
     }
 
-    private Role getRole(DRProducerNodeStats producerStats)
+    private Role getRole(State state)
     {
         if (m_vdb.getReplicationRole() == ReplicationRole.REPLICA) {
             return Role.REPLICA;
-        } else if (producerStats != null && producerStats.state != State.DISABLED) {
+        } else if (state != State.DISABLED) {
             if (m_vdb.getConsumerDRGateway() == null) {
                 return Role.MASTER;
             } else {
@@ -146,6 +141,31 @@ public class DRRoleStats extends StatsSource {
         } else {
             return Role.NONE;
         }
+    }
+
+    private static Map<Byte, State> mergeProducerConsumerStates(Map<Byte, DRProducerNodeStats> producerStats,
+                                                                Map<Byte, State> consumerStates)
+    {
+        Map<Byte, State> states = new HashMap<>();
+        for (byte clusterId : Sets.union(producerStats.keySet(), consumerStates.keySet())) {
+            final DRProducerNodeStats producerNodeStats = producerStats.get(clusterId);
+            final State consumerState = consumerStates.get(clusterId);
+            State finalState = State.DISABLED;
+            if (producerNodeStats != null) {
+                finalState = finalState.and(producerNodeStats.state);
+            }
+            if (consumerState != null) {
+                finalState = finalState.and(consumerState);
+            }
+            states.put(clusterId, finalState);
+        }
+
+        // Remove the -1 placeholder if there are real cluster states
+        if (states.size() > 1) {
+            states.remove((byte) -1);
+        }
+
+        return states;
     }
 
     /**

--- a/src/frontend/org/voltdb/ProducerDRGateway.java
+++ b/src/frontend/org/voltdb/ProducerDRGateway.java
@@ -68,7 +68,7 @@ public interface ProducerDRGateway {
 
     public abstract void updateCatalog(final CatalogContext catalog, final int listenPort);
 
-    public abstract int getDRClusterId();
+    public abstract byte getDRClusterId();
 
     public void cacheSnapshotRestoreTruncationPoint(Map<Integer, Long> sequenceNumbers);
 

--- a/src/frontend/org/voltdb/ProducerDRGateway.java
+++ b/src/frontend/org/voltdb/ProducerDRGateway.java
@@ -114,7 +114,7 @@ public interface ProducerDRGateway {
      * Get the DR producer node stats. This method may block because the task
      * runs on the producer thread and it waits for the asynchronous task to
      * finish.
-     * @return The producer node stats or null if on error
+     * @return The producer node stats keyed by cluster IDs or null if on error
      */
-    public DRProducerNodeStats getNodeDRStats();
+    public Map<Byte, DRProducerNodeStats> getNodeDRStats();
 }

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -137,7 +137,7 @@ public class LocalCluster extends VoltServerConfig {
     }
 
     // Produce a (presumably) available IP port number.
-    public final PortGeneratorForTest portGenerator = new PortGeneratorForTest();
+    public static final PortGeneratorForTest portGenerator = new PortGeneratorForTest();
     private InternalPortGeneratorForTest internalPortGenerator;
     private int numberOfCoordinators = 1;
     private String m_voltdbroot = "";

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
@@ -46,45 +46,49 @@ import org.voltdb.regressionsuites.StatisticsTestSuiteBase;
 public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
 
     private static int REPLICATION_PORT = 11000;
-    private static int CONSUMER_CLUSTER_COUNT = 2;
 
-    private static final ColumnInfo[] expectedDRNodeStatsSchema = new ColumnInfo[9];
-    private static final ColumnInfo[] expectedDRPartitionStatsSchema = new ColumnInfo[15];
+    private static final ColumnInfo[] expectedDRNodeStatsSchema;
+    private static final ColumnInfo[] expectedDRPartitionStatsSchema;
 
     static {
-        expectedDRNodeStatsSchema[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
-        expectedDRNodeStatsSchema[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
-        expectedDRNodeStatsSchema[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedDRNodeStatsSchema[3] = new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT);
-        expectedDRNodeStatsSchema[4] = new ColumnInfo("STATE", VoltType.STRING);
-        expectedDRNodeStatsSchema[5] = new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING);
-        expectedDRNodeStatsSchema[6] = new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT);
-        expectedDRNodeStatsSchema[7] = new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT);
-        expectedDRNodeStatsSchema[8] = new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT);
+        expectedDRNodeStatsSchema = new ColumnInfo[] {
+            new ColumnInfo("TIMESTAMP", VoltType.BIGINT),
+            new ColumnInfo("HOST_ID", VoltType.INTEGER),
+            new ColumnInfo("HOSTNAME", VoltType.STRING),
+            new ColumnInfo("CLUSTERID", VoltType.SMALLINT),
+            new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT),
+            new ColumnInfo("STATE", VoltType.STRING),
+            new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING),
+            new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT),
+            new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT),
+            new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT)
+        };
 
-        expectedDRPartitionStatsSchema[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
-        expectedDRPartitionStatsSchema[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
-        expectedDRPartitionStatsSchema[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedDRPartitionStatsSchema[3] = new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT);
-        expectedDRPartitionStatsSchema[4] = new ColumnInfo("PARTITION_ID", VoltType.INTEGER);
-        expectedDRPartitionStatsSchema[5] = new ColumnInfo("STREAMTYPE", VoltType.STRING);
-        expectedDRPartitionStatsSchema[6] = new ColumnInfo("TOTALBYTES", VoltType.BIGINT);
-        expectedDRPartitionStatsSchema[7] = new ColumnInfo("TOTALBYTESINMEMORY", VoltType.BIGINT);
-        expectedDRPartitionStatsSchema[8] = new ColumnInfo("TOTALBUFFERS", VoltType.BIGINT);
-        expectedDRPartitionStatsSchema[9] = new ColumnInfo("LASTQUEUEDDRID", VoltType.BIGINT);
-        expectedDRPartitionStatsSchema[10] = new ColumnInfo("LASTACKDRID", VoltType.BIGINT);
-        expectedDRPartitionStatsSchema[11] = new ColumnInfo("LASTQUEUEDTIMESTAMP", VoltType.TIMESTAMP);
-        expectedDRPartitionStatsSchema[12] = new ColumnInfo("LASTACKTIMESTAMP", VoltType.TIMESTAMP);
-        expectedDRPartitionStatsSchema[13] = new ColumnInfo("ISSYNCED", VoltType.STRING);
-        expectedDRPartitionStatsSchema[14] = new ColumnInfo("MODE", VoltType.STRING);
+        expectedDRPartitionStatsSchema = new ColumnInfo[] {
+            new ColumnInfo("TIMESTAMP", VoltType.BIGINT),
+            new ColumnInfo("HOST_ID", VoltType.INTEGER),
+            new ColumnInfo("HOSTNAME", VoltType.STRING),
+            new ColumnInfo("CLUSTERID", VoltType.SMALLINT),
+            new ColumnInfo("CONSUMERCLUSTERID", VoltType.SMALLINT),
+            new ColumnInfo("PARTITION_ID", VoltType.INTEGER),
+            new ColumnInfo("STREAMTYPE", VoltType.STRING),
+            new ColumnInfo("TOTALBYTES", VoltType.BIGINT),
+            new ColumnInfo("TOTALBYTESINMEMORY", VoltType.BIGINT),
+            new ColumnInfo("TOTALBUFFERS", VoltType.BIGINT),
+            new ColumnInfo("LASTQUEUEDDRID", VoltType.BIGINT),
+            new ColumnInfo("LASTACKDRID", VoltType.BIGINT),
+            new ColumnInfo("LASTQUEUEDTIMESTAMP", VoltType.TIMESTAMP),
+            new ColumnInfo("LASTACKTIMESTAMP", VoltType.TIMESTAMP),
+            new ColumnInfo("ISSYNCED", VoltType.STRING),
+            new ColumnInfo("MODE", VoltType.STRING)
+        };
     }
 
     public TestStatisticsSuiteDRStats(String name) {
         super(name);
     }
 
-    // TODO temporarily disabled until the node stats fields have been decided for multiple consumer clusters case
-    public void notestDRNodeStatistics() throws Exception {
+    public void testDRNodeStatistics() throws Exception {
         if (!VoltDB.instance().getConfig().m_isEnterprise) {
             System.out.println("SKIPPING DRNODE STATS TESTS FOR COMMUNITY VERSION");
             return;
@@ -92,7 +96,6 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         System.out.println("\n\nTESTING DRNODE STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
-        assertEquals("Expected DRNodeStatistics schema length is 9", 9, expectedDRNodeStatsSchema.length);
         VoltTable expectedTable2 = new VoltTable(expectedDRNodeStatsSchema);
 
         //
@@ -118,7 +121,6 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         System.out.println("\n\nTESTING DRPRODUCERPARTITION STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
-        assertEquals("Expected DRPartitionStatistics schema length is 15", 15, expectedDRPartitionStatsSchema.length);
         VoltTable expectedTable1 = new VoltTable(expectedDRPartitionStatsSchema);
 
         //
@@ -142,7 +144,6 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         List<Client> consumerClients = new ArrayList<>();
         List<LocalCluster> consumerClusters = new ArrayList<>();
 
-        assertEquals("Expected DRPartitionStatistics schema length is 15", 15, expectedDRPartitionStatsSchema.length);
         VoltTable expectedTable1 = new VoltTable(expectedDRPartitionStatsSchema);
 
         ClientResponse cr = primaryClient.callProcedure("@AdHoc", "insert into employee values(1, 25);");
@@ -152,6 +153,7 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         String secondaryRoot = "/tmp/" + System.getProperty("user.name") + "-dr-stats-secondary";
 
         try {
+            int CONSUMER_CLUSTER_COUNT = 2;
             for (int n = 1; n <= CONSUMER_CLUSTER_COUNT; n++) {
                 LocalCluster consumerCluster = LocalCluster.createLocalCluster(drSchema, SITES, HOSTS, KFACTOR, n,
                         REPLICATION_PORT + 100 * n, REPLICATION_PORT, secondaryRoot, jarName, true);
@@ -207,8 +209,7 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         }
     }
 
-    // TODO temporarily disabled until the node stats fields have been decided for multiple consumer clusters case
-    public void notestDRStatistics() throws Exception {
+    public void testDRStatistics() throws Exception {
         if (!VoltDB.instance().getConfig().m_isEnterprise) {
             System.out.println("SKIPPING DR STATS TESTS FOR COMMUNITY VERSION");
             return;
@@ -216,10 +217,7 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         System.out.println("\n\nTESTING DR STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
-        assertEquals("Expected DRPartitionStatistics schema length is 15", 15, expectedDRPartitionStatsSchema.length);
         VoltTable expectedTable1 = new VoltTable(expectedDRPartitionStatsSchema);
-
-        assertEquals("Expected DRNodeStatistics schema length is 9", 9, expectedDRNodeStatsSchema.length);
         VoltTable expectedTable2 = new VoltTable(expectedDRNodeStatsSchema);
 
         //
@@ -232,17 +230,10 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
         System.out.println("Test DR table: " + results[1].toString());
         validateSchema(results[0], expectedTable1);
         validateSchema(results[1], expectedTable2);
-        // One row per site (including the MPI on each host),
-        // don't have HSID for ease of check, just check a bunch of stuff
-        assertEquals(HOSTS * SITES + HOSTS, results[0].getRowCount());
-        results[0].advanceRow();
-        Map<String, String> columnTargets = new HashMap<>();
-        columnTargets.put("HOSTNAME", results[0].getString("HOSTNAME"));
-        validateRowSeenAtAllHosts(results[0], columnTargets, false);
-        results[0].advanceRow();
-        validateRowSeenAtAllPartitions(results[0], "HOSTNAME", results[0].getString("HOSTNAME"), false);
+
         // One row per host for DRNODE stats
         results[1].advanceRow();
+        Map<String, String> columnTargets = new HashMap<>();
         columnTargets.put("HOSTNAME", results[1].getString("HOSTNAME"));
         validateRowSeenAtAllHosts(results[1], columnTargets, true);
     }


### PR DESCRIPTION
- Return one row per conversation in DR producer and consumer node
  stats.

- Roll DR producer and consumer node stats into DRROLE stats for each
  conversation.

- This patch doesn't contain the work for the STOPPED state on the
  producer. It requires break replication to work on the producer.