### PR TITLE
ENG-11718: remove conversions from jar to bytes or bytes to jar when …

### DIFF
--- a/src/frontend/org/voltdb/CatalogContext.java
+++ b/src/frontend/org/voltdb/CatalogContext.java
@@ -413,4 +413,8 @@ public class CatalogContext {
     {
         return catalogHash;
     }
+
+    public InMemoryJarfile getCatalogJar() {
+        return m_jarfile;
+    }
 }

--- a/src/frontend/org/voltdb/compiler/AsyncCompilerAgentHelper.java
+++ b/src/frontend/org/voltdb/compiler/AsyncCompilerAgentHelper.java
@@ -62,40 +62,29 @@ public class AsyncCompilerAgentHelper
             // will complete with newCatalogBytes actually containing the bytes of the
             // catalog to be applied, and deploymentString will contain an actual deployment string,
             // or null if it still needs to be filled in.
-            byte[] newCatalogBytes = work.operationBytes;
+            InMemoryJarfile newCatalogJar = null;
+            InMemoryJarfile oldJar = context.getCatalogJar().deepCopy();
+
             String deploymentString = work.operationString;
-            if (work.invocationName.equals("@UpdateApplicationCatalog")) {
-                // Do the straight-forward thing with the args, filling in nulls as appropriate
-                // Grab the current catalog bytes if @UAC had a null catalog
-                // (deployment-only update)
-                if (newCatalogBytes == null) {
-                    try {
-                        newCatalogBytes = context.getCatalogJarBytes();
-                    }
-                    catch (IOException ioe) {
-                        retval.errorMsg = "Unexpected exception retrieving internal catalog bytes: " +
-                            ioe.getMessage();
-                        return retval;
-                    }
+            if ("@UpdateApplicationCatalog".equals(work.invocationName)) {
+                // Grab the current catalog bytes if @UAC had a null catalog from deployment-only update
+                if (work.operationBytes == null) {
+                    newCatalogJar = oldJar;
+                } else {
+                    newCatalogJar = CatalogUtil.loadInMemoryJarFile(work.operationBytes);
                 }
                 // If the deploymentString is null, we'll fill it in with current deployment later
                 // Otherwise, deploymentString has the right contents, don't need to touch it
             }
-            else if (work.invocationName.equals("@UpdateClasses")) {
-                // Need the original catalog bytes, then delete classes, then add
-                try {
-                    newCatalogBytes = context.getCatalogJarBytes();
-                }
-                catch (IOException ioe) {
-                    retval.errorMsg = "Unexpected IO exception retrieving internal catalog bytes: " +
-                        ioe.getMessage();
-                    return retval;
-                }
+            else if ("@UpdateClasses".equals(work.invocationName)) {
                 // provided operationString is really a String with class patterns to delete,
-                // provided operationBytes is the jarfile with the upsertable classes
+                // provided newCatalogJar is the jarfile with the new classes
+                if (work.operationBytes != null) {
+                    newCatalogJar = new InMemoryJarfile(work.operationBytes);
+                }
                 try {
-                    newCatalogBytes = modifyCatalogClasses(newCatalogBytes, work.operationString,
-                            work.operationBytes);
+                    newCatalogJar = modifyCatalogClasses(oldJar, work.operationString,
+                            newCatalogJar);
                 }
                 catch (IOException e) {
                     retval.errorMsg = "Unexpected IO exception @UpdateClasses modifying classes " +
@@ -106,12 +95,10 @@ public class AsyncCompilerAgentHelper
                 // here and let it get filled in correctly later.
                 deploymentString = null;
             }
-            else if (work.invocationName.startsWith("@AdHoc")) {
-                // newCatalogBytes and deploymentString should be null.
+            else if ("@AdHoc".equals(work.invocationName)) {
                 // work.adhocDDLStmts should be applied to the current catalog
                 try {
-                    newCatalogBytes = addDDLToCatalog(context.catalog, context.getCatalogJarBytes(),
-                            work.adhocDDLStmts);
+                    newCatalogJar = addDDLToCatalog(context.catalog, oldJar, work.adhocDDLStmts);
                 }
                 catch (VoltCompilerException vce) {
                     retval.errorMsg = vce.getMessage();
@@ -128,8 +115,8 @@ public class AsyncCompilerAgentHelper
                     compilerLog.error(retval.errorMsg);
                     return retval;
                 }
-                assert(newCatalogBytes != null);
-                if (newCatalogBytes == null) {
+                assert(newCatalogJar != null);
+                if (newCatalogJar == null) {
                     // Shouldn't ever get here
                     retval.errorMsg =
                         "Unexpected failure in applying DDL statements to original catalog";
@@ -150,7 +137,7 @@ public class AsyncCompilerAgentHelper
             // try to get the new catalog from the params
             Pair<InMemoryJarfile, String> loadResults = null;
             try {
-                loadResults = CatalogUtil.loadAndUpgradeCatalogFromJar(newCatalogBytes);
+                loadResults = CatalogUtil.loadAndUpgradeCatalogFromJar(newCatalogJar);
             }
             catch (IOException ioe) {
                 // Preserve a nicer message from the jarfile loading rather than
@@ -158,8 +145,7 @@ public class AsyncCompilerAgentHelper
                 retval.errorMsg = ioe.getMessage();
                 return retval;
             }
-            newCatalogBytes = loadResults.getFirst().getFullJarBytes();
-            retval.catalogBytes = newCatalogBytes;
+            retval.catalogBytes = loadResults.getFirst().getFullJarBytes();
             retval.isForReplay = work.isForReplay();
             if (!retval.isForReplay) {
                 retval.catalogHash = loadResults.getFirst().getSha1Hash();
@@ -264,11 +250,9 @@ public class AsyncCompilerAgentHelper
      * jarfile
      * @throws VoltCompilerException
      */
-    private byte[] addDDLToCatalog(Catalog oldCatalog, byte[] oldCatalogBytes, String[] adhocDDLStmts)
+    private InMemoryJarfile addDDLToCatalog(Catalog oldCatalog, InMemoryJarfile jarfile, String[] adhocDDLStmts)
     throws IOException, VoltCompilerException
     {
-        InMemoryJarfile jarfile = CatalogUtil.loadInMemoryJarFile(oldCatalogBytes);
-
         StringBuilder sb = new StringBuilder();
         compilerLog.info("Applying the following DDL to cluster:");
         for (String stmt : adhocDDLStmts) {
@@ -281,16 +265,14 @@ public class AsyncCompilerAgentHelper
 
         VoltCompiler compiler = new VoltCompiler();
         compiler.compileInMemoryJarfileWithNewDDL(jarfile, newDDL, oldCatalog);
-        return jarfile.getFullJarBytes();
+        return jarfile;
     }
 
-    private byte[] modifyCatalogClasses(byte[] oldCatalogBytes, String deletePatterns,
-            byte[] newClassBytes) throws IOException
+    private InMemoryJarfile modifyCatalogClasses(InMemoryJarfile jarfile, String deletePatterns,
+            InMemoryJarfile newJarfile) throws IOException
     {
-        // Create a new InMemoryJarfile based on the original catalog bytes,
-        // modify it in place based on the @UpdateClasses inputs, and then
+        // modify the old jar in place based on the @UpdateClasses inputs, and then
         // recompile it if necessary
-        InMemoryJarfile jarfile = CatalogUtil.loadInMemoryJarFile(oldCatalogBytes);
         boolean deletedClasses = false;
         if (deletePatterns != null) {
             String[] patterns = deletePatterns.split(",");
@@ -312,8 +294,7 @@ public class AsyncCompilerAgentHelper
             }
         }
         boolean foundClasses = false;
-        if (newClassBytes != null) {
-            InMemoryJarfile newJarfile = new InMemoryJarfile(newClassBytes);
+        if (newJarfile != null) {
             for (Entry<String, byte[]> e : newJarfile.entrySet()) {
                 String filename = e.getKey();
                 if (!filename.endsWith(".class")) {
@@ -328,6 +309,6 @@ public class AsyncCompilerAgentHelper
             VoltCompiler compiler = new VoltCompiler();
             compiler.compileInMemoryJarfile(jarfile);
         }
-        return jarfile.getFullJarBytes();
+        return jarfile;
     }
 }

--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -1743,10 +1743,7 @@ public class VoltCompiler {
             InMemoryJarfile jarOut = compileInternal(canonicalDDLReader, oldCatalog, ddlList, jarfile);
             // Trim the compiler output to try to provide a concise failure
             // explanation
-            if (jarOut != null) {
-                compilerLog.debug("Successfully recompiled InMemoryJarfile");
-            }
-            else {
+            if (jarOut == null) {
                 String errString = "Adhoc DDL failed";
                 if (m_errors.size() > 0) {
                     errString = m_errors.get(m_errors.size() - 1).getLogString();
@@ -1757,6 +1754,7 @@ public class VoltCompiler {
                 String trimmed = errString.substring(0, endtrim);
                 throw new VoltCompilerException(trimmed);
             }
+            compilerLog.debug("Successfully recompiled InMemoryJarfile");
         }
         finally {
             // Restore the original class loader

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -218,6 +218,20 @@ public abstract class CatalogUtil {
     {
         // Throws IOException on load failure.
         InMemoryJarfile jarfile = loadInMemoryJarFile(catalogBytes);
+
+        return loadAndUpgradeCatalogFromJar(jarfile);
+    }
+
+    /**
+     * Load a catalog from the InMemoryJarfile.
+     *
+     * @param jarfile
+     * @return Pair containing updated InMemoryJarFile and upgraded version (or null if it wasn't upgraded)
+     * @throws IOException if there is no version information in the catalog.
+     */
+    public static Pair<InMemoryJarfile, String> loadAndUpgradeCatalogFromJar(InMemoryJarfile jarfile)
+        throws IOException
+    {
         // Let VoltCompiler do a version check and upgrade the catalog on the fly.
         // I.e. jarfile may be modified.
         VoltCompiler compiler = new VoltCompiler();
@@ -289,9 +303,7 @@ public abstract class CatalogUtil {
         assert(catalogBytes != null);
 
         InMemoryJarfile jarfile = new InMemoryJarfile(catalogBytes);
-        byte[] serializedCatalogBytes = jarfile.get(CATALOG_FILENAME);
-
-        if (null == serializedCatalogBytes) {
+        if (!jarfile.containsKey(CATALOG_FILENAME)) {
             throw new IOException("Database catalog not found - please build your application using the current version of VoltDB.");
         }
 

--- a/src/frontend/org/voltdb/utils/InMemoryJarfile.java
+++ b/src/frontend/org/voltdb/utils/InMemoryJarfile.java
@@ -56,7 +56,7 @@ import org.voltdb.compiler.VoltCompiler;
 public class InMemoryJarfile extends TreeMap<String, byte[]> {
 
     private static final long serialVersionUID = 1L;
-    protected final JarLoader m_loader = new JarLoader();;
+    protected final JarLoader m_loader = new JarLoader();
 
     ///////////////////////////////////////////////////////
     // CONSTRUCTION
@@ -382,6 +382,10 @@ public class InMemoryJarfile extends TreeMap<String, byte[]> {
         public Set<String> getClassNames() {
             return m_classNames;
         }
+
+        public void initFrom(JarLoader loader) {
+            m_classNames.addAll(loader.getClassNames());
+        }
     }
 
     public JarLoader getLoader() {
@@ -442,5 +446,14 @@ public class InMemoryJarfile extends TreeMap<String, byte[]> {
     @Override
     public java.util.Map.Entry<String, byte[]> pollLastEntry() {
         throw new UnsupportedOperationException();
+    }
+
+    public InMemoryJarfile deepCopy () {
+        InMemoryJarfile copy = new InMemoryJarfile();
+        for (Entry<String, byte[]> e: this.entrySet()) {
+            copy.put(e.getKey(), e.getValue().clone());
+        }
+        copy.m_loader.initFrom(m_loader);
+        return copy;
     }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/TestCatalogUpdateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCatalogUpdateSuite.java
@@ -591,7 +591,7 @@ public class TestCatalogUpdateSuite extends RegressionSuite {
             fail();
         }
         catch (Exception e) {
-            assertTrue(e.getMessage().startsWith("Database catalog not found"));
+            assertTrue(e.getMessage().contains("Database catalog not found"));
         }
     }
 


### PR DESCRIPTION
…they are unnecessary

There are so redundant conversion between jar to bytes. This PR tries to minimize the conversions which take time.