### PR TITLE
Backed out a recent over-aggressive assert causing debug crashes.

### DIFF
--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -494,7 +494,6 @@ public:
     }
 
     void unsetTableForStreamIndexing() {
-        assert(m_tableForStreamIndexing);
         if (m_tableForStreamIndexing) {
             m_tableForStreamIndexing->decrementRefcount();
             m_tableForStreamIndexing = NULL;


### PR DESCRIPTION
I had added this superfluous assert on a guess that it was safe. 
Backing it out as it looks like I guessed wrong.
Fixes MOST of the ENG-11745 debug crashes.