### PR TITLE
ENG-11752 elastic joining fix

### DIFF
--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1513,26 +1513,6 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
     }
 
-    /**
-     * For elastic join. Block on this call until the number of ready hosts is
-     * equal to the number of expected joining hosts.
-     */
-    public void waitForJoiningHostsToBeReady(int expectedHosts) {
-        try {
-            m_zk.create(CoreZK.readyjoininghosts_host, null, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
-            while (true) {
-                ZKUtil.FutureWatcher fw = new ZKUtil.FutureWatcher();
-                int readyHosts = m_zk.getChildren(CoreZK.readyjoininghosts, fw).size();
-                if ( readyHosts == expectedHosts) {
-                    break;
-                }
-                fw.get();
-            }
-        } catch (KeeperException | InterruptedException e) {
-            org.voltdb.VoltDB.crashLocalVoltDB("Error waiting for hosts to be ready", false, e);
-        }
-    }
-
     public void shutdown() throws InterruptedException
     {
         if (m_zk != null) {

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1519,6 +1519,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
      */
     public void waitForJoiningHostsToBeReady(int expectedHosts, int localHostId) {
         try {
+            //register this host as joining. The host registration will be deleted after joining is completed.
             m_zk.create(ZKUtil.joinZKPath(CoreZK.readyjoininghosts, Integer.toString(localHostId)) , null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             while (true) {
                 ZKUtil.FutureWatcher fw = new ZKUtil.FutureWatcher();

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1513,6 +1513,26 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
     }
 
+    /**
+     * For elastic join. Block on this call until the number of ready hosts is
+     * equal to the number of expected joining hosts.
+     */
+    public void waitForJoiningHostsToBeReady(int expectedHosts, int localHostId) {
+        try {
+            m_zk.create(ZKUtil.joinZKPath(CoreZK.readyjoininghosts, Integer.toString(localHostId)) , null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            while (true) {
+                ZKUtil.FutureWatcher fw = new ZKUtil.FutureWatcher();
+                int readyHosts = m_zk.getChildren(CoreZK.readyjoininghosts, fw).size();
+                if ( readyHosts == expectedHosts) {
+                    break;
+                }
+                fw.get();
+            }
+        } catch (KeeperException | InterruptedException e) {
+            org.voltdb.VoltDB.crashLocalVoltDB("Error waiting for hosts to be ready", false, e);
+        }
+    }
+
     public void shutdown() throws InterruptedException
     {
         if (m_zk != null) {

--- a/src/frontend/org/voltcore/zk/CoreZK.java
+++ b/src/frontend/org/voltcore/zk/CoreZK.java
@@ -44,6 +44,7 @@ public class CoreZK {
     public static final String hosts_host = "/core/hosts/host";
     public static final String readyhosts = "/core/readyhosts";
     public static final String readyhosts_host = "/core/readyhosts/host";
+    public static final String readyjoininghosts = "/core/readyjoininghosts";
 
     // hosts since beginning of time (persistent)
     public static final String hostids = "/core/hostids";
@@ -55,7 +56,7 @@ public class CoreZK {
 
     // Persistent nodes (mostly directories) to create on startup
     public static final String[] ZK_HIERARCHY = {
-        root, hosts, readyhosts, hostids
+        root, hosts, readyhosts, readyjoininghosts, hostids
     };
 
     /**
@@ -149,6 +150,30 @@ public class CoreZK {
             if (e.code() == KeeperException.Code.NONODE ||
                 e.code() == KeeperException.Code.BADVERSION) {
                 // Okay if the rejoin blocker for the given hostId is already gone.
+                return true;
+            }
+        } catch (InterruptedException e) {
+            return false;
+        }
+        return false;
+    }
+
+    /**
+     * Removes the join indicator for the given host ID.
+     * @return true if the indicator is removed successfully, false otherwise.
+     */
+    public static boolean removeJoinNodeIndicatorForHost(ZooKeeper zk, int hostId)
+    {
+        try {
+            Stat stat = new Stat();
+            String path = ZKUtil.joinZKPath(readyjoininghosts, Integer.toString(hostId));
+            zk.getData(path, false, stat);
+            zk.delete(path, stat.getVersion());
+            return true;
+        } catch (KeeperException e) {
+            if (e.code() == KeeperException.Code.NONODE ||
+                    e.code() == KeeperException.Code.BADVERSION) {
+                // Okay if the join indicator for the given hostId is already gone.
                 return true;
             }
         } catch (InterruptedException e) {

--- a/src/frontend/org/voltcore/zk/CoreZK.java
+++ b/src/frontend/org/voltcore/zk/CoreZK.java
@@ -44,8 +44,6 @@ public class CoreZK {
     public static final String hosts_host = "/core/hosts/host";
     public static final String readyhosts = "/core/readyhosts";
     public static final String readyhosts_host = "/core/readyhosts/host";
-    public static final String readyjoininghosts = "/core/readyjoininghosts";
-    public static final String readyjoininghosts_host = "/core/readyjoininghosts/host";
 
     // hosts since beginning of time (persistent)
     public static final String hostids = "/core/hostids";
@@ -57,7 +55,7 @@ public class CoreZK {
 
     // Persistent nodes (mostly directories) to create on startup
     public static final String[] ZK_HIERARCHY = {
-        root, hosts, readyhosts, readyjoininghosts, hostids
+        root, hosts, readyhosts, hostids
     };
 
     /**

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1331,17 +1331,16 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("Failed to validate cluster build string", false, e);
             }
-            // initial start or recover
-            if (!isRejoin && !m_joining) {
-                int expectedHosts = m_catalogContext.getClusterSettings().hostcount();
-                m_messenger.waitForAllHostsToBeReady(expectedHosts);
-            }
 
-            // elastic join, make sure all the joining nodes are ready
+            //elastic join, make sure all the joining nodes are ready
             //so that the secondary connections can be created.
             if (m_joining) {
                 int expectedHosts = m_configuredReplicationFactor + 1;
                 m_messenger.waitForJoiningHostsToBeReady(expectedHosts, this.m_myHostId);
+            } else if (!isRejoin) {
+                // initial start or recover
+                int expectedHosts = m_catalogContext.getClusterSettings().hostcount();
+                m_messenger.waitForAllHostsToBeReady(expectedHosts);
             }
 
             // Create secondary connections within partition group

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1332,15 +1332,13 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 VoltDB.crashLocalVoltDB("Failed to validate cluster build string", false, e);
             }
 
-            if (!isRejoin) {
-                if (m_joining) {
-                    // elastic join
-                    int expectedHosts = m_configuredReplicationFactor + 1;
-                    m_messenger.waitForJoiningHostsToBeReady(expectedHosts);
-                } else {
-                    // initial start or recover
+            if (!isRejoin && !m_joining) {
+                try {
                     int expectedHosts = m_catalogContext.getClusterSettings().hostcount();
                     m_messenger.waitForAllHostsToBeReady(expectedHosts);
+                } catch (Exception e) {
+                    hostLog.fatal("Failed to announce ready state", e);
+                    VoltDB.crashLocalVoltDB("Failed to announce ready state", false, null);
                 }
             }
 


### PR DESCRIPTION
Removed unnecessary waiting for all the rejoining nodes in RealVoltDB initialization since the scenario has been handled in ElasticJoinCoordinator.