### PR TITLE
Fix several problems with strings, and with aliases in order by lists.

### DIFF
--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -1142,7 +1142,7 @@ private:
     }
 
     /**
-     * This funciton does not check NULL value.
+     * This function does not check NULL value.
      */
     double getNumberFromString() const
     {

--- a/src/ee/common/ThreadLocalPool.cpp
+++ b/src/ee/common/ThreadLocalPool.cpp
@@ -38,11 +38,6 @@ struct voltdb_pool_allocator_new_delete
     static void free(char * const block);
 };
 
-// This needs to be >= the VoltType.MAX_VALUE_LENGTH defined in java, currently 1048576.
-// The rationale for making it any larger would be to allow calculating wider "temp"
-// values for use in situations where they are not being stored as column values.
-const int ThreadLocalPool::POOLED_MAX_VALUE_LENGTH = 1024 * 1024;
-
 /**
  * Thread local key for storing thread specific memory pools
  */

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -48,7 +48,10 @@ public:
         Sized(int32_t requested_size) : m_size(requested_size) { }
     };
 
-    static const int POOLED_MAX_VALUE_LENGTH;
+    // This needs to be >= the VoltType.MAX_VALUE_LENGTH defined in java, currently 1048576.
+    // The rationale for making it any larger would be to allow calculating wider "temp"
+    // values for use in situations where they are not being stored as column values.
+    static const int POOLED_MAX_VALUE_LENGTH = 1024 * 1024;
 
     /**
      * Allocate space from a page of objects of the requested size.

--- a/src/ee/expressions/stringfunctions.h
+++ b/src/ee/expressions/stringfunctions.h
@@ -79,10 +79,15 @@ template<> inline NValue NValue::callUnary<FUNC_SPACE>() const {
 
     int32_t count = static_cast<int32_t>(castAsBigIntAndGetValue());
     if (count < 0) {
-        char msg[1024];
-        snprintf(msg, 1024, "data exception: substring error");
         throw SQLException(SQLException::data_exception_string_data_length_mismatch,
-            msg);
+                           "The argument to the SPACE function is negative");
+    } else if (ThreadLocalPool::POOLED_MAX_VALUE_LENGTH < count) {
+        std::ostringstream oss;
+        oss << "The argument to the SPACE function is larger than the maximum size allowed for strings ("
+            << ThreadLocalPool::POOLED_MAX_VALUE_LENGTH << " bytes). "
+            << "Reduce either the string size or repetition count.";
+        throw SQLException(SQLException::data_exception_string_data_length_mismatch,
+                           oss.str().c_str());
     }
 
     std::string spacesStr(count, ' ');
@@ -218,10 +223,8 @@ template<> inline NValue NValue::call<FUNC_LEFT>(const std::vector<NValue>& argu
     }
     int32_t count = static_cast<int32_t>(startArg.castAsBigIntAndGetValue());
     if (count < 0) {
-        char msg[1024];
-        snprintf(msg, 1024, "data exception: substring error");
         throw SQLException(SQLException::data_exception_string_data_length_mismatch,
-            msg);
+                           "The argument to the LEFT function is negative");
     }
     if (count == 0) {
         return getTempStringValue("", 0);
@@ -251,10 +254,8 @@ template<> inline NValue NValue::call<FUNC_RIGHT>(const std::vector<NValue>& arg
 
     int32_t count = static_cast<int32_t>(startArg.castAsBigIntAndGetValue());
     if (count < 0) {
-        char msg[1024];
-        snprintf(msg, 1024, "data exception: substring error");
         throw SQLException(SQLException::data_exception_string_data_length_mismatch,
-            msg);
+                           "The argument to the RIGHT function is negative.");
     }
     if (count == 0) {
         return getTempStringValue("", 0);

--- a/src/frontend/org/voltdb/planner/ParsedColInfo.java
+++ b/src/frontend/org/voltdb/planner/ParsedColInfo.java
@@ -139,6 +139,7 @@ public class ParsedColInfo implements Cloneable {
                     (child.name.equals("win_aggregation") == false) &&
                     (child.name.equals("function") == false) &&
                     (child.name.equals("rank") == false) &&
+                    (child.name.equals("value") == false) &&
                     (child.name.equals("columnref") == false)) {
                throw new RuntimeException(
                        "ORDER BY parsed with strange child node type: " +

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionValue.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionValue.java
@@ -31,12 +31,8 @@
 
 package org.hsqldb_voltpatches;
 
-import org.hsqldb_voltpatches.types.Type;
-// A VoltDB extension to allow X'..' as numeric literals
-import org.hsqldb_voltpatches.store.ValuePool;
 import org.hsqldb_voltpatches.types.BinaryData;
-
-import java.math.BigInteger;
+import org.hsqldb_voltpatches.types.Type;
 // End VoltDB extension
 /**
  * Implementation of value access operations.
@@ -60,6 +56,7 @@ public class ExpressionValue extends Expression {
         valueData = o;
     }
 
+    @Override
     public String getSQL() {
 
         switch (opType) {
@@ -76,6 +73,7 @@ public class ExpressionValue extends Expression {
         }
     }
 
+    @Override
     protected String describe(Session session, int blanks) {
 
         StringBuffer sb = new StringBuffer(64);
@@ -99,6 +97,7 @@ public class ExpressionValue extends Expression {
         }
     }
 
+    @Override
     public Object getValue(Session session) {
         return valueData;
     }
@@ -115,7 +114,9 @@ public class ExpressionValue extends Expression {
      * @return true for a successful conversion and false otherwise.
      */
     public static boolean voltMutateToBigintType(Expression maybeConstantNode, Expression parent, int childIndex) {
-        if (maybeConstantNode.opType == OpTypes.VALUE && maybeConstantNode.dataType.isBinaryType()) {
+        if (maybeConstantNode.opType == OpTypes.VALUE
+                && maybeConstantNode.dataType != null
+                && maybeConstantNode.dataType.isBinaryType()) {
             ExpressionValue exprVal = (ExpressionValue)maybeConstantNode;
             if (exprVal.valueData == null) {
                 return false;


### PR DESCRIPTION
The SPACE sql function did not check for arguments being too large.  As
a result we would try to allocate a large amount of string space, which
caused allocator failures.

These same queries showed up problems in the planner with aliases in
order by lists.  If a select list element is a constant, and there is a
reference to it as an alias in the order by list, we didn't expect it
and we threw an error. There are also cases where data types for select
list aliases are not set in the Volt expression structures when we
expect them to be.  This can cause NPEs when converting from strings to
BIGINT values.  These have been fixed.

FWIW, this fixes ENG-11683, ENG-11684 and ENG-11762. 