### PR TITLE
ENG-11459: Generate version aware DR catalog commands.

### DIFF
--- a/src/catgen/catalog.py
+++ b/src/catgen/catalog.py
@@ -73,6 +73,7 @@ def genjava( classes, javaOnlyClasses, prepath, postpath, package ):
     os.system( interp( "cp $prepath/CatalogDiffEngine.java $postpath", locals() ) )
     os.system( interp( "cp $prepath/FilteredCatalogDiffEngine.java $postpath", locals() ) )
     os.system( interp( "cp $prepath/DRCatalogDiffEngine.java $postpath", locals() ) )
+    os.system( interp( "cp $prepath/DRCatalogCommands.java $postpath", locals() ) )
     os.system( interp( "cp $prepath/DatabaseConfiguration.java $postpath", locals() ) )
 
     ##########

--- a/src/catgen/in/javasrc/DRCatalogCommands.java
+++ b/src/catgen/in/javasrc/DRCatalogCommands.java
@@ -1,0 +1,35 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* WARNING: THIS FILE IS AUTO-GENERATED
+            DO NOT MODIFY THIS SOURCE
+            ALL CHANGES MUST BE MADE IN THE CATALOG GENERATOR */
+
+package org.voltdb.catalog;
+
+public class DRCatalogCommands {
+    public final int protocolVersion;
+    public final long crc;
+    public final String commands;
+
+    public DRCatalogCommands(int version, long crc, String commands)
+    {
+        this.protocolVersion = version;
+        this.crc = crc;
+        this.commands = commands;
+    }
+}

--- a/src/catgen/spec.txt
+++ b/src/catgen/spec.txt
@@ -40,6 +40,7 @@ begin Database                       "A set of schema, procedures and other meta
   Procedure* procedures              "The set of stored procedures/transactions for this database"
   Connector* connectors              "Export connector configuration"
   SnapshotSchedule* snapshotSchedule "Schedule for automated snapshots"
+  bool   isActiveActiveDRed          "Are all DR tables in this database active-active DRed"
   string securityprovider            "The security provider used to authenticate users"
 end
 

--- a/src/frontend/org/voltdb/dr2/DRProtocol.java
+++ b/src/frontend/org/voltdb/dr2/DRProtocol.java
@@ -1,0 +1,26 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.dr2;
+
+public interface DRProtocol {
+    // Also update DRTupleStream.h if version changes
+    public static final int PROTOCOL_VERSION = Integer.getInteger("DR_PROTOCOL_VERSION", 7);
+    public static final int COMPATIBLE_PROTOCOL_VERSION = 3;
+    public static final int MIXED_SIZE_PROTOCOL_VERSION = 4;
+    public static final int MUTLICLUSTER_PROTOCOL_VERSION = 7;
+}

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -77,6 +76,7 @@ import org.voltdb.VoltProcedure.VoltAbortException;
 import org.voltdb.VoltTable;
 import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Cluster;
+import org.voltdb.catalog.DRCatalogCommands;
 import org.voltdb.catalog.DRCatalogDiffEngine;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Deployment;
@@ -1497,9 +1497,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         m_ee.quiesce(m_lastCommittedSpHandle);
         m_ee.updateCatalog(m_context.m_uniqueId, diffCmds);
         if (DRCatalogChange) {
-            final Pair<Long, String> catalogCommands = DRCatalogDiffEngine.serializeCatalogCommandsForDr(m_context.catalog);
+            final DRCatalogCommands catalogCommands = DRCatalogDiffEngine.serializeCatalogCommandsForDr(m_context.catalog, -1);
             generateDREvent( EventType.CATALOG_UPDATE, uniqueId, m_lastCommittedSpHandle,
-                    spHandle, catalogCommands.getSecond().getBytes(Charsets.UTF_8));
+                    spHandle, catalogCommands.commands.getBytes(Charsets.UTF_8));
         }
 
         return true;

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -129,7 +129,6 @@ import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.importer.ImportDataProcessor;
 import org.voltdb.importer.formatter.AbstractFormatterFactory;
 import org.voltdb.importer.formatter.FormatterBuilder;
-import org.voltdb.licensetool.LicenseApi;
 import org.voltdb.planner.parseinfo.StmtTableScan;
 import org.voltdb.planner.parseinfo.StmtTargetTableScan;
 import org.voltdb.plannodes.AbstractPlanNode;
@@ -1942,12 +1941,17 @@ public abstract class CatalogUtil {
     private static void setDrInfo(Catalog catalog, DrType dr, ClusterType clusterType) {
         int clusterId;
         Cluster cluster = catalog.getClusters().get("cluster");
+        final Database db = cluster.getDatabases().get("database");
         assert cluster != null;
         if (dr != null) {
             ConnectionType drConnection = dr.getConnection();
             cluster.setDrproducerenabled(dr.isListen());
             cluster.setDrproducerport(dr.getPort());
             cluster.setDrrole(dr.getRole().name().toLowerCase());
+            if (dr.getRole() == DrRoleType.XDCR) {
+                // Setting this for compatibility mode only, don't use in new code
+                db.setIsactiveactivedred(true);
+            }
 
             // Backward compatibility to support cluster id in DR tag
             if (clusterType.getId() == null && dr.getId() != null) {

--- a/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
@@ -755,7 +755,7 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T1;";
         Catalog masterCatalog = createCatalog(masterSchema);
 
-        String commands = DRCatalogDiffEngine.serializeCatalogCommandsForDr(masterCatalog).getSecond();
+        String commands = DRCatalogDiffEngine.serializeCatalogCommandsForDr(masterCatalog, -1).commands;
         String decodedCommands = Encoder.decodeBase64AndDecompress(commands);
         decodedCommands = decodedCommands.replaceFirst("set \\$PREV isDRed true", "set \\$PREV isDRed true\nset \\$PREV isASquirrel false");
         boolean threw = false;
@@ -779,7 +779,7 @@ public class TestDRCatalogDiffs {
             replicaCatalog.getClusters().get("cluster").setDrrole(DrRoleType.XDCR.value());
         }
 
-        String commands = DRCatalogDiffEngine.serializeCatalogCommandsForDr(masterCatalog).getSecond();
+        String commands = DRCatalogDiffEngine.serializeCatalogCommandsForDr(masterCatalog, -1).commands;
         Catalog deserializedMasterCatalog = DRCatalogDiffEngine.deserializeCatalogCommandsForDr(commands);
         return new DRCatalogDiffEngine(replicaCatalog, deserializedMasterCatalog);
     }


### PR DESCRIPTION
For compatibility mode, we can't generate catalog commands with new
keywords. Fallback to old keyword for XDCR.