### PR TITLE
We don't need awaitProducerSnapshot flag anymore because the consumer

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -51,7 +51,7 @@ public interface ConsumerDRGateway extends Promotable {
 
     void producerTopologyUpdated(final MeshMemberInfo existingCluster);
 
-    void startConsumerDispatcher(final MeshMemberInfo member, final boolean awaitProducerSnapshot);
+    void startConsumerDispatcher(final MeshMemberInfo member);
 
     void addLocallyLedPartition(int partitionId);
 }


### PR DESCRIPTION
pauses itself until SS is complete.