### PR TITLE
ENG-11868: Agg bench performance regression

### DIFF
--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -503,7 +503,7 @@ void NValue::streamTimestamp(std::stringstream& value) const
     int64_t epoch_micros = getTimestamp();
     boost::gregorian::date as_date;
     boost::posix_time::time_duration as_time;
-    micros_to_date_and_time("CAST", epoch_micros, as_date, as_time);
+    micros_to_date_and_time(epoch_micros, as_date, as_time);
 
     long micro = epoch_micros % 1000000;
     if (epoch_micros < 0 && micro < 0) {


### PR DESCRIPTION
My last commit related to timestamps improved error reporting but slowed down the agg bench performance test.  My theory was that my improved error reporting (which included function names in error messages) was slower because it was instantiating a `std::string` for each range check.  This refactoring avoids instantiating the function name until a range check fails.

If this doesn't work, I'll roll back the original commit that caused the regression.