### PR TITLE
ENG-11779: Fix refineValueTypes for CASE WHEN expression

### DIFF
--- a/src/frontend/org/voltdb/expressions/OperatorExpression.java
+++ b/src/frontend/org/voltdb/expressions/OperatorExpression.java
@@ -93,6 +93,15 @@ public class OperatorExpression extends AbstractExpression {
         if (! needsRightExpression()) {
             return;
         }
+
+        if (getExpressionType() == ExpressionType.OPERATOR_CASE_WHEN) {
+            assert(m_right.getExpressionType() == ExpressionType.OPERATOR_ALTERNATIVE);
+            m_right.refineValueType(neededType, neededSize);
+            m_valueType = m_right.getValueType();
+            m_valueSize = m_right.getValueSize();
+            return;
+        }
+
         // The intent here is to allow operands to have the maximum flexibility given the
         // desired result type. The interesting cases are basically integer, decimal, and
         // float. If any of the lhs, rhs, or target result type are float, then any ambiguity

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlUpdateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlUpdateSuite.java
@@ -64,7 +64,7 @@ public class TestSqlUpdateSuite extends RegressionSuite {
 
     }
 
-    public void notestUpdate()
+    public void testUpdate()
     throws IOException, ProcCallException
     {
         Client client = getClient();
@@ -224,14 +224,14 @@ public class TestSqlUpdateSuite extends RegressionSuite {
         if (!config.compile(project)) fail();
         builder.addServerConfig(config);
 
-//        config = new LocalCluster("sqlupdate-hsql.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
-//        if (!config.compile(project)) fail();
-//        builder.addServerConfig(config);
-//
-//        // Cluster
-//        config = new LocalCluster("sqlupdate-cluster.jar", 2, 3, 1, BackendTarget.NATIVE_EE_JNI);
-//        if (!config.compile(project)) fail();
-//        builder.addServerConfig(config);
+        config = new LocalCluster("sqlupdate-hsql.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
+        if (!config.compile(project)) fail();
+        builder.addServerConfig(config);
+
+        // Cluster
+        config = new LocalCluster("sqlupdate-cluster.jar", 2, 3, 1, BackendTarget.NATIVE_EE_JNI);
+        if (!config.compile(project)) fail();
+        builder.addServerConfig(config);
 
         return builder;
     }


### PR DESCRIPTION
CASE WHEN isn't like other operators, which are mostly binary or unary.

RHS of the CASE WHEN operator is the OPERATOR_ALTERNATIVE, which is what really helps define type of output, so defer to RHS when refining.
