### PR TITLE
extended-config.py: just reduced the numeric precision of the

### DIFF
--- a/tests/sqlcoverage/config/extended-config.py
+++ b/tests/sqlcoverage/config/extended-config.py
@@ -83,7 +83,7 @@
                          "ddl": "DDL.sql",
                          "template": "numeric-decimals.sql",
                          "normalizer": "normalizer.py",
-                         "precision": "9"},
+                         "precision": "8"},
     "numeric-ints": {"schema": "int-schema.py",
                      "ddl": "int-DDL.sql",
                      "template": "numeric-ints.sql",


### PR DESCRIPTION
numeric-decimals test suite, from 9 to 8 (significant digits), because
Ruth noticed that it was failing often, with tiny decimal differences.