### PR TITLE
ddl.sql: just removed the PRIMARY KEY from one of the CREATE STREAM

### DIFF
--- a/tests/geb/vmc/server/ddl.sql
+++ b/tests/geb/vmc/server/ddl.sql
@@ -111,7 +111,6 @@ CREATE STREAM export_mirror_partitioned_table PARTITION ON COLUMN rowid
 --, type_not_null_point       GEOGRAPHY_POINT NOT NULL
 --, type_null_polygon         GEOGRAPHY
 --, type_not_null_polygon     GEOGRAPHY       NOT NULL
-, PRIMARY KEY (rowid)
 );
 
 CREATE STREAM export_done_table PARTITION ON COLUMN txnid


### PR DESCRIPTION
definitions, since this is no longer allowed (& never actually worked), and was causing the tests not to run.