### PR TITLE
ENG-11954 add "export to target ..." to ddl files, needed in V7.0 & beyond

### DIFF
--- a/tests/test_apps/genqa/ddl-nocat-geo.sql
+++ b/tests/test_apps/genqa/ddl-nocat-geo.sql
@@ -236,7 +236,7 @@ CREATE STREAM export_geo_partitioned_table PARTITION ON COLUMN rowid EXPORT TO T
 
 -- should be an exact copy of the stream. Used for verifiing
 -- export stream contents.
-CREATE STREAM export_geo_mirror_partitioned_table PARTITION ON COLUMN rowid
+CREATE TABLE export_geo_mirror_partitioned_table
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -266,6 +266,7 @@ CREATE STREAM export_geo_mirror_partitioned_table PARTITION ON COLUMN rowid
 , type_null_geography_point GEOGRAPHY_POINT
 , type_not_null_geography_point GEOGRAPHY_POINT NOT NULL
 );
+PARTITION TABLE export_geo_mirror_partitioned_table ON COLUMN rowid;
 
 CREATE STREAM export_geo_done_table PARTITION ON COLUMN txnid EXPORT TO TARGET abc
 (

--- a/tests/test_apps/genqa/ddl2.sql
+++ b/tests/test_apps/genqa/ddl2.sql
@@ -1,7 +1,7 @@
 IMPORT CLASS genqa2.procedures.SampleRecord;
 
 -- Export Table for Partitioned Data Table deletions
-CREATE STREAM export_partitioned_table2 PARTITION ON COLUMN rowid
+CREATE STREAM export_partitioned_table2 PARTITION ON COLUMN rowid export to target default
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -56,13 +56,13 @@ CREATE TABLE export_mirror_partitioned_table2
 );
 PARTITION TABLE export_mirror_partitioned_table2 ON COLUMN rowid;
 
-CREATE STREAM export_skinny_partitioned_table2 PARTITION ON COLUMN rowid
+CREATE STREAM export_skinny_partitioned_table2 PARTITION ON COLUMN rowid export to target default
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
 );
 
-CREATE STREAM export_done_table PARTITION ON COLUMN txnid
+CREATE STREAM export_done_table PARTITION ON COLUMN txnid export to target default
 (
   txnid                     BIGINT        NOT NULL
 );

--- a/tests/test_apps/genqa/ddl3.sql
+++ b/tests/test_apps/genqa/ddl3.sql
@@ -46,7 +46,7 @@ AS
  GROUP BY rowid_group;
 
 -- Export Table for Partitioned Data Table deletions
-CREATE STREAM export_partitioned_table PARTITION ON COLUMN rowid
+CREATE STREAM export_partitioned_table PARTITION ON COLUMN rowid export to target default
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -128,7 +128,7 @@ CREATE TABLE export_mirror_partitioned_table
 );
 PARTITION TABLE export_mirror_partitioned_table ON COLUMN rowid;
 
-CREATE STREAM export_done_table PARTITION ON COLUMN txnid
+CREATE STREAM export_done_table PARTITION ON COLUMN txnid export to target default
 (
   txnid                     BIGINT        NOT NULL
 );
@@ -183,7 +183,7 @@ AS
  GROUP BY rowid_group;
 
 -- Export Table for Replicated Data Table deletions
-CREATE STREAM export_replicated_table
+CREATE STREAM export_replicated_table export to target default
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -237,7 +237,7 @@ CREATE STREAM export_replicated_table_foo EXPORT TO TARGET foo
 , type_not_null_varchar1024 VARCHAR(1024) NOT NULL
 );
 
-CREATE STREAM export_skinny_partitioned_table PARTITION ON COLUMN rowid
+CREATE STREAM export_skinny_partitioned_table PARTITION ON COLUMN rowid export to target default
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL

--- a/tests/test_apps/genqa/ddl4.sql
+++ b/tests/test_apps/genqa/ddl4.sql
@@ -1,7 +1,7 @@
 IMPORT CLASS genqa2.procedures.SampleRecord;
 
 -- Export Table for Partitioned Data Table deletions
-CREATE STREAM export_partitioned_table2 PARTITION ON COLUMN rowid
+CREATE STREAM export_partitioned_table2 PARTITION ON COLUMN rowid export to target default
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -28,7 +28,7 @@ CREATE STREAM export_partitioned_table2 PARTITION ON COLUMN rowid
 , type_not_null_varchar1024 VARCHAR(1024) NOT NULL
 );
 
-CREATE STREAM export_partitioned_table2_foo PARTITION ON COLUMN rowid
+CREATE STREAM export_partitioned_table2_foo PARTITION ON COLUMN rowid export to target default
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -83,7 +83,7 @@ CREATE TABLE export_mirror_partitioned_table2
 );
 PARTITION TABLE export_mirror_partitioned_table2 ON COLUMN rowid;
 
-CREATE STREAM export_skinny_partitioned_table2 PARTITION ON COLUMN rowid
+CREATE STREAM export_skinny_partitioned_table2 PARTITION ON COLUMN rowid export to target default
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -95,7 +95,7 @@ CREATE STREAM export_skinny_partitioned_table2_foo PARTITION ON COLUMN rowid EXP
 , rowid                     BIGINT        NOT NULL
 );
 
-CREATE STREAM export_done_table PARTITION ON COLUMN txnid
+CREATE STREAM export_done_table PARTITION ON COLUMN txnid export to target default
 (
   txnid                     BIGINT        NOT NULL
 );


### PR DESCRIPTION
Changes in ddl for Volt 7 -- export table becomes stream -- also need "export to target <name>". Previously the export would go to "default" if none named in the ddl. Now nothing is actually exported if there no "export to...".

This has caused the Server-Export system test suite to fail.

So this change adds "export to target <name>" where required.

There's a small additional change for one table that had been changed to stream but shouldn't have been.