### PR TITLE
ssl support for jdbc

### DIFF
--- a/src/frontend/org/voltdb/client/ClientConfig.java
+++ b/src/frontend/org/voltdb/client/ClientConfig.java
@@ -40,6 +40,7 @@ import javax.security.auth.login.LoginException;
 
 import org.voltcore.utils.ssl.SSLConfiguration;
 import org.voltcore.utils.ssl.SSLConfiguration.SslConfig;
+
 import org.voltdb.types.VoltDecimalHelper;
 
 /**
@@ -71,7 +72,7 @@ public class ClientConfig {
     long m_maxConnectionRetryIntervalMS = DEFAULT_MAX_CONNECTION_RETRY_INTERVAL_MS;
     boolean m_sendReadsToReplicasBytDefaultIfCAEnabled = false;
     final AtomicReference<SSLContext> m_sslContextRef = new AtomicReference<>();
-    final SslConfig m_sslConfig;
+    SslConfig m_sslConfig;
     boolean m_topologyChangeAware = false;
     boolean m_enableSSL = false;
     String m_sslPropsFile = null;
@@ -555,6 +556,18 @@ public class ClientConfig {
      */
     public static void setRoundingConfig(boolean isEnabled, RoundingMode mode) {
         VoltDecimalHelper.setRoundingConfig(isEnabled, mode);
+    }
+
+    /**
+     * Configure SSL properties based on properties supplied with ssl config.
+     * Note if system properties like "javax.net.ssl.keyStore" are set, they
+     * take precedence
+     */
+    public void setSSLConfig(SSLConfiguration.SslConfig sslConfig) {
+        if (m_enableSSL && sslConfig != null) {
+            m_sslConfig = sslConfig;
+            SSLConfiguration.applySystemProperties(m_sslConfig);
+        }
     }
 
     /**

--- a/src/frontend/org/voltdb/jdbc/Driver.java
+++ b/src/frontend/org/voltdb/jdbc/Driver.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -36,6 +35,8 @@ import java.util.Properties;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import org.voltcore.utils.ssl.SSLConfiguration;
+
 public class Driver implements java.sql.Driver
 {
     public static final String JDBC_PROP_FILE_ENV = "VOLTDB_JDBC_PROPERTIES";
@@ -43,6 +44,12 @@ public class Driver implements java.sql.Driver
     public static final String DEFAULT_PROP_FILENAME = "voltdb.properties";
     //Driver URL prefix.
     private static final String URL_PREFIX = "jdbc:voltdb:";
+
+    static final String SSL_PROP= "ssl";
+    static final String KEYSTORE_CONFIG_PROP = "keystore";
+    static final String KEYSTORE_PASSWORD_PROP = "keystorepassword";
+    static final String TRUSTSTORE_CONFIG_PROP = "truststore";
+    static final String TRUSTSTORE_PASSWORD_PROP = "truststorepassword";
 
     // Static so it's unit-testable, yes, lazy me
     static String[] getServersFromURL(String url) {
@@ -134,6 +141,12 @@ public class Driver implements java.sql.Driver
                 boolean heavyweight = false;
                 int maxoutstandingtxns = 0;
                 boolean reconnectOnConnectionLoss = false;
+                boolean enableSSL = false;
+                String keystorePath = null;
+                String keystorePassword = null;
+                String truststorePath = null;
+                String truststorePassword = null;
+
                 for (Enumeration<?> e = info.propertyNames(); e.hasMoreElements();)
                 {
                     String key = (String) e.nextElement();
@@ -147,15 +160,39 @@ public class Driver implements java.sql.Driver
                                 value.toLowerCase().equals("1"));
                     else if (key.toLowerCase().equals("maxoutstandingtxns"))
                         maxoutstandingtxns = Integer.parseInt(value);
-                    else if ("autoreconnect".equals(key)){
+                    else if ("autoreconnect".equals(key)) {
                         reconnectOnConnectionLoss = ("true".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value) || "1".equals(value));
                     }
+                    else if (key.toLowerCase().equals(SSL_PROP)) {
+                        enableSSL = value.toLowerCase().equals("true");
+                    }
+                    else if (key.toLowerCase().equals(KEYSTORE_CONFIG_PROP)) {
+                        if ((value != null) && value.trim().length() > 0) {
+                            keystorePath = value.trim();
+                        }
+                    }
+                    else if (key.toLowerCase().equals(KEYSTORE_PASSWORD_PROP)) {
+                        keystorePassword = value;
+                    }
+                    else if (key.toLowerCase().equals(TRUSTSTORE_CONFIG_PROP)) {
+                        if ((value != null) && value.trim().length() > 0) {
+                            truststorePath = value.trim();
+                        }
+                    }
+                    else if (key.toLowerCase().equals(TRUSTSTORE_PASSWORD_PROP)) {
+                        truststorePassword = value;
+                    }
                     // else - unknown; ignore
+                }
+                SSLConfiguration.SslConfig sslConfig = null;
+                if (enableSSL) {
+                    sslConfig = new SSLConfiguration.SslConfig(keystorePath, keystorePassword,
+                            truststorePath, truststorePassword);
                 }
 
                 // Return JDBC connection wrapper for the client
                 return  new JDBC4Connection(JDBC4ClientConnectionPool.get(servers, user, password,
-                            heavyweight, maxoutstandingtxns, reconnectOnConnectionLoss),
+                            heavyweight, maxoutstandingtxns, reconnectOnConnectionLoss, sslConfig),
                         info);
 
             } catch (Exception x) {

--- a/src/frontend/org/voltdb/jdbc/Driver.java
+++ b/src/frontend/org/voltdb/jdbc/Driver.java
@@ -46,8 +46,6 @@ public class Driver implements java.sql.Driver
     private static final String URL_PREFIX = "jdbc:voltdb:";
 
     static final String SSL_PROP= "ssl";
-    static final String KEYSTORE_CONFIG_PROP = "keystore";
-    static final String KEYSTORE_PASSWORD_PROP = "keystorepassword";
     static final String TRUSTSTORE_CONFIG_PROP = "truststore";
     static final String TRUSTSTORE_PASSWORD_PROP = "truststorepassword";
 
@@ -142,8 +140,6 @@ public class Driver implements java.sql.Driver
                 int maxoutstandingtxns = 0;
                 boolean reconnectOnConnectionLoss = false;
                 boolean enableSSL = false;
-                String keystorePath = null;
-                String keystorePassword = null;
                 String truststorePath = null;
                 String truststorePassword = null;
 
@@ -166,14 +162,6 @@ public class Driver implements java.sql.Driver
                     else if (key.toLowerCase().equals(SSL_PROP)) {
                         enableSSL = value.toLowerCase().equals("true");
                     }
-                    else if (key.toLowerCase().equals(KEYSTORE_CONFIG_PROP)) {
-                        if ((value != null) && value.trim().length() > 0) {
-                            keystorePath = value.trim();
-                        }
-                    }
-                    else if (key.toLowerCase().equals(KEYSTORE_PASSWORD_PROP)) {
-                        keystorePassword = value;
-                    }
                     else if (key.toLowerCase().equals(TRUSTSTORE_CONFIG_PROP)) {
                         if ((value != null) && value.trim().length() > 0) {
                             truststorePath = value.trim();
@@ -186,8 +174,7 @@ public class Driver implements java.sql.Driver
                 }
                 SSLConfiguration.SslConfig sslConfig = null;
                 if (enableSSL) {
-                    sslConfig = new SSLConfiguration.SslConfig(keystorePath, keystorePassword,
-                            truststorePath, truststorePassword);
+                    sslConfig = new SSLConfiguration.SslConfig(null, null, truststorePath, truststorePassword);
                 }
 
                 // Return JDBC connection wrapper for the client

--- a/src/frontend/org/voltdb/jdbc/JDBC4ClientConnection.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ClientConnection.java
@@ -26,6 +26,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.voltcore.utils.ssl.SSLConfiguration;
+
+import org.voltdb.client.BatchTimeoutOverrideType;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientFactory;
@@ -33,7 +36,6 @@ import org.voltdb.client.ClientImpl;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ClientStats;
 import org.voltdb.client.ClientStatsContext;
-import org.voltdb.client.BatchTimeoutOverrideType;
 import org.voltdb.client.NoConnectionsException;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.client.ProcedureCallback;
@@ -120,6 +122,55 @@ public class JDBC4ClientConnection implements Closeable {
             int maxOutstandingTxns, boolean reconnectOnConnectionLoss)
                     throws UnknownHostException, IOException
     {
+        this(clientConnectionKeyBase, clientConnectionKey, servers, user, password, isHeavyWeight,
+                maxOutstandingTxns, reconnectOnConnectionLoss, null);
+    }
+    /**
+     * Creates a new native client wrapper from the given parameters (internal use only).
+     *
+     * @param clientConnectionKeyBase
+     *            the base hash/key for this connection, as defined by the pool.
+     * @param clientConnectionKey
+     *            the actual hash/key for this connection, as defined by the pool (may contain a
+     *            trailing index when the pool decides a new client needs to be created based on the
+     *            number of clients).
+     * @param servers
+     *            the list of VoltDB servers to connect to in hostname[:port] format.
+     * @param user
+     *            the user name to use when connecting to the server(s).
+     * @param password
+     *            the password to use when connecting to the server(s).
+     * @param isHeavyWeight
+     *            the flag indicating callback processes on this connection will be heavy (long
+     *            running callbacks). By default the connection only allocates one background
+     *            processing thread to process callbacks. If those callbacks run for a long time,
+     *            the network stack can get clogged with pending responses that have yet to be
+     *            processed, at which point the server will disconnect the application, thinking it
+     *            died and is not reading responses as fast as it is pushing requests. When the flag
+     *            is set to 'true', an additional 2 processing thread will deal with processing
+     *            callbacks, thus mitigating the issue.
+     * @param maxOutstandingTxns
+     *            the number of transactions the client application may push against a specific
+     *            connection before getting blocked on back-pressure. By default the connection
+     *            allows 3,000 open transactions before preventing the client from posting more
+     *            work, thus preventing server fire-hosing. In some cases however, with very fast,
+     *            small transactions, this limit can be raised.
+     * @param reconnectOnConnectionLoss
+     *            Attempts to reconnect to a node with retry after connection loss
+     * @param sslConfig
+     *            Contains properties - trust store path and password, key store path and password,
+     *            used for connecting with server over SSL. For unencrypted connection, passed in ssl
+     *            config is null
+     * @throws IOException
+     * @throws UnknownHostException
+     */
+    protected JDBC4ClientConnection(
+            String clientConnectionKeyBase, String clientConnectionKey,
+            String[] servers, String user, String password, boolean isHeavyWeight,
+            int maxOutstandingTxns, boolean reconnectOnConnectionLoss,
+            SSLConfiguration.SslConfig sslConfig)
+                    throws UnknownHostException, IOException
+    {
         // Save the list of trimmed non-empty server names.
         this.servers = new ArrayList<String>(servers.length);
         for (String server : servers) {
@@ -135,13 +186,19 @@ public class JDBC4ClientConnection implements Closeable {
         this.keyBase = clientConnectionKeyBase;
         this.key = clientConnectionKey;
 
+        boolean enableSSL = (sslConfig != null) ? true : false;
+
         // Create configuration
-        this.config = new ClientConfig(user, password);
+        this.config = new ClientConfig(user, password, enableSSL);
         config.setHeavyweight(isHeavyWeight);
         if (maxOutstandingTxns > 0)
             config.setMaxOutstandingTxns(maxOutstandingTxns);
 
         this.config.setReconnectOnConnectionLoss(reconnectOnConnectionLoss);
+
+        if (enableSSL) {
+            config.setSSLConfig(sslConfig);
+        }
 
         // Create client and connect.
         createClientAndConnect();

--- a/tests/frontend/org/voltdb/jdbc/JDBCTestCommons.java
+++ b/tests/frontend/org/voltdb/jdbc/JDBCTestCommons.java
@@ -1,0 +1,50 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Properties;
+
+import org.voltdb.client.ClientConfig;
+
+public class JDBCTestCommons {
+
+    final static String SSL_URL_SUFFIX = "ssl=true&trustStore=tests/frontend/org/voltdb/keystore&trustStorePassword=password";
+
+    static Connection getJdbcConnection(String url, Properties props) throws Exception
+    {
+        Class.forName("org.voltdb.jdbc.Driver");
+        if (ClientConfig.ENABLE_SSL_FOR_TEST) {
+            if (url.contains("?")) {
+                url = url + "&" + SSL_URL_SUFFIX;
+            }
+            else {
+                url = url + "?" + SSL_URL_SUFFIX;
+            }
+        }
+        return DriverManager.getConnection(url, props);
+    }
+
+}

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCAutoReconnectOnLoss.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCAutoReconnectOnLoss.java
@@ -34,23 +34,25 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.voltdb.BackendTarget;
 import org.voltdb.ServerThread;
 import org.voltdb.VoltDB.Configuration;
 import org.voltdb.client.ArbitraryDurationProc;
+import org.voltdb.client.ClientConfig;
 import org.voltdb.client.TestClientFeatures;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltFile;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 public class TestJDBCAutoReconnectOnLoss {
 
     String m_testjar;
 
-    static final String  DRIVER_URL="jdbc:voltdb://localhost:21212?autoreconnect=true";
+    static String driverUrl ="jdbc:voltdb://localhost:21212?autoreconnect=true";
     static final String  TEST_SQL = "select  count(*) from TT";
 
     VoltProjectBuilder m_builder;
@@ -81,7 +83,9 @@ public class TestJDBCAutoReconnectOnLoss {
 
         MiscUtils.copyFile(m_builder.getPathToDeployment(), Configuration.getPathToCatalogForTest("jdbcreconnecttest.xml"));
         m_testjar = Configuration.getPathToCatalogForTest("jdbcreconnecttest.jar");
-
+        if (ClientConfig.ENABLE_SSL_FOR_TEST) {
+            driverUrl = driverUrl + JDBCTestCommons.SSL_URL_SUFFIX;
+        }
         startServer();
         connect();
     }
@@ -113,7 +117,7 @@ public class TestJDBCAutoReconnectOnLoss {
     private void connect() throws ClassNotFoundException, SQLException
     {
         Class.forName("org.voltdb.jdbc.Driver");
-        m_connection =  DriverManager.getConnection(DRIVER_URL, new Properties());
+        m_connection =  DriverManager.getConnection(driverUrl, new Properties());
     }
 
     @Test
@@ -152,7 +156,7 @@ public class TestJDBCAutoReconnectOnLoss {
 
         org.apache.tomcat.jdbc.pool.DataSource ds = new org.apache.tomcat.jdbc.pool.DataSource();
         ds.setDriverClassName("org.voltdb.jdbc.Driver");
-        ds.setUrl(DRIVER_URL);
+        ds.setUrl(driverUrl);
         ds.setInitialSize(5);
         ds.setMaxActive(10);
         ds.setMaxIdle(5);

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
@@ -48,18 +48,20 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.voltdb.BackendTarget;
 import org.voltdb.ServerThread;
 import org.voltdb.VoltDB.Configuration;
 import org.voltdb.VoltType;
 import org.voltdb.client.ArbitraryDurationProc;
+import org.voltdb.client.ClientConfig;
 import org.voltdb.client.TestClientFeatures;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.types.VoltDecimalHelper;
 import org.voltdb.utils.MiscUtils;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TestJDBCDriver {
     static String testjar;
@@ -67,6 +69,8 @@ public class TestJDBCDriver {
     static Connection conn;
     static Connection myconn;
     static VoltProjectBuilder pb;
+
+
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -148,14 +152,14 @@ public class TestJDBCDriver {
         server.waitForInitialization();
 
         Class.forName("org.voltdb.jdbc.Driver");
-        conn = DriverManager.getConnection("jdbc:voltdb://localhost:21212");
-        myconn = null;
-    }
+        if(ClientConfig.ENABLE_SSL_FOR_TEST) {
+            conn = DriverManager.getConnection("jdbc:voltdb://localhost:21212?" + JDBCTestCommons.SSL_URL_SUFFIX);
+        }
+        else {
+            conn = DriverManager.getConnection("jdbc:voltdb://localhost:21212");
+        }
 
-    private static Connection getJdbcConnection(String url, Properties props) throws Exception
-    {
-        Class.forName("org.voltdb.jdbc.Driver");
-        return DriverManager.getConnection(url, props);
+        myconn = null;
     }
 
     private static void stopServer() throws SQLException {
@@ -767,7 +771,7 @@ public class TestJDBCDriver {
     public void testQueryTimeout() throws Exception {
         Properties props = new Properties();
         // Check default setting, timeout unit should be TimeUnit.SECONDS
-        myconn = getJdbcConnection("jdbc:voltdb://localhost:21212", props);
+        myconn = JDBCTestCommons.getJdbcConnection("jdbc:voltdb://localhost:21212", props);
         assertTrue(runQueryWithTimeout(7000, 1));
         assertFalse(runQueryWithTimeout(7000, 30));
         assertTrue(runQueryWithTimeout(7000, -1));
@@ -775,7 +779,7 @@ public class TestJDBCDriver {
 
         // Check set time unit to MILLISECONDS
         // through url
-        myconn = getJdbcConnection(
+        myconn = JDBCTestCommons.getJdbcConnection(
                 "jdbc:voltdb://localhost:21212?jdbc.querytimeout.unit=milliseconds",
                 props);
         assertTrue(runQueryWithTimeout(7000, 1));
@@ -786,7 +790,7 @@ public class TestJDBCDriver {
         // Check set time unit to MILLISECONDS
         // through Java Propeties
         props.setProperty(JDBC4Connection.QUERYTIMEOUT_UNIT, "milliseconds");
-        myconn = getJdbcConnection("jdbc:voltdb://localhost:21212", props);
+        myconn = JDBCTestCommons.getJdbcConnection("jdbc:voltdb://localhost:21212", props);
         assertTrue(runQueryWithTimeout(7000, 1));
         assertTrue(runQueryWithTimeout(7000, 30));
         assertTrue(runQueryWithTimeout(7000, -1));
@@ -795,7 +799,7 @@ public class TestJDBCDriver {
         // Check set time unit to other unsupported unit, should by default
         // still use TimeUnit.SECONDS
         props.setProperty(JDBC4Connection.QUERYTIMEOUT_UNIT, "nanoseconds");
-        myconn = getJdbcConnection("jdbc:voltdb://localhost:21212", props);
+        myconn = JDBCTestCommons.getJdbcConnection("jdbc:voltdb://localhost:21212", props);
         assertTrue(runQueryWithTimeout(7000, 1));
         assertFalse(runQueryWithTimeout(7000, 30));
         assertTrue(runQueryWithTimeout(7000, -1));
@@ -881,20 +885,20 @@ public class TestJDBCDriver {
     {
         Properties props = new Properties();
         // Check default behavior
-        myconn = getJdbcConnection("jdbc:voltdb://localhost:21212", props);
+        myconn = JDBCTestCommons.getJdbcConnection("jdbc:voltdb://localhost:21212", props);
         checkSafeMode(myconn);
         myconn.close();
 
         // Check commit and setAutoCommit
         props.setProperty(JDBC4Connection.COMMIT_THROW_EXCEPTION, "true");
         props.setProperty(JDBC4Connection.ROLLBACK_THROW_EXCEPTION, "true");
-        myconn = getJdbcConnection("jdbc:voltdb://localhost:21212", props);
+        myconn = JDBCTestCommons.getJdbcConnection("jdbc:voltdb://localhost:21212", props);
         checkSafeMode(myconn);
         myconn.close();
 
         props.setProperty(JDBC4Connection.COMMIT_THROW_EXCEPTION, "false");
         props.setProperty(JDBC4Connection.ROLLBACK_THROW_EXCEPTION, "false");
-        myconn = getJdbcConnection("jdbc:voltdb://localhost:21212", props);
+        myconn = JDBCTestCommons.getJdbcConnection("jdbc:voltdb://localhost:21212", props);
         checkCarlosDanger(myconn);
         myconn.close();
     }
@@ -904,18 +908,18 @@ public class TestJDBCDriver {
     {
         Properties props = new Properties();
         // Check default behavior
-        myconn = getJdbcConnection("jdbc:voltdb://localhost:21212", props);
+        myconn = JDBCTestCommons.getJdbcConnection("jdbc:voltdb://localhost:21212", props);
         checkSafeMode(myconn);
         myconn.close();
 
         // Check commit and setAutoCommit
-        myconn = getJdbcConnection("jdbc:voltdb://localhost:21212?" +
+        myconn = JDBCTestCommons.getJdbcConnection("jdbc:voltdb://localhost:21212?" +
                 JDBC4Connection.COMMIT_THROW_EXCEPTION + "=true" + "&" +
                 JDBC4Connection.ROLLBACK_THROW_EXCEPTION + "=true", props);
         checkSafeMode(myconn);
         myconn.close();
 
-        myconn = getJdbcConnection("jdbc:voltdb://localhost:21212?" +
+        myconn = JDBCTestCommons.getJdbcConnection("jdbc:voltdb://localhost:21212?" +
                 JDBC4Connection.COMMIT_THROW_EXCEPTION + "=false" + "&" +
                 JDBC4Connection.ROLLBACK_THROW_EXCEPTION + "=false", props);
         checkCarlosDanger(myconn);
@@ -953,7 +957,7 @@ public class TestJDBCDriver {
 
             System.setProperty(Driver.JDBC_PROP_FILE_PROP, propfile);
             props = new Properties();
-            myconn = getJdbcConnection("jdbc:voltdb://localhost:21212", props);
+            myconn = JDBCTestCommons.getJdbcConnection("jdbc:voltdb://localhost:21212", props);
             checkCarlosDanger(myconn);
             myconn.close();
         }
@@ -963,5 +967,22 @@ public class TestJDBCDriver {
                 tmp.delete();
             }
         }
+    }
+
+    @Test
+    public void testSSLPropertiesFromURLnSystemProperties() {
+        String url = "jdbc:voltdb://server1:21212,server2?"
+                + "ssl=true&keystore=/tmp/abc&keystorepassword=password&"
+                + "truststore=/tmp/xyz&truststorepassword=password";
+        String[] servers = Driver.getServersFromURL(url);
+        assertEquals("server1:21212", servers[0]);
+        assertEquals("server2", servers[1]);
+        Map<String, String> propMap = Driver.getPropsFromURL(url);
+        assertEquals(5, propMap.size());
+        assertEquals("true", propMap.get(Driver.SSL_PROP));
+        assertEquals("/tmp/abc", propMap.get(Driver.KEYSTORE_CONFIG_PROP));
+        assertEquals("password", propMap.get(Driver.KEYSTORE_PASSWORD_PROP));
+        assertEquals("/tmp/xyz", propMap.get(Driver.TRUSTSTORE_CONFIG_PROP));
+        assertEquals("password", propMap.get(Driver.TRUSTSTORE_PASSWORD_PROP));
     }
 }

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
@@ -972,16 +972,13 @@ public class TestJDBCDriver {
     @Test
     public void testSSLPropertiesFromURL() {
         String url = "jdbc:voltdb://server1:21212,server2?"
-                + "ssl=true&keystore=/tmp/abc&keystorepassword=password&"
-                + "truststore=/tmp/xyz&truststorepassword=password";
+                + "ssl=true&truststore=/tmp/xyz&truststorepassword=password";
         String[] servers = Driver.getServersFromURL(url);
         assertEquals("server1:21212", servers[0]);
         assertEquals("server2", servers[1]);
         Map<String, String> propMap = Driver.getPropsFromURL(url);
-        assertEquals(5, propMap.size());
+        assertEquals(3, propMap.size());
         assertEquals("true", propMap.get(Driver.SSL_PROP));
-        assertEquals("/tmp/abc", propMap.get(Driver.KEYSTORE_CONFIG_PROP));
-        assertEquals("password", propMap.get(Driver.KEYSTORE_PASSWORD_PROP));
         assertEquals("/tmp/xyz", propMap.get(Driver.TRUSTSTORE_CONFIG_PROP));
         assertEquals("password", propMap.get(Driver.TRUSTSTORE_PASSWORD_PROP));
     }

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
@@ -970,7 +970,7 @@ public class TestJDBCDriver {
     }
 
     @Test
-    public void testSSLPropertiesFromURLnSystemProperties() {
+    public void testSSLPropertiesFromURL() {
         String url = "jdbc:voltdb://server1:21212,server2?"
                 + "ssl=true&keystore=/tmp/abc&keystorepassword=password&"
                 + "truststore=/tmp/xyz&truststorepassword=password";

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCMultiConnection.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCMultiConnection.java
@@ -41,9 +41,12 @@ import org.voltdb.BackendTarget;
 import org.voltdb.ServerThread;
 import org.voltdb.VoltDB.Configuration;
 import org.voltdb.client.ArbitraryDurationProc;
+import org.voltdb.client.ClientConfig;
 import org.voltdb.client.TestClientFeatures;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.utils.MiscUtils;
+
+import org.hsqldb_voltpatches.jdbc.JDBCDriver;
 
 public class TestJDBCMultiConnection {
     static String m_testJar;
@@ -101,7 +104,12 @@ public class TestJDBCMultiConnection {
     {
         Class.forName("org.voltdb.jdbc.Driver");
         for (int i = 0; i < m_connections.length; ++i) {
-            m_connections[i] = DriverManager.getConnection("jdbc:voltdb://localhost:21212");
+            if (ClientConfig.ENABLE_SSL_FOR_TEST) {
+                m_connections[i] = DriverManager.getConnection("jdbc:voltdb://localhost:21212?" + JDBCTestCommons.SSL_URL_SUFFIX);
+            }
+            else {
+                m_connections[i] = DriverManager.getConnection("jdbc:voltdb://localhost:21212");
+            }
         }
     }
 

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCMultiNodeConnection.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCMultiNodeConnection.java
@@ -31,17 +31,17 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
-
-import junit.framework.Test;
-
 import org.voltdb.BackendTarget;
 import org.voltdb.client.Client;
+import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
 import org.voltdb.regressionsuites.RegressionSuite;
 import org.voltdb.utils.MiscUtils;
+
+import junit.framework.Test;
 
 public class TestJDBCMultiNodeConnection extends RegressionSuite
 {
@@ -89,6 +89,9 @@ public class TestJDBCMultiNodeConnection extends RegressionSuite
         final List<String> listeners = m_config.getListenerAddresses();
         for (String listener : listeners) {
             sb.append(listener).append(",");
+        }
+        if (ClientConfig.ENABLE_SSL_FOR_TEST) {
+            sb.append("?").append(JDBCTestCommons.SSL_URL_SUFFIX);
         }
         String JDBCURL = sb.toString();
         System.out.println("Connecting to JDBC URL: " + JDBCURL);

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
@@ -42,17 +42,19 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 
+import org.voltdb.BackendTarget;
+import org.voltdb.ServerThread;
+import org.voltdb.VoltDB.Configuration;
+import org.voltdb.client.ClientConfig;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.utils.Encoder;
+import org.voltdb.utils.MiscUtils;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.voltdb.BackendTarget;
-import org.voltdb.ServerThread;
-import org.voltdb.VoltDB.Configuration;
-import org.voltdb.compiler.VoltProjectBuilder;
-import org.voltdb.utils.Encoder;
-import org.voltdb.utils.MiscUtils;
 
 public class TestJDBCQueries {
     private static final String TEST_XML = "jdbcparameterstest.xml";
@@ -60,7 +62,6 @@ public class TestJDBCQueries {
     static String testjar;
     static ServerThread server;
     static Connection conn;
-    static Connection myconn;
     static VoltProjectBuilder pb;
 
     static class Data
@@ -392,18 +393,18 @@ public class TestJDBCQueries {
         server.waitForInitialization();
 
         Class.forName("org.voltdb.jdbc.Driver");
-        conn = DriverManager.getConnection("jdbc:voltdb://localhost:21212");
-        myconn = null;
+        if(ClientConfig.ENABLE_SSL_FOR_TEST) {
+            conn = DriverManager.getConnection("jdbc:voltdb://localhost:21212?" + JDBCTestCommons.SSL_URL_SUFFIX);
+        }
+        else {
+            conn = DriverManager.getConnection("jdbc:voltdb://localhost:21212");
+        }
     }
 
     private static void stopServer() throws SQLException {
         if (conn != null) {
             conn.close();
             conn = null;
-        }
-        if (myconn != null) {
-            myconn.close();
-            myconn = null;
         }
         if (server != null) {
             try { server.shutdown(); } catch (InterruptedException e) { /*empty*/ }

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCStreamQueries.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCStreamQueries.java
@@ -36,15 +36,17 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.voltdb.BackendTarget;
+import org.voltdb.ServerThread;
+import org.voltdb.VoltDB.Configuration;
+import org.voltdb.client.ClientConfig;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.utils.MiscUtils;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.voltdb.BackendTarget;
-import org.voltdb.ServerThread;
-import org.voltdb.VoltDB.Configuration;
-import org.voltdb.compiler.VoltProjectBuilder;
-import org.voltdb.utils.MiscUtils;
 
 public class TestJDBCStreamQueries {
     private static final String TEST_XML = "jdbcstreamstest.xml";
@@ -100,7 +102,12 @@ public class TestJDBCStreamQueries {
         server.waitForInitialization();
 
         Class.forName("org.voltdb.jdbc.Driver");
-        conn = DriverManager.getConnection("jdbc:voltdb://localhost:21212");
+        if (ClientConfig.ENABLE_SSL_FOR_TEST) {
+            conn = DriverManager.getConnection("jdbc:voltdb://localhost:21212?" + JDBCTestCommons.SSL_URL_SUFFIX);
+        }
+        else {
+            conn = DriverManager.getConnection("jdbc:voltdb://localhost:21212");
+        }
     }
 
     private static void stopServer() throws SQLException {


### PR DESCRIPTION
Add support for JDBC client to connect to the server over SSL. To connect JDBC client to server over SSL transport following properties key can be supplied along either with jdbc driver url or using system properties (ssl properties specified using system properties takes precedence over url properties):

URL properties for connecting over ssl
- Property: ssl; value description: "true" or "false" specifying whether to connect over SSL transport. Required if want to connect over SSL
- Property: truststore; value description: trust store path (optional)
- Property: truststorepassword; value description: trust store path (optional)

Example: 
Valid urls: 
- jdbc:voltdb://server1:21212,server2?ssl=true&truststore=/tmp/xyz&truststorepassword=password"
- jdbc:voltdb://server1:21212,server2?ssl=true" (If trust store system properties are set it will be used else will use null)

Following will not connect over ssl instead using plain-text connection
- jdbc:voltdb://server1:21212,server2?truststore=/tmp/xyz&truststorepassword=password" (ssl property needed for ssl connection)
- jdbc:voltdb://server1:21212,server2?ssl=false"