### PR TITLE
Add PROCEDUREDETAIL selector

### DIFF
--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -51,7 +51,13 @@ public class StatsAgent extends OpsAgent
     protected void dispatchFinalAggregations(PendingOpsRequest request)
     {
         StatsSelector subselector = StatsSelector.valueOf(request.subselector);
+        // the base table is the output of PROCEDUREDETAIL, all the other procedure-related
+        // sub-selectors need to build their final output by aggregating the base table.
         switch (subselector) {
+        case PROCEDURE:
+            request.aggregateTables =
+            aggregateProcedureStats(request.aggregateTables);
+            break;
         case PROCEDUREPROFILE:
             request.aggregateTables =
             aggregateProcedureProfileStats(request.aggregateTables);
@@ -181,6 +187,18 @@ public class StatsAgent extends OpsAgent
         return new VoltTable[] { timeTable.sortByOutput("PROCEDURE_OUTPUT") };
     }
 
+    /**
+     * Produce PROCEDURE aggregation of PROCEDURE subselector
+     */
+
+    private VoltTable[] aggregateProcedureStats(VoltTable[] baseStats)
+    {
+        if (baseStats == null || baseStats.length != 1) {
+            return baseStats;
+        }
+        // TODO: Build in the future tickets.
+        return baseStats;
+    }
 
     /**
      * Need to release references to catalog related stats sources
@@ -397,6 +415,7 @@ public class StatsAgent extends OpsAgent
         case PROCEDUREINPUT:
         case PROCEDUREOUTPUT:
         case PROCEDUREPROFILE:
+        case PROCEDUREDETAIL:
             stats = collectStats(StatsSelector.PROCEDURE, interval);
             break;
         case STARVATION:

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -34,6 +34,7 @@ public enum StatsSelector {
     SNAPSHOTSTATUS,
     PROCEDUREINPUT,
     PROCEDUREOUTPUT,
+    PROCEDUREDETAIL,  // provides more granular statistics for procedure calls at the per-statement level.
 
     /*
      * DRPRODUCERPARTITION and DRPRODUCERNODE are internal names

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDatabaseElementStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDatabaseElementStats.java
@@ -228,6 +228,12 @@ public class TestStatisticsSuiteDatabaseElementStats extends StatisticsTestSuite
         for (int ii = 0; ii < 3; ii++) {
             results = client.callProcedure("GoSleep", 3000, 0, null).getResults();
         }
+
+        // For now, just validate the schema of proceduredetail to be the same as procedure.
+        results = client.callProcedure("@Statistics", "proceduredetail", 0).getResults();
+        assertEquals(1, results.length);
+        validateSchema(results[0], expectedTable);
+
         results = client.callProcedure("@Statistics", "procedure", 0).getResults();
         System.out.println("Test procedures table: " + results[0].toString());
         // one aggregate table returned


### PR DESCRIPTION
In this pull request, I added the `PROCEDUREDETAIL` selector and it will now print the same output as the `PROCEDURE` selector.

The current output of the `PROCEDURE` selector is the base table for `PROCEDUREINPUT`, `PROCEDUREOUTPUT`, and `PROCEDUREPROFILE`.