### PR TITLE
ENG-11968 fix rejoin node blocker check

### DIFF
--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -113,9 +113,6 @@ public class VoltZK {
     public static final String rejoinActiveBlocker = ZKUtil.joinZKPath(catalogUpdateBlockers, "rejoin_blocker");
     public static final String request_truncation_snapshot_node = ZKUtil.joinZKPath(request_truncation_snapshot, "request_");
 
-    // root for rejoin nodes
-    public static final String rejoinNodeBlocker = "/db/rejoin_nodes_blocker";
-
     // Synchronized State Machine
     public static final String syncStateMachine = "/db/synchronized_states";
 

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -41,6 +41,7 @@ import org.voltcore.messaging.BinaryPayloadMessage;
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
+import org.voltcore.zk.CoreZK;
 import org.voltcore.zk.LeaderElector;
 import org.voltcore.zk.ZKUtil;
 import org.voltdb.AbstractTopology;
@@ -539,7 +540,7 @@ public class Cartographer extends StatsSource
                     }
                     // check if any node still in rejoin status
                     try {
-                        if (m_zk.exists(VoltZK.rejoinNodeBlocker, false) != null) {
+                        if (m_zk.exists(CoreZK.rejoin_node_blocker, false) != null) {
                             return false;
                         }
                     } catch (KeeperException.NoNodeException ignore) {} // shouldn't happen


### PR DESCRIPTION
Use the presence of node /core/rejoin_nodes_blocker as rejoin indicator for cluster safety check.