### PR TITLE
ENG-11984: Force a stats collection at pause time, so that empty db c…

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/Pause.java
+++ b/src/frontend/org/voltdb/sysprocs/Pause.java
@@ -122,6 +122,10 @@ public class Pause extends VoltSystemProcedure {
             }
         }
 
+        // Force a tick so that stats will be updated.
+        // Primarily added to get latest table stats for DR pause and empty db check.
+        ctx.getSiteProcedureConnection().tick();
+
         VoltTable t = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
         t.addRow(VoltSystemProcedure.STATUS_OK);
         return (new VoltTable[] {t});


### PR DESCRIPTION
…check from DR after that pause will give the latest.
Also in general it is not a bad idea to force stats collection at pause time.