### PR TITLE
ENG-11999: Don't serialize view info on DR tables for DR schema check.

### DIFF
--- a/src/catgen/in/javasrc/CatalogType.java
+++ b/src/catgen/in/javasrc/CatalogType.java
@@ -22,6 +22,7 @@
 package org.voltdb.catalog;
 
 import java.lang.reflect.Field;
+import java.util.Collection;
 
 
 /**
@@ -270,9 +271,19 @@ public abstract class CatalogType implements Comparable<CatalogType> {
     }
 
     void writeChildCommands(StringBuilder sb)  {
+        writeChildCommands(sb, null);
+    }
+
+    /**
+     * Write catalog commands of the children in the white list.
+     * @param whiteList A white list of CatalogType classes
+     */
+    void writeChildCommands(StringBuilder sb, Collection<Class<? extends CatalogType> > whiteList)  {
         for (String childCollection : getChildCollections()) {
             CatalogMap<? extends CatalogType> map = getCollection(childCollection);
-            map.writeCommandsForMembers(sb);
+            if (whiteList == null || whiteList.contains(map.m_cls)) {
+                map.writeCommandsForMembers(sb);
+            }
         }
     }
 

--- a/src/catgen/in/javasrc/DRCatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/DRCatalogDiffEngine.java
@@ -23,6 +23,7 @@ package org.voltdb.catalog;
 
 import java.util.List;
 
+import com.google_voltpatches.common.collect.Sets;
 import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
 import org.voltdb.common.Constants;
 import org.voltdb.compiler.deploymentfile.DrRoleType;
@@ -60,7 +61,7 @@ public class DRCatalogDiffEngine extends CatalogDiffEngine {
             if (t.getIsdred() && t.getMaterializer() == null && !CatalogUtil.isTableExportOnly(db, t)) {
                 t.writeCreationCommand(sb);
                 t.writeFieldCommands(sb);
-                t.writeChildCommands(sb);
+                t.writeChildCommands(sb, Sets.newHashSet(Column.class, Index.class, Constraint.class, Statement.class));
             }
         }
         String catalogCommands = sb.toString();

--- a/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
@@ -768,6 +768,27 @@ public class TestDRCatalogDiffs {
         assertTrue(threw);
     }
 
+    /**
+     * Don't serialize views, DR doesn't care.
+     */
+    @Test
+    public void testFilterViewInfo() throws Exception {
+        String masterSchema =
+        "CREATE TABLE T1 (C1 INTEGER NOT NULL, C2 INTEGER NOT NULL);\n" +
+        "CREATE TABLE T2 (C1 INTEGER NOT NULL, C2 INTEGER NOT NULL);\n" +
+        "CREATE VIEW foo (C1, total) AS SELECT C1, COUNT(*) FROM T1 GROUP BY C1;\n" +
+        "CREATE VIEW foo2 (C1, total) AS SELECT T1.C1, COUNT(*) FROM T1 JOIN T2 ON T1.C1 = T2.C1 GROUP BY T1.C1;\n" +
+        "DR TABLE T1;\n" +
+        "DR TABLE T2;\n";
+        Catalog masterCatalog = createCatalog(masterSchema);
+
+        String commands = DRCatalogDiffEngine.serializeCatalogCommandsForDr(masterCatalog, -1).commands;
+        String decodedCommands = Encoder.decodeBase64AndDecompress(commands);
+
+        assertFalse(decodedCommands.contains(" views "));
+        assertFalse(decodedCommands.contains(" mvHandlerInfo "));
+    }
+
     private CatalogDiffEngine runCatalogDiff(String masterSchema, boolean isMasterXDCR,
                                              String replicaSchema, boolean isReplicaXDCR) throws Exception {
         Catalog masterCatalog = createCatalog(masterSchema);


### PR DESCRIPTION
Use a white list to filter out information on DR tables that DR doesn't
care about, such as views.

A recent addition to the view catalog commands was made which caused DR
upgrade path to generate catalog commands that older version doesn't
understand. This fixes the backward compatibility issue.