### PR TITLE
Catch UnknownHostException for run in docker

### DIFF
--- a/src/frontend/org/voltcore/messaging/SocketJoiner.java
+++ b/src/frontend/org/voltcore/messaging/SocketJoiner.java
@@ -636,7 +636,8 @@ public class SocketJoiner {
             catch (java.net.ConnectException
                   |java.nio.channels.UnresolvedAddressException
                   |java.net.NoRouteToHostException
-                  |java.net.PortUnreachableException e)
+                  |java.net.PortUnreachableException
+                  |java.net.UnknownHostException e)
             {
                 // reset the socket to null for loop purposes
                 socket = null;


### PR DESCRIPTION
When first container starts and I specify "HOSTS=voltdb1,voltdb2,voltdb3" voltdb process exit with UnknownHostException because other containers not started and they unreacheable by dns resolution. After this fix all works fine.