### PR TITLE
ENG-11990: Protect parallel client connection setups from racing with…

### DIFF
--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -112,9 +112,6 @@ public class VoltDB {
     static {
         REAL_DEFAULT_TIMEZONE = TimeZone.getDefault();
         setDefaultTimezone();
-        EstTimeUpdater.start();
-        VoltLogger.startAsynchronousLogging();
-        ReverseDNSCache.start();
         ClientFactory.increaseClientCountToOne();
     }
 

--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -949,7 +949,21 @@ class Distributer {
         final int hostId = (int)instanceIdWhichIsTimestampAndLeaderIp[0];
 
         NodeConnection cxn = new NodeConnection(instanceIdWhichIsTimestampAndLeaderIp);
-        Connection c = m_network.registerChannel( aChannel, cxn);
+        Connection c = null;
+        try {
+            if (aChannel != null) {
+                c = m_network.registerChannel(aChannel, cxn);
+            }
+        }
+        catch (Exception e) {
+            // Need to clean up the socket if there was any failure
+            try {
+                aChannel.close();
+            } catch (IOException e1) {
+                //Don't care connection is already lost anyways
+            }
+            Throwables.propagate(e);
+        }
         cxn.m_connection = c;
 
         synchronized (this) {

--- a/tests/frontend/org/voltdb/client/TestClientClose.java
+++ b/tests/frontend/org/voltdb/client/TestClientClose.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CountDownLatch;
 
+import org.voltcore.network.ReverseDNSCache;
 import org.voltdb.ServerThread;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltDB.Configuration;
@@ -62,7 +63,15 @@ public class TestClientClose extends TestCase {
             localServer = new ServerThread(config);
             localServer.start();
             localServer.waitForInitialization();
-            ClientFactory.ACTIVE_CLIENT_COUNT.set(0);
+            ClientFactory.m_preserveResources = false;
+            while (ClientFactory.m_activeClientCount > 0) {
+                try {
+                    ClientFactory.decreaseClientNum();
+                }
+                catch (InterruptedException e) {}
+            }
+            // The DNS cache is always initialized in the started state
+            ReverseDNSCache.start();
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
… network initialization. (#4284)

1. Protect parallel client connection setups from racing with network initialization.
2. Clean up socket in distributer when/if channel registration fails.