### PR TITLE
ENG-11866: (#4257)

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -37,7 +37,18 @@ public interface ConsumerDRGateway extends Promotable {
 
     Map<Byte, DRRoleStats.State> getStates();
 
-    void initialize(boolean resumeReplication, final byte dataSourceCluster, List<MeshMemberInfo> expectedClusterMembers);
+    /**
+     * If this cluster was a joiner (at some point) dataSourceCluster will not be -1. If this is the case
+     * the trackers for this clusterId must exist. If they don't exist, this cluster did not finish loading
+     * the snapshot as a joiner.
+     * @param dataSourceCluster
+     * @param expectedClusterMembers
+     * @return false if this cluster is a joiner and the sync snapshot did not finish loading form the
+     *         leader cluster
+     */
+    boolean isSyncSnapshotComplete(byte dataSourceCluster, List<MeshMemberInfo> expectedClusterMembers);
+
+    void initialize(boolean resumeReplication);
 
     void shutdown(final boolean blocking) throws InterruptedException, ExecutionException;
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1257,7 +1257,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 getStatsAgent().registerStatsSource(StatsSelector.DRPRODUCERPARTITION, 0,
                         new DRProducerStatsBase.DRProducerPartitionStatsBase());
             }
-            createDRConsumerIfNeeded();
             m_drRoleStats = new DRRoleStats(this);
             getStatsAgent().registerStatsSource(StatsSelector.DRROLE, 0, m_drRoleStats);
 
@@ -3221,18 +3220,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
                 // 6. Perform updates required by the DR subsystem
 
-                // 6.1. Create the DR consumer if we've just enabled active-active.
-                // Perform any actions that would have been taken during the ordinary
-                // initialization path
-                if (createDRConsumerIfNeeded()) {
-                    for (int pid : m_cartographer.getPartitions()) {
-                        // Notify the consumer of leaders because it was disabled before
-                        ClientInterfaceRepairCallback callback = (ClientInterfaceRepairCallback) m_consumerDRGateway;
-                        callback.repairCompleted(pid, m_cartographer.getHSIdForMaster(pid));
-                    }
-                    // Even though we are active-active, we must be a joiner so our conversation file must be empty
-                    m_consumerDRGateway.initialize(false, (byte)-1, new ArrayList<>());
-                } else if (m_consumerDRGateway != null) {
+                // 6.1. Perform any actions that would have been taken during the ordinary initialization path
+                if (m_consumerDRGateway != null) {
                     // 6.2. If we are a DR replica and the consumer was created
                     // before the catalog update, we may care about a deployment
                     // update. If it was created above, no need to notify
@@ -3487,8 +3476,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_snmp.hostUp("Host is now a cluster member");
 
             if (m_producerDRGateway != null && !m_producerDRGateway.isStarted()) {
-                // Initialize DR producer and start listening on the DR ports
+                // Initialize DR producer and consumer start listening on the DR ports
                 initializeDRProducer();
+                createDRConsumerIfNeeded();
                 prepareReplication();
             }
         }
@@ -3723,6 +3713,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
 
             // Start listening on the DR ports
+            createDRConsumerIfNeeded();
             prepareReplication();
             startResourceUsageMonitor();
 
@@ -3843,18 +3834,18 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
     private void prepareReplication() {
         try {
+            boolean okToStartDR = true;
             if (m_consumerDRGateway != null) {
-                Pair<Byte, List<MeshMemberInfo>> expectedClusterMembers;
-                if (m_producerDRGateway != null) {
-                    expectedClusterMembers = m_producerDRGateway.getInitialConversations();
+                if (m_config.m_startAction == StartAction.RECOVER) {
+                    Pair<Byte, List<MeshMemberInfo>> expectedClusterMembers = m_producerDRGateway.getInitialConversations();
+                    okToStartDR = m_consumerDRGateway.isSyncSnapshotComplete(expectedClusterMembers.getFirst(),
+                            expectedClusterMembers.getSecond());
                 }
-                else {
-                    expectedClusterMembers = Pair.of((byte)-1, new ArrayList<>());
+                if (okToStartDR) {
+                    m_consumerDRGateway.initialize(m_config.m_startAction != StartAction.CREATE);
                 }
-                m_consumerDRGateway.initialize(m_config.m_startAction != StartAction.CREATE,
-                        expectedClusterMembers.getFirst(), expectedClusterMembers.getSecond());
             }
-            if (m_producerDRGateway != null) {
+            if (m_producerDRGateway != null && okToStartDR) {
                 m_producerDRGateway.startListening(m_catalogContext.cluster.getDrproducerenabled(),
                                                    VoltDB.getReplicationPort(m_catalogContext.cluster.getDrproducerport()),
                                                    VoltDB.getDefaultReplicationInterface());
@@ -3872,20 +3863,13 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     }
 
     private boolean createDRConsumerIfNeeded() {
-        if (!m_config.m_isEnterprise
-                || (m_consumerDRGateway != null)
-                || !m_catalogContext.cluster.getDrconsumerenabled()) {
+        if (!m_config.m_isEnterprise || (m_consumerDRGateway != null)) {
             return false;
         }
         final String drRole = m_catalogContext.getCluster().getDrrole();
         if (DrRoleType.REPLICA.value().equals(drRole) || DrRoleType.XDCR.value().equals(drRole)) {
-            String drProducerHost = m_catalogContext.cluster.getDrmasterhost();
             byte drConsumerClusterId = (byte)m_catalogContext.cluster.getDrclusterid();
             final Pair<String, Integer> drIfAndPort = VoltZK.getDRInterfaceAndPortFromMetadata(m_localMetadata);
-            if (m_catalogContext.cluster.getDrconsumerenabled() &&
-                    (drProducerHost == null || drProducerHost.isEmpty())) {
-                VoltDB.crashLocalVoltDB("Cannot start as DR consumer without an enabled DR data connection.");
-            }
             try {
                 Class<?> rdrgwClass = Class.forName("org.voltdb.dr2.ConsumerDRGatewayImpl");
                 Constructor<?> rdrgwConstructor = rdrgwClass.getConstructor(

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -1966,6 +1966,8 @@ public class LocalCluster extends VoltServerConfig {
         System.out.println("Starting local cluster.");
         lc.setHasLocalServer(hasLocalServer);
         lc.overrideAnyRequestForValgrind();
+        lc.setJavaProperty("DR_QUERY_INTERVAL", "5");
+        lc.setJavaProperty("DR_RECV_TIMEOUT", "5000");
         if (!lc.isNewCli()) {
             lc.setDeploymentAndVoltDBRoot(builder.getPathToDeployment(), pathToVoltDBRoot);
             lc.startUp(false);


### PR DESCRIPTION
* ENG-11866:
1. Move initialization of DR ConsumerGateway to the cluster initialization time. This then allows the producer to leak connections and start cursors to the cluster even if no data source has been specified.
2. Enable breaking of producer and consumer connections to isolate a ServerThread or LocalCluster host with hasLocalServer set to true.
3. Change QueryInterval in DRConnectionInterface from static final to instance final so that it can be set to a low value for unit tests that use ServerThread. This accelerates unit tests that require discovery to detect rejoined or recovered hosts.
3. Add a unit test to multiCluster to verify that a joiner cluster and a network isolated mesh leader cluster can find eachother and sync up after the network isolation has been removed.