### PR TITLE
ENG-12041: override the equals method for DRConsumerNodeStats and DRConsumerPart…

### DIFF
--- a/src/frontend/org/voltdb/DRConsumerStatsBase.java
+++ b/src/frontend/org/voltdb/DRConsumerStatsBase.java
@@ -64,6 +64,12 @@ public class DRConsumerStatsBase {
         protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
             return ImmutableSet.of().iterator();
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            return false;
+        }
     }
 
     public static class DRConsumerPartitionStatsBase extends StatsSource {
@@ -88,6 +94,12 @@ public class DRConsumerStatsBase {
         @Override
         protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
             return ImmutableSet.of().iterator();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            return false;
         }
     }
 

--- a/src/frontend/org/voltdb/DRConsumerStatsBase.java
+++ b/src/frontend/org/voltdb/DRConsumerStatsBase.java
@@ -45,7 +45,6 @@ public class DRConsumerStatsBase {
     }
 
     public static class DRConsumerNodeStatsBase extends StatsSource {
-
         public DRConsumerNodeStatsBase() {
             super(false);
         }
@@ -64,16 +63,9 @@ public class DRConsumerStatsBase {
         protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
             return ImmutableSet.of().iterator();
         }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            return false;
-        }
     }
 
     public static class DRConsumerPartitionStatsBase extends StatsSource {
-
         public DRConsumerPartitionStatsBase() {
             super(false);
         }
@@ -94,12 +86,6 @@ public class DRConsumerStatsBase {
         @Override
         protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
             return ImmutableSet.of().iterator();
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            return false;
         }
     }
 


### PR DESCRIPTION
…itionStats

We registerStatsSource each time we create a new DRConsumerDispatcher.

Each new instances of DRConsumerNodeStats and DRConsumerPartitionStats need to be treated as unequal.