### PR TITLE
Add ddl/schema argument support to get command

### DIFF
--- a/lib/python/voltcli/voltdb.d/get.py
+++ b/lib/python/voltcli/voltdb.d/get.py
@@ -17,41 +17,38 @@
 import sys, os, subprocess
 from voltcli import utility
 
-dir_spec_help = ('Specifies the root directory for the database. The default '
-                   'is voltdbroot under the current working directory.')
-get_resource_help = ('Supported configuration resources for get command are \'deployment\', \'schema\' and \'classes\'.\n'
+dir_spec_help = ('Specifies the root directory for the database. The default is the current working directory.')
+get_resource_help = ('Supported configuration resources for get command are \'deployment\' and \'schema\'.\n'
                      '    deployment - gets deployment configuration of current node\n'
-                     '    schema     - gets schema of current node\n'
-                     '    classes    - gets Java stored procedures of current node\n')
+                     '    schema     - gets schema of current node\n')
 
 @VOLT.Command(
     description = 'Get voltdb configuration resource.',
     options = (
-        VOLT.StringOption('-o', '--output', 'output', 'Specifies file to save the configuration resource to.', default=None),
+        VOLT.StringOption('-o', '--output', 'output', 'Specifies file to save the configuration resource to.',
+                          default=None),
         VOLT.StringOption('-D', '--dir', 'directory_spec', dir_spec_help, default=None),
-        VOLT.BooleanOption('-f', '--force', 'force', 'Stores the output file even if the VoltDB managed directories '
-                                                     'contain files from a previous session that may be overwritten.')
+        VOLT.BooleanOption('-f', '--force', 'force', 'Stores the output file even if the resouces file from the '
+                                                     'previous session that may be overwritten.')
     ),
     arguments = (
-        VOLT.StringArgument('resource', get_resource_help, default = None),
+        VOLT.StringArgument('resource', get_resource_help, default=None),
     )
 )
 
 def get(runner):
     runner.args.extend(['get'])
 
-    if runner.opts.resource in ('deployment', 'schema', 'classes'):
+    if runner.opts.resource in ('deployment', 'schema'):
         runner.args.extend([runner.opts.resource])
     else:
-        utility.abort('Expected actions for get command are deployment, schema or classes')
+        utility.abort('Expected arguments for get command are deployment and schema')
 
     if runner.opts.output:
         runner.args.extend(['file', runner.opts.output])
     if runner.opts.directory_spec:
         runner.args.extend(['getvoltdbroot', runner.opts.directory_spec])
     if runner.opts.force:
-        runner.args.extend(['force'])
-
-    print('Args: %s' % runner.args)
+        runner.args.extend(['forceget'])
 
     runner.java_execute('org.voltdb.VoltDB', None, *runner.args)

--- a/lib/python/voltcli/voltdb.d/get.py
+++ b/lib/python/voltcli/voltdb.d/get.py
@@ -18,18 +18,19 @@ import sys, os, subprocess
 from voltcli import utility
 
 dir_spec_help = ('Specifies the root directory for the database. The default is the current working directory.')
-get_resource_help = ('Supported configuration resources for get command are \'deployment\' and \'schema\'.\n'
-                     '    deployment - gets deployment configuration of current node\n'
-                     '    schema     - gets schema of current node\n')
+get_resource_help = ('Supported configuration resources for get command are \'deployment\' and \'schema\'.\r\n'
+                     '           deployment - gets deployment configuration of current node\n'
+                     '           schema     - gets schema of current node\n')
+output_help = ("Specifies the path and file name for the output file. Defaults are: "
+               "Deployment - deployment.xml;\r\n"
+               "Schema - schema.sql;")
 
 @VOLT.Command(
-    description = 'Get voltdb configuration resource.',
+    description = 'Write the selected database resource (deployment or schema) to a file.',
     options = (
-        VOLT.StringOption('-o', '--output', 'output', 'Specifies file to save the configuration resource to.',
-                          default=None),
+        VOLT.StringOption('-o', '--output', 'output', output_help, default=None),
         VOLT.StringOption('-D', '--dir', 'directory_spec', dir_spec_help, default=None),
-        VOLT.BooleanOption('-f', '--force', 'force', 'Stores the output file even if the resouces file from the '
-                                                     'previous session that may be overwritten.')
+        VOLT.BooleanOption('-f', '--force', 'force', 'Overwrites an existing file.')
     ),
     arguments = (
         VOLT.StringArgument('resource', get_resource_help, default=None),

--- a/src/frontend/org/voltdb/GetActionArgument.java
+++ b/src/frontend/org/voltdb/GetActionArgument.java
@@ -19,16 +19,43 @@ package org.voltdb;
 
 public enum GetActionArgument {
 
-    DEPLOYMENT("deployment"),
-    DDL("ddl");
+    DEPLOYMENT("deployment") {
+        @Override
+        public String getDefaultOutput() {
+            return "deployment.xml";
+        }
+    },
+    SCHEMA("schema") {
+        @Override
+        public String getDefaultOutput() {
+            return "schema.sql";
+        }
+    },
+    CLASSES("classes") {
+        @Override
+        public String getDefaultOutput() {
+            return "procedures.jar";
+        }
+    };
 
-    final String m_verb;
+    final String m_resource;
 
-    GetActionArgument() {
-        m_verb = name().toLowerCase();
-    }
+    public String getDefaultOutput() { return ""; }
+    public String getVerb() { return m_resource; }
+
+//    GetActionArgument() {
+//        m_resource = name().toLowerCase();
+//    }
 
     GetActionArgument(String verb) {
-        m_verb = verb;
+        m_resource = verb;
+    }
+
+    public static String supportedVerbs() {
+        StringBuilder verbNames = new StringBuilder();
+        for (GetActionArgument verb: GetActionArgument.values()) {
+            verbNames.append(verb.name().toLowerCase() + " ");
+        }
+        return verbNames.toString();
     }
 }

--- a/src/frontend/org/voltdb/GetActionArgument.java
+++ b/src/frontend/org/voltdb/GetActionArgument.java
@@ -19,37 +19,28 @@ package org.voltdb;
 
 public enum GetActionArgument {
 
-    DEPLOYMENT("deployment") {
+    DEPLOYMENT() {
         @Override
         public String getDefaultOutput() {
             return "deployment.xml";
         }
     },
-    SCHEMA("schema") {
+    SCHEMA() {
         @Override
         public String getDefaultOutput() {
             return "schema.sql";
         }
     },
-    CLASSES("classes") {
+    CLASSES() {
         @Override
         public String getDefaultOutput() {
             return "procedures.jar";
         }
     };
 
-    final String m_resource;
-
     public String getDefaultOutput() { return ""; }
-    public String getVerb() { return m_resource; }
 
-//    GetActionArgument() {
-//        m_resource = name().toLowerCase();
-//    }
-
-    GetActionArgument(String verb) {
-        m_resource = verb;
-    }
+    GetActionArgument() { }
 
     public static String supportedVerbs() {
         StringBuilder verbNames = new StringBuilder();

--- a/src/frontend/org/voltdb/GetActionArgument.java
+++ b/src/frontend/org/voltdb/GetActionArgument.java
@@ -17,36 +17,19 @@
 
 package org.voltdb;
 
+import java.util.Arrays;
+
 public enum GetActionArgument {
 
-    DEPLOYMENT() {
-        @Override
-        public String getDefaultOutput() {
-            return "deployment.xml";
-        }
-    },
-    SCHEMA() {
-        @Override
-        public String getDefaultOutput() {
-            return "schema.sql";
-        }
-    },
-    CLASSES() {
-        @Override
-        public String getDefaultOutput() {
-            return "procedures.jar";
-        }
-    };
+    DEPLOYMENT("deployment.xml"),
+    SCHEMA("schema.sql");
 
-    public String getDefaultOutput() { return ""; }
+    final String m_defaultOutput;
+    public String getDefaultOutput() { return m_defaultOutput; }
 
-    GetActionArgument() { }
+    GetActionArgument(String value) { m_defaultOutput = value; }
 
     public static String supportedVerbs() {
-        StringBuilder verbNames = new StringBuilder();
-        for (GetActionArgument verb: GetActionArgument.values()) {
-            verbNames.append(verb.name().toLowerCase() + " ");
-        }
-        return verbNames.toString();
+        return Arrays.asList(values()).toString().replaceAll("^.|.$", "");
     }
 }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -67,6 +67,22 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.aeonbits.owner.ConfigFactory;
+import org.apache.cassandra_voltpatches.GCInspector;
+import org.apache.log4j.Appender;
+import org.apache.log4j.DailyRollingFileAppender;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Logger;
+import org.apache.zookeeper_voltpatches.CreateMode;
+import org.apache.zookeeper_voltpatches.KeeperException;
+import org.apache.zookeeper_voltpatches.WatchedEvent;
+import org.apache.zookeeper_voltpatches.Watcher;
+import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
+import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.apache.zookeeper_voltpatches.data.Stat;
+import org.json_voltpatches.JSONException;
+import org.json_voltpatches.JSONObject;
+import org.json_voltpatches.JSONStringer;
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
@@ -80,7 +96,6 @@ import org.voltcore.utils.VersionChecker;
 import org.voltcore.zk.CoreZK;
 import org.voltcore.zk.ZKCountdownLatch;
 import org.voltcore.zk.ZKUtil;
-
 import org.voltdb.ProducerDRGateway.MeshMemberInfo;
 import org.voltdb.TheHashinator.HashinatorType;
 import org.voltdb.VoltDB.Configuration;
@@ -153,23 +168,6 @@ import org.voltdb.utils.SystemStatsCollector;
 import org.voltdb.utils.TopologyZKUtils;
 import org.voltdb.utils.VoltFile;
 import org.voltdb.utils.VoltSampler;
-
-import org.aeonbits.owner.ConfigFactory;
-import org.apache.cassandra_voltpatches.GCInspector;
-import org.apache.log4j.Appender;
-import org.apache.log4j.DailyRollingFileAppender;
-import org.apache.log4j.FileAppender;
-import org.apache.log4j.Logger;
-import org.apache.zookeeper_voltpatches.CreateMode;
-import org.apache.zookeeper_voltpatches.KeeperException;
-import org.apache.zookeeper_voltpatches.WatchedEvent;
-import org.apache.zookeeper_voltpatches.Watcher;
-import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
-import org.apache.zookeeper_voltpatches.ZooKeeper;
-import org.apache.zookeeper_voltpatches.data.Stat;
-import org.json_voltpatches.JSONException;
-import org.json_voltpatches.JSONObject;
-import org.json_voltpatches.JSONStringer;
 
 import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.base.Joiner;
@@ -656,10 +654,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         }
     }
 
-    void outputProcedure(Configuration config) {
-    }
-
-
     @Override
     public void cli(Configuration config) {
         if (config.m_startAction != StartAction.GET) {
@@ -686,9 +680,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 break;
             case SCHEMA:
                 outputSchema(config);
-                break;
-            case CLASSES:
-                outputProcedure(config);
                 break;
         }
         VoltDB.exit(0);

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -597,12 +597,13 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             File configInfoDir = new VoltFile(config.m_voltdbRoot, Constants.CONFIG_DIR);
             File depFH = new VoltFile(configInfoDir, "deployment.xml");
             if (!depFH.isFile() || !depFH.canRead()) {
-                System.out.println("Failed to get configuration or deployment configuration is invalid. " + depFH.getCanonicalPath());
+                System.out.println("FATAL: Failed to get configuration or deployment configuration is invalid. "
+                        + depFH.getAbsolutePath());
                 VoltDB.exit(-1);
             }
             config.m_pathToDeployment = depFH.getCanonicalPath();
         } catch (IOException e) {
-            System.err.println("Failed to read deployment: " + e.getMessage());
+            System.err.println("FATAL: Failed to read deployment: " + e.getMessage());
             VoltDB.exit(-1);
         }
 
@@ -613,28 +614,31 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             String out;
             if ((out = CatalogUtil.getDeployment(dt, true)) != null) {
                 if ((new File(config.m_getOutput)).exists() && !config.m_forceGetCreate) {
-                    System.err.println("Failed to save deployment, file already exists: " + config.m_getOutput);
+                    System.err.println("FATAL: Failed to save deployment, file already exists: " + config.m_getOutput);
                     VoltDB.exit(-1);
                 }
                 try (FileOutputStream fos = new FileOutputStream(config.m_getOutput.trim())){
                     fos.write(out.getBytes());
                 } catch (IOException e) {
-                    System.out.println("Failed to write deployment output to " + config.m_getOutput);
+                    System.out.println("FATAL: Failed to write deployment to " + config.m_getOutput
+                            + " : " + e.getMessage());
                     VoltDB.exit(-1);
                 }
                 System.out.println("Deployment configuration saved at " + config.m_getOutput.trim());
             } else {
-                System.err.println("Failed to get configuration or deployment configuration is invalid.");
+                System.err.println("FATAL: Failed to get configuration or deployment configuration is invalid.");
+                VoltDB.exit(-1);
             }
         } catch (Exception e) {
-            System.out.println("Failed to get configuration or deployment configuration is invalid. Please make sure voltdbroot is a valid directory. " + e);
+            System.out.println("FATAL: Failed to get configuration or deployment configuration is invalid. "
+                    + "Please make sure voltdbroot is a valid directory. " + e.getMessage());
             VoltDB.exit(-1);
         }
     }
 
     private void outputSchema(Configuration config) {
         if ((new File(config.m_getOutput)).exists() && !config.m_forceGetCreate) {
-            System.err.println("Failed to save scehma file, file already exists: " + config.m_getOutput);
+            System.err.println("FATAL: Failed to save schema file, file already exists: " + config.m_getOutput);
             VoltDB.exit(-1);
         }
 
@@ -644,12 +648,14 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             try (FileOutputStream fos = new FileOutputStream(config.m_getOutput.trim())){
                 fos.write(ddl.getBytes());
             } catch (IOException e) {
-                System.out.println("Failed to write schema output to " + config.m_getOutput);
+                System.out.println("FATAL: Failed to write schema to " + config.m_getOutput
+                        + " : " + e.getMessage());
                 VoltDB.exit(-1);
             }
             System.out.println("Schema file saved at " + config.m_getOutput.trim());
-        } catch (IOException excp) {
-            System.err.println("Failed to load the catalog jar from " + config.m_pathToCatalog);
+        } catch (IOException e) {
+            System.err.println("FATAL: Failed to load the catalog jar from " + config.m_pathToCatalog
+                    + " : " + e.getMessage());
             VoltDB.exit(-1);
         }
     }
@@ -663,7 +669,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
         if (!config.m_voltdbRoot.exists() || !config.m_voltdbRoot.canRead() || !config.m_voltdbRoot.canExecute() || !config.m_voltdbRoot.isDirectory()) {
             try {
-                System.err.println("Invalid Voltdbroot directory: " + config.m_voltdbRoot.getCanonicalPath());
+                System.err.println("FATAL: Invalid Voltdbroot directory: " + config.m_voltdbRoot.getCanonicalPath());
             } catch (IOException ex) {
                 //Ignore;
             }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -614,7 +614,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             // We don't have catalog context so host count is not there.
             String out;
             if ((out = CatalogUtil.getDeployment(dt, true)) != null) {
-                if ((new File(config.m_getOutput)).exists() && !config.m_forceVoltdbCreate) {
+                if ((new File(config.m_getOutput)).exists() && !config.m_forceGetCreate) {
                     System.err.println("Failed to save deployment, file already exists: " + config.m_getOutput);
                     VoltDB.exit(-1);
                 }
@@ -635,7 +635,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     }
 
     private void outputSchema(Configuration config) {
-        if ((new File(config.m_getOutput)).exists() && !config.m_forceVoltdbCreate) {
+        if ((new File(config.m_getOutput)).exists() && !config.m_forceGetCreate) {
             System.err.println("Failed to save scehma file, file already exists: " + config.m_getOutput);
             VoltDB.exit(-1);
         }

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -241,7 +241,15 @@ public class VoltDB {
 
         /** GET option */
         public GetActionArgument m_getOption = null;
+        /**
+         * Name of output file in which get command will store it's result
+         */
         public String m_getOutput = null;
+        /**
+         * Flag to indicate whether to force store the result even if there is already an existing
+         * file with same name
+         */
+        public boolean m_forceGetCreate = false;
 
         private final static void referToDocAndExit() {
             System.out.println("Please refer to VoltDB documentation for command line usage.");
@@ -619,23 +627,26 @@ public class VoltDB {
                     }
                 } else if (arg.equalsIgnoreCase("get")) {
                     m_startAction = StartAction.GET;
-                    String actionVerb = args[++i];
-                    if (actionVerb == null || actionVerb.trim().length() == 0) {
-                        System.err.println("FATAL: Supply valid action verb for \"get\" command. "
-                                + "Supported action verbs for get are: " + GetActionArgument.supportedVerbs());
+                    String argument = args[++i];
+                    if (argument == null || argument.trim().length() == 0) {
+                        System.err.println("FATAL: Supply a valid non-null argument for \"get\" command. "
+                                + "Supported arguments for get are: " + GetActionArgument.supportedVerbs());
                         referToDocAndExit();
                     }
 
                     try {
-                        m_getOption = GetActionArgument.valueOf(GetActionArgument.class, actionVerb.trim().toUpperCase());
+                        m_getOption = GetActionArgument.valueOf(GetActionArgument.class, argument.trim().toUpperCase());
                     } catch (IllegalArgumentException excp) {
-                        System.err.println(actionVerb + " is not a valid \"get\" verb. Please provide valid action verb: " + GetActionArgument.supportedVerbs());
+                        System.err.println("FATAL:" + argument + " is not a valid \"get\" command argument. Please provide a valid argument: " + GetActionArgument.supportedVerbs());
                         referToDocAndExit();
                     }
                     m_getOutput = m_getOption.getDefaultOutput();
                 } else if (arg.equalsIgnoreCase("file")) {
                     m_getOutput = args[++i].trim();
-                } else {
+                } else if (arg.equalsIgnoreCase("forceget")) {
+                    m_forceGetCreate = true;
+                }
+                else {
                     System.err.println("FATAL: Unrecognized option to VoltDB: " + arg);
                     referToDocAndExit();
                 }

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -637,7 +637,7 @@ public class VoltDB {
                     try {
                         m_getOption = GetActionArgument.valueOf(GetActionArgument.class, argument.trim().toUpperCase());
                     } catch (IllegalArgumentException excp) {
-                        System.err.println("FATAL:" + argument + " is not a valid \"get\" command argument. Please provide a valid argument: " + GetActionArgument.supportedVerbs());
+                        System.err.println("FATAL:" + argument + " is not a valid \"get\" command argument. Valid arguments for get command are: " + GetActionArgument.supportedVerbs());
                         referToDocAndExit();
                     }
                     m_getOutput = m_getOption.getDefaultOutput();
@@ -734,8 +734,7 @@ public class VoltDB {
                     m_pathToDeployment = depFH.getAbsolutePath();
                     return;
                 }
-                case SCHEMA:
-                case CLASSES: {
+                case SCHEMA: {
                     File catalogFH = new VoltFile(configInfoDir, "catalog.jar");
                     if (!catalogFH.exists()) {
                         System.out.println("FATAL: Catalog jar file \"" + catalogFH.getAbsolutePath() + "\" not found. "

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -58,10 +58,19 @@ import javax.xml.namespace.QName;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
+import org.apache.zookeeper_voltpatches.CreateMode;
+import org.apache.zookeeper_voltpatches.KeeperException;
+import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
+import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.json_voltpatches.JSONException;
+import org.mindrot.BCrypt;
+import org.xml.sax.SAXException;
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.Pair;
-
 import org.voltdb.HealthMonitor;
 import org.voltdb.SystemProcedureCatalog;
 import org.voltdb.VoltDB;
@@ -131,17 +140,6 @@ import org.voltdb.settings.DbSettings;
 import org.voltdb.settings.NodeSettings;
 import org.voltdb.snmp.DummySnmpTrapSender;
 import org.voltdb.types.ConstraintType;
-
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
-import org.apache.zookeeper_voltpatches.CreateMode;
-import org.apache.zookeeper_voltpatches.KeeperException;
-import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
-import org.apache.zookeeper_voltpatches.ZooKeeper;
-import org.json_voltpatches.JSONException;
-import org.mindrot.BCrypt;
-import org.xml.sax.SAXException;
 
 import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.collect.ImmutableMap;
@@ -302,12 +300,12 @@ public abstract class CatalogUtil {
     public static String getAutoGenDDLFromJar(InMemoryJarfile jarfile)
             throws IOException
     {
-        // Read the raw build info bytes.
+        // Read the raw auto generated ddl bytes.
         byte[] ddlBytes = jarfile.get(VoltCompiler.AUTOGEN_DDL_FILE_NAME);
         if (ddlBytes == null) {
             throw new IOException("Auto generated schema DDL not found - please make sure the database is initialized with valid schema.");
         }
-        String ddl = new String(ddlBytes, Constants.UTF8ENCODING);
+        String ddl = new String(ddlBytes, StandardCharsets.UTF_8);
         return ddl.trim();
     }
 

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -307,8 +307,6 @@ public abstract class CatalogUtil {
         if (ddlBytes == null) {
             throw new IOException("Auto generated schema DDL not found - please make sure the database is initialized with valid schema.");
         }
-
-        // Convert the bytes to a string and split by lines.
         String ddl = new String(ddlBytes, Constants.UTF8ENCODING);
         return ddl.trim();
     }

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -58,18 +58,10 @@ import javax.xml.namespace.QName;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
-import org.apache.zookeeper_voltpatches.CreateMode;
-import org.apache.zookeeper_voltpatches.KeeperException;
-import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
-import org.apache.zookeeper_voltpatches.ZooKeeper;
-import org.json_voltpatches.JSONException;
-import org.mindrot.BCrypt;
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.Pair;
+
 import org.voltdb.HealthMonitor;
 import org.voltdb.SystemProcedureCatalog;
 import org.voltdb.VoltDB;
@@ -139,6 +131,16 @@ import org.voltdb.settings.DbSettings;
 import org.voltdb.settings.NodeSettings;
 import org.voltdb.snmp.DummySnmpTrapSender;
 import org.voltdb.types.ConstraintType;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
+import org.apache.zookeeper_voltpatches.CreateMode;
+import org.apache.zookeeper_voltpatches.KeeperException;
+import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
+import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.json_voltpatches.JSONException;
+import org.mindrot.BCrypt;
 import org.xml.sax.SAXException;
 
 import com.google_voltpatches.common.base.Charsets;
@@ -288,6 +290,27 @@ public abstract class CatalogUtil {
         }
 
         return buildInfoLines;
+    }
+
+    /**
+     * Get the auto generated DDL from the catalog jar.
+     *
+     * @param jarfile in-memory catalog jar file
+     * @return Auto generated DDL stored in catalog.jar
+     * @throws IOException If the catalog or the auto generated ddl cannot be loaded.
+     */
+    public static String getAutoGenDDLFromJar(InMemoryJarfile jarfile)
+            throws IOException
+    {
+        // Read the raw build info bytes.
+        byte[] ddlBytes = jarfile.get(VoltCompiler.AUTOGEN_DDL_FILE_NAME);
+        if (ddlBytes == null) {
+            throw new IOException("Auto generated schema DDL not found - please make sure the database is initialized with valid schema.");
+        }
+
+        // Convert the bytes to a string and split by lines.
+        String ddl = new String(ddlBytes, Constants.UTF8ENCODING);
+        return ddl.trim();
     }
 
     /**

--- a/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterAllOutOfProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterAllOutOfProcess.java
@@ -24,31 +24,29 @@
 package org.voltdb.regressionsuites;
 
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
 import org.voltdb.BackendTarget;
-import org.voltdb.ServerThread;
-import org.voltdb.VoltDB;
-import org.voltdb.VoltDB.Configuration;
-import org.voltdb.VoltDB.SimulatedExitException;
 import org.voltdb.VoltTable;
 import org.voltdb.client.Client;
-import org.voltdb.client.ClientFactory;
-import org.voltdb.common.Constants;
-import org.voltdb.compiler.VoltProjectBuilder;
-import org.voltdb.compiler.deploymentfile.DeploymentType;
-import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.MiscUtils;
 
+import static junit.framework.TestCase.assertTrue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.voltdb.ServerThread;
+import org.voltdb.VoltDB;
+import org.voltdb.VoltDB.Configuration;
+import org.voltdb.client.ClientFactory;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.DeploymentType;
+import org.voltdb.utils.CatalogUtil;
 import org.voltdb_testprocs.regressionsuites.failureprocs.CrashJVM;
 import org.voltdb_testprocs.regressionsuites.failureprocs.CrashVoltDBProc;
 
@@ -136,7 +134,7 @@ public class TestInitStartLocalClusterAllOutOfProcess extends JUnit4LocalCluster
 
         try {
             server.cli();
-        } catch (SimulatedExitException ex) {
+        } catch (Throwable ex) {
             //Good
         }
 
@@ -156,14 +154,14 @@ public class TestInitStartLocalClusterAllOutOfProcess extends JUnit4LocalCluster
 
         try {
             server.cli();
-        } catch (SimulatedExitException ex) {
+        } catch (Throwable ex) {
             //Good
         }
 
         byte[] encoded = Files.readAllBytes(Paths.get(schema.getAbsolutePath()));
         assertNotNull(encoded);
         assertTrue(encoded.length > 0);
-        String ddl = new String(encoded, Constants.UTF8ENCODING);
+        String ddl = new String(encoded, StandardCharsets.UTF_8);
         assertTrue(ddl.toLowerCase().contains("create table blah ("));
         assertTrue(ddl.toLowerCase().contains("ival bigint default '0' not null"));
         assertTrue(ddl.toLowerCase().contains("primary key (ival)"));

--- a/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterAllOutOfProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterAllOutOfProcess.java
@@ -24,24 +24,31 @@
 package org.voltdb.regressionsuites;
 
 
-import java.io.File;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import org.voltdb.BackendTarget;
-import org.voltdb.VoltTable;
-import org.voltdb.client.Client;
-import org.voltdb.utils.MiscUtils;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
 
-import static junit.framework.TestCase.assertTrue;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.voltdb.BackendTarget;
 import org.voltdb.ServerThread;
 import org.voltdb.VoltDB;
+import org.voltdb.VoltDB.Configuration;
+import org.voltdb.VoltDB.SimulatedExitException;
+import org.voltdb.VoltTable;
+import org.voltdb.client.Client;
 import org.voltdb.client.ClientFactory;
+import org.voltdb.common.Constants;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.compiler.deploymentfile.DeploymentType;
 import org.voltdb.utils.CatalogUtil;
+import org.voltdb.utils.MiscUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.voltdb_testprocs.regressionsuites.failureprocs.CrashJVM;
 import org.voltdb_testprocs.regressionsuites.failureprocs.CrashVoltDBProc;
 
@@ -60,6 +67,7 @@ public class TestInitStartLocalClusterAllOutOfProcess extends JUnit4LocalCluster
     String listener;
     Client client;
     String voltDbRootPath;
+    String voltDBRootParent;
 
     @Before
     public void setUp() throws Exception {
@@ -87,6 +95,7 @@ public class TestInitStartLocalClusterAllOutOfProcess extends JUnit4LocalCluster
             voltDbRoot = new File(voltDbFilePrefix, builder.getPathToVoltRoot().getPath());
         }
         voltDbRootPath = voltDbRoot.getCanonicalPath();
+        voltDBRootParent = voltDbRoot.getParent();
         listener = cluster.getListenerAddresses().get(0);
         client = ClientFactory.createClient();
         client.createConnection(listener);
@@ -113,23 +122,51 @@ public class TestInitStartLocalClusterAllOutOfProcess extends JUnit4LocalCluster
         }
         assertTrue(found);
         assertEquals(org.voltcore.common.Constants.DEFAULT_HEARTBEAT_TIMEOUT_SECONDS, timeout);
+    }
 
-        File out = File.createTempFile("get_deployment", ".xm");
-        VoltDB.Configuration c1 = new VoltDB.Configuration(new String[]{"get", "deployment",
-            "getvoltdbroot", voltDbRootPath,
-            "file", out.getAbsolutePath() + "l"});
+    @Test
+    public void testGetDeployment() throws Exception {
+        File deployment = File.createTempFile("get_deployment", ".xm");
+        if (deployment.exists()) deployment.delete();
+
+        Configuration c1 = new VoltDB.Configuration(new String[]{"get", "deployment",
+            "getvoltdbroot", voltDBRootParent,
+            "file", deployment.getAbsolutePath() + "l"});
         ServerThread server = new ServerThread(c1);
 
         try {
             server.cli();
-        } catch (Throwable ex) {
+        } catch (SimulatedExitException ex) {
             //Good
         }
 
-        DeploymentType dt = CatalogUtil.parseDeployment(out.getAbsolutePath() + "l");
+        DeploymentType dt = CatalogUtil.parseDeployment(deployment.getAbsolutePath() + "l");
         assertNotNull(dt);
         assertEquals(dt.getPaths().getVoltdbroot().getPath(), voltDbRootPath);
+    }
 
+    @Test
+    public void testGetSchema() throws Exception {
+        File schema = File.createTempFile("schema", ".sql");
+
+        Configuration c1 = new VoltDB.Configuration(new String[]{"get", "schema",
+            "getvoltdbroot", voltDBRootParent,
+            "file", schema.getAbsolutePath(), "forceget"});
+        ServerThread server = new ServerThread(c1);
+
+        try {
+            server.cli();
+        } catch (SimulatedExitException ex) {
+            //Good
+        }
+
+        byte[] encoded = Files.readAllBytes(Paths.get(schema.getAbsolutePath()));
+        assertNotNull(encoded);
+        assertTrue(encoded.length > 0);
+        String ddl = new String(encoded, Constants.UTF8ENCODING);
+        assertTrue(ddl.toLowerCase().contains("create table blah ("));
+        assertTrue(ddl.toLowerCase().contains("ival bigint default '0' not null"));
+        assertTrue(ddl.toLowerCase().contains("primary key (ival)"));
     }
 
 }

--- a/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterAllOutOfProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterAllOutOfProcess.java
@@ -65,7 +65,7 @@ public class TestInitStartLocalClusterAllOutOfProcess extends JUnit4LocalCluster
     String listener;
     Client client;
     String voltDbRootPath;
-    String voltDBRootParent;
+    String voltDBRootParentPath;
 
     @Before
     public void setUp() throws Exception {
@@ -93,7 +93,7 @@ public class TestInitStartLocalClusterAllOutOfProcess extends JUnit4LocalCluster
             voltDbRoot = new File(voltDbFilePrefix, builder.getPathToVoltRoot().getPath());
         }
         voltDbRootPath = voltDbRoot.getCanonicalPath();
-        voltDBRootParent = voltDbRoot.getParent();
+        voltDBRootParentPath = voltDbRoot.getParentFile().getCanonicalPath();
         listener = cluster.getListenerAddresses().get(0);
         client = ClientFactory.createClient();
         client.createConnection(listener);
@@ -123,12 +123,18 @@ public class TestInitStartLocalClusterAllOutOfProcess extends JUnit4LocalCluster
     }
 
     @Test
+    // Test get deployment
     public void testGetDeployment() throws Exception {
+        // get command is not supported in legacy cli as voltdbroot
+        // under the parent can't be determined deterministically
+        // using voltdbroot as the root of database directory
+        if (!cluster.isNewCli()) return;
+
         File deployment = File.createTempFile("get_deployment", ".xm");
         if (deployment.exists()) deployment.delete();
 
         Configuration c1 = new VoltDB.Configuration(new String[]{"get", "deployment",
-            "getvoltdbroot", voltDBRootParent,
+            "getvoltdbroot", voltDBRootParentPath,
             "file", deployment.getAbsolutePath() + "l"});
         ServerThread server = new ServerThread(c1);
 
@@ -144,11 +150,17 @@ public class TestInitStartLocalClusterAllOutOfProcess extends JUnit4LocalCluster
     }
 
     @Test
+    // Test get schema
     public void testGetSchema() throws Exception {
+        // get command is not supported in legacy cli as voltdbroot
+        // under the parent can't be determined deterministically
+        // using voltdbroot as the root of database directory
+        if (!cluster.isNewCli()) return;
+
         File schema = File.createTempFile("schema", ".sql");
 
         Configuration c1 = new VoltDB.Configuration(new String[]{"get", "schema",
-            "getvoltdbroot", voltDBRootParent,
+            "getvoltdbroot", voltDBRootParentPath,
             "file", schema.getAbsolutePath(), "forceget"});
         ServerThread server = new ServerThread(c1);
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterInProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterInProcess.java
@@ -63,7 +63,7 @@ public class TestInitStartLocalClusterInProcess extends JUnit4LocalClusterTest {
     String listener;
     Client client;
     String voltDbRootPath;
-    String voltDBRootParent;
+    String voltDBRootParentPath;
 
     @Before
     public void setUp() throws Exception {
@@ -89,7 +89,7 @@ public class TestInitStartLocalClusterInProcess extends JUnit4LocalClusterTest {
             voltDbRoot = new File(voltDbFilePrefix, builder.getPathToVoltRoot().getPath());
         }
         voltDbRootPath = voltDbRoot.getCanonicalPath();
-        voltDBRootParent = voltDbRoot.getParent();
+        voltDBRootParentPath = voltDbRoot.getParentFile().getCanonicalPath();
         listener = cluster.getListenerAddresses().get(0);
         client = ClientFactory.createClient();
         client.createConnection(listener);
@@ -118,11 +118,17 @@ public class TestInitStartLocalClusterInProcess extends JUnit4LocalClusterTest {
     }
 
     @Test
+    // Test get deployment
     public void testGetDeployment() throws Exception {
+        // get command is not supported in legacy cli as voltdbroot
+        // under the parent can't be determined deterministically
+        // using voltdbroot as the root of database directory
+        if (!cluster.isNewCli()) return;
+
         File deployment = File.createTempFile("get_deployment", ".xm");
 
         Configuration c1 = new VoltDB.Configuration(new String[]{"get", "deployment",
-            "getvoltdbroot", voltDBRootParent,
+            "getvoltdbroot", voltDBRootParentPath,
             "file", deployment.getAbsolutePath() + "l", "forceget"});
         ServerThread server = new ServerThread(c1);
 
@@ -138,12 +144,18 @@ public class TestInitStartLocalClusterInProcess extends JUnit4LocalClusterTest {
     }
 
     @Test
+    // Test get schema
     public void testGetSchema() throws Exception {
+        // get command is not supported in legacy cli as voltdbroot
+        // under the parent can't be determined deterministically
+        // using voltdbroot as the root of database directory
+        if (!cluster.isNewCli()) return;
+
         File schema = File.createTempFile("schema", ".sql");
         if (schema.exists()) schema.delete();
 
         Configuration c1 = new VoltDB.Configuration(new String[]{"get", "schema",
-            "getvoltdbroot", voltDBRootParent,
+            "getvoltdbroot", voltDBRootParentPath,
             "file", schema.getAbsolutePath()});
         ServerThread server = new ServerThread(c1);
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterInProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterInProcess.java
@@ -115,22 +115,28 @@ public class TestInitStartLocalClusterInProcess extends JUnit4LocalClusterTest {
         }
         assertTrue(found);
         assertEquals(org.voltcore.common.Constants.DEFAULT_HEARTBEAT_TIMEOUT_SECONDS, timeout);
+
+
+        if (!cluster.isNewCli()) {
+            // get command is not supported in legacy cli as voltdbroot
+            // under the parent can't be determined deterministically
+            // using voltdbroot as the root of database directory
+            return;
+        }
+
+        testGetDeployment();
+        testGetSchema();
     }
 
-    @Test
     // Test get deployment
     public void testGetDeployment() throws Exception {
-        // get command is not supported in legacy cli as voltdbroot
-        // under the parent can't be determined deterministically
-        // using voltdbroot as the root of database directory
-        if (!cluster.isNewCli()) return;
+
 
         File deployment = File.createTempFile("get_deployment", ".xm");
-
-        Configuration c1 = new VoltDB.Configuration(new String[]{"get", "deployment",
+        Configuration config = new VoltDB.Configuration(new String[]{"get", "deployment",
             "getvoltdbroot", voltDBRootParentPath,
             "file", deployment.getAbsolutePath() + "l", "forceget"});
-        ServerThread server = new ServerThread(c1);
+        ServerThread server = new ServerThread(config);
 
         try {
             server.cli();
@@ -143,21 +149,14 @@ public class TestInitStartLocalClusterInProcess extends JUnit4LocalClusterTest {
         assertEquals(dt.getPaths().getVoltdbroot().getPath(), voltDbRootPath);
     }
 
-    @Test
     // Test get schema
     public void testGetSchema() throws Exception {
-        // get command is not supported in legacy cli as voltdbroot
-        // under the parent can't be determined deterministically
-        // using voltdbroot as the root of database directory
-        if (!cluster.isNewCli()) return;
 
         File schema = File.createTempFile("schema", ".sql");
-        if (schema.exists()) schema.delete();
-
-        Configuration c1 = new VoltDB.Configuration(new String[]{"get", "schema",
+        Configuration config = new VoltDB.Configuration(new String[]{"get", "schema",
             "getvoltdbroot", voltDBRootParentPath,
-            "file", schema.getAbsolutePath()});
-        ServerThread server = new ServerThread(c1);
+            "file", schema.getAbsolutePath(), "forceget"});
+        ServerThread server = new ServerThread(config);
 
         try {
             server.cli();

--- a/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterInProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterInProcess.java
@@ -24,31 +24,29 @@
 package org.voltdb.regressionsuites;
 
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import org.voltdb.BackendTarget;
-import org.voltdb.ServerThread;
-import org.voltdb.VoltDB;
-import org.voltdb.VoltDB.Configuration;
-import org.voltdb.VoltDB.SimulatedExitException;
-import org.voltdb.VoltTable;
-import org.voltdb.client.Client;
-import org.voltdb.client.ClientFactory;
-import org.voltdb.common.Constants;
-import org.voltdb.compiler.VoltProjectBuilder;
-import org.voltdb.compiler.deploymentfile.DeploymentType;
-import org.voltdb.utils.CatalogUtil;
-import org.voltdb.utils.MiscUtils;
-
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.voltdb.BackendTarget;
+import org.voltdb.VoltTable;
+import org.voltdb.client.Client;
+import org.voltdb.utils.MiscUtils;
+
+import org.voltdb.ServerThread;
+import org.voltdb.VoltDB;
+import org.voltdb.VoltDB.Configuration;
+import org.voltdb.client.ClientFactory;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.DeploymentType;
+import org.voltdb.utils.CatalogUtil;
 
 
 /**
@@ -130,7 +128,7 @@ public class TestInitStartLocalClusterInProcess extends JUnit4LocalClusterTest {
 
         try {
             server.cli();
-        } catch (SimulatedExitException ex) {
+        } catch (Throwable ex) {
             //Good
         }
 
@@ -151,14 +149,14 @@ public class TestInitStartLocalClusterInProcess extends JUnit4LocalClusterTest {
 
         try {
             server.cli();
-        } catch (SimulatedExitException ex) {
+        } catch (Throwable ex) {
             //Good
         }
 
         byte[] encoded = Files.readAllBytes(Paths.get(schema.getAbsolutePath()));
         assertNotNull(encoded);
         assertTrue(encoded.length > 0);
-        String ddl = new String(encoded, Constants.UTF8ENCODING);
+        String ddl = new String(encoded, StandardCharsets.UTF_8);
         assertTrue(ddl.toLowerCase().contains("create table blah ("));
         assertTrue(ddl.toLowerCase().contains("ival bigint default '0' not null"));
         assertTrue(ddl.toLowerCase().contains("primary key (ival)"));


### PR DESCRIPTION
- Add ddl/schema argument support to get command. By default the sql stored in auto generated ddl file in catalog.jar is stored to the file location provided by user. If not output location is provided, store the file as schema.sql in current working directory.
- Update "get deployment" to output the deployment to deployment.xml in cwd if no output location is specified.