### PR TITLE
Benchmark.java: temporarily change txnid2's default swapratio to 0, so

### DIFF
--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/Benchmark.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/Benchmark.java
@@ -167,7 +167,7 @@ public class Benchmark {
         float mpratio = (float)0.20;
 
         @Option(desc = "Allow set ratio of swap to truncate table workload.")
-        float swapratio = (float)0.50;
+        float swapratio = (float)0.0;
 
         @Option(desc = "Allow set ratio of upsert to insert workload.")
         float upsertratio = (float)0.50;


### PR DESCRIPTION
that the System Tests can run without being bothered by ENG-12093 and
ENG-12092.