### PR TITLE
ENG-11662: Relieve internal adapter lock contention.

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -79,6 +79,7 @@ import org.voltdb.common.Constants;
 import org.voltdb.dtxn.InitiatorStats.InvocationInfo;
 import org.voltdb.iv2.Cartographer;
 import org.voltdb.iv2.Iv2Trace;
+import org.voltdb.iv2.MpInitiator;
 import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.messaging.InitiateResponseMessage;
 import org.voltdb.messaging.Iv2EndOfLogMessage;
@@ -127,7 +128,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     public static final long SNAPSHOT_UTIL_CID          = Long.MIN_VALUE + 2;
     public static final long ELASTIC_JOIN_CID           = Long.MIN_VALUE + 3;
     // public static final long UNUSED_CID (was DR)     = Long.MIN_VALUE + 4;
-    public static final long INTERNAL_CID               = Long.MIN_VALUE + 5;
+    // public static final long UNUSED_CID              = Long.MIN_VALUE + 5;
     public static final long EXECUTE_TASK_CID           = Long.MIN_VALUE + 6;
     public static final long DR_DISPATCHER_CID          = Long.MIN_VALUE + 7;
     public static final long RESTORE_SCHEMAS_CID        = Long.MIN_VALUE + 8;
@@ -140,6 +141,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     public static final long DR_REPLICATION_SNAPSHOT_BASE_CID  = Long.MIN_VALUE + setBaseValue(2);
     public static final long DR_REPLICATION_NORMAL_BASE_CID    = Long.MIN_VALUE + setBaseValue(3);
     public static final long DR_REPLICATION_MP_BASE_CID        = Long.MIN_VALUE + setBaseValue(4);
+    public static final long INTERNAL_CID                      = Long.MIN_VALUE + setBaseValue(5);
 
     private static final VoltLogger log = new VoltLogger(ClientInterface.class.getName());
     private static final VoltLogger authLog = new VoltLogger("AUTH");
@@ -1145,12 +1147,16 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                 .siteId(m_siteId)
                 .build();
 
-        InternalClientResponseAdapter internalAdapter = new InternalClientResponseAdapter(INTERNAL_CID);
-        ClientInterfaceHandleManager ichm = bindAdapter(internalAdapter, null, true);
-        m_internalConnectionHandler = new InternalConnectionHandler(internalAdapter, ichm);
+        m_internalConnectionHandler = new InternalConnectionHandler();
 
         m_executeTaskAdpater = new SimpleClientResponseAdapter(ClientInterface.EXECUTE_TASK_CID, "ExecuteTaskAdapter", true);
         bindAdapter(m_executeTaskAdpater, null);
+    }
+
+    private InternalClientResponseAdapter createInternalAdapter(int pid) {
+        InternalClientResponseAdapter internalAdapter = new InternalClientResponseAdapter(INTERNAL_CID + pid);
+        bindAdapter(internalAdapter, null, true);
+        return internalAdapter;
     }
 
     public InternalConnectionHandler getInternalConnectionHandler() {
@@ -1175,6 +1181,9 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                     failOverConnection(partitionId, initiatorHSId, cihm.connection);
                 }
             }
+
+            // Create adapters here so that it works for both startup and elastic add.
+            m_internalConnectionHandler.addAdapter(partitionId, createInternalAdapter(partitionId));
         } catch (Exception e) {
             hostLog.warn("Error handling partition fail over at ClientInterface, continuing anyways", e);
         }
@@ -1581,10 +1590,6 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
 
     public boolean isAcceptingConnections() {
         return m_isAcceptingConnections.get();
-    }
-
-    static final int getPartitionForProcedure(Procedure procedure, StoredProcedureInvocation task) throws Exception {
-        return InvocationDispatcher.getPartitionForProcedure(procedure, task);
     }
 
     @Override

--- a/src/frontend/org/voltdb/ImporterServerAdapterImpl.java
+++ b/src/frontend/org/voltdb/ImporterServerAdapterImpl.java
@@ -22,6 +22,8 @@ import org.voltdb.importer.AbstractImporter;
 import org.voltdb.importer.ImporterServerAdapter;
 import org.voltdb.importer.ImporterStatsCollector;
 
+import java.util.function.Function;
+
 /**
  * Implementation that uses the server internal classes to execute procedures and
  * to report information for statistics collection.
@@ -41,14 +43,9 @@ public class ImporterServerAdapterImpl implements ImporterServerAdapter {
     }
 
     @Override
-    public boolean callProcedure(AbstractImporter importer, String proc, Object... fieldList) {
-        return callProcedure(importer, null, proc, fieldList);
-    }
-
-    @Override
-    public boolean callProcedure(AbstractImporter importer, ProcedureCallback procCallback, String proc, Object... fieldList) {
+    public boolean callProcedure(AbstractImporter importer, Function<Integer, Boolean> backPressurePredicate, ProcedureCallback procCallback, String proc, Object... fieldList) {
         return getInternalConnectionHandler()
-                .callProcedure(importer, m_statsCollector, procCallback, proc, fieldList);
+                .callProcedure(importer, backPressurePredicate, m_statsCollector, procCallback, proc, fieldList);
     }
 
     private InternalConnectionHandler getInternalConnectionHandler() {

--- a/src/frontend/org/voltdb/InternalAdapterTaskAttributes.java
+++ b/src/frontend/org/voltdb/InternalAdapterTaskAttributes.java
@@ -53,13 +53,6 @@ final class InternalAdapterTaskAttributes implements InvocationClientHandler, In
         return m_name;
     }
 
-    @Override
-    final public void setBackPressure(boolean hasBackPressure) {
-        if (m_proxy != null) {
-            m_proxy.setBackPressure(hasBackPressure);
-        }
-    }
-
     final public InvocationClientHandler asHandler() {
         return this;
     }

--- a/src/frontend/org/voltdb/InternalConnectionContext.java
+++ b/src/frontend/org/voltdb/InternalConnectionContext.java
@@ -24,5 +24,4 @@ package org.voltdb;
 public interface InternalConnectionContext
 {
     public String getName();
-    public void setBackPressure(boolean hasBackPressure);
 }

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -83,6 +83,7 @@ import org.voltdb.compiler.deploymentfile.DrRoleType;
 import org.voltdb.compilereport.ViewExplainer;
 import org.voltdb.iv2.Cartographer;
 import org.voltdb.iv2.Iv2Trace;
+import org.voltdb.iv2.MpInitiator;
 import org.voltdb.jni.ExecutionEngine;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.messaging.MultiPartitionParticipantMessage;
@@ -1842,7 +1843,7 @@ public final class InvocationDispatcher {
             // break out the Hashinator and calculate the appropriate partition
             return getPartitionForProcedure( ppi.index, ppi.type, task);
         } else {
-            return -1;
+            return MpInitiator.MP_INIT_PID;
         }
     }
 

--- a/src/frontend/org/voltdb/importer/AbstractImporter.java
+++ b/src/frontend/org/voltdb/importer/AbstractImporter.java
@@ -18,7 +18,7 @@
 package org.voltdb.importer;
 
 import java.net.URI;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
@@ -53,7 +53,7 @@ public abstract class AbstractImporter
     private final VoltLogger m_logger;
     private ImporterServerAdapter m_importServerAdapter;
     private volatile boolean m_stopping;
-    private AtomicInteger m_backPressureCount = new AtomicInteger(0);
+    private final Function<Integer, Boolean> m_backPressurePredicate = (x) -> shouldRun();
 
     protected AbstractImporter() {
         m_logger = new VoltLogger(getName());
@@ -102,46 +102,15 @@ public abstract class AbstractImporter
     protected final boolean callProcedure(Invocation invocation, ProcedureCallback callback)
     {
         try {
-            boolean result = m_importServerAdapter.callProcedure(this, callback, invocation.getProcedure(), invocation.getParams());
+            boolean result = m_importServerAdapter.callProcedure(this,
+                                                                 m_backPressurePredicate,
+                                                                 callback, invocation.getProcedure(), invocation.getParams());
             reportStat(result, invocation.getProcedure());
-            applyBackPressureAsNeeded();
             return result;
         } catch (Exception ex) {
             rateLimitedLog(Level.ERROR, ex, "%s: Error trying to import", getName());
             reportFailureStat(invocation.getProcedure());
             return false;
-        }
-    }
-
-    private void applyBackPressureAsNeeded()
-    {
-        int count = m_backPressureCount.get();
-        if (count > 0) {
-            try { // increase sleep time exponentially to a max of 256ms
-                if (count > 8) {
-                    Thread.sleep(256);
-                } else {
-                    Thread.sleep(1<<count);
-                }
-            } catch(InterruptedException e) {
-                if (m_logger.isDebugEnabled()) {
-                    m_logger.debug("Sleep for back pressure interrupted", e);
-                }
-            }
-        }
-    }
-
-    /**
-     * Called by the internal framework code to indicate if back pressure must
-     * be applied on the importer because the server is busy.
-     */
-    @Override
-    public void setBackPressure(boolean hasBackPressure)
-    {
-        if (hasBackPressure) {
-            m_backPressureCount.incrementAndGet();
-        } else {
-            m_backPressureCount.set(0);
         }
     }
 

--- a/src/frontend/org/voltdb/importer/ImporterServerAdapter.java
+++ b/src/frontend/org/voltdb/importer/ImporterServerAdapter.java
@@ -19,6 +19,7 @@ package org.voltdb.importer;
 
 import org.voltdb.client.ProcedureCallback;
 
+import java.util.function.Function;
 
 
 /**
@@ -34,23 +35,19 @@ public interface ImporterServerAdapter {
      *
      * @param importer the calling importer instance. This may be used by the importer framework
      * to report back pressure.
-     * @param proc the name of the procedure that is to be executed
-     * @param fieldList the parameters to be passed in to the procedure
-     * @return returns true if the procedure execution was queued successfully; false otherwise.
-     */
-    public boolean callProcedure(AbstractImporter importer, String proc, Object... fieldList);
-
-    /**
-     * This is used by importers to execute procedures in the server.
-     *
-     * @param importer the calling importer instance. This may be used by the importer framework
-     * to report back pressure.
+     * @param backPressurePredicate the predicate to check when the partition is
+     *                              on back pressure for over a certain amount
+     *                              of time. The partition ID will be passed to
+     *                              the predicate. If the predicate evaluates to
+     *                              true, it keeps waiting for back pressure to
+     *                              be relieved. Otherwise, it ignores back
+     *                              pressure and initiates the transaction.
      * @param callback the callback object that will receive procedure execution status
      * @param proc the name of the procedure that is to be executed
      * @param fieldList the parameters to be passed in to the procedure
      * @return returns true if the procedure execution was queued successfully; false otherwise.
      */
-    public boolean callProcedure(AbstractImporter importer, ProcedureCallback callback, String proc, Object... fieldList);
+    public boolean callProcedure(AbstractImporter importer, Function<Integer, Boolean> backPressurePredicate, ProcedureCallback callback, String proc, Object... fieldList);
 
     /**
      * This should be used by importers to report failure while trying to execute a procedure.


### PR DESCRIPTION
Instead of using a global internal adapter for all importer
transactions, create one adapter for each partition lazily. This
relieves the contention on the ClientInterfaceHandleManager because the
usage will be bound to the same thread for each partition.

The adapters are created when partition leaders are elected so that it
can also pick up elastically added partitions.