### PR TITLE
ENG-12020: Sanitize JSONP parameter to prevent cross-site scripting

### DIFF
--- a/src/frontend/org/voltdb/utils/HTTPAdminListener.java
+++ b/src/frontend/org/voltdb/utils/HTTPAdminListener.java
@@ -365,10 +365,13 @@ public class HTTPAdminListener {
             super.handle(target, baseRequest, request, response);
             if (baseRequest.isHandled()) return;
             //jsonp is specified when response is expected to go to javascript function.
-            String jsonp = request.getParameter("jsonp");
+            String jsonp = request.getParameter(HTTPClientInterface.JSONP);
             AuthenticationResult authResult = null;
             try {
                 response.setContentType(jsonContentType);
+                if (!HTTPClientInterface.validateJSONP(jsonp, baseRequest, response)) {
+                    return;
+                }
                 response.setStatus(HttpServletResponse.SC_OK);
                 authResult = authenticate(baseRequest);
                 if (!authResult.isAuthenticated()) {
@@ -494,10 +497,13 @@ public class HTTPAdminListener {
             if (baseRequest.isHandled()) return;
 
             //jsonp is specified when response is expected to go to javascript function.
-            String jsonp = request.getParameter("jsonp");
+            String jsonp = request.getParameter(HTTPClientInterface.JSONP);
             AuthenticationResult authResult = null;
             try {
                 response.setContentType(jsonContentType);
+                if (!HTTPClientInterface.validateJSONP(jsonp, baseRequest, response)) {
+                    return;
+                }
                 response.setStatus(HttpServletResponse.SC_OK);
 
                 //Requests require authentication.
@@ -808,7 +814,7 @@ public class HTTPAdminListener {
                     }
                     mapper.writeValue(response.getWriter(), id);
                 } else {
-                    response.getWriter().write("");
+                    response.getWriter().write("[]");
                 }
                 if (jsonp != null) {
                     response.getWriter().write(")");


### PR DESCRIPTION
There are currently 3 HTTP endpoints that handle and process JSONP. They are /api/1.0, /deployment and some of its subresources, and finally /profile.

With this change, /api/1.0 will check JSONP value for "jsonp" key in both headers and parameters, while /deployment and /profile will check it in parameters. If the JSONP value is invalid (only alphanumeric, underscore and dollar sign are allowed), a response with status code 400 and message "Invalid jsonp callback function name" will be sent back.

Added a test case for this in TestJSONInterface.

Also fixed a small bug: for /deployment/users resources, if there is no user, an empty JSON list string should be returned instead of an empty string because an empty string is not a valid JSON string.