### PR TITLE
Mike A's fix for SQL ERROR, possible ceash, on INSERT VALUES w/ subquery

### DIFF
--- a/src/frontend/org/voltdb/plannodes/MaterializePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializePlanNode.java
@@ -67,6 +67,7 @@ public class MaterializePlanNode extends ProjectionPlanNode {
     public void resolveColumnIndexes() {
         // MaterializePlanNodes have no children
         assert(m_children.size() == 0);
+        resolveSubqueryColumnIndexes();
     }
 
     @Override

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlDeleteSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlDeleteSuite.java
@@ -568,7 +568,7 @@ public class TestSqlDeleteSuite extends RegressionSuite {
 
             // delete rows where ID is IN 0..3
             VoltTable vt = client.callProcedure("@AdHoc",
-                    "DELETE FROM " + table + " WHERE ID IN (SELECT ID FROM R1)")
+                    "DELETE FROM " + table + " WHERE ID IN (SELECT NUM FROM R1)")
                     .getResults()[0];
             validateTableOfScalarLongs(vt, new long[] { 4 });
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlInsertSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlInsertSuite.java
@@ -110,17 +110,17 @@ public class TestSqlInsertSuite extends RegressionSuite {
         // clean-up R1
         validateTableOfLongs(client, "delete from r1;", new long[][] {{1}});
         validateTableOfLongs(client, "insert into r1 (ccc, bbb, aaa, zzz, yyy, xxx) " +
-                "select (select max(ccc) from r2), 3, 3, 3, 3, 3 from r2;",
+                "select (select max(aaa) from r2), 3, 3, 3, 3, 3 from r2;",
                 new long[][] {{2}});
-        expected = new long[][] {{2}, {2}};
+        expected = new long[][] {{4}, {4}};
         validateTableOfLongs(client, "select ccc from r1 order by ccc", expected);
 
         // clean-up R1
         validateTableOfLongs(client, "delete from r1;", new long[][] {{2}});
         validateTableOfLongs(client, "insert into r1 (ccc, bbb, aaa, zzz, yyy, xxx) " +
-                "values ((select max(ccc) from r2), 3, 3, 3, 3, 3);",
+                "values ((select max(aaa) from r2), 3, 3, 3, 3, 3);",
                 new long[][] {{1}});
-        expected = new long[][] {{2}};
+        expected = new long[][] {{4}};
         validateTableOfLongs(client, "select ccc from r1 order by ccc", expected);
 
         // clean-up R1

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlUpdateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlUpdateSuite.java
@@ -184,7 +184,7 @@ public class TestSqlUpdateSuite extends RegressionSuite {
             validateTableOfScalarLongs(client, stmt, new long[] { 4, 5, 6, 7, 8, 9, 20, 21, 22, 23 });
 
             vt = client.callProcedure("@AdHoc",
-                    "UPDATE " + table + " SET NUM = (SELECT NUM FROM R2 WHERE ID = 3)")
+                    "UPDATE " + table + " SET NUM = (SELECT MAX(NUM) FROM R2)")
                     .getResults()[0];
             validateTableOfScalarLongs(vt, new long[] { 10 });
 


### PR DESCRIPTION
Mike A suggested this one line change via e-mail and sent these junit test tweaks so that tests do not succeed by relying on column indexes selected by happy accident.

This presented as a SQL ERROR in manual internal testing but generally had cluster crashing potential.