### PR TITLE
ENG-12092, fix wrong swap on table for stream indexing when calling @SwapTables along with an onging index snapshot.

### DIFF
--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -481,15 +481,15 @@ public:
         return this;
     }
 
-    void setTableForStreamIndexing(PersistentTable* tb) {
+    void setTableForStreamIndexing(PersistentTable* tb, PersistentTable* tbForStreamIndexing) {
         if (this == tb) {
             // For example, two identical swap statements in the same XA
             // should restore the status quo.
             // Likewise, the swapTable call to undo a SWAP TABLES statement.
             unsetTableForStreamIndexing();
         }
-        m_tableForStreamIndexing = (tb->m_tableForStreamIndexing == NULL) ?
-            tb : tb->m_tableForStreamIndexing;
+        m_tableForStreamIndexing = (tbForStreamIndexing == NULL) ?
+            tb : tbForStreamIndexing;
         m_tableForStreamIndexing->incrementRefcount();
     }
 

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -488,8 +488,7 @@ public:
             // Likewise, the swapTable call to undo a SWAP TABLES statement.
             unsetTableForStreamIndexing();
         }
-        m_tableForStreamIndexing = (tbForStreamIndexing == NULL) ?
-            tb : tbForStreamIndexing;
+        m_tableForStreamIndexing = tbForStreamIndexing;
         m_tableForStreamIndexing->incrementRefcount();
     }
 


### PR DESCRIPTION
And a trivial Pro PR: https://github.com/VoltDB/pro/pull/1787