### PR TITLE
Benchmark.java: change txnid2's default swapratio back to 0.50 (from 0),

### DIFF
--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/Benchmark.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/Benchmark.java
@@ -167,7 +167,7 @@ public class Benchmark {
         float mpratio = (float)0.20;
 
         @Option(desc = "Allow set ratio of swap to truncate table workload.")
-        float swapratio = (float)0.0;
+        float swapratio = (float)0.50;
 
         @Option(desc = "Allow set ratio of upsert to insert workload.")
         float upsertratio = (float)0.50;


### PR DESCRIPTION
so that the System Tests can test @SwapTables again.