### PR TITLE
ENG-10627-preSnapshot: reset single DR

### DIFF
--- a/lib/python/voltcli/voltadmin.d/dr.py
+++ b/lib/python/voltcli/voltadmin.d/dr.py
@@ -15,7 +15,7 @@
 # along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
 
 def reset(runner):
-    status = runner.call_proc('@ResetDR', [], []).table(0).tuple(0).column_integer(0)
+    status = runner.call_proc('@ResetDR', [VOLT.FastSerializer.VOLTTYPE_TINYINT, VOLT.FastSerializer.VOLTTYPE_TINYINT], [-1, 0]).table(0).tuple(0).column_integer(0)
     if status == 0:
         runner.info('Conversation log is reset.')
     else:

--- a/lib/python/voltcli/voltadmin.d/dr.py
+++ b/lib/python/voltcli/voltadmin.d/dr.py
@@ -15,14 +15,14 @@
 # along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
 
 def reset_local(runner):
-    status = runner.call_proc('@ResetDR', [VOLT.FastSerializer.VOLTTYPE_TINYINT, VOLT.FastSerializer.VOLTTYPE_TINYINT], [runner.opts.clusterId, runner.opts.clusterId * 1]).table(0).tuple(0).column_integer(0)
+    status = runner.call_proc('@ResetDR', [VOLT.FastSerializer.VOLTTYPE_TINYINT, VOLT.FastSerializer.VOLTTYPE_TINYINT], [runner.opts.clusterId, runner.opts.forcing * 1]).table(0).tuple(0).column_integer(0)
     if status == 0:
         runner.info('Conversation log is reset.')
     else:
         runner.error('The cluster failed to reset conversation log with status: %d' % status)
 
 def reset_remote(runner):
-    status = runner.call_proc('@ResetDR', [VOLT.FastSerializer.VOLTTYPE_TINYINT, VOLT.FastSerializer.VOLTTYPE_TINYINT], [runner.opts.clusterId, runner.opts.clusterId * 1]).table(0).tuple(0).column_integer(0)
+    status = runner.call_proc('@ResetDR', [VOLT.FastSerializer.VOLTTYPE_TINYINT, VOLT.FastSerializer.VOLTTYPE_TINYINT], [runner.opts.clusterId, runner.opts.forcing * 1]).table(0).tuple(0).column_integer(0)
     if status == 0:
         runner.info('Conversation log is reset.')
     else:
@@ -33,7 +33,7 @@ def reset_remote(runner):
     description = 'DR control command.',
     options = (
             VOLT.BooleanOption('-f', '--force', 'forcing', 'bypass precheck', default = False),
-            VOLT.BooleanOption('-c', '--cluster', 'clusterId', 'drCluster Id', default = -1),
+            VOLT.BooleanOption('-c', '--cluster', 'clusterId', 'dr cluster Id', default = -1),
     ),
     modifiers = (
             VOLT.Modifier('resetlocal', reset_local, 'remove local cluster from its dr cluster mesh.'),

--- a/lib/python/voltcli/voltadmin.d/dr.py
+++ b/lib/python/voltcli/voltadmin.d/dr.py
@@ -36,7 +36,7 @@ def reset_remote(runner):
             VOLT.BooleanOption('-c', '--cluster', 'clusterId', 'dr cluster Id', default = -1),
     ),
     modifiers = (
-            VOLT.Modifier('resetlocal', reset_local, 'remove local cluster from its dr cluster mesh.'),
+            VOLT.Modifier('resetlocal', reset_local, 'remove local cluster from dr cluster mesh.'),
             VOLT.Modifier('reset', reset_remote, 'reset one/all remote dr cluster(s).'),
     )
 )

--- a/lib/python/voltcli/voltadmin.d/dr.py
+++ b/lib/python/voltcli/voltadmin.d/dr.py
@@ -14,29 +14,23 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
 
-def reset_local(runner):
-    status = runner.call_proc('@ResetDR', [VOLT.FastSerializer.VOLTTYPE_TINYINT, VOLT.FastSerializer.VOLTTYPE_TINYINT], [runner.opts.clusterId, runner.opts.forcing * 1]).table(0).tuple(0).column_integer(0)
-    if status == 0:
-        runner.info('Conversation log is reset.')
-    else:
-        runner.error('The cluster failed to reset conversation log with status: %d' % status)
-
 def reset_remote(runner):
-    status = runner.call_proc('@ResetDR', [VOLT.FastSerializer.VOLTTYPE_TINYINT, VOLT.FastSerializer.VOLTTYPE_TINYINT], [runner.opts.clusterId, runner.opts.forcing * 1]).table(0).tuple(0).column_integer(0)
+    result = runner.call_proc('@ResetDR', [VOLT.FastSerializer.VOLTTYPE_TINYINT, VOLT.FastSerializer.VOLTTYPE_TINYINT], [runner.opts.clusterId, runner.opts.forcing * 1]).table(0)
+    status = result.tuple(0).column_integer(0)
+    message = result.tuple(0).column_string(1)
     if status == 0:
-        runner.info('Conversation log is reset.')
+        runner.info(message)
     else:
-        runner.error('The cluster failed to reset conversation log with status: %d' % status)
+        runner.error(message)
 
 @VOLT.Multi_Command(
     bundles = VOLT.AdminBundle(),
     description = 'DR control command.',
     options = (
             VOLT.BooleanOption('-f', '--force', 'forcing', 'bypass precheck', default = False),
-            VOLT.BooleanOption('-c', '--cluster', 'clusterId', 'dr cluster Id', default = -1),
+            VOLT.IntegerOption('-c', '--cluster', 'clusterId', 'dr cluster Id', default = -1),
     ),
     modifiers = (
-            VOLT.Modifier('resetlocal', reset_local, 'remove local cluster from dr cluster mesh.'),
             VOLT.Modifier('reset', reset_remote, 'reset one/all remote dr cluster(s).'),
     )
 )

--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -499,6 +499,7 @@ enum TaskType {
     TASK_TYPE_RESET_DR_APPLIED_TRACKER = 7,      // not supported in EE
     TASK_TYPE_SET_MERGED_DRID_TRACKER = 8,       // not supported in EE
     TASK_TYPE_INIT_DRID_TRACKER = 9,             // not supported in EE
+    TASK_TYPE_RESET_DR_APPLIED_TRACKER_SINGLE = 10, // not supported in EE
 };
 
 // ------------------------------------------------------------------

--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -64,5 +64,13 @@ public interface ConsumerDRGateway extends Promotable {
 
     void startConsumerDispatcher(final MeshMemberInfo member);
 
+    void deactiveConsumerDispatcher(byte clusterId);
+
     void addLocallyLedPartition(int partitionId);
+
+    boolean isSafeForReset(byte clusterId);
+
+    void pauseConsumerDispatcher(byte clusterId);
+
+    void resumeConsumerDispatcher(byte clusterId);
 }

--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -64,7 +64,7 @@ public interface ConsumerDRGateway extends Promotable {
 
     void startConsumerDispatcher(final MeshMemberInfo member);
 
-    void deactiveConsumerDispatcher(byte clusterId);
+    void deactivateConsumerDispatcher(byte clusterId);
 
     void addLocallyLedPartition(int partitionId);
 

--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -73,4 +73,6 @@ public interface ConsumerDRGateway extends Promotable {
     void pauseConsumerDispatcher(byte clusterId);
 
     void resumeConsumerDispatcher(byte clusterId);
+
+    void resetDrAppliedTracker(byte clusterId);
 }

--- a/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
+++ b/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
@@ -38,6 +38,8 @@ import com.google_voltpatches.common.collect.Range;
 import com.google_voltpatches.common.collect.RangeSet;
 import com.google_voltpatches.common.collect.TreeRangeSet;
 
+import static org.voltdb.DRLogSegmentId.isEmptyDRId;
+
 /*
  * WARNING:
  * The implementation assumes that the range set is never completely empty in methods like
@@ -112,6 +114,14 @@ public class DRConsumerDrIdTracker implements Serializable {
         DRConsumerDrIdTracker newTracker = new DRConsumerDrIdTracker(spUniqueId, mpUniqueId, producerPartitionId);
         newTracker.addRange(initialAckPoint, initialAckPoint);
         return newTracker;
+    }
+
+    public boolean isRealTracker() {
+        return (m_lastSpUniqueId > 0) || (m_lastMpUniqueId > 0);
+    }
+
+    public boolean isDummyTracker() {
+        return (m_lastSpUniqueId == Long.MIN_VALUE) && (m_lastMpUniqueId == Long.MIN_VALUE) && isEmptyDRId(getLastDrId());
     }
 
     public DRConsumerDrIdTracker(DRConsumerDrIdTracker other) {

--- a/src/frontend/org/voltdb/ProducerDRGateway.java
+++ b/src/frontend/org/voltdb/ProducerDRGateway.java
@@ -140,7 +140,10 @@ public interface ProducerDRGateway {
     /**
      * Clear all queued DR buffers for a master, useful when the replica goes away
      */
-    public void deactivateDRProducer();
+    public void deactivateDR();
+
+    public void deactivateDR(byte clusterId);
+
     public void activateDRProducer();
 
     /**
@@ -183,4 +186,12 @@ public interface ProducerDRGateway {
      * @return The producer node stats keyed by cluster IDs or null if on error
      */
     public Map<Byte, DRProducerNodeStats> getNodeDRStats();
+
+    public void resumeReaders(byte clusterId);
+
+    public void pauseReaders(byte clusterId);
+
+    public void resumeAllReaders();
+
+    public void pauseAllReaders();
 }

--- a/src/frontend/org/voltdb/ProducerDRGateway.java
+++ b/src/frontend/org/voltdb/ProducerDRGateway.java
@@ -187,11 +187,7 @@ public interface ProducerDRGateway {
      */
     public Map<Byte, DRProducerNodeStats> getNodeDRStats();
 
-    public void resumeReaders(byte clusterId);
+    public void resumeAllReadersAsync();
 
-    public void pauseReaders(byte clusterId);
-
-    public void resumeAllReaders();
-
-    public void pauseAllReaders();
+    public void pauseAllReadersAsync();
 }

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -697,6 +697,19 @@ public class StatsAgent extends OpsAgent
         return existingSource;
     }
 
+    public void deregisterStatsSource(StatsSelector selector, long siteId, StatsSource source) {
+        assert selector != null;
+        assert source != null;
+        final NonBlockingHashMap<Long, NonBlockingHashSet<StatsSource>> siteIdToStatsSources =
+                m_registeredStatsSources.get(selector);
+        assert siteIdToStatsSources != null;
+
+        NonBlockingHashSet<StatsSource> statsSources = siteIdToStatsSources.get(siteId);
+        if (statsSources != null) {
+            statsSources.remove(source);
+        }
+    }
+
     public void deregisterStatsSourcesFor(StatsSelector selector, long siteId) {
         assert selector != null;
         final NonBlockingHashMap<Long, NonBlockingHashSet<StatsSource>> siteIdToStatsSources =

--- a/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
+++ b/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
@@ -104,6 +104,8 @@ public interface SystemProcedureExecutionContext {
 
     public void resetDrAppliedTracker();
 
+    public void resetDrAppliedTracker(byte clusterId);
+
     public void initDRAppliedTracker(Map<Byte, Integer> clusterIdToPartitionCountMap);
 
     public Map<Integer, Map<Integer, DRConsumerDrIdTracker>> getDrAppliedTrackers();

--- a/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
+++ b/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
@@ -106,6 +106,8 @@ public interface SystemProcedureExecutionContext {
 
     public void resetDrAppliedTracker(byte clusterId);
 
+    public boolean hasRealDrAppliedTracker(byte clusterId);
+
     public void initDRAppliedTracker(Map<Byte, Integer> clusterIdToPartitionCountMap);
 
     public Map<Integer, Map<Integer, DRConsumerDrIdTracker>> getDrAppliedTrackers();

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -299,7 +299,6 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
             throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
         }
 
-
         @Override
         public void initDRAppliedTracker(Map<Byte, Integer> clusterIdToPartitionCountMap) {
             throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
@@ -310,6 +309,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
         {
             throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
         }
+
         @Override
         public Pair<Long, Long> getDrLastAppliedUniqueIds()
         {

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -290,6 +290,11 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
         }
 
         @Override
+        public void resetDrAppliedTracker(byte clusterId) {
+            throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
+        }
+
+        @Override
         public void initDRAppliedTracker(Map<Byte, Integer> clusterIdToPartitionCountMap) {
             throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
         }

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -295,6 +295,12 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
         }
 
         @Override
+        public boolean hasRealDrAppliedTracker(byte clusterId) {
+            throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
+        }
+
+
+        @Override
         public void initDRAppliedTracker(Map<Byte, Integer> clusterIdToPartitionCountMap) {
             throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
         }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -453,16 +453,10 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             Map<Integer, DRConsumerDrIdTracker> clusterSources = m_maxSeenDrLogsBySrcPartition.get(producerClusterId);
             if (clusterSources == null) {
                 // Don't have a tracker for this cluster
-                if (DRLogSegmentId.isEmptyDRId(lastReceivedDRId)) {
-                    return DRIdempotencyResult.SUCCESS;
-                } else {
-                    if (drLog.isTraceEnabled()) {
-                        drLog.trace(String.format("P%d binary log site idempotency check failed. " +
-                                                  "Site doesn't have tracker for this cluster while the last received is %s",
-                                                  producerPartitionId,
-                                                  DRLogSegmentId.getDebugStringFromDRId(lastReceivedDRId)));
-                    }
-                }
+                drLog.warn(String.format("P%d binary log site idempotency check failed. " +
+                                    "Site doesn't have tracker for this cluster while the last received is %s",
+                            producerPartitionId,
+                            DRLogSegmentId.getDebugStringFromDRId(lastReceivedDRId)));
             }
             else {
                 DRConsumerDrIdTracker targetTracker = clusterSources.get(producerPartitionId);

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -546,8 +546,23 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             m_lastLocalMpUniqueId = -1L;
         }
 
+        @Override
         public void resetDrAppliedTracker(byte clusterId) {
             m_maxSeenDrLogsBySrcPartition.remove((int) clusterId);
+        }
+
+        @Override
+        public boolean hasRealDrAppliedTracker(byte clusterId) {
+            boolean has = false;
+            if (m_maxSeenDrLogsBySrcPartition.containsKey((int) clusterId)) {
+                for (DRConsumerDrIdTracker tracker: m_maxSeenDrLogsBySrcPartition.get((int) clusterId).values()) {
+                    if (tracker.isRealTracker()) {
+                        has = true;
+                        break;
+                    }
+                }
+            }
+            return has;
         }
 
         @Override

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -546,6 +546,10 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             m_lastLocalMpUniqueId = -1L;
         }
 
+        public void resetDrAppliedTracker(byte clusterId) {
+            m_maxSeenDrLogsBySrcPartition.remove((int) clusterId);
+        }
+
         @Override
         public void initDRAppliedTracker(Map<Byte, Integer> clusterIdToPartitionCountMap) {
             for (Map.Entry<Byte, Integer> entry : clusterIdToPartitionCountMap.entrySet()) {

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -542,6 +542,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         @Override
         public void resetDrAppliedTracker() {
             m_maxSeenDrLogsBySrcPartition.clear();
+            if (drLog.isDebugEnabled()) {
+                drLog.debug("Cleared DR Applied tracker");
+            }
             m_lastLocalSpUniqueId = -1L;
             m_lastLocalMpUniqueId = -1L;
         }
@@ -549,6 +552,13 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         @Override
         public void resetDrAppliedTracker(byte clusterId) {
             m_maxSeenDrLogsBySrcPartition.remove((int) clusterId);
+            if (drLog.isDebugEnabled()) {
+                drLog.debug("Reset DR Applied tracker for " + clusterId);
+            }
+            if (m_maxSeenDrLogsBySrcPartition.isEmpty()) {
+                m_lastLocalSpUniqueId = -1L;
+                m_lastLocalMpUniqueId = -1L;
+            }
         }
 
         @Override

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -453,10 +453,16 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             Map<Integer, DRConsumerDrIdTracker> clusterSources = m_maxSeenDrLogsBySrcPartition.get(producerClusterId);
             if (clusterSources == null) {
                 // Don't have a tracker for this cluster
-                drLog.warn(String.format("P%d binary log site idempotency check failed. " +
-                                    "Site doesn't have tracker for this cluster while the last received is %s",
-                            producerPartitionId,
-                            DRLogSegmentId.getDebugStringFromDRId(lastReceivedDRId)));
+                if (DRLogSegmentId.isEmptyDRId(lastReceivedDRId)) {
+                    return DRIdempotencyResult.SUCCESS;
+                } else {
+                    if (drLog.isTraceEnabled()) {
+                        drLog.trace(String.format("P%d binary log site idempotency check failed. " +
+                                        "Site doesn't have tracker for this cluster while the last received is %s",
+                                producerPartitionId,
+                                DRLogSegmentId.getDebugStringFromDRId(lastReceivedDRId)));
+                    }
+                }
             }
             else {
                 DRConsumerDrIdTracker targetTracker = clusterSources.get(producerPartitionId);

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -69,7 +69,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         GENERATE_DR_EVENT(6),
         RESET_DR_APPLIED_TRACKER(7),
         SET_MERGED_DRID_TRACKER(8),
-        INIT_DRID_TRACKER(9);
+        INIT_DRID_TRACKER(9),
+        RESET_DR_APPLIED_TRACKER_SINGLE(10);
 
         private TaskType(int taskId) {
             this.taskId = taskId;

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask_SP.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask_SP.java
@@ -54,7 +54,7 @@ public class ExecuteTask_SP extends VoltSystemProcedure {
      * @param partitionParam  key for routing stored procedure to correct site
      * @param taskId          type of the task to execute
      */
-    public void run(SystemProcedureExecutionContext ctx, byte[] partitionParam, byte taskId)
+    public void run(SystemProcedureExecutionContext ctx, byte[] partitionParam, byte taskId, byte clusterId)
     {
         TaskType taskType = TaskType.values()[taskId];
         switch (taskType) {
@@ -67,6 +67,9 @@ public class ExecuteTask_SP extends VoltSystemProcedure {
                 throw new VoltAbortException("DRConsumerDrIdTracker could not be converted to JSON");
             }
 
+            break;
+        case RESET_DR_APPLIED_TRACKER_SINGLE:
+            ctx.resetDrAppliedTracker(clusterId);
             break;
         default:
             throw new VoltAbortException("Unable to find the task associated with the given task id");

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask_SP.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask_SP.java
@@ -52,10 +52,12 @@ public class ExecuteTask_SP extends VoltSystemProcedure {
      *
      * @param ctx  execution context
      * @param partitionParam  key for routing stored procedure to correct site
-     * @param taskId          type of the task to execute
+     * @param params          additional parameter(s) for the task to execute, first one is always task type
      */
-    public void run(SystemProcedureExecutionContext ctx, byte[] partitionParam, byte taskId, byte clusterId)
+    public void run(SystemProcedureExecutionContext ctx, byte[] partitionParam, byte[] params)
     {
+        assert params.length > 0;
+        byte taskId = params[0];
         TaskType taskType = TaskType.values()[taskId];
         switch (taskType) {
         case SP_JAVA_GET_DRID_TRACKER:
@@ -69,6 +71,8 @@ public class ExecuteTask_SP extends VoltSystemProcedure {
 
             break;
         case RESET_DR_APPLIED_TRACKER_SINGLE:
+            assert params.length == 2;
+            byte clusterId = params[1];
             ctx.resetDrAppliedTracker(clusterId);
             break;
         default:

--- a/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
+++ b/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
@@ -196,6 +196,12 @@ public class SysProcFragmentId
     public static final long PF_postResetDR = 282;
     public static final long PF_postResetDRAggregate = 283;
 
+    // @ResetDRSingle
+    public static final long PF_preResetDRSingle = 284;
+    public static final long PF_preResetDRSingleAggregate = 285;
+    public static final long PF_postResetDRSingle = 286;
+    public static final long PF_postResetDRSingleAggregate = 287;
+
     // @ExecuteTask
     public static final long PF_executeTask = 290;
     public static final long PF_executeTaskAggregate = 291;

--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -994,7 +994,7 @@ public class SQLCommand
         Procedures.put("@GC",
                 ImmutableMap.<Integer, List<String>>builder().put( 0, new ArrayList<String>()).build());
         Procedures.put("@ResetDR",
-                ImmutableMap.<Integer, List<String>>builder().put( 0, new ArrayList<String>()).build());
+                ImmutableMap.<Integer, List<String>>builder().put( 2, Arrays.asList("tinyint", "tinyint")).build());
         Procedures.put("@SwapTables",
                 ImmutableMap.<Integer, List<String>>builder().put( 2, Arrays.asList("varchar", "varchar")).build());
         Procedures.put("@Trace",


### PR DESCRIPTION
Pro Side: https://github.com/VoltDB/pro/pull/1790
This PR only handles the case when target cluster haven't finished applied syncSnapshot.
This guarantees the target cluster won't send any binary logs to any cluster in the mesh. So it guarantees there won't be any divergences in the remaining clusters.
The way to detect syncSnapshot haven't applied is by looking at Producer Cluster's Consumer Side partitionReceivers' existence. (Since we on-demand create them.) As well as site's local applied tracker.(Mainly for the recovery case when the target cluster is also down).

changes including following

## ResetDR sysProc now taken two parameters: clusterId and force
  * executing global reset if clusterId == -1 **or** there's only one consumerCluster Connected
  * for single reset, if force == 0, it will pause and check **all** bufferReceivers for whether received "STREAM_START_EVENT" or not. If anyone hasreceived, it won't be able to safe reset.
  * if force == 1 or it's safe to reset, sysProc calls DRProducer.deactiveDR()
  * DRProducer then request a breakReplication Task to the State Machine. For now, it keeps DR_STATUS and using REMOVE_SINGLE as the DR_STATE_CHANGE_TYPE.
  * This task will then call DRProducer.breakReplication method on each host for doing the real cleanup works, which includes removing conversion and metadata.
  * If this cluster is Active-Active, it will then stop ConsumerDispatcher for the target cluster.

## PAUSE mode in DRBinaryLogPartitionStreamReader
This pauses adding InvocationBuffer to toSend queue.
The aim of adding this is for delaying stream_start_event till sync snapshot applied.

the pause mode now using two different flags:
"m_mode" is used for pauseAllReaders()/resumeAllReaders() to enable the abiltiy to pause readers externally.

"m_covering" follows the original "m_mode" logic, it will be set once resetToDRId() being executed

## PAUSE state for DRConsumerDispatcher
This pauses Dispatcher offer InvocationBuffer to m_dispatcherState.
This aim for adding this is for preventing bufferReceivers received stream_start_event while we are checking whether it's safe to reset or not.

The PAUSE state is a special case of RECEIVE state. The only difference is the m_dispatcherState.m_state changes into PAUSE.
PAUSE state only supports transfer from and to RECEIVE state.

## new DR_STATE_CHANGE_TYPE in ProducerDRState:
 REMOVE_SINGLE

## ConsumerDRGateway new methods:
  * isSafeForReset, pauseConsumerDispatcher, resumeConsumerDispatcher: used in ResetDR sysProc for preChecking
  * deactiveConsumerDispatcher: used from DRProducer to stop its target Consumer Dispatcher

## ProducerDRGateway new methods:
  * deactivateDRProducer(byte clusterId): called from sysProc
  * pauseAllReaders(): this called from (Conumser Cluster) syncSnapshotPreconditions to pause all DRBinaryLogPartitionStreamReader
  * resumeAllReaders(): this called from (Conumser Cluster) transitionToNormalBuffers to resume all DRBinaryLogPartitionStreamReader

## Site can reset per cluster applied tracker
via resetDrAppliedTracker(byte clusterId)

## DRConusmer Stats Enhancement
unregister per cluster stats when removed
