### PR TITLE
Make it possible to format TimestampType independent of time zone.

### DIFF
--- a/src/frontend/org/voltdb/types/TimestampType.java
+++ b/src/frontend/org/voltdb/types/TimestampType.java
@@ -19,6 +19,7 @@ package org.voltdb.types;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.json_voltpatches.JSONString;
 import org.voltdb.common.Constants;
@@ -143,11 +144,33 @@ public class TimestampType implements JSONString, Comparable<TimestampType> {
     }
 
     /**
-     * toString for debugging and printing VoltTables
+     * An implementation of toString for debugging and printing VoltTables.
+     * This formats the timestamp value using a standard ODBC date format,
+     * similar to ISO-8601.  The format is yyyy-MM-dd HH:mm:ss.SSSSSS.
+     * Here, unlike the Java SimpleDateFormat formatter, the SSSSSS part
+     * is the number of microseconds.  The timezone is the default
+     * timezone of the server.
      */
     @Override
     public String toString() {
+        return toString(TimeZone.getDefault());
+    }
+
+    /**
+     * An implementation of toString for debugging and printing VoltTables
+     * which allows the specification of a timezone.
+     *
+     * @param zone
+     * @return
+     */
+    public String toString(TimeZone zone) {
+        // This should all be replaced with Java 8's java.time
+        // facilities.
         SimpleDateFormat sdf = new SimpleDateFormat(Constants.ODBC_DATE_FORMAT_STRING);
+
+        if (zone != null) {
+            sdf.setTimeZone(zone);
+        }
         Date dateToMillis = (Date) m_date.clone(); // deep copy as we change it later
         short usecs = m_usecs;
         if (usecs < 0) {

--- a/src/frontend/org/voltdb/types/TimestampType.java
+++ b/src/frontend/org/voltdb/types/TimestampType.java
@@ -149,7 +149,10 @@ public class TimestampType implements JSONString, Comparable<TimestampType> {
      * similar to ISO-8601.  The format is yyyy-MM-dd HH:mm:ss.SSSSSS.
      * Here, unlike the Java SimpleDateFormat formatter, the SSSSSS part
      * is the number of microseconds.  The timezone is the default
-     * timezone of the server.
+     * timezone of the JVM.  This will be the timezone of the application,
+     * which may not match the timezone of the database server.  See the overload
+     * of this function which accepts a time zone for more control
+     * over the specification of the timezone.
      */
     @Override
     public String toString() {

--- a/tests/frontend/org/voltdb/TestVoltType.java
+++ b/tests/frontend/org/voltdb/TestVoltType.java
@@ -26,10 +26,11 @@ package org.voltdb;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
-import junit.framework.TestCase;
+import java.util.TimeZone;
 
 import org.voltdb.types.TimestampType;
+
+import junit.framework.TestCase;
 
 public class TestVoltType extends TestCase {
 
@@ -270,15 +271,18 @@ public class TestVoltType extends TestCase {
 
     public void testTimestampToStringBeforeEpoch() {
         long micros = -48932323284323L;
+        TimeZone tz = TimeZone.getTimeZone("America/New_York");
         TimestampType beforeEpoch = new TimestampType(micros);
-        assertEquals("1968-06-13 11:41:16.715677", beforeEpoch.toString());
+        String answer = beforeEpoch.toString(tz);
+        assertEquals("1968-06-13 11:41:16.715677", answer);
         assertEquals(micros, beforeEpoch.getTime());
 
         // test Long.MIN as NULL_TimestampType
         // NULL_TimestampType is translated to VoltType.NULL_BIGINT in
         // @see org.voltdb.ParameterSet#flattenToBuffer()
         beforeEpoch = new TimestampType(VoltType.NULL_BIGINT);
-        assertEquals("290303-12-10 14:59:05.224192", beforeEpoch.toString());
+        answer = beforeEpoch.toString(tz);
+        assertEquals("290303-12-10 14:59:05.224192", answer);
         assertEquals(VoltType.NULL_BIGINT, beforeEpoch.getTime());
     }
 


### PR DESCRIPTION
The test TestVoltType.testTimestampToStringBeforeEpoch failed if it was
run on a machine whose timezone was not America/New_York.  This change
allows the user to choose a SimpleDateFormatter for the toString method,
which lets the test be time zone independent.

This is not actually the most general one could do, but it's better than
before.