### PR TITLE
ENG-12139: Fix internal adapter initialization error.

### DIFF
--- a/src/frontend/org/voltdb/InternalConnectionHandler.java
+++ b/src/frontend/org/voltdb/InternalConnectionHandler.java
@@ -55,6 +55,11 @@ public class InternalConnectionHandler {
         m_adapters = builder.build();
     }
 
+    public boolean hasAdapter(int pid)
+    {
+        return m_adapters.containsKey(pid);
+    }
+
     /**
      * Returns true if a table with the given name exists in the server catalog.
      */

--- a/tests/frontend/org/voltdb/TestJSONInterface.java
+++ b/tests/frontend/org/voltdb/TestJSONInterface.java
@@ -182,6 +182,10 @@ public class TestJSONInterface extends TestCase {
         return httpUrlOverJSON("POST", protocolPrefix + "localhost:8095/api/1.0/", null, null, null, expectedCode, null, params);
     }
 
+    public static String callProcOverJSONRaw(Map params, int httpPort, final int expectedCode) throws Exception {
+        return httpUrlOverJSON("POST", protocolPrefix + "localhost:" + httpPort + "/api/1.0/", null, null, null, expectedCode, null, params);
+    }
+
     public static String callProcOverJSONRaw(String varString, final int expectedCode) throws Exception {
         return httpUrlOverJSONExecute("POST", protocolPrefix + "localhost:8095/api/1.0/", null, null, null, expectedCode, null, varString);
     }
@@ -315,10 +319,10 @@ public class TestJSONInterface extends TestCase {
     }
 
     public static String callProcOverJSON(String procName, ParameterSet pset, String username, String password, boolean preHash, boolean admin, int expectedCode, ClientAuthScheme scheme) throws Exception {
-        return callProcOverJSON(procName, pset, username, password, preHash, admin, expectedCode /* HTTP_OK */, scheme, -1);
+        return callProcOverJSON(procName, pset, 8095, username, password, preHash, admin, expectedCode /* HTTP_OK */, scheme, -1);
     }
 
-    public static String callProcOverJSON(String procName, ParameterSet pset, String username, String password, boolean preHash, boolean admin, int expectedCode, ClientAuthScheme scheme, int procCallTimeout) throws Exception {
+    public static String callProcOverJSON(String procName, ParameterSet pset, int httpPort, String username, String password, boolean preHash, boolean admin, int expectedCode, ClientAuthScheme scheme, int procCallTimeout) throws Exception {
         // Call insert
         String paramsInJSON = pset.toJSONString();
         //System.out.println(paramsInJSON);
@@ -342,11 +346,11 @@ public class TestJSONInterface extends TestCase {
             params.put("admin", "true");
         }
 
-        String ret = callProcOverJSONRaw(params, expectedCode);
+        String ret = callProcOverJSONRaw(params, httpPort, expectedCode);
         if (preHash) {
             //If prehash make same call with SHA1 to check expected code.
             params.put("Hashedpassword", getHashedPasswordForHTTPVar(password, ClientAuthScheme.HASH_SHA1));
-            callProcOverJSONRaw(params, expectedCode);
+            callProcOverJSONRaw(params, httpPort, expectedCode);
         }
         return ret;
     }
@@ -1333,7 +1337,7 @@ public class TestJSONInterface extends TestCase {
             }
 
             pset = ParameterSet.fromArrayNoCopy(100000);
-            String response = callProcOverJSON("TestJSONInterface$LongReadProc", pset, null, null, false, false, 200, ClientAuthScheme.HASH_SHA256, 1);
+            String response = callProcOverJSON("TestJSONInterface$LongReadProc", pset, 8095, null, null, false, false, 200, ClientAuthScheme.HASH_SHA256, 1);
             Response r = responseFromJSON(response);
             assertEquals(ClientResponse.GRACEFUL_FAILURE, r.status);
             assertTrue(r.statusString.contains("Transaction Interrupted"));


### PR DESCRIPTION
Rejoining node won't get notified of partition master promotions. The
internal adapters have to be created during initialization. They are now
created in the constructor of ClientInterface and later can be added if
not exist during master promotion.