### PR TITLE
ENG-12144: Fix memory leak on @UAC in export.

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -791,12 +791,13 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             if (first_unpolled_block == null) {
                 m_pollFuture = fut;
             } else {
+                final AckingContainer ackingContainer = new AckingContainer(first_unpolled_block.unreleasedContainer(),
+                                                                            first_unpolled_block.uso() + first_unpolled_block.totalUso());
                 try {
-                    fut.set(
-                            new AckingContainer(first_unpolled_block.unreleasedContainer(),
-                                    first_unpolled_block.uso() + first_unpolled_block.totalUso()));
+                    fut.set(ackingContainer);
                 } catch (RejectedExecutionException reex) {
                     //We are closing source.
+                    ackingContainer.discard();
                 }
                 m_pollFuture = null;
             }


### PR DESCRIPTION
On @UAC or during shutdown, some of the export decoder executor services
may be shutdown when the buffer is polled. Setting the buffer on the
future will throw RejectedExecutionException in this case because the
listener tries to schedule itself on those executor services. It has to
catch the exception and properly discard the containers that was just
created to avoid leaking memory.