### PR TITLE
Eng 12133 skip loading hsqldb ctx

### DIFF
--- a/src/frontend/org/voltdb/DefaultProcedureManager.java
+++ b/src/frontend/org/voltdb/DefaultProcedureManager.java
@@ -51,10 +51,10 @@ public class DefaultProcedureManager {
 
     Map<String, Procedure> m_defaultProcMap = new HashMap<>();
 
-    final Database m_db;
+    private final Database m_db;
     // fake db makes it easy to create procedures that aren't
     // part of the main catalog
-    final Database m_fakeDb;
+    private final Database m_fakeDb;
 
     public DefaultProcedureManager(Database db) {
         m_db = db;
@@ -159,7 +159,7 @@ public class DefaultProcedureManager {
         }
     }
 
-    public String sqlForDefaultProc(Procedure defaultProc) {
+    public static String sqlForDefaultProc(Procedure defaultProc) {
         String name = defaultProc.getClassname();
         String[] parts = name.split("\\.");
         String action = parts[1];
@@ -245,7 +245,7 @@ public class DefaultProcedureManager {
      * @param sb string buffer accumulating the sql statement
      * @return offset in the index of the partition column
      */
-    private int generateCrudPKeyWhereClause(Column partitioncolumn,
+    private static int generateCrudPKeyWhereClause(Column partitioncolumn,
             Constraint pkey, StringBuilder sb)
     {
         // Sort the catalog index columns by index column order.
@@ -276,7 +276,7 @@ public class DefaultProcedureManager {
      * @param table
      * @param sb
      */
-    private void generateCrudExpressionColumns(Table table, StringBuilder sb) {
+    private static void generateCrudExpressionColumns(Table table, StringBuilder sb) {
         boolean first = true;
 
         // Sort the catalog table columns by column order.
@@ -296,7 +296,7 @@ public class DefaultProcedureManager {
     /**
      * Helper to generate a full col1, col2, col3 list.
      */
-    private void generateCrudColumnList(Table table, StringBuilder sb) {
+    private static void generateCrudColumnList(Table table, StringBuilder sb) {
         boolean first = true;
         sb.append("(");
 
@@ -321,7 +321,7 @@ public class DefaultProcedureManager {
      * Create a statement like:
      *  "delete from <table> where {<pkey-column =?>...}"
      */
-    private String generateCrudDelete(Table table, Column partitioncolumn, Constraint pkey) {
+    private static String generateCrudDelete(Table table, Column partitioncolumn, Constraint pkey) {
         StringBuilder sb = new StringBuilder();
         sb.append("DELETE FROM " + table.getTypeName());
 
@@ -335,7 +335,7 @@ public class DefaultProcedureManager {
      * Create a statement like:
      * "update <table> set {<each-column = ?>...} where {<pkey-column = ?>...}
      */
-    private String generateCrudUpdate(Table table, Column partitioncolumn, Constraint pkey) {
+    private static String generateCrudUpdate(Table table, Column partitioncolumn, Constraint pkey) {
         StringBuilder sb = new StringBuilder();
         sb.append("UPDATE " + table.getTypeName() + " SET ");
 
@@ -350,7 +350,7 @@ public class DefaultProcedureManager {
      * Create a statement like:
      *  "insert into <table> values (?, ?, ...);"
      */
-    private String generateCrudInsert(Table table, Column partitioncolumn) {
+    private static String generateCrudInsert(Table table, Column partitioncolumn) {
         StringBuilder sb = new StringBuilder();
         sb.append("INSERT INTO " + table.getTypeName() + " VALUES ");
 
@@ -365,7 +365,7 @@ public class DefaultProcedureManager {
      * Hack simple case of implementation SQL MERGE
      *  "upsert into <table> values (?, ?, ...);"
      */
-    private String generateCrudUpsert(Table table, Column partitioncolumn) {
+    private static String generateCrudUpsert(Table table, Column partitioncolumn) {
         StringBuilder sb = new StringBuilder();
         sb.append("UPSERT INTO " + table.getTypeName() + " VALUES ");
 
@@ -380,7 +380,7 @@ public class DefaultProcedureManager {
      *  "insert into <table> values (?, ?, ...);"
      *  for a replicated table.
      */
-    private String generateCrudReplicatedInsert(Table table) {
+    private static String generateCrudReplicatedInsert(Table table) {
         StringBuilder sb = new StringBuilder();
         sb.append("INSERT INTO " + table.getTypeName() + " VALUES ");
 
@@ -395,7 +395,7 @@ public class DefaultProcedureManager {
      *  "update <table> set {<each-column = ?>...} where {<pkey-column = ?>...}
      *  for a replicated table.
      */
-    private String generateCrudReplicatedUpdate(Table table, Constraint pkey)
+    private static String generateCrudReplicatedUpdate(Table table, Constraint pkey)
     {
         StringBuilder sb = new StringBuilder();
         sb.append("UPDATE " + table.getTypeName() + " SET ");
@@ -412,7 +412,7 @@ public class DefaultProcedureManager {
      *  "delete from <table> where {<pkey-column =?>...}"
      * for a replicated table.
      */
-    private String generateCrudReplicatedDelete(Table table, Constraint pkey)
+    private static String generateCrudReplicatedDelete(Table table, Constraint pkey)
     {
         StringBuilder sb = new StringBuilder();
         sb.append("DELETE FROM " + table.getTypeName());
@@ -423,7 +423,7 @@ public class DefaultProcedureManager {
         return sb.toString();
     }
 
-    private String generateCrudReplicatedUpsert(Table table, Constraint pkey)
+    private static String generateCrudReplicatedUpsert(Table table, Constraint pkey)
     {
         StringBuilder sb = new StringBuilder();
         sb.append("UPSERT INTO " + table.getTypeName() + " VALUES ");
@@ -438,7 +438,7 @@ public class DefaultProcedureManager {
      * Create a statement like:
      *  "select * from <table> where pkey_col1 = ?, pkey_col2 = ? ... ;"
      */
-    private String generateCrudSelect(Table table, Column partitioncolumn, Constraint pkey)
+    private static String generateCrudSelect(Table table, Column partitioncolumn, Constraint pkey)
     {
         StringBuilder sb = new StringBuilder();
         sb.append("SELECT * FROM " + table.getTypeName());

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -1601,7 +1601,8 @@ public final class InvocationDispatcher {
                           changeResult.reasonsForEmptyTables,
                           changeResult.requiresSnapshotIsolation ? 1 : 0,
                           changeResult.worksWithElastic ? 1 : 0,
-                          changeResult.deploymentHash);
+                          changeResult.deploymentHash,
+                          changeResult.hasSchemaChange ? 1 : 0);
            task.clientHandle = changeResult.clientHandle;
            // DR stuff
            task.type = changeResult.invocationType;

--- a/src/frontend/org/voltdb/LoadedProcedureSet.java
+++ b/src/frontend/org/voltdb/LoadedProcedureSet.java
@@ -293,7 +293,7 @@ public class LoadedProcedureSet {
         if (pr == null) {
             Procedure catProc = m_defaultProcManager.checkForDefaultProcedure(procName);
             if (catProc != null) {
-                String sqlText = m_defaultProcManager.sqlForDefaultProc(catProc);
+                String sqlText = DefaultProcedureManager.sqlForDefaultProc(catProc);
                 Procedure newCatProc = StatementCompiler.compileDefaultProcedure(m_plannerTool, catProc, sqlText);
                 VoltProcedure voltProc = new ProcedureRunner.StmtProcedure();
                 pr = new ProcedureRunner(null, voltProc, m_site, newCatProc, m_csp);

--- a/src/frontend/org/voltdb/ParameterDeserializationPolicy.java
+++ b/src/frontend/org/voltdb/ParameterDeserializationPolicy.java
@@ -35,21 +35,22 @@ public class ParameterDeserializationPolicy extends InvocationValidationPolicy {
     public ClientResponseImpl shouldAccept(AuthUser user,
             StoredProcedureInvocation invocation,
             Procedure proc) {
-        if (proc.getSystemproc()) {
-            try {
-                invocation.getParams();
-            } catch (RuntimeException e) {
-                Writer result = new StringWriter();
-                PrintWriter pw = new PrintWriter(result);
-                e.printStackTrace(pw);
-                return new ClientResponseImpl(ClientResponseImpl.GRACEFUL_FAILURE,
-                        new VoltTable[0],
-                        "Exception while deserializing procedure params\n" +
-                                result.toString(),
-                        invocation.clientHandle);
-            }
+        if (! proc.getSystemproc()) {
+            return null;
         }
 
+        try {
+            invocation.getParams();
+        } catch (RuntimeException e) {
+            Writer result = new StringWriter();
+            PrintWriter pw = new PrintWriter(result);
+            e.printStackTrace(pw);
+            return new ClientResponseImpl(ClientResponseImpl.GRACEFUL_FAILURE,
+                    new VoltTable[0],
+                    "Exception while deserializing procedure params\n" +
+                            result.toString(),
+                            invocation.clientHandle);
+        }
         return null;
     }
 }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3224,7 +3224,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             long currentTxnId,
             long currentTxnUniqueId,
             byte[] deploymentBytes,
-            byte[] deploymentHash)
+            byte[] deploymentHash,
+            boolean hasSchemaChange)
     {
         try {
             synchronized(m_catalogUpdateLock) {
@@ -3276,7 +3277,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                             diffCommands,
                             true,
                             deploymentBytes,
-                            m_messenger);
+                            m_messenger,
+                            hasSchemaChange);
                 final CatalogSpecificPlanner csp = new CatalogSpecificPlanner( m_asyncCompilerAgent, m_catalogContext);
                 m_txnIdToContextTracker.put(currentTxnId,
                         new ContextTracker(

--- a/src/frontend/org/voltdb/ReplicaInvocationAcceptancePolicy.java
+++ b/src/frontend/org/voltdb/ReplicaInvocationAcceptancePolicy.java
@@ -49,13 +49,13 @@ public class ReplicaInvocationAcceptancePolicy extends InvocationValidationPolic
 
         if (isReadOnly) {
             return null;
-        } else {
-            return new ClientResponseImpl(ClientResponseImpl.UNEXPECTED_FAILURE,
-                    new VoltTable[0],
-                    "Write procedure " + invocation.getProcName() +
-                    " is not allowed in replica cluster",
-                    invocation.clientHandle);
         }
+
+        return new ClientResponseImpl(ClientResponseImpl.UNEXPECTED_FAILURE,
+                new VoltTable[0],
+                "Write procedure " + invocation.getProcName() +
+                " is not allowed in replica cluster",
+                invocation.clientHandle);
     }
 
     @Override

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -161,7 +161,8 @@ public interface VoltDBInterface
             long currentTxnId,
             long currentTxnTimestamp,
             byte[] deploymentBytes,
-            byte[] deploymentHash);
+            byte[] deploymentHash,
+            boolean hasSchemaChange);
 
     /**
      * Updates the cluster setting of this VoltDB

--- a/src/frontend/org/voltdb/compiler/AsyncCompilerAgentHelper.java
+++ b/src/frontend/org/voltdb/compiler/AsyncCompilerAgentHelper.java
@@ -57,6 +57,7 @@ public class AsyncCompilerAgentHelper
         retval.hostname = work.hostname;
         retval.user = work.user;
         retval.tablesThatMustBeEmpty = new String[0]; // ensure non-null
+        retval.hasSchemaChange = true;
 
         try {
             // catalog change specific boiler plate
@@ -97,6 +98,9 @@ public class AsyncCompilerAgentHelper
                 // Real deploymentString should be the current deployment, just set it to null
                 // here and let it get filled in correctly later.
                 deploymentString = null;
+
+                // mark it as non-schema change
+                retval.hasSchemaChange = false;
             }
             else if ("@AdHoc".equals(work.invocationName)) {
                 // work.adhocDDLStmts should be applied to the current catalog

--- a/src/frontend/org/voltdb/compiler/CatalogChangeResult.java
+++ b/src/frontend/org/voltdb/compiler/CatalogChangeResult.java
@@ -40,4 +40,6 @@ public class CatalogChangeResult extends AsyncCompilerResult {
     public boolean isForReplay;
     public long replayTxnId;
     public long replayUniqueId;
+    // mark it false for UpdateClasses, in future may be marked false for deployment changes
+    public boolean hasSchemaChange;
 }

--- a/src/frontend/org/voltdb/compiler/MaterializedViewProcessor.java
+++ b/src/frontend/org/voltdb/compiler/MaterializedViewProcessor.java
@@ -631,7 +631,6 @@ public class MaterializedViewProcessor {
             fallbackQueryStmt.setSqltext(query);
             StatementCompiler.compileStatementAndUpdateCatalog(m_compiler,
                               m_hsql,
-                              db.getCatalog(),
                               db,
                               estimates,
                               fallbackQueryStmt,
@@ -657,7 +656,6 @@ public class MaterializedViewProcessor {
             fallbackQueryStmt.setSqltext(query);
             StatementCompiler.compileStatementAndUpdateCatalog(m_compiler,
                               m_hsql,
-                              db.getCatalog(),
                               db,
                               estimates,
                               fallbackQueryStmt,
@@ -688,7 +686,6 @@ public class MaterializedViewProcessor {
         createQuery.setSqltext(query);
         StatementCompiler.compileStatementAndUpdateCatalog(m_compiler,
                           m_hsql,
-                          db.getCatalog(),
                           db,
                           estimates,
                           createQueryInfer,
@@ -701,7 +698,6 @@ public class MaterializedViewProcessor {
         mvHandlerInfo.getCreatequery().delete("createQueryInfer");
         StatementCompiler.compileStatementAndUpdateCatalog(m_compiler,
                           m_hsql,
-                          db.getCatalog(),
                           db,
                           estimates,
                           createQuery,

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -28,7 +28,6 @@ import org.voltdb.PlannerStatsCollector.CacheUse;
 import org.voltdb.StatsAgent;
 import org.voltdb.StatsSelector;
 import org.voltdb.VoltDB;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.common.Constants;
 import org.voltdb.planner.BoundPlan;
@@ -49,22 +48,20 @@ public class PlannerTool {
     private static final VoltLogger hostLog = new VoltLogger("HOST");
     private static final VoltLogger compileLog = new VoltLogger("COMPILE");
 
-    private final Database m_database;
-    private final Cluster m_cluster;
+    private Database m_database;
+    private byte[] m_catalogHash;
+    private AdHocCompilerCache m_cache;
+
     private final HSQLInterface m_hsql;
-    private final byte[] m_catalogHash;
-    private final AdHocCompilerCache m_cache;
     private static PlannerStatsCollector m_plannerStats;
 
     private static final int AD_HOC_JOINED_TABLE_LIMIT = 5;
 
-    public PlannerTool(final Cluster cluster, final Database database, byte[] catalogHash)
+    public PlannerTool(final Database database, byte[] catalogHash)
     {
-        assert(cluster != null);
         assert(database != null);
 
         m_database = database;
-        m_cluster = cluster;
         m_catalogHash = catalogHash;
         m_cache = AdHocCompilerCache.getCacheForCatalogHash(catalogHash);
 
@@ -86,8 +83,9 @@ public class PlannerTool {
                 throw new RuntimeException("Error creating hsql: " + e.getMessage() + " in DDL statement: " + decoded_cmd);
             }
         }
-
-        hostLog.debug("hsql loaded");
+        if (hostLog.isDebugEnabled()) {
+            hostLog.debug("hsql loaded");
+        }
 
         // Create and register a singleton planner stats collector, if this is the first time.
         if (m_plannerStats == null) {
@@ -103,6 +101,14 @@ public class PlannerTool {
             }
         }
     }
+
+    public PlannerTool updateWhenNoSchemaChange(Database database, byte[] catalogHash) {
+        m_database = database;
+        m_catalogHash = catalogHash;
+
+        return this;
+    }
+
 
     public AdHocPlannedStatement planSqlForTest(String sqlIn) {
         StatementPartitioning infer = StatementPartitioning.inferPartitioning();
@@ -120,7 +126,7 @@ public class PlannerTool {
         TrivialCostModel costModel = new TrivialCostModel();
         DatabaseEstimates estimates = new DatabaseEstimates();
         QueryPlanner planner = new QueryPlanner(
-            sql, "PlannerTool", "PlannerToolProc", m_cluster, m_database,
+            sql, "PlannerTool", "PlannerToolProc", m_database,
             partitioning, m_hsql, estimates, !VoltCompiler.DEBUG_MODE,
             AD_HOC_JOINED_TABLE_LIMIT, costModel, null, null, DeterminismMode.FASTER);
 
@@ -196,7 +202,7 @@ public class PlannerTool {
             TrivialCostModel costModel = new TrivialCostModel();
             DatabaseEstimates estimates = new DatabaseEstimates();
             QueryPlanner planner = new QueryPlanner(
-                    sql, "PlannerTool", "PlannerToolProc", m_cluster, m_database,
+                    sql, "PlannerTool", "PlannerToolProc", m_database,
                     partitioning, m_hsql, estimates, !VoltCompiler.DEBUG_MODE,
                     AD_HOC_JOINED_TABLE_LIMIT, costModel, null, null, DeterminismMode.FASTER);
 

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -83,9 +83,7 @@ public class PlannerTool {
                 throw new RuntimeException("Error creating hsql: " + e.getMessage() + " in DDL statement: " + decoded_cmd);
             }
         }
-        if (hostLog.isDebugEnabled()) {
-            hostLog.debug("hsql loaded");
-        }
+        hostLog.debug("hsql loaded");
 
         // Create and register a singleton planner stats collector, if this is the first time.
         if (m_plannerStats == null) {

--- a/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
+++ b/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
@@ -34,7 +34,6 @@ import org.voltdb.VoltProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
 import org.voltdb.VoltTypeException;
-import org.voltdb.catalog.Catalog;
 import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.Database;
@@ -70,7 +69,6 @@ public abstract class ProcedureCompiler implements GroovyCodeBlockConstants {
     static void compile(VoltCompiler compiler,
                         HSQLInterface hsql,
                         DatabaseEstimates estimates,
-                        Catalog catalog,
                         Database db,
                         ProcedureDescriptor procedureDescriptor,
                         InMemoryJarfile jarOutput)
@@ -82,10 +80,10 @@ public abstract class ProcedureCompiler implements GroovyCodeBlockConstants {
         assert(estimates != null);
 
         if (procedureDescriptor.m_singleStmt == null) {
-            compileJavaProcedure(compiler, hsql, estimates, catalog, db, procedureDescriptor, jarOutput);
+            compileJavaProcedure(compiler, hsql, estimates, db, procedureDescriptor, jarOutput);
         }
         else {
-            compileSingleStmtProcedure(compiler, hsql, estimates, catalog, db, procedureDescriptor);
+            compileSingleStmtProcedure(compiler, hsql, estimates, db, procedureDescriptor);
         }
     }
 
@@ -278,7 +276,6 @@ public abstract class ProcedureCompiler implements GroovyCodeBlockConstants {
     static void compileJavaProcedure(VoltCompiler compiler,
                                      HSQLInterface hsql,
                                      DatabaseEstimates estimates,
-                                     Catalog catalog,
                                      Database db,
                                      ProcedureDescriptor procedureDescriptor,
                                      InMemoryJarfile jarOutput)
@@ -409,7 +406,7 @@ public abstract class ProcedureCompiler implements GroovyCodeBlockConstants {
             StatementPartitioning partitioning =
                 info.singlePartition ? StatementPartitioning.forceSP() :
                                        StatementPartitioning.forceMP();
-            boolean cacheHit = StatementCompiler.compileFromSqlTextAndUpdateCatalog(compiler, hsql, catalog, db,
+            boolean cacheHit = StatementCompiler.compileFromSqlTextAndUpdateCatalog(compiler, hsql, db,
                     estimates, catalogStmt, stmt.getText(), stmt.getJoinOrder(),
                     detMode, partitioning);
 
@@ -642,7 +639,6 @@ public abstract class ProcedureCompiler implements GroovyCodeBlockConstants {
     static void compileSingleStmtProcedure(VoltCompiler compiler,
                                            HSQLInterface hsql,
                                            DatabaseEstimates estimates,
-                                           Catalog catalog,
                                            Database db,
                                            ProcedureDescriptor procedureDescriptor)
                                                    throws VoltCompiler.VoltCompilerException
@@ -700,7 +696,7 @@ public abstract class ProcedureCompiler implements GroovyCodeBlockConstants {
             info.singlePartition ? StatementPartitioning.forceSP() :
                                    StatementPartitioning.forceMP();
         // default to FASTER detmode because stmt procs can't feed read output into writes
-        StatementCompiler.compileFromSqlTextAndUpdateCatalog(compiler, hsql, catalog, db,
+        StatementCompiler.compileFromSqlTextAndUpdateCatalog(compiler, hsql, db,
                 estimates, catalogStmt, procedureDescriptor.m_singleStmt,
                 procedureDescriptor.m_joinOrder, DeterminismMode.FASTER, partitioning);
 

--- a/src/frontend/org/voltdb/compiler/StatementCompiler.java
+++ b/src/frontend/org/voltdb/compiler/StatementCompiler.java
@@ -87,7 +87,7 @@ public abstract class StatementCompiler {
      * @param  partitioning Partition info for statement
     */
     static boolean compileStatementAndUpdateCatalog(VoltCompiler compiler, HSQLInterface hsql,
-            Catalog catalog, Database db, DatabaseEstimates estimates,
+            Database db, DatabaseEstimates estimates,
             Statement catalogStmt, VoltXMLElement xml, String stmt, String joinOrder,
             DeterminismMode detMode, StatementPartitioning partitioning)
     throws VoltCompiler.VoltCompilerException {
@@ -177,7 +177,7 @@ public abstract class StatementCompiler {
 
         CompiledPlan plan = null;
         QueryPlanner planner = new QueryPlanner(
-                sql, stmtName, procName,  catalog.getClusters().get("cluster"), db,
+                sql, stmtName, procName,  db,
                 partitioning, hsql, estimates, false, DEFAULT_MAX_JOIN_TABLES,
                 costModel, null, joinOrder, detMode);
         try {
@@ -310,11 +310,11 @@ public abstract class StatementCompiler {
     }
 
     static boolean compileFromSqlTextAndUpdateCatalog(VoltCompiler compiler, HSQLInterface hsql,
-            Catalog catalog, Database db, DatabaseEstimates estimates,
+            Database db, DatabaseEstimates estimates,
             Statement catalogStmt, String sqlText, String joinOrder,
             DeterminismMode detMode, StatementPartitioning partitioning)
     throws VoltCompiler.VoltCompilerException {
-        return compileStatementAndUpdateCatalog(compiler, hsql, catalog, db, estimates, catalogStmt,
+        return compileStatementAndUpdateCatalog(compiler, hsql, db, estimates, catalogStmt,
                 null, sqlText, joinOrder, detMode, partitioning);
     }
 

--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -1041,7 +1041,6 @@ public class VoltCompiler {
             // if we generated a plan that is content-non-deterministic.
             StatementCompiler.compileStatementAndUpdateCatalog(this,
                     hsql,
-                    db.getCatalog(),
                     db,
                     m_estimates,
                     stmt,
@@ -1147,7 +1146,7 @@ public class VoltCompiler {
             else {
                 m_currentFilename = procedureName;
             }
-            ProcedureCompiler.compile(this, hsql, m_estimates, m_catalog, db, procedureDescriptor, jarOutput);
+            ProcedureCompiler.compile(this, hsql, m_estimates, db, procedureDescriptor, jarOutput);
         }
         // done handling files
         m_currentFilename = NO_FILENAME;

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -17,8 +17,6 @@
 
 package org.voltdb.planner;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -198,11 +196,10 @@ public abstract class AbstractParsedStmt {
      * @param parsedStmt
      * @param sql
      * @param xmlSQL
-     * @param db
      * @param joinOrder
      */
     private static void parse(AbstractParsedStmt parsedStmt, String sql,
-            VoltXMLElement stmtTypeElement, Database db, String joinOrder) {
+            VoltXMLElement stmtTypeElement, String joinOrder) {
         // parse tables and parameters
         parsedStmt.parseTablesAndParams(stmtTypeElement);
 
@@ -229,7 +226,7 @@ public abstract class AbstractParsedStmt {
         NEXT_PARAMETER_ID = 0;
         AbstractParsedStmt retval = getParsedStmt(stmtTypeElement, paramValues, db);
 
-        parse(retval, sql, stmtTypeElement, db, joinOrder);
+        parse(retval, sql, stmtTypeElement, joinOrder);
         return retval;
     }
 
@@ -1560,7 +1557,7 @@ public abstract class AbstractParsedStmt {
         subquery.m_paramsById.putAll(m_paramsById);
         subquery.m_paramsByIndex = m_paramsByIndex;
 
-        AbstractParsedStmt.parse(subquery, m_sql, queryNode, m_db, m_joinOrder);
+        AbstractParsedStmt.parse(subquery, m_sql, queryNode, m_joinOrder);
         subquery.m_parentStmt = this;
         return subquery;
     }
@@ -1571,7 +1568,7 @@ public abstract class AbstractParsedStmt {
         subQuery.m_parentStmt = this;
         subQuery.m_paramsById.putAll(m_paramsById);
 
-        AbstractParsedStmt.parse(subQuery, m_sql, suqueryElmt, m_db, m_joinOrder);
+        AbstractParsedStmt.parse(subQuery, m_sql, suqueryElmt, m_joinOrder);
         updateContentDeterminismMessage(subQuery.calculateContentDeterminismMessage());
         return subQuery;
     }

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import org.json_voltpatches.JSONException;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.CatalogMap;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.ColumnRef;
 import org.voltdb.catalog.Constraint;
@@ -52,7 +51,6 @@ import org.voltdb.planner.parseinfo.BranchNode;
 import org.voltdb.planner.parseinfo.JoinNode;
 import org.voltdb.planner.parseinfo.StmtSubqueryScan;
 import org.voltdb.planner.parseinfo.StmtTableScan;
-import org.voltdb.plannodes.IndexSortablePlanNode;
 import org.voltdb.plannodes.AbstractJoinPlanNode;
 import org.voltdb.plannodes.AbstractPlanNode;
 import org.voltdb.plannodes.AbstractReceivePlanNode;
@@ -61,6 +59,7 @@ import org.voltdb.plannodes.AggregatePlanNode;
 import org.voltdb.plannodes.DeletePlanNode;
 import org.voltdb.plannodes.HashAggregatePlanNode;
 import org.voltdb.plannodes.IndexScanPlanNode;
+import org.voltdb.plannodes.IndexSortablePlanNode;
 import org.voltdb.plannodes.IndexUseForOrderBy;
 import org.voltdb.plannodes.InsertPlanNode;
 import org.voltdb.plannodes.LimitPlanNode;
@@ -112,8 +111,6 @@ public class PlanAssembler {
         }
     }
 
-    /** convenience pointer to the cluster object in the catalog */
-    private final Cluster m_catalogCluster;
     /** convenience pointer to the database object in the catalog */
     private final Database m_catalogDb;
 
@@ -151,16 +148,12 @@ public class PlanAssembler {
     private boolean m_bestAndOnlyPlanWasGenerated = false;
 
     /**
-     *
-     * @param catalogCluster
-     *            Catalog info about the physical layout of the cluster.
      * @param catalogDb
      *            Catalog info about schema, metadata and procedures.
      * @param partitioning
      *            Describes the specified and inferred partition context.
      */
-    PlanAssembler(Cluster catalogCluster, Database catalogDb, StatementPartitioning partitioning, PlanSelector planSelector) {
-        m_catalogCluster = catalogCluster;
+    PlanAssembler(Database catalogDb, StatementPartitioning partitioning, PlanSelector planSelector) {
         m_catalogDb = catalogDb;
         m_partitioning = partitioning;
         m_planSelector = planSelector;
@@ -746,8 +739,7 @@ public class PlanAssembler {
             StatementPartitioning partitioning = (StatementPartitioning)m_partitioning.clone();
             PlanSelector planSelector = (PlanSelector) m_planSelector.clone();
             planSelector.m_planId = planId;
-            PlanAssembler assembler = new PlanAssembler(
-                    m_catalogCluster, m_catalogDb, partitioning, planSelector);
+            PlanAssembler assembler = new PlanAssembler(m_catalogDb, partitioning, planSelector);
             CompiledPlan bestChildPlan = assembler.getBestCostPlan(parsedChildStmt);
             partitioning = assembler.m_partitioning;
 
@@ -863,8 +855,7 @@ public class PlanAssembler {
         PlanSelector planSelector = (PlanSelector) m_planSelector.clone();
         planSelector.m_planId = planId;
         StatementPartitioning currentPartitioning = (StatementPartitioning)m_partitioning.clone();
-        PlanAssembler assembler = new PlanAssembler(
-                m_catalogCluster, m_catalogDb, currentPartitioning, planSelector);
+        PlanAssembler assembler = new PlanAssembler(m_catalogDb, currentPartitioning, planSelector);
         CompiledPlan compiledPlan = assembler.getBestCostPlan(subQuery);
         // make sure we got a winner
         if (compiledPlan == null) {

--- a/src/frontend/org/voltdb/planner/PlanSelector.java
+++ b/src/frontend/org/voltdb/planner/PlanSelector.java
@@ -22,7 +22,6 @@ import java.io.File;
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
-import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.DeterminismMode;
 import org.voltdb.compiler.ScalarValueHints;
@@ -39,8 +38,6 @@ import org.voltdb.utils.BuildDirectoryUtils;
  *
  */
 public class PlanSelector implements Cloneable {
-    /** pointer to the database object in the catalog */
-    final Database m_db;
     /** pointer to the database estimates */
     DatabaseEstimates m_estimates;
     /** The name of the sql statement to be planned */
@@ -81,12 +78,11 @@ public class PlanSelector implements Cloneable {
      * @param quietPlanner Controls the output.
      * @param fullDebug Controls the debug output.
      */
-    public PlanSelector(Database db, DatabaseEstimates estimates,
+    public PlanSelector(DatabaseEstimates estimates,
             String stmtName, String procName, String sql,
             AbstractCostModel costModel, ScalarValueHints[] paramHints,
             DeterminismMode detMode, boolean quietPlanner)
     {
-        m_db = db;
         m_estimates = estimates;
         m_stmtName = stmtName;
         m_procName = procName;
@@ -103,7 +99,7 @@ public class PlanSelector implements Cloneable {
      */
     @Override
     public Object clone() {
-        return new PlanSelector(m_db, m_estimates, m_stmtName, m_procName, m_sql,
+        return new PlanSelector(m_estimates, m_stmtName, m_procName, m_sql,
                 m_costModel, m_paramHints, m_detMode, m_quietPlanner);
     }
 
@@ -155,7 +151,7 @@ public class PlanSelector implements Cloneable {
         AbstractPlanNode planGraph = plan.rootPlanGraph;
 
         // compute statistics about a plan
-        planGraph.computeEstimatesRecursively(m_stats, m_db, m_estimates, m_paramHints);
+        planGraph.computeEstimatesRecursively(m_stats, m_estimates, m_paramHints);
 
         // compute the cost based on the resources using the current cost model
         plan.cost = m_costModel.getPlanCost(m_stats);

--- a/src/frontend/org/voltdb/planner/PlanSelector.java
+++ b/src/frontend/org/voltdb/planner/PlanSelector.java
@@ -22,7 +22,6 @@ import java.io.File;
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.DeterminismMode;
@@ -40,8 +39,6 @@ import org.voltdb.utils.BuildDirectoryUtils;
  *
  */
 public class PlanSelector implements Cloneable {
-    /** pointer to the cluster object in the catalog */
-    final Cluster m_cluster;
     /** pointer to the database object in the catalog */
     final Database m_db;
     /** pointer to the database estimates */
@@ -73,7 +70,6 @@ public class PlanSelector implements Cloneable {
     /**
      * Initialize plan processor.
      *
-     * @param cluster Catalog info about the physical layout of the cluster.
      * @param db Catalog info about schema, metadata and procedures.
      * @param estimates database estimates
      * @param stmtName The name of the sql statement to be planned.
@@ -85,12 +81,11 @@ public class PlanSelector implements Cloneable {
      * @param quietPlanner Controls the output.
      * @param fullDebug Controls the debug output.
      */
-    public PlanSelector(Cluster cluster, Database db, DatabaseEstimates estimates,
+    public PlanSelector(Database db, DatabaseEstimates estimates,
             String stmtName, String procName, String sql,
             AbstractCostModel costModel, ScalarValueHints[] paramHints,
             DeterminismMode detMode, boolean quietPlanner)
     {
-        m_cluster = cluster;
         m_db = db;
         m_estimates = estimates;
         m_stmtName = stmtName;
@@ -108,7 +103,7 @@ public class PlanSelector implements Cloneable {
      */
     @Override
     public Object clone() {
-        return new PlanSelector(m_cluster, m_db, m_estimates, m_stmtName, m_procName, m_sql,
+        return new PlanSelector(m_db, m_estimates, m_stmtName, m_procName, m_sql,
                 m_costModel, m_paramHints, m_detMode, m_quietPlanner);
     }
 
@@ -160,7 +155,7 @@ public class PlanSelector implements Cloneable {
         AbstractPlanNode planGraph = plan.rootPlanGraph;
 
         // compute statistics about a plan
-        planGraph.computeEstimatesRecursively(m_stats, m_cluster, m_db, m_estimates, m_paramHints);
+        planGraph.computeEstimatesRecursively(m_stats, m_db, m_estimates, m_paramHints);
 
         // compute the cost based on the resources using the current cost model
         plan.cost = m_costModel.getPlanCost(m_stats);

--- a/src/frontend/org/voltdb/planner/QueryPlanner.java
+++ b/src/frontend/org/voltdb/planner/QueryPlanner.java
@@ -125,7 +125,7 @@ public class QueryPlanner {
         m_paramHints = paramHints;
         m_joinOrder = joinOrder;
         m_detMode = detMode;
-        m_planSelector = new PlanSelector(m_db, m_estimates, m_stmtName,
+        m_planSelector = new PlanSelector(m_estimates, m_stmtName,
                 m_procName, m_sql, m_costModel, m_paramHints, m_detMode,
                 suppressDebugOutput);
         m_isUpsert = false;

--- a/src/frontend/org/voltdb/planner/QueryPlanner.java
+++ b/src/frontend/org/voltdb/planner/QueryPlanner.java
@@ -26,7 +26,6 @@ import org.hsqldb_voltpatches.HSQLInterface.HSQLParseException;
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.voltdb.ParameterSet;
 import org.voltdb.VoltType;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Constraint;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Table;
@@ -52,7 +51,6 @@ public class QueryPlanner {
     String m_procName;
     HSQLInterface m_HSQL;
     DatabaseEstimates m_estimates;
-    Cluster m_cluster;
     Database m_db;
     String m_recentErrorMsg;
     StatementPartitioning m_partitioning;
@@ -84,7 +82,6 @@ public class QueryPlanner {
      * @param sql Literal SQL statement to parse
      * @param stmtName The name of the statement for logging/debugging
      * @param procName The name of the proc for logging/debugging
-     * @param catalogCluster Catalog info about the physical layout of the cluster.
      * @param catalogDb Catalog info about schema, metadata and procedures.
      * @param partitioning Describes the specified and inferred partition context.
      * @param HSQL HSQLInterface pointer used for parsing SQL into XML.
@@ -98,7 +95,6 @@ public class QueryPlanner {
     public QueryPlanner(String sql,
                         String stmtName,
                         String procName,
-                        Cluster catalogCluster,
                         Database catalogDb,
                         StatementPartitioning partitioning,
                         HSQLInterface HSQL,
@@ -113,10 +109,8 @@ public class QueryPlanner {
         assert(stmtName != null);
         assert(procName != null);
         assert(HSQL != null);
-        assert(catalogCluster != null);
         assert(catalogDb != null);
         assert(costModel != null);
-        assert(catalogDb.getCatalog() == catalogCluster.getCatalog());
         assert(detMode != null);
 
         m_sql = sql;
@@ -124,7 +118,6 @@ public class QueryPlanner {
         m_procName = procName;
         m_HSQL = HSQL;
         m_db = catalogDb;
-        m_cluster = catalogCluster;
         m_estimates = estimates;
         m_partitioning = partitioning;
         m_maxTablesPerJoin = maxTablesPerJoin;
@@ -132,7 +125,7 @@ public class QueryPlanner {
         m_paramHints = paramHints;
         m_joinOrder = joinOrder;
         m_detMode = detMode;
-        m_planSelector = new PlanSelector(m_cluster, m_db, m_estimates, m_stmtName,
+        m_planSelector = new PlanSelector(m_db, m_estimates, m_stmtName,
                 m_procName, m_sql, m_costModel, m_paramHints, m_detMode,
                 suppressDebugOutput);
         m_isUpsert = false;
@@ -429,7 +422,7 @@ public class QueryPlanner {
 
         // Init Assembler. Each plan assembler requires a new instance of the PlanSelector
         // to keep track of the best plan
-        PlanAssembler assembler = new PlanAssembler(m_cluster, m_db, m_partitioning,
+        PlanAssembler assembler = new PlanAssembler(m_db, m_partitioning,
                 (PlanSelector) m_planSelector.clone());
         // find the plan with minimal cost
         CompiledPlan bestPlan = assembler.getBestCostPlan(parsedStmt);

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -392,7 +392,6 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
      * TODO(XIN): It takes at least 14% planner CPU. Optimize it.
      */
     public final void computeEstimatesRecursively(PlanStatistics stats,
-                                                  Database db,
                                                   DatabaseEstimates estimates,
                                                   ScalarValueHints[] paramHints)
     {
@@ -404,7 +403,7 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         // recursively compute and collect stats from children
         long childOutputTupleCountEstimate = 0;
         for (AbstractPlanNode child : m_children) {
-            child.computeEstimatesRecursively(stats, db, estimates, paramHints);
+            child.computeEstimatesRecursively(stats, estimates, paramHints);
             m_outputColumnHints.addAll(child.m_outputColumnHints);
             childOutputTupleCountEstimate += child.m_estimatedOutputTupleCount;
         }
@@ -413,11 +412,11 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         for (Entry<PlanNodeType, AbstractPlanNode> entry : m_inlineNodes.entrySet()) {
             AbstractPlanNode inlineNode = entry.getValue();
             if (inlineNode instanceof AbstractScanPlanNode) {
-                inlineNode.computeCostEstimates(0, db, estimates, paramHints);
+                inlineNode.computeCostEstimates(0, estimates, paramHints);
             }
         }
 
-        computeCostEstimates(childOutputTupleCountEstimate, db, estimates, paramHints);
+        computeCostEstimates(childOutputTupleCountEstimate, estimates, paramHints);
         stats.incrementStatistic(0, StatsField.TUPLES_READ, m_estimatedProcessedTupleCount);
     }
 
@@ -428,7 +427,6 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
      * {@see AbstractPlanNode#computeEstimatesRecursively(PlanStatistics, Cluster, Database, DatabaseEstimates, ScalarValueHints[])}.
      */
     protected void computeCostEstimates(long childOutputTupleCountEstimate,
-                                        Database db,
                                         DatabaseEstimates estimates,
                                         ScalarValueHints[] paramHints)
     {

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -37,7 +37,6 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONString;
 import org.json_voltpatches.JSONStringer;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
@@ -393,7 +392,6 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
      * TODO(XIN): It takes at least 14% planner CPU. Optimize it.
      */
     public final void computeEstimatesRecursively(PlanStatistics stats,
-                                                  Cluster cluster,
                                                   Database db,
                                                   DatabaseEstimates estimates,
                                                   ScalarValueHints[] paramHints)
@@ -406,7 +404,7 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         // recursively compute and collect stats from children
         long childOutputTupleCountEstimate = 0;
         for (AbstractPlanNode child : m_children) {
-            child.computeEstimatesRecursively(stats, cluster, db, estimates, paramHints);
+            child.computeEstimatesRecursively(stats, db, estimates, paramHints);
             m_outputColumnHints.addAll(child.m_outputColumnHints);
             childOutputTupleCountEstimate += child.m_estimatedOutputTupleCount;
         }
@@ -415,11 +413,11 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         for (Entry<PlanNodeType, AbstractPlanNode> entry : m_inlineNodes.entrySet()) {
             AbstractPlanNode inlineNode = entry.getValue();
             if (inlineNode instanceof AbstractScanPlanNode) {
-                inlineNode.computeCostEstimates(0, cluster, db, estimates, paramHints);
+                inlineNode.computeCostEstimates(0, db, estimates, paramHints);
             }
         }
 
-        computeCostEstimates(childOutputTupleCountEstimate, cluster, db, estimates, paramHints);
+        computeCostEstimates(childOutputTupleCountEstimate, db, estimates, paramHints);
         stats.incrementStatistic(0, StatsField.TUPLES_READ, m_estimatedProcessedTupleCount);
     }
 
@@ -430,7 +428,6 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
      * {@see AbstractPlanNode#computeEstimatesRecursively(PlanStatistics, Cluster, Database, DatabaseEstimates, ScalarValueHints[])}.
      */
     protected void computeCostEstimates(long childOutputTupleCountEstimate,
-                                        Cluster cluster,
                                         Database db,
                                         DatabaseEstimates estimates,
                                         ScalarValueHints[] paramHints)

--- a/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
@@ -376,7 +376,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
     public void resolveColumnIndexes(){}
 
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         // Cost counting index scans as constant, almost negligible work.
         // This might be unfair, as the tree has O(logn) complexity, but we
         // really want to pick this kind of search over others.

--- a/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
@@ -24,12 +24,10 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hsqldb_voltpatches.HSQLInterface;
-import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.ColumnRef;
 import org.voltdb.catalog.Database;
@@ -378,7 +376,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
     public void resolveColumnIndexes(){}
 
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, Cluster cluster, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         // Cost counting index scans as constant, almost negligible work.
         // This might be unfair, as the tree has O(logn) complexity, but we
         // really want to pick this kind of search over others.

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -30,7 +30,6 @@ import org.hsqldb_voltpatches.lib.StringUtil;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.ColumnRef;
 import org.voltdb.catalog.Database;
@@ -589,7 +588,6 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
 
     @Override
     public void computeCostEstimates(long unusedChildOutputTupleCountEstimate,
-                                     Cluster unusedCluster,
                                      Database unusedDb,
                                      DatabaseEstimates estimates,
                                      ScalarValueHints[] unusedParamHints) {

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -588,7 +588,6 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
 
     @Override
     public void computeCostEstimates(long unusedChildOutputTupleCountEstimate,
-                                     Database unusedDb,
                                      DatabaseEstimates estimates,
                                      ScalarValueHints[] unusedParamHints) {
 

--- a/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
@@ -93,7 +93,7 @@ public class MaterializedScanPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         // assume constant cost. Most of the cost of the SQL-IN will be measured by the NLIJ that is always paired with this element
         m_estimatedProcessedTupleCount = 1;
         m_estimatedOutputTupleCount = 1;

--- a/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
@@ -94,7 +93,7 @@ public class MaterializedScanPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, Cluster cluster, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         // assume constant cost. Most of the cost of the SQL-IN will be measured by the NLIJ that is always paired with this element
         m_estimatedProcessedTupleCount = 1;
         m_estimatedOutputTupleCount = 1;

--- a/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
@@ -224,7 +223,7 @@ public class NestLoopIndexPlanNode extends AbstractJoinPlanNode {
     }
 
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, Cluster cluster, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
 
         // Add the cost of the inlined index scan to the cost of processing the input tuples.
         // This isn't really a fair representation of what's going on, as the index is scanned once

--- a/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
@@ -223,7 +223,7 @@ public class NestLoopIndexPlanNode extends AbstractJoinPlanNode {
     }
 
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
 
         // Add the cost of the inlined index scan to the cost of processing the input tuples.
         // This isn't really a fair representation of what's going on, as the index is scanned once

--- a/src/frontend/org/voltdb/plannodes/NestLoopPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopPlanNode.java
@@ -17,7 +17,6 @@
 
 package org.voltdb.plannodes;
 
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
@@ -37,7 +36,6 @@ public class NestLoopPlanNode extends AbstractJoinPlanNode {
 
     @Override
     public void computeCostEstimates(long childOutputTupleCountEstimate,
-                                     Cluster cluster,
                                      Database db,
                                      DatabaseEstimates estimates,
                                      ScalarValueHints[] paramHints)

--- a/src/frontend/org/voltdb/plannodes/NestLoopPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopPlanNode.java
@@ -17,7 +17,6 @@
 
 package org.voltdb.plannodes;
 
-import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
 import org.voltdb.types.PlanNodeType;
@@ -36,7 +35,6 @@ public class NestLoopPlanNode extends AbstractJoinPlanNode {
 
     @Override
     public void computeCostEstimates(long childOutputTupleCountEstimate,
-                                     Database db,
                                      DatabaseEstimates estimates,
                                      ScalarValueHints[] paramHints)
     {

--- a/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
@@ -141,7 +140,6 @@ public class OrderByPlanNode extends AbstractPlanNode {
 
     @Override
     public void computeCostEstimates(long childOutputTupleCountEstimate,
-                                     Cluster cluster,
                                      Database db,
                                      DatabaseEstimates estimates,
                                      ScalarValueHints[] paramHints) {

--- a/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
@@ -140,7 +140,6 @@ public class OrderByPlanNode extends AbstractPlanNode {
 
     @Override
     public void computeCostEstimates(long childOutputTupleCountEstimate,
-                                     Database db,
                                      DatabaseEstimates estimates,
                                      ScalarValueHints[] paramHints) {
         // This method doesn't do anything besides what the parent method does,

--- a/src/frontend/org/voltdb/plannodes/SendPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SendPlanNode.java
@@ -20,7 +20,6 @@ package org.voltdb.plannodes;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
@@ -67,7 +66,7 @@ public class SendPlanNode extends AbstractPlanNode {
 
     @Override
     public void computeCostEstimates(long childOutputTupleCountEstimate,
-            Cluster cluster, Database db, DatabaseEstimates estimates,
+            Database db, DatabaseEstimates estimates,
             ScalarValueHints[] paramHints) {
         assert(estimates != null);
         // Recursively compute and collect stats from the child node,

--- a/src/frontend/org/voltdb/plannodes/SendPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SendPlanNode.java
@@ -66,7 +66,7 @@ public class SendPlanNode extends AbstractPlanNode {
 
     @Override
     public void computeCostEstimates(long childOutputTupleCountEstimate,
-            Database db, DatabaseEstimates estimates,
+            DatabaseEstimates estimates,
             ScalarValueHints[] paramHints) {
         assert(estimates != null);
         // Recursively compute and collect stats from the child node,

--- a/src/frontend/org/voltdb/plannodes/SeqScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SeqScanPlanNode.java
@@ -19,7 +19,6 @@ package org.voltdb.plannodes;
 
 import java.util.List;
 
-import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Table;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.DatabaseEstimates.TableEstimates;
@@ -74,7 +73,7 @@ public class SeqScanPlanNode extends AbstractScanPlanNode {
 
     private static final TableEstimates SUBQUERY_TABLE_ESTIMATES_HACK = new TableEstimates();
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         if (m_isSubQuery) {
             // Get estimates from the sub-query
             // @TODO For the sub-query the cost estimates will be calculated separately

--- a/src/frontend/org/voltdb/plannodes/SeqScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SeqScanPlanNode.java
@@ -19,7 +19,6 @@ package org.voltdb.plannodes;
 
 import java.util.List;
 
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Table;
 import org.voltdb.compiler.DatabaseEstimates;
@@ -75,7 +74,7 @@ public class SeqScanPlanNode extends AbstractScanPlanNode {
 
     private static final TableEstimates SUBQUERY_TABLE_ESTIMATES_HACK = new TableEstimates();
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, Cluster cluster, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         if (m_isSubQuery) {
             // Get estimates from the sub-query
             // @TODO For the sub-query the cost estimates will be calculated separately

--- a/src/frontend/org/voltdb/plannodes/TableCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/TableCountPlanNode.java
@@ -78,7 +78,7 @@ public class TableCountPlanNode extends AbstractScanPlanNode {
     }
 
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         m_estimatedProcessedTupleCount = 1;
         m_estimatedOutputTupleCount = 1;
     }

--- a/src/frontend/org/voltdb/plannodes/TableCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/TableCountPlanNode.java
@@ -17,7 +17,6 @@
 
 package org.voltdb.plannodes;
 
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
@@ -79,7 +78,7 @@ public class TableCountPlanNode extends AbstractScanPlanNode {
     }
 
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, Cluster cluster, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate, Database db, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         m_estimatedProcessedTupleCount = 1;
         m_estimatedOutputTupleCount = 1;
     }

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -492,7 +492,7 @@ public class MockVoltDB implements VoltDBInterface
     public Pair<CatalogContext, CatalogSpecificPlanner> catalogUpdate(String diffCommands,
             byte[] catalogBytes, byte[] catalogHash, int expectedCatalogVersion,
             long currentTxnId, long currentTxnTimestamp, byte[] deploymentBytes,
-            byte[] deploymentHash)
+            byte[] deploymentHash, boolean hasSchemaChange)
     {
         throw new UnsupportedOperationException("unimplemented");
     }

--- a/tests/frontend/org/voltdb/planner/PlannerTestAideDeCamp.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestAideDeCamp.java
@@ -31,8 +31,6 @@ import java.util.List;
 import org.hsqldb_voltpatches.HSQLInterface;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
-import org.voltdb.catalog.Catalog;
-import org.voltdb.catalog.Cluster;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Procedure;
 import org.voltdb.catalog.Statement;
@@ -53,7 +51,6 @@ import org.voltdb.utils.BuildDirectoryUtils;
  */
 public class PlannerTestAideDeCamp {
 
-    private final Catalog catalog;
     private final Procedure proc;
     private final HSQLInterface hsql;
     private final Database db;
@@ -69,12 +66,11 @@ public class PlannerTestAideDeCamp {
      */
     public PlannerTestAideDeCamp(URL ddlurl, String basename) throws Exception {
         assert(ddlurl != null);
-        String pth = ddlurl.getPath();
         String schemaPath = URLDecoder.decode(ddlurl.getPath(), "UTF-8");
         VoltCompiler compiler = new VoltCompiler(false);
         hsql = HSQLInterface.loadHsqldb();
         VoltCompiler.DdlProceduresToLoad no_procs = DdlProceduresToLoad.NO_DDL_PROCEDURES;
-        catalog = compiler.loadSchema(hsql, no_procs, schemaPath);
+        compiler.loadSchema(hsql, no_procs, schemaPath);
         db = compiler.getCatalogDatabase();
         proc = db.getProcedures().add(basename);
     }
@@ -146,8 +142,7 @@ public class PlannerTestAideDeCamp {
             partitioning = StatementPartitioning.forceMP();
         }
         String procName = catalogStmt.getParent().getTypeName();
-        Cluster catalogCluster = catalog.getClusters().get("cluster");
-        QueryPlanner planner = new QueryPlanner(sql, stmtLabel, procName, catalogCluster, db,
+        QueryPlanner planner = new QueryPlanner(sql, stmtLabel, procName, db,
                 partitioning, hsql, estimates, false, StatementCompiler.DEFAULT_MAX_JOIN_TABLES,
                 costModel, null, joinOrder, detMode);
 

--- a/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
@@ -63,7 +63,7 @@ public class TestAdHocPlans extends AdHocQueryTester {
                 config.asClusterSettings().asSupplier(),
                 NodeSettings.create(config.asPathSettingsMap()));
         CatalogContext context = new CatalogContext(0, 0, catalog, dbSettings, bytes, null, new byte[] {}, 0, mock(HostMessenger.class));
-        m_pt = new PlannerTool(context.cluster, context.database, context.getCatalogHash());
+        m_pt = new PlannerTool(context.database, context.getCatalogHash());
     }
 
     @Test

--- a/tests/frontend/org/voltdb/planner/TestPlannerTool.java
+++ b/tests/frontend/org/voltdb/planner/TestPlannerTool.java
@@ -69,7 +69,7 @@ public class TestPlannerTool extends TestCase {
         DbSettings settings = new DbSettings(ClusterSettings.create().asSupplier(),NodeSettings.create());
         CatalogContext context = new CatalogContext(0, 0, catalog, settings, bytes, null, new byte[] {}, 0, mock(HostMessenger.class));
 
-        m_pt = new PlannerTool(context.cluster, context.database, context.getCatalogHash());
+        m_pt = new PlannerTool(context.database, context.getCatalogHash());
 
         AdHocPlannedStatement result = null;
         result = m_pt.planSqlForTest("select * from warehouse;");
@@ -165,7 +165,7 @@ public class TestPlannerTool extends TestCase {
         DbSettings settings = new DbSettings(ClusterSettings.create().asSupplier(), NodeSettings.create());
         CatalogContext context = new CatalogContext(0, 0, c, settings, bytes, null, new byte[] {}, 0, mock(HostMessenger.class));
 
-        m_pt = new PlannerTool(context.cluster, context.database, context.getCatalogHash());
+        m_pt = new PlannerTool(context.database, context.getCatalogHash());
 
         // Bad DDL would kill the planner before it starts and this query
         // would return a Stream Closed error


### PR DESCRIPTION
1. Skip default procedures building work for update classes
2. Skip hsqldb reloading work for update classes
3. Remove unnecessary cluster/database objects and code cleanup