### PR TITLE
ENG-12147: Fix race in internal adapter creation.

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -1146,6 +1146,14 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
         m_adminAcceptor = null;
         m_adminAcceptor = new ClientAcceptor(adminIntf, adminPort, messenger.getNetwork(), true, sslContext);
 
+        // Create the per-partition adapters before creating the mailbox. Once
+        // the mailbox is created, the master promotion notification may race
+        // with this.
+        m_internalConnectionHandler = new InternalConnectionHandler();
+        for (int pid : m_cartographer.getPartitions()) {
+            m_internalConnectionHandler.addAdapter(pid, createInternalAdapter(pid));
+        }
+
         m_mailbox = new LocalMailbox(messenger,  messenger.getHSIdForLocalSite(HostMessenger.CLIENT_INTERFACE_SITE_ID)) {
             LinkedBlockingQueue<VoltMessage> m_d = new LinkedBlockingQueue<VoltMessage>();
             @Override
@@ -1197,11 +1205,6 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                 .plannerSiteId(m_plannerSiteId)
                 .siteId(m_siteId)
                 .build();
-
-        m_internalConnectionHandler = new InternalConnectionHandler();
-        for (int pid : m_cartographer.getPartitions()) {
-            m_internalConnectionHandler.addAdapter(pid, createInternalAdapter(pid));
-        }
 
         m_executeTaskAdpater = new SimpleClientResponseAdapter(ClientInterface.EXECUTE_TASK_CID, "ExecuteTaskAdapter", true);
         bindAdapter(m_executeTaskAdpater, null);

--- a/src/frontend/org/voltdb/InternalConnectionHandler.java
+++ b/src/frontend/org/voltdb/InternalConnectionHandler.java
@@ -47,7 +47,8 @@ public class InternalConnectionHandler {
     private final AtomicLong m_submitSuccessCount = new AtomicLong();
     private volatile Map<Integer, InternalClientResponseAdapter> m_adapters = ImmutableMap.of();
 
-    public void addAdapter(int pid, InternalClientResponseAdapter adapter)
+    // Synchronized in case multiple partitions are added concurrently.
+    public synchronized void addAdapter(int pid, InternalClientResponseAdapter adapter)
     {
         final ImmutableMap.Builder<Integer, InternalClientResponseAdapter> builder = ImmutableMap.builder();
         builder.putAll(m_adapters);


### PR DESCRIPTION
Create the per-partition adapters before creating the ClientInterface
mailbox. Once the mailbox is created, the master promotion notification
may be called before the ClientInterface is fully constructed. What a
mess!