### PR TITLE
ENG-12128:

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3833,27 +3833,36 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     }
 
     private void prepareReplication() {
-        try {
-            boolean okToStartDR = true;
-            if (m_consumerDRGateway != null) {
-                if (m_config.m_startAction == StartAction.RECOVER) {
-                    Pair<Byte, List<MeshMemberInfo>> expectedClusterMembers = m_producerDRGateway.getInitialConversations();
-                    okToStartDR = m_consumerDRGateway.isSyncSnapshotComplete(expectedClusterMembers.getFirst(),
-                            expectedClusterMembers.getSecond());
-                }
-                if (okToStartDR) {
-                    m_consumerDRGateway.initialize(m_config.m_startAction != StartAction.CREATE);
+        Runnable t = new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                // Warning: This is called on the site thread if this host is rejoining
+                try {
+                    boolean okToStartDR = true;
+                    if (m_consumerDRGateway != null) {
+                        if (m_config.m_startAction != StartAction.CREATE) {
+                            Pair<Byte, List<MeshMemberInfo>> expectedClusterMembers = m_producerDRGateway.getInitialConversations();
+                            okToStartDR = m_consumerDRGateway.isSyncSnapshotComplete(expectedClusterMembers.getFirst(),
+                                    expectedClusterMembers.getSecond());
+                        }
+                        if (okToStartDR) {
+                            m_consumerDRGateway.initialize(m_config.m_startAction != StartAction.CREATE);
+                        }
+                    }
+                    if (m_producerDRGateway != null && okToStartDR) {
+                        m_producerDRGateway.startListening(m_catalogContext.cluster.getDrproducerenabled(),
+                                                           VoltDB.getReplicationPort(m_catalogContext.cluster.getDrproducerport()),
+                                                           VoltDB.getDefaultReplicationInterface());
+                    }
+                } catch (Exception ex) {
+                    CoreUtils.printPortsInUse(hostLog);
+                    VoltDB.crashLocalVoltDB("Failed to initialize DR", false, ex);
                 }
             }
-            if (m_producerDRGateway != null && okToStartDR) {
-                m_producerDRGateway.startListening(m_catalogContext.cluster.getDrproducerenabled(),
-                                                   VoltDB.getReplicationPort(m_catalogContext.cluster.getDrproducerport()),
-                                                   VoltDB.getDefaultReplicationInterface());
-            }
-        } catch (Exception ex) {
-            CoreUtils.printPortsInUse(hostLog);
-            VoltDB.crashLocalVoltDB("Failed to initialize DR", false, ex);
-        }
+        };
+        m_periodicPriorityWorkThread.submit(t);
     }
 
     private boolean shouldInitiatorCreateMPDRGateway(Initiator initiator) {


### PR DESCRIPTION
The Consumer was not started on rejoined hosts because they were only initialized on create and recover. In addition, as part of initialization, the DR code determines whether this cluster is the original data source, and if not, it verifies that there are valid site trackers for the data source cluster (implying that the snapshot completed). However, for rejoin, this check would be done on the Site thread causing a deadlock. Therefore, Starting the DR services is now always done on a seperate executor thread.

Note that this is the periodic work thread, which will block until the site trackers are returned. Therefore, scheduled work will also block until DR initialization completes.