### PR TITLE
ENG-12172:

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -46,7 +46,7 @@ public interface ConsumerDRGateway extends Promotable {
      * @return false if this cluster is a joiner and the sync snapshot did not finish loading form the
      *         leader cluster
      */
-    boolean isSyncSnapshotComplete(byte dataSourceCluster, List<MeshMemberInfo> expectedClusterMembers);
+    void setInitialConversationMembership(byte dataSourceCluster, List<MeshMemberInfo> expectedClusterMembers);
 
     void initialize(boolean resumeReplication);
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3959,36 +3959,25 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     }
 
     private void prepareReplication() {
-        Runnable t = new Runnable()
-        {
-            @Override
-            public void run()
-            {
-                // Warning: This is called on the site thread if this host is rejoining
-                try {
-                    boolean okToStartDR = true;
-                    if (m_consumerDRGateway != null) {
-                        if (m_config.m_startAction != StartAction.CREATE) {
-                            Pair<Byte, List<MeshMemberInfo>> expectedClusterMembers = m_producerDRGateway.getInitialConversations();
-                            okToStartDR = m_consumerDRGateway.isSyncSnapshotComplete(expectedClusterMembers.getFirst(),
-                                    expectedClusterMembers.getSecond());
-                        }
-                        if (okToStartDR) {
-                            m_consumerDRGateway.initialize(m_config.m_startAction != StartAction.CREATE);
-                        }
-                    }
-                    if (m_producerDRGateway != null && okToStartDR) {
-                        m_producerDRGateway.startListening(m_catalogContext.cluster.getDrproducerenabled(),
-                                                           VoltDB.getReplicationPort(m_catalogContext.cluster.getDrproducerport()),
-                                                           VoltDB.getDefaultReplicationInterface());
-                    }
-                } catch (Exception ex) {
-                    CoreUtils.printPortsInUse(hostLog);
-                    VoltDB.crashLocalVoltDB("Failed to initialize DR", false, ex);
+        // Warning: This is called on the site thread if this host is rejoining
+        try {
+            if (m_consumerDRGateway != null) {
+                if (m_config.m_startAction != StartAction.CREATE) {
+                    Pair<Byte, List<MeshMemberInfo>> expectedClusterMembers = m_producerDRGateway.getInitialConversations();
+                    m_consumerDRGateway.setInitialConversationMembership(expectedClusterMembers.getFirst(),
+                            expectedClusterMembers.getSecond());
                 }
+                m_consumerDRGateway.initialize(m_config.m_startAction != StartAction.CREATE);
             }
-        };
-        m_periodicPriorityWorkThread.submit(t);
+            if (m_producerDRGateway != null) {
+                m_producerDRGateway.startListening(m_catalogContext.cluster.getDrproducerenabled(),
+                                                   VoltDB.getReplicationPort(m_catalogContext.cluster.getDrproducerport()),
+                                                   VoltDB.getDefaultReplicationInterface());
+            }
+        } catch (Exception ex) {
+            CoreUtils.printPortsInUse(hostLog);
+            VoltDB.crashLocalVoltDB("Failed to initialize DR", false, ex);
+        }
     }
 
     private boolean shouldInitiatorCreateMPDRGateway(Initiator initiator) {


### PR DESCRIPTION
If the producer is not initialized before the cluster is up, binary logs can arrive before DR is ready and Producer stats are also not initialized early enough. Because of this we reverted back to starting the producer and consumer synchronously for all paths (create, recover and rejoin). However, now we do the sync snapshot completion check once in the initialize path of the gateway and prevent the consumer from starting. The consequence of this is that the producer will be initialized even if we determine later that the sync snapshot was never delivered.