### PR TITLE
sql-grammar.txt: 3 major changes:

### DIFF
--- a/tests/sqlgrammar/sql-grammar.txt
+++ b/tests/sqlgrammar/sql-grammar.txt
@@ -315,9 +315,11 @@ window-function         ::= {window-agg-func-expr} 4| COUNT(*) | RANK() | DENSE_
 window-agg-func-expr    ::= {non-num-aggregate-func}({column-expression}) 3| \
                             {num-only-aggregate-func}({numeric-expression})
 
-# It is possible for this to be empty, but that is less interesting, so we make it less likely
-partition-or-order-by   ::=  PARTITION BY {partition-by-list}   ORDER BY {window-order-by-list} 2| \
-                            [PARTITION BY {partition-by-list}]  ORDER BY {window-order-by-list}  | \
+# This is somewhat redundant, but since some window functions (RANK, DENSE_RANK)
+# require an ORDER BY, we make that more likely; and while other window functions
+# do allow this to be empty, that is less interesting, even when legal, so we
+# make it less likely
+partition-or-order-by   ::= [PARTITION BY {partition-by-list}]  ORDER BY {window-order-by-list} | \
                             [PARTITION BY {partition-by-list}] [ORDER BY {window-order-by-list}]
 partition-by-list       ::= {column-expression} [[, {partition-by-list}]]
 

--- a/tests/sqlgrammar/sql-grammar.txt
+++ b/tests/sqlgrammar/sql-grammar.txt
@@ -47,13 +47,18 @@
 
 ################################################################################
 # Table and view names pre-defined in the DDL associated with this test
-table-name              ::= P1 | R1 | P2 | R2
-view-name               ::= VP1 | VR1 | VP2 | VR2
+# (and very occasionally, a nonexistent table name, view name, or, below,
+# column name is used)
+legit-table-name        ::= P1  | R1  | P2  | R2
+legit-view-name         ::= VP1 | VR1 | VP2 | VR2
+table-name              ::= {legit-table-name} 199| NONEXISTENT_TABLE
+view-name               ::= {legit-view-name}  199| NONEXISTENT_VIEW
 
 # TODO: also pre-define some Indexes & Stored Procedures
 
 # Column names used in the pre-defined DDL, of every possible data type ...
 int-column-name         ::= ID | TINY | SMALL | INT | BIG
+byte-column-name        ::= TINY
 
 # The "5" before the "|" makes the "int-column-name" option 5 times as likely
 # as the other options, making each numeric column name equally likely
@@ -70,7 +75,8 @@ non-int-str-column-name ::= {geo-column-name} 2| {timestamp-column-name} | {varb
 table-column-name       ::= {numeric-column-name} 2| {string-column-name} | {non-int-str-column-name}
 view-column-name        ::= {table-column-name} | {table-column-name}_COUNT | TOTAL_COUNT | \
                             {numeric-column-name}_SUM | {numeric-column-name}_AVG
-column-name             ::= {table-column-name} 9| {view-column-name}
+legit-column-name       ::= {table-column-name} 9| {view-column-name}
+column-name             ::= {legit-column-name} 399| NONEXISTENT_COLUMN
 column-list             ::= {column-name} [, {column-list}]
 
 # These are obviously not the complete lists of all possible table and column
@@ -182,11 +188,16 @@ simple-upsert-select    ::= UP{in-or-up-sert-select}
 ################################################################################
 # Grammar rules for an UPDATE statement:
 ################################################################################
-update-statement        ::= UPDATE {table-name} SET {column-updates} \
-                            [{where-clause}]
+update-statement        ::= UPDATE {table-name} SET {column-updates} [{where-clause}]
 
-column-update           ::= {column-name} = {value-expression}
 column-updates          ::= {column-update} [, {column-updates}]
+column-update           ::= {column-name}           = {value-expression}     | \
+                            {numeric-column-name}   = {numeric-expression}  7| \
+                            {string-column-name}    = {string-expression}   3| \
+                            {timestamp-column-name} = {timestamp-expression} | \
+                            {varbinary-column-name} = {varbinary-expression} | \
+                            {point-column-name}     = {point-expression}     | \
+                            {polygon-column-name}   = {polygon-expression}
 
 ################################################################################
 # Grammar rules for a DELETE (or TRUNCATE) statement:
@@ -197,27 +208,29 @@ column-updates          ::= {column-update} [, {column-updates}]
 #
 delete-statement        ::= {basic-delete-statement} 9| {truncate-statement}
 
-basic-delete-statement  ::= DELETE FROM {table-name} \
-                            [{where-clause}] [{sort-clause}]
+basic-delete-statement  ::= DELETE FROM {table-name} [{where-clause}] [{sort-clause}]
 
 truncate-statement      ::= TRUNCATE TABLE {table-name}
 
 ################################################################################
 # Grammar rules for a SELECT statement (lots of these!):
 ################################################################################
-select-statement        ::= {basic-select-statement} 4| {select-statement} {set-operator} {select-statement}
+select-statement        ::= {basic-select-statement} 9| {select-statement} {set-operator} {select-statement}
 set-operator            ::= UNION [ALL] | INTERSECT [ALL] | EXCEPT
 
 # Putting the "top-clause" and "all-or-distinct" in more than one set of
 # brackets makes them less likely
-basic-select-statement  ::= SELECT [[[{top-clause}]]] [[{all-or-distinct}]] {select-list} FROM {table-references} \
-                            [[{join-clause}]] [[{where-clause}]] [[{group-clause}]] [{sort-clause}]
+basic-select-statement  ::= SELECT {top-all-or-distinct} {select-list} FROM {from-clause}
+top-all-or-distinct     ::= [[[{top-clause}]]] [[{all-or-distinct}]]
+from-clause             ::= {table-references} [[{join-clause}]] [[{where-clause}]] [[{group-clause}]] [{sort-clause}]
+from-clause-no-limit    ::= {table-references} [[{join-clause}]] [[{where-clause}]] [[{group-clause}]] [{order-by-clause}]
 
 all-or-distinct         ::= ALL | DISTINCT
-select-list             ::= {select-list-item} [, {select-list}]
-select-list-item        ::= {star} | {column-expression} [[AS] {column-alias}]
-column-expression       ::= {column-name} | {selection-expression}
-column-reference        ::= {column-name} | {column-alias}
+select-list             ::= {select-list-item} [[, {select-list}]]
+select-list-item        ::= {star} 5| {column-expression} [[AS] {column-alias}] 14| {window-function-expr} [[AS] {column-alias}]
+column-expression       ::= {column-name} 2| {selection-expression}
+column-reference        ::= {column-name} 2| {column-alias}
+column-ref-or-expr      ::= {column-reference} | {column-expression}
 
 # Putting the ", {table-references}" in more than one set of brackets makes it less likely
 table-references        ::= {table-reference} [[, {table-references}]]
@@ -226,44 +239,103 @@ table-references        ::= {table-reference} [[, {table-references}]]
 # before the "view-name..." option, makes them more likely than the "sub-query..."
 # option, making simple, valid statements more likely
 table-reference         ::= {table-name} [[AS] {table-alias}] 3| {view-name} [[AS] {table-alias}] 2| {sub-query} [AS] {table-alias}
-sub-query               ::= ({select-statement})
 
 # Defining these separately so that they can optionally be overridden, for use
 # with SQLCoverage, to avoid syntax (TOP) not supported by PostgreSQL, and
 # issues with Geospatial types (point & polygon), where using * can be a problem
 top-clause              ::= TOP {non-negative-int-value}
+top-one                 ::= TOP 1
 star                    ::= *
 
 where-clause            ::= WHERE {boolean-expression}
-# TODO: simplified, non-recursive, for now:
-#boolean-expression      ::= [NOT] {boolean-type-expr} [{and-or} {boolean-expression}]
-boolean-expression      ::= [NOT] {boolean-type-expr} [{and-or} {boolean-type-expr}]
+boolean-expression      ::=   [NOT ] {boolean-type-expr}   [[{and-or} {boolean-expression}]] 3| \
+                            ([[NOT ]]{boolean-expression}) [[{and-or} {boolean-expression}]]
 and-or                  ::= AND | OR
 
 # TODO: allow for multi-joins (on more than 2 tables)
 join-clause             ::= [{join-type}] JOIN {table-reference} [{join-condition}]
 join-type               ::= INNER | {left-or-right} [OUTER]
 left-or-right           ::= LEFT | RIGHT | FULL
-join-condition          ::= ON {join-expression} | USING {column-reference}
+join-condition          ::= ON {join-expression} | USING ({column-reference})
 # TODO: probably should be more specific (e.g. equi-join)
 join-expression         ::= {boolean-expression}
 
 group-clause            ::= GROUP BY  {group-by-list}  [HAVING {boolean-expression}]
-sort-clause             ::= [ORDER BY {order-by-list}] [LIMIT {non-negative-int-value}] [OFFSET {non-negative-int-value}]
-group-by-list           ::= {column-reference}                 [, {group-by-list}]
-order-by-list           ::= {column-reference} [{asc-or-desc}] [, {order-by-list}]
+order-by-clause         ::= [ORDER BY {order-by-list}]
+sort-clause             ::= {order-by-clause} [LIMIT {non-negative-int-value}] [OFFSET {non-negative-int-value}]
+group-by-list           ::= {column-ref-or-expr}                 [, {group-by-list}]
+order-by-list           ::= {column-ref-or-expr} [{asc-or-desc}] [, {order-by-list}]
 asc-or-desc             ::= ASC | DESC
 
 # TODO: add more expression types, and boolean expression types,
 # using different data types (varbinary, point, polygon)
 value-expression        ::= {numeric-expression} | {string-expression} | {timestamp-expression}
 selection-expression    ::= {value-expression} 9| COUNT(*)
-boolean-type-expr       ::= {column-expression} IS [NOT ]NULL | {boolean-numeric-expr} | {boolean-string-expr} | \
-                            {boolean-timestamp-expr}
-boolean-numeric-expr    ::= {numeric-expression} {comparison-operator} {numeric-expression}
-boolean-string-expr     ::= {string-expression} {comparison-operator} {string-expression}
-boolean-timestamp-expr  ::= {timestamp-expression} {comparison-operator} {timestamp-expression}
+boolean-type-expr       ::= {column-expression} IS [NOT ]NULL | {sub-query} | \
+                            {boolean-numeric-expr} 7| {boolean-string-expr} 3| {boolean-timestamp-expr} | \
+                            EXISTS {sub-query}
+boolean-numeric-expr    ::= {numeric-expression}   {comparison-operator} {numeric-expression}   4| \
+                            {numeric-column-name}   IN {numeric-sub-query}
+boolean-string-expr     ::= {string-expression}    {comparison-operator} {string-expression}    4| \
+                            {string-column-name}    IN {string-sub-query}
+boolean-timestamp-expr  ::= {timestamp-expression} {comparison-operator} {timestamp-expression} 4| \
+                            {timestamp-column-name} IN {timestamp-sub-query}
 comparison-operator     ::= = | <> | != | < | > | <= | >=
+
+################################################################################
+# Sub-queries, scalar and otherwise, of various types
+#
+sub-query               ::= ({select-statement}) 3| {scalar-sub-query}
+scalar-sub-query        ::= {numeric-scalar-sub-q} 7| {string-scalar-sub-q} 3| \
+                            {timestamp-scalar-sub-q}
+
+numeric-sub-query       ::= (SELECT {top-all-or-distinct}   {numeric-expression} FROM {from-clause})
+string-sub-query        ::= (SELECT {top-all-or-distinct}    {string-expression} FROM {from-clause})
+timestamp-sub-query     ::= (SELECT {top-all-or-distinct} {timestamp-expression} FROM {from-clause})
+numeric-scalar-sub-q    ::= (SELECT  {aggregate-function}({numeric-expression})  FROM {from-clause}) 3| \
+                            (SELECT {num-result-aggr-func}({column-expression})  FROM {from-clause}) 3| \
+                            (SELECT COUNT(*)                                     FROM {from-clause})  | \
+                            (SELECT {top-one}   {numeric-expression} FROM {from-clause-no-limit})     | \
+                            (SELECT             {numeric-expression} FROM {from-clause-no-limit} LIMIT 1)
+string-scalar-sub-q     ::= (SELECT {min-or-max-aggr-func}({string-expression})  FROM {from-clause}) 6| \
+                            (SELECT {top-one}    {string-expression} FROM {from-clause-no-limit})     | \
+                            (SELECT              {string-expression} FROM {from-clause-no-limit} LIMIT 1)
+timestamp-scalar-sub-q  ::= (SELECT {min-or-max-aggr-func}({timestamp-expression}) FROM {from-clause}) 6| \
+                            (SELECT {top-one} {timestamp-expression} FROM {from-clause-no-limit})       | \
+                            (SELECT           {timestamp-expression} FROM {from-clause-no-limit} LIMIT 1)
+
+################################################################################
+# Window functions - a.k.a. analytic functions
+#
+window-function-expr    ::= {window-function} OVER ({partition-or-order-by})
+window-function         ::= {window-agg-func-expr} 4| COUNT(*) | RANK() | DENSE_RANK()
+
+# SUM can only take numeric argument; others can take any type;
+# (AVG not actually supported here, but it should not crash)
+window-agg-func-expr    ::= {non-num-aggregate-func}({column-expression}) 3| \
+                            {num-only-aggregate-func}({numeric-expression})
+
+# It is possible for this to be empty, but that is less interesting, so we make it less likely
+partition-or-order-by   ::=  PARTITION BY {partition-by-list}   ORDER BY {window-order-by-list} 2| \
+                            [PARTITION BY {partition-by-list}]  ORDER BY {window-order-by-list}  | \
+                            [PARTITION BY {partition-by-list}] [ORDER BY {window-order-by-list}]
+partition-by-list       ::= {column-expression} [[, {partition-by-list}]]
+
+# Some window functions (RANK, DENSE_RANK) only allow a single int or timestamp
+# expression in the ORDER BY clause, so we make those options more likely
+window-order-by-list    ::= {window-order-by-item} [{asc-or-desc}] [[, {window-order-by-list}]]
+window-order-by-item    ::= {column-expression} 2| {int-expression} | {timestamp-expression}
+
+################################################################################
+# Aggregate functions - used with various data types defined below
+# (and in the window functions and scalar sub-queries above)
+#
+# TODO: More use of these in GROUP BY queries
+num-only-aggregate-func ::= SUM | AVG
+num-result-aggr-func    ::= COUNT 3| APPROX_COUNT_DISTINCT
+min-or-max-aggr-func    ::= MIN | MAX
+non-num-aggregate-func  ::= {min-or-max-aggr-func} 2| {num-result-aggr-func}
+aggregate-function      ::= {non-num-aggregate-func} 2| {num-only-aggregate-func}
 
 ################################################################################
 # Numeric constant values, functions, operators and expressions
@@ -284,18 +356,23 @@ byte-value              ::= {byte-non-null-value}    3| NULL
 integer-value           ::= {integer-non-null-value} 3| NULL
 numeric-value           ::= {numeric-non-null-value} 3| NULL
 
-int-expression          ::= {integer-value} |     {int-column-name} |     {int-function-expr}
-numeric-expression      ::= {numeric-value} | {numeric-column-name} | {numeric-function-expr} | {int-expression}
+int-expression          ::= {integer-value}  2|     {int-column-name}  5|     {int-function-expr}  2| \
+                            {aggregate-function}({int-expression})
+byte-expression         ::= {byte-value}      |    {byte-column-name}  3|    {byte-function-expr}
+numeric-expression      ::= {numeric-value} 20| {numeric-column-name} 30| {numeric-function-expr} 20| {int-expression} 20| \
+                            {aggregate-function}({numeric-expression}) 9| {numeric-scalar-sub-q}
 
 int-function-expr       ::= {int-expression} {math-operator} {int-expression} | \
                             {int-function-2args}({int-expression}, {int-expression}) | \
                             {int-valued-string-expr} | {int-valued-time-expr} | {int-valued-t-unit-expr}
+byte-function-expr      ::= {byte-expression} {math-operator} {byte-expression} | \
+                            {int-function-2args}({byte-expression}, {byte-expression})
 numeric-function-expr   ::= {numeric-expression} {math-operator} {numeric-expression} | \
                             {math-function-0args}[()] | \
                             {math-function-1arg}({numeric-expression}) 14| \
                             {math-function-2args}({numeric-expression}, {numeric-expression}) | \
                             {num-valued-time-expr}
-math-operator           ::= + | - | * | / | %
+math-operator           ::= + | - | * | /
 math-function-0args     ::= PI
 math-function-1arg      ::= ABS | CEILING | EXP | FLOOR | LN | LOG | LOG10 | SQRT | SIN | COS | TAN | CSC | SEC | COT
 math-function-2args     ::= POWER
@@ -314,7 +391,8 @@ string-non-null-value   ::= '{characters}'
 # likely as the NULL option, making NULL values less likely
 string-value            ::= {string-non-null-value} 3| NULL
 
-string-expression       ::= {string-value} | {string-column-name} | {string-function-expr}
+string-expression       ::= {string-value} 20| {string-column-name} 50| {string-function-expr} 20| \
+                            {non-num-aggregate-func}({string-expression}) 9| {string-scalar-sub-q}
 string-function-expr    ::= {string-expression} {string-operator} {string-expression} | \
                             {string-function-1arg} ({string-expression}) | \
                             {string-function-2args}({string-expression}, {string-expression}) | \
@@ -324,7 +402,7 @@ string-function-expr    ::= {string-expression} {string-operator} {string-expres
                             {string-valued-int-expr}  | {string-val-str-int-expr} | \
                             {string-val-num-int-expr} | {string-special-func-expr}
 string-operator         ::= || | +
-string-function-1arg    ::= CONCAT | LOWER | TRIM | UPPER
+string-function-1arg    ::= LOWER  | TRIM | UPPER
 string-function-2args   ::= CONCAT | REGEXP_POSITION
 string-function-3args   ::= CONCAT | REPLACE
 string-function-4args   ::= CONCAT
@@ -341,10 +419,14 @@ string-valued-int-func  ::= BIN | CHAR | HEX | SPACE
 string-valued-int-expr  ::= {string-valued-int-func}({int-expression})
 
 # Some functions of a string and an integer (or 2) produce a string value
-string-val-str-int-func ::= LEFT | RIGHT | REPEAT | SUBSTRING
+string-val-str-int-func ::= LEFT | RIGHT | SUBSTRING
+# We only allow byte values in the REPEAT function, because giving it large values can
+# freeze VoltDB, consume all CPU time, and slow down your machine to a crawl; see ENG-12118
+string-val-str-byte-fun ::= REPEAT
 string-val-str-2int-fun ::= SUBSTRING
-string-val-str-int-expr ::= {string-val-str-int-func}({string-expression}, {int-expression}) | \
-                            {string-val-str-2int-fun}({string-expression}, {int-expression}, {int-expression})
+string-val-str-int-expr ::= {string-val-str-int-func}({string-expression}, {int-expression})  3| \
+                            {string-val-str-byte-fun}({string-expression}, {byte-expression})  | \
+                            {string-val-str-2int-fun}({string-expression}, {int-expression},  {int-expression})
 
 # One function of 2 numbers (1 decimal and 1 integer) produces string values
 string-val-num-int-func ::= FORMAT_CURRENCY
@@ -358,7 +440,7 @@ string-val-num-int-expr ::= {string-val-num-int-func}({numeric-expression}, {int
 # Some string functions use special keywords (e.g. PLACING, FROM, FOR)
 string-special-func-expr::= OVERLAY({string-expression} PLACING {string-expression} FROM {int-expression} [FOR {int-expression}]) | \
                             SUBSTRING({string-expression} FROM {int-expression} [FOR {int-expression}]) | \
-                            TRIM([[{trim-keyword}] [{character} FROM ]{string-expression})
+                            TRIM([[{trim-keyword} ]['{character}'] FROM ]{string-expression})
 trim-keyword            ::= LEADING | TRAILING | BOTH
 
 ################################################################################
@@ -382,7 +464,8 @@ timestamp-non-null-value::= '{year}-{month}-{day} {hour}:{minute-or-second}:{min
 # likely as the NULL option, making NULL values less likely
 timestamp-value         ::= {timestamp-non-null-value} 3| NULL
 
-timestamp-expression    ::= {timestamp-value} | {timestamp-column-name} | {timestamp-function-expr}
+timestamp-expression    ::= {timestamp-value} 20| {timestamp-column-name} 50| {timestamp-function-expr} 20| \
+                            {non-num-aggregate-func}({timestamp-expression}) 9| {timestamp-scalar-sub-q}
 timestamp-function-expr ::= CURRENT_TIMESTAMP[()] | NOW[()] | \
                             FROM_UNIXTIME({int-expression}) | \
                             TO_TIMESTAMP({short-time-unit}, {int-expression}) | \
@@ -426,14 +509,19 @@ varbin-non-null-value   ::= x'{even-num-of-hex-digits}'
 varbinary-value         ::= {varbin-non-null-value} 3| NULL
 
 # TODO: flesh this part out, with varbinary functions, expressions ...
+#varbinary-expression    ::= {varbinary-value} 20| {varbinary-column-name} 50| {varbinary-function-expr} 20| \
+#                            {non-num-aggregate-func}({varbinary-expression}) 9| {varbinary-scalar-sub-q}
+# This will do for now:
+varbinary-expression    ::= {varbinary-column-name} 3| {varbinary-value}
 
 ################################################################################
 # Geospatial Point constant values, functions, operators and expressions
 #
 # TODO: flesh this part out ...
-number-less-than-100    ::= {digit}[{digit}][.{non-negative-int-value}]
+
 # Latitude is a number between -100 and 100 (exclusive); longitude is between
 # -200 and 200 (exclusive); these include some illegal values, which is OK
+number-less-than-100    ::= {digit}[{digit}][.{non-negative-int-value}]
 latitude                ::= [-]{number-less-than-100}
 longitude               ::= [-][1]{number-less-than-100}
 point-non-null-value    ::= pointFromText('POINT({longitude} {latitude})')
@@ -443,6 +531,10 @@ point-non-null-value    ::= pointFromText('POINT({longitude} {latitude})')
 point-value             ::= {point-non-null-value} 3| NULL
 
 # TODO: flesh this part out, with point functions, expressions ...
+#point-expression        ::= {point-value} 20| {point-column-name} 50| {point-function-expr} 20| \
+#                            {non-num-aggregate-func}({point-expression}) 9| {point-scalar-sub-q}
+# This will do for now:
+point-expression        ::= {point-column-name} 3| {point-value}
 
 ################################################################################
 # Geospatial Polygon constant values, functions, operators and expressions
@@ -458,6 +550,10 @@ polygon-non-null-value  ::= polygonFromText('POLYGON((0 0, {longitude} 0, 0 {lat
 polygon-value           ::= {polygon-non-null-value} 3| NULL
 
 # TODO: flesh this part out, with polygon functions, expressions ...
+#polygon-expression      ::= {polygon-value} 20| {polygon-column-name} 50| {polygon-function-expr} 20| \
+#                            {non-num-aggregate-func}({polygon-expression}) 9| {polygon-scalar-sub-q}
+# This will do for now:
+polygon-expression      ::= {polygon-column-name} 3| {polygon-value}
 
 ################################################################################
 # Non-geospatial (ng-) alternative values of some of the above definitions, for
@@ -503,9 +599,3 @@ ng-star                    ::= ID, TINY, SMALL, INT, BIG, NUM, DEC, VCHAR, VCHAR
 ng-point-value             ::= NULL
 ng-polygon-value           ::= NULL
 
-
-
-# TODO: More expression & function types TBD:
-num-only-aggregate-func ::= SUM | AVG
-non-num-aggregate-func  ::= COUNT | APPROX_COUNT_DISTINCT | MAX | MIN
-aggregate-function      ::= {non-num-aggregate-func} 2| {num-only-aggregate-func}

--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -84,7 +84,7 @@ def get_grammar(grammar={}, grammar_filename='sql-grammar.txt', grammar_dir='.')
         if debug:
             if symbol_name in grammar:
                 replacing_definition = True
-                print "WARNING: replacing definition:", symbol_name, '::=', grammar[symbol_name]
+                print "WARNING: replacing definition:", symbol_name, ' ::= ', grammar[symbol_name]
 
         if len(options) is 1:
             # When there are are no alternative options (i.e., no '|'),
@@ -98,7 +98,7 @@ def get_grammar(grammar={}, grammar_filename='sql-grammar.txt', grammar_dir='.')
             grammar[symbol_name] = dict([ (options[i].strip(), weights[i]) for i in range(len(options)) ])
 
         if debug and replacing_definition:
-            print "          with new definition:", symbol_name, '::=', grammar[symbol_name]
+            print "          with new definition:", symbol_name, ' ::= ', grammar[symbol_name]
 
     return grammar
 
@@ -109,12 +109,15 @@ def get_one_sql_statement(grammar, sql_statement_type='sql-statement', max_depth
        to that depth) and optional percent (meaning that option clauses, in
        brackets, have that percentage chance of being used).
     """
+    global symbol_depth
+
     sql = '{' + sql_statement_type + '}'
 #     print 'DEBUG: sql:', sql
 
     max_count = 10000
     count = 0
-    depth = {}
+    symbol_count = 0
+    symbol_depth = {}
     symbol = __SYMBOL_REF.search(sql)
     while symbol and count < max_count:
         count += 1
@@ -128,14 +131,18 @@ def get_one_sql_statement(grammar, sql_statement_type='sql-statement', max_depth
             print "ERROR: Could not find symbol_name '" + str(symbol_name) + "' in grammar dictionary!!!"
             break
         # Check how deep into a recursive definition we're going
-        depth[symbol_name] = depth.get(symbol_name, 0) + 1
+        if symbol_depth.get(symbol_name):
+            symbol_depth[symbol_name][0] += 1
+        else:
+            symbol_depth[symbol_name] = [1, symbol_count]
+            symbol_count += 1
         if isinstance(definition, list):
             random_index = randrange(0, len(definition))
             #print 'DEBUG: len(definition):', str(len(definition))
             #print 'DEBUG: random_index:', str(random_index)
             # Avoid going too deep into a recursive definition, if possible:
             # if there are alternatives, pick one
-            if (depth[symbol_name] > max_depth and bracketed_name in definition[random_index] and
+            if (symbol_depth[symbol_name][0] > max_depth and bracketed_name in definition[random_index] and
                     any(bracketed_name not in definition[i] for i in range(len(definition)) ) ):
                 while bracketed_name in definition[random_index]:
                     random_index = randrange(0, len(definition))
@@ -172,6 +179,9 @@ def get_one_sql_statement(grammar, sql_statement_type='sql-statement', max_depth
 
     if count >= max_count:
         print "Gave up after", count, "iterations: possible infinite loop in grammar dictionary!!!"
+        if debug > 4:
+            print "DEBUG: sql:", sql.strip()
+            print "DEBUG: symbol_depth:\n", symbol_depth
 
     return sql.strip() + ';'
 
@@ -189,7 +199,10 @@ def print_file_tail(from_file, to_file, number_of_lines=50):
     tail_message = '\n\nLast ' + str(number_of_lines) + ' lines of ' + from_file + ':\n' \
                  + tail_proc.communicate()[0].replace('\\n', '\n')
 
-    error_types = ['Error compiling query', 'ERROR: IN: NodeSchema', 'ERROR']
+    # Note that the Java exceptions are listed after 'ERROR', and will therefore
+    # not be included in the 'ERROR' totals, since they are in a separate category
+    error_types = ['Error compiling query', 'ERROR: IN: NodeSchema', 'ERROR', \
+                   'NullPointerException', 'ClassCastException', 'IndexOutOfBoundsException', 'VoltTypeException']
     error_count = 0
     for e in error_types:
         command = 'grep -c "' + e + '" ' + from_file
@@ -199,11 +212,12 @@ def print_file_tail(from_file, to_file, number_of_lines=50):
         grep_proc = Popen(command, shell=True, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
         num_errors = int(grep_proc.communicate()[0].replace('\\n', ''))
         if e is 'ERROR':
-            tail_message += "\nNumber of all other 'ERROR' messages    : " + str(num_errors - error_count)
-            tail_message += "\nTotal Number of all 'ERROR' messages    : " + str(num_errors)
+            tail_message += "\nNumber of all other 'ERROR' messages        : {:4d}".format(num_errors - error_count)
+            tail_message += "\nTotal Number of all 'ERROR' messages        : {:4d}".format(num_errors)
+            tail_message += "\nJava Exceptions: "
         else:
             error_count  += num_errors
-            tail_message += "\nNumber of '"+e+"' errors: " + str(num_errors)
+            tail_message += "\nNumber of {:27s} errors: {:4d}".format("'"+e+"'", num_errors)
 
     print >> to_file, tail_message
 
@@ -220,7 +234,7 @@ def print_summary(error_message=''):
     prematurely, due a VoltDB server crash.
     """
     global start_time, sql_output_file, sqlcmd_output_file, sqlcmd_summary_file, \
-        options, count_sql_statements
+        options, echo_substrings, count_sql_statements
 
     # Generate the summary message (to be printed below)
     try:
@@ -251,6 +265,8 @@ def print_summary(error_message=''):
                     summary_message += '{0:7d} '.format(count) + validity + ' ({0:3d}%),'.format(percent)
             percent = int(round(100.0 * sql_type_count / total_count))
             summary_message += '{0:7d} '.format(sql_type_count) + 'total ({0:3d}%)'.format(percent)
+            if 'ECHO' in sql_type.upper():
+                summary_message += "  - containing " + " AND ".join("'"+x+"'" for x in echo_substrings) + "]"
     except Exception as e:
         print '\n\nCaught exception attempting to print SUMMARY message:'
         print_exc()
@@ -287,18 +303,18 @@ def increment_sql_statement_indexes(index1, index2):
         count_sql_statements[index1][index2] = 1
 
 
-def increment_sql_statement_type(type=None, validity=None):
+def increment_sql_statement_type(type=None, validity=None, incrementTotal=True):
     """Increment the value of 'count_sql_statements' (a 2D dictionary, i.e.,
     a dict of dict), both for the 'total', 'total' element and for the 'type',
     if specified (i.e., for the type, 'total' element); also, if the 'validity'
     is specified (normally equal to 'valid' or 'invalid'), increment those
     values as well (i.e., the 'total', validity and type, validity elements).
     """
-    global count_sql_statements
 
-    increment_sql_statement_indexes('total', 'total')
-    if validity:
-        increment_sql_statement_indexes('total', validity)
+    if incrementTotal:
+        increment_sql_statement_indexes('total', 'total')
+        if validity:
+            increment_sql_statement_indexes('total', validity)
     if type:
         increment_sql_statement_indexes(type, 'total')
         if validity:
@@ -312,7 +328,7 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
     STDOUT).
     """
     global sql_output_file, sqlcmd_output_file, echo_output_file, sqlcmd_proc, \
-        last_n_sql_statements, options, debug
+        last_n_sql_statements, options, echo_substrings, symbol_depth, debug
 
     # Print the specified SQL statement to the specified output file
     print >> sql_output_file, sql
@@ -322,9 +338,9 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
     # debugging things that were recently added to the SQL grammar (e.g., a
     # new function name)
     sql_contains_echo_substring = False
-    if options.echo and options.echo in sql:
+    if options.echo and all(x in sql for x in echo_substrings):
         sql_contains_echo_substring = True
-        print >> echo_output_file, '\n' + sql
+        print >> echo_output_file, '\n', sql, '\n'
 
     # If a sqlcmd sub-process has been defined, use it
     if sqlcmd_proc:
@@ -358,6 +374,8 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                         'Command succeeded.' in output):
                     if sql_was_echoed_as_output:
                         increment_sql_statement_type(sql[0:num_chars_in_sql_type], 'valid')
+                        if sql_contains_echo_substring:
+                            increment_sql_statement_type(' [echo', 'valid', False)
                         break
                     else:  # this should never happen
                         print "\nWARNING: Unexpected condition (should never happen?!): found ", \
@@ -368,10 +386,17 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                 elif 'ERROR' in output.upper():
                     if sql_was_echoed_as_output:
                         increment_sql_statement_type(sql[0:num_chars_in_sql_type], 'invalid')
+                        if sql_contains_echo_substring:
+                            increment_sql_statement_type(' [echo', 'invalid', False)
                         break
-                    elif debug > 2:  # this can happen, though it's uncommon
-                        print 'DEBUG: Found ERROR before SQL echoed, ', \
-                              'with:\n  sql   :', sql, '\n  output:', output
+                    elif debug > 3:
+                        # this can happen, though it's uncommon, when there is a multi-line
+                        # error message, which uses the word 'ERROR' on more than one line
+                        previous = ''
+                        if last_n_sql_statements and len(last_n_sql_statements) > 1:
+                            previous = '\n  previous: ' + last_n_sql_statements[len(last_n_sql_statements) - 2]
+                        print 'DEBUG: Found ERROR before SQL echoed, with:', \
+                                '\n  sql     :', sql, previous, '\n  output  :', output
 
                 # Check if sqlcmd command not found, or if sqlcmd cannot, or
                 # can no longer, reach the VoltDB server
@@ -385,6 +410,11 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                     print_summary(error_message)
                     sqlcmd_proc.communicate('exit')
                     exit(99)
+        if sql_contains_echo_substring and options.echo_grammar:
+            print >> echo_output_file, '\nGrammar symbols used (in order), and how many times:'
+            for order, symbol, count in sorted([(v[1],v[0],k) for k,v in symbol_depth.items()]):
+                print >> echo_output_file, symbol, ':', count
+
     else:
         increment_sql_statement_type(sql[0:num_chars_in_sql_type])
 
@@ -438,7 +468,7 @@ if __name__ == "__main__":
     parser.add_option("-g", "--grammar", dest="grammar_files", default="sql-grammar.txt",
                       help="a file path/name, or comma-separated list of files, that defines the SQL grammar "
                          + "[default: sql-grammar.txt]")
-    parser.add_option("-r", "--seed", dest="seed",
+    parser.add_option("-r", "--seed", dest="seed", default=None,
                       help="seed for random number generator; a blank string, or None, means that the seed "
                           + "should itself be randomly generated [default: None]")
     parser.add_option("-i", "--initial_type", dest="initial_type", default="insert-statement",
@@ -485,15 +515,20 @@ if __name__ == "__main__":
                       help="the number of lines to 'tail' from the 'log' file(s); only applies "
                          + "if 'summary' and 'log' are also specified [default: 100]")
     parser.add_option("-e", "--echo", dest="echo", default=None,
-                      help="a substring to be searched for in all SQL statements sent to sqlcmd: if this is specified, "
-                         + "then all SQL statements that contain this substring, and their results, will be echoed (to "
-                         + "'echo_file'); this is useful for debugging new features, e.g., if you just added the LOG10 "
-                         + "function, you can set this to 'LOG10', to see its effect [default: None]")
-    parser.add_option("-E", "--echo_file", dest="echo_file", default=100,
+                      help="a substring, or comma-separated list of substrings, to be searched for in all SQL "
+                         + "statements sent to sqlcmd: if this is specified, then all SQL statements that contain "
+                         + "this substring (or list of substrings), and their results, will be echoed (to "
+                         + "'echo_file'); this is useful for debugging new features, e.g., if you just added the "
+                         + "LOG10 function, you can set this to 'LOG10', to see its effect [default: None]")
+    parser.add_option("-E", "--echo_file", dest="echo_file", default=None,
                       help="a file path/name to which to send 'echo' output; if not specified, 'echo' output "
                          + "(if any) goes to STDOUT [default: None]")
+    parser.add_option("-G", "--echo_grammar", dest="echo_grammar", default=False,
+                      help="a boolean value (True or False), specifying whether to include, in the 'echo_file', "
+                         + "the list of grammar symbols, and how many times each one was used, for each of the "
+                         + "SQL statements that is echoed [default: False]")
     parser.add_option("-D", "--debug", dest="debug", default=0,
-                      help="print debug info: 0 for none, increasing values (1-5) for more [default: 0]")
+                      help="print debug info: 0 for none, increasing values (1-6) for more [default: 0]")
     (options, args) = parser.parse_args()
 
     # If 'minutes' is specified, change the default for 'number'
@@ -522,6 +557,7 @@ if __name__ == "__main__":
         print "DEBUG: options.log_number    :", options.log_number
         print "DEBUG: options.echo          :", options.echo
         print "DEBUG: options.echo_file     :", options.echo_file
+        print "DEBUG: options.echo_grammar  :", options.echo_grammar
         print "DEBUG: options.debug         :", options.debug
         print "DEBUG: options (all):\n", options
         print "DEBUG: args (all):", args
@@ -549,10 +585,11 @@ if __name__ == "__main__":
     # Define the grammar to be used to generate SQL statements, based upon
     # the input grammar file(s)
     grammar = {}
+    symbol_depth = {}
     for grammar_file in options.grammar_files.split(','):
         grammar = get_grammar(grammar, grammar_file, options.path)
 
-    if debug > 4:
+    if debug > 5:
         print 'DEBUG: grammar:'
         for key in grammar.keys():
             print '   ', key + ':', grammar[key]
@@ -565,10 +602,14 @@ if __name__ == "__main__":
 
     # Open the output file for SQL statements to be echoed, if specified
     echo_output_file = None
+    echo_substrings = []
     if options.echo:
+        echo_substrings = options.echo.split(",")
         echo_output_file = sys.stdout
         if options.echo_file:
             echo_output_file = open(options.echo_file, 'w', 0)
+            print >> echo_output_file, "SQL statements containing " \
+                + " AND ".join("'"+x+"'" for x in echo_substrings) + ":\n"
 
     # Open the sub-process used to execute SQL statements in sqlcmd,
     # and the output file for sqlcmd results, if specified
@@ -601,7 +642,7 @@ if __name__ == "__main__":
         generate_sql_statements(sql_statement_type, int(options.number), int(options.max_save),
                                 options.delete_type, options.delete_number)
 
-    if debug > 3:
+    if debug > 4:
         print_sql_statement('select * from P1;')
         print_sql_statement('select * from R1;')
         print_sql_statement('select ID, TINY, SMALL, INT, BIG, NUM, DEC, VCHAR, VCHAR_INLINE_MAX, VCHAR_INLINE, TIME from P1;')


### PR DESCRIPTION
added Window functions (RANK, etc.), and associated syntax; 
expanded the use of aggregate functions, used as Window functions and
otherwise; 
expanded the use of sub-queries, scalar and otherwise.
And multiple minor changes:
added very occasional use of nonexistent table, view, and column names; 
added symbols for byte columns and expressions, and use them as args for
the REPEAT function, to avoid ENG-12118; 
improved UPDATE statements, to get the column types right most of the
time; 
expanded boolean expressions, to include multiple AND or OR, optionally
using parentheses; 
fixed USING clauses, by adding parentheses; 
added EXISTS and IN clauses; 
removed the nonexistent % operator (SQL has the MOD function, but no
remainder op); 
removed the use of CONCAT with only one argument, which does not work; 
fixed use of the TRIM function, by adding single-quotes and fixing an
unmatched '['; 
added the beginnings of varbinary, point, and polygon expressions
(though more work is needed in this area); 
and other minor tweaks, e.g. to likelihoods of different grammar
options.

sql_grammar_generator.py: 
added the ability to specify SQL statements containing multiple phrases
(e.g., 'INSERT' and 'SELECT') to be echoed to a file (with their
results), and optionally, with the grammar symbols that were used to
create them, and the ability to count the number and percent of such
statements that were valid versus invalid (all of which helps to debug
changes to the grammar file);
added (to the summary file) counts of the number of certain Java
Exceptions (e.g. NPE's) found in the VoltDB log or console output; 
and tweaked various comments and debug print.