### PR TITLE
ENG-12094: Add log message when restarting database with no command log.

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1013,7 +1013,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             //If terminus is present we will recover from shutdown save so dont move.
             if (!durable && m_config.m_startAction.doesRecover() && determination.terminusNonce == null) {
                 if (m_nodeSettings.clean()) {
-                    String msg = "Archived previous snapshot directory to " + m_nodeSettings.getSnapshoth() + ".1";
+                    String msg = "Archiving old snapshots to " + m_nodeSettings.getSnapshoth() +
+                                 ".1 and starting an empty database." +
+                                 " Use voltadmin restore if you wish to restore an old database instance.";
                     consoleLog.info(msg);
                     hostLog.info(msg);
                 }


### PR DESCRIPTION
If there is no command log or snapshot data to recover from when
restarting the database, print an INFO level message to the log file and
the console indicating that the database will start empty.