### PR TITLE
ENG-12132: Test failing, now in memcheck-nodebug mode

### DIFF
--- a/tests/frontend/org/voltdb/regressionsuites/TestGroupByComplexMaterializedViewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGroupByComplexMaterializedViewSuite.java
@@ -1509,7 +1509,7 @@ public class TestGroupByComplexMaterializedViewSuite extends RegressionSuite {
 
         // With view size limits in place, it's actually not possible
         // to delete all the rows from the source table
-        if (!isValgrind()) {
+        if (!LocalCluster.isMemcheckDefined()) {
             // we are truncating here, but in the back end, we actually delete row-by-row,
             // hence this failure.
             verifyStmtFails(client, "truncate table r6", "exceeds the size");


### PR DESCRIPTION
I should have used `isMemcheckDefined()` instead of `isValgrind()`.

The test is sensitive to how tuple blocks are allocated with regards to truncate and views.  See the older pull request for more details:

https://github.com/VoltDB/voltdb/pull/4355