### PR TITLE
ENG-12173: In XDCR mode, consumer should be in enabled state regardle…

### DIFF
--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -1952,6 +1952,11 @@ public abstract class CatalogUtil {
                 cluster.setDrmasterhost(drSource);
                 cluster.setDrconsumerenabled(drConnection.isEnabled());
                 hostLog.info("Configured connection for DR replica role to host " + drSource);
+            } else {
+                if (dr.getRole() == DrRoleType.XDCR) {
+                    // consumer should be enabled even without connection source for XDCR
+                    cluster.setDrconsumerenabled(true);
+                }
             }
         } else {
             cluster.setDrrole(DrRoleType.NONE.value());


### PR DESCRIPTION
…ss of whether is a <connection> element.

Dispatchers may be created in XDCR mode by the producer through startCursor requests.