### PR TITLE
ENG-12229. Stop building kits we no longer need.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -891,24 +891,6 @@ DISTRIBUTION
         </fileset>
     </chmod>
 
-    <!-- create an archive for distribution -->
-    <exec executable="mv" failonerror="true">
-        <arg value="${raw.dist.dir}/dist-client-java"/>
-        <arg value="${raw.dist.dir}/voltdb-client-java-${dist.version}"/>
-    </exec>
-    <exec executable="tar" failonerror="true">
-        <arg value="-cz"/>
-        <arg value="-C"/>
-        <arg value="${raw.dist.dir}"/>
-        <arg value="-f"/>
-        <arg value="${raw.dist.dir}/voltdb-client-java-${dist.version}.tar.gz"/>
-        <arg value="voltdb-client-java-${dist.version}"/>
-    </exec>
-    <!-- move it back to dist directory for downstream dependencies -->
-    <exec executable="mv" failonerror="true">
-        <arg value="${raw.dist.dir}/voltdb-client-java-${dist.version}"/>
-        <arg value="${raw.dist.dir}/dist-client-java"/>
-    </exec>
 </target>
 
 <target name="prep_libvoltdb">

--- a/build.xml
+++ b/build.xml
@@ -88,8 +88,6 @@
 <property name='deployment.parsergen.dir'    location='${src.gpl.dir}/org/voltdb/compiler/deploymentfile' />
 <property name='deployment.parsergen.pkg'    value='org.voltdb.compiler.deploymentfile' />
 <property name='deployment.parsergen.xsd'    value='org/voltdb/compiler/DeploymentFileSchema.xsd' />
-<property name='debian.package.dir'          value='obj/debian' />
-<property name='rpm.package.dir'             value='obj/rpms' />
 
 <!-- os.mac is set when build is running on Mac OSX -->
 <condition property="os.mac">
@@ -1012,7 +1010,7 @@ CLEANING
 <target name='clean'
     description="Remove all compiled and generated files."
     depends="cleantmp, clean_client, clean_deployment_gen,
-             clean_debian_package, clean_rpm_package, clean_bindoc, clean_other_gen">
+             clean_bindoc, clean_other_gen">
   <exec dir='examples/adperformance' executable='/usr/bin/env'><arg line="bash run.sh cleanall"/></exec>
   <exec dir='examples/bank-offers' executable='/usr/bin/env'><arg line="bash run.sh cleanall"/></exec>
   <exec dir='examples/callcenter' executable='/usr/bin/env'><arg line="bash run.sh cleanall"/></exec>
@@ -2708,64 +2706,6 @@ DBBPool.java preprocessing
 </target>
 
 
-<!--
-***********************
-DEBIAN PACKAGE CREATION
-***********************
--->
 
-<target name="debian_package"
-      depends="buildinfo"
-        description="Create Debian/Ubuntu package. Uses sudo, so it may prompt for a password.">
-    <exec executable="sudo" failonerror="true">
-        <arg value="python" />
-        <arg value="${base.dir}/tools/voltdb-install.py" />
-        <arg value="-D" />
-        <arg value="${raw.dist.dir}/voltdb-${dist.version}.tar.gz" />
-    </exec>
-</target>
-
-<!-- This debian package cleaning target is safe. It doesn't run as root. -->
-<target name="clean_debian_package"
-      depends=""
-        description="Remove all Debian/Ubuntu package build artifacts.">
-    <exec dir='.' executable='/bin/sh' failonerror='false'>
-        <arg line="-c 'rm -rfv ${debian.package.dir}'" />
-    </exec>
-</target>
-
-<!-- Use this if permissions are messed up by interrupted package building as root. -->
-<target name="force_clean_debian_package"
-      depends=""
-        description="Forceably remove all Debian/Ubuntu package build artifacts as root.">
-    <exec dir="." executable="sudo" failonerror="false">
-        <arg line="/bin/sh -c 'rm -rfv ${debian.package.dir}'" />
-    </exec>
-</target>
-
-<!--
-***********************
-RPM PACKAGE CREATION
-***********************
--->
-
-<target name="rpm_package"
-        depends="buildinfo"
-        description="Create RPM package">
-    <exec executable="python" failonerror="true">
-        <arg value="${base.dir}/tools/voltdb-install.py" />
-        <arg value="-R" />
-        <arg value="${raw.dist.dir}/voltdb-${dist.version}.tar.gz" />
-    </exec>
-</target>
-
-<!-- This cleaning target is safe. It doesn't run as root. -->
-<target name="clean_rpm_package"
-      depends=""
-        description="Remove all RPM build artifacts.">
-    <exec dir='.' executable='/bin/sh' failonerror='false'>
-        <arg line="-c 'rm -rfv ${rpm.package.dir}'" />
-    </exec>
-</target>
 <!-- END PROJECT -->
 </project>

--- a/build.xml
+++ b/build.xml
@@ -648,7 +648,7 @@ PRIMARY ENTRY POINTS
     description="Create production JAR files."
 />
 <target name="dist"
-    depends="dist_client, dist_internal, dist_tools"
+    depends="dist_client, dist_internal"
     description="Create VoltDB release packages with examples and documentation."
 />
 
@@ -660,52 +660,6 @@ PRIMARY ENTRY POINTS
     </exec>
 </target>
 
-<target name="dist_tools" depends="buildinfo, bindoc"
-        description="Create VoltDB tools release package.">
-
-    <!-- add tools and support files -->
-    <dist_tools_macro distlabel="-tools" />
-
-    <!-- add README.voltadmin -->
-    <copy todir="${dist.dir}-tools" file="${base.dir}/README.voltadmin"/>
-
-    <!-- LICENSE isn't handled by dist_tools_macro -->
-    <copy todir="${dist.dir}-tools" file="${dist.dir}/LICENSE"/>
-
-    <!-- tools/volt is unwanted for now in the tools distribution -->
-    <delete dir="${dist.dir}-tools/tools" failonerror="false" />
-
-    <!-- copy recursively to the tarball staging directory -->
-    <copy todir="${raw.dist.dir}/voltdb-tools-${dist.version}">
-        <fileset dir="${dist.dir}-tools" defaultexcludes="yes">
-            <include name="**" />
-        </fileset>
-    </copy>
-
-    <!-- make bin and tools contents executable -->
-    <chmod perm="ugo+rx">
-        <fileset dir="${raw.dist.dir}/voltdb-tools-${dist.version}">
-            <include name="bin/*"/>
-            <include name="tools/*"/>
-        </fileset>
-    </chmod>
-
-    <!-- create the tools distribution tarball -->
-    <exec executable="tar" failonerror="true">
-        <arg value="-cz"/>
-        <arg value="-C"/>
-        <arg value="${raw.dist.dir}"/>
-        <arg value="-f"/>
-        <arg value="${raw.dist.dir}/voltdb-tools-${dist.version}.tar.gz"/>
-        <arg value="voltdb-tools-${dist.version}"/>
-    </exec>
-
-    <!-- remove the tarball staging directory -->
-    <exec dir='.' executable='/bin/sh'>
-        <arg line="-c 'rm -rfv ${raw.dist.dir}/voltdb-tools-${dist.version}'"/>
-    </exec>
-
-</target>
 
 <!--
 ***************************************

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -180,8 +180,6 @@ def copyCommunityFilesToReleaseDir(releaseDir, version, operatingsys):
         "%s/voltdb-%s.tar.gz" % (releaseDir, version))
     get("%s/voltdb/obj/release/voltdb-client-java-%s.tar.gz" % (builddir, version),
         "%s/voltdb-client-java-%s.tar.gz" % (releaseDir, version))
-    get("%s/voltdb/obj/release/voltdb-tools-%s.tar.gz" % (builddir, version),
-        "%s/voltdb-tools-%s.tar.gz" % (releaseDir, version))
 
     # add stripped symbols
     if operatingsys == "LINUX":

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -64,14 +64,6 @@ def makeReleaseDir(releaseDir):
 
 
 ################################################
-# SEE IF HAS ZIP TARGET
-###############################################
-def versionHasZipTarget():
-    with settings(warn_only=True):
-        with cd(os.path.join(builddir,'pro')):
-                return run("ant -p -f mmt.xml | grep dist.pro.zip")
-
-################################################
 # BUILD THE COMMUNITY VERSION
 ################################################
 
@@ -128,14 +120,12 @@ def buildRabbitMQExport(version):
         run("git status")
         run("git describe --dirty", warn_only=True)
         run("VOLTDIST=../pro/obj/pro/voltdb-ent-%s ant" % version)
-    # Repackage the pro tarball and zip file with the RabbitMQ connector Jar
+    # Repackage the pro tarball with the RabbitMQ connector Jar
     with cd("%s/pro/obj/pro" % builddir):
         run("pwd")
         run("gunzip voltdb-ent-%s.tar.gz" % version)
         run("tar uvf voltdb-ent-%s.tar voltdb-ent-%s/lib/extension/voltdb-rabbitmq.jar" % (version, version))
-        if versionHasZipTarget():
-            run("gzip voltdb-ent-%s.tar" % version)
-            run("zip -r voltdb-ent-%s.zip voltdb-ent-%s" % (version, version))
+        run("gzip voltdb-ent-%s.tar" % version)
 
 ################################################
 # MAKE AN ENTERPRISE TRIAL LICENSE
@@ -145,14 +135,6 @@ def buildRabbitMQExport(version):
 def makeTrialLicense(days=30, dr_and_xdcr="true", nodes=12):
     with cd(builddir + "/pro/tools"):
         run("./make_trial_licenses.pl -t %d -H %d -W %s" % (days, nodes, dr_and_xdcr ))
-
-################################################
-# MAKE AN ENTERPRISE ZIP FILE FOR SOME PARTNER UPLOAD SITES
-################################################
-
-def makeEnterpriseZip():
-    with cd(builddir + "/pro"):
-        run("VOLTCORE=../voltdb ant -f mmt.xml dist.pro.zip")
 
 ################################################
 # MAKE AN JAR FILES NEEDED TO PUSH TO MAVEN
@@ -188,10 +170,6 @@ def copyCommunityFilesToReleaseDir(releaseDir, version, operatingsys):
 def copyTrialLicenseToReleaseDir(releaseDir):
     get("%s/pro/trial_*.xml" % (builddir),
         "%s/license.xml" % (releaseDir))
-
-def copyEnterpriseZipToReleaseDir(releaseDir, version, operatingsys):
-    get("%s/pro/obj/pro/voltdb-ent-%s.zip" % (builddir, version),
-        "%s/voltdb-ent-%s.zip" % (releaseDir, version))
 
 def copyMavenJarsToReleaseDir(releaseDir, version):
     #The .jars and upload file must be in a directory called voltdb - it is the projectname
@@ -349,9 +327,6 @@ try:
         copyFilesToReleaseDir(releaseDir, versionCentos, "pro")
         makeTrialLicense()
         copyTrialLicenseToReleaseDir(releaseDir)
-        if versionHasZipTarget():
-            makeEnterpriseZip()
-            copyEnterpriseZipToReleaseDir(releaseDir, versionCentos, "LINUX")
         makeMavenJars()
         copyMavenJarsToReleaseDir(releaseDir, versionCentos)
 

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -178,8 +178,6 @@ def copyFilesToReleaseDir(releaseDir, version, type=None):
 def copyCommunityFilesToReleaseDir(releaseDir, version, operatingsys):
     get("%s/voltdb/obj/release/voltdb-%s.tar.gz" % (builddir, version),
         "%s/voltdb-%s.tar.gz" % (releaseDir, version))
-    get("%s/voltdb/obj/release/voltdb-client-java-%s.tar.gz" % (builddir, version),
-        "%s/voltdb-client-java-%s.tar.gz" % (releaseDir, version))
 
     # add stripped symbols
     if operatingsys == "LINUX":


### PR DESCRIPTION
**Do not squash merge. This will enable us to revert any part individually in the future.**

Removed build and build_kit support for the following builds:

1. voltdb-tools-n.n.tar.gz. This contained voltadmin and vdm. This has not been available for download for years.
2. voltdb-client-java-n.n.tar.gz.  The client is available in the server kit and also in maven. We have not had a separate java-client download for years.
3. .rpm and .deb.  This was removed from the download site at least a year ago.
4. voltdb-ent-n.n.zip.  This used to uploaded to a partner site and needed to be .zip.  That partner site now just has a link, so no .zip is needed.

With this change, the official kit_build job will only make the following:

- voltdb community, pro and enterprise kits
- mavenjars directory that are used in another job when we upload releases to maven
- temp license.xml
- checksums.txt (note, this is going away when ENG-11993 is complete)
- other/symbols file





