### PR TITLE
ENG-11012: Online Tracing System.

### DIFF
--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -42,6 +42,10 @@ class Topend {
     virtual int loadNextDependency(
         int32_t dependencyId, voltdb::Pool *pool, Table* destination) = 0;
 
+    virtual void traceLog(bool isBegin,
+                          const char *name,
+                          const char *args) {};
+
     // Update the topend on query progress and give the topend a chance to tell the
     // query to stop.
     // Return 0 if the Topend wants the EE to stop processing the current fragment

--- a/src/ee/common/executorcontext.hpp
+++ b/src/ee/common/executorcontext.hpp
@@ -110,7 +110,8 @@ class ExecutorContext {
                                int64_t txnId,
                                int64_t spHandle,
                                int64_t lastCommittedSpHandle,
-                               int64_t uniqueId)
+                               int64_t uniqueId,
+                               bool traceOn)
     {
         m_undoQuantum = undoQuantum;
         m_spHandle = spHandle;
@@ -119,6 +120,7 @@ class ExecutorContext {
         m_uniqueId = uniqueId;
         m_currentTxnTimestamp = (m_uniqueId >> 23) + VOLT_EPOCH_IN_MILLIS;
         m_currentDRTimestamp = createDRTimestampHiddenValue(static_cast<int64_t>(m_drClusterId), m_uniqueId);
+        m_traceOn = traceOn;
     }
 
     // data available via tick()
@@ -212,6 +214,10 @@ class ExecutorContext {
     /** DR timestamp field value for this transaction */
     int64_t currentDRTimestamp() {
         return m_currentDRTimestamp;
+    }
+
+    bool isTraceOn() {
+        return m_traceOn;
     }
 
     /** Executor List for a given sub statement id */
@@ -408,6 +414,8 @@ class ExecutorContext {
     int64_t m_uniqueId;
     int64_t m_currentTxnTimestamp;
     int64_t m_currentDRTimestamp;
+
+    bool m_traceOn;
   public:
     int64_t m_lastCommittedSpHandle;
     int64_t m_siteId;

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -32,6 +32,9 @@ public:
 
     inline JNITopend* updateJNIEnv(JNIEnv *env) { m_jniEnv = env; return this; }
     int loadNextDependency(int32_t dependencyId, Pool *stringPool, Table* destination);
+    void traceLog(bool isBegin,
+                  const char *name,
+                  const char *args);
     int64_t fragmentProgressUpdate(
                 int32_t batchIndex,
                 PlanNodeType planNodeType,
@@ -71,6 +74,7 @@ private:
     jobject m_javaExecutionEngine;
     jmethodID m_fallbackToEEAllocatedBufferMID;
     jmethodID m_nextDependencyMID;
+    jmethodID m_traceLogMID;
     jmethodID m_fragmentProgressUpdateMID;
     jmethodID m_planForFragmentIdMID;
     jmethodID m_crashVoltDBMID;

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -187,7 +187,8 @@ class __attribute__((visibility("default"))) VoltDBEngine {
                                  int64_t spHandle,
                                  int64_t lastCommittedSpHandle,
                                  int64_t uniqueId,
-                                 int64_t undoToken);
+                                 int64_t undoToken,
+                                 bool traceOn);
 
         /**
          * Execute a single, top-level plan fragment.  This method is
@@ -503,7 +504,8 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         int executePlanFragment(int64_t planfragmentId,
                                 int64_t inputDependencyId,
                                 bool first,
-                                bool last);
+                                bool last,
+                                bool traceOn);
 
         /**
          * Set up the vector of executors for a given fragment id.

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -802,7 +802,8 @@ void VoltDBIPC::executePlanFragments(struct ipc_command *cmd) {
                                                 ntohll(queryCommand->spHandle),
                                                 ntohll(queryCommand->lastCommittedSpHandle),
                                                 ntohll(queryCommand->uniqueId),
-                                                ntohll(queryCommand->undoToken));
+                                                ntohll(queryCommand->undoToken),
+                                                false);
     }
     catch (const FatalException &e) {
         crashVoltDB(e);

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -561,7 +561,8 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExecu
         jlong spHandle,
         jlong lastCommittedSpHandle,
         jlong uniqueId,
-        jlong undoToken)
+        jlong undoToken,
+        jboolean traceOn)
 {
     //VOLT_DEBUG("nativeExecutePlanFragments() start");
 
@@ -598,7 +599,8 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExecu
                                                     spHandle,
                                                     lastCommittedSpHandle,
                                                     uniqueId,
-                                                    undoToken);
+                                                    undoToken,
+                                                    traceOn == JNI_TRUE);
 
         if (failures > 0) {
             return org_voltdb_jni_ExecutionEngine_ERRORCODE_ERROR;

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -291,6 +291,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     public static final int SNAPSHOT_DAEMON_ID = -10;
     public static final int SNAPSHOT_IO_AGENT_ID = -11;
     public static final int DR_CONSUMER_MP_COORDINATOR_ID = -12;
+    public static final int TRACE_SITE_ID = -13;
 
     // we should never hand out this site ID.  Use it as an empty message destination
     public static final int VALHALLA = Integer.MIN_VALUE;

--- a/src/frontend/org/voltcore/utils/CoreUtils.java
+++ b/src/frontend/org/voltcore/utils/CoreUtils.java
@@ -850,6 +850,9 @@ public class CoreUtils {
     public static String hsIdToString(long hsId) {
         return Integer.toString((int)hsId) + ":" + Integer.toString((int)(hsId >> 32));
     }
+    public static void hsIdToString(long hsId, StringBuilder sb) {
+        sb.append((int)hsId).append(":").append((int)(hsId >> 32));
+    }
 
     public static String hsIdCollectionToString(Collection<Long> ids) {
         List<String> idstrings = new ArrayList<String>();

--- a/src/frontend/org/voltdb/DummyCommandLog.java
+++ b/src/frontend/org/voltdb/DummyCommandLog.java
@@ -52,7 +52,7 @@ public class DummyCommandLog implements CommandLog {
             int[] involvedPartitions,
             DurabilityListener l,
             TransactionTask handle) {
-        return Futures.immediateFuture(null);
+        return null;
     }
 
     @Override

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -98,6 +98,7 @@ import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import com.google_voltpatches.common.util.concurrent.ListenableFutureTask;
+import org.voltdb.utils.VoltTrace;
 
 public final class InvocationDispatcher {
 
@@ -318,8 +319,20 @@ public final class InvocationDispatcher {
                 // Deserialize the client's request and map to a catalog stored procedure
         final CatalogContext catalogContext = m_catalogContext.get();
 
-        String procName = task.getProcName();
-        Procedure catProc = getProcedureFromName(procName, catalogContext);
+        final String procName = task.getProcName();
+        final String threadName = Thread.currentThread().getName(); // Thread name has to be materialized here
+        final StoredProcedureInvocation finalTask = task;
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.CI);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.meta("process_name", "name", CoreUtils.getHostnameOrAddress()))
+                    .add(() -> VoltTrace.meta("thread_name", "name", threadName))
+                    .add(() -> VoltTrace.meta("thread_sort_index", "sort_index", Integer.toString(1)))
+                    .add(() -> VoltTrace.beginAsync("recvtxn", finalTask.getClientHandle(),
+                                                    "name", procName,
+                                                    "clientHandle", Long.toString(finalTask.getClientHandle())));
+        }
+
+        Procedure catProc = getProcedureFromName(task.getProcName(), catalogContext);
 
         if (catProc == null) {
             String errorMessage = "Procedure " + procName + " was not found";
@@ -415,6 +428,9 @@ public final class InvocationDispatcher {
             }
             else if ("@SystemInformation".equals(procName)) {
                 return dispatchStatistics(OpsSelector.SYSTEMINFORMATION, task, ccxn);
+            }
+            else if ("@Trace".equals(procName)) {
+                return dispatchStatistics(OpsSelector.TRACE, task, ccxn);
             }
             else if ("@StopNode".equals(procName)) {
                 return dispatchStopNode(task);
@@ -1415,6 +1431,13 @@ public final class InvocationDispatcher {
     private final void dispatchAdHocCommon(StoredProcedureInvocation task,
             InvocationClientHandler handler, Connection ccxn, ExplainMode explainMode,
             String sql, Object[] userParams, Object[] userPartitionKey, AuthSystem.AuthUser user) {
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.CI);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.beginAsync("planadhoc", task.getClientHandle(),
+                                                    "clientHandle", Long.toString(task.getClientHandle()),
+                                                    "sql", sql));
+        }
+
         List<String> sqlStatements = SQLLexer.splitStatements(sql);
         String[] stmtsArray = sqlStatements.toArray(new String[sqlStatements.size()]);
 
@@ -1465,6 +1488,11 @@ public final class InvocationDispatcher {
                 if (result instanceof AdHocPlannedStmtBatch) {
                     final AdHocPlannedStmtBatch plannedStmtBatch = (AdHocPlannedStmtBatch) result;
                     ExplainMode explainMode = plannedStmtBatch.getExplainMode();
+
+                    final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.CI);
+                    if (traceLog != null) {
+                        traceLog.add(() -> VoltTrace.endAsync("planadhoc", plannedStmtBatch.clientHandle));
+                    }
 
                     // assume all stmts have the same catalog version
                     if ((plannedStmtBatch.getPlannedStatementCount() > 0) &&
@@ -1877,6 +1905,17 @@ public final class InvocationDispatcher {
                     handle,
                     connectionId,
                     isForReplay);
+
+        Long finalInitiatorHSId = initiatorHSId;
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.CI);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.instantAsync("inittxn",
+                                                      invocation.getClientHandle(),
+                                                      "clientHandle", Long.toString(invocation.getClientHandle()),
+                                                      "ciHandle", Long.toString(handle),
+                                                      "partition", Integer.toString(partition),
+                                                      "dest", CoreUtils.hsIdToString(finalInitiatorHSId)));
+        }
 
         Iv2Trace.logCreateTransaction(workRequest);
         m_mailbox.send(initiatorHSId, workRequest);

--- a/src/frontend/org/voltdb/OpsSelector.java
+++ b/src/frontend/org/voltdb/OpsSelector.java
@@ -27,7 +27,8 @@ public enum OpsSelector {
     SNAPSHOTSCAN(SnapshotScanAgent.class, HostMessenger.SNAPSHOTDELETE_SITE_ID),
     STATISTICS(StatsAgent.class, HostMessenger.STATS_SITE_ID),
     SYSTEMCATALOG(SystemCatalogAgent.class, HostMessenger.SYSCATALOG_SITE_ID),
-    SYSTEMINFORMATION(SystemInformationAgent.class, HostMessenger.SYSINFO_SITE_ID);
+    SYSTEMINFORMATION(SystemInformationAgent.class, HostMessenger.SYSINFO_SITE_ID),
+    TRACE(TraceAgent.class, HostMessenger.TRACE_SITE_ID);
 
     // OpsAgent subclass providing the implementation for this OPS selector
     private final Class<? extends OpsAgent> m_agentClass;

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -66,6 +66,7 @@ import org.voltdb.utils.Encoder;
 import org.voltdb.utils.MiscUtils;
 
 import com.google_voltpatches.common.base.Charsets;
+import org.voltdb.utils.VoltTrace;
 
 public class ProcedureRunner {
 
@@ -1656,7 +1657,8 @@ public class ProcedureRunner {
                    m_txnState.txnId,
                    m_txnState.m_spHandle,
                    m_txnState.uniqueId,
-                   m_isReadOnly);
+                   m_isReadOnly,
+                   VoltTrace.log(VoltTrace.Category.EE) != null);
        } catch (Throwable ex) {
            if (! m_isReadOnly) {
                // roll back the current batch and re-throw the EE exception

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -116,7 +116,8 @@ public interface SiteProcedureConnection {
             long txnId,
             long spHandle,
             long uniqueId,
-            boolean readOnly) throws EEException;
+            boolean readOnly,
+            boolean traceOn) throws EEException;
 
     /**
      * Let the EE know which batch of sql is running so it can include this

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -187,6 +187,7 @@ public class SystemProcedureCatalog {
         builder.put("@SendSentinel",            new Config(null,                                           true,  false, false, 0,    VoltType.INVALID,   true,  false, false, true,      false,  false,            true  ));
         builder.put("@PrepareShutdown",         new Config("org.voltdb.sysprocs.PrepareShutdown",          false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  true ,            true  ));
         builder.put("@SwapTables",              new Config(null,                                           false, false, true,  0,    VoltType.INVALID,   false, true,  true,  true,      true,   false,            true  ));
+        builder.put("@Trace",                   new Config(null,                                           false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true  ));
         listing = builder.build();
     }
 }

--- a/src/frontend/org/voltdb/TraceAgent.java
+++ b/src/frontend/org/voltdb/TraceAgent.java
@@ -1,0 +1,125 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb;
+
+import org.json_voltpatches.JSONObject;
+import org.voltcore.network.Connection;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.utils.VoltTrace;
+
+import java.io.File;
+
+public class TraceAgent extends OpsAgent {
+    public TraceAgent()
+    {
+        super("TraceAgent");
+    }
+
+    @Override
+    protected void collectStatsImpl(Connection c, long clientHandle, OpsSelector selector,
+                                    ParameterSet params) throws Exception
+    {
+        JSONObject obj = new JSONObject();
+        obj.put("selector", OpsSelector.TRACE);
+        String err;
+        if (selector == OpsSelector.TRACE) {
+            err = parseParamsForSystemInformation(params, obj);
+        } else {
+            err = "TraceAgent received non-TRACE selector: " + selector.name();
+        }
+        if (err != null) {
+            sendErrorResponse(c, ClientResponse.GRACEFUL_FAILURE, err, clientHandle);
+            return;
+        }
+
+        PendingOpsRequest psr = new PendingOpsRequest(selector,
+                                                      obj.getString("subselector"),
+                                                      c,
+                                                      clientHandle,
+                                                      System.currentTimeMillis(),
+                                                      obj);
+        distributeOpsWork(psr, obj);
+    }
+
+    // Parse the provided parameter set object and fill in subselector and interval into
+    // the provided JSONObject.  If there's an error, return that in the String, otherwise
+    // return null.  Yes, ugly.  Bang it out, then refactor later.
+    private String parseParamsForSystemInformation(ParameterSet params, JSONObject obj) throws Exception
+    {
+        // Default with no args is OVERVIEW
+        String subselector = "off";
+        if (params.toArray().length < 1) {
+            return "Incorrect number of arguments to @Trace (expects as least 1, received " +
+                   params.toArray().length + ")";
+        }
+        if (params.toArray().length >= 1) {
+            Object first = params.toArray()[0];
+            if (!(first instanceof String)) {
+                return "First argument to @Trace must be a valid STRING selector, instead was " +
+                       first;
+            }
+            subselector = (String)first;
+            if (!(subselector.equalsIgnoreCase("on") ||
+                  subselector.equalsIgnoreCase("off") ||
+                  subselector.equalsIgnoreCase("enable") ||
+                  subselector.equalsIgnoreCase("disable") ||
+                  subselector.equalsIgnoreCase("dump"))) {
+                return "Invalid @Trace selector " + subselector;
+            }
+        }
+        // Would be nice to have subselector validation here, maybe.  Maybe later.
+        obj.put("subselector", subselector);
+        if (params.toArray().length >= 2) {
+            obj.put("categories", params.toArray()[1]);
+        }
+        obj.put("interval", false);
+
+        return null;
+    }
+
+    @Override
+    protected void handleJSONMessage(JSONObject obj) throws Exception
+    {
+        VoltTable[] results = new VoltTable[] {new VoltTable(new VoltTable.ColumnInfo("STATUS", VoltType.STRING))};
+
+        OpsSelector selector = OpsSelector.valueOf(obj.getString("selector").toUpperCase());
+        if (selector != OpsSelector.TRACE) {
+            hostLog.warn("TraceAgent received a non-TRACE OPS selector: " + selector);
+        }
+
+        final String subselector = obj.getString("subselector");
+        if (subselector.equalsIgnoreCase("on")) {
+            VoltTrace.start(new File(VoltDB.instance().getVoltDBRootPath(), "trace_logs").getAbsolutePath());
+        } else if (subselector.equalsIgnoreCase("off")) {
+            VoltTrace.closeAllAndShutdown(false, 0);
+        } else if (subselector.equalsIgnoreCase("dump")) {
+            final String filePath = VoltTrace.dump();
+            if (filePath != null) {
+                results[0].addRow(filePath);
+            } else {
+                results[0].addRow("A trace file write request is already in progress");
+            }
+        } else if (subselector.equalsIgnoreCase("enable")) {
+            VoltTrace.enableCategories(VoltTrace.Category.valueOf(obj.getString("categories").toUpperCase()));
+        } else if (subselector.equalsIgnoreCase("disable")) {
+            VoltTrace.disableCategories(VoltTrace.Category.valueOf(obj.getString("categories").toUpperCase()));
+        }
+
+        sendOpsResponse(results, obj);
+    }
+}

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -35,6 +35,7 @@ import java.util.NavigableSet;
 import java.util.Queue;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 
@@ -64,6 +65,7 @@ import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableSortedSet;
 import com.google_voltpatches.common.net.HostAndPort;
+import org.voltdb.utils.VoltTrace;
 
 /**
  * VoltDB provides main() for the VoltDB server
@@ -1213,6 +1215,9 @@ public class VoltDB {
                 if (!turnOffClientInterface()) {
                     return; // this will jump to the finally block and die faster
                 }
+
+                // Flush trace files
+                VoltTrace.closeAllAndShutdown(true, TimeUnit.SECONDS.toMillis(10));
 
                 // Even if the logger is null, don't stop.  We want to log the stack trace and
                 // any other pertinent information to a .dmp file for crash diagnosis

--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -38,6 +38,7 @@ import org.voltdb.rejoin.TaskLog;
 import org.voltdb.utils.LogKeys;
 
 import com.google_voltpatches.common.collect.Maps;
+import org.voltdb.utils.VoltTrace;
 
 /**
  * Implements the Multi-partition procedure ProcedureTask.
@@ -102,6 +103,15 @@ public class MpProcedureTask extends ProcedureTask
     @Override
     public void run(SiteProcedureConnection siteConnection)
     {
+        final String threadName = Thread.currentThread().getName(); // Thread name has to be materialized here
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.MPSITE);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.meta("thread_name", "name", threadName))
+                    .add(() -> VoltTrace.meta("thread_sort_index", "sort_index", Integer.toString(1000)))
+                    .add(() -> VoltTrace.beginDuration("mpinittask",
+                                                       "txnId", TxnEgo.txnIdToString(getTxnId())));
+        }
+
         hostLog.debug("STARTING: " + this);
         // Cast up. Could avoid ugliness with Iv2TransactionClass baseclass
         MpTransactionState txn = (MpTransactionState)m_txnState;
@@ -179,6 +189,10 @@ public class MpProcedureTask extends ProcedureTask
             restartTransaction();
             hostLog.debug("RESTART: " + this);
         }
+
+        if (traceLog != null) {
+            traceLog.add(VoltTrace::endDuration);
+        }
     }
 
     @Override
@@ -197,6 +211,14 @@ public class MpProcedureTask extends ProcedureTask
     @Override
     void completeInitiateTask(SiteProcedureConnection siteConnection)
     {
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.MPSITE);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.instant("sendcomplete",
+                                                 "txnId", TxnEgo.txnIdToString(getTxnId()),
+                                                 "commit", Boolean.toString(!m_txnState.needsRollback()),
+                                                 "dest", CoreUtils.hsIdCollectionToString(m_initiatorHSIds)));
+        }
+
         CompleteTransactionMessage complete = new CompleteTransactionMessage(
                 m_initiator.getHSId(), // who is the "initiator" now??
                 m_initiator.getHSId(),

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -579,7 +579,8 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
             long txnId,
             long spHandle,
             long uniqueId,
-            boolean readOnly)
+            boolean readOnly,
+            boolean traceOn)
             throws EEException
     {
         throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");

--- a/src/frontend/org/voltdb/iv2/MpTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionState.java
@@ -42,10 +42,12 @@ import org.voltdb.messaging.DumpMessage;
 import org.voltdb.messaging.FragmentResponseMessage;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
+import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltTableUtil;
 
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.collect.Maps;
+import org.voltdb.utils.VoltTrace;
 
 public class MpTransactionState extends TransactionState
 {
@@ -167,6 +169,15 @@ public class MpTransactionState extends TransactionState
             long[] non_local_hsids = new long[m_useHSIds.size()];
             for (int i = 0; i < m_useHSIds.size(); i++) {
                 non_local_hsids[i] = m_useHSIds.get(i);
+
+                int finalI = i;
+                final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.MPSITE);
+                if (traceLog != null) {
+                    traceLog.add(() -> VoltTrace.beginAsync("sendfragment",
+                                                            MiscUtils.hsIdPairTxnIdToString(m_mbox.getHSId(), non_local_hsids[finalI], txnId),
+                                                            "txnId", TxnEgo.txnIdToString(txnId),
+                                                            "dest", CoreUtils.hsIdToString(non_local_hsids[finalI])));
+                }
             }
             // send to all non-local sites
             if (non_local_hsids.length > 0) {
@@ -196,6 +207,8 @@ public class MpTransactionState extends TransactionState
     @Override
     public Map<Integer, List<VoltTable>> recursableRun(SiteProcedureConnection siteConnection)
     {
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.MPSITE);
+
         // if we're restarting this transaction, and we only have local work, add some dummy
         // remote work so that we can avoid injecting a borrow task into the local buddy site
         // before the CompleteTransactionMessage with the restart flag reaches it.
@@ -238,6 +251,11 @@ public class MpTransactionState extends TransactionState
             // cause ProcedureRunner to do the right thing and cause rollback.
             while (!checkDoneReceivingFragResponses()) {
                 FragmentResponseMessage msg = pollForResponses();
+                if (traceLog != null) {
+                    traceLog.add(() -> VoltTrace.endAsync("sendfragment",
+                                                          MiscUtils.hsIdPairTxnIdToString(m_mbox.getHSId(), msg.m_sourceHSId, txnId),
+                                                          "status", Byte.toString(msg.getStatusCode())));
+                }
                 boolean expectedMsg = handleReceivedFragResponse(msg);
                 if (expectedMsg) {
                     // Will roll-back and throw if this message has an exception
@@ -257,11 +275,24 @@ public class MpTransactionState extends TransactionState
         if (!usedNullFragment) {
             borrowmsg.addInputDepMap(m_remoteDepTables);
         }
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.beginAsync("sendborrow",
+                                                    MiscUtils.hsIdPairTxnIdToString(m_mbox.getHSId(), m_buddyHSId, txnId),
+                                                    "txnId", TxnEgo.txnIdToString(txnId),
+                                                    "dest", CoreUtils.hsIdToString(m_buddyHSId)));
+        }
         m_mbox.send(m_buddyHSId, borrowmsg);
 
         FragmentResponseMessage msg;
         while (true){
             msg = pollForResponses();
+            final FragmentResponseMessage finalMsg = msg;
+            if (traceLog != null) {
+                traceLog.add(() -> VoltTrace.endAsync("sendborrow",
+                                                      MiscUtils.hsIdPairTxnIdToString(m_mbox.getHSId(), m_buddyHSId, txnId),
+                                                      "status", Byte.toString(finalMsg.getStatusCode())));
+            }
+
             assert(msg.getTableCount() > 0);
             // If this is a restarted TXN, verify that this is not a stale message from a different Dependency
             if (!m_isRestart || (msg.m_sourceHSId == m_buddyHSId &&

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1433,7 +1433,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                                             long txnId,
                                             long spHandle,
                                             long uniqueId,
-                                            boolean readOnly)
+                                            boolean readOnly,
+                                            boolean traceOn)
             throws EEException
     {
         return m_ee.executePlanFragments(
@@ -1446,7 +1447,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                 spHandle,
                 m_lastCommittedSpHandle,
                 uniqueId,
-                readOnly ? Long.MAX_VALUE : getNextUndoTokenBroken());
+                readOnly ? Long.MAX_VALUE : getNextUndoTokenBroken(),
+                traceOn);
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
+++ b/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
@@ -23,6 +23,8 @@ import org.voltcore.logging.VoltLogger;
 import org.voltdb.CommandLog;
 import org.voltdb.CommandLog.DurabilityListener;
 import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
+import org.voltdb.utils.MiscUtils;
+import org.voltdb.utils.VoltTrace;
 
 /**
  * This class is not thread-safe. Most of its usage is on the Site thread.
@@ -150,6 +152,13 @@ public class SpDurabilityListener implements DurabilityListener {
         private void queuePendingTasks() {
             // Notify all sync transactions and the SP UniqueId listeners
             for (TransactionTask o : m_pendingTransactions) {
+                final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+                if (traceLog != null) {
+                    traceLog.add(() -> VoltTrace.endAsync("durability",
+                                                          MiscUtils.hsIdTxnIdToString(m_spScheduler.m_mailbox.getHSId(),
+                                                                                      o.getSpHandle())));
+                }
+
                 m_pendingTasks.offer(o);
                 // Make sure all queued tasks for this MP txn are released
                 if (!o.getTransactionState().isSinglePartition()) {

--- a/src/frontend/org/voltdb/iv2/SpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/SpProcedureTask.java
@@ -33,6 +33,8 @@ import org.voltdb.messaging.InitiateResponseMessage;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.rejoin.TaskLog;
 import org.voltdb.utils.LogKeys;
+import org.voltdb.utils.MiscUtils;
+import org.voltdb.utils.VoltTrace;
 
 /**
  * Implements the single partition procedure ProcedureTask.
@@ -55,6 +57,15 @@ public class SpProcedureTask extends ProcedureTask
        super(initiator, procName, new SpTransactionState(msg), queue);
     }
 
+    @Override
+    protected void durabilityTraceEnd() {
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.endAsync("durability",
+                                                  MiscUtils.hsIdTxnIdToString(m_initiator.getHSId(), getSpHandle())));
+        }
+    }
+
     /** Run is invoked by a run-loop to execute this transaction. */
     @Override
     public void run(SiteProcedureConnection siteConnection)
@@ -65,6 +76,13 @@ public class SpProcedureTask extends ProcedureTask
         if (HOST_DEBUG_ENABLED) {
             hostLog.debug("STARTING: " + this);
         }
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.beginDuration("runsptask",
+                                                       "txnId", TxnEgo.txnIdToString(getTxnId()),
+                                                       "partition", Integer.toString(siteConnection.getCorrespondingPartitionId())));
+        }
+
         if (!m_txnState.isReadOnly()) {
             m_txnState.setBeginUndoToken(siteConnection.getLatestUndoToken());
         }
@@ -99,6 +117,9 @@ public class SpProcedureTask extends ProcedureTask
         }
         if (HOST_DEBUG_ENABLED) {
             hostLog.debug("COMPLETE: " + this);
+        }
+        if (traceLog != null) {
+            traceLog.add(VoltTrace::endDuration);
         }
 
         logToDR(siteConnection.getDRGateway(), txnState, response);

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -41,7 +41,6 @@ import org.voltdb.CommandLog;
 import org.voltdb.CommandLog.DurabilityListener;
 import org.voltdb.Consistency;
 import org.voltdb.Consistency.ReadLevel;
-import org.voltdb.PartitionDRGateway;
 import org.voltdb.SnapshotCompletionInterest;
 import org.voltdb.SnapshotCompletionMonitor;
 import org.voltdb.SystemProcedureCatalog;
@@ -68,6 +67,8 @@ import com.google_voltpatches.common.primitives.Ints;
 import com.google_voltpatches.common.primitives.Longs;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import com.google_voltpatches.common.util.concurrent.SettableFuture;
+import org.voltdb.utils.MiscUtils;
+import org.voltdb.utils.VoltTrace;
 
 public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 {
@@ -512,6 +513,16 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             // The leader will be responsible to replicate messages to replicas.
             // Don't replicate reads, not matter FAST or SAFE.
             if (m_isLeader && (!msg.isReadOnly()) && (m_sendToHSIds.length > 0)) {
+                for (long hsId : m_sendToHSIds) {
+                    Iv2InitiateTaskMessage finalMsg = msg;
+                    final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+                    if (traceLog != null) {
+                        traceLog.add(() -> VoltTrace.beginAsync("replicateSP",
+                                                                MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), hsId, finalMsg.getSpHandle()),
+                                                                "txnId", TxnEgo.txnIdToString(finalMsg.getTxnId()),
+                                                                "dest", CoreUtils.hsIdToString(hsId)));
+                    }
+                }
                 Iv2InitiateTaskMessage replmsg =
                     new Iv2InitiateTaskMessage(m_mailbox.getHSId(),
                             m_mailbox.getHSId(),
@@ -560,6 +571,20 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
      */
     private void doLocalInitiateOffer(Iv2InitiateTaskMessage msg)
     {
+        final String threadName = Thread.currentThread().getName(); // Thread name has to be materialized here
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.meta("process_name", "name", CoreUtils.getHostnameOrAddress()))
+                    .add(() -> VoltTrace.meta("thread_name", "name", threadName))
+                    .add(() -> VoltTrace.meta("thread_sort_index", "sort_index", Integer.toString(10000)))
+                    .add(() -> VoltTrace.beginAsync("initsp",
+                                                    MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), m_mailbox.getHSId(), msg.getSpHandle()),
+                                                    "ciHandle", Long.toString(msg.getClientInterfaceHandle()),
+                                                    "txnId", TxnEgo.txnIdToString(msg.getTxnId()),
+                                                    "partition", Integer.toString(m_partitionId),
+                                                    "hsId", CoreUtils.hsIdToString(m_mailbox.getHSId())));
+        }
+
         /**
          * A shortcut read is a read operation sent to any replica and completed with no
          * confirmation or communication with other replicas. In a partition scenario, it's
@@ -570,13 +595,19 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         final SpProcedureTask task =
             new SpProcedureTask(m_mailbox, procedureName, m_pendingTasks, msg);
         if (!shortcutRead) {
+            if (traceLog != null) {
+                traceLog.add(() -> VoltTrace.beginAsync("durability",
+                                                        MiscUtils.hsIdTxnIdToString(m_mailbox.getHSId(), msg.getSpHandle()),
+                                                        "txnId", TxnEgo.txnIdToString(msg.getTxnId()),
+                                                        "partition", Integer.toString(m_partitionId)));
+            }
+
             ListenableFuture<Object> durabilityBackpressureFuture =
                     m_cl.log(msg, msg.getSpHandle(), null, m_durabilityListener, task);
             //Durability future is always null for sync command logging
             //the transaction will be delivered again by the CL for execution once durable
             //Async command logging has to offer the task immediately with a Future for backpressure
             if (m_cl.canOfferTask()) {
-                assert durabilityBackpressureFuture != null;
                 m_pendingTasks.offer(task.setDurabilityBackpressureFuture(durabilityBackpressureFuture));
             }
         } else {
@@ -690,10 +721,19 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
          * confirmation or communication with other replicas. In a partition scenario, it's
          * possible to read an unconfirmed transaction's writes that will be lost.
          */
+        final long spHandle = message.getSpHandle();
+        final DuplicateCounterKey dcKey = new DuplicateCounterKey(message.getTxnId(), spHandle);
+        DuplicateCounter counter = m_duplicateCounters.get(dcKey);
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+
         // All reads will have no duplicate counter.
         // Avoid all the lookup below.
         // Also, don't update the truncation handle, since it won't have meaning for anyone.
         if (message.isReadOnly()) {
+            if (traceLog != null) {
+                traceLog.add(() -> VoltTrace.endAsync("initsp", MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle())));
+            }
+
             if (m_defaultConsistencyReadLevel == ReadLevel.FAST) {
                 // the initiatorHSId is the ClientInterface mailbox.
                 m_mailbox.send(message.getInitiatorHSId(), message);
@@ -709,10 +749,17 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             }
         }
 
-        final long spHandle = message.getSpHandle();
-        final DuplicateCounterKey dcKey = new DuplicateCounterKey(message.getTxnId(), spHandle);
-        DuplicateCounter counter = m_duplicateCounters.get(dcKey);
         if (counter != null) {
+            String traceName = "initsp";
+            if (message.m_sourceHSId != m_mailbox.getHSId()) {
+                traceName = "replicatesp";
+            }
+            String finalTraceName = traceName;
+            if (traceLog != null) {
+                traceLog.add(() -> VoltTrace.endAsync(finalTraceName, MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle()),
+                                                      "hash", String.valueOf(message.getClientResponseData().getHash())));
+            }
+
             int result = counter.offer(message);
             if (result == DuplicateCounter.DONE) {
                 m_duplicateCounters.remove(dcKey);
@@ -724,6 +771,9 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             }
         }
         else {
+            if (traceLog != null) {
+                traceLog.add(() -> VoltTrace.endAsync("initsp", MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle())));
+            }
             // the initiatorHSId is the ClientInterface mailbox.
             // this will be on SPI without k-safety or replica only with k-safety
             assert(!message.isReadOnly());
@@ -742,6 +792,15 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         long newSpHandle = getMaxScheduledTxnSpHandle();
         Iv2Trace.logFragmentTaskMessage(message.getFragmentTaskMessage(),
                 m_mailbox.getHSId(), newSpHandle, true);
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.beginAsync("recvfragment",
+                                                    MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), m_mailbox.getHSId(), newSpHandle),
+                                                    "txnId", TxnEgo.txnIdToString(message.getTxnId()),
+                                                    "partition", Integer.toString(m_partitionId),
+                                                    "hsId", CoreUtils.hsIdToString(m_mailbox.getHSId())));
+        }
+
         TransactionState txn = m_outstandingTxns.get(message.getTxnId());
 
         if (txn == null) {
@@ -820,6 +879,17 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
              * In that case don't propagate it to avoid a determinism check and extra messaging overhead
              */
             if (m_sendToHSIds.length > 0 && (!message.isReadOnly() || msg.isSysProcTask())) {
+                for (long hsId : m_sendToHSIds) {
+                    FragmentTaskMessage finalMsg = msg;
+                    final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+                    if (traceLog != null) {
+                        traceLog.add(() -> VoltTrace.beginAsync("replicatefragment",
+                                                                MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), hsId, finalMsg.getSpHandle()),
+                                                                "txnId", TxnEgo.txnIdToString(finalMsg.getTxnId()),
+                                                                "dest", CoreUtils.hsIdToString(hsId)));
+                    }
+                }
+
                 FragmentTaskMessage replmsg =
                     new FragmentTaskMessage(m_mailbox.getHSId(),
                             m_mailbox.getHSId(), msg);
@@ -865,6 +935,20 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
      */
     private void doLocalFragmentOffer(FragmentTaskMessage msg)
     {
+        final String threadName = Thread.currentThread().getName(); // Thread name has to be materialized here
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.meta("process_name", "name", CoreUtils.getHostnameOrAddress()))
+                    .add(() -> VoltTrace.meta("thread_name", "name", threadName))
+                    .add(() -> VoltTrace.meta("thread_sort_index", "sort_index", Integer.toString(10000)))
+                    .add(() -> VoltTrace.beginAsync("recvfragment",
+                                                    MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), m_mailbox.getHSId(), msg.getSpHandle()),
+                                                    "txnId", TxnEgo.txnIdToString(msg.getTxnId()),
+                                                    "partition", Integer.toString(m_partitionId),
+                                                    "hsId", CoreUtils.hsIdToString(m_mailbox.getHSId()),
+                                                    "final", Boolean.toString(msg.isFinalTask())));
+        }
+
         TransactionState txn = m_outstandingTxns.get(msg.getTxnId());
         boolean logThis = false;
         // bit of a hack...we will probably not want to create and
@@ -904,6 +988,13 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
                                  m_pendingTasks, msg, null);
         }
         if (logThis) {
+            if (traceLog != null) {
+                traceLog.add(() -> VoltTrace.beginAsync("durability",
+                                                        MiscUtils.hsIdTxnIdToString(m_mailbox.getHSId(), msg.getSpHandle()),
+                                                        "txnId", TxnEgo.txnIdToString(msg.getTxnId()),
+                                                        "partition", Integer.toString(m_partitionId)));
+            }
+
             ListenableFuture<Object> durabilityBackpressureFuture =
                     m_cl.log(msg.getInitiateTask(), msg.getSpHandle(), Ints.toArray(msg.getInvolvedPartitions()),
                              m_durabilityListener, task);
@@ -911,7 +1002,6 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             //the transaction will be delivered again by the CL for execution once durable
             //Async command logging has to offer the task immediately with a Future for backpressure
             if (m_cl.canOfferTask()) {
-                assert durabilityBackpressureFuture != null;
                 m_pendingTasks.offer(task.setDurabilityBackpressureFuture(durabilityBackpressureFuture));
             } else {
                 /* Getting here means that the task is the first fragment of an MP txn and
@@ -941,6 +1031,20 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         Queue<TransactionTask> pendingTasks = m_mpsPendingDurability.get(txnId);
         if (pendingTasks != null) {
             for (TransactionTask task : pendingTasks) {
+                if (task instanceof SpProcedureTask) {
+                    final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+                    if (traceLog != null) {
+                        traceLog.add(() -> VoltTrace.endAsync("durability",
+                                                              MiscUtils.hsIdTxnIdToString(m_mailbox.getHSId(), task.getSpHandle())));
+                    }
+                } else if (task instanceof FragmentTask) {
+                    final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+                    if (traceLog != null) {
+                        traceLog.add(() -> VoltTrace.endAsync("durability",
+                                                              MiscUtils.hsIdTxnIdToString(m_mailbox.getHSId(), ((FragmentTask) task).m_fragmentMsg.getSpHandle())));
+                    }
+                }
+
                 m_pendingTasks.offer(task);
             }
             m_mpsPendingDurability.remove(txnId);
@@ -969,11 +1073,24 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     // FragmentResponses from its replicas.
     private void handleFragmentResponseMessage(FragmentResponseMessage message)
     {
+        final TransactionState txnState = m_outstandingTxns.get(message.getTxnId());
+        final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+
         // Send the message to the duplicate counter, if any
         DuplicateCounter counter =
             m_duplicateCounters.get(new DuplicateCounterKey(message.getTxnId(), message.getSpHandle()));
         final TransactionState txn = m_outstandingTxns.get(message.getTxnId());
         if (counter != null) {
+            String traceName = "recvfragment";
+            if (message.m_sourceHSId != m_mailbox.getHSId()) {
+                traceName = "replicatefragment";
+            }
+            String finalTraceName = traceName;
+            if (traceLog != null) {
+                traceLog.add(() -> VoltTrace.endAsync(finalTraceName, MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle()),
+                                                      "status", Byte.toString(message.getStatusCode())));
+            }
+
             int result = counter.offer(message);
             if (result == DuplicateCounter.DONE) {
                 if (txn != null && txn.isDone()) {
@@ -1011,6 +1128,11 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             setRepairLogTruncationHandle(txn.m_spHandle);
         }
 
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.endAsync("recvfragment", MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle()),
+                                                  "status", Byte.toString(message.getStatusCode())));
+        }
+
         m_mailbox.send(message.getDestinationSiteId(), message);
     }
 
@@ -1036,6 +1158,16 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         // now, fix that later.
         if (txn != null)
         {
+            final FragmentTaskMessage frag = (FragmentTaskMessage) txn.getNotice();
+            CompleteTransactionMessage finalMsg = msg;
+            final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
+            if (traceLog != null) {
+                traceLog.add(() -> VoltTrace.instant("recvCompleteTxn",
+                                                     "txnId", TxnEgo.txnIdToString(finalMsg.getTxnId()),
+                                                     "partition", Integer.toString(m_partitionId),
+                                                     "hsId", CoreUtils.hsIdToString(m_mailbox.getHSId())));
+            }
+
             final boolean isSysproc = ((FragmentTaskMessage) txn.getNotice()).isSysProcTask();
             if (m_sendToHSIds.length > 0 && !msg.isRestart() && (!msg.isReadOnly() || isSysproc)) {
                 DuplicateCounter counter;
@@ -1200,7 +1332,6 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         // the transaction will be delivered again by the CL for execution once durable
         // Async command logging has to offer the task immediately with a Future for backpressure
         if (m_cl.canOfferTask()) {
-            assert durabilityBackpressureFuture != null;
             m_pendingTasks.offer(task.setDurabilityBackpressureFuture(durabilityBackpressureFuture));
         }
     }

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -45,6 +45,7 @@ import org.voltdb.sysprocs.SysProcFragmentId;
 import org.voltdb.utils.Encoder;
 import org.voltdb.utils.LogKeys;
 import org.voltdb.utils.VoltTableUtil;
+import org.voltdb.utils.VoltTrace;
 
 public class SysprocFragmentTask extends TransactionTask
 {
@@ -192,6 +193,14 @@ public class SysprocFragmentTask extends TransactionTask
             // equivalent to dep.depId:
             // final int outputDepId = m_fragmentMsg.getOutputDepId(frag);
 
+            final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPSITE);
+            if (traceLog != null) {
+                traceLog.add(() -> VoltTrace.beginDuration("runfragmenttask",
+                                                           "txnId", TxnEgo.txnIdToString(getTxnId()),
+                                                           "partition", Integer.toString(siteConnection.getCorrespondingPartitionId()),
+                                                           "fragmentId", String.valueOf(fragmentId)));
+            }
+
             ParameterSet params = m_fragmentMsg.getParameterSetForFragment(frag);
 
             try {
@@ -253,6 +262,10 @@ public class SysprocFragmentTask extends TransactionTask
                             new VoltTable(new ColumnInfo[] {new ColumnInfo("UNUSED", VoltType.INTEGER)}, 1));
                 }
                 break;
+            }
+
+            if (traceLog != null) {
+                traceLog.add(VoltTrace::endDuration);
             }
         }
         return currentFragResponse;

--- a/src/frontend/org/voltdb/iv2/TxnEgo.java
+++ b/src/frontend/org/voltdb/iv2/TxnEgo.java
@@ -164,6 +164,10 @@ final public class TxnEgo {
         return "(" + (TxnEgo.getSequence(txnId) - TxnEgo.SEQUENCE_ZERO) + ":" +
             TxnEgo.getPartitionId(txnId) + ")";
     }
+    public static void txnIdToString(long txnId, StringBuilder sb)
+    {
+        sb.append("(").append(TxnEgo.getSequence(txnId) - TxnEgo.SEQUENCE_ZERO).append(":").append(TxnEgo.getPartitionId(txnId)).append(")");
+    }
 
     public static String txnIdCollectionToString(Collection<Long> ids) {
         List<String> idstrings = new ArrayList<String>();

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -954,7 +954,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             final long spHandle,
             final long lastCommittedSpHandle,
             final long uniqueId,
-            final long undoToken) throws EEException {
+            final long undoToken, boolean traceOn) throws EEException {
         sendPlanFragmentsInvocation(Commands.QueryPlanFragments,
                 numFragmentIds, planFragmentIds, inputDepIds, parameterSets, txnId,
                 spHandle, lastCommittedSpHandle, uniqueId, undoToken);

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -319,6 +319,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
     /**
      * @param undoToken Token identifying undo quantum for generated undo info
+     * @param traceOn
      */
     @Override
     protected VoltTable[] coreExecutePlanFragments(
@@ -330,7 +331,8 @@ public class ExecutionEngineJNI extends ExecutionEngine {
             final long spHandle,
             final long lastCommittedSpHandle,
             long uniqueId,
-            final long undoToken) throws EEException
+            final long undoToken,
+            final boolean traceOn) throws EEException
     {
         // plan frag zero is invalid
         assert((numFragmentIds == 0) || (planFragmentIds[0] != 0));
@@ -389,7 +391,8 @@ public class ExecutionEngineJNI extends ExecutionEngine {
                     spHandle,
                     lastCommittedSpHandle,
                     uniqueId,
-                    undoToken);
+                    undoToken,
+                    traceOn);
 
         try {
             checkErrorCode(errorCode);

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -53,7 +53,7 @@ public class MockExecutionEngine extends ExecutionEngine {
             final long spHandle,
             final long lastCommittedSpHandle,
             final long uniqueId,
-            final long undoToken) throws EEException
+            final long undoToken, boolean traceOn) throws EEException
     {
         if (numFragmentIds != 1) {
             return null;

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -41,13 +41,14 @@ import java.util.regex.Pattern;
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONObject;
 import org.voltcore.logging.VoltLogger;
-import org.voltdb.ReplicationRole;
+import org.voltcore.utils.CoreUtils;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.deploymentfile.DrRoleType;
+import org.voltdb.iv2.TxnEgo;
 import org.voltdb.licensetool.LicenseApi;
 import org.voltdb.licensetool.LicenseException;
 
@@ -989,5 +990,23 @@ public class MiscUtils {
             assert this.value != null;
             return this.value;
         }
+    }
+
+    public static String hsIdTxnIdToString(long hsId, long txnId) {
+        final StringBuilder sb = new StringBuilder();
+        CoreUtils.hsIdToString(hsId, sb);
+        sb.append(" ");
+        TxnEgo.txnIdToString(txnId, sb);
+        return sb.toString();
+    }
+
+    public static String hsIdPairTxnIdToString(long srcHsId, long destHsId, long txnId) {
+        final StringBuilder sb = new StringBuilder(32);
+        CoreUtils.hsIdToString(srcHsId, sb);
+        sb.append("->");
+        CoreUtils.hsIdToString(destHsId, sb);
+        sb.append(" ");
+        TxnEgo.txnIdToString(txnId, sb);
+        return sb.toString();
     }
 }

--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -997,6 +997,10 @@ public class SQLCommand
                 ImmutableMap.<Integer, List<String>>builder().put( 0, new ArrayList<String>()).build());
         Procedures.put("@SwapTables",
                 ImmutableMap.<Integer, List<String>>builder().put( 2, Arrays.asList("varchar", "varchar")).build());
+        Procedures.put("@Trace",
+                ImmutableMap.<Integer, List<String>>builder().put( 0, new ArrayList<String>())
+                                                             .put( 1, Arrays.asList("varchar"))
+                                                             .put( 2, Arrays.asList("varchar", "varchar")).build());
     }
 
     private static Client getClient(ClientConfig config, String[] servers, int port) throws Exception

--- a/src/frontend/org/voltdb/utils/TraceFileWriter.java
+++ b/src/frontend/org/voltdb/utils/TraceFileWriter.java
@@ -1,0 +1,105 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb.utils;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.Queue;
+import java.util.zip.GZIPOutputStream;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.voltcore.logging.VoltLogger;
+
+
+/**
+ * Reads trace events from VoltTrace queue and writes them to files.
+ */
+public class TraceFileWriter implements Runnable {
+    private static final VoltLogger s_logger = new VoltLogger("TRACER");
+
+    private final File m_path;
+    private final Queue<VoltTrace.TraceEventBatch> m_events;
+
+    public TraceFileWriter(File path, Queue<VoltTrace.TraceEventBatch> events) {
+        m_events = events;
+        m_path = path;
+    }
+
+    @Override
+    public void run() {
+        final ObjectMapper jsonMapper = new ObjectMapper();
+        BufferedWriter fileWriter = null;
+        long firstEventTime = 0;
+        long count = 0;
+
+        try {
+            VoltTrace.TraceEventBatch eventSupplier;
+            while ((eventSupplier = m_events.poll()) != null) {
+                VoltTrace.TraceEvent event;
+                while ((event = eventSupplier.nextEvent()) != null) {
+                    if (fileWriter == null) {
+                        fileWriter = startTraceFile(m_path);
+                        firstEventTime = event.getNanos();
+                    } else {
+                        fileWriter.write(",");
+                    }
+
+                    event.setSyncNanos(firstEventTime);
+                    String json = jsonMapper.writeValueAsString(event);
+                    fileWriter.newLine();
+                    fileWriter.write(json);
+                    fileWriter.flush();
+
+                    count++;
+                }
+            }
+        } catch(IOException e) { // also catches JSON exceptions
+            s_logger.info("Unexpected IO exception in trace file writer. Stopping trace file writer.", e);
+        }
+
+        if (fileWriter != null) {
+            close(fileWriter);
+        }
+
+        s_logger.info("Wrote " + count + " trace events to " + m_path.getAbsolutePath());
+    }
+
+    private static void close(BufferedWriter bw) {
+        try {
+            bw.newLine();
+            bw.write("]");
+            bw.newLine();
+            bw.flush();
+            bw.close();
+        } catch(IOException e) {
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug("Exception closing trace file buffered writer", e);
+            }
+        }
+    }
+
+    private static BufferedWriter startTraceFile(File path) throws IOException {
+        // Uses the default platform encoding for now.
+        final BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream(new FileOutputStream(path))));
+        bw.write("[");
+        bw.flush();
+        return bw;
+    }
+}

--- a/src/frontend/org/voltdb/utils/VoltTrace.java
+++ b/src/frontend/org/voltdb/utils/VoltTrace.java
@@ -1,0 +1,613 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import com.google_voltpatches.common.collect.EvictingQueue;
+import com.google_voltpatches.common.collect.ImmutableSet;
+import com.google_voltpatches.common.util.concurrent.Futures;
+import com.google_voltpatches.common.util.concurrent.ListenableFuture;
+import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
+import com.google_voltpatches.common.util.concurrent.SettableFuture;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.voltcore.logging.VoltLogger;
+import org.voltcore.utils.CoreUtils;
+
+/**
+ * Utility class to log Chrome Trace Event format trace messages into files.
+ * Trace events are queued in a ring buffer. When the buffer is full, oldest
+ * events will be removed to make room for new events. Events in the ring buffer
+ * can be dumped to a file on user's request.
+ *
+ * This class is thread-safe.
+ */
+public class VoltTrace implements Runnable {
+    private static final VoltLogger s_logger = new VoltLogger("TRACER");
+
+    // Current process id. Used by all trace events.
+    private static final int s_pid;
+    static {
+        s_pid = Integer.parseInt(CoreUtils.getPID());
+    }
+
+    public enum Category {
+        CI, MPI, MPSITE, SPI, SPSITE, EE, DRPRODUCER, DRCONSUMER
+    }
+
+    private static Map<Character, TraceEventType> s_typeMap = new HashMap<>();
+    public enum TraceEventType {
+
+        ASYNC_BEGIN('b'),
+        ASYNC_END('e'),
+        ASYNC_INSTANT('n'),
+        CLOCK_SYNC('c'),
+        COMPLETE('X'),
+        CONTEXT(','),
+        COUNTER('C'),
+        DURATION_BEGIN('B'),
+        DURATION_END('E'),
+        FLOW_END('f'),
+        FLOW_START('s'),
+        FLOW_STEP('t'),
+        INSTANT('i'),
+        MARK('R'),
+        MEMORY_DUMP_GLOBAL('V'),
+        MEMORY_DUMP_PROCESS('v'),
+        METADATA('M'),
+        OBJECT_CREATED('N'),
+        OBJECT_DESTROYED('D'),
+        OBJECT_SNAPSHOT('O'),
+        SAMPLE('P');
+
+        private final char m_typeChar;
+
+        TraceEventType(char typeChar) {
+            m_typeChar = typeChar;
+            s_typeMap.put(typeChar, this);
+        }
+
+        public char getTypeChar() {
+            return m_typeChar;
+        }
+
+        public static TraceEventType fromTypeChar(char ch) {
+            return s_typeMap.get(ch);
+        }
+    }
+
+    /**
+     * Trace event class annotated with JSON annotations to serialize events in the exact format
+     * required by Chrome.
+     */
+    @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+    public static class TraceEvent {
+        private TraceEventType m_type;
+        private String m_name;
+        private Category m_category;
+        private String m_id;
+        private long m_tid;
+        private long m_nanos;
+        private double m_ts;
+        private Object[] m_argsArr;
+        private Map<String, String> m_args;
+
+        // Empty constructor and setters for jackson deserialization for ease of testing
+        public TraceEvent() {
+        }
+
+        public TraceEvent(TraceEventType type,
+                          String name,
+                          String asyncId,
+                          Object... args) {
+            m_type = type;
+            m_name = name;
+            m_id = asyncId;
+            m_argsArr = args;
+        }
+
+        private void mapFromArgArray() {
+            m_args = new HashMap<>();
+            if (m_argsArr == null) {
+                return;
+            }
+
+            for (int i=0; i<m_argsArr.length; i+=2) {
+                if (i+1 == m_argsArr.length) break;
+                m_args.put(m_argsArr[i].toString(), m_argsArr[i+1].toString());
+            }
+        }
+
+        /**
+         * Use the nanoTime of the first event for this file to set the sync time.
+         * This is used to sync first event time on all volt nodes to zero and thus
+         * make it easy to visualize multiple volt node traces.
+         *
+         * @param syncNanos
+         */
+        public void setSyncNanos(long syncNanos) {
+            m_ts = (m_nanos - syncNanos)/1000.0;
+        }
+
+        @JsonIgnore
+        public TraceEventType getType() {
+            return m_type;
+        }
+
+        @JsonProperty("ph")
+        public char getTypeChar() {
+            return m_type.getTypeChar();
+        }
+
+        @JsonProperty("ph")
+        public void setTypeChar(char ch) {
+            m_type = TraceEventType.fromTypeChar(ch);
+        }
+
+        public String getName() {
+            if (m_name != null) {
+                return m_name;
+            } else {
+                return null;
+            }
+        }
+
+        public void setName(String name) {
+            m_name = name;
+        }
+
+        @JsonProperty("cat")
+        public String getCategory() {
+            if (m_category != null) {
+                return m_category.name();
+            } else {
+                return null;
+            }
+        }
+
+        @JsonProperty("cat")
+        public void setCategory(Category cat) {
+            m_category = cat;
+        }
+
+        public String getId() {
+            return m_id;
+        }
+
+        public void setId(String id) {
+            m_id = id;
+        }
+
+        public int getPid() {
+            return s_pid;
+        }
+
+        public void setPid(int pid) {
+        }
+
+        public long getTid() {
+            return m_tid;
+        }
+
+        public void setTid(long tid) {
+            m_tid = tid;
+        }
+
+        @JsonIgnore
+        public long getNanos() {
+            return m_nanos;
+        }
+
+        @JsonIgnore
+        public void setNanos(long nanos) {
+            m_nanos = nanos;
+        }
+
+        /**
+         * The event timestamp in microseconds.
+         * @return
+         */
+        @JsonSerialize(using = CustomDoubleSerializer.class)
+        public double getTs() {
+            return m_ts;
+        }
+
+        public void setTs(long ts) {
+            m_ts = ts;
+        }
+
+        public Map<String, String> getArgs() {
+            if (m_args==null) {
+                mapFromArgArray();
+            }
+            return m_args;
+        }
+
+        public void setArgs(Map<String, String> args) {
+            m_args = args;
+        }
+
+        @Override
+        public String toString() {
+            return m_type + " " + m_name + " " + m_category + " " + m_id + " " + m_tid + " " + m_ts + " " +
+                   m_nanos + " " + m_args;
+        }
+    }
+
+    /**
+     * Custom serializer to serialize doubles in an easily readable format in the trace file.
+     */
+    private static class CustomDoubleSerializer extends JsonSerializer<Double> {
+
+        private DecimalFormat m_format = new DecimalFormat("#0.00");
+
+        @Override
+        public void serialize(Double value, JsonGenerator jsonGen, SerializerProvider sp)
+        throws IOException {
+            if (value == null) {
+                jsonGen.writeNull();
+            } else {
+                jsonGen.writeNumber(m_format.format(value));
+            }
+        }
+    }
+
+    /**
+     * Represents a batch of trace events that belong to the same category and thread.
+     */
+    public static class TraceEventBatch {
+        private final Category m_cat;
+        private final long m_tid;
+
+        private LinkedList<TraceEventWrapper> m_events = new LinkedList<>();
+
+        public TraceEventBatch(Category cat) {
+            m_cat = cat;
+            m_tid = Thread.currentThread().getId();
+        }
+
+        /**
+         * Add the event into the ring buffer. The event will stay in the buffer
+         * unless user instruct to write the queue to file. If the ring buffer is
+         * full, old events will be removed to make room for new events.
+         * @param s A supplier of the trace event. You can use Java 8's lambda
+         *          function to delay materializing the parameters in the event
+         *          because they could be expensive. If the event is never written
+         *          to file, the parameters will never be materialized.
+         */
+        public TraceEventBatch add(Supplier<TraceEvent> s) {
+            m_events.add(new TraceEventWrapper(s));
+            return this;
+        }
+
+        protected TraceEvent nextEvent() {
+            final TraceEventWrapper wrapper = m_events.poll();
+            if (wrapper != null) {
+                return wrapper.get(m_cat, m_tid);
+            } else {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Wraps around the event supplier so that we can capture timestamp
+     * at the time of the log.
+     */
+    private static class TraceEventWrapper {
+        private final long m_ts = System.nanoTime();
+        private final Supplier<TraceEvent> m_event;
+
+        public TraceEventWrapper(Supplier<TraceEvent> event) {
+            m_event = event;
+        }
+
+        public TraceEvent get(Category cat, long tid) {
+            final TraceEvent event = m_event.get();
+            event.setCategory(cat);
+            event.setTid(tid);
+            event.setNanos(m_ts);
+            return event;
+        }
+    }
+
+    static final int QUEUE_SIZE = Integer.getInteger("VOLTTRACE_QUEUE_SIZE", 4096);
+    private static volatile VoltTrace s_tracer;
+
+    private final String m_voltroot;
+    // Events from trace producers are put into this queue.
+    // TraceFileWriter takes events from this queue and writes them to files.
+    private EvictingQueue<TraceEventBatch> m_traceEvents = EvictingQueue.create(QUEUE_SIZE);
+    private EvictingQueue<TraceEventBatch> m_emptyQueue = EvictingQueue.create(QUEUE_SIZE);
+    private final ListeningExecutorService m_writerThread = CoreUtils.getCachedSingleThreadExecutor("VoltTrace Writer", 1000);
+
+    private volatile boolean m_shutdown = false;
+    private volatile Runnable m_shutdownCallback = null;
+
+    private volatile Set<Category> m_enabledCategories = ImmutableSet.of();
+    private final LinkedTransferQueue<Runnable> m_work = new LinkedTransferQueue<>();
+
+    protected VoltTrace(String voltroot) {
+        m_voltroot = voltroot;
+    }
+
+    private boolean isCategoryEnabled(Category cat) {
+        return m_enabledCategories.contains(cat);
+    }
+
+    private void queueEvent(TraceEventBatch s) {
+        m_work.offer(() -> m_traceEvents.offer(s));
+        // If queue is full, drop oldest events
+    }
+
+    private ListenableFuture dumpEvents(File path) {
+        if (m_emptyQueue == null || m_traceEvents.isEmpty()) {
+            return null;
+        }
+
+        final EvictingQueue<TraceEventBatch> writeQueue = m_traceEvents;
+        m_traceEvents = m_emptyQueue;
+        m_emptyQueue = null;
+
+        final ListenableFuture future = m_writerThread.submit(new TraceFileWriter(path, writeQueue));
+        future.addListener(() -> m_work.offer(() -> m_emptyQueue = writeQueue), CoreUtils.SAMETHREADEXECUTOR);
+        return future;
+    }
+
+    /**
+     * Write the events in the queue to file.
+     * @param path    The directory to write the file to.
+     * @return The file path if successfully written, or null if the there is
+     * already a write in progress.
+     */
+    private String write() throws IOException, ExecutionException, InterruptedException {
+        final File file = new File(m_voltroot, "trace_" + System.currentTimeMillis() + ".json.gz");
+        if (file.exists()) {
+            throw new IOException("Trace file " + file.getAbsolutePath() + " already exists");
+        }
+        if (!file.getParentFile().canWrite() || !file.getParentFile().canExecute()) {
+            throw new IOException("Trace file " + file.getAbsolutePath() + " is not writable");
+        }
+
+        SettableFuture<Future> f = SettableFuture.create();
+        m_work.offer(() -> f.set(dumpEvents(file)));
+        final Future writeFuture = f.get();
+        if (writeFuture != null) {
+            writeFuture.get(); // Wait for the write to finish without blocking new events
+            return file.getAbsolutePath();
+        } else {
+            // A write is already in progress, ignore this request
+            return null;
+        }
+    }
+
+    @Override
+    public void run() {
+        while (!m_shutdown) {
+            try {
+                final Runnable work = m_work.take();
+                if (work != null) {
+                    work.run();
+                }
+            } catch (Throwable t) {}
+        }
+    }
+
+    private void shutdown() {
+        if (m_shutdownCallback != null) {
+            try {
+                m_shutdownCallback.run();
+            } catch (Throwable t) {}
+        }
+        m_shutdown = true;
+    }
+
+    /**
+     * Create a trace event batch for the given category. The events that go
+     * into this batch should all originate from the same thread.
+     * @param cat The category to write the events to.
+     * @return The batch object to add events to, or null if trace logging for
+     * the category is not enabled.
+     */
+    public static TraceEventBatch log(Category cat) {
+        final VoltTrace tracer = s_tracer;
+        if (tracer != null && tracer.isCategoryEnabled(cat)) {
+            final TraceEventBatch batch = new TraceEventBatch(cat);
+            tracer.queueEvent(batch);
+            return batch;
+        } else {
+            return null;
+        }
+    }
+    /**
+     * Creates a metadata trace event. This method does not queue the
+     * event. Call {@link TraceEventBatch#add(Supplier)} to queue the event.
+     */
+    public static TraceEvent meta(String name, Object... args) {
+        return new TraceEvent(TraceEventType.METADATA, name, null, args);
+    }
+
+    /**
+     * Creates an instant trace event. This method does not queue the
+     * event. Call {@link TraceEventBatch#add(Supplier)} to queue the event.
+     */
+    public static TraceEvent instant(String name, Object... args) {
+        return new TraceEvent(TraceEventType.INSTANT, name, null, args);
+    }
+
+    /**
+     * Creates a begin duration trace event. This method does not queue the
+     * event. Call {@link TraceEventBatch#add(Supplier)} to queue the event.
+     */
+    public static TraceEvent beginDuration(String name, Object... args) {
+        return new TraceEvent(TraceEventType.DURATION_BEGIN, name, null, args);
+    }
+
+    /**
+     * Creates an end duration trace event. This method does not queue the
+     * event. Call {@link TraceEventBatch#add(Supplier)} to queue the event.
+     */
+    public static TraceEvent endDuration(Object... args) {
+        return new TraceEvent(TraceEventType.DURATION_END, null, null, args);
+    }
+
+    /**
+     * Creates a begin async trace event. This method does not queue the
+     * event. Call {@link TraceEventBatch#add(Supplier)} to queue the event.
+     */
+    public static TraceEvent beginAsync(String name, Object id, Object... args) {
+        return new TraceEvent(TraceEventType.ASYNC_BEGIN, name, String.valueOf(id), args);
+    }
+
+    /**
+     * Creates an end async trace event. This method does not queue the
+     * event. Call {@link TraceEventBatch#add(Supplier)} to queue the event.
+     */
+    public static TraceEvent endAsync(String name, Object id, Object... args) {
+        return new TraceEvent(TraceEventType.ASYNC_END, name, String.valueOf(id), args);
+    }
+
+    /**
+     * Creates an async instant trace event. This method does not queue the
+     * event. Call {@link TraceEventBatch#add(Supplier)} to queue the event.
+     */
+    public static TraceEvent instantAsync(String name, Object id, Object... args) {
+        return new TraceEvent(TraceEventType.ASYNC_INSTANT, name, String.valueOf(id), args);
+    }
+
+    /**
+     * Close all open files and wait for shutdown.
+     * @param dump             Dump all queued events
+     * @param timeOutMillis    Timeout in milliseconds. Negative to not wait
+     * @return The path to the trace file if written, or null if a write is already in progress.
+     */
+    public static String closeAllAndShutdown(boolean dump, long timeOutMillis) {
+        String path = null;
+        final VoltTrace tracer = s_tracer;
+
+        if (tracer != null) {
+            if (dump) {
+                path = dump();
+            }
+
+            s_tracer = null;
+
+            if (timeOutMillis >= 0) {
+                try {
+                    tracer.m_writerThread.shutdownNow();
+                    tracer.m_writerThread.awaitTermination(timeOutMillis, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                }
+            }
+
+            tracer.shutdown();
+        }
+
+        return path;
+    }
+
+    /**
+     * Creates and starts a new tracer. If one already exists, this is a no-op.
+     */
+    public static void start(String voltroot) throws IOException {
+        if (s_tracer == null) {
+            final File dir = new File(voltroot);
+            if (!dir.getParentFile().canWrite() || !dir.getParentFile().canExecute()) {
+                throw new IOException("Trace log parent directory " + dir.getParentFile().getAbsolutePath() +
+                                      " is not writable");
+            }
+            if (!dir.exists()) {
+                if (!dir.mkdir()) {
+                    throw new IOException("Failed to create trace log directory " + dir.getAbsolutePath());
+                }
+            }
+
+            final VoltTrace tracer = new VoltTrace(voltroot);
+            final Thread thread = new Thread(tracer);
+            thread.setDaemon(true);
+            thread.start();
+            s_tracer = tracer;
+        }
+    }
+
+    /**
+     * Write all trace events in the queue to file.
+     * @return The file path if written successfully, or null if a write is already in progress.
+     */
+    public static String dump() {
+        String path = null;
+        final VoltTrace tracer = s_tracer;
+
+        if (tracer != null) {
+            try {
+                path = tracer.write();
+            } catch (Exception e) {
+                s_logger.info("Unable to write trace file: " + e.getMessage(), e);
+            }
+        }
+
+        return path;
+    }
+
+    public static void enableCategories(Category... categories) {
+        final VoltTrace tracer = VoltTrace.s_tracer;
+
+        if (tracer == null) {
+            return;
+        }
+
+        final ImmutableSet.Builder<Category> builder = ImmutableSet.builder();
+        builder.addAll(tracer.m_enabledCategories);
+        builder.addAll(Arrays.asList(categories));
+        tracer.m_enabledCategories = builder.build();
+    }
+
+    public static void disableCategories(Category... categories) {
+        final VoltTrace tracer = VoltTrace.s_tracer;
+
+        if (tracer == null) {
+            return;
+        }
+
+        final List<Category> toDisable = Arrays.asList(categories);
+        final ImmutableSet.Builder<Category> builder = ImmutableSet.builder();
+        for (Category enabledCategory : tracer.m_enabledCategories) {
+            if (!toDisable.contains(enabledCategory)) {
+                builder.add(enabledCategory);
+            }
+        }
+        tracer.m_enabledCategories = builder.build();
+    }
+}

--- a/tests/ee/common/PerFragmentStatsTest.cpp
+++ b/tests/ee/common/PerFragmentStatsTest.cpp
@@ -125,7 +125,7 @@ TEST_F(PerFragmentStatsTest, TestPerFragmentStatsBuffer) {
     voltdb::ReferenceSerializeInputBE params(m_parameter_buffer.get(), m_smallBufferSize);
     m_engine->resetPerFragmentStatsOutputBuffer();
     // This batch should succeed and return 0.
-    ASSERT_EQ(0, m_engine->executePlanFragments(4, planfragmentIds, NULL, params, 1000, 1000, 1000, 1000, 1));
+    ASSERT_EQ(0, m_engine->executePlanFragments(4, planfragmentIds, NULL, params, 1000, 1000, 1000, 1000, 1, false));
     // Fetch the results. We have forced them to be written
     // to our own buffer in the local engine.  But we don't
     // know how much of the buffer is actually used.  So we
@@ -164,7 +164,7 @@ TEST_F(PerFragmentStatsTest, TestPerFragmentStatsBuffer) {
     addParameters(1, 4.0, "str%%");
     // This batch should FAIL and return 1.
     m_engine->resetPerFragmentStatsOutputBuffer();
-    ASSERT_EQ(1, m_engine->executePlanFragments(4, planfragmentIds, NULL, params, 1001, 1001, 1001, 1001, 2));
+    ASSERT_EQ(1, m_engine->executePlanFragments(4, planfragmentIds, NULL, params, 1001, 1001, 1001, 1001, 2, false));
     // Verify that 2 out of 4 fragments succeeded.
     validatePerFragmentStatsBuffer(2, 4);
     delete[] planfragmentIds;

--- a/tests/ee/execution/engine_test.cpp
+++ b/tests/ee/execution/engine_test.cpp
@@ -541,7 +541,7 @@ TEST_F(ExecutionEngineTest, Execute_PlanFragmentInfo) {
     // Execute the plan.  You'd think this would be more
     // impressive.
     //
-    m_engine->executePlanFragments(1, &fragmentId, NULL, emptyParams, 1000, 1000, 1000, 1000, 1);
+    m_engine->executePlanFragments(1, &fragmentId, NULL, emptyParams, 1000, 1000, 1000, 1000, 1, false);
 
     // Fetch the results.  We have forced them to be written
     // to our own buffer in the local engine.  But we don't

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -205,7 +205,7 @@ public:
             }
         }
         m_engine->setUndoToken(++m_undoToken);
-        ExecutorContext::getExecutorContext()->setupForPlanFragments(m_engine->getCurrentUndoQuantum(), 0, 0, 0, 0);
+        ExecutorContext::getExecutorContext()->setupForPlanFragments(m_engine->getCurrentUndoQuantum(), 0, 0, 0, 0, false);
         m_tuplesDeletedInLastUndo = 0;
         m_tuplesInsertedInLastUndo = 0;
     }

--- a/tests/ee/storage/CopyOnWriteTest.cpp
+++ b/tests/ee/storage/CopyOnWriteTest.cpp
@@ -302,7 +302,7 @@ public:
         }
         m_engine->setUndoToken(++m_undoToken);
         ExecutorContext::getExecutorContext()->setupForPlanFragments(m_engine->getCurrentUndoQuantum(),
-                                                                     0, 0, 0, 0);
+                                                                     0, 0, 0, 0, false);
         m_tuplesDeletedInLastUndo = 0;
         m_tuplesInsertedInLastUndo = 0;
     }
@@ -1086,7 +1086,7 @@ public:
             m_engine->releaseUndoToken(m_undoToken);
         }
         ExecutorContext::getExecutorContext()->setupForPlanFragments(m_engine->getCurrentUndoQuantum(),
-                                                                     0, 0, 0, 0);
+                                                                     0, 0, 0, 0, false);
         m_undoToken++;
     }
 
@@ -1283,7 +1283,7 @@ TEST_F(CopyOnWriteTest, BigTestWithUndo) {
     addRandomUniqueTuples( m_table, tupleCount);
     m_engine->setUndoToken(0);
     ExecutorContext::getExecutorContext()->setupForPlanFragments(m_engine->getCurrentUndoQuantum(),
-                                                                 0, 0, 0, 0);
+                                                                 0, 0, 0, 0, false);
     for (int qq = 0; qq < NUM_REPETITIONS; qq++) {
         T_ValueSet originalTuples;
         voltdb::TableIterator& iterator = m_table->iterator();
@@ -1351,7 +1351,7 @@ TEST_F(CopyOnWriteTest, BigTestUndoEverything) {
     addRandomUniqueTuples( m_table, tupleCount);
     m_engine->setUndoToken(0);
     ExecutorContext::getExecutorContext()->setupForPlanFragments(m_engine->getCurrentUndoQuantum(),
-                                                                 0, 0, 0, 0);
+                                                                 0, 0, 0, 0, false);
     for (int qq = 0; qq < NUM_REPETITIONS; qq++) {
         T_ValueSet originalTuples;
         voltdb::TableIterator& iterator = m_table->iterator();
@@ -1409,7 +1409,7 @@ TEST_F(CopyOnWriteTest, BigTestUndoEverything) {
             m_engine->undoUndoToken(m_undoToken);
             m_engine->setUndoToken(++m_undoToken);
             ExecutorContext::getExecutorContext()->setupForPlanFragments(m_engine->getCurrentUndoQuantum(),
-                                                                         0, 0, 0, 0);
+                                                                         0, 0, 0, 0, false);
         }
 
         checkTuples(0, originalTuples, COWTuples);
@@ -1977,7 +1977,6 @@ TEST_F(CopyOnWriteTest, SnapshotAndIndex) {
             checkIndex(testRange2.label("streamed"), &streamedIndex2, predicates2, true);
         }
 
-        itest++;
     }
 }
 

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -322,7 +322,7 @@ public:
 
         UndoQuantum* uq = isReadOnly() ? NULL : m_undoLog.generateUndoQuantum(m_undoToken);
         engine->getExecutorContext()->setupForPlanFragments(uq, addPartitionId(txnId), addPartitionId(spHandle),
-                                                            addPartitionId(lastCommittedSpHandle), addPartitionId(uniqueId));
+                                                            addPartitionId(lastCommittedSpHandle), addPartitionId(uniqueId), false);
         engine->getExecutorContext()->checkTransactionForDR();
     }
 
@@ -1209,7 +1209,7 @@ TEST_F(DRBinaryLogTest, PartialTxnRollback) {
     // Simulate a second batch within the same txn
     UndoQuantum* uq = m_undoLog.generateUndoQuantum(m_undoToken + 1);
     m_engine->getExecutorContext()->setupForPlanFragments(uq, addPartitionId(99), addPartitionId(99),
-                                     addPartitionId(98), addPartitionId(70));
+                                                          addPartitionId(98), addPartitionId(70), false);
 
     insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
 

--- a/tests/ee/storage/StreamedTable_test.cpp
+++ b/tests/ee/storage/StreamedTable_test.cpp
@@ -95,7 +95,7 @@ public:
         m_quantum->release();
         m_quantum = new (*m_pool) UndoQuantum(i + tokenOffset, m_pool);
         // quant, currTxnId, committedTxnId
-        m_context->setupForPlanFragments(m_quantum, i, i, i - 1, 0);
+        m_context->setupForPlanFragments(m_quantum, i, i, i - 1, 0, false);
     }
 
     virtual ~StreamedTableTest() {

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -92,7 +92,8 @@ protected:
             0,  // txn id
             0,  // sp handle
             0,  // last committed sp handle
-            m_uniqueId);
+            m_uniqueId,
+            false);
         // DR timestamp discards the low 14 bits of the unique ID,
         // so we must increment by this amount to produce a new DR
         // timestamp next time around.

--- a/tests/ee/storage/table_and_indexes_test.cpp
+++ b/tests/ee/storage/table_and_indexes_test.cpp
@@ -99,7 +99,7 @@ class TableAndIndexTest : public Test {
             mem = 0;
             *reinterpret_cast<int64_t*>(signature) = 42;
 
-            eContext->setupForPlanFragments(NULL, 44, 44, 44, 44);
+            eContext->setupForPlanFragments(NULL, 44, 44, 44, 44, false);
 
             vector<voltdb::ValueType> districtColumnTypes;
             vector<int32_t> districtColumnLengths;
@@ -397,7 +397,7 @@ TEST_F(TableAndIndexTest, DrTest) {
     drStream.m_enabled = true;
     districtTable->setDR(true);
     //Prepare to insert in a new txn
-    eContext->setupForPlanFragments( NULL, addPartitionId(99), addPartitionId(99), addPartitionId(98), addPartitionId(70));
+    eContext->setupForPlanFragments( NULL, addPartitionId(99), addPartitionId(99), addPartitionId(98), addPartitionId(70), false);
 
     vector<NValue> cachedStringValues;//To free at the end of the test
     TableTuple temp_tuple = districtTempTable->tempTuple();
@@ -459,7 +459,7 @@ TEST_F(TableAndIndexTest, DrTest) {
     EXPECT_EQ(nextTuple.getNValue(7).compare(cachedStringValues.back()), 0);
 
     //Prepare to insert in a new txn
-    eContext->setupForPlanFragments( NULL, addPartitionId(100), addPartitionId(100), addPartitionId(99), addPartitionId(72));
+    eContext->setupForPlanFragments( NULL, addPartitionId(100), addPartitionId(100), addPartitionId(99), addPartitionId(72), false);
 
     /*
      * Test that update propagates
@@ -504,7 +504,7 @@ TEST_F(TableAndIndexTest, DrTest) {
     ASSERT_FALSE(toDelete.isNullTuple());
 
     //Prep another transaction to test propagating a delete
-    eContext->setupForPlanFragments( NULL, addPartitionId(102), addPartitionId(102), addPartitionId(101), addPartitionId(89));
+    eContext->setupForPlanFragments( NULL, addPartitionId(102), addPartitionId(102), addPartitionId(101), addPartitionId(89), false);
 
     districtTable->deleteTuple(toDelete, true);
 
@@ -540,7 +540,7 @@ TEST_F(TableAndIndexTest, DrTestNoPK) {
     drStream.m_enabled = true;
     districtTable->setDR(true);
     //Prepare to insert in a new txn
-    eContext->setupForPlanFragments( NULL, addPartitionId(99), addPartitionId(99), addPartitionId(98), addPartitionId(70));
+    eContext->setupForPlanFragments( NULL, addPartitionId(99), addPartitionId(99), addPartitionId(98), addPartitionId(70), false);
 
     vector<NValue> cachedStringValues;//To free at the end of the test
     TableTuple temp_tuple = districtTempTable->tempTuple();
@@ -602,7 +602,7 @@ TEST_F(TableAndIndexTest, DrTestNoPK) {
     EXPECT_EQ(nextTuple.getNValue(7).compare(cachedStringValues.back()), 0);
 
     //Prepare to insert in a new txn
-    eContext->setupForPlanFragments( NULL, addPartitionId(100), addPartitionId(100), addPartitionId(99), addPartitionId(72));
+    eContext->setupForPlanFragments( NULL, addPartitionId(100), addPartitionId(100), addPartitionId(99), addPartitionId(72), false);
 
     /*
      * Test that delete propagates
@@ -643,7 +643,7 @@ TEST_F(TableAndIndexTest, DrTestNoPKUninlinedColumn) {
     drStream.m_enabled = true;
     customerTable->setDR(true);
     //Prepare to insert in a new txn
-    eContext->setupForPlanFragments( NULL, addPartitionId(99), addPartitionId(99), addPartitionId(98), addPartitionId(70));
+    eContext->setupForPlanFragments( NULL, addPartitionId(99), addPartitionId(99), addPartitionId(98), addPartitionId(70), false);
 
     vector<NValue> cachedStringValues;//To free at the end of the test
     TableTuple temp_tuple = customerTempTable->tempTuple();
@@ -720,7 +720,7 @@ TEST_F(TableAndIndexTest, DrTestNoPKUninlinedColumn) {
     EXPECT_EQ(nextTuple.getNValue(20).compare(cachedStringValues.back()), 0);
 
     //Prepare to insert in a new txn
-    eContext->setupForPlanFragments( NULL, addPartitionId(100), addPartitionId(100), addPartitionId(99), addPartitionId(72));
+    eContext->setupForPlanFragments( NULL, addPartitionId(100), addPartitionId(100), addPartitionId(99), addPartitionId(72), false);
 
     /*
      * Test that delete propagates

--- a/tests/ee/test_utils/plan_testing_baseclass.h
+++ b/tests/ee/test_utils/plan_testing_baseclass.h
@@ -247,7 +247,7 @@ public:
             // impressive.
             //
             try {
-                m_engine->executePlanFragments(1, &fragmentId, NULL, emptyParams, 1000, 1000, 1000, 1000, 1);
+                m_engine->executePlanFragments(1, &fragmentId, NULL, emptyParams, 1000, 1000, 1000, 1000, 1, false);
             } catch (voltdb::SerializableEEException &ex) {
                 throw;
             }

--- a/tests/frontend/org/voltdb/TestTwoSitePlans.java
+++ b/tests/frontend/org/voltdb/TestTwoSitePlans.java
@@ -202,7 +202,7 @@ public class TestTwoSitePlans extends TestCase {
                 1,
                 0,
                 42,
-                Long.MAX_VALUE);
+                Long.MAX_VALUE, false);
         assert(results.length == 1);
         assert(results[0].asScalarLong() == 1L);
 
@@ -218,7 +218,7 @@ public class TestTwoSitePlans extends TestCase {
                 2,
                 1,
                 42,
-                Long.MAX_VALUE);
+                Long.MAX_VALUE, false);
         assert(results.length == 1);
         assert(results[0].asScalarLong() == 1L);
     }
@@ -233,7 +233,7 @@ public class TestTwoSitePlans extends TestCase {
                 null,
                 new ParameterSet[] { params },
                 new String[] { selectStmt.getSqltext() },
-                3, 3, 2, 42, Long.MAX_VALUE)[0];
+                3, 3, 2, 42, Long.MAX_VALUE, false)[0];
         try {
             System.out.println(dependency1.toString());
         } catch (Exception e) {
@@ -247,7 +247,7 @@ public class TestTwoSitePlans extends TestCase {
                 null,
                 new ParameterSet[] { params },
                 new String[] { selectStmt.getSqltext() },
-                3, 3, 2, 42, Long.MAX_VALUE)[0];
+                3, 3, 2, 42, Long.MAX_VALUE, false)[0];
         try {
             System.out.println(dependency2.toString());
         } catch (Exception e) {
@@ -264,7 +264,7 @@ public class TestTwoSitePlans extends TestCase {
                 new long[] { outDepId },
                 new ParameterSet[] { params },
                 new String[] { selectStmt.getSqltext() },
-                3, 3, 2, 42, Long.MAX_VALUE)[0];
+                3, 3, 2, 42, Long.MAX_VALUE, false)[0];
         try {
             System.out.println("Final Result");
             System.out.println(dependency1.toString());

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -133,7 +133,7 @@ public class TestFragmentProgressUpdate extends TestCase {
                 null,
                 new ParameterSet[] { params },
                 new String[] { selectStmt.getSqltext() },
-                3, 3, 2, 42, Long.MAX_VALUE);
+                3, 3, 2, 42, Long.MAX_VALUE, false);
         // Like many fully successful operations, a single row fetch counts as 2 logical row operations,
         // one for locating the row and one for retrieving it.
         assertEquals(1, m_ee.m_callsFromEE);
@@ -186,7 +186,7 @@ public class TestFragmentProgressUpdate extends TestCase {
                 null,
                 new ParameterSet[] { params },
                 new String[] { selectStmt.getSqltext() },
-                3, 3, 2, 42, Long.MAX_VALUE);
+                3, 3, 2, 42, Long.MAX_VALUE, false);
 
         // Like many fully successful operations, a single row fetch counts as 2 logical row operations,
         // one for locating the row and one for retrieving it.
@@ -222,7 +222,7 @@ public class TestFragmentProgressUpdate extends TestCase {
                 null,
                 new ParameterSet[] { params },
                 new String[] { deleteStmt.getSqltext() },
-                3, 3, 2, 42, WRITE_TOKEN);
+                3, 3, 2, 42, WRITE_TOKEN, false);
 
         // populate plan cache
         ActivePlanRepository.clear();
@@ -237,7 +237,7 @@ public class TestFragmentProgressUpdate extends TestCase {
                 null,
                 new ParameterSet[] { params },
                 new String[] { selectStmt.getSqltext() },
-                3, 3, 2, 42, Long.MAX_VALUE);
+                3, 3, 2, 42, Long.MAX_VALUE, false);
         assertTrue(m_ee.m_callsFromEE > 2);
         // here the m_lastTuplesAccessed is just the same as threshold, since we start a new fragment
         assertEquals(longOpthreshold, m_ee.m_lastTuplesAccessed);
@@ -292,7 +292,7 @@ public class TestFragmentProgressUpdate extends TestCase {
                 null,
                 new ParameterSet[] { params },
                 new String[] { selectStmt.getSqltext() },
-                3, 3, 2, 42, READ_ONLY_TOKEN);
+                3, 3, 2, 42, READ_ONLY_TOKEN, false);
 
         // If want to see the stats, please uncomment the following line.
         // It is '8 393216 262144' on my machine.
@@ -470,7 +470,7 @@ public class TestFragmentProgressUpdate extends TestCase {
                     paramSets,
                     sqlTexts,
                     3, 3, 2, 42,
-                    readOnly ? READ_ONLY_TOKEN : WRITE_TOKEN);
+                    readOnly ? READ_ONLY_TOKEN : WRITE_TOKEN, false);
             if (readOnly && timeout > 0) {
                 // only time out read queries
                 fail();

--- a/tests/frontend/org/voltdb/utils/TestVoltTrace.java
+++ b/tests/frontend/org/voltdb/utils/TestVoltTrace.java
@@ -1,0 +1,345 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.utils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.zip.GZIPInputStream;
+
+import org.codehaus.jackson.map.ObjectMapper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TestVoltTrace {
+
+    private static final String FILE_NAME_PREFIX = "tracetest";
+
+    private ObjectMapper m_mapper = new ObjectMapper();
+    private File m_tempDir = null;
+
+    @Before
+    public void setUp() throws Exception {
+        m_tempDir = VoltFile.createTempFile(FILE_NAME_PREFIX, null);
+        assertTrue(m_tempDir.delete());
+        assertTrue(m_tempDir.mkdir());
+        VoltTrace.start(m_tempDir.getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        VoltTrace.closeAllAndShutdown(false, 0);
+        VoltFile.recursivelyDelete(m_tempDir);
+        m_tempDir = null;
+    }
+
+    @Test
+    public void testFileWriter() throws IOException {
+        final File f = VoltFile.createTempFile(FILE_NAME_PREFIX, "json");
+        f.deleteOnExit();
+
+        LinkedList<VoltTrace.TraceEventBatch> events = new LinkedList<>();
+        LinkedList<VoltTrace.TraceEvent> flatEvents = new LinkedList<>();
+        for (int i = 0; i < 10; i++) {
+            final VoltTrace.TraceEventBatch batch = new VoltTrace.TraceEventBatch(VoltTrace.Category.CI);
+            for (int j = 0; j < 10; j++) {
+                final VoltTrace.TraceEvent e = randomEvent();
+                batch.add(() -> e);
+                flatEvents.add(e);
+            }
+            events.add(batch);
+        }
+        new TraceFileWriter(f, events).run();
+
+        verifyFileContents(flatEvents, f.getAbsolutePath());
+    }
+
+    @Test
+    public void testCategoryToggle() {
+        // Nothing is enabled by default
+        for (VoltTrace.Category category : VoltTrace.Category.values()) {
+            assertNull(VoltTrace.log(category));
+        }
+
+        // Enable two categories
+        VoltTrace.enableCategories(VoltTrace.Category.CI, VoltTrace.Category.SPI);
+        for (VoltTrace.Category category : VoltTrace.Category.values()) {
+            if (category == VoltTrace.Category.CI || category == VoltTrace.Category.SPI) {
+                assertNotNull(VoltTrace.log(category));
+            } else {
+                assertNull(VoltTrace.log(category));
+            }
+        }
+
+        // Disable one of them
+        VoltTrace.disableCategories(VoltTrace.Category.CI);
+        for (VoltTrace.Category category : VoltTrace.Category.values()) {
+            if (category == VoltTrace.Category.SPI) {
+                assertNotNull(VoltTrace.log(category));
+            } else {
+                assertNull(VoltTrace.log(category));
+            }
+        }
+    }
+
+    @Test
+    public void testBasicTrace() throws Exception {
+        VoltTrace.enableCategories(VoltTrace.Category.values());
+        final SenderRunnable sender = new SenderRunnable();
+        sender.run();
+        final String path = VoltTrace.closeAllAndShutdown(true, 0);
+
+        verifyFileContents(sender.getSentList(), path);
+    }
+
+    @Test
+    public void testTraceLimit() throws IOException {
+        VoltTrace.enableCategories(VoltTrace.Category.values());
+
+        // These events should be purged once the limit is reached
+        for (int i = 0; i < 10; i++) {
+            VoltTrace.log(VoltTrace.Category.CI).add(this::randomEvent);
+        }
+
+        // Fill the queue with exactly the limit number of events
+        final SenderRunnable sender = new SenderRunnable(VoltTrace.QUEUE_SIZE);
+        sender.run();
+
+        verifyFileContents(sender.getSentList(), VoltTrace.closeAllAndShutdown(true, 0));
+    }
+
+    private ArrayList<VoltTrace.TraceEventType> m_allEventTypes = new ArrayList<>(EnumSet.allOf(VoltTrace.TraceEventType.class));
+    private Random m_random = new Random();
+    private VoltTrace.TraceEvent randomEvent() {
+        VoltTrace.TraceEvent event = null;
+        while (event==null) {
+            VoltTrace.TraceEventType type = m_allEventTypes.get(m_random.nextInt(m_allEventTypes.size()));
+            switch(type) {
+            case ASYNC_BEGIN:
+                event = randomAsync(true);
+                break;
+            case ASYNC_END:
+                event = randomAsync(false);
+                break;
+            case ASYNC_INSTANT:
+                event = randomInstant(true);
+                break;
+            case DURATION_BEGIN:
+                event = randomDurationBegin();
+                break;
+            case DURATION_END:
+                event = randomDurationEnd();
+                break;
+            case INSTANT:
+                event = randomInstant(false);
+                break;
+            case METADATA:
+                event = randomMeta();
+                break;
+            default:
+                break;
+            }
+        }
+
+        event.setTid(Thread.currentThread().getId());
+        event.setNanos(System.nanoTime());
+
+        return event;
+    }
+
+    private VoltTrace.TraceEvent randomDurationBegin() {
+        return new VoltTrace.TraceEvent(VoltTrace.TraceEventType.DURATION_BEGIN,
+                                        "name"+m_random.nextInt(5), null, randomArgs());
+    }
+
+    private VoltTrace.TraceEvent randomDurationEnd() {
+        return new VoltTrace.TraceEvent(VoltTrace.TraceEventType.DURATION_END,
+                                        null, null);
+    }
+
+    private VoltTrace.TraceEvent randomAsync(boolean begin) {
+        VoltTrace.TraceEventType type = (begin) ?
+                VoltTrace.TraceEventType.ASYNC_BEGIN : VoltTrace.TraceEventType.ASYNC_END;
+        return new VoltTrace.TraceEvent(type, "name"+m_random.nextInt(5),
+                                        Long.toString(m_random.nextLong()), randomArgs());
+    }
+
+    private VoltTrace.TraceEvent randomInstant(boolean async) {
+        VoltTrace.TraceEventType type = (async) ?
+                VoltTrace.TraceEventType.ASYNC_INSTANT : VoltTrace.TraceEventType.INSTANT;
+        String id = (async) ? Long.toString(m_random.nextLong()) : null;
+        return new VoltTrace.TraceEvent(type,
+                "name"+m_random.nextInt(5),
+                                        id, randomArgs());
+    }
+
+    private static String[] s_metadataNames = { "process_name", "process_labels", "process_sort_index",
+            "thread_name", "thread_sort_index"
+    };
+    private VoltTrace.TraceEvent randomMeta() {
+        String name = s_metadataNames[m_random.nextInt(s_metadataNames.length)];
+        return new VoltTrace.TraceEvent(VoltTrace.TraceEventType.METADATA, name, null,
+                                        randomArgs());
+    }
+
+    private static String[] s_argKeys = { "name", "dest", "ciHandle", "txnid", "commit", "key1", "keyn" };
+    private Object[] randomArgs() {
+        int count = m_random.nextInt(4);
+        String[] args = new String[count*2];
+        for (int i=0; i<count; i++) {
+            String key = s_argKeys[m_random.nextInt(s_argKeys.length)];
+            args[i*2] = key;
+            args[i*2+1] = key+"-val";
+        }
+
+        return args;
+    }
+
+    private void verifyFileContents(List<VoltTrace.TraceEvent> expectedList, String outfile)
+        throws IOException {
+        List<VoltTrace.TraceEvent> readEvents = new ArrayList<>();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(outfile))));
+        String line;
+        while ((line=reader.readLine()) != null) {
+            line = line.trim();
+            if (line.equals("]") || line.equals("[")) {
+                continue;
+            }
+
+            if (line.charAt(line.length()-1)==',') {
+                line = line.substring(0, line.length()-1);
+            }
+            readEvents.add(m_mapper.readValue(line, VoltTrace.TraceEvent.class));
+        }
+        reader.close();
+        assertEquals(expectedList.size(), readEvents.size());
+
+        readEvents.sort(Comparator.comparingDouble(VoltTrace.TraceEvent::getTs));
+        expectedList.sort(Comparator.comparingDouble(VoltTrace.TraceEvent::getNanos));
+        System.out.println("Expected");
+        expectedList.forEach(System.out::println);
+        System.out.println("Read");
+        readEvents.forEach(System.out::println);
+        for (int i = 0; i < expectedList.size(); i++) {
+            compare(expectedList.get(i), readEvents.get(i));
+        }
+    }
+
+    private void compare(VoltTrace.TraceEvent expected, VoltTrace.TraceEvent actual) {
+        assertEquals(expected.getCategory(), actual.getCategory());
+        assertEquals(expected.getName(), actual.getName());
+        assertEquals(expected.getPid(), actual.getPid());
+        assertEquals(expected.getTid(), actual.getTid());
+        assertEquals(expected.getTypeChar(), actual.getTypeChar());
+        assertEquals(expected.getId(), actual.getId());
+        assertEquals(expected.getType(), actual.getType());
+        assertEquals(expected.getArgs(), actual.getArgs());
+    }
+
+    public class SenderRunnable implements Runnable {
+        private final long m_count;
+        private List<VoltTrace.TraceEvent> m_sentList = new ArrayList<>();
+
+        public SenderRunnable() {
+            this(10);
+        }
+
+        public SenderRunnable(long count) {
+            m_count = count;
+        }
+
+        public void run() {
+            try {
+                for (int i = 0; i < m_count; i++) {
+                    final VoltTrace.Category category = VoltTrace.Category.values()[m_random.nextInt(VoltTrace.Category.values().length)];
+                    final VoltTrace.TraceEventBatch log = VoltTrace.log(category);
+                    assert log != null;
+
+                    VoltTrace.TraceEvent event = randomEvent();
+                    event.setCategory(category);
+
+                    String[] args = new String[event.getArgs().size()*2];
+                    int j=0;
+                    for (String key : event.getArgs().keySet()) {
+                        args[j++] = key;
+                        args[j++] = event.getArgs().get(key);
+                    }
+                    switch(event.getType()) {
+                    case ASYNC_BEGIN:
+                        log.add(() -> VoltTrace.beginAsync(event.getName(),
+                                                           event.getId(),
+                                                           (Object[]) args));
+                        break;
+                    case ASYNC_END:
+                        log.add(() -> VoltTrace.endAsync(event.getName(),
+                                                         event.getId(),
+                                                         (Object[]) args));
+                        break;
+                    case ASYNC_INSTANT:
+                        log.add(() -> VoltTrace.instantAsync(event.getName(),
+                                                             event.getId(),
+                                                             (Object[]) args));
+                        break;
+                    case DURATION_BEGIN:
+                        log.add(() -> VoltTrace.beginDuration(event.getName(),
+                                                              (Object[]) args));
+                        break;
+                    case DURATION_END:
+                        log.add(VoltTrace::endDuration);
+                        break;
+                    case INSTANT:
+                        log.add(() -> VoltTrace.instant(event.getName(),
+                                                        (Object[]) args));
+                        break;
+                    case METADATA:
+                        log.add(() -> VoltTrace.meta(event.getName(),
+                                                     (Object[]) args));
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported event type: " + event.getType());
+                    }
+                    m_sentList.add(event);
+                }
+            } catch(Throwable t) {
+                t.printStackTrace();
+            }
+        }
+
+        public List<VoltTrace.TraceEvent> getSentList() {
+            return m_sentList;
+        }
+    }
+}


### PR DESCRIPTION
Introducing an online tracing system that can be turned on and off at
runtime without significantly impacting the workload. Trace events will
be cached in a ring buffer in memory unless instructed to be written to
file. Since the ring buffer is bounded, old trace events will be removed
if the buffer is filled up. This allows tracing to be turned on without
worrying about running out of heap. The ring buffer size can be tweaked
using the Java system property "VOLTTRACE_QUEUE_SIZE". By default, it is
set to 4096 event batches, each batch can contain several events.

The tracing system can be turned on/off for each of VoltDB's subsystems
individually. Trace events are currently available for the following
subsystems.

- CI: Client Interface.
- MPI: Multi-partition Initiator.
- MPSITE: Multi-partition Site.
- SPI: Single-partition Initiator.
- SPSITE: Single-partition Site.
- EE: Execution Engine. Please note that turning this category on may
  introduce significant performance impact because each statement in
  each fragment batch will result in a JNI call and some new objects
  being created on the heap.
- DRPRODUCER: DR Producer.
- DRCONSUMER: DR Consumer.

The trace points available now are sufficient to diagnose most
transaction related problems such as slow query/transaction, overhead
incurred by command logging (sync or async), or spikes in transaction
latency, etc. More trace points can be added to other parts of the
system.

The output file format is JSON. The JSON content conforms to the Chrome
Trace Event format, so it can easily be loaded into Chrome's tracing
tool for visualization. It is also easy to parse and analyze in
programs.

There is a system procedure, @Trace, to manage the tracing system at
runtime. It has the following parameters.

- @Trace on: Turn on the tracing system if it's not turned on already.
- @Trace off: Turn the tracing system off if it is on.
- @Trace dump: Write all trace events in the ring buffer to file and
  return the file path.
- @Trace enable category: Enable tracing for the given category.
- @Trace disable category: Disable tracing for the given category.

SQLCmd currently recognizes the @Trace sysproc, but VMC does not. It
could also be added to voltadmin for ease of use.

Based on preliminary benchmark results, turning the tracing system on
for all existing categories doesn't add noticeable overhead to
throughput but adds several milliseconds to the latency. If tracing is
turned off, it adds almost zero overhead to the system.

If you are a Volt developer and would like to add some trace events,
here are some guidelines.

1. Get a TraceEventBatch by calling VoltTrace.log(category) with the
   appropriate category listed above. If the category you have in mind
   doesn't exist yet, add it to the Category enum first. If a non-null
   TraceEventBatch is returned, that means the trace event logging for
   this category is enabled. If the returned value is null, either trace
   event logging is completely disabled or this category is
   disabled. Skip logging in this case.

2. Always wrap your trace event logging code with a null check of the
   returned TraceEventBatch object for both safety and performance
   reasons.

3. The returned TraceEventBatch object can contain multiple trace
   events. Use the same batch as long as you are still in the same
   thread logging for the same category. Call TraceEventBatch.add() to
   add events. The method takes a Supplier, which can easily be created
   using Java 8's lambda expression. The reason for using a Supplier
   here is to delay potentially expensive materialization of the
   parameters on performance sensitive paths. Materialization will be
   delayed until they are written to file, or they will never
   materialize if they are never written to file. For example, to create
   an instant event that captures some interesting variables, you can do
   the following,

       batch.add(() -> VoltTrace.instant("myInstantEvent",
                                         "argName", "argValue"));

4. Always add some meta events to record a human friendly process name
   and a thread name if the event you are logging could be the first
   event in this VoltDB process, e.g. when a stored procedure invocation
   request first arrives at a server node. This helps visualization
   later.

5. For the async events, async begin/end and async instant, you have to
   provide a unique ID to tie them together. The ID has to be globally
   unique across threads and processes. You can use string as ID. For
   example, in order to track transaction messages across the cluster, I
   use (sender HSID, receiver HSID, transaction ID) as the identifier
   for the corresponding async events. This ID has to be consistent for
   the events in the series, or they will not be linked together in the
   visualization.