### PR TITLE
Update message severity level during validation of start action

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -75,6 +75,7 @@ import org.apache.log4j.FileAppender;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper_voltpatches.CreateMode;
 import org.apache.zookeeper_voltpatches.KeeperException;
+import org.apache.zookeeper_voltpatches.KeeperException.Code;
 import org.apache.zookeeper_voltpatches.WatchedEvent;
 import org.apache.zookeeper_voltpatches.Watcher;
 import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
@@ -1711,38 +1712,57 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     }
 
     private void validateStartAction() {
+        ZooKeeper zk = m_messenger.getZK();
+        boolean initCompleted = false;
+        List<String> children = null;
+
         try {
-            ZooKeeper zk = m_messenger.getZK();
-            boolean initCompleted = zk.exists(VoltZK.init_completed, false) != null;
-            List<String> children = zk.getChildren(VoltZK.start_action, new StartActionWatcher(), null);
-            if (!children.isEmpty()) {
-                for (String child : children) {
-                    byte[] data = zk.getData(VoltZK.start_action + "/" + child, false, null);
-                    if (data == null) {
-                        VoltDB.crashLocalVoltDB("Couldn't find " + VoltZK.start_action + "/" + child);
+            initCompleted = zk.exists(VoltZK.init_completed, false) != null;
+            children = zk.getChildren(VoltZK.start_action, new StartActionWatcher(), null);
+        } catch (KeeperException e) {
+            hostLog.error("Failed to validate the start actions", e);
+            return;
+        } catch (InterruptedException e) {
+            VoltDB.crashLocalVoltDB("Interrupted during start action validation:" + e.getMessage(), true, e);
+        }
+
+        if (children != null && !children.isEmpty()) {
+            for (String child : children) {
+                byte[] data = null;
+                try {
+                    data = zk.getData(VoltZK.start_action + "/" + child, false, null);
+                } catch (KeeperException excp) {
+                    if (excp.code() == Code.NONODE) {
+                        hostLog.warn("Failed to validate the start action due to node "
+                                + VoltZK.start_action + "/" + child + " disconnected", excp);
+                    } else {
+                        hostLog.error("Failed to validate the start actions ", excp);
                     }
-                    String startAction = new String(data);
-                    if ((startAction.equals(StartAction.JOIN.toString()) ||
-                            startAction.equals(StartAction.REJOIN.toString()) ||
-                            startAction.equals(StartAction.LIVE_REJOIN.toString())) &&
-                            !initCompleted) {
-                        int nodeId = VoltZK.getHostIDFromChildName(child);
-                        if (nodeId == m_messenger.getHostId()) {
-                            VoltDB.crashLocalVoltDB("This node was started with start action " + startAction + " during cluster creation. "
-                                    + "All nodes should be started with matching create or recover actions when bring up a cluster. "
-                                    + "Join and rejoin are for adding nodes to an already running cluster.");
-                        } else {
-                            hostLog.warn("Node " + nodeId + " tried to " + startAction + " cluster but it is not allowed during cluster creation. "
-                                    + "All nodes should be started with matching create or recover actions when bring up a cluster. "
-                                    + "Join and rejoin are for adding nodes to an already running cluster.");
-                        }
+                    return;
+                } catch (InterruptedException e) {
+                    VoltDB.crashLocalVoltDB("Interrupted during start action validation:" + e.getMessage(), true, e);
+                }
+
+                if (data == null) {
+                    VoltDB.crashLocalVoltDB("Couldn't find " + VoltZK.start_action + "/" + child);
+                }
+                String startAction = new String(data);
+                if ((startAction.equals(StartAction.JOIN.toString()) ||
+                        startAction.equals(StartAction.REJOIN.toString()) ||
+                        startAction.equals(StartAction.LIVE_REJOIN.toString())) &&
+                        !initCompleted) {
+                    int nodeId = VoltZK.getHostIDFromChildName(child);
+                    if (nodeId == m_messenger.getHostId()) {
+                        VoltDB.crashLocalVoltDB("This node was started with start action " + startAction + " during cluster creation. "
+                                + "All nodes should be started with matching create or recover actions when bring up a cluster. "
+                                + "Join and rejoin are for adding nodes to an already running cluster.");
+                    } else {
+                        hostLog.warn("Node " + nodeId + " tried to " + startAction + " cluster but it is not allowed during cluster creation. "
+                                + "All nodes should be started with matching create or recover actions when bring up a cluster. "
+                                + "Join and rejoin are for adding nodes to an already running cluster.");
                     }
                 }
             }
-        } catch (KeeperException e) {
-            hostLog.error("Failed to validate the start actions", e);
-        } catch (InterruptedException e) {
-            VoltDB.crashLocalVoltDB("Interrupted during start action validation:" + e.getMessage(), true, e);
         }
     }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1733,8 +1733,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     data = zk.getData(VoltZK.start_action + "/" + child, false, null);
                 } catch (KeeperException excp) {
                     if (excp.code() == Code.NONODE) {
-                        hostLog.warn("Failed to validate the start action as node "
-                                + VoltZK.start_action + "/" + child + " got disconnected", excp);
+                        if (hostLog.isDebugEnabled())
+                            hostLog.warn("Failed to validate the start action as node "
+                                    + VoltZK.start_action + "/" + child + " got disconnected", excp);
                     } else {
                         hostLog.error("Failed to validate the start actions ", excp);
                     }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1733,8 +1733,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     data = zk.getData(VoltZK.start_action + "/" + child, false, null);
                 } catch (KeeperException excp) {
                     if (excp.code() == Code.NONODE) {
-                        if (hostLog.isDebugEnabled())
-                            hostLog.warn("Failed to validate the start action as node "
+                            hostLog.debug("Failed to validate the start action as node "
                                     + VoltZK.start_action + "/" + child + " got disconnected", excp);
                     } else {
                         hostLog.error("Failed to validate the start actions ", excp);

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1733,8 +1733,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     data = zk.getData(VoltZK.start_action + "/" + child, false, null);
                 } catch (KeeperException excp) {
                     if (excp.code() == Code.NONODE) {
-                        hostLog.warn("Failed to validate the start action due to node "
-                                + VoltZK.start_action + "/" + child + " disconnected", excp);
+                        hostLog.warn("Failed to validate the start action as node "
+                                + VoltZK.start_action + "/" + child + " got disconnected", excp);
                     } else {
                         hostLog.error("Failed to validate the start actions ", excp);
                     }


### PR DESCRIPTION
During validation of start action, there is a rare window where the node can be disconnected in time frame where it was reported it exists to when it queried for data and currently this gets reported at error level. This showed up in rejoin system tests once where nodes were getting killed in cluster. After logging it at error level, the cluster was operational though test failed due to msg seen at error level. Dropping the severity for the msg at which it gets logged for this particular case. Updated logic to have try/catch block around the accessors which generate the handled exception cases.