### PR TITLE
ENG-12008: DR consumer streams should pause on swap table event and unpause on local swap table callback

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -19,6 +19,7 @@ package org.voltdb;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import org.voltcore.utils.Pair;
@@ -36,7 +37,7 @@ public interface ConsumerDRGateway extends Promotable {
      */
     void updateCatalog(CatalogContext catalog, String newConnectionSource);
 
-    void swapTables(final Pair<String, Long> oneTable, final Pair<String, Long> otherTable);
+    void swapTables(final Set<Pair<String, Long>> swappedTables);
 
     Map<Byte, DRRoleStats.State> getStates();
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -4398,7 +4398,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             if (tableA.getIsdred() && tableB.getIsdred()) {
                 long signatureHashA = Hashing.sha1().hashString(tableA.getSignature(), Charsets.UTF_8).asLong();
                 long signatureHashB = Hashing.sha1().hashString(tableB.getSignature(), Charsets.UTF_8).asLong();
-                m_consumerDRGateway.swapTables(Pair.of(oneTable, signatureHashA), Pair.of(otherTable, signatureHashB));
+                m_consumerDRGateway.swapTables(
+                        Pair.of(oneTable.toUpperCase(), signatureHashA),
+                        Pair.of(otherTable.toUpperCase(), signatureHashB));
             }
         }
     }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -4398,9 +4398,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             if (tableA.getIsdred() && tableB.getIsdred()) {
                 long signatureHashA = Hashing.sha1().hashString(tableA.getSignature(), Charsets.UTF_8).asLong();
                 long signatureHashB = Hashing.sha1().hashString(tableB.getSignature(), Charsets.UTF_8).asLong();
-                m_consumerDRGateway.swapTables(
-                        Pair.of(oneTable.toUpperCase(), signatureHashA),
-                        Pair.of(otherTable.toUpperCase(), signatureHashB));
+                Set<Pair<String, Long>> swappedTables = new HashSet<>();
+                swappedTables.add(Pair.of(oneTable.toUpperCase(), signatureHashA));
+                swappedTables.add(Pair.of(otherTable.toUpperCase(), signatureHashB));
+                m_consumerDRGateway.swapTables(swappedTables);
             }
         }
     }

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -2002,6 +2002,22 @@ public class LocalCluster extends VoltServerConfig {
     public static LocalCluster createLocalCluster(String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
                                                   int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
                                                   DrRoleType drRole, boolean hasLocalServer, VoltProjectBuilder builder) throws IOException {
+        return createLocalCluster(schemaDDL, siteCount, hostCount, kfactor, clusterId, replicationPort, remoteReplicationPort,
+                pathToVoltDBRoot, jar, drRole, hasLocalServer, builder, null);
+    }
+
+    public static LocalCluster createLocalCluster(String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
+                                                  int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
+                                                  DrRoleType drRole, boolean hasLocalServer, String callingMethodName) throws IOException {
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        return createLocalCluster(schemaDDL, siteCount, hostCount, kfactor, clusterId, replicationPort, remoteReplicationPort,
+                pathToVoltDBRoot, jar, drRole, hasLocalServer, builder, callingMethodName);
+    }
+
+    public static LocalCluster createLocalCluster(String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
+                                                  int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
+                                                  DrRoleType drRole, boolean hasLocalServer, VoltProjectBuilder builder,
+                                                  String callingMethodName) throws IOException {
         builder.addLiteralSchema(schemaDDL);
         builder.setDrProducerEnabled();
         if (drRole == DrRoleType.REPLICA) {
@@ -2014,6 +2030,9 @@ public class LocalCluster extends VoltServerConfig {
         }
         LocalCluster lc = new LocalCluster(jar, siteCount, hostCount, kfactor, clusterId, BackendTarget.NATIVE_EE_JNI, false);
         lc.setReplicationPort(replicationPort);
+        if (callingMethodName != null) {
+            lc.setCallingMethodName(callingMethodName);
+        }
         boolean success = lc.compile(builder, pathToVoltDBRoot);
         assert(success);
 
@@ -2041,6 +2060,12 @@ public class LocalCluster extends VoltServerConfig {
         for (String address : getListenerAddresses()) {
             client.createConnection(address);
         }
+        return client;
+    }
+
+    public Client createAdminClient(ClientConfig config) throws IOException {
+        Client client = ClientFactory.createClient(config);
+        client.createConnection(getAdminAddress(0));
         return client;
     }
 


### PR DESCRIPTION
* Use a set of Pair<String, Long> instead of two parameters to make equality check more straightforward and code clearer.
* Add a variant of createLocalCluster() helper function to allow manual specification of callingMethodName, which is used in the output file name.
* Add a helper function to create a client that connects to the admin port of the cluster, which is used to perform some tasks when the cluster is paused.