### PR TITLE
Eng 12113 fix flaky update logging unit test.

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -336,6 +336,11 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     private boolean m_isBare = false;
     private static final String SECONDARY_PICONETWORK_THREADS = "secondaryPicoNetworkThreads";
 
+    /** Last transaction ID at which the logging config updated.
+     * Also, use the intrinsic lock to safeguard access from multiple
+     * execution site threads */
+    private Long m_lastLogUpdateTxnId = 0L;
+
     /**
      * Startup snapshot nonce taken on shutdown --save
      */
@@ -3181,26 +3186,21 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         }
     }
 
-    /** Last transaction ID at which the logging config updated.
-     * Also, use the intrinsic lock to safeguard access from multiple
-     * execution site threads */
-    private static Long lastLogUpdate_txnId = 0L;
     @Override
     synchronized public void logUpdate(String xmlConfig, long currentTxnId, File voltroot)
     {
-        hostLog.info("Trying to update logging currentTxnId=" + currentTxnId + " lastLogUpdate_txnId=" + lastLogUpdate_txnId);
         // another site already did this work.
-        if (currentTxnId == lastLogUpdate_txnId) {
+        if (currentTxnId == m_lastLogUpdateTxnId) {
             return;
         }
-        else if (currentTxnId < lastLogUpdate_txnId) {
+        else if (currentTxnId < m_lastLogUpdateTxnId) {
             throw new RuntimeException(
-                    "Trying to update logging config at transaction " + lastLogUpdate_txnId
+                    "Trying to update logging config at transaction " + m_lastLogUpdateTxnId
                     + " with an older transaction: " + currentTxnId);
         }
         hostLog.info("Updating RealVoltDB logging config from txnid: " +
-                lastLogUpdate_txnId + " to " + currentTxnId);
-        lastLogUpdate_txnId = currentTxnId;
+                m_lastLogUpdateTxnId + " to " + currentTxnId);
+        m_lastLogUpdateTxnId = currentTxnId;
         VoltLogger.configure(xmlConfig, voltroot);
     }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3188,6 +3188,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     @Override
     synchronized public void logUpdate(String xmlConfig, long currentTxnId, File voltroot)
     {
+        hostLog.info("Trying to update logging currentTxnId=" + currentTxnId + " lastLogUpdate_txnId=" + lastLogUpdate_txnId);
         // another site already did this work.
         if (currentTxnId == lastLogUpdate_txnId) {
             return;

--- a/src/frontend/org/voltdb/iv2/Scheduler.java
+++ b/src/frontend/org/voltdb/iv2/Scheduler.java
@@ -125,7 +125,6 @@ abstract public class Scheduler implements InitiatorMessageHandler
     final protected TxnEgo advanceTxnEgo()
     {
         m_txnEgo = m_txnEgo.makeNext();
-        hostLog.info("advance txnId to " + m_txnEgo.getTxnId());
         return m_txnEgo;
     }
 

--- a/src/frontend/org/voltdb/iv2/Scheduler.java
+++ b/src/frontend/org/voltdb/iv2/Scheduler.java
@@ -125,6 +125,7 @@ abstract public class Scheduler implements InitiatorMessageHandler
     final protected TxnEgo advanceTxnEgo()
     {
         m_txnEgo = m_txnEgo.makeNext();
+        hostLog.info("advance txnId to " + m_txnEgo.getTxnId());
         return m_txnEgo;
     }
 


### PR DESCRIPTION
Change the static variable defined in RealVoltDB to member variable.

Some local cluster unit tests prefer using server thread instead of a voltdb process.
The value of static variables defined in VoltDB code will be carried over to next
unit test, which create many undesired effect. This bug is one of them!