### PR TITLE
ENG-12105: Fix memory issues in C++ unit tests

### DIFF
--- a/build.py
+++ b/build.py
@@ -554,8 +554,9 @@ if whichtests in ("${eetestsuite}", "structures"):
 
 if whichtests in ("${eetestsuite}", "plannodes"):
     CTX.TESTS['plannodes'] = """
-     WindowFunctionPlanNodeTest
      PlanNodeFragmentTest
+     PlanNodeUtilTest
+     WindowFunctionPlanNodeTest
     """
 
 ###############################################################################

--- a/buildtools.py
+++ b/buildtools.py
@@ -636,8 +636,8 @@ class ValgrindError:
         return self.line
 
 class ValgrindErrorState:
-    def __init__(self, expectNoErrors, valgrindFile):
-        self.expectErrors = not expectNoErrors
+    def __init__(self, expectErrorsIn, valgrindFile):
+        self.expectErrors = expectErrorsIn
         self.foundErrors    = False
         self.valgrindFile = valgrindFile
         self.errorStrings = []
@@ -648,7 +648,7 @@ class ValgrindErrorState:
         root = tree.getroot()
         errs = root.findall(".//error")
         for err in errs:
-            foundErrors = True
+            self.foundErrors = True
             self.errorStrings += [self._toString(err)]
 
     def _toString(self, err):
@@ -746,7 +746,7 @@ def runTests(CTX):
     for dir, test in tests:
         # We expect valgrind failures in all tests in memleaktests
         # except for the test named no_losses.
-        expectNoMemLeaks = not (dir == "memleaktests") or not ( test == "no_losses" )
+        expectMemLeaks = (dir == "memleaktests") and not (test.endswith("no_losses"))
         binname, objectname, sourcename = namesForTestCode(test)
         targetpath = OUTPUT_PREFIX + "/" + binname
         retval = 0
@@ -774,7 +774,7 @@ def runTests(CTX):
                 out_err = process.stderr.readlines()
                 retval = process.wait()
                 fileName = makeValgrindFile("%d" % process.pid)
-                errorState = ValgrindErrorState(expectNoMemLeaks, fileName)
+                errorState = ValgrindErrorState(expectMemLeaks, fileName)
                 # If there are as many errors as we expect,
                 # then delete the xml file.  Otherwise keep it.
                 # It may be useful.

--- a/src/ee/common/ValuePeeker.hpp
+++ b/src/ee/common/ValuePeeker.hpp
@@ -81,7 +81,20 @@ public:
         if (value.isNull()) {
             return NULL;
         }
+
         return value.getObjectValue_withoutNull();
+    }
+
+    static const char* peekObject(const NValue& value, int32_t* lengthOut) {
+        assert(isVariableLengthType(value.getValueType()));
+        if (value.isNull()) {
+            if (lengthOut != NULL) {
+                *lengthOut = 0;
+                return NULL;
+            }
+        }
+
+        return value.getObject_withoutNull(lengthOut);
     }
 
     static const char* peekObject_withoutNull(const NValue& value, int32_t* lengthOut) {

--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -88,7 +88,7 @@ ExecutorContext::ExecutorContext(int64_t siteId,
     m_undoQuantum(undoQuantum),
     m_staticParams(MAX_PARAM_COUNT),
     m_tuplesModifiedStack(),
-    m_executorsMap(),
+    m_executorsMap(NULL),
     m_drStream(drStream),
     m_drReplicatedStream(drReplicatedStream),
     m_engine(engine),
@@ -205,10 +205,14 @@ Table* ExecutorContext::getSubqueryOutputTable(int subqueryId) const
 
 void ExecutorContext::cleanupAllExecutors()
 {
-    typedef std::map<int, std::vector<AbstractExecutor*>* >::value_type MapEntry;
-    BOOST_FOREACH(MapEntry& entry, *m_executorsMap) {
-        int subqueryId = entry.first;
-        cleanupExecutorsForSubquery(subqueryId);
+    // If something failed before we could even instantiate the plan,
+    // there won't even be an executors map.
+    if (m_executorsMap != NULL) {
+        typedef std::map<int, std::vector<AbstractExecutor*>* >::value_type MapEntry;
+        BOOST_FOREACH(MapEntry& entry, *m_executorsMap) {
+            int subqueryId = entry.first;
+            cleanupExecutorsForSubquery(subqueryId);
+        }
     }
 
     // Clear any cached results from executed subqueries
@@ -265,14 +269,17 @@ void ExecutorContext::reportProgressToTopend(const TempTableLimits *limits) {
 }
 
 bool ExecutorContext::allOutputTempTablesAreEmpty() const {
-    typedef std::map<int, std::vector<AbstractExecutor*>* >::value_type MapEntry;
-    BOOST_FOREACH (MapEntry &entry, *m_executorsMap) {
-        BOOST_FOREACH(AbstractExecutor* executor, *(entry.second)) {
-            if (! executor->outputTempTableIsEmpty()) {
-                return false;
+    if (m_executorsMap != NULL) {
+        typedef std::map<int, std::vector<AbstractExecutor*>* >::value_type MapEntry;
+        BOOST_FOREACH (MapEntry &entry, *m_executorsMap) {
+            BOOST_FOREACH(AbstractExecutor* executor, *(entry.second)) {
+                if (! executor->outputTempTableIsEmpty()) {
+                    return false;
+                }
             }
         }
     }
+
     return true;
 }
 

--- a/src/ee/plannodes/abstractjoinnode.cpp
+++ b/src/ee/plannodes/abstractjoinnode.cpp
@@ -54,7 +54,15 @@
 
 namespace voltdb {
 
-AbstractJoinPlanNode::AbstractJoinPlanNode() { }
+AbstractJoinPlanNode::AbstractJoinPlanNode()
+    : m_preJoinPredicate()
+    , m_joinPredicate()
+    , m_wherePredicate()
+    , m_joinType(JOIN_TYPE_INVALID)
+    , m_outputSchemaPreAgg()
+    , m_tupleSchemaPreAgg(nullptr)
+{
+}
 
 AbstractJoinPlanNode::~AbstractJoinPlanNode()
 {

--- a/src/ee/plannodes/abstractjoinnode.cpp
+++ b/src/ee/plannodes/abstractjoinnode.cpp
@@ -60,7 +60,7 @@ AbstractJoinPlanNode::AbstractJoinPlanNode()
     , m_wherePredicate()
     , m_joinType(JOIN_TYPE_INVALID)
     , m_outputSchemaPreAgg()
-    , m_tupleSchemaPreAgg(nullptr)
+    , m_tupleSchemaPreAgg(NULL)
 {
 }
 

--- a/src/ee/plannodes/abstractplannode.cpp
+++ b/src/ee/plannodes/abstractplannode.cpp
@@ -58,9 +58,18 @@ using namespace std;
 namespace voltdb {
 
 AbstractPlanNode::AbstractPlanNode()
-    : m_planNodeId(-1),
-      m_isInline(false),
-      m_validOutputColumnCount(0) { }
+    : m_planNodeId(-1)
+    , m_children()
+    , m_childIds()
+    , m_executor()
+    , m_inlineNodes()
+    , m_isInline(false)
+    , m_outputTable()
+    , m_inputTables()
+    , m_validOutputColumnCount(0)
+    , m_outputSchema()
+{
+}
 
 AbstractPlanNode::~AbstractPlanNode()
 {

--- a/src/ee/plannodes/abstractscannode.h
+++ b/src/ee/plannodes/abstractscannode.h
@@ -73,7 +73,7 @@ public:
 protected:
     AbstractScanPlanNode()
         : m_target_table_name()
-        , m_tcd(nullptr)
+        , m_tcd(NULL)
         , m_predicate()
         , m_isSubQuery(false)
         , m_isEmptyScan(false)

--- a/src/ee/plannodes/abstractscannode.h
+++ b/src/ee/plannodes/abstractscannode.h
@@ -71,7 +71,14 @@ public:
     bool isEmptyScan() const { return m_isEmptyScan; }
 
 protected:
-    AbstractScanPlanNode() { }
+    AbstractScanPlanNode()
+        : m_target_table_name()
+        , m_tcd(nullptr)
+        , m_predicate()
+        , m_isSubQuery(false)
+        , m_isEmptyScan(false)
+    {
+    }
 
     void loadFromJSONObject(PlannerDomValue obj);
 

--- a/src/ee/plannodes/aggregatenode.h
+++ b/src/ee/plannodes/aggregatenode.h
@@ -53,7 +53,19 @@ namespace voltdb {
 class AggregatePlanNode : public AbstractPlanNode
 {
 public:
-    AggregatePlanNode(PlanNodeType type) : m_type(type) { }
+    AggregatePlanNode(PlanNodeType type)
+        : m_aggregates()
+        , m_distinctAggregates()
+        , m_aggregateOutputColumns()
+        , m_aggregateInputExpressions()
+        , m_groupByExpressions()
+        , m_partialGroupByColumns()
+        , m_type(type)
+        , m_prePredicate()
+        , m_postPredicate()
+    {
+    }
+
     ~AggregatePlanNode();
     PlanNodeType getPlanNodeType() const;
     std::string debugInfo(const std::string &spacer) const;

--- a/src/ee/plannodes/deletenode.h
+++ b/src/ee/plannodes/deletenode.h
@@ -55,7 +55,11 @@ namespace voltdb {
  */
 class DeletePlanNode : public AbstractOperationPlanNode {
 public:
-    DeletePlanNode() : m_truncate(false) { }
+    DeletePlanNode()
+        : m_truncate(false)
+    {
+    }
+
     PlanNodeType getPlanNodeType() const;
     bool getTruncate() const { return m_truncate; }
 

--- a/src/ee/plannodes/indexcountnode.h
+++ b/src/ee/plannodes/indexcountnode.h
@@ -29,9 +29,16 @@ namespace voltdb {
 class IndexCountPlanNode : public AbstractScanPlanNode {
 public:
     IndexCountPlanNode()
-        : m_lookup_type(INDEX_LOOKUP_TYPE_EQ)
+        : m_target_index_name()
+        , m_searchkey_expressions()
+        , m_compare_not_distinct()
+        , m_endkey_expressions()
+        , m_lookup_type(INDEX_LOOKUP_TYPE_EQ)
         , m_end_type(INDEX_LOOKUP_TYPE_EQ)
-    { }
+        , m_skip_null_predicate()
+    {
+    }
+
     ~IndexCountPlanNode();
     PlanNodeType getPlanNodeType() const;
     std::string debugInfo(const std::string &spacer) const;

--- a/src/ee/plannodes/indexscannode.h
+++ b/src/ee/plannodes/indexscannode.h
@@ -56,9 +56,17 @@ namespace voltdb {
 class IndexScanPlanNode : public AbstractScanPlanNode {
 public:
     IndexScanPlanNode()
-        : m_lookup_type(INDEX_LOOKUP_TYPE_EQ)
+        : m_target_index_name()
+        , m_searchkey_expressions()
+        , m_compare_not_distinct()
+        , m_end_expression()
+        , m_initial_expression()
+        , m_lookup_type(INDEX_LOOKUP_TYPE_EQ)
         , m_sort_direction(SORT_DIRECTION_TYPE_INVALID)
-    { }
+        , m_skip_null_predicate()
+    {
+    }
+
     ~IndexScanPlanNode();
     PlanNodeType getPlanNodeType() const;
     std::string debugInfo(const std::string &spacer) const;

--- a/src/ee/plannodes/limitnode.h
+++ b/src/ee/plannodes/limitnode.h
@@ -65,7 +65,7 @@ public:
         , offset(0)
         , limitParamIdx(-1)
         , offsetParamIdx(-1)
-        , limitExpression(nullptr)
+        , limitExpression(NULL)
     {
     }
 

--- a/src/ee/plannodes/limitnode.h
+++ b/src/ee/plannodes/limitnode.h
@@ -60,8 +60,15 @@ class Table;
  */
 class LimitPlanNode : public AbstractPlanNode {
 public:
-    LimitPlanNode() : limit(-1), offset(0), limitParamIdx(-1), offsetParamIdx(-1)
-    {}
+    LimitPlanNode()
+        : limit(-1)
+        , offset(0)
+        , limitParamIdx(-1)
+        , offsetParamIdx(-1)
+        , limitExpression(nullptr)
+    {
+    }
+
     ~LimitPlanNode();
     PlanNodeType getPlanNodeType() const;
 

--- a/src/ee/plannodes/materializenode.h
+++ b/src/ee/plannodes/materializenode.h
@@ -66,7 +66,11 @@ class MaterializePlanNode : public ProjectionPlanNode {
     // Andy - 06/25/2008
     //
 public:
-    MaterializePlanNode() { }
+    MaterializePlanNode()
+        : m_batched(false)
+    {
+    }
+
     ~MaterializePlanNode();
     PlanNodeType getPlanNodeType() const;
     std::string debugInfo(const std::string &spacer) const;

--- a/src/ee/plannodes/mergereceivenode.cpp
+++ b/src/ee/plannodes/mergereceivenode.cpp
@@ -51,9 +51,11 @@
 
 namespace voltdb {
 
-MergeReceivePlanNode::MergeReceivePlanNode() :
-    AbstractReceivePlanNode(), m_outputSchemaPreAgg()
-{ }
+MergeReceivePlanNode::MergeReceivePlanNode()
+    : AbstractReceivePlanNode()
+    , m_outputSchemaPreAgg()
+{
+}
 
 MergeReceivePlanNode::~MergeReceivePlanNode()
 {

--- a/src/ee/plannodes/orderbynode.h
+++ b/src/ee/plannodes/orderbynode.h
@@ -52,7 +52,12 @@ namespace voltdb {
 class OrderByPlanNode : public AbstractPlanNode
 {
 public:
-    OrderByPlanNode() { }
+    OrderByPlanNode()
+        : m_sortExpressions()
+        , m_sortDirections()
+    {
+    }
+
     ~OrderByPlanNode();
     PlanNodeType getPlanNodeType() const;
     std::string debugInfo(const std::string &spacer) const;

--- a/src/ee/plannodes/projectionnode.h
+++ b/src/ee/plannodes/projectionnode.h
@@ -55,7 +55,14 @@ namespace voltdb {
 class ProjectionPlanNode : public AbstractPlanNode
 {
 public:
-    ProjectionPlanNode() { }
+    ProjectionPlanNode()
+        : m_outputColumnNames()
+        , m_outputColumnTypes()
+        , m_outputColumnSizes()
+        , m_outputColumnExpressions()
+    {
+    }
+
     ~ProjectionPlanNode();
 
     PlanNodeType getPlanNodeType() const;

--- a/src/ee/plannodes/swaptablesnode.h
+++ b/src/ee/plannodes/swaptablesnode.h
@@ -61,7 +61,10 @@ public:
     SwapTablesPlanNode()
         : m_otherTcd(NULL)
         , m_otherTargetTableName("NOT SPECIFIED")
-    { }
+        , m_theIndexes()
+        , m_otherIndexes()
+    {
+    }
 
     virtual ~SwapTablesPlanNode();
     virtual PlanNodeType getPlanNodeType() const;

--- a/src/ee/plannodes/windowfunctionnode.h
+++ b/src/ee/plannodes/windowfunctionnode.h
@@ -27,7 +27,15 @@ public:
                                const std::string &label,
                                const OwningExpressionVector & exprs) const;
     WindowFunctionPlanNode()
-        : AbstractPlanNode() {}
+        : AbstractPlanNode()
+        , m_aggregates()
+        , m_aggregateOutputColumns()
+        , m_aggregateInputExpressions()
+        , m_partitionByExpressions()
+        , m_orderByExpressions()
+    {
+    }
+
     virtual ~WindowFunctionPlanNode();
 
     PlanNodeType getPlanNodeType() const;

--- a/tests/ee/common/PerFragmentStatsTest.cpp
+++ b/tests/ee/common/PerFragmentStatsTest.cpp
@@ -72,8 +72,8 @@ protected:
         ASSERT_EQ(valueA, voltdb::ValuePeeker::peekInteger(tuple.getNValue(0)));
         ASSERT_EQ(valueB, voltdb::ValuePeeker::peekDouble(tuple.getNValue(1)));
 
-	int32_t length = 0;
-	const char* data = voltdb::ValuePeeker::peekObject(tuple.getNValue(2), &length);
+        int32_t length = 0;
+        const char* data = voltdb::ValuePeeker::peekObject(tuple.getNValue(2), &length);
         ASSERT_EQ(0, strncmp(valueC, data, length));
     }
 

--- a/tests/ee/common/PerFragmentStatsTest.cpp
+++ b/tests/ee/common/PerFragmentStatsTest.cpp
@@ -71,7 +71,10 @@ protected:
     void validateRow(voltdb::TableTuple &tuple, int32_t valueA, double valueB, const char* valueC) {
         ASSERT_EQ(valueA, voltdb::ValuePeeker::peekInteger(tuple.getNValue(0)));
         ASSERT_EQ(valueB, voltdb::ValuePeeker::peekDouble(tuple.getNValue(1)));
-        ASSERT_EQ(0, strcmp(valueC, voltdb::ValuePeeker::peekObjectValue(tuple.getNValue(2))));
+
+	int32_t length = 0;
+	const char* data = voltdb::ValuePeeker::peekObject(tuple.getNValue(2), &length);
+        ASSERT_EQ(0, strncmp(valueC, data, length));
     }
 
     void validatePerFragmentStatsBuffer(int32_t expectedSucceededFragmentsCount, int32_t batchSize) {

--- a/tests/ee/executors/OptimizedProjectorTest.cpp
+++ b/tests/ee/executors/OptimizedProjectorTest.cpp
@@ -53,7 +53,7 @@
 #include "storage/temptable.h"
 
 
-static int64_t NUM_ROWS = 10000;
+static int64_t NUM_ROWS = 100;
 static int64_t NUM_COLS = 32;
 
 namespace voltdb {

--- a/tests/ee/plannodes/PlanNodeUtilTest.cpp
+++ b/tests/ee/plannodes/PlanNodeUtilTest.cpp
@@ -1,0 +1,95 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <memory>
+#include <vector>
+
+#include <boost/foreach.hpp>
+
+#include "harness.h"
+
+#include "plannodes/plannodeutil.h"
+
+
+
+using namespace voltdb;
+
+class PlanNodeUtilTest : public Test
+{
+};
+
+/**
+ * This is just a simple unit test that instantiates an empty plan
+ * node for each node type.  If there are memory errors here
+ * (such as uninitialized reads when the empty nodes are destructed)
+ * then valgrind should catch them.
+ */
+TEST_F(PlanNodeUtilTest, getEmptyPlanNode) {
+
+    std::vector<PlanNodeType> nodeTypes{
+            PLAN_NODE_TYPE_INVALID,
+
+            PLAN_NODE_TYPE_SEQSCAN,
+            PLAN_NODE_TYPE_INDEXSCAN,
+            PLAN_NODE_TYPE_INDEXCOUNT,
+            PLAN_NODE_TYPE_TABLECOUNT,
+            PLAN_NODE_TYPE_MATERIALIZEDSCAN,
+            PLAN_NODE_TYPE_TUPLESCAN,
+
+            PLAN_NODE_TYPE_NESTLOOP,
+            PLAN_NODE_TYPE_NESTLOOPINDEX,
+
+            PLAN_NODE_TYPE_UPDATE,
+            PLAN_NODE_TYPE_INSERT,
+            PLAN_NODE_TYPE_DELETE,
+            PLAN_NODE_TYPE_SWAPTABLES,
+
+            PLAN_NODE_TYPE_SEND,
+            PLAN_NODE_TYPE_RECEIVE,
+            PLAN_NODE_TYPE_MERGERECEIVE,
+
+            PLAN_NODE_TYPE_AGGREGATE,
+            PLAN_NODE_TYPE_HASHAGGREGATE,
+            PLAN_NODE_TYPE_UNION,
+            PLAN_NODE_TYPE_ORDERBY,
+            PLAN_NODE_TYPE_PROJECTION,
+            PLAN_NODE_TYPE_MATERIALIZE,
+            PLAN_NODE_TYPE_LIMIT,
+            PLAN_NODE_TYPE_PARTIALAGGREGATE,
+            PLAN_NODE_TYPE_WINDOWFUNCTION
+    };
+
+    BOOST_FOREACH(PlanNodeType pnt, nodeTypes) {
+        try {
+            std::unique_ptr<AbstractPlanNode> node(plannodeutil::getEmptyPlanNode(pnt));
+            ASSERT_NE(PLAN_NODE_TYPE_INVALID, pnt);
+        }
+        catch (const voltdb::FatalException& fe) {
+            ASSERT_EQ(PLAN_NODE_TYPE_INVALID, pnt);
+        }
+    }
+}
+
+int main() {
+    return TestSuite::globalInstance()->runAll();
+}

--- a/tests/ee/plannodes/PlanNodeUtilTest.cpp
+++ b/tests/ee/plannodes/PlanNodeUtilTest.cpp
@@ -83,6 +83,7 @@ TEST_F(PlanNodeUtilTest, getEmptyPlanNode) {
         try {
             std::unique_ptr<AbstractPlanNode> node(plannodeutil::getEmptyPlanNode(pnt));
             ASSERT_NE(PLAN_NODE_TYPE_INVALID, pnt);
+            ASSERT_NE(NULL, node.get());
         }
         catch (const voltdb::FatalException& fe) {
             ASSERT_EQ(PLAN_NODE_TYPE_INVALID, pnt);

--- a/tests/ee/test_utils/LoadTableFrom.hpp
+++ b/tests/ee/test_utils/LoadTableFrom.hpp
@@ -129,7 +129,7 @@ TempTable *loadTableFrom(ReferenceSerializeInputBE& result, bool skipMsgHeader =
                                        schema, // Transfers ownership to the table.
                                        columnNames,
                                        NULL);
-    table->loadTuplesFromNoHeader(result);
+    table->loadTuplesFromNoHeader(result, ExecutorContext::getTempStringPool());
     return table;
 }
 

--- a/tests/ee/test_utils/plan_testing_baseclass.h
+++ b/tests/ee/test_utils/plan_testing_baseclass.h
@@ -135,16 +135,16 @@ public:
         m_engine.reset(new voltdb::VoltDBEngine(m_topend.get()));
 
         m_parameter_buffer.reset(new char[m_smallBufferSize]);
-	::memset(m_parameter_buffer.get(), 0, m_smallBufferSize);
+        ::memset(m_parameter_buffer.get(), 0, m_smallBufferSize);
 
         m_per_fragment_stats_buffer.reset(new char[m_smallBufferSize]);
-	::memset(m_per_fragment_stats_buffer.get(), 0, m_smallBufferSize);
+        ::memset(m_per_fragment_stats_buffer.get(), 0, m_smallBufferSize);
 
         m_result_buffer.reset(new char[m_resultBufferSize]);
-	::memset(m_result_buffer.get(), 0, m_resultBufferSize);
+        ::memset(m_result_buffer.get(), 0, m_resultBufferSize);
 
         m_exception_buffer.reset(new char[m_smallBufferSize]);
-	::memset(m_exception_buffer.get(), 0, m_smallBufferSize);
+        ::memset(m_exception_buffer.get(), 0, m_smallBufferSize);
 
         m_engine->setBuffers(m_parameter_buffer.get(), m_smallBufferSize,
                              m_per_fragment_stats_buffer.get(), m_smallBufferSize,

--- a/tests/ee/test_utils/plan_testing_baseclass.h
+++ b/tests/ee/test_utils/plan_testing_baseclass.h
@@ -133,10 +133,19 @@ public:
          */
         m_topend.reset(TOPEND::newInstance());
         m_engine.reset(new voltdb::VoltDBEngine(m_topend.get()));
+
         m_parameter_buffer.reset(new char[m_smallBufferSize]);
+	::memset(m_parameter_buffer.get(), 0, m_smallBufferSize);
+
         m_per_fragment_stats_buffer.reset(new char[m_smallBufferSize]);
+	::memset(m_per_fragment_stats_buffer.get(), 0, m_smallBufferSize);
+
         m_result_buffer.reset(new char[m_resultBufferSize]);
+	::memset(m_result_buffer.get(), 0, m_resultBufferSize);
+
         m_exception_buffer.reset(new char[m_smallBufferSize]);
+	::memset(m_exception_buffer.get(), 0, m_smallBufferSize);
+
         m_engine->setBuffers(m_parameter_buffer.get(), m_smallBufferSize,
                              m_per_fragment_stats_buffer.get(), m_smallBufferSize,
                              m_result_buffer.get(), m_resultBufferSize,


### PR DESCRIPTION
This makes the EE more robust if we happen to get an invalid plan from Java.  If a plan node destructor fired before a plan node is completely initialized (due to wonky JSON), then we were trying to call delete on uninitialized pointers.

I'll make another pull request to fix the bogus plan.