### PR TITLE
build.xml: the removed line:

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -129,7 +129,6 @@
 <property name="j2se_api" value="http://docs.oracle.com/javase/7/docs/api/"/>
 
 <path id='project.classpath'>
-    <pathelement location='${build.instr.dir}' />
     <pathelement location='${build.client.dir}' />
     <pathelement location='${build.prod.dir}' />
     <pathelement location='${build.testproc.dir}' />


### PR DESCRIPTION
    <pathelement location='${build.instr.dir}' />
which was leftover from Peter’s removal of Emma, and was breaking SqlCoverage.