### PR TITLE
ENG-12204: Fix issue with EXISTS simplification

### DIFF
--- a/src/ee/executors/seqscanexecutor.cpp
+++ b/src/ee/executors/seqscanexecutor.cpp
@@ -233,7 +233,7 @@ bool SeqScanExecutor::p_execute(const NValueArray &params) {
                 }
                 pmp.countdownProgress();
             }
-        }
+        } // end while we have more tuples to scan
 
         if (m_aggExec != NULL) {
             m_aggExec->p_execute_finish();

--- a/src/frontend/org/voltdb/compiler/MatViewFallbackQueryXMLGenerator.java
+++ b/src/frontend/org/voltdb/compiler/MatViewFallbackQueryXMLGenerator.java
@@ -31,14 +31,14 @@ public class MatViewFallbackQueryXMLGenerator {
 
     private VoltXMLElement m_xml;
     private int m_maxElementId;
-    private ArrayList<ParsedColInfo> m_groupByColumnsParsedInfo;
-    private ArrayList<ParsedColInfo> m_displayColumnsParsedInfo;
+    private List<ParsedColInfo> m_groupByColumnsParsedInfo;
+    private List<ParsedColInfo> m_displayColumnsParsedInfo;
     private ArrayList<VoltXMLElement> m_fallbackQueryXMLs;
     private final boolean m_isMultiTableView;
 
     public MatViewFallbackQueryXMLGenerator(VoltXMLElement xmlquery,
-                                            ArrayList<ParsedColInfo> groupByColumnsParsedInfo,
-                                            ArrayList<ParsedColInfo> displayColumnsParsedInfo,
+                                            List<ParsedColInfo> groupByColumnsParsedInfo,
+                                            List<ParsedColInfo> displayColumnsParsedInfo,
                                             boolean isMultiTableView) {
         m_xml = xmlquery.duplicate();
         m_groupByColumnsParsedInfo = groupByColumnsParsedInfo;

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -212,7 +212,7 @@ public class PlanAssembler {
         return false;
     }
 
-    private boolean isPartitionColumnInGroupbyList(ArrayList<ParsedColInfo> groupbyColumns) {
+    private boolean isPartitionColumnInGroupbyList(List<ParsedColInfo> groupbyColumns) {
         assert(m_parsedSelect != null);
 
         if (groupbyColumns == null) {
@@ -305,7 +305,7 @@ public class PlanAssembler {
             m_subAssembler = new SelectSubPlanAssembler(m_catalogDb, m_parsedSelect, m_partitioning);
 
             // Process the GROUP BY information, decide whether it is group by the partition column
-            if (isPartitionColumnInGroupbyList(m_parsedSelect.m_groupByColumns)) {
+            if (isPartitionColumnInGroupbyList(m_parsedSelect.groupByColumns())) {
                 m_parsedSelect.setHasPartitionColumnInGroupby();
             }
             if (isPartitionColumnInWindowedAggregatePartitionByList()) {
@@ -2675,7 +2675,7 @@ public class PlanAssembler {
                 top_agg_schema.addColumn(top_schema_col);
             }// end for each ParsedColInfo in m_aggResultColumns
 
-            for (ParsedColInfo col : m_parsedSelect.m_groupByColumns) {
+            for (ParsedColInfo col : m_parsedSelect.groupByColumns()) {
                 aggNode.addGroupByExpression(col.expression);
 
                 if (topAggNode != null) {
@@ -2715,7 +2715,7 @@ public class PlanAssembler {
                 index, fromTableAlias, bindings);
         gbInfo.m_canBeFullySerialized =
                 (gbInfo.m_coveredGroupByColumns.size() ==
-                m_parsedSelect.m_groupByColumns.size());
+                m_parsedSelect.groupByColumns().size());
     }
 
     // Turn sequential scan to index scan for group by if possible
@@ -2729,7 +2729,7 @@ public class PlanAssembler {
         String fromTableAlias = root.getTargetTableAlias();
         assert(fromTableAlias != null);
 
-        ArrayList<ParsedColInfo> groupBys = m_parsedSelect.m_groupByColumns;
+        List<ParsedColInfo> groupBys = m_parsedSelect.groupByColumns();
         Table targetTable = m_catalogDb.getTables().get(root.getTargetTableName());
         assert(targetTable != null);
         CatalogMap<Index> allIndexes = targetTable.getIndexes();
@@ -2783,7 +2783,7 @@ public class PlanAssembler {
             List<AbstractExpression> bindings) {
         List<Integer> coveredGroupByColumns = new ArrayList<>();
 
-        ArrayList<ParsedColInfo> groupBys = m_parsedSelect.m_groupByColumns;
+        List<ParsedColInfo> groupBys = m_parsedSelect.groupByColumns();
         String exprsjson = index.getExpressionsjson();
         if (exprsjson.isEmpty()) {
             List<ColumnRef> indexedColRefs =
@@ -3161,7 +3161,7 @@ public class PlanAssembler {
         AggregatePlanNode distinctAggNode = new HashAggregatePlanNode();
         distinctAggNode.setOutputSchema(m_parsedSelect.getDistinctProjectionSchema());
 
-        for (ParsedColInfo col : m_parsedSelect.m_distinctGroupByColumns) {
+        for (ParsedColInfo col : m_parsedSelect.distinctGroupByColumns()) {
             distinctAggNode.addGroupByExpression(col.expression);
         }
 

--- a/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
@@ -738,11 +738,12 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         assertTrue(pn.getChild(0) instanceof SeqScanPlanNode);
         verifyTrivialSchemaLimitOffset(((SeqScanPlanNode) pn.getChild(0)).getPredicate(), -1, 0);
 
-        // Subquery subquery-without-having with group by and no limit => select max(c) from r2 limit 1
+        // Subquery subquery-without-having with group by and no limit
+        //   => select a, max(c) from r2 group by a limit 1
         pn = compile("select a from r1 where exists " +
                 " (select a, max(c) from r2 group by a order by max(c))");
         assertTrue(pn.getChild(0) instanceof SeqScanPlanNode);
-        verifyAggregateSubquery(((SeqScanPlanNode)pn.getChild(0)).getPredicate(), 1, 0, false);
+        verifyAggregateSubquery(((SeqScanPlanNode)pn.getChild(0)).getPredicate(), 2, 1, false);
 
         // Subquery subquery-without-having with group by and offset 3 => subquery-without-having with group by and offset 3
         pn = compile("select a from r1 where exists " +
@@ -834,7 +835,6 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         assertTrue(pn instanceof SeqScanPlanNode);
         AbstractPlanNode inline = pn.getInlinePlanNode(PlanNodeType.PROJECTION);
         assertNotNull(inline);
-        assertEquals(1, inline.getOutputSchema().size());
         inline = pn.getInlinePlanNode(PlanNodeType.LIMIT);
         assertNotNull(inline);
         assertEquals(limit, ((LimitPlanNode) inline).getLimit());


### PR DESCRIPTION
I fixed an issue in simplifyExistsSubqueryStmt that caused a non-sensical statement to be generated: a groupless agg with passthrough columns.  This was causing the EE to crash.  The fix was to be less aggressive in simplifying exists subqueries.  In particular I removed code that attempted to do away with aggregation altogether.  There are ripple effects to what the old code was doing that seem really difficult to get a handle on.

I encapsulated ParsedSelectStmt.m_groupByColumns and m_distinctGroupByColumns in order to aid my debugging.

