### PR TITLE
ENG-12332: The new isSafeWithNonEmptySource in Index should be ignore…

### DIFF
--- a/src/catgen/in/javasrc/Catalog.java
+++ b/src/catgen/in/javasrc/Catalog.java
@@ -247,7 +247,7 @@ public class Catalog extends CatalogType {
     public String serialize() {
         StringBuilder sb = new StringBuilder();
 
-        writeFieldCommands(sb);
+        writeFieldCommands(sb, null);
         writeChildCommands(sb);
 
         return sb.toString();

--- a/src/catgen/in/javasrc/CatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/CatalogDiffEngine.java
@@ -1342,7 +1342,7 @@ public class CatalogDiffEngine {
         // write the commands to make it so
         // they will be ignored if the change is unsupported
         newType.writeCreationCommand(m_sb);
-        newType.writeFieldCommands(m_sb);
+        newType.writeFieldCommands(m_sb, null);
         newType.writeChildCommands(m_sb);
 
         // add it to the set of additions to later compute descriptive text

--- a/src/catgen/in/javasrc/CatalogMap.java
+++ b/src/catgen/in/javasrc/CatalogMap.java
@@ -23,6 +23,7 @@ package org.voltdb.catalog;
 
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -188,10 +189,10 @@ public final class CatalogMap<T extends CatalogType> implements Iterable<T> {
         }
     }
 
-    void writeCommandsForMembers(StringBuilder sb) {
+    void writeCommandsForMembers(StringBuilder sb, Set<String> whiteListFields) {
         for (T type : this) {
             type.writeCreationCommand(sb);
-            type.writeFieldCommands(sb);
+            type.writeFieldCommands(sb, whiteListFields);
             type.writeChildCommands(sb);
         }
     }

--- a/src/catgen/in/javasrc/CatalogType.java
+++ b/src/catgen/in/javasrc/CatalogType.java
@@ -23,6 +23,7 @@ package org.voltdb.catalog;
 
 import java.lang.reflect.Field;
 import java.util.Collection;
+import java.util.Set;
 
 
 /**
@@ -262,27 +263,29 @@ public abstract class CatalogType implements Comparable<CatalogType> {
         sb.append("\n");
     }
 
-    void writeFieldCommands(StringBuilder sb) {
+    void writeFieldCommands(StringBuilder sb, Set<String> whiteListFields) {
         int i = 0;
         for (String field : getFields()) {
-            writeCommandForField(sb, field, i == 0);
-            ++i;
+            if (whiteListFields == null || whiteListFields.contains(field)) {
+                writeCommandForField(sb, field, i == 0);
+                ++i;
+            }
         }
     }
 
     void writeChildCommands(StringBuilder sb)  {
-        writeChildCommands(sb, null);
+        writeChildCommands(sb, null, null);
     }
 
     /**
      * Write catalog commands of the children in the white list.
      * @param whiteList A white list of CatalogType classes
      */
-    void writeChildCommands(StringBuilder sb, Collection<Class<? extends CatalogType> > whiteList)  {
+    void writeChildCommands(StringBuilder sb, Collection<Class<? extends CatalogType> > whiteList, Set<String> whiteListFields)  {
         for (String childCollection : getChildCollections()) {
             CatalogMap<? extends CatalogType> map = getCollection(childCollection);
             if (whiteList == null || whiteList.contains(map.m_cls)) {
-                map.writeCommandsForMembers(sb);
+                map.writeCommandsForMembers(sb, whiteListFields);
             }
         }
     }

--- a/src/catgen/in/javasrc/DRCatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/DRCatalogDiffEngine.java
@@ -40,7 +40,8 @@ import org.voltdb.utils.Encoder;
  * - All shared DR tables have the same unique indexes/primary keys
  */
 public class DRCatalogDiffEngine extends CatalogDiffEngine {
-    /* White list of fields for the catalog types that we care about for DR.
+    /* White list of fields that we care about for DR for table children classes.
+       This is used only in serialize commands for DR method.
        There are duplicates added to the set because it lists all the fields per type */
     private static Set<String> s_whiteListFields = Sets.newHashSet(
             /* Column */

--- a/src/catgen/in/javasrc/DRCatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/DRCatalogDiffEngine.java
@@ -22,6 +22,7 @@
 package org.voltdb.catalog;
 
 import java.util.List;
+import java.util.Set;
 
 import com.google_voltpatches.common.collect.Sets;
 import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
@@ -39,6 +40,19 @@ import org.voltdb.utils.Encoder;
  * - All shared DR tables have the same unique indexes/primary keys
  */
 public class DRCatalogDiffEngine extends CatalogDiffEngine {
+    /* White list of fields for the catalog types that we care about for DR.
+       There are duplicates added to the set because it lists all the fields per type */
+    private static Set<String> s_whiteListFields = Sets.newHashSet(
+            /* Column */
+            "index", "type", "size", "nullable", "name", "defaultvalue", "defaulttype", "aggregatetype", "matviewsource", "matview", "inbytes",
+            /* Index */
+            "unique", "assumeUnique", "countable", "type", "expressionsjson", "predicatejson",
+            /* Constraint */
+            "type", "oncommit", "index", "foreignkeytable",
+            /* Statement */
+            "sqltext", "querytype", "readonly", "singlepartition", "replicatedtabledml", "iscontentdeterministic", "isorderdeterministic", "nondeterminismdetail",
+            "cost", "seqscancount", "explainplan", "tablesread", "tablesupdated", "indexesused", "cachekeyprefix"
+            );
     public DRCatalogDiffEngine(Catalog localCatalog, Catalog remoteCatalog) {
         super(localCatalog, remoteCatalog);
     }
@@ -60,8 +74,8 @@ public class DRCatalogDiffEngine extends CatalogDiffEngine {
         for (Table t : db.getTables()) {
             if (t.getIsdred() && t.getMaterializer() == null && !CatalogUtil.isTableExportOnly(db, t)) {
                 t.writeCreationCommand(sb);
-                t.writeFieldCommands(sb);
-                t.writeChildCommands(sb, Sets.newHashSet(Column.class, Index.class, Constraint.class, Statement.class));
+                t.writeFieldCommands(sb, null);
+                t.writeChildCommands(sb, Sets.newHashSet(Column.class, Index.class, Constraint.class, Statement.class), s_whiteListFields);
             }
         }
         String catalogCommands = sb.toString();

--- a/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
@@ -772,10 +772,11 @@ public class TestDRCatalogDiffs {
      * Don't serialize views, DR doesn't care.
      */
     @Test
-    public void testFilterViewInfo() throws Exception {
+    public void testFilterForDR() throws Exception {
         String masterSchema =
         "CREATE TABLE T1 (C1 INTEGER NOT NULL, C2 INTEGER NOT NULL);\n" +
         "CREATE TABLE T2 (C1 INTEGER NOT NULL, C2 INTEGER NOT NULL);\n" +
+        "CREATE INDEX T1_IDX ON T1 (C2);\n" +
         "CREATE VIEW foo (C1, total) AS SELECT C1, COUNT(*) FROM T1 GROUP BY C1;\n" +
         "CREATE VIEW foo2 (C1, total) AS SELECT T1.C1, COUNT(*) FROM T1 JOIN T2 ON T1.C1 = T2.C1 GROUP BY T1.C1;\n" +
         "DR TABLE T1;\n" +
@@ -787,6 +788,7 @@ public class TestDRCatalogDiffs {
 
         assertFalse(decodedCommands.contains(" views "));
         assertFalse(decodedCommands.contains(" mvHandlerInfo "));
+        assertFalse(decodedCommands.contains(" isSafeWithNonemptySources "));
     }
 
     private CatalogDiffEngine runCatalogDiff(String masterSchema, boolean isMasterXDCR,


### PR DESCRIPTION
…d while serializing for DR because

pre-7.2 clusters don't understand this field. Added a white list of fields as a temporary fix for this problem.