### PR TITLE
Eng 12296 add prerequisite check to plan_upgrade

### DIFF
--- a/lib/python/voltcli/voltadmin.d/plan_upgrade.py
+++ b/lib/python/voltcli/voltadmin.d/plan_upgrade.py
@@ -107,21 +107,24 @@ def basicCheck(runner):
                                 [VOLT.FastSerializer.VOLTTYPE_STRING, VOLT.FastSerializer.VOLTTYPE_STRING],
                                 [runner.opts.newKit, runner.opts.newRoot])
     error = False
+    warnings = ""
     for tuple in response.table(0).tuples():
         hostId = tuple[0]
         result = tuple[1]
-        warnings = tuple[2]
+        warning = tuple[2]
         if result != 'Success':
             error = True
             host = hosts.hosts_by_id[hostId]
             if host is None:
                 runner.abort('@CheckUpgradePlanNT returns a host id ' + hostId + " that doesn't belong to the cluster.")
             runner.error('Check failed on host ' + getHostnameOrIp(host) + " with the cause: " + result)
-        if warnings is not None:
-            runner.warning('host ' + getHostnameOrIp(host) + ': ' + warnings)
+        if warning is not None:
+            warnings += 'On host ' + getHostnameOrIp(host) + ': \n' + warning
 
     if error:
         runner.abort("Failed to pass pre-upgrade check. Abort. ")
+    if warnings != "":
+        runner.warning(warnings)
 
     print '[1/4] Passed new VoltDB kit version check.'
     print '[2/4] Passed new VoltDB root path existence check.'

--- a/lib/python/voltcli/voltadmin.d/plan_upgrade.py
+++ b/lib/python/voltcli/voltadmin.d/plan_upgrade.py
@@ -458,7 +458,7 @@ def createDeploymentForOriginalCluster(runner, xmlString, drSource, origin_clust
     dr = et.getroot().find('./dr')
     if dr is None:
         runner.abort("This cluster doesn't have a DR tag in its deployment file, hence we can't generate online upgrade plan for it. " +
-                     "Adding DR tag to your deployment file requires to shutdown and restart the database.")
+                     "In order to add DR tag to the deployment file, users are required to shutdown the database.")
 
     if 'id' not in dr.attrib:
         clusterId = 0;  # by default clusterId is 0

--- a/lib/python/voltcli/voltadmin.d/plan_upgrade.py
+++ b/lib/python/voltcli/voltadmin.d/plan_upgrade.py
@@ -119,12 +119,15 @@ def basicCheck(runner):
                 runner.abort('@CheckUpgradePlanNT returns a host id ' + hostId + " that doesn't belong to the cluster.")
             runner.error('Check failed on host ' + getHostnameOrIp(host) + " with the cause: " + result)
         if warning is not None:
-            warnings += 'On host ' + getHostnameOrIp(host) + ': \n' + warning
+            host = hosts.hosts_by_id[hostId]
+            if host is None:
+                runner.abort('@CheckUpgradePlanNT returns a host id ' + hostId + " that doesn't belong to the cluster.")
+            warnings += 'On host ' + getHostnameOrIp(host) + ': \n' + warning + '\n'
 
     if error:
         runner.abort("Failed to pass pre-upgrade check. Abort. ")
     if warnings != "":
-        runner.warning(warnings)
+        runner.warning(warnings[:-1])  # get rid of last '\n'
 
     print '[1/4] Passed new VoltDB kit version check.'
     print '[2/4] Passed new VoltDB root path existence check.'

--- a/lib/python/voltcli/voltadmin.d/plan_upgrade.py
+++ b/lib/python/voltcli/voltadmin.d/plan_upgrade.py
@@ -110,15 +110,19 @@ def basicCheck(runner):
     for tuple in response.table(0).tuples():
         hostId = tuple[0]
         result = tuple[1]
+        warnings = tuple[2]
         if result != 'Success':
             error = True
             host = hosts.hosts_by_id[hostId]
             if host is None:
                 runner.abort('@CheckUpgradePlanNT returns a host id ' + hostId + " that doesn't belong to the cluster.")
             runner.error('Check failed on host ' + getHostnameOrIp(host) + " with the cause: " + result)
+        if warnings is not None:
+            runner.warning('host ' + getHostnameOrIp(host) + ': ' + warnings)
 
     if error:
         runner.abort("Failed to pass pre-upgrade check. Abort. ")
+
     print '[1/4] Passed new VoltDB kit version check.'
     print '[2/4] Passed new VoltDB root path existence check.'
 
@@ -447,8 +451,8 @@ def createDeploymentForOriginalCluster(runner, xmlString, drSource, origin_clust
 
     dr = et.getroot().find('./dr')
     if dr is None:
-        runner.abort("This cluster doesn't have a DR tag in its deployment file, hence we can't generate online upgrade plan for it. \
-                    Please note add DR tag to your deployment file requires to shutdown and restart the database.")
+        runner.abort("This cluster doesn't have a DR tag in its deployment file, hence we can't generate online upgrade plan for it. " +
+                     "Adding DR tag to your deployment file requires to shutdown and restart the database.")
 
     if 'id' not in dr.attrib:
         clusterId = 0;  # by default clusterId is 0

--- a/src/frontend/org/voltdb/sysprocs/CheckUpgradePlanNT.java
+++ b/src/frontend/org/voltdb/sysprocs/CheckUpgradePlanNT.java
@@ -25,11 +25,16 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.voltdb.CatalogContext;
+import org.voltdb.VoltDB;
 import org.voltdb.VoltNTSystemProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
+import org.voltdb.catalog.Table;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.compiler.deploymentfile.DrRoleType;
+import org.voltdb.licensetool.LicenseApi;
 
 /*
  * Some simple file system path checks, the goal is using NT procedure to do the check on
@@ -37,18 +42,22 @@ import org.voltdb.client.ClientResponse;
  */
 public class CheckUpgradePlanNT extends VoltNTSystemProcedure {
     private final static String SUCCESS = "Success";
+    private final static int MINIMUM_MAJOR_VERSION = 7;
+    private final static int MINIMUM_MINOR_VERSION = 2;
 
     public static class PrerequisitesCheckNT extends VoltNTSystemProcedure {
-        private final static int MINIMUM_MAJOR_VERSION = 7;
-        private final static int MINIMUM_MINOR_VERSION = 2;
 
         public VoltTable run(String newKitPath, String newRootPath) throws InterruptedException, ExecutionException {
             String ret = checkVoltDBKitExistence(newKitPath);
             String ret2 = checkVoltDBRootExistence(newRootPath);
+            String ret3 = validateXDCRRequirement();
+            String warning = nonFatalCheck();
             VoltTable vt = new VoltTable(
                     new ColumnInfo[] { new ColumnInfo("KIT_CHECK_RESULT", VoltType.STRING),
-                                       new ColumnInfo("ROOT_CHECK_RESULT", VoltType.STRING) });
-            vt.addRow(ret, ret2);
+                                       new ColumnInfo("ROOT_CHECK_RESULT", VoltType.STRING),
+                                       new ColumnInfo("XDCR_CHECK_RESULT", VoltType.STRING),
+                                       new ColumnInfo("WARNINGS", VoltType.STRING)});
+            vt.addRow(ret, ret2, ret3, warning);
             return vt;
         }
 
@@ -59,25 +68,35 @@ public class CheckUpgradePlanNT extends VoltNTSystemProcedure {
             } else if (!Files.isDirectory(newKit)) {
                 return newKitPath + " is not a directory.";
             }
-
+            // Check the new VoltDB kit version
+            int[] newKitVersion = new int[2];
             try {
                 String version = new String(Files.readAllBytes(Paths.get(newKitPath, "version.txt")));
-                String[] versionNumber = version.split("\\.");
-                if (versionNumber.length < 2) {
-                    return "Illegal version string format found in " + newKitPath + ": " + version;
-                }
-                int majorVersion = Integer.parseInt(versionNumber[0].trim());
-                int minorVersion = Integer.parseInt(versionNumber[1].trim());
-                if ( majorVersion < MINIMUM_MAJOR_VERSION ||
-                                (majorVersion == MINIMUM_MAJOR_VERSION && minorVersion < MINIMUM_MINOR_VERSION)) {
-                    return "Version of new VoltDB kit is lower than the minimum supported version (v" +
-                            MINIMUM_MAJOR_VERSION + "." + MINIMUM_MINOR_VERSION + ")";
-                } else {
-                    return SUCCESS;
+                String cause = checkVersionString(version, newKitPath, newKitVersion);
+                if (cause != null) {
+                    return cause;
                 }
             } catch (IOException | NumberFormatException e) {
                 return "Failed to parse version string in the new VoltDB kit";
             }
+
+            // Check version of current VoltDB instance
+            int[] currentVersion = new int[2];
+            try {
+                String cause = checkVersionString(VoltDB.instance().getVersionString(), null, currentVersion);
+                if (cause != null) {
+                    return cause;
+                }
+            } catch (NumberFormatException e) {
+                return "Failed to parse version of target VoltDB cluster";
+            }
+
+            // Check whether upgrade/downgrade across two major versions
+            if (Math.abs(newKitVersion[0] - currentVersion[0]) >= 2) {
+                return "Online upgrade/downgrade across two major versions is not supported.";
+            }
+
+            return SUCCESS;
         }
 
         private static String checkVoltDBRootExistence(String newRootPath) {
@@ -89,25 +108,86 @@ public class CheckUpgradePlanNT extends VoltNTSystemProcedure {
             }
             return SUCCESS;
         }
+
+        private static String validateXDCRRequirement() {
+            LicenseApi licenseApi = VoltDB.instance().getLicenseApi();
+            if (!licenseApi.isDrActiveActiveAllowed()) {
+                return "Target VoltDB cluster doesn't have a valid XDCR license.";
+            }
+
+            CatalogContext context = VoltDB.instance().getCatalogContext();
+            if (context.getDeployment().getDr() != null && context.getDeployment().getDr().getRole() != DrRoleType.XDCR) {
+                return "Target VoltDB cluster must have XDCR enabled (DRRole=\"xdcr\").";
+            }
+
+            return SUCCESS;
+        }
+
+        private static String nonFatalCheck() {
+            StringBuilder warning = new StringBuilder();
+            CatalogContext context = VoltDB.instance().getCatalogContext();
+            for (Table tb : context.database.getTables()) {
+                if (!tb.getIsdred()) {
+                    warning.append(tb.getTypeName()).append(" is not a DR table.\n");
+                }
+            }
+            if (context.getDeployment().getDr() != null && context.getDeployment().getDr().isListen() == false) {
+                warning.append("Target VoltDB cluster is not listening on DR port.");
+            }
+            if (warning.length() != 0) {
+                return warning.toString();
+            }
+            return null;
+        }
+
+        private static String checkVersionString(String ver, String newKitPath, int[] versionNumber) throws NumberFormatException {
+            String[] versions = ver.split("\\.");
+            if (newKitPath != null && versionNumber.length < 2) {
+                return "Illegal version string format found in " + newKitPath + ": " + ver;
+            }
+            int majorVersion = Integer.parseInt(versions[0].trim());
+            int minorVersion = Integer.parseInt(versions[1].trim());
+            if ( majorVersion < MINIMUM_MAJOR_VERSION ||
+                            (majorVersion == MINIMUM_MAJOR_VERSION && minorVersion < MINIMUM_MINOR_VERSION)) {
+                if (newKitPath != null) {
+                    return "Version of new VoltDB kit is lower than the minimum supported version (v7.2)";
+                }
+                return "Version of target VoltDB cluster is lower than the minimum supported version (v7.2)";
+            }
+            versionNumber[0] = majorVersion;
+            versionNumber[1] = minorVersion;
+            return null;
+        }
     }
 
-    // Be user-friendly, return reasons of all the failed check.
-    private static String aggregatePerHostResults(VoltTable vtable) {
+    // Be user-friendly, return reasons of all failed checks.
+    private static String[] aggregatePerHostResults(VoltTable vtable) {
+        String[] ret = new String[2];
         vtable.advanceRow();
         String kitCheckResult = vtable.getString("KIT_CHECK_RESULT");
         String rootCheckResult = vtable.getString("ROOT_CHECK_RESULT");
+        String xdcrCheckResult = vtable.getString("XDCR_CHECK_RESULT");
         StringBuilder result = new StringBuilder();
-        if (!kitCheckResult.equals(SUCCESS)){
-            result.append(kitCheckResult);
+        if (!kitCheckResult.equals(SUCCESS)) {
+            result.append(kitCheckResult).append("\n");
         }
         if (!rootCheckResult.equals(SUCCESS)) {
-            result.append(rootCheckResult);
+            result.append(rootCheckResult).append("\n");
+        }
+        if (!xdcrCheckResult.equals(SUCCESS)) {
+            result.append(xdcrCheckResult);
         }
         if (result.length() == 0) {
             result.append(SUCCESS);
         }
 
-        return result.toString();
+        ret[0] = result.toString();
+        String warnings = vtable.getString("WARNINGS");
+        if (warnings != null) {
+            ret[1] = warnings;
+        }
+
+        return ret;
     }
 
     public VoltTable run(String newKitPath, String newRootPath) throws InterruptedException, ExecutionException {
@@ -116,10 +196,12 @@ public class CheckUpgradePlanNT extends VoltNTSystemProcedure {
         Map<Integer,ClientResponse> cr = pf.get();
         VoltTable vt = new VoltTable(
                 new ColumnInfo[] { new ColumnInfo("HOST_ID", VoltType.INTEGER),
-                                   new ColumnInfo("CHECK_RESULT", VoltType.STRING) });
+                                   new ColumnInfo("CHECK_RESULT", VoltType.STRING),
+                                   new ColumnInfo("WARNINGS", VoltType.STRING)});
         cr.entrySet().stream()
         .forEach(e -> {
-            vt.addRow(e.getKey(), aggregatePerHostResults(e.getValue().getResults()[0]));
+            String[] ret = aggregatePerHostResults(e.getValue().getResults()[0]);
+            vt.addRow(e.getKey(), ret[0], ret[1]);
         });
 
         return vt;


### PR DESCRIPTION
Now these are following prerequisite checks:
1. Original cluster is licensed for XDCR.
2. Original cluster is running in "xdcr" role.
3. New kit is >=7.2 and is within 1 major release of running version, vice versa for downgrade.
4. Running version is >= 7.2
5. Create warnings if not all the tables are DR tables.