### PR TITLE
ENG-12282: Add debug message for export generation rolling.

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -114,6 +114,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     private final LinkedTransferQueue<RunnableWithES> m_queuedActions = new LinkedTransferQueue<>();
     private RunnableWithES m_firstAction = null;
 
+    // Record the stacktrace of when this data source calls drain to help debug a race condition.
+    private volatile Exception m_drainTraceForDebug = null;
+
     /**
      * Create a new data source.
      * @param db
@@ -486,6 +489,8 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     m_pollFuture = null;
                 }
                 if (m_onDrain != null) {
+                    m_drainTraceForDebug = new Exception("Push USO " + uso + " endOfStream " + endOfStream +
+                                                         " poll " + poll);
                     m_onDrain.run();
                 }
             } else {
@@ -614,6 +619,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                             m_pollFuture = null;
                         }
                         if (m_onDrain != null) {
+                            m_drainTraceForDebug = new Exception("Truncation txnId " + txnId);
                             m_onDrain.run();
                         }
                     }
@@ -749,6 +755,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     //We are closing source.
                 }
                 if (m_onDrain != null) {
+                    m_drainTraceForDebug = new Exception();
                     m_onDrain.run();
                 }
                 return;
@@ -800,6 +807,11 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     ackingContainer.discard();
                 }
                 m_pollFuture = null;
+
+                if (m_drainTraceForDebug != null) {
+                    VoltDB.crashLocalVoltDB("Rolling generation " + m_generation + " before it is fully drained. " +
+                                            "Drain was called from " + Throwables.getStackTraceAsString(m_drainTraceForDebug));
+                }
             }
         } catch (Throwable t) {
             fut.setException(t);
@@ -908,6 +920,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
      private void ackImpl(long uso) {
 
         if (uso == Long.MIN_VALUE && m_onDrain != null) {
+            m_drainTraceForDebug = new Exception("Acking USO " + uso);
             m_onDrain.run();
             return;
         }


### PR DESCRIPTION
There is a race condition during export generation rolling that causes buffers
to not be discarded because the generation signalled done when it's not fully
drained yet. This may cause data loss, or memory leak at the very least.

I added some code to record the stack traces of when a generation signals done
and crash the local node if a buffer was created after that. Hopefully, this
will give us some insights into what is racing.