### PR TITLE
ENG-12179: Populate dummy tracker even when consumer gateway is disabled

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -50,8 +50,6 @@ public interface ConsumerDRGateway extends Promotable {
      * the snapshot as a joiner.
      * @param dataSourceCluster
      * @param expectedClusterMembers
-     * @return false if this cluster is a joiner and the sync snapshot did not finish loading form the
-     *         leader cluster
      */
     void setInitialConversationMembership(byte dataSourceCluster, List<MeshMemberInfo> expectedClusterMembers);
 
@@ -82,4 +80,6 @@ public interface ConsumerDRGateway extends Promotable {
     void resumeConsumerDispatcher(byte clusterId);
 
     void resetDrAppliedTracker(byte clusterId);
+
+    void populateEmptyTrackersIfNeeded(byte producerClusterId, int producerPartitionCount);
 }

--- a/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
+++ b/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
@@ -319,6 +319,7 @@ public class VoltProjectBuilder {
 
     private String m_drMasterHost;
     private Integer m_preferredSource;
+    private Boolean m_drConsumerConnectionEnabled = null;
     private Boolean m_drProducerEnabled = null;
     private DrRoleType m_drRole = DrRoleType.MASTER;
 
@@ -747,6 +748,14 @@ public class VoltProjectBuilder {
 
     public void setPreferredSource(int preferredSource) {
         m_preferredSource = preferredSource;
+    }
+
+    public void setDrConsumerConnectionEnabled() {
+        m_drConsumerConnectionEnabled = true;
+    }
+
+    public void setDrConsumerConnectionDisabled() {
+        m_drConsumerConnectionEnabled = false;
     }
 
     public void setDrProducerEnabled()
@@ -1291,6 +1300,7 @@ public class VoltProjectBuilder {
             dr.setConnection(conn);
             conn.setSource(m_drMasterHost);
             conn.setPreferredSource(m_preferredSource);
+            conn.setEnabled(m_drConsumerConnectionEnabled);
         }
 
         // Have some yummy boilerplate!

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -452,32 +452,18 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         {
             Map<Integer, DRConsumerDrIdTracker> clusterSources = m_maxSeenDrLogsBySrcPartition.get(producerClusterId);
             if (clusterSources == null) {
-                // Don't have a tracker for this cluster
-                if (DRLogSegmentId.isEmptyDRId(lastReceivedDRId)) {
-                    return DRIdempotencyResult.SUCCESS;
-                } else {
-                    if (drLog.isTraceEnabled()) {
-                        drLog.trace(String.format("P%d binary log site idempotency check failed. " +
-                                        "Site doesn't have tracker for this cluster while the last received is %s",
-                                producerPartitionId,
-                                DRLogSegmentId.getDebugStringFromDRId(lastReceivedDRId)));
-                    }
-                }
+                drLog.warn(String.format("P%d binary log site idempotency check failed. " +
+                                "Site doesn't have tracker for this cluster while the last received is %s",
+                        producerPartitionId,
+                        DRLogSegmentId.getDebugStringFromDRId(lastReceivedDRId)));
             }
             else {
                 DRConsumerDrIdTracker targetTracker = clusterSources.get(producerPartitionId);
                 if (targetTracker == null) {
-                    // Don't have a tracker for this partition
-                    if (DRLogSegmentId.isEmptyDRId(lastReceivedDRId)) {
-                        return DRIdempotencyResult.SUCCESS;
-                    } else {
-                        if (drLog.isTraceEnabled()) {
-                            drLog.trace(String.format("P%d binary log site idempotency check failed. " +
-                                                      "Site's tracker is null while the last received is %s",
-                                                      producerPartitionId,
-                                                      DRLogSegmentId.getDebugStringFromDRId(lastReceivedDRId)));
-                        }
-                    }
+                    drLog.warn(String.format("P%d binary log site idempotency check failed. " +
+                                    "Site's tracker is null while the last received is %s",
+                            producerPartitionId,
+                            DRLogSegmentId.getDebugStringFromDRId(lastReceivedDRId)));
                 }
                 else {
                     assert (targetTracker.size() > 0);

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -592,6 +592,12 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                                     Long.MIN_VALUE, Long.MIN_VALUE, i);
                     clusterSources.put(i, tracker);
                 }
+                DRConsumerDrIdTracker tracker =
+                        DRConsumerDrIdTracker.createPartitionTracker(
+                                DRLogSegmentId.makeEmptyDRId(producerClusterId),
+                                Long.MIN_VALUE, Long.MIN_VALUE, MpInitiator.MP_INIT_PID);
+                clusterSources.put(MpInitiator.MP_INIT_PID, tracker);
+
                 m_maxSeenDrLogsBySrcPartition.put(producerClusterId, clusterSources);
             }
         }


### PR DESCRIPTION
* Make populateEmptyTrackersIfNeeded a method in ConsumerDRGateway interface as now it will be called on producer side
* Add API to VoltProjectBuilder to set DR consumer connection to be enabled/disabled in deployment file
* Do not tolerate lack of tracker in site DR idempotency check anymore as there will always be dummy tracker for existing cluster for the joiner cluster even if the leader cluster has DR consumer connection disabled and dummy trackers will be populated in the consumer clusters if needed when consumer goes into RECEIVE state for other replication pairs