### PR TITLE
Eng 12359 fix several bugs found in manual testing.

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/CheckUpgradePlanNT.java
+++ b/src/frontend/org/voltdb/sysprocs/CheckUpgradePlanNT.java
@@ -118,10 +118,6 @@ public class CheckUpgradePlanNT extends VoltNTSystemProcedure {
             }
 
             CatalogContext context = VoltDB.instance().getCatalogContext();
-            System.out.println("Is DR null: " + (context.getDeployment().getDr() == null));
-            if (context.getDeployment().getDr() != null) {
-                System.out.println("DR role: " + context.getDeployment().getDr().getRole());
-            }
             if (context.getDeployment().getDr() == null || context.getDeployment().getDr().getRole() != DrRoleType.XDCR) {
                 return "Target VoltDB cluster must have XDCR enabled (set role=\"xdcr\" under DR tag of the deployment file).";
             }

--- a/src/frontend/org/voltdb/sysprocs/CheckUpgradePlanNT.java
+++ b/src/frontend/org/voltdb/sysprocs/CheckUpgradePlanNT.java
@@ -118,7 +118,11 @@ public class CheckUpgradePlanNT extends VoltNTSystemProcedure {
             }
 
             CatalogContext context = VoltDB.instance().getCatalogContext();
-            if (context.getDeployment().getDr() != null && context.getDeployment().getDr().getRole() != DrRoleType.XDCR) {
+            System.out.println("Is DR null: " + (context.getDeployment().getDr() == null));
+            if (context.getDeployment().getDr() != null) {
+                System.out.println("DR role: " + context.getDeployment().getDr().getRole());
+            }
+            if (context.getDeployment().getDr() == null || context.getDeployment().getDr().getRole() != DrRoleType.XDCR) {
                 return "Target VoltDB cluster must have XDCR enabled (set role=\"xdcr\" under DR tag of the deployment file).";
             }
 
@@ -138,8 +142,9 @@ public class CheckUpgradePlanNT extends VoltNTSystemProcedure {
             }
 
             for (Table tb : context.database.getTables()) {
-                if (!tb.getTypeName().equals(CatalogUtil.DR_CONFLICTS_PARTITIONED_EXPORT_TABLE)
+                if (!tb.getTypeName().equals(CatalogUtil.DR_CONFLICTS_PARTITIONED_EXPORT_TABLE)         /* skip conflict export table */
                         && !tb.getTypeName().equals(CatalogUtil.DR_CONFLICTS_REPLICATED_EXPORT_TABLE)
+                        && tb.getMaterializer() == null                                                 /* skip view table */
                         && !tb.getIsdred()) {
                     warning.append(tb.getTypeName()).append(" is not a DR table.").append("\n");
                 }


### PR DESCRIPTION
1. In multi-cluster case, plan_upgrade doesn't generate DR reset command for the new cluster (the one to be upgraded).
2. In multi-cluster case, plan_upgrade sometimes choose the wrong host to kill, which StopNode reject to do because it violates K-safety.
3. "not a DR table" Warning also applies to view table, which should be skipped.
4. add a step to disbale DR connection in stand-alone cluster upgrade.
5. reorder steps to seperate prepare and upgrade phase.