### PR TITLE
Eng 12082 human readable latency stats

### DIFF
--- a/src/frontend/org/voltdb/AdmissionControlGroup.java
+++ b/src/frontend/org/voltdb/AdmissionControlGroup.java
@@ -26,7 +26,7 @@ import org.HdrHistogram_voltpatches.AbstractHistogram;
 import org.cliffc_voltpatches.high_scale_lib.NonBlockingHashMap;
 import org.voltcore.logging.VoltLogger;
 import org.voltdb.dtxn.InitiatorStats.InvocationInfo;
-import org.voltdb.dtxn.LatencyStats;
+import org.voltdb.dtxn.LatencyHistogramStats;
 
 /**
  * Manage admission control for incoming requests by tracking the size of outstanding requests
@@ -99,7 +99,7 @@ public class AdmissionControlGroup implements org.voltcore.network.QueueMonitor
     private final ConcurrentHashMap<Long, Map<String, org.voltdb.dtxn.InitiatorStats.InvocationInfo>> m_connectionStates =
                  new ConcurrentHashMap<Long, Map<String, org.voltdb.dtxn.InitiatorStats.InvocationInfo>>(1024, .75f, 1);
 
-    private final AbstractHistogram m_latencyInfo = LatencyStats.constructHistogram(true);
+    private final AbstractHistogram m_latencyInfo = LatencyHistogramStats.constructHistogram(true);
 
     public AdmissionControlGroup(int maxBytes, int maxRequests)
     {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -123,6 +123,7 @@ import org.voltdb.compiler.deploymentfile.PathsType;
 import org.voltdb.compiler.deploymentfile.SecurityType;
 import org.voltdb.compiler.deploymentfile.SystemSettingsType;
 import org.voltdb.dtxn.InitiatorStats;
+import org.voltdb.dtxn.LatencyUncompressedHistogramStats;
 import org.voltdb.dtxn.LatencyHistogramStats;
 import org.voltdb.dtxn.LatencyStats;
 import org.voltdb.dtxn.SiteTracker;
@@ -429,9 +430,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     // The configured license api: use to decide enterprise/community edition feature enablement
     LicenseApi m_licenseApi;
     String m_licenseInformation = "";
-    private LatencyStats m_latencyStats;
 
-    private LatencyHistogramStats m_latencyHistogramStats;
+    private LatencyStats m_latencyStats;
+    private LatencyHistogramStats m_latencyCompressedStats;
+    private LatencyUncompressedHistogramStats m_latencyHistogramStats;
 
     private File getConfigDirectory() {
         return getConfigDirectory(m_config);
@@ -1263,9 +1265,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_initiatorStats = new InitiatorStats(m_myHostId);
             m_liveClientsStats = new LiveClientsStats();
             getStatsAgent().registerStatsSource(StatsSelector.LIVECLIENTS, 0, m_liveClientsStats);
+
             m_latencyStats = new LatencyStats(m_myHostId);
-            getStatsAgent().registerStatsSource(StatsSelector.LATENCY_COMPRESSED, 0, m_latencyStats);
-            m_latencyHistogramStats = new LatencyHistogramStats(m_myHostId);
+            getStatsAgent().registerStatsSource(StatsSelector.LATENCY, 0, m_latencyStats);
+            m_latencyCompressedStats = new LatencyHistogramStats(m_myHostId);
+            getStatsAgent().registerStatsSource(StatsSelector.LATENCY_COMPRESSED, 0, m_latencyCompressedStats);
+            m_latencyHistogramStats = new LatencyUncompressedHistogramStats(m_myHostId);
             getStatsAgent().registerStatsSource(StatsSelector.LATENCY_HISTOGRAM,
                     0, m_latencyHistogramStats);
 
@@ -3237,7 +3242,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 m_computationService = null;
                 m_catalogContext = null;
                 m_initiatorStats = null;
-                m_latencyStats = null;
+                m_latencyCompressedStats = null;
                 m_latencyHistogramStats = null;
 
                 AdHocCompilerCache.clearHashCache();

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1264,7 +1264,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_liveClientsStats = new LiveClientsStats();
             getStatsAgent().registerStatsSource(StatsSelector.LIVECLIENTS, 0, m_liveClientsStats);
             m_latencyStats = new LatencyStats(m_myHostId);
-            getStatsAgent().registerStatsSource(StatsSelector.LATENCY, 0, m_latencyStats);
+            getStatsAgent().registerStatsSource(StatsSelector.LATENCY_COMPRESSED, 0, m_latencyStats);
             m_latencyHistogramStats = new LatencyHistogramStats(m_myHostId);
             getStatsAgent().registerStatsSource(StatsSelector.LATENCY_HISTOGRAM,
                     0, m_latencyHistogramStats);

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3242,6 +3242,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 m_computationService = null;
                 m_catalogContext = null;
                 m_initiatorStats = null;
+                m_latencyStats = null;
                 m_latencyCompressedStats = null;
                 m_latencyHistogramStats = null;
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1266,7 +1266,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_liveClientsStats = new LiveClientsStats();
             getStatsAgent().registerStatsSource(StatsSelector.LIVECLIENTS, 0, m_liveClientsStats);
 
-            m_latencyStats = new LatencyStats(m_myHostId);
+            m_latencyStats = new LatencyStats();
             getStatsAgent().registerStatsSource(StatsSelector.LATENCY, 0, m_latencyStats);
             m_latencyCompressedStats = new LatencyHistogramStats(m_myHostId);
             getStatsAgent().registerStatsSource(StatsSelector.LATENCY_COMPRESSED, 0, m_latencyCompressedStats);

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -532,6 +532,9 @@ public class StatsAgent extends OpsAgent
         case LIVECLIENTS:
             stats = collectStats(StatsSelector.LIVECLIENTS, interval);
             break;
+        case LATENCY:
+            stats = collectStats(StatsSelector.LATENCY, false);
+            break;
         case LATENCY_COMPRESSED:
             stats = collectStats(StatsSelector.LATENCY_COMPRESSED, interval);
             break;

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -532,8 +532,8 @@ public class StatsAgent extends OpsAgent
         case LIVECLIENTS:
             stats = collectStats(StatsSelector.LIVECLIENTS, interval);
             break;
-        case LATENCY:
-            stats = collectStats(StatsSelector.LATENCY, interval);
+        case LATENCY_COMPRESSED:
+            stats = collectStats(StatsSelector.LATENCY_COMPRESSED, interval);
             break;
         case LATENCY_HISTOGRAM:
             stats = collectStats(StatsSelector.LATENCY_HISTOGRAM, interval);

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -22,7 +22,7 @@ public enum StatsSelector {
     PROCEDURE,        // invoked as @stat procedure
     STARVATION,
     INITIATOR,        // invoked as @stat initiator
-    LATENCY,          // invoked as @stat latency
+    LATENCY_COMPRESSED,          // invoked as @stat latency
     LATENCY_HISTOGRAM,
     PARTITIONCOUNT,
     IOSTATS,

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -23,7 +23,7 @@ public enum StatsSelector {
     STARVATION,
     INITIATOR,        // invoked as @stat initiator
     LATENCY,          // invoked as @stat latency
-    LATENCY_COMPRESSED,    // pre-7.3 this was @Statistics LATENCY
+    LATENCY_COMPRESSED,  // before V7.3 this was @Statistics LATENCY
     LATENCY_HISTOGRAM,
     PARTITIONCOUNT,
     IOSTATS,

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -22,7 +22,8 @@ public enum StatsSelector {
     PROCEDURE,        // invoked as @stat procedure
     STARVATION,
     INITIATOR,        // invoked as @stat initiator
-    LATENCY_COMPRESSED,          // invoked as @stat latency
+    LATENCY,          // invoked as @stat latency
+    LATENCY_COMPRESSED,    // pre-7.3 this was @Statistics LATENCY
     LATENCY_HISTOGRAM,
     PARTITIONCOUNT,
     IOSTATS,

--- a/src/frontend/org/voltdb/dtxn/LatencyHistogramStats.java
+++ b/src/frontend/org/voltdb/dtxn/LatencyHistogramStats.java
@@ -17,26 +17,137 @@
 
 package org.voltdb.dtxn;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.HdrHistogram_voltpatches.AbstractHistogram;
+import org.HdrHistogram_voltpatches.AtomicHistogram;
+import org.HdrHistogram_voltpatches.Histogram;
+import org.voltcore.utils.CompressionStrategySnappy;
+import org.voltdb.ClientInterface;
+import org.voltdb.SiteStatsSource;
+import org.voltdb.VoltDB;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
 
-public class LatencyHistogramStats extends LatencyStats {
+import com.google_voltpatches.common.base.Supplier;
+import com.google_voltpatches.common.base.Suppliers;
+
+/** Source of @Statistics LATENCY_COMPRESSED.
+ * Latency information is provided in buckets. Each bucket contains the
+ * number of procedures with latencies in the range.
+ */
+public class LatencyHistogramStats extends SiteStatsSource {
+    /**
+     * A dummy iterator that wraps and int and provides the
+     * Iterator<Object> necessary for getStatsRowKeyIterator()
+     *
+     */
+    private static class DummyIterator implements Iterator<Object> {
+        boolean oneRow = false;
+
+        @Override
+        public boolean hasNext() {
+            if (!oneRow) {
+                oneRow = true;
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public Object next() {
+            return null;
+        }
+
+        @Override
+        public void remove() {
+
+        }
+    }
+
+    public static AbstractHistogram constructHistogram(boolean threadSafe) {
+        final long highestTrackableValue = 60L * 60L * 1000000L;
+        final int numberOfSignificantValueDigits = 3;
+        if (threadSafe) {
+            return new AtomicHistogram( highestTrackableValue, numberOfSignificantValueDigits);
+        } else {
+            return new Histogram( highestTrackableValue, numberOfSignificantValueDigits);
+        }
+    }
+
+    private WeakReference<byte[]> m_compressedCache = null;
+    private WeakReference<byte[]> m_serializedCache = null;
+
+    private AbstractHistogram m_totals = constructHistogram(false);
+
+    private final static int EXPIRATION = Integer.getInteger("LATENCY_CACHE_EXPIRATION", 900);
+
+    private Supplier<AbstractHistogram> getHistogramSupplier() {
+        return Suppliers.memoizeWithExpiration(new Supplier<AbstractHistogram>() {
+            @Override
+            public AbstractHistogram get() {
+                m_totals.reset();
+                ClientInterface ci = VoltDB.instance().getClientInterface();
+                if (ci != null) {
+                    List<AbstractHistogram> thisci = ci.getLatencyStats();
+                    for (AbstractHistogram info : thisci) {
+                        m_totals.add(info);
+                    }
+                }
+                m_compressedCache = null;
+                m_serializedCache = null;
+
+                return m_totals;
+            }
+        }, EXPIRATION, TimeUnit.MILLISECONDS);
+    }
+    private Supplier<AbstractHistogram> m_histogramSupplier = getHistogramSupplier();
+
+    public byte[] getSerializedCache() {
+        byte[] retval = null;
+        if (m_serializedCache == null || (retval = m_serializedCache.get()) == null) {
+            retval = m_histogramSupplier.get().toUncompressedBytes();
+            m_serializedCache = new WeakReference<byte[]>(retval);
+        }
+        return retval;
+    }
+
+    public byte[] getCompressedCache() {
+        byte[] retval = null;
+        if (m_compressedCache == null || (retval = m_compressedCache.get()) == null) {
+            retval = AbstractHistogram.toCompressedBytes(getSerializedCache(), CompressionStrategySnappy.INSTANCE);
+            m_compressedCache = new WeakReference<byte[]>(retval);
+        }
+        return retval;
+    }
+
+    public AbstractHistogram getHistogram() {
+        return m_histogramSupplier.get();
+    }
 
     public LatencyHistogramStats(long siteId) {
-        super(siteId);
+        super(siteId, false);
+    }
+
+    @Override
+    protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
+        m_histogramSupplier.get();
+        return new DummyIterator();
     }
 
     @Override
     protected void populateColumnSchema(ArrayList<ColumnInfo> columns) {
         super.populateColumnSchema(columns);
-        columns.add(new ColumnInfo("UNCOMPRESSED_HISTOGRAM", VoltType.VARBINARY));
+        columns.add(new ColumnInfo("HISTOGRAM", VoltType.VARBINARY));
     }
 
     @Override
     protected void updateStatsRow(Object rowKey, Object[] rowValues) {
-        rowValues[columnNameToIndex.get("UNCOMPRESSED_HISTOGRAM")] = getSerializedCache();
+        rowValues[columnNameToIndex.get("HISTOGRAM")] = getCompressedCache();
         super.updateStatsRow(rowKey, rowValues);
     }
 }

--- a/src/frontend/org/voltdb/dtxn/LatencyStats.java
+++ b/src/frontend/org/voltdb/dtxn/LatencyStats.java
@@ -139,12 +139,12 @@ public class LatencyStats extends StatsSource {
         rowValues[columnNameToIndex.get("INTERVAL")]  = INTERVAL_MS;
         rowValues[columnNameToIndex.get("COUNT")]     = diffHist.getTotalCount();
         rowValues[columnNameToIndex.get("TPS")]       = (int) (TimeUnit.SECONDS.toMillis(diffHist.getTotalCount()) / INTERVAL_MS);
-        rowValues[columnNameToIndex.get("P50")]       = diffHist.getValueAtPercentile(50.0);
-        rowValues[columnNameToIndex.get("P95")]       = diffHist.getValueAtPercentile(95.0);
-        rowValues[columnNameToIndex.get("P99")]       = diffHist.getValueAtPercentile(99.0);
-        rowValues[columnNameToIndex.get("P99.9")]     = diffHist.getValueAtPercentile(99.9);
-        rowValues[columnNameToIndex.get("P99.99")]    = diffHist.getValueAtPercentile(99.99);
-        rowValues[columnNameToIndex.get("P99.999")]   = diffHist.getValueAtPercentile(99.999);
+        rowValues[columnNameToIndex.get("P50")]       = diffHist.getValueAtPercentile(50D);
+        rowValues[columnNameToIndex.get("P95")]       = diffHist.getValueAtPercentile(95D);
+        rowValues[columnNameToIndex.get("P99")]       = diffHist.getValueAtPercentile(99D);
+        rowValues[columnNameToIndex.get("P99.9")]     = diffHist.getValueAtPercentile(99.9D);
+        rowValues[columnNameToIndex.get("P99.99")]    = diffHist.getValueAtPercentile(99.99D);
+        rowValues[columnNameToIndex.get("P99.999")]   = diffHist.getValueAtPercentile(99.999D);
         rowValues[columnNameToIndex.get("MAX")]       = diffHist.getMaxValue();
     }
 }

--- a/src/frontend/org/voltdb/dtxn/LatencyStats.java
+++ b/src/frontend/org/voltdb/dtxn/LatencyStats.java
@@ -34,9 +34,20 @@ import org.voltdb.VoltType;
 import org.voltdb.types.TimestampType;
 import org.voltdb.VoltTable.ColumnInfo;
 
-/** Source of @Statistics LATENCY.
- * This aims to provide useful data for lightweight monitoring.
- * To get a complete latency curve, get the whole histogram via @Statistics LATENCY_COMPRESSED or @Statistics LATENCY_HISTOGRAM (both undocumented)
+/** Source of @Statistics LATENCY, which provides key latency metrics from the past 5 seconds of transactions.
+ * This is intended to be used as part of a manual or automatic monitoring solution,
+ * where plotting latency fluctuations over time with minimal post-processing is desired.
+ *
+ * Each call returns latency percentiles from the most recent complete window,
+ * along with the timestamp associated with that window.
+ * Samples are calculated by using a differential histogram,
+ * subtracting the previous window's histogram from the current one.
+ * Tables with the same HOST_ID and TIMESTAMP represent the same data.
+ *
+ * Statistics are returned with one row for each node.
+ *
+ * To get a complete latency curve which includes all data since VoltDB started,
+ * get the whole histogram via @Statistics LATENCY_COMPRESSED or @Statistics LATENCY_HISTOGRAM (both undocumented).
  */
 public class LatencyStats extends StatsSource {
 

--- a/src/frontend/org/voltdb/dtxn/LatencyStats.java
+++ b/src/frontend/org/voltdb/dtxn/LatencyStats.java
@@ -139,12 +139,12 @@ public class LatencyStats extends StatsSource {
         rowValues[columnNameToIndex.get("INTERVAL")]  = INTERVAL_MS;
         rowValues[columnNameToIndex.get("COUNT")]     = diffHist.getTotalCount();
         rowValues[columnNameToIndex.get("TPS")]       = (int) (TimeUnit.SECONDS.toMillis(diffHist.getTotalCount()) / INTERVAL_MS);
-        rowValues[columnNameToIndex.get("P50")]       = diffHist.getValueAtPercentile(0.50);
-        rowValues[columnNameToIndex.get("P95")]       = diffHist.getValueAtPercentile(0.95);
-        rowValues[columnNameToIndex.get("P99")]       = diffHist.getValueAtPercentile(0.99);
-        rowValues[columnNameToIndex.get("P99.9")]     = diffHist.getValueAtPercentile(0.999);
-        rowValues[columnNameToIndex.get("P99.99")]    = diffHist.getValueAtPercentile(0.9999);
-        rowValues[columnNameToIndex.get("P99.999")]   = diffHist.getValueAtPercentile(0.99999);
+        rowValues[columnNameToIndex.get("P50")]       = diffHist.getValueAtPercentile(50.0);
+        rowValues[columnNameToIndex.get("P95")]       = diffHist.getValueAtPercentile(95.0);
+        rowValues[columnNameToIndex.get("P99")]       = diffHist.getValueAtPercentile(99.0);
+        rowValues[columnNameToIndex.get("P99.9")]     = diffHist.getValueAtPercentile(99.9);
+        rowValues[columnNameToIndex.get("P99.99")]    = diffHist.getValueAtPercentile(99.99);
+        rowValues[columnNameToIndex.get("P99.999")]   = diffHist.getValueAtPercentile(99.999);
         rowValues[columnNameToIndex.get("MAX")]       = diffHist.getMaxValue();
     }
 }

--- a/src/frontend/org/voltdb/dtxn/LatencyStats.java
+++ b/src/frontend/org/voltdb/dtxn/LatencyStats.java
@@ -17,42 +17,60 @@
 
 package org.voltdb.dtxn;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.HdrHistogram_voltpatches.AbstractHistogram;
-import org.HdrHistogram_voltpatches.AtomicHistogram;
 import org.HdrHistogram_voltpatches.Histogram;
-import org.voltcore.utils.CompressionStrategySnappy;
 import org.voltdb.ClientInterface;
 import org.voltdb.SiteStatsSource;
 import org.voltdb.VoltDB;
-import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
+import org.voltdb.types.TimestampType;
+import org.voltdb.VoltTable.ColumnInfo;
 
-import com.google_voltpatches.common.base.Supplier;
-import com.google_voltpatches.common.base.Suppliers;
-
-/**
- * Class that provides latency information in buckets. Each bucket contains the
- * number of procedures with latencies in the range.
- */
 public class LatencyStats extends SiteStatsSource {
-    /**
-     * A dummy iterator that wraps and int and provides the
-     * Iterator<Object> necessary for getStatsRowKeyIterator()
-     *
-     */
-    private static class DummyIterator implements Iterator<Object> {
-        boolean oneRow = false;
+
+    public static final int INTERVAL_SECONDS = 5;
+
+    private AtomicReference<AbstractHistogram> m_diffHistProvider = new AtomicReference<AbstractHistogram>();
+    private ScheduledExecutorService m_updater = Executors.newScheduledThreadPool(1);
+
+    private class UpdaterJob implements Runnable {
+
+        private AbstractHistogram m_previousHist = LatencyHistogramStats.constructHistogram(false);
+
+        @Override
+        public void run() {
+            AbstractHistogram currentHist = LatencyHistogramStats.constructHistogram(false);
+            ClientInterface ci = VoltDB.instance().getClientInterface();
+            if (ci != null) {
+                List<AbstractHistogram> thisci = ci.getLatencyStats();
+                for (AbstractHistogram info : thisci) {
+                    currentHist.add(info);
+                }
+            }
+            AbstractHistogram diffHist = currentHist.copy();
+            diffHist.subtract(m_previousHist);
+            diffHist.setEndTimeStamp(System.currentTimeMillis());
+            m_previousHist = currentHist;
+            m_diffHistProvider.set(diffHist);
+        }
+    }
+
+    /** A dummy iterator that lets getStatsRowKeyIterator() access a single row. */
+    private static class SingleRowIterator implements Iterator<Object> {
+        boolean rowProvided = false;
 
         @Override
         public boolean hasNext() {
-            if (!oneRow) {
-                oneRow = true;
+            if (!rowProvided) {
+                rowProvided = true;
                 return true;
             }
             return false;
@@ -69,81 +87,46 @@ public class LatencyStats extends SiteStatsSource {
         }
     }
 
-    public static AbstractHistogram constructHistogram(boolean threadSafe) {
-        final long highestTrackableValue = 60L * 60L * 1000000L;
-        final int numberOfSignificantValueDigits = 3;
-        if (threadSafe) {
-            return new AtomicHistogram( highestTrackableValue, numberOfSignificantValueDigits);
-        } else {
-            return new Histogram( highestTrackableValue, numberOfSignificantValueDigits);
-        }
-    }
-
-    private WeakReference<byte[]> m_compressedCache = null;
-    private WeakReference<byte[]> m_serializedCache = null;
-
-    private AbstractHistogram m_totals = constructHistogram(false);
-
-    private final static int EXPIRATION = Integer.getInteger("LATENCY_CACHE_EXPIRATION", 900);
-
-    private Supplier<AbstractHistogram> getHistogramSupplier() {
-        return Suppliers.memoizeWithExpiration(new Supplier<AbstractHistogram>() {
-            @Override
-            public AbstractHistogram get() {
-                m_totals.reset();
-                ClientInterface ci = VoltDB.instance().getClientInterface();
-                if (ci != null) {
-                    List<AbstractHistogram> thisci = ci.getLatencyStats();
-                    for (AbstractHistogram info : thisci) {
-                        m_totals.add(info);
-                    }
-                }
-                m_compressedCache = null;
-                m_serializedCache = null;
-
-                return m_totals;
-            }
-        }, EXPIRATION, TimeUnit.MILLISECONDS);
-    }
-    private Supplier<AbstractHistogram> m_histogramSupplier = getHistogramSupplier();
-
-    public byte[] getSerializedCache() {
-        byte[] retval = null;
-        if (m_serializedCache == null || (retval = m_serializedCache.get()) == null) {
-            retval = m_histogramSupplier.get().toUncompressedBytes();
-            m_serializedCache = new WeakReference<byte[]>(retval);
-        }
-        return retval;
-    }
-
-    public byte[] getCompressedCache() {
-        byte[] retval = null;
-        if (m_compressedCache == null || (retval = m_compressedCache.get()) == null) {
-            retval = AbstractHistogram.toCompressedBytes(getSerializedCache(), CompressionStrategySnappy.INSTANCE);
-            m_compressedCache = new WeakReference<byte[]>(retval);
-        }
-        return retval;
-    }
-
     public LatencyStats(long siteId) {
         super(siteId, false);
+        m_diffHistProvider.set(LatencyHistogramStats.constructHistogram(false));
+        final int initialDelay = 0;
+        m_updater.scheduleAtFixedRate(new UpdaterJob(), initialDelay, INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override
     protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
-        m_histogramSupplier.get();
-        return new DummyIterator();
+        return new SingleRowIterator();
     }
 
     @Override
     protected void populateColumnSchema(ArrayList<ColumnInfo> columns) {
         super.populateColumnSchema(columns);
-        columns.add(new ColumnInfo("HISTOGRAM", VoltType.VARBINARY));
+        columns.add(new ColumnInfo("TIMESTAMP", VoltType.TIMESTAMP));
+        columns.add(new ColumnInfo("INTERVAL",  VoltType.INTEGER));   // seconds
+        columns.add(new ColumnInfo("P50",       VoltType.BIGINT));    // microseconds
+        columns.add(new ColumnInfo("P95",       VoltType.BIGINT));    // microseconds
+        columns.add(new ColumnInfo("P99",       VoltType.BIGINT));    // microseconds
+        columns.add(new ColumnInfo("P99.9",     VoltType.BIGINT));    // microseconds
+        columns.add(new ColumnInfo("P99.99",    VoltType.BIGINT));    // microseconds
+        columns.add(new ColumnInfo("P99.999",   VoltType.BIGINT));    // microseconds
     }
 
     @Override
     protected void updateStatsRow(Object rowKey, Object[] rowValues) {
-        rowValues[columnNameToIndex.get("HISTOGRAM")] = getCompressedCache();
+
+        AbstractHistogram diffHist = m_diffHistProvider.get();
+        long histTimestamp = diffHist.getEndTimeStamp();
+        assert histTimestamp > 0; // histTimestamp is in milliseconds since the epoch
+
+        rowValues[columnNameToIndex.get("TIMESTAMP")] = new TimestampType(TimeUnit.MILLISECONDS.toMicros(histTimestamp));
+        rowValues[columnNameToIndex.get("INTERVAL")]  = INTERVAL_SECONDS;
+        rowValues[columnNameToIndex.get("P50")]       = diffHist.getValueAtPercentile(0.50);
+        rowValues[columnNameToIndex.get("P95")]       = diffHist.getValueAtPercentile(0.95);
+        rowValues[columnNameToIndex.get("P99")]       = diffHist.getValueAtPercentile(0.99);
+        rowValues[columnNameToIndex.get("P99.9")]     = diffHist.getValueAtPercentile(0.999);
+        rowValues[columnNameToIndex.get("P99.99")]    = diffHist.getValueAtPercentile(0.9999);
+        rowValues[columnNameToIndex.get("P99.999")]   = diffHist.getValueAtPercentile(0.99999);
         super.updateStatsRow(rowKey, rowValues);
     }
 }

--- a/src/frontend/org/voltdb/dtxn/LatencyStats.java
+++ b/src/frontend/org/voltdb/dtxn/LatencyStats.java
@@ -52,11 +52,11 @@ public class LatencyStats extends StatsSource {
         @Override
         public void run() {
             AbstractHistogram currentHist = LatencyHistogramStats.constructHistogram(false);
-            ClientInterface ci = VoltDB.instance().getClientInterface();
-            if (ci != null) {
-                List<AbstractHistogram> thisci = ci.getLatencyStats();
-                for (AbstractHistogram info : thisci) {
-                    currentHist.add(info);
+            ClientInterface clientInterface = VoltDB.instance().getClientInterface();
+            if (clientInterface != null) {
+                List<AbstractHistogram> statsHists = clientInterface.getLatencyStats();
+                for (AbstractHistogram hist : statsHists) {
+                    currentHist.add(hist);
                 }
             }
             AbstractHistogram diffHist = currentHist.copy();
@@ -105,16 +105,17 @@ public class LatencyStats extends StatsSource {
 
     @Override
     protected void populateColumnSchema(ArrayList<ColumnInfo> columns) {
-        super.populateColumnSchema(columns);
-        columns.add(new ColumnInfo("COUNT",   VoltType.INTEGER)); // samples
-        columns.add(new ColumnInfo("TPS",     VoltType.INTEGER)); // samples per second
-        columns.add(new ColumnInfo("P50",     VoltType.BIGINT));  // microseconds
-        columns.add(new ColumnInfo("P95",     VoltType.BIGINT));  // microseconds
-        columns.add(new ColumnInfo("P99",     VoltType.BIGINT));  // microseconds
-        columns.add(new ColumnInfo("P99.9",   VoltType.BIGINT));  // microseconds
-        columns.add(new ColumnInfo("P99.99",  VoltType.BIGINT));  // microseconds
-        columns.add(new ColumnInfo("P99.999", VoltType.BIGINT));  // microseconds
-        columns.add(new ColumnInfo("MAX",     VoltType.BIGINT));  // microseconds
+        super.populateColumnSchema(columns);                       // timestamp is milliseconds
+        columns.add(new ColumnInfo("INTERVAL", VoltType.INTEGER)); // milliseconds
+        columns.add(new ColumnInfo("COUNT",    VoltType.INTEGER)); // samples
+        columns.add(new ColumnInfo("TPS",      VoltType.INTEGER)); // samples per second
+        columns.add(new ColumnInfo("P50",      VoltType.BIGINT));  // microseconds
+        columns.add(new ColumnInfo("P95",      VoltType.BIGINT));  // microseconds
+        columns.add(new ColumnInfo("P99",      VoltType.BIGINT));  // microseconds
+        columns.add(new ColumnInfo("P99.9",    VoltType.BIGINT));  // microseconds
+        columns.add(new ColumnInfo("P99.99",   VoltType.BIGINT));  // microseconds
+        columns.add(new ColumnInfo("P99.999",  VoltType.BIGINT));  // microseconds
+        columns.add(new ColumnInfo("MAX",      VoltType.BIGINT));  // microseconds
     }
 
     @Override
@@ -124,6 +125,7 @@ public class LatencyStats extends StatsSource {
 
         // Override timestamp from the procedure call with the one from when the data was fetched.
         rowValues[columnNameToIndex.get("TIMESTAMP")] = diffHist.getEndTimeStamp();
+        rowValues[columnNameToIndex.get("INTERVAL")]  = INTERVAL_MS;
         rowValues[columnNameToIndex.get("COUNT")]     = diffHist.getTotalCount();
         rowValues[columnNameToIndex.get("TPS")]       = (int) (TimeUnit.SECONDS.toMillis(diffHist.getTotalCount()) / INTERVAL_MS);
         rowValues[columnNameToIndex.get("P50")]       = diffHist.getValueAtPercentile(0.50);

--- a/src/frontend/org/voltdb/dtxn/LatencyUncompressedHistogramStats.java
+++ b/src/frontend/org/voltdb/dtxn/LatencyUncompressedHistogramStats.java
@@ -1,0 +1,43 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.dtxn;
+
+import java.util.ArrayList;
+
+import org.voltdb.VoltTable.ColumnInfo;
+import org.voltdb.VoltType;
+
+/** Source of @Statistics LATENCY_HISTOGRAM */
+public class LatencyUncompressedHistogramStats extends LatencyHistogramStats {
+
+    public LatencyUncompressedHistogramStats(long siteId) {
+        super(siteId);
+    }
+
+    @Override
+    protected void populateColumnSchema(ArrayList<ColumnInfo> columns) {
+        super.populateColumnSchema(columns);
+        columns.add(new ColumnInfo("UNCOMPRESSED_HISTOGRAM", VoltType.VARBINARY));
+    }
+
+    @Override
+    protected void updateStatsRow(Object rowKey, Object[] rowValues) {
+        rowValues[columnNameToIndex.get("UNCOMPRESSED_HISTOGRAM")] = getSerializedCache();
+        super.updateStatsRow(rowKey, rowValues);
+    }
+}

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -249,66 +249,32 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         return results[0].getLong("TIMESTAMP"); // milliseconds
     }
 
-    // Helper for testLatencyTiming
-    private static VoltTable runLatencyStatsCall(Client client) throws Exception {
-        VoltTable[] results = client.callProcedure("@Statistics", "LATENCY", 0).getResults();
-        assertEquals(1, results.length);
-        // HOST_ID ordering isn't deterministic, so guarantee the same host is always used.
-        do {
-            results[0].advanceRow();
-        } while (results[0].getLong("HOST_ID") != 0);
-        return results[0];
-    }
-
-    // Ensures @Statistics LATENCY timestamp reflects the time slice associated with the statistics.
     public void testLatencyTiming() throws Exception {
         System.out.println("\n\nTESTING LATENCY STATS TIMING\n\n\n");
         Client client = getFullyConnectedClient();
 
-        final int maxIterations = 100000;
-        final int requiredBinRollovers = 2;
-        final int fudgeFactorMs = LatencyStats.INTERVAL_MS / 5;
-        System.out.println("LOGGING TEST PARAMETERS");
-        System.out.println("maxIterations = " + maxIterations);
-        System.out.println("requiredBinRollovers = " + requiredBinRollovers);
-        System.out.println("LatencyStats.INTERVAL_MS = " + LatencyStats.INTERVAL_MS);
-        System.out.println("fudgeFactorMs = " + fudgeFactorMs);
-
-        VoltTable resultsPrevious = runLatencyStatsCall(client);
-        long timePrevious = resultsPrevious.getLong("TIMESTAMP"); // milliseconds
-        int iterationCount = 0;
-        int numTimeHops = 0;
-        do {
-            if ((iterationCount % 1000) == 0) {
-                System.out.println(iterationCount + " iterations of " + maxIterations + " max completed");
-            }
-            VoltTable resultsCurrent = runLatencyStatsCall(client);
-            long timeCurrent = resultsPrevious.getLong("TIMESTAMP"); // milliseconds
-
-            if (timeCurrent != timePrevious) {
-                if ((timePrevious + LatencyStats.INTERVAL_MS - fudgeFactorMs < timeCurrent)
-                 && (timePrevious + LatencyStats.INTERVAL_MS + fudgeFactorMs > timeCurrent))
-                {
-                    System.out.println("Latency bin rollover detected. Timestamp jumped from " + timePrevious + " to " + timeCurrent);
-                    System.out.println("Time difference of " + (timeCurrent - timePrevious) / 1000.0 + " seconds.");
-                    numTimeHops++;
-                } else {
-                    System.err.println("\n\nFOUND A PROBLEM: Timestamp changed from " + timePrevious + " to " + timeCurrent);
-                    System.err.println("Time difference of " + (timeCurrent - timePrevious) / 1000.0 + " seconds.");
-                    System.err.println("Previous VoltTable: " + resultsPrevious);
-                    System.err.println("Current VoltTable: " + resultsCurrent);
-                    fail("Timestamp changed, but not by the expected bin interval");
-                }
-            }
-            resultsPrevious = resultsCurrent;
-            timePrevious = timeCurrent;
-        } while ((numTimeHops < requiredBinRollovers) && (iterationCount++ < maxIterations));
-
-        if (numTimeHops != requiredBinRollovers) {
-            System.err.println("Last timestamp is " + timePrevious);
-            System.err.println("Last VoltTable: " + resultsPrevious);
-            fail("Timestamp never changed!");
+        // To verify that subsequent timestamps are the same,
+        // take 3 samples and validate that at least one pair of adjacent samples match.
+        // This means sampling on both sides of a rollover doesn't result in failure.
+        final long ts1 = getTimestampFromLatencyStatsCall(client);
+        final long ts2 = getTimestampFromLatencyStatsCall(client);
+        final long ts3 = getTimestampFromLatencyStatsCall(client);
+        if (ts1 != ts3){
+            System.out.println("WARNING: Consecutive timestamp samples are not all from the same window.");
+            System.out.println("This is a rare but benign corner case, but may indicate a bug.");
         }
+        System.out.println("Consecutive timestamps: " + ts1 + ", " + ts2 + ", " + ts3);
+        assertTrue((ts1 == ts2) || (ts2 == ts3));
+        assertTrue(ts3 >= ts1);
+
+        // Verify that 5 seconds later the timestamps are not the same.
+        final int delayMsec = LatencyStats.INTERVAL_MS;
+        final int fudgeFactorMsec = 10;
+        final long ts4 = getTimestampFromLatencyStatsCall(client); // don't let above printing affect timing
+        Thread.sleep(delayMsec + fudgeFactorMsec);
+        final long ts5 = getTimestampFromLatencyStatsCall(client);
+        System.out.println("Non-consecutive timestamps: " + ts4 + ", " + ts5);
+        assertTrue(ts5 > ts4);
     }
 
     public void testLatencyCompressed() throws Exception {

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -168,19 +168,20 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         System.out.println("\n\nTESTING LATENCY STATS VALIDITY\n\n\n");
         Client client  = getFullyConnectedClient();
 
-        ColumnInfo[] expectedSchema = new ColumnInfo[12];
-        expectedSchema[0]  = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
-        expectedSchema[1]  = new ColumnInfo("HOST_ID", VoltType.INTEGER);
-        expectedSchema[2]  = new ColumnInfo("HOSTNAME", VoltType.STRING);
-        expectedSchema[3]  = new ColumnInfo("COUNT",   VoltType.INTEGER); // samples
-        expectedSchema[4]  = new ColumnInfo("TPS",     VoltType.INTEGER); // samples per second
-        expectedSchema[5]  = new ColumnInfo("P50",     VoltType.BIGINT);  // microseconds
-        expectedSchema[6]  = new ColumnInfo("P95",     VoltType.BIGINT);  // microseconds
-        expectedSchema[7]  = new ColumnInfo("P99",     VoltType.BIGINT);  // microseconds
-        expectedSchema[8]  = new ColumnInfo("P99.9",   VoltType.BIGINT);  // microseconds
-        expectedSchema[9]  = new ColumnInfo("P99.99",  VoltType.BIGINT);  // microseconds
-        expectedSchema[10] = new ColumnInfo("P99.999", VoltType.BIGINT);  // microseconds
-        expectedSchema[11] = new ColumnInfo("MAX",     VoltType.BIGINT);  // microseconds
+        ColumnInfo[] expectedSchema = new ColumnInfo[13];
+        expectedSchema[0]  = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);  // milliseconds
+        expectedSchema[1]  = new ColumnInfo("HOST_ID",   VoltType.INTEGER);
+        expectedSchema[2]  = new ColumnInfo("HOSTNAME",  VoltType.STRING);
+        expectedSchema[3]  = new ColumnInfo("INTERVAL",  VoltType.INTEGER); // milliseconds
+        expectedSchema[4]  = new ColumnInfo("COUNT",     VoltType.INTEGER); // samples
+        expectedSchema[5]  = new ColumnInfo("TPS",       VoltType.INTEGER); // samples per second
+        expectedSchema[6]  = new ColumnInfo("P50",       VoltType.BIGINT);  // microseconds
+        expectedSchema[7]  = new ColumnInfo("P95",       VoltType.BIGINT);  // microseconds
+        expectedSchema[8]  = new ColumnInfo("P99",       VoltType.BIGINT);  // microseconds
+        expectedSchema[9]  = new ColumnInfo("P99.9",     VoltType.BIGINT);  // microseconds
+        expectedSchema[10] = new ColumnInfo("P99.99",    VoltType.BIGINT);  // microseconds
+        expectedSchema[11] = new ColumnInfo("P99.999",   VoltType.BIGINT);  // microseconds
+        expectedSchema[12] = new ColumnInfo("MAX",       VoltType.BIGINT);  // microseconds
         VoltTable expectedTable = new VoltTable(expectedSchema);
 
         VoltTable[] results = null;
@@ -215,17 +216,19 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
             results[0].resetRowPosition();
             invocations = 0;
             while (results[0].advanceRow()) {
-                final long count = results[0].getLong("COUNT"); // samples
-                final long tps = results[0].getLong("TPS"); // samples per second
-                final long p50 = results[0].getLong("P50");  // microseconds
-                final long p95 = results[0].getLong("P95");  // microseconds
-                final long p99 = results[0].getLong("P99");  // microseconds
-                final long p39 = results[0].getLong("P99.9");  // microseconds
-                final long p49 = results[0].getLong("P99.99");  // microseconds
-                final long p59 = results[0].getLong("P99.999");  // microseconds
-                final long max = results[0].getLong("MAX");  // microseconds
-                // need to do calculation exact same way due to rounding errors
-                assertEquals(tps, (int) (TimeUnit.SECONDS.toMillis(count) / LatencyStats.INTERVAL_MS));
+                final long interval = results[0].getLong("INTERVAL"); // milliseconds
+                final long count    = results[0].getLong("COUNT");    // samples
+                final long tps      = results[0].getLong("TPS");      // samples per second
+                final long p50      = results[0].getLong("P50");      // microseconds
+                final long p95      = results[0].getLong("P95");      // microseconds
+                final long p99      = results[0].getLong("P99");      // microseconds
+                final long p39      = results[0].getLong("P99.9");    // microseconds
+                final long p49      = results[0].getLong("P99.99");   // microseconds
+                final long p59      = results[0].getLong("P99.999");  // microseconds
+                final long max      = results[0].getLong("MAX");      // microseconds
+                assertEquals(interval, LatencyStats.INTERVAL_MS);
+                // Test needs to do this calculation the exact same way as code due to fixed point rounding errors
+                assertEquals(tps, (int) (TimeUnit.SECONDS.toMillis(count) / interval));
                 assertTrue(p50 <= p95);
                 assertTrue(p95 <= p99);
                 assertTrue(p99 <= p39);

--- a/third_party/java/src/org/HdrHistogram_voltpatches/AbstractHistogram.java
+++ b/third_party/java/src/org/HdrHistogram_voltpatches/AbstractHistogram.java
@@ -2407,23 +2407,20 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
 
     public static Histogram fromCompressedBytes(byte bytes[], CompressionStrategy strategy) {
         try {
-            return fromUncompressedBytes(strategy.uncompress(bytes));
+            ByteBuffer buf = ByteBuffer.wrap(strategy.uncompress(bytes));
+            buf.order(ByteOrder.LITTLE_ENDIAN);
+            final long lTrackableValue = buf.getLong();
+            final long hTrackableValue = buf.getLong();
+            final int nSVD = buf.getInt();
+            Histogram h = new Histogram(lTrackableValue, hTrackableValue, nSVD);
+            h.addToTotalCount(buf.getLong());
+            for (int ii = 0; ii < h.countsArrayLength; ii++) {
+                h.addToCountAtIndex(ii, buf.getLong());
+            }
+            return h;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static Histogram fromUncompressedBytes(byte[] bytes) {
-        ByteBuffer buf = ByteBuffer.wrap(bytes);
-        buf.order(ByteOrder.LITTLE_ENDIAN);
-        final long lTrackableValue = buf.getLong();
-        final long hTrackableValue = buf.getLong();
-        final int nSVD = buf.getInt();
-        Histogram h = new Histogram(lTrackableValue, hTrackableValue, nSVD);
-        h.addToTotalCount(buf.getLong());
-        for (int ii = 0; ii < h.countsArrayLength; ii++) {
-            h.addToCountAtIndex(ii, buf.getLong());
-        }
-        return h;
-    }
 }

--- a/third_party/java/src/org/HdrHistogram_voltpatches/AbstractHistogram.java
+++ b/third_party/java/src/org/HdrHistogram_voltpatches/AbstractHistogram.java
@@ -2407,20 +2407,23 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
 
     public static Histogram fromCompressedBytes(byte bytes[], CompressionStrategy strategy) {
         try {
-            ByteBuffer buf = ByteBuffer.wrap(strategy.uncompress(bytes));
-            buf.order(ByteOrder.LITTLE_ENDIAN);
-            final long lTrackableValue = buf.getLong();
-            final long hTrackableValue = buf.getLong();
-            final int nSVD = buf.getInt();
-            Histogram h = new Histogram(lTrackableValue, hTrackableValue, nSVD);
-            h.addToTotalCount(buf.getLong());
-            for (int ii = 0; ii < h.countsArrayLength; ii++) {
-                h.addToCountAtIndex(ii, buf.getLong());
-            }
-            return h;
+            return fromUncompressedBytes(strategy.uncompress(bytes));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
+    public static Histogram fromUncompressedBytes(byte[] bytes) {
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+        final long lTrackableValue = buf.getLong();
+        final long hTrackableValue = buf.getLong();
+        final int nSVD = buf.getInt();
+        Histogram h = new Histogram(lTrackableValue, hTrackableValue, nSVD);
+        h.addToTotalCount(buf.getLong());
+        for (int ii = 0; ii < h.countsArrayLength; ii++) {
+            h.addToCountAtIndex(ii, buf.getLong());
+        }
+        return h;
+    }
 }


### PR DESCRIPTION
Rename current @Statistics LATENCY to @Statistics LATENCY_COMPRESSED.
Add new, to-be-documented @Statistics LATENCY that provides human readable latency statistics that are updated every 5 seconds.

Currently git is mangling the rename-and-replace of LatencyStats.java, which moved to LatencyHistogramStats.java. I may need to find a more VCS-friendly approach.

In Pro I updated a single JUnit to reflect the name change, but did not modify code or add tests there.
https://github.com/VoltDB/pro/pull/1867/files