### PR TITLE
Patch for voltdbclient.py

### DIFF
--- a/lib/python/voltdbclient.py
+++ b/lib/python/voltdbclient.py
@@ -854,6 +854,7 @@ class VoltColumn:
     def __init__(self, fser = None, type = None, name = None):
         if fser != None:
             self.type = fser.readByte()
+            self.name = None
         elif type != None and name != None:
             self.type = type
             self.name = name
@@ -862,7 +863,7 @@ class VoltColumn:
         # If the name is empty, use the default "modified tuples". Has to do
         # this because HSQLDB doesn't return a column name if the table is
         # empty.
-        return "(%s: %d)" % (self.name and self.name or "modified tuples",
+        return "(%s: %d)" % (self.name or "modified tuples" ,
                              self.type)
 
     def __eq__(self, other):
@@ -935,6 +936,7 @@ class VoltTable:
         headersize = self.fser.readInt32()
         statuscode = self.fser.readByte()
         columncount = self.fser.readInt16()
+        if statuscode: columncount=0
         for i in xrange(columncount):
             column = VoltColumn(fser = self.fser)
             self.columns.append(column)
@@ -942,6 +944,7 @@ class VoltTable:
 
         # 3.
         rowcount = self.fser.readInt32()
+        if statuscode: rowcount=0
         for i in xrange(rowcount):
             rowsize = self.fser.readInt32()
             # list comprehension: build list by calling read for each column in

--- a/lib/python/voltdbclient.py
+++ b/lib/python/voltdbclient.py
@@ -932,11 +932,11 @@ class VoltTable:
     def readFromSerializer(self):
         # 1.
         tablesize = self.fser.readInt32()
+        limit_position = self.fser.read_buffer._off + tablesize
         # 2.
         headersize = self.fser.readInt32()
         statuscode = self.fser.readByte()
         columncount = self.fser.readInt16()
-        if statuscode: columncount=0
         for i in xrange(columncount):
             column = VoltColumn(fser = self.fser)
             self.columns.append(column)
@@ -944,7 +944,6 @@ class VoltTable:
 
         # 3.
         rowcount = self.fser.readInt32()
-        if statuscode: rowcount=0
         for i in xrange(rowcount):
             rowsize = self.fser.readInt32()
             # list comprehension: build list by calling read for each column in
@@ -952,6 +951,10 @@ class VoltTable:
             row = [self.fser.read(self.columns[j].type)
                    for j in xrange(columncount)]
             self.tuples.append(row)
+
+        # advance offset to end of table-size on read_buffer
+        if self.fser.read_buffer._off != limit_position:
+            self.fser.read_buffer._off = limit_position
 
         return self
 


### PR DESCRIPTION
Using voltdbclient.py to call stored procedure, I noticed that I get a error in some case.

Usually we use java client program to call stored procedures in our system.
To make a test our stored procedure easy, I have tried to write a script by python.
I got error result sometimes, not always.
Compared to voltdb-client-cpp code, I got idea some sequence mismatch on reading VoltTable from buffer in voltdbclient.py

I summalized that I have faced to situation below.
- The stored procedure on this case, written by java, returns 4 table.
- In the error,the first table returns no record.
- The table's size on wire-protocol message is about more 500 byte by tracing.
- In the timing voltdbclient.py complete to read first table, the buffer pointer do not indicate next table header.
- (It seems no error when first table returns one record or more.)

By reference to voltdb-cpp-client code(InvocationResponse.hpp), I wrote a patch for voltdbclient.py to fix this situation.
