### PR TITLE
Eng 12425 ignore ee diff commands if possible

### DIFF
--- a/src/catgen/in/javasrc/CatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/CatalogDiffEngine.java
@@ -126,6 +126,8 @@ public class CatalogDiffEngine {
     // true if the difference is allowed in a running system
     private boolean m_supported;
 
+    private boolean m_requiresCatalogDiffCmdsApplyToEE = false;
+
     // true if table changes require the catalog change runs
     // while no snapshot is running
     private boolean m_requiresSnapshotIsolation = false;
@@ -208,6 +210,10 @@ public class CatalogDiffEngine {
 
     public boolean supported() {
         return m_supported;
+    }
+
+    public boolean requiresCatalogDiffCmdsApplyToEE() {
+        return m_requiresCatalogDiffCmdsApplyToEE;
     }
 
     /**
@@ -1235,6 +1241,10 @@ public class CatalogDiffEngine {
             processModifyResponses(errorMessage, responseList);
         }
 
+        if (! m_requiresCatalogDiffCmdsApplyToEE && checkCatalogDiffShouldApplyToEE(newType)) {
+            m_requiresCatalogDiffCmdsApplyToEE = true;
+        }
+
         // write the commands to make it so
         // they will be ignored if the change is unsupported
         newType.writeCommandForField(m_sb, field, true);
@@ -1248,6 +1258,49 @@ public class CatalogDiffEngine {
         }
         CatalogChangeGroup cgrp = m_changes.get(DiffClass.get(newType));
         cgrp.processChange(newType, prevType, field);
+    }
+
+    /**
+     * Our EE has a list of Catalog items that are in use, but Java catalog contains much more.
+     * Some of the catalog diff commands will only be useful to Java. So this function will
+     * decide whether the @param suspect catalog item will be used in EE or not.
+     * @param suspect
+     * @param prevType
+     * @param field
+     * @return true if the suspect catalog will be updated in EE, false otherwise.
+     */
+    protected static boolean checkCatalogDiffShouldApplyToEE(final CatalogType suspect)
+    {
+        // Warning:
+        // This check list should be consistent with catalog items defined in EE
+        // Once a new catalog type is added in EE, we should add it here.
+
+        if (suspect instanceof Cluster || suspect instanceof Database) {
+            return true;
+        }
+
+        if (suspect instanceof Table ||
+                suspect instanceof Column || suspect instanceof ColumnRef ||
+                suspect instanceof Index || suspect instanceof IndexRef ||
+                suspect instanceof Constraint || suspect instanceof ConstraintRef ||
+                suspect instanceof MaterializedViewInfo) {
+            return true;
+        }
+
+        if (suspect instanceof Statement || suspect instanceof PlanFragment) {
+            return true;
+        }
+
+        if (suspect instanceof Connector ||
+                suspect instanceof ConnectorProperty ||
+                suspect instanceof ConnectorTableInfo) {
+            // export table related change, should not skip EE
+            return true;
+        }
+
+        // The other changes in the catalog will not be applied to EE,
+        // including User, Group, Procedures, etc
+        return false;
     }
 
     /**

--- a/src/catgen/in/javasrc/CatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/CatalogDiffEngine.java
@@ -1364,6 +1364,10 @@ public class CatalogDiffEngine {
             processModifyResponses(errorMessage, responseList);
         }
 
+        if (! m_requiresCatalogDiffCmdsApplyToEE && checkCatalogDiffShouldApplyToEE(prevType)) {
+            m_requiresCatalogDiffCmdsApplyToEE = true;
+        }
+
         // write the commands to make it so
         // they will be ignored if the change is unsupported
         m_sb.append("delete ").append(prevType.getParent().getCatalogPath()).append(" ");
@@ -1394,6 +1398,10 @@ public class CatalogDiffEngine {
                 responseList = Collections.singletonList(response);
             }
             processModifyResponses(errorMessage, responseList);
+        }
+
+        if (! m_requiresCatalogDiffCmdsApplyToEE && checkCatalogDiffShouldApplyToEE(newType)) {
+            m_requiresCatalogDiffCmdsApplyToEE = true;
         }
 
         // write the commands to make it so

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -92,13 +92,13 @@ import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 import org.voltdb.utils.Encoder;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltFile;
+import org.voltdb.utils.VoltTrace;
 
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import com.google_voltpatches.common.util.concurrent.ListenableFutureTask;
-import org.voltdb.utils.VoltTrace;
 
 public final class InvocationDispatcher {
 
@@ -1713,6 +1713,7 @@ public final class InvocationDispatcher {
                           changeResult.requiresSnapshotIsolation ? 1 : 0,
                           changeResult.worksWithElastic ? 1 : 0,
                           changeResult.deploymentHash,
+                          changeResult.requireCatalogDiffCmdsApplyToEE ? 1 : 0,
                           changeResult.hasSchemaChange ? 1 : 0,
                           changeResult.requiresNewExportGeneration ? 1 : 0);
            task.clientHandle = changeResult.clientHandle;

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -57,7 +57,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -123,9 +122,9 @@ import org.voltdb.compiler.deploymentfile.PathsType;
 import org.voltdb.compiler.deploymentfile.SecurityType;
 import org.voltdb.compiler.deploymentfile.SystemSettingsType;
 import org.voltdb.dtxn.InitiatorStats;
-import org.voltdb.dtxn.LatencyUncompressedHistogramStats;
 import org.voltdb.dtxn.LatencyHistogramStats;
 import org.voltdb.dtxn.LatencyStats;
+import org.voltdb.dtxn.LatencyUncompressedHistogramStats;
 import org.voltdb.dtxn.SiteTracker;
 import org.voltdb.export.ExportManager;
 import org.voltdb.importer.ImportManager;
@@ -3305,6 +3304,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             long currentTxnUniqueId,
             byte[] deploymentBytes,
             byte[] deploymentHash,
+            boolean requireCatalogDiffCmdsApplyToEE,
             boolean hasSchemaChange,
             boolean requiresNewExportGeneration)
     {
@@ -3388,7 +3388,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
 
                 // 1. update the export manager.
-                ExportManager.instance().updateCatalog(m_catalogContext, diffCommands, requiresNewExportGeneration, partitions);
+                ExportManager.instance().updateCatalog(m_catalogContext, requireCatalogDiffCmdsApplyToEE, requiresNewExportGeneration, partitions);
 
                 // 1.1 Update the elastic join throughput settings
                 if (m_elasticJoinService != null) m_elasticJoinService.updateConfig(m_catalogContext);
@@ -3427,7 +3427,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 // this after flushing the stats -- this will re-register
                 // the MPI statistics.
                 if (m_MPI != null) {
-                    m_MPI.updateCatalog(diffCommands, m_catalogContext, csp, requiresNewExportGeneration);
+                    m_MPI.updateCatalog(diffCommands, m_catalogContext, csp,
+                            requireCatalogDiffCmdsApplyToEE, requiresNewExportGeneration);
                 }
 
                 // Update catalog for import processor this should be just/stop start and updat partitions.

--- a/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
+++ b/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
@@ -77,7 +77,8 @@ public interface SystemProcedureExecutionContext {
     public void updateBackendLogLevels();
 
     public boolean updateCatalog(String catalogDiffCommands, CatalogContext context,
-            CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation, long uniqueId, long spHandle, boolean requiresNewExportGeneration);
+            CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation, long uniqueId, long spHandle,
+            boolean requireCatalogDiffCmdsApplyToEE, boolean requiresNewExportGeneration);
 
     public boolean updateSettings(CatalogContext context, CatalogSpecificPlanner csp);
 

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -162,6 +162,7 @@ public interface VoltDBInterface
             long currentTxnTimestamp,
             byte[] deploymentBytes,
             byte[] deploymentHash,
+            boolean requireCatalogDiffCmdsApplyToEE,
             boolean hasSchemaChange,
             boolean requiresNewExportGeneration);
 

--- a/src/frontend/org/voltdb/compiler/AsyncCompilerAgentHelper.java
+++ b/src/frontend/org/voltdb/compiler/AsyncCompilerAgentHelper.java
@@ -233,6 +233,7 @@ public class AsyncCompilerAgentHelper
             String commands = diff.commands();
             compilerLog.info(diff.getDescriptionOfChanges(updatedClass));
 
+            retval.requireCatalogDiffCmdsApplyToEE = diff.requiresCatalogDiffCmdsApplyToEE();
             // since diff commands can be stupidly big, compress them here
             retval.encodedDiffCommands = Encoder.compressAndBase64Encode(commands);
             retval.diffCommandsLength = commands.length();

--- a/src/frontend/org/voltdb/compiler/CatalogChangeResult.java
+++ b/src/frontend/org/voltdb/compiler/CatalogChangeResult.java
@@ -40,8 +40,11 @@ public class CatalogChangeResult extends AsyncCompilerResult {
     public boolean isForReplay;
     public long replayTxnId;
     public long replayUniqueId;
+
+    // Should catalog diff commands apply to EE or not
+    public boolean requireCatalogDiffCmdsApplyToEE;
     // mark it false for UpdateClasses, in future may be marked false for deployment changes
     public boolean hasSchemaChange;
-    //This is set to true if schema change involves stream or connector changes or a view on stream is created or dropped.
+    // This is set to true if schema change involves stream or connector changes or a view on stream is created or dropped.
     public boolean requiresNewExportGeneration;
 }

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -51,7 +51,6 @@ import org.voltdb.utils.VoltFile;
 
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.base.Throwables;
-import org.voltdb.utils.CatalogUtil;
 
 /**
  * Bridges the connection to an OLAP system and the buffers passed
@@ -623,7 +622,7 @@ public class ExportManager
         return m_connCount;
     }
 
-    public synchronized void updateCatalog(CatalogContext catalogContext, String diffCommands, boolean requiresNewExportGeneration, List<Integer> partitions)
+    public synchronized void updateCatalog(CatalogContext catalogContext, boolean requireCatalogDiffCmdsApplyToEE, boolean requiresNewExportGeneration, List<Integer> partitions)
     {
         final Cluster cluster = catalogContext.catalog.getClusters().get("cluster");
         final Database db = cluster.getDatabases().get("database");
@@ -645,7 +644,7 @@ public class ExportManager
          * EE does not roll to new generation and thus we need to ignore creating new generation roll with the current generation.
          * If anything changes in getDiffCommandsForEE or design changes pay attention to fix this.
          */
-        if (CatalogUtil.getDiffCommandsForEE(diffCommands).length() == 0) {
+        if (requireCatalogDiffCmdsApplyToEE == false) {
             exportLog.info("Skipped rolling generations as generation not created in EE.");
             return;
         }

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -201,10 +201,12 @@ public class MpInitiator extends BaseInitiator implements Promotable
      * be blocked running the EveryPartitionTask for the catalog update, this
      * is currently safe with no locking.  And yes, I'm a horrible person.
      */
-    public void updateCatalog(String diffCmds, CatalogContext context, CatalogSpecificPlanner csp, boolean requiresNewExportGeneration)
+    public void updateCatalog(String diffCmds, CatalogContext context, CatalogSpecificPlanner csp,
+            boolean requireCatalogDiffCmdsApplyToEE, boolean requiresNewExportGeneration)
     {
         // note this will never require snapshot isolation because the MPI has no snapshot funtionality
-        m_executionSite.updateCatalog(diffCmds, context, csp, false, true, Long.MIN_VALUE, Long.MIN_VALUE, requiresNewExportGeneration);
+        m_executionSite.updateCatalog(diffCmds, context, csp, false, true, Long.MIN_VALUE, Long.MIN_VALUE,
+                requireCatalogDiffCmdsApplyToEE, requiresNewExportGeneration);
         MpScheduler sched = (MpScheduler)m_scheduler;
         sched.updateCatalog(diffCmds, context, csp);
     }

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -57,9 +57,9 @@ import org.voltdb.dtxn.SiteTracker;
 import org.voltdb.dtxn.TransactionState;
 import org.voltdb.dtxn.UndoAction;
 import org.voltdb.exceptions.EEException;
+import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.settings.ClusterSettings;
 import org.voltdb.settings.NodeSettings;
-import org.voltdb.messaging.FastDeserializer;
 
 /**
  * An implementation of Site which provides only the functionality
@@ -229,7 +229,8 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
 
         @Override
         public boolean updateCatalog(String diffCmds, CatalogContext context,
-                CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation, long uniqueId, long spHandle, boolean requiresNewExportGeneration)
+                CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation, long uniqueId, long spHandle,
+                boolean requireCatalogDiffCmdsApplyToEE, boolean requiresNewExportGeneration)
         {
             throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
         }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -101,15 +101,14 @@ import org.voltdb.rejoin.TaskLog;
 import org.voltdb.settings.ClusterSettings;
 import org.voltdb.settings.NodeSettings;
 import org.voltdb.sysprocs.SysProcFragmentId;
-import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.LogKeys;
 import org.voltdb.utils.MinimumRatioMaintainer;
 
-import vanilla.java.affinity.impl.PosixJNAAffinity;
-
 import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.base.Preconditions;
+
+import vanilla.java.affinity.impl.PosixJNAAffinity;
 
 public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConnection
 {
@@ -395,10 +394,13 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         @Override
         public boolean updateCatalog(String diffCmds, CatalogContext context,
                 CatalogSpecificPlanner csp, boolean requiresSnapshotIsolation,
-                long uniqueId, long spHandle, boolean requiresNewExportGeneration)
+                long uniqueId, long spHandle,
+                boolean requireCatalogDiffCmdsApplyToEE,
+                boolean requiresNewExportGeneration)
         {
             return Site.this.updateCatalog(diffCmds, context, csp, requiresSnapshotIsolation,
-                    false, uniqueId, spHandle, requiresNewExportGeneration);
+                    false, uniqueId, spHandle,
+                    requireCatalogDiffCmdsApplyToEE, requiresNewExportGeneration);
         }
 
         @Override
@@ -1495,7 +1497,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
      * Update the catalog.  If we're the MPI, don't bother with the EE.
      */
     public boolean updateCatalog(String diffCmds, CatalogContext context, CatalogSpecificPlanner csp,
-            boolean requiresSnapshotIsolationboolean, boolean isMPI, long uniqueId, long spHandle, boolean requiresNewExportGeneration)
+            boolean requiresSnapshotIsolationboolean, boolean isMPI, long uniqueId, long spHandle,
+            boolean requireCatalogDiffCmdsApplyToEE,
+            boolean requiresNewExportGeneration)
     {
         m_context = context;
         m_ee.setBatchTimeout(m_context.cluster.getDeployment().get("deployment").
@@ -1507,14 +1511,13 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             return true;
         }
 
-        CatalogMap<Table> tables = m_context.catalog.getClusters().get("cluster").getDatabases().get("database").getTables();
-
-        diffCmds = CatalogUtil.getDiffCommandsForEE(diffCmds);
-        if (diffCmds.length() == 0) {
+        if (requireCatalogDiffCmdsApplyToEE == false) {
             // empty diff cmds for the EE to apply, so skip the JNI call
             hostLog.info("Skipped applying diff commands on EE.");
             return true;
         }
+
+        CatalogMap<Table> tables = m_context.catalog.getClusters().get("cluster").getDatabases().get("database").getTables();
 
         boolean DRCatalogChange = false;
         for (Table t : tables) {

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -492,7 +492,8 @@ public class MockVoltDB implements VoltDBInterface
     public Pair<CatalogContext, CatalogSpecificPlanner> catalogUpdate(String diffCommands,
             byte[] catalogBytes, byte[] catalogHash, int expectedCatalogVersion,
             long currentTxnId, long currentTxnTimestamp, byte[] deploymentBytes,
-            byte[] deploymentHash, boolean hasSchemaChange, boolean requiresNewExportGeneration)
+            byte[] deploymentHash, boolean requireCatalogDiffCmdsApplyToEE,
+            boolean hasSchemaChange, boolean requiresNewExportGeneration)
     {
         throw new UnsupportedOperationException("unimplemented");
     }

--- a/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
@@ -96,8 +96,17 @@ public class TestCatalogDiffs extends TestCase {
             Catalog catOriginal,
             Catalog catUpdated)
     {
+        //Default expect no generation roll, but with EE diff commands.
+        return verifyDiff(catOriginal, catUpdated, null, null, true, false, true);
+    }
+
+    private String verifyDiff(
+            Catalog catOriginal,
+            Catalog catUpdated,
+            boolean expectApplyCatalogDiffToEE)
+    {
         //Default expect no generation roll.
-        return verifyDiff(catOriginal, catUpdated, null, null, false, true);
+        return verifyDiff(catOriginal, catUpdated, null, null, expectApplyCatalogDiffToEE, false, true);
     }
 
     private String verifyDiff(
@@ -105,6 +114,7 @@ public class TestCatalogDiffs extends TestCase {
             Catalog catUpdated,
             Boolean expectSnapshotIsolation,
             Boolean worksWithElastic,
+            Boolean expectApplyCatalogDiffToEE,
             Boolean expectedNewGeneration, Boolean execute)
     {
         CatalogDiffEngine diff = new CatalogDiffEngine(catOriginal, catUpdated);
@@ -122,6 +132,9 @@ public class TestCatalogDiffs extends TestCase {
         }
         if (worksWithElastic != null) {
             assertEquals((boolean)worksWithElastic, diff.worksWithElastic());
+        }
+        if (expectApplyCatalogDiffToEE != null) {
+        	assertEquals(expectApplyCatalogDiffToEE.booleanValue(), diff.requiresCatalogDiffCmdsApplyToEE());
         }
         if (expectedNewGeneration != null) {
             //TODO: Enable real check.
@@ -177,7 +190,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compile("expanded", EXPANDEDPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        String report = verifyDiff(catOriginal, catUpdated);
+        String report = verifyDiff(catOriginal, catUpdated, false);
         assertTrue(report.contains("Procedure slev added."));
     }
 
@@ -197,7 +210,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compile("fewer", FEWERPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        String report = verifyDiff(catOriginal, catUpdated);
+        String report = verifyDiff(catOriginal, catUpdated, false);
         assertTrue(report.contains("Procedure delivery dropped."));
     }
 
@@ -210,7 +223,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compileWithGroups(false, null, gi, null, "base", BASEPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        verifyDiff(catOriginal, catUpdated);
+        verifyDiff(catOriginal, catUpdated, false);
     }
 
     public void testAddGroupAndUser() throws IOException {
@@ -226,7 +239,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compileWithGroups(false, null, gi, ui, "base", BASEPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        verifyDiff(catOriginal, catUpdated);
+        verifyDiff(catOriginal, catUpdated, false);
     }
 
     public void testModifyUser() throws IOException {
@@ -246,7 +259,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compileWithGroups(false, null, gi2, ui, "base", BASEPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        verifyDiff(catOriginal, catUpdated);
+        verifyDiff(catOriginal, catUpdated, false);
     }
 
     public void testDeleteUser() throws IOException {
@@ -263,7 +276,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compileWithGroups(false, null, gi, null, "base", BASEPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        verifyDiff(catOriginal, catUpdated);
+        verifyDiff(catOriginal, catUpdated, false);
     }
 
     public void testDeleteGroupAndUser() throws IOException {
@@ -280,7 +293,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compileWithGroups(false, null, null, null, "base", BASEPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        verifyDiff(catOriginal, catUpdated);
+        verifyDiff(catOriginal, catUpdated, false);
     }
 
     public void testChangeUsersAssignedGroups() throws IOException {
@@ -301,7 +314,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compileWithGroups(false, null, gi, ui, "base", BASEPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        verifyDiff(catOriginal, catUpdated);
+        verifyDiff(catOriginal, catUpdated, false);
     }
 
     public void testChangeSecurityEnabled() throws IOException {
@@ -320,7 +333,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compileWithGroups(true, "hash", gi, ui, "base", BASEPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        verifyDiff (catOriginal, catUpdated);
+        verifyDiff (catOriginal, catUpdated, false);
     }
 
     public void testChangeSecurityProvider() throws IOException {
@@ -339,7 +352,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compileWithGroups(true, "kerberos", gi, ui, "base", BASEPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        verifyDiff (catOriginal, catUpdated);
+        verifyDiff (catOriginal, catUpdated, false);
     }
 
     public void testDiffOfIdenticalCatalogs() throws IOException {
@@ -448,7 +461,7 @@ public class TestCatalogDiffs extends TestCase {
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "testaddtable2.jar"));
         Catalog catUpdated = catalogForJar(testDir + File.separator + "testaddtable2.jar");
 
-        verifyDiff(catOriginal, catUpdated, false, null, false, true);
+        verifyDiff(catOriginal, catUpdated, false, null, true, false, true);
     }
 
     public void testDropTable() throws IOException {
@@ -467,7 +480,7 @@ public class TestCatalogDiffs extends TestCase {
         // Create a catalog with just table A
         Catalog catUpdated = getCatalogForTable("A", "droptable2");
 
-        verifyDiff(catOriginal, catUpdated, false, null, false, true);
+        verifyDiff(catOriginal, catUpdated, false, null, true, false, true);
     }
 
     public void testViewConversion() throws IOException {
@@ -508,7 +521,7 @@ public class TestCatalogDiffs extends TestCase {
     public void testAddTableColumn() throws IOException {
         Catalog catOriginal = getCatalogForTable("A", "addtablecolumnrejected1");
         Catalog catUpdated = get2ColumnCatalogForTable("A", "addtablecolumnrejected2");
-        verifyDiff(catOriginal, catUpdated, true, null, false, true);
+        verifyDiff(catOriginal, catUpdated, true, null, true, false, true);
 
         VoltTable t1 = TableHelper.quickTable("(INTEGER, VARCHAR40)");
         VoltTable t2 = TableHelper.quickTable("(INTEGER, VARCHAR40, VARCHAR120)");
@@ -520,7 +533,7 @@ public class TestCatalogDiffs extends TestCase {
     public void testRemoveTableColumn() throws IOException {
         Catalog catOriginal = get2ColumnCatalogForTable("A", "removetablecolumn2");
         Catalog catUpdated = getCatalogForTable("A", "removetablecolumn1");
-        verifyDiff(catOriginal, catUpdated, true, null, false, true);
+        verifyDiff(catOriginal, catUpdated, true, null, true, false, true);
 
         VoltTable t1 = TableHelper.quickTable("(INTEGER, VARCHAR40, VARCHAR120)");
         VoltTable t2 = TableHelper.quickTable("(INTEGER, VARCHAR40)");
@@ -535,14 +548,14 @@ public class TestCatalogDiffs extends TestCase {
         VoltTable t2 = TableHelper.quickTable("(INTEGER, VARCHAR40, VARCHAR120)");
         Catalog catOriginal = getCatalogForTable("A", "modtablecolumn1", t1);
         Catalog catUpdated = getCatalogForTable("A", "modtablecolumn2", t2);
-        verifyDiff(catOriginal, catUpdated, true, null, false, true);
+        verifyDiff(catOriginal, catUpdated, true, null, true, false, true);
 
         // even pass when crossing the inline/out-of-line boundary
         t1 = TableHelper.quickTable("(VARBINARY30)");
         t2 = TableHelper.quickTable("(VARBINARY70)");
         catOriginal = getCatalogForTable("A", "modtablecolumn1", t1);
         catUpdated = getCatalogForTable("A", "modtablecolumn2", t2);
-        verifyDiff(catOriginal, catUpdated, true, null, false, true);
+        verifyDiff(catOriginal, catUpdated, true, null, true, false, true);
 
         // fail integer contraction if non-empty empty
         t1 = TableHelper.quickTable("(BIGINT)");
@@ -697,7 +710,7 @@ public class TestCatalogDiffs extends TestCase {
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "testAddUniqueCoveringTableIndex2.jar"));
         Catalog catUpdated = catalogForJar(testDir + File.separator + "testAddUniqueCoveringTableIndex2.jar");
 
-        verifyDiff(catOriginal, catUpdated, false, null, false, true);
+        verifyDiff(catOriginal, catUpdated, false, null, true, false, true);
     }
 
     public void testAddUniqueNonCoveringTableIndexRejectedIfNotEmpty() throws IOException {
@@ -1197,10 +1210,10 @@ public class TestCatalogDiffs extends TestCase {
         // Making a deep copy to the original catalog so that it doesn't apply
         // the changes to the catalogs.
         verifyDiff(noneCatalog.deepCopy(), defaultCatalog);
-        assertTrue(verifyDiff(defaultCatalog.deepCopy(), masterCatalog).contains("No changes detected"));
+        assertTrue(verifyDiff(defaultCatalog.deepCopy(), masterCatalog, false).contains("No changes detected"));
         verifyDiff(replicaCatalog.deepCopy(), masterCatalog);
         verifyDiff(replicaCatalog.deepCopy(), defaultCatalog);
-        assertTrue(verifyDiff(masterCatalog.deepCopy(), defaultCatalog).contains("No changes detected"));
+        assertTrue(verifyDiff(masterCatalog.deepCopy(), defaultCatalog, false).contains("No changes detected"));
         verifyDiffRejected(defaultCatalog.deepCopy(), replicaCatalog);
         verifyDiffRejected(masterCatalog.deepCopy(), replicaCatalog);
     }
@@ -1228,7 +1241,7 @@ public class TestCatalogDiffs extends TestCase {
 
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "elastic2.jar"));
         Catalog catUpdated = catalogForJar(testDir + File.separator + "elastic2.jar");
-        verifyDiff(catOriginal, catUpdated, null, true, false, true);
+        verifyDiff(catOriginal, catUpdated, null, true, false, false, true);
     }
 
     public void testChangeNotCompatibleWithElasticAddProcedure() throws IOException {
@@ -1242,7 +1255,7 @@ public class TestCatalogDiffs extends TestCase {
         builder.addStmtProcedure("another_procedure", "select * from A;");
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "elastic2.jar"));
         Catalog catUpdated = catalogForJar(testDir + File.separator + "elastic2.jar");
-        verifyDiff(catOriginal, catUpdated, null, false, false, true);
+        verifyDiff(catOriginal, catUpdated, null, false, false, false, true);
     }
 
     public void testChangeNotCompatibleWithElasticAddTable() throws IOException {
@@ -1256,7 +1269,7 @@ public class TestCatalogDiffs extends TestCase {
         builder.addLiteralSchema("\nCREATE TABLE another_table (C1 BIGINT NOT NULL, C2 BIGINT NOT NULL);");
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "elastic2.jar"));
         Catalog catUpdated = catalogForJar(testDir + File.separator + "elastic2.jar");
-        verifyDiff(catOriginal, catUpdated, null, false, false, true);
+        verifyDiff(catOriginal, catUpdated, null, false, true, false, true);
     }
 
     public void testEnableDROnEmptyTable() throws IOException {
@@ -1485,10 +1498,10 @@ public class TestCatalogDiffs extends TestCase {
         msg = CatalogUtil.compileDeployment(modTypeCat, modTypeDepl, false);
         assertTrue("Deployment file failed to parse: " + msg, msg == null);
 
-        verifyDiff(newPropCat, origCat, null, null, true, false); // test delete
-        verifyDiff(origCat, newPropCat, null, null, true, false); // test add
-        verifyDiff(origCat, modPropCat, null, null, true, false); // test modification
-        verifyDiff(modPropCat, modTypeCat, null, null, true, false); // test modification
+        verifyDiff(newPropCat, origCat, null, null, true, true, false); // test delete
+        verifyDiff(origCat, newPropCat, null, null, true, true, false); // test add
+        verifyDiff(origCat, modPropCat, null, null, true, true, false); // test modification
+        verifyDiff(modPropCat, modTypeCat, null, null, true, true, false); // test modification
     }
 
     public void testAddStreamRollGeneration() throws IOException {
@@ -1528,10 +1541,10 @@ public class TestCatalogDiffs extends TestCase {
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "exp5.jar"));
         Catalog catUpdatedWithNewStream = catalogForJar(testDir + File.separator + "exp5.jar");
 
-        verifyDiff(catOriginal, catUpdatedWithNewStream, null, null, true, false); // add stream and roll
-        verifyDiff(catOriginal, catUpdatedWithDropStream, null, null, true, false); // drop stream and roll
-        verifyDiff(catOriginal, catUpdatedWithNewTable, null, null, false, false); // add table and dont roll
-        verifyDiff(catOriginal, catUpdatedWithDroppedTable, null, null, false, false); // drop table and dont roll
+        verifyDiff(catOriginal, catUpdatedWithNewStream, null, null, true, true, false); // add stream and roll
+        verifyDiff(catOriginal, catUpdatedWithDropStream, null, null, true, true, false); // drop stream and roll
+        verifyDiff(catOriginal, catUpdatedWithNewTable, null, null, true, false, false); // add table and dont roll
+        verifyDiff(catOriginal, catUpdatedWithDroppedTable, null, null, true, false, false); // drop table and dont roll
 
         builder = new VoltProjectBuilder();
         builder.addLiteralSchema("CREATE STREAM A PARTITION ON COLUMN C1 (C1 BIGINT NOT NULL, C2 BIGINT NOT NULL);"
@@ -1540,8 +1553,8 @@ public class TestCatalogDiffs extends TestCase {
                 + "\nCREATE VIEW V_A (C1 , NUM_A) AS SELECT C1, COUNT(*) FROM A GROUP BY C1;");
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "exp6.jar"));
         Catalog catUpdatedWithStreamView = catalogForJar(testDir + File.separator + "exp6.jar");
-        verifyDiff(catOriginal, catUpdatedWithStreamView, null, null, false, false); // create view on stream and roll
-        verifyDiff(catUpdatedWithStreamView, catOriginal, null, null, false, false); // drop view on stream and roll
+        verifyDiff(catOriginal, catUpdatedWithStreamView, null, null, true, false, false); // create view on stream and roll
+        verifyDiff(catUpdatedWithStreamView, catOriginal, null, null, true, false, false); // drop view on stream and roll
 
     }
 

--- a/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
@@ -134,7 +134,7 @@ public class TestCatalogDiffs extends TestCase {
             assertEquals((boolean)worksWithElastic, diff.worksWithElastic());
         }
         if (expectApplyCatalogDiffToEE != null) {
-        	assertEquals(expectApplyCatalogDiffToEE.booleanValue(), diff.requiresCatalogDiffCmdsApplyToEE());
+            assertEquals(expectApplyCatalogDiffToEE.booleanValue(), diff.requiresCatalogDiffCmdsApplyToEE());
         }
         if (expectedNewGeneration != null) {
             //TODO: Enable real check.


### PR DESCRIPTION
Whenever there is a catalog change, the diff engine will generate the diff commands. However, only some of the diff commands are applicable to EE catalog, others will be ignored. 

Instead of triggering a EE JNI call with unnecessary diff commands, the diff engine will check whether the catalog change requires a EE JNI call or not. And we pass this flag to update catalog.