### PR TITLE
ENG-12280 improvement of partition master assignment  with missing node startup

### DIFF
--- a/src/frontend/org/voltdb/AbstractTopology.java
+++ b/src/frontend/org/voltdb/AbstractTopology.java
@@ -43,6 +43,7 @@ import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableSet;
 import com.google_voltpatches.common.collect.ImmutableSortedSet;
 import com.google_voltpatches.common.collect.LinkedListMultimap;
+import com.google_voltpatches.common.collect.Lists;
 import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.collect.Multimap;
 import com.google_voltpatches.common.collect.Sets;
@@ -81,7 +82,7 @@ public class AbstractTopology {
     public static class Partition implements Comparable<Partition>{
         public final int id;
         public final int k;
-        public final int leaderHostId;
+        public int leaderHostId;
         public final ImmutableSortedSet<Integer> hostIds;
 
         private Partition(int id, int k, int leaderHostId, Collection<Integer> hostIds) {
@@ -1373,7 +1374,7 @@ public class AbstractTopology {
     }
 
     /**
-     * reassign partition leaders from the hosts to other hosts.
+     * reassign partition leaders from the missing hosts to other hosts.
      * @param topology current topology
      * @param missingHosts The hosts on which partition leaders will be reassigned.
      * @return new AbstractTopology
@@ -1403,17 +1404,32 @@ public class AbstractTopology {
                 mutableHost.partitions.add(mp);
             }
             int leaderId = partition.leaderHostId;
-            if (missingHosts.contains(partition.leaderHostId)) {
-                //find the first non-missing host that has the partition
+            if (missingHosts.contains(leaderId)) {
+                List<Host> perspectiveHosts = Lists.newArrayList();
                 for (Host host : topology.hostsById.values()) {
                     if (!missingHosts.contains(host.id)) {
                         List<Integer> list = topology.getPartitionIdList(host.id);
                         if (list.contains(partition.id)) {
-                            leaderId = host.id;
-                            break;
+                            perspectiveHosts.add(host);
                         }
                     }
                 }
+
+                //Place the partition master to a node which hosts the partition and has the least masters.
+                assert(!perspectiveHosts.isEmpty());
+                perspectiveHosts.sort((Host a, Host b) -> {
+                    int result = 0;
+                    for (Partition p : topology.partitionsById.values()) {
+                        if ( a.id == p.leaderHostId) {
+                            result++;
+                        } else if ( b.id == p.leaderHostId) {
+                            result--;
+                        }
+                    }
+                    return result;
+                });
+                leaderId = perspectiveHosts.get(0).id;
+                partition.leaderHostId = leaderId;
             }
             mp.leader = mutableHostMap.get(leaderId);
         }


### PR DESCRIPTION
assign masters more evenly among the nodes during cluster startup with missing nodes.