### PR TITLE
ENG-9346: use BIGINT for cache hits and misses which could exceed INT max value

### DIFF
--- a/src/frontend/org/voltdb/PlannerStatsCollector.java
+++ b/src/frontend/org/voltdb/PlannerStatsCollector.java
@@ -315,9 +315,9 @@ public class PlannerStatsCollector extends StatsSource {
         columns.add(new ColumnInfo("PARTITION_ID",  VoltType.INTEGER));
         columns.add(new ColumnInfo("CACHE1_LEVEL",  VoltType.INTEGER));
         columns.add(new ColumnInfo("CACHE2_LEVEL",  VoltType.INTEGER));
-        columns.add(new ColumnInfo("CACHE1_HITS",   VoltType.INTEGER));
-        columns.add(new ColumnInfo("CACHE2_HITS",   VoltType.INTEGER));
-        columns.add(new ColumnInfo("CACHE_MISSES",  VoltType.INTEGER));
+        columns.add(new ColumnInfo("CACHE1_HITS",   VoltType.BIGINT));
+        columns.add(new ColumnInfo("CACHE2_HITS",   VoltType.BIGINT));
+        columns.add(new ColumnInfo("CACHE_MISSES",  VoltType.BIGINT));
         columns.add(new ColumnInfo("PLAN_TIME_MIN", VoltType.BIGINT));
         columns.add(new ColumnInfo("PLAN_TIME_MAX", VoltType.BIGINT));
         columns.add(new ColumnInfo("PLAN_TIME_AVG", VoltType.BIGINT));


### PR DESCRIPTION
Trivial change from INTEGER to BIGINT for 3 columns of PLANNER stats that can grow larger than INT max value with enough @AdHoc invocations (it happened at 2 customers already).