### PR TITLE
PostgreSQLBackend.java: modified the nowQueryTransformer, to strictly

### DIFF
--- a/src/frontend/org/voltdb/NonVoltDBBackend.java
+++ b/src/frontend/org/voltdb/NonVoltDBBackend.java
@@ -61,6 +61,8 @@ public abstract class NonVoltDBBackend {
     protected String m_database_type = null;
     protected Connection dbconn;
     protected static FileWriter transformedSqlFileWriter;
+    protected static long countCaughtExceptions = 0;
+    protected static final long MAX_CAUGHT_EXCEPTION_MESSAGES = 100;
     protected static final boolean DEBUG = false;
 
     /** Pattern used to recognize "variables", such as {table} or {column:pk},
@@ -366,6 +368,18 @@ public abstract class NonVoltDBBackend {
 
     }
 
+    /** Print a message about an Exception that was caught; but limit the number
+     *  of such print messages, so that the console is not swamped by them. */
+    protected static void printCaughtException(String exceptionMessage) {
+        if (++countCaughtExceptions <= MAX_CAUGHT_EXCEPTION_MESSAGES) {
+            System.out.println(exceptionMessage);
+        }
+        if (countCaughtExceptions == MAX_CAUGHT_EXCEPTION_MESSAGES) {
+            System.out.println("In NonVoltDBBackend, reached limit of " + MAX_CAUGHT_EXCEPTION_MESSAGES
+                    + " exception messages to be printed.");
+        }
+    }
+
     /** Returns all column names for the specified table, in the order defined
      *  in the DDL. */
     protected List<String> getAllColumns(String tableName) {
@@ -378,7 +392,7 @@ public abstract class NonVoltDBBackend {
                 columns.add(rs.getString(4));
             }
         } catch (SQLException e) {
-            System.out.println("In NonVoltDBBackend.getAllColumns, caught SQLException: " + e);
+            printCaughtException("In NonVoltDBBackend.getAllColumns, caught SQLException: " + e);
         }
         return columns;
     }
@@ -395,7 +409,7 @@ public abstract class NonVoltDBBackend {
                 pkCols.add(rs.getString(4));
             }
         } catch (SQLException e) {
-            System.out.println("In NonVoltDBBackend.getPrimaryKeys, caught SQLException: " + e);
+            printCaughtException("In NonVoltDBBackend.getPrimaryKeys, caught SQLException: " + e);
         }
         return pkCols;
     }
@@ -461,7 +475,7 @@ public abstract class NonVoltDBBackend {
                     }
                 }
             } catch (SQLException e) {
-                System.out.println("In NonVoltDBBackend.isColumnType, with tableName "+tableName+", columnName "
+                printCaughtException("In NonVoltDBBackend.isColumnType, with tableName "+tableName+", columnName "
                         + columnName+", columnTypes "+columnTypes+", caught SQLException:\n  " + e);
             }
         }
@@ -716,9 +730,9 @@ public abstract class NonVoltDBBackend {
                 transformedSqlFileWriter.write("original SQL: " + originalSql + "\n");
                 transformedSqlFileWriter.write("modified SQL: " + modifiedSql + "\n");
             } catch (IOException e) {
-                System.out.println("Caught IOException:\n    " + e);
-                System.out.println("original SQL: " + originalSql);
-                System.out.println("modified SQL: " + modifiedSql);
+                printCaughtException("Caught IOException:\n    " + e
+                        + "\noriginal SQL: " + originalSql
+                        + "\nmodified SQL: " + modifiedSql);
             }
         }
     }

--- a/src/frontend/org/voltdb/PostgreSQLBackend.java
+++ b/src/frontend/org/voltdb/PostgreSQLBackend.java
@@ -192,7 +192,7 @@ public class PostgreSQLBackend extends NonVoltDBBackend {
 
     // Captures the use of NOW, without parentheses
     private static final Pattern nowQuery = Pattern.compile(
-            "(?<now>NOW)(?!\\s*\\()", Pattern.CASE_INSENSITIVE);
+            "\\b(?<now>NOW)\\b(?!\\s*\\()", Pattern.CASE_INSENSITIVE);
     // Modifies a query containing NOW, without parentheses, which PostgreSQL
     // does not support, and simply replaces it with NOW(), with parentheses,
     // which it does support.

--- a/tools/killstragglers.sh
+++ b/tools/killstragglers.sh
@@ -18,7 +18,7 @@ fi
 # this might not work when the process command is extremely long
 for PROC in `$SUDO pgrep -f org.voltdb.VoltDB | xargs`
 do
-    logger -sp user.notice -t TESTKILL "User $USER $BUILD_TAG Killing `$SUDO ps -p $PROC -o pid=,user=,command=`"
+    logger -sp user.notice -t TESTKILL "User $USER $BUILD_TAG Killing `$SUDO ps -p $PROC -o pid= -o user= -o command=`"
     $SUDO kill -9 $PROC
 done
 
@@ -55,7 +55,7 @@ for PORT in $STANDARD_VOLTDB_PORTS
 do
     $GET_PORT_PROCESS_COMMAND
     if [ -n "$PROC" ]; then
-        logger -sp user.notice -t TESTKILL "User $USER Port $PORT $BUILD_TAG Killing ($KILL_PORT_PROCESS_COMMAND): `$SUDO ps -p $PROC -o pid=,user=,command=`"
+        logger -sp user.notice -t TESTKILL "User $USER Port $PORT $BUILD_TAG Killing ($KILL_PORT_PROCESS_COMMAND): `$SUDO ps -p $PROC -o pid= -o user= -o command=`"
         $KILL_PORT_PROCESS_COMMAND
     fi
 done

--- a/tools/killstragglers.sh
+++ b/tools/killstragglers.sh
@@ -49,6 +49,8 @@ if [[ "$OSTYPE" != darwin* ]] && type fuser > /dev/null 2>&1; then
 elif type lsof > /dev/null 2>&1; then
     GET_PORT_PROCESS_COMMAND=get_port_process_using_lsof
     KILL_PORT_PROCESS_COMMAND=kill_port_process_using_lsof
+else
+    echo "Unable to kill processes using VoltDB ports: neither fuser (-k) nor lsof is installed on this system."
 fi
 
 PROC=

--- a/tools/killstragglers.sh
+++ b/tools/killstragglers.sh
@@ -1,47 +1,63 @@
 #!/bin/bash
 
 # Kill (VoltDB server) processes that are listening on any of the usual ports
+STANDARD_VOLTDB_PORTS="3021 7181 21211 21212 5555"
 
 HOUR=`date +%H`
 DAY=`date +%u`
 IGNORE="JENKINS_HOME|zookeeper.server.quorum.QuorumPeerMain|kafka.Kafka"
 
-# Use sudo if USER is 'test'
+# If USER is 'test', use sudo and include 8080 in the ports to be killed
+# (but if not running as 'test', I don't want to kill my browser)
 if [ $USER = "test" ]; then
     SUDO=sudo
+    STANDARD_VOLTDB_PORTS="$STANDARD_VOLTDB_PORTS 8080"
 fi
 
 # Make an attempt to kill any VoltDB server processes; however,
 # this might not work when the process command is extremely long
-for P in `$SUDO pgrep -f org.voltdb.VoltDB | xargs`
+for PROC in `$SUDO pgrep -f org.voltdb.VoltDB | xargs`
 do
-    logger -sp user.notice -t TESTKILL "User $USER $BUILD_TAG Killing `$SUDO ps --no-headers -p $P -o pid,user,command`"
-    $SUDO kill -9 $P
+    logger -sp user.notice -t TESTKILL "User $USER $BUILD_TAG Killing `$SUDO ps -p $PROC -o pid=,user=,command=`"
+    $SUDO kill -9 $PROC
 done
 
 # If the fuser -k or lsof command exists on this system, use it to kill any
-# processes that are using any of the standard VoltDB ports (first, list the
-# processes about to be killed)
-kill_port_processes_using_fuser() {
-    $SUDO fuser    ${PORT}/tcp
+# processes that are using any of the standard VoltDB ports; but first, list
+# and log (in the system log) the process about to be killed
+get_port_process_using_fuser() {
+    $SUDO fuser ${PORT}/tcp
+    PROC=`$SUDO fuser ${PORT}/tcp`
+}
+kill_port_process_using_fuser() {
     $SUDO fuser -k ${PORT}/tcp
 }
-kill_port_processes_using_lsof() {
+get_port_process_using_lsof() {
     $SUDO lsof -i tcp:${PORT}
-    $SUDO lsof -i tcp:${PORT} | grep -v PID | awk '{print $2}' | xargs kill
+    PROC=`$SUDO lsof -i tcp:$PORT | grep -v PID | awk '{print $2}'`
+}
+kill_port_process_using_lsof() {
+    $SUDO kill -9 $PROC
 }
 
-KILL_PORT_PROCESSES_COMMAND=
-# Mac OS (OSTYPE darwin*) supports fuser, but not fuser -k
+GET_PORT_PROCESS_COMMAND=
+KILL_PORT_PROCESS_COMMAND=
+# Mac OS (OSTYPE darwin*) supports fuser, but not fuser -k {port}/tcp
 if [[ "$OSTYPE" != darwin* ]] && type fuser > /dev/null 2>&1; then
-    KILL_PORT_PROCESSES_COMMAND=kill_port_processes_using_fuser
+    GET_PORT_PROCESS_COMMAND=get_port_process_using_fuser
+    KILL_PORT_PROCESS_COMMAND=kill_port_process_using_fuser
 elif type lsof > /dev/null 2>&1; then
-    KILL_PORT_PROCESSES_COMMAND=kill_port_processes_using_lsof
+    GET_PORT_PROCESS_COMMAND=get_port_process_using_lsof
+    KILL_PORT_PROCESS_COMMAND=kill_port_process_using_lsof
 fi
 
-for PORT in 3021 7181 21211 21212 8080 5555
+for PORT in $STANDARD_VOLTDB_PORTS
 do
-    $KILL_PORT_PROCESSES_COMMAND
+    $GET_PORT_PROCESS_COMMAND
+    if [ -n "$PROC" ]; then
+        logger -sp user.notice -t TESTKILL "User $USER Port $PORT $BUILD_TAG Killing ($KILL_PORT_PROCESS_COMMAND): `$SUDO ps -p $PROC -o pid=,user=,command=`"
+        $KILL_PORT_PROCESS_COMMAND
+    fi
 done
 
 exit 0

--- a/tools/killstragglers.sh
+++ b/tools/killstragglers.sh
@@ -51,6 +51,7 @@ elif type lsof > /dev/null 2>&1; then
     KILL_PORT_PROCESS_COMMAND=kill_port_process_using_lsof
 fi
 
+PROC=
 for PORT in $STANDARD_VOLTDB_PORTS
 do
     $GET_PORT_PROCESS_COMMAND

--- a/tools/killstragglers.sh
+++ b/tools/killstragglers.sh
@@ -1,19 +1,47 @@
 #!/bin/bash
 
-# Kill any/all java processes that are listening on any port(s)
-# sudo kill if USER is 'test' and we're in the evening test hours and/or on specific volt hosts...
-# If you need to run overnight, schedule with qa.
+# Kill (VoltDB server) processes that are listening on any of the usual ports
 
 HOUR=`date +%H`
 DAY=`date +%u`
 IGNORE="JENKINS_HOME|zookeeper.server.quorum.QuorumPeerMain|kafka.Kafka"
 
+# Use sudo if USER is 'test'
 if [ $USER = "test" ]; then
     SUDO=sudo
 fi
+
+# Make an attempt to kill any VoltDB server processes; however,
+# this might not work when the process command is extremely long
 for P in `$SUDO pgrep -f org.voltdb.VoltDB | xargs`
 do
     logger -sp user.notice -t TESTKILL "User $USER $BUILD_TAG Killing `$SUDO ps --no-headers -p $P -o pid,user,command`"
     $SUDO kill -9 $P
 done
+
+# If the fuser -k or lsof command exists on this system, use it to kill any
+# processes that are using any of the standard VoltDB ports (first, list the
+# processes about to be killed)
+kill_port_processes_using_fuser() {
+    $SUDO fuser    ${PORT}/tcp
+    $SUDO fuser -k ${PORT}/tcp
+}
+kill_port_processes_using_lsof() {
+    $SUDO lsof -i tcp:${PORT}
+    $SUDO lsof -i tcp:${PORT} | grep -v PID | awk '{print $2}' | xargs kill
+}
+
+KILL_PORT_PROCESSES_COMMAND=
+# Mac OS (OSTYPE darwin*) supports fuser, but not fuser -k
+if [[ "$OSTYPE" != darwin* ]] && type fuser > /dev/null 2>&1; then
+    KILL_PORT_PROCESSES_COMMAND=kill_port_processes_using_fuser
+elif type lsof > /dev/null 2>&1; then
+    KILL_PORT_PROCESSES_COMMAND=kill_port_processes_using_lsof
+fi
+
+for PORT in 3021 7181 21211 21212 8080 5555
+do
+    $KILL_PORT_PROCESSES_COMMAND
+done
+
 exit 0


### PR DESCRIPTION
add parentheses after NOW when it's a separate word (presumably the NOW
SQL function), rather than in the middle of a word (e.g., in a randomly
generated VARCHAR value).

NonVoltDBBackend.java: modified to limit the number of messages that are
printed about caught exceptions (in a few cases, the console was swamped
with them).

killstragglers.sh: added code to kill any processes that are using any
of the usual VoltDB ports (3021, 7181, 21211, 21212, 8080, 5555).