### PR TITLE
Fixes to apply the optimization for Statement and PlanFragment under …

### DIFF
--- a/src/catgen/in/javasrc/CatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/CatalogDiffEngine.java
@@ -1287,7 +1287,15 @@ public class CatalogDiffEngine {
             return true;
         }
 
-        if (suspect instanceof Statement || suspect instanceof PlanFragment) {
+        // Statement can be children of Table or MaterilizedViewInfo, which should apply to EE
+        // But if they are under Procedure, we can skip them.
+        if (suspect instanceof Statement && (suspect.getParent() instanceof Procedure == false)) {
+            return true;
+        }
+
+        // PlanFragment is a similar case like Statement
+        if (suspect instanceof PlanFragment && suspect.getParent() instanceof Statement &&
+                (suspect.getParent().getParent() instanceof Procedure == false)) {
             return true;
         }
 

--- a/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
@@ -200,7 +200,7 @@ public class TestCatalogDiffs extends TestCase {
         String updated = compile("conflict", CONFLICTPROCS);
         Catalog catUpdated = catalogForJar(updated);
 
-        String report = verifyDiff(catOriginal, catUpdated);
+        String report = verifyDiff(catOriginal, catUpdated, false);
         assertTrue(report.contains("Procedure InsertNewOrder has been modified."));
     }
 


### PR DESCRIPTION
…Procedure changes

The original check does not differentiate the Statement catalog item under Procedure or Table. Now it can skip applying more diff commands to EE.