### PR TITLE
ENG-12374: Deprecate Java client's UAC helper methods.

### DIFF
--- a/src/frontend/org/voltdb/client/Client.java
+++ b/src/frontend/org/voltdb/client/Client.java
@@ -198,6 +198,10 @@ public interface Client {
      * result is available. A {@link ProcCallException} is thrown if the
      * response is anything other then success.</p>
      *
+     * <p>Deprecated to be removed in 8.0. Note, you can still call the UpdateApplicationCatalog
+     * system procedure directly using the {@link #callProcedure(String, Object...)} family of
+     * methods.</p>
+     *
      * <p>This method is a convenience method that is equivalent to reading the catalog
      * file into a byte array in Java code, then calling {@link #callProcedure(String, Object...)}
      * with "@UpdateApplicationCatalog" as the procedure name, followed by they bytes of the catalog
@@ -210,6 +214,7 @@ public interface Client {
      * @throws NoConnectionsException if this {@link Client} instance is not connected to any servers.
      * @throws ProcCallException on any VoltDB specific failure.
      */
+    @Deprecated
     public ClientResponse updateApplicationCatalog(File catalogPath, File deploymentPath)
     throws IOException, NoConnectionsException, ProcCallException;
 
@@ -219,6 +224,10 @@ public interface Client {
      * backpressure on all connections to the cluster then the invocation will
      * not be queued. Check the return value to determine if queuing actually
      * took place.</p>
+     *
+     * <p>Deprecated to be removed in 8.0. Note, you can still call the UpdateApplicationCatalog
+     * system procedure directly using the {@link #callProcedure(String, Object...)} family of
+     * methods.</p>
      *
      * <p>This method is a convenience method that is equivalent to reading the catalog
      * file into a byte array in Java code, then calling
@@ -233,6 +242,7 @@ public interface Client {
      * @throws IOException If the files cannot be serialized or if there is a Java network error.
      * @throws NoConnectionsException if this {@link Client} instance is not connected to any servers.
      */
+    @Deprecated
     public boolean updateApplicationCatalog(ProcedureCallback callback,
                                             File catalogPath,
                                             File deploymentPath)


### PR DESCRIPTION
Leave UpdateClasses helper methods intact.