### PR TITLE
ENG-10599, show additional information about plan in hash mismatch error message.

### DIFF
--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -163,6 +163,7 @@ public abstract class BaseInitiator implements Initiator
             LoadedProcedureSet procSet = new LoadedProcedureSet(m_executionSite);
             procSet.loadProcedures(catalogContext, csp);
             m_executionSite.setLoadedProcedures(procSet);
+            m_scheduler.setProcedureSet(procSet);
             m_scheduler.setCommandLog(cl);
 
             m_siteThread = new Thread(m_executionSite);

--- a/src/frontend/org/voltdb/iv2/DeterminismHash.java
+++ b/src/frontend/org/voltdb/iv2/DeterminismHash.java
@@ -83,12 +83,7 @@ public class DeterminismHash {
 
         m_inputCRC.update(m_hashCount);
         m_inputCRC.update(m_catalogVersion);
-        // no work done means 0 hash to convey that
-        if (m_hashCount == 0) {
-            retval[0] = 0;
-        } else {
-            retval[0] = (int) m_inputCRC.getValue();
-        }
+        retval[0] = (int) m_inputCRC.getValue();
         retval[1] = m_catalogVersion;
         retval[2] = m_hashCount;
         return retval;

--- a/src/frontend/org/voltdb/iv2/DeterminismHash.java
+++ b/src/frontend/org/voltdb/iv2/DeterminismHash.java
@@ -65,7 +65,6 @@ public class DeterminismHash {
     final int[] m_hashes = new int[MAX_HASHES_COUNT + HEADER_OFFSET];
 
     protected final HybridCrc32 m_inputCRC = new HybridCrc32();
-    protected final HybridCrc32 m_stmtParamCRC = new HybridCrc32();
 
     public void reset(int catalogVersion) {
         m_catalogVersion = catalogVersion;
@@ -102,17 +101,11 @@ public class DeterminismHash {
     public void offerStatement(SQLStmt stmt, int offset, ByteBuffer psetBuffer) {
         int stmtHash = SQLStmtAdHocHelper.getHash(stmt);
         m_inputCRC.update(stmtHash);
+        m_inputCRC.updateFromPosition(offset, psetBuffer);
 
         if (m_hashCount < MAX_HASHES_COUNT) {
-            m_stmtParamCRC.reset();
-            m_stmtParamCRC.updateFromPosition(offset, psetBuffer);
-
-            int perStmtCRC = (int) m_stmtParamCRC.getValue();
             m_hashes[m_hashCount] = stmtHash;
-            m_hashes[m_hashCount + 1] = perStmtCRC;
-            m_inputCRC.update(perStmtCRC);
-        } else {
-            m_inputCRC.updateFromPosition(offset, psetBuffer);
+            m_hashes[m_hashCount + 1] = (int) m_inputCRC.getValue();
         }
         m_hashCount += 2;
     }

--- a/src/frontend/org/voltdb/iv2/Scheduler.java
+++ b/src/frontend/org/voltdb/iv2/Scheduler.java
@@ -25,6 +25,7 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.messaging.VoltMessage;
+import org.voltdb.LoadedProcedureSet;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.StarvationTracker;
 import org.voltdb.VoltDB;
@@ -78,6 +79,7 @@ abstract public class Scheduler implements InitiatorMessageHandler
     protected boolean m_isLeader = false;
     private TxnEgo m_txnEgo;
     final protected int m_partitionId;
+    protected LoadedProcedureSet m_procSet;
 
     // helper class to put command log work in order
     protected final ReplaySequencer m_replaySequencer = new ReplaySequencer();
@@ -160,6 +162,10 @@ abstract public class Scheduler implements InitiatorMessageHandler
     public void setDurableUniqueIdListener(DurableUniqueIdListener listener) {
         // Durability Listeners should never be assigned to the MP Scheduler
         assert false;
+    }
+
+    public void setProcedureSet(LoadedProcedureSet procSet) {
+        m_procSet = procSet;
     }
 
     /**

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -772,11 +772,11 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             }
             else if (result == DuplicateCounter.MISMATCH) {
                 RealVoltDB.printDiagnosticInformation(VoltDB.instance().getCatalogContext(),
-                        counter.getStoredProcedureName());
+                        counter.getStoredProcedureName(), m_procSet);
                 VoltDB.crashGlobalVoltDB("HASH MISMATCH: replicas produced different results.", true, null);
             } else if (result == DuplicateCounter.ABORT) {
                 RealVoltDB.printDiagnosticInformation(VoltDB.instance().getCatalogContext(),
-                        counter.getStoredProcedureName());
+                        counter.getStoredProcedureName(), m_procSet);
                 VoltDB.crashGlobalVoltDB("PARTIAL ROLLBACK/ABORT: transaction succeeded on one replica but failed on another replica.", true, null);
             }
         }


### PR DESCRIPTION
Also contains two trivial optimizations:
1. In `DeterminismHash`, remove the use of parameter hash. This because we only care about whether two hashes of parameter are the same, not the actual hash.
2. Always return the overall hash to client response, even when there is no per-statement hash.   

Change-Id: I0e63326e59b31361e643aa0bf8b808331fd8aa9c