### PR TITLE
Fix ENG-11832 error in UPDATE stream view

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDML.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDML.java
@@ -654,6 +654,7 @@ public class ParserDML extends ParserDQL {
             }
         }
 
+        /* Disabled for ENG-11832
         if (!targetTable.isView) {
             return;
         }
@@ -666,6 +667,7 @@ public class ParserDML extends ParserDQL {
                 colExpressions[i].replaceColumnReferences(rangeVariables[0],
                     select.exprColumns);
         }
+        */
     }
 
     void readSetClauseList(RangeVariable[] rangeVars, OrderedHashSet colNames,


### PR DESCRIPTION
The fix for this bug is disabling some reference replacement code in HSQL.
The team had the concern that it may affect the answers we collect from the HSQL backend, we will see what the Jenkins say. My current guess is it won't.

Manual test completed:
* TestGroupByComplexMaterializedViewSuite
* TestMaterializedViewNonemptyTablesSuite
* TestMaterializedViewSuite
* TestStreamView
