### PR TITLE
ENG-12504 make 'init --classes' compile using the specified jar file rather than simply adding it to the CLASSPATH.

### DIFF
--- a/lib/python/voltcli/voltdb.d/init.py
+++ b/lib/python/voltcli/voltdb.d/init.py
@@ -45,11 +45,8 @@ def init(runner):
         runner.args.extend(['force'])
     if runner.opts.schema:
         runner.args.extend(['schema', runner.opts.schema])
+    if runner.opts.classes_jarfile:
+        runner.args.extend(['classes', runner.opts.classes_jarfile])
 
     args = runner.args
-
-    if runner.opts.classes_jarfile:
-        kwargs = dict(classpath=runner.opts.classes_jarfile)
-        runner.java_execute(VoltDB, None, *args, **kwargs)
-    else:
-        runner.java_execute(VoltDB, None, *args)
+    runner.java_execute(VoltDB, None, *args)

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2225,7 +2225,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         final boolean standalone = false;
         final boolean isXCDR = false;
         VoltCompiler compiler = new VoltCompiler(standalone, isXCDR);
-        if (!compiler.compileFromDDL(stagedCatalogFH.getAbsolutePath(), config.m_userSchema.getAbsolutePath())) {
+        if (!compiler.compileFromSchemaAndClasses(config.m_userSchema, config.m_stagedClassesPath, stagedCatalogFH)) {
             VoltDB.crashLocalVoltDB("Could not compile specified schema " + config.m_userSchema);
         }
     }

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -316,8 +316,11 @@ public class VoltDB {
         /** apply safe mode strategy when recovering */
         public boolean m_safeMode = false;
 
-        /** location of user supplied DDL */
+        /** location of user supplied schema */
         public File m_userSchema = null;
+
+        /** location of user supplied classes and resources jar file */
+        public File m_stagedClassesPath = null;
 
         public int getZKPort() {
             return MiscUtils.getPortFromHostnameColonPort(m_zkInterface, org.voltcore.common.Constants.DEFAULT_ZK_PORT);
@@ -665,18 +668,32 @@ public class VoltDB {
                     m_getOutput = args[++i].trim();
                 } else if (arg.equalsIgnoreCase("forceget")) {
                     m_forceGetCreate = true;
-                } else if (arg.equalsIgnoreCase("schema")){
+                } else if (arg.equalsIgnoreCase("schema")) {
                     m_userSchema = new File(args[++i].trim());
-                    if (!m_userSchema.exists()){
+                    if (!m_userSchema.exists()) {
                         System.err.println("FATAL: Supplied schema file " + m_userSchema + " does not exist.");
                         referToDocAndExit();
                     }
-                    if (!m_userSchema.canRead()){
+                    if (!m_userSchema.canRead()) {
                         System.err.println("FATAL: Supplied schema file " + m_userSchema + " can't be read.");
                         referToDocAndExit();
                     }
-                    if (!m_userSchema.isFile()){
+                    if (!m_userSchema.isFile()) {
                         System.err.println("FATAL: Supplied schema file " + m_userSchema + " is not an ordinary file.");
+                        referToDocAndExit();
+                    }
+                } else if (arg.equalsIgnoreCase("classes")) {
+                    m_stagedClassesPath = new File(args[++i].trim());
+                    if (!m_stagedClassesPath.exists()){
+                        System.err.println("FATAL: Supplied classes jar file " + m_stagedClassesPath + " does not exist.");
+                        referToDocAndExit();
+                    }
+                    if (!m_stagedClassesPath.canRead()) {
+                        System.err.println("FATAL: Supplied classes jar file " + m_stagedClassesPath + " can't be read.");
+                        referToDocAndExit();
+                    }
+                    if (!m_stagedClassesPath.isFile()) {
+                        System.err.println("FATAL: Supplied classes jar file " + m_stagedClassesPath + " is not an ordinary file.");
                         referToDocAndExit();
                     }
                 } else {

--- a/tests/frontend/org/voltdb/TestInitStartAction.java
+++ b/tests/frontend/org/voltdb/TestInitStartAction.java
@@ -23,16 +23,18 @@
 
 package org.voltdb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.util.EnumSet;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -51,6 +53,9 @@ import org.voltdb.utils.InMemoryJarfile;
 import org.voltdb.utils.VoltFile;
 
 import com.google_voltpatches.common.base.Joiner;
+import com.google_voltpatches.common.io.CharStreams;
+import com.google_voltpatches.common.reflect.ClassPath;
+import com.google_voltpatches.common.reflect.ClassPath.ClassInfo;
 
 /** Tests starting the server with init + start without a schema,
  * and 'init --schema --classes'.
@@ -252,7 +257,7 @@ final public class TestInitStartAction {
      * @param schema Schema used to generate the staged catalog
      * @throws Exception upon test failure or error (unable to write temp file for example)
      */
-    private void validateStagedCatalog(String schema) throws Exception {
+    private void validateStagedCatalog(String schema, InMemoryJarfile proceduresJar) throws Exception {
         // setup reference point for the supplied schema
         File schemaFile = VoltProjectBuilder.writeStringToTempFile(schema);
         schemaFile.deleteOnExit();
@@ -277,6 +282,18 @@ final public class TestInitStartAction {
 
         assertEquals(true, referenceFile.delete());
         assertEquals(true, schemaFile.delete());
+
+        if (proceduresJar != null) {
+            // Validate that the list of files in the supplied jarfile are present in the staged catalog also.
+            InMemoryJarfile strippedReferenceJar = CatalogUtil.getCatalogJarWithoutDefaultArtifacts(proceduresJar);
+            InMemoryJarfile strippedTestJar = CatalogUtil.getCatalogJarWithoutDefaultArtifacts(stagedCatalogJar);
+            for (Entry<String, byte[]> entry : strippedReferenceJar.entrySet()) {
+                System.out.println("Checking " + entry.getKey());
+                byte[] testClass = strippedTestJar.get(entry.getKey());
+                assertNotNull(entry.getKey() + " was not found in staged catalog", testClass);
+                assertArrayEquals(entry.getValue(), testClass);
+            }
+        }
     }
 
     /** Test that a valid schema with no procedures can be used to stage a matching catalog.
@@ -298,7 +315,7 @@ final public class TestInitStartAction {
         server.start();
         server.join();
         expectSimulatedExit(0);
-        validateStagedCatalog(schema);
+        validateStagedCatalog(schema, null);
         assertEquals(true, schemaFile.delete());
     }
 
@@ -326,7 +343,7 @@ final public class TestInitStartAction {
             server.start();
             server.join();
             expectSimulatedExit(0);
-            validateStagedCatalog(schema);
+            validateStagedCatalog(schema, null);
             clearCrash();
         }
         try {
@@ -384,6 +401,47 @@ final public class TestInitStartAction {
         assertTrue(VoltDB.wasCrashCalled);
         assertTrue(VoltDB.crashMessage.contains("Could not compile specified schema"));
         assertEquals(true, schemaFile.delete());
+    }
+
+    /** Tests that when there are base classes and non-class files in the stored procedures,
+     * that these also exist in the staged catalog.
+     * @throws Exception upon failure or error
+     */
+    @Test
+    public void testInitWithClassesAndArtifacts() throws Exception {
+
+        System.out.println("Loading the schema from testprocs");
+        File resource = new File("tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/ddl.sql");
+        InputStream schemaReader = new FileInputStream(resource);
+        assertNotNull("Could not find " + resource, schemaReader);
+        String schema = CharStreams.toString(new InputStreamReader(schemaReader));
+
+        System.out.println("Creating a .jar file using all of the classes associated with this test.");
+        InMemoryJarfile originalInMemoryJar = new InMemoryJarfile();
+        VoltCompiler compiler = new VoltCompiler(false, false);
+        ClassPath classpath = ClassPath.from(this.getClass().getClassLoader());
+        String packageName = "org.voltdb_testprocs.fakeusecase.greetings";
+        int classesFound = 0;
+        for (ClassInfo myclass : classpath.getTopLevelClassesRecursive(packageName)) {
+            compiler.addClassToJar(originalInMemoryJar, myclass.load());
+            classesFound++;
+        }
+        // check that classes were found and loaded. If another test modifies "fakeusecase.greetings" it should modify this assert also.
+        assertEquals(5, classesFound);
+
+        System.out.println("Writing " + classesFound + " classes to jar file");
+        File classesJarfile = File.createTempFile("TestInitStartWithClasses-procedures", ".jar");
+        classesJarfile.deleteOnExit();
+        originalInMemoryJar.writeToFile(classesJarfile);
+
+        Configuration c1 = new Configuration(
+                    new String[]{"initialize", "voltdbroot", rootDH.getPath(), "force", "schema", resource.getPath(), "classes", classesJarfile.getPath()});
+        ServerThread server = new ServerThread(c1);
+        server.setUncaughtExceptionHandler(handleUncaught);
+        server.start();
+        server.join();
+
+        validateStagedCatalog(schema, originalInMemoryJar);
     }
 
     /* For 'voltdb start' test coverage see TestStartWithSchema and (in Pro) TestStartWithSchemaAndDurability.

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingBase.java
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingBase.java
@@ -1,0 +1,45 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.fakeusecase.greetings;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+
+/** A base class with no external dependencies. */
+public class GetGreetingBase extends VoltProcedure {
+
+    protected static final SQLStmt SELECT_BY_LANGUAGE_STATEMENT = new SQLStmt("SELECT * FROM greetings WHERE language = ?");
+    protected static final SQLStmt INCREMENT_STATS_STATEMENT = new SQLStmt("UPDATE greetings SET querycount = querycount + 1 WHERE language = ?");
+
+    protected void incrementCounterIfNeeded(VoltTable[] resultsFromSelect, boolean thisIsLast) {
+        if (resultsFromSelect.length > 0 && resultsFromSelect[0].getRowCount() > 0) {
+            resultsFromSelect[0].advanceRow();
+            // Fetch language again because, in derived classes, it may be different than the argument passed in.
+            String language = resultsFromSelect[0].getString("language");
+            voltQueueSQL(INCREMENT_STATS_STATEMENT, EXPECT_EMPTY, language);
+            voltExecuteSQL(thisIsLast);
+        }
+    }
+}

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingCaseInsensitive.java
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingCaseInsensitive.java
@@ -1,0 +1,41 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.fakeusecase.greetings;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltTable;
+
+/** A class which depends on a base class. */
+public class GetGreetingCaseInsensitive extends GetGreetingBase {
+
+    protected static final SQLStmt SELECT_BY_LANGUAGE_STATEMENT = new SQLStmt("SELECT * FROM greetings WHERE LOWER(language) = ?");
+
+    /** Gets the greeting which matches the specified language exactly */
+    public VoltTable[] run(String language) {
+        voltQueueSQL(SELECT_BY_LANGUAGE_STATEMENT, EXPECT_ZERO_OR_ONE_ROW, language.toLowerCase());
+        VoltTable[] results = voltExecuteSQL();
+        incrementCounterIfNeeded(results, true);
+        return results;
+    }
+}

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingExactMatch.java
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingExactMatch.java
@@ -1,0 +1,36 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.fakeusecase.greetings;
+
+import org.voltdb.VoltTable;
+
+public class GetGreetingExactMatch extends GetGreetingBase {
+    /** Gets the greeting which matches the specified language exactly */
+    public VoltTable[] run(String language) {
+        voltQueueSQL(SELECT_BY_LANGUAGE_STATEMENT, EXPECT_ZERO_OR_ONE_ROW, language);
+        VoltTable[] results = voltExecuteSQL();
+        incrementCounterIfNeeded(results, true);
+        return results;
+    }
+}

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/LoadGreetings.java
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/LoadGreetings.java
@@ -1,0 +1,67 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.fakeusecase.greetings;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+
+/** A stored procedure which depends on a non-class resource in the jarfile. */
+public class LoadGreetings extends VoltProcedure {
+
+    private static final String GREETINGS_FILE_NAME = "/greetinglist.txt";
+    private static final SQLStmt INSERT_GREETING_STMT = new SQLStmt("INSERT INTO greetings VALUES (?, ?, ?, 0);");
+
+    public VoltTable[] run() {
+        InputStream stream = this.getClass().getResourceAsStream(GREETINGS_FILE_NAME);
+        if (stream == null) {
+            throw new VoltAbortException("Could not find " + GREETINGS_FILE_NAME);
+        }
+        BufferedReader buffer = new BufferedReader(new InputStreamReader(stream));
+        try {
+            String line;
+            while ((line = buffer.readLine()) != null) {
+                String[] greeting = line.trim().split(",");
+                if (greeting.length != 3) {
+                    throw new VoltAbortException("Could not parse greeting - must be 3 comma separated values. \"" + line + '\"');
+                }
+                voltQueueSQL(INSERT_GREETING_STMT, EXPECT_EMPTY, greeting[0], greeting[1], greeting[2]);
+            }
+            return voltExecuteSQL(true);
+        } catch (IOException e) {
+            throw new VoltAbortException(e);
+        } finally {
+            try {
+                buffer.close();
+            } catch (IOException disregard) {
+                disregard.printStackTrace(); // BSDBG this is just so I don't get spurious exceptions flying
+            }
+        }
+    }
+}

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/ddl.sql
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/ddl.sql
@@ -1,0 +1,11 @@
+CREATE TABLE greetings
+(
+    language VARCHAR(32) NOT NULL PRIMARY KEY,
+    english_version VARCHAR(32) NOT NULL,
+    native_version VARCHAR(64) NOT NULL,
+    querycount BIGINT NOT NULL
+);
+
+CREATE PROCEDURE FROM CLASS org.voltdb_testprocs.fakeusecase.greetings.GetGreetingExactMatch;
+CREATE PROCEDURE FROM CLASS org.voltdb_testprocs.fakeusecase.greetings.GetGreetingCaseInsensitive;
+CREATE PROCEDURE FROM CLASS org.voltdb_testprocs.fakeusecase.greetings.LoadGreetings;

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/greetinglist.txt
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/greetinglist.txt
@@ -1,0 +1,8 @@
+English,Hello,Hello
+Spanish,Hola,Hola
+French,Bonjour,Bonjour
+Italian,Ciao,Ciao
+Simplified Chinese,Ni Hau,你好
+Japanese,Konnichiwa,こんにちは
+Hindi,Namaste,नमस्ते
+Arabic,Marhabaan,مرحبا

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/package-info.java
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/package-info.java
@@ -1,0 +1,28 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * A fake use case intended for use verifying that 'voltdb init --classes' works with non-trivial use cases.
+ * The theme is querying translations for 'Hello' in different languages.
+ */
+package fakeusecase.greetings;

--- a/tests/testverbs/voltverbstest.py
+++ b/tests/testverbs/voltverbstest.py
@@ -99,7 +99,7 @@ verbose = Opt('verbose', 'verbose', None, 2)
 output = Opt('output', 'file', str, 2)
 # Ddir = Opt('
 schema = Opt('schema', 'schema', str, 2)
-classes = Opt('classes', 'classpath', str, 2)
+classes = Opt('classes', 'classes', str, 2)
 
 # negative opt
 unknown = Opt('unknown', None, None, 0)
@@ -318,13 +318,10 @@ def compare_result(stdout, stderr, verb, opts, reportout, expectedOut=None, expe
         return True, description
 
     # match the opts
-    # ignore 'classpath' - it gets filtered out
     output_tokens = output_str.lstrip(verb).split()
     expected_tokens = []
     for k, v in opts.items():
-        if k == "classpath":
-            pass
-        elif v:
+        if v:
             expected_tokens.extend([k, v])
         else:
             expected_tokens.append(k)


### PR DESCRIPTION
You can now use 'init --classes' when a base class exists.
If --schema is supplied to init but the schema does not use all of the available classes and/or resources, the unused resources are now in the catalog for later use.

Arguably this is just a workaround for the base class issue - VoltCompiler still isn't smart enough to resolve all the dependencies. We just ensure the output staged-catalog.jar contains everything the user's jar did.

The 'fake use case' in the test is not currently 100% functional as a stand-alone app, but it does contain:
- base classes
- utility classes (package-info.java)
- non-class artifacts
This means that the JUnit test is able to cover these cases regardless.