### PR TITLE
ENG-11682: Add more definitive pro trial license handling.

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -798,7 +798,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 if (config.m_isEnterprise) {
                     if (m_licenseApi.isEnterprise()) edition = "Enterprise Edition";
                     if (m_licenseApi.isPro()) edition = "Pro Edition";
-                    if (m_licenseApi.isTrial()) edition = "Enterprise Edition";
+                    if (m_licenseApi.isEnterpriseTrial()) edition = "Enterprise Edition";
+                    if (m_licenseApi.isProTrial()) edition = "Pro Edition";
                     if (m_licenseApi.isAWSMarketplace()) edition = "AWS Marketplace Pro Edition";
                 }
 
@@ -1095,7 +1096,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             try {
                 SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM d, yyyy");
                 JSONObject jo = new JSONObject();
-                jo.put("trial", m_licenseApi.isTrial());
+                jo.put("trial", m_licenseApi.isAnyKindOfTrial());
                 jo.put("hostcount",m_licenseApi.maxHostcount());
                 jo.put("commandlogging", m_licenseApi.isCommandLoggingAllowed());
                 jo.put("wanreplication", m_licenseApi.isDrReplicationAllowed());

--- a/src/frontend/org/voltdb/licensetool/LicenseApi.java
+++ b/src/frontend/org/voltdb/licensetool/LicenseApi.java
@@ -27,7 +27,9 @@ import java.util.Calendar;
 public interface LicenseApi {
     public boolean initializeFromFile(File license);
     public boolean secondaryInitialization();
-    public boolean isTrial();
+    public boolean isAnyKindOfTrial();
+    public boolean isProTrial();
+    public boolean isEnterpriseTrial();
     public boolean isAWSMarketplace();
     public boolean isEnterprise();
     public boolean isPro();

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -137,7 +137,17 @@ public class MiscUtils {
                 }
 
                 @Override
-                public boolean isTrial() {
+                public boolean isAnyKindOfTrial() {
+                    return false;
+                }
+
+                @Override
+                public boolean isProTrial() {
+                    return false;
+                }
+
+                @Override
+                public boolean isEnterpriseTrial() {
                     return false;
                 }
 
@@ -335,7 +345,7 @@ public class MiscUtils {
 
         if (yesterday.after(licenseApi.expires())) {
             if (licenseApi.hardExpiration()) {
-                if (licenseApi.isTrial()) {
+                if (licenseApi.isAnyKindOfTrial()) {
                     hostLog.fatal("VoltDB trial license expired on " + expiresStr + ".");
                 }
                 else {
@@ -392,7 +402,7 @@ public class MiscUtils {
         long diffDays = diff / (24 * 60 * 60 * 1000);
 
         // print out trial success message
-        if (licenseApi.isTrial()) {
+        if (licenseApi.isAnyKindOfTrial()) {
             consoleLog.info("Starting VoltDB with trial license. License expires on " + expiresStr + " (" + diffDays + " days remaining).");
             return true;
         }

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -680,7 +680,17 @@ public class MockVoltDB implements VoltDBInterface
             }
 
             @Override
-            public boolean isTrial() {
+            public boolean isAnyKindOfTrial() {
+                return false;
+            }
+
+            @Override
+            public boolean isProTrial() {
+                return false;
+            }
+
+            @Override
+            public boolean isEnterpriseTrial() {
                 return false;
             }
 


### PR DESCRIPTION
Now it prints "pro" when it's a pro trial.

No license schema updates.

Pro pull: https://github.com/VoltDB/pro/pull/1899
JIRA Ticket: https://issues.voltdb.com/browse/ENG-11682