### PR TITLE
ENG-11091:

### DIFF
--- a/src/catgen/in/javasrc/CatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/CatalogDiffEngine.java
@@ -159,11 +159,6 @@ public class CatalogDiffEngine {
     private final Map<String, CatalogMap<Index>> m_originalIndexesByTable = new HashMap<>();
     private final Map<String, CatalogMap<Index>> m_newIndexesByTable = new HashMap<>();
 
-    // Since we find out if it is compatible in the ctor, this cannot be set in DRCatalogDiffEngine class.
-    // By the time it is set in that class, which will be after call to super(),
-    // compatiblity would already be calculated and it too late to set this.
-    private final boolean m_isXDCR;
-
     /**
      * Instantiate a new diff. The resulting object can return the text
      * of the difference and report whether the difference is allowed in a
@@ -172,7 +167,7 @@ public class CatalogDiffEngine {
      * @param next Tip of the new catalog.
      */
     public CatalogDiffEngine(Catalog prev, Catalog next, boolean forceVerbose) {
-        m_isXDCR = prev.getClusters().get("cluster").getDrrole().equals(DrRoleType.XDCR.value());
+        initialize(prev, next);
         m_supported = true;
         if (forceVerbose) {
             m_triggeredVerbosity = true;
@@ -210,8 +205,11 @@ public class CatalogDiffEngine {
         this(prev, next, false);
     }
 
-    public boolean isXDCR() {
-        return m_isXDCR;
+    /**
+     * Override this to do initializations before the diff is calculated.
+     * The parameters are the same catalog parameters passed into the constructor.
+     */
+    protected void initialize(Catalog prev, Catalog next) {
     }
 
     public String commands() {

--- a/src/catgen/in/javasrc/DRCatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/DRCatalogDiffEngine.java
@@ -60,7 +60,6 @@ public class DRCatalogDiffEngine extends CatalogDiffEngine {
 
     public DRCatalogDiffEngine(Catalog localCatalog, Catalog remoteCatalog) {
         super(localCatalog, remoteCatalog);
-        localCatalog.getClusters().get("cluster").getDrclusterid();
     }
 
     protected void initialize(Catalog prev, Catalog next) {

--- a/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
@@ -103,6 +103,10 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertTrue(diff.errors(), diff.supported());
+
+        // Not supported in XDCR mode
+        diff = runCatalogDiff(masterSchema, true, replicaSchema, true);
+        assertFalse(diff.supported());
     }
 
     @Test
@@ -118,6 +122,10 @@ public class TestDRCatalogDiffs {
                 "DR TABLE T2;";
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertTrue(diff.errors(), diff.supported());
+
+        // Not supported in XDCR mode
+        diff = runCatalogDiff(masterSchema, true, replicaSchema, true);
+        assertFalse(diff.supported());
     }
 
     @Test

--- a/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
@@ -70,7 +70,7 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing DR table T2 on replica cluster"));
+        assertTrue(diff.errors().contains("Missing DR table T2 on local cluster"));
     }
 
     @Test
@@ -87,7 +87,7 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Table T1 has DR enabled on the master"));
+        assertTrue(diff.errors().contains("Table T1 has DR enabled on the remote cluster"));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Column{C2} from Table{T1} on master"));
+        assertTrue(diff.errors().contains("Missing Column{C2} from Table{T1} on remote cluster"));
     }
 
     @Test
@@ -153,7 +153,7 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Column{C2} from Table{T1} on replica"));
+        assertTrue(diff.errors().contains("Missing Column{C2} from Table{T1} on local cluster"));
     }
 
     @Test
@@ -431,7 +431,7 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Index{FOO} from Table{T1} on master"));
+        assertTrue(diff.errors().contains("Missing Index{FOO} from Table{T1} on remote cluster"));
     }
 
     @Test
@@ -446,7 +446,7 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Index{FOO} from Table{T1} on replica"));
+        assertTrue(diff.errors().contains("Missing Index{FOO} from Table{T1} on local cluster"));
     }
 
     @Test
@@ -514,8 +514,8 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Index{FOO} from Table{T1} on replica"));
-        assertTrue(diff.errors().contains("Missing Index{FOO} from Table{T2} on master"));
+        assertTrue(diff.errors().contains("Missing Index{FOO} from Table{T1} on local cluster"));
+        assertTrue(diff.errors().contains("Missing Index{FOO} from Table{T2} on remote cluster"));
     }
 
     @Test
@@ -529,7 +529,7 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1} from Table{T1} on master"));
+        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1} from Table{T1} on remote cluster"));
     }
 
     @Test
@@ -543,7 +543,7 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1} from Table{T1} on replica"));
+        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1} from Table{T1} on local cluster"));
     }
 
     @Test
@@ -557,8 +557,8 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1_C2} from Table{T1} on master"));
-        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1} from Table{T1} on replica"));
+        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1_C2} from Table{T1} on remote cluster"));
+        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1} from Table{T1} on local cluster"));
     }
 
     @Test
@@ -572,8 +572,8 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1_C2} from Table{T1} on replica"));
-        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1} from Table{T1} on master"));
+        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1_C2} from Table{T1} on local cluster"));
+        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1} from Table{T1} on remote cluster"));
     }
 
     @Test
@@ -587,8 +587,8 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, replicaSchema, false);
         assertFalse(diff.supported());
-        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1_C2} from Table{T1} on replica"));
-        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C2_C1} from Table{T1} on master"));
+        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C1_C2} from Table{T1} on local cluster"));
+        assertTrue(diff.errors().contains("Missing Index{VOLTDB_AUTOGEN_IDX_PK_T1_C2_C1} from Table{T1} on remote cluster"));
     }
 
     @Test
@@ -711,7 +711,7 @@ public class TestDRCatalogDiffs {
 
         CatalogDiffEngine diff = runCatalogDiff(masterSchema, false, "", false);
         assertFalse(diff.errors(), diff.supported());
-        assertTrue(diff.errors().contains("Missing DR table T1 on replica cluster"));
+        assertTrue(diff.errors().contains("Missing DR table T1 on local cluster"));
     }
 
     @Test

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -2154,6 +2154,7 @@ public class LocalCluster extends VoltServerConfig {
         if (remoteReplicationPort != 0) {
             builder.setDRMasterHost("localhost:" + remoteReplicationPort);
         }
+        builder.setUseDDLSchema(true);
         LocalCluster lc = new LocalCluster(jar, siteCount, hostCount, kfactor, clusterId, BackendTarget.NATIVE_EE_JNI, false);
         lc.setReplicationPort(replicationPort);
         if (callingMethodName != null) {


### PR DESCRIPTION
- Send catalog update events even if DR tables are deleted.
- In XDCR mode, DR schema compatibility check should fail if the producer side deleted DR'ed tables.