### PR TITLE
ENG-12560 fix a JUnit that fails intermittently

### DIFF
--- a/tests/frontend/org/voltdb/TestInitStartAction.java
+++ b/tests/frontend/org/voltdb/TestInitStartAction.java
@@ -150,10 +150,9 @@ final public class TestInitStartAction {
 
         File deplFH = new VoltFile(new VoltFile(new VoltFile(rootDH, "voltdbroot"), "config"), "deployment.xml");
         Configuration c1 = new Configuration(
-                new String[]{"initialize", "voltdbroot", rootDH.getPath(), "deployment", legacyDeploymentFH.getPath()});
+                new String[]{"initialize", "voltdbroot", rootDH.getPath(), "force", "deployment", legacyDeploymentFH.getPath()});
         ServerThread server = new ServerThread(c1);
         server.setUncaughtExceptionHandler(handleUncaught);
-        c1.m_forceVoltdbCreate = false;
 
         server.start();
         server.join();


### PR DESCRIPTION
Fix intermittent test failure due to tests getting run out of order. One test assumes there is no voltdbroot in the directory, which was fine when there was only one test but has not been true since 'init --schema' was added.