### PR TITLE
Eng 12112 empty path.properties file

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2644,6 +2644,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
             return new ReadDeploymentResults(deploymentBytes, deployment);
         } catch (SettingsException e) {
+        	// Handling some setting errors (e.g. IO / Null Pointer) and print out
+        	// error messages.
             consoleLog.info("FATAL ERROR: " + e.getMessage());
             throw new RuntimeException(e);
         } catch (Exception e) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2644,6 +2644,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
             return new ReadDeploymentResults(deploymentBytes, deployment);
         } catch (Exception e) {
+        	consoleLog.info("FATAL ERROR: Unable to parse path.properties file." + 
+        					" Please check your properties file.");
             throw new RuntimeException(e);
         }
     }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2644,8 +2644,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
             return new ReadDeploymentResults(deploymentBytes, deployment);
         } catch (Exception e) {
-        	consoleLog.info("FATAL ERROR: Unable to parse path.properties file." + 
-        					" Please check your properties file.");
+        	consoleLog.info("FATAL ERROR: " + e.getMessage());
             throw new RuntimeException(e);
         }
     }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2644,8 +2644,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
             return new ReadDeploymentResults(deploymentBytes, deployment);
         } catch (SettingsException e) {
-        	// Handling some setting errors (e.g. IO / Null Pointer) and print out
-        	// error messages.
+            // Handling some setting errors (e.g. IO / Null Pointer) and print out
+            // error messages.
             consoleLog.error("[FATAL ERROR] " + e.getMessage());
             throw new RuntimeException(e);
         } catch (Exception e) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2646,7 +2646,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         } catch (SettingsException e) {
         	// Handling some setting errors (e.g. IO / Null Pointer) and print out
         	// error messages.
-            consoleLog.error("FATAL ERROR: " + e.getMessage());
+            consoleLog.error("[FATAL ERROR] " + e.getMessage());
             throw new RuntimeException(e);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2646,7 +2646,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         } catch (SettingsException e) {
         	// Handling some setting errors (e.g. IO / Null Pointer) and print out
         	// error messages.
-            consoleLog.info("FATAL ERROR: " + e.getMessage());
+            consoleLog.error("FATAL ERROR: " + e.getMessage());
             throw new RuntimeException(e);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2643,8 +2643,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 }
             }
             return new ReadDeploymentResults(deploymentBytes, deployment);
+        } catch (SettingsException e) {
+            consoleLog.info("FATAL ERROR: " + e.getMessage());
+            throw new RuntimeException(e);
         } catch (Exception e) {
-        	consoleLog.info("FATAL ERROR: " + e.getMessage());
             throw new RuntimeException(e);
         }
     }

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -29,11 +29,12 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.aeonbits.owner.Config.Sources;
-import org.aeonbits.owner.ConfigFactory;
 import org.voltdb.common.Constants;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltFile;
+
+import org.aeonbits.owner.Config.Sources;
+import org.aeonbits.owner.ConfigFactory;
 
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableMap;

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -182,10 +182,15 @@ public interface NodeSettings extends Settings {
     default Properties asProperties() {
         ImmutableMap.Builder<String, String> mb = ImmutableMap.builder();
         try {
-            // Check if the VoltDBRoot exists
+        	/*
+        	 * Check if the VoltDBRoot exists to avoid NullPointerException
+        	 * Note that the VoltDB root directory info may not exist in path.properties file
+        	 * or the path.properties file can be empty
+        	 */
             if (getVoltDBRoot() == null) {
+            	// The exception will be handled and printed out in RealVoltDB.java
                 throw new SettingsException("Missing VoltDB root " +
-                                            "information in properties file!");
+                                            "information in properties file.");
             }
             mb.put(VOLTDBROOT_PATH_KEY, getVoltDBRoot().getCanonicalPath());
             for (Map.Entry<String, File> e: getManagedArtifactPaths().entrySet()) {

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -183,6 +183,11 @@ public interface NodeSettings extends Settings {
     default Properties asProperties() {
         ImmutableMap.Builder<String, String> mb = ImmutableMap.builder();
         try {
+            // Check if the VoltDBRoot exists
+        	if (getVoltDBRoot() == null) {
+        	    throw new SettingsException("Missing VoltDB root " + 
+        	                                "information in properties file!");
+        	}
             mb.put(VOLTDBROOT_PATH_KEY, getVoltDBRoot().getCanonicalPath());
             for (Map.Entry<String, File> e: getManagedArtifactPaths().entrySet()) {
                 mb.put(e.getKey(), e.getValue().getCanonicalPath());

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -183,13 +183,13 @@ public interface NodeSettings extends Settings {
     default Properties asProperties() {
         ImmutableMap.Builder<String, String> mb = ImmutableMap.builder();
         try {
-        	/*
-        	 * Check if the VoltDBRoot exists to avoid NullPointerException
-        	 * Note that the VoltDB root directory info may not exist in path.properties file
-        	 * or the path.properties file can be empty
-        	 */
+            /*
+             * Check if the VoltDBRoot exists to avoid NullPointerException
+             * Note that the VoltDB root directory info may not exist in path.properties file
+             * or the path.properties file can be empty
+             */
             if (getVoltDBRoot() == null) {
-            	// The exception will be handled and printed out in RealVoltDB.java
+                // The exception will be handled and printed out in RealVoltDB.java
                 throw new SettingsException("Missing VoltDB root " +
                                             "information in path.properties file.");
             }

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -191,7 +191,7 @@ public interface NodeSettings extends Settings {
             if (getVoltDBRoot() == null) {
             	// The exception will be handled and printed out in RealVoltDB.java
                 throw new SettingsException("Missing VoltDB root " +
-                                            "information in properties file.");
+                                            "information in path.properties file.");
             }
             mb.put(VOLTDBROOT_PATH_KEY, getVoltDBRoot().getCanonicalPath());
             for (Map.Entry<String, File> e: getManagedArtifactPaths().entrySet()) {

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -185,7 +185,7 @@ public interface NodeSettings extends Settings {
             // Check if the VoltDBRoot exists
             if (getVoltDBRoot() == null) {
                 throw new SettingsException("Missing VoltDB root " +
-        	                                "information in properties file!");
+                                            "information in properties file!");
             }
             mb.put(VOLTDBROOT_PATH_KEY, getVoltDBRoot().getCanonicalPath());
             for (Map.Entry<String, File> e: getManagedArtifactPaths().entrySet()) {

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -29,12 +29,11 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.aeonbits.owner.Config.Sources;
+import org.aeonbits.owner.ConfigFactory;
 import org.voltdb.common.Constants;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltFile;
-
-import org.aeonbits.owner.Config.Sources;
-import org.aeonbits.owner.ConfigFactory;
 
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableMap;
@@ -184,10 +183,10 @@ public interface NodeSettings extends Settings {
         ImmutableMap.Builder<String, String> mb = ImmutableMap.builder();
         try {
             // Check if the VoltDBRoot exists
-        	if (getVoltDBRoot() == null) {
-        	    throw new SettingsException("Missing VoltDB root " + 
+            if (getVoltDBRoot() == null) {
+                throw new SettingsException("Missing VoltDB root " +
         	                                "information in properties file!");
-        	}
+            }
             mb.put(VOLTDBROOT_PATH_KEY, getVoltDBRoot().getCanonicalPath());
             for (Map.Entry<String, File> e: getManagedArtifactPaths().entrySet()) {
                 mb.put(e.getKey(), e.getValue().getCanonicalPath());


### PR DESCRIPTION
Added print out message when the properties file is empty or does not contain necessary field. This resolves the print out message problem when the path.properties is empty in some case.
