### PR TITLE
Eng 12112 missing properties file error message

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2652,7 +2652,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
              * we probably just want to crash the DB anyway
              */
             consoleLog.fatal(e.getMessage());
-            VoltDB.crashLocalVoltDB(e.getMessage(), true, null);
+            VoltDB.crashLocalVoltDB(e.getMessage());
             return null;
         }
     }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2646,17 +2646,14 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 }
             }
             return new ReadDeploymentResults(deploymentBytes, deployment);
-        } catch (SettingsException e) {
+        } catch (Exception e) {
             /*
              * When a settings exception is caught (e.g. reading a broken properties file),
-             * we probably just want to crash the DB anyway, without printing the stack
-             * trace.
+             * we probably just want to crash the DB anyway
              */
             consoleLog.fatal(e.getMessage());
-            VoltDB.crashLocalVoltDB(e.getMessage());
+            VoltDB.crashLocalVoltDB(e.getMessage(), true, null);
             return null;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2652,7 +2652,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
              * trace.
              */
             consoleLog.fatal(e.getMessage());
-            VoltDB.crashLocalVoltDB(e.getMessage(), false, null);
+            VoltDB.crashLocalVoltDB(e.getMessage());
             return null;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2645,13 +2645,14 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 }
             }
             return new ReadDeploymentResults(deploymentBytes, deployment);
-        } catch (SettingsException e) {
-            // Handling some setting errors (e.g. IO / Null Pointer) and print out
-            // error messages.
-            consoleLog.error("[FATAL ERROR] " + e.getMessage());
-            throw new RuntimeException(e);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            /*
+             * When a runtime exception is caught (e.g. reading a broken properties file),
+             * we probably just want to crash the DB anyway
+             */
+            consoleLog.fatal(e.getMessage());
+            VoltDB.crashLocalVoltDB(e.getMessage(), false, null);
+            return new ReadDeploymentResults(null, null);
         }
     }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2645,15 +2645,17 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 }
             }
             return new ReadDeploymentResults(deploymentBytes, deployment);
-        } catch (Exception e) {
+        } catch (SettingsException e) {
             /*
-             * When a runtime exception is caught (e.g. reading a broken properties file),
+             * When a settings exception is caught (e.g. reading a broken properties file),
              * we probably just want to crash the DB anyway, without printing the stack
              * trace.
              */
             consoleLog.fatal(e.getMessage());
             VoltDB.crashLocalVoltDB(e.getMessage(), false, null);
             return null;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2653,7 +2653,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
              */
             consoleLog.fatal(e.getMessage());
             VoltDB.crashLocalVoltDB(e.getMessage(), false, null);
-            return new ReadDeploymentResults(null, null);
+            return null;
         }
     }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2648,7 +2648,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         } catch (Exception e) {
             /*
              * When a runtime exception is caught (e.g. reading a broken properties file),
-             * we probably just want to crash the DB anyway
+             * we probably just want to crash the DB anyway, without printing the stack
+             * trace.
              */
             consoleLog.fatal(e.getMessage());
             VoltDB.crashLocalVoltDB(e.getMessage(), false, null);


### PR DESCRIPTION
Improvement: Crash the database directly in RealVoltDB.java when any exception is caught. Print out the fatal error message.