### PR TITLE
Eng 5532 read-only procedure non-deterministic no warning

### DIFF
--- a/tests/frontend/org/voltdb/planner/TestDeterminism.java
+++ b/tests/frontend/org/voltdb/planner/TestDeterminism.java
@@ -1101,8 +1101,10 @@ public class TestDeterminism extends PlannerTestCase {
         System.out.println(outputStream.toString());
         // There is no warnings generated for read-only ND queries
         String msg = outputStream.toString();
-        assert(!msg.contains("ND"));
-        assert(!msg.contains("WARN"));
+        assertFalse(stringContains(msg, "ND"));
+        assertFalse(stringContains(msg, "WARN"));
+        assertTrue(stringContains(msg, "Successfully created"));
+        assertTrue(stringContains(msg, "Catalog contains"));
         outputStream.close();
     }
 
@@ -1200,4 +1202,11 @@ public class TestDeterminism extends PlannerTestCase {
         assertMPPlanDeterminismCombo(sql, ORDERED, CONSISTENT, tryOrderBy, null, DeterminismMode.SAFER);
     }
 
+    /*
+     * Helper function for sub-string regex matching
+     */
+    private boolean stringContains(String msg, String regex) {
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(regex);
+        return pattern.matcher(msg).find();
+    }
 }

--- a/tests/frontend/org/voltdb/planner/TestDeterminism.java
+++ b/tests/frontend/org/voltdb/planner/TestDeterminism.java
@@ -23,7 +23,15 @@
 
 package org.voltdb.planner;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.URL;
+import java.net.URLDecoder;
+
+import org.hsqldb_voltpatches.HSQLInterface;
 import org.voltdb.compiler.DeterminismMode;
+import org.voltdb.compiler.VoltCompiler;
+import org.voltdb.compiler.VoltCompiler.DdlProceduresToLoad;
 
 public class TestDeterminism extends PlannerTestCase {
     @Override
@@ -1072,6 +1080,30 @@ public class TestDeterminism extends PlannerTestCase {
         // indexes defined on both the tables. At most one row output is not guaranteed.
         sql = "select * from punique, ppk where punique.a = ppk.a";
         assertMPPlanDeterminismCore(sql, UNORDERED, CONSISTENT, false, DeterminismMode.FASTER);
+    }
+
+    /*
+     * A test that runs some read-only non-deterministic DDLs, check that the output does not contain
+     * any ND warnings
+     */
+    public void testDeterminismReadOnlyNoWarning() throws Exception {
+        // Should the members be reused here?
+        HSQLInterface hsql = HSQLInterface.loadHsqldb();
+        VoltCompiler compiler = new VoltCompiler(false);
+        VoltCompiler.DdlProceduresToLoad all_procs = DdlProceduresToLoad.NO_DDL_PROCEDURES;
+
+        URL path = TestDeterminism.class.getResource("testplans-determinism-read-only.sql");
+        String pathStr = URLDecoder.decode(path.getPath(), "UTF-8");
+        compiler.loadSchema(hsql, all_procs, pathStr);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        compiler.summarizeSuccess(new PrintStream(outputStream), null, "");
+        System.out.println(outputStream.toString());
+        // There is no warnings generated for read-only ND queries
+        String msg = outputStream.toString();
+        assert(!msg.contains("ND"));
+        assert(!msg.contains("WARN"));
+        outputStream.close();
     }
 
     private void assertMPPlanDeterminismCore(String sql, boolean order, boolean content, DeterminismMode detMode) {

--- a/tests/frontend/org/voltdb/planner/testplans-determinism-read-only.sql
+++ b/tests/frontend/org/voltdb/planner/testplans-determinism-read-only.sql
@@ -1,0 +1,9 @@
+create table test (a int not null);
+partition table test on column a;
+
+create procedure tp as select top 3 * from test;
+
+create table test2 (a int primary key, b int not null);
+partition table test2 on column b;
+
+create procedure tp2 as select top 1 * from test2;

--- a/tests/frontend/org/voltdb/planner/testplans-determinism-read-only.sql
+++ b/tests/frontend/org/voltdb/planner/testplans-determinism-read-only.sql
@@ -3,7 +3,7 @@ partition table test on column a;
 
 create procedure tp as select top 3 * from test;
 
-create table test2 (a int primary key, b int not null);
+create table test2 (a int, b int not null, primary key (a, b));
 partition table test2 on column b;
 
 create procedure tp2 as select top 1 * from test2;

--- a/tests/frontend/org/voltdb/planner/testplans-determinism-read-only.sql
+++ b/tests/frontend/org/voltdb/planner/testplans-determinism-read-only.sql
@@ -6,4 +6,9 @@ create procedure tp as select top 3 * from test;
 create table test2 (a int, b int not null, primary key (a, b));
 partition table test2 on column b;
 
-create procedure tp2 as select top 1 * from test2;
+create procedure tp2 as select b, count(*) from test2 group by b limit 3;
+
+create table test3 (a int, b int not null, c int not null, primary key (a, b, c));
+partition table test3 on column b;
+
+create procedure tp3 as select max(temp.b) from (select top 3 * from test3) as temp;


### PR DESCRIPTION
The problem has already been addressed in various previous commits. The non-deterministic warning is checked in summarizeSuccess() method and checks if the query is read-only or not.

This PR adds a test method for checking the output of summarizeSuccess() and see if any unwanted warning is given for any non-deterministic read-only queries.