### PR TITLE
PostgreSQLBackend.shutdown(): just tweaked to make sure that the

### DIFF
--- a/src/frontend/org/voltdb/PostGISBackend.java
+++ b/src/frontend/org/voltdb/PostGISBackend.java
@@ -252,11 +252,11 @@ public class PostGISBackend extends PostgreSQLBackend {
     static public PostGISBackend initializePostGISBackend(CatalogContext context)
     {
         synchronized(backendLock) {
-            if (m_backend == null) {
-                try {
-                    if (m_permanent_db_backend == null) {
-                        m_permanent_db_backend = new PostgreSQLBackend();
-                    }
+            try {
+                if (m_permanent_db_backend == null) {
+                    m_permanent_db_backend = new PostgreSQLBackend();
+                }
+                if (m_backend == null) {
                     Statement stmt = m_permanent_db_backend.getConnection().createStatement();
                     stmt.execute("drop database if exists " + m_database_name + ";");
                     stmt.execute("create database " + m_database_name + ";");
@@ -274,10 +274,10 @@ public class PostGISBackend extends PostgreSQLBackend {
                         m_backend.runDDL(decoded_cmd);
                     }
                 }
-                catch (final Exception e) {
-                    hostLog.fatal("Unable to construct PostGIS backend");
-                    VoltDB.crashLocalVoltDB(e.getMessage(), true, e);
-                }
+            }
+            catch (final Exception e) {
+                hostLog.fatal("Unable to construct PostGIS backend");
+                VoltDB.crashLocalVoltDB(e.getMessage(), true, e);
             }
             return (PostGISBackend) m_backend;
         }


### PR DESCRIPTION
connection to the "permanent", "postgres" database is really closed, and set to null; and to save the System.gc() until the end.

PostGISBackend.initializePostGISBackend(): just tweaked by reordering it to be like PostgreSQLBackend.initializePostgreSQLBackend(), by having a separate check as to whether m_permanent_db_backend is null, and putting the try/catch around the whole thing.