### PR TITLE
ENG-12610: Offer clang as compiler option in 5.8.5.debug2

### DIFF
--- a/build.py
+++ b/build.py
@@ -72,8 +72,12 @@ if (CTX.compilerName() == 'clang') and (CTX.compilerMajorVersion() == 3 and CTX.
 if (CTX.compilerName() == 'clang') and (CTX.compilerMajorVersion() == 7):
     CTX.CPPFLAGS += " -Wno-unused-local-typedefs -Wno-absolute-value"
 
+if (CTX.compilerName() == 'clang' and len(CTX.SANITIZE) > 0):
+    CTX.CPPFLAGS += (" -fsanitize=%s" % CTX.SANITIZE)
+
 if (CTX.compilerName() != 'gcc') or (CTX.compilerMajorVersion() == 4 and CTX.compilerMinorVersion() >= 3) or (CTX.compilerMajorVersion() == 5):
     CTX.CPPFLAGS += " -Wno-ignored-qualifiers -fno-strict-aliasing"
+
 
 
 if CTX.PROFILE:
@@ -108,8 +112,10 @@ CTX.THIRD_PARTY_INPUT_PREFIX = "third_party/cpp"
 CTX.TEST_PREFIX = "tests/ee/"
 
 # linker flags
-CTX.LDFLAGS += """ -g3"""
+CTX.LDFLAGS += """ -L/usr/lib/llvm-3.8/lib/clang/3.8.0/lib/linux  -g3 """
 CTX.LASTLDFLAGS += """ -lpcre2-8 """
+#CTX.LASTLDFLAGS += """ -lpcre2-8 -lclang_rt.asan-x86_64"""
+#CTX.LASTLDFLAGS += """ -lpcre2-8 /usr/lib/llvm-3.8/lib/clang/3.8.0/lib/linux/libclang_rt.asan-x86_64.a"""
 CTX.LASTIPCLDFLAGS = """ -ldl """
 
 ###############################################################################

--- a/build.py
+++ b/build.py
@@ -48,6 +48,10 @@ CTX.CPPFLAGS += """-Wall -Wextra -Werror -Woverloaded-virtual
             -fvisibility=default
             -DBOOST_SP_DISABLE_THREADS -DBOOST_DISABLE_THREADS -DBOOST_ALL_NO_LIB"""
 
+if CTX.PLATFORM == "Linux":
+    # must appear before other flags that suppress specific warnings
+    CTX.CPPFLAGS += " -Wconversion -Wcast-align"
+
 # clang doesn't seem to want this
 if CTX.compilerName() == 'gcc':
     CTX.CPPFLAGS += " -pthread"
@@ -62,8 +66,9 @@ if CTX.compilerName() == 'gcc':
 	    CTX.CPPFLAGS += " -Wno-conversion -Wno-unused-but-set-variable -Wno-unused-local-typedefs"
 
 if (CTX.compilerName() == 'clang') and (CTX.compilerMajorVersion() == 3 and CTX.compilerMinorVersion() >= 4):
-    CTX.CPPFLAGS += " -Wno-varargs"
+    CTX.CPPFLAGS += " -Wno-varargs -Wno-sign-conversion -Wno-cast-align"
 
+# latest version of clang is 4.0... following lines are unused?
 if (CTX.compilerName() == 'clang') and (CTX.compilerMajorVersion() == 7):
     CTX.CPPFLAGS += " -Wno-unused-local-typedefs -Wno-absolute-value"
 
@@ -159,7 +164,7 @@ if CTX.PLATFORM == "Darwin":
     CTX.JNIFLAGS = "-framework JavaVM,1.7"
 
 if CTX.PLATFORM == "Linux":
-    CTX.CPPFLAGS += " -Wno-attributes -Wcast-align -Wconversion -DLINUX -fpic"
+    CTX.CPPFLAGS += " -Wno-attributes -DLINUX -fpic"
     CTX.NMFLAGS += " --demangle"
 
 ###############################################################################

--- a/build.xml
+++ b/build.xml
@@ -1512,7 +1512,7 @@ NATIVE EE STUFF
         <env key="TEST_DIR" value="${build.testobjects.dir}" />
         <env key="EETESTSUITE" value="${eetestsuite}"/>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} test" />
+        <arg line="build.py ${build} ${compiler} test" />
     </exec>
 </target>
 
@@ -1522,7 +1522,7 @@ NATIVE EE STUFF
         <env key="TEST_DIR" value="${build.testobjects.dir}" />
         <env key="EETESTSUITE" value="${eetestsuite}"/>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} build" />
+        <arg line="build.py ${build} ${compiler} build" />
     </exec>
 </target>
 
@@ -1530,7 +1530,7 @@ NATIVE EE STUFF
     description="Build the IPC client.">
     <exec dir='.' executable='python' failonerror='true'>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} voltdbipc" />
+        <arg line="build.py ${build} ${compiler} voltdbipc" />
     </exec>
 </target>
 
@@ -1539,7 +1539,7 @@ NATIVE EE STUFF
     <exec dir='.' executable='python' failonerror='true'>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
         <env key="EESKIPBUILDMAKEFILE" value="true" />
-        <arg line="build.py ${build}" />
+        <arg line="build.py ${build} ${compiler}" />
     </exec>
     <antcall target="prep_libvoltdb"/>
 </target>
@@ -1566,7 +1566,7 @@ NATIVE EE STUFF
     <exec dir='.' executable='python' failonerror='true'>
         <env key="EEONLYBUILDMAKEFILE" value="true"/>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build}" />
+        <arg line="build.py ${build} ${compiler}" />
     </exec>
 </target>
 
@@ -1574,7 +1574,7 @@ NATIVE EE STUFF
     description="Build C++ JNI library and copy it to production folder.">
     <exec dir='.' executable='python' failonerror='true'>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build}" />
+        <arg line="build.py ${build} ${compiler}" />
     </exec>
     <antcall target="prep_libvoltdb"/>
 </target>
@@ -1583,7 +1583,7 @@ NATIVE EE STUFF
     description="Build C++ JNI lib dl-ing perf tools and copy it to production folder.">
     <exec dir='.' executable='python' failonerror='true'>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} profile" />
+        <arg line="build.py ${build} ${compiler} profile" />
     </exec>
 </target>
 
@@ -1591,7 +1591,7 @@ NATIVE EE STUFF
         description="Create test program that loads catalog and tables and executes a plan fragment.">
     <exec dir='.' executable='python' failonerror='true'>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py EXECPLANFRAG ${build}" />
+        <arg line="build.py EXECPLANFRAG ${build} ${compiler}" />
     </exec>
 </target>
 
@@ -2071,7 +2071,7 @@ TEST CASES
   <!-- Whether any work needs doing is left to the C++ makefile -->
   <exec dir='.' executable='python' failonerror='true'>
     <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-    <arg line="build.py ${build} coverage" />
+    <arg line="build.py ${build} ${compiler} coverage" />
   </exec>
   <mkdir dir="${lcov.dir}" />
   <!-- Reset all counters -->
@@ -2133,7 +2133,7 @@ TEST CASES
     <exec dir='.' executable='python' failonerror='true'>
         <env key="TEST_DIR" value="${build.dir}-coverage/testobjects" />
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} test coverage" />
+        <arg line="build.py ${build} ${compiler} test coverage" />
     </exec>
 </target>
 

--- a/build.xml
+++ b/build.xml
@@ -1512,7 +1512,7 @@ NATIVE EE STUFF
         <env key="TEST_DIR" value="${build.testobjects.dir}" />
         <env key="EETESTSUITE" value="${eetestsuite}"/>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} ${compiler} test" />
+        <arg line="build.py ${build} ${compiler} sanitize=${sanitize} test" />
     </exec>
 </target>
 
@@ -1522,7 +1522,7 @@ NATIVE EE STUFF
         <env key="TEST_DIR" value="${build.testobjects.dir}" />
         <env key="EETESTSUITE" value="${eetestsuite}"/>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} ${compiler} build" />
+        <arg line="build.py ${build} ${compiler} sanitize=${sanitize} build" />
     </exec>
 </target>
 
@@ -1530,7 +1530,7 @@ NATIVE EE STUFF
     description="Build the IPC client.">
     <exec dir='.' executable='python' failonerror='true'>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} ${compiler} voltdbipc" />
+        <arg line="build.py ${build} ${compiler} sanitize=${sanitize} voltdbipc" />
     </exec>
 </target>
 
@@ -1539,7 +1539,7 @@ NATIVE EE STUFF
     <exec dir='.' executable='python' failonerror='true'>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
         <env key="EESKIPBUILDMAKEFILE" value="true" />
-        <arg line="build.py ${build} ${compiler}" />
+        <arg line="build.py ${build} ${compiler} sanitize=${sanitize}" />
     </exec>
     <antcall target="prep_libvoltdb"/>
 </target>
@@ -1566,7 +1566,7 @@ NATIVE EE STUFF
     <exec dir='.' executable='python' failonerror='true'>
         <env key="EEONLYBUILDMAKEFILE" value="true"/>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} ${compiler}" />
+        <arg line="build.py ${build} ${compiler} sanitize=${sanitize}" />
     </exec>
 </target>
 
@@ -1574,7 +1574,7 @@ NATIVE EE STUFF
     description="Build C++ JNI library and copy it to production folder.">
     <exec dir='.' executable='python' failonerror='true'>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} ${compiler}" />
+        <arg line="build.py ${build} ${compiler} sanitize=${sanitize}" />
     </exec>
     <antcall target="prep_libvoltdb"/>
 </target>
@@ -1583,7 +1583,7 @@ NATIVE EE STUFF
     description="Build C++ JNI lib dl-ing perf tools and copy it to production folder.">
     <exec dir='.' executable='python' failonerror='true'>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} ${compiler} profile" />
+        <arg line="build.py ${build} ${compiler} sanitize=${sanitize} profile" />
     </exec>
 </target>
 
@@ -1591,7 +1591,7 @@ NATIVE EE STUFF
         description="Create test program that loads catalog and tables and executes a plan fragment.">
     <exec dir='.' executable='python' failonerror='true'>
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py EXECPLANFRAG ${build} ${compiler}" />
+        <arg line="build.py EXECPLANFRAG ${build} ${compiler} sanitize=${sanitize}" />
     </exec>
 </target>
 
@@ -2071,7 +2071,7 @@ TEST CASES
   <!-- Whether any work needs doing is left to the C++ makefile -->
   <exec dir='.' executable='python' failonerror='true'>
     <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-    <arg line="build.py ${build} ${compiler} coverage" />
+    <arg line="build.py ${build} ${compiler} sanitize=${sanitize} coverage" />
   </exec>
   <mkdir dir="${lcov.dir}" />
   <!-- Reset all counters -->
@@ -2133,7 +2133,7 @@ TEST CASES
     <exec dir='.' executable='python' failonerror='true'>
         <env key="TEST_DIR" value="${build.dir}-coverage/testobjects" />
         <env key="VOLT_LOG_LEVEL" value="${VOLT_LOG_LEVEL}"/>
-        <arg line="build.py ${build} ${compiler} test coverage" />
+        <arg line="build.py ${build} ${compiler} sanitize=${sanitize} test coverage" />
     </exec>
 </target>
 

--- a/buildtools.py
+++ b/buildtools.py
@@ -38,6 +38,7 @@ class BuildContext:
         self.MAJORVERSION = 0
         self.MINORVERSION = 0
         self.PATCHLEVEL   = 0
+        self.SANITIZE = ""
         for arg in [x.strip().upper() for x in args]:
             if arg in ["DEBUG", "RELEASE", "MEMCHECK", "MEMCHECK_NOFREELIST"]:
                 self.LEVEL = arg
@@ -50,6 +51,8 @@ class BuildContext:
             if arg in ["CLANG", "CLANG++"]:
                 self.CC = "clang"
                 self.CXX = "clang++"
+            if arg.startswith("SANITIZE"):
+                self.SANITIZE=(arg.lower().split("="))[1]
         # Exec build.local if available, a python script provided with this
         # BuildContext object as the update-able symbol BUILD.  These example
         # build.local lines force the use of clang instead of gcc/g++.

--- a/buildtools.py
+++ b/buildtools.py
@@ -47,6 +47,9 @@ class BuildContext:
                 self.COVERAGE = True
             if arg in ["PROFILE"]:
                 self.PROFILE = True
+            if arg in ["CLANG", "CLANG++"]:
+                self.CC = "clang"
+                self.CXX = "clang++"
         # Exec build.local if available, a python script provided with this
         # BuildContext object as the update-able symbol BUILD.  These example
         # build.local lines force the use of clang instead of gcc/g++.
@@ -55,7 +58,7 @@ class BuildContext:
         buildLocal = os.path.join(os.path.dirname(__file__), "build.local")
         if os.path.exists(buildLocal):
             execfile(buildLocal, dict(BUILD = self))
-        
+
     def compilerName(self):
         self.getCompilerVersion()
         if self.COMPILER_NAME:
@@ -138,7 +141,7 @@ def replaceSuffix(name, suffix):
         return name + suffix;
     else:
         return name[:pos] + suffix;
-    
+
 def outputNamesForSource(filename):
     relativepath = "/".join(filename.split("/")[2:])
     jni_objname = "objects/" + replaceSuffix(relativepath, ".o")
@@ -316,7 +319,7 @@ def buildMakefile(CTX):
         IPC_EXENAME = "prod/voltdbipc "
     makefile.write(".PHONY: test\n")
     makefile.write("test: %s%s\n" % (IPC_EXENAME, formatList((namesForTestCode(test)[0] for test in tests))))
-        
+
     makefile.write("objects/volt.a: objects/harness.o %s\n" % formatList(jni_objects))
     makefile.write("\t$(AR) $(ARFLAGS) $@ $?\n")
     harness_source = TEST_PREFIX + "/harness.cpp"
@@ -325,7 +328,7 @@ def buildMakefile(CTX):
     makefile.write("-include %s\n" % "objects/harness.d")
     makefile.write("\n")
     cleanobjs += ["objects/volt.a", "objects/harness.o", "objects/harness.d"]
-    
+
     makefile.write("########################################################################\n")
     makefile.write("#\n# %s\n#\n" % "Volt Files")
     makefile.write("########################################################################\n")
@@ -545,4 +548,3 @@ def runTests(CTX):
     print "==============================================================================="
 
     return failures
-

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -72,6 +72,15 @@ bool InsertExecutor::p_init(AbstractPlanNode* abstractNode,
 {
     VOLT_TRACE("init Insert Executor");
 
+    // static int cntr = 0;
+
+    // ++cntr;
+    // if (cntr % 5000 == 0) {
+    //     int* p = new int(32);
+    //     delete p;
+    //     printf("%d\n", ++(*p));
+    // }
+
     m_node = dynamic_cast<InsertPlanNode*>(abstractNode);
     assert(m_node);
     assert(m_node->getTargetTable());

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -204,7 +204,7 @@ SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeCrea
 
     jobject java_ee = env->NewGlobalRef(obj);
     if (java_ee == NULL) {
-        assert(!"Failed to allocate global reference to java EE.");
+        //assert(!"Failed to allocate global reference to java EE.");
         throw std::exception();
         return 0;
     }

--- a/third_party/cpp/jsoncpp/jsoncpp.cpp
+++ b/third_party/cpp/jsoncpp/jsoncpp.cpp
@@ -2492,7 +2492,7 @@ Value::asBool() const
    case uintValue:
       return value_.uint_ ? true : false;
    case realValue:
-      return value_.real_ ? true : false;
+      return (value_.real_ != 0.0) ? true : false;
    default:
       break;
    }

--- a/tools/asan_env
+++ b/tools/asan_env
@@ -1,0 +1,9 @@
+export LD_PRELOAD=/usr/lib/llvm-3.8/lib/clang/3.8.0/lib/linux/libclang_rt.asan-x86_64.so
+export ASAN_OPTIONS=suppressions=${VOLTDB_HOME}/tools/asan.supp:handle_segv=0
+export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-3.8/bin/llvm-symbolizer
+
+echo
+echo LD_PRELOAD=${LD_PRELOAD}
+echo ASAN_OPTIONS=${ASAN_OPTIONS}
+echo ASAN_SYMBOLIZER_PATH=${ASAN_SYMBOLIZER_PATH}
+echo


### PR DESCRIPTION
This change makes it so you can select clang on the ant command line:
```bash
ant -Dbuild=release -Dcompiler=clang clean default
```