### PR TITLE
Eng 11957 fix hashmismatch backportv5.8

### DIFF
--- a/src/frontend/org/voltdb/LoadedProcedureSet.java
+++ b/src/frontend/org/voltdb/LoadedProcedureSet.java
@@ -291,7 +291,7 @@ public class LoadedProcedureSet {
         if (pr == null) {
             Procedure catProc = m_defaultProcManager.checkForDefaultProcedure(procName);
             if (catProc != null) {
-                String sqlText = m_defaultProcManager.sqlForDefaultProc(catProc);
+                String sqlText = DefaultProcedureManager.sqlForDefaultProc(catProc);
                 Procedure newCatProc = StatementCompiler.compileDefaultProcedure(m_plannerTool, catProc, sqlText);
                 VoltProcedure voltProc = new ProcedureRunner.StmtProcedure();
                 pr = new ProcedureRunner(null, voltProc, m_site, newCatProc, m_csp);

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3045,7 +3045,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
             sb.append("\n");
         }
 
-
         hostLog.error(sb.toString());
     }
 }

--- a/src/frontend/org/voltdb/messaging/DumpPlanThenExitMessage.java
+++ b/src/frontend/org/voltdb/messaging/DumpPlanThenExitMessage.java
@@ -1,0 +1,87 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2015 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.messaging;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.voltcore.messaging.VoltMessage;
+import org.voltcore.utils.CoreUtils;
+import org.voltdb.common.Constants;
+
+/**
+ * Message from an initiator to its replicas, instructing the
+ * site to dump the compile plan from specified stored procedure
+ * and default CRUD procedures. After dumping the plan, the site
+ * calls crashLocalVoltDB() to stop current node.
+ *
+ */
+public class DumpPlanThenExitMessage extends VoltMessage
+{
+    String m_procName;
+
+    /** Empty constructor for de-serialization */
+    public DumpPlanThenExitMessage() {
+        super();
+    }
+
+    public DumpPlanThenExitMessage(String procName)
+    {
+        super();
+        m_procName = procName;
+    }
+
+    public String getProcName() {
+        return m_procName;
+    }
+
+    @Override
+    public int getSerializedSize()
+    {
+        int msgsize = super.getSerializedSize();
+        msgsize += 4 /*string length */
+                + m_procName.length();
+        return msgsize;
+    }
+
+    @Override
+    public void flattenToBuffer(ByteBuffer buf) throws IOException
+    {
+        buf.put(VoltDbMessageFactory.DEBUG);
+        buf.putInt(m_procName.length());
+        buf.put(m_procName.getBytes(Constants.UTF8ENCODING));
+
+        assert(buf.capacity() == buf.position());
+        buf.limit(buf.position());
+    }
+
+    @Override
+    public void initFromBuffer(ByteBuffer buf) throws IOException {
+        FastDeserializer in = new FastDeserializer(buf);
+        m_procName = in.readString().intern();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("DEBUG " + m_procName + "(FROM ");
+        sb.append(CoreUtils.hsIdToString(m_sourceHSId));
+        return sb.toString();
+    }
+}

--- a/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
+++ b/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
@@ -46,6 +46,7 @@ public class VoltDbMessageFactory extends VoltMessageFactory
     final public static byte MP_REPLAY_ACK_ID = VOLTCORE_MESSAGE_ID_MAX + 20;
     final public static byte SNAPSHOT_CHECK_REQUEST_ID = VOLTCORE_MESSAGE_ID_MAX + 21;
     final public static byte SNAPSHOT_CHECK_RESPONSE_ID = VOLTCORE_MESSAGE_ID_MAX + 22;
+    final public static byte DEBUG = VOLTCORE_MESSAGE_ID_MAX + 23;
 
     /**
      * Overridden by subclasses to create message types unknown by voltcore
@@ -124,6 +125,9 @@ public class VoltDbMessageFactory extends VoltMessageFactory
             break;
         case SNAPSHOT_CHECK_RESPONSE_ID:
             message = new SnapshotCheckResponseMessage();
+            break;
+        case DEBUG:
+            message = new DumpPlanThenExitMessage();
             break;
         default:
             message = null;

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -88,6 +88,7 @@ import org.voltdb.catalog.Group;
 import org.voltdb.catalog.GroupRef;
 import org.voltdb.catalog.Index;
 import org.voltdb.catalog.PlanFragment;
+import org.voltdb.catalog.Procedure;
 import org.voltdb.catalog.SnapshotSchedule;
 import org.voltdb.catalog.Statement;
 import org.voltdb.catalog.Systemsettings;
@@ -123,6 +124,7 @@ import org.voltdb.export.ExportManager;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.importer.ImportDataProcessor;
 import org.voltdb.licensetool.LicenseApi;
+import org.voltdb.planner.ActivePlanRepository;
 import org.voltdb.planner.parseinfo.StmtTableScan;
 import org.voltdb.planner.parseinfo.StmtTargetTableScan;
 import org.voltdb.plannodes.AbstractPlanNode;
@@ -2293,5 +2295,28 @@ public abstract class CatalogUtil {
             }
         }
         return exprsjson.isEmpty();
+    }
+
+    /*
+     * Print procedure detail, such as statement text, frag id and json plan.
+     *
+     * @Param proc  Catalog procedure
+     */
+    public static String printProcedureDetail(Procedure proc) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Procedure:" + proc.getTypeName()).append("\n");
+        for (Statement stmt : proc.getStatements()) {
+            for (PlanFragment frag : stmt.getFragments()) {
+                byte[] planHash = Encoder.hexDecode(frag.getPlanhash());
+                long planId = ActivePlanRepository.getFragmentIdForPlanHash(planHash);
+                String stmtText = ActivePlanRepository.getStmtTextForPlanHash(planHash);
+                byte[] jsonPlan = ActivePlanRepository.planForFragmentId(planId);
+                sb.append("Plan Stmt Text:").append(stmtText);
+                sb.append(", Plan Fragment Id:").append(planId);
+                sb.append(", Json Plan:").append(new String(jsonPlan));
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
     }
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionAggregate.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionAggregate.java
@@ -31,6 +31,8 @@
 
 package org.hsqldb_voltpatches;
 
+import java.util.Objects;
+
 import org.hsqldb_voltpatches.lib.ArrayListIdentity;
 import org.hsqldb_voltpatches.lib.HsqlList;
 import org.hsqldb_voltpatches.store.ValuePool;
@@ -245,20 +247,24 @@ public class ExpressionAggregate extends Expression {
     }
 
     @Override
-    public boolean equals(Expression other) {
+    public int hashCode() {
+        return super.hashCode() * 31 + Objects.hashCode(isDistinctAggregate);
+    }
 
+    @Override
+    public boolean equals(Object other) {
         if (other == this) {
             return true;
         }
 
-        if (other == null) {
+        if (!super.equals(other)) {
             return false;
         }
-
-        return opType == other.opType && exprSubType == other.exprSubType
-               && isDistinctAggregate
-                  == ((ExpressionAggregate) other)
-                      .isDistinctAggregate && equals(nodes, other.nodes);
+        if (other instanceof ExpressionAggregate) {
+            return isDistinctAggregate ==
+                    ((ExpressionAggregate) other).isDistinctAggregate;
+        }
+        return false;
     }
 
     public Object updateAggregatingValue(Session session, Object currValue) {

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
@@ -31,6 +31,9 @@
 
 package org.hsqldb_voltpatches;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 import org.hsqldb_voltpatches.HsqlNameManager.HsqlName;
 import org.hsqldb_voltpatches.HsqlNameManager.SimpleName;
 import org.hsqldb_voltpatches.lib.ArrayListIdentity;
@@ -811,6 +814,33 @@ public class ExpressionColumn extends Expression {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        // A VoltDB extension
+        int val = Objects.hashCode(opType);
+        switch (opType) {
+        case OpTypes.SIMPLE_COLUMN :
+            return val + Objects.hashCode(columnIndex) ;
+
+        case OpTypes.COALESCE :
+            return val + Arrays.hashCode(nodes);
+
+        case OpTypes.COLUMN :
+            return val + Objects.hashCode(column);
+
+        case OpTypes.ASTERISK :
+            return val;
+
+        case OpTypes.DYNAMIC_PARAM :
+            return val + Objects.hashCode(parameterIndex);
+        // End of VoltDB extension
+
+        default :
+            return super.hashCode();
+    }
+    }
+
+    @Override
     public boolean equals(Expression other) {
 
         if (other == this) {
@@ -826,7 +856,6 @@ public class ExpressionColumn extends Expression {
         }
 
         switch (opType) {
-
             case OpTypes.SIMPLE_COLUMN :
                 return this.columnIndex == other.columnIndex;
 
@@ -835,12 +864,12 @@ public class ExpressionColumn extends Expression {
 
             case OpTypes.COLUMN :
                 return column == other.getColumn();
-
             // A VoltDB extension
             case OpTypes.ASTERISK :
                 return true;
+            case OpTypes.DYNAMIC_PARAM :
+                return parameterIndex == other.parameterIndex;
             // End of VoltDB extension
-
             default :
                 return false;
         }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLike.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLike.java
@@ -36,6 +36,8 @@ import org.hsqldb_voltpatches.lib.Set;
 import org.hsqldb_voltpatches.types.BinaryData;
 import org.hsqldb_voltpatches.types.Type;
 
+import java.util.Objects;
+
 /**
  * Implementation of LIKE operations
  *
@@ -423,5 +425,24 @@ public final class ExpressionLike extends ExpressionLogical {
         sb.append(likeObject.describe(session));
 
         return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!super.equals(other)) {
+            return false;
+        }
+
+        if (other instanceof ExpressionLike) {
+            if (noOptimisation == ((ExpressionLike)other).noOptimisation) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() + Objects.hashCode(noOptimisation);
     }
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionOrderBy.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionOrderBy.java
@@ -31,6 +31,8 @@
 
 package org.hsqldb_voltpatches;
 
+import java.util.Objects;
+
 /**
  * Implementation of ORDER BY operations
  *
@@ -132,4 +134,26 @@ public class ExpressionOrderBy extends Expression {
 
         return sb.toString();
     }
+
+    /************************* Volt DB Extensions *************************/
+    @Override
+    public boolean equals(Object other) {
+        if (!super.equals(other)) return false;
+        if (other instanceof ExpressionOrderBy == false) return false;
+
+        ExpressionOrderBy orderby = (ExpressionOrderBy) other;
+        if (orderby.isNullsLast() != isNullsLast()) return false;
+        if (orderby.isDescending() != isDescending()) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int val = super.hashCode();
+        val += Objects.hashCode(isDescending);
+        val += Objects.hashCode(isNullsLast);
+        return val;
+    }
+    /**********************************************************************/
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionCustom.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionCustom.java
@@ -33,6 +33,7 @@ package org.hsqldb_voltpatches;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Objects;
 
 import org.hsqldb_voltpatches.lib.IntKeyIntValueHashMap;
 import org.hsqldb_voltpatches.store.ValuePool;
@@ -1767,5 +1768,28 @@ public class FunctionCustom extends FunctionSQL {
 
     private static String DISABLED_IN_FUNCTIONCUSTOM_CONSTRUCTOR = "Custom Function";
     private static String DISABLED_IN_FUNCTIONCUSTOM_FACTORY_METHOD = "Custom Function Special Case";
+
+    public int getExtraSpace() {
+        return extractSpec;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!super.equals(other)) return false;
+        if (other instanceof FunctionCustom == false) return false;
+
+        FunctionCustom function = (FunctionCustom) other;
+        if (function.getExtraSpace() != extractSpec) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int val = super.hashCode();
+        val += Objects.hashCode(extractSpec);
+        return val;
+    }
+
     /**********************************************************************/
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
@@ -34,6 +34,7 @@ package org.hsqldb_voltpatches;
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.hsqldb_voltpatches.types.Type;
 
@@ -525,6 +526,28 @@ public class FunctionForVoltDB extends FunctionSQL {
         }
         sb.append(Tokens.T_CLOSEBRACKET);
         return sb.toString();
+    }
+
+    public FunctionId getFunctionId() {
+        return m_def;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!super.equals(other)) return false;
+        if (other instanceof FunctionForVoltDB == false) return false;
+
+        FunctionForVoltDB function = (FunctionForVoltDB) other;
+        if (function.getFunctionId().getId() != m_def.getId()) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int val = super.hashCode();
+        val += Objects.hashCode(m_def.getId());
+        return val;
     }
 
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQLInvoked.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQLInvoked.java
@@ -197,4 +197,9 @@ public class FunctionSQLInvoked extends Expression {
     public String describe(Session session) {
         return super.describe(session);
     }
+
+    /************************* Volt DB Extensions *************************/
+    // When we start to use it, we need to override equals and hashCode function
+
+    /**********************************************************************/
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Session.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Session.java
@@ -2039,13 +2039,18 @@ public class Session implements SessionInterface {
     }
 
     long nextExpressionNodeId = 1;
-    java.util.Map<Long, Long> hsqlExpressionNodeIdsToVoltNodeIds = new java.util.HashMap<Long, Long>();
+    java.util.Map<Expression, Long> hsqlExpressionNodeIdsToVoltNodeIds = new java.util.HashMap<Expression, Long>();
 
-    public long getNodeIdForExpression(long hsqlId) {
-        Long id = hsqlExpressionNodeIdsToVoltNodeIds.get(hsqlId);
+    public long getNodeIdForExpression(Expression expr) {
+        Long id = null;
+        // Add a special rule of not reusing node id for value type, to mimic existing HSQL behavior
+        if (expr.getType() == OpTypes.VALUE) {
+            return nextExpressionNodeId++;
+        }
+        id = hsqlExpressionNodeIdsToVoltNodeIds.get(expr);
         if (id == null) {
             id = nextExpressionNodeId++;
-            hsqlExpressionNodeIdsToVoltNodeIds.put(hsqlId, id);
+            hsqlExpressionNodeIdsToVoltNodeIds.put(expr, id);
         }
         return id;
     }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/SubQuery.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/SubQuery.java
@@ -277,4 +277,43 @@ class SubQuery implements ObjectComparator {
                                           : -1;
         }
     }
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + level;
+        result = prime * result + ((queryExpression == null) ? 0 : queryExpression.hashCode());
+        result = prime * result + ((database == null) ? 0 : database.hashCode());
+        result = prime * result + ((view == null) ? 0 : view.hashCode());
+        result = prime * result + (isExistsPredicate ? 1231 : 1237);
+        result = prime * result + (isUniquePredicate ? 1231 : 1237);
+        result = prime * result + (isDataExpression ? 1231 : 1237);
+        result = prime * result + (isCorrelated ? 1231 : 1237);
+        result = prime * result + (uniqueRows ? 1231 : 1237);
+        return result;
+    }
+
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null) {
+            return false;
+        }
+
+        if (other instanceof SubQuery) {
+            return ((SubQuery) other).level == level
+                   && ((SubQuery) other).queryExpression == queryExpression
+                   && ((SubQuery) other).database == database
+                   && ((SubQuery) other).view == view
+                   && ((SubQuery) other).isExistsPredicate == isExistsPredicate
+                   && ((SubQuery) other).isUniquePredicate == isUniquePredicate
+                   && ((SubQuery) other).isDataExpression == isDataExpression
+                   && ((SubQuery) other).isCorrelated == isCorrelated
+                   && ((SubQuery) other).uniqueRows == uniqueRows;
+        }
+
+        return false;
+    }
+
 }


### PR DESCRIPTION
When HSQLDB parse the sql expression, it uses a hash map to cache expression ids it has already computed. But it uses the hash code of object instead of the object itself as the key, which is not guaranteed to be unique for different instances. In some rare cases, this will cause hash key collision which let the SQL parser returns incorrect columns for values to be inserted into the table.