### PR TITLE
ENG-12450 fixed command line naming convention conflicts

### DIFF
--- a/src/frontend/org/voltdb/utils/CSVLoader.java
+++ b/src/frontend/org/voltdb/utils/CSVLoader.java
@@ -294,7 +294,7 @@ public class CSVLoader implements BulkLoaderErrorHandler {
 
         // add a charset flag as "c"
         @Option(shortOpt = "c", desc = "character set , default system character set")
-        String characterSet = "utf-8";
+        String charset = "utf-8";
 
         @Option(desc = "Disables the quote character. All characters between delimiters, including quote characters, are included in the input.",
                 hasArg = false)
@@ -423,7 +423,7 @@ public class CSVLoader implements BulkLoaderErrorHandler {
                 listReader = new CsvListReader(tokenizer, csvPreference);
             } else {
                 FileInputStream fis = new FileInputStream(config.file);
-                InputStreamReader isr = new InputStreamReader(fis, config.characterSet);
+                InputStreamReader isr = new InputStreamReader(fis, config.charset);
                 tokenizer = new Tokenizer(isr,
                           csvPreference,
                           config.strictquotes,

--- a/tests/frontend/org/voltdb/utils/TestCSVLoader.java
+++ b/tests/frontend/org/voltdb/utils/TestCSVLoader.java
@@ -1384,7 +1384,7 @@ public class TestCSVLoader {
 
         String []myOptions = {
                 "-f" + path_csv,
-                "--characterSet=utf8",
+                "--charset=utf8",
                 "--reportdir=" + reportDir,
                 "--maxerrors=50",
                 "--user=",
@@ -1458,7 +1458,7 @@ public class TestCSVLoader {
 
         String []myOptions = {
                 "-f" + path_csv,
-                "--characterSet=gbk",
+                "--charset=gbk",
                 "--reportdir=" + reportDir,
                 "--maxerrors=50",
                 "--user=",
@@ -1536,7 +1536,7 @@ public class TestCSVLoader {
 
         String []myOptions = {
                 "-f" + path_csv,
-                "--characterSet=gbk",    // use gbk to decode it
+                "--charset=gbk",    // use gbk to decode it
                 "--reportdir=" + reportDir,
                 "--maxerrors=50",
                 "--user=",
@@ -1614,7 +1614,7 @@ public class TestCSVLoader {
 
         String []myOptions = {
                 "-f" + path_csv,
-                "--characterSet=gbk",
+                "--charset=gbk",
                 "--reportdir=" + reportDir,
                 "--maxerrors=50",
                 "--user=",
@@ -1687,7 +1687,7 @@ public class TestCSVLoader {
 
         String []myOptions = {
                 "-f" + path_csv,
-                "--characterSet=gb2312",
+                "--charset=gb2312",
                 "--reportdir=" + reportDir,
                 "--maxerrors=50",
                 "--user=",


### PR DESCRIPTION
None of our command line arguments are mixed case, except the short names that can be a single uppercase character. Otherwise, the options are all lowercase. So I changed "--characterSet" to "--charset"