### PR TITLE
ENG-12663: Add authentication timeout to the Java client.

### DIFF
--- a/src/frontend/org/voltdb/client/ConnectionUtil.java
+++ b/src/frontend/org/voltdb/client/ConnectionUtil.java
@@ -186,7 +186,7 @@ public class ConnectionUtil {
         if (addr.isUnresolved()) {
             throw new java.net.UnknownHostException(addr.getHostName());
         }
-        SocketChannel aChannel = SocketChannel.open(addr);
+        final SocketChannel aChannel = SocketChannel.open(addr);
         returnArray[0] = aChannel;
         assert(aChannel.isConnected());
         if (!aChannel.isConnected()) {

--- a/src/frontend/org/voltdb/client/ConnectionUtil.java
+++ b/src/frontend/org/voltdb/client/ConnectionUtil.java
@@ -21,6 +21,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.SocketChannel;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -335,6 +336,10 @@ public class ConnectionUtil {
 
             aChannel.socket().setKeepAlive(true);
             success = true;
+        } catch (AsynchronousCloseException ignore) {
+            // If the authentication times out, the channel will be closed
+            // and this exception will be thrown from reads. Ignore it and
+            // let the finally block throw the proper timeout exception.
         } finally {
             if (timeoutFuture != null && !timeoutFuture.cancel(false)) {
                 // Failed to cancel, which means the timeout task must have run

--- a/src/frontend/org/voltdb/client/ConnectionUtil.java
+++ b/src/frontend/org/voltdb/client/ConnectionUtil.java
@@ -100,7 +100,7 @@ public class ConnectionUtil {
 
     // Thread pool for checking authentication timeout
     private static final ScheduledThreadPoolExecutor m_periodicWorkThread =
-        CoreUtils.getScheduledThreadPoolExecutor("Periodic Work", 0, CoreUtils.SMALL_STACK_SIZE);
+        CoreUtils.getScheduledThreadPoolExecutor("Authentication Timer", 0, CoreUtils.SMALL_STACK_SIZE);
 
     /**
      * Get a hashed password using SHA-1 in a consistent way.

--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -899,7 +899,8 @@ class Distributer {
     throws UnknownHostException, IOException
     {
         final Object socketChannelAndInstanceIdAndBuildString[] =
-            ConnectionUtil.getAuthenticatedConnection(host, program, hashedPassword, port, m_subject, scheme);
+            ConnectionUtil.getAuthenticatedConnection(host, program, hashedPassword, port, m_subject, scheme,
+                                                      TimeUnit.NANOSECONDS.toMillis(m_connectionResponseTimeoutNanos));
         final SocketChannel aChannel = (SocketChannel)socketChannelAndInstanceIdAndBuildString[0];
         final long instanceIdWhichIsTimestampAndLeaderIp[] = (long[])socketChannelAndInstanceIdAndBuildString[1];
         final int hostId = (int)instanceIdWhichIsTimestampAndLeaderIp[0];

--- a/tests/frontend/org/voltdb/client/TestDistributer.java
+++ b/tests/frontend/org/voltdb/client/TestDistributer.java
@@ -251,6 +251,12 @@ public class TestDistributer extends TestCase {
             } catch (IOException e) {
                 e.printStackTrace();
             }
+        }
+
+        public void shutdown() throws InterruptedException {
+            shutdown.set(true);
+            join();
+
             try {
                 network.shutdown();
             } catch (InterruptedException e) {
@@ -269,11 +275,6 @@ public class TestDistributer extends TestCase {
                     e.printStackTrace();
                 }
             }
-        }
-
-        public void shutdown() throws InterruptedException {
-            shutdown.set(true);
-            join();
         }
 
         private AtomicBoolean shutdown = new AtomicBoolean(false);

--- a/tests/frontend/org/voltdb/client/TestDistributer.java
+++ b/tests/frontend/org/voltdb/client/TestDistributer.java
@@ -354,6 +354,33 @@ public class TestDistributer extends TestCase {
     }
 
     @Test
+    public void testAuthenticationTimeout() throws Exception {
+        MockVolt volt0 = null;
+        try {
+            // create a fake server but don't start it.
+            // It will not read anything from the socket.
+            volt0 = new MockVolt(20000);
+
+            // Create a new distributor with a short connection timeout.
+            // Authentication should time out because the server is not
+            // reading anything.
+            Distributer dist = new Distributer(false,
+                                               ClientConfig.DEFAULT_PROCEDURE_TIMOUT_NANOS,
+                                               10,
+                                               false, false, null);
+            dist.createConnection("localhost", "", "", 20000, ClientAuthScheme.HASH_SHA1);
+
+            fail("Should have timed out");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("timed out"));
+        } finally {
+            if (volt0 != null) {
+                volt0.shutdown();
+            }
+        }
+    }
+
+    @Test
     public void testCreateConnectionSha256() throws Exception {
         MockVolt volt0 = null;
         MockVolt volt1 = null;
@@ -887,7 +914,7 @@ public class TestDistributer extends TestCase {
         final String hostname = "doesnotexist";
         boolean threwException = false;
         try {
-            ConnectionUtil.getAuthenticatedConnection(hostname, "", new byte[0], 32, null, ClientAuthScheme.HASH_SHA1);
+            ConnectionUtil.getAuthenticatedConnection(hostname, "", new byte[0], 32, null, ClientAuthScheme.HASH_SHA1, 0);
         } catch (java.net.UnknownHostException e) {
             threwException = true;
             assertTrue(e.getMessage().equals(hostname));

--- a/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
@@ -348,7 +348,7 @@ public class RegressionSuite extends TestCase {
         }
         final SocketChannel channel = (SocketChannel)
             ConnectionUtil.getAuthenticatedConnection(
-                    hNp.getHostText(), m_username, hashedPassword, port, null, ClientAuthScheme.getByUnencodedLength(hashedPassword.length))[0];
+                    hNp.getHostText(), m_username, hashedPassword, port, null, ClientAuthScheme.getByUnencodedLength(hashedPassword.length), 0)[0];
         channel.configureBlocking(true);
         if (!noTearDown) {
             synchronized (m_clientChannels) {


### PR DESCRIPTION
Time out authentication on the client side if it takes longer than the
connection timeout setting in case the server dies or the connection is broken
during the authentication process. It is governed by the same connection timeout
setting specified in the ClientConfig.

If authentication times out, it throws an IOException.