### PR TITLE
ENG-12683, fix some SQL junit tests failures introduced by ENG-11957.

### DIFF
--- a/tests/frontend/org/voltdb/AdHocQueryTester.java
+++ b/tests/frontend/org/voltdb/AdHocQueryTester.java
@@ -85,8 +85,15 @@ public abstract class AdHocQueryTester extends JUnit4LocalClusterTest {
                 "create view V_REPPED1 (REPPEDVAL, num_rows, sum_bigint) as " +
                 "select REPPEDVAL, count(*), sum(NONPART) from REPPED1 group by REPPEDVAL;" +
 
-                "create table long_query_table (id INTEGER NOT NULL, NAME VARCHAR(16));" +
                 "";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("create table long_query_table (id INTEGER NOT NULL, ");
+        for (int i = 1; i < 1022; i++) {
+            sb.append("id" + i + " INTEGER NOT NULL, ");
+        }
+        sb.append("NAME VARCHAR(16));");
+        schema += sb.toString();
 
         builder.addLiteralSchema(schema);
         builder.addPartitionInfo("PARTED1", "PARTVAL");
@@ -272,8 +279,14 @@ public abstract class AdHocQueryTester extends JUnit4LocalClusterTest {
         StringBuilder string = new StringBuilder("SELECT count(*) FROM long_query_table ");
         if (numberOfPredicates > 0) {
             string.append("WHERE ID = 123 ");
-            for (int i = 1; i < numberOfPredicates; i++) {
-                string.append("AND ID > 100 ");
+            int columnNum = Math.min(1022, numberOfPredicates);
+            for (int i = 1; i < columnNum; i++) {
+                string.append("AND ID" + i + " > 100 ");
+            }
+            if (columnNum < numberOfPredicates) {
+                for (int i = numberOfPredicates - columnNum; i < numberOfPredicates; i++) {
+                    string.append("AND ID > 100 ");
+                }
             }
         }
         string.append(";");

--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -614,10 +614,9 @@ public class TestAdHocQueries extends AdHocQueryTester {
         m_client = ClientFactory.createClient();
         m_client.createConnection("localhost", config.m_port);
 
-        String sql = getQueryForLongQueryTable(2000);
+        String sql = getQueryForLongQueryTable(200000);
         try {
             m_client.callProcedure("@AdHoc", sql);
-            fail("Query was expected to generate stack overflow error");
         }
         catch (Exception exception) {
             System.out.println(exception.getMessage());
@@ -627,6 +626,7 @@ public class TestAdHocQueries extends AdHocQueryTester {
             boolean foundMsg = exception.getMessage().contains(expectedMsg);
             assertTrue("Expected text \"" + expectedMsg + "\" did not appear in exception "
                     + "\"" + exception.getMessage() + "\"", foundMsg);
+            fail("Unexpected stack overflow error");
         }
         finally {
             if (m_client != null) {

--- a/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
@@ -82,11 +82,11 @@ public class TestAdHocPlans extends AdHocQueryTester {
         sql = getQueryForLongQueryTable(2000);
         try {
             runQueryTest(sql, 1, 1, 1, VALIDATING_SP_RESULT);
-            fail("Query was expected to generate stack over flow error");
         }
         catch (StackOverflowError error) {
+            fail("Unexpected stack over flow error");
             // The test-only interface to the PlannerTool tests at a level below
-            // any StackOverflowError handling, so expect the raw StackOverflowError.
+            // any StackOverflowError handling.
         }
     }
 


### PR DESCRIPTION
I believe the expected StackOverflow will no longer happen because of ENG-11957, which same column-ref will be reused in the JSON plan. This patch will change these tests to be positive test.

But I don't know why TestMultipleOuterJoinPlans.testOuterSimplificationJoin() fails. This patch doesn't fix that.