### PR TITLE
Fix up some junit test failures.

### DIFF
--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -614,9 +614,11 @@ public class TestAdHocQueries extends AdHocQueryTester {
         m_client = ClientFactory.createClient();
         m_client.createConnection("localhost", config.m_port);
 
-        String sql = getQueryForLongQueryTable(2000);
         try {
-            m_client.callProcedure("@AdHoc", sql);
+            for (int len = 2000; len < 100000; len += 1000) {
+                String sql = getQueryForLongQueryTable(len);
+                m_client.callProcedure("@AdHoc", sql);
+            }
             fail("Query was expected to generate stack overflow error");
         }
         catch (Exception exception) {

--- a/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
@@ -79,9 +79,11 @@ public class TestAdHocPlans extends AdHocQueryTester {
         runQueryTest(sql, 1, 1, 1, VALIDATING_SP_RESULT);
 
         // generate query with lots of predicate to simulate stack overflow when parsing the expression
-        sql = getQueryForLongQueryTable(2000);
         try {
-            runQueryTest(sql, 1, 1, 1, VALIDATING_SP_RESULT);
+            for (int numberPredicates = 2000; numberPredicates < 100000; numberPredicates += 1000) {
+                sql = getQueryForLongQueryTable(numberPredicates);
+                runQueryTest(sql, 1, 1, 1, VALIDATING_SP_RESULT);
+            }
             fail("Query was expected to generate stack over flow error");
         }
         catch (StackOverflowError error) {

--- a/tests/frontend/org/voltdb/planner/TestMultipleOuterJoinPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestMultipleOuterJoinPlans.java
@@ -263,7 +263,7 @@ public class TestMultipleOuterJoinPlans  extends PlannerTestCase {
         n = n.getChild(1);
         // HSQL doubles the join expression for the first join. Once it's corrected the join expression type
         // should be ExpressionType.COMPARE_EQUAL
-        verifyJoinNode(n, PlanNodeType.NESTLOOP, JoinType.INNER, null, ExpressionType.CONJUNCTION_AND, null, PlanNodeType.SEQSCAN, PlanNodeType.SEQSCAN);
+        verifyJoinNode(n, PlanNodeType.NESTLOOP, JoinType.INNER, null, ExpressionType.COMPARE_EQUAL, null, PlanNodeType.SEQSCAN, PlanNodeType.SEQSCAN);
 
         // The R4 FULL join is an outer node in the R5 FULL join and can not be simplified by the R1.A = R5.A ON expression
         // R1 RIGHT JOIN R2 ON R1.A = R2.A                  R1 JOIN R3 ON R1.A = R3.A


### PR DESCRIPTION
There are two categories of errors.  The first is TestAdHocPlans,
TestAdHocQueries and TestProcCompiler.  In each of these cases we make
progressively larger SQL strings, with more complicated expressions
until we make one that's big enough that it breaks the parser.  We then
declare victory.  The second class is TestMultipleOuterJoinPlans.  It
seems that the hash collision problem fixed in voltdb commit
4a7020630c047eb5a16c1005f61a99e6aab83ba7 caused an expression to be
hashed differently, which caused an expression to be corrected.

https://issues.voltdb.com/browse/ENG-12683