### PR TITLE
ENG-12697: reset the AdHoc planner cache after UpdateClasses

### DIFF
--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -103,6 +103,7 @@ public class PlannerTool {
     public PlannerTool updateWhenNoSchemaChange(Database database, byte[] catalogHash) {
         m_database = database;
         m_catalogHash = catalogHash;
+        m_cache = AdHocCompilerCache.getCacheForCatalogHash(catalogHash);
 
         return this;
     }

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/TestProcWithSQLStmt.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/TestProcWithSQLStmt.java
@@ -1,0 +1,40 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb_testprocs.updateclasses;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+
+public class TestProcWithSQLStmt extends VoltProcedure {
+
+    public final SQLStmt Q1 = new SQLStmt("select a + ? from t1 order by 1");
+    public final SQLStmt Q2 = new SQLStmt("insert into t1 values(?, ?);");
+
+    public long run(long param0)
+    {
+        voltQueueSQL(Q1, param0);
+        voltExecuteSQL();
+        return 1;
+    }
+}


### PR DESCRIPTION
One of the UpdateClasses optimizations skips HSQLDB compiler reconstruction and also reuse the AdHoc planner cache underneath.

If there is any following AdHoc queries that hit the old AdHoc Planner thread, the cached AdHoc query plan that contains the catalog hash will not match the most recent catalog hash. Thus, the AdHoc query planner thread will keep replanning the work and not return to the client.

Impact:
If this is the case, any following AdHoc queries, DDL changes, deployment changes on the same node will not be executed. Queries issued on the other node can be executed successfully.
Workaround:
Node rejoin and fix the issue, but this is not a good solution.

Fixes:
1. Any non-schema changes that reuse the Hsqldb compiler should clear the AdHoc queries cache.
or
2. Update the cached plan with the most recent catalog hash, which can still reuse the plan.

Reasons for regression:
1. Not fully understand the impact of reusing Hsqldb compiler.
2. Testing hole related to UpdateClasses.