### PR TITLE
ENG-12573:

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2857,8 +2857,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_clusterSettings.get().store();
         } else if (m_myHostId == 0) {
             if (hostLog.isDebugEnabled()) {
-                hostLog.debug("Storing with hostcount: " +
-                               m_clusterSettings.get().getProperty(ClusterSettings.HOST_COUNT));
+                hostLog.debug("Writing initial hostcount " +
+                               m_clusterSettings.get().getProperty(ClusterSettings.HOST_COUNT) +
+                               " to ZK");
             }
             m_clusterSettings.store(m_messenger.getZK());
         }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2856,6 +2856,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_clusterSettings.load(m_messenger.getZK());
             m_clusterSettings.get().store();
         } else if (m_myHostId == 0) {
+            if (hostLog.isDebugEnabled()) {
+                hostLog.debug("Storing with hostcount: " +
+                               m_clusterSettings.get().getProperty(ClusterSettings.HOST_COUNT));
+            }
             m_clusterSettings.store(m_messenger.getZK());
         }
         m_clusterCreateTime = m_messenger.getInstanceId().getTimestamp();

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -156,14 +156,14 @@ public class VoltZK {
             callbacks.add(cb);
             zk.create(VoltZK.ZK_HIERARCHY[i], null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT, cb, null);
         }
-        try {
-            for (ZKUtil.StringCallback cb : callbacks) {
+        for (ZKUtil.StringCallback cb : callbacks) {
+            try {
                 cb.get();
+            } catch (org.apache.zookeeper_voltpatches.KeeperException.NodeExistsException e) {
+                // this is an expected race.
+            } catch (Exception e) {
+                VoltDB.crashLocalVoltDB(e.getMessage(), true, e);
             }
-        } catch (org.apache.zookeeper_voltpatches.KeeperException.NodeExistsException e) {
-            // this is an expected race.
-        } catch (Exception e) {
-            VoltDB.crashLocalVoltDB(e.getMessage(), true, e);
         }
     }
 

--- a/src/frontend/org/voltdb/settings/ClusterSettingsRef.java
+++ b/src/frontend/org/voltdb/settings/ClusterSettingsRef.java
@@ -55,6 +55,10 @@ public class ClusterSettingsRef extends AtomicStampedReference<ClusterSettings>
         } catch (KeeperException|InterruptedException e) {
             throw new SettingsException("Failed to initialize from ZooKeeper", e);
         }
+
+        if (bytes==null) {
+            throw new SettingsException("Failed to initialize cluster settings from ZooKeeper");
+        }
         set(ClusterSettings.create(bytes), stat.getVersion());
         return stat.getVersion();
     }


### PR DESCRIPTION
- Added debug log when cluster settings is stored in ZK.
- Fixed create persistent node method so that it doesn't exit prematurely on NodeExists exception.
- If cluster settings loaded from ZK is null, throw a better error message instead of NPE.