### PR TITLE
ENG-11657 do not resume replication for DR consumer if durability is off

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -353,7 +353,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
      */
     String m_terminusNonce = null;
 
-//  m_durable means commandlogging is enabled.
+    // m_durable means commandlogging is enabled.
     boolean m_durable = false;
 
     private int m_maxThreadsCount;


### PR DESCRIPTION
If you use the new CLI without command logging, the database will pick the recover start action internally when you "start" after the first time even though there is nothing to recover from. This tricks the DR system into thinking that it can resume replication. It eventually fails of course, but it may confuse the remote cluster and generate confusing error messages.

Now before resuming replication, we check if durability is turned on and if there is a completed snapshot. If durability is off or no snapshot is found, we start fresh.