### PR TITLE
ENG-12677: Fix race condition between BulkLoader accounting and callback

### DIFF
--- a/src/frontend/org/voltdb/client/VoltBulkLoader/PerPartitionTable.java
+++ b/src/frontend/org/voltdb/client/VoltBulkLoader/PerPartitionTable.java
@@ -207,13 +207,13 @@ public class PerPartitionTable {
             ProcedureCallback callback = new ProcedureCallback() {
                 @Override
                 public void clientCallback(ClientResponse response) throws Exception {
-                    row.m_loader.m_loaderCompletedCnt.incrementAndGet();
-                    row.m_loader.m_outstandingRowCount.decrementAndGet();
-
                     //one insert at a time callback
                     if (response.getStatus() != ClientResponse.SUCCESS) {
                         row.m_loader.m_notificationCallBack.failureCallback(row.m_rowHandle, row.m_rowData, response);
                     }
+
+                    row.m_loader.m_loaderCompletedCnt.incrementAndGet();
+                    row.m_loader.m_outstandingRowCount.decrementAndGet();
                 }
             };
 


### PR DESCRIPTION
BulkLoader keeps track of the outstanding row count and uses it in the drain()
method to make sure everything is processed. Users can also use the counter
directly to track how many rows are in-flight.

If a row fails to be inserted, it will be retried automatically. If the retry
fails, too, a user-specified callback will be invoked to notify the user of the
failed row.

However, the callback is invoked after the outstanding row count has already
been decremented. In other words, a user watching the outstanding row count
could see it go to zero, meaning all rows are processed, but not see the failure
callback to be invoked even if there are failed rows. When the callback will be
invoked depends on thread scheduling, which is nondeterministic.

The outstanding row count is now updated AFTER the failure callback has been
invoked.