### PR TITLE
Fixing testJsonAuth test failure. When password is getting updated by…

### DIFF
--- a/tests/frontend/org/voltdb/TestJSONInterface.java
+++ b/tests/frontend/org/voltdb/TestJSONInterface.java
@@ -359,7 +359,9 @@ public class TestJSONInterface extends TestCase {
         varString = getHTTPVarString(params);
 
         String ret = callProcOverJSONRaw(varString, expectedCode);
-        if (preHash) {
+        // Update application catalog sometimes changes the password.
+        // The second procedure call will fail in that case, so don't call it a second time.
+        if (preHash && !procName.equals("@UpdateApplicationCatalog")) {
             //If prehash make same call with SHA1 to check expected code.
             params.put("Hashedpassword", getHashedPasswordForHTTPVar(password, ClientAuthScheme.HASH_SHA1));
             varString = getHTTPVarString(params);


### PR DESCRIPTION
… UAC call,

don't make the same client twice with the first password because the password is updated
by the first call and second call will fail.