### PR TITLE
ENG-12034 When an error is seen distributing channel assignments, reacquire the channels before resending the assignments.

### DIFF
--- a/src/frontend/org/voltdb/importclient/socket/PullSocketImporterConfig.java
+++ b/src/frontend/org/voltdb/importclient/socket/PullSocketImporterConfig.java
@@ -69,7 +69,7 @@ public class PullSocketImporterConfig implements ImporterConfig
     {
         String hosts = props.getProperty("addresses", "").trim();
         if (hosts.isEmpty()) {
-            throw new IllegalArgumentException("'adresses' is a required property and must be defined");
+            throw new IllegalArgumentException("'addresses' is a required property and must be defined");
         }
         String procedure = props.getProperty("procedure", "").trim();
         if (procedure.isEmpty()) {

--- a/src/frontend/org/voltdb/importer/ChannelDistributer.java
+++ b/src/frontend/org/voltdb/importer/ChannelDistributer.java
@@ -722,7 +722,7 @@ public class ChannelDistributer implements ChannelChangeCallback {
                                 + ") Retrying channel assignment because write attempt to "
                                 + setter.path + " failed with " + setter.getCallbackCode()
                                );
-                        m_es.submit(new AssignChannels(seed));
+                        m_es.submit(new GetChannels(MASTER_DN));
                         return;
                     }
                 }

--- a/src/frontend/org/voltdb/importer/ChannelDistributer.java
+++ b/src/frontend/org/voltdb/importer/ChannelDistributer.java
@@ -641,16 +641,13 @@ public class ChannelDistributer implements ChannelChangeCallback {
         final NavigableMap<String,AtomicInteger> hosts = m_hosts.getReference();
 
         final int seed;
-        final boolean firstTime;
 
         AssignChannels(final int seed) {
             this.seed = seed;
-            firstTime = false;
         }
 
         AssignChannels() {
             seed = System.identityHashCode(this);
-            firstTime = true;
         }
 
         @Override
@@ -718,19 +715,17 @@ public class ChannelDistributer implements ChannelChangeCallback {
                     }
                 }
                 // wait for the last write to complete
-                int setterCount = 0;
                 for (SetNodeChannels setter: setters) {
-                    if ((setterCount == 2 && firstTime) || (setter.getCallbackCode() != Code.OK && !m_done.get())) {
+                    if (setter.getCallbackCode() != Code.OK && !m_done.get()) {
                         LOG.warn(
                                 "LEADER (" + m_hostId
                                 + ") Retrying channel assignment because write attempt to "
                                 + setter.path + " failed with " + setter.getCallbackCode()
                                );
-                        m_es.submit(new GetChannels(MASTER_DN));
-// BSDBG                       m_es.submit(new AssignChannels(seed));
+// BSDBG                        m_es.submit(new GetChannels(MASTER_DN));
+                        m_es.submit(new AssignChannels(seed));
                         return;
                     }
-                    setterCount++;
                 }
             } catch (JSONException|IllegalArgumentException e) {
                 LOG.fatal("unable to create json document to assign imported channels to nodes", e);

--- a/src/frontend/org/voltdb/importer/ImportManager.java
+++ b/src/frontend/org/voltdb/importer/ImportManager.java
@@ -268,8 +268,9 @@ public class ImportManager implements ChannelChangeCallback {
 }
 
     public static int getPartitionsCount() {
-        if (m_self.m_processor.get() != null) {
-            return m_self.m_processor.get().getPartitionsCount();
+        ImportDataProcessor processor = m_self.m_processor.get();
+        if (processor != null) {
+            return processor.getPartitionsCount();
         }
         return 0;
     }

--- a/src/frontend/org/voltdb/importer/ImporterLifeCycleManager.java
+++ b/src/frontend/org/voltdb/importer/ImporterLifeCycleManager.java
@@ -214,7 +214,7 @@ public class ImporterLifeCycleManager implements ChannelChangeCallback
         }
     }
 
-    private final static Predicate<URI> notUriIn(final Set<URI> uris) {
+    final static Predicate<URI> notUriIn(final Set<URI> uris) {
         return new Predicate<URI>() {
             @Override
             final public boolean apply(URI uri) {

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -72,6 +72,7 @@ import org.json_voltpatches.JSONException;
 import org.mindrot.BCrypt;
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
+import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
 import org.voltdb.HealthMonitor;
 import org.voltdb.SystemProcedureCatalog;
@@ -1355,8 +1356,15 @@ public abstract class CatalogUtil {
                 String bundlelocation = System.getProperty(VOLTDB_BUNDLE_LOCATION_PROPERTY_NAME);
                 if (bundlelocation == null || bundlelocation.trim().length() == 0) {
                     String rpath = CatalogUtil.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
-                    hostLog.info("Module base is: " + rpath + "/../bundles/");
-                    String bpath = (new File(rpath)).getParent() + "/../bundles/" + bundleUrl;
+                    if (CoreUtils.isJunitTest()) {
+                        assert rpath.endsWith("obj/release/prod/");
+                        rpath = rpath.substring(0, rpath.indexOf("/release/prod/"));
+                        bundlelocation = (new File(rpath)).getParent() + "/bundles/";
+                    } else {
+                        bundlelocation = (new File(rpath)).getParent() + "/../bundles/";
+                    }
+                    hostLog.info("Module base is: " + bundlelocation);
+                    String bpath = bundlelocation + bundleUrl;
                     is = new FileInputStream(new File(bpath));
                     bundleUrl = "file:" + bpath;
                 } else {

--- a/tests/frontend/org/voltdb/importer/TestChannelDistributer.java
+++ b/tests/frontend/org/voltdb/importer/TestChannelDistributer.java
@@ -113,7 +113,7 @@ public class TestChannelDistributer extends ZKTestBase {
             received += assignment.getRemoved().size();
             sbldr.addAll(assignment.getRemoved());
         }
-        //assertEquals("failed to poll the expected number of removed", expected, received);
+        assertEquals("failed to poll the expected number of removed", expected, received);
         assertTrue(queue.isEmpty());
         return sbldr.build();
     }
@@ -126,7 +126,7 @@ public class TestChannelDistributer extends ZKTestBase {
             received += assignment.getAdded().size();
             sbldr.addAll(assignment.getAdded());
         }
-        //assertEquals("failed to poll the expected number of removed", expected, received);
+        assertEquals("failed to poll the expected number of removed", expected, received);
         assertTrue(queue.isEmpty());
         return sbldr.build();
     }
@@ -158,7 +158,7 @@ public class TestChannelDistributer extends ZKTestBase {
         distributers.get(UNO).registerChannels(YO, uris);
         Set<URI> actual = getAdded(9);
 
-//        assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         Set<URI> pruned = generateURIs(6);
         expected = Sets.difference(uris, pruned);
@@ -166,7 +166,7 @@ public class TestChannelDistributer extends ZKTestBase {
         distributers.get(DUE).registerChannels(YO, pruned);
         actual = getRemoved(3);
 
-//        assertEquals(expected, actual);
+        assertEquals(expected, actual);
         // register the same
         distributers.get(ZERO).registerChannels(YO, pruned);
         assertNull(queue.poll(200, TimeUnit.MILLISECONDS));
@@ -177,14 +177,14 @@ public class TestChannelDistributer extends ZKTestBase {
         distributers.get(UNO).registerChannels(YO, uris);
         actual = getAdded(2);
 
-//        assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         expected = uris;
         // remove all
         distributers.get(UNO).registerChannels(YO, ImmutableSet.<URI>of());
         actual = getRemoved(8);
 
-//        assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         int leaderCount = 0;
         for (ChannelDistributer distributer: distributers.values()) {
@@ -203,13 +203,13 @@ public class TestChannelDistributer extends ZKTestBase {
         distributers.get(UNO).registerChannels(YO, uris);
         Set<URI> actual = getAdded(9);
 
-//        assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         // let's wait for the mesh to settle
-        int attempts = 4000;
+        int attempts = 4;
         boolean settled = false;
         while (!settled && --attempts >=0) {
-            Thread.sleep(150);
+            Thread.sleep(50);
             settled = true;
             int stamp = distributers.get(ZERO).m_specs.getStamp();
             for (ChannelDistributer distributer: distributers.values()) {
@@ -222,15 +222,12 @@ public class TestChannelDistributer extends ZKTestBase {
                 distributers.get(DUE).m_specs.getReference(),
                 equalTo(ZERO))
                 .navigableKeySet();
-        //assertTrue(inZERO.size() > 0);
+        assertTrue(inZERO.size() > 0);
 
         zks.get(ZERO).close();
 
-        Thread.sleep(1000);
-        zks.get(UNO).close();
-
         actual = getAdded(inZERO.size());
-        //assertEquals(inZERO, asSpecs(actual));
+        assertEquals(inZERO, asSpecs(actual));
     }
 
     @After

--- a/tests/frontend/org/voltdb/regressionsuites/TestImporterWithMultipleNodeKill.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestImporterWithMultipleNodeKill.java
@@ -1,0 +1,110 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.regressionsuites;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.voltdb.BackendTarget;
+import org.voltdb.InvocationDispatcher;
+import org.voltdb.VoltDB;
+import org.voltdb.VoltTable;
+import org.voltdb.client.ArbitraryDurationProc;
+import org.voltdb.client.Client;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.client.ProcCallException;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.utils.CatalogUtil;
+import org.voltdb.utils.MiscUtils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileReader;
+import java.util.*;
+
+/**
+ * Created by bshaw on 7/7/17.
+ */
+public class TestImporterWithMultipleNodeKill {
+
+    private LocalCluster m_cluster = null;
+
+    @Before
+    public void setUp() throws Exception {
+        final int HOST_COUNT = 5;
+
+        String bundleLocation = System.getProperty("user.dir").split("obj", 2)[0] + "/bundles";
+        System.out.println(bundleLocation);
+        System.setProperty(CatalogUtil.VOLTDB_BUNDLE_LOCATION_PROPERTY_NAME, bundleLocation);
+        // Lightweight 5 node, K4 cluster to allow 2 nodes to be killed and rejoined
+        m_cluster = new LocalCluster(
+                "CREATE TABLE test ( val BIGINT NOT NULL );",
+                null,
+                1, HOST_COUNT, HOST_COUNT - 1, 0,
+                BackendTarget.NATIVE_EE_JNI,
+                LocalCluster.FailureState.ALL_RUNNING,
+                false, false, null);
+        m_cluster.setHasLocalServer(false);
+        m_cluster.overrideAnyRequestForValgrind();
+        VoltProjectBuilder project = new VoltProjectBuilder();
+        project.setUseDDLSchema(true);
+
+        // configure socket importer 1
+        for (int i = 0; i < 224; i++) {
+            String portStartString = Integer.toString(7001 + i * HOST_COUNT);
+            Properties props = RegressionSuite.buildProperties(
+                    "port", portStartString,
+                    "decode", "true",
+                    "procedure", "test.insert");
+            project.addImport(true, "custom", "csv", "socketstream.jar", props);
+        }
+
+        m_cluster.compileDeploymentOnly(project);
+        new File(project.getPathToDeployment()).deleteOnExit();
+        m_cluster.setExpectedToCrash(false);
+
+        m_cluster.startUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        m_cluster.shutDown();
+        System.clearProperty(CatalogUtil.VOLTDB_BUNDLE_LOCATION_PROPERTY_NAME);
+    }
+
+    @Test
+    public void testMultipleNodeKill() throws Exception {
+        int iters = 0;
+        final int numIters = 4;
+        do {
+            m_cluster.killSingleHost(3);
+            m_cluster.killSingleHost(4);
+            Thread.sleep(2000);
+            m_cluster.recoverOne(3, 0, "");
+            m_cluster.recoverOne(4, 0, "");
+            Thread.sleep(2000);
+        } while (++iters < numIters);
+    }
+}


### PR DESCRIPTION
This addresses a multiple node kill scenario where the Zookeeper data went stale midway through sending the assignments.

When the leader is distributing a new set of importer channel assignments, it will retry sending ALL assignments if ANY fail. This is fine if the first assignment fails, but in this scenario there is a race condition between the distribution of channel assignments and a mesh monitor responding to the node failure. In the original problem report, the leader has sent roughly 2/3 of the assignments out before Zookeeper throws a "bad version" error. When the entire re-send gets retried, the very first assignment gets flagged as a duplicate resulting in the reported error. The retry is aborted, meaning the remaining channel assignments don't get distributed.

Anyone who sees this in production should first be sure the cluster didn't initiate a global crash (if it did, all nodes will be gone soon and there are bigger issues). Then pause the cluster, verify the pause has completed (due to an unrelated issue), and then resume the cluster. This will restart the importers, refreshing their channel assignments. The data which was unable to import will remain in Kafka - data won't be loss unless Kafka deletes it.

The primary change is in ChannelDistributer. I also add some test logic in an attempt to make the issue more easily caught in JUnit, and I fix a rare unrelated NPE.

{TEST SCHEME STILL A WORK IN PROGRESS}