### PR TITLE
ENG-12772: fix the NPE during UpdateClasses

### DIFF
--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -1871,10 +1871,6 @@ public class VoltCompiler {
                 for (Statement prevStmt : prevProc.getStatements()) {
                     addStatementToCache(prevStmt);
                 }
-
-                // clear up the previous procedure contents
-                prevProc.getStatements().clear();
-                prevProc.getParameters().clear();
             }
 
             // Use the in-memory jarfile-provided class loader so that procedure
@@ -1893,6 +1889,10 @@ public class VoltCompiler {
                     // UpdateClasses does not need to update system procedures
                     continue;
                 }
+
+                // clear up the previous procedure contents before recompiling java user procedures
+                procedure.getStatements().clear();
+                procedure.getParameters().clear();
 
                 final String className = procedure.getClassname();
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestUpdateClasses.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUpdateClasses.java
@@ -834,6 +834,9 @@ public class TestUpdateClasses extends AdhocDDLTestBase {
                 fail("@UpdateClasses should not fail with message: " + pce.getMessage());
             }
 
+            resp = m_client.callProcedure("proc1", 3);
+            assertEquals(ClientResponse.SUCCESS, resp.getStatus());
+
             // create procedure
             resp = m_client.callProcedure("@AdHoc", "CREATE PROCEDURE FROM CLASS org.voltdb_testprocs.updateclasses.testImportProc;");
             assertEquals(ClientResponse.SUCCESS, resp.getStatus());


### PR DESCRIPTION
ENG-12772: UpdateClasses skip recompiling single-statement procedure and system procedures. Unfortunately, we clear their statements and parameters members too early.

We do have test case covering the single-statement procedure case, but the NPE exception is thrown on server side and gets caught without fatal exception. So the test case is passed even with this NPE. In this pull, we will call the single-statement procedure again after UpdateClasses and verify its procedure status to make sure everything looks OK.

This NPE bug is introduced by ENG-12027 with commit: 7c155ab93036e62e13e61516d6f5835d4dfe64cb