### PR TITLE
ENG-12779 Queue depth

### DIFF
--- a/src/frontend/org/voltdb/QueueDepthTracker.java
+++ b/src/frontend/org/voltdb/QueueDepthTracker.java
@@ -111,7 +111,7 @@ public class QueueDepthTracker extends SiteStatsSource {
         super.populateColumnSchema(columns);
         columns.add(new ColumnInfo("CURRENT_DEPTH", VoltType.INTEGER));
         columns.add(new ColumnInfo("POLL_COUNT", VoltType.BIGINT));
-        columns.add(new ColumnInfo("MEAN_WAIT", VoltType.BIGINT));
+        columns.add(new ColumnInfo("AVG_WAIT", VoltType.BIGINT));
         columns.add(new ColumnInfo("MAX_WAIT", VoltType.BIGINT));
     }
 
@@ -143,8 +143,8 @@ public class QueueDepthTracker extends SiteStatsSource {
         }
         rowValues[columnNameToIndex.get("CURRENT_DEPTH")] = m_depth;
         rowValues[columnNameToIndex.get("POLL_COUNT")] = totalPollCountInWindow;
-        rowValues[columnNameToIndex.get("MEAN_WAIT")] = totalWaitTimeInWindow / Math.max(1, totalPollCountInWindow) / 1000;
-        rowValues[columnNameToIndex.get("MAX_WAIT")] = maxWaitTimeInWindow / 1000;
+        rowValues[columnNameToIndex.get("AVG_WAIT")] = totalWaitTimeInWindow / Math.max(1, totalPollCountInWindow);
+        rowValues[columnNameToIndex.get("MAX_WAIT")] = maxWaitTimeInWindow;
 
         super.updateStatsRow(rowKey, rowValues);
     }
@@ -175,4 +175,5 @@ public class QueueDepthTracker extends SiteStatsSource {
 
         };
     }
+
 }

--- a/src/frontend/org/voltdb/QueueDepthTracker.java
+++ b/src/frontend/org/voltdb/QueueDepthTracker.java
@@ -1,0 +1,178 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.concurrent.LinkedTransferQueue;
+
+import org.voltdb.VoltTable.ColumnInfo;
+import org.voltdb.iv2.SiteTasker;
+
+/**
+ * A class to track and generate statistics regarding queue depth.
+ * Generate information on instantaneous queue depth and number of tasks
+ * pulled from queue, average wait time and max wait time within a 5-second window
+ */
+public class QueueDepthTracker extends SiteStatsSource {
+
+    public QueueDepthTracker(long siteId) {
+        super(siteId, false);
+        m_historicalData = new ArrayDeque<QueueStatus>();
+    }
+    private int m_depth;
+    private long m_lastWaitTime;
+    private Deque<QueueStatus> m_historicalData;
+    private LinkedTransferQueue<SiteTasker> m_tasks;
+    private long m_maxWaitTimeWindowSize = 5000000000L; // window size set to 5 seconds
+    private long m_maxWaitLastLogTime;
+    private long m_recentMaxWaitTime;
+    private long m_recentTotalWaitTime;
+    private long m_recentPollCount;
+    private long m_recentWindowSize = m_maxWaitTimeWindowSize / 500;
+
+    public class QueueStatus {
+        public long timestamp;
+        public long maxWait;
+        public long totalWait;
+        public long pollCount;
+
+        public QueueStatus(long timestamp, long max, long total, long count) {
+            this.timestamp = timestamp;
+            this.maxWait = max;
+            this.totalWait = total;
+            this.pollCount = count;
+        }
+    }
+
+    public synchronized void offerUpdate() {
+        m_depth++;
+    }
+
+    public synchronized void pollUpdate(long offerTime) {
+        m_depth--;
+        long currentTime = System.nanoTime();
+        m_lastWaitTime = currentTime - offerTime;
+        // if max wait time was last logged less than m_recentWindowSize ago
+        // keep the max wait time in m_recentMaxWaitTime
+        // or log and reset the recentMaxWaitTime, update last log time
+        if (currentTime - m_maxWaitLastLogTime < m_recentWindowSize) {
+            m_recentMaxWaitTime = Math.max(m_recentMaxWaitTime, m_lastWaitTime);
+            m_recentTotalWaitTime += m_lastWaitTime;
+            m_recentPollCount++;
+        } else {
+            m_historicalData.addLast(new QueueStatus(currentTime,
+                    m_recentMaxWaitTime,
+                    m_recentTotalWaitTime,
+                    m_recentPollCount));
+            m_recentMaxWaitTime = m_lastWaitTime;
+            m_recentTotalWaitTime = m_lastWaitTime;
+            m_recentPollCount = 1;
+            m_maxWaitLastLogTime = currentTime;
+            // remove out of date historical data
+            while (!m_historicalData.isEmpty() &&
+                    m_historicalData.peekFirst().timestamp <
+                    currentTime - m_maxWaitTimeWindowSize) {
+                m_historicalData.pollFirst();
+            }
+        }
+    }
+
+    public synchronized void beginQueueDepth(int depth, LinkedTransferQueue<SiteTasker> tasks) {
+
+        m_depth = depth;
+        m_lastWaitTime = 0;
+        m_maxWaitLastLogTime = System.nanoTime();
+        m_recentMaxWaitTime = 0;
+        m_recentTotalWaitTime = 0;
+        m_recentPollCount = 0;
+        m_tasks = tasks;
+    }
+
+
+    @Override
+    protected void populateColumnSchema(ArrayList<ColumnInfo> columns) {
+        super.populateColumnSchema(columns);
+        columns.add(new ColumnInfo("CURRENT_DEPTH", VoltType.INTEGER));
+        columns.add(new ColumnInfo("POLL_COUNT", VoltType.BIGINT));
+        columns.add(new ColumnInfo("MEAN_WAIT", VoltType.BIGINT));
+        columns.add(new ColumnInfo("MAX_WAIT", VoltType.BIGINT));
+    }
+
+    @Override
+    protected synchronized void updateStatsRow(Object rowKey, Object rowValues[]) {
+        long currentTime = System.nanoTime();
+        // check if current wait time exceeds the maxWaitTime
+        long currentWaitTime;
+        SiteTasker nextTask = m_tasks.peek();
+        if (nextTask == null) {
+            currentWaitTime = 0;
+        } else {
+            currentWaitTime = currentTime - nextTask.getTimestamp();
+        }
+        // check historicalMaxWaitTime, report max wait time and mean wait time in window
+        long maxWaitTimeInWindow = Math.max(currentWaitTime, m_recentMaxWaitTime);
+        long totalWaitTimeInWindow = 0;
+        long totalPollCountInWindow = 0;
+        if (!m_historicalData.isEmpty()) {
+            // iterate through all past max wait times
+            // only process those within the window
+            for (QueueStatus status : m_historicalData) {
+                if (status.timestamp >= currentTime - m_maxWaitTimeWindowSize) {
+                    maxWaitTimeInWindow = Math.max(maxWaitTimeInWindow, status.maxWait);
+                    totalWaitTimeInWindow += status.totalWait;
+                    totalPollCountInWindow += status.pollCount;
+                }
+            }
+        }
+        rowValues[columnNameToIndex.get("CURRENT_DEPTH")] = m_depth;
+        rowValues[columnNameToIndex.get("POLL_COUNT")] = totalPollCountInWindow;
+        rowValues[columnNameToIndex.get("MEAN_WAIT")] = totalWaitTimeInWindow / Math.max(1, totalPollCountInWindow) / 1000;
+        rowValues[columnNameToIndex.get("MAX_WAIT")] = maxWaitTimeInWindow / 1000;
+
+        super.updateStatsRow(rowKey, rowValues);
+    }
+
+    @Override
+    protected Iterator<Object> getStatsRowKeyIterator(final boolean interval) {
+        return new Iterator<Object>() {
+            boolean returnRow = true;
+            @Override
+            public boolean hasNext() {
+                return returnRow;
+            }
+
+            @Override
+            public Object next() {
+                if (returnRow) {
+                    returnRow = false;
+                    return new Object();
+                } else {
+                    return null;
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+
+        };
+    }
+}

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -526,6 +526,9 @@ public class StatsAgent extends OpsAgent
         case STARVATION:
             stats = collectStats(StatsSelector.STARVATION, interval);
             break;
+        case QUEUEDEPTH:
+            stats = collectStats(StatsSelector.QUEUEDEPTH, interval);
+            break;
         case PLANNER:
             stats = collectStats(StatsSelector.PLANNER, interval);
             break;
@@ -627,17 +630,18 @@ public class StatsAgent extends OpsAgent
         VoltTable[] tStats = collectStats(StatsSelector.TABLE, interval);
         VoltTable[] indStats = collectStats(StatsSelector.INDEX, interval);
         VoltTable[] sStats = collectStats(StatsSelector.STARVATION, interval);
+        VoltTable[] qStats = collectStats(StatsSelector.QUEUEDEPTH, interval);
         VoltTable[] cStats = collectStats(StatsSelector.CPU, interval);
         // Ugh, this is ugly.  Currently need to return null if
         // we're missing any of the tables so that we
         // don't screw up the aggregation in handleStatsResponse (see my rant there)
         if (mStats == null || iStats == null || pStats == null ||
                 ioStats == null || tStats == null || indStats == null ||
-                sStats == null || cStats == null)
+                sStats == null || qStats == null || cStats == null)
         {
             return null;
         }
-        VoltTable[] stats = new VoltTable[8];
+        VoltTable[] stats = new VoltTable[9];
         stats[0] = mStats[0];
         stats[1] = iStats[0];
         stats[2] = pStats[0];
@@ -646,6 +650,7 @@ public class StatsAgent extends OpsAgent
         stats[5] = indStats[0];
         stats[6] = sStats[0];
         stats[7] = cStats[0];
+        stats[8] = qStats[0];
 
         return stats;
     }

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -526,8 +526,8 @@ public class StatsAgent extends OpsAgent
         case STARVATION:
             stats = collectStats(StatsSelector.STARVATION, interval);
             break;
-        case QUEUEDEPTH:
-            stats = collectStats(StatsSelector.QUEUEDEPTH, interval);
+        case QUEUE:
+            stats = collectStats(StatsSelector.QUEUE, interval);
             break;
         case PLANNER:
             stats = collectStats(StatsSelector.PLANNER, interval);
@@ -630,7 +630,7 @@ public class StatsAgent extends OpsAgent
         VoltTable[] tStats = collectStats(StatsSelector.TABLE, interval);
         VoltTable[] indStats = collectStats(StatsSelector.INDEX, interval);
         VoltTable[] sStats = collectStats(StatsSelector.STARVATION, interval);
-        VoltTable[] qStats = collectStats(StatsSelector.QUEUEDEPTH, interval);
+        VoltTable[] qStats = collectStats(StatsSelector.QUEUE, interval);
         VoltTable[] cStats = collectStats(StatsSelector.CPU, interval);
         // Ugh, this is ugly.  Currently need to return null if
         // we're missing any of the tables so that we

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -21,6 +21,7 @@ public enum StatsSelector {
     INDEX,            // invoked as @stat index
     PROCEDURE,        // invoked as @stat procedure
     STARVATION,
+    QUEUEDEPTH,
     INITIATOR,        // invoked as @stat initiator
     LATENCY,          // invoked as @stat latency
     LATENCY_COMPRESSED,  // before V7.3 this was @Statistics LATENCY

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -21,7 +21,7 @@ public enum StatsSelector {
     INDEX,            // invoked as @stat index
     PROCEDURE,        // invoked as @stat procedure
     STARVATION,
-    QUEUEDEPTH,
+    QUEUE,
     INITIATOR,        // invoked as @stat initiator
     LATENCY,          // invoked as @stat latency
     LATENCY_COMPRESSED,  // before V7.3 this was @Statistics LATENCY

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -29,6 +29,7 @@ import org.voltdb.CatalogSpecificPlanner;
 import org.voltdb.CommandLog;
 import org.voltdb.LoadedProcedureSet;
 import org.voltdb.MemoryStats;
+import org.voltdb.QueueDepthTracker;
 import org.voltdb.StartAction;
 import org.voltdb.StarvationTracker;
 import org.voltdb.StatsAgent;
@@ -108,6 +109,13 @@ public abstract class BaseInitiator implements Initiator
         agent.registerStatsSource(StatsSelector.STARVATION,
                                   getInitiatorHSId(),
                                   st);
+        //////////////////////////////////////////////////////////////////
+        QueueDepthTracker qdt = new QueueDepthTracker(getInitiatorHSId());
+        m_scheduler.setQueueDepthTracker(qdt);
+        agent.registerStatsSource(StatsSelector.QUEUEDEPTH,
+                                  getInitiatorHSId(),
+                                  qdt);
+        ////////////////////////////////////////////////////
 
         String partitionString = " ";
         if (m_partitionId != -1) {

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -109,13 +109,11 @@ public abstract class BaseInitiator implements Initiator
         agent.registerStatsSource(StatsSelector.STARVATION,
                                   getInitiatorHSId(),
                                   st);
-        //////////////////////////////////////////////////////////////////
         QueueDepthTracker qdt = new QueueDepthTracker(getInitiatorHSId());
         m_scheduler.setQueueDepthTracker(qdt);
-        agent.registerStatsSource(StatsSelector.QUEUEDEPTH,
+        agent.registerStatsSource(StatsSelector.QUEUE,
                                   getInitiatorHSId(),
                                   qdt);
-        ////////////////////////////////////////////////////
 
         String partitionString = " ";
         if (m_partitionId != -1) {

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -124,9 +124,8 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
         // respond to the coordinator with the sink HSID
         RejoinMessage msg = new RejoinMessage(m_mailbox.getHSId(), -1, sinkHSId);
         m_mailbox.send(m_coordinatorHsId, msg);
-
-        m_taskQueue.offer(this);
         m_taskQueue.setQueueDepthTracker(new QueueDepthTracker(m_partitionId));
+        m_taskQueue.offer(this);
         JOINLOG.info("P" + m_partitionId + " received initiation");
     }
 

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -27,7 +27,6 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.utils.CoreUtils;
-import org.voltdb.QueueDepthTracker;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.SnapshotCompletionInterest.SnapshotCompletionEvent;
 import org.voltdb.VoltDB;
@@ -124,7 +123,6 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
         // respond to the coordinator with the sink HSID
         RejoinMessage msg = new RejoinMessage(m_mailbox.getHSId(), -1, sinkHSId);
         m_mailbox.send(m_coordinatorHsId, msg);
-        m_taskQueue.setQueueDepthTracker(new QueueDepthTracker(m_partitionId));
         m_taskQueue.offer(this);
         JOINLOG.info("P" + m_partitionId + " received initiation");
     }

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -27,6 +27,7 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.utils.CoreUtils;
+import org.voltdb.QueueDepthTracker;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.SnapshotCompletionInterest.SnapshotCompletionEvent;
 import org.voltdb.VoltDB;
@@ -125,6 +126,7 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
         m_mailbox.send(m_coordinatorHsId, msg);
 
         m_taskQueue.offer(this);
+        m_taskQueue.setQueueDepthTracker(new QueueDepthTracker(m_partitionId));
         JOINLOG.info("P" + m_partitionId + " received initiation");
     }
 

--- a/src/frontend/org/voltdb/iv2/MpRoSitePool.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSitePool.java
@@ -30,6 +30,7 @@ import org.voltdb.BackendTarget;
 import org.voltdb.CatalogContext;
 import org.voltdb.CatalogSpecificPlanner;
 import org.voltdb.LoadedProcedureSet;
+import org.voltdb.QueueDepthTracker;
 import org.voltdb.StarvationTracker;
 
 /**
@@ -59,6 +60,7 @@ class MpRoSitePool {
             m_queue = new SiteTaskerQueue();
             // IZZY: Just need something non-null for now
             m_queue.setStarvationTracker(new StarvationTracker(siteId));
+            m_queue.setQueueDepthTracker(new QueueDepthTracker(siteId));
             m_site = new MpRoSite(m_queue, siteId, backend, m_catalogContext, partitionId);
             m_loadedProcedures = new LoadedProcedureSet(m_site);
             m_loadedProcedures.loadProcedures(m_catalogContext, csp);

--- a/src/frontend/org/voltdb/iv2/Scheduler.java
+++ b/src/frontend/org/voltdb/iv2/Scheduler.java
@@ -26,6 +26,7 @@ import org.voltcore.messaging.Mailbox;
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.messaging.VoltMessage;
 import org.voltdb.LoadedProcedureSet;
+import org.voltdb.QueueDepthTracker;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.StarvationTracker;
 import org.voltdb.VoltDB;
@@ -153,6 +154,10 @@ abstract public class Scheduler implements InitiatorMessageHandler
 
     public void setStarvationTracker(StarvationTracker tracker) {
         m_tasks.setStarvationTracker(tracker);
+    }
+
+    public void setQueueDepthTracker(QueueDepthTracker tracker) {
+        m_tasks.setQueueDepthTracker(tracker);
     }
 
     public void setLock(Object o) {

--- a/src/frontend/org/voltdb/iv2/SiteTasker.java
+++ b/src/frontend/org/voltdb/iv2/SiteTasker.java
@@ -24,14 +24,14 @@ import org.voltdb.rejoin.TaskLog;
 
 public abstract class SiteTasker {
 
-    private long timestamp = -1L;
+    private long queueOfferTime = -1L;
 
-    public void setTimestamp() {
-        timestamp = System.nanoTime();
+    public void setQueueOfferTime() {
+        queueOfferTime = System.nanoTime();
     }
 
-    public long getTimestamp() {
-        return timestamp;
+    public long getQueueOfferTime() {
+        return queueOfferTime;
     }
 
     public static abstract class SiteTaskerRunnable extends SiteTasker {

--- a/src/frontend/org/voltdb/iv2/SiteTasker.java
+++ b/src/frontend/org/voltdb/iv2/SiteTasker.java
@@ -19,19 +19,30 @@ package org.voltdb.iv2;
 
 import java.io.IOException;
 
+import org.voltdb.SiteProcedureConnection;
 import org.voltdb.rejoin.TaskLog;
 
-import org.voltdb.SiteProcedureConnection;
-
 public abstract class SiteTasker {
+
+    private long timestamp = -1L;
+
+    public void setTimestamp() {
+        timestamp = System.nanoTime();
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
 
     public static abstract class SiteTaskerRunnable extends SiteTasker {
         abstract void run();
 
+        @Override
         public void run(SiteProcedureConnection siteConnection) {
             run();
         }
 
+        @Override
         public void runForRejoin(SiteProcedureConnection siteConnection,
                 TaskLog rejoinTaskLog) throws IOException {
             run();

--- a/src/frontend/org/voltdb/iv2/SiteTaskerQueue.java
+++ b/src/frontend/org/voltdb/iv2/SiteTaskerQueue.java
@@ -20,6 +20,7 @@ package org.voltdb.iv2;
 import java.util.concurrent.LinkedTransferQueue;
 
 import org.voltcore.utils.CoreUtils;
+import org.voltdb.QueueDepthTracker;
 import org.voltdb.StarvationTracker;
 
 /** SiteTaskerScheduler orders SiteTaskers for execution. */
@@ -27,9 +28,13 @@ public class SiteTaskerQueue
 {
     private final LinkedTransferQueue<SiteTasker> m_tasks = new LinkedTransferQueue<SiteTasker>();
     private StarvationTracker m_starvationTracker;
+    private QueueDepthTracker m_queueDepthTracker;
 
     public boolean offer(SiteTasker task)
     {
+        task.setTimestamp();
+        m_queueDepthTracker.offerUpdate();
+//        System.err.println("Offerred at " + task.getTimestamp());
         return m_tasks.offer(task);
     }
 
@@ -37,13 +42,19 @@ public class SiteTaskerQueue
     public SiteTasker take() throws InterruptedException
     {
         SiteTasker task = m_tasks.poll();
+
         if (task == null) {
             m_starvationTracker.beginStarvation();
         } else {
+            m_queueDepthTracker.pollUpdate(task.getTimestamp());
             return task;
         }
         try {
-            return CoreUtils.queueSpinTake(m_tasks);
+            task = CoreUtils.queueSpinTake(m_tasks);
+            if (task != null) {
+                m_queueDepthTracker.pollUpdate(task.getTimestamp());
+            }
+            return task;
         } finally {
             m_starvationTracker.endStarvation();
         }
@@ -52,7 +63,11 @@ public class SiteTaskerQueue
     // Non-blocking poll on the site tasker queue.
     public SiteTasker poll()
     {
-        return m_tasks.poll();
+        SiteTasker task = m_tasks.poll();
+        if (task != null) {
+            m_queueDepthTracker.pollUpdate(task.getTimestamp());
+        }
+        return task;
     }
 
     // Non-blocking peek on the site tasker queue.
@@ -67,5 +82,10 @@ public class SiteTaskerQueue
 
     public void setStarvationTracker(StarvationTracker tracker) {
         m_starvationTracker = tracker;
+    }
+
+    public void setQueueDepthTracker(QueueDepthTracker tracker) {
+        m_queueDepthTracker = tracker;
+        m_queueDepthTracker.beginQueueDepth(m_tasks.size(), m_tasks);
     }
 }

--- a/src/frontend/org/voltdb/iv2/SiteTaskerQueue.java
+++ b/src/frontend/org/voltdb/iv2/SiteTaskerQueue.java
@@ -34,7 +34,6 @@ public class SiteTaskerQueue
     {
         task.setTimestamp();
         m_queueDepthTracker.offerUpdate();
-//        System.err.println("Offerred at " + task.getTimestamp());
         return m_tasks.offer(task);
     }
 

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
@@ -37,8 +37,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.junit.Test;
@@ -52,6 +50,7 @@ import org.voltdb.CommandLog;
 import org.voltdb.Consistency;
 import org.voltdb.ParameterSet;
 import org.voltdb.ProcedureRunner;
+import org.voltdb.QueueDepthTracker;
 import org.voltdb.SnapshotCompletionMonitor;
 import org.voltdb.StarvationTracker;
 import org.voltdb.StoredProcedureInvocation;
@@ -62,6 +61,8 @@ import org.voltdb.messaging.InitiateResponseMessage;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
+
+import junit.framework.TestCase;
 
 public class TestSpSchedulerDedupe extends TestCase
 {
@@ -79,6 +80,7 @@ public class TestSpSchedulerDedupe extends TestCase
     private static SiteTaskerQueue getSiteTaskerQueue() {
         SiteTaskerQueue queue = new SiteTaskerQueue();
         queue.setStarvationTracker(new StarvationTracker(0));
+        queue.setQueueDepthTracker(new QueueDepthTracker(0));
         return queue;
     }
 

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerSpHandle.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerSpHandle.java
@@ -36,8 +36,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.junit.Test;
@@ -48,12 +46,15 @@ import org.voltcore.utils.CoreUtils;
 import org.voltcore.zk.MapCache;
 import org.voltdb.CommandLog;
 import org.voltdb.ProcedureRunner;
+import org.voltdb.QueueDepthTracker;
 import org.voltdb.SnapshotCompletionMonitor;
 import org.voltdb.StarvationTracker;
 import org.voltdb.VoltDBInterface;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
+
+import junit.framework.TestCase;
 
 public class TestSpSchedulerSpHandle extends TestCase
 {
@@ -72,6 +73,7 @@ public class TestSpSchedulerSpHandle extends TestCase
     private static SiteTaskerQueue getSiteTaskerQueue() {
         SiteTaskerQueue queue = new SiteTaskerQueue();
         queue.setStarvationTracker(new StarvationTracker(0));
+        queue.setQueueDepthTracker(new QueueDepthTracker(0));
         return queue;
     }
 

--- a/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
+++ b/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
@@ -29,14 +29,15 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
+import org.voltdb.QueueDepthTracker;
 import org.voltdb.StarvationTracker;
 import org.voltdb.dtxn.TransactionState;
 import org.voltdb.messaging.CompleteTransactionMessage;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
+
+import junit.framework.TestCase;
 
 public class TestTransactionTaskQueue extends TestCase
 {
@@ -44,6 +45,7 @@ public class TestTransactionTaskQueue extends TestCase
     private static SiteTaskerQueue getSiteTaskerQueue() {
         SiteTaskerQueue queue = new SiteTaskerQueue();
         queue.setStarvationTracker(new StarvationTracker(0));
+        queue.setQueueDepthTracker(new QueueDepthTracker(0));
         return queue;
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -31,8 +31,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Test;
-
 import org.HdrHistogram_voltpatches.AbstractHistogram;
 import org.HdrHistogram_voltpatches.Histogram;
 import org.voltcore.utils.CompressionStrategySnappy;
@@ -45,6 +43,8 @@ import org.voltdb.dtxn.LatencyStats;
 import org.voltdb.iv2.MpInitiator;
 import org.voltdb.regressionsuites.StatisticsTestSuiteBase;
 import org.voltdb_testprocs.regressionsuites.malicious.GoSleep;
+
+import junit.framework.Test;
 
 public class TestStatisticsSuite extends StatisticsTestSuiteBase {
 
@@ -653,6 +653,41 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         validateRowSeenAtAllHosts(results[0], columnTargets, false);
     }
 
+    public void testQueueDepthStatistics() throws Exception {
+        System.out.println("\n\nTESTING QUEUEDEPTH STATS\n\n\n");
+        Client client  = getFullyConnectedClient();
+
+        ColumnInfo[] expectedSchema = new ColumnInfo[8];
+        expectedSchema[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
+        expectedSchema[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
+        expectedSchema[2] = new ColumnInfo("HOSTNAME", VoltType.STRING);
+        expectedSchema[3] = new ColumnInfo("SITE_ID", VoltType.INTEGER);
+        expectedSchema[4] = new ColumnInfo("CURRENT_DEPTH", VoltType.INTEGER);
+        expectedSchema[5] = new ColumnInfo("POLL_COUNT", VoltType.BIGINT);
+        expectedSchema[6] = new ColumnInfo("AVG_WAIT", VoltType.BIGINT);
+        expectedSchema[7] = new ColumnInfo("MAX_WAIT", VoltType.BIGINT);
+
+        VoltTable expectedTable = new VoltTable(expectedSchema);
+
+        VoltTable[] results = null;
+        //
+        // QUEUEDEPTH
+        //
+        results = client.callProcedure("@Statistics", "QUEUEDEPTH", 0).getResults();
+        // one aggregate table returned
+        assertEquals(1, results.length);
+        System.out.println("Test QueueDepth table: " + results[0].toString());
+        validateSchema(results[0], expectedTable);
+        // One row per site, we don't use HSID though, so hard to do straightforward
+        // per-site unique check.  Finesse it.
+        // We also get starvation stats for the MPI, so we need to add a site per host.
+        assertEquals(HOSTS * (SITES + 1), results[0].getRowCount());
+        results[0].advanceRow();
+        Map<String, String> columnTargets = new HashMap<String, String>();
+        columnTargets.put("HOSTNAME", results[0].getString("HOSTNAME"));
+        validateRowSeenAtAllHosts(results[0], columnTargets, false);
+    }
+
     public void testManagementStats() throws Exception {
         System.out.println("\n\nTESTING MANAGEMENT STATS\n\n\n");
         Client client  = getFullyConnectedClient();
@@ -664,7 +699,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         results = client.callProcedure("@Statistics", "MANAGEMENT", 0).getResults();
         // eight aggregate tables returned.  Assume that we have selected the right
         // subset of stats internally, just check that we get stuff.
-        assertEquals(8, results.length);
+        assertEquals(9, results.length);
     }
 
     //

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -673,7 +673,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         //
         // QUEUEDEPTH
         //
-        results = client.callProcedure("@Statistics", "QUEUEDEPTH", 0).getResults();
+        results = client.callProcedure("@Statistics", "QUEUE", 0).getResults();
         // one aggregate table returned
         assertEquals(1, results.length);
         System.out.println("Test QueueDepth table: " + results[0].toString());
@@ -697,7 +697,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         // LIVECLIENTS
         //
         results = client.callProcedure("@Statistics", "MANAGEMENT", 0).getResults();
-        // eight aggregate tables returned.  Assume that we have selected the right
+        // nine aggregate tables returned.  Assume that we have selected the right
         // subset of stats internally, just check that we get stuff.
         assertEquals(9, results.length);
     }


### PR DESCRIPTION


Currently we have the following performance statistics:

- Initiator stats or latency stats (intra-cluster latency)
- Procedure stats (partition execution time)
- Command log stats

The closest to client-side latency is the initiator stats. It doesn't include the network round-trip time between the client and the server and any delay incurred on the client. The procedure stats only show the duration of the run() methods of procedures. It only accounts for the computation portion of SPs.

Looking at these stats typically gives a good idea of the cluster performance, but they are not enough to diagnose any latency issues. There is a big gap between the intra-cluster latency and the procedure execution time. They are usually magnitudes apart.

A big portion of the difference between the intra-cluster latency and the procedure execution time is the time the procedure request sitting in the partition queue. If command logging is used, back pressure from the command log and/or fsyncing time can also account for the difference.

Exposing the partition queue depth can help us answer some latency-related questions. The stats include the following:

- Queue depth
- Average wait time in the past 5s
- Max wait time in the past 5s

