### PR TITLE
ENG-12044-Failed-Snapshot-Exit-Code

### DIFF
--- a/lib/python/voltcli/utility.py
+++ b/lib/python/voltcli/utility.py
@@ -1346,7 +1346,7 @@ class VoltTableWrapper(object):
             abort('Bad tuple index %d (%d tuples available).' % (index, len(self.table.tuples)))
         return VoltTupleWrapper(self.table.tuples[index])
     def tuples(self):
-        return self.table.tuples
+        return [VoltTupleWrapper(t) for t in self.table.tuples]
     def format_table(self, caption = None):
         return format_volt_table(self.table, caption = caption)
     def __str__(self):

--- a/lib/python/voltcli/voltadmin.d/save.py
+++ b/lib/python/voltcli/voltadmin.d/save.py
@@ -16,6 +16,7 @@
 
 import os
 import urllib
+import sys
 
 @VOLT.Command(
     bundles = VOLT.AdminBundle(),
@@ -87,4 +88,8 @@ def save(runner):
     columns = [VOLT.FastSerializer.VOLTTYPE_STRING]
     response = runner.call_proc('@SnapshotSave', columns,
                                 ['{%s}' % (','.join(raw_json_opts))])
-    print response.table(0).format_table(caption = 'Snapshot Save Results')
+    res_table = response.table(0)
+    has_failure = any([t.column(3) != 'SUCCESS' for t in res_table.tuples()])
+    print res_table.format_table(caption = 'Snapshot Save Results')
+    if has_failure:
+        sys.exit(1)


### PR DESCRIPTION
Check the column of ”RESULT“ from the returned table which tells whether snapshots were successful. If there exists a failed one, return exit code 1.