### PR TITLE
Eng 12769 queue depth with log

### DIFF
--- a/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
+++ b/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
@@ -227,6 +227,11 @@
                 <xs:attribute name="timeout" type="latencyType" default="10000"/>
             </xs:complexType>
         </xs:element>
+         <xs:element name="procedure" minOccurs="0" maxOccurs="1">
+            <xs:complexType>
+                <xs:attribute name="warningtimeout" type="latencyType" default="10000"/>
+            </xs:complexType>
+        </xs:element>
         <xs:element name="resourcemonitor" minOccurs="0" maxOccurs="1" type="resourceMonitorType"/>
     </xs:all>
   </xs:complexType>

--- a/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
+++ b/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
@@ -229,7 +229,7 @@
         </xs:element>
          <xs:element name="procedure" minOccurs="0" maxOccurs="1">
             <xs:complexType>
-                <xs:attribute name="warningtimeout" type="latencyType" default="10000"/>
+                <xs:attribute name="loginfo" type="latencyType" default="10000"/>
             </xs:complexType>
         </xs:element>
         <xs:element name="resourcemonitor" minOccurs="0" maxOccurs="1" type="resourceMonitorType"/>

--- a/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
+++ b/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
@@ -309,6 +309,7 @@ public class VoltProjectBuilder {
     private Integer m_elasticThroughput = null;
     private Integer m_elasticDuration = null;
     private Integer m_queryTimeout = null;
+    private Integer m_procedureTimeout = null;
     private String m_rssLimit = null;
     private String m_snmpRssLimit = null;
     private Integer m_resourceCheckInterval = null;
@@ -325,6 +326,11 @@ public class VoltProjectBuilder {
 
     public VoltProjectBuilder setQueryTimeout(int target) {
         m_queryTimeout = target;
+        return this;
+    }
+
+    public VoltProjectBuilder setProcedureTimeout(int target) {
+        m_procedureTimeout = target;
         return this;
     }
 
@@ -1336,6 +1342,11 @@ public class VoltProjectBuilder {
             SystemSettingsType.Query query = factory.createSystemSettingsTypeQuery();
             query.setTimeout(m_queryTimeout);
             systemSettingType.setQuery(query);
+        }
+        if (m_procedureTimeout != null) {
+            SystemSettingsType.Procedure procedure = factory.createSystemSettingsTypeProcedure();
+            procedure.setWarningtimeout(m_procedureTimeout);
+            systemSettingType.setProcedure(procedure);
         }
         if (m_rssLimit != null || m_snmpRssLimit != null) {
             ResourceMonitorType monitorType = initializeResourceMonitorType(systemSettingType, factory);

--- a/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
+++ b/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
@@ -309,7 +309,7 @@ public class VoltProjectBuilder {
     private Integer m_elasticThroughput = null;
     private Integer m_elasticDuration = null;
     private Integer m_queryTimeout = null;
-    private Integer m_procedureTimeout = null;
+    private Integer m_procedureLogThreshold = null;
     private String m_rssLimit = null;
     private String m_snmpRssLimit = null;
     private Integer m_resourceCheckInterval = null;
@@ -329,8 +329,8 @@ public class VoltProjectBuilder {
         return this;
     }
 
-    public VoltProjectBuilder setProcedureTimeout(int target) {
-        m_procedureTimeout = target;
+    public VoltProjectBuilder setProcedureLogThreshold(int target) {
+        m_procedureLogThreshold = target;
         return this;
     }
 
@@ -1343,9 +1343,9 @@ public class VoltProjectBuilder {
             query.setTimeout(m_queryTimeout);
             systemSettingType.setQuery(query);
         }
-        if (m_procedureTimeout != null) {
+        if (m_procedureLogThreshold != null) {
             SystemSettingsType.Procedure procedure = factory.createSystemSettingsTypeProcedure();
-            procedure.setWarningtimeout(m_procedureTimeout);
+            procedure.setLoginfo(m_procedureLogThreshold);
             systemSettingType.setProcedure(procedure);
         }
         if (m_rssLimit != null || m_snmpRssLimit != null) {

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -57,7 +57,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
                 new MpScheduler(
                     MP_INIT_PID,
                     buddyHSIds,
-                    new SiteTaskerQueue()),
+                    new SiteTaskerQueue(MP_INIT_PID)),
                 "MP",
                 agent,
                 StartAction.CREATE /* never for rejoin */);

--- a/src/frontend/org/voltdb/iv2/MpRoSitePool.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSitePool.java
@@ -57,7 +57,7 @@ class MpRoSitePool {
                 ThreadFactory threadFactory)
         {
             m_catalogContext = context;
-            m_queue = new SiteTaskerQueue();
+            m_queue = new SiteTaskerQueue(partitionId);
             // IZZY: Just need something non-null for now
             m_queue.setStarvationTracker(new StarvationTracker(siteId));
             m_queue.setQueueDepthTracker(new QueueDepthTracker(siteId));

--- a/src/frontend/org/voltdb/iv2/SiteTaskerQueue.java
+++ b/src/frontend/org/voltdb/iv2/SiteTaskerQueue.java
@@ -29,6 +29,15 @@ public class SiteTaskerQueue
     private final LinkedTransferQueue<SiteTasker> m_tasks = new LinkedTransferQueue<SiteTasker>();
     private StarvationTracker m_starvationTracker;
     private QueueDepthTracker m_queueDepthTracker;
+    private int m_partitionId;
+
+    public SiteTaskerQueue(int partitionId) {
+        m_partitionId = partitionId;
+    }
+
+    public int getPartitionId() {
+        return m_partitionId;
+    }
 
     public boolean offer(SiteTasker task)
     {

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -76,7 +76,7 @@ public class SpInitiator extends BaseInitiator implements Promotable
             StartAction startAction)
     {
         super(VoltZK.iv2masters, messenger, partition,
-                new SpScheduler(partition, new SiteTaskerQueue(), snapMonitor),
+                new SpScheduler(partition, new SiteTaskerQueue(partition), snapMonitor),
                 "SP", agent, startAction);
         m_leaderCache = new LeaderCache(messenger.getZK(), VoltZK.iv2appointees, m_leadersChangeHandler);
         m_tickProducer = new TickProducer(m_scheduler.m_tasks);

--- a/src/frontend/org/voltdb/iv2/TickProducer.java
+++ b/src/frontend/org/voltdb/iv2/TickProducer.java
@@ -61,7 +61,7 @@ public class TickProducer extends SiteTasker implements Runnable
     public void run()
     {
         m_taskQueue.offer(this);
-
+        // check if previous task is running for more than 5 seconds
         SiteTasker task = m_taskQueue.peek();
         long currentTime = System.nanoTime();
         long headOfQueueOfferTime;
@@ -79,7 +79,6 @@ public class TickProducer extends SiteTasker implements Runnable
                     + "No other jobs will be executed until that process completes.";
             long waitTime = (currentTime - m_previousTaskPeekTime)/1_000_000_000L; // in seconds
             m_logger.rateLimitedLog(SUPPRESS_INTERVAL, Level.WARN, null, fmt, waitTime, m_partitionId);
-//            m_logger.warn(logStr);
         }
     }
 

--- a/src/frontend/org/voltdb/iv2/TickProducer.java
+++ b/src/frontend/org/voltdb/iv2/TickProducer.java
@@ -18,13 +18,13 @@
 package org.voltdb.iv2;
 
 import java.io.IOException;
-
 import java.util.concurrent.TimeUnit;
 
-import org.voltdb.rejoin.TaskLog;
-
+import org.voltcore.logging.Level;
+import org.voltcore.logging.VoltLogger;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.VoltDB;
+import org.voltdb.rejoin.TaskLog;
 
 /**
  * Runs the tick operation against the EE
@@ -32,10 +32,18 @@ import org.voltdb.VoltDB;
 public class TickProducer extends SiteTasker implements Runnable
 {
     private final SiteTaskerQueue m_taskQueue;
+    private final long m_taskTimeThreshold = 5_000_000_000L; // 5 seconds
+    private final long SUPPRESS_INTERVAL = 60; // 60 seconds
+    private VoltLogger m_logger;
+    private int m_partitionId;
+    private long m_previousTaskTimestamp = -1;
+    private long m_previousTaskPeekTime = -1;
 
     public TickProducer(SiteTaskerQueue taskQueue)
     {
         m_taskQueue = taskQueue;
+        m_logger = new VoltLogger("HOST");
+        m_partitionId = taskQueue.getPartitionId();
     }
 
     // start schedules a 1 second tick.
@@ -53,6 +61,26 @@ public class TickProducer extends SiteTasker implements Runnable
     public void run()
     {
         m_taskQueue.offer(this);
+
+        SiteTasker task = m_taskQueue.peek();
+        long currentTime = System.nanoTime();
+        long headOfQueueOfferTime;
+        if (task != null) {
+            headOfQueueOfferTime = task.getQueueOfferTime();
+        } else {
+            headOfQueueOfferTime = currentTime;
+        }
+        if (headOfQueueOfferTime != m_previousTaskTimestamp) {
+            m_previousTaskTimestamp = headOfQueueOfferTime;
+            m_previousTaskPeekTime = currentTime;
+        } else if (currentTime - m_previousTaskPeekTime >= m_taskTimeThreshold) {
+            String fmt = " A process (procedure, fragment, or operational task) is taking a long time "
+                    + "-- over %d seconds -- and blocking the queue for site %d. "
+                    + "No other jobs will be executed until that process completes.";
+            long waitTime = (currentTime - m_previousTaskPeekTime)/1_000_000_000L; // in seconds
+            m_logger.rateLimitedLog(SUPPRESS_INTERVAL, Level.WARN, null, fmt, waitTime, m_partitionId);
+//            m_logger.warn(logStr);
+        }
     }
 
     @Override

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -143,7 +143,6 @@ import org.voltdb.plannodes.AbstractPlanNode;
 import org.voltdb.settings.ClusterSettings;
 import org.voltdb.settings.DbSettings;
 import org.voltdb.settings.NodeSettings;
-import org.voltdb.settings.SettingsException;
 import org.voltdb.snmp.DummySnmpTrapSender;
 import org.voltdb.types.ConstraintType;
 import org.xml.sax.SAXException;
@@ -977,6 +976,11 @@ public abstract class CatalogUtil {
         if (query == null) {
             query = new SystemSettingsType.Query();
             ss.setQuery(query);
+        }
+        SystemSettingsType.Procedure procedure = ss.getProcedure();
+        if (procedure == null) {
+            procedure = new SystemSettingsType.Procedure();
+            ss.setProcedure(procedure);
         }
         SystemSettingsType.Snapshot snap = ss.getSnapshot();
         if (snap == null) {

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
@@ -78,7 +78,7 @@ public class TestSpSchedulerDedupe extends TestCase
     static final long dut_hsid = 11223344l;
 
     private static SiteTaskerQueue getSiteTaskerQueue() {
-        SiteTaskerQueue queue = new SiteTaskerQueue();
+        SiteTaskerQueue queue = new SiteTaskerQueue(0);
         queue.setStarvationTracker(new StarvationTracker(0));
         queue.setQueueDepthTracker(new QueueDepthTracker(0));
         return queue;

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerSpHandle.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerSpHandle.java
@@ -71,7 +71,7 @@ public class TestSpSchedulerSpHandle extends TestCase
 
 
     private static SiteTaskerQueue getSiteTaskerQueue() {
-        SiteTaskerQueue queue = new SiteTaskerQueue();
+        SiteTaskerQueue queue = new SiteTaskerQueue(0);
         queue.setStarvationTracker(new StarvationTracker(0));
         queue.setQueueDepthTracker(new QueueDepthTracker(0));
         return queue;

--- a/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
+++ b/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
@@ -43,7 +43,7 @@ public class TestTransactionTaskQueue extends TestCase
 {
 
     private static SiteTaskerQueue getSiteTaskerQueue() {
-        SiteTaskerQueue queue = new SiteTaskerQueue();
+        SiteTaskerQueue queue = new SiteTaskerQueue(0);
         queue.setStarvationTracker(new StarvationTracker(0));
         queue.setQueueDepthTracker(new QueueDepthTracker(0));
         return queue;

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -656,7 +656,6 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
     public void testQueueDepthStatistics() throws Exception {
         System.out.println("\n\nTESTING QUEUEDEPTH STATS\n\n\n");
         Client client  = getFullyConnectedClient();
-        Thread.sleep(7000);
         ColumnInfo[] expectedSchema = new ColumnInfo[8];
         expectedSchema[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
         expectedSchema[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -126,7 +126,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         return hostsSeen.size();
     }
 
-    public void NotestInvalidCalls() throws Exception {
+    public void testInvalidCalls() throws Exception {
         System.out.println("\n\nTESTING INVALID CALLS\n\n\n");
         Client client = getFullyConnectedClient();
         //
@@ -165,7 +165,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
 
     // Make sure @Statistics LATENCY returns sane data in the expected formats.
     //
-    public void NotestLatencyValidity() throws Exception {
+    public void testLatencyValidity() throws Exception {
         System.out.println("\n\nTESTING LATENCY STATS VALIDITY\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -276,7 +276,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
      * Keep trying until identical timestamps are observed -
      * an implementation that gives each call a unique timestamp will still fail the test.
      */
-    public void NotestLatencyTiming() throws Exception {
+    public void testLatencyTiming() throws Exception {
         System.out.println("\n\nTESTING LATENCY STATS TIMING\n\n\n");
         Client client = getFullyConnectedClient();
 
@@ -319,7 +319,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertTrue(afterTimestamp > beforeTimestamp);
     }
 
-    public void NotestLatencyCompressed() throws Exception {
+    public void testLatencyCompressed() throws Exception {
         System.out.println("\n\nTESTING LATENCY_COMPRESSED STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -362,7 +362,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertTrue(invocations > 0);
     }
 
-    public void NotestInitiatorStatistics() throws Exception {
+    public void testInitiatorStatistics() throws Exception {
         System.out.println("\n\nTESTING INITIATOR STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -420,7 +420,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         validateRowSeenAtAllHosts(results[0], columnTargets, true);
     }
 
-    public void NotestPartitionCount() throws Exception {
+    public void testPartitionCount() throws Exception {
         System.out.println("\n\nTESTING PARTITION COUNT\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -443,7 +443,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertEquals(PARTITIONS, partCount);
     }
 
-    public void NotestMemoryStatistics() throws Exception {
+    public void testMemoryStatistics() throws Exception {
         System.out.println("\n\nTESTING MEMORY STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -484,7 +484,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         validateRowSeenAtAllHosts(results[0], columnTargets, true);
     }
 
-    public void NotestIOStatistics() throws Exception {
+    public void testIOStatistics() throws Exception {
         System.out.println("\n\nTESTING IO STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -514,7 +514,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         validateSchema(results[0], expectedTable);
     }
 
-    public void NotestTopoStatistics() throws Exception {
+    public void testTopoStatistics() throws Exception {
         System.out.println("\n\nTESTING TOPO STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -580,7 +580,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertEquals(1, results[1].getRowCount());
     }
 
-    public void NotestLiveClientsStatistics() throws Exception {
+    public void testLiveClientsStatistics() throws Exception {
         System.out.println("\n\nTESTING LIVECLIENTS STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -617,7 +617,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertEquals(claimRecentAnalysis(), HOSTS, hostsHeardFrom);
     }
 
-    public void NotestStarvationStatistics() throws Exception {
+    public void testStarvationStatistics() throws Exception {
         System.out.println("\n\nTESTING STARVATION STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -688,7 +688,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         validateRowSeenAtAllHosts(results[0], columnTargets, false);
     }
 
-    public void NotestManagementStats() throws Exception {
+    public void testManagementStats() throws Exception {
         System.out.println("\n\nTESTING MANAGEMENT STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -126,7 +126,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         return hostsSeen.size();
     }
 
-    public void testInvalidCalls() throws Exception {
+    public void NotestInvalidCalls() throws Exception {
         System.out.println("\n\nTESTING INVALID CALLS\n\n\n");
         Client client = getFullyConnectedClient();
         //
@@ -165,7 +165,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
 
     // Make sure @Statistics LATENCY returns sane data in the expected formats.
     //
-    public void testLatencyValidity() throws Exception {
+    public void NotestLatencyValidity() throws Exception {
         System.out.println("\n\nTESTING LATENCY STATS VALIDITY\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -276,7 +276,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
      * Keep trying until identical timestamps are observed -
      * an implementation that gives each call a unique timestamp will still fail the test.
      */
-    public void testLatencyTiming() throws Exception {
+    public void NotestLatencyTiming() throws Exception {
         System.out.println("\n\nTESTING LATENCY STATS TIMING\n\n\n");
         Client client = getFullyConnectedClient();
 
@@ -319,7 +319,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertTrue(afterTimestamp > beforeTimestamp);
     }
 
-    public void testLatencyCompressed() throws Exception {
+    public void NotestLatencyCompressed() throws Exception {
         System.out.println("\n\nTESTING LATENCY_COMPRESSED STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -362,7 +362,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertTrue(invocations > 0);
     }
 
-    public void testInitiatorStatistics() throws Exception {
+    public void NotestInitiatorStatistics() throws Exception {
         System.out.println("\n\nTESTING INITIATOR STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -420,7 +420,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         validateRowSeenAtAllHosts(results[0], columnTargets, true);
     }
 
-    public void testPartitionCount() throws Exception {
+    public void NotestPartitionCount() throws Exception {
         System.out.println("\n\nTESTING PARTITION COUNT\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -443,7 +443,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertEquals(PARTITIONS, partCount);
     }
 
-    public void testMemoryStatistics() throws Exception {
+    public void NotestMemoryStatistics() throws Exception {
         System.out.println("\n\nTESTING MEMORY STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -484,7 +484,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         validateRowSeenAtAllHosts(results[0], columnTargets, true);
     }
 
-    public void testIOStatistics() throws Exception {
+    public void NotestIOStatistics() throws Exception {
         System.out.println("\n\nTESTING IO STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -514,7 +514,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         validateSchema(results[0], expectedTable);
     }
 
-    public void testTopoStatistics() throws Exception {
+    public void NotestTopoStatistics() throws Exception {
         System.out.println("\n\nTESTING TOPO STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -580,7 +580,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertEquals(1, results[1].getRowCount());
     }
 
-    public void testLiveClientsStatistics() throws Exception {
+    public void NotestLiveClientsStatistics() throws Exception {
         System.out.println("\n\nTESTING LIVECLIENTS STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -617,7 +617,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         assertEquals(claimRecentAnalysis(), HOSTS, hostsHeardFrom);
     }
 
-    public void testStarvationStatistics() throws Exception {
+    public void NotestStarvationStatistics() throws Exception {
         System.out.println("\n\nTESTING STARVATION STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 
@@ -656,7 +656,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
     public void testQueueDepthStatistics() throws Exception {
         System.out.println("\n\nTESTING QUEUEDEPTH STATS\n\n\n");
         Client client  = getFullyConnectedClient();
-
+        Thread.sleep(7000);
         ColumnInfo[] expectedSchema = new ColumnInfo[8];
         expectedSchema[0] = new ColumnInfo("TIMESTAMP", VoltType.BIGINT);
         expectedSchema[1] = new ColumnInfo("HOST_ID", VoltType.INTEGER);
@@ -688,7 +688,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         validateRowSeenAtAllHosts(results[0], columnTargets, false);
     }
 
-    public void testManagementStats() throws Exception {
+    public void NotestManagementStats() throws Exception {
         System.out.println("\n\nTESTING MANAGEMENT STATS\n\n\n");
         Client client  = getFullyConnectedClient();
 


### PR DESCRIPTION
If a stored procedure takes a long, long time in Java code, there was nothing in the logfile to indicate that a procedure is doing too much Java. There are only warnings for long-running MP (possible mp deadlock) or long SQL execution times.

This is a watch on the sites to show that there is a long-running txn. A warning is generated if no task was polled from the partition queue in the last {X} seconds, where {X} is configurable from deployment file with default value 10 seconds.