### PR TITLE
Eng 12787 kafkaloader ssl

### DIFF
--- a/tests/test_apps/kafkaimporter/kafkaloader10-SSL.props
+++ b/tests/test_apps/kafkaimporter/kafkaloader10-SSL.props
@@ -4,3 +4,7 @@ auto.offset.reset=earliest
 request.timeout.ms=20000
 session.timeout.ms=10000
 fetch.max.wait.ms=10000
+
+security.protocol=SSL
+ssl.truststore.location=apprunner-keystore
+ssl.truststore.password=password


### PR DESCRIPTION
Changes to setup SSL end to end for the kafkaloader test.

Community side changes:
  - add SSL option and setup to Java client
  - add SSL properties file for the kafkaloader
  - trim obsolete properties from Kafka 10 props file