### PR TITLE
Add “H” as a short-form for “hosts”, to be consistent with voltadmin …

### DIFF
--- a/src/frontend/org/voltdb/importclient/kafka/KafkaExternalLoaderCLIArguments.java
+++ b/src/frontend/org/voltdb/importclient/kafka/KafkaExternalLoaderCLIArguments.java
@@ -64,7 +64,7 @@ public class KafkaExternalLoaderCLIArguments extends CLIConfig {
     @Option(desc = "Default port for VoltDB servers.")
     public String port = "";
 
-    @Option(desc = "Comma separated list of VoltDB servers (host[:port]) to connect to.")
+    @Option(shortOpt = "H", desc = "Comma separated list of VoltDB servers (host[:port]) to connect to.")
     public String host = "";
 
     @Option(shortOpt = "s", desc = "Comma separated list of VoltDB servers (host[:port]) to connect to. Deprecated; use 'host' instead.")


### PR DESCRIPTION
…and voltdb start. Request per Andrew.