### PR TITLE
Eng 12834 inline insert crash

### DIFF
--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -171,7 +171,8 @@ void InsertExecutor::executePurgeFragmentIfNeeded(PersistentTable** ptrToTable) 
 }
 
 bool InsertExecutor::p_execute_init(const TupleSchema *inputSchema,
-                                    TempTable *newOutputTable) {
+                                    TempTable *newOutputTable,
+                                    TableTuple &temp_tuple) {
     assert(m_node == dynamic_cast<InsertPlanNode*>(m_abstractNode));
     assert(m_node);
     assert(inputSchema);
@@ -228,7 +229,13 @@ bool InsertExecutor::p_execute_init(const TupleSchema *inputSchema,
                                "single-row" : "multi-row"),
                m_engine->getPartitionId());
     VOLT_DEBUG("Offset of partition column is %d", m_partitionColumn);
+    //
+    // Return a tuple whose schema we can use as an
+    // input.
+    //
     m_tempPool = ExecutorContext::getTempStringPool();
+    char *storage = static_cast<char *>(m_tempPool->allocateZeroes(inputSchema->tupleLength() + TUPLE_HEADER_SIZE));
+    temp_tuple = TableTuple(storage, inputSchema);
     return false;
 }
 
@@ -358,8 +365,9 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
     // we only insert on one site.  For all other sites we just
     // do nothing.
     //
+    TableTuple inputTuple;
     const TupleSchema *inputSchema = m_inputTable->schema();
-    if (p_execute_init(inputSchema, m_tmpOutputTable)) {
+    if (p_execute_init(inputSchema, m_tmpOutputTable, inputTuple)) {
         p_execute_finish();
         return true;
     }
@@ -369,7 +377,6 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
     // and insert any tuple that we find into our targetTable. It doesn't get any easier than that!
     //
     TableIterator iterator = m_inputTable->iterator();
-    TableTuple inputTuple = TableTuple(inputSchema);
     while (iterator.next(inputTuple)) {
         p_execute_tuple(inputTuple);
     }

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -285,7 +285,7 @@ void InsertExecutor::p_execute_tuple(TableTuple &tuple) {
             // tables with no views on them.
             // When there are views, be strict and throw mispartitioned
             // tuples to force partitioned data to be generated only
-            // where partitoned view rows are maintained.
+            // where partitioned view rows are maintained.
             if (!m_isStreamed || m_hasStreamView) {
                 throw ConstraintFailureException(
                                                  m_targetTable, m_templateTuple,

--- a/src/ee/executors/insertexecutor.h
+++ b/src/ee/executors/insertexecutor.h
@@ -93,7 +93,8 @@ class InsertExecutor : public AbstractExecutor
      * don't have any work to do.
      */
     bool p_execute_init(const TupleSchema *inputSchema,
-                        TempTable *newOutputTable);
+                        TempTable *newOutputTable,
+                        TableTuple &temp_tuple);
 
     /**
      * Insert a row into the target table and then count it.

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -285,9 +285,9 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
     // specified for this table and whether or not there is an inlined
     // projection.
     //
-    // If there is an projection, then we'll just steal that
+    // If there is an inline projection, then we'll just steal that
     // output schema as our own.
-    // If there is no inlined insert or projection, then, if there are no scan columns
+    // If there is no existing projection, then, if there are no scan columns
     // specified, use the entire table's schema as the output schema.
     // Otherwise add an inline projection that projects the scan columns
     // and then take that output schema as our own.


### PR DESCRIPTION
Get tuple schemas right in the scan executors.

The tuple schema handling was incorrect in the scan executors for inline insert into select.
We have three interesing schemas.  One is the schema of the scanned input table, one is the
schema of the insert target table and one is the schema of the derived table of the select
statement.  The latter comes from the expressions in the select list.  We were using the
schema from the target table in the insert statement where the last was wanted.  This
caused wrong answers for sequential scan and a server crash for index scan.

I don't know why this was not caught by the unit tests. If the schema of the scanned
table is not exactly like the schema of the insert's target table something will go wrong.
I think this only affects inline insert.  Without inline insert there is an extra temp table to
hold the select column values, and we know to use the schema of that table.
With inline insert there is no extra temp table, so we had to create a tuple from the
schema of the select list.
 
There is a unit test for this now.
