### PR TITLE
ENG-12672: Refactor DR cluster id and creation id into a single object throughout DR code base

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import org.voltcore.utils.Pair;
+import org.voltdb.ProducerDRGateway.ClusterIdentity;
 import org.voltdb.ProducerDRGateway.MeshMemberInfo;
 
 // Interface through which the outside world can interact with the consumer side
@@ -45,13 +46,13 @@ public interface ConsumerDRGateway extends Promotable {
     Map<Byte, DRRoleStats.State> getStates();
 
     /**
-     * If this cluster was a joiner (at some point) dataSourceCluster will not be -1. If this is the case
+     * If this cluster was a joiner (at some point) dataSourceCluster will not be null. If this is the case
      * the trackers for this clusterId must exist. If they don't exist, this cluster did not finish loading
      * the snapshot as a joiner.
      * @param dataSourceCluster
      * @param expectedClusterMembers
      */
-    void setInitialConversationMembership(byte dataSourceCluster, List<MeshMemberInfo> expectedClusterMembers);
+    void setInitialConversationMembership(ClusterIdentity dataSource, List<MeshMemberInfo> expectedClusterMembers);
 
     void initialize(boolean resumeReplication);
 
@@ -69,7 +70,7 @@ public interface ConsumerDRGateway extends Promotable {
 
     void startConsumerDispatcher(final MeshMemberInfo member);
 
-    void deactivateConsumerDispatcher(byte clusterId);
+    void deactivateConsumerDispatcher(ClusterIdentity producerClusterIdentity);
 
     void addLocallyLedPartition(int partitionId);
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -102,6 +102,7 @@ import org.voltcore.zk.CoreZK;
 import org.voltcore.zk.ZKCountdownLatch;
 import org.voltcore.zk.ZKUtil;
 import org.voltdb.CatalogContext.CatalogJarWriteMode;
+import org.voltdb.ProducerDRGateway.ClusterIdentity;
 import org.voltdb.ProducerDRGateway.MeshMemberInfo;
 import org.voltdb.TheHashinator.HashinatorType;
 import org.voltdb.VoltDB.Configuration;
@@ -4206,7 +4207,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         try {
             if (m_consumerDRGateway != null) {
                 if (m_config.m_startAction != StartAction.CREATE) {
-                    Pair<Byte, List<MeshMemberInfo>> expectedClusterMembers = m_producerDRGateway.getInitialConversations();
+                    Pair<ClusterIdentity, List<MeshMemberInfo>> expectedClusterMembers = m_producerDRGateway.getInitialConversations();
                     m_consumerDRGateway.setInitialConversationMembership(expectedClusterMembers.getFirst(),
                             expectedClusterMembers.getSecond());
                 }
@@ -4245,6 +4246,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                         Cartographer.class,
                         HostMessenger.class,
                         byte.class,
+                        long.class,
                         byte.class,
                         String.class,
                         int.class);
@@ -4253,6 +4255,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                         m_cartographer,
                         m_messenger,
                         drConsumerClusterId,
+                        getClusterCreateTime(),
                         (byte) m_catalogContext.cluster.getPreferredsource(),
                         drIfAndPort.getFirst(),
                         drIfAndPort.getSecond());

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2050,7 +2050,7 @@ public abstract class CatalogUtil {
             } else if (clusterType.getId() == null && dr.getId() == null) {
                 clusterId = 0;
             } else {
-                if (clusterType.getId() == dr.getId()) {
+                if (clusterType.getId().equals(dr.getId())) {
                     clusterId = clusterType.getId();
                 } else {
                     throw new RuntimeException("Detected two conflicting cluster ids in deployement file, setting cluster id in DR tag is "


### PR DESCRIPTION
Wrapped DR cluster id and cluster creation id into instances of ClusterIdentity class, so that comparison is easier and it is also easier to embed it into log messages. In most of the maps, cluster id is still used as the map key for the initial lookup, and then cluster identity is compared to verify it is the very cluster we are looking for. 