### PR TITLE
ENG-12852: increase the initial NT procedure pool size

### DIFF
--- a/src/frontend/org/voltdb/NTProcedureService.java
+++ b/src/frontend/org/voltdb/NTProcedureService.java
@@ -114,13 +114,13 @@ public class NTProcedureService {
 
     // runs the initial run() method of nt procs
     // (doesn't run nt procs if started by other nt procs)
-    // from 1 to 20 threads in parallel, with an unbounded queue
+    // from 10 to 20 threads in parallel, with an unbounded queue
     private final ExecutorService m_primaryExecutorService = new ThreadPoolExecutor(
-            1,
+            10,
             20,
             60,
             TimeUnit.SECONDS,
-            new ArrayBlockingQueue<Runnable>(10000),
+            new ArrayBlockingQueue<Runnable>(1000),
             new ThreadFactoryBuilder()
                 .setNameFormat(NTPROC_THREADPOOL_NAMEPREFIX + "%d")
                 .build());


### PR DESCRIPTION
According to documentation of ThreadPoolExecutor, unfortunately, we used corePoolSize one which basically means it's single thread execution for NT-Procedure until the number of NT-invocations exceeds the queue size 10k. 

This PR tries to increase the corePoolSize and reduce the queue size before starting a new thread. This may start up with more idle threads than before, but still maxed out at 20 or less because of back-pressure. 

John W will run his concurrent UAC/AdHoc system tests against this branch as well.