### PR TITLE
Fix dependency checking for TABLE COUNT plans

### DIFF
--- a/src/frontend/org/voltdb/plannodes/TableCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/TableCountPlanNode.java
@@ -28,17 +28,15 @@ public class TableCountPlanNode extends AbstractScanPlanNode {
         super();
     }
 
-    public TableCountPlanNode(String tableName, String tableAlias) {
-        super(tableName, tableAlias);
-        assert(tableName != null && tableAlias != null);
-    }
-
     public TableCountPlanNode(AbstractScanPlanNode child, AggregatePlanNode apn) {
         super(child.getTargetTableName(), child.getTargetTableAlias());
         m_outputSchema = apn.getOutputSchema().clone();
         m_hasSignificantOutputSchema = true;
         m_estimatedOutputTupleCount = 1;
         m_tableSchema = child.getTableSchema();
+
+        m_tableScan = child.m_tableScan;
+        m_tableScanSchema = child.m_tableScanSchema;
 
         m_isSubQuery = child.isSubQuery();
         if (m_isSubQuery) {

--- a/src/frontend/org/voltdb/plannodes/TupleScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/TupleScanPlanNode.java
@@ -30,6 +30,12 @@ import org.voltdb.expressions.ParameterValueExpression;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.types.PlanNodeType;
 
+/**
+ * This type of plan node wraps a subquery expression for queries like this
+ *
+ *  SELECT * FROM T WHERE (T.f, T.f) > (SELECT R.f R.g FROM R LIMIT 1);
+ *
+ */
 public class TupleScanPlanNode extends AbstractScanPlanNode {
 
     public enum Members {

--- a/tests/frontend/org/voltdb/TestAdhocDropTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocDropTable.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.junit.After;
 import org.junit.Test;
 import org.voltdb.VoltDB.Configuration;
 import org.voltdb.client.ClientResponse;
@@ -36,6 +37,11 @@ import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.utils.MiscUtils;
 
 public class TestAdhocDropTable extends AdhocDDLTestBase {
+
+    @After
+    public void tearItDown() throws Exception {
+        teardownSystem();
+    }
 
     @Test
     public void testDropTableBasic() throws Exception {
@@ -68,93 +74,88 @@ public class TestAdhocDropTable extends AdhocDDLTestBase {
         config.m_pathToCatalog = pathToCatalog;
         config.m_pathToDeployment = pathToDeployment;
 
+        startSystem(config);
+        // Check basic drop of partitioned table that should work.
+        ClientResponse resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        System.out.println(resp.getResults()[0]);
+        assertTrue(findTableInSystemCatalogResults("DROPME"));
+
+        // eng7297, start with 6 rows in @Statistics table (one per table per site)
+        VoltTable stats = getStatWaitOnRowCount("TABLE", 6);
+        assertEquals(6, stats.getRowCount());
+        stats = getStatWaitOnRowCount("INDEX", 6);
+        assertEquals(6, stats.getRowCount());
+
         try {
-            startSystem(config);
-            // Check basic drop of partitioned table that should work.
-            ClientResponse resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertTrue(findTableInSystemCatalogResults("DROPME"));
-
-            // eng7297, start with 6 rows in @Statistics table (one per table per site)
-            VoltTable stats = getStatWaitOnRowCount("TABLE", 6);
-            assertEquals(6, stats.getRowCount());
-            stats = getStatWaitOnRowCount("INDEX", 6);
-            assertEquals(6, stats.getRowCount());
-
-            try {
-                m_client.callProcedure("@AdHoc", "drop table DROPME;");
-            }
-            catch (ProcCallException pce) {
-                fail("drop table should have succeeded");
-            }
-            resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertFalse(findTableInSystemCatalogResults("DROPME"));
-            // eng7297, now only 4 rows in @Statistics table (one per table per site)
-            stats = getStatWaitOnRowCount("TABLE", 4);
-            assertEquals(4, stats.getRowCount());
-            stats = getStatWaitOnRowCount("INDEX", 4);
-            assertEquals(4, stats.getRowCount());
-
-            // Check basic drop of replicated table that should work.
-            resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertTrue(findTableInSystemCatalogResults("DROPME_R"));
-            try {
-                m_client.callProcedure("@AdHoc", "drop table DROPME_R;");
-            }
-            catch (ProcCallException pce) {
-                fail("drop table should have succeeded");
-            }
-            resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertFalse(findTableInSystemCatalogResults("DROPME_R"));
-            // eng7297, now only 2 rows in @Statistics table (one per table per site)
-            stats = getStatWaitOnRowCount("TABLE", 2);
-            assertEquals(2, stats.getRowCount());
-            stats = getStatWaitOnRowCount("INDEX", 2);
-            assertEquals(2, stats.getRowCount());
-
-            // Verify dropping a table that doesn't exist fails
-            boolean threw = false;
-            try {
-                m_client.callProcedure("@AdHoc", "drop table DROPME;");
-            }
-            catch (ProcCallException pce) {
-                assertTrue(pce.getMessage().contains("object not found: DROPME"));
-                threw = true;
-            }
-            assertTrue("Dropping bad table should have failed", threw);
-
-            // Verify dropping a table that doesn't exist is fine with IF EXISTS
-            threw = false;
-            try {
-                m_client.callProcedure("@AdHoc", "drop table DROPME IF EXISTS;");
-            }
-            catch (ProcCallException pce) {
-                threw = true;
-            }
-            assertFalse("Dropping bad table with IF EXISTS should not have failed", threw);
-
-            // ENG-7297, Drop the last table and make sure that the statistics are correct
-            try {
-                m_client.callProcedure("@AdHoc", "drop table BLAH;");
-            }
-            catch (ProcCallException pce) {
-                fail("drop table should have succeeded");
-            }
-            resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertFalse(findTableInSystemCatalogResults("BLAH"));
-            // eng7297, now should be zero rows in the stats
-            stats = getStatWaitOnRowCount("TABLE", 0);
-            assertEquals(0, stats.getRowCount());
-            stats = getStatWaitOnRowCount("INDEX", 0);
-            assertEquals(0, stats.getRowCount());
+            m_client.callProcedure("@AdHoc", "drop table DROPME;");
         }
-        finally {
-            teardownSystem();
+        catch (ProcCallException pce) {
+            fail("drop table should have succeeded");
         }
+        resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        System.out.println(resp.getResults()[0]);
+        assertFalse(findTableInSystemCatalogResults("DROPME"));
+        // eng7297, now only 4 rows in @Statistics table (one per table per site)
+        stats = getStatWaitOnRowCount("TABLE", 4);
+        assertEquals(4, stats.getRowCount());
+        stats = getStatWaitOnRowCount("INDEX", 4);
+        assertEquals(4, stats.getRowCount());
+
+        // Check basic drop of replicated table that should work.
+        resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        System.out.println(resp.getResults()[0]);
+        assertTrue(findTableInSystemCatalogResults("DROPME_R"));
+        try {
+            m_client.callProcedure("@AdHoc", "drop table DROPME_R;");
+        }
+        catch (ProcCallException pce) {
+            fail("drop table should have succeeded");
+        }
+        resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        System.out.println(resp.getResults()[0]);
+        assertFalse(findTableInSystemCatalogResults("DROPME_R"));
+        // eng7297, now only 2 rows in @Statistics table (one per table per site)
+        stats = getStatWaitOnRowCount("TABLE", 2);
+        assertEquals(2, stats.getRowCount());
+        stats = getStatWaitOnRowCount("INDEX", 2);
+        assertEquals(2, stats.getRowCount());
+
+        // Verify dropping a table that doesn't exist fails
+        boolean threw = false;
+        try {
+            m_client.callProcedure("@AdHoc", "drop table DROPME;");
+        }
+        catch (ProcCallException pce) {
+            assertTrue(pce.getMessage().contains("object not found: DROPME"));
+            threw = true;
+        }
+        assertTrue("Dropping bad table should have failed", threw);
+
+        // Verify dropping a table that doesn't exist is fine with IF EXISTS
+        threw = false;
+        try {
+            m_client.callProcedure("@AdHoc", "drop table DROPME IF EXISTS;");
+        }
+        catch (ProcCallException pce) {
+            threw = true;
+        }
+        assertFalse("Dropping bad table with IF EXISTS should not have failed", threw);
+
+        // ENG-7297, Drop the last table and make sure that the statistics are correct
+        try {
+            m_client.callProcedure("@AdHoc", "drop table BLAH;");
+        }
+        catch (ProcCallException pce) {
+            fail("drop table should have succeeded");
+        }
+        resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        System.out.println(resp.getResults()[0]);
+        assertFalse(findTableInSystemCatalogResults("BLAH"));
+        // eng7297, now should be zero rows in the stats
+        stats = getStatWaitOnRowCount("TABLE", 0);
+        assertEquals(0, stats.getRowCount());
+        stats = getStatWaitOnRowCount("INDEX", 0);
+        assertEquals(0, stats.getRowCount());
     }
 
     @Test
@@ -192,73 +193,109 @@ public class TestAdhocDropTable extends AdhocDDLTestBase {
         config.m_pathToCatalog = pathToCatalog;
         config.m_pathToDeployment = pathToDeployment;
 
+        startSystem(config);
+        // Check basic drop of table with an index on it
+        ClientResponse resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        System.out.println(resp.getResults()[0]);
+        assertTrue(findTableInSystemCatalogResults("DROPME"));
+        resp = m_client.callProcedure("@SystemCatalog", "INDEXINFO");
+        System.out.println(resp.getResults()[0]);
+        assertTrue(findIndexInSystemCatalogResults("PKEY_IDX"));
         try {
-            startSystem(config);
-            // Check basic drop of table with an index on it
-            ClientResponse resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertTrue(findTableInSystemCatalogResults("DROPME"));
-            resp = m_client.callProcedure("@SystemCatalog", "INDEXINFO");
-            System.out.println(resp.getResults()[0]);
-            assertTrue(findIndexInSystemCatalogResults("PKEY_IDX"));
-            try {
-                m_client.callProcedure("@AdHoc", "drop table DROPME;");
-            }
-            catch (ProcCallException pce) {
-                fail("drop table should have succeeded");
-            }
-            resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertFalse(findTableInSystemCatalogResults("DROPME"));
-            resp = m_client.callProcedure("@SystemCatalog", "INDEXINFO");
-            System.out.println(resp.getResults()[0]);
-            assertFalse(findIndexInSystemCatalogResults("PKEY_IDX"));
-
-            // Verify that we can't drop a table that a procedure depends on
-            resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertTrue(findTableInSystemCatalogResults("BLAH"));
-            boolean threw = false;
-            try {
-                m_client.callProcedure("@AdHoc", "drop table BLAH;");
-            }
-            catch (ProcCallException pce) {
-                // The error message is really confusing for this case, not sure
-                // how to make it better though
-                pce.printStackTrace();
-                threw = true;
-            }
-            assertTrue("Shouldn't be able to drop a table used in a procedure", threw);
-            resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertTrue(findTableInSystemCatalogResults("BLAH"));
-
-            threw = false;
-            try {
-                m_client.callProcedure("@AdHoc", "drop table VIEWBASE;");
-            }
-            catch (ProcCallException pce) {
-                threw = true;
-            }
-            assertTrue("Shouldn't be able to drop a table used in a view", threw);
-            resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertTrue(findTableInSystemCatalogResults("VIEWBASE"));
-            assertTrue(findTableInSystemCatalogResults("BLAT"));
-
-            try {
-                m_client.callProcedure("@AdHoc", "drop table VIEWBASE cascade;");
-            }
-            catch (ProcCallException pce) {
-                fail("Should be able to drop table and view with cascade");
-            }
-            resp = m_client.callProcedure("@SystemCatalog", "TABLES");
-            System.out.println(resp.getResults()[0]);
-            assertFalse(findTableInSystemCatalogResults("VIEWBASE"));
-            assertFalse(findTableInSystemCatalogResults("BLAT"));
+            m_client.callProcedure("@AdHoc", "drop table DROPME;");
         }
-        finally {
-            teardownSystem();
+        catch (ProcCallException pce) {
+            fail("drop table should have succeeded");
         }
+        resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        System.out.println(resp.getResults()[0]);
+        assertFalse(findTableInSystemCatalogResults("DROPME"));
+        resp = m_client.callProcedure("@SystemCatalog", "INDEXINFO");
+        System.out.println(resp.getResults()[0]);
+        assertFalse(findIndexInSystemCatalogResults("PKEY_IDX"));
+
+        // Verify that we can't drop a table that a procedure depends on
+        resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        System.out.println(resp.getResults()[0]);
+        assertTrue(findTableInSystemCatalogResults("BLAH"));
+        boolean threw = false;
+        try {
+            m_client.callProcedure("@AdHoc", "drop table BLAH;");
+        }
+        catch (ProcCallException pce) {
+            // The error message is really confusing for this case, not sure
+            // how to make it better though
+            pce.printStackTrace();
+            threw = true;
+        }
+        assertTrue("Shouldn't be able to drop a table used in a procedure", threw);
+        resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        System.out.println(resp.getResults()[0]);
+        assertTrue(findTableInSystemCatalogResults("BLAH"));
+
+        threw = false;
+        try {
+            m_client.callProcedure("@AdHoc", "drop table VIEWBASE;");
+        }
+        catch (ProcCallException pce) {
+            threw = true;
+        }
+        assertTrue("Shouldn't be able to drop a table used in a view", threw);
+        resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        assertTrue(findTableInSystemCatalogResults("VIEWBASE"));
+        assertTrue(findTableInSystemCatalogResults("BLAT"));
+
+        try {
+            m_client.callProcedure("@AdHoc", "drop table VIEWBASE cascade;");
+        }
+        catch (ProcCallException pce) {
+            fail("Should be able to drop table and view with cascade");
+        }
+        resp = m_client.callProcedure("@SystemCatalog", "TABLES");
+        System.out.println(resp.getResults()[0]);
+        assertFalse(findTableInSystemCatalogResults("VIEWBASE"));
+        assertFalse(findTableInSystemCatalogResults("BLAT"));
+    }
+
+    @Test
+    public void testEng12816() throws Exception {
+
+        String pathToCatalog = Configuration.getPathToCatalogForTest("adhocddl.jar");
+        String pathToDeployment = Configuration.getPathToCatalogForTest("adhocddl.xml");
+
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        builder.setUseDDLSchema(true);
+        boolean success = builder.compile(pathToCatalog, 2, 1, 0);
+        assertTrue("Schema compilation failed", success);
+        MiscUtils.copyFile(builder.getPathToDeployment(), pathToDeployment);
+
+        VoltDB.Configuration config = new VoltDB.Configuration();
+        config.m_pathToCatalog = pathToCatalog;
+        config.m_pathToDeployment = pathToDeployment;
+
+        startSystem(config);
+
+        ClientResponse cr;
+        cr = m_client.callProcedure("@AdHoc",
+                "create table t_eng12816 ( "
+                        + "i integer not null primary key, "
+                        + "vc varchar(32) "
+                        + "); ");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        cr = m_client.callProcedure("@AdHoc", "create procedure proc1 as select count(*) from t_eng12816;");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+
+        try {
+            m_client.callProcedure("@AdHoc", "drop table t_eng12816;");
+            fail("expected an exception!");
+        }
+        catch (ProcCallException pce) {
+            assertTrue(pce.getMessage().contains("object not found"));
+        }
+
+        cr = m_client.callProcedure("@SystemCatalog", "TABLES");
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+        assertTrue(findTableInSystemCatalogResults("T_ENG12816"));
     }
 }

--- a/tests/frontend/org/voltdb/planner/TestGetTablesAndIndexes.java
+++ b/tests/frontend/org/voltdb/planner/TestGetTablesAndIndexes.java
@@ -109,6 +109,14 @@ public class TestGetTablesAndIndexes extends PlannerTestCase {
                 "INDEX SCAN",
                 Arrays.asList("CUSTOMER", "ITEM"),
                 Arrays.asList("VOLTDB_AUTOGEN_IDX_CT_CUSTOMER_C_W_ID_C_D_ID_C_LAST_C_FIRST"));
+        // Following query tests the TUPLE_SCAN plan node (TupleScanPlanNode)
+        assertTablesAndIndexes("select * "
+                + "from customer "
+                + "where (c_id,c_w_id) > (select ol_o_id, ol_d_id from order_line where ol_w_id = 0)",
+                "INDEX SCAN",
+                Arrays.asList("CUSTOMER", "ORDER_LINE"),
+                Arrays.asList("VOLTDB_AUTOGEN_IDX_CT_CUSTOMER_C_W_ID_C_D_ID_C_LAST_C_FIRST",
+                        "IDX_ORDER_LINE_TREE"));
     }
 
     private void assertUpdatedTable(String stmt, String expectedTable) {

--- a/tests/frontend/org/voltdb/planner/TestGetTablesAndIndexes.java
+++ b/tests/frontend/org/voltdb/planner/TestGetTablesAndIndexes.java
@@ -1,0 +1,138 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.planner;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.voltdb.benchmark.tpcc.TPCCProjectBuilder;
+import org.voltdb.planner.parseinfo.StmtTargetTableScan;
+import org.voltdb.plannodes.AbstractPlanNode;
+
+public class TestGetTablesAndIndexes extends PlannerTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        setupSchema(TPCCProjectBuilder.class.getResource("tpcc-ddl.sql"), "testGetTablesAndIndexes", false);
+    }
+
+    private void assertTablesAndIndexes(String stmt,
+            String expectedPlanNode,
+            Collection<String> expectedTables,
+            Collection<String> expectedIndexes) {
+        List<AbstractPlanNode> fragments = compileToFragments(stmt);
+
+        Map<String, StmtTargetTableScan> actualTables = new HashMap<>();
+        Set<String> actualIndexes = new HashSet<>();
+        boolean foundExpectedPlanNode = false;
+        for (AbstractPlanNode frag : fragments) {
+            frag.getTablesAndIndexes(actualTables, actualIndexes);
+            String explainPlan = frag.toExplainPlanString();
+            if (explainPlan.contains(expectedPlanNode)) {
+                foundExpectedPlanNode = true;
+            }
+        }
+
+        assertTrue(foundExpectedPlanNode);
+
+        for (String expectedTable : expectedTables) {
+            assertTrue(actualTables.containsKey(expectedTable));
+        }
+        assertEquals(expectedTables.size(), actualTables.size());
+
+        if (expectedIndexes != null) {
+            for (String expectedIndex : expectedIndexes) {
+                assertTrue(actualIndexes.contains(expectedIndex));
+            }
+            assertEquals(expectedIndexes.size(), actualIndexes.size());
+        }
+        else {
+            assertTrue(actualIndexes.isEmpty());
+        }
+    }
+
+    public void testSelectStatements() {
+        // Make sure that all the leaf nodes report the tables they access
+        assertTablesAndIndexes("select * from history", "SEQUENTIAL SCAN",
+                Arrays.asList("HISTORY"), null);
+        assertTablesAndIndexes("select count(*) from history", "TABLE COUNT",
+                Arrays.asList("HISTORY"), null);
+
+        assertTablesAndIndexes("select * from warehouse", "INDEX SCAN",
+                Arrays.asList("WAREHOUSE"),
+                Arrays.asList("VOLTDB_AUTOGEN_CONSTRAINT_IDX_W_PK_TREE"));
+        assertTablesAndIndexes("select COUNT(*) from warehouse where w_id > 100", "INDEX COUNT",
+                Arrays.asList("WAREHOUSE"),
+                Arrays.asList("VOLTDB_AUTOGEN_CONSTRAINT_IDX_W_PK_TREE"));
+
+        assertTablesAndIndexes(
+                "select * "
+                + "from orders as o inner join order_line as ol "
+                + "on o.o_id = ol.ol_o_id and o_w_id = ol_w_id "
+                + "where o_d_id = 32",
+                "INDEX SCAN",
+                Arrays.asList("ORDERS", "ORDER_LINE"),
+                Arrays.asList("VOLTDB_AUTOGEN_CONSTRAINT_IDX_O_PK_HASH"));
+
+        // Test subqueries!
+        assertTablesAndIndexes("select * from (select * from customer where c_w_id > 50) as c;",
+                "INDEX SCAN",
+                Arrays.asList("CUSTOMER"),
+                Arrays.asList("IDX_CUSTOMER"));
+        assertTablesAndIndexes("select (select max(i_price) from item) as maxprice from customer",
+                "INDEX SCAN",
+                Arrays.asList("CUSTOMER", "ITEM"),
+                Arrays.asList("VOLTDB_AUTOGEN_IDX_CT_CUSTOMER_C_W_ID_C_D_ID_C_LAST_C_FIRST"));
+    }
+
+    private void assertUpdatedTable(String stmt, String expectedTable) {
+        List<AbstractPlanNode> fragments = compileToFragments(stmt);
+
+        String actualTable = null;
+        for (AbstractPlanNode fragment : fragments) {
+            String tbl = fragment.getUpdatedTable();
+            if (tbl != null) {
+                assertNull(actualTable);
+                actualTable = tbl;
+            }
+        }
+
+        assertNotNull(actualTable);
+        assertEquals(expectedTable, actualTable);
+    }
+
+    public void testDmlStatements() {
+        assertUpdatedTable("insert into new_order values (0, 0, 0)", "NEW_ORDER");
+        assertUpdatedTable("upsert into new_order values (0, 0, 0)", "NEW_ORDER");
+        assertUpdatedTable("delete from new_order", "NEW_ORDER");
+        assertUpdatedTable("update new_order set no_w_id = 3 where no_d_id = 10", "NEW_ORDER");
+        assertUpdatedTable("truncate table new_order", "NEW_ORDER");
+    }
+
+}

--- a/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewSuite.java
@@ -1857,6 +1857,7 @@ public class TestMaterializedViewSuite extends RegressionSuite {
         if (! isHSQL()) {
             System.out.println("Now testing view data catching-up.");
             try {
+                client.callProcedure("@AdHoc", "DROP PROCEDURE TruncateMatViewDataMP;");
                 client.callProcedure("@AdHoc", "DROP VIEW ORDER_DETAIL_WITHPCOL;");
             } catch (ProcCallException pce) {
                 pce.printStackTrace();
@@ -1875,6 +1876,7 @@ public class TestMaterializedViewSuite extends RegressionSuite {
                                    "JOIN ORDERITEMS ON ORDERS.ORDER_ID = ORDERITEMS.ORDER_ID " +
                                    "JOIN PRODUCTS ON ORDERITEMS.PID = PRODUCTS.PID " +
                     "GROUP BY CUSTOMERS.NAME, ORDERS.ORDER_ID;");
+                client.callProcedure("@AdHoc", "CREATE PROCEDURE FROM CLASS org.voltdb_testprocs.regressionsuites.matviewprocs.TruncateMatViewDataMP");
             } catch (ProcCallException pce) {
                 pce.printStackTrace();
                 fail("Should be able to create a view.");


### PR DESCRIPTION
We weren't reporting the set of tables that are used correctly for plans that have a TABLE COUNT node.  As a result it was possible to drop a table that has a plan with a TABLE COUNT node on that table.