### PR TITLE
Eng 12481 test query timeout

### DIFF
--- a/tests/frontend/org/voltdb/regressionsuites/TestQueryTimeout.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestQueryTimeout.java
@@ -96,7 +96,13 @@ public class TestQueryTimeout extends RegressionSuite {
         truncateData(client, "R1");
     }
 
-    public void testReplicatedProcTimeout() throws IOException, ProcCallException, InterruptedException {
+    public void notestReplicatedProcTimeout() throws IOException, ProcCallException, InterruptedException {
+        // If the authentication information is
+        // incorrect, shutdown will not succeed.
+        // So, we need to set this in any case.
+        // Feel free to reset it later on.
+        m_username = "adminUser";
+        m_password = "password";
         if (isValgrind() || isDebug()) {
             // Disable the memcheck/debug for this test, it takes too long
             return;
@@ -142,7 +148,13 @@ public class TestQueryTimeout extends RegressionSuite {
         }
     }
 
-    public void testPartitionedProcTimeout() throws IOException, ProcCallException, InterruptedException {
+    public void notestPartitionedProcTimeout() throws IOException, ProcCallException, InterruptedException {
+        // If the authentication information is
+        // incorrect, shutdown will not succeed.
+        // So, we need to set this in any case.
+        // Feel free to reset it later on.
+        m_username = "adminUser";
+        m_password = "password";
         if (isValgrind() || isDebug()) {
             // Disable the memcheck/debug for this test, it takes too long
             return;
@@ -186,18 +198,19 @@ public class TestQueryTimeout extends RegressionSuite {
         }
     }
 
-    final String PROMPTMSG = " is supposed to timed out, but succeed eventually!";
+    final String PROMPTMSG = " is supposed to time out, but succeeded eventually!";
 
     private void checkTimeoutIncreasedProcSucceed(boolean sync, Client client, String procName, Object...params)
             throws IOException, ProcCallException, InterruptedException {
         checkDeploymentPropertyValue(client, "querytimeout", Integer.toString(TIMEOUT_NORMAL));
-
         try {
             client.callProcedure(procName, params);
             fail(procName + PROMPTMSG);
         }
-        catch (Exception ex) {
-            assertTrue(ex.toString() + " did not contain " + ERRORMSG,
+        catch (ProcCallException ex) {
+            assertTrue("Unexpected exception raised in procedure \""
+                       + procName + "\": "
+                       + ex.getMessage(),
                        ex.getMessage().contains(ERRORMSG));
         }
 
@@ -209,7 +222,6 @@ public class TestQueryTimeout extends RegressionSuite {
                 client.callProcedureWithTimeout(TIMEOUT_LONG, procName, params);
             }
             catch (Exception ex) {
-                System.err.println(ex.getMessage());
                 fail(procName + " is supposed to succeed but failed with message: !"
                         + ex.getMessage());
             }
@@ -228,8 +240,10 @@ public class TestQueryTimeout extends RegressionSuite {
             client.callProcedure(procName, params);
             fail(procName + PROMPTMSG);
         }
-        catch (Exception ex) {
-            assertTrue(ex.toString() + " did not contain " + ERRORMSG,
+        catch (ProcCallException ex) {
+            assertTrue("Unexpected exception raised in procedure \""
+                       + procName + "\": "
+                       + ex.getMessage(),
                        ex.getMessage().contains(ERRORMSG));
         }
 
@@ -239,13 +253,14 @@ public class TestQueryTimeout extends RegressionSuite {
     private void checkTimeoutIncreasedProcFailed(boolean sync, Client client, String procName, Object...params)
             throws IOException, ProcCallException, InterruptedException {
         checkDeploymentPropertyValue(client, "querytimeout", Integer.toString(TIMEOUT_NORMAL));
-
         try {
             client.callProcedure(procName, params);
             fail(procName + PROMPTMSG);
         }
-        catch (Exception ex) {
-            assertTrue(ex.toString() + " did not contain " + ERRORMSG,
+        catch (ProcCallException ex) {
+            assertTrue("Unexpected exception raised in procedure \""
+                       + procName + "\": "
+                       + ex.getMessage(),
                        ex.getMessage().contains(ERRORMSG));
         }
 
@@ -410,6 +425,12 @@ public class TestQueryTimeout extends RegressionSuite {
     }
 
     public void testIndividualProcTimeout() throws IOException, ProcCallException, InterruptedException {
+        // If the authentication information is
+        // incorrect, shutdown will not succeed.
+        // So, we need to set this in any case.
+        // Feel free to reset it later on.
+        m_username="adminUser";
+        m_password="password";
         if (isValgrind() || isDebug()) {
             // Disable the memcheck/debug for this test, it takes too long
             return;

--- a/tests/frontend/org/voltdb/regressionsuites/TestQueryTimeout.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestQueryTimeout.java
@@ -37,9 +37,11 @@ import org.voltdb.compiler.VoltProjectBuilder.UserInfo;
 
 public class TestQueryTimeout extends RegressionSuite {
 
+    // These are dimensionless multipliers.
     private static final double TIMEOUT_INCREASE = 50.0;
     private static final double TIMEOUT_DECREASE = 1/500.0;
 
+    // These are all in milliseconds.
     private static final int TIMEOUT_NORMAL = 1000;
     private static final int TIMEOUT_LONG   = (int)(1000 * TIMEOUT_INCREASE);
     private static final int TIMEOUT_SHORT  = (int)(1000 * TIMEOUT_DECREASE);
@@ -96,7 +98,7 @@ public class TestQueryTimeout extends RegressionSuite {
         truncateData(client, "R1");
     }
 
-    public void notestReplicatedProcTimeout() throws IOException, ProcCallException, InterruptedException {
+    public void testReplicatedProcTimeout() throws IOException, ProcCallException, InterruptedException {
         // If the authentication information is
         // incorrect, shutdown will not succeed.
         // So, we need to set this in any case.
@@ -148,7 +150,7 @@ public class TestQueryTimeout extends RegressionSuite {
         }
     }
 
-    public void notestPartitionedProcTimeout() throws IOException, ProcCallException, InterruptedException {
+    public void testPartitionedProcTimeout() throws IOException, ProcCallException, InterruptedException {
         // If the authentication information is
         // incorrect, shutdown will not succeed.
         // So, we need to set this in any case.
@@ -273,7 +275,7 @@ public class TestQueryTimeout extends RegressionSuite {
                 client.callProcedureWithTimeout(TIMEOUT_LONG, procName, params);
                 fail(procName + PROMPTMSG);
             }
-            catch (Exception ex) {
+            catch (ProcCallException ex) {
                 assertTrue(ex.toString() + " did not contain " + ERRORMSG,
                            ex.getMessage().contains(ERRORMSG));
             }
@@ -292,7 +294,7 @@ public class TestQueryTimeout extends RegressionSuite {
             client.callProcedure(procName, params);
             fail(procName + PROMPTMSG);
         }
-        catch (Exception ex) {
+        catch (ProcCallException ex) {
             assertTrue(ex.toString() + " did not contain " + ERRORMSG,
                        ex.getMessage().contains(ERRORMSG));
         }
@@ -344,7 +346,6 @@ public class TestQueryTimeout extends RegressionSuite {
                     + " is supposed to succeed, but failed with message "
                     + ex.getMessage()
                     + "\n");
-            ex.printStackTrace();
         }
 
         checkDeploymentPropertyValue(client, "querytimeout", Integer.toString(TIMEOUT_NORMAL));
@@ -372,7 +373,7 @@ public class TestQueryTimeout extends RegressionSuite {
             // truncate the data
             truncateTables(client);
             // load more data
-            loadTables(client, 5000, 3000);
+            loadTables(client, 10000, 3000);
 
             if (isAdmin) {
                 checkTimeoutIncreasedProcSucceed(sync, client, "SPPartitionReadOnlyProc", 1);
@@ -437,8 +438,6 @@ public class TestQueryTimeout extends RegressionSuite {
         }
         Client client;
 
-        m_username = "adminUser";
-        m_password = "password";
         client = getClient();
         checkIndividualProcTimeout(client, true);
 


### PR DESCRIPTION
Fix authentication credentials in debug.

When this is executed in debug it doesn't actually do the tests.  There is a test for isDebug() and isValgrind() which short circuits any actual testing.  But this also short circuits setting the authentication credentials.  Before, since we had started up a server already, the test couldn't create a client to shut the server down cleanly.  This caused the test to throw an exception and fail.

https://issues.voltdb.com/browse/ENG-12481
