### PR TITLE
Eng 4928 - Add meshmonitor to kit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -515,6 +515,21 @@ PRIMARY ENTRY POINTS
 </target>
 
 
+<target name="meshmmonitor">
+     <!-- copy meshmonitor -->
+    <mkdir dir="${dist.dir}/tools/meshmonitor" />
+    <ant antfile="${base.dir}/tools/meshmonitor/build.xml"
+	 target="dist" inheritAll="false" dir="${base.dir}/tools/meshmonitor">
+        <property name="build" value="${build}"/>
+    </ant>
+    <copy todir="${dist.dir}/tools/meshmonitor">
+        <fileset dir="${base.dir}/tools/meshmonitor/dist" defaultexcludes="yes">
+            <include name="**"/>
+        </fileset>
+    </copy>
+
+</target>
+
 <!--
 ***************************************
 DISTRIBUTION
@@ -674,8 +689,10 @@ DISTRIBUTION
 
     <!-- copy meshmonitor -->
     <mkdir dir="${dist.dir}/tools/meshmonitor" />
-    <ant antfile="${base.dir}/tools/meshmonitor/build.xml" target="dist" inheritAll="false">
-        <property name="build" value="${build}"/>
+    <ant antfile="${base.dir}/tools/meshmonitor/build.xml"
+	 target="dist" inheritAll="false"
+	 dir="${base.dir}/tools/meshmonitor">
+        <property name="volthome" value="${base.dir}"/>
     </ant>
     <copy todir="${dist.dir}/tools/meshmonitor">
         <fileset dir="${base.dir}/tools/meshmonitor/dist" defaultexcludes="yes">

--- a/build.xml
+++ b/build.xml
@@ -672,6 +672,18 @@ DISTRIBUTION
 
     <antcall target="copy_pro_bin"/>
 
+    <!-- copy meshmonitor -->
+    <mkdir dir="${dist.dir}/tools/meshmonitor" />
+    <ant antfile="${base.dir}/tools/meshmonitor/build.xml" target="dist" inheritAll="false">
+        <property name="build" value="${build}"/>
+    </ant>
+    <copy todir="${dist.dir}/tools/meshmonitor">
+        <fileset dir="${base.dir}/tools/meshmonitor/dist" defaultexcludes="yes">
+            <include name="**"/>
+        </fileset>
+    </copy>
+
+
     <!-- make shell scripts executable -->
     <chmod perm="ugo+rx">
         <fileset dir="${dist.dir}" defaultexcludes="yes">

--- a/build.xml
+++ b/build.xml
@@ -514,22 +514,6 @@ PRIMARY ENTRY POINTS
     </exec>
 </target>
 
-
-<target name="meshmmonitor">
-     <!-- copy meshmonitor -->
-    <mkdir dir="${dist.dir}/tools/meshmonitor" />
-    <ant antfile="${base.dir}/tools/meshmonitor/build.xml"
-	 target="dist" inheritAll="false" dir="${base.dir}/tools/meshmonitor">
-        <property name="build" value="${build}"/>
-    </ant>
-    <copy todir="${dist.dir}/tools/meshmonitor">
-        <fileset dir="${base.dir}/tools/meshmonitor/dist" defaultexcludes="yes">
-            <include name="**"/>
-        </fileset>
-    </copy>
-
-</target>
-
 <!--
 ***************************************
 DISTRIBUTION

--- a/tools/meshmonitor/README.md
+++ b/tools/meshmonitor/README.md
@@ -1,0 +1,105 @@
+Overview
+---------------
+Mesh Monitor is a tool that simulates the VoltDB heartbeat paths. It is
+useful in diagnosing issues such as network delays and instability, mysterious
+timeouts and hangs and scheduling problems that delay message passing. A
+common use for this tool is when sites are experiencing dead host timeouts
+without any obvious network event.
+
+Meshmonitor has threads that measure and report on 3 parameters:
+
+1. **Sending heartbeats.** A *send* thread wakes up every 5 milliseconds and
+sends heartbeats to all the other servers running meshmonitor. This tracks
+the liveness of the server (i.e. its ability of a thread to get scheduled
+in a timely manner and send a message out.)
+2. **Receiving heartbeats.** A *receive* thread that is blocked reading the
+socket that receives messages sent from the other servers.
+3. **Timestamp differences**.The *receive* thread also
+measures the difference in time between the timestamp encoded in the
+heartbeat and when the heartbeat was processed.
+
+If any of these values exceeds the hiccuptime (default of 20 milliseconds),
+a message is printed out.  Otherwise, the meshmonitor prints a message
+"nothing to report".
+
+Log information
+---------------
+There are 3 kinds of messages, for the 3 measurements:
+
+* delta send - delta between sending heartbeats
+* delta receive - delta between receiving heartbeats
+* delta timestamp - delta between remotely recorded sent timestamp and
+  locally recorded receive time
+
+**Log message fields (in order):**
+
+*Identifying information:*  
+Date  
+Time  
+This node address  
+Other node address (i.e. message sender)  
+Message type  
+
+*Latency Information:*  
+Max latency  
+Average Latency  
+99.0    percentile latency  
+99.9    percentile latency  
+99.99   percentile latency  
+99.999  percentile latency  
+
+Example:  
+`2014-11-07 15:53:49,019	/10.10.181.102:41924   volt14a/10.10.181.19:12222  delta receive - MaxLat:   96 Avg:   5.58 99th-Pct:   9  86  96  96`
+
+
+Interpreting Results
+---------------------
+Log files from all the nodes should be compared in order to establish where
+the problem lies. There can be delays in many parts of the system. 
+By comparing log files from different nodes you can often match deltas in
+send times on one node to deltas in receive times on the others. This
+can indicate that a sender is not properly scheduling its threads.  Deltas
+in receive times with no correlated deltas in send times can indicate a
+bottleneck in the network.
+
+Starting Meshmonitor
+--------------------
+Copy meshmonitor.jar to all the nodes you want to run on.
+
+meshmonitorhelper.sh is used to help facilitate executing mesh monitor
+program.  Log will be created with the 'hostname-mesh.log' structure.  This
+script will help generate the commands needed to run on all other nodes for
+testing.  Please ensure network port chosen is free on all nodes.
+
+```
+Usage: ./meshmonitorhelper.sh NODESFILE <HICCUPSIZE> <LOGINTERVAL> <NETWORKPORT>
+   NODESFILE - required parameter         - file with list of nodes on each line
+   <HICCUPSIZE>  - optional               - mininum latency in milliseconds to report, default value = 20
+   <LOGINTERVAL> - optional               - interval of logging in seconds, default value = 10
+   <NETWORKPORT> - optional               - network port used, default value = 12222
+
+```
+
+Sample output for a nodes.txt that lists 3 nodes:  
+prod1  
+prod2  
+client1  
+
+```
+> ./meshmonitorhelper.sh nodes.txt
+Using list of hosts file: nodes.txt
+Using default minimum hiccup size: 20
+Using default logging interval in seconds: 10
+Using default network port: 12222
+
+Generating the commands needed to run on all other nodes:
+
+#prod1: In <VOLTDB_HOME>/tools/meshmonitor directory, run the following command:
+nohup java -jar meshmonitor.jar 20 10 prod1:12222 > prod1-mesh.log &
+
+#prod2: In <VOLTDB_HOME>/tools/meshmonitor directory, run the following command:
+nohup java -jar meshmonitor.jar 20 10 prod2:12222 prod1:12222 > prod2-mesh.log &
+
+#client1: In <VOLTDB_HOME>/tools/meshmonitor directory, run the following command:
+nohup java -jar meshmonitor.jar 20 10 client1:12222 prod2:12222 prod1:12222 > client1-mesh.log &
+```

--- a/tools/meshmonitor/build.xml
+++ b/tools/meshmonitor/build.xml
@@ -2,12 +2,12 @@
 
     <!-- make environment var foo available as env.foo -->
     <property environment="env"/>
-    <!-- VOLTCORE env variable points to voltdb checkout -->
-    <condition property="voltcore" value="${env.VOLTCORE}" else="../..">
-      <isset property="env.VOLTCORE"/>
+    <!-- VOLTHOME env variable points to voltdb checkout -->
+    <condition property="volthome" value="${env.VOLTHOME}" else="../..">
+      <isset property="env.VOLTHOME"/>
     </condition>
 
-    <property name='voltcore.obj' value="${voltcore}/obj/release/prod"/>
+    <property name='volthome.obj' value="${volthome}/obj/release/prod"/>
 
     <target name="clean">
         <delete includeEmptyDirs="true" dir="build"/>
@@ -20,7 +20,7 @@
             includeantruntime="false"
             srcdir="src"
             destdir="build/classes">
-            <classpath path="${voltcore.obj}"/>
+            <classpath path="${volthome.obj}"/>
         </javac>
     </target>
 
@@ -29,7 +29,7 @@
         <mkdir dir="build/jar"/>
         <jar destfile="build/jar/MeshMonitor.jar">
             <fileset dir="build/classes"/>
-	    <fileset dir="${voltcore.obj}">
+	    <fileset dir="${volthome.obj}">
 	        <include name="org/HdrHistogram_voltpatches/**"/>
 		<include name="com/google_voltpatches/common/net/**"/>
 		<include name="com/google_voltpatches/common/base/**"/>

--- a/tools/meshmonitor/build.xml
+++ b/tools/meshmonitor/build.xml
@@ -1,0 +1,50 @@
+<project name="meshmonitor" default="dist">
+
+    <!-- make environment var foo available as env.foo -->
+    <property environment="env"/>
+    <!-- VOLTCORE env variable points to voltdb checkout -->
+    <condition property="voltcore" value="${env.VOLTCORE}" else="../..">
+      <isset property="env.VOLTCORE"/>
+    </condition>
+
+    <property name='voltcore.obj' value="${voltcore}/obj/release/prod"/>
+
+    <target name="clean">
+        <delete includeEmptyDirs="true" dir="build"/>
+        <delete includeEmptyDirs="true" dir="dist"/>
+    </target>
+
+    <target name="compile">
+        <mkdir dir="build/classes"/>
+        <javac
+            includeantruntime="false"
+            srcdir="src"
+            destdir="build/classes">
+            <classpath path="${voltcore.obj}"/>
+        </javac>
+    </target>
+
+
+    <target name="jar" depends="clean,compile">
+        <mkdir dir="build/jar"/>
+        <jar destfile="build/jar/MeshMonitor.jar">
+            <fileset dir="build/classes"/>
+	    <fileset dir="${voltcore.obj}">
+	        <include name="org/HdrHistogram_voltpatches/**"/>
+		<include name="com/google_voltpatches/common/net/**"/>
+		<include name="com/google_voltpatches/common/base/**"/>
+	    </fileset>
+            <manifest>
+                <attribute name="Main-Class" value="MeshMonitor"/>
+            </manifest>
+        </jar>
+    </target>
+
+
+    <target name="dist" depends="clean,jar">
+        <mkdir dir="dist"/>
+        <copy file="meshmonitorhelper.sh" tofile="dist/meshmonitorhelper.sh"/>
+        <copy file="build/jar/MeshMonitor.jar" tofile="dist/meshmonitor.jar"/>
+        <copy file="README.md" tofile="dist/README"/>
+    </target>
+</project>

--- a/tools/meshmonitor/meshmonitorhelper.sh
+++ b/tools/meshmonitor/meshmonitorhelper.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+#meshmonitorhelper.sh is used to create lines used to run meshmonitor application on multiple nodes
+#Refer to README for more information.
+
+#declare variables; default values
+LISTOFHOSTS=		# $1 required
+MINHICCUPSIZE=20	# $2
+LOGINTERVAL=10 		# $3
+NETWORKPORT=12222	# $4
+HOSTSLIST=
+
+# display syntax and exit
+syntax() {
+	echo "Usage: $0 NODESFILE <HICCUPSIZE> <LOGINTERVAL> <NETWORKPORT>"
+	echo "   NODESFILE - required parameter         - file with list of nodes on each line"
+	echo "   <HICCUPSIZE>  - optional               - mininum latency in milliseconds to report, default value = 20"
+	echo "   <LOGINTERVAL> - optional               - interval of logging in seconds, default value = 10"
+	echo "   <NETWORKPORT> - optional               - network port used, default value = 12222"
+	echo "Please see README for more details."
+	exit 0
+
+}
+
+# exit program with error message
+exitprogram () {
+	echo >&2 "$@"
+	exit 1
+}
+
+# check for numeric value
+isNum (){
+echo $1 | grep -E -q '^[0-9]+$'
+}
+
+# main loop
+
+#check no parameters and help switch and exit
+if [ $# -eq 0 ] || [ "$1" == "-h" ]; then
+    syntax
+fi
+
+# check $1/listofNODES - required parameter
+LISTOFHOSTS=$1
+if [ -f $LISTOFHOSTS ];	then
+	echo "Using list of hosts file: $LISTOFHOSTS"
+else
+	exitprogram "ERROR: file '$LISTOFHOSTS' does not exist"
+fi
+
+
+# check $2/HICCUPSIZE - optional parameter
+# check if there is a value
+if [ ! -z "$2" ]; then 
+		# if its a non integer; exit
+		isNum $2 || exitprogram "Input Value '$2' - ERROR - Please choose a value between 0 and 50000 ms" 
+		# check for value between 0 and 50000ms
+		if [ "$2" -gt "0" ] && [ "$2" -lt "50000" ]; then
+			MINHICCUPSIZE=$2
+			echo "Using minimum hiccup size: $MINHICCUPSIZE"
+		else 
+			exitprogram "minimum hiccup size - ERROR - Please choose a value between 0 and 50000 ms"
+		fi
+else
+	echo "Using default minimum hiccup size: $MINHICCUPSIZE"
+fi
+
+
+# check $3/LOGINTERVAL - optional parameter
+# check if there is a value
+
+if [ ! -z "$3" ]; then 
+	# if its a non integer; exit
+	isNum $3 || exitprogram "Input value '$3' - ERROR - Please choose a numeric value larger then 0" # if its a non integer; exit
+	# check for value larger then 0
+	if [ "$2" -gt "0" ]; then
+		LOGINTERVAL=$3
+		echo "Using logging interval in seconds: $LOGINTERVAL"
+	else 
+		exitprogram "logging interval - ERROR - Please choose a numeric value larger then 0"
+	fi
+else
+	echo "Using default logging interval in seconds: $LOGINTERVAL"
+fi
+
+# check $4/NETWORKPORT - optional parameter
+# check if there is a value
+if [ ! -z "$4" ]; then
+	isNum $4 || exitprogram "Input Value '$4' - ERROR - Please choose an unused network port between 1-65535"
+	# check for value larger then 0
+	if [ "$4" -gt "0" ] && [ "$4" -lt "65535" ]; then
+	 	NETWORKPORT=$4
+		echo "Using network port: $NETWORKPORT"
+	else
+		exitprogram "network port - ERROR - Please choose an unused network port between 1-65535"
+	fi
+else
+	echo "Using default network port: $NETWORKPORT"
+fi
+
+# print commands to execute
+echo
+echo "Generating the commands needed to run on all other nodes:"
+echo
+for f in $(cat $LISTOFHOSTS); do
+	export HOSTSLIST="$f:$NETWORKPORT $HOSTSLIST"
+	echo "#$f: In <VOLTDB_HOME>/tools/meshmonitor directory, run the following command:"
+	echo "nohup java -jar meshmonitor.jar $MINHICCUPSIZE $LOGINTERVAL $HOSTSLIST> $f-mesh.log &"
+	echo
+done
+

--- a/tools/meshmonitor/src/MeshMonitor.java
+++ b/tools/meshmonitor/src/MeshMonitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2014 VoltDB Inc.
+ * Copyright (C) 2008-2017 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -130,23 +130,23 @@ public class MeshMonitor {
             if ( ( keptmin == new Date().getMinutes() && keptsec == new Date().getSeconds() ) || firstrunconnect ) {
 		        System.out.printf( formatUTC.format( new Date()) + " %-22s %-33s "
 	        		+ " connected to remote endpoint " + m_sc.socket().getRemoteSocketAddress() + "\n"
-	        		, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress() 
+	        		, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress()
 	        	);
 		        if (firstrunconnect) {
 		        	firstrunconnect = false;
 		        }
             }
-            
+
             boolean haveOutliers = false;
-    		
+
             synchronized (receiveLock) {
                 if (m_receiveHistogram.getMaxValue() > minHiccupSize) {
                     haveOutliers = true;
-                    ps.printf( formatUTC.format(new Date()) + " %-22s %-33s  delta receive      - MaxLat: %4d Avg: %6.2f 99th-Pct: %3d %3d %3d %3d \n" 
-                    	, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress() 
+                    ps.printf( formatUTC.format(new Date()) + " %-22s %-33s  delta receive      - MaxLat: %4d Avg: %6.2f 99th-Pct: %3d %3d %3d %3d \n"
+                    	, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress()
                     	, m_receiveHistogram.getMaxValue(), m_receiveHistogram.getMean()
                     	, m_receiveHistogram.getValueAtPercentile(99.0), m_receiveHistogram.getValueAtPercentile(99.9)
-                    	, m_receiveHistogram.getValueAtPercentile(99.99), m_receiveHistogram.getValueAtPercentile(99.999) 
+                    	, m_receiveHistogram.getValueAtPercentile(99.99), m_receiveHistogram.getValueAtPercentile(99.999)
                     );
                 }
                 m_receiveHistogram = new Histogram(24 * 60 * 60 * 1000, 3);
@@ -154,11 +154,11 @@ public class MeshMonitor {
             synchronized (deltaLock) {
                 if (m_deltaHistogram.getMaxValue() > minHiccupSize) {
                     haveOutliers = true;
-                    ps.printf( formatUTC.format(new Date()) + " %-22s %-33s  delta timestamp    - MaxLat: %4d Avg: %6.2f 99th-Pct: %3d %3d %3d %3d \n" 
+                    ps.printf( formatUTC.format(new Date()) + " %-22s %-33s  delta timestamp    - MaxLat: %4d Avg: %6.2f 99th-Pct: %3d %3d %3d %3d \n"
                     	, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress()
                     	, m_deltaHistogram.getMaxValue(), m_deltaHistogram.getMean()
                     	, m_deltaHistogram.getValueAtPercentile(99.0), m_deltaHistogram.getValueAtPercentile(99.9)
-                    	, m_deltaHistogram.getValueAtPercentile(99.99), m_deltaHistogram.getValueAtPercentile(99.999)	
+                    	, m_deltaHistogram.getValueAtPercentile(99.99), m_deltaHistogram.getValueAtPercentile(99.999)
                     );
                 }
                 m_deltaHistogram = new Histogram(24 * 60 * 60 * 1000, 3);
@@ -166,11 +166,11 @@ public class MeshMonitor {
             synchronized(sendLock) {
                 if (m_sendHistogram.getMaxValue() > minHiccupSize) {
                     haveOutliers = true;
-                    ps.printf( formatUTC.format(new Date()) + " %-22s %-33s  delta send         - MaxLat: %4d Avg: %6.2f 99th-Pct: %3d %3d %3d %3d \n" 
-                    	, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress() 
+                    ps.printf( formatUTC.format(new Date()) + " %-22s %-33s  delta send         - MaxLat: %4d Avg: %6.2f 99th-Pct: %3d %3d %3d %3d \n"
+                    	, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress()
                     	, m_sendHistogram.getMaxValue(), m_sendHistogram.getMean()
                     	, m_sendHistogram.getValueAtPercentile(99.0), m_sendHistogram.getValueAtPercentile(99.9)
-                    	, m_sendHistogram.getValueAtPercentile(99.99), m_sendHistogram.getValueAtPercentile(99.999) 
+                    	, m_sendHistogram.getValueAtPercentile(99.99), m_sendHistogram.getValueAtPercentile(99.999)
                     );
                 }
                 m_sendHistogram = new Histogram(24 * 60 * 60 * 1000, 3);
@@ -179,14 +179,14 @@ public class MeshMonitor {
             if (haveOutliers) {
                 System.out.print(new String(baos.toByteArray(), Charsets.UTF_8));
             } else {
-            	System.out.printf( formatUTC.format(new Date()) + " %-22s %-33s " 
+            	System.out.printf( formatUTC.format(new Date()) + " %-22s %-33s "
             			+ " Threshold not reached: " + minHiccupSize + "ms; nothing to report \n"
-            			, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress() 
+            			, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress()
             	);
             }
         }
     }
-    
+
 	public static void printUsageAndExit() {
 		int minutes = new Date().getMinutes();
         System.out.println("args: minHiccupSize reportInterval [interface]:port host1 host2... hostN ");

--- a/tools/meshmonitor/src/MeshMonitor.java
+++ b/tools/meshmonitor/src/MeshMonitor.java
@@ -1,0 +1,246 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2014 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.Date;
+import java.util.TimeZone;
+import java.text.SimpleDateFormat;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.HdrHistogram_voltpatches.Histogram;
+import com.google_voltpatches.common.base.Charsets;
+import com.google_voltpatches.common.net.HostAndPort;
+
+public class MeshMonitor {
+
+    public static class Monitor {
+        private final Object receiveLock = new Object();
+        private Histogram m_receiveHistogram = new Histogram(24 * 60 * 60 * 1000, 3);
+        private final Object sendLock = new Object();
+        private Histogram m_sendHistogram = new Histogram(24 * 60 * 60 * 1000, 3);
+        private final Object deltaLock = new Object();
+        private Histogram m_deltaHistogram = new Histogram(24 * 60 * 60 * 1000, 3);
+        private final SocketChannel m_sc;
+        private int keptmin = new Date().getMinutes();
+        private int keptsec = new Date().getSeconds();
+
+        private boolean firstrunconnect = true;
+
+        public Monitor(SocketChannel sc) {
+            m_sc = sc;
+            new Thread(sc.socket().getRemoteSocketAddress() + " send thread") {
+                @Override
+                public void run() {
+                    long lastRuntime = System.currentTimeMillis();
+                    while (true) {
+                        try {
+                            Thread.sleep(5);
+                            long now = System.currentTimeMillis();
+                            long valueToRecord = now - lastRuntime;
+                            if (valueToRecord > m_sendHistogram.getHighestTrackableValue()
+                                    || valueToRecord < 0) {
+                                System.err.println(new Date() + " ERROR: Delta betweens sends was " + valueToRecord);
+                            } else {
+                                synchronized (sendLock) {
+                                    now = System.currentTimeMillis();
+                                    m_sendHistogram.recordValue(valueToRecord, 5);
+                                }
+                            }
+                            lastRuntime = now;
+                            ByteBuffer sendBuf = ByteBuffer.allocate(8);
+                            sendBuf.putLong(now);
+                            sendBuf.flip();
+                            while (sendBuf.hasRemaining()) {
+                                m_sc.write(sendBuf);
+                            }
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                            System.exit(-1);
+                        }
+                    }
+                }
+            }.start();
+            new Thread(sc.socket().getRemoteSocketAddress() + " receive thread") {
+                @Override
+                public void run() {
+                    try {
+                        long lastRecvTime = System.currentTimeMillis();
+                        while (true) {
+                            ByteBuffer recvBuf = ByteBuffer.allocate(8);
+                            while (recvBuf.hasRemaining()) {
+                                m_sc.read(recvBuf);
+                            }
+                            recvBuf.flip();
+                            long sentTime = recvBuf.getLong();
+                            long now = System.currentTimeMillis();
+                            long valueToRecord = now - lastRecvTime;
+                            if (valueToRecord > m_receiveHistogram.getHighestTrackableValue()
+                                    || valueToRecord < 0) {
+                                System.err.println(new Date() + " ERROR: Delta between receives was " + valueToRecord);
+                            } else {
+                                synchronized (receiveLock) {
+                                    m_receiveHistogram.recordValue(valueToRecord, 5);
+                                }
+                            }
+                            lastRecvTime = now;
+                            //Abs because clocks can be slightly out of sync...
+                            valueToRecord = Math.abs(now - sentTime);
+                            if (valueToRecord > m_deltaHistogram.getHighestTrackableValue()) {
+                                System.err.println(new Date() + " ERROR: Delta between remote send time and recorded receive time was " + valueToRecord);
+                            } else {
+                                synchronized (deltaLock) {
+                                    m_deltaHistogram.recordValue(valueToRecord, 5);
+                                }
+                            }
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        System.exit(-1);
+                    }
+                }
+            }.start();
+        }
+
+        public void printResults(int minHiccupSize) throws Exception {
+        	SimpleDateFormat formatUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
+    		formatUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(baos);
+            if ( ( keptmin == new Date().getMinutes() && keptsec == new Date().getSeconds() ) || firstrunconnect ) {
+		        System.out.printf( formatUTC.format( new Date()) + " %-22s %-33s "
+	        		+ " connected to remote endpoint " + m_sc.socket().getRemoteSocketAddress() + "\n"
+	        		, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress() 
+	        	);
+		        if (firstrunconnect) {
+		        	firstrunconnect = false;
+		        }
+            }
+            
+            boolean haveOutliers = false;
+    		
+            synchronized (receiveLock) {
+                if (m_receiveHistogram.getMaxValue() > minHiccupSize) {
+                    haveOutliers = true;
+                    ps.printf( formatUTC.format(new Date()) + " %-22s %-33s  delta receive      - MaxLat: %4d Avg: %6.2f 99th-Pct: %3d %3d %3d %3d \n" 
+                    	, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress() 
+                    	, m_receiveHistogram.getMaxValue(), m_receiveHistogram.getMean()
+                    	, m_receiveHistogram.getValueAtPercentile(99.0), m_receiveHistogram.getValueAtPercentile(99.9)
+                    	, m_receiveHistogram.getValueAtPercentile(99.99), m_receiveHistogram.getValueAtPercentile(99.999) 
+                    );
+                }
+                m_receiveHistogram = new Histogram(24 * 60 * 60 * 1000, 3);
+            }
+            synchronized (deltaLock) {
+                if (m_deltaHistogram.getMaxValue() > minHiccupSize) {
+                    haveOutliers = true;
+                    ps.printf( formatUTC.format(new Date()) + " %-22s %-33s  delta timestamp    - MaxLat: %4d Avg: %6.2f 99th-Pct: %3d %3d %3d %3d \n" 
+                    	, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress()
+                    	, m_deltaHistogram.getMaxValue(), m_deltaHistogram.getMean()
+                    	, m_deltaHistogram.getValueAtPercentile(99.0), m_deltaHistogram.getValueAtPercentile(99.9)
+                    	, m_deltaHistogram.getValueAtPercentile(99.99), m_deltaHistogram.getValueAtPercentile(99.999)	
+                    );
+                }
+                m_deltaHistogram = new Histogram(24 * 60 * 60 * 1000, 3);
+            }
+            synchronized(sendLock) {
+                if (m_sendHistogram.getMaxValue() > minHiccupSize) {
+                    haveOutliers = true;
+                    ps.printf( formatUTC.format(new Date()) + " %-22s %-33s  delta send         - MaxLat: %4d Avg: %6.2f 99th-Pct: %3d %3d %3d %3d \n" 
+                    	, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress() 
+                    	, m_sendHistogram.getMaxValue(), m_sendHistogram.getMean()
+                    	, m_sendHistogram.getValueAtPercentile(99.0), m_sendHistogram.getValueAtPercentile(99.9)
+                    	, m_sendHistogram.getValueAtPercentile(99.99), m_sendHistogram.getValueAtPercentile(99.999) 
+                    );
+                }
+                m_sendHistogram = new Histogram(24 * 60 * 60 * 1000, 3);
+            }
+            ps.flush();
+            if (haveOutliers) {
+                System.out.print(new String(baos.toByteArray(), Charsets.UTF_8));
+            } else {
+            	System.out.printf( formatUTC.format(new Date()) + " %-22s %-33s " 
+            			+ " Threshold not reached: " + minHiccupSize + "ms; nothing to report \n"
+            			, m_sc.socket().getLocalSocketAddress(), m_sc.socket().getRemoteSocketAddress() 
+            	);
+            }
+        }
+    }
+    
+	public static void printUsageAndExit() {
+		int minutes = new Date().getMinutes();
+        System.out.println("args: minHiccupSize reportInterval [interface]:port host1 host2... hostN ");
+        System.exit(-1);
+    }
+
+    private static final ScheduledExecutorService m_ses = Executors.newSingleThreadScheduledExecutor();
+
+    /**
+     * @param args
+     */
+    public static void main(String[] args) throws Exception {
+        ServerSocketChannel ssc = ServerSocketChannel.open();
+        if (args.length == 0) {
+            printUsageAndExit();
+        }
+        final int minHiccupSize = Integer.parseInt(args[0]);
+        final int reportInterval = Integer.parseInt(args[1]);
+        HostAndPort bindAddress = HostAndPort.fromString(args[2]);
+        InetSocketAddress address = new InetSocketAddress(bindAddress.getHostText(), bindAddress.getPort());
+        ssc.socket().bind(address);
+
+        for (int ii = 3; ii < args.length; ii++) {
+            HostAndPort connectStuff = HostAndPort.fromString(args[ii]);
+            InetSocketAddress connectAddress =
+                    new InetSocketAddress(connectStuff.getHostText(), connectStuff.getPort());
+            SocketChannel sc = SocketChannel.open(connectAddress);
+            final Monitor m = new Monitor(sc);
+            m_ses.scheduleAtFixedRate(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                    	m.printResults(minHiccupSize);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }, reportInterval, reportInterval, TimeUnit.SECONDS);
+        }
+
+        while (true) {
+            SocketChannel sc = ssc.accept();
+            final Monitor m = new Monitor(sc);
+            m_ses.scheduleAtFixedRate(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                    	m.printResults(minHiccupSize);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }, reportInterval, reportInterval, TimeUnit.SECONDS);
+        }
+    }
+
+}


### PR DESCRIPTION
Add meshmonitor to the kit in the tools/meshmonitor directory.
When put in the distribution,  this directory will contain
1. meshmonitor.jar which can be put on the machines that user wants to run it on
2. meshmonitorhelper.sh which will user to create the command-lines to run on all test machines
3. README about what it does and how to use it.
