### PR TITLE
ENG-12902 Fix crash due to UAC while cluster is paused and importers are enabled

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -408,7 +408,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     SnmpTrapSender m_snmp;
 
     private volatile OperationMode m_mode = OperationMode.INITIALIZING;
-    private OperationMode m_startMode = OperationMode.RUNNING;
+    private OperationMode m_startMode = null;
 
     volatile String m_localMetadata = "";
 
@@ -926,7 +926,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             // set the mode first thing
             m_mode = OperationMode.INITIALIZING;
             m_config = config;
-            m_startMode = OperationMode.RUNNING;
+            m_startMode = null;
 
             // set a bunch of things to null/empty/new for tests
             // which reusue the process

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -408,7 +408,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     SnmpTrapSender m_snmp;
 
     private volatile OperationMode m_mode = OperationMode.INITIALIZING;
-    private OperationMode m_startMode = null;
+    private OperationMode m_startMode = OperationMode.RUNNING;
 
     volatile String m_localMetadata = "";
 
@@ -926,7 +926,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             // set the mode first thing
             m_mode = OperationMode.INITIALIZING;
             m_config = config;
-            m_startMode = null;
+            m_startMode = OperationMode.RUNNING;
 
             // set a bunch of things to null/empty/new for tests
             // which reusue the process

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -408,7 +408,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     SnmpTrapSender m_snmp;
 
     private volatile OperationMode m_mode = OperationMode.INITIALIZING;
-    private OperationMode m_startMode = null;
+    private volatile OperationMode m_startMode = null;
 
     volatile String m_localMetadata = "";
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -408,7 +408,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     SnmpTrapSender m_snmp;
 
     private volatile OperationMode m_mode = OperationMode.INITIALIZING;
-    private volatile OperationMode m_startMode = null;
+    private OperationMode m_startMode = null;
 
     volatile String m_localMetadata = "";
 

--- a/src/frontend/org/voltdb/importer/ImportManager.java
+++ b/src/frontend/org/voltdb/importer/ImportManager.java
@@ -59,17 +59,13 @@ public class ImportManager implements ChannelChangeCallback {
 
     /** Obtain the global ImportManager via its instance() method */
     private static ImportManager m_self;
+    private final HostMessenger m_messenger;
 
     private final int m_myHostId;
     private ChannelDistributer m_distributer;
     private volatile boolean m_serverStarted;
     private final ImporterStatsCollector m_statsCollector;
     private final ModuleManager m_moduleManager;
-
-    // State we get from VoltDB via our callbacks
-    private OperationMode m_clusterMode;
-    private CatalogContext m_catalogContext;
-    private HostMessenger m_messenger;
 
     // Maintains the record of the importer bundles that have been loaded into the memory based on importer config.
     // These loaded loaded bundles remains in memory. ready for use and don't get loaded/unloaded
@@ -91,17 +87,11 @@ public class ImportManager implements ChannelChangeCallback {
         return ModuleManager.instance();
     }
 
-    private ImportManager(int myHostId,
-                          HostMessenger messenger,
-                          ImporterStatsCollector statsCollector,
-                          CatalogContext catalogContext,
-                          OperationMode mode) throws IOException {
+    private ImportManager(int myHostId, HostMessenger messenger, ImporterStatsCollector statsCollector) throws IOException {
         m_myHostId = myHostId;
         m_messenger = messenger;
         m_statsCollector = statsCollector;
         m_moduleManager = getModuleManager();
-        m_clusterMode = mode;
-        m_catalogContext = catalogContext;
     }
 
     private void initializeChannelDistributer() throws BundleException {
@@ -122,15 +112,14 @@ public class ImportManager implements ChannelChangeCallback {
     public static synchronized void initialize(int myHostId, CatalogContext catalogContext, HostMessenger messenger) throws BundleException, IOException {
         ImporterStatsCollector statsCollector = new ImporterStatsCollector(myHostId);
         OperationMode startMode = VoltDB.instance().getMode();
-        ImportManager em = new ImportManager(myHostId, messenger, statsCollector, catalogContext, startMode);
+        ImportManager em = new ImportManager(myHostId, messenger, statsCollector);
         VoltDB.instance().getStatsAgent().registerStatsSource(
                 StatsSelector.IMPORTER,
                 myHostId,
                 statsCollector);
-
         try {
-            Map<String, ImportConfiguration> newProcessorConfig = em.loadNewConfigAndBundles();
-            if (em.m_clusterMode != OperationMode.PAUSED) {
+            Map<String, ImportConfiguration> newProcessorConfig = em.loadNewConfigAndBundles(catalogContext);
+            if (startMode != OperationMode.PAUSED) {
                 em.startImporters(newProcessorConfig);
             }
         } catch (final Exception e) {
@@ -159,12 +148,13 @@ public class ImportManager implements ChannelChangeCallback {
     /**
      * Parses importer configs and loads the formatters and bundles needed into memory.
      * This is used to generate a new configuration either to load or to compare with existing.
+     * @param catalogContext new catalog context
      * @return new importer configuration
      */
-    private synchronized Map<String, ImportConfiguration> loadNewConfigAndBundles() {
+    private synchronized Map<String, ImportConfiguration> loadNewConfigAndBundles(CatalogContext catalogContext) {
         Map<String, ImportConfiguration> newProcessorConfig;
 
-        ImportType importElement = m_catalogContext.getDeployment().getImport();
+        ImportType importElement = catalogContext.getDeployment().getImport();
         if (importElement == null || importElement.getConfiguration().isEmpty()) {
             newProcessorConfig = new HashMap<>();
         } else {
@@ -183,9 +173,9 @@ public class ImportManager implements ChannelChangeCallback {
             String procedure = properties.getProperty(ImportDataProcessor.IMPORT_PROCEDURE);
             assert procedure != null;
             //TODO: If processors is a list dont start till all procedures exists.
-            Procedure catProc = m_catalogContext.procedures.get(procedure);
+            Procedure catProc = catalogContext.procedures.get(procedure);
             if (catProc == null) {
-                catProc = m_catalogContext.m_defaultProcs.checkForDefaultProcedure(procedure);
+                catProc = catalogContext.m_defaultProcs.checkForDefaultProcedure(procedure);
             }
             if (catProc == null) {
                 importLog.info("Importer " + configName + " Procedure " + procedure +
@@ -300,28 +290,27 @@ public class ImportManager implements ChannelChangeCallback {
     }
 
     private synchronized void resume() {
+        CatalogContext catalogContext = VoltDB.instance().getCatalogContext();
         try {
-            Map<String, ImportConfiguration> newProcessorConfig = loadNewConfigAndBundles();
+            Map<String, ImportConfiguration> newProcessorConfig = loadNewConfigAndBundles(catalogContext);
             startImporters(newProcessorConfig);
         } catch (final Exception e) {
             VoltDB.crashLocalVoltDB("Error creating import processor", true, e);
         }
-        readyForDataInternal();
+        readyForDataInternal(catalogContext, VoltDB.instance().getHostMessenger());
     }
 
     public synchronized void updateCatalog(CatalogContext catalogContext, HostMessenger messenger) {
-        m_catalogContext = catalogContext;
-        assert m_messenger.equals(messenger);
-        m_messenger = messenger;
         try {
-            Map<String, ImportConfiguration> newProcessorConfig = loadNewConfigAndBundles();
+            Map<String, ImportConfiguration> newProcessorConfig = loadNewConfigAndBundles(catalogContext);
             if (m_processorConfig == null || !m_processorConfig.equals(newProcessorConfig)) {
-                if (m_clusterMode != OperationMode.PAUSED) {
+                OperationMode clusterMode = VoltDB.instance().getMode();
+                if (clusterMode != OperationMode.PAUSED) {
                     close();
                     startImporters(newProcessorConfig);
-                    readyForDataInternal();
+                    readyForDataInternal(catalogContext, messenger);
                 } else if (importLog.isDebugEnabled()) {
-                    importLog.debug("Catalog update is not restarting importers because cluster state is " + m_clusterMode);
+                    importLog.debug("Catalog update is not restarting importers because cluster state is " + clusterMode);
                 }
             }
         } catch (final Exception e) {
@@ -330,17 +319,13 @@ public class ImportManager implements ChannelChangeCallback {
     }
 
     public synchronized void readyForData(CatalogContext catalogContext, HostMessenger messenger) {
-        assert m_catalogContext.equals(catalogContext);
-        assert m_messenger.equals(messenger);
-        m_catalogContext = catalogContext;
-        m_messenger = messenger;
         m_serverStarted = true; // Note that server is ready, so that we know whether to process catalog updates
-        if (m_clusterMode != OperationMode.PAUSED) {
-            readyForDataInternal();
+        if (VoltDB.instance().getMode() != OperationMode.PAUSED) {
+            readyForDataInternal(catalogContext, messenger);
         }
     }
 
-    private synchronized void readyForDataInternal() {
+    private synchronized void readyForDataInternal(CatalogContext catalogContext, HostMessenger messenger) {
         if (!m_serverStarted) {
             if (importLog.isDebugEnabled()) {
                 importLog.debug("Server not started. Not sending readyForData to ImportProcessor");
@@ -353,7 +338,7 @@ public class ImportManager implements ChannelChangeCallback {
             return;
         }
         //Tell import processors and in turn ImportHandlers that we are ready to take in data.
-        m_processor.get().readyForData(m_catalogContext, m_messenger);
+        m_processor.get().readyForData(catalogContext, messenger);
     }
 
     @Override
@@ -363,8 +348,7 @@ public class ImportManager implements ChannelChangeCallback {
 
     @Override
     public synchronized void onClusterStateChange(VersionedOperationMode mode) {
-        m_clusterMode = mode.getMode();
-        switch (m_clusterMode) {
+        switch (mode.getMode()) {
             case PAUSED:
                 importLog.info("Cluster is paused shutting down all importers.");
                 close();

--- a/src/frontend/org/voltdb/importer/ImportManager.java
+++ b/src/frontend/org/voltdb/importer/ImportManager.java
@@ -91,12 +91,16 @@ public class ImportManager implements ChannelChangeCallback {
         return ModuleManager.instance();
     }
 
-    private ImportManager(int myHostId, HostMessenger messenger, ImporterStatsCollector statsCollector, CatalogContext catalogContext) throws IOException {
+    private ImportManager(int myHostId,
+                          HostMessenger messenger,
+                          ImporterStatsCollector statsCollector,
+                          CatalogContext catalogContext,
+                          OperationMode mode) throws IOException {
         m_myHostId = myHostId;
         m_messenger = messenger;
         m_statsCollector = statsCollector;
         m_moduleManager = getModuleManager();
-        m_clusterMode = VoltDB.instance().getStartMode();
+        m_clusterMode = mode;
         m_catalogContext = catalogContext;
     }
 
@@ -117,7 +121,8 @@ public class ImportManager implements ChannelChangeCallback {
      */
     public static synchronized void initialize(int myHostId, CatalogContext catalogContext, HostMessenger messenger) throws BundleException, IOException {
         ImporterStatsCollector statsCollector = new ImporterStatsCollector(myHostId);
-        ImportManager em = new ImportManager(myHostId, messenger, statsCollector, catalogContext);
+        OperationMode startMode = VoltDB.instance().getMode();
+        ImportManager em = new ImportManager(myHostId, messenger, statsCollector, catalogContext, startMode);
         VoltDB.instance().getStatsAgent().registerStatsSource(
                 StatsSelector.IMPORTER,
                 myHostId,

--- a/tests/frontend/org/voltdb/TestImportSuite.java
+++ b/tests/frontend/org/voltdb/TestImportSuite.java
@@ -346,7 +346,7 @@ public class TestImportSuite extends RegressionSuite {
         pushDataToImporters(1000, 3);
         verifyData(m_client, 3000);
 
-        applySchemaChange(m_client, "create table nudge(id integer);");
+        applySchemaChange("create table nudge(id integer);");
 
         pushDataToImporters(1000, 4);
         // log4j will lose some events because of reconnection delay
@@ -362,10 +362,10 @@ public class TestImportSuite extends RegressionSuite {
         // Run data pushers until they are explicitly stopped.
         asyncPushDataToImporters(0, 3);
 
-        applySchemaChange(m_client, "CREATE TABLE nudge(id integer);");
-        applySchemaChange(m_client, "CREATE PROCEDURE NudgeThatDB AS INSERT INTO nudge VALUES (?);");
-        applySchemaChange(m_client, "DROP PROCEDURE NudgeThatDB;");
-        applySchemaChange(m_client, "DROP TABLE nudge;");
+        applySchemaChange("CREATE TABLE nudge(id integer);");
+        applySchemaChange("CREATE PROCEDURE NudgeThatDB AS INSERT INTO nudge VALUES (?);");
+        applySchemaChange("DROP PROCEDURE NudgeThatDB;");
+        applySchemaChange("DROP TABLE nudge;");
 
         waitForData();
     }
@@ -413,14 +413,14 @@ public class TestImportSuite extends RegressionSuite {
         testConnector.tryPush(5);
 
         // importer uses CRUD procedure associated with this table.
-        applySchemaChange(m_client, "DROP TABLE importTable;");
+        applySchemaChange("DROP TABLE importTable;");
         try {
             testConnector.tryPush(5);
             fail("Importer is still running even though its procedure is disabled");
         } catch (IOException expected) {
         }
 
-        applySchemaChange(m_client, "CREATE TABLE IMPORTTABLE (PKEY bigint NOT NULL, A_INTEGER_VALUE bigint); PARTITION TABLE IMPORTTABLE ON COLUMN PKEY;");
+        applySchemaChange("CREATE TABLE IMPORTTABLE (PKEY bigint NOT NULL, A_INTEGER_VALUE bigint); PARTITION TABLE IMPORTTABLE ON COLUMN PKEY;");
         testConnector.tryPush(5);
     }
 
@@ -433,7 +433,6 @@ public class TestImportSuite extends RegressionSuite {
         testConnector.tryPush(5);
 
         m_adminClient.callProcedure("@Pause");
-        applySchemaChange(m_adminClient, "CREATE TABLE ENSURE_SCHEMA_SURVIVAL (STUFF bigint NOT NULL);");
         updateDeploymentFile(m_adminClient, true, false, true);
         try {
             testConnector.tryPush(5);
@@ -443,7 +442,6 @@ public class TestImportSuite extends RegressionSuite {
 
         m_adminClient.callProcedure("@Resume");
         testConnector.tryPush(5);
-        applySchemaChange(m_client, "DROP TABLE ENSURE_SCHEMA_SURVIVAL;");
     }
 
     /**
@@ -474,8 +472,8 @@ public class TestImportSuite extends RegressionSuite {
         super(name);
     }
 
-    private static void applySchemaChange(Client clientToUse, String adhocddl) throws Exception {
-        ClientResponse response = clientToUse.callProcedure("@AdHoc", adhocddl);
+    private void applySchemaChange(String adhocddl) throws Exception {
+        ClientResponse response = m_client.callProcedure("@AdHoc", adhocddl);
         assertEquals(ClientResponse.SUCCESS, response.getStatus());
     }
 

--- a/tests/frontend/org/voltdb/importer/SocketImporterConnector.java
+++ b/tests/frontend/org/voltdb/importer/SocketImporterConnector.java
@@ -1,0 +1,69 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+package org.voltdb.importer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+
+/** Allows the test thread to check if the importer is alive by writing data to it. */
+public class SocketImporterConnector {
+    private final String m_server;
+    private final int m_port;
+    private final char m_separator;
+    private int m_counter = 0;
+
+    public SocketImporterConnector(String server, int port, char separator) {
+        m_separator = separator;
+        m_server = server;
+        m_port = port;
+    }
+
+    /** Tries to write data to the importer, but may fail. */
+    public void tryPush(int maxAttempts) throws IOException {
+        int numConnectAttempts = 0;
+        do {
+            try {
+                Socket pushSocket = new Socket(m_server, m_port);
+                OutputStream socketStream = pushSocket.getOutputStream();
+                System.out.printf("Connected to VoltDB socket importer at: %s.\n", m_server + ":" + m_port);
+                String s = String.valueOf(m_counter) + m_separator + System.currentTimeMillis() + "\n";
+                socketStream.write(s.getBytes());
+                pushSocket.close();
+                m_counter++;
+                return;
+            } catch (IOException e) {
+                numConnectAttempts++;
+                if (numConnectAttempts >= maxAttempts) {
+                    throw e;
+                }
+                try {
+                    Thread.sleep((int) (Math.random() * 1000) + 500);
+                } catch (InterruptedException ignore) {
+                }
+            }
+        } while (true);
+    }
+}


### PR DESCRIPTION
A state check added in V7.4 fires and causes a crash due to a long standing bug where importers do not check if the cluster is paused when restarting.

Additional test scenarios will be added in Pro. No pull request there yet.