### PR TITLE
ENG-12778-CSVLoader-Hang-On-Error

### DIFF
--- a/src/frontend/org/voltdb/client/VoltBulkLoader/PerPartitionTable.java
+++ b/src/frontend/org/voltdb/client/VoltBulkLoader/PerPartitionTable.java
@@ -261,7 +261,7 @@ public class PerPartitionTable {
                     row_args[i] = ParameterConverter.tryToMakeCompatible(type.classFromType(),
                             currRow.m_rowData[i]);
                 }
-            } catch (VoltTypeException e) {
+            } catch (Exception e) {
                 loader.generateError(currRow.m_rowHandle, currRow.m_rowData, e.getMessage());
                 loader.m_outstandingRowCount.decrementAndGet();
                 it.remove();

--- a/tests/frontend/org/voltdb/utils/TestCSVLoader.java
+++ b/tests/frontend/org/voltdb/utils/TestCSVLoader.java
@@ -1764,6 +1764,33 @@ public class TestCSVLoader {
         }
     }
 
+    // A bad decimal input should not make csvloader hang on forever
+    @Test(timeout=2000)
+    public void testBadDecimal() throws Exception {
+        String []myOptions = {
+                "-f" + path_csv,
+                "--reportdir=" + reportDir,
+                "--maxerrors=50",
+                "--user=",
+                "--password=",
+                "--port=",
+                "--separator=,",
+                "--quotechar=\"",
+                "--escape=\\",
+                "--skip=0",
+                "--limitrows=100",
+                "BlAh"
+        };
+        String currentTime = new TimestampType().toString();
+        String []myData = {
+                "1 ,1,1,11111111,first,2000000000000000000000000000000.000000000000,1.11,"+currentTime+",POINT(1 1),\"POLYGON((0 0, 1 0, 0 1, 0 0))\"",
+        };
+        int invalidLineCnt = 1;
+        int validLineCnt = 0;
+
+        test_Interface(myOptions, myData, invalidLineCnt, validLineCnt);
+    }
+
     private void createCSVFile(String encoding) {
         String FILENAME = encoding+"_encoded_text.csv";
         BufferedWriter bw = null;


### PR DESCRIPTION
The errors occurs when VoltDecimalHelper fails to deserialize decimal from a string and throws out a RuntimeException. This exception is not caught in PerPartitionTable.buildTable(), so it will eventually propagate to the console. Also, m_outstandingRowCount is not properly updated, which is why the loader doesn't stop running.