### PR TITLE
ENG-12902 resolve importer IllegalStateException by forcing importer into a valid state.

### DIFF
--- a/src/frontend/org/voltdb/importer/ImportManager.java
+++ b/src/frontend/org/voltdb/importer/ImportManager.java
@@ -134,7 +134,10 @@ public class ImportManager implements ChannelChangeCallback {
     }
 
     private synchronized void startImporters(Map<String, ImportConfiguration> newProcessorConfig) throws BundleException {
-        Preconditions.checkState(m_processor.get() == null, "Attempt to start importers when they may already be running");
+        // ENG-12902 - there are scenarios where m_processor.get() is NOT null.
+        // Since these are not fully understood, always call close() as this ensure the importer is in a valid state.
+        close();
+
         m_processorConfig = newProcessorConfig;
         importLog.info("Currently loaded importer modules: " + m_loadedBundles.keySet() + ", types: " + m_importersByType.keySet());
 


### PR DESCRIPTION
This is intended as a low risk fix for a crash scenario when the importer sees a UAC during pause and then resumes. It does not eliminate the root cause scenario or resolve importers starting when the database is paused, but the database can now continue into a valid state without crashing.