### PR TITLE
Eng 12867 perf benchmark

### DIFF
--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1089,7 +1089,6 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         boolean ready = true;
         for (int peer : m_peers) {
             ready = ready && m_foreignHosts.get(peer).size() == (m_secondaryConnections + 1);
-            m_hostLog.warn("NotifyOfConnection For hostId " + hostId + " ready=" + ready);
         }
         if (ready) {
             // Now it's time to use secondary pico network, see comments in presend() to know why we can't
@@ -1304,7 +1303,10 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                 if (fhost == null) {
                     int index = Math.abs(m_nextForeignHost.getAndIncrement() % fhosts.size());
                     fhost = (ForeignHost) fhosts.toArray()[index];
-                    m_hostLog.warn("bind " + CoreUtils.getHostIdFromHSId(hsId) + ":" + CoreUtils.getSiteIdFromHSId(hsId) + " to " + fhost);
+                    if (m_hostLog.isDebugEnabled()) {
+                        m_hostLog.debug("bind " + CoreUtils.getHostIdFromHSId(hsId) + ":" + CoreUtils.getSiteIdFromHSId(hsId) +
+                                " to " + fhost.hostnameAndIPAndPort());
+                    }
                     bindForeignHost(hsId, fhost);
                 }
             } else {
@@ -1741,22 +1743,11 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                 strBuilder.append(h).append(" ");
             });
             strBuilder.append(">");
-            m_hostLog.warn("Host " + strBuilder.toString() + "belongs to the same partition group.");
+            m_hostLog.info("Host " + strBuilder.toString() + " belongs to the same partition group.");
         }
         partitionGroupPeers.remove(m_localHostId);
         m_peers = partitionGroupPeers;
-        m_hostLog.warn("Set m_peers to " + dumpSet(m_peers));
         m_secondaryConnections = computeSecondaryConnections(hostCount);
-    }
-
-    private String dumpSet(Set<Integer> dumpSet) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{ ");
-        for (Integer h : dumpSet) {
-            sb.append(h).append(" ");
-        }
-        sb.append(" }");
-        return sb.toString();
     }
 
     private int computeSecondaryConnections(int hostCount) {
@@ -1781,9 +1772,9 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         Integer configNumberOfConnections = Integer.getInteger(SECONDARY_PICONETWORK_THREADS);
         if (configNumberOfConnections != null) {
             secondaryConnections = configNumberOfConnections;
-            m_hostLog.warn("Overridden secondary PicoNetwork network thread count:" + configNumberOfConnections);
+            m_hostLog.info("Overridden secondary PicoNetwork network thread count:" + configNumberOfConnections);
         } else {
-            m_hostLog.warn("This node has " + secondaryConnections + " secondary PicoNetwork thread" + ((secondaryConnections > 1) ? "s" :""));
+            m_hostLog.info("This node has " + secondaryConnections + " secondary PicoNetwork thread" + ((secondaryConnections > 1) ? "s" :""));
         }
         return secondaryConnections;
     }
@@ -1831,7 +1822,6 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         boolean ready = true;
         for (int hostId : m_peers) {
             ready = ready && m_foreignHosts.get(hostId).size() == (m_secondaryConnections + 1);
-            m_hostLog.warn("For hostId " + hostId + " ready=" + ready);
         }
         if (ready) {
             // Now it's time to use secondary pico network, see comments in presend() to know why we can't

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1288,8 +1288,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
             return null;
         }
         ForeignHost fhost = null;
-        if (CoreUtils.getSiteIdFromHSId(hsId) < 0 ) {
-            // special mailbox, always use primary connection
+        if (fhosts.size() == 1 || CoreUtils.getSiteIdFromHSId(hsId) < 0 ) {
+            // Always use primary connection to send to well-known mailbox
             fhost = getPrimary(fhosts, hostId);
         } else {
             /**

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1733,11 +1733,20 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
     }
 
-    public void setPartitionGroup(Set<Integer> partitionGroup) {
-        Set<Integer> peersWithoutMe = partitionGroup;
-        peersWithoutMe.remove(m_localHostId);
-        m_peers = peersWithoutMe;
+    public void setPartitionGroupPeers(Set<Integer> partitionGroupPeers, int hostCount) {
+        if (partitionGroupPeers.size() > 1) {
+            StringBuilder strBuilder = new StringBuilder();
+            strBuilder.append("< ");
+            partitionGroupPeers.forEach((h) -> {
+                strBuilder.append(h).append(" ");
+            });
+            strBuilder.append(">");
+            m_hostLog.warn("Host " + strBuilder.toString() + "belongs to the same partition group.");
+        }
+        partitionGroupPeers.remove(m_localHostId);
+        m_peers = partitionGroupPeers;
         m_hostLog.warn("Set m_peers to " + dumpSet(m_peers));
+        m_secondaryConnections = computeSecondaryConnections(hostCount);
     }
 
     private String dumpSet(Set<Integer> dumpSet) {
@@ -1780,9 +1789,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     }
 
     // Create connections to nodes within the same partition group
-    public void createAuxiliaryConnections(int hostCount, boolean isRejoin) {
-
-        m_secondaryConnections = computeSecondaryConnections(hostCount);
+    public void createAuxiliaryConnections(boolean isRejoin) {
         Set<Integer> hostsToConnect = Sets.newHashSet();
         if (isRejoin) {
             hostsToConnect.addAll(m_peers);

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1088,7 +1088,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         fhost.enableRead(VERBOTEN_THREADS);
         boolean ready = true;
         for (int peer : m_peers) {
-            ready = ready && m_foreignHosts.get(peer).size() == m_secondaryConnections;
+            ready = ready && m_foreignHosts.get(peer).size() == (m_secondaryConnections + 1);
             m_hostLog.warn("NotifyOfConnection For hostId " + hostId + " ready=" + ready);
         }
         if (ready) {
@@ -1823,7 +1823,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
         boolean ready = true;
         for (int hostId : m_peers) {
-            ready = ready && m_foreignHosts.get(hostId).size() == m_secondaryConnections;
+            ready = ready && m_foreignHosts.get(hostId).size() == (m_secondaryConnections + 1);
             m_hostLog.warn("For hostId " + hostId + " ready=" + ready);
         }
         if (ready) {

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -75,11 +75,13 @@ import org.voltdb.probe.MeshProber;
 
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.base.Predicate;
+import com.google_voltpatches.common.collect.ArrayListMultimap;
 import com.google_voltpatches.common.collect.ImmutableCollection;
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableMultimap;
 import com.google_voltpatches.common.collect.Maps;
+import com.google_voltpatches.common.collect.Multimap;
 import com.google_voltpatches.common.collect.Multimaps;
 import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.net.HostAndPort;
@@ -1332,6 +1334,21 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                            .put(hsId, fh)
                            .build();
         }
+    }
+
+    public String dumpBinding() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{ ");
+        Multimap<ForeignHost, Long> dest = ArrayListMultimap.create();
+        Multimaps.invertFrom(m_fhMapping.asMultimap(), dest);
+        int count = 0;
+        for (ForeignHost fh : dest.keySet()) {
+            if (count++ > 0) sb.append(", ");
+            sb.append(fh.m_network.toString()).append(":");
+            sb.append(CoreUtils.hsIdCollectionToString(dest.get(fh))).append("\n");
+        }
+        sb.append(" }");
+        return sb.toString();
     }
 
     private ForeignHost getPrimary(ImmutableCollection<ForeignHost> fhosts, int hostId) {

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1289,11 +1289,11 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
         ForeignHost fhost = null;
         if (fhosts.size() == 1 || CoreUtils.getSiteIdFromHSId(hsId) < 0 ) {
-            // Always use primary connection to send to well-known mailbox
+            // Always use primary connection to send to well-known mailboxes
             fhost = getPrimary(fhosts, hostId);
         } else {
             /**
-             * Because the secondary connections are created rather late, just after cluster mesh network has
+             * Because the secondary connections are created late in the initialization, after cluster mesh network has
              * established, but before the whole cluster has been initialized. It's possible that some non-transactional
              * iv2 messages to be sent through foreign host when there is only one primary connection, So in
              * case of binding all sites to the primary connection, this check has been added to prevent it.
@@ -1762,7 +1762,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
          * so it becomes (targetConnectionsWithinPG - existingConnectionsWithinPG) + (existingConnectionsWithinPG - 1)
          * which equals to (targetConnectionsWithinPG - 1).
          *
-         * All the numbers are per node basis, PG is short for Partition Group
+         * All the numbers are on per node basis, PG is short for Partition Group
          */
         int connectionsWithoutPG = hostCount - 1;
         int existingConnectionsWithinPG = m_peers.size();
@@ -1772,9 +1772,9 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         Integer configNumberOfConnections = Integer.getInteger(SECONDARY_PICONETWORK_THREADS);
         if (configNumberOfConnections != null) {
             secondaryConnections = configNumberOfConnections;
-            m_hostLog.info("Overridden secondary PicoNetwork network thread count:" + configNumberOfConnections);
+            m_hostLog.warn("Overridden secondary PicoNetwork network thread count:" + configNumberOfConnections);
         } else {
-            m_hostLog.info("This node has " + secondaryConnections + " secondary PicoNetwork thread" + ((secondaryConnections > 1) ? "s" :""));
+            m_hostLog.warn("This node has " + secondaryConnections + " secondary PicoNetwork thread" + ((secondaryConnections > 1) ? "s" :""));
         }
         return secondaryConnections;
     }

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1089,6 +1089,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         boolean ready = true;
         for (int peer : m_peers) {
             ready = ready && m_foreignHosts.get(peer).size() == m_secondaryConnections;
+            m_hostLog.warn("NotifyOfConnection For hostId " + hostId + " ready=" + ready);
         }
         if (ready) {
             // Now it's time to use secondary pico network, see comments in presend() to know why we can't
@@ -1303,6 +1304,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                 if (fhost == null) {
                     int index = Math.abs(m_nextForeignHost.getAndIncrement() % fhosts.size());
                     fhost = (ForeignHost) fhosts.toArray()[index];
+                    m_hostLog.warn("bind " + CoreUtils.getHostIdFromHSId(hsId) + ":" + CoreUtils.getSiteIdFromHSId(hsId) + " to " + fhost);
                     bindForeignHost(hsId, fhost);
                 }
             } else {
@@ -1735,6 +1737,17 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         Set<Integer> peersWithoutMe = partitionGroup;
         peersWithoutMe.remove(m_localHostId);
         m_peers = peersWithoutMe;
+        m_hostLog.warn("Set m_peers to " + dumpSet(m_peers));
+    }
+
+    private String dumpSet(Set<Integer> dumpSet) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{ ");
+        for (Integer h : dumpSet) {
+            sb.append(h).append(" ");
+        }
+        sb.append(" }");
+        return sb.toString();
     }
 
     private int computeSecondaryConnections(int hostCount) {
@@ -1811,6 +1824,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         boolean ready = true;
         for (int hostId : m_peers) {
             ready = ready && m_foreignHosts.get(hostId).size() == m_secondaryConnections;
+            m_hostLog.warn("For hostId " + hostId + " ready=" + ready);
         }
         if (ready) {
             // Now it's time to use secondary pico network, see comments in presend() to know why we can't

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -741,7 +741,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         ForeignHost fhost = null;
         try {
             fhost = new ForeignHost(this, hostId, socket, m_config.deadHostTimeout,
-                    listeningAddress, new PicoNetwork(socket));
+                    listeningAddress, new PicoNetwork(socket, false));
             putForeignHost(hostId, fhost);
             fhost.enableRead(VERBOTEN_THREADS);
         } catch (java.io.IOException e) {
@@ -863,7 +863,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                  * Now add the host to the mailbox system
                  */
                 fhost = new ForeignHost(this, hostId, socket, m_config.deadHostTimeout,
-                        listeningAddress, new PicoNetwork(socket));
+                        listeningAddress, new PicoNetwork(socket, false));
                 putForeignHost(hostId, fhost);
                 fhost.enableRead(VERBOTEN_THREADS);
 
@@ -997,7 +997,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
             ForeignHost fhost = null;
             try {
                 fhost = new ForeignHost(this, hosts[ii], sockets[ii], m_config.deadHostTimeout,
-                        listeningAddresses[ii], new PicoNetwork(sockets[ii]));
+                        listeningAddresses[ii], new PicoNetwork(sockets[ii], false));
                 putForeignHost(hosts[ii], fhost);
             } catch (java.io.IOException e) {
                 org.voltdb.VoltDB.crashLocalVoltDB("Failed to instantiate foreign host", true, e);
@@ -1076,7 +1076,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         prepSocketChannel(socket);
         // Auxiliary connection never time out
         ForeignHost fhost = new ForeignHost(this, hostId, socket, Integer.MAX_VALUE,
-                listeningAddress, new PicoNetwork(socket));
+                listeningAddress, new PicoNetwork(socket, true));
         putForeignHost(hostId, fhost);
         fhost.enableRead(VERBOTEN_THREADS);
 }
@@ -1711,7 +1711,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                         SocketChannel socket = m_joiner.requestForConnection(fh.m_listeningAddress);
                         // Auxiliary connection never time out
                         ForeignHost fhost = new ForeignHost(this, hostId, socket, Integer.MAX_VALUE,
-                                fh.m_listeningAddress, new PicoNetwork(socket));
+                                fh.m_listeningAddress, new PicoNetwork(socket, true));
                         putForeignHost(hostId, fhost);
                         fhost.enableRead(VERBOTEN_THREADS);
                     } catch (IOException | JSONException e) {

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -75,13 +75,11 @@ import org.voltdb.probe.MeshProber;
 
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.base.Predicate;
-import com.google_voltpatches.common.collect.ArrayListMultimap;
 import com.google_voltpatches.common.collect.ImmutableCollection;
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableMultimap;
 import com.google_voltpatches.common.collect.Maps;
-import com.google_voltpatches.common.collect.Multimap;
 import com.google_voltpatches.common.collect.Multimaps;
 import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.net.HostAndPort;
@@ -1352,21 +1350,6 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                            .put(hsId, fh)
                            .build();
         }
-    }
-
-    public String dumpBinding() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{ ");
-        Multimap<ForeignHost, Long> dest = ArrayListMultimap.create();
-        Multimaps.invertFrom(m_fhMapping.asMultimap(), dest);
-        int count = 0;
-        for (ForeignHost fh : dest.keySet()) {
-            if (count++ > 0) sb.append(", ");
-            sb.append(fh.m_network.toString()).append(":");
-            sb.append(CoreUtils.hsIdCollectionToString(dest.get(fh))).append("\n");
-        }
-        sb.append(" }");
-        return sb.toString();
     }
 
     private ForeignHost getPrimary(ImmutableCollection<ForeignHost> fhosts, int hostId) {

--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -393,7 +393,7 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
             retval.put(
                     m_ih.connectionId(),
                     Pair.of(
-                            getHostnameOrIP(),
+                            getHostnameOrIP()+"_p",
                             new long[]{
                                     read,
                                     messagesRead,
@@ -402,7 +402,7 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
             retval.put(
                     -1L,
                     Pair.of(
-                            "GLOBAL",
+                            "GLOBAL_p",
                             new long[] {
                                     read,
                                     messagesRead,

--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -127,17 +127,25 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
         m_thread.start();
     }
 
-    public PicoNetwork(SocketChannel sc) {
+    /**
+     * Create a pico network thread
+     * @param sc  SocketChannel
+     * @param isSecondary  Is this a secondary thread?
+     */
+    public PicoNetwork(SocketChannel sc, boolean isSecondary) {
         m_sc = sc;
         InetSocketAddress remoteAddress = (InetSocketAddress)sc.socket().getRemoteSocketAddress();
         m_remoteSocketAddress = remoteAddress;
         m_remoteSocketAddressString = remoteAddress.getAddress().getHostAddress();
         m_remoteHostAndAddressAndPort = "/" + m_remoteSocketAddressString + ":" + m_remoteSocketAddress.getPort();
-        m_toString = super.toString() + ":" + m_remoteHostAndAddressAndPort;
         String remoteHost = ReverseDNSCache.hostnameOrAddress(m_remoteSocketAddress.getAddress());
         if (!remoteHost.equals(m_remoteSocketAddress.getAddress().getHostAddress())) {
             m_remoteHostname = remoteHost;
             m_remoteHostAndAddressAndPort = remoteHost + m_remoteHostAndAddressAndPort;
+        }
+        if (isSecondary) {
+            m_toString = super.toString() + ":" + m_remoteHostAndAddressAndPort + "(s)";
+        } else {
             m_toString = super.toString() + ":" + m_remoteHostAndAddressAndPort;
         }
 

--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -393,7 +393,7 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
             retval.put(
                     m_ih.connectionId(),
                     Pair.of(
-                            getHostnameOrIP()+"_p",
+                            m_toString + "_p",
                             new long[]{
                                     read,
                                     messagesRead,

--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -127,10 +127,6 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
         m_thread.start();
     }
 
-    public String toString() {
-        return m_toString;
-    }
-
     /**
      * Create a pico network thread
      * @param sc  SocketChannel
@@ -393,7 +389,7 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
             retval.put(
                     m_ih.connectionId(),
                     Pair.of(
-                            m_toString + "_p",
+                            getHostnameOrIP(),
                             new long[]{
                                     read,
                                     messagesRead,
@@ -402,7 +398,7 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
             retval.put(
                     -1L,
                     Pair.of(
-                            "GLOBAL_p",
+                            "GLOBAL",
                             new long[] {
                                     read,
                                     messagesRead,

--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -127,6 +127,10 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
         m_thread.start();
     }
 
+    public String toString() {
+        return m_toString;
+    }
+
     /**
      * Create a pico network thread
      * @param sc  SocketChannel

--- a/src/frontend/org/voltdb/AbstractTopology.java
+++ b/src/frontend/org/voltdb/AbstractTopology.java
@@ -37,6 +37,7 @@ import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
+
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableSet;
@@ -1350,15 +1351,15 @@ public class AbstractTopology {
      * @param hostId the given hostId
      * @return all the hostIds in the partition group
      */
-    public Set<Integer> getPartitionGroupHostIds(int hostId) {
-        Set<Integer> partitionGroupHostIds = Sets.newHashSet();
+    public Set<Integer> getPartitionGroupPeers(int hostId) {
+        Set<Integer> peers = Sets.newHashSet();
         for (Integer pid : getPartitionIdList(hostId)) {
             Partition p = partitionsById.get(pid);
             if (p != null) {
-                partitionGroupHostIds.addAll(p.hostIds);
+                peers.addAll(p.hostIds);
             }
         }
-        return partitionGroupHostIds;
+        return peers;
     }
 
     public List<Integer> getPartitionIdList(int hostId) {

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -392,7 +392,6 @@ public final class InvocationDispatcher {
                 return dispatchStatistics(OpsSelector.SYSTEMINFORMATION, task, ccxn);
             }
             else if ("@Trace".equals(procName)) {
-                hostLog.warn(VoltDB.instance().getHostMessenger().dumpBinding());
                 return dispatchStatistics(OpsSelector.TRACE, task, ccxn);
             }
             else if ("@StopNode".equals(procName)) {

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -392,6 +392,7 @@ public final class InvocationDispatcher {
                 return dispatchStatistics(OpsSelector.SYSTEMINFORMATION, task, ccxn);
             }
             else if ("@Trace".equals(procName)) {
+                hostLog.warn(VoltDB.instance().getHostMessenger().dumpBinding());
                 return dispatchStatistics(OpsSelector.TRACE, task, ccxn);
             }
             else if ("@StopNode".equals(procName)) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1175,7 +1175,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                                                                           m_messenger.getHostId(),
                                                                           hostGroups);
                     }
-                    partitionGroupPeers = m_cartographer.getHostIdsWithinPartitionGroup(m_messenger.getHostId());
+                    partitionGroupPeers = m_cartographer.findPartitionGroupPeers(partitions);
                     if (partitions.size() == 0) {
                         VoltDB.crashLocalVoltDB("The VoltDB cluster already has enough nodes to satisfy " +
                                 "the requested k-safety factor of " +
@@ -1185,7 +1185,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 } else {
                     m_configuredNumberOfPartitions = topo.getPartitionCount();
                     partitions = topo.getPartitionIdList(m_messenger.getHostId());
-                    partitionGroupPeers = topo.getPartitionGroupHostIds(m_messenger.getHostId());
+                    partitionGroupPeers = topo.getPartitionGroupPeers(m_messenger.getHostId());
                 }
                 m_messenger.setPartitionGroupPeers(partitionGroupPeers, m_clusterSettings.get().hostcount());
                 for (int ii = 0; ii < partitions.size(); ii++) {

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -337,6 +337,23 @@ public class Cartographer extends StatsSource
     }
 
     /**
+     * Convenient method, given a hostId, return the hostId of its buddies (including itself) which both
+     * belong to the same partition group.
+     * @param partitions A list of partitions that to be assigned to the newly rejoined host
+     * @return A set of host IDs (includes the given hostId) that both belong to the same partition group
+     */
+    public Set<Integer> findPartitionGroupPeers(List<Integer> partitions) {
+        Set<Integer> hostIds = Sets.newHashSet();
+        Multimap<Integer, Integer> hostToPartitions = getHostToPartitionMap();
+        Multimap<Integer, Integer> partitionByIds = ArrayListMultimap.create();
+        Multimaps.invertFrom(hostToPartitions, partitionByIds);
+        for (int p : partitions) {
+            hostIds.addAll(partitionByIds.get(p));
+        }
+        return hostIds;
+    }
+
+    /**
      * Given a partition ID, return a list of HSIDs of all the sites with copies of that partition
      */
     public List<Long> getReplicasForPartition(int partition) {

--- a/tests/frontend/org/voltcore/network/TestPicoNetwork.java
+++ b/tests/frontend/org/voltcore/network/TestPicoNetwork.java
@@ -32,11 +32,11 @@ import java.util.HashSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import junit.framework.TestCase;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 public class TestPicoNetwork extends TestCase {
 
@@ -134,7 +134,7 @@ public class TestPicoNetwork extends TestCase {
         networkChannel = ssc.accept();
         rawChannel.finishConnect();
         rawChannel.configureBlocking(true);
-        pn = new PicoNetwork(networkChannel);
+        pn = new PicoNetwork(networkChannel, true);
         handler = new MockInputHandler();
         pn.start(handler, new HashSet<Long>());
     }


### PR DESCRIPTION
When the cluster has >3 hosts and K-factor set to be >= 1, nodes within the cluster will automatically be assigned into groups ( a.k.a partition group, each group has K+1 members). To fully utilize CPU cores, we used to create a few secondary PicoNetwork thread to evenly distribute the internal traffic across those threads. However there was a bug which will prevent some members within a partition group to use secondary PicoNetwork threads, which in turn leads to a traffic skew between PicoNetwork threads.  

Profiler result also shows performance hotspot in primary PicoNetwork thread, which slows down Site threads.

This patch fixes the problem by monitoring how many secondary PicoNetwork threads are created on *every* host, once there are enough threads then HostMessenger mark itself as ready to use secondary PicoNetwork threads.

This patch also gives secondary PicoNetwork a different name by adding a _p suffix, this helps identifying thread in @Statistics IOStats. 

