### PR TITLE
Eng 12169 (#4691)

### DIFF
--- a/src/frontend/org/voltcore/agreement/AgreementSite.java
+++ b/src/frontend/org/voltcore/agreement/AgreementSite.java
@@ -42,6 +42,7 @@ import org.apache.zookeeper_voltpatches.server.ServerCnxn;
 import org.apache.zookeeper_voltpatches.server.ZooKeeperServer;
 import org.json_voltpatches.JSONObject;
 import org.voltcore.TransactionIdManager;
+import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.AgreementTaskMessage;
 import org.voltcore.messaging.BinaryPayloadMessage;
@@ -55,6 +56,7 @@ import org.voltcore.messaging.RecoveryMessage;
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
+import org.voltcore.utils.RateLimitedLogger;
 
 import com.google_voltpatches.common.collect.ImmutableSet;
 
@@ -353,7 +355,13 @@ public class AgreementSite implements org.apache.zookeeper_voltpatches.server.Zo
     private long m_lastHeartbeatTime = System.nanoTime();
     private void processMessage(VoltMessage message) throws Exception {
         if (!m_hsIds.contains(message.m_sourceHSId)) {
-            m_recoveryLog.info("Dropping message " + message + " because it is not from a known up site");
+            String messageFormat = "Dropping message " + message + " because it is not from a known up site";
+            RateLimitedLogger.tryLogForMessage(m_lastHeartbeatTime,
+                                               10000,
+                                               TimeUnit.MILLISECONDS,
+                                               m_agreementLog,
+                                               Level.INFO,
+                                               messageFormat);
             return;
         }
         if (message instanceof TransactionInfoBaseMessage) {


### PR DESCRIPTION
* wrap recoverylog in rate limit logger

* remove comments

* change log interval from 2s to 10s, remove tabs

* wrap into RateLimitedLogger.tryLogForMessage()

* remove tabs

* remove comments