### PR TITLE
ENG-12812: Hide voltQueueSQLExperimental from the visible procedure API.

### DIFF
--- a/src/frontend/org/voltdb/SQLStmtAdHocHelper.java
+++ b/src/frontend/org/voltdb/SQLStmtAdHocHelper.java
@@ -77,4 +77,24 @@ public class SQLStmtAdHocHelper {
     public static int getHash(SQLStmt sqlStmt) {
         return sqlStmt.sqlCRC;
     }
+
+    /**
+     * <p>Queue the adhoc SQL statement for execution. The adhoc SQL statement will have
+     * to be planned which is orders of magnitude slower then using a precompiled SQL statements.</p>
+     *
+     * <p>If the query is parameterized it is possible to pass in the parameters.</p>
+     *
+     * <p>This method is hidden here so users won't be distracted by it, and so people will be less
+     * likely to try it. It's not removed outright because it's a feature we DO intend to ship at some
+     * point, and there's some value in making sure it doesn't regress. It's currently used in a
+     * few tests and in txnid-selfcheck2.</p>
+     *
+     * @deprecated This method is experimental and not intended for production use yet.
+     * @param sql An ad-hoc SQL string to be run transactionally in this procedure.
+     * @param args Parameter values for the SQL string.
+     */
+    @Deprecated
+    public static void voltQueueSQLExperimental(VoltProcedure proc, String sql, Object... args) {
+        proc.m_runner.voltQueueSQL(sql, args);
+    }
 }

--- a/src/frontend/org/voltdb/VoltProcedure.java
+++ b/src/frontend/org/voltdb/VoltProcedure.java
@@ -218,28 +218,6 @@ public abstract class VoltProcedure {
         return m_runner.getTransactionTime();
     }
 
-    /*
-     * Commented this out and nothing broke? It's cluttering up the javadoc AW 9/2/11
-     */
-//    public void checkExpectation(Expectation expectation, VoltTable table) {
-//        Expectation.check(m_procedureName, "NO STMT", 0, expectation, table);
-//    }
-
-    /**
-     * <p>Queue the adhoc SQL statement for execution. The adhoc SQL statement will have
-     * to be planned which is orders of magnitude slower then using a precompiled SQL statements.</p>
-     *
-     * <p>If the query is parameterized it is possible to pass in the parameters.</p>
-     *
-     * @deprecated This method is experimental and not intended for production use yet.
-     * @param sql An ad-hoc SQL string to be run transactionally in this procedure.
-     * @param args Parameter values for the SQL string.
-     */
-    @Deprecated
-    public void voltQueueSQLExperimental(String sql, Object... args) {
-        m_runner.voltQueueSQL(sql, args);
-    }
-
     /**
      * <p>Queue the SQL {@link org.voltdb.SQLStmt statement} for execution with the specified argument list,
      * and an Expectation describing the expected results. If the Expectation is not met then VoltAbortException

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadMPInProcAdHoc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadMPInProcAdHoc.java
@@ -23,6 +23,7 @@
 
 package txnIdSelfCheck.procedures;
 
+import org.voltdb.SQLStmtAdHocHelper;
 import org.voltdb.VoltTable;
 
 public class ReadMPInProcAdHoc extends ReadMP {
@@ -30,7 +31,7 @@ public class ReadMPInProcAdHoc extends ReadMP {
     @SuppressWarnings("deprecation")
     @Override
     public VoltTable[] run(byte cid) {
-        voltQueueSQLExperimental("SELECT * FROM replicated r INNER JOIN dimension d ON r.cid=d.cid WHERE r.cid = ? ORDER BY r.cid, r.rid desc;", cid);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "SELECT * FROM replicated r INNER JOIN dimension d ON r.cid=d.cid WHERE r.cid = ? ORDER BY r.cid, r.rid desc;", cid);
         return voltExecuteSQL(true);
     }
 

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadSPInProcAdHoc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadSPInProcAdHoc.java
@@ -23,6 +23,7 @@
 
 package txnIdSelfCheck.procedures;
 
+import org.voltdb.SQLStmtAdHocHelper;
 import org.voltdb.VoltTable;
 
 public class ReadSPInProcAdHoc extends ReadSP {
@@ -31,7 +32,7 @@ public class ReadSPInProcAdHoc extends ReadSP {
     @Override
     public VoltTable[] run(byte cid) {
         // join partitioned tbl to replicated tbl. This enables detection of some replica faults.
-        voltQueueSQLExperimental("SELECT * FROM partitioned p INNER JOIN dimension d ON p.cid=d.cid WHERE p.cid = ? ORDER BY p.cid, p.rid desc;", cid);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "SELECT * FROM partitioned p INNER JOIN dimension d ON p.cid=d.cid WHERE p.cid = ? ORDER BY p.cid, p.rid desc;", cid);
         return voltExecuteSQL(true);
     }
 

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateBaseProc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateBaseProc.java
@@ -24,6 +24,7 @@
 package txnIdSelfCheck.procedures;
 
 import org.voltdb.SQLStmt;
+import org.voltdb.SQLStmtAdHocHelper;
 import org.voltdb.VoltProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTableRow;
@@ -183,9 +184,9 @@ public class UpdateBaseProc extends VoltProcedure {
 
     @SuppressWarnings("deprecation")
     protected VoltTable[] doWorkInProcAdHoc(byte cid, long rid, byte[] value, byte shouldRollback) {
-        voltQueueSQLExperimental("SELECT * FROM replicated r INNER JOIN dimension d ON r.cid=d.cid WHERE r.cid = ? ORDER BY r.cid, r.rid desc;", cid);
-        voltQueueSQLExperimental("SELECT * FROM adhocr ORDER BY ts DESC, id LIMIT 1");
-        voltQueueSQLExperimental("SELECT * FROM replview WHERE cid = ? ORDER BY cid desc;", cid);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "SELECT * FROM replicated r INNER JOIN dimension d ON r.cid=d.cid WHERE r.cid = ? ORDER BY r.cid, r.rid desc;", cid);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "SELECT * FROM adhocr ORDER BY ts DESC, id LIMIT 1");
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "SELECT * FROM replview WHERE cid = ? ORDER BY cid desc;", cid);
         VoltTable[] results = voltExecuteSQL();
         VoltTable data = results[0];
         VoltTable adhoc = results[1];
@@ -224,11 +225,11 @@ public class UpdateBaseProc extends VoltProcedure {
                     " for cid " + cid);
         }
 
-        voltQueueSQLExperimental("INSERT INTO replicated (txnid, prevtxnid, ts, cid, cidallhash, rid, cnt, adhocinc, adhocjmp, value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);", txnid, prevtxnid, ts, cid, cidallhash, rid, cnt, adhocInc, adhocJmp, value);
-        voltQueueSQLExperimental("INSERT INTO replicated_export VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);", txnid, prevtxnid, ts, cid, cidallhash, rid, cnt, adhocInc, adhocJmp, value);
-        voltQueueSQLExperimental("DELETE FROM replicated WHERE cid = ? and cnt < ?;", cid, cnt - 10);
-        voltQueueSQLExperimental("SELECT * FROM replicated r INNER JOIN dimension d ON r.cid=d.cid WHERE r.cid = ? ORDER BY r.cid, r.rid desc;", cid);
-        voltQueueSQLExperimental("SELECT * FROM replview WHERE cid = ? ORDER BY cid desc;", cid);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "INSERT INTO replicated (txnid, prevtxnid, ts, cid, cidallhash, rid, cnt, adhocinc, adhocjmp, value) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);", txnid, prevtxnid, ts, cid, cidallhash, rid, cnt, adhocInc, adhocJmp, value);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "INSERT INTO replicated_export VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);", txnid, prevtxnid, ts, cid, cidallhash, rid, cnt, adhocInc, adhocJmp, value);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "DELETE FROM replicated WHERE cid = ? and cnt < ?;", cid, cnt - 10);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "SELECT * FROM replicated r INNER JOIN dimension d ON r.cid=d.cid WHERE r.cid = ? ORDER BY r.cid, r.rid desc;", cid);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "SELECT * FROM replview WHERE cid = ? ORDER BY cid desc;", cid);
         VoltTable[] retval = voltExecuteSQL();
         // Verify that our update happened.  The client is reporting data errors on this validation
         // not seen by the server, hopefully this will bisect where they're occurring.

--- a/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLMP.java
+++ b/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLMP.java
@@ -32,6 +32,7 @@ package org.voltdb_testprocs.adhoc;
 
 import org.voltdb.ProcInfo;
 import org.voltdb.SQLStmt;
+import org.voltdb.SQLStmtAdHocHelper;
 import org.voltdb.VoltProcedure;
 import org.voltdb.VoltTable;
 
@@ -40,10 +41,12 @@ import org.voltdb.VoltTable;
 )
 public class executeSQLMP extends VoltProcedure {
     public static final SQLStmt testStmt = new SQLStmt("select * from PARTED1 order by partval");
+
+    @SuppressWarnings("deprecation")
     public VoltTable[] run(long partval, String sql) {
-        voltQueueSQLExperimental(sql);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, sql);
         voltQueueSQL(testStmt);
-        voltQueueSQLExperimental("select * from PARTED1 where partval = ?", partval);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "select * from PARTED1 where partval = ?", partval);
         voltQueueSQL(testStmt);
         return voltExecuteSQL(true);
     }

--- a/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLMPWRITE.java
+++ b/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLMPWRITE.java
@@ -32,6 +32,7 @@ package org.voltdb_testprocs.adhoc;
 
 import org.voltdb.ProcInfo;
 import org.voltdb.SQLStmt;
+import org.voltdb.SQLStmtAdHocHelper;
 import org.voltdb.VoltProcedure;
 import org.voltdb.VoltTable;
 
@@ -40,8 +41,10 @@ import org.voltdb.VoltTable;
 )
 public class executeSQLMPWRITE extends VoltProcedure {
     public static final SQLStmt marker = new SQLStmt("INSERT into PARTED1 values (?, ?)");
+
+    @SuppressWarnings("deprecation")
     public VoltTable[] run(long partval, String sql) {
-        voltQueueSQLExperimental(sql);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, sql);
         //voltQueueSQL("select * from PARTED1 where partval = ?", partval);
         return voltExecuteSQL(true);
     }

--- a/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLSP.java
+++ b/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLSP.java
@@ -32,6 +32,7 @@ package org.voltdb_testprocs.adhoc;
 
 import org.voltdb.ProcInfo;
 import org.voltdb.SQLStmt;
+import org.voltdb.SQLStmtAdHocHelper;
 import org.voltdb.VoltProcedure;
 import org.voltdb.VoltTable;
 
@@ -44,9 +45,9 @@ public class executeSQLSP extends VoltProcedure {
 
     @SuppressWarnings("deprecation")
     public VoltTable[] run(long partval, String sql) {
-        voltQueueSQLExperimental(sql);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, sql);
         voltQueueSQL(testStmt);
-        voltQueueSQLExperimental("select * from PARTED1 where partval = ?;", partval);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "select * from PARTED1 where partval = ?;", partval);
         voltQueueSQL(testStmt);
 
         return voltExecuteSQL(true);

--- a/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLSPWRITE.java
+++ b/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLSPWRITE.java
@@ -32,6 +32,7 @@ package org.voltdb_testprocs.adhoc;
 
 import org.voltdb.ProcInfo;
 import org.voltdb.SQLStmt;
+import org.voltdb.SQLStmtAdHocHelper;
 import org.voltdb.VoltProcedure;
 import org.voltdb.VoltTable;
 
@@ -44,8 +45,8 @@ public class executeSQLSPWRITE extends VoltProcedure {
 
     @SuppressWarnings("deprecation")
     public VoltTable[] run(long partval, String sql) {
-        voltQueueSQLExperimental(sql);
-        voltQueueSQLExperimental("select * from PARTED1 where partval = ?", partval);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, sql);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, "select * from PARTED1 where partval = ?", partval);
         return voltExecuteSQL(true);
     }
 }

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/AdHocPartitionReadOnlyProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/AdHocPartitionReadOnlyProc.java
@@ -23,6 +23,7 @@
 
 package org.voltdb_testprocs.regressionsuites.querytimeout;
 
+import org.voltdb.SQLStmtAdHocHelper;
 import org.voltdb.VoltProcedure;
 import org.voltdb.VoltTable;
 
@@ -34,7 +35,7 @@ public class AdHocPartitionReadOnlyProc extends VoltProcedure {
 
     @SuppressWarnings("deprecation")
     public VoltTable[] run() {
-        voltQueueSQLExperimental(longRunningCrossJoinAgg);
+        SQLStmtAdHocHelper.voltQueueSQLExperimental(this, longRunningCrossJoinAgg);
         return voltExecuteSQL(true);
     }
 }


### PR DESCRIPTION
Moved inside SQLStmtAdHocHelper where some other stuff is "public" but hidden from users.

Tests updated to new location. No functionality changed, just significantly reduced the visibility of a deprecated API.