### PR TITLE
ENG-12379-Log-Addr-Match-With-Stats

### DIFF
--- a/src/frontend/org/voltdb/HTTPClientInterface.java
+++ b/src/frontend/org/voltdb/HTTPClientInterface.java
@@ -330,10 +330,10 @@ public class HTTPClientInterface {
                     continuation.complete();
                     return;
                 }
-                success = callProcedure(authResult, queryTimeout, cb, procName, hostname, paramSet.toArray());
+                success = callProcedure(hostname, authResult, queryTimeout, cb, procName, paramSet.toArray());
             }
             else {
-                success = callProcedure(authResult, queryTimeout, cb, procName, hostname);
+                success = callProcedure(hostname, authResult, queryTimeout, cb, procName);
             }
             if (!success) {
                 ok(jsonp, "Server is not accepting work at this time.", response);
@@ -356,12 +356,12 @@ public class HTTPClientInterface {
         }
     }
 
-    public boolean callProcedure(final AuthenticationResult ar, int timeout, ProcedureCallback cb, String procName, String hostname, Object...args) {
-        return m_invocationHandler.get().callProcedure(ar.m_authUser, ar.m_adminMode, timeout, cb, false, null, procName, hostname, args);
+    public boolean callProcedure(String hostname, final AuthenticationResult ar, int timeout, ProcedureCallback cb, String procName, Object...args) {
+        return m_invocationHandler.get().callProcedure(hostname, ar.m_authUser, ar.m_adminMode, timeout, cb, false, null, procName, args);
     }
 
-    public boolean callProcedure(final AuthUser user, boolean adminMode, int timeout, ProcedureCallback cb, String procName, String hostname, Object...args) {
-        return m_invocationHandler.get().callProcedure(user, adminMode, timeout, cb, false, null, procName, hostname, args);
+    public boolean callProcedure(String hostname, final AuthUser user, boolean adminMode, int timeout, ProcedureCallback cb, String procName, Object...args) {
+        return m_invocationHandler.get().callProcedure(hostname, user, adminMode, timeout, cb, false, null, procName, args);
     }
 
     Configuration getVoltDBConfig() {

--- a/src/frontend/org/voltdb/HTTPClientInterface.java
+++ b/src/frontend/org/voltdb/HTTPClientInterface.java
@@ -310,6 +310,7 @@ public class HTTPClientInterface {
 
             JSONProcCallback cb = new JSONProcCallback(continuation, jsonp);
             boolean success;
+            String hostname = request.getRemoteHost();
             if (params != null) {
                 ParameterSet paramSet = null;
                 try {
@@ -329,10 +330,10 @@ public class HTTPClientInterface {
                     continuation.complete();
                     return;
                 }
-                success = callProcedure(authResult, queryTimeout, cb, procName, paramSet.toArray());
+                success = callProcedure(authResult, queryTimeout, cb, procName, hostname, paramSet.toArray());
             }
             else {
-                success = callProcedure(authResult, queryTimeout, cb, procName);
+                success = callProcedure(authResult, queryTimeout, cb, procName, hostname);
             }
             if (!success) {
                 ok(jsonp, "Server is not accepting work at this time.", response);
@@ -355,12 +356,12 @@ public class HTTPClientInterface {
         }
     }
 
-    public boolean callProcedure(final AuthenticationResult ar, int timeout, ProcedureCallback cb, String procName, Object...args) {
-        return m_invocationHandler.get().callProcedure(ar.m_authUser, ar.m_adminMode, timeout, cb, procName, args);
+    public boolean callProcedure(final AuthenticationResult ar, int timeout, ProcedureCallback cb, String procName, String hostname, Object...args) {
+        return m_invocationHandler.get().callProcedure(ar.m_authUser, ar.m_adminMode, timeout, cb, false, null, procName, hostname, args);
     }
 
-    public boolean callProcedure(final AuthUser user, boolean adminMode, int timeout, ProcedureCallback cb, String procName, Object...args) {
-        return m_invocationHandler.get().callProcedure(user, adminMode, timeout, cb, procName, args);
+    public boolean callProcedure(final AuthUser user, boolean adminMode, int timeout, ProcedureCallback cb, String procName, String hostname, Object...args) {
+        return m_invocationHandler.get().callProcedure(user, adminMode, timeout, cb, false, null, procName, hostname, args);
     }
 
     Configuration getVoltDBConfig() {

--- a/src/frontend/org/voltdb/InternalConnectionHandler.java
+++ b/src/frontend/org/voltdb/InternalConnectionHandler.java
@@ -102,6 +102,20 @@ public class InternalConnectionHandler {
             String procName,
             Object...args)
     {
+        return callProcedure(user, isAdmin, timeout, cb, ntPriority, backPressurePredicate, procName, null, args);
+    }
+
+    public boolean callProcedure(
+            AuthUser user,
+            boolean isAdmin,
+            int timeout,
+            ProcedureCallback cb,
+            boolean ntPriority,
+            Function<Integer, Boolean> backPressurePredicate,
+            String procName,
+            String hostname,
+            Object...args)
+    {
         Procedure catProc = InvocationDispatcher.getProcedureFromName(procName, getCatalogContext());
         if (catProc == null) {
             String fmt = "Cannot invoke procedure %s. Procedure not found.";
@@ -139,8 +153,9 @@ public class InternalConnectionHandler {
 
         boolean mp = (partitions[0] == MpInitiator.MP_INIT_PID) || (partitions.length > 1);
         final InternalClientResponseAdapter adapter = mp ? m_adapters.get(MpInitiator.MP_INIT_PID) : m_adapters.get(partitions[0]);
+        String adapterName = (hostname == null ? DEFAULT_INTERNAL_ADAPTER_NAME : hostname);
         InternalAdapterTaskAttributes kattrs = new InternalAdapterTaskAttributes(
-                DEFAULT_INTERNAL_ADAPTER_NAME, isAdmin, adapter.connectionId());
+                adapterName, isAdmin, adapter.connectionId());
 
         if (!adapter.createTransaction(kattrs, procName, catProc, cb, null, task, user, partitions, ntPriority, backPressurePredicate)) {
             m_failedCount.incrementAndGet();

--- a/src/frontend/org/voltdb/InternalConnectionHandler.java
+++ b/src/frontend/org/voltdb/InternalConnectionHandler.java
@@ -102,10 +102,11 @@ public class InternalConnectionHandler {
             String procName,
             Object...args)
     {
-        return callProcedure(user, isAdmin, timeout, cb, ntPriority, backPressurePredicate, procName, null, args);
+        return callProcedure(null, user, isAdmin, timeout, cb, ntPriority, backPressurePredicate, procName, args);
     }
 
     public boolean callProcedure(
+            String hostname,
             AuthUser user,
             boolean isAdmin,
             int timeout,
@@ -113,7 +114,6 @@ public class InternalConnectionHandler {
             boolean ntPriority,
             Function<Integer, Boolean> backPressurePredicate,
             String procName,
-            String hostname,
             Object...args)
     {
         Procedure catProc = InvocationDispatcher.getProcedureFromName(procName, getCatalogContext());

--- a/src/frontend/org/voltdb/utils/HTTPAdminListener.java
+++ b/src/frontend/org/voltdb/utils/HTTPAdminListener.java
@@ -678,7 +678,7 @@ public class HTTPAdminListener {
                 }
                 Object[] params = new Object[] { null, dep};
                 SyncCallback cb = new SyncCallback();
-                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", params);
+                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", baseRequest.getRemoteHost(), params);
                 cb.waitForResponse();
                 ClientResponseImpl r = ClientResponseImpl.class.cast(cb.getResponse());
                 if (r.getStatus() == ClientResponse.SUCCESS) {
@@ -744,7 +744,7 @@ public class HTTPAdminListener {
                 Object[] params = new Object[] { null, dep};
                 //Call sync as nothing else can happen when this is going on.
                 SyncCallback cb = new SyncCallback();
-                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", params);
+                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", baseRequest.getRemoteHost(), params);
                 cb.waitForResponse();
                 ClientResponseImpl r = ClientResponseImpl.class.cast(cb.getResponse());
                 if (r.getStatus() == ClientResponse.SUCCESS) {
@@ -815,7 +815,7 @@ public class HTTPAdminListener {
                 Object[] params = new Object[] { null, dep};
                 //Call sync as nothing else can happen when this is going on.
                 SyncCallback cb = new SyncCallback();
-                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", params);
+                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", baseRequest.getRemoteHost(), params);
                 cb.waitForResponse();
                 ClientResponseImpl r = ClientResponseImpl.class.cast(cb.getResponse());
                 if (r.getStatus() == ClientResponse.SUCCESS) {
@@ -863,7 +863,7 @@ public class HTTPAdminListener {
                 Object[] params = new Object[] { null, dep};
                 //Call sync as nothing else can happen when this is going on.
                 SyncCallback cb = new SyncCallback();
-                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", params);
+                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", baseRequest.getRemoteHost(), params);
                 cb.waitForResponse();
                 ClientResponseImpl r = ClientResponseImpl.class.cast(cb.getResponse());
                 response.setStatus(HttpServletResponse.SC_NO_CONTENT);

--- a/src/frontend/org/voltdb/utils/HTTPAdminListener.java
+++ b/src/frontend/org/voltdb/utils/HTTPAdminListener.java
@@ -678,7 +678,7 @@ public class HTTPAdminListener {
                 }
                 Object[] params = new Object[] { null, dep};
                 SyncCallback cb = new SyncCallback();
-                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", baseRequest.getRemoteHost(), params);
+                httpClientInterface.callProcedure(baseRequest.getRemoteHost(), ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", params);
                 cb.waitForResponse();
                 ClientResponseImpl r = ClientResponseImpl.class.cast(cb.getResponse());
                 if (r.getStatus() == ClientResponse.SUCCESS) {
@@ -744,7 +744,7 @@ public class HTTPAdminListener {
                 Object[] params = new Object[] { null, dep};
                 //Call sync as nothing else can happen when this is going on.
                 SyncCallback cb = new SyncCallback();
-                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", baseRequest.getRemoteHost(), params);
+                httpClientInterface.callProcedure(baseRequest.getRemoteHost(), ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", params);
                 cb.waitForResponse();
                 ClientResponseImpl r = ClientResponseImpl.class.cast(cb.getResponse());
                 if (r.getStatus() == ClientResponse.SUCCESS) {
@@ -815,7 +815,7 @@ public class HTTPAdminListener {
                 Object[] params = new Object[] { null, dep};
                 //Call sync as nothing else can happen when this is going on.
                 SyncCallback cb = new SyncCallback();
-                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", baseRequest.getRemoteHost(), params);
+                httpClientInterface.callProcedure(baseRequest.getRemoteHost(), ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", params);
                 cb.waitForResponse();
                 ClientResponseImpl r = ClientResponseImpl.class.cast(cb.getResponse());
                 if (r.getStatus() == ClientResponse.SUCCESS) {
@@ -863,7 +863,7 @@ public class HTTPAdminListener {
                 Object[] params = new Object[] { null, dep};
                 //Call sync as nothing else can happen when this is going on.
                 SyncCallback cb = new SyncCallback();
-                httpClientInterface.callProcedure(ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", baseRequest.getRemoteHost(), params);
+                httpClientInterface.callProcedure(baseRequest.getRemoteHost(), ar, BatchTimeoutOverrideType.NO_TIMEOUT, cb, "@UpdateApplicationCatalog", params);
                 cb.waitForResponse();
                 ClientResponseImpl r = ClientResponseImpl.class.cast(cb.getResponse());
                 response.setStatus(HttpServletResponse.SC_NO_CONTENT);


### PR DESCRIPTION
If one calls system procedure from VMC, the INITIATOR stats will show correct ip address of the caller, rather than "+!_InternalAdapter_!+"