### PR TITLE
add contributing guidelines for pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Thank you for your interest in contributing. VoltDB uses GitHub to manage reviews of pull requests. We welcome your contributions to VoltDB or to any of the related libraries and tools.
+
+VoltDB uses the standard github workflow, meaning we make use of forking and pull requests.
+
+* If you have a trivial fix or improvement, go ahead and create a pull request.
+
+* If you are interested in contributing something more involved, feel free to discuss your ideas in [VoltDB Public](http://chat.voltdb.com/) on Slack.
+
+## Contributor License Agreement
+
+In order to contribute code to VoltDB, you must first sign the [VoltDB Contributor License Agreement (CLA)](https://www.voltdb.com/contributor-license-agreement/) and email an image or PDF of the document including your hand-written signature to [support@voltdb.com](mailto:support@voltdb.com). VoltDB will sign and return the final copy of the agreement for your records.
+
+## How to submit code
+
+The workflow is essentially the following:
+
+1. Fork the VoltDB project
+2. Make a branch. Commit your changes to this branch. (See note below)
+3. Issue a pull request on the VoltDB repository.
+
+Once you have signed the CLA, a VoltDB engineer will review your pull request.
+
+Note:
+
+It will be easier to keep your work merge-able (conflict-free) if you don't work directly on your master branch in your VoltDB fork. Rather, keep your master branch in sync with the VoltDB repository and apply your changes on a branch of your fork.
+
+For further reading:
+
+* [How to fork a GitHub repository](https://help.github.com/articles/fork-a-repo)
+* [Using pull requests](https://help.github.com/articles/using-pull-requests/)
+
+## Additional Resources
+
+* [VoltDB Wiki](https://github.com/VoltDB/voltdb/wiki) on Github
+* [VoltDB Public](http://chat.voltdb.com/) on Slack
+* [VoltDB Community Forum](https://forum.voltdb.com/)


### PR DESCRIPTION
Having a CONTRIBUTING.md file in the root of the repository will cause Github to show a link to it on the page when contributors are opening a pull request. See: https://github.com/blog/1184-contributing-guidelines

This is mostly boilerplate I cut and pasted from emails to contributors, our wiki guidelines, and other examples.  Edits welcome!