### PR TITLE
ENG-12969. Fix meshmonitor build when build= is not default.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -677,6 +677,7 @@ DISTRIBUTION
 	 target="dist" inheritAll="false"
 	 dir="${base.dir}/tools/meshmonitor">
         <property name="volthome" value="${base.dir}"/>
+        <property name="voltdb.build" value="${build}"/>
     </ant>
     <copy todir="${dist.dir}/tools/meshmonitor">
         <fileset dir="${base.dir}/tools/meshmonitor/dist" defaultexcludes="yes">

--- a/tools/meshmonitor/build.xml
+++ b/tools/meshmonitor/build.xml
@@ -1,13 +1,8 @@
 <project name="meshmonitor" default="dist">
 
-    <!-- make environment var foo available as env.foo -->
-    <property environment="env"/>
-    <!-- VOLTHOME env variable points to voltdb checkout -->
-    <condition property="volthome" value="${env.VOLTHOME}" else="../..">
-      <isset property="env.VOLTHOME"/>
-    </condition>
-
-    <property name='volthome.obj' value="${volthome}/obj/release/prod"/>
+    <property name='volthome' location="../.."/>
+    <property name='voltdb.build' value='release'/>
+    <property name='volthome.obj' location="${volthome}/obj/${voltdb.build}/prod"/>
 
     <target name="clean">
         <delete includeEmptyDirs="true" dir="build"/>
@@ -23,7 +18,6 @@
             <classpath path="${volthome.obj}"/>
         </javac>
     </target>
-
 
     <target name="jar" depends="clean,compile">
         <mkdir dir="build/jar"/>


### PR DESCRIPTION
{build} is now passed in by the voltdb build.xml. I also removed some extraneous environment stuff from meshmonitor's build.xml.