### PR TITLE
ENG-12968 NT-Procedure memory leak fix

### DIFF
--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -282,7 +282,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     // I want to make these more dynamic at some point in the future --izzy
     public static final int AGREEMENT_SITE_ID = -1;
     public static final int STATS_SITE_ID = -2;
-    public static final int ASYNC_COMPILER_SITE_ID = -3;
+    public static final int ASYNC_COMPILER_SITE_ID = -3; // not used since NT-Procedure conversion
     public static final int CLIENT_INTERFACE_SITE_ID = -4;
     public static final int SYSCATALOG_SITE_ID = -5;
     public static final int SYSINFO_SITE_ID = -6;

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -231,23 +231,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     };
 
     final long m_siteId;
-    final long m_plannerSiteId;
-
     final Mailbox m_mailbox;
-
-    /**
-     * This boolean allows the DTXN to communicate to the
-     * ClientInputHandler the presence of DTXN backpressure.
-     * The m_connections ArrayList is used as the synchronization
-     * point to ensure that modifications to read interest ops
-     * that are based on the status of this information are atomic.
-     * Additionally each connection must be synchronized on before modification
-     * because the disabling of read selection for an individual connection
-     * due to backpressure (not DTXN backpressure, client backpressure due to a client
-     * that refuses to read responses) occurs inside the SimpleDTXNInitiator which
-     * doesn't have access to m_connections
-     */
-    private final boolean m_hasDTXNBackPressure = false;
 
     // MAX_CONNECTIONS is updated to be (FD LIMIT - 300) after startup
     private final AtomicInteger MAX_CONNECTIONS = new AtomicInteger(800);
@@ -794,11 +778,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
 
         @Override
         public int getMaxRead() {
-            if (m_hasDTXNBackPressure) {
-                return 0;
-            } else {
-                return Math.max( MAX_READ, getNextMessageLength());
-            }
+            return Math.max( MAX_READ, getNextMessageLength());
         }
 
         @Override
@@ -1241,7 +1221,6 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
             }
         };
         messenger.createMailbox(m_mailbox.getHSId(), m_mailbox);
-        m_plannerSiteId = messenger.getHSIdForLocalSite(HostMessenger.ASYNC_COMPILER_SITE_ID);
         m_zk = messenger.getZK();
         m_siteId = m_mailbox.getHSId();
 
@@ -1256,7 +1235,6 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                 .catalogContext(m_catalogContext)
                 .mailbox(m_mailbox)
                 .clientInterfaceHandleManagerMap(m_cihm)
-                .plannerSiteId(m_plannerSiteId)
                 .siteId(m_siteId)
                 .build();
     }

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -1225,14 +1225,8 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                         }
                     };
 
-                    m_internalConnectionHandler.callProcedure(m_catalogContext.get().authSystem.getInternalAdminUser(),
-                                                              true,
-                                                              1000 * 120,
-                                                              cb,
-                                                              true, // priority NT
-                                                              null, // back pressure predicate
-                                                              invocation.getProcName(),
-                                                              itm.getParameters());
+                    m_dispatcher.getInternelAdapterNT().callProcedure(m_catalogContext.get().authSystem.getInternalAdminUser(),
+                            true, 1000 * 120, cb, invocation.getProcName(), itm.getParameters());
                 }
                 else {
                     // m_d is for test only

--- a/src/frontend/org/voltdb/InternalClientResponseAdapter.java
+++ b/src/frontend/org/voltdb/InternalClientResponseAdapter.java
@@ -60,7 +60,7 @@ public class InternalClientResponseAdapter implements Connection, WriteStream {
     public final static long SUPPRESS_INTERVAL = 120;
     private static final int BACK_PRESSURE_WAIT_TIME = Integer.getInteger("INTERNAL_BACK_PRESSURE_WAIT_TIME", 50);
 
-    public interface Callback {
+    private interface Callback {
         public void handleResponse(ClientResponse response) throws Exception;
         public String getProcedureName();
         public int[] getPartitionIds();

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -240,6 +240,10 @@ public final class InvocationDispatcher {
         m_NTProcedureService.update(m_catalogContext.get());
     }
 
+    LightweightNTClientResponseAdapter getInternelAdapterNT () {
+        return m_NTProcedureService.m_internalNTClientAdapter;
+    }
+
     /*
      * This does a ZK lookup which apparently is full of fail
      * if you run TestRejoinEndToEnd. Kind of lame, but initializing this data

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -129,7 +129,6 @@ public final class InvocationDispatcher {
         Mailbox m_mailbox;
         ReplicationRole m_replicationRole;
         SnapshotDaemon m_snapshotDaemon;
-        long m_plannerSiteId;
         long m_siteId;
 
         public Builder clientInterface(ClientInterface clientInterface) {
@@ -162,11 +161,6 @@ public final class InvocationDispatcher {
             return this;
         }
 
-        public Builder plannerSiteId(long plannerSiteId) {
-            m_plannerSiteId = plannerSiteId;
-            return this;
-        }
-
         public Builder snapshotDaemon(SnapshotDaemon snapshotDaemon) {
             m_snapshotDaemon = checkNotNull(snapshotDaemon,"given snapshot daemon is null");
             return this;
@@ -186,7 +180,6 @@ public final class InvocationDispatcher {
                     m_mailbox,
                     m_snapshotDaemon,
                     m_replicationRole,
-                    m_plannerSiteId,
                     m_siteId
                     );
         }
@@ -204,7 +197,6 @@ public final class InvocationDispatcher {
             Mailbox mailbox,
             SnapshotDaemon snapshotDaemon,
             ReplicationRole replicationRole,
-            long plannerSiteId,
             long siteId)
     {
         m_siteId = siteId;


### PR DESCRIPTION
Use internal NT-Procedure connection handler to invoke NT-Procedures and track the call backs. Otherwise the NT-Procedure callAllNodeNTProcedure API ends up keeping all the reference of NT-Procedure internal invocations and eventually hit OOM.