### PR TITLE
ENG-12951

### DIFF
--- a/src/frontend/org/voltdb/importclient/kafka/KafkaExternalLoader.java
+++ b/src/frontend/org/voltdb/importclient/kafka/KafkaExternalLoader.java
@@ -281,10 +281,10 @@ public class KafkaExternalLoader implements ImporterLifecycle, ImporterLogger {
 
         Map<URI, KafkaStreamImporterConfig> configs = createKafkaImporterConfigFromProperties(m_args);
         ExecutorService executor = Executors.newFixedThreadPool(configs.size());
-        m_log.warn("Created " + configs.size() + " configurations for partitions:");
+        m_log.info("Created " + configs.size() + " configurations for partitions:");
 
         for (URI uri : configs.keySet()) {
-            m_log.warn(" " + uri);
+            m_log.info(" " + uri);
             KafkaStreamImporterConfig cfg = configs.get(uri);
             LoaderTopicPartitionImporter importer = new LoaderTopicPartitionImporter(cfg, lifecycle, logger);
             executor.submit(importer);
@@ -435,7 +435,7 @@ public class KafkaExternalLoader implements ImporterLifecycle, ImporterLogger {
                 String brokerInfo = new String(zk.getData("/brokers/ids/" + id, false, null));
                 Broker broker = Broker.createBroker(Integer.valueOf(id), brokerInfo);
                 if (broker != null) {
-                    m_log.warn("Adding broker: " + broker.connectionString());
+                    m_log.info("Adding broker: " + broker.connectionString());
                     brokers.add(new HostAndPort(broker.host(), broker.port()));
                 }
             }

--- a/src/frontend/org/voltdb/importclient/kafka/KafkaExternalLoaderCLIArguments.java
+++ b/src/frontend/org/voltdb/importclient/kafka/KafkaExternalLoaderCLIArguments.java
@@ -190,6 +190,14 @@ public class KafkaExternalLoaderCLIArguments extends CLIConfig {
         if (prop != null) {
             zookeeperSessionTimeoutMillis = Integer.parseInt(prop);
         }
+        // If following properties are set that means we are using commit policy of time this is for backward compatibility
+        // "auto.commit.interval.ms"
+        // "auto.commit.enable"
+        prop = props.getProperty("auto.commit.enable", "false");
+        if (Boolean.valueOf(prop)) {
+            String ts = props.getProperty("auto.commit.interval.ms", "1000");
+            commitpolicy = ts + "ms";
+        }
 
     }
 

--- a/tests/frontend/org/voltdb/importer/kafka/TestKafkaLoaderArgumentParsing.java
+++ b/tests/frontend/org/voltdb/importer/kafka/TestKafkaLoaderArgumentParsing.java
@@ -36,6 +36,7 @@ import org.voltdb.importclient.kafka.KafkaExternalLoaderCLIArguments;
 import org.voltdb.importclient.kafka.KafkaImporterCommitPolicy;
 
 import junit.framework.Assert;
+import static junit.framework.TestCase.assertEquals;
 
 public class TestKafkaLoaderArgumentParsing {
 
@@ -142,6 +143,7 @@ public class TestKafkaLoaderArgumentParsing {
         Properties props = new Properties();
         props.setProperty("group.id", "myGroup");
         props.setProperty("ignored", "foo");
+        props.setProperty("auto.commit.enable", "true");
 
         File tempFile = File.createTempFile(this.getClass().getName(), ".properties");
         tempFile.deleteOnExit();
@@ -151,6 +153,7 @@ public class TestKafkaLoaderArgumentParsing {
         KafkaExternalLoaderCLIArguments args = new KafkaExternalLoaderCLIArguments(new PrintWriter(sw));
         args.parse("KafaExternalLoader", new String[] { "--config", tempFile.getAbsolutePath(), "-z", "localhost:2181", "-t", "volt-topic", "KAFKA_IMPORT" } );
 
+        assertEquals(args.commitpolicy, "1000ms");
         Assert.assertEquals("myGroup", args.groupid);
     }
 


### PR DESCRIPTION
Backward compatibility of auto.commit.enable and log message downgrades. Does not need to be on 7.6 but low risk enough.