### PR TITLE
Eng-12849-sqlcmd-continuation

### DIFF
--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -225,7 +225,8 @@ public class SQLCommand
         boolean isRecall = false;
 
         while (true) {
-            String prompt = isRecall ? "" : ((statement.length() > 0 ? "  " : "") + (RecallableSessionLines.size() + 1) + "> ");
+            String stmtContinuationStr = (statement.length() > 0 ? "  " : "");
+            String prompt = isRecall ? "" : ( stmtContinuationStr + (RecallableSessionLines.size() + 1) + "> ");
             isRecall = false;
             String line = interactiveReader.readLine(prompt);
             if (line == null) {

--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -225,7 +225,7 @@ public class SQLCommand
         boolean isRecall = false;
 
         while (true) {
-            String prompt = isRecall ? "" : ((RecallableSessionLines.size() + 1) + "> ");
+            String prompt = isRecall ? "" : ((statement.length() > 0 ? "  " : "") + (RecallableSessionLines.size() + 1) + "> ");
             isRecall = false;
             String line = interactiveReader.readLine(prompt);
             if (line == null) {

--- a/tests/frontend/org/voltdb/utils/TestSqlCommandParserInteractive.java
+++ b/tests/frontend/org/voltdb/utils/TestSqlCommandParserInteractive.java
@@ -91,6 +91,14 @@ public class TestSqlCommandParserInteractive extends TestCase {
             return result;
         }
 
+        // we add a two spaces and character at the beginning of the prompt
+        // to indicate a multi-line statement definition is in progress
+        public boolean isContinuationPrompt() {
+            // get the prompt after the last statement
+            String lastPrompt = baos.toString().substring(baos.toString().lastIndexOf("\n") + 1);
+            return lastPrompt.startsWith("  ");
+        }
+
         public void close() throws Exception
         {
             pos.close();
@@ -182,18 +190,23 @@ public class TestSqlCommandParserInteractive extends TestCase {
         CommandStuff cmd = new CommandStuff();
         Future<List<String>> result = cmd.openQuery();
 
+        assertFalse(cmd.isContinuationPrompt());
         cmd.submitText("--insert into goats values (0, 1); select * from goats;\n");
         Thread.sleep(100);
         assertFalse(result.isDone());
+        assertFalse(cmd.isContinuationPrompt());
         cmd.submitText(";\n");
         cmd.waitOnResult();
         System.out.println("RESULT: " + result.get());
         assertEquals(0, result.get().size());
 
         result = cmd.openQuery();
+        assertFalse(cmd.isContinuationPrompt());
         cmd.submitText("insert into goats values (0, 1)");
         Thread.sleep(100);
         assertFalse(result.isDone());
+        // a new prompt is obtained only after \n
+        assertFalse(cmd.isContinuationPrompt());
         cmd.submitText("; --select * from goats;\n");
         cmd.waitOnResult();
         System.out.println("RESULT: " + result.get());
@@ -252,15 +265,19 @@ public class TestSqlCommandParserInteractive extends TestCase {
     {
         CommandStuff cmd = new CommandStuff();
         Future<List<String>> result = cmd.openQuery();
+        assertFalse(cmd.isContinuationPrompt());
         cmd.submitText("create table foo (\n");
         Thread.sleep(100);
         assertFalse(result.isDone());
+        assertTrue(cmd.isContinuationPrompt());
         cmd.submitText("col1 integer,\n");
         Thread.sleep(100);
         assertFalse(result.isDone());
+        assertTrue(cmd.isContinuationPrompt());
         cmd.submitText("col2 varchar(50) default ';'\n");
         Thread.sleep(100);
         assertFalse(result.isDone());
+        assertTrue(cmd.isContinuationPrompt());
         cmd.submitText(");\n");
         cmd.waitOnResult();
         System.out.println("RESULT: " + result.get());
@@ -286,6 +303,7 @@ public class TestSqlCommandParserInteractive extends TestCase {
         CommandStuff cmd = new CommandStuff();
         for (int i = 0; i < alterStmts.length; ++i) {
             Future<List<String>> result = cmd.openQuery();
+            assertFalse(cmd.isContinuationPrompt());
             cmd.submitText(alterStmts[i] + ";\n");
             cmd.waitOnResult();
             System.out.println("RESULT: " + result.get());
@@ -310,6 +328,7 @@ public class TestSqlCommandParserInteractive extends TestCase {
     {
         CommandStuff cmd = new CommandStuff();
         Future<List<String>> result = cmd.openQuery();
+        assertFalse(cmd.isContinuationPrompt());
         String create = "create view foo (col1, col2) as select col1, count(*) from foo group by col1";
         cmd.submitText(create + ";\n");
         cmd.waitOnResult();
@@ -319,6 +338,7 @@ public class TestSqlCommandParserInteractive extends TestCase {
 
         // From ENG-6641
         result = cmd.openQuery();
+        assertFalse(cmd.isContinuationPrompt());
         create = "create view foo\n" +
                  "(\n" +
                  "C1\n" +


### PR DESCRIPTION
command lines use a special prompt when you are on a continuation line
For sqlcmd,  we add two few spaces at the beginning of the prompt to indicate a multi-line statement definition is in progress

so for sqlcmd continuation prompt -
two spaces, line number, angle bracket, space.