### PR TITLE
Eng 12463 Tool for comparing table snapshots to detect divergence

### DIFF
--- a/src/frontend/org/voltdb/ParameterSet.java
+++ b/src/frontend/org/voltdb/ParameterSet.java
@@ -841,7 +841,7 @@ public class ParameterSet implements JSONString {
         }
     }
 
-    static long timestampToMicroseconds(Object obj) {
+    public static long timestampToMicroseconds(Object obj) {
         long micros = 0;
         // Adapt the Java standard classes' millisecond count to TIMESTAMP's microseconds.
         if (obj instanceof java.util.Date) {

--- a/src/frontend/org/voltdb/types/VoltDecimalHelper.java
+++ b/src/frontend/org/voltdb/types/VoltDecimalHelper.java
@@ -116,6 +116,9 @@ public class VoltDecimalHelper {
 
     private final static String m_defaultRoundingMode = "HALF_UP";
 
+    public static byte[] getNullIndecator() {
+        return NULL_INDICATOR;
+    }
     /*
      * This is the class of rounding configurations.  This is really
      * a pair, dressed up in glad rags.  Note that the only way to set


### PR DESCRIPTION
Active-Active cluster topologies can diverge when particular transactions happen concurrently on different clusters. Currently we report a possible divergence flag in the conflict logs of one or both clusters. However, cluster divergence can also occur when a cluster is forcibly RESET on two or more other clusters. This divergence can occur because there is no guarantee that the remaining clusters have all acked the exact same set of transactions from the reset cluster.

This is a tool for comparing the state of multiple clusters. If there is possible divergence, we can find out if the divergence has occurred or what the difference between the two or more clusters is. The current solution is to pause and drain all clusters and then snapshot the tables, move all the snapshot files of the two clusters to be compared to the same server, then the tool can compare the snapshots pair by pair and identify divergence.

The comparison is done table by table. If the table is partitioned, only one copy of the same partition will be examined. Rows in each table will be repartitioned using the partition column or the unique key column (or the first column if neither of these exists) so that columns with the same key will be send to the same partition. At the time of repartition, the entire row data of each row will be hashed. Each repartition file will keep a set of the row hashes it contains and count the number of hash collisions within this repartition. For a particular repartition, we will do a comparison between the two files generated from repartitioning the two snapshots. If the collision counts for both snapshots are zero, we compare the hash value of rows only; else we will compare the entire row data. The difference will be written to a output file grouped by partition/unique key values. 

The inputs are: locations， nonces and lists of host IDs of both snapshots, the location for output, and the number of repartitions of the partitioned tables and replicated tables.
