### PR TITLE
ENG-12732: DR consumer must add new partition receivers and update partition count on the consumer side

### DIFF
--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -337,7 +337,7 @@ void ExecutorContext::setDrReplicatedStream(AbstractDRTupleStream *drReplicatedS
  */
 void ExecutorContext::checkTransactionForDR() {
     if (UniqueId::isMpUniqueId(m_uniqueId) && m_undoQuantum != NULL) {
-        if (m_drStream) {
+        if (m_drStream && m_drStream->drStreamStarted()) {
             if (m_drStream->transactionChecks(m_lastCommittedSpHandle,
                         m_spHandle, m_uniqueId))
             {
@@ -346,7 +346,7 @@ void ExecutorContext::checkTransactionForDR() {
                                 m_drStream->m_committedUso,
                                 0));
             }
-            if (m_drReplicatedStream) {
+            if (m_drReplicatedStream && m_drReplicatedStream->drStreamStarted()) {
                 if (m_drReplicatedStream->transactionChecks(m_lastCommittedSpHandle,
                             m_spHandle, m_uniqueId))
                 {

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2188,7 +2188,9 @@ void VoltDBEngine::executeTask(TaskType taskType, ReferenceSerializeInputBE &tas
         assert(uq);
         uq->registerUndoAction(
                 new (*uq) ExecuteTaskUndoGenerateDREventAction(
-                        m_executorContext->drStream(), m_executorContext->drReplicatedStream(), type, lastCommittedSpHandle,
+                        m_executorContext->drStream(), m_executorContext->drReplicatedStream(),
+                        m_executorContext->m_partitionId,
+                        type, lastCommittedSpHandle,
                         spHandle, uniqueId, payloads));
         break;
     }

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -625,9 +625,10 @@ void DRTupleStream::generateDREvent(DREventType type, int64_t lastCommittedSpHan
         ReferenceSerializeInputBE input(payloads.data(), 8);
         int oldPartitionCnt = input.readInt();
         if (m_partitionId >= oldPartitionCnt && m_partitionId != 16383) {
-            // Hack change the event to a StreamStart
-            ByteArray emptyBuff = ByteArray(payloads.data(), 0);
-            writeEventData(DR_STREAM_START, emptyBuff);
+            // Hack change the event to a DR_STREAM_START with isNewStreamForElasticAdd set to true
+            ByteArray flagBuf = ByteArray(1);
+            flagBuf[0] = 1;
+            writeEventData(DR_STREAM_START, flagBuf);
         }
         else {
             writeEventData(type, payloads);

--- a/src/ee/storage/ExecuteTaskUndoGenerateDREventAction.h
+++ b/src/ee/storage/ExecuteTaskUndoGenerateDREventAction.h
@@ -24,28 +24,45 @@ namespace voltdb {
 
 class ExecuteTaskUndoGenerateDREventAction : public voltdb::UndoAction {
 public:
-        ExecuteTaskUndoGenerateDREventAction(AbstractDRTupleStream* drStream, AbstractDRTupleStream* drReplicatedStream , DREventType type, int64_t lastCommittedSpHandle,
-                int64_t spHandle, int64_t uniqueId, ByteArray payloads)
-    : m_drStream(drStream), m_drReplicatedStream(drReplicatedStream), m_type(type), m_lastCommittedSpHandle(lastCommittedSpHandle),m_spHandle(spHandle), m_uniqueId(uniqueId), m_payloads(payloads)
-    {
-    }
+    ExecuteTaskUndoGenerateDREventAction(
+            AbstractDRTupleStream* drStream, AbstractDRTupleStream* drReplicatedStream,
+            CatalogId partitionId,
+            DREventType type, int64_t lastCommittedSpHandle,
+            int64_t spHandle, int64_t uniqueId, ByteArray payloads)
+        : m_drStream(drStream)
+        , m_drReplicatedStream(drReplicatedStream)
+        , m_partitionId(partitionId)
+        , m_type(type)
+        , m_lastCommittedSpHandle(lastCommittedSpHandle)
+        , m_spHandle(spHandle)
+        , m_uniqueId(uniqueId)
+        , m_payloads(payloads)
+    { }
 
-    void undo() {
-    }
+    void undo() { }
 
     void release() {
-        if (m_type == DR_STREAM_START || m_drStream->drStreamStarted()) {
-            m_drStream ->generateDREvent(m_type, m_lastCommittedSpHandle, m_spHandle, m_uniqueId, m_payloads);
-        }
-
         if (m_drReplicatedStream && (m_type == DR_STREAM_START || m_drReplicatedStream->drStreamStarted())) {
-            m_drReplicatedStream ->generateDREvent(m_type, m_lastCommittedSpHandle, m_spHandle, m_uniqueId, m_payloads);
+            m_drReplicatedStream->generateDREvent(m_type, m_lastCommittedSpHandle, m_spHandle, m_uniqueId, m_payloads);
+        }
+        if (m_type == DR_ELASTIC_CHANGE) {
+            ReferenceSerializeInputBE input(m_payloads.data(), 8);
+            int oldPartitionCnt = input.readInt();
+            if (m_partitionId >= oldPartitionCnt && m_partitionId != 16383) {
+                // skip the drStreamStarted() check as this DR_ELASTIC_CHANGE will be transformed into DR_STREAM_START
+                m_drStream->generateDREvent(m_type, m_lastCommittedSpHandle, m_spHandle, m_uniqueId, m_payloads);
+                return;
+            }
+        }
+        if (m_type == DR_STREAM_START || m_drStream->drStreamStarted()) {
+            m_drStream->generateDREvent(m_type, m_lastCommittedSpHandle, m_spHandle, m_uniqueId, m_payloads);
         }
     }
 
 private:
     AbstractDRTupleStream* m_drStream;
     AbstractDRTupleStream* m_drReplicatedStream;
+    CatalogId m_partitionId;
     DREventType m_type;
     int64_t m_lastCommittedSpHandle;
     int64_t m_spHandle;

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -322,7 +322,7 @@ void PersistentTable::deleteAllTuples(bool, bool fallible) {
 }
 
 bool PersistentTable::doDRActions(AbstractDRTupleStream* drStream) {
-    return (m_drEnabled && drStream && drStream->drStreamStarted());
+    return m_drEnabled && !m_isMaterialized && drStream && drStream->drStreamStarted();
 }
 
 void PersistentTable::truncateTableUndo(TableCatalogDelegate* tcd,

--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -86,4 +86,6 @@ public interface ConsumerDRGateway extends Promotable {
     void dropLocal();
 
     boolean isSafeForDropLocal();
+
+    void handleProducerClusterElasticChange(byte producerClusterId, int newProducerPartitionCount);
 }

--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -69,8 +69,6 @@ public interface ConsumerDRGateway extends Promotable {
 
     void startConsumerDispatcher(final MeshMemberInfo member);
 
-    void createNewPartitionBufferReceiver(byte clusterId, int newPartitionCount);
-
     void deactivateConsumerDispatcher(byte clusterId);
 
     void addLocallyLedPartition(int partitionId);

--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -69,6 +69,8 @@ public interface ConsumerDRGateway extends Promotable {
 
     void startConsumerDispatcher(final MeshMemberInfo member);
 
+    void createNewPartitionBufferReceiver(byte clusterId, int newPartitionCount);
+
     void deactivateConsumerDispatcher(byte clusterId);
 
     void addLocallyLedPartition(int partitionId);

--- a/src/frontend/org/voltdb/ParameterSet.java
+++ b/src/frontend/org/voltdb/ParameterSet.java
@@ -332,6 +332,10 @@ public class ParameterSet implements JSONString {
         return m_params[index];
     }
 
+    public boolean hasParam(int index) {
+        return m_params.length > index;
+    }
+
     /**
      * Returns a copy of the parameter array
      * @return


### PR DESCRIPTION
This PR includes work for both ENG-12512 and ENG-12732. It enables elastic add to happen on DR producer cluster while DR is active. In this first phase, it cannot safely replicate producer cluster DR table changes before elastic add finishes yet, therefore it's not really useful yet as elastic add can take a long time. For now, you have to issue new transactions on DR table on producer cluster after elastic add has finished.

It handles DR_ELASTIC_CHANGE event on DR consumer side and adds partition buffer receivers for new producer partitions, it also makes sure consumer will recover partition buffer receivers and proceed correctly in case that any consumer cluster node fails during @ApplyBinaryLogMP for the DR_ELASTIC_CHANGE event.