### PR TITLE
ENG-12985: Delta tables used for joins in materialized views should never generate DR records

### DIFF
--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -73,13 +73,12 @@ Table* TableCatalogDelegate::getTable() const {
 }
 
 TupleSchema* TableCatalogDelegate::createTupleSchema(catalog::Table const& catalogTable,
-                                                     bool isXDCR,
-                                                     bool forceNoDR) {
+                                                     bool isXDCR) {
     // Columns:
     // Column is stored as map<std::string, Column*> in Catalog. We have to
     // sort it by Column index to preserve column order.
     auto numColumns = catalogTable.columns().size();
-    bool needsDRTimestamp = isXDCR && !forceNoDR && catalogTable.isDRed();
+    bool needsDRTimestamp = isXDCR && catalogTable.isDRed();
     TupleSchemaBuilder schemaBuilder(numColumns,
                                      needsDRTimestamp ? 1 : 0); // number of hidden columns
 
@@ -281,7 +280,7 @@ Table* TableCatalogDelegate::constructTableFromCatalog(catalog::Database const& 
     }
 
     // get the schema for the table
-    TupleSchema* schema = createTupleSchema(catalogTable, isXDCR, forceNoDR);
+    TupleSchema* schema = createTupleSchema(catalogTable, isXDCR);
 
     // Indexes
     std::map<std::string, TableIndexScheme> index_map;
@@ -448,7 +447,7 @@ PersistentTable* TableCatalogDelegate::createDeltaTable(catalog::Database const&
     // Delta table will only have one row (currently).
     // Set the table block size to 64KB to achieve better space efficiency.
     // FYI: maximum column count = 1024, largest fixed length data type is short varchars (64 bytes)
-    Table* deltaTable = constructTableFromCatalog(catalogDatabase, catalogTable, false, 1024 * 64, true);
+    Table* deltaTable = constructTableFromCatalog(catalogDatabase, catalogTable, false, true, 1024 * 64);
     deltaTable->incrementRefcount();
     // We have the restriction that view on joined table cannot have non-persistent table source.
     // So here we could use static_cast. But if we in the future want to lift this limitation,

--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -263,8 +263,8 @@ TableCatalogDelegate::getIndexIdString(const TableIndexScheme& indexScheme) {
 Table* TableCatalogDelegate::constructTableFromCatalog(catalog::Database const& catalogDatabase,
                                                        catalog::Table const& catalogTable,
                                                        bool isXDCR,
-                                                       bool forceNoDR,
-                                                       int tableAllocationTargetSize) {
+                                                       int tableAllocationTargetSize,
+                                                       bool forceNoDR) {
     // Create a persistent table for this table in our catalog
     int32_t tableId = catalogTable.relativeIndex();
 
@@ -447,7 +447,7 @@ PersistentTable* TableCatalogDelegate::createDeltaTable(catalog::Database const&
     // Delta table will only have one row (currently).
     // Set the table block size to 64KB to achieve better space efficiency.
     // FYI: maximum column count = 1024, largest fixed length data type is short varchars (64 bytes)
-    Table* deltaTable = constructTableFromCatalog(catalogDatabase, catalogTable, false, true, 1024 * 64);
+    Table* deltaTable = constructTableFromCatalog(catalogDatabase, catalogTable, false, 1024 * 64, true);
     deltaTable->incrementRefcount();
     // We have the restriction that view on joined table cannot have non-persistent table source.
     // So here we could use static_cast. But if we in the future want to lift this limitation,

--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -447,6 +447,8 @@ PersistentTable* TableCatalogDelegate::createDeltaTable(catalog::Database const&
     // Delta table will only have one row (currently).
     // Set the table block size to 64KB to achieve better space efficiency.
     // FYI: maximum column count = 1024, largest fixed length data type is short varchars (64 bytes)
+    // Delta table must be forced to have DR disabled even if the source table is DRed,
+    // therefore true is passed in for the forceNoDR parameter
     Table* deltaTable = constructTableFromCatalog(catalogDatabase, catalogTable, false, 1024 * 64, true);
     deltaTable->incrementRefcount();
     // We have the restriction that view on joined table cannot have non-persistent table source.

--- a/src/ee/storage/TableCatalogDelegate.hpp
+++ b/src/ee/storage/TableCatalogDelegate.hpp
@@ -87,7 +87,8 @@ class TableCatalogDelegate {
                               bool isXDCR);
 
     static TupleSchema *createTupleSchema(catalog::Table const &catalogTable,
-                                          bool isXDCR);
+                                          bool isXDCR,
+                                          bool forceNoDR);
 
     static bool getIndexScheme(catalog::Table const &catalogTable,
                                catalog::Index const &catalogIndex,
@@ -144,6 +145,7 @@ class TableCatalogDelegate {
     Table *constructTableFromCatalog(catalog::Database const &catalogDatabase,
                                      catalog::Table const &catalogTable,
                                      bool isXDCR,
+                                     bool forceNoDR = false,
                                      int tableAllocationTargetSize = 0);
 
     voltdb::Table *m_table;

--- a/src/ee/storage/TableCatalogDelegate.hpp
+++ b/src/ee/storage/TableCatalogDelegate.hpp
@@ -87,8 +87,7 @@ class TableCatalogDelegate {
                               bool isXDCR);
 
     static TupleSchema *createTupleSchema(catalog::Table const &catalogTable,
-                                          bool isXDCR,
-                                          bool forceNoDR);
+                                          bool isXDCR);
 
     static bool getIndexScheme(catalog::Table const &catalogTable,
                                catalog::Index const &catalogIndex,

--- a/src/ee/storage/TableCatalogDelegate.hpp
+++ b/src/ee/storage/TableCatalogDelegate.hpp
@@ -144,8 +144,8 @@ class TableCatalogDelegate {
     Table *constructTableFromCatalog(catalog::Database const &catalogDatabase,
                                      catalog::Table const &catalogTable,
                                      bool isXDCR,
-                                     bool forceNoDR = false,
-                                     int tableAllocationTargetSize = 0);
+                                     int tableAllocationTargetSize = 0,
+                                     bool forceNoDR = false);
 
     voltdb::Table *m_table;
     bool m_exportEnabled;

--- a/src/ee/storage/TableCatalogDelegate.hpp
+++ b/src/ee/storage/TableCatalogDelegate.hpp
@@ -145,6 +145,9 @@ class TableCatalogDelegate {
                                      catalog::Table const &catalogTable,
                                      bool isXDCR,
                                      int tableAllocationTargetSize = 0,
+                                     /* indicates whether the constructed table should inherit isDRed attributed from
+                                      * the provided catalog table or set isDRed to false forcefully. Currently, only
+                                      * delta tables for joins in materialized views use the second option */
                                      bool forceNoDR = false);
 
     voltdb::Table *m_table;


### PR DESCRIPTION
The delta table used in joins in materialized views used to inherit the "DR" catalog attribute from its source table. If the source table is a DR table, so will the delta table, which essentially records all operations on delta table into the DR stream, which is undesirable because 1) it breaks DR binary log structural constraint in case of snapshot restore and 2) it causes the consumer cluster to diverge from the producer cluster.

To fix this, delta tables should always be set as non-DR tables.