### PR TITLE
ENG-13000: moving catalog zk writes into beginning of @UpdateCore but…

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -543,13 +543,6 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
             }
         }
         long genId = getNextGenerationId();
-        try {
-            CatalogUtil.updateCatalogToZK(zk, ccr.expectedCatalogVersion + 1, genId,
-                    ccr.catalogBytes, ccr.catalogHash, ccr.deploymentBytes);
-        } catch (KeeperException | InterruptedException e) {
-            errMsg = "error writing catalog bytes on ZK";
-            return cleanupAndMakeResponse(ClientResponseImpl.GRACEFUL_FAILURE, errMsg);
-        }
 
         // update the catalog jar
         return callProcedure("@UpdateCore",

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -47,6 +47,7 @@ import org.voltdb.catalog.Table;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.dtxn.DtxnConstants;
 import org.voltdb.exceptions.SpecifiedException;
+import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.Encoder;
 import org.voltdb.utils.VoltTableUtil;
@@ -435,6 +436,14 @@ public class UpdateCore extends VoltSystemProcedure {
         ZooKeeper zk = VoltDB.instance().getHostMessenger().getZK();
 
         try {
+            try {
+                CatalogUtil.updateCatalogToZK(zk, expectedCatalogVersion + 1, genId,
+                        catalogBytes, catalogHash, deploymentBytes);
+            } catch (KeeperException | InterruptedException e) {
+                log.error("error writing catalog bytes on ZK during @UpdateCore");
+                throw e;
+            }
+
             // log the start of UpdateCore
             log.info("New catalog update from: " + VoltDB.instance().getCatalogContext().getCatalogLogString());
             log.info("To: catalog hash: " + Encoder.hexEncode(catalogHash).substring(0, 10) +


### PR DESCRIPTION
… before the first MP fragment, this will guarrantee the correctness of catalog bytes on ZK when node failures happens. Putting it on the first fragment should not introduce more blocking time on SP sites, but the procedure statistics of @UpdateCore will not show the real blocking time.