### PR TITLE
Eng-12929-Importer-In-Pause-Start-Mode

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3806,7 +3806,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         ExportManager.instance().startPolling(m_catalogContext);
 
         //Tell import processors that they can start ingesting data.
-        ImportManager.instance().readyForData(m_catalogContext, m_messenger);
+        if (m_mode != OperationMode.PAUSED) {
+            ImportManager.instance().readyForData(m_catalogContext, m_messenger);
+        }
 
         if (m_config.m_startAction == StartAction.REJOIN) {
             consoleLog.info(
@@ -3880,6 +3882,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             {
                 m_config.m_isPaused = false;
                 m_statusTracker.setNodeState(NodeState.UP);
+                if (mode == OperationMode.RUNNING) {
+                    ImportManager.instance().readyForData(m_catalogContext, m_messenger);
+                }
                 hostLog.info("Server is exiting admin mode and resuming operation.");
             }
         }
@@ -4032,7 +4037,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             ExportManager.instance().startPolling(m_catalogContext);
 
             //Tell import processors that they can start ingesting data.
-            ImportManager.instance().readyForData(m_catalogContext, m_messenger);
+            if (m_mode != OperationMode.PAUSED) {
+                ImportManager.instance().readyForData(m_catalogContext, m_messenger);
+            }
 
             try {
                 if (m_adminListener != null) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3805,7 +3805,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         // as at this juncture the initial truncation snapshot is already complete
         ExportManager.instance().startPolling(m_catalogContext);
 
-        //Tell import processors that they can start ingesting data.
+        // If Volt does not start under pause mode, tell import processors that they can start ingesting data.
         if (m_mode != OperationMode.PAUSED) {
             ImportManager.instance().readyForData(m_catalogContext, m_messenger);
         }
@@ -3882,6 +3882,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             {
                 m_config.m_isPaused = false;
                 m_statusTracker.setNodeState(NodeState.UP);
+                // Admin resumed the cluster, so let import processors ingest data.
                 if (mode == OperationMode.RUNNING) {
                     ImportManager.instance().readyForData(m_catalogContext, m_messenger);
                 }
@@ -4036,7 +4037,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             // as at this juncture the initial truncation snapshot is already complete
             ExportManager.instance().startPolling(m_catalogContext);
 
-            //Tell import processors that they can start ingesting data.
+            // If Volt does not start under pause mode, tell import processors that they can start ingesting data.
             if (m_mode != OperationMode.PAUSED) {
                 ImportManager.instance().readyForData(m_catalogContext, m_messenger);
             }


### PR DESCRIPTION
If VoltDB starts under pause mode, importers will remain closed until after resume.