### PR TITLE
ENG-13006: Correctly handle statement splitting for sqlcmd batches

### DIFF
--- a/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
+++ b/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
@@ -822,7 +822,7 @@ public abstract class ProcedureCompiler {
         }
         assert(info != null);
 
-        String[] stmts = SQLLexer.splitStatements(stmtsStr).completelyParsedStmts.toArray(new String[0]);
+        String[] stmts = SQLLexer.splitStatements(stmtsStr).getCompletelyParsedStmts().toArray(new String[0]);
 
         // ADD THE STATEMENTS in a loop
         int stmtNum = 0;

--- a/src/frontend/org/voltdb/parser/SQLLexer.java
+++ b/src/frontend/org/voltdb/parser/SQLLexer.java
@@ -358,9 +358,6 @@ public class SQLLexer extends SQLPatternFactory
         String sCommentEnd = null;
         // Index to start of current statement.
         int iStart = 0;
-        // Index to current character.
-        // IMPORTANT: The loop is structured in a way that requires all if/else/... blocks to bump
-        // iCur appropriately. Failure of a corner case to bump iCur will cause an infinite loop.
         boolean statementIsComment = false;
         boolean inStatement = false;
         // To indicate if inside multi statement procedure
@@ -368,6 +365,9 @@ public class SQLLexer extends SQLPatternFactory
         boolean checkForNextBegin = false;
         // To indicate if inside CASE .. WHEN .. END
         int inCase = 0;
+        // Index to current character.
+        // IMPORTANT: The loop is structured in a way that requires all if/else/... blocks to bump
+        // iCur appropriately. Failure of a corner case to bump iCur will cause an infinite loop.
         int iCur = 0;
         while (iCur < buf.length) {
             // Eat up whitespace outside of a statement
@@ -487,8 +487,9 @@ public class SQLLexer extends SQLPatternFactory
             }
         }
         // Get the last statement, if any.
-        // we are still processing a multi statement procedure if we are still in begin...end
+        // we are still processing a multi-statement procedure if we are still in begin...end
         String incompleteStmt = null;
+        int incompleteStmtOffset = -1;
         if (iStart < buf.length) {
             if (!inBegin) {
                 String statement = String.copyValueOf(buf, iStart, iCur - iStart).trim();
@@ -498,11 +499,12 @@ public class SQLLexer extends SQLPatternFactory
             } else {
                 // we only check for incomplete multi statement procedures right now
                 // add a mandatory space..
+                incompleteStmtOffset = iStart;
                 incompleteStmt = String.copyValueOf(buf, iStart, iCur - iStart);
             }
         }
 
-        return new SplitStmtResults(statements, incompleteStmt);
+        return new SplitStmtResults(statements, incompleteStmt, incompleteStmtOffset);
     }
 
     /**

--- a/src/frontend/org/voltdb/parser/SQLLexer.java
+++ b/src/frontend/org/voltdb/parser/SQLLexer.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.voltdb.utils.SplitStmtResults;
 
 /**
@@ -344,7 +345,6 @@ public class SQLLexer extends SQLPatternFactory
      */
       public static SplitStmtResults splitStatements(final String sql) {
         List<String> statements = new ArrayList<>();
-        SplitStmtResults results = new SplitStmtResults();
 
         // strip out comments
         String sqlNoComments = SQLParser.AnyWholeLineComments.matcher(sql).replaceAll("");
@@ -488,6 +488,7 @@ public class SQLLexer extends SQLPatternFactory
         }
         // Get the last statement, if any.
         // we are still processing a multi statement procedure if we are still in begin...end
+        String incompleteStmt = null;
         if (iStart < buf.length) {
             if (!inBegin) {
                 String statement = String.copyValueOf(buf, iStart, iCur - iStart).trim();
@@ -497,12 +498,11 @@ public class SQLLexer extends SQLPatternFactory
             } else {
                 // we only check for incomplete multi statement procedures right now
                 // add a mandatory space..
-                results.incompleteMuliStmtProc = String.copyValueOf(buf, iStart, iCur - iStart);
+                incompleteStmt = String.copyValueOf(buf, iStart, iCur - iStart);
             }
         }
 
-        results.completelyParsedStmts = statements;
-        return results;
+        return new SplitStmtResults(statements, incompleteStmt);
     }
 
     /**

--- a/src/frontend/org/voltdb/parser/SQLParser.java
+++ b/src/frontend/org/voltdb/parser/SQLParser.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,6 @@ import org.voltdb.types.GeographyPointValue;
 import org.voltdb.types.GeographyValue;
 import org.voltdb.types.TimestampType;
 import org.voltdb.utils.Encoder;
-import org.voltdb.utils.SplitStmtResults;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
 
@@ -423,7 +421,6 @@ public class SQLParser extends SQLPatternFactory
             Pattern.MULTILINE);
 
     private static final Pattern OneWhitespace = Pattern.compile("\\s");
-    private static final Pattern EscapedSingleQuote = Pattern.compile("''", Pattern.MULTILINE);
     private static final Pattern SingleQuotedString = Pattern.compile("'[^']*'", Pattern.MULTILINE);
     private static final Pattern SingleQuotedStringContainingParameterSeparators =
             Pattern.compile(
@@ -590,9 +587,6 @@ public class SQLParser extends SQLPatternFactory
             "\\s*",              // extra spaces
             Pattern.MULTILINE + Pattern.CASE_INSENSITIVE);
 
-    private static final SimpleDateFormat FullDateParser = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-    private static final SimpleDateFormat WholeSecondDateParser = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    private static final SimpleDateFormat DayDateParser = new SimpleDateFormat("yyyy-MM-dd");
     private static final Pattern Unquote = Pattern.compile("^'|'$", Pattern.MULTILINE);
 
     private static final Map<String, String> FRIENDLY_TYPE_NAMES =

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
@@ -128,7 +128,7 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
         assert(validatedHomogeonousSQL != null);
         assert(validatedHomogeonousSQL.size() == 0);
 
-        List<String> sqlStatements = SQLLexer.splitStatements(sql).completelyParsedStmts;
+        List<String> sqlStatements = SQLLexer.splitStatements(sql).getCompletelyParsedStmts();
 
         // do initial naive scan of statements for DDL, forbid mixed DDL and (DML|DQL)
         Boolean hasDDL = null;

--- a/src/frontend/org/voltdb/sysprocs/AdHocSpForTest.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocSpForTest.java
@@ -51,7 +51,7 @@ public class AdHocSpForTest extends AdHocNTBase {
             userParams = Arrays.copyOfRange(paramArray, 2, paramArray.length);
         }
 
-        List<String> sqlStatements = SQLLexer.splitStatements(sql).completelyParsedStmts;
+        List<String> sqlStatements = SQLLexer.splitStatements(sql).getCompletelyParsedStmts();
         if (sqlStatements.size() != 1) {
             return makeQuickResponse(
                     ClientResponse.GRACEFUL_FAILURE,

--- a/src/frontend/org/voltdb/sysprocs/ExplainProc.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainProc.java
@@ -46,7 +46,7 @@ public class ExplainProc extends AdHocNTBase {
          * so I THINK that the string is always a single procname symbol and all this
          * splitting and iterating is a no-op.
          */
-        List<String> procNames = SQLLexer.splitStatements(procedureNames).completelyParsedStmts;
+        List<String> procNames = SQLLexer.splitStatements(procedureNames).getCompletelyParsedStmts();
         int size = procNames.size();
         VoltTable[] vt = new VoltTable[size];
 

--- a/src/frontend/org/voltdb/sysprocs/ExplainView.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainView.java
@@ -44,7 +44,7 @@ public class ExplainView extends AdHocNTBase {
          * so I THINK that the string is always a single view symbol and all this
          * splitting and iterating is a no-op.
          */
-        List<String> viewNames = SQLLexer.splitStatements(fullViewNames).completelyParsedStmts;
+        List<String> viewNames = SQLLexer.splitStatements(fullViewNames).getCompletelyParsedStmts();
         int size = viewNames.size();
         VoltTable[] vt = new VoltTable[size];
         CatalogMap<Table> tables = context.database.getTables();

--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -811,7 +811,7 @@ public class SQLCommand
                         statementStarted = false;
                     }
                 }
-                else { // not in a batch:
+                else { // when in a batch:
                     SplitStmtResults splitResults = SQLLexer.splitStatements(statementString);
                     if (splitResults.getIncompleteStmt() == null) {
                         // not in the middle of a statement.

--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -792,19 +792,12 @@ public class SQLCommand
             if (SQLParser.isSemiColonTerminated(line)) {
                 String statementString = statement.toString();
                 if (batch == null) {
-                    // Trim here avoids a "missing statement" error from adhoc in an edge case
-                    // like a blank line from stdin.
-                    if ( ! statementString.trim().isEmpty()) {
-                        //* enable to debug */ if (m_debug) System.out.println("DEBUG QUERY:'" + statementString + "'");
-                        String incompleteStmt = executeStatements(statementString, callback, reader.getLineNumber());
-                        if (incompleteStmt != null) {
-                            statement = new StringBuilder(incompleteStmt);
-                        }
-                        else {
-                            statement.setLength(0);
-                            statementStarted = false;
-                        }
-                    } else {
+                    //* enable to debug */ if (m_debug) System.out.println("DEBUG QUERY:'" + statementString + "'");
+                    String incompleteStmt = executeStatements(statementString, callback, reader.getLineNumber());
+                    if (incompleteStmt != null) {
+                        statement = new StringBuilder(incompleteStmt);
+                    }
+                    else {
                         statement.setLength(0);
                         statementStarted = false;
                     }

--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -729,7 +729,7 @@ public class SQLCommand
             }
 
             if ( ! statementStarted) {
-                if (line.trim().equals("") || SQLParser.isWholeLineComment(line)) {
+                if (line.trim().isEmpty() || SQLParser.isWholeLineComment(line)) {
                     // We don't strictly have to include a blank line or whole-line
                     // comment at the start of a statement, but when we want to preserve line
                     // numbers (in a batch), we should at least append a newline.
@@ -796,9 +796,9 @@ public class SQLCommand
                     // like a blank line from stdin.
                     if ( ! statementString.trim().isEmpty()) {
                         //* enable to debug */ if (m_debug) System.out.println("DEBUG QUERY:'" + statementString + "'");
-                        String incompleteSt = executeStatements(statementString, callback, reader.getLineNumber());
-                        if (incompleteSt != null) {
-                            statement = new StringBuilder(incompleteSt);
+                        String incompleteStmt = executeStatements(statementString, callback, reader.getLineNumber());
+                        if (incompleteStmt != null) {
+                            statement = new StringBuilder(incompleteStmt);
                         }
                         else {
                             statement.setLength(0);
@@ -814,10 +814,17 @@ public class SQLCommand
                     if (splitResults.getIncompleteStmt() == null) {
                         // not in the middle of a statement.
                         statementStarted = false;
+                        batch.append(statement);
+                        statement.setLength(0);
                     }
-
-                    batch.append(statement);
-                    statement.setLength(0);
+                    else {
+                        int incompleteStmtOffset = splitResults.getIncompleteStmtOffset();
+                        statementStarted = true;
+                        if (incompleteStmtOffset != 0) {
+                            batch.append(statementString.substring(0, incompleteStmtOffset));
+                            statement = new StringBuilder(statementString.substring(incompleteStmtOffset));
+                        }
+                    }
                 }
             }
             else {

--- a/src/frontend/org/voltdb/utils/SplitStmtResults.java
+++ b/src/frontend/org/voltdb/utils/SplitStmtResults.java
@@ -17,7 +17,6 @@
 
 package org.voltdb.utils;
 import java.util.List;
-import java.util.ArrayList;
 
 /**
  * To store the statements which are parsed/split by the SQLLexer.splitStatements().
@@ -27,17 +26,23 @@ import java.util.ArrayList;
 public class SplitStmtResults {
     private final List<String> m_completelyParsedStmts;
     private final String m_incompleteStmt;
+    private final int m_incompleteStmtOffset;
 
-    public SplitStmtResults(List<String> completelyParsedStmts, String incompleteStmt) {
+    public SplitStmtResults(List<String> completelyParsedStmts, String incompleteStmt, int incompleteStmtOffset) {
         m_completelyParsedStmts = completelyParsedStmts;
         m_incompleteStmt = incompleteStmt;
+        m_incompleteStmtOffset = incompleteStmtOffset;
     }
 
-	public String getIncompleteStmt() {
-		return m_incompleteStmt;
-	}
+    public String getIncompleteStmt() {
+        return m_incompleteStmt;
+    }
 
-	public List<String> getCompletelyParsedStmts() {
-		return m_completelyParsedStmts;
-	}
+    public List<String> getCompletelyParsedStmts() {
+        return m_completelyParsedStmts;
+    }
+
+    public int getIncompleteStmtOffset() {
+        return m_incompleteStmtOffset;
+    }
 }

--- a/src/frontend/org/voltdb/utils/SplitStmtResults.java
+++ b/src/frontend/org/voltdb/utils/SplitStmtResults.java
@@ -20,16 +20,24 @@ import java.util.List;
 import java.util.ArrayList;
 
 /**
- * To store the statements which are parsed/split by the SQLLexer.splitStatements()
- * currently the incompleteStmt is used to store the incomplete multi statement procedure
- * and is used to return back to SQLCMD so that more user input can be appended at the end of it
+ * To store the statements which are parsed/split by the SQLLexer.splitStatements().
+ * Currently the incompleteStmt is used to store statements that are not complete,
+ * so that more user input can be appended at the end of it.
  */
 public class SplitStmtResults {
-    public List<String> completelyParsedStmts;
-    public String incompleteMuliStmtProc;
+    private final List<String> m_completelyParsedStmts;
+    private final String m_incompleteStmt;
 
-    public SplitStmtResults() {
-        completelyParsedStmts = new ArrayList<String>();
-        incompleteMuliStmtProc = null;
+    public SplitStmtResults(List<String> completelyParsedStmts, String incompleteStmt) {
+        m_completelyParsedStmts = completelyParsedStmts;
+        m_incompleteStmt = incompleteStmt;
     }
+
+	public String getIncompleteStmt() {
+		return m_incompleteStmt;
+	}
+
+	public List<String> getCompletelyParsedStmts() {
+		return m_completelyParsedStmts;
+	}
 }

--- a/tests/frontend/org/voltdb/TestInitStartAction.java
+++ b/tests/frontend/org/voltdb/TestInitStartAction.java
@@ -317,9 +317,20 @@ final public class TestInitStartAction {
     public void testInitWithSchemaValidNoProcedures() throws Exception {
 
         final String schema =
-                "create table books (cash integer default 23 not null, title varchar(3) default 'foo', PRIMARY KEY(cash));" +
+                "create table books (cash integer default 23 not null, title varchar(3) default 'foo', PRIMARY KEY(cash));\n" +
+                "-- here is a comment\n" +
                 "create procedure Foo as select * from books;\n" +
-                "PARTITION TABLE books ON COLUMN cash;";
+                "-- here is another comment\n" +
+                "PARTITION TABLE -- hmmm\n" +
+                "-- VoltDB-specific mid statement comment\n" +
+                "books ON COLUMN cash; -- end of line comment\n" +
+                "-- comment comment comment\n" +
+                "CREATE STREAM mystream (\n" +
+                "  -- a column:\n" +
+                "  eventid BIGINT NOT NULL,\n" +
+                "  data VARBINARY(64)\n" +
+                "); -- end of line comment\n" +
+                "-- the end.\n";
         File schemaFile = VoltProjectBuilder.writeStringToTempFile(schema);
 
         Configuration c1 = new Configuration(

--- a/tests/frontend/org/voltdb/utils/TestSplitSQLStatements.java
+++ b/tests/frontend/org/voltdb/utils/TestSplitSQLStatements.java
@@ -40,11 +40,11 @@ public class TestSplitSQLStatements {
     public void setUp() throws Exception {
     }
 
-    private void checkSplitter(final String strIn, final String... strsCmp) {
-        final List<String> strsOut = SQLLexer.splitStatements(strIn).getCompletelyParsedStmts();
-        assertEquals(strsCmp.length, strsOut.size());
-        for (int i = 0; i < strsCmp.length; ++i) {
-            assertEquals(strsCmp[i], strsOut.get(i));
+    private void checkSplitter(final String inputStmts, final String... expectedStmts) {
+        final List<String> strsOut = SQLLexer.splitStatements(inputStmts).getCompletelyParsedStmts();
+        assertEquals(expectedStmts.length, strsOut.size());
+        for (int i = 0; i < expectedStmts.length; ++i) {
+            assertEquals(expectedStmts[i], strsOut.get(i));
         }
     }
 
@@ -285,16 +285,20 @@ public class TestSplitSQLStatements {
     @Test
     public void testProcSQLSplitWithComments() {
 
-        String sql = "create procedure thisproc as "
+        String sql = "-- preceding comment\n"
+                  + "create procedure thisproc as "
                   + "begin --one\n"
                   + "select * from t;"
-                  + "select * from r where f = 'foo';"
+                  + "select * from r where f = 'foo';\n"
+                  + "-- mid-statement comment\n"
                   + "select * from r where f = 'begin' or f = 'END';"
-                  + "end;";
+                  + "end;\n"
+                  + "-- trailing comment\n";
         String expected = "create procedure thisproc as "
                     + "begin \n"
                     + "select * from t;"
-                    + "select * from r where f = 'foo';"
+                    + "select * from r where f = 'foo';\n"
+                    + "\n"
                     + "select * from r where f = 'begin' or f = 'END';"
                     + "end";
         checkSplitter(sql, expected);

--- a/tests/frontend/org/voltdb/utils/TestSplitSQLStatements.java
+++ b/tests/frontend/org/voltdb/utils/TestSplitSQLStatements.java
@@ -41,7 +41,7 @@ public class TestSplitSQLStatements {
     }
 
     private void checkSplitter(final String strIn, final String... strsCmp) {
-        final List<String> strsOut = SQLLexer.splitStatements(strIn).completelyParsedStmts;
+        final List<String> strsOut = SQLLexer.splitStatements(strIn).getCompletelyParsedStmts();
         assertEquals(strsCmp.length, strsOut.size());
         for (int i = 0; i < strsCmp.length; ++i) {
             assertEquals(strsCmp[i], strsOut.get(i));
@@ -89,8 +89,8 @@ public class TestSplitSQLStatements {
         // because begin has not end yet, they are incomplete
         String sql = "as begin en";
         SplitStmtResults parsedOut = SQLLexer.splitStatements(sql);
-        assertEquals(0, parsedOut.completelyParsedStmts.size());
-        assertEquals(sql, parsedOut.incompleteMuliStmtProc);
+        assertEquals(0, parsedOut.getCompletelyParsedStmts().size());
+        assertEquals(sql, parsedOut.getIncompleteStmt());
 
         sql = "create table begin (a int);";
         checkSplitter(sql, sql.substring(0, sql.length() - 1));
@@ -135,14 +135,14 @@ public class TestSplitSQLStatements {
         // there is no END statement for BEGIN, so the ; is included as the parsing of BEGIN is not complete
         sql = "CREATE PROCEDURE foo AS BEGIN SELECT * from t; SELECT * from t;";
         parsedOut = SQLLexer.splitStatements(sql);
-        assertEquals(0, parsedOut.completelyParsedStmts.size());
-        assertEquals(sql, parsedOut.incompleteMuliStmtProc);
+        assertEquals(0, parsedOut.getCompletelyParsedStmts().size());
+        assertEquals(sql, parsedOut.getIncompleteStmt());
 
         // enf is not end of statement for BEGIN, so the ; is included as the parsing of BEGIN is not complete
         sql = "CREATE PROCEDURE foo AS BEGIN SELECT * from t; SELECT * from t; ENF;";
         parsedOut = SQLLexer.splitStatements(sql);
-        assertEquals(0, parsedOut.completelyParsedStmts.size());
-        assertEquals(sql, parsedOut.incompleteMuliStmtProc);
+        assertEquals(0, parsedOut.getCompletelyParsedStmts().size());
+        assertEquals(sql, parsedOut.getIncompleteStmt());
 
         checkSplitter("CREATE PROCEDURE foo AS BEGIN SELECT * from t; SELECT * from t; ENF; end",
                 "CREATE PROCEDURE foo AS BEGIN SELECT * from t; SELECT * from t; ENF; end");
@@ -278,8 +278,8 @@ public class TestSplitSQLStatements {
         // parsing AS BEGIN will only end with END
         sql = "create table as begin (a int);";
         parsedOut = SQLLexer.splitStatements(sql + sql1);
-        assertEquals(0, parsedOut.completelyParsedStmts.size());
-        assertEquals(sql + sql1, parsedOut.incompleteMuliStmtProc);
+        assertEquals(0, parsedOut.getCompletelyParsedStmts().size());
+        assertEquals(sql + sql1, parsedOut.getIncompleteStmt());
     }
 
     @Test

--- a/tests/frontend/org/voltdb/utils/TestSqlCmdInterface.java
+++ b/tests/frontend/org/voltdb/utils/TestSqlCmdInterface.java
@@ -473,7 +473,7 @@ public class TestSqlCmdInterface
     }
 
     private void assertThis(String qryStr, int numOfQry, int testID) {
-        List<String> parsed = SQLLexer.splitStatements(qryStr).completelyParsedStmts;
+        List<String> parsed = SQLLexer.splitStatements(qryStr).getCompletelyParsedStmts();
         String msg = "Test ID: " + testID + ". ";
         assertNotNull(msg + "SQLCommand.parseQuery returned a NULL obj!!", parsed);
         assertEquals(msg, numOfQry, parsed.size());
@@ -486,7 +486,7 @@ public class TestSqlCmdInterface
     }
 
     private void assertThis(String qryStr, String cleanQryStr, int numOfQry, int testID, int blockCommentCount) {
-        List<String> parsed = SQLLexer.splitStatements(qryStr).completelyParsedStmts;
+        List<String> parsed = SQLLexer.splitStatements(qryStr).getCompletelyParsedStmts();
         String msg = "\nTest ID: " + testID + ". ";
         String err1 = "\nExpected # of queries: " + numOfQry + "\n";
         err1 += "Actual # of queries: " + parsed.size() + "\n";

--- a/tests/sqlcmd/baselines/batching/file_inlinebatch_simple.outbaseline
+++ b/tests/sqlcmd/baselines/batching/file_inlinebatch_simple.outbaseline
@@ -15,6 +15,16 @@ create index tidx on t(i);
 create procedure p as
     select * from t;
 
+-- here is another table
+create table commented_table (
+   id integer not null,
+   v1 float,
+   f2 bigint
+);
+-- here is a comment
+partition table commented_table on column id;
+-- that is it for commented_table
+
 
 Batch command succeeded.
 

--- a/tests/sqlcmd/baselines/batching/file_inlinebatch_simple_via_file.outbaseline
+++ b/tests/sqlcmd/baselines/batching/file_inlinebatch_simple_via_file.outbaseline
@@ -17,6 +17,16 @@ create index tidx on t(i);
 create procedure p as
     select * from t;
 
+-- here is another table
+create table commented_table (
+   id integer not null,
+   v1 float,
+   f2 bigint
+);
+-- here is a comment
+partition table commented_table on column id;
+-- that is it for commented_table
+
 
 Batch command succeeded.
 

--- a/tests/sqlcmd/scripts/batching/file_inlinebatch_simple.in
+++ b/tests/sqlcmd/scripts/batching/file_inlinebatch_simple.in
@@ -8,6 +8,16 @@ create index tidx on t(i);
 create procedure p as
     select * from t;
 
+-- here is another table
+create table commented_table (
+   id integer not null,
+   v1 float,
+   f2 bigint
+);
+-- here is a comment
+partition table commented_table on column id;
+-- that is it for commented_table
+
 EOF
 
 exec p;


### PR DESCRIPTION
For `voltdb init --schema=ddl.sql` we use a sqlcmd inline batch under the hood.  The changes that support multi-statement procedures tweaked sqlcmd's logic in a subtle way and made it so we weren't trimming comments appearing in between DDL statements in batches.

The test doesn't actually reproduce the issue, since sqlcmd will use a different codepath when invoked from the command line.  I wasn't able to reproduce it outside of `voltdb init`.  But at least it gets us more coverage.  

I did some refactoring of SplitStmtResults to make it an immutable class.  The functional changes are all in SQLCommand.java.