### PR TITLE
ENG-13015: add log message to report exact block time for @UpdateCore…

### DIFF
--- a/src/frontend/org/voltdb/CatalogContext.java
+++ b/src/frontend/org/voltdb/CatalogContext.java
@@ -135,6 +135,7 @@ public class CatalogContext {
     // Some people may be interested in the JAXB rather than the raw deployment bytes.
     private DeploymentType m_memoizedDeployment;
 
+    public long m_lastUpdateCoreDuration = -1; // in nano seconds
 
     /**
      * Constructor especially used during @CatalogContext update when @param hasSchemaChange is false.

--- a/src/frontend/org/voltdb/sysprocs/SystemInformation.java
+++ b/src/frontend/org/voltdb/sysprocs/SystemInformation.java
@@ -441,6 +441,9 @@ public class SystemInformation extends VoltSystemProcedure
         vt.addRow(hostId, "STARTTIME", Long.toString(startTimeMs));
         vt.addRow(hostId, "UPTIME", MiscUtils.formatUptime(VoltDB.instance().getClusterUptime()));
 
+        vt.addRow(hostId, "LAST_UPDATECORE_DURATION",
+                Long.toString(VoltDB.instance().getCatalogContext().m_lastUpdateCoreDuration));
+
         SocketHubAppender hubAppender =
             (SocketHubAppender) Logger.getRootLogger().getAppender("hub");
         int port = 0;

--- a/tests/test_apps/uacbench/client/uac/UpdateClassesBenchmark.java
+++ b/tests/test_apps/uacbench/client/uac/UpdateClassesBenchmark.java
@@ -51,6 +51,7 @@ import java.util.concurrent.CountDownLatch;
 import org.voltcore.utils.Pair;
 import org.voltdb.CLIConfig;
 import org.voltdb.VoltTable;
+import org.voltdb.VoltType;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientFactory;
@@ -239,63 +240,55 @@ public class UpdateClassesBenchmark {
         }
     }
 
-    /**
-     * Returns Pair<NUMBER OF UPDATECORES FOUND, TIME SPENT IN UPDATECORE>
-     */
-    private static Pair<Integer, Long> uacBlockTimeCore(Client client, int interval) throws Exception {
-        int updateCoreCounts = 0;
+    static long uacBlockTime(Client client) throws Exception {
         long blockDuration = 0;
 
-        VoltTable vt = client.callProcedure("@Statistics", "PROCEDURE", interval).getResults()[0];
-        updateCoreCounts = 0;
-        while(vt.advanceRow()) {
-            if ("org.voltdb.sysprocs.UpdateCore".equals(vt.getString(5))) {
-                blockDuration += vt.getLong(8);
-                updateCoreCounts++;
+        VoltTable vt = client.callProcedure("@Statistics", "TOPO").getResults()[0];
+
+        int mpiHostId = 0;
+        while (vt.advanceRow()) {
+            if (vt.get(0, VoltType.INTEGER).equals(16383)) {
+                mpiHostId = Integer.parseInt(vt.getString(2).split(":")[0]);
+                break;
             }
         }
+        Thread.sleep(100);
+
+        vt = client.callProcedure("@SystemInformation").getResults()[0];
+        while (vt.advanceRow()) {
+            if (vt.get(0, VoltType.INTEGER).equals(mpiHostId) && vt.getString(1).equals("LAST_UPDATECORE_DURATION")) {
+                blockDuration = Long.parseLong(vt.getString(2));
+            }
+        }
+
         if (blockDuration < 0) {
             System.err.println(vt);
             throw new RuntimeException("Negative UpdateCore duration " + blockDuration);
         }
-
-        return new Pair<Integer, Long>(updateCoreCounts, blockDuration);
-    }
-
-    static long uacBlockTime(Client client, int interval, boolean requireFound) throws Exception {
-        Pair<Integer, Long> results = uacBlockTimeCore(client, interval);
-
-        while ((results.getFirst() < 1) && requireFound) {
-            Thread.sleep(100);
-            results = uacBlockTimeCore(client, interval);
-        }
-
-        return results.getSecond();
+        return blockDuration;
     }
 
     static UACTime doUpdateClassesWork(Client client, String prevStmts, byte[] jar,
             String delPattern, String stmts) throws Exception {
-        uacBlockTime(client, 0, false);
-
         long startTS = System.nanoTime();
         long sumBlockTime = 0;
         ClientResponse cr = null;
         if (prevStmts != null && prevStmts.length() > 0) {
             cr = client.callProcedure("@AdHoc", prevStmts);
             assert(cr.getStatus() == ClientResponse.SUCCESS);
-            sumBlockTime += uacBlockTime(client, 1, true);
+            sumBlockTime += uacBlockTime(client);
         }
 
         if (jar != null || delPattern != null) {
             cr = client.callProcedure("@UpdateClasses", jar, delPattern);
             assert(cr.getStatus() == ClientResponse.SUCCESS);
-            sumBlockTime += uacBlockTime(client, 1, true);
+            sumBlockTime += uacBlockTime(client);
         }
 
         if (stmts != null && stmts.length() > 0) {
             cr = client.callProcedure("@AdHoc", stmts);
             assert(cr.getStatus() == ClientResponse.SUCCESS);
-            sumBlockTime += uacBlockTime(client, 1, true);
+            sumBlockTime += uacBlockTime(client);
         }
 
         return new UACTime(System.nanoTime() - startTS, sumBlockTime);


### PR DESCRIPTION
…. The block time starts recording when issuing first MP fragment to other SP sites, ends on receving the last fragment aggregated response. Also update the blocking time calculation for the UAC benchmark app.