### PR TITLE
ENG-13032: Add timeout setting for run everywhere NT-Procedure @Verif…

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -1168,10 +1168,6 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
 
                     // handle all host NT procedure callbacks
                     if (response.getClientConnectionId() == NT_REMOTE_PROC_CID) {
-                        //int hostId = VoltDB.instance().getHostMessenger().getHostId();
-                        //System.out.printf("HostID %d got a response from an all-host NT proc\n", hostId);
-                        //System.out.flush();
-
                         m_dispatcher.handleAllHostNTProcedureResponse(response.getClientResponseData());
                         return;
                     }

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -1352,6 +1352,10 @@ public final class InvocationDispatcher {
     public void handleAllHostNTProcedureResponse(ClientResponseImpl clientResponseData) {
         long handle = clientResponseData.getClientHandle();
         ProcedureRunnerNT runner = m_NTProcedureService.m_outstanding.get(handle);
+        if (runner == null) {
+            hostLog.info("Run everywhere NTProcedure early returned, probably gets timed out.");
+            return;
+        }
         runner.allHostNTProcedureCallback(clientResponseData);
     }
 

--- a/src/frontend/org/voltdb/NTProcedureService.java
+++ b/src/frontend/org/voltdb/NTProcedureService.java
@@ -112,6 +112,8 @@ public class NTProcedureService {
     final static String NTPROC_THREADPOOL_NAMEPREFIX = "NTPServiceThread-";
     final static String NTPROC_THREADPOOL_PRIORITY_SUFFIX = "Priority-";
 
+    public static final String NTPROCEDURE_RUN_EVERYWHERE_TIMEOUT = "NTPROCEDURE_RUN_EVERYWHERE_TIMEOUT";
+
     // runs the initial run() method of nt procs
     // (doesn't run nt procs if started by other nt procs)
     // from 1 to 20 threads in parallel, with an unbounded queue


### PR DESCRIPTION
…yCatalogAndWriteJar and abort the catalog update before invoking the transactional procedure @UpdateCore. Thus it will remove the UAC blocker on ZK node and other rejoin node will be resumed to proceed. Without this change, the run everywhere NT-Procedure API may send invocation to rejoining node whose client interface has not been setted up yet, thus the message is lost and no response will be returned to the primary NT thread.