### PR TITLE
ENG-13031, fix NPE found during extensive UAC test.

### DIFF
--- a/src/catgen/in/javasrc/CatalogType.java
+++ b/src/catgen/in/javasrc/CatalogType.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Field;
  * have a name and a path (from the root). They have fields and children.
  * All fields are simple types. All children are CatalogType instances.
  *
+ * MUST BE THREAD SAFE, MUITIPLE THREADS ACCESS IT!
  */
 public abstract class CatalogType implements Comparable<CatalogType> {
 
@@ -36,25 +37,32 @@ public abstract class CatalogType implements Comparable<CatalogType> {
 
         T m_value = null;
         String m_unresolvedPath = null;
+        Object m_lock = new Object();
 
         public void setUnresolved(String path) {
-            // if null: value will be set to null
-            m_value = null;
-            m_unresolvedPath = path;
+            synchronized (m_lock) {
+                // if null: value will be set to null
+                m_value = null;
+                m_unresolvedPath = path;
+            }
         }
 
         public void set(T value) {
-            m_value = value;
-            m_unresolvedPath = null;
+            synchronized (m_lock) {
+                m_value = value;
+                m_unresolvedPath = null;
+            }
         }
 
         @SuppressWarnings("unchecked")
         T resolve() {
-            if (m_unresolvedPath != null) {
-                m_value = (T) getCatalog().getItemForPath(m_unresolvedPath);
-                m_unresolvedPath = null;
+            synchronized (m_lock) {
+                if (m_unresolvedPath != null) {
+                    m_value = (T) getCatalog().getItemForPath(m_unresolvedPath);
+                    m_unresolvedPath = null;
+                }
+                return m_value;
             }
-            return m_value;
         }
 
         public T get() {


### PR DESCRIPTION
CatalogTypeReference is not thread safe, during UAC both Site thread and Ad Hoc Planner thread may access the same object.

Change-Id: I1f4c8ffa559a24f40ffd0644daa20d4de62f3ebe