### PR TITLE
ENG-13052: Use 10 minutes max waiting time for rejoin to check UAC bl…

### DIFF
--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -48,6 +48,7 @@ import org.voltdb.sysprocs.saverestore.StreamSnapshotRequestConfig;
 import org.voltdb.utils.FixedDBBPool;
 
 import com.google_voltpatches.common.base.Preconditions;
+import com.google_voltpatches.common.base.Stopwatch;
 import com.google_voltpatches.common.collect.ArrayListMultimap;
 import com.google_voltpatches.common.collect.Multimap;
 
@@ -182,26 +183,28 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
     @Override
     public void initialize(int kfactor) throws JSONException, KeeperException, InterruptedException, ExecutionException
     {
-        final long maxWaitTime = TimeUnit.MINUTES.toSeconds(60); // 60 minutes
-        long remainingWaitTime = maxWaitTime;
-        final long retryInterval = 10; // 10 seconds
+        final long maxWaitTime = TimeUnit.MINUTES.toSeconds(10); // 10 minutes
+        final long checkInterval = 1; // 1 second
 
-        while(remainingWaitTime > 0) {
+        Stopwatch sw = Stopwatch.createStarted();
+        long elapsed = 0;
+        while ((elapsed = sw.elapsed(TimeUnit.SECONDS)) < maxWaitTime) {
             String blockerError = VoltZK.createCatalogUpdateBlocker(m_messenger.getZK(), VoltZK.rejoinActiveBlocker,
                                                                     REJOINLOG, "node rejoin");
             if (blockerError == null) {
                 return;
             }
 
-            REJOINLOG.info(String.format("Rejoin node will wait %d seconds for catalog update or elastic join to finish",
-                    retryInterval));
-
-            try {
-                Thread.sleep(TimeUnit.SECONDS.toMillis(retryInterval));
-            } catch (InterruptedException ignoreIt) {
+            if (elapsed % 10 == 5) {
+                // log the info message every 10 seconds, log the initial message under 5 seconds
+                REJOINLOG.info(String.format("Rejoin node is waiting for catalog update or elastic join to finish, "
+                        + "time elapsed " + elapsed + " seconds"));
             }
 
-            remainingWaitTime -= retryInterval;
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(checkInterval));
+            } catch (InterruptedException ignoreIt) {
+            }
         }
 
         VoltDB.crashLocalVoltDB("Rejoin node is timed out " + maxWaitTime +


### PR DESCRIPTION
…ocker instead one hour; Ask the rejoin node to check the UAC ZK blocker node more frequently, using 1 second check interval instead of 10 seconds. In this way, our system test running UAC continuously will not alway block rejoin node to initialize. In real world, it is not possible to see a 10 minute catalog update. If there is, there must be other issues.