### PR TITLE
ENG-13060: remove blocking waiting for UpdateCore response on NT thre…

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -475,8 +475,12 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
         CatalogChangeResult ccr = null;
 
         try {
-            String errMsg = VoltZK.createNTCatalogUpdateBlocker(zk, "catalog update(" + invocationName + ")" );
+            String errMsg = VoltZK.createUpdateCoreBlocker(zk, "catalog update(" + invocationName + ")" );
             if (errMsg != null) {
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, errMsg);
+            }
+
+            if (VoltZK.zkNodeExists(zk, VoltZK.uacActiveBlocker)) {
                 return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, errMsg);
             }
 

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -424,6 +424,7 @@ public class UpdateCore extends VoltSystemProcedure {
                            byte[] catalogHash,
                            byte[] deploymentBytes,
                            byte[] deploymentHash,
+                           byte worksWithElastic,
                            String[] tablesThatMustBeEmpty,
                            String[] reasonsForEmptyTables,
                            byte requiresSnapshotIsolation,
@@ -437,6 +438,34 @@ public class UpdateCore extends VoltSystemProcedure {
         long start, duration = 0;
 
         try {
+            if (worksWithElastic == 0 && !zk.getChildren(VoltZK.catalogUpdateBlockers, false).isEmpty()) {
+                throw new VoltAbortException("Can't do a catalog update while an elastic join is active");
+            }
+            String errMsg = VoltZK.createCatalogUpdateBlocker(zk, VoltZK.uacActiveBlocker, log,
+                    "catalog update(@UpdateCore)" );
+            if (errMsg != null) {
+                throw new VoltAbortException("Can't do a catalog update while a rejoin is active");
+            }
+
+            // impossible to happen since we only allow catalog update sequentially
+            final CatalogContext context = VoltDB.instance().getCatalogContext();
+            if (context.catalogVersion != expectedCatalogVersion) {
+                if (context.catalogVersion == (expectedCatalogVersion + 1) &&
+                    Arrays.equals(context.getCatalogHash(), catalogHash) &&
+                    Arrays.equals(context.getDeploymentHash(), deploymentHash)) {
+                    log.info("Restarting catalog update");
+                } else {
+                    errMsg = "Invalid catalog update.  Catalog or deployment change was planned " +
+                            "against one version of the cluster configuration but that version was " +
+                            "no longer live when attempting to apply the change.  This is likely " +
+                            "the result of multiple concurrent attempts to change the cluster " +
+                            "configuration.  Please make such changes synchronously from a single " +
+                            "connection to the cluster.";
+                    log.warn(errMsg);
+                    throw new VoltAbortException(errMsg);
+                }
+            }
+
             try {
                 CatalogUtil.updateCatalogToZK(zk, expectedCatalogVersion + 1, genId,
                         catalogBytes, catalogHash, deploymentBytes);

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -447,6 +447,10 @@ public class UpdateCore extends VoltSystemProcedure {
                 throw new VoltAbortException("Can't do a catalog update while a rejoin is active");
             }
 
+            if (VoltZK.zkNodeExists(zk, VoltZK.updateCoreBlocker)) {
+                throw new VoltAbortException("Can't do a catalog update while a catalog update is active");
+            }
+
             // impossible to happen since we only allow catalog update sequentially
             final CatalogContext context = VoltDB.instance().getCatalogContext();
             if (context.catalogVersion != expectedCatalogVersion) {


### PR DESCRIPTION
…ads, and replace the ZK UAC blocker with NT UAC blocker. In this way, our NT thread executing of catalog update will be sequential. Also the UpdateCore will be sent to MPI in sequential order as well. The main motivation is that we could not hold one ZK lock during the NT thread and MPI.