### PR TITLE
ENG-10378: UAC can be broken into two stage: NT + TXN. We see two con…

### DIFF
--- a/src/frontend/org/voltdb/CatalogContext.java
+++ b/src/frontend/org/voltdb/CatalogContext.java
@@ -20,6 +20,7 @@ package org.voltdb;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -119,7 +120,7 @@ public class CatalogContext {
     public final int catalogVersion;
     public final CatalogInfo m_catalogInfo;
     // prepared catalog information in non-blocking path
-    public CatalogInfo m_preparedCatalogInfo;
+    public CatalogInfo m_preparedCatalogInfo = null;
 
     public final long m_genId; // export generation id
 
@@ -505,6 +506,25 @@ public class CatalogContext {
 
     public byte[] getDeploymentHash() {
         return m_catalogInfo.m_deploymentHash;
+    }
+
+    /**
+     * @param catalogHash
+     * @param deploymentHash
+     * @return true if the prepared catalog mismatch the catalog update invocation, false otherwise
+     */
+    public boolean checkMismatchedPreparedCatalog(byte[] catalogHash, byte[] deploymentHash) {
+        if (m_preparedCatalogInfo == null) {
+            // this is the replay case that does not prepare the catalog
+            return false;
+        }
+
+        if (!Arrays.equals(m_preparedCatalogInfo.m_catalogHash, catalogHash) ||
+            !Arrays.equals(m_preparedCatalogInfo.m_deploymentHash, deploymentHash)) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -475,13 +475,9 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
         CatalogChangeResult ccr = null;
 
         try {
-            String errMsg = VoltZK.createUpdateCoreBlocker(zk, "catalog update(" + invocationName + ")" );
+            String errMsg = VoltZK.createCatalogUpdateBlocker(zk, VoltZK.uacActiveBlockerNT,  hostLog,
+                    "catalog update(" + invocationName + ")" );
             if (errMsg != null) {
-                return makeQuickResponse(ClientResponse.USER_ABORT, errMsg);
-            }
-
-            if (VoltZK.zkNodeExists(zk, VoltZK.uacActiveBlocker)) {
-                errMsg = "Can't do a " + invocationName + "  while a catalog update is active";
                 return makeQuickResponse(ClientResponse.USER_ABORT, errMsg);
             }
 
@@ -541,7 +537,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
             // MPI node may fail before receiving @UpdateCore invocation, this transactional procedure
             // may never send out. However, we need to clean up the UAC ZK blocker now and check version
             // in @UpdateCore
-            VoltZK.removeNTCatalogUpdateBlocker(zk, hostLog);
+            VoltZK.removeCatalogUpdateBlocker(zk, VoltZK.uacActiveBlockerNT, hostLog);
         }
 
         long genId = getNextGenerationId();


### PR DESCRIPTION
…current UAC running in unexpected order, like NT1, NT2, TXN1, which TXN1 crashed in the middle of update catalog using corrupted prepared catalog information from NT2. We should guard against this case to happen and abort the UpdateCore TXN by checking the prepared catalog hash and deployment hash. Addiontally, we should check UAC ZK NT lock and TXN lock before starting to run rejoin.