### PR TITLE
Fix interactive inline batch bug.

### DIFF
--- a/src/frontend/org/voltdb/parser/SQLParser.java
+++ b/src/frontend/org/voltdb/parser/SQLParser.java
@@ -1365,9 +1365,10 @@ public class SQLParser extends SQLPatternFactory
                 return m_file.getPath();
             case INLINEBATCH:
             default:
+                String filePath = (m_context == null) ? "no file" : m_context.getFilePath();
                 assert(m_option == FileOption.INLINEBATCH);
                 return "(inline batch delimited by '" + m_delimiter +
-                        "' in " + m_context.getFilePath() + ")";
+                        "' in " + filePath + ")";
             }
         }
 
@@ -1415,7 +1416,7 @@ public class SQLParser extends SQLPatternFactory
 
         String remainder = statement.substring(fileMatcher.end(), statement.length());
 
-        List<FileInfo> filesInfo = new ArrayList<FileInfo>();
+        List<FileInfo> filesInfo = new ArrayList<>();
 
         Matcher inlineBatchMatcher = DashInlineBatchToken.matcher(remainder);
         if (inlineBatchMatcher.lookingAt()) {
@@ -1447,7 +1448,7 @@ public class SQLParser extends SQLPatternFactory
 
         // split filenames assuming they are separated by space ignoring spaces within quotes
         // tests for parsing in TestSqlCmdInterface.java
-        List<String> filenames = new ArrayList<String>();
+        List<String> filenames = new ArrayList<>();
         Pattern regex = Pattern.compile("[^\\s\']+|'[^']*'");
         Matcher regexMatcher = regex.matcher(remainder);
         while (regexMatcher.find()) {

--- a/src/frontend/org/voltdb/parser/SQLParser.java
+++ b/src/frontend/org/voltdb/parser/SQLParser.java
@@ -1365,7 +1365,7 @@ public class SQLParser extends SQLPatternFactory
                 return m_file.getPath();
             case INLINEBATCH:
             default:
-                String filePath = (m_context == null) ? "no file" : m_context.getFilePath();
+                String filePath = (m_context == null) ? "AdHoc DDL Input" : m_context.getFilePath();
                 assert(m_option == FileOption.INLINEBATCH);
                 return "(inline batch delimited by '" + m_delimiter +
                         "' in " + filePath + ")";


### PR DESCRIPTION
The command "file -inlinebatch EOB" failed interactively.  This is
because we create context to remember the name of the input file.  But
an interactive command execution has no input file, so this context is
null.  The NPE is not handled properly.

I don't actually know how to test this other than manually.  The problem
does not show up in sqlcmdtest, since this input is not interactive.