### PR TITLE
ENG-13039, partially revert ENG-11743 to fix a race condition that could leads to StatsAgent thread hang forever.

### DIFF
--- a/src/frontend/org/voltdb/NTProcedureService.java
+++ b/src/frontend/org/voltdb/NTProcedureService.java
@@ -344,8 +344,7 @@ public class NTProcedureService {
 
         m_procs = ImmutableMap.<String, ProcedureRunnerNTGenerator>builder().putAll(runnerGeneratorMap).build();
 
-        // reload all sysprocs (I wish we didn't have to do this, but their stats source
-        // gets wiped out)
+        // reload all sysprocs
         loadSystemProcedures(false);
 
         // Set the system to start accepting work again now that ebertything is updated.

--- a/src/frontend/org/voltdb/NTProcedureService.java
+++ b/src/frontend/org/voltdb/NTProcedureService.java
@@ -180,16 +180,17 @@ public class NTProcedureService {
             m_paramTypes = paramTypes;
 
             // make a stats source for this proc
-            m_statsCollector = VoltDB.instance().getStatsAgent().registerProcedureStatsSource(
+            m_statsCollector = new ProcedureStatsCollector(
                     CoreUtils.getSiteIdFromHSId(m_mailbox.getHSId()),
-                    new ProcedureStatsCollector(
-                            CoreUtils.getSiteIdFromHSId(m_mailbox.getHSId()),
-                            0,
-                            m_procClz.getName(),
-                            false,
-                            null,
-                            false)
-                    );
+                    0,
+                    m_procClz.getName(),
+                    false,
+                    null,
+                    false);
+            VoltDB.instance().getStatsAgent().registerStatsSource(
+                    StatsSelector.PROCEDURE,
+                    CoreUtils.getSiteIdFromHSId(m_mailbox.getHSId()),
+                    m_statsCollector);
         }
 
         /**

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -195,15 +195,15 @@ public class ProcedureRunner {
         m_site = site;
         // Normally m_statsCollector is returned as it is and there is no affect to assign it to itself.
         // Sometimes when this procedure statistics needs to reuse the existing one, the old stats gets returned.
-        m_statsCollector = VoltDB.instance().getStatsAgent().registerProcedureStatsSource(
-                site.getCorrespondingSiteId(),
-                new ProcedureStatsCollector(
-                        site.getCorrespondingSiteId(),
-                        site.getCorrespondingPartitionId(),
-                        m_catProc,
-                        m_stmtList,
-                        true)
-                );
+        m_statsCollector = new ProcedureStatsCollector(
+                                    site.getCorrespondingSiteId(),
+                                    site.getCorrespondingPartitionId(),
+                                    m_catProc,
+                                    m_stmtList,
+                                    true);
+        VoltDB.instance().getStatsAgent().registerStatsSource(StatsSelector.PROCEDURE,
+                                                              site.getCorrespondingSiteId(),
+                                                              m_statsCollector);
 
         // Read the ProcStatsOption annotation from the procedure class.
         // Basically, it is about setting the sampling interval for this stored procedure.

--- a/src/frontend/org/voltdb/ProcedureStatsCollector.java
+++ b/src/frontend/org/voltdb/ProcedureStatsCollector.java
@@ -420,43 +420,4 @@ public class ProcedureStatsCollector extends SiteStatsSource {
     public String toString() {
         return m_procName;
     }
-
-    public int getPartitionId() {
-        return m_partitionId;
-    }
-
-    public String getProcName() {
-        return m_procName;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if(super.equals(obj) == false) return false;
-        if (obj instanceof ProcedureStatsCollector == false) return false;
-
-        ProcedureStatsCollector stats = (ProcedureStatsCollector) obj;
-        if (stats.getPartitionId() != m_partitionId) return false;
-        if (! m_procName.equals(stats.getProcName())) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode() + m_partitionId + m_procName.hashCode();
-    }
-
-    /**
-     * @return true if this procedure statistics should be reset
-     */
-    public boolean resetAfterCatalogChange() {
-        // UpdateCore system procedure statistics should be kept
-        if (m_isUAC) {
-            return false;
-        }
-
-        // TODO: we want want to keep other system procedure statistics ?
-        // TODO: we may want to only reset updated user procedure statistics but keeping others.
-        return true;
-    }
 }

--- a/src/frontend/org/voltdb/SiteStatsSource.java
+++ b/src/frontend/org/voltdb/SiteStatsSource.java
@@ -47,26 +47,4 @@ public abstract class SiteStatsSource extends StatsSource {
         rowValues[columnNameToIndex.get(VoltSystemProcedure.CNAME_SITE_ID)] = CoreUtils.getSiteIdFromHSId(m_siteId);
         super.updateStatsRow(rowKey, rowValues);
     }
-
-    public long getSiteId() {
-        return m_siteId;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (super.equals(obj) == false)
-            return false;
-        if (obj instanceof SiteStatsSource == false)
-            return false;
-
-        SiteStatsSource stats = (SiteStatsSource) obj;
-        if (stats.getSiteId() != m_siteId)
-            return false;
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode() + Long.hashCode(m_siteId);
-    }
 }

--- a/src/frontend/org/voltdb/StatsSource.java
+++ b/src/frontend/org/voltdb/StatsSource.java
@@ -194,25 +194,4 @@ public abstract class StatsSource {
      * @return Iterator of Objects representing keys that identify unique stats rows
      */
     abstract protected Iterator<Object> getStatsRowKeyIterator(boolean interval);
-
-    public Integer getHostId() {
-        return m_hostId;
-    }
-
-    /**
-     * Not widely used other than PROCEDURE stats for hash map purpose.
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof StatsSource == false) return false;
-        StatsSource stats = (StatsSource) obj;
-        if (stats.isEEStats() != m_isEEStats) return false;
-        if (stats.getHostId() != m_hostId) return false;
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return Boolean.hashCode(m_isEEStats) + m_hostId;
-    }
 }

--- a/tests/frontend/org/voltdb/TestNTProcs.java
+++ b/tests/frontend/org/voltdb/TestNTProcs.java
@@ -35,8 +35,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-import junit.framework.TestCase;
-
 import org.voltdb.VoltDB.Configuration;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientFactory;
@@ -49,9 +47,10 @@ import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.sysprocs.AdHoc_RO_MP;
 import org.voltdb.sysprocs.GC;
-import org.voltdb.sysprocs.UpdateCore;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltTableUtil;
+
+import junit.framework.TestCase;
 
 public class TestNTProcs extends TestCase {
 
@@ -697,11 +696,7 @@ public class TestNTProcs extends TestCase {
         // CHECK STATS
         VoltTable statsT = getStats(client, "PROCEDURE");
         System.out.println("STATS: " + statsT.toFormattedString());
-
-        assertTrue(VoltTableUtil.tableContainsString(statsT, "UpdateCore", true));
-
-        Map<String, Long> stats = aggregateProcRow(client, UpdateCore.class.getName());
-        assertEquals(1, stats.get("INVOCATIONS").longValue());
+        assertEquals(0, statsT.getRowCount());
 
         localServer.shutdown();
         localServer.join();

--- a/tests/frontend/org/voltdb/TestVoltProcedure.java
+++ b/tests/frontend/org/voltdb/TestVoltProcedure.java
@@ -512,14 +512,5 @@ public class TestVoltProcedure extends TestCase {
             m_selector = selector;
             m_catalogId = catalogId;
         }
-
-        @Override
-        public ProcedureStatsCollector registerProcedureStatsSource(long catalogId, ProcedureStatsCollector source) {
-            m_source = source;
-            m_selector = StatsSelector.PROCEDURE;
-            m_catalogId = catalogId;
-
-            return source;
-        }
     }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/TestUpdateClasses.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUpdateClasses.java
@@ -742,7 +742,7 @@ public class TestUpdateClasses extends AdhocDDLTestBase {
 
             // check stats after UAC
             vt = m_client.callProcedure("@Statistics", "PROCEDURE", 0).getResults()[0];
-            // All system procedure stats are cleared after catalog change
+            // All procedure stats are cleared after catalog change
             assertEquals(0, vt.getRowCount());
 
             // create procedure 0
@@ -750,7 +750,7 @@ public class TestUpdateClasses extends AdhocDDLTestBase {
                     PROC_CLASSES[0].getCanonicalName() + ";");
             // check stats after UAC
             vt = m_client.callProcedure("@Statistics", "PROCEDURE", 0).getResults()[0];
-            // All system procedure stats are cleared after catalog change
+            // All procedure stats are cleared after catalog change
             assertEquals(vt.getRowCount(), 0);
 
             // invoke a new user procedure
@@ -763,7 +763,7 @@ public class TestUpdateClasses extends AdhocDDLTestBase {
 
             // check stats
             vt = m_client.callProcedure("@Statistics", "PROCEDURE", 0).getResults()[0];
-            // All system procedure stats are cleared after catalog change
+            // All procedure stats are cleared after catalog change
             assertEquals(1, vt.getRowCount());
             assertTrue(vt.toString().contains("org.voltdb_testprocs.updateclasses.testImportProc"));
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestUpdateClasses.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUpdateClasses.java
@@ -742,18 +742,16 @@ public class TestUpdateClasses extends AdhocDDLTestBase {
 
             // check stats after UAC
             vt = m_client.callProcedure("@Statistics", "PROCEDURE", 0).getResults()[0];
-            assertEquals(1, vt.getRowCount());
-            vt.advanceRow();
-            assertEquals("org.voltdb.sysprocs.UpdateCore", vt.getString(5));
+            // All system procedure stats are cleared after catalog change
+            assertEquals(0, vt.getRowCount());
 
             // create procedure 0
             resp = m_client.callProcedure("@AdHoc", "create procedure from class " +
                     PROC_CLASSES[0].getCanonicalName() + ";");
             // check stats after UAC
             vt = m_client.callProcedure("@Statistics", "PROCEDURE", 0).getResults()[0];
-            assertEquals(vt.getRowCount(), 1);
-            vt.advanceRow();
-            assertEquals("org.voltdb.sysprocs.UpdateCore", vt.getString(5));
+            // All system procedure stats are cleared after catalog change
+            assertEquals(vt.getRowCount(), 0);
 
             // invoke a new user procedure
             vt = m_client.callProcedure(PROC_CLASSES[0].getSimpleName()).getResults()[0];
@@ -765,30 +763,28 @@ public class TestUpdateClasses extends AdhocDDLTestBase {
 
             // check stats
             vt = m_client.callProcedure("@Statistics", "PROCEDURE", 0).getResults()[0];
-            assertEquals(2, vt.getRowCount());
+            // All system procedure stats are cleared after catalog change
+            assertEquals(1, vt.getRowCount());
             assertTrue(vt.toString().contains("org.voltdb_testprocs.updateclasses.testImportProc"));
-            assertTrue(vt.toString().contains("org.voltdb.sysprocs.UpdateCore"));
 
             // create procedure 1
             resp = m_client.callProcedure("@AdHoc", "create procedure from class " +
                     PROC_CLASSES[1].getCanonicalName() + ";");
             // check stats
             vt = m_client.callProcedure("@Statistics", "PROCEDURE", 0).getResults()[0];
-            assertEquals(1, vt.getRowCount());
-            vt.advanceRow();
-            assertEquals("org.voltdb.sysprocs.UpdateCore", vt.getString(5));
+            assertEquals(0, vt.getRowCount());
 
             resp = m_client.callProcedure(PROC_CLASSES[1].getSimpleName(), 1l, "", "");
             assertEquals(ClientResponse.SUCCESS, resp.getStatus());
 
             vt = m_client.callProcedure("@Statistics", "PROCEDURE", 0).getResults()[0];
-            assertEquals(2, vt.getRowCount());
+            assertEquals(1, vt.getRowCount());
 
             vt = m_client.callProcedure(PROC_CLASSES[0].getSimpleName()).getResults()[0];
             assertEquals(10L, vt.asScalarLong());
 
             vt = m_client.callProcedure("@Statistics", "PROCEDURE", 0).getResults()[0];
-            assertEquals(3, vt.getRowCount());
+            assertEquals(2, vt.getRowCount());
 
         }
         finally {


### PR DESCRIPTION
During schema change, Site thread starts to update all the related data structures, including clearing the stats sources in StatsAgent class, but there is a race window that in the meantime StatsAgent thread is iteratoring the stats sources to response a statisticss request. Deleting the procedure statisticss source while StatsAgent thread is iteratoring may fooled this thread to think now is in startup time and thus it's better to yield CPU for a little while and retry later, which in current case is hang forever.

ENG-11743 introduced this race window, it is partially reverted because we no longer need to keep @UpdateCore stats during schema change.
