### PR TITLE
Fix issues in multi-stmt create procedure branch

### DIFF
--- a/src/frontend/org/voltdb/parser/SQLLexer.java
+++ b/src/frontend/org/voltdb/parser/SQLLexer.java
@@ -325,6 +325,65 @@ public class SQLLexer extends SQLPatternFactory
             return false;
     }
 
+    // Returns true if this character is A-Z of either case
+    private static boolean isLetterFast(char c) {
+        return (c >= 65 && c <= 90) || (c >= 97 && c <= 122);
+    }
+
+    // Returns true if character is 0-9
+    private static boolean isDigitFast(char c) {
+        return (c >= 48 && c <= 57);
+    }
+
+    private static boolean isLetterOrDigitFast(char c) {
+        return isDigitFast(c) || isLetterFast(c);
+    }
+
+    // Converts a standard ASCII letter to lowercase
+    // (Does not work on non-ASCII characters)
+    private static char toLowerFast(char c) {
+        return (char)(c | 0x20);
+    }
+
+    /**
+     * Quickly determine if the characters in a char array match the given token.
+     * Token must be specified in lower case, and must be all ASCII letters.
+     * Will return false if the token is preceded by alphanumeric characters---
+     * it may be embedded in an indentifier in this case.
+     * Similar to the method matchesToken, but makes some assumptions that may
+     * enhance performance.
+     * @param buffer          char array in which to look for token
+     * @param position        position in char array to look for token
+     * @param lowercaseToken  token to look for, must be all lowercase ASCII characters
+     * @return true if the token is found, and false otherwise
+     */
+    private static boolean matchTokenFast(char[] buffer, int position, String lowercaseToken) {
+        if (position != 0 && isLetterOrDigitFast(buffer[position - 1])) {
+            // character at position is preceded by a letter or digit
+            return false;
+        }
+
+        int tokenLength = lowercaseToken.length();
+        if (position + tokenLength > buffer.length) {
+            // Buffer not long enough to contain token.
+            return false;
+        }
+
+        if (position + tokenLength < buffer.length && isLetterOrDigitFast(buffer[position + tokenLength])) {
+            // Character after where token would be is a letter
+            return false;
+        }
+
+        for (int i = 0; i < tokenLength; ++i) {
+            char c = buffer[position + i];
+            if (!isLetterFast(c) || (toLowerFast(c) != lowercaseToken.charAt(i))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     /**
      * Determine if a character buffer contains the specified string a the specified index.
      * Avoids an array index exception if the buffer is too short.
@@ -468,20 +527,20 @@ public class SQLLexer extends SQLPatternFactory
                 // Outside of a quoted string or comment - watch for the next separator, quote or comment.
 
                 // 'BEGIN' should only follow 'AS'
-                if (checkForNextBegin && matchToken(sql, iCur, "begin") ) {
+                if (checkForNextBegin && matchTokenFast(buf, iCur, "begin") ) {
                     // 'BEGIN' should only be followed after 'AS'
                     // otherwise it is a column or table name
                     inBegin = true;
                     currentStmt.append(sql.substring(iCur, iCur + 5));
                     iCur += 5;
                 }
-                else if (matchToken(sql, iCur, "case") ) {
+                else if (matchTokenFast(buf, iCur, "case") ) {
                     checkForNextBegin = false;
                     inCase++;
                     currentStmt.append(sql.substring(iCur, iCur + 4));
                     iCur += 4;
                 }
-                else if (matchToken(sql, iCur, "as") ) {
+                else if (matchTokenFast(buf, iCur, "as") ) {
                     checkForNextBegin = true;
                     currentStmt.append(sql.substring(iCur, iCur + 2));
                     iCur += 2;

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
@@ -42,7 +42,6 @@ import org.voltdb.compiler.PlannerTool;
 import org.voltdb.parser.SQLLexer;
 import org.voltdb.planner.StatementPartitioning;
 import org.voltdb.utils.MiscUtils;
-import org.voltdb.utils.SplitStmtResults;
 import org.voltdb.utils.VoltTrace;
 
 import com.google_voltpatches.common.base.Charsets;
@@ -137,10 +136,6 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
             // Simulate an unhandled exception? (ENG-7653)
             if (DEBUG_MODE.isTrue() && stmt.equals(DEBUG_EXCEPTION_DDL)) {
                 throw new IndexOutOfBoundsException(DEBUG_EXCEPTION_DDL);
-            }
-
-            if (SQLLexer.isComment(stmt) || stmt.trim().isEmpty()) {
-                continue;
             }
 
             String ddlToken = SQLLexer.extractDDLToken(stmt);

--- a/tests/frontend/org/voltdb/TestAdhocWithOnlyComment.java
+++ b/tests/frontend/org/voltdb/TestAdhocWithOnlyComment.java
@@ -71,14 +71,8 @@ public class TestAdhocWithOnlyComment extends AdhocDDLTestBase {
                         "/* this never hung the server, \n but test it! */");
             }
             catch (ProcCallException pce) {
-                // this takes a different path because it isn't treated as a
-                // comment by the AsyncCompilerAgent and makes it through to
-                // the DDLCompiler which complains because it never finds a
-                // semicolon-terminated statement.  Updating the error message
-                // check here will be left as an unexpected exercise for
-                // whoever gets stuck making the returned message consistent.
-                assertTrue("wrong exception details returned",
-                        pce.getMessage().contains("unexpected end of statement"));
+                assertTrue("wrong exception details returned: " + pce.getMessage(),
+                        pce.getMessage().contains("no SQL statement provided"));
                 threw = true;
             }
             assertTrue("Adhoc with no statements should return an error", threw);

--- a/tests/frontend/org/voltdb/utils/TestSqlCmdInterface.java
+++ b/tests/frontend/org/voltdb/utils/TestSqlCmdInterface.java
@@ -127,40 +127,7 @@ public class TestSqlCmdInterface
         assertThis(raw, expected, 1, ID);
     }
 
-    // 8) To test 2 select statements with --union
-    //    Everything after --union should be ignored
-    //    ENG-3354
-    @Test
-    public void testParseQuery8() {
-        String raw = "SELECT * FROM table --UNION SELECT * FROM table2;";
-        ID = 8;
-        String expected = "SELECT * FROM table;";
-        assertThis(raw, expected, 1, ID);
-    }
-
-    // 9) To test 2 select statements with --union
-    //    Slightly different from test case 8 - there is '--' directly
-    //    in front of the key word 'select'. So the 2nd select statement
-    //    is treated as a comment. This test should pass.
-    @Test
-    public void testParseQuery9() {
-        String raw = "SELECT * FROM table --UNION --SELECT * FROM table2;";
-        ID = 9;
-        String expected = "SELECT * FROM table;";
-        assertThis(raw, expected, 1, ID);
-    }
-
-    // 10) To test 2 select statements with --
-    //     Slightly different from test case 9 - there is a space " " in between
-    //     '--' and the 2nd select statement. In theory, this test should pass.
-    @Test
-    public void testParseQuery10() {
-        String raw = "SELECT * FROM table -- SELECT * FROM table2;";
-        ID = 10;
-        String expected = "SELECT * FROM table;";
-        assertThis(raw, expected, 1, ID);
-
-    }
+    // Test cases 8, 9, 10 moved to TestSplitSQLStatements
 
     // As of today, 07/13/2012, sqlcmd does not support create, yet.
     // Just to check what's got returned.
@@ -333,21 +300,6 @@ public class TestSqlCmdInterface
         assertThis(raw, qryFrmFile, numOfQueries, ID, blockCommentCount);
     }
 
-    @Test
-    public void testParseQuery22() {
-        ID = 22;
-        String raw = " select -- comment no semicolon\n"
-                + "* -- comment no semicolon\n"
-                + "from -- comment no semicolon\n"
-                + "table -- comment with semicolon;";
-
-        String expected = "select \n"
-                + "* \n"
-                + "from \n"
-                + "table;";
-        assertThis(raw, expected, 1, ID);
-    }
-
     // To test parseQueryProcedureCallParameters()
     // To test a valid query: 'select * from dummy' as a proc call.
     @Test
@@ -355,21 +307,6 @@ public class TestSqlCmdInterface
         ID = 22;
         String query = "select * from dummy";
         assertTrue(SQLParser.parseExecuteCallWithoutParameterTypes(query) == null);
-    }
-
-    @Test
-    public void testParseQuery23() {
-        ID = 23;
-        String raw = "select -- comment no semicolon\n"
-                + "* -- comment with this ; a semicolon inside\n"
-                + "from -- comment with this ; a semicolon inside\n"
-                + "table-- comment with semicolon;";
-
-        String expected = "select \n"
-                + "* \n"
-                + "from \n"
-                + "table;";
-        assertThis(raw, expected, 1, ID);
     }
 
     // To assert the help page printed by SQLCommand.printHelp() is identical to the


### PR DESCRIPTION
Made improvements to SQLLexer.splitStatements:
- Don't use any regular expressions
- Remove comments from output

I also added new tests, and moved some tests around.  The test `TestSqlCmdInterface` is kind of awful but having enough testing in this area is important so I am loathe to remove it.  I added a bunch of tests to `TestSplitSQLStatements`.