### PR TITLE
Eng 13045 fail host on truncation snapshot failure

### DIFF
--- a/src/frontend/org/voltdb/DeferredSnapshotSetup.java
+++ b/src/frontend/org/voltdb/DeferredSnapshotSetup.java
@@ -72,7 +72,7 @@ public class DeferredSnapshotSetup implements Callable<DeferredSnapshotSetup> {
                 SNAP_LOG.error("Failed to run deferred snapshot setup", e);
 
                 // Data target creation failed, close all created ones and replace them with DevNull.
-                m_plan.createAllDevNullTargets();
+                m_plan.createAllDevNullTargets(m_error);
             }
         }
 

--- a/src/frontend/org/voltdb/DevNullSnapshotTarget.java
+++ b/src/frontend/org/voltdb/DevNullSnapshotTarget.java
@@ -30,7 +30,15 @@ import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 public class DevNullSnapshotTarget implements SnapshotDataTarget {
 
     Runnable m_onClose = null;
+    Exception m_lastWriteException = null;
     volatile IOException m_reportedSerializationFailure = null;
+
+    public DevNullSnapshotTarget() {
+    }
+
+    public DevNullSnapshotTarget(Exception lastWriteException) {
+        m_lastWriteException = lastWriteException;
+    }
 
     @Override
     public int getHeaderSize() {
@@ -84,7 +92,7 @@ public class DevNullSnapshotTarget implements SnapshotDataTarget {
 
     @Override
     public Throwable getLastWriteException() {
-        return null;
+        return m_lastWriteException;
     }
 
     @Override

--- a/src/frontend/org/voltdb/SiteSnapshotConnection.java
+++ b/src/frontend/org/voltdb/SiteSnapshotConnection.java
@@ -31,6 +31,7 @@ public interface SiteSnapshotConnection
             SnapshotFormat format,
             Deque<SnapshotTableTask> tasks,
             long txnId,
+            boolean isTruncation,
             ExtensibleSnapshotDigestData extraSnapshotData);
 
     public void startSnapshotWithTargets(Collection<SnapshotDataTarget> targets);

--- a/src/frontend/org/voltdb/TableStreamer.java
+++ b/src/frontend/org/voltdb/TableStreamer.java
@@ -98,12 +98,11 @@ public class TableStreamer {
      * is to stream
      * @throws SnapshotSerializationException
      */
-    @SuppressWarnings("rawtypes")
-    public Pair<ListenableFuture, Boolean> streamMore(SystemProcedureExecutionContext context,
+    public Pair<ListenableFuture<?>, Boolean> streamMore(SystemProcedureExecutionContext context,
                                                       List<DBBPool.BBContainer> outputBuffers,
                                                       int[] rowCountAccumulator)
     {
-        ListenableFuture writeFuture = null;
+        ListenableFuture<?> writeFuture = null;
 
         prepareBuffers(outputBuffers);
 

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1019,8 +1019,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             SnapshotFormat format,
             Deque<SnapshotTableTask> tasks,
             long txnId,
+            boolean isTruncation,
             ExtensibleSnapshotDigestData extraSnapshotData) {
-        m_snapshotter.initiateSnapshots(m_sysprocContext, format, tasks, txnId, extraSnapshotData);
+        m_snapshotter.initiateSnapshots(m_sysprocContext, format, tasks, txnId, isTruncation, extraSnapshotData);
     }
 
     /*

--- a/src/frontend/org/voltdb/sysprocs/saverestore/CSVSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/CSVSnapshotWritePlan.java
@@ -183,7 +183,7 @@ public class CSVSnapshotWritePlan extends SnapshotWritePlan
             {
                 NativeSnapshotWritePlan.createFileBasedCompletionTasks(file_path, pathType, file_nonce,
                         txnId, partitionTransactionIds, context, extraSnapshotData, null, timestamp,
-                        context.getNumberOfPartitions(), tables);
+                        context.getNumberOfPartitions(), tables, false);
 
                 for (SnapshotTableTask task : replicatedSnapshotTasks) {
                     final SnapshotDataTarget target = createDataTargetForTable(file_path, file_nonce,

--- a/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
@@ -192,7 +192,8 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
                         hashinatorData,
                         timestamp,
                         newPartitionCount,
-                        tables);
+                        tables,
+                        isTruncationSnapshot);
 
                 for (SnapshotTableTask task : replicatedSnapshotTasks) {
                     SnapshotDataTarget target = getSnapshotDataTarget(numTables, task);
@@ -308,7 +309,8 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
             ExtensibleSnapshotDigestData extraSnapshotData,
             HashinatorSnapshotData hashinatorData,
             long timestamp, int newPartitionCount,
-            Table[] tables) throws IOException
+            Table[] tables,
+            boolean isTruncationSnapshot) throws IOException
     {
         InstanceId instId = VoltDB.instance().getHostMessenger().getInstanceId();
         Runnable completionTask = SnapshotUtil.writeSnapshotDigest(
@@ -324,22 +326,23 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
                 instId,
                 timestamp,
                 newPartitionCount,
-                context.getClusterId());
+                context.getClusterId(),
+                isTruncationSnapshot);
         if (completionTask != null) {
             SnapshotSiteProcessor.m_tasksOnSnapshotCompletion.offer(completionTask);
         }
         if (hashinatorData != null) {
             completionTask = SnapshotUtil.writeHashinatorConfig(
-                    instId, file_path, file_nonce, context.getHostId(), hashinatorData);
+                    instId, file_path, file_nonce, context.getHostId(), hashinatorData, isTruncationSnapshot);
             if (completionTask != null) {
                 SnapshotSiteProcessor.m_tasksOnSnapshotCompletion.offer(completionTask);
             }
         }
-        completionTask = SnapshotUtil.writeSnapshotCatalog(file_path, file_nonce);
+        completionTask = SnapshotUtil.writeSnapshotCatalog(file_path, file_nonce, isTruncationSnapshot);
         if (completionTask != null) {
             SnapshotSiteProcessor.m_tasksOnSnapshotCompletion.offer(completionTask);
         }
-        completionTask = SnapshotUtil.writeSnapshotCompletion(file_path, file_nonce, context.getHostId(), SNAP_LOG);
+        completionTask = SnapshotUtil.writeSnapshotCompletion(file_path, file_nonce, context.getHostId(), SNAP_LOG, isTruncationSnapshot);
         if (completionTask != null) {
             SnapshotSiteProcessor.m_tasksOnSnapshotCompletion.offer(completionTask);
         }

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotWritePlan.java
@@ -165,7 +165,7 @@ public abstract class SnapshotWritePlan
      * This method will close all existing data targets and replace all with DevNullDataTargets
      * so that snapshot can be drained.
      */
-    public void createAllDevNullTargets()
+    public void createAllDevNullTargets(Exception lastWriteException)
     {
         Map<Integer, SnapshotDataTarget> targets = Maps.newHashMap();
         final AtomicInteger numTargets = new AtomicInteger();
@@ -183,7 +183,7 @@ public abstract class SnapshotWritePlan
 
                 SnapshotDataTarget target = targets.get(task.m_table.getRelativeIndex());
                 if (target == null) {
-                    target = new DevNullSnapshotTarget();
+                    target = new DevNullSnapshotTarget(lastWriteException);
                     final Runnable onClose = new TargetStatsClosure(target,
                             task.m_table.getTypeName(),
                             numTargets,


### PR DESCRIPTION
Be more careful about incorrectly reporting success after a snapshot. Specifically, the last reporting host could overwrite a failure with success for snapshot completion listeners such as CommandLogging. In CommandLogging's case, this could cause a trucation even though the snapshot did not complete successfully.

Make sure that any IO errors generated for a Truncation Snapshot brings down the host. Detect IO errors on table, digest, completion, and catalog files.

Add Unit test that uses hacks in table file construction to force an IO exception. Verify that this generates a crash for truncation snapshots only.

Another case was SnapshotStatus Statistics, which could report a successful snapshot if a failure occured during file open or the writing of the initial table header. This is because a header write failure caused the NativeSnapshotTarget to be replaced with the DevNullSnapshotTarget, which did not preserve the earlier exception. Now, DevNullSnapshotTarget can optionally be constructed to include and propagate earlier exceptions to snapshot statistics so that snapshot stats correctly mark the result for that file as "FAILURE".