### PR TITLE
ENG-13046: Add WARN log for HOST logger in case of MP routed to SPI

### DIFF
--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -61,6 +61,7 @@ import org.voltdb.iv2.UniqueIdGenerator;
 import org.voltdb.jni.ExecutionEngine;
 import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.messaging.FragmentTaskMessage;
+import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.planner.ActivePlanRepository;
 import org.voltdb.sysprocs.AdHocBase;
 import org.voltdb.sysprocs.AdHocNTBase;
@@ -75,6 +76,7 @@ import com.google_voltpatches.common.base.Charsets;
 public class ProcedureRunner {
 
     private static final VoltLogger log = new VoltLogger("HOST");
+    private static final VoltLogger misrouteLog = new VoltLogger("MISROUTE");
     private static final boolean HOST_TRACE_ENABLED;
     static {
         HOST_TRACE_ENABLED = log.isTraceEnabled();
@@ -567,6 +569,19 @@ public class ProcedureRunner {
             return false;
         } else {
             if (!m_catProc.getEverysite() && m_site.getCorrespondingPartitionId() != MpInitiator.MP_INIT_PID) {
+                if (misrouteLog.isDebugEnabled()) {
+                    misrouteLog.debug("MP txn misrouted to SPI");
+                    misrouteLog.debug("catProc: name: " + m_catProc.getTypeName() +
+                            ", site partition id: " + m_site.getCorrespondingPartitionId() +
+                            ", site HSId: " + m_site.getCorrespondingHostId() + ":" + m_site.getCorrespondingSiteId() +
+                            ", txnState.initiatorHSId: " + CoreUtils.hsIdToString(txnState.initiatorHSId));
+                    if (txnState.getNotice() instanceof Iv2InitiateTaskMessage) {
+                        Iv2InitiateTaskMessage initiateTaskMessage = (Iv2InitiateTaskMessage) txnState.getNotice();
+                        misrouteLog.debug("Iv2InitiateTaskMessage: sourceHSId: " +
+                                CoreUtils.hsIdToString(initiateTaskMessage.m_sourceHSId) +
+                                ", dump: " + initiateTaskMessage);
+                    }
+                }
                 // MP txn misrouted to SPI, possible to happen during catalog update
                 throw new ExpectedProcedureException("Multi-partition procedure routed to single-partition initiator");
             }

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -568,12 +568,13 @@ public class ProcedureRunner {
             return false;
         } else {
             if (!m_catProc.getEverysite() && m_site.getCorrespondingPartitionId() != MpInitiator.MP_INIT_PID) {
-                log.warn("Detected MP txn misrouted to SPI. It is possible to happen during catalog update " +
-                    "but could also be an anomaly");
-                log.warn("catProc name: " + m_catProc.getTypeName() +
+                log.warn("Detected MP transaction misrouted to SPI. This can happen during a schema update. " +
+                        "Otherwise, it is unexpected behavior. " +
+                        "Please report the following information to support@voltdb.com");
+                log.warn("procedure name: " + m_catProc.getTypeName() +
                         ", site partition id: " + m_site.getCorrespondingPartitionId() +
                         ", site HSId: " + m_site.getCorrespondingHostId() + ":" + m_site.getCorrespondingSiteId() +
-                        ", txnState.initiatorHSId: " + CoreUtils.hsIdToString(txnState.initiatorHSId));
+                        ", txnState initiatorHSId: " + CoreUtils.hsIdToString(txnState.initiatorHSId));
                 if (txnState.getNotice() instanceof Iv2InitiateTaskMessage) {
                     Iv2InitiateTaskMessage initiateTaskMessage = (Iv2InitiateTaskMessage) txnState.getNotice();
                     log.warn("Iv2InitiateTaskMessage: sourceHSId: " +

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -76,7 +76,6 @@ import com.google_voltpatches.common.base.Charsets;
 public class ProcedureRunner {
 
     private static final VoltLogger log = new VoltLogger("HOST");
-    private static final VoltLogger misrouteLog = new VoltLogger("MISROUTE");
     private static final boolean HOST_TRACE_ENABLED;
     static {
         HOST_TRACE_ENABLED = log.isTraceEnabled();
@@ -569,18 +568,17 @@ public class ProcedureRunner {
             return false;
         } else {
             if (!m_catProc.getEverysite() && m_site.getCorrespondingPartitionId() != MpInitiator.MP_INIT_PID) {
-                if (misrouteLog.isDebugEnabled()) {
-                    misrouteLog.debug("MP txn misrouted to SPI");
-                    misrouteLog.debug("catProc: name: " + m_catProc.getTypeName() +
-                            ", site partition id: " + m_site.getCorrespondingPartitionId() +
-                            ", site HSId: " + m_site.getCorrespondingHostId() + ":" + m_site.getCorrespondingSiteId() +
-                            ", txnState.initiatorHSId: " + CoreUtils.hsIdToString(txnState.initiatorHSId));
-                    if (txnState.getNotice() instanceof Iv2InitiateTaskMessage) {
-                        Iv2InitiateTaskMessage initiateTaskMessage = (Iv2InitiateTaskMessage) txnState.getNotice();
-                        misrouteLog.debug("Iv2InitiateTaskMessage: sourceHSId: " +
-                                CoreUtils.hsIdToString(initiateTaskMessage.m_sourceHSId) +
-                                ", dump: " + initiateTaskMessage);
-                    }
+                log.warn("Detected MP txn misrouted to SPI. It is possible to happen during catalog update " +
+                    "but could also be an anomaly");
+                log.warn("catProc name: " + m_catProc.getTypeName() +
+                        ", site partition id: " + m_site.getCorrespondingPartitionId() +
+                        ", site HSId: " + m_site.getCorrespondingHostId() + ":" + m_site.getCorrespondingSiteId() +
+                        ", txnState.initiatorHSId: " + CoreUtils.hsIdToString(txnState.initiatorHSId));
+                if (txnState.getNotice() instanceof Iv2InitiateTaskMessage) {
+                    Iv2InitiateTaskMessage initiateTaskMessage = (Iv2InitiateTaskMessage) txnState.getNotice();
+                    log.warn("Iv2InitiateTaskMessage: sourceHSId: " +
+                            CoreUtils.hsIdToString(initiateTaskMessage.m_sourceHSId) +
+                            ", dump: " + initiateTaskMessage);
                 }
                 // MP txn misrouted to SPI, possible to happen during catalog update
                 throw new ExpectedProcedureException("Multi-partition procedure routed to single-partition initiator");


### PR DESCRIPTION
After this is merged to master, the system tests can turn on DEBUG level logging for this one-time MISROUTE logger so that we may have more information if this happens again.