### PR TITLE
ENG-12282: Don't send acks from an export replica.

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -864,9 +864,13 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
     private void forwardAckToOtherReplicas(long uso) {
         if (m_runEveryWhere && m_replicaRunning) {
-           //we dont forward if we are running as replica in replicated export
-           return;
+            //we dont forward if we are running as replica in replicated export
+            return;
+        } else if (!m_runEveryWhere && !m_mastershipAccepted.get()) {
+            // Don't forward acks if we are a replica in non-replicated export mode.
+            return;
         }
+
         Pair<Mailbox, ImmutableList<Long>> p = m_ackMailboxRefs.get();
         Mailbox mbx = p.getFirst();
         if (mbx != null && p.getSecond().size() > 0) {


### PR DESCRIPTION
Only send acks from master to replicas, never from a replica to other
replicas. This could happen when a node rejoins and drains its on-disk
generations. Other replicas don't expect to receive these acks with Long.MIN as
the USO. If the receiving replica gets promoted due to master failure, the new
master will fail to roll its generation.

All replicas will either receive the acks from the master or drain the
generations themselves.