### PR TITLE
ENG-12806: add default export configuration to DR conflict table in init time

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -868,6 +868,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     consoleLog.info(msg);
                     hostLog.info(msg);
                 }
+                if (readDepl.deployment.getDr() != null && DrRoleType.XDCR.equals(readDepl.deployment.getDr().getRole())) {
+                    // add default export configuration to DR conflict table
+                    CatalogUtil.addExportConfigToDRConflictsTable(readDepl.deployment.getExport());
+                }
                 stageDeploymentFileForInitialize(config, readDepl.deployment);
                 stageSchemaFiles(config, readDepl.deployment.getDr() != null && DrRoleType.XDCR.equals(readDepl.deployment.getDr().getRole()));
                 stageInitializedMarker(config);

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -1476,7 +1476,7 @@ public abstract class CatalogUtil {
         Database db = cluster.getDatabases().get("database");
         if (DrRoleType.XDCR.value().equals(cluster.getDrrole())) {
             // add default export configuration to DR conflict table
-            exportType = addExportConfigToDRConflictsTable(catalog, exportType);
+            exportType = addExportConfigToDRConflictsTable(exportType);
         }
 
         if (exportType == null) {
@@ -2534,10 +2534,9 @@ public abstract class CatalogUtil {
     /**
      * Add default configuration to DR conflicts export target if deployment file doesn't have the configuration
      *
-     * @param catalog  current catalog
      * @param export   list of export configuration
      */
-    public static ExportType addExportConfigToDRConflictsTable(Catalog catalog, ExportType export) {
+    public static ExportType addExportConfigToDRConflictsTable(ExportType export) {
         if (export == null) {
             export = new ExportType();
         }


### PR DESCRIPTION
Previously, we generate DR conflicts export group in runtime if DRRole is XDCR.
This additional export configuration will be persistent to local deployment.xml after @UAC even there are no changes to the deployment.
If a user joins (or restarts) with another fresh host using original deployment file, the joining phase won't be progress as it considers the deployment is incompatible.

The solution in this PR is persistenting this additional export configuration in the init phase.