### PR TITLE
ENG-12931: Ensure DR is started before verifying poison pill path. Al…

### DIFF
--- a/third_party/cpp/stx/btree_map.h
+++ b/third_party/cpp/stx/btree_map.h
@@ -533,7 +533,7 @@ public:
     /// Erase the key/data pair referenced by the iterator.
     void erase(iterator iter)
     {
-	return tree.erase(iter);
+        tree.erase(iter);
     }
 
 #ifdef BTREE_TODO


### PR DESCRIPTION
…so update C++ UniqueId object to provide equivalent toString as Java and use it to print out better UniqueIds in PoisonPill messages. Fix minor IDE complaint in btree_map.h where we try to return a value in a void method.