### PR TITLE
Eng 13130 fix hash mismatch

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -394,9 +394,9 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                     AtomicReference<String> timeoutRef = null;
                     try {
 
-                        /*
-                         * Enforce a limit on the maximum number of connections
-                         */
+                    /*
+                     * Enforce a limit on the maximum number of connections
+                     */
                         if (m_numConnections.get() >= MAX_CONNECTIONS.get()) {
                             networkLog.warn("Rejected connection from " +
                                     m_socket.socket().getRemoteSocketAddress() +
@@ -419,11 +419,11 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                             return;
                         }
 
-                        /*
-                         * Increment the number of connections even though this one hasn't been authenticated
-                         * so that a flood of connection attempts (with many doomed) will not result in
-                         * successful authentication of connections that would put us over the limit.
-                         */
+                    /*
+                     * Increment the number of connections even though this one hasn't been authenticated
+                     * so that a flood of connection attempts (with many doomed) will not result in
+                     * successful authentication of connections that would put us over the limit.
+                     */
                         m_numConnections.incrementAndGet();
 
                         //Populated on timeout
@@ -950,11 +950,10 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
             }
 
             // Reuse the creation time of the original invocation to have accurate internal latency
-            if (response.isMispartitioned()) {
-                // If the transaction is restarted, don't send a response to the client yet.
-                if (restartTransaction(clientData.m_messageSize, clientData.m_creationTimeNanos)) {
-                    return DeferredSerialization.EMPTY_MESSAGE_LENGTH;
-                }
+            if (restartTransaction(clientData.m_messageSize, clientData.m_creationTimeNanos)) {
+                // If the transaction is successfully restarted, don't send a response to the
+                // client yet.
+                return DeferredSerialization.EMPTY_MESSAGE_LENGTH;
             }
 
             final long now = System.nanoTime();
@@ -995,50 +994,54 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
         }
 
         /**
-         * Restart mis-partitioned transaction if possible
+         * Checks if the transaction needs to be restarted, if so, restart it.
          * @param messageSize the original message size when the invocation first came in
          * @return true if the transaction is restarted successfully, false otherwise.
          */
         private boolean restartTransaction(int messageSize, long nowNanos)
         {
-            // Restart a mis-partitioned transaction
-            assert response.getInvocation() != null;
-            assert response.getCurrentHashinatorConfig() != null;
-            assert(catProc != null);
+            if (response.isMispartitioned()) {
+                // Restart a mis-partitioned transaction
+                assert response.getInvocation() != null;
+                assert response.getCurrentHashinatorConfig() != null;
+                assert(catProc != null);
 
-            // before rehashing, update the hashinator
-            TheHashinator.updateHashinator(
-                    TheHashinator.getConfiguredHashinatorClass(),
-                    response.getCurrentHashinatorConfig().getFirst(), // version
-                    response.getCurrentHashinatorConfig().getSecond(), // config bytes
-                    false); // cooked (true for snapshot serialization only)
+                // before rehashing, update the hashinator
+                TheHashinator.updateHashinator(
+                        TheHashinator.getConfiguredHashinatorClass(),
+                        response.getCurrentHashinatorConfig().getFirst(), // version
+                        response.getCurrentHashinatorConfig().getSecond(), // config bytes
+                        false); // cooked (true for snapshot serialization only)
 
-            // if we are recovering, the mispartitioned txn must come from the log,
-            // don't restart it. The correct txn will be replayed by another node.
-            if (VoltDB.instance().getMode() == OperationMode.INITIALIZING) {
-                return false;
+                // if we are recovering, the mispartitioned txn must come from the log,
+                // don't restart it. The correct txn will be replayed by another node.
+                if (VoltDB.instance().getMode() == OperationMode.INITIALIZING) {
+                    return false;
+                }
+
+                boolean isReadonly = catProc.getReadonly();
+
+                try {
+                    ProcedurePartitionInfo ppi = (ProcedurePartitionInfo)catProc.getAttachment();
+                    int partition = InvocationDispatcher.getPartitionForProcedureParameter(ppi.index,
+                            ppi.type, response.getInvocation());
+                    m_dispatcher.createTransaction(cihm.connection.connectionId(),
+                            response.getInvocation(),
+                            isReadonly,
+                            true, // Only SP could be mis-partitioned
+                            false, // Only SP could be mis-partitioned
+                            new int [] { partition },
+                            messageSize,
+                            nowNanos);
+                    return true;
+                } catch (Exception e) {
+                    // unable to hash to a site, return an error
+                    assert(clientResponse == null);
+                    clientResponse = getMispartitionedErrorResponse(response.getInvocation(), catProc, e);
+                }
             }
 
-            boolean isReadonly = catProc.getReadonly();
-
-            try {
-                ProcedurePartitionInfo ppi = (ProcedurePartitionInfo)catProc.getAttachment();
-                int partition = InvocationDispatcher.getPartitionForProcedureParameter(ppi.index,
-                        ppi.type, response.getInvocation());
-                m_dispatcher.createTransaction(cihm.connection.connectionId(),
-                        response.getInvocation(),
-                        isReadonly,
-                        true, // Only SP could be mis-partitioned
-                        false, // Only SP could be mis-partitioned
-                        new int [] { partition },
-                        messageSize,
-                        nowNanos);
-            } catch (Exception e) {
-                // unable to hash to a site, return an error
-                assert(clientResponse == null);
-                clientResponse = getMispartitionedErrorResponse(response.getInvocation(), catProc, e);
-            }
-            return true;
+            return false;
         }
     }
 

--- a/src/frontend/org/voltdb/ClientInterfaceHandleManager.java
+++ b/src/frontend/org/voltdb/ClientInterfaceHandleManager.java
@@ -17,15 +17,18 @@
 
 package org.voltdb;
 
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.network.Connection;
+import org.voltdb.iv2.MpInitiator;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableMap.Builder;
@@ -42,6 +45,7 @@ public class ClientInterfaceHandleManager
 {
     private static final VoltLogger tmLog = new VoltLogger("TM");
 
+    static final long READ_BIT = 1L << 63;
     //Add an extra bit so compared to the 14-bits in txnids so there
     //can be a short circuit read partition id
     static final int PART_ID_BITS = 15;
@@ -59,8 +63,9 @@ public class ClientInterfaceHandleManager
 
     private volatile boolean m_wantsTopologyUpdates = false;
 
-    private ImmutableMap<Integer, PartitionInFlightTracker> m_trackerMap
-        = new Builder<Integer, PartitionInFlightTracker>().build();
+    private HandleGenerator m_shortCircuitHG = new HandleGenerator(SHORT_CIRCUIT_PART_ID);
+
+    private final Map<Long, Iv2InFlight> m_shortCircuitReads = new HashMap<Long, Iv2InFlight>();
 
     private static class HandleGenerator
     {
@@ -79,6 +84,25 @@ public class ClientInterfaceHandleManager
             }
             return ((m_partitionId << PART_ID_SHIFT) | m_sequence++);
         }
+    }
+
+    public static int getPartIdFromHandle(long handle)
+    {
+        return (int)((handle >> PART_ID_SHIFT) & MP_PART_ID);
+    }
+
+    public static long getSeqNumFromHandle(long handle)
+    {
+        return handle & SEQNUM_MAX;
+    }
+
+    public static String handleToString(long handle)
+    {
+        return "(pid " + getPartIdFromHandle(handle) + " seq " + getSeqNumFromHandle(handle) + ")";
+    }
+
+    private boolean isShortCircuitReadHandle(long handle) {
+        return (handle >> PART_ID_SHIFT) == SHORT_CIRCUIT_PART_ID;
     }
 
     static class Iv2InFlight
@@ -101,14 +125,18 @@ public class ClientInterfaceHandleManager
         }
     }
 
-    static class PartitionInFlightTracker {
+    static class PartitionData {
         private final HandleGenerator m_generator;
-        private final Map<Long, Iv2InFlight> m_inFlights = new HashMap<Long, Iv2InFlight>();
+        private final Deque<Iv2InFlight> m_reads = new ArrayDeque<Iv2InFlight>();
+        private final Deque<Iv2InFlight> m_writes = new ArrayDeque<Iv2InFlight>();
 
-        private PartitionInFlightTracker(int partitionId) {
+        private PartitionData(int partitionId) {
             m_generator = new HandleGenerator(partitionId);
         }
     }
+
+    private ImmutableMap<Integer, PartitionData> m_partitionStuff =
+            new Builder<Integer, PartitionData>().build();
 
     ClientInterfaceHandleManager(boolean isAdmin, Connection connection, ClientInterfaceRepairCallback repairCallback, AdmissionControlGroup acg)
     {
@@ -130,9 +158,9 @@ public class ClientInterfaceHandleManager
             @Override
             synchronized long getHandle(boolean isSinglePartition, int partitionId,
                     long clientHandle, int messageSize, long creationTimeNanos, String procName, long initiatorHSId,
-                    boolean isShortCircuitRead) {
+                    boolean readOnly, boolean isShortCircuitRead) {
                 return super.getHandle(isSinglePartition, partitionId,
-                        clientHandle, messageSize, creationTimeNanos, procName, initiatorHSId, isShortCircuitRead);
+                        clientHandle, messageSize, creationTimeNanos, procName, initiatorHSId, readOnly, isShortCircuitRead);
             }
             @Override
             synchronized Iv2InFlight findHandle(long ciHandle) {
@@ -169,7 +197,7 @@ public class ClientInterfaceHandleManager
      * Create a new handle for a transaction and store the client information
      * for that transaction in the internal structures.
      * ClientInterface handles have the partition ID encoded in them as the 10
-     * high-order non-sign bits (where the SHORT_CIRCUIT_PART_ID is the max value),
+     * high-order non-sign bits (where the MP partition ID is the max value),
      * and a 53 bit sequence number in the low 53 bits.
      */
     long getHandle(
@@ -180,34 +208,68 @@ public class ClientInterfaceHandleManager
             long creationTimeNanos,
             String procName,
             long initiatorHSId,
-            boolean isShortCircuitReadOrNTProc)
+            boolean readOnly,
+            boolean isShortCircuitRead)
     {
         assert(!shouldCheckThreadIdAssertion() || m_expectedThreadId == Thread.currentThread().getId());
-        if (isShortCircuitReadOrNTProc) {
-            partitionId = SHORT_CIRCUIT_PART_ID;
-        } else if (!isSinglePartition) {
+        if (!isSinglePartition) {
             partitionId = MP_PART_ID;
         }
 
-        PartitionInFlightTracker tracker = m_trackerMap.get(partitionId);
-        if (tracker == null) {
-            tracker = new PartitionInFlightTracker(partitionId);
-            m_trackerMap =
-                    new Builder<Integer, PartitionInFlightTracker>().
-                    putAll(m_trackerMap).
-                    put(partitionId, tracker).build();
+        PartitionData partitionStuff = m_partitionStuff.get(partitionId);
+        if (partitionStuff == null) {
+            partitionStuff = new PartitionData(partitionId);
+            m_partitionStuff =
+                    new Builder<Integer, PartitionData>().
+                        putAll(m_partitionStuff).
+                        put(partitionId, partitionStuff).build();
         }
 
-        long ciHandle = tracker.m_generator.getNextHandle();
-        Iv2InFlight inFlight = new Iv2InFlight(ciHandle, clientHandle, messageSize,
-                                               creationTimeNanos, procName, initiatorHSId);
+        long ciHandle =
+                isShortCircuitRead ? m_shortCircuitHG.getNextHandle() : partitionStuff.m_generator.getNextHandle();
+        Iv2InFlight inFlight =
+                new Iv2InFlight(ciHandle, clientHandle, messageSize, creationTimeNanos, procName, initiatorHSId);
 
-        tracker.m_inFlights.put(ciHandle, inFlight);
+        if (isShortCircuitRead) {
+            /*
+             * Short circuit reads don't use a handle that is partition specific
+             * because ordering doesn't really matter since it isn't used for failure handling
+             * because the read is local to this process
+             */
+            m_shortCircuitReads.put(ciHandle, inFlight);
+        } else {
+            /*
+             * Reads are not ordered with writes, writes might block due to command logging
+             * so track them separately because they will come back in mixed order
+             */
+            if (readOnly) {
+                /*
+                 * Encode the read only-ness into the handle
+                 */
+                ciHandle = setReadBit(ciHandle);
+                partitionStuff.m_reads.offer(inFlight);
+            } else {
+                partitionStuff.m_writes.offer(inFlight);
+            }
+        }
 
         m_outstandingTxns++;
         m_acg.increaseBackpressure(messageSize);
         return ciHandle;
     }
+
+    private static boolean getReadBit(long handle) {
+        return (handle & READ_BIT) != 0;
+    }
+
+    private static long unsetReadBit(long handle) {
+        return handle & ~READ_BIT;
+    }
+
+    private static long setReadBit(long handle) {
+        return (handle |= READ_BIT);
+    }
+
 
     /**
      * Retrieve the client information for the specified handle
@@ -215,12 +277,46 @@ public class ClientInterfaceHandleManager
     Iv2InFlight findHandle(long ciHandle)
     {
         assert(!shouldCheckThreadIdAssertion() || m_expectedThreadId == Thread.currentThread().getId());
+        //Check read only encoded bit
+        final boolean readOnly = getReadBit(ciHandle);
+        //Remove read only encoding so comparison works
+        ciHandle = unsetReadBit(ciHandle);
 
         /*
-         * Check the partition specific queue of handles
+         * Check for a short circuit read
+         */
+        Iv2InFlight inflight = m_shortCircuitReads.remove(ciHandle);
+        if (inflight != null) {
+            m_acg.reduceBackpressure(inflight.m_messageSize);
+            m_outstandingTxns--;
+            return inflight;
+        }
+        // Normal short circuit read has been handled above.
+        // If this handle is for short circuit read, it must be a NT transaction.
+        // NT transactions are handled as short circuit read for simplicity.
+        if (isShortCircuitReadHandle(ciHandle)) {
+            // This can happen for NT transactions which are accepted at a non-MPI node
+            // and have finished with a response while the MPI-node dies and MPI fails
+            // over to this particular node. In this scenario, there is a race between
+            // the delivery of the actual transaction response to CI site and the
+            // delivery of MPI fail over callback, the first event will try to remove
+            // this particular short circuit read handle and send the response back to
+            // the client, the second event will try to remove all short circuit read
+            // handles and send a "transaction dropped due to change of mastership and
+            // may be committed" response for all of them. If the first event happens
+            // first, the second event can still handle it correctly so it's fine.
+            // If the second event happens first, we need to tolerate it here. In either
+            // case, the client will receive a response for this handle so there's no
+            // problem.
+            return null;
+        }
+
+        /*
+         * Not a short circuit read, check the partition specific
+         * queue of handles
          */
         int partitionId = getPartIdFromHandle(ciHandle);
-        PartitionInFlightTracker partitionStuff = m_trackerMap.get(partitionId);
+        PartitionData partitionStuff = m_partitionStuff.get(partitionId);
         if (partitionStuff == null) {
             // whoa, bad
             tmLog.error("Unable to find handle list for partition: " + partitionId +
@@ -228,13 +324,41 @@ public class ClientInterfaceHandleManager
             return null;
         }
 
-        Iv2InFlight inFlight = partitionStuff.m_inFlights.remove(ciHandle);
-        if (inFlight != null) {
-            m_acg.reduceBackpressure(inFlight.m_messageSize);
-            m_outstandingTxns--;
-            return inFlight;
+        final Deque<Iv2InFlight> perPartDeque = readOnly ? partitionStuff.m_reads : partitionStuff.m_writes;
+        while (perPartDeque.peekFirst() != null) {
+            Iv2InFlight inFlight = perPartDeque.pollFirst();
+            if (inFlight.m_ciHandle < ciHandle) {
+                // lost txn, do something eventually
+                tmLog.debug("CI found dropped transaction with handle: " + inFlight.m_ciHandle +
+                        " for partition: " + partitionId + " while searching for handle " +
+                        ciHandle);
+                ClientResponseImpl errorResponse =
+                    new ClientResponseImpl(
+                            ClientResponseImpl.RESPONSE_UNKNOWN,
+                            new VoltTable[0], "Transaction dropped during fault recovery",
+                            inFlight.m_clientHandle);
+                ByteBuffer buf = ByteBuffer.allocate(errorResponse.getSerializedSize() + 4);
+                buf.putInt(buf.capacity() - 4);
+                errorResponse.flattenToBuffer(buf);
+                buf.flip();
+                connection.writeStream().enqueue(buf);
+                m_outstandingTxns--;
+                m_acg.reduceBackpressure(inFlight.m_messageSize);
+            }
+            else if (inFlight.m_ciHandle > ciHandle) {
+                // we've gone too far, need to jam this back into the front of the deque and run away.
+                tmLog.debug("CI clientData lookup missing handle: " + ciHandle
+                        + ". Next expected client data handle is: " + inFlight.m_ciHandle);
+                perPartDeque.addFirst(inFlight);
+                break;
+            }
+            else {
+                m_acg.reduceBackpressure(inFlight.m_messageSize);
+                m_outstandingTxns--;
+                return inFlight;
+            }
         }
-
+        tmLog.debug("Unable to find Client data for client interface handle: " + ciHandle);
         return null;
     }
 
@@ -242,12 +366,31 @@ public class ClientInterfaceHandleManager
     Iv2InFlight removeHandle(long ciHandle)
     {
         assert(!shouldCheckThreadIdAssertion() || m_expectedThreadId == Thread.currentThread().getId());
+        //Check read only encoded bit
+        final boolean readOnly = getReadBit(ciHandle);
+        //Remove read only encoding so comparison works
+        ciHandle = unsetReadBit(ciHandle);
+
+        // Shouldn't see any reads in this path, since the whole point of this
+        // method is to remove writes during replay which aren't going to get
+        // done.  However, this is logically correct, so go ahead and allow it.
+        Iv2InFlight inflight = m_shortCircuitReads.remove(ciHandle);
+        if (inflight != null) {
+            m_acg.reduceBackpressure(inflight.m_messageSize);
+            m_outstandingTxns--;
+            return inflight;
+        }
+        if (isShortCircuitReadHandle(ciHandle)) {
+            // Refer to the corresponding part in findHandle() above for explanation
+            return null;
+        }
 
         /*
-         * Check the partition specific queue of handles
+         * Not a short circuit read, check the partition specific
+         * queue of handles
          */
         int partitionId = getPartIdFromHandle(ciHandle);
-        PartitionInFlightTracker partitionStuff = m_trackerMap.get(partitionId);
+        PartitionData partitionStuff = m_partitionStuff.get(partitionId);
         if (partitionStuff == null) {
             // whoa, bad
             tmLog.error("Unable to find handle list for removal for partition: " + partitionId +
@@ -255,11 +398,22 @@ public class ClientInterfaceHandleManager
             return null;
         }
 
-        Iv2InFlight inFlight = partitionStuff.m_inFlights.remove(ciHandle);
-        if (inFlight != null) {
-            m_acg.reduceBackpressure(inFlight.m_messageSize);
-            m_outstandingTxns--;
-            return inFlight;
+        final Deque<Iv2InFlight> perPartDeque = readOnly ? partitionStuff.m_reads : partitionStuff.m_writes;
+        Iterator<Iv2InFlight> iter = perPartDeque.iterator();
+        while (iter.hasNext()) {
+            Iv2InFlight inFlight = iter.next();
+            if (inFlight.m_ciHandle > ciHandle) {
+                // we've gone too far, this handle doesn't exist
+                tmLog.error("CI clientData lookup for remove missing handle: " + ciHandle
+                        + ". Next expected client data handle is: " + inFlight.m_ciHandle);
+                break;
+            }
+            else if (inFlight.m_ciHandle == ciHandle) {
+                m_acg.reduceBackpressure(inFlight.m_messageSize);
+                m_outstandingTxns--;
+                iter.remove();
+                return inFlight;
+            }
         }
         tmLog.error("Unable to find Client data to remove client interface handle: " + ciHandle);
         return null;
@@ -279,32 +433,76 @@ public class ClientInterfaceHandleManager
      */
     void freeOutstandingTxns() {
         assert(!shouldCheckThreadIdAssertion() || m_expectedThreadId == Thread.currentThread().getId());
-        for (PartitionInFlightTracker tracker : m_trackerMap.values()) {
-            for (Iv2InFlight inflight : tracker.m_inFlights.values()) {
+        for (PartitionData pd : m_partitionStuff.values()) {
+            for (Iv2InFlight inflight : pd.m_reads) {
+                m_outstandingTxns--;
+                m_acg.reduceBackpressure(inflight.m_messageSize);
+            }
+            for (Iv2InFlight inflight : pd.m_writes) {
                 m_outstandingTxns--;
                 m_acg.reduceBackpressure(inflight.m_messageSize);
             }
         }
+        for (Iv2InFlight inflight : m_shortCircuitReads.values()) {
+            m_outstandingTxns--;
+            m_acg.reduceBackpressure(inflight.m_messageSize);
+        }
     }
 
-    List<Iv2InFlight> removeHandlesForPartitionAndInitiator(Integer partitionId, Long initiatorHSId) {
+    List<Iv2InFlight> removeHandlesForPartitionAndInitiator(Integer partitionId,
+            Long initiatorHSId) {
         assert(!shouldCheckThreadIdAssertion() || m_expectedThreadId == Thread.currentThread().getId());
         List<Iv2InFlight> retval = new ArrayList<Iv2InFlight>();
 
-        if (!m_trackerMap.containsKey(partitionId)) return retval;
+        if (!m_partitionStuff.containsKey(partitionId)) return retval;
 
         /*
-         * Clear pending responses
+         * First clear the pending reads
          */
-        PartitionInFlightTracker partitionStuff = m_trackerMap.get(partitionId);
-        Iterator<Entry<Long, Iv2InFlight>> iter = partitionStuff.m_inFlights.entrySet().iterator();
-        while (iter.hasNext()) {
-            Entry<Long, Iv2InFlight> entry = iter.next();
-            if (entry.getValue().m_initiatorHSId != initiatorHSId) {
-                iter.remove();
-                retval.add(entry.getValue());
+        PartitionData partitionStuff = m_partitionStuff.get(partitionId);
+        Deque<Iv2InFlight> inFlight = partitionStuff.m_reads;
+        Iterator<Iv2InFlight> i = inFlight.iterator();
+        while (i.hasNext()) {
+            Iv2InFlight entry = i.next();
+            if (entry.m_initiatorHSId != initiatorHSId) {
+                i.remove();
+                retval.add(entry);
                 m_outstandingTxns--;
-                m_acg.reduceBackpressure(entry.getValue().m_messageSize);
+                m_acg.reduceBackpressure(entry.m_messageSize);
+            }
+        }
+
+        /*
+         * MP short circuit reads can be remote, which necessitate repair
+         */
+        if (partitionId == MpInitiator.MP_INIT_PID) {
+            Iterator<Map.Entry<Long, Iv2InFlight>> itr =
+                    m_shortCircuitReads.entrySet().iterator();
+            while (itr.hasNext()) {
+                Map.Entry<Long, Iv2InFlight> e = itr.next();
+                Iv2InFlight entry = e.getValue();
+
+                if (entry.m_initiatorHSId != initiatorHSId) {
+                    itr.remove();
+                    retval.add(entry);
+                    m_outstandingTxns--;
+                    m_acg.reduceBackpressure(entry.m_messageSize);
+                }
+            }
+        }
+
+        /*
+         * Then clear the pending writes
+         */
+        inFlight = partitionStuff.m_writes;
+        i = inFlight.iterator();
+        while (i.hasNext()) {
+            Iv2InFlight entry = i.next();
+            if (entry.m_initiatorHSId != initiatorHSId) {
+                i.remove();
+                retval.add(entry);
+                m_outstandingTxns--;
+                m_acg.reduceBackpressure(entry.m_messageSize);
             }
         }
         return retval;
@@ -323,21 +521,5 @@ public class ClientInterfaceHandleManager
 
     public boolean wantsTopologyUpdates() {
         return m_wantsTopologyUpdates;
-    }
-
-    public static int getPartIdFromHandle(long handle)
-    {
-        // SHORT_CIRCUIT_PART_ID has 15 bits
-        return (int)((handle >> PART_ID_SHIFT) & ((MP_PART_ID << 1) + 1));
-    }
-
-    public static long getSeqNumFromHandle(long handle)
-    {
-        return handle & SEQNUM_MAX;
-    }
-
-    public static String handleToString(long handle)
-    {
-        return "(pid " + getPartIdFromHandle(handle) + " seq " + getSeqNumFromHandle(handle) + ")";
     }
 }

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -719,6 +719,7 @@ public final class InvocationDispatcher {
                                      nowNanos,
                                      task.getProcName(),
                                      NTPROC_JUNK_ID,
+                                     true,
                                      true); // We are using shortcut read here on purpose
                                             // it's the simplest place to keep the handle because it
                                             // doesn't do as much work with partitions.
@@ -1228,7 +1229,7 @@ public final class InvocationDispatcher {
         }
 
         long handle = cihm.getHandle(isSinglePartition, isSinglePartition ? partitions[0] : -1, invocation.getClientHandle(),
-                messageSize, nowNanos, invocation.getProcName(), initiatorHSId, isShortCircuitRead);
+                messageSize, nowNanos, invocation.getProcName(), initiatorHSId, isReadOnly, isShortCircuitRead);
 
         Iv2InitiateTaskMessage workRequest =
             new Iv2InitiateTaskMessage(m_siteId,

--- a/src/frontend/org/voltdb/NTProcedureService.java
+++ b/src/frontend/org/voltdb/NTProcedureService.java
@@ -116,9 +116,9 @@ public class NTProcedureService {
 
     // runs the initial run() method of nt procs
     // (doesn't run nt procs if started by other nt procs)
-    // from 2 to 20 threads in parallel, with a bounded queue
+    // from 1 to 20 threads in parallel, with an unbounded queue
     private final ExecutorService m_primaryExecutorService = new ThreadPoolExecutor(
-            2,
+            1,
             20,
             60,
             TimeUnit.SECONDS,
@@ -389,9 +389,9 @@ public class NTProcedureService {
             prntg = m_procs.get(procName);
         }
 
-        final ProcedureRunnerNT runner;
+        ProcedureRunnerNT tempRunner = null;
         try {
-            runner = prntg.generateProcedureRunnerNT(user, ccxn, isAdmin, ciHandle, task.getClientHandle(), task.getBatchTimeout());
+            tempRunner = prntg.generateProcedureRunnerNT(user, ccxn, isAdmin, ciHandle, task.getClientHandle(), task.getBatchTimeout());
         } catch (InstantiationException | IllegalAccessException e1) {
             // I don't expect to hit this, but it's here...
             // must be done as IRM to CI mailbox for backpressure accounting
@@ -405,6 +405,7 @@ public class NTProcedureService {
             m_mailbox.deliver(irm);
             return;
         }
+        final ProcedureRunnerNT runner = tempRunner;
         m_outstanding.put(runner.m_id, runner);
 
         Runnable invocationRunnable = new Runnable() {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1915,10 +1915,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             } catch (IOException e) {
                 hostLog.error("Failed to writing catalog jar to disk: " + e.getMessage(), e);
                 e.printStackTrace();
-
-                VoltZK.removeCatalogUpdateBlocker(VoltDB.instance().getHostMessenger().getZK(),
-                                                  VoltZK.uacActiveBlocker,
-                                                  hostLog);
                 VoltDB.crashLocalVoltDB("Fatal error when writing the catalog jar to disk.", true, e);
             }
             logDeployment();

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -113,7 +113,6 @@ public class VoltZK {
     // being able to use as constant string
     public static final String elasticJoinActiveBlocker = catalogUpdateBlockers + "/join_blocker";
     public static final String rejoinActiveBlocker = catalogUpdateBlockers + "/rejoin_blocker";
-    public static final String uacActiveBlocker = catalogUpdateBlockers + "/uac_blocker";
     public static final String uacActiveBlockerNT = catalogUpdateBlockers + "/uac_nt_blocker";
 
     public static final String request_truncation_snapshot_node = ZKUtil.joinZKPath(request_truncation_snapshot, "request_");
@@ -338,20 +337,6 @@ public class VoltZK {
         try {
             switch (node) {
             case uacActiveBlockerNT:
-                if (zk.exists(VoltZK.uacActiveBlocker, false) != null) {
-                    errorMsg = "while another catalog update is active";
-                    break;
-                }
-                if (zk.exists(VoltZK.rejoinActiveBlocker, false) != null) {
-                    errorMsg = "while node rejoin is active";
-                    break;
-                }
-                break;
-            case uacActiveBlocker:
-                if (zk.exists(VoltZK.uacActiveBlockerNT, false) != null) {
-                    errorMsg = "while catalog update is active";
-                    break;
-                }
                 if (zk.exists(VoltZK.rejoinActiveBlocker, false) != null) {
                     errorMsg = "while node rejoin is active";
                     break;

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -582,9 +582,9 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
      */
     private void doLocalInitiateOffer(Iv2InitiateTaskMessage msg)
     {
+        final String threadName = Thread.currentThread().getName(); // Thread name has to be materialized here
         final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
         if (traceLog != null) {
-            final String threadName = Thread.currentThread().getName(); // Thread name has to be materialized here
             traceLog.add(() -> VoltTrace.meta("process_name", "name", CoreUtils.getHostnameOrAddress()))
                     .add(() -> VoltTrace.meta("thread_name", "name", threadName))
                     .add(() -> VoltTrace.meta("thread_sort_index", "sort_index", Integer.toString(10000)))

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -480,70 +480,69 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
         ZooKeeper zk = VoltDB.instance().getHostMessenger().getZK();
         CatalogChangeResult ccr = null;
 
+        String errMsg = VoltZK.createCatalogUpdateBlocker(zk, VoltZK.uacActiveBlockerNT,  hostLog,
+                "catalog update(" + invocationName + ")" );
+        if (errMsg != null) {
+            return makeQuickResponse(ClientResponse.USER_ABORT, errMsg);
+        }
+
+        // Now we holds the UAC blocker lock
         try {
-            String errMsg = VoltZK.createCatalogUpdateBlocker(zk, VoltZK.uacActiveBlockerNT,  hostLog,
-                    "catalog update(" + invocationName + ")" );
-            if (errMsg != null) {
-                return makeQuickResponse(ClientResponse.USER_ABORT, errMsg);
-            }
+            ccr = prepareApplicationCatalogDiff(invocationName,
+                                                operationBytes,
+                                                operationString,
+                                                adhocDDLStmts,
+                                                replayHashOverride,
+                                                isPromotion,
+                                                useAdhocDDL,
+                                                getHostname(),
+                                                getUsername());
+        } catch (Exception e) {
+            VoltZK.removeCatalogUpdateBlocker(zk, VoltZK.uacActiveBlockerNT, hostLog);
+            errMsg = "Unexpected error during preparing catalog diffs: " + e.getMessage();
+            return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, errMsg);
+        }
 
+        if (ccr.errorMsg != null) {
+            VoltZK.removeCatalogUpdateBlocker(zk, VoltZK.uacActiveBlockerNT, hostLog);
+            return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, ccr.errorMsg);
+        }
+        // Log something useful about catalog upgrades when they occur.
+        if (ccr.upgradedFromVersion != null) {
+            compilerLog.info(String.format("catalog was automatically upgraded from version %s.",
+                    ccr.upgradedFromVersion));
+        }
+        if (ccr.encodedDiffCommands.trim().length() == 0) {
+            VoltZK.removeCatalogUpdateBlocker(zk, VoltZK.uacActiveBlockerNT, hostLog);
+            String msg = invocationName + " with no catalog changes was skipped.";
+            compilerLog.info(msg);
+            return makeQuickResponse(ClientResponseImpl.SUCCESS, msg);
+        }
+        if (isRestoring() && !isPromotion && "UpdateApplicationCatalog".equals(invocationName)) {
+            // This means no more @UAC calls when using DDL mode.
+            noteRestoreCompleted();
+            compilerLog.info("No more @UpdateApplicationCatalog calls when using DDL mode");
+        }
+
+        // write the new catalog to a temporary jar file
+        errMsg = verifyAndWriteCatalogJar(ccr);
+        if (errMsg != null) {
+            VoltZK.removeCatalogUpdateBlocker(zk, VoltZK.uacActiveBlockerNT, hostLog);
+            return makeQuickResponse(ClientResponseImpl.GRACEFUL_FAILURE, errMsg);
+        }
+
+        // only copy the current catalog when @UpdateCore could fail
+        if (ccr.tablesThatMustBeEmpty.length != 0) {
             try {
-                ccr = prepareApplicationCatalogDiff(invocationName,
-                                                    operationBytes,
-                                                    operationString,
-                                                    adhocDDLStmts,
-                                                    replayHashOverride,
-                                                    isPromotion,
-                                                    useAdhocDDL,
-                                                    getHostname(),
-                                                    getUsername());
-            } catch (Exception e) {
-                errMsg = "Unexpected error during preparing catalog diffs: " + e.getMessage();
-                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, errMsg);
-            }
-
-            if (ccr.errorMsg != null) {
-                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, ccr.errorMsg);
-            }
-            // Log something useful about catalog upgrades when they occur.
-            if (ccr.upgradedFromVersion != null) {
-                compilerLog.info(String.format("catalog was automatically upgraded from version %s.",
-                        ccr.upgradedFromVersion));
-            }
-            if (ccr.encodedDiffCommands.trim().length() == 0) {
-                String msg = invocationName + " with no catalog changes was skipped.";
-                compilerLog.info(msg);
-                return makeQuickResponse(ClientResponseImpl.SUCCESS, msg);
-            }
-            if (isRestoring() && !isPromotion && "UpdateApplicationCatalog".equals(invocationName)) {
-                // This means no more @UAC calls when using DDL mode.
-                noteRestoreCompleted();
-                compilerLog.info("No more @UpdateApplicationCatalog calls when using DDL mode");
-            }
-
-            // write the new catalog to a temporary jar file
-            errMsg = verifyAndWriteCatalogJar(ccr);
-            if (errMsg != null) {
+                // read the current catalog bytes
+                byte[] data = zk.getData(VoltZK.catalogbytes, false, null);
+                // write to the previous catalog bytes place holder
+                zk.setData(VoltZK.catalogbytesPrevious, data, -1);
+            } catch (KeeperException | InterruptedException e) {
+                VoltZK.removeCatalogUpdateBlocker(zk, VoltZK.uacActiveBlockerNT, hostLog);
+                errMsg = "error copying catalog bytes or write catalog bytes on ZK";
                 return makeQuickResponse(ClientResponseImpl.GRACEFUL_FAILURE, errMsg);
             }
-
-            // only copy the current catalog when @UpdateCore could fail
-            if (ccr.tablesThatMustBeEmpty.length != 0) {
-                try {
-                    // read the current catalog bytes
-                    byte[] data = zk.getData(VoltZK.catalogbytes, false, null);
-                    // write to the previous catalog bytes place holder
-                    zk.setData(VoltZK.catalogbytesPrevious, data, -1);
-                } catch (KeeperException | InterruptedException e) {
-                    errMsg = "error copying catalog bytes or write catalog bytes on ZK";
-                    return makeQuickResponse(ClientResponseImpl.GRACEFUL_FAILURE, errMsg);
-                }
-            }
-        } finally {
-            // MPI node may fail before receiving @UpdateCore invocation, this transactional procedure
-            // may never send out. However, we need to clean up the UAC ZK blocker now and check version
-            // in @UpdateCore
-            VoltZK.removeCatalogUpdateBlocker(zk, VoltZK.uacActiveBlockerNT, hostLog);
         }
 
         long genId = getNextGenerationId();

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
@@ -1259,7 +1259,7 @@ public class ExpressionColumn extends Expression {
             return val + Arrays.hashCode(nodes);
 
         case OpTypes.COLUMN :
-            return val + Objects.hashCode(column);
+            return val + Objects.hashCode(rangeVariable) + Objects.hashCode(column);
 
         case OpTypes.ASTERISK :
             return val;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/RangeVariable.java
@@ -31,6 +31,8 @@
 
 package org.hsqldb_voltpatches;
 
+import java.util.Arrays;
+
 import org.hsqldb_voltpatches.HSQLInterface.HSQLParseException;
 import org.hsqldb_voltpatches.HsqlNameManager.SimpleName;
 import org.hsqldb_voltpatches.ParserDQL.CompileContext;
@@ -1297,6 +1299,129 @@ final class RangeVariable {
         }
 
         return scan;
+    }
+
+
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(columnAliasNames);
+        result = prime * result + Arrays.hashCode(columnsInGroupBy);
+        result = prime * result + Arrays.hashCode(emptyData);
+        result = prime * result + (hasKeyedColumnInGroupBy ? 1231 : 1237);
+        result = prime * result + (isJoinIndex ? 1231 : 1237);
+        result = prime * result + (isLeftJoin ? 1231 : 1237);
+        result = prime * result + (isMultiFindFirst ? 1231 : 1237);
+        result = prime * result + (isRightJoin ? 1231 : 1237);
+        result = prime * result + (isVariable ? 1231 : 1237);
+        result = prime * result + level;
+        result = prime * result + multiColumnCount;
+        result = prime * result + ((namedJoinColumns == null) ? 0
+                : namedJoinColumns.hashCode());
+        result = prime * result
+                + ((rangeIndex == null) ? 0 : rangeIndex.hashCode());
+        result = prime * result + rangePosition;
+        result = prime * result
+                + ((rangeTable == null) ? 0 : rangeTable.hashCode());
+        result = prime * result
+                + ((tableAlias == null) ? 0 : tableAlias.hashCode());
+        result = prime * result + Arrays.hashCode(updatedColumns);
+        result = prime * result + Arrays.hashCode(usedColumns);
+        result = prime * result
+                + ((variables == null) ? 0 : variables.hashCode());
+        return result;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        RangeVariable other = (RangeVariable) obj;
+        if (!Arrays.equals(columnAliasNames, other.columnAliasNames)) {
+            return false;
+        }
+        if (!Arrays.equals(columnsInGroupBy, other.columnsInGroupBy)) {
+            return false;
+        }
+        if (!Arrays.equals(emptyData, other.emptyData)) {
+            return false;
+        }
+        if (hasKeyedColumnInGroupBy != other.hasKeyedColumnInGroupBy) {
+            return false;
+        }
+        if (isJoinIndex != other.isJoinIndex) {
+            return false;
+        }
+        if (isLeftJoin != other.isLeftJoin) {
+            return false;
+        }
+        if (isMultiFindFirst != other.isMultiFindFirst) {
+            return false;
+        }
+        if (isRightJoin != other.isRightJoin) {
+            return false;
+        }
+        if (isVariable != other.isVariable) {
+            return false;
+        }
+        if (level != other.level) {
+            return false;
+        }
+        if (multiColumnCount != other.multiColumnCount) {
+            return false;
+        }
+        if (namedJoinColumns == null) {
+            if (other.namedJoinColumns != null) {
+                return false;
+            }
+        } else if (!namedJoinColumns.equals(other.namedJoinColumns)) {
+            return false;
+        }
+        if (rangeIndex == null) {
+            if (other.rangeIndex != null) {
+                return false;
+            }
+        } else if (!rangeIndex.equals(other.rangeIndex)) {
+            return false;
+        }
+        if (rangePosition != other.rangePosition) {
+            return false;
+        }
+        if (rangeTable == null) {
+            if (other.rangeTable != null) {
+                return false;
+            }
+        } else if (!rangeTable.equals(other.rangeTable)) {
+            return false;
+        }
+        if (tableAlias == null) {
+            if (other.tableAlias != null) {
+                return false;
+            }
+        } else if (!tableAlias.equals(other.tableAlias)) {
+            return false;
+        }
+        if (!Arrays.equals(updatedColumns, other.updatedColumns)) {
+            return false;
+        }
+        if (!Arrays.equals(usedColumns, other.usedColumns)) {
+            return false;
+        }
+        if (variables == null) {
+            if (other.variables != null) {
+                return false;
+            }
+        } else if (!variables.equals(other.variables)) {
+            return false;
+        }
+        return true;
     }
 
     /* (non-Javadoc)

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Session.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Session.java
@@ -2090,7 +2090,7 @@ public class Session implements SessionInterface {
         if (id == null) {
             id = nextExpressionNodeId++;
             hsqlExpressionNodeIdsToVoltNodeIds.put(expr, id);
-        }
+        } 
         return id;
     }
 

--- a/tests/frontend/org/voltdb/TestClientInterfaceHandleManager.java
+++ b/tests/frontend/org/voltdb/TestClientInterfaceHandleManager.java
@@ -23,8 +23,7 @@
 
 package org.voltdb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -47,19 +46,19 @@ public class TestClientInterfaceHandleManager {
                         null,
                         AdmissionControlGroup.getDummy());
 
-        long handle = dut.getHandle(true, 7, 31337, 10, 10l, "foo", 0, false);
+        long handle = dut.getHandle(true, 7, 31337, 10, 10l, "foo", 0, false, false);
         assertEquals(7, ClientInterfaceHandleManager.getPartIdFromHandle(handle));
         assertEquals(0, ClientInterfaceHandleManager.getSeqNumFromHandle(handle));
         ClientInterfaceHandleManager.Iv2InFlight inflight = dut.findHandle(handle);
         assertEquals(handle, inflight.m_ciHandle);
         assertEquals(31337, inflight.m_clientHandle);
 
-        handle = dut.getHandle(false, 12, 31338, 10, 10l, "yankees", 0, false);
+        handle = dut.getHandle(false, 12, 31338, 10, 10l, "yankees", 0, true, false);
         assertEquals(ClientInterfaceHandleManager.MP_PART_ID,
                 ClientInterfaceHandleManager.getPartIdFromHandle(handle));
         assertEquals(0, ClientInterfaceHandleManager.getSeqNumFromHandle(handle));
         inflight = dut.findHandle(handle);
-        assertEquals(handle, inflight.m_ciHandle);
+        assertEquals(handle, inflight.m_ciHandle | ClientInterfaceHandleManager.READ_BIT);
         assertEquals(31338, inflight.m_clientHandle);
     }
 
@@ -76,14 +75,14 @@ public class TestClientInterfaceHandleManager {
                         AdmissionControlGroup.getDummy());
         List<Long> handles = new ArrayList<Long>();
         for (int i = 0; i < 10; i++) {
-            handles.add(dut.getHandle(true, 7, 31337 + i, 10, 10l, "yankeefoo", 0, false));
+            handles.add(dut.getHandle(true, 7, 31337 + i, 10, 10l, "yankeefoo", 0, i % 2 == 0 ? true : false, false));
         }
         // pretend handles 0-4 were lost
         for (int i = 5; i < 10; i++) {
             ClientInterfaceHandleManager.Iv2InFlight inflight = dut.findHandle(handles.get(i));
             assertEquals(
                     (long)handles.get(i),
-                    inflight.m_ciHandle);
+                    i % 2 == 0 ? inflight.m_ciHandle | ClientInterfaceHandleManager.READ_BIT : inflight.m_ciHandle);
             assertEquals(31337 + i, inflight.m_clientHandle);
         }
     }
@@ -102,7 +101,7 @@ public class TestClientInterfaceHandleManager {
         List<Long> handles = new ArrayList<Long>();
         // Add 10 handles
         for (int i = 0; i < 10; i++) {
-            handles.add(dut.getHandle(true, 7, 31337 + i, 10, 10l, "yankeefoo", 0, false));
+            handles.add(dut.getHandle(true, 7, 31337 + i, 10, 10l, "yankeefoo", 0, i % 2 == 0 ? true : false, false));
         }
         // remove handle 6
         ClientInterfaceHandleManager.Iv2InFlight six = dut.removeHandle(handles.get(6));


### PR DESCRIPTION
This patch addresses two different causes of recent hash mismatch exception.
1) Stored procedure generates inconsistent query plans or catalog hashes on different nodes, 
2) Stored procedure succeed on one side but failed because wrong number of parameters on the other side.

Also just for precaution, this patch reverts a previous commit that allow two NT-threads running in a single node. 