### PR TITLE
ENG-13096: add advertised.host.name kafka server properties to junit …

### DIFF
--- a/src/frontend/org/voltdb/importclient/kafka/KafkaStreamImporterConfig.java
+++ b/src/frontend/org/voltdb/importclient/kafka/KafkaStreamImporterConfig.java
@@ -246,7 +246,7 @@ public class KafkaStreamImporterConfig implements ImporterConfig
                 kafka.javaapi.TopicMetadataResponse resp = consumer.send(req);
 
                 List<TopicMetadata> metaData = resp.topicsMetadata();
-                if (metaData == null) {
+                if (metaData == null || metaData.isEmpty()) {
                     attempts.add(new FailedMetaDataAttempt(
                             "Failed to get topic metadata for topic " + topic + " from host " + hp.getHost(), null
                             ));
@@ -256,6 +256,13 @@ public class KafkaStreamImporterConfig implements ImporterConfig
                 }
                 int partitionCount = 0;
                 for (TopicMetadata item : metaData) {
+                    if (item.partitionsMetadata().isEmpty()) {
+                        attempts.add(new FailedMetaDataAttempt(
+                                "Failed to get partition metadata for topic " + topic + " from host " + hp.getHost()
+                                + ":" + metaData.toString(), null
+                                ));
+                        continue;
+                    }
                     for (PartitionMetadata part : item.partitionsMetadata()) {
                         ++partitionCount;
                         URI uri;

--- a/tests/frontend/org/voltdb/regressionsuites/TestKafkaImportSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestKafkaImportSuite.java
@@ -65,7 +65,7 @@ public class TestKafkaImportSuite extends RegressionSuite {
         super(name);
     }
 
-    final static String TEST_TOPIC = "volt_topic_xin";
+    final static String TEST_TOPIC = "volt_topic";
     static String KAFKA_PORT = "9092";
     static String LOCALHOST_NAME = CoreUtils.getHostnameOrAddress();
     static String KAFKA_HOST_PORT = LOCALHOST_NAME + ":" + KAFKA_PORT;
@@ -116,7 +116,7 @@ public class TestKafkaImportSuite extends RegressionSuite {
         // check Kafka importer result
         Stopwatch sw = Stopwatch.createStarted();
         boolean foundImportData = false;
-        while (sw.elapsed(TimeUnit.SECONDS) < (30)) {
+        while (sw.elapsed(TimeUnit.SECONDS) < (10)) {
             VoltTable vt = client.callProcedure("@AdHoc", "Select * from tmap order by val;").getResults()[0];
             System.out.println("Elapsed " + sw.elapsed(TimeUnit.SECONDS) + " seconds, Test table contents: " + vt);
             if (10 == vt.getRowCount()) {
@@ -190,6 +190,8 @@ public class TestKafkaImportSuite extends RegressionSuite {
         kafkaProperties.setProperty("log.dirs", KAFKA_LOG_DIR);
         kafkaProperties.setProperty("num.partitions", "1");
         kafkaProperties.setProperty("replication", "0");
+        // Kafka requires the machine's hostname to be resolveable
+        kafkaProperties.setProperty("advertised.host.name", LOCALHOST_NAME);
         kafkaProperties.setProperty("port", KAFKA_PORT);
         kafkaProperties.setProperty("zookeeper.connect", LOCALHOST_NAME + ":" + ZOOKEEPER_PORT);
         kafkaProperties.setProperty("zookeeper.connection.timeout.ms", "6000");
@@ -240,7 +242,7 @@ public class TestKafkaImportSuite extends RegressionSuite {
 
         // configure socket importer
         Properties props = buildProperties(
-                "brokers", "localhost:9092",
+                "brokers", "localhost:" + KAFKA_PORT,
                 "topics", TEST_TOPIC,
                 "procedure", "TMAP.insert");
         project.addImport(true, "kafka", "csv", null, props);

--- a/tests/frontend/org/voltdb/regressionsuites/TestKafkaImportSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestKafkaImportSuite.java
@@ -90,6 +90,22 @@ public class TestKafkaImportSuite extends RegressionSuite {
         return data;
     }
 
+    private static void produceOneMessage(String message) {
+        //produce message here
+        Properties props = new Properties();
+        props.put("metadata.broker.list", KAFKA_HOST_PORT);
+        props.put("serializer.class", "kafka.serializer.StringEncoder");
+
+        // start producer
+        ProducerConfig config = new ProducerConfig(props);
+        Producer<String, String> producer = new Producer<String, String>(config);
+        // send one message to local kafkaLocalServer server:
+        System.out.println("Producing message: " + message);
+        KeyedMessage<String, String> data =
+                new KeyedMessage<String, String>(TEST_TOPIC, message);
+        producer.send(data);
+    }
+
     public void testImportSimpleData() throws Exception {
         System.out.println("testImportSimpleData");
 
@@ -205,6 +221,9 @@ public class TestKafkaImportSuite extends RegressionSuite {
 
         //start kafka
         m_kafkaLocalCluster = new KafkaLocalCluster(kafkaProperties, zkProperties);
+
+        // produce a message forcing kafka cluster to be fully initialized
+        produceOneMessage("test-message-0");
 
         super.setUp();
     }


### PR DESCRIPTION
…tests to have hostname resolveable for zookeeper clients. If this properites not set, the kafka simple consumer may not get topic metadata information from kafka cluster because of kafka.common.LeaderNotAvailableException, thus not able to start importer on VoltDB side. Also add more checks on VoltDB server side when configuring importer and log the errors if possible.