### PR TITLE
ENG-13229:

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2154,7 +2154,7 @@ int64_t VoltDBEngine::applyBinaryLog(int64_t txnId,
                                              uniqueId,
                                              false);
 
-    int64_t rowCount = m_wrapper.apply(log, m_tablesBySignatureHash, &m_stringPool, this, remoteClusterId);
+    int64_t rowCount = m_wrapper.apply(log, m_tablesBySignatureHash, &m_stringPool, this, remoteClusterId, uniqueId);
     return rowCount;
 }
 

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -491,7 +491,8 @@ BinaryLogSink::BinaryLogSink() {}
 int64_t BinaryLogSink::applyTxn(ReferenceSerializeInputLE *taskInfo,
                                 boost::unordered_map<int64_t, PersistentTable*> &tables,
                                 Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
-                                const char *txnStart) {
+                                const char *txnStart,
+                                int64_t localUniqueId) {
     int64_t      rowCount = 0;
     DRRecordType type;
     int64_t      uniqueId;
@@ -508,7 +509,7 @@ int64_t BinaryLogSink::applyTxn(ReferenceSerializeInputLE *taskInfo,
     DRTxnPartitionHashFlag hashFlag = static_cast<DRTxnPartitionHashFlag>(taskInfo->readByte());
     taskInfo->readInt();  // txnLength
     partitionHash = taskInfo->readInt();
-    bool isLocalMpTxn = UniqueId::isMpUniqueId(uniqueId);
+    bool isLocalMpTxn = UniqueId::isMpUniqueId(localUniqueId);
     bool isLocalRegularMpTxn = isLocalMpTxn && (hashFlag==TXN_PAR_HASH_SINGLE || hashFlag==TXN_PAR_HASH_MULTI);
     // Read the whole txn since there is only one version number at the beginning
     type = static_cast<DRRecordType>(taskInfo->readByte());

--- a/src/ee/storage/BinaryLogSink.h
+++ b/src/ee/storage/BinaryLogSink.h
@@ -38,7 +38,8 @@ public:
     int64_t applyTxn(ReferenceSerializeInputLE *taskInfo,
                      boost::unordered_map<int64_t, PersistentTable*> &tables,
                      Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
-                     const char *txnStart);
+                     const char *txnStart,
+                     int64_t localUniqueId);
 
 private:
     int64_t apply(ReferenceSerializeInputLE *taskInfo, const DRRecordType type,

--- a/src/ee/storage/BinaryLogSinkWrapper.cpp
+++ b/src/ee/storage/BinaryLogSinkWrapper.cpp
@@ -24,7 +24,7 @@ using namespace std;
 using namespace voltdb;
 
 int64_t BinaryLogSinkWrapper::apply(const char* taskParams, boost::unordered_map<int64_t, PersistentTable*> &tables,
-                                    Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId)
+                                    Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId)
 {
     ReferenceSerializeInputLE taskInfo(taskParams + 4, ntohl(*reinterpret_cast<const int32_t*>(taskParams)));
 
@@ -38,7 +38,7 @@ int64_t BinaryLogSinkWrapper::apply(const char* taskParams, boost::unordered_map
         const uint8_t drVersion = taskInfo.readByte();
         if (drVersion >= DRTupleStream::COMPATIBLE_PROTOCOL_VERSION) {
             rowCount += m_sink.applyTxn(&taskInfo, tables, pool, engine, remoteClusterId,
-                                        recordStart);
+                                        recordStart, localUniqueId);
         } else {
             throwFatalException("Unsupported DR version %d", drVersion);
         }

--- a/src/ee/storage/BinaryLogSinkWrapper.h
+++ b/src/ee/storage/BinaryLogSinkWrapper.h
@@ -36,7 +36,7 @@ public:
     BinaryLogSinkWrapper() {}
 
     int64_t apply(const char* taskParams, boost::unordered_map<int64_t, PersistentTable*> &tables,
-                  Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId);
+                  Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId);
 private:
     BinaryLogSink m_sink;
 };

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -461,11 +461,12 @@ public:
     void flushAndApply(int64_t lastCommittedSpHandle, bool success = true) {
         ASSERT_TRUE(flush(lastCommittedSpHandle));
 
+        int64_t uniqueId = addPartitionId(m_spHandleReplica);
         beginTxn(m_engineReplica,
-                 addPartitionId(m_spHandleReplica), // txnid
-                 addPartitionId(m_spHandleReplica), // sphandle
+                 uniqueId, // txnid
+                 uniqueId, // sphandle
                  addPartitionId(m_spHandleReplica - 1), // last sphandle
-                 addPartitionId(m_spHandleReplica)); // fake uniqueid
+                 uniqueId); // fake uniqueid
         m_spHandleReplica++;
 
         boost::unordered_map<int64_t, PersistentTable*> tables;
@@ -478,7 +479,7 @@ public:
             m_drStream.m_enabled = false;
             m_drReplicatedStream.m_enabled = false;
             DRStreamData data = getDRStreamData();
-            m_sinkWrapper.apply(&data.first[data.second], tables, &m_pool, m_engineReplica, 1);
+            m_sinkWrapper.apply(&data.first[data.second], tables, &m_pool, m_engineReplica, 1, uniqueId);
             m_drStream.m_enabled = true;
             m_drReplicatedStream.m_enabled = true;
         }

--- a/tests/ee/storage/table_and_indexes_test.cpp
+++ b/tests/ee/storage/table_and_indexes_test.cpp
@@ -442,7 +442,7 @@ TEST_F(TableAndIndexTest, DrTest) {
     *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
     drStream.m_enabled = false;
     districtTable->setDR(false);
-    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1);
+    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(70));
     drStream.m_enabled = true;
     districtTable->setDR(true);
 
@@ -485,7 +485,7 @@ TEST_F(TableAndIndexTest, DrTest) {
     *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
     drStream.m_enabled = false;
     districtTable->setDR(false);
-    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1);
+    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(72));
     drStream.m_enabled = true;
     districtTable->setDR(true);
 
@@ -521,7 +521,7 @@ TEST_F(TableAndIndexTest, DrTest) {
     *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
     drStream.m_enabled = false;
     districtTable->setDR(false);
-    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1);
+    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(89));
     drStream.m_enabled = true;
     districtTable->setDR(true);
 
@@ -586,7 +586,7 @@ TEST_F(TableAndIndexTest, DrTestNoPK) {
     *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
     drStream.m_enabled = false;
     districtTable->setDR(false);
-    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1);
+    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(70));
     drStream.m_enabled = true;
     districtTable->setDR(true);
 
@@ -625,7 +625,7 @@ TEST_F(TableAndIndexTest, DrTestNoPK) {
     *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
     drStream.m_enabled = false;
     districtTable->setDR(false);
-    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1);
+    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(72));
     drStream.m_enabled = true;
     districtTable->setDR(true);
 
@@ -705,7 +705,7 @@ TEST_F(TableAndIndexTest, DrTestNoPKUninlinedColumn) {
     *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
     drStream.m_enabled = false;
     customerTable->setDR(false);
-    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1);
+    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(70));
     drStream.m_enabled = true;
     customerTable->setDR(true);
 
@@ -744,7 +744,7 @@ TEST_F(TableAndIndexTest, DrTestNoPKUninlinedColumn) {
     *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
     drStream.m_enabled = false;
     customerTable->setDR(false);
-    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1);
+    sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(72));
     drStream.m_enabled = true;
     customerTable->setDR(true);
 


### PR DESCRIPTION
We were using remote uniqueId to check if local txn was MP or not.
Fixed to use local unique id.