### PR TITLE
Fix tests failing with NEW_CLI=false and doing community recover.

### DIFF
--- a/tests/frontend/org/voltdb/TestDeleteInExportRecoverWithView.java
+++ b/tests/frontend/org/voltdb/TestDeleteInExportRecoverWithView.java
@@ -102,9 +102,9 @@ public class TestDeleteInExportRecoverWithView extends JUnit4LocalClusterTest {
         assertEquals(ClientResponse.SUCCESS, response.getStatus());
         assertEquals(response.getResults()[0].asScalarLong(), 4999);
         Thread.sleep(500);
+        db.overrideStartCommandVerb("recover");
         if (MiscUtils.isPro()) {
             db.shutDown();
-            db.overrideStartCommandVerb("recover");
         } else {
             client.close();
             db.shutdownSave(adminClient);

--- a/tests/frontend/org/voltdb/TestExportRecoverWithView.java
+++ b/tests/frontend/org/voltdb/TestExportRecoverWithView.java
@@ -101,9 +101,9 @@ public class TestExportRecoverWithView extends JUnit4LocalClusterTest {
         assertEquals(ClientResponse.SUCCESS, response.getStatus());
         assertEquals(response.getResults()[0].asScalarLong(), 5000);
         Thread.sleep(500);
+        db.overrideStartCommandVerb("recover");
         if (MiscUtils.isPro()) {
             db.shutDown();
-            db.overrideStartCommandVerb("recover");
         } else {
             client.close();
             db.shutdownSave(adminClient);

--- a/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExportRecover.java
+++ b/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExportRecover.java
@@ -239,9 +239,9 @@ public class TestExportSuiteReplicatedSocketExportRecover extends TestExportBase
         waitForStreamedAllocatedMemoryZero(client);
         exportVerify(true, 1000);
         client.close();
+        config.overrideStartCommandVerb("recover");
         if (MiscUtils.isPro()) {
             config.shutDown();
-            config.overrideStartCommandVerb("recover");
         } else {
             config.shutdownSave(adminClient);
             config.waitForNodesToShutdown();

--- a/tests/frontend/org/voltdb/TestUpdateInExportRecoverWithView.java
+++ b/tests/frontend/org/voltdb/TestUpdateInExportRecoverWithView.java
@@ -101,9 +101,9 @@ public class TestUpdateInExportRecoverWithView extends JUnit4LocalClusterTest {
         assertEquals(ClientResponse.SUCCESS, response.getStatus());
         assertEquals(response.getResults()[0].asScalarLong(), 10);
         Thread.sleep(500);
+        db.overrideStartCommandVerb("recover");
         if (MiscUtils.isPro()) {
             db.shutDown();
-            db.overrideStartCommandVerb("recover");
         } else {
             client.close();
             db.shutdownSave(adminClient);

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -180,7 +180,8 @@ public class LocalCluster extends VoltServerConfig {
     // with the port numbers and command line parameter value specific to that
     // instance.
     private final CommandLine templateCmdLine = new CommandLine(StartAction.CREATE);
-    private boolean isNewCli = Boolean.valueOf(System.getenv("NEW_CLI") == null ? "true" : System.getenv("NEW_CLI"));
+    //NEW_CLI can be picked up from env var or -D to JVM.
+    private boolean isNewCli = Boolean.valueOf(System.getenv("NEW_CLI") == null ? Boolean.toString(Boolean.getBoolean("NEW_CLI")) : System.getenv("NEW_CLI"));
     public boolean isNewCli() { return isNewCli; };
     public void setNewCli(boolean flag) {
         isNewCli = flag;


### PR DESCRIPTION
When NEW_CLI=false tests doing shutdownSave are not starting with recover and thus failing.