### PR TITLE
ENG-13257: add available_hosts param to doStatus call

### DIFF
--- a/lib/python/voltcli/voltadmin.d/status.py
+++ b/lib/python/voltcli/voltadmin.d/status.py
@@ -40,8 +40,8 @@ RELEASE_MINOR_VERSION = 2
 )
 
 def status(runner):
+    available_hosts = []
     if runner.opts.continuous:
-        available_hosts = []
         try:
             while True:
                 # clear screen first
@@ -52,7 +52,7 @@ def status(runner):
         except KeyboardInterrupt, e:
             pass # don't care
     else:
-        doStatus(runner)
+        doStatus(runner, available_hosts)
 
 def doStatus(runner, available_hosts):
     # the cluster(host) which voltadmin is running on always comes first


### PR DESCRIPTION
This corrects an issue introduced in v7.7 where "voltadmin status" would throw an error, but it worked correctly with -c or --continuous parameter.

I tested it manually and I no longer get the error, I get the status. I created a separate ticket for new tests to be created for voltadmin status, which will likely be for a later release.