### PR TITLE
Eng 13210. Rename community build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -717,19 +717,19 @@ DISTRIBUTION
     <!-- create an archive for distribution -->
     <exec executable="mv" failonerror="true">
         <arg value="${raw.dist.dir}/dist"/>
-        <arg value="${raw.dist.dir}/voltdb-${dist.version}"/>
+        <arg value="${raw.dist.dir}/voltdb-community-${dist.version}"/>
     </exec>
     <exec executable="tar" failonerror="true">
         <arg value="-cz"/>
         <arg value="-C"/>
         <arg value="${raw.dist.dir}"/>
         <arg value="-f"/>
-        <arg value="${raw.dist.dir}/voltdb-${dist.version}.tar.gz"/>
-        <arg value="voltdb-${dist.version}"/>
+        <arg value="${raw.dist.dir}/voltdb-community-${dist.version}.tar.gz"/>
+        <arg value="voltdb-community-${dist.version}"/>
     </exec>
     <!-- move it back to dist directory for downstream dependencies -->
     <exec executable="mv" failonerror="true">
-        <arg value="${raw.dist.dir}/voltdb-${dist.version}"/>
+        <arg value="${raw.dist.dir}/voltdb-community-${dist.version}"/>
         <arg value="${raw.dist.dir}/dist"/>
     </exec>
 

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -169,8 +169,8 @@ def copyFilesToReleaseDir(releaseDir, version, type=None):
         "%s/voltdb%s-%s.SHA256SUM" % (releaseDir, typeString, version))
 
 def copyCommunityFilesToReleaseDir(releaseDir, version, operatingsys):
-    get("%s/voltdb/obj/release/voltdb-%s.tar.gz" % (builddir, version),
-        "%s/voltdb-%s.tar.gz" % (releaseDir, version))
+    get("%s/voltdb/obj/release/voltdb-community-%s.tar.gz" % (builddir, version),
+        "%s/voltdb-community-%s.tar.gz" % (releaseDir, version))
 
     # add stripped symbols
     if operatingsys == "LINUX":

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -244,8 +244,8 @@ parser.add_argument('--nomac', action='store_true', help="Don't build Mac OSX")
 parser.add_argument('--nocommunity', action='store_true', help="Don't build community")
 args = parser.parse_args()
 
-proTreeish = args.voltdb_sha
-voltdbTreeish = args.pro_sha
+proTreeish = args.pro_sha
+voltdbTreeish = args.voltdb_sha
 rbmqExportTreeish = args.rabbitmq_sha
 
 print args

--- a/tools/kit_tools/upload_kits.py
+++ b/tools/kit_tools/upload_kits.py
@@ -48,7 +48,7 @@ def upload_kits(version,
 
     dry_run = str_option_to_bool(dry_run)
     ent_kits = ["voltdb-ent-%s.tar.gz","voltdb-ent-%s.SHA256SUM","LINUX-voltdb-ent-%s.tar.gz","MAC-voltdb-ent-%s.tar.gz"]
-    all_kits = ent_kits + ["voltdb-pro-%s.tar.gz","voltdb-pro-%s.SHA256SUM", "voltdb-%s.tar.gz"]
+    all_kits = ent_kits + ["voltdb-pro-%s.tar.gz","voltdb-pro-%s.SHA256SUM", "voltdb-%s.tar.gz", "voltdb-community-%s.tar.gz]
     kits_home = kit_dir + "/voltdb-" + version
     count=0
 


### PR DESCRIPTION
Community kit will now be voltdb-community-x.ytar.gz and will unpack to a directory of the same name.  I also fixed an arg-parsing bug in build_kits.py.