### PR TITLE
ENG-13201:

### DIFF
--- a/src/ee/storage/AbstractDRTupleStream.cpp
+++ b/src/ee/storage/AbstractDRTupleStream.cpp
@@ -23,7 +23,7 @@ using namespace std;
 using namespace voltdb;
 
 AbstractDRTupleStream::AbstractDRTupleStream(int partitionId, size_t defaultBufferSize, uint8_t drProtocolVersion)
-        : TupleStreamBase(defaultBufferSize, MAGIC_DR_TRANSACTION_PADDING),
+        : TupleStreamBase(defaultBufferSize, MAGIC_DR_TRANSACTION_PADDING, SECONDARY_BUFFER_SIZE),
           m_enabled(true),
           m_guarded(false),
           m_openSequenceNumber(-1),

--- a/src/ee/storage/TupleStreamBase.cpp
+++ b/src/ee/storage/TupleStreamBase.cpp
@@ -58,7 +58,7 @@ TupleStreamBase::TupleStreamBase(size_t defaultBufferSize, size_t extraHeaderSpa
 }
 
 void
-TupleStreamBase::setDefaultCapacity(size_t capacity)
+TupleStreamBase::setDefaultCapacityForTest(size_t capacity)
 {
     assert (capacity > 0);
     if (m_uso != 0 || m_openSpHandle != 0 ||

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -59,7 +59,7 @@ public:
      * This allows testcases to use significantly smaller buffers
      * to test buffer rollover.
      */
-    void setDefaultCapacity(size_t capacity);
+    void setDefaultCapacityForTest(size_t capacity);
     virtual void setSecondaryCapacity(size_t capacity) {}
 
     virtual void pushExportBuffer(StreamBlock *block, bool sync, bool endOfStream) = 0;

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -41,7 +41,7 @@ const int EL_BUFFER_SIZE = /* 1024; */ (2 * 1024 * 1024) + MAGIC_HEADER_SPACE_FO
 class TupleStreamBase {
 public:
 
-    TupleStreamBase(size_t defaultBufferSizes, size_t extraHeaderSpace = 0);
+    TupleStreamBase(size_t defaultBufferSize, size_t extraHeaderSpace = 0, int maxBufferSize = -1);
 
     virtual ~TupleStreamBase()
     {
@@ -90,6 +90,9 @@ public:
 
     /** size of buffer requested from the top-end */
     size_t m_defaultCapacity;
+
+    /** max allowed buffer capacity */
+    size_t m_maxCapacity;
 
     /** Universal stream offset. Total bytes appended to this stream. */
     size_t m_uso;

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -70,7 +70,7 @@ StreamedTable::createForTest(size_t wrapperBufSize, ExecutorContext *ctx,
     TupleSchema *schema, std::vector<std::string> & columnNames) {
     StreamedTable * st = new StreamedTable(true);
     st->initializeWithColumns(schema, columnNames, false, wrapperBufSize);
-    st->m_wrapper->setDefaultCapacity(wrapperBufSize);
+    st->m_wrapper->setDefaultCapacityForTest(wrapperBufSize);
     return st;
 }
 

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -184,7 +184,7 @@ public:
         m_engine(new MockVoltDBEngine(CLUSTER_ID, &m_topend, &m_pool, &m_drStream, &m_drReplicatedStream)),
         m_engineReplica(new MockVoltDBEngine(CLUSTER_ID_REPLICA, &m_topend, &m_pool, &m_drStreamReplica, &m_drReplicatedStreamReplica))
     {
-        m_drStream.setDefaultCapacity(BUFFER_SIZE);
+        m_drStream.setDefaultCapacityForTest(BUFFER_SIZE);
         m_drStream.setSecondaryCapacity(LARGE_BUFFER_SIZE);
 
         m_drStream.setLastCommittedSequenceNumber(0);

--- a/tests/ee/storage/DRTupleStream_test.cpp
+++ b/tests/ee/storage/DRTupleStream_test.cpp
@@ -124,7 +124,8 @@ public:
         m_tuple->move(m_tupleMemory);
 
         m_largeTuple = new TableTuple(m_largeSchema);
-        m_largeTuple->move(new char[m_largeTuple->tupleLength()]);
+        m_largeTupleMemory = new char[m_largeTuple->tupleLength()];
+        m_largeTuple->move(m_largeTupleMemory);
     }
 
     size_t appendTuple(int64_t lastCommittedSpHandle, int64_t currentSpHandle, DRRecordType type = DR_RECORD_INSERT)
@@ -158,6 +159,7 @@ public:
     virtual ~DRTupleStreamTest() {
         delete m_tuple;
         delete m_largeTuple;
+        if (m_largeTupleMemory) delete [] m_largeTupleMemory;
         if (m_schema)
             TupleSchema::freeTupleSchema(m_schema);
         if (m_largeSchema)
@@ -169,6 +171,7 @@ protected:
     TupleSchema* m_schema;
     TupleSchema* m_largeSchema;
     char m_tupleMemory[(COLUMN_COUNT + 1) * 8];
+    char* m_largeTupleMemory = NULL;
     TableTuple* m_tuple;
     TableTuple* m_largeTuple;
     DummyTopend m_topend;

--- a/tests/ee/storage/DRTupleStream_test.cpp
+++ b/tests/ee/storage/DRTupleStream_test.cpp
@@ -110,7 +110,7 @@ public:
                                          largeColumnAllowNull);
 
         // excercise a smaller buffer capacity
-        m_wrapper.setDefaultCapacity(BUFFER_SIZE + MAGIC_HEADER_SPACE_FOR_JAVA + MAGIC_DR_TRANSACTION_PADDING);
+        m_wrapper.setDefaultCapacityForTest(BUFFER_SIZE + MAGIC_HEADER_SPACE_FOR_JAVA + MAGIC_DR_TRANSACTION_PADDING);
         m_wrapper.setSecondaryCapacity(LARGE_BUFFER_SIZE + MAGIC_HEADER_SPACE_FOR_JAVA + MAGIC_DR_TRANSACTION_PADDING);
 
         // set up the tuple we're going to use to fill the buffer
@@ -516,6 +516,8 @@ TEST_F(DRTupleStreamTest, TupleLargerThanDefaultSize)
     m_wrapper.endTransaction(addPartitionId(1));
     m_wrapper.periodicFlush(-1, addPartitionId(1));
     ASSERT_TRUE(m_topend.receivedDRBuffer);
+    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
+    ASSERT_TRUE(BUFFER_SIZE < results->offset() && LARGE_BUFFER_SIZE >= results->offset());
 }
 
 /**

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -81,7 +81,7 @@ public:
         m_wrapper = new ExportTupleStream(1, 1);
 
         // excercise a smaller buffer capacity
-        m_wrapper->setDefaultCapacity(BUFFER_SIZE);
+        m_wrapper->setDefaultCapacityForTest(BUFFER_SIZE);
 
         // set up the tuple we're going to use to fill the buffer
         // set the tuple's memory to zero


### PR DESCRIPTION
Now allows a single extendBufferChain for defaultSize < minLength <= maxSize.

DR should allow changes where a single tuple size exceeds the default size but is less than the max size. Before this change, extendBufferChain in TupleStreamBase checked if the requested extension is greater than the default size and failed if it was, which is incorrect behavior for DR. This PR changes TupleStreamBase to support maxSize also and changed extendBufferChain accordingly.