### PR TITLE
Fix ENG-13271-check-as-begin-syntax

### DIFF
--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -925,9 +925,9 @@ public class DDLCompiler {
     private static int kStateReadingEndCodeBlockNextDelim = 11;   // dealing with ending code block delimiter ###
 
     // To indicate if inside multi statement procedure
-    private static boolean inBegin = false;
+    private static boolean inAsBegin = false;
     // To indicate if inside CASE .. WHEN .. END
-    private static int inCase = 0;
+    private static int inCaseWhen = 0;
     // BEGIN should follow AS for create procedure
     // added this case since 'begin' can be table or column name
     private static boolean checkForNextBegin = false;
@@ -937,35 +937,34 @@ public class DDLCompiler {
 
     private static int readingState(char[] nchar, DDLStatement retval) {
 
-        if (!Character.isLetterOrDigit(nchar[0])) {
+        if ( ! Character.isUnicodeIdentifierPart(nchar[0])) {
             char prev = prevChar(retval.statement);
-            /* since we only have access to the current character and the characters we have seen so far,
-             * we can check for the token only after its completed and then look if it matches the required token
-             */
+            /* Since we only have access to the current character and the characters we have seen so far,
+             * we can check for the token only after its completed and then look if it matches the required token. */
             if (checkForNextBegin) {
                 if (prev == 'n' || prev == 'N') {
-                    if( checkForNextBegin && SQLLexer.matchToken(retval.statement, retval.statement.length() - 5, "begin") ) {
-                        inBegin = true;
+                    if (SQLLexer.matchToken(retval.statement, retval.statement.length() - 5, "begin") ) {
+                        inAsBegin = true;
                     }
                 }
                 checkForNextBegin = false;
             }
             if (prev == 'd' || prev == 'D') {
-                if( SQLLexer.matchToken(retval.statement, retval.statement.length() - 3, "end") ) {
-                    if (inCase > 0) {
-                        inCase--;
+                if (SQLLexer.matchToken(retval.statement, retval.statement.length() - 3, "end") ) {
+                    if (inCaseWhen > 0) {
+                        inCaseWhen--;
                     } else {
                         // we can terminate BEGIN ... END for multi stmt proc
                         // after all CASE ... END stmts are completed
-                        inBegin = false;
+                        inAsBegin = false;
                     }
                 }
             } else if (prev == 'e' || prev == 'E') {
-                if( SQLLexer.matchToken(retval.statement, retval.statement.length() - 4, "case") ) {
-                    inCase++;
+                if (SQLLexer.matchToken(retval.statement, retval.statement.length() - 4, "case") ) {
+                    inCaseWhen++;
                 }
             } else if (prev == 's' || prev == 'S') {
-                if( SQLLexer.matchToken(retval.statement, retval.statement.length() - 2, "as") ) {
+                if (SQLLexer.matchToken(retval.statement, retval.statement.length() - 2, "as") ) {
                     checkForNextBegin = true;
                 }
             }
@@ -986,7 +985,7 @@ public class DDLCompiler {
             // end of the statement
             retval.statement += nchar[0];
             // statement completed only if outside of begin..end
-            if(!inBegin)
+            if(!inAsBegin)
                 return kStateCompleteStatement;
         }
         else if (nchar[0] == '\'') {
@@ -1175,8 +1174,8 @@ public class DDLCompiler {
             // Set the line number to the start of the real statement.
             retval.lineNo = currLineNo;
             retval.endLineNo = currLineNo;
-            inBegin = false;
-            inCase = 0;
+            inAsBegin = false;
+            inCaseWhen = 0;
             checkForNextBegin = false;
 
             while (state != kStateCompleteStatement) {

--- a/src/frontend/org/voltdb/parser/SQLLexer.java
+++ b/src/frontend/org/voltdb/parser/SQLLexer.java
@@ -310,7 +310,7 @@ public class SQLLexer extends SQLPatternFactory
         final char firstUp = Character.toUpperCase(token.charAt(0));
 
         if(     // character before token is non alphanumeric i.e., token is not embedded in an identifier
-                (position == 0 || !Character.isLetterOrDigit(buffer.charAt(position-1)))
+                (position == 0 || ! isIdentifierPartFast(buffer.charAt(position-1)))
                 // perform a region match only if the first character matches
                 && (buffer.charAt(position) == firstLo || buffer.charAt(position) == firstUp)
                 // match only if the length of the remaining string is the atleast the length of the token
@@ -318,7 +318,7 @@ public class SQLLexer extends SQLPatternFactory
                 // search for token
                 && buffer.regionMatches(true, position, token, 0, tokLength)
                 // character after token is non alphanumeric i.e., token is not embedded in an identifier
-                && (position + tokLength == bufLength || !Character.isLetterOrDigit(buffer.charAt(position + tokLength)))
+                && (position + tokLength == bufLength || ! isIdentifierPartFast(buffer.charAt(position + tokLength)))
                 )
             return true;
         else
@@ -335,8 +335,8 @@ public class SQLLexer extends SQLPatternFactory
         return (c >= 48 && c <= 57);
     }
 
-    private static boolean isLetterOrDigitFast(char c) {
-        return isDigitFast(c) || isLetterFast(c);
+    private static boolean isIdentifierPartFast(char c) {
+        return isDigitFast(c) || isLetterFast(c) || c == '_';
     }
 
     // Converts a standard ASCII letter to lowercase
@@ -358,7 +358,7 @@ public class SQLLexer extends SQLPatternFactory
      * @return true if the token is found, and false otherwise
      */
     private static boolean matchTokenFast(char[] buffer, int position, String lowercaseToken) {
-        if (position != 0 && isLetterOrDigitFast(buffer[position - 1])) {
+        if (position != 0 && isIdentifierPartFast(buffer[position - 1])) {
             // character at position is preceded by a letter or digit
             return false;
         }
@@ -369,7 +369,7 @@ public class SQLLexer extends SQLPatternFactory
             return false;
         }
 
-        if (position + tokenLength < buffer.length && isLetterOrDigitFast(buffer[position + tokenLength])) {
+        if (position + tokenLength < buffer.length && isIdentifierPartFast(buffer[position + tokenLength])) {
             // Character after where token would be is a letter
             return false;
         }

--- a/src/frontend/org/voltdb/parser/SQLLexer.java
+++ b/src/frontend/org/voltdb/parser/SQLLexer.java
@@ -309,7 +309,7 @@ public class SQLLexer extends SQLPatternFactory
         final char firstLo = Character.toLowerCase(token.charAt(0));
         final char firstUp = Character.toUpperCase(token.charAt(0));
 
-        if(     // character before token is non alphanumeric i.e., token is not embedded in an identifier
+        if (    // character before token is non alphanumeric i.e., token is not embedded in an identifier
                 (position == 0 || ! isIdentifierPartFast(buffer.charAt(position-1)))
                 // perform a region match only if the first character matches
                 && (buffer.charAt(position) == firstLo || buffer.charAt(position) == firstUp)

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -829,9 +829,6 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
         // Parse the expression.  We may substitute for this later
         // on, but it's a place to start.
         AbstractExpression colExpr = parseExpressionTree(child);
-        if (colExpr instanceof ConstantValueExpression) {
-            assert(colExpr.getValueType() != VoltType.NUMERIC);
-        }
         assert(colExpr != null);
 
         if (isDistributed) {
@@ -839,6 +836,9 @@ public class ParsedSelectStmt extends AbstractParsedStmt {
             updateAvgExpressions();
         }
         ExpressionUtil.finalizeValueTypes(colExpr);
+        if (colExpr instanceof ConstantValueExpression) {
+            assert(colExpr.getValueType() != VoltType.NUMERIC);
+        }
 
         if (colExpr.getValueType() == VoltType.BOOLEAN) {
             throw new PlanningErrorException(

--- a/tests/frontend/org/voltdb/TestAdhocCreateStatementProc.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateStatementProc.java
@@ -43,6 +43,8 @@ public class TestAdhocCreateStatementProc extends AdhocDDLTestBase {
                 "CREATE TABLE T (\n" +
                 "   COLUMN_CASE tinyint,\n" +
                 "   CASE_COLUMN tinyint\n" +
+                "   AS_BEGIN tinyint\n" +
+                "   END_COLUMN tinyint\n" +
                 ");\n" +
                 "CREATE PROCEDURE PROC1\n" +
                 "AS BEGIN\n" +

--- a/tests/frontend/org/voltdb/TestAdhocCreateStatementProc.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateStatementProc.java
@@ -36,6 +36,28 @@ import org.voltdb.utils.MiscUtils;
 public class TestAdhocCreateStatementProc extends AdhocDDLTestBase {
 
     @Test
+    public void testENG13271() throws Exception {
+        String pathToCatalog = Configuration.getPathToCatalogForTest("adhocddl.jar");
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        builder.addLiteralSchema(
+            "CREATE TABLE T (\n" +
+            "   COLUMN_CASE tinyint\n" +
+            ");\n" +
+            "CREATE PROCEDURE PROC1\n" +
+            "AS BEGIN\n" +
+            "   INSERT INTO T (COLUMN_CASE) VALUES (?);\n" +
+            "END;\n" +
+            "CREATE PROCEDURE PROC2\n" +
+            "AS BEGIN\n" +
+            "   SELECT * FROM T;\n" +
+            "END;\n"
+            );
+        builder.setUseDDLSchema(true);
+        boolean success = builder.compile(pathToCatalog, 2, 1, 0);
+        assertTrue("Schema compilation failed", success);
+    }
+
+    @Test
     public void testBasicCreateStatementProc() throws Exception
     {
         String pathToCatalog = Configuration.getPathToCatalogForTest("adhocddl.jar");

--- a/tests/frontend/org/voltdb/TestAdhocCreateStatementProc.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateStatementProc.java
@@ -42,8 +42,8 @@ public class TestAdhocCreateStatementProc extends AdhocDDLTestBase {
         builder.addLiteralSchema(
                 "CREATE TABLE T (\n" +
                 "   COLUMN_CASE tinyint,\n" +
-                "   CASE_COLUMN tinyint\n" +
-                "   AS_BEGIN tinyint\n" +
+                "   CASE_COLUMN tinyint,\n" +
+                "   AS_BEGIN tinyint,\n" +
                 "   END_COLUMN tinyint\n" +
                 ");\n" +
                 "CREATE PROCEDURE PROC1\n" +

--- a/tests/frontend/org/voltdb/TestAdhocCreateStatementProc.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateStatementProc.java
@@ -40,17 +40,19 @@ public class TestAdhocCreateStatementProc extends AdhocDDLTestBase {
         String pathToCatalog = Configuration.getPathToCatalogForTest("adhocddl.jar");
         VoltProjectBuilder builder = new VoltProjectBuilder();
         builder.addLiteralSchema(
-            "CREATE TABLE T (\n" +
-            "   COLUMN_CASE tinyint\n" +
-            ");\n" +
-            "CREATE PROCEDURE PROC1\n" +
-            "AS BEGIN\n" +
-            "   INSERT INTO T (COLUMN_CASE) VALUES (?);\n" +
-            "END;\n" +
-            "CREATE PROCEDURE PROC2\n" +
-            "AS BEGIN\n" +
-            "   SELECT * FROM T;\n" +
-            "END;\n"
+                "CREATE TABLE T (\n" +
+                "   COLUMN_CASE tinyint,\n" +
+                "   CASE_COLUMN tinyint\n" +
+                ");\n" +
+                "CREATE PROCEDURE PROC1\n" +
+                "AS BEGIN\n" +
+                "   INSERT INTO T (COLUMN_CASE) VALUES (?);\n" +
+                "   INSERT INTO T (CASE_COLUMN) VALUES (?);\n" +
+                "END;\n" +
+                "CREATE PROCEDURE PROC2\n" +
+                "AS BEGIN\n" +
+                "   SELECT * FROM T;\n" +
+                "END;\n"
             );
         builder.setUseDDLSchema(true);
         boolean success = builder.compile(pathToCatalog, 2, 1, 0);


### PR DESCRIPTION
When splitting statements, we checked for keywords like "as", "begin", "case", "end" because they could change our semantics for a semicolon that we usually use to determine the end of a statement.

We used `Character.isLetterOrDigit` and `isLetterOrDigitFast` to check whether the token we checked was indeed a standalone token or a part of another token. But those two functions will return wrong answers when the tokens have "_" before or after them.

This pull request updates the functions we use so we can give right answers when underscores are presented.