### PR TITLE
ENG-12827 No Replicated Stream

### DIFF
--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -548,7 +548,7 @@ enum DRTxnPartitionHashFlag {
 // Masks for DR records type and DR transaction partition hash flag
 // ------------------------------------------------------------------
 // Keep sync with Java REPLICATED_TABLE_MASK at PartitionDRGateway.java
-// This mask uses -128 which corresponds to 0b10000000
+// This mask uses -128 which corresponds to 0x80
 // The first bit is set with this mask to indicate that subsequent records are for replicated tables
 static const int8_t REPLICATED_TABLE_MASK = INT8_MIN;
 

--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -544,6 +544,14 @@ enum DRTxnPartitionHashFlag {
     TXN_PAR_HASH_SPECIAL = 4      // txn contains TRUNCATE_TABLE record(s)
 };
 
+// ------------------------------------------------------------------
+// Masks for DR records type and DR transaction partition hash flag
+// ------------------------------------------------------------------
+// Keep sync with Java REPLICATED_TABLE_MASK at PartitionDRGateway.java
+// This mask uses -128 which corresponds to 0b10000000
+// The first bit is set with this mask to indicate that subsequent records are for replicated tables
+static const int8_t REPLICATED_TABLE_MASK = INT8_MIN;
+
 inline size_t rowCostForDRRecord(DRRecordType type) {
     // Warning: Currently, the PersistentTableUndo*Actions rely on
     // DR_RECORD_{0}_BY_INDEX costing the same as DR_RECORD_{0}

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -498,6 +498,8 @@ int64_t BinaryLogSink::applyTxn(ReferenceSerializeInputLE *taskInfo,
     int64_t      uniqueId;
     int64_t      sequenceNumber;
     int32_t      partitionHash;
+    bool         isCurrentTxnForReplicatedTable;
+    bool         isCurrentRecordForReplicatedTable;
     bool         isForLocalPartition;
     bool         skipWrongHashRows;
 
@@ -506,41 +508,51 @@ int64_t BinaryLogSink::applyTxn(ReferenceSerializeInputLE *taskInfo,
     uniqueId = taskInfo->readLong();
     sequenceNumber = taskInfo->readLong();
 
-    DRTxnPartitionHashFlag hashFlag = static_cast<DRTxnPartitionHashFlag>(taskInfo->readByte());
+    int8_t rawHashFlag = taskInfo->readByte();
+    isCurrentRecordForReplicatedTable = rawHashFlag & DRTupleStream::REPLICATED_TABLE_MASK;
+    DRTxnPartitionHashFlag hashFlag = static_cast<DRTxnPartitionHashFlag>(rawHashFlag & ~DRTupleStream::REPLICATED_TABLE_MASK);
+    isCurrentTxnForReplicatedTable = hashFlag == TXN_PAR_HASH_REPLICATED;
     taskInfo->readInt();  // txnLength
     partitionHash = taskInfo->readInt();
     bool isLocalMpTxn = UniqueId::isMpUniqueId(localUniqueId);
-    bool isLocalRegularSpTxn = !isLocalMpTxn && (hashFlag==TXN_PAR_HASH_SINGLE || hashFlag==TXN_PAR_HASH_MULTI);
-    bool isLocalRegularMpTxn = isLocalMpTxn && (hashFlag==TXN_PAR_HASH_SINGLE || hashFlag==TXN_PAR_HASH_MULTI);
+    bool isLocalRegularSpTxn = !isLocalMpTxn && (hashFlag == TXN_PAR_HASH_SINGLE || hashFlag == TXN_PAR_HASH_MULTI);
+    bool isLocalRegularMpTxn = isLocalMpTxn && (hashFlag == TXN_PAR_HASH_SINGLE || hashFlag == TXN_PAR_HASH_MULTI);
     // Read the whole txn since there is only one version number at the beginning
     type = static_cast<DRRecordType>(taskInfo->readByte());
     while (type != DR_RECORD_END_TXN) {
-        isForLocalPartition = engine->isLocalSite(partitionHash);
-        // - Remote MP txns are always executed as local MP txns. Skip hashes that don't match for these.
-        // - Remote single-hash SP txns must throw mispartitioned exception for hashes that don't match.
-        // - Remote SP txns with multihash will be routed as MP txns for mixed size clusters.
-        //   It is OK to skip in this case because they will go
-        //   to all partitions and the records will get applied on the correct partitions.
-        // - Remote SP txns with multihash will be routed as SP txns for same size clusters.
-        //   We should throw mispartitioned for these because for same size, they should
-        //   always map to the same partition on both clusters.
-        // Conclusion: If it is local MP txn, skip. If not, throw mispartitioned.
-        // Replicated (MP txns) and Truncate table txns (could be SP, if runeverywhere) don't have partitionHash value.
-        // So don't throw for those either.
-        if (!isForLocalPartition && isLocalRegularSpTxn) {
-            /** temporary debug stmts **/
-            /*
-            VOLT_ERROR("Throwing mispartitioned from site with partitionId=%d", engine->getPartitionId());
-            VOLT_ERROR("hashFlag=%d, partitionHash=%d, drRecordType=%d", (int) hashFlag, partitionHash, (int) type);
-            */
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED,
-                "Binary log txns were sent to the wrong partition");
+        // fast path for replicated table change, save calls to VoltDBEngine::isLocalSite()
+        if (isCurrentTxnForReplicatedTable || isCurrentRecordForReplicatedTable) {
+            skipWrongHashRows = false;
+        } else {
+            isForLocalPartition = engine->isLocalSite(partitionHash);
+            // - Remote MP txns are always executed as local MP txns. Skip hashes that don't match for these.
+            // - Remote single-hash SP txns must throw mispartitioned exception for hashes that don't match.
+            // - Remote SP txns with multihash will be routed as MP txns for mixed size clusters.
+            //   It is OK to skip in this case because they will go
+            //   to all partitions and the records will get applied on the correct partitions.
+            // - Remote SP txns with multihash will be routed as SP txns for same size clusters.
+            //   We should throw mispartitioned for these because for same size, they should
+            //   always map to the same partition on both clusters.
+            // Conclusion: If it is local MP txn, skip. If not, throw mispartitioned.
+            // Replicated (MP txns) and Truncate table txns (could be SP, if runeverywhere) don't have partitionHash value.
+            // So don't throw for those either.
+            if (!isForLocalPartition && isLocalRegularSpTxn) {
+                /** temporary debug stmts **/
+                /*
+                VOLT_ERROR("Throwing mispartitioned from site with partitionId=%d", engine->getPartitionId());
+                VOLT_ERROR("hashFlag=%d, partitionHash=%d, drRecordType=%d", (int) hashFlag, partitionHash, (int) type);
+                */
+                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED,
+                    "Binary log txns were sent to the wrong partition");
+            }
+            skipWrongHashRows = (!isForLocalPartition && isLocalRegularMpTxn);
         }
-        skipWrongHashRows = (!isForLocalPartition && isLocalRegularMpTxn);
         rowCount += apply(taskInfo, type, tables, pool, engine, remoteClusterId,
                 txnStart, sequenceNumber, uniqueId, skipWrongHashRows);
-        type = static_cast<DRRecordType>(taskInfo->readByte());
+        int8_t rawType = taskInfo->readByte();
+        type = static_cast<DRRecordType>(rawType & ~DRTupleStream::REPLICATED_TABLE_MASK);
         if (type == DR_RECORD_HASH_DELIMITER) {
+            isCurrentRecordForReplicatedTable = rawType & DRTupleStream::REPLICATED_TABLE_MASK;
             partitionHash = taskInfo->readInt();
             type = static_cast<DRRecordType>(taskInfo->readByte());
         }

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -509,8 +509,8 @@ int64_t BinaryLogSink::applyTxn(ReferenceSerializeInputLE *taskInfo,
     sequenceNumber = taskInfo->readLong();
 
     int8_t rawHashFlag = taskInfo->readByte();
-    isCurrentRecordForReplicatedTable = rawHashFlag & DRTupleStream::REPLICATED_TABLE_MASK;
-    DRTxnPartitionHashFlag hashFlag = static_cast<DRTxnPartitionHashFlag>(rawHashFlag & ~DRTupleStream::REPLICATED_TABLE_MASK);
+    isCurrentRecordForReplicatedTable = rawHashFlag & REPLICATED_TABLE_MASK;
+    DRTxnPartitionHashFlag hashFlag = static_cast<DRTxnPartitionHashFlag>(rawHashFlag & ~REPLICATED_TABLE_MASK);
     isCurrentTxnForReplicatedTable = hashFlag == TXN_PAR_HASH_REPLICATED;
     taskInfo->readInt();  // txnLength
     partitionHash = taskInfo->readInt();
@@ -550,9 +550,9 @@ int64_t BinaryLogSink::applyTxn(ReferenceSerializeInputLE *taskInfo,
         rowCount += apply(taskInfo, type, tables, pool, engine, remoteClusterId,
                 txnStart, sequenceNumber, uniqueId, skipWrongHashRows);
         int8_t rawType = taskInfo->readByte();
-        type = static_cast<DRRecordType>(rawType & ~DRTupleStream::REPLICATED_TABLE_MASK);
+        type = static_cast<DRRecordType>(rawType & ~REPLICATED_TABLE_MASK);
         if (type == DR_RECORD_HASH_DELIMITER) {
-            isCurrentRecordForReplicatedTable = rawType & DRTupleStream::REPLICATED_TABLE_MASK;
+            isCurrentRecordForReplicatedTable = rawType & REPLICATED_TABLE_MASK;
             partitionHash = taskInfo->readInt();
             type = static_cast<DRRecordType>(taskInfo->readByte());
         }

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -747,7 +747,11 @@ int32_t DRTupleStream::getTestDRBuffer(uint8_t drProtocolVersion,
                                        long startSequenceNumber,
                                        char *outBytes)
 {
-    DRTupleStream stream(partitionId,
+    int tupleStreamPartitionId = partitionId;
+    if (partitionId == 16383 && drProtocolVersion >= NO_REPLICATED_STREAM_PROTOCOL_VERSION) {
+        tupleStreamPartitionId = 0;
+    }
+    DRTupleStream stream(tupleStreamPartitionId,
                          2 * 1024 * 1024 + MAGIC_HEADER_SPACE_FOR_JAVA + MAGIC_DR_TRANSACTION_PADDING, // 2MB
                          drProtocolVersion);
 

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -48,6 +48,9 @@ DRTupleStream::DRTupleStream(int partitionId, size_t defaultBufferSize, uint8_t 
       m_hashFlag(m_initialHashFlag),
       m_firstParHash(LONG_MAX),
       m_lastParHash(LONG_MAX),
+      m_hasReplicatedStream(drProtocolVersion < NO_REPLICATED_STREAM_PROTOCOL_VERSION),
+      m_wasFirstChangeReplicatedTable(false),
+      m_wasLastChangeReplicatedTable(false),
       m_beginTxnUso(0),
       m_lastCommittedSpUniqueId(0),
       m_lastCommittedMpUniqueId(0)
@@ -97,7 +100,11 @@ size_t DRTupleStream::truncateTable(int64_t lastCommittedSpHandle,
                              m_currBlock->remaining());
 
     if (requireHashDelimiter) {
-        io.writeByte(static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        if (m_wasLastChangeReplicatedTable) {
+            io.writeByte(REPLICATED_TABLE_MASK | static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        } else {
+            io.writeByte(static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        }
         io.writeInt(-1);  // hash delimiter for TRUNCATE_TABLE records is always -1
     }
     io.writeByte(static_cast<int8_t>(DR_RECORD_TRUNCATE_TABLE));
@@ -132,8 +139,19 @@ bool DRTupleStream::updateParHash(bool isReplicatedTable, int64_t parHash)
         // For replicated table changes, the hash flag should stay the same as
         // the initial value, which is TXN_PAR_HASH_REPLICATED, if it's older
         // versions.
-        assert(m_drProtocolVersion >= NO_REPLICATED_STREAM_PROTOCOL_VERSION ||
-               m_hashFlag == m_initialHashFlag);
+        assert(!m_hasReplicatedStream || m_hashFlag == m_initialHashFlag);
+        if (m_hasReplicatedStream) {
+            return false;
+        }
+        if (m_hashFlag == TXN_PAR_HASH_PLACEHOLDER) {
+            m_wasFirstChangeReplicatedTable = true;
+            m_wasLastChangeReplicatedTable = true;
+            return false;
+        }
+        else if (!m_wasLastChangeReplicatedTable) {
+            m_wasLastChangeReplicatedTable = true;
+            return true;
+        }
         return false;
     }
 
@@ -144,6 +162,11 @@ bool DRTupleStream::updateParHash(bool isReplicatedTable, int64_t parHash)
         m_hashFlag = (parHash == LONG_MAX) ? TXN_PAR_HASH_SPECIAL : TXN_PAR_HASH_SINGLE;
         // no delimiter needed for first record
         return false;
+    }
+    else if (m_wasLastChangeReplicatedTable) {
+        m_lastParHash = parHash;
+        m_wasLastChangeReplicatedTable = false;
+        return true;
     }
     else if (parHash != m_lastParHash) {
         m_lastParHash = parHash;
@@ -225,7 +248,11 @@ size_t DRTupleStream::appendTuple(int64_t lastCommittedSpHandle,
                              m_currBlock->remaining());
 
     if (requireHashDelimiter) {
-        io.writeByte(static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        if (m_wasLastChangeReplicatedTable) {
+            io.writeByte(REPLICATED_TABLE_MASK | static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        } else {
+            io.writeByte(static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        }
         io.writeInt(static_cast<int32_t>(m_lastParHash));
     }
 
@@ -303,7 +330,11 @@ size_t DRTupleStream::appendUpdateRecord(int64_t lastCommittedSpHandle,
                                  m_currBlock->remaining());
 
     if (requireHashDelimiter) {
-        io.writeByte(static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        if (m_wasLastChangeReplicatedTable) {
+            io.writeByte(REPLICATED_TABLE_MASK | static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        } else {
+            io.writeByte(static_cast<int8_t>(DR_RECORD_HASH_DELIMITER));
+        }
         io.writeInt(static_cast<int32_t>(m_lastParHash));
     }
 
@@ -555,7 +586,11 @@ void DRTupleStream::endTransaction(int64_t uniqueId)
     ExportSerializeOutput extraio(m_currBlock->mutableDataPtr() - txnLength,
                                   txnLength);
     extraio.position(BEGIN_RECORD_HEADER_SIZE);
-    extraio.writeByte(static_cast<int8_t>(m_hashFlag));
+    if (m_wasFirstChangeReplicatedTable) {
+        extraio.writeByte(REPLICATED_TABLE_MASK | static_cast<int8_t>(m_hashFlag));
+    } else {
+        extraio.writeByte(static_cast<int8_t>(m_hashFlag));
+    }
     extraio.writeInt(txnLength);
     // if it is the replicated stream or first record is TRUNCATE_TABLE
     // m_firstParHash will be LONG_MAX, and will be written as -1 after casting

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -40,11 +40,11 @@ public:
     // Also update DRProducerProtocol.java if version changes
     // whenever PROTOCOL_VERSION changes, check if DRBufferParser needs to be updated,
     // check if unit tests that use MockPartitionQueue and getTestDRBuffer() need to be updated
-    static const uint8_t PROTOCOL_VERSION = 8;
+    static const uint8_t PROTOCOL_VERSION = 9;
     static const uint8_t COMPATIBLE_PROTOCOL_VERSION = 7;
 
     static const uint8_t ELASTICADD_PROTOCOL_VERSION = 8;
-    static const uint8_t NO_REPLICATED_STREAM_PROTOCOL_VERSION = 8;
+    static const uint8_t NO_REPLICATED_STREAM_PROTOCOL_VERSION = 9;
 
     static const int8_t REPLICATED_TABLE_MASK = INT8_MIN;
 

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -46,8 +46,6 @@ public:
     static const uint8_t ELASTICADD_PROTOCOL_VERSION = 8;
     static const uint8_t NO_REPLICATED_STREAM_PROTOCOL_VERSION = 9;
 
-    static const int8_t REPLICATED_TABLE_MASK = INT8_MIN;
-
     DRTupleStream(int partitionId, size_t defaultBufferSize, uint8_t drProtocolVersion=PROTOCOL_VERSION);
 
     virtual ~DRTupleStream() {}

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -40,7 +40,7 @@ public:
     // Also update DRProducerProtocol.java if version changes
     // whenever PROTOCOL_VERSION changes, check if DRBufferParser needs to be updated,
     // check if unit tests that use MockPartitionQueue and getTestDRBuffer() need to be updated
-    static const uint8_t PROTOCOL_VERSION = 9;
+    static const uint8_t PROTOCOL_VERSION = 8;
     static const uint8_t COMPATIBLE_PROTOCOL_VERSION = 7;
 
     static const uint8_t ELASTICADD_PROTOCOL_VERSION = 8;

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -44,7 +44,9 @@ public:
     static const uint8_t COMPATIBLE_PROTOCOL_VERSION = 7;
 
     static const uint8_t ELASTICADD_PROTOCOL_VERSION = 8;
-    static const uint8_t NO_REPLICATED_STREAM_PROTOCOL_VERSION = 9;
+    static const uint8_t NO_REPLICATED_STREAM_PROTOCOL_VERSION = 8;
+
+    static const int8_t REPLICATED_TABLE_MASK = INT8_MIN;
 
     DRTupleStream(int partitionId, size_t defaultBufferSize, uint8_t drProtocolVersion=PROTOCOL_VERSION);
 
@@ -137,6 +139,9 @@ private:
     DRTxnPartitionHashFlag m_hashFlag;
     int64_t m_firstParHash;
     int64_t m_lastParHash;
+    bool m_hasReplicatedStream;
+    bool m_wasFirstChangeReplicatedTable;
+    bool m_wasLastChangeReplicatedTable;
     size_t m_beginTxnUso;
 
     int64_t m_lastCommittedSpUniqueId;

--- a/src/frontend/org/voltdb/PartitionDRGateway.java
+++ b/src/frontend/org/voltdb/PartitionDRGateway.java
@@ -50,6 +50,11 @@ public class PartitionDRGateway implements DurableUniqueIdListener {
         SPECIAL
     }
 
+    // Keep sync with EE REPLICATED_TABLE_MASK at types.h
+    // This mask uses -128 which corresponds to 0b10000000
+    // The first bit is set with this mask to indicate that subsequent records are for replicated tables
+    public static final byte REPLICATED_TABLE_MASK = Byte.MIN_VALUE;
+
     public static enum DRRowType {
         EXISTING_ROW,
         EXPECTED_ROW,

--- a/src/frontend/org/voltdb/PartitionDRGateway.java
+++ b/src/frontend/org/voltdb/PartitionDRGateway.java
@@ -51,7 +51,7 @@ public class PartitionDRGateway implements DurableUniqueIdListener {
     }
 
     // Keep sync with EE REPLICATED_TABLE_MASK at types.h
-    // This mask uses -128 which corresponds to 0b10000000
+    // This mask uses -128 which corresponds to 0x80
     // The first bit is set with this mask to indicate that subsequent records are for replicated tables
     public static final byte REPLICATED_TABLE_MASK = Byte.MIN_VALUE;
 

--- a/src/frontend/org/voltdb/dr2/DRProtocol.java
+++ b/src/frontend/org/voltdb/dr2/DRProtocol.java
@@ -26,7 +26,7 @@ public interface DRProtocol {
     public static final int MIXED_SIZE_PROTOCOL_VERSION = 4;
     public static final int MULTICLUSTER_PROTOCOL_VERSION = 7;
     public static final int ELASTICADD_PROTOCOL_VERSION = 8;
-    public static final int NO_REPLICATED_STREAM_PROTOCOL_VERSION = 9;
+    public static final int NO_REPLICATED_STREAM_PROTOCOL_VERSION = 8;
 
     // all partial MP txns go into SP streams
     public static final int DR_NO_MP_START_PROTOCOL_VERSION = 3;

--- a/src/frontend/org/voltdb/dr2/DRProtocol.java
+++ b/src/frontend/org/voltdb/dr2/DRProtocol.java
@@ -19,7 +19,7 @@ package org.voltdb.dr2;
 
 public interface DRProtocol {
     // Also update DRTupleStream.h if version changes
-    public static final int PROTOCOL_VERSION = 9;
+    public static final int PROTOCOL_VERSION = 8;
     public static final int COMPATIBLE_PROTOCOL_VERSION = 7;
 
     // constant versions that don't change across releases

--- a/src/frontend/org/voltdb/dr2/DRProtocol.java
+++ b/src/frontend/org/voltdb/dr2/DRProtocol.java
@@ -19,14 +19,14 @@ package org.voltdb.dr2;
 
 public interface DRProtocol {
     // Also update DRTupleStream.h if version changes
-    public static final int PROTOCOL_VERSION = 8;
+    public static final int PROTOCOL_VERSION = 9;
     public static final int COMPATIBLE_PROTOCOL_VERSION = 7;
 
     // constant versions that don't change across releases
     public static final int MIXED_SIZE_PROTOCOL_VERSION = 4;
     public static final int MULTICLUSTER_PROTOCOL_VERSION = 7;
     public static final int ELASTICADD_PROTOCOL_VERSION = 8;
-    public static final int NO_REPLICATED_STREAM_PROTOCOL_VERSION = 8;
+    public static final int NO_REPLICATED_STREAM_PROTOCOL_VERSION = 9;
 
     // all partial MP txns go into SP streams
     public static final int DR_NO_MP_START_PROTOCOL_VERSION = 3;


### PR DESCRIPTION
Fix DR binary log generation and handling of replicated table changes in non-16383 stream, the hash flag in BEGIN_TXN and HASH_DELIMITER is ANDed with a mask to indicate the next records are for replicated tables until the next HASH_DELIMITER or the END_TXN.

On the receiving side, also avoid calling isLocalSite() if we know the record is for a replicated table.

Backward compatible with old format where there will be no mask and replicated table changes are replicated in a specialized replicated stream, in that case, the hash flag will be TXN_PAR_HASH_REPLICATED and all the records in the txn will be replicated table change and handled accordingly.