### PR TITLE
Fix error message for ENG-13094

### DIFF
--- a/src/catgen/in/javasrc/CatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/CatalogDiffEngine.java
@@ -1034,6 +1034,10 @@ public class CatalogDiffEngine {
                     }
                 }
                 else {
+                    // ENG-13094 If the data type already changed, we do not throw more errors about the size.
+                    if ( ! field.equals("type")) {
+                        return null;
+                    }
                     restrictionQualifier = " from " + oldType.toSQLString() +
                                            " to " + newType.toSQLString();
                 }


### PR DESCRIPTION
When we change the type and the size of a column at the same time and both changes are disallowed, we do not throw two separate error messages now because it will be confusing.
