### PR TITLE
ENG-13248, allow user to stop node by IP address.

### DIFF
--- a/lib/python/voltcli/hostinfo.py
+++ b/lib/python/voltcli/hostinfo.py
@@ -63,7 +63,7 @@ class Hosts(object):
         connection_host = None
         target_host = None
         for host in self.hosts_by_id.values():
-            if host.hostname == host_name and host.internalport == port:
+            if (host.hostname == host_name or host.ipaddress == host_name) and host.internalport == port:
                 target_host = host
             elif connection_host is None:
                 connection_host = host


### PR DESCRIPTION
If machine has multiple network interfaces, remember to add --externalinterface option in command line arguments to let voltdb know which one you are using. Otherwise voltdb would pick whatever comes first.

Change-Id: Icb28bc41fd2ed0c4192e96e41a6f3b32b3a9f2cb