### PR TITLE
ENG-13279:

### DIFF
--- a/src/frontend/org/voltdb/CommandLog.java
+++ b/src/frontend/org/voltdb/CommandLog.java
@@ -132,9 +132,9 @@ public interface CommandLog {
 
     public interface DurabilityListener {
         /**
-         * Assign the listener that we will send SP and MP UniqueId durability notifications to
+         * Assign or remove the listener that we will send SP and MP UniqueId durability notifications to
          */
-        public void setUniqueIdListener(DurableUniqueIdListener listener);
+        public void configureUniqueIdListener(DurableUniqueIdListener listener, boolean install);
 
         /**
          * Called from Scheduler to set up how all future completion checks will be handled

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -4235,14 +4235,14 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     }
 
     @Override
-    public void setDurabilityUniqueIdListener(Integer partition, DurableUniqueIdListener listener) {
+    public void configureDurabilityUniqueIdListener(Integer partition, DurableUniqueIdListener listener, boolean install) {
         if (partition == MpInitiator.MP_INIT_PID) {
-            m_iv2Initiators.get(m_iv2Initiators.firstKey()).setDurableUniqueIdListener(listener);
+            m_iv2Initiators.get(m_iv2Initiators.firstKey()).configureDurableUniqueIdListener(listener, install);
         }
         else {
             Initiator init = m_iv2Initiators.get(partition);
             assert init != null;
-            init.setDurableUniqueIdListener(listener);
+            init.configureDurableUniqueIdListener(listener, install);
         }
     }
 

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -244,7 +244,7 @@ public interface VoltDBInterface
 
     public ConsumerDRGateway getConsumerDRGateway();
 
-    public void setDurabilityUniqueIdListener(Integer partition, DurableUniqueIdListener listener);
+    public void configureDurabilityUniqueIdListener(Integer partition, DurableUniqueIdListener listener, boolean install);
 
     public void onSyncSnapshotCompletion();
 

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -219,7 +219,7 @@ public abstract class BaseInitiator implements Initiator
     }
 
     @Override
-    public void setDurableUniqueIdListener(DurableUniqueIdListener listener)
+    public void configureDurableUniqueIdListener(DurableUniqueIdListener listener, boolean install)
     {
         // Durability Listeners should never be assigned to the MP Scheduler
         assert false;

--- a/src/frontend/org/voltdb/iv2/Initiator.java
+++ b/src/frontend/org/voltdb/iv2/Initiator.java
@@ -73,6 +73,6 @@ public interface Initiator
     /** Write a viable replay set to the command log */
     public void enableWritingIv2FaultLog();
 
-    /** Assign a listener to the spScheduler for notification of CommandLogged (durable) UniqueIds */
-    public void setDurableUniqueIdListener(DurableUniqueIdListener listener);
+    /** Assign or remove a listener to/from the spScheduler for notification of CommandLogged (durable) UniqueIds */
+    public void configureDurableUniqueIdListener(DurableUniqueIdListener listener, boolean install);
 }

--- a/src/frontend/org/voltdb/iv2/Scheduler.java
+++ b/src/frontend/org/voltdb/iv2/Scheduler.java
@@ -164,7 +164,7 @@ abstract public class Scheduler implements InitiatorMessageHandler
         m_lock = o;
     }
 
-    public void setDurableUniqueIdListener(DurableUniqueIdListener listener) {
+    public void configureDurableUniqueIdListener(final DurableUniqueIdListener listener, final boolean install) {
         // Durability Listeners should never be assigned to the MP Scheduler
         assert false;
     }

--- a/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
+++ b/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
@@ -188,11 +188,16 @@ public class SpDurabilityListener implements DurabilityListener {
     }
 
     @Override
-    public void setUniqueIdListener(DurableUniqueIdListener listener) {
-        m_uniqueIdListeners.add(listener);
-        if (m_currentCompletionChecks != null && !m_commandLoggingEnabled) {
-            // Since command logging is disabled set the durable uniqueId to maxLong
-            listener.lastUniqueIdsMadeDurable(Long.MAX_VALUE, Long.MAX_VALUE);
+    public void configureUniqueIdListener(DurableUniqueIdListener listener, boolean install) {
+        if (install) {
+            m_uniqueIdListeners.add(listener);
+            if (m_currentCompletionChecks != null && !m_commandLoggingEnabled) {
+                // Since command logging is disabled set the durable uniqueId to maxLong
+                listener.lastUniqueIdsMadeDurable(Long.MAX_VALUE, Long.MAX_VALUE);
+            }
+        }
+        else {
+            m_uniqueIdListeners.remove(listener);
         }
     }
 

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -127,14 +127,14 @@ public class SpInitiator extends BaseInitiator implements Promotable
         // configure DR
         PartitionDRGateway drGateway = PartitionDRGateway.getInstance(m_partitionId, nodeDRGateway, startAction);
         if (asyncCommandLogEnabled) {
-            setDurableUniqueIdListener(drGateway);
+            configureDurableUniqueIdListener(drGateway, true);
         }
 
         final PartitionDRGateway mpPDRG;
         if (createMpDRGateway) {
             mpPDRG = PartitionDRGateway.getInstance(MpInitiator.MP_INIT_PID, nodeDRGateway, startAction);
             if (asyncCommandLogEnabled) {
-                setDurableUniqueIdListener(mpPDRG);
+                configureDurableUniqueIdListener(mpPDRG, true);
             }
         } else {
             mpPDRG = null;
@@ -237,9 +237,9 @@ public class SpInitiator extends BaseInitiator implements Promotable
     }
 
     @Override
-    public void setDurableUniqueIdListener(DurableUniqueIdListener listener)
+    public void configureDurableUniqueIdListener(DurableUniqueIdListener listener, boolean install)
     {
-        m_scheduler.setDurableUniqueIdListener(listener);
+        m_scheduler.configureDurableUniqueIdListener(listener, install);
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -206,12 +206,12 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     }
 
     @Override
-    public void setDurableUniqueIdListener(final DurableUniqueIdListener listener) {
+    public void configureDurableUniqueIdListener(final DurableUniqueIdListener listener, final boolean install) {
         m_tasks.offer(new SiteTaskerRunnable() {
             @Override
             void run()
             {
-                m_durabilityListener.setUniqueIdListener(listener);
+                m_durabilityListener.configureUniqueIdListener(listener, install);
             }
         });
     }

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -818,7 +818,7 @@ public class MockVoltDB implements VoltDBInterface
     }
 
     @Override
-    public void setDurabilityUniqueIdListener(Integer partition, DurableUniqueIdListener listener) {
+    public void configureDurabilityUniqueIdListener(Integer partition, DurableUniqueIdListener listener, boolean install) {
     }
 
     @Override

--- a/tests/frontend/org/voltdb/iv2/TestDurabilityListener.java
+++ b/tests/frontend/org/voltdb/iv2/TestDurabilityListener.java
@@ -70,7 +70,7 @@ public class TestDurabilityListener {
         m_listener = new SimpleListener();
 
         dut = new SpDurabilityListener(m_sched, m_taskQueue);
-        dut.setUniqueIdListener(m_listener);
+        dut.configureUniqueIdListener(m_listener, true);
     }
 
     @Test
@@ -163,7 +163,7 @@ public class TestDurabilityListener {
         TransactionTaskQueue taskQueue = mock(TransactionTaskQueue.class);
         SimpleListener listener = new SimpleListener();
         SpDurabilityListener dut = new SpDurabilityListener(sched, taskQueue);
-        dut.setUniqueIdListener(listener);
+        dut.configureUniqueIdListener(listener, true);
 
         int cnt = 0;
         ArgumentCaptor<SiteTasker.SiteTaskerRunnable> captor =


### PR DESCRIPTION
When the Consumer is shut down, due to a reset, a disable, or an ElasticAdd, the objects are not garbage collected because the references for each BufferReceiver are maintained in the Scheduler's DurabilityListener, even when new instances are started. This is fixed by unregistering the listener from the BufferReceiver's shutdown path. Note that the receivers and dispatcher are only leaked when commandlogging is Asynchronous and in a same-size cluster.