### PR TITLE
ENG-13162 Guard window function partition/order by subquery

### DIFF
--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -635,6 +635,10 @@ public abstract class AbstractParsedStmt {
                     if (ele.name.equals("partitionbyList")) {
                         for (VoltXMLElement childNode : ele.children) {
                             AbstractExpression expr = parseExpressionNode(childNode);
+                            if (expr.hasSubquerySubexpression()) {
+                                throw new PlanningErrorException(
+                                        "SQL window function calls partitioned by subquery expression arguments are not allowed.");
+                            }
                             ExpressionUtil.finalizeValueTypes(expr);
                             partitionbyExprs.add(expr);
                         }
@@ -647,6 +651,10 @@ public abstract class AbstractParsedStmt {
                                     SortDirectionType.ASC;
 
                             AbstractExpression expr = parseExpressionNode(childNode.children.get(0));
+                            if (expr.hasSubquerySubexpression()) {
+                                throw new PlanningErrorException(
+                                        "SQL window function calls ordered by subquery expression arguments are not allowed.");
+                            }
                             ExpressionUtil.finalizeValueTypes(expr);
                             orderbyExprs.add(expr);
                             orderbyDirs.add(sortDir);

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -637,7 +637,7 @@ public abstract class AbstractParsedStmt {
                             AbstractExpression expr = parseExpressionNode(childNode);
                             if (expr.hasSubquerySubexpression()) {
                                 throw new PlanningErrorException(
-                                        "SQL window function calls partitioned by subquery expression arguments are not allowed.");
+                                        "SQL window functions cannot be partitioned by subquery expression arguments.");
                             }
                             ExpressionUtil.finalizeValueTypes(expr);
                             partitionbyExprs.add(expr);
@@ -653,7 +653,7 @@ public abstract class AbstractParsedStmt {
                             AbstractExpression expr = parseExpressionNode(childNode.children.get(0));
                             if (expr.hasSubquerySubexpression()) {
                                 throw new PlanningErrorException(
-                                        "SQL window function calls ordered by subquery expression arguments are not allowed.");
+                                        "SQL window functions cannot be ordered by subquery expression arguments.");
                             }
                             ExpressionUtil.finalizeValueTypes(expr);
                             orderbyExprs.add(expr);

--- a/tests/frontend/org/voltdb/planner/TestWindowedFunctions.java
+++ b/tests/frontend/org/voltdb/planner/TestWindowedFunctions.java
@@ -550,6 +550,10 @@ public class TestWindowedFunctions extends PlannerTestCase {
                       "DISTINCT is not allowed in window functions.");
         failToCompile("SELECT COUNT(DISTINCT A+B) OVER (PARTITION BY A ORDER BY B) AS ARANK FROM AAA",
                       "DISTINCT is not allowed in window functions.");
+        failToCompile("SELECT SUM(A) OVER (ORDER BY (SELECT A FROM AAA)) AS ARANK FROM AAA_TIMESTAMP",
+                      "SQL window function calls ordered by subquery expression arguments are not allowed.");
+        failToCompile("SELECT SUM(A) OVER (PARTITION BY (SELECT A FROM AAA)) AS ARANK FROM AAA_TIMESTAMP",
+                      "SQL window function calls partitioned by subquery expression arguments are not allowed.");
     }
     public void testExplainPlanText() {
         String windowedQuery = "SELECT RANK() OVER (PARTITION BY A ORDER BY B DESC) FROM AAA;";

--- a/tests/frontend/org/voltdb/planner/TestWindowedFunctions.java
+++ b/tests/frontend/org/voltdb/planner/TestWindowedFunctions.java
@@ -551,9 +551,9 @@ public class TestWindowedFunctions extends PlannerTestCase {
         failToCompile("SELECT COUNT(DISTINCT A+B) OVER (PARTITION BY A ORDER BY B) AS ARANK FROM AAA",
                       "DISTINCT is not allowed in window functions.");
         failToCompile("SELECT SUM(A) OVER (ORDER BY (SELECT A FROM AAA)) AS ARANK FROM AAA_TIMESTAMP",
-                      "SQL window function calls ordered by subquery expression arguments are not allowed.");
+                      "SQL window functions cannot be ordered by subquery expression arguments.");
         failToCompile("SELECT SUM(A) OVER (PARTITION BY (SELECT A FROM AAA)) AS ARANK FROM AAA_TIMESTAMP",
-                      "SQL window function calls partitioned by subquery expression arguments are not allowed.");
+                      "SQL window functions cannot be partitioned by subquery expression arguments.");
     }
     public void testExplainPlanText() {
         String windowedQuery = "SELECT RANK() OVER (PARTITION BY A ORDER BY B DESC) FROM AAA;";


### PR DESCRIPTION
We now do not allow ORDER BY subquery. We add similar guards for ORDER BY and PARTITION BY subqueries for the window functions.

Can Andrew confirm if the message is OK?