### PR TITLE
ENG-13194  Fix failure to shutdown a node with@StopNode

### DIFF
--- a/src/frontend/org/voltdb/dtxn/TransactionState.java
+++ b/src/frontend/org/voltdb/dtxn/TransactionState.java
@@ -207,4 +207,7 @@ public abstract class TransactionState extends OrderableTransaction  {
     public List<UndoAction> getUndoLog() {
         return m_undoLog;
     }
+
+    public void terminateTransaction() {
+    }
 }

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -199,8 +199,6 @@ public abstract class BaseInitiator implements Initiator
 
         if (m_siteThread != null) {
             try {
-                //add a null task to unblock the queue
-                m_scheduler.getQueue().offer(Scheduler.m_nullTask);
                 m_siteThread.join();
             } catch (InterruptedException e) {
                 tmLog.info("Interrupted during shutdown", e);

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -199,6 +199,8 @@ public abstract class BaseInitiator implements Initiator
 
         if (m_siteThread != null) {
             try {
+                //add a null task to unblock the queue
+                m_scheduler.getQueue().offer(Scheduler.m_nullTask);
                 m_siteThread.join();
             } catch (InterruptedException e) {
                 tmLog.info("Interrupted during shutdown", e);

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -95,6 +95,8 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     // Current topology
     int m_partitionId;
 
+    //a place holder for current running transaction on this site
+    //the transaction will be terminated upon node shutdown.
     private TransactionState m_txnState = null;
 
     @Override
@@ -409,6 +411,8 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     public void startShutdown()
     {
         m_shouldContinue = false;
+
+        //abort the current transaction
         if (m_txnState != null) {
             m_txnState.terminateTransaction();
         }

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -95,6 +95,8 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     // Current topology
     int m_partitionId;
 
+    private TransactionState m_txnState = null;
+
     @Override
     public long getLatestUndoToken()
     {
@@ -376,6 +378,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
         try {
             while (m_shouldContinue) {
                 // Normal operation blocks the site thread on the sitetasker queue.
+                m_txnState = null;
                 SiteTasker task = m_scheduler.take();
                 task.run(getSiteProcedureConnection());
             }
@@ -395,7 +398,6 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
                 " encountered an " + "unexpected error and will die, taking this VoltDB node down.";
             VoltDB.crashLocalVoltDB(errmsg, true, t);
         }
-        shutdown();
     }
 
     /**
@@ -407,9 +409,9 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     public void startShutdown()
     {
         m_shouldContinue = false;
-    }
-
-    void shutdown() {
+        if (m_txnState != null) {
+            m_txnState.terminateTransaction();
+        }
     }
 
     //
@@ -471,7 +473,10 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     public Map<Integer, List<VoltTable>> recursableRun(
             TransactionState currentTxnState)
     {
-        return currentTxnState.recursableRun(this);
+        m_txnState = currentTxnState;
+        Map<Integer, List<VoltTable>> results = currentTxnState.recursableRun(this);
+        m_txnState = null;
+        return results;
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/MpRoSitePool.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSitePool.java
@@ -195,6 +195,7 @@ class MpRoSitePool {
      */
     boolean canAcceptWork()
     {
+        //lock down the pool and accept no more work upon shutting down.
         if (m_shuttingDown) {
             return false;
         }

--- a/src/frontend/org/voltdb/iv2/MpRoSitePool.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSitePool.java
@@ -107,6 +107,7 @@ class MpRoSitePool {
     private CatalogContext m_catalogContext;
     private ThreadFactory m_poolThreadFactory;
     private final int m_poolSize;
+    private boolean m_shuttingDown = false;
 
     MpRoSitePool(
             long siteId,
@@ -194,8 +195,10 @@ class MpRoSitePool {
      */
     boolean canAcceptWork()
     {
-        boolean retval = (!m_idleSites.isEmpty() || m_busySites.get().size() < m_poolSize);
-        return retval;
+        if (m_shuttingDown) {
+            return false;
+        }
+        return (!m_idleSites.isEmpty() || m_busySites.get().size() < m_poolSize);
     }
 
     /**
@@ -256,6 +259,7 @@ class MpRoSitePool {
 
     void shutdown()
     {
+        m_shuttingDown = true;
         // Shutdown all, then join all, hopefully save some shutdown time for tests.
         for (MpRoSiteContext site : m_idleSites) {
             site.shutdown();

--- a/src/frontend/org/voltdb/iv2/MpRoSitePool.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSitePool.java
@@ -19,6 +19,7 @@ package org.voltdb.iv2;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ThreadFactory;
@@ -30,7 +31,6 @@ import org.voltdb.BackendTarget;
 import org.voltdb.CatalogContext;
 import org.voltdb.LoadedProcedureSet;
 import org.voltdb.StarvationTracker;
-import com.google.common.collect.Maps;
 
 /**
  * Provide a pool of MP Read-only sites to do MP RO work.
@@ -140,7 +140,7 @@ class MpRoSitePool {
                         m_initiatorMailbox,
                         m_poolThreadFactory));
         }
-        m_busySites.set(Maps.newHashMap());
+        m_busySites.set(new HashMap<Long, MpRoSiteContext>());
     }
 
     /**
@@ -225,7 +225,7 @@ class MpRoSitePool {
             }
             site = m_idleSites.pop();
             busySites.put(txnId, site);
-            m_busySites.compareAndSet(m_busySites.get(), busySites);
+            m_busySites.set(busySites);
         }
         site.offer(task);
         return true;

--- a/src/frontend/org/voltdb/iv2/MpRoSitePool.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSitePool.java
@@ -248,7 +248,7 @@ class MpRoSitePool {
         }
     }
 
-    void shutdown()
+    synchronized void shutdown()
     {
         // Shutdown all, then join all, hopefully save some shutdown time for tests.
         for (MpRoSiteContext site : m_idleSites) {

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -115,8 +115,8 @@ public class MpScheduler extends Scheduler
         // never run; the site thread is expected to be told to stop.
         m_pendingTasks.shutdown();
         m_pendingTasks.repair(m_nullTask, m_iv2Masters, m_partitionMasters);
+        m_tasks.offer(m_nullTask);
     }
-
 
     @Override
     public void updateReplicas(final List<Long> replicas, final Map<Integer, Long> partitionMasters)

--- a/src/frontend/org/voltdb/messaging/FragmentResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/FragmentResponseMessage.java
@@ -41,6 +41,7 @@ public class FragmentResponseMessage extends VoltMessage {
     public static final byte SUCCESS          = 1;
     public static final byte USER_ERROR       = 2;
     public static final byte UNEXPECTED_ERROR = 3;
+    public static final byte ABORT = 4;
 
     long m_executorHSId;
     long m_destinationHSId;


### PR DESCRIPTION
When MP sites are in the middle of transaction processing, @StopNode  may cause MP deadlock and fail to stope a node. The pull request tries to terminate these transactions with a poison fragment response and then shutdown  MP Ro site pool.  and also offer a fake task to unblock sites to be shutdown.