### PR TITLE
ENG-13914 node shutdown

### DIFF
--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -1236,6 +1236,8 @@ public class ProcedureRunner {
         } else if (e.getClass() == org.voltdb.exceptions.TransactionRestartException.class) {
             status = ClientResponse.TXN_RESTART;
             msg.append("TRANSACTION RESTART\n");
+        } else if (e.getClass() == org.voltdb.exceptions.TransactionTerminationException.class) {
+            msg.append("Transaction Interrupted\n");
         }
         // SpecifiedException means the dev wants control over status and
         // message

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3220,9 +3220,11 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     // The reason to halt MP sites first is that it may wait for some fragment dependencies
     // to be done on SP sites, kill SP sites first may risk MP site to wait forever.
     private void shutdownInitiators() {
-        if (m_iv2Initiators != null) {
-            m_iv2Initiators.descendingMap().values().stream().forEach(p->p.shutdown());
+        if (m_iv2Initiators == null) {
+            return;
         }
+
+            m_iv2Initiators.descendingMap().values().stream().forEach(p->p.shutdown());
     }
 
     @Override
@@ -3673,10 +3675,31 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             public void run() {
                 hostLog.warn("VoltDB node shutting down as requested by @StopNode command.");
                 shutdownInitiators();
+                m_isRunning = false;
+                hostLog.warn("VoltDB node has been shutdown By @StopNode");
                 System.exit(0);
             }
         };
+
+        //if the resources can not be released in 5 seconds, shutdown the node
+        Thread watchThread = new Thread() {
+            @Override
+            public void run() {
+                final long now = System.nanoTime();
+                while (m_isRunning) {
+                    final long delta = System.nanoTime() - now;
+                    if (delta > TimeUnit.SECONDS.toNanos(5)) {
+                        hostLog.warn("VoltDB node has been shutdown.");
+                        System.exit(0);
+                    }
+                    try {
+                        Thread.sleep(5);
+                    } catch (Exception e) {}
+                }
+            }
+        };
         shutdownThread.start();
+        watchThread.start();
     }
 
     /**

--- a/src/frontend/org/voltdb/exceptions/SerializableException.java
+++ b/src/frontend/org/voltdb/exceptions/SerializableException.java
@@ -86,6 +86,12 @@ public class SerializableException extends VoltProcedure.VoltAbortException impl
                 return new TransactionRestartException(b);
             }
         },
+        TransactionTerminationException() {
+            @Override
+            protected SerializableException deserializeException(ByteBuffer b) {
+                return new TransactionTerminationException(b);
+            }
+        },
         SpecifiedException() {
             @Override
             protected SerializableException deserializeException(ByteBuffer b) {

--- a/src/frontend/org/voltdb/exceptions/TransactionTerminationException.java
+++ b/src/frontend/org/voltdb/exceptions/TransactionTerminationException.java
@@ -1,0 +1,59 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb.exceptions;
+
+import java.nio.ByteBuffer;
+
+/**
+ * This exception is used in IV2 MPI to terminate the currently running
+ * MP transaction at the MPI while a node is being shutdown
+ */
+public class TransactionTerminationException extends SerializableException {
+    public static final long serialVersionUID = 0L;
+    private long m_txnId;
+
+    public TransactionTerminationException(String message, long txnId) {
+        super(message);
+        m_txnId = txnId;
+    }
+
+    public TransactionTerminationException(ByteBuffer b) {
+        super(b);
+        m_txnId = b.getLong();
+    }
+
+    public long getTxnId()
+    {
+        return m_txnId;
+    }
+
+    @Override
+    protected SerializableExceptions getExceptionType() {
+        return SerializableExceptions.TransactionTerminationException;
+    }
+
+    @Override
+    protected int p_getSerializedSize() {
+        return 8;
+    }
+
+    @Override
+    protected void p_serializeToBuffer(ByteBuffer b) {
+        b.putLong(m_txnId);
+    }
+}
+

--- a/src/frontend/org/voltdb/iv2/MpTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionState.java
@@ -37,6 +37,7 @@ import org.voltdb.VoltTable;
 import org.voltdb.dtxn.TransactionState;
 import org.voltdb.exceptions.SerializableException;
 import org.voltdb.exceptions.TransactionRestartException;
+import org.voltdb.exceptions.TransactionTerminationException;
 import org.voltdb.messaging.BorrowTaskMessage;
 import org.voltdb.messaging.DumpMessage;
 import org.voltdb.messaging.FragmentResponseMessage;
@@ -298,7 +299,7 @@ public class MpTransactionState extends TransactionState
 
             assert(msg.getTableCount() > 0);
             // If this is a restarted TXN, verify that this is not a stale message from a different Dependency
-            if (msg.getStatusCode()== FragmentResponseMessage.ABORT || !m_isRestart || (msg.m_sourceHSId == m_buddyHSId &&
+            if (msg.getStatusCode()== FragmentResponseMessage.TERMINATION || !m_isRestart || (msg.m_sourceHSId == m_buddyHSId &&
                     msg.getTableDependencyIdAtIndex(0) == m_localWork.getOutputDepId(0))) {
                 // Will roll-back and throw if this message has an exception
                 checkForException(msg);
@@ -459,9 +460,9 @@ public class MpTransactionState extends TransactionState
         }
         FragmentTaskMessage dummy = new FragmentTaskMessage(0L, 0L, 0L, 0L, false, false, false);
         FragmentResponseMessage poison = new FragmentResponseMessage(dummy, 0L);
-        TransactionRestartException restart = new TransactionRestartException(
-                "Transaction being aborted due to shutdown.", txnId);
-        poison.setStatus(FragmentResponseMessage.ABORT, restart);
+        TransactionTerminationException termination = new TransactionTerminationException(
+                "Transaction interrupted.", txnId);
+        poison.setStatus(FragmentResponseMessage.TERMINATION, termination);
         offerReceivedFragmentResponse(poison);
      }
 

--- a/src/frontend/org/voltdb/messaging/FragmentResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/FragmentResponseMessage.java
@@ -41,7 +41,7 @@ public class FragmentResponseMessage extends VoltMessage {
     public static final byte SUCCESS          = 1;
     public static final byte USER_ERROR       = 2;
     public static final byte UNEXPECTED_ERROR = 3;
-    public static final byte ABORT = 4;
+    public static final byte TERMINATION = 4;
 
     long m_executorHSId;
     long m_destinationHSId;


### PR DESCRIPTION
If the resources can not be released in 5 seconds while a node is being shutdown, force shutdown the node.  Change the affected transactions from RESTART to Unexpected error, transaction interrupted.