### PR TITLE
ENG-13345: Add kerberos authentication support to CSVLoader

### DIFF
--- a/src/frontend/org/voltdb/utils/CSVLoader.java
+++ b/src/frontend/org/voltdb/utils/CSVLoader.java
@@ -308,6 +308,9 @@ public class CSVLoader implements BulkLoaderErrorHandler {
         @Option(desc = "Enable SSL, Optionally provide configuration file.")
         String ssl = "";
 
+        @Option(desc = "Enable Kerberos and use provided JAAS login configuration entry key.")
+        String kerberos = "";
+
         /**
          * Batch size for processing batched operations.
          */
@@ -465,6 +468,9 @@ public class CSVLoader implements BulkLoaderErrorHandler {
         if (config.ssl != null && !config.ssl.trim().isEmpty()) {
             c_config.setTrustStoreConfigFromPropertyFile(config.ssl);
             c_config.enableSSL();
+        }
+        if (!config.kerberos.trim().isEmpty()) {
+            c_config.enableKerberosAuthentication(config.kerberos);
         }
         c_config.setProcedureCallTimeout(0); // Set procedure all to infinite
         Client csvClient = null;


### PR DESCRIPTION
Added a --kerberos=<jaas file configuration entry id> parameter to CSVLoader. 

Example usage:

    kinit someuser@DOMAIN
    ...
    csvloader --kerberos=VoltDBClient -f some_file.csv TABLENAME