### PR TITLE
Eng 12926 Don't reverse hole loops.

### DIFF
--- a/src/frontend/org/voltdb/types/GeographyValue.java
+++ b/src/frontend/org/voltdb/types/GeographyValue.java
@@ -88,6 +88,24 @@ public class GeographyValue {
      * @param rings  A list of lists of points that will form a polygon.
      */
      public GeographyValue(List<List<GeographyPointValue>> rings) {
+         this(rings, false);
+     }
+
+     /**
+      * Create a polygon from a list of rings.  This is internal.  If the
+      * argument ringsAreInS2Order is true then we will not reorder any holes.
+      * Since the OGC text format, WKT, used CCW shells and CW holes, and S2
+      * uses all CCW loops, we need to reverse holes for S2, and this is the
+      * vertex order we use internally.  But if this is an operation on rings
+      * which are already in S2 order, say for the polynomial creation or
+      * algebra operations, we don't want to reorder the loops again.  The
+      * argument holesAreInS2Order is true in this case.
+      *
+      * @param rings
+      * @param holesAreInS2Order
+      */
+     private GeographyValue(List<List<GeographyPointValue>> rings,
+                            boolean holesAreInS2Order) {
          if (rings == null || rings.size() < 1) {
              throw new IllegalArgumentException("GeographyValue must be instantiated with at least one ring");
          }
@@ -95,15 +113,15 @@ public class GeographyValue {
          // first loop, since the EE wants them all in CCW order,
          // and the OGC order for holes is CW.
          //
-         m_loops = new ArrayList<List<XYZPoint>>();
+         m_loops = new ArrayList<>();
          boolean firstLoop = true;
          for (List<GeographyPointValue> loop : rings) {
              diagnoseLoop(loop, "Invalid loop for GeographyValue: ");
-             List<XYZPoint> oneLoop = new ArrayList<XYZPoint>();
+             List<XYZPoint> oneLoop = new ArrayList<>();
              int startIdx;
              int endIdx;
              int delta;
-             if (firstLoop) {
+             if (firstLoop || holesAreInS2Order) {
                  startIdx = 1;
                  // Don't copy the last vertex.
                  endIdx = loop.size() - 1;
@@ -194,11 +212,11 @@ public class GeographyValue {
          * reverse the order of holes.  We take care to leave the first vertex
          * the same.
          */
-        List<List<GeographyPointValue>> llLoops = new ArrayList<List<GeographyPointValue>>();
+        List<List<GeographyPointValue>> llLoops = new ArrayList<>();
 
         boolean isShell = true;
         for (List<XYZPoint> xyzLoop : m_loops) {
-            List<GeographyPointValue> llLoop = new ArrayList<GeographyPointValue>();
+            List<GeographyPointValue> llLoop = new ArrayList<>();
             // Add the first of xyzLoop first.
             llLoop.add(xyzLoop.get(0).toGeographyPointValue());
             // Add shells left to right, and holes right to left.  Make sure
@@ -389,8 +407,10 @@ public class GeographyValue {
         buf.put((byte)1); // owns_loops_
         buf.put((byte)(m_loops.size() > 1 ? 1 : 0)); // has_holes_
         buf.putInt(m_loops.size());
+        int depth = 0;
         for (List<XYZPoint> loop : m_loops) {
-            flattenLoopToBuffer(loop, buf);
+            flattenLoopToBuffer(loop, depth, buf);
+            depth = 1;
         }
         flattenEmptyBoundToBuffer(buf);
     }
@@ -423,10 +443,10 @@ public class GeographyValue {
         inBuffer.get(); // owns loops
         inBuffer.get(); // has holes
         int numLoops = inBuffer.getInt();
-        List<List<XYZPoint>> loops = new ArrayList<List<XYZPoint>>();
+        List<List<XYZPoint>> loops = new ArrayList<>();
         int indexOfOuterRing = 0;
         for (int i = 0; i < numLoops; ++i) {
-            List<XYZPoint> loop = new ArrayList<XYZPoint>();
+            List<XYZPoint> loop = new ArrayList<>();
             int depth = unflattenLoopFromBuffer(inBuffer, loop);
             if (depth == 0) {
                 indexOfOuterRing = i;
@@ -435,13 +455,6 @@ public class GeographyValue {
             loops.add(loop);
         }
 
-        // S2 will order loops in depth-first order, which will leave the outer ring last.
-        // Make it first so it looks right when converted back to WKT.
-        if (version == COMPLETE_ENCODING && indexOfOuterRing != 0) {
-                    List<XYZPoint> outerRing = loops.get(indexOfOuterRing);
-                    loops.set(indexOfOuterRing, loops.get(0));
-                    loops.set(0, outerRing);
-        }
         unflattenBoundFromBuffer(inBuffer);
 
         return polygonFromXyzPoints(loops);
@@ -561,7 +574,7 @@ public class GeographyValue {
         buf.putDouble(GeographyPointValue.NULL_COORD);
     }
 
-    private static void flattenLoopToBuffer(List<XYZPoint> loop, ByteBuffer buf) {
+    private static void flattenLoopToBuffer(List<XYZPoint> loop, int depth, ByteBuffer buf) {
         //   1 byte     for encoding version
         //   4 bytes    for number of vertices
         //   number of vertices * 8 * 3  bytes  for vertices as XYZPoints
@@ -577,7 +590,7 @@ public class GeographyValue {
         }
 
         buf.put((byte)0); // origin_inside_
-        buf.putInt(0); // depth_
+        buf.putInt(depth);// depth
         flattenEmptyBoundToBuffer(buf);
     }
 
@@ -660,7 +673,7 @@ public class GeographyValue {
         tokenizer.eolIsSignificant(false);
 
         List<XYZPoint> currentLoop = null;
-        List<List<XYZPoint>> loops = new ArrayList<List<XYZPoint>>();
+        List<List<XYZPoint>> loops = new ArrayList<>();
         boolean is_shell = true;
         try {
             int token = tokenizer.nextToken();
@@ -684,7 +697,7 @@ public class GeographyValue {
                     if (currentLoop != null) {
                         throw new IllegalArgumentException(msgPrefix + "missing closing parenthesis");
                     }
-                    currentLoop = new ArrayList<XYZPoint>();
+                    currentLoop = new ArrayList<>();
                     break;
                 case StreamTokenizer.TT_NUMBER:
                     if (currentLoop == null) {
@@ -773,15 +786,15 @@ public class GeographyValue {
      * @return  The resulting GeographyValue.
      */
     public GeographyValue add(GeographyPointValue offset) {
-        List<List<GeographyPointValue>> newLoops = new ArrayList<List<GeographyPointValue>>();
+        List<List<GeographyPointValue>> newLoops = new ArrayList<>();
         for (List<XYZPoint> oneLoop : m_loops) {
-            List<GeographyPointValue> loop = new ArrayList<GeographyPointValue>();
+            List<GeographyPointValue> loop = new ArrayList<>();
             for (XYZPoint p : oneLoop) {
                 loop.add(p.toGeographyPointValue().add(offset));
             }
             loop.add(oneLoop.get(0).toGeographyPointValue().add(offset));
             newLoops.add(loop);
         }
-        return new GeographyValue(newLoops);
+        return new GeographyValue(newLoops, true);
     }
 }

--- a/src/frontend/org/voltdb/types/GeographyValue.java
+++ b/src/frontend/org/voltdb/types/GeographyValue.java
@@ -785,6 +785,7 @@ public class GeographyValue {
      * @param offset  The point by which to translate vertices in this
      * @return  The resulting GeographyValue.
      */
+    @Deprecated
     public GeographyValue add(GeographyPointValue offset) {
         List<List<GeographyPointValue>> newLoops = new ArrayList<>();
         for (List<XYZPoint> oneLoop : m_loops) {

--- a/src/frontend/org/voltdb/utils/PolygonFactory.java
+++ b/src/frontend/org/voltdb/utils/PolygonFactory.java
@@ -47,7 +47,7 @@ public class PolygonFactory {
             int numVertices,
             double sizeOfHole) {
         assert(0 <= sizeOfHole && sizeOfHole < 1.0);
-        double phi = 360.0/numVertices;
+        double phi = -360.0/numVertices;
         GeographyPointValue holeFirstVertex = null;
         if (sizeOfHole > 0) {
             holeFirstVertex = firstVertex.scale(center, sizeOfHole);
@@ -55,8 +55,8 @@ public class PolygonFactory {
         List<GeographyPointValue> oneLoop = new ArrayList<>();
         List<GeographyPointValue> hole = (sizeOfHole < 0 ? null : new ArrayList<>());
         // We will add the nth point at angle n*phi.  We want to
-        // add points in a counter clockwise order, so phi must be
-        // a positive angle.  We will have twice as many vertices
+        // add points in a clockwise order, so phi must be
+        // a negative angle.  We will have twice as many vertices
         // as points.
         for (int idx = 0; idx < numVertices; idx += 1) {
             oneLoop.add(firstVertex.rotate(idx*phi, center));
@@ -148,7 +148,7 @@ public class PolygonFactory {
         //
         // We have to add all shells in counter clockwise order, and all
         // holes in clockwise order.  This amounts to rotating the shell
-        // generator vector by phi and the hole generator vector by -phi.
+        // generator vector by -phi and the hole generator vector by phi.
         //
         List<GeographyPointValue> outerLoop = new ArrayList<>();
         List<GeographyPointValue> holeLoop = null;

--- a/src/frontend/org/voltdb/utils/PolygonFactory.java
+++ b/src/frontend/org/voltdb/utils/PolygonFactory.java
@@ -41,27 +41,29 @@ public class PolygonFactory {
      *                   is scaled by sizeOfHole.  This value must be in the range [0,1).
      * @return
      */
+    @Deprecated
     public static GeographyValue CreateRegularConvex(
             GeographyPointValue center,
             GeographyPointValue firstVertex,
             int numVertices,
             double sizeOfHole) {
         assert(0 <= sizeOfHole && sizeOfHole < 1.0);
-        double phi = -360.0/numVertices;
+        double phi = 360.0/numVertices;
         GeographyPointValue holeFirstVertex = null;
         if (sizeOfHole > 0) {
             holeFirstVertex = firstVertex.scale(center, sizeOfHole);
         }
         List<GeographyPointValue> oneLoop = new ArrayList<>();
         List<GeographyPointValue> hole = (sizeOfHole < 0 ? null : new ArrayList<>());
-        // We will add the nth point at angle n*phi.  We want to
-        // add points in a clockwise order, so phi must be
-        // a negative angle.  We will have twice as many vertices
-        // as points.
+        // We will add the nth point at angle n*phi.  For shells
+        // We want to add points in a CCW order, so phi must be
+        // a positive angle.  For holes we want to add in a CW order,
+        // so phy mist be a negative angle.
         for (int idx = 0; idx < numVertices; idx += 1) {
+            int holeIdx = numVertices-idx;
             oneLoop.add(firstVertex.rotate(idx*phi, center));
             if (sizeOfHole > 0) {
-                hole.add(holeFirstVertex.rotate(-(idx*phi), center));
+                hole.add(holeFirstVertex.rotate(-(holeIdx*phi), center));
             }
         }
         // Add the closing vertices.
@@ -102,6 +104,7 @@ public class PolygonFactory {
      * @return
      * @throws IllegalArgumentException
      */
+    @Deprecated
     public static GeographyValue CreateStar(
             GeographyPointValue center,
             GeographyPointValue firstVertex,
@@ -189,6 +192,7 @@ public class PolygonFactory {
      * @param goodPolygon
      * @return
      */
+    @Deprecated
     public static GeographyValue reverseLoops(GeographyValue goodPolygon) {
         List<List<GeographyPointValue>> newLoops = new ArrayList<>();
         List<List<GeographyPointValue>> oldLoops = goodPolygon.getRings();

--- a/tests/ee/storage/DRTupleStream_test.cpp
+++ b/tests/ee/storage/DRTupleStream_test.cpp
@@ -76,6 +76,7 @@ class DRTupleStreamTest : public Test {
 public:
     DRTupleStreamTest()
         : m_wrapper(42, 64*1024),
+          m_largeTuple(NULL),
           m_context(new ExecutorContext(1, 1, NULL, &m_topend, NULL, (VoltDBEngine*)NULL,
                                         "localhost", 2, &m_wrapper, NULL, 0))
     {
@@ -171,7 +172,7 @@ protected:
     TupleSchema* m_schema;
     TupleSchema* m_largeSchema;
     char m_tupleMemory[(COLUMN_COUNT + 1) * 8];
-    char* m_largeTupleMemory = NULL;
+    char* m_largeTupleMemory;
     TableTuple* m_tuple;
     TableTuple* m_largeTuple;
     DummyTopend m_topend;

--- a/tests/ee/storage/DRTupleStream_test.cpp
+++ b/tests/ee/storage/DRTupleStream_test.cpp
@@ -76,7 +76,6 @@ class DRTupleStreamTest : public Test {
 public:
     DRTupleStreamTest()
         : m_wrapper(42, 64*1024),
-          m_largeTuple(NULL),
           m_context(new ExecutorContext(1, 1, NULL, &m_topend, NULL, (VoltDBEngine*)NULL,
                                         "localhost", 2, &m_wrapper, NULL, 0))
     {

--- a/tests/frontend/org/voltdb/types/TestGeographyValue.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyValue.java
@@ -172,6 +172,7 @@ public class TestGeographyValue extends TestCase {
         String rtStr = "POLYGON ((0.0 20.0, -17.320508076 -10.0, 17.320508076 -10.0, 0.0 20.0))";
         rtGeog = new GeographyValue(rtStr);
         assertEquals(rtStr, rtGeog.toString());
+        assertEquals(rtGeog, new GeographyValue(rtGeog.toWKT()));
 
         // serialize this.
         ByteBuffer buf = ByteBuffer.allocate(geog.getLengthInBytes());
@@ -226,7 +227,7 @@ public class TestGeographyValue extends TestCase {
     }
 
     public void testGeographyValueNegativeCases() {
-        List<GeographyPointValue> outerLoop = new ArrayList<GeographyPointValue>();
+        List<GeographyPointValue> outerLoop = new ArrayList<>();
         outerLoop.add(new GeographyPointValue(-64.751, 32.305));
         outerLoop.add(new GeographyPointValue(-80.437, 25.244));
         outerLoop.add(new GeographyPointValue(-66.371, 18.476));

--- a/tests/frontend/org/voltdb/types/TestGeographyValue.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyValue.java
@@ -321,6 +321,18 @@ public class TestGeographyValue extends TestCase {
         }
     }
 
+    public void testAddFunction() {
+        String WKT = "POLYGON((3 3, -3 3, -3 -3, 3 -3, 3 3), (1 1, 1 2, 2 1, 1 1), (-1 -1, -1 -2, -2 -1, -1 -1))";
+        String WKTOff = "POLYGON ((4.0 5.0, -2.0 5.0, -2.0 -1.0, 4.0 -1.0, 4.0 5.0), (2.0 3.0, 2.0 4.0, 3.0 3.0, 2.0 3.0), (0.0 1.0, 0.0 0.0, -1.0 1.0, 0.0 1.0))";
+        GeographyValue gv = GeographyValue.fromWKT(WKT);
+        GeographyPointValue gpv = new GeographyPointValue(1, 2);
+        GeographyPointValue origin = new GeographyPointValue(0, 0);
+        GeographyValue gvoff = gv.add(origin);
+        assertEquals(gvoff, gv);
+        gvoff = gv.add(gpv);
+        assertEquals(GeographyValue.fromWKT(WKTOff), gvoff);
+    }
+
     /**
      * This tests that the maximum error when we transform a latitude/longitude pair to an
      * S2, 3-dimensinal point and then back again is less than 1.0e-13.

--- a/tests/frontend/org/voltdb/utils/TestPolygonFactory.java
+++ b/tests/frontend/org/voltdb/utils/TestPolygonFactory.java
@@ -119,10 +119,10 @@ public class TestPolygonFactory extends TestCase {
                                                                  int numHoleSizes,
                                                                  double xmul,
                                                                  double ymul) {
-        List<List<GeographyValue>> answer = new ArrayList<List<GeographyValue>>();
+        List<List<GeographyValue>> answer = new ArrayList<>();
         for (int numVertices = minNumberVertices; numVertices <= maxNumberVertices; numVertices += 1) {
             int idx = numVertices - minNumberVertices;
-            List<GeographyValue> oneSize = new ArrayList<GeographyValue>();
+            List<GeographyValue> oneSize = new ArrayList<>();
             // The x coordinate is humHoleSizes*idx.
             GeographyPointValue sCenter = firstCenter.add(x.mul(numHoleSizes*idx));
             for (int hidx = 0; hidx < numHoleSizes; hidx += 1) {
@@ -158,15 +158,15 @@ public class TestPolygonFactory extends TestCase {
                                                                      int numHoleSizeLevels,
                                                                      double xmul,
                                                                      double ymul) {
-        List<List<List<GeographyValue>>> answer = new ArrayList<List<List<GeographyValue>>>();
+        List<List<List<GeographyValue>>> answer = new ArrayList<>();
         for (int numSides = minNumPoints; numSides <= maxNumPoints; numSides += 1) {
             int idx = numSides - minNumPoints;
             // The x coordinate is xmul * idx
             GeographyPointValue column = x.mul(xmul*idx);
-            List<List<GeographyValue>> oneSize = new ArrayList<List<GeographyValue>>();
+            List<List<GeographyValue>> oneSize = new ArrayList<>();
             for (int ratioLevel = 0; ratioLevel < numIRLevels; ratioLevel += 1) {
                 GeographyPointValue irCenter = column.add(y.mul(numHoleSizeLevels*ymul*ratioLevel));
-                List<GeographyValue> oneRadius = new ArrayList<GeographyValue>();
+                List<GeographyValue> oneRadius = new ArrayList<>();
                 for (int holeNumber = 0; holeNumber < numHoleSizeLevels; holeNumber += 1) {
                     GeographyPointValue offset = irCenter.add(y.mul(ymul*holeNumber));
                     GeographyPointValue center = firstCenter.add(offset);


### PR DESCRIPTION
In the OGC polygon format, WKT, we represent a polygon as a counter clockwise shell followed by zero or more clockwise holes.  In S2 these are all counter clockwise, and S2 maintains the nesting relationship in a different way.  This means we need to reorder vertices in polygons to send them to S2.  In the Java GeographyValue class we represent polygons using the S2 conventions, but the constructor uses the OGC conventions.  This works alright except for the GeographyValue.add function.  This function is internal, and operates on the loops directly from the internal arrays.   Consequently, the add function does not need to reverse the order of holes.  In this commit we make sure this happens.
