### PR TITLE
ENG-13366: Fix XDCR conflict log in mixed version mode.

### DIFF
--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -372,20 +372,6 @@ public:
     std::string debug(const std::string& tableName) const;
     std::string debugNoHeader() const;
 
-    std::string toJsonArray() const {
-        int totalColumns = sizeInValues();
-        Json::Value array(Json::arrayValue);
-
-        array.resize(totalColumns);
-        for (int i = 0; i < totalColumns; i++) {
-            array[i] = getNValue(i).toString();
-        }
-
-        std::string retval = Json::FastWriter().write(array);
-        // The FastWritter always writes a newline at the end, ignore it
-        return std::string(retval, 0, retval.length() - 1);
-    }
-
     std::string toJsonString(const std::vector<std::string>& columnNames) const {
         Json::Value object;
         for (int i = 0; i < sizeInValues(); i++) {

--- a/tests/ee/common/tabletuple_test.cpp
+++ b/tests/ee/common/tabletuple_test.cpp
@@ -126,36 +126,6 @@ TEST_F(TableTupleTest, HiddenColumns)
     nvalVisibleString.free();
 }
 
-TEST_F(TableTupleTest, ToJsonArray)
-{
-    TupleSchemaBuilder builder(3, 2);
-    builder.setColumnAtIndex(0, VALUE_TYPE_BIGINT);
-    builder.setColumnAtIndex(1, VALUE_TYPE_VARCHAR, 256);
-    builder.setColumnAtIndex(2, VALUE_TYPE_VARCHAR, 256);
-    builder.setHiddenColumnAtIndex(0, VALUE_TYPE_BIGINT);
-    builder.setHiddenColumnAtIndex(1, VALUE_TYPE_VARCHAR, 10);
-    ScopedTupleSchema schema(builder.build());
-
-    StandAloneTupleStorage autoStorage(schema.get());
-    const TableTuple& tuple = autoStorage.tuple();
-
-    NValue nvalVisibleBigint = ValueFactory::getBigIntValue(999);
-    NValue nvalVisibleString = ValueFactory::getStringValue("数据库");
-    NValue nvalHiddenBigint = ValueFactory::getBigIntValue(1066);
-    NValue nvalHiddenString = ValueFactory::getStringValue("platypus");
-
-    tuple.setNValue(0, nvalVisibleBigint);
-    tuple.setNValue(1, nvalVisibleString);
-    tuple.setNValue(2, ValueFactory::getNullValue());
-    tuple.setHiddenNValue(0, nvalHiddenBigint);
-    tuple.setHiddenNValue(1, nvalHiddenString);
-
-    EXPECT_EQ(0, strcmp(tuple.toJsonArray().c_str(), "[\"999\",\"数据库\",\"null\"]"));
-
-    nvalHiddenString.free();
-    nvalVisibleString.free();
-}
-
 int main() {
     return TestSuite::globalInstance()->runAll();
 }


### PR DESCRIPTION
The schema of the conflict export table has changed without updating the
compatibility binary log sink code. Whenever there is a conflict using mixed
version XDCR, it fails to write the conflict and breaks replication. I brought
all the changes in the original commit that updated the schema to the
compatibility mode. The commit that introduced the change was
91a0c902d31d4830313e782403d678225a078683. See the commit message for details of
what's included.