### PR TITLE
ENG-13363 Add property for kerberos authentication to JDBC driver

### DIFF
--- a/src/frontend/org/voltdb/jdbc/Driver.java
+++ b/src/frontend/org/voltdb/jdbc/Driver.java
@@ -48,6 +48,7 @@ public class Driver implements java.sql.Driver
     static final String SSL_PROP= "ssl";
     static final String TRUSTSTORE_CONFIG_PROP = "truststore";
     static final String TRUSTSTORE_PASSWORD_PROP = "truststorepassword";
+    static final String KERBEROS_CONFIG_PROP = "kerberos";
 
     // Static so it's unit-testable, yes, lazy me
     static String[] getServersFromURL(String url) {
@@ -142,6 +143,7 @@ public class Driver implements java.sql.Driver
                 boolean enableSSL = false;
                 String truststorePath = null;
                 String truststorePassword = null;
+                String kerberosConfig = null;
 
                 for (Enumeration<?> e = info.propertyNames(); e.hasMoreElements();)
                 {
@@ -170,6 +172,11 @@ public class Driver implements java.sql.Driver
                     else if (key.toLowerCase().equals(TRUSTSTORE_PASSWORD_PROP)) {
                         truststorePassword = value;
                     }
+                    else if (key.toLowerCase().equals(KERBEROS_CONFIG_PROP)) {
+                        if (value != null && value.trim().length() > 0) {
+                            kerberosConfig = value.trim();
+                        }
+                    }
                     // else - unknown; ignore
                 }
                 SSLConfiguration.SslConfig sslConfig = null;
@@ -179,8 +186,9 @@ public class Driver implements java.sql.Driver
 
                 // Return JDBC connection wrapper for the client
                 return  new JDBC4Connection(JDBC4ClientConnectionPool.get(servers, user, password,
-                            heavyweight, maxoutstandingtxns, reconnectOnConnectionLoss, sslConfig),
-                        info);
+                                                                          heavyweight, maxoutstandingtxns, reconnectOnConnectionLoss, sslConfig,
+                                                                          kerberosConfig),
+                                            info);
 
             } catch (Exception x) {
                 throw SQLError.get(x, SQLError.CONNECTION_UNSUCCESSFUL);

--- a/src/frontend/org/voltdb/jdbc/JDBC4ClientConnection.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ClientConnection.java
@@ -122,7 +122,7 @@ public class JDBC4ClientConnection implements Closeable {
                     throws UnknownHostException, IOException
     {
         this(clientConnectionKeyBase, clientConnectionKey, servers, user, password, isHeavyWeight,
-                maxOutstandingTxns, reconnectOnConnectionLoss, null);
+             maxOutstandingTxns, reconnectOnConnectionLoss, null, null);
     }
     /**
      * Creates a new native client wrapper from the given parameters (internal use only).
@@ -160,6 +160,8 @@ public class JDBC4ClientConnection implements Closeable {
      *            Contains properties - trust store path and password, key store path and password,
      *            used for connecting with server over SSL. For unencrypted connection, passed in ssl
      *            config is null
+     * @param kerberosConfig
+     *            Uses specified JAAS file entry id for kerberos authentication if set.
      * @throws IOException
      * @throws UnknownHostException
      */
@@ -167,7 +169,7 @@ public class JDBC4ClientConnection implements Closeable {
             String clientConnectionKeyBase, String clientConnectionKey,
             String[] servers, String user, String password, boolean isHeavyWeight,
             int maxOutstandingTxns, boolean reconnectOnConnectionLoss,
-            SSLConfiguration.SslConfig sslConfig)
+            SSLConfiguration.SslConfig sslConfig, String kerberosConfig)
                     throws UnknownHostException, IOException
     {
         // Save the list of trimmed non-empty server names.
@@ -198,6 +200,10 @@ public class JDBC4ClientConnection implements Closeable {
         if (enableSSL) {
             config.setTrustStore(sslConfig.trustStorePath, sslConfig.trustStorePassword);
             config.enableSSL();
+        }
+
+        if (kerberosConfig != null) {
+            config.enableKerberosAuthentication(kerberosConfig.trim());
         }
 
         // Create client and connect.

--- a/src/frontend/org/voltdb/jdbc/JDBC4ClientConnectionPool.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ClientConnectionPool.java
@@ -72,7 +72,7 @@ public class JDBC4ClientConnectionPool {
      */
     public static JDBC4ClientConnection get(String[] servers, String user,
             String password, boolean isHeavyWeight, int maxOutstandingTxns, boolean reconnectOnConnectionLoss) throws Exception {
-        return get(servers, user, password, isHeavyWeight, maxOutstandingTxns, reconnectOnConnectionLoss, null);
+        return get(servers, user, password, isHeavyWeight, maxOutstandingTxns, reconnectOnConnectionLoss, null, null);
     }
 
     /**
@@ -107,12 +107,15 @@ public class JDBC4ClientConnectionPool {
      *            Contains properties - trust store path and password, key store path and password,
      *            used for connecting with server over SSL. For unencrypted connection, passed in ssl
      *            config is null
+     * @param kerberosConfig
+     *            Uses specified JAAS file entry id for kerberos authentication if set.
      * @return the client connection object the caller should use to post requests.
      * @see #get(String servers, int port, String user, String password, boolean isHeavyWeight, int
      *      maxOutstandingTxns, reconnectOnConnectionLoss)
      */
     public static JDBC4ClientConnection get(String[] servers, String user, String password, boolean isHeavyWeight,
-            int maxOutstandingTxns, boolean reconnectOnConnectionLoss, SSLConfiguration.SslConfig sslConfig) throws Exception {
+                                            int maxOutstandingTxns, boolean reconnectOnConnectionLoss,
+                                            SSLConfiguration.SslConfig sslConfig, String kerberosConfig) throws Exception {
         String clientConnectionKeyBase = getClientConnectionKeyBase(servers, user, password,
                 isHeavyWeight, maxOutstandingTxns, reconnectOnConnectionLoss);
         String clientConnectionKey = clientConnectionKeyBase;
@@ -122,7 +125,7 @@ public class JDBC4ClientConnectionPool {
                 ClientConnections.put(clientConnectionKey, new JDBC4ClientConnection(
                         clientConnectionKeyBase, clientConnectionKey, servers, user,
                         password, isHeavyWeight, maxOutstandingTxns, reconnectOnConnectionLoss,
-                        sslConfig));
+                        sslConfig, kerberosConfig));
             return ClientConnections.get(clientConnectionKey).use();
         }
     }


### PR DESCRIPTION
To enable kerberos authentication for the VoltDB JDBC driver, set the JDBC property "kerberos=VoltDBClient". This will use the "VoltDBClient" configuration entry id in your JAAS file, similar to sqlcmd and java clients.