### PR TITLE
Eng 12889 nibble delete sysproc

### DIFF
--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -215,6 +215,7 @@ public class SystemProcedureCatalog {
         builder.put("@StartNodeDRConsumerNT",   new Config("org.voltdb.sysprocs.RestartDRConsumerNT$StartNodeDRConsumerNT",
                                                                                                            false, false, false, 0,    VoltType.INVALID,   true,  false, true,  true,      false,  false,            false,        false ));
         builder.put("@NibbleDeleteSP",          new Config("org.voltdb.sysprocs.NibbleDeleteSP",           true,  false, false, 0,    VoltType.INVALID,   false, false, true,  true,      true,   false,            true,         false ));
+        builder.put("@NibbleDeleteMP",          new Config("org.voltdb.sysprocs.NibbleDeleteMP",           false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      true,   false,            true,         false ));
         listing = builder.build();
     }
 }

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -214,6 +214,7 @@ public class SystemProcedureCatalog {
                                                                                                            false, false, false, 0,    VoltType.INVALID,   true,  false, true,  true,      false,  false,            false,        false ));
         builder.put("@StartNodeDRConsumerNT",   new Config("org.voltdb.sysprocs.RestartDRConsumerNT$StartNodeDRConsumerNT",
                                                                                                            false, false, false, 0,    VoltType.INVALID,   true,  false, true,  true,      false,  false,            false,        false ));
+        builder.put("@NibbleDeleteSP",          new Config("org.voltdb.sysprocs.NibbleDeleteSP",           true,  false, false, 0,    VoltType.INVALID,   false, false, true,  true,      true,   false,            true,         false ));
         listing = builder.build();
     }
 }

--- a/src/frontend/org/voltdb/compiler/StatementCompiler.java
+++ b/src/frontend/org/voltdb/compiler/StatementCompiler.java
@@ -612,7 +612,7 @@ public abstract class StatementCompiler {
     /**
      * Update the plan fragment and return the bytes of the plan
      */
-    static byte[] writePlanBytes(PlanFragment fragment, AbstractPlanNode planGraph) {
+    public static byte[] writePlanBytes(PlanFragment fragment, AbstractPlanNode planGraph) {
         // get the plan bytes
         PlanNodeList node_list = new PlanNodeList(planGraph, false);
         String json = node_list.toJSONString();

--- a/src/frontend/org/voltdb/compiler/StatementCompiler.java
+++ b/src/frontend/org/voltdb/compiler/StatementCompiler.java
@@ -23,11 +23,13 @@ import java.security.NoSuchAlgorithmException;
 import org.hsqldb_voltpatches.HSQLInterface;
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.voltcore.logging.VoltLogger;
+import org.voltdb.CatalogContext;
 import org.voltdb.CatalogContext.ProcedurePartitionInfo;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.Catalog;
 import org.voltdb.catalog.CatalogMap;
+import org.voltdb.catalog.Column;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Function;
 import org.voltdb.catalog.PlanFragment;
@@ -48,6 +50,7 @@ import org.voltdb.plannodes.DeletePlanNode;
 import org.voltdb.plannodes.InsertPlanNode;
 import org.voltdb.plannodes.PlanNodeList;
 import org.voltdb.plannodes.UpdatePlanNode;
+import org.voltdb.sysprocs.NibbleDeleteSP.ComparisonConstant;
 import org.voltdb.types.QueryType;
 import org.voltdb.utils.BuildDirectoryUtils;
 import org.voltdb.utils.CatalogUtil;
@@ -612,7 +615,7 @@ public abstract class StatementCompiler {
     /**
      * Update the plan fragment and return the bytes of the plan
      */
-    public static byte[] writePlanBytes(PlanFragment fragment, AbstractPlanNode planGraph) {
+    static byte[] writePlanBytes(PlanFragment fragment, AbstractPlanNode planGraph) {
         // get the plan bytes
         PlanNodeList node_list = new PlanNodeList(planGraph, false);
         String json = node_list.toJSONString();
@@ -621,5 +624,156 @@ public abstract class StatementCompiler {
         String bin64String = CompressionService.compressAndBase64Encode(jsonBytes);
         fragment.setPlannodetree(bin64String);
         return jsonBytes;
+    }
+
+    private static String genSelectSql(Table table, Column column,
+            ComparisonConstant comparison) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("SELECT COUNT(*) FROM " + table.getTypeName());
+        sb.append(" WHERE " + column.getName() + " " + comparison.toString() + " ?;");
+        return sb.toString();
+    }
+
+    private static String genDeleteSql(Table table, Column column,
+            ComparisonConstant comparison) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("DELETE FROM " + table.getTypeName());
+        sb.append(" WHERE " + column.getName() + " " + comparison.toString() + " ?;");
+        return sb.toString();
+    }
+
+    private static String genValueAtOffsetSql(Table table, Column column) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("SELECT " + column.getName() + " FROM " + table.getTypeName());
+        sb.append(" ORDER BY " + column.getName());
+        sb.append(" ASC OFFSET ? LIMIT 1;");
+        return sb.toString();
+    }
+
+    private static Procedure addProcedure(Table catTable, String procName) {
+        // fake db makes it easy to create procedures that aren't part of the main catalog
+        Database fakeDb = new Catalog().getClusters().add("cluster").getDatabases().add("database");
+        Column partitionColumn = catTable.getPartitioncolumn();
+        Procedure newCatProc = fakeDb.getProcedures().add(procName);
+        newCatProc.setClassname(procName);
+        newCatProc.setDefaultproc(false);
+        newCatProc.setEverysite(false);
+        newCatProc.setHasjava(false);
+        newCatProc.setPartitioncolumn(catTable.getPartitioncolumn());
+        if (catTable.getIsreplicated()) {
+            newCatProc.setPartitionparameter(-1);
+        } else {
+            newCatProc.setPartitionparameter(partitionColumn.getIndex());
+        }
+        newCatProc.setPartitiontable(catTable);
+        newCatProc.setReadonly(false);
+        newCatProc.setSinglepartition(!catTable.getIsreplicated());
+        newCatProc.setSystemproc(false);
+        if (!catTable.getIsreplicated()) {
+            newCatProc.setAttachment(
+                    new ProcedurePartitionInfo(
+                            VoltType.get((byte)partitionColumn.getType()),
+                            partitionColumn.getIndex()));
+        }
+
+        return newCatProc;
+    }
+
+    private static void addStatement(Table catTable, Procedure newCatProc, String sqlText, String index) {
+        CatalogMap<Statement> statements = newCatProc.getStatements();
+        assert(statements != null);
+
+        // determine the type of the query
+        QueryType qtype = QueryType.getFromSQL(sqlText);
+
+        CatalogContext context = VoltDB.instance().getCatalogContext();
+        PlannerTool plannerTool = context.m_ptool;
+
+        StatementPartitioning partitioning =
+                newCatProc.getSinglepartition() ? StatementPartitioning.forceSP() :
+                                               StatementPartitioning.forceMP();
+
+        CompiledPlan plan = plannerTool.planSqlCore(sqlText, partitioning);
+        /* since there can be multiple statements in a procedure,
+         * we name the statements starting from 'sql0' even for single statement procedures
+         * since we reuse the same code for single and multi-statement procedures
+         *     statements of all single statement procedures are named 'sql0'
+        */
+        Statement stmt = statements.add(VoltDB.ANON_STMT_NAME + index);
+        stmt.setSqltext(sqlText);
+        stmt.setReadonly(newCatProc.getReadonly());
+        stmt.setQuerytype(qtype.getValue());
+        stmt.setSinglepartition(newCatProc.getSinglepartition());
+        stmt.setIscontentdeterministic(true);
+        stmt.setIsorderdeterministic(true);
+        stmt.setNondeterminismdetail("NO CONTENT FOR DEFAULT PROCS");
+        stmt.setSeqscancount(plan.countSeqScans());
+        stmt.setReplicatedtabledml(!newCatProc.getReadonly() && catTable.getIsreplicated());
+
+        // Input Parameters
+        // We will need to update the system catalogs with this new information
+        for (int i = 0; i < plan.getParameters().length; ++i) {
+            StmtParameter catalogParam = stmt.getParameters().add(String.valueOf(i));
+            catalogParam.setIndex(i);
+            ParameterValueExpression pve = plan.getParameters()[i];
+            catalogParam.setJavatype(pve.getValueType().getValue());
+            catalogParam.setIsarray(pve.getParamIsVector());
+        }
+
+        PlanFragment frag = stmt.getFragments().add("0");
+
+        // compute a hash of the plan
+        MessageDigest md = null;
+        try {
+            md = MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            assert(false);
+            System.exit(-1); // should never happen with healthy jvm
+        }
+
+        byte[] planBytes = writePlanBytes(frag, plan.rootPlanGraph);
+        md.update(planBytes, 0, planBytes.length);
+        // compute the 40 bytes of hex from the 20 byte sha1 hash of the plans
+        md.reset();
+        md.update(planBytes);
+        frag.setPlanhash(Encoder.hexEncode(md.digest()));
+
+        if (plan.subPlanGraph != null) {
+            frag.setHasdependencies(true);
+            frag.setNontransactional(true);
+            frag.setMultipartition(true);
+
+            frag = stmt.getFragments().add("1");
+            frag.setHasdependencies(false);
+            frag.setNontransactional(false);
+            frag.setMultipartition(true);
+            byte[] subBytes = writePlanBytes(frag, plan.subPlanGraph);
+            // compute the 40 bytes of hex from the 20 byte sha1 hash of the plans
+            md.reset();
+            md.update(subBytes);
+            frag.setPlanhash(Encoder.hexEncode(md.digest()));
+        }
+        else {
+            frag.setHasdependencies(false);
+            frag.setNontransactional(false);
+            frag.setMultipartition(false);
+        }
+    }
+
+    public static Procedure compileNibbleDeleteProcedure(Table catTable, String procName,
+            Column col, ComparisonConstant comp) {
+        Procedure newCatProc = addProcedure(catTable, procName);
+
+        String countingQuery = genSelectSql(catTable, col, comp);
+        addStatement(catTable, newCatProc, countingQuery, "0");
+
+        String deleteQuery = genDeleteSql(catTable, col, comp);
+        addStatement(catTable, newCatProc, deleteQuery, "1");
+
+        String valueAtQuery = genValueAtOffsetSql(catTable, col);
+        addStatement(catTable, newCatProc, valueAtQuery, "2");
+
+        return newCatProc;
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/NibbleDeleteMP.java
+++ b/src/frontend/org/voltdb/sysprocs/NibbleDeleteMP.java
@@ -123,10 +123,14 @@ public class NibbleDeleteMP extends VoltSystemProcedure {
 
         // so far should only be single column, single row table
         int columnCount = table.getColumnCount();
+        if (columnCount > 1) {
+            throw new VoltAbortException("Only support one input parameter now.");
+        }
         assert(columnCount == 1);
         table.resetRowPosition();
+        table.advanceRow();
         Object[] params = new Object[columnCount];
-        for (int i = 0; table.advanceRow(); i++) {
+        for (int i = 0; i < columnCount; i++) {
             params[i] = table.get(i, table.getColumnType(i));
         }
         assert (params.length == 1);

--- a/src/frontend/org/voltdb/sysprocs/NibbleDeleteMP.java
+++ b/src/frontend/org/voltdb/sysprocs/NibbleDeleteMP.java
@@ -17,8 +17,6 @@
 
 package org.voltdb.sysprocs;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -26,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.RateLimitedLogger;
-import org.voltdb.CatalogContext;
 import org.voltdb.DependencyPair;
 import org.voltdb.ParameterSet;
 import org.voltdb.SQLStmt;
@@ -36,24 +33,13 @@ import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
-import org.voltdb.catalog.Catalog;
-import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Column;
-import org.voltdb.catalog.Database;
-import org.voltdb.catalog.PlanFragment;
 import org.voltdb.catalog.Procedure;
 import org.voltdb.catalog.Statement;
-import org.voltdb.catalog.StmtParameter;
 import org.voltdb.catalog.Table;
-import org.voltdb.compiler.PlannerTool;
 import org.voltdb.compiler.StatementCompiler;
-import org.voltdb.expressions.ParameterValueExpression;
-import org.voltdb.planner.CompiledPlan;
-import org.voltdb.planner.StatementPartitioning;
 import org.voltdb.sysprocs.NibbleDeleteSP.ComparisonConstant;
-import org.voltdb.types.QueryType;
 import org.voltdb.utils.CatalogUtil;
-import org.voltdb.utils.Encoder;
 
 public class NibbleDeleteMP extends VoltSystemProcedure {
     private static VoltLogger hostLog = new VoltLogger("HOST");
@@ -72,127 +58,8 @@ public class NibbleDeleteMP extends VoltSystemProcedure {
     public DependencyPair executePlanFragment(
             Map<Integer, List<VoltTable>> dependencies, long fragmentId,
             ParameterSet params, SystemProcedureExecutionContext context) {
-        // TODO Auto-generated method stub
+        // Never called, we do all the work in run()
         return null;
-    }
-
-    private String genSelectSql(Table table, Column column,
-            ComparisonConstant comparison) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("SELECT COUNT(*) FROM " + table.getTypeName());
-        sb.append(" WHERE " + column.getName() + " " + comparison.toString() + " ?;");
-        return sb.toString();
-    }
-
-    private String genDeleteSql(Table table, Column column,
-            ComparisonConstant comparison) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("DELETE FROM " + table.getTypeName());
-        sb.append(" WHERE " + column.getName() + " " + comparison.toString() + " ?;");
-        return sb.toString();
-    }
-
-    private String genValueAtOffsetSql(Table table, Column column) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("SELECT " + column.getName() + " FROM " + table.getTypeName());
-        sb.append(" ORDER BY " + column.getName());
-        sb.append(" ASC OFFSET ? LIMIT 1;");
-        return sb.toString();
-    }
-
-    private Procedure addProcedure(Table catTable, String tableName) {
-        // fake db makes it easy to create procedures that aren't part of the main catalog
-        Database fakeDb = new Catalog().getClusters().add("cluster").getDatabases().add("database");
-        Procedure newCatProc = fakeDb.getProcedures().add(this.getClass().getName() + "-" + tableName);
-        newCatProc.setClassname(this.getClass().getName() + "-" + tableName);
-        newCatProc.setDefaultproc(false);
-        newCatProc.setEverysite(false);
-        newCatProc.setHasjava(false);
-        newCatProc.setPartitioncolumn(null);
-        newCatProc.setPartitionparameter(-1);
-        newCatProc.setPartitiontable(catTable);
-        newCatProc.setReadonly(false);
-        newCatProc.setSinglepartition(false);
-        newCatProc.setSystemproc(false);
-        return newCatProc;
-    }
-
-    private void addStatement(Table catTable, Procedure newCatProc, String sqlText, String index) {
-        CatalogMap<Statement> statements = newCatProc.getStatements();
-        assert(statements != null);
-
-        // determine the type of the query
-        QueryType qtype = QueryType.getFromSQL(sqlText);
-
-        CatalogContext context = VoltDB.instance().getCatalogContext();
-        PlannerTool plannerTool = context.m_ptool;
-        CompiledPlan plan = plannerTool.planSqlCore(sqlText, StatementPartitioning.forceMP());
-        /* since there can be multiple statements in a procedure,
-         * we name the statements starting from 'sql0' even for single statement procedures
-         * since we reuse the same code for single and multi-statement procedures
-         *     statements of all single statement procedures are named 'sql0'
-        */
-
-        Statement stmt = statements.add(VoltDB.ANON_STMT_NAME + index);
-        stmt.setSqltext(sqlText);
-        stmt.setReadonly(newCatProc.getReadonly());
-        stmt.setQuerytype(qtype.getValue());
-        stmt.setSinglepartition(newCatProc.getSinglepartition());
-        stmt.setIscontentdeterministic(true);
-        stmt.setIsorderdeterministic(true);
-        stmt.setNondeterminismdetail("NO CONTENT FOR DEFAULT PROCS");
-        stmt.setSeqscancount(plan.countSeqScans());
-        stmt.setReplicatedtabledml(!newCatProc.getReadonly() && catTable.getIsreplicated());
-
-        // Input Parameters
-        // We will need to update the system catalogs with this new information
-        for (int i = 0; i < plan.getParameters().length; ++i) {
-            StmtParameter catalogParam = stmt.getParameters().add(String.valueOf(i));
-            catalogParam.setIndex(i);
-            ParameterValueExpression pve = plan.getParameters()[i];
-            catalogParam.setJavatype(pve.getValueType().getValue());
-            catalogParam.setIsarray(pve.getParamIsVector());
-        }
-
-        PlanFragment frag = stmt.getFragments().add("0");
-
-        // compute a hash of the plan
-        MessageDigest md = null;
-        try {
-            md = MessageDigest.getInstance("SHA-1");
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-            assert(false);
-            System.exit(-1); // should never happen with healthy jvm
-        }
-
-        byte[] planBytes = StatementCompiler.writePlanBytes(frag, plan.rootPlanGraph);
-        md.update(planBytes, 0, planBytes.length);
-        // compute the 40 bytes of hex from the 20 byte sha1 hash of the plans
-        md.reset();
-        md.update(planBytes);
-        frag.setPlanhash(Encoder.hexEncode(md.digest()));
-
-        if (plan.subPlanGraph != null) {
-            frag.setHasdependencies(true);
-            frag.setNontransactional(true);
-            frag.setMultipartition(true);
-
-            frag = stmt.getFragments().add("1");
-            frag.setHasdependencies(false);
-            frag.setNontransactional(false);
-            frag.setMultipartition(true);
-            byte[] subBytes = StatementCompiler.writePlanBytes(frag, plan.subPlanGraph);
-            // compute the 40 bytes of hex from the 20 byte sha1 hash of the plans
-            md.reset();
-            md.update(subBytes);
-            frag.setPlanhash(Encoder.hexEncode(md.digest()));
-        }
-        else {
-            frag.setHasdependencies(false);
-            frag.setNontransactional(false);
-            frag.setMultipartition(false);
-        }
     }
 
     /**
@@ -278,13 +145,9 @@ public class NibbleDeleteMP extends VoltSystemProcedure {
         }
         ComparisonConstant comparisonConstant = ComparisonConstant.values()[comparison];
 
-        Procedure newCatProc = addProcedure(catTable, tableName);
-        String countingQuery = genSelectSql(catTable, column,comparisonConstant);
-        addStatement(catTable, newCatProc, countingQuery, "0");
-        String deleteQuery = genDeleteSql(catTable, column, comparisonConstant);
-        addStatement(catTable, newCatProc, deleteQuery, "1");
-        String valueAtQuery = genValueAtOffsetSql(catTable, column);
-        addStatement(catTable, newCatProc, valueAtQuery, "2");
+        // TODO: should cache the plan in somewhere
+        Procedure newCatProc = StatementCompiler.compileNibbleDeleteProcedure(catTable,
+                this.getClass().getName() + "-" + tableName, column, comparisonConstant);
 
         Statement countStmt = newCatProc.getStatements().get(VoltDB.ANON_STMT_NAME + "0");
         Statement deleteStmt = newCatProc.getStatements().get(VoltDB.ANON_STMT_NAME + "1");

--- a/src/frontend/org/voltdb/sysprocs/NibbleDeleteSP.java
+++ b/src/frontend/org/voltdb/sysprocs/NibbleDeleteSP.java
@@ -1,0 +1,254 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.sysprocs;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+
+import org.voltdb.CatalogContext;
+import org.voltdb.CatalogContext.ProcedurePartitionInfo;
+import org.voltdb.DependencyPair;
+import org.voltdb.ParameterSet;
+import org.voltdb.SystemProcedureExecutionContext;
+import org.voltdb.VoltDB;
+import org.voltdb.VoltSystemProcedure;
+import org.voltdb.VoltTable;
+import org.voltdb.VoltType;
+import org.voltdb.catalog.Catalog;
+import org.voltdb.catalog.CatalogMap;
+import org.voltdb.catalog.Column;
+import org.voltdb.catalog.Database;
+import org.voltdb.catalog.PlanFragment;
+import org.voltdb.catalog.ProcParameter;
+import org.voltdb.catalog.Procedure;
+import org.voltdb.catalog.Statement;
+import org.voltdb.catalog.StmtParameter;
+import org.voltdb.catalog.Table;
+import org.voltdb.compiler.PlannerTool;
+import org.voltdb.compiler.StatementCompiler;
+import org.voltdb.expressions.ParameterValueExpression;
+import org.voltdb.planner.CompiledPlan;
+import org.voltdb.planner.StatementPartitioning;
+import org.voltdb.types.QueryType;
+import org.voltdb.utils.CatalogUtil;
+import org.voltdb.utils.Encoder;
+
+public class NibbleDeleteSP extends VoltSystemProcedure {
+
+    public static enum ComparisonConstant {
+        GREATER_THAN (">"),
+        LESS_THAN ("<"),
+        GREATER_OR_EQUAL (">="),
+        LESS_OR_EQUAL ("<="),
+        EQUAL ("=");
+
+        private final String m_symbol;
+
+        private ComparisonConstant(String symbol) {
+            m_symbol = symbol;
+        }
+
+        public String toString() { return m_symbol; }
+    }
+
+    public long[] getPlanFragmentIds() {
+        return new long[]{};
+    }
+
+    public DependencyPair executePlanFragment(
+            Map<Integer, List<VoltTable>> dependencies, long fragmentId,
+            ParameterSet params, SystemProcedureExecutionContext context) {
+        // Never called, we do all the work in run()
+        return null;
+    }
+
+    private String genereateSelectSql(Table table, Column column,
+            ComparisonConstant comparison) {
+        // TODO: to be implemented.
+        // Index scan first then delete? Performance impact?
+        return null;
+    }
+
+    private String generateNibbleDeleteSql(Table table, Column column,
+            ComparisonConstant comparison, long chunksize) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("DELETE FROM " + table.getTypeName());
+        sb.append(" WHERE " + column.getName() + " " + comparison.toString() + " ?");
+        sb.append(" LIMIT " + chunksize);
+        sb.append(" ORDER BY " + column.getName());
+        sb.append(";");
+
+        return sb.toString();
+    }
+
+    private Procedure compileProcedure(Table catTable, String tableName, String sqlText) {
+        CatalogContext context = VoltDB.instance().getCatalogContext();
+        PlannerTool plannerTool = context.m_ptool;
+        CompiledPlan plan = plannerTool.planSqlCore(sqlText, StatementPartitioning.forceSP());
+        // fake db makes it easy to create procedures that aren't part of the main catalog
+        Database fakeDb = new Catalog().getClusters().add("cluster").getDatabases().add("database");
+        Column partitionColumn = catTable.getPartitioncolumn();
+        Procedure newCatProc = fakeDb.getProcedures().add(this.getClass().getName() + "-" + tableName);
+        newCatProc.setClassname(this.getClass().getName() + "-" + tableName);
+        newCatProc.setDefaultproc(false);
+        newCatProc.setEverysite(false);
+        newCatProc.setHasjava(false);
+        newCatProc.setPartitioncolumn(partitionColumn);
+        newCatProc.setPartitionparameter(partitionColumn.getIndex());
+        newCatProc.setPartitiontable(catTable);
+        newCatProc.setReadonly(false);
+        newCatProc.setSinglepartition(true);
+        newCatProc.setSystemproc(false);
+        newCatProc.setAttachment(
+                new ProcedurePartitionInfo(
+                        VoltType.get((byte)partitionColumn.getType()),
+                        partitionColumn.getIndex()));
+
+        CatalogMap<Statement> statements = newCatProc.getStatements();
+        assert(statements != null);
+        /* since there can be multiple statements in a procedure,
+         * we name the statements starting from 'sql0' even for single statement procedures
+         * since we reuse the same code for single and multi-statement procedures
+         *     statements of all single statement procedures are named 'sql0'
+        */
+        Statement stmt = statements.add(VoltDB.ANON_STMT_NAME + "0");
+        stmt.setSqltext(sqlText);
+        stmt.setReadonly(newCatProc.getReadonly());
+        stmt.setQuerytype(QueryType.DELETE.getValue());
+        stmt.setSinglepartition(newCatProc.getSinglepartition());
+        stmt.setIscontentdeterministic(true);
+        stmt.setIsorderdeterministic(true);
+        stmt.setNondeterminismdetail("NO CONTENT FOR DEFAULT PROCS");
+        stmt.setSeqscancount(plan.countSeqScans());
+        stmt.setReplicatedtabledml(!newCatProc.getReadonly() && catTable.getIsreplicated());
+
+        // Input Parameters
+        // We will need to update the system catalogs with this new information
+        for (int i = 0; i < plan.getParameters().length; ++i) {
+            StmtParameter catalogParam = stmt.getParameters().add(String.valueOf(i));
+            catalogParam.setIndex(i);
+            ParameterValueExpression pve = plan.getParameters()[i];
+            catalogParam.setJavatype(pve.getValueType().getValue());
+            catalogParam.setIsarray(pve.getParamIsVector());
+        }
+
+        PlanFragment frag = stmt.getFragments().add("0");
+
+        // compute a hash of the plan
+        MessageDigest md = null;
+        try {
+            md = MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            assert(false);
+            System.exit(-1); // should never happen with healthy jvm
+        }
+
+        byte[] planBytes = StatementCompiler.writePlanBytes(frag, plan.rootPlanGraph);
+        md.update(planBytes, 0, planBytes.length);
+        // compute the 40 bytes of hex from the 20 byte sha1 hash of the plans
+        md.reset();
+        md.update(planBytes);
+        frag.setPlanhash(Encoder.hexEncode(md.digest()));
+
+        if (plan.subPlanGraph != null) {
+            frag.setHasdependencies(true);
+            frag.setNontransactional(true);
+            frag.setMultipartition(true);
+
+            frag = stmt.getFragments().add("1");
+            frag.setHasdependencies(false);
+            frag.setNontransactional(false);
+            frag.setMultipartition(true);
+            byte[] subBytes = StatementCompiler.writePlanBytes(frag, plan.subPlanGraph);
+            // compute the 40 bytes of hex from the 20 byte sha1 hash of the plans
+            md.reset();
+            md.update(subBytes);
+            frag.setPlanhash(Encoder.hexEncode(md.digest()));
+        }
+        else {
+            frag.setHasdependencies(false);
+            frag.setNontransactional(false);
+            frag.setMultipartition(false);
+        }
+
+        // set the procedure parameter types from the statement parameter types
+        int paramCount = 0;
+        for (StmtParameter stmtParam : CatalogUtil.getSortedCatalogItems(stmt.getParameters(), "index")) {
+            // name each parameter "param1", "param2", etc...
+            ProcParameter procParam = newCatProc.getParameters().add("param" + String.valueOf(paramCount));
+            procParam.setIndex(stmtParam.getIndex());
+            procParam.setIsarray(stmtParam.getIsarray());
+            procParam.setType(stmtParam.getJavatype());
+            paramCount++;
+        }
+
+        return newCatProc;
+    }
+
+    /**
+     * Nibble delete procedure for partitioned tables
+     *
+     * @param ctx         Internal API provided to all system procedures
+     * @param partitionParam Partition parameter used to match invocation to partition
+     * @param tableName   Name of persistent partitioned table
+     * @param columnName  A column in the given table that its value can be used to provide
+     *                    order for delete action. (Unique or non-unique) index is expected
+     *                    on the column, if not a warning message will be printed.
+     * @param comparison  "GREATER_THAN", "LESS_THAN"
+     * @param value       value to compare
+     * @param chunksize   maximum number of rows allow to be deleted
+     * @return how many rows are deleted and how many rows left to be deleted (if any)
+     */
+    public VoltTable run(SystemProcedureExecutionContext ctx, String tableName, String columnName,
+            ComparisonConstant comparison, Object value, long chunksize) {
+        // Some basic checks
+        Table catTable = ctx.getDatabase().getTables().getIgnoreCase(tableName);
+        if (catTable == null) {
+            throw new VoltAbortException("Table not present in catalog");
+        }
+        if (catTable.getIsreplicated()) {
+            throw new VoltAbortException(
+                    String.format("%s incompatible with replicated table %s.",
+                            this.getClass().getName(), tableName));
+        }
+        Column column = catTable.getColumns().get(columnName);
+        if (column == null) {
+            throw new VoltAbortException(
+                    String.format("Column %s does not exist in table %s", columnName, tableName));
+        }
+        if (VoltType.typeFromObject(value) != VoltType.valueOf(column.getTypeName())) {
+            throw new VoltAbortException(
+                    String.format("Parameter type %s doesn't match column type %s",
+                            VoltType.typeFromObject(value).toString(),
+                            column.getTypeName()));
+        }
+
+        // Generate sql text for given column name and comparison constant
+        String sqlText = generateNibbleDeleteSql(catTable, column, comparison, chunksize);
+
+        Procedure newCatProc = compileProcedure(catTable, tableName, )
+
+
+        return null;
+    }
+
+}

--- a/src/frontend/org/voltdb/sysprocs/NibbleDeleteSP.java
+++ b/src/frontend/org/voltdb/sysprocs/NibbleDeleteSP.java
@@ -135,10 +135,14 @@ public class NibbleDeleteSP extends VoltSystemProcedure {
 
         // so far should only be single column, single row table
         int columnCount = table.getColumnCount();
+        if (columnCount > 1) {
+            throw new VoltAbortException("Only support one input parameter now.");
+        }
         assert(columnCount == 1);
         table.resetRowPosition();
+        table.advanceRow();
         Object[] params = new Object[columnCount];
-        for (int i = 0; table.advanceRow(); i++) {
+        for (int i = 0; i < columnCount; i++) {
             params[i] = table.get(i, table.getColumnType(i));
         }
         assert (params.length == 1);

--- a/src/frontend/org/voltdb/sysprocs/NibbleDeleteSP.java
+++ b/src/frontend/org/voltdb/sysprocs/NibbleDeleteSP.java
@@ -17,8 +17,6 @@
 
 package org.voltdb.sysprocs;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -26,8 +24,6 @@ import java.util.concurrent.TimeUnit;
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.RateLimitedLogger;
-import org.voltdb.CatalogContext;
-import org.voltdb.CatalogContext.ProcedurePartitionInfo;
 import org.voltdb.DependencyPair;
 import org.voltdb.ParameterSet;
 import org.voltdb.SQLStmt;
@@ -37,23 +33,12 @@ import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
-import org.voltdb.catalog.Catalog;
-import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Column;
-import org.voltdb.catalog.Database;
-import org.voltdb.catalog.PlanFragment;
 import org.voltdb.catalog.Procedure;
 import org.voltdb.catalog.Statement;
-import org.voltdb.catalog.StmtParameter;
 import org.voltdb.catalog.Table;
-import org.voltdb.compiler.PlannerTool;
 import org.voltdb.compiler.StatementCompiler;
-import org.voltdb.expressions.ParameterValueExpression;
-import org.voltdb.planner.CompiledPlan;
-import org.voltdb.planner.StatementPartitioning;
-import org.voltdb.types.QueryType;
 import org.voltdb.utils.CatalogUtil;
-import org.voltdb.utils.Encoder;
 
 public class NibbleDeleteSP extends VoltSystemProcedure {
     private static VoltLogger hostLog = new VoltLogger("HOST");
@@ -88,130 +73,6 @@ public class NibbleDeleteSP extends VoltSystemProcedure {
             ParameterSet params, SystemProcedureExecutionContext context) {
         // Never called, we do all the work in run()
         return null;
-    }
-
-    private String genSelectSql(Table table, Column column,
-            ComparisonConstant comparison) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("SELECT COUNT(*) FROM " + table.getTypeName());
-        sb.append(" WHERE " + column.getName() + " " + comparison.toString() + " ?;");
-        return sb.toString();
-    }
-
-    private String genDeleteSql(Table table, Column column,
-            ComparisonConstant comparison) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("DELETE FROM " + table.getTypeName());
-        sb.append(" WHERE " + column.getName() + " " + comparison.toString() + " ?;");
-        return sb.toString();
-    }
-
-    private String genValueAtOffsetSql(Table table, Column column) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("SELECT " + column.getName() + " FROM " + table.getTypeName());
-        sb.append(" ORDER BY " + column.getName());
-        sb.append(" ASC OFFSET ? LIMIT 1;");
-        return sb.toString();
-    }
-
-    private Procedure addProcedure(Table catTable, String tableName) {
-        // fake db makes it easy to create procedures that aren't part of the main catalog
-        Database fakeDb = new Catalog().getClusters().add("cluster").getDatabases().add("database");
-        Column partitionColumn = catTable.getPartitioncolumn();
-        Procedure newCatProc = fakeDb.getProcedures().add(this.getClass().getName() + "-" + tableName);
-        newCatProc.setClassname(this.getClass().getName() + "-" + tableName);
-        newCatProc.setDefaultproc(false);
-        newCatProc.setEverysite(false);
-        newCatProc.setHasjava(false);
-        newCatProc.setPartitioncolumn(partitionColumn);
-        newCatProc.setPartitionparameter(partitionColumn.getIndex());
-        newCatProc.setPartitiontable(catTable);
-        newCatProc.setReadonly(false);
-        newCatProc.setSinglepartition(true);
-        newCatProc.setSystemproc(false);
-        newCatProc.setAttachment(
-                new ProcedurePartitionInfo(
-                        VoltType.get((byte)partitionColumn.getType()),
-                        partitionColumn.getIndex()));
-
-        return newCatProc;
-    }
-
-    private void addStatement(Table catTable, Procedure newCatProc, String sqlText, String index) {
-        CatalogMap<Statement> statements = newCatProc.getStatements();
-        assert(statements != null);
-
-        // determine the type of the query
-        QueryType qtype = QueryType.getFromSQL(sqlText);
-
-        CatalogContext context = VoltDB.instance().getCatalogContext();
-        PlannerTool plannerTool = context.m_ptool;
-        CompiledPlan plan = plannerTool.planSqlCore(sqlText, StatementPartitioning.forceSP());
-        /* since there can be multiple statements in a procedure,
-         * we name the statements starting from 'sql0' even for single statement procedures
-         * since we reuse the same code for single and multi-statement procedures
-         *     statements of all single statement procedures are named 'sql0'
-        */
-        Statement stmt = statements.add(VoltDB.ANON_STMT_NAME + index);
-        stmt.setSqltext(sqlText);
-        stmt.setReadonly(newCatProc.getReadonly());
-        stmt.setQuerytype(qtype.getValue());
-        stmt.setSinglepartition(newCatProc.getSinglepartition());
-        stmt.setIscontentdeterministic(true);
-        stmt.setIsorderdeterministic(true);
-        stmt.setNondeterminismdetail("NO CONTENT FOR DEFAULT PROCS");
-        stmt.setSeqscancount(plan.countSeqScans());
-        stmt.setReplicatedtabledml(!newCatProc.getReadonly() && catTable.getIsreplicated());
-
-        // Input Parameters
-        // We will need to update the system catalogs with this new information
-        for (int i = 0; i < plan.getParameters().length; ++i) {
-            StmtParameter catalogParam = stmt.getParameters().add(String.valueOf(i));
-            catalogParam.setIndex(i);
-            ParameterValueExpression pve = plan.getParameters()[i];
-            catalogParam.setJavatype(pve.getValueType().getValue());
-            catalogParam.setIsarray(pve.getParamIsVector());
-        }
-
-        PlanFragment frag = stmt.getFragments().add("0");
-
-        // compute a hash of the plan
-        MessageDigest md = null;
-        try {
-            md = MessageDigest.getInstance("SHA-1");
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-            assert(false);
-            System.exit(-1); // should never happen with healthy jvm
-        }
-
-        byte[] planBytes = StatementCompiler.writePlanBytes(frag, plan.rootPlanGraph);
-        md.update(planBytes, 0, planBytes.length);
-        // compute the 40 bytes of hex from the 20 byte sha1 hash of the plans
-        md.reset();
-        md.update(planBytes);
-        frag.setPlanhash(Encoder.hexEncode(md.digest()));
-
-        if (plan.subPlanGraph != null) {
-            frag.setHasdependencies(true);
-            frag.setNontransactional(true);
-            frag.setMultipartition(true);
-
-            frag = stmt.getFragments().add("1");
-            frag.setHasdependencies(false);
-            frag.setNontransactional(false);
-            frag.setMultipartition(true);
-            byte[] subBytes = StatementCompiler.writePlanBytes(frag, plan.subPlanGraph);
-            // compute the 40 bytes of hex from the 20 byte sha1 hash of the plans
-            md.reset();
-            md.update(subBytes);
-            frag.setPlanhash(Encoder.hexEncode(md.digest()));
-        }
-        else {
-            frag.setHasdependencies(false);
-            frag.setNontransactional(false);
-            frag.setMultipartition(false);
-        }
     }
 
     /**
@@ -296,13 +157,10 @@ public class NibbleDeleteSP extends VoltSystemProcedure {
         }
         ComparisonConstant comparisonConstant = ComparisonConstant.values()[comparison];
 
-        Procedure newCatProc = addProcedure(catTable, tableName);
-        String countingQuery = genSelectSql(catTable, column,comparisonConstant);
-        addStatement(catTable, newCatProc, countingQuery, "0");
-        String deleteQuery = genDeleteSql(catTable, column, comparisonConstant);
-        addStatement(catTable, newCatProc, deleteQuery, "1");
-        String valueAtQuery = genValueAtOffsetSql(catTable, column);
-        addStatement(catTable, newCatProc, valueAtQuery, "2");
+        // TODO: should cache the plan in somewhere
+        Procedure newCatProc = StatementCompiler.compileNibbleDeleteProcedure(catTable,
+                this.getClass().getName() + "-" + tableName, column, comparisonConstant);
+
 
         Statement countStmt = newCatProc.getStatements().get(VoltDB.ANON_STMT_NAME + "0");
         Statement deleteStmt = newCatProc.getStatements().get(VoltDB.ANON_STMT_NAME + "1");

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2997,4 +2997,21 @@ public abstract class CatalogUtil {
     public static boolean isProcedurePartitioned(Procedure proc) {
         return proc.getSinglepartition() || proc.getPartitioncolumn2() != null;
     }
+
+    // Does index exists on given columns?
+    public static boolean hasIndex(Table t, Column c) {
+        CatalogMap<Index> allIndexes = t.getIndexes();
+        boolean found = false;
+        for (Index index : allIndexes) {
+            List<ColumnRef> columnRefs = CatalogUtil.getSortedCatalogItems(index.getColumns(), "index");
+            for (ColumnRef ref : columnRefs) {
+                if (ref.getColumn().equals(c)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (found) break;
+        }
+        return found;
+    }
 }

--- a/tests/frontend/org/voltdb/sysprocs/TestNibbleDelete.java
+++ b/tests/frontend/org/voltdb/sysprocs/TestNibbleDelete.java
@@ -47,7 +47,7 @@ import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.sysprocs.NibbleDeleteSP.ComparisonConstant;
 import org.voltdb.types.TimestampType;
 
-public class TestNibbleDeleteSP {
+public class TestNibbleDelete {
 
     LocalCluster m_cluster = null;
     Client m_client = null;

--- a/tests/frontend/org/voltdb/sysprocs/TestNibbleDeleteSP.java
+++ b/tests/frontend/org/voltdb/sysprocs/TestNibbleDeleteSP.java
@@ -1,0 +1,242 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2017 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.sysprocs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.voltdb.BackendTarget;
+import org.voltdb.VoltTable;
+import org.voltdb.VoltTable.ColumnInfo;
+import org.voltdb.VoltType;
+import org.voltdb.client.Client;
+import org.voltdb.client.ClientFactory;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.client.NoConnectionsException;
+import org.voltdb.client.ProcCallException;
+import org.voltdb.client.SyncCallback;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.regressionsuites.LocalCluster;
+import org.voltdb.sysprocs.NibbleDeleteSP.ComparisonConstant;
+import org.voltdb.types.TimestampType;
+
+public class TestNibbleDeleteSP {
+
+    LocalCluster m_cluster = null;
+    Client m_client = null;
+
+    @Before
+    public void setUp() throws IOException {
+        String testSchema =
+                "CREATE TABLE part (\n"
+              + "    id BIGINT not null, \n"
+              + "    ts TIMESTAMP not null, \n"
+              + "    description VARCHAR(200), "
+              + "    PRIMARY KEY (id) \n"
+              + " ); \n"
+              + "PARTITION TABLE part ON COLUMN id;"
+              + "CREATE INDEX partindex ON part (ts);"
+
+              + "CREATE TABLE rep (\n"
+              + "    id BIGINT not null, \n"
+              + "    ts TIMESTAMP not null, \n"
+              + "    description VARCHAR(200), "
+              + "    PRIMARY KEY (id) \n"
+              + " ); \n"
+              + "CREATE INDEX repindex ON rep (ts);";
+
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        builder.addLiteralSchema(testSchema);
+        builder.addPartitionInfo("part", "id");
+        builder.addStmtProcedure("partcount", "select count(*) from part;");
+        builder.addStmtProcedure("repcount", "select count(*) from rep;");
+        m_cluster = new LocalCluster("foo.jar", 2, 1, 0, BackendTarget.NATIVE_EE_JNI);
+        m_cluster.setHasLocalServer(true);
+        m_cluster.compile(builder);
+        m_cluster.startUp();
+    }
+
+    @After
+    public void tearDown() throws InterruptedException {
+        if (m_client != null) {
+            m_client.close();
+        }
+        if (m_cluster != null) {
+            m_cluster.shutDown();
+            m_cluster = null;
+        }
+    }
+
+    private VoltTable createTable(int numberOfItems, int indexBase)
+    {
+        VoltTable partition_table =
+            new VoltTable(new ColumnInfo("ID", VoltType.BIGINT),
+            new ColumnInfo("TS", VoltType.TIMESTAMP),
+            new ColumnInfo("DESCRIPTION", VoltType.STRING)
+        );
+
+        for (int i = indexBase; i < numberOfItems + indexBase; i++)
+        {
+            Object[] row = new Object[] { i,
+                                          new TimestampType(i),
+                                          "name_" + i };
+            partition_table.addRow(row);
+        }
+        return partition_table;
+    }
+
+
+    private VoltTable[] loadTable(Client client, String tableName, boolean replicated,
+                                  VoltTable table)
+    {
+        VoltTable[] results = null;
+        try
+        {
+            if (replicated) {
+                client.callProcedure("@LoadMultipartitionTable", tableName,
+                      (byte) 0, table); // using insert
+            } else {
+                ArrayList<SyncCallback> callbacks = new ArrayList<>();
+                VoltType columnTypes[] = new VoltType[table.getColumnCount()];
+                for (int ii = 0; ii < columnTypes.length; ii++) {
+                    columnTypes[ii] = table.getColumnType(ii);
+                }
+                while (table.advanceRow()) {
+                    SyncCallback cb = new SyncCallback();
+                    callbacks.add(cb);
+                    Object params[] = new Object[table.getColumnCount()];
+                    for (int ii = 0; ii < columnTypes.length; ii++) {
+                        params[ii] = table.get(ii, columnTypes[ii]);
+                    }
+                    client.callProcedure(cb, tableName + ".insert", params);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            ex.printStackTrace();
+            fail("loadTable exception: " + ex.getMessage());
+        }
+        return results;
+    }
+
+
+    @Test
+    public void testPartitionedTable() throws IOException, InterruptedException {
+
+        m_client = ClientFactory.createClient();
+        m_client.createConnection(m_cluster.getListenerAddress(0));
+
+        int numberOfItems = 10000;
+        VoltTable part_table = createTable(numberOfItems, 0);
+        loadTable(m_client, "part", false, part_table);
+
+        VoltTable partitionKeys = null;
+        try {
+            partitionKeys = m_client.callProcedure("@GetPartitionKeys", "INTEGER").getResults()[0];
+        } catch (ProcCallException e1) {
+            fail("Failed to get partition keys.");
+        }
+        TimestampType value = new TimestampType(8888);
+        VoltTable table = new VoltTable(new ColumnInfo[] {
+                new ColumnInfo("col1", VoltType.typeFromObject(value)),
+        });
+        table.addRow(value);
+        long totalRowsDeleted = 0;
+        while (partitionKeys.advanceRow()) {
+            int partitionKey = (int)partitionKeys.getLong("PARTITION_KEY");
+            try {
+                ClientResponse response = m_client.callProcedure("@NibbleDeleteSP",
+                        partitionKey,
+                        "part",
+                        "ts",
+                        ComparisonConstant.LESS_THAN.ordinal(),
+                        table,
+                        1000);
+                VoltTable result = response.getResults()[0];
+                assertEquals(1, result.getRowCount());
+                result.advanceRow();
+                long deletedRows = result.getLong("DELETED_ROWS");
+                totalRowsDeleted += deletedRows;
+                assertEquals(1000, deletedRows);
+                long leftoverRows = result.getLong("LEFTOVER_ROWS");
+            } catch (ProcCallException e) {
+                fail("Failed to run NibbleDeleteSP: " + e.getMessage());
+            }
+        }
+        try {
+            long rowCount = m_client.callProcedure("partcount").getResults()[0].asScalarLong();
+            assertEquals(numberOfItems - totalRowsDeleted, rowCount);
+        } catch (ProcCallException e) {
+            fail("Failed to get row count from Table part");
+        }
+    }
+
+    @Test
+    public void testReplicatedTable() throws NoConnectionsException, IOException {
+
+        m_client = ClientFactory.createClient();
+        m_client.createConnection(m_cluster.getListenerAddress(0));
+
+        int numberOfItems = 10000;
+        VoltTable rep_table = createTable(numberOfItems, 0);
+        loadTable(m_client, "rep", true, rep_table);
+
+        TimestampType value = new TimestampType(8888);
+        VoltTable table = new VoltTable(new ColumnInfo[] {
+                new ColumnInfo("col1", VoltType.typeFromObject(value)),
+        });
+        table.addRow(value);
+        long deletedRows = 0;
+        try {
+            ClientResponse response = m_client.callProcedure("@NibbleDeleteMP",
+                    "rep",
+                    "ts",
+                    ComparisonConstant.LESS_THAN.ordinal(),
+                    table,
+                    1000);
+            VoltTable result = response.getResults()[0];
+            assertEquals(1, result.getRowCount());
+            result.advanceRow();
+            deletedRows = result.getLong("DELETED_ROWS");
+            assertEquals(1000, deletedRows);
+            long leftoverRows = result.getLong("LEFTOVER_ROWS");
+        } catch (ProcCallException e) {
+            fail("Fail to run NibbleDeleteSP: " + e.getMessage());
+        }
+        try {
+            long rowCount = m_client.callProcedure("repcount").getResults()[0].asScalarLong();
+            assertEquals(numberOfItems - deletedRows, rowCount);
+        } catch (ProcCallException e) {
+            fail("Failed to get row count from Table part");
+        }
+    }
+
+}


### PR DESCRIPTION
The sysproc copies pattern from windowing app, it has three statements:
1) select numbers of rows that meet the delete criteria,
2) find the value sits on boundary of delete chunk size, if rows to be deleted are more than chunk size,
3) delete rows based on the value given in parameter, or the boundary value.

It's mostly ad-hoc style, compiles a plan based on replicated/partitioned table and column every time.
Maybe I should also cache the plan in LoadedProcedureSet, like CRUD procedure.