### PR TITLE
ENG-12540:

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.h
+++ b/src/ee/common/SynchronizedThreadLock.h
@@ -152,6 +152,15 @@ public:
     ExecuteWithMpMemory();
     ~ExecuteWithMpMemory();
 };
+
+class ConditionalExecuteWithMpMemory {
+public:
+    ConditionalExecuteWithMpMemory(bool needMpMemory);
+    ~ConditionalExecuteWithMpMemory();
+
+private:
+    bool m_usingMpMemory;
+};
 }
 
 

--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -156,43 +156,13 @@ UniqueTempTableResult ExecutorContext::executeExecutors(const std::vector<Abstra
     try {
         BOOST_FOREACH (AbstractExecutor *executor, executorList) {
             assert(executor);
-            PlanNodeType nextPlanNodeType = executor->getPlanNode()->getPlanNodeType();
-            if (nextPlanNodeType >= PLAN_NODE_TYPE_UPDATE && nextPlanNodeType <= PLAN_NODE_TYPE_SWAPTABLES) {
-                AbstractOperationPlanNode* node = dynamic_cast<AbstractOperationPlanNode*>(executor->getPlanNode());
-                assert(node);
-                Table* targetTable = node->getTargetTable();
-                PersistentTable *persistentTarget = dynamic_cast<PersistentTable*>(targetTable);
-                if (persistentTarget != NULL && persistentTarget->isCatalogTableReplicated()) {
-                    if (SynchronizedThreadLock::countDownGlobalTxnStartCount(m_engine->isLowestSite())) {
-                        ExecuteWithMpMemory useMpMemory;
-                        // Call the execute method to actually perform whatever action
-                        // it is that the node is supposed to do...
-                        if (!executor->execute(m_staticParams)) {
-                            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                               "Unspecified execution error detected");
-                        }
-                        ++ctr;
-                        // Assign the correct pool back to this thread
-                        SynchronizedThreadLock::signalLowestSiteFinished();
-                    }
-                } else {
-                    // Call the execute method to actually perform whatever action
-                    // it is that the node is supposed to do...
-                    if (!executor->execute(m_staticParams)) {
-                        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                            "Unspecified execution error detected");
-                    }
-                    ++ctr;
-                }
-            } else {
-                // Call the execute method to actually perform whatever action
-                // it is that the node is supposed to do...
-                if (!executor->execute(m_staticParams)) {
-                    throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                        "Unspecified execution error detected");
-                }
-                ++ctr;
+            // Call the execute method to actually perform whatever action
+            // it is that the node is supposed to do...
+            if (!executor->execute(m_staticParams)) {
+                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                    "Unspecified execution error detected");
             }
+            ++ctr;
         }
     } catch (const SerializableEEException &e) {
         if (SynchronizedThreadLock::isInSingleThreadMode()) {

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -68,9 +68,12 @@ bool DeleteExecutor::p_init(AbstractPlanNode *abstract_node,
 
     m_node = dynamic_cast<DeletePlanNode*>(abstract_node);
     assert(m_node);
-    assert(m_node->getTargetTable());
 
     setDMLCountOutputTable(limits);
+
+    PersistentTable* targetTable = dynamic_cast<PersistentTable*>(m_node->getTargetTable());
+    assert(targetTable);
+    m_replicatedTableOperation = targetTable->isCatalogTableReplicated();
 
     m_truncate = m_node->getTruncate();
     if (m_truncate) {
@@ -89,56 +92,60 @@ bool DeleteExecutor::p_init(AbstractPlanNode *abstract_node,
 bool DeleteExecutor::p_execute(const NValueArray &params) {
     // target table should be persistenttable
     // update target table reference from table delegate
+    // Note that the target table pointer in the node's tcd can change between p_init and p_execute
     PersistentTable* targetTable = dynamic_cast<PersistentTable*>(m_node->getTargetTable());
     assert(targetTable);
 
     TableTuple targetTuple(targetTable->schema());
 
     int64_t modified_tuples = 0;
+    {
+        assert(m_replicatedTableOperation == targetTable->isCatalogTableReplicated());
+        ConditionalExecuteWithMpMemory possiblyUseMpMemory(m_replicatedTableOperation);
 
-    if (m_truncate) {
-        VOLT_TRACE("truncating table %s...", targetTable->name().c_str());
-        // count the truncated tuples as deleted
-        modified_tuples = targetTable->visibleTupleCount();
+        if (m_truncate) {
+            VOLT_TRACE("truncating table %s...", targetTable->name().c_str());
+            // count the truncated tuples as deleted
+            modified_tuples = targetTable->visibleTupleCount();
 
-        VOLT_TRACE("Delete all rows from table : %s with %d active, %d visible, %d allocated",
-                   targetTable->name().c_str(),
-                   (int)targetTable->activeTupleCount(),
-                   (int)targetTable->visibleTupleCount(),
-                   (int)targetTable->allocatedTupleCount());
+            VOLT_TRACE("Delete all rows from table : %s with %d active, %d visible, %d allocated",
+                       targetTable->name().c_str(),
+                       (int)targetTable->activeTupleCount(),
+                       (int)targetTable->visibleTupleCount(),
+                       (int)targetTable->allocatedTupleCount());
 
-        // empty the table either by table swap or iteratively deleting tuple-by-tuple
-        targetTable->truncateTable(m_engine);
-    }
-    else {
-        assert(m_inputTable);
-        assert(m_inputTuple.sizeInValues() == m_inputTable->columnCount());
-        assert(targetTuple.sizeInValues() == targetTable->columnCount());
-        std::unique_ptr<TableIterator> inputIterator(m_inputTable->makeIterator());
-        while (inputIterator->next(m_inputTuple)) {
-            //
-            // OPTIMIZATION: Single-Sited Query Plans
-            // If our beloved DeletePlanNode is apart of a single-site query plan,
-            // then the first column in the input table will be the address of a
-            // tuple on the target table that we will want to blow away. This saves
-            // us the trouble of having to do an index lookup
-            //
-            void *targetAddress = m_inputTuple.getNValue(0).castAsAddress();
-            targetTuple.move(targetAddress);
-
-            // Delete from target table
-            targetTable->deleteTuple(targetTuple, true);
+            // empty the table either by table swap or iteratively deleting tuple-by-tuple
+            targetTable->truncateTable(m_engine);
         }
-        modified_tuples = m_inputTable->tempTableTupleCount();
-        VOLT_TRACE("Deleted %d rows from table : %s with %d active, %d visible, %d allocated",
-                   (int)modified_tuples,
-                   targetTable->name().c_str(),
-                   (int)targetTable->activeTupleCount(),
-                   (int)targetTable->visibleTupleCount(),
-                   (int)targetTable->allocatedTupleCount());
+        else {
+            assert(m_inputTable);
+            assert(m_inputTuple.sizeInValues() == m_inputTable->columnCount());
+            assert(targetTuple.sizeInValues() == targetTable->columnCount());
+            std::unique_ptr<TableIterator> inputIterator(m_inputTable->makeIterator());
+            while (inputIterator->next(m_inputTuple)) {
+                //
+                // OPTIMIZATION: Single-Sited Query Plans
+                // If our beloved DeletePlanNode is apart of a single-site query plan,
+                // then the first column in the input table will be the address of a
+                // tuple on the target table that we will want to blow away. This saves
+                // us the trouble of having to do an index lookup
+                //
+                void *targetAddress = m_inputTuple.getNValue(0).castAsAddress();
+                targetTuple.move(targetAddress);
 
+                // Delete from target table
+                targetTable->deleteTuple(targetTuple, true);
+            }
+            modified_tuples = m_inputTable->tempTableTupleCount();
+            VOLT_TRACE("Deleted %d rows from table : %s with %d active, %d visible, %d allocated",
+                       (int)modified_tuples,
+                       targetTable->name().c_str(),
+                       (int)targetTable->activeTupleCount(),
+                       (int)targetTable->visibleTupleCount(),
+                       (int)targetTable->allocatedTupleCount());
+
+        }
     }
-
     TableTuple& count_tuple = m_node->getOutputTable()->tempTuple();
     count_tuple.setNValue(0, ValueFactory::getBigIntValue(modified_tuples));
     // try to put the tuple into the output table

--- a/src/ee/executors/deleteexecutor.h
+++ b/src/ee/executors/deleteexecutor.h
@@ -87,6 +87,8 @@ protected:
     /** reference to the engine/context to store the number of
         modified tuples */
     VoltDBEngine* m_engine;
+
+    PersistentTable* m_targetTable;
 };
 
 }

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -110,6 +110,7 @@ bool InsertExecutor::p_init(AbstractPlanNode* abstractNode,
 
     if (persistentTarget) {
         m_partitionColumn = persistentTarget->partitionColumn();
+        m_replicatedTableOperation = persistentTarget->isCatalogTableReplicated();
     }
 
     m_multiPartition = m_node->isMultiPartition();
@@ -204,131 +205,134 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
         return true;
     }
 
-    TableTuple templateTuple = m_templateTuple.tuple();
+    {
+        assert(!persistentTable || m_replicatedTableOperation == persistentTable->isCatalogTableReplicated());
+        ConditionalExecuteWithMpMemory possiblyUseMpMemory(m_replicatedTableOperation);
+        TableTuple templateTuple = m_templateTuple.tuple();
 
-    std::vector<int>::iterator it;
-    for (it = m_nowFields.begin(); it != m_nowFields.end(); ++it) {
-        templateTuple.setNValue(*it, NValue::callConstant<FUNC_CURRENT_TIMESTAMP>());
-    }
-
-    VOLT_DEBUG("This is a %s-row insert on partition with id %d",
-               m_node->getChildren()[0]->getPlanNodeType() == PLAN_NODE_TYPE_MATERIALIZE ?
-               "single" : "multi", m_engine->getPartitionId());
-    VOLT_DEBUG("Offset of partition column is %d", m_partitionColumn);
-
-    //
-    // An insert is quite simple really. We just loop through our m_inputTable
-    // and insert any tuple that we find into our targetTable. It doesn't get any easier than that!
-    //
-    TableTuple inputTuple(m_inputTable->schema());
-    assert (inputTuple.sizeInValues() == m_inputTable->columnCount());
-    std::unique_ptr<TableIterator> iterator(m_inputTable->makeIterator());
-    Pool* tempPool = ExecutorContext::getTempStringPool();
-    const std::vector<int>& fieldMap = m_node->getFieldMap();
-    std::size_t mapSize = fieldMap.size();
-    while (iterator->next(inputTuple)) {
-
-        for (int i = 0; i < mapSize; ++i) {
-            // Most executors will just call setNValue instead of
-            // setNValueAllocateForObjectCopies.
-            //
-            // However, We need to call
-            // setNValueAllocateForObjectCopies here.  Sometimes the
-            // input table's schema has an inlined string field, and
-            // it's being assigned to the target table's outlined
-            // string field.  In this case we need to tell the NValue
-            // where to allocate the string data.
-            // For an "upsert", this templateTuple setup has two effects --
-            // It sets the primary key column(s) and it sets the
-            // updated columns to their new values.
-            // If the primary key value (combination) is new, the
-            // templateTuple is the exact combination of new values
-            // and default values required by the insert.
-            // If the primary key value (combination) already exists,
-            // only the NEW values stored on the templateTuple get updated
-            // in the existing tuple and its other columns keep their existing
-            // values -- the DEFAULT values that are stored in templateTuple
-            // DO NOT get copied to an existing tuple.
-            templateTuple.setNValueAllocateForObjectCopies(fieldMap[i],
-                                                           inputTuple.getNValue(i),
-                                                           tempPool);
+        std::vector<int>::iterator it;
+        for (it = m_nowFields.begin(); it != m_nowFields.end(); ++it) {
+            templateTuple.setNValue(*it, NValue::callConstant<FUNC_CURRENT_TIMESTAMP>());
         }
 
-        VOLT_TRACE("Inserting tuple '%s' into target table '%s' with table schema: %s",
-                   templateTuple.debug(targetTable->name()).c_str(), targetTable->name().c_str(),
-                   targetTable->schema()->debug().c_str());
+        VOLT_DEBUG("This is a %s-row insert on partition with id %d",
+                   m_node->getChildren()[0]->getPlanNodeType() == PLAN_NODE_TYPE_MATERIALIZE ?
+                   "single" : "multi", m_engine->getPartitionId());
+        VOLT_DEBUG("Offset of partition column is %d", m_partitionColumn);
 
-        // If there is a partition column for the target table
-        if (m_partitionColumn != -1) {
-            // get the value for the partition column
-            NValue value = templateTuple.getNValue(m_partitionColumn);
-            bool isLocal = m_engine->isLocalSite(value);
+        //
+        // An insert is quite simple really. We just loop through our m_inputTable
+        // and insert any tuple that we find into our targetTable. It doesn't get any easier than that!
+        //
+        TableTuple inputTuple(m_inputTable->schema());
+        assert (inputTuple.sizeInValues() == m_inputTable->columnCount());
+        std::unique_ptr<TableIterator> iterator(m_inputTable->makeIterator());
+        Pool* tempPool = ExecutorContext::getTempStringPool();
+        const std::vector<int>& fieldMap = m_node->getFieldMap();
+        std::size_t mapSize = fieldMap.size();
+        while (iterator->next(inputTuple)) {
 
-            // if it doesn't map to this partiton
-            if (!isLocal) {
-                if (m_multiPartition) {
-                    // The same row is presumed to also be generated
-                    // on some other partition, where the partition key
-                    // belongs.
+            for (int i = 0; i < mapSize; ++i) {
+                // Most executors will just call setNValue instead of
+                // setNValueAllocateForObjectCopies.
+                //
+                // However, We need to call
+                // setNValueAllocateForObjectCopies here.  Sometimes the
+                // input table's schema has an inlined string field, and
+                // it's being assigned to the target table's outlined
+                // string field.  In this case we need to tell the NValue
+                // where to allocate the string data.
+                // For an "upsert", this templateTuple setup has two effects --
+                // It sets the primary key column(s) and it sets the
+                // updated columns to their new values.
+                // If the primary key value (combination) is new, the
+                // templateTuple is the exact combination of new values
+                // and default values required by the insert.
+                // If the primary key value (combination) already exists,
+                // only the NEW values stored on the templateTuple get updated
+                // in the existing tuple and its other columns keep their existing
+                // values -- the DEFAULT values that are stored in templateTuple
+                // DO NOT get copied to an existing tuple.
+                templateTuple.setNValueAllocateForObjectCopies(fieldMap[i],
+                                                               inputTuple.getNValue(i),
+                                                               tempPool);
+            }
+
+            VOLT_TRACE("Inserting tuple '%s' into target table '%s' with table schema: %s",
+                       templateTuple.debug(targetTable->name()).c_str(), targetTable->name().c_str(),
+                       targetTable->schema()->debug().c_str());
+
+            // If there is a partition column for the target table
+            if (m_partitionColumn != -1) {
+                // get the value for the partition column
+                NValue value = templateTuple.getNValue(m_partitionColumn);
+                bool isLocal = m_engine->isLocalSite(value);
+
+                // if it doesn't map to this partiton
+                if (!isLocal) {
+                    if (m_multiPartition) {
+                        // The same row is presumed to also be generated
+                        // on some other partition, where the partition key
+                        // belongs.
+                        continue;
+                    }
+                    // When a streamed table has no views, let an SP insert execute.
+                    // This is backward compatible with when there were only export
+                    // tables with no views on them.
+                    // When there are views, be strict and throw mispartitioned
+                    // tuples to force partitioned data to be generated only
+                    // where partitoned view rows are maintained.
+                    if (!m_isStreamed || m_hasStreamView) {
+                        throw ConstraintFailureException(
+                            targetTable, templateTuple,
+                            "Mispartitioned tuple in single-partition insert statement.");
+                    }
+                }
+            }
+
+            if (m_isUpsert) {
+                // upsert execution logic
+                assert(persistentTable->primaryKeyIndex() != NULL);
+                TableTuple existsTuple = persistentTable->lookupTupleByValues(templateTuple);
+
+                if (!existsTuple.isNullTuple()) {
+                    // The tuple exists already, update (only) the templateTuple columns
+                    // that were initialized from the input tuple via the field map.
+                    // Technically, this includes setting primary key values,
+                    // but they are getting set to equivalent values, so that's OK.
+                    // A simple setNValue works here because any required object
+                    // allocations were handled when copying the input values into
+                    // the templateTuple.
+                    upsertTuple.move(templateTuple.address());
+                    TableTuple &tempTuple = persistentTable->copyIntoTempTuple(existsTuple);
+                    for (int i = 0; i < mapSize; ++i) {
+                        tempTuple.setNValue(fieldMap[i],
+                                            templateTuple.getNValue(fieldMap[i]));
+                    }
+
+                    persistentTable->updateTupleWithSpecificIndexes(existsTuple, tempTuple,
+                                                                    persistentTable->allIndexes());
+                    // successfully updated
+                    ++modifiedTuples;
                     continue;
                 }
-                // When a streamed table has no views, let an SP insert execute.
-                // This is backward compatible with when there were only export
-                // tables with no views on them.
-                // When there are views, be strict and throw mispartitioned
-                // tuples to force partitioned data to be generated only
-                // where partitoned view rows are maintained.
-                if (!m_isStreamed || m_hasStreamView) {
-                    throw ConstraintFailureException(
-                        targetTable, templateTuple,
-                        "Mispartitioned tuple in single-partition insert statement.");
-                }
+                // else, the primary key did not match,
+                // so fall through to the "insert" logic
             }
-        }
 
-        if (m_isUpsert) {
-            // upsert execution logic
-            assert(persistentTable->primaryKeyIndex() != NULL);
-            TableTuple existsTuple = persistentTable->lookupTupleByValues(templateTuple);
-
-            if (!existsTuple.isNullTuple()) {
-                // The tuple exists already, update (only) the templateTuple columns
-                // that were initialized from the input tuple via the field map.
-                // Technically, this includes setting primary key values,
-                // but they are getting set to equivalent values, so that's OK.
-                // A simple setNValue works here because any required object
-                // allocations were handled when copying the input values into
-                // the templateTuple.
-                upsertTuple.move(templateTuple.address());
-                TableTuple &tempTuple = persistentTable->copyIntoTempTuple(existsTuple);
-                for (int i = 0; i < mapSize; ++i) {
-                    tempTuple.setNValue(fieldMap[i],
-                                        templateTuple.getNValue(fieldMap[i]));
-                }
-
-                persistentTable->updateTupleWithSpecificIndexes(existsTuple, tempTuple,
-                                                                persistentTable->allIndexes());
-                // successfully updated
-                ++modifiedTuples;
-                continue;
+            // try to put the tuple into the target table
+            if (m_hasPurgeFragment) {
+                executePurgeFragmentIfNeeded(&persistentTable);
+                // purge fragment might have truncated the table, and
+                // refreshed the persistent table pointer.  Make sure to
+                // use it when doing the insert below.
+                targetTable = persistentTable;
             }
-            // else, the primary key did not match,
-            // so fall through to the "insert" logic
+            targetTable->insertTuple(templateTuple);
+            // successfully inserted
+            ++modifiedTuples;
         }
-
-        // try to put the tuple into the target table
-        if (m_hasPurgeFragment) {
-            executePurgeFragmentIfNeeded(&persistentTable);
-            // purge fragment might have truncated the table, and
-            // refreshed the persistent table pointer.  Make sure to
-            // use it when doing the insert below.
-            targetTable = persistentTable;
-        }
-        targetTable->insertTuple(templateTuple);
-        // successfully inserted
-        ++modifiedTuples;
     }
-
     count_tuple.setNValue(0, ValueFactory::getBigIntValue(modifiedTuples));
     // put the tuple into the output table
     outputTable->insertTuple(count_tuple);

--- a/src/ee/executors/swaptablesexecutor.cpp
+++ b/src/ee/executors/swaptablesexecutor.cpp
@@ -53,14 +53,15 @@ using namespace voltdb;
 
 bool SwapTablesExecutor::p_init(AbstractPlanNode* abstract_node, TempTableLimits* limits) {
     VOLT_TRACE("init SwapTable Executor");
-#ifndef NDEBUG
     SwapTablesPlanNode* node = dynamic_cast<SwapTablesPlanNode*>(m_abstractNode);
+#ifndef NDEBUG
     assert(node);
     assert(node->getTargetTable());
     assert(node->getOtherTargetTable());
     assert(node->getInputTableCount() == 0);
 #endif
 
+    m_replicatedTableOperation = static_cast<PersistentTable*>(node->getTargetTable())->isCatalogTableReplicated();
     setDMLCountOutputTable(limits);
     return true;
 }
@@ -81,26 +82,30 @@ bool SwapTablesExecutor::p_execute(NValueArray const& params) {
     VOLT_TRACE("swap tables %s and %s",
                theTargetTable->name().c_str(),
                otherTargetTable->name().c_str());
-    // count the active tuples in both tables as modified
-    modified_tuples = theTargetTable->visibleTupleCount() +
-            otherTargetTable->visibleTupleCount();
+    {
+        assert(m_replicatedTableOperation == theTargetTable->isCatalogTableReplicated());
+        ConditionalExecuteWithMpMemory possiblyUseMpMemory(m_replicatedTableOperation);
 
-    VOLT_TRACE("Swap Tables: %s with %d active, %d visible, %d allocated"
-               " and %s with %d active, %d visible, %d allocated",
-               theTargetTable->name().c_str(),
-               (int)theTargetTable->activeTupleCount(),
-               (int)theTargetTable->visibleTupleCount(),
-               (int)theTargetTable->allocatedTupleCount(),
-               otherTargetTable->name().c_str(),
-               (int)otherTargetTable->activeTupleCount(),
-               (int)otherTargetTable->visibleTupleCount(),
-               (int)otherTargetTable->allocatedTupleCount());
+        // count the active tuples in both tables as modified
+        modified_tuples = theTargetTable->visibleTupleCount() +
+                otherTargetTable->visibleTupleCount();
 
-    // Swap the table catalog delegates and corresponding indexes and views.
-    theTargetTable->swapTable(otherTargetTable,
-                              node->theIndexes(),
-                              node->otherIndexes());
+        VOLT_TRACE("Swap Tables: %s with %d active, %d visible, %d allocated"
+                   " and %s with %d active, %d visible, %d allocated",
+                   theTargetTable->name().c_str(),
+                   (int)theTargetTable->activeTupleCount(),
+                   (int)theTargetTable->visibleTupleCount(),
+                   (int)theTargetTable->allocatedTupleCount(),
+                   otherTargetTable->name().c_str(),
+                   (int)otherTargetTable->activeTupleCount(),
+                   (int)otherTargetTable->visibleTupleCount(),
+                   (int)otherTargetTable->allocatedTupleCount());
 
+        // Swap the table catalog delegates and corresponding indexes and views.
+        theTargetTable->swapTable(otherTargetTable,
+                                  node->theIndexes(),
+                                  node->otherIndexes());
+    }
     TableTuple& count_tuple = m_tmpOutputTable->tempTuple();
     count_tuple.setNValue(0, ValueFactory::getBigIntValue(modified_tuples));
     // try to put the tuple into the output table


### PR DESCRIPTION
PlanNodes allocate TempTables during execution. This can be problematic when making Replicated Table changes because the TempTable rows are allocated in an MP memory context but are cleaned up in the Partitioned memory context during UAC or Shutdown. To resolve this we now only assume the memory context inside the executor either before or after touching the temp table.

Also fixed another unit test that manuplates multiple engines directly by assigning the engines explicitly to threads.