### PR TITLE
ENG-12540:

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.cpp
+++ b/src/ee/common/SynchronizedThreadLock.cpp
@@ -160,7 +160,7 @@ void SynchronizedThreadLock::resetMemory(int32_t partitionId) {
         // remove the Replicated table memory pools allocated on the lowest site
         // thread before the MP Site was initialized.
         if (s_mpEngine.context != NULL) {
-            VOLT_DEBUG("Reset memory pool for Replicated Tables on thread %d", ThreadLocalPool::getThreadPartitionId());
+            VOLT_TRACE("Reset memory pool for Replicated Tables on thread %d", ThreadLocalPool::getThreadPartitionId());
             assert(s_mpEngine.poolData->first == 1);
             delete s_mpEngine.poolData->second;
             delete s_mpEngine.poolData;
@@ -183,9 +183,13 @@ void SynchronizedThreadLock::resetMemory(int32_t partitionId) {
                 if (!allocMap.empty()) {
                     ThreadLocalPool::AllocTraceMap_t::iterator nextAlloc = allocMap.begin();
                     do {
+#ifdef VOLT_TRACE_ALLOCATIONS
                         VOLT_ERROR("Missing deallocation for %p at:", nextAlloc->first);
                         nextAlloc->second->printLocalTrace();
                         delete nextAlloc->second;
+#else
+                        VOLT_ERROR("Missing deallocation for %p at:", *nextAlloc);
+#endif
                         nextAlloc++;
                     } while (nextAlloc != allocMap.end());
                     allocMap.clear();

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -181,10 +181,12 @@ public:
     int32_t allocatingEngine;
     int32_t allocatingThread;
     StackTrace allocationTrace;
-#endif
-#ifdef VOLT_TRACE_ENABLED
     static pthread_mutex_t s_sharedMemoryMutex;
+#ifdef VOLT_TRACE_ALLOCATIONS
     typedef std::unordered_map<void *, StackTrace*> AllocTraceMap_t;
+#else
+    typedef std::unordered_set<void *> AllocTraceMap_t;
+#endif
     typedef std::unordered_map<std::size_t, AllocTraceMap_t> SizeBucketMap_t;
     typedef std::unordered_map<int32_t, SizeBucketMap_t> PartitionBucketMap_t;
     static PartitionBucketMap_t s_allocations;

--- a/src/ee/common/debuglog.h
+++ b/src/ee/common/debuglog.h
@@ -70,7 +70,7 @@ namespace voltdb {
 #define VOLT_LEVEL_ALL    0
 
 #define VOLT_LOG_TIME_FORMAT "%Y-%m-%d %H:%M:%S"
-
+//#define VOLT_TRACE_ALLOCATIONS
 // Compile Option
 #ifndef VOLT_LOG_LEVEL
     // TODO : any way to use pragma message in GCC?

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -115,7 +115,7 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
                        (int)targetTable->allocatedTupleCount());
 
             // empty the table either by table swap or iteratively deleting tuple-by-tuple
-            targetTable->truncateTable(m_engine);
+            targetTable->truncateTable(m_engine, m_replicatedTableOperation);
         }
         else {
             assert(m_inputTable);

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -394,7 +394,7 @@ template<class T> static inline PersistentTable* constructEmptyDestTable(
     return destEmptyTable;
 }
 
-void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
+void PersistentTable::truncateTable(VoltDBEngine* engine, bool replicatedTable, bool fallible) {
     if (isPersistentTableEmpty()) {
         return;
     }
@@ -520,8 +520,7 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool fallible) {
         emptyTable->swapPurgeExecutorVector(evPtr);
     }
 
-    // TODO: Fix this to coordinate the truncate for replicated tables by the last site.
-    engine->rebuildTableCollections(false);
+    engine->rebuildTableCollections(replicatedTable);
 
     ExecutorContext* ec = ExecutorContext::getExecutorContext();
     AbstractDRTupleStream* drStream = getDRTupleStream(ec);

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -255,7 +255,7 @@ public:
     // ------------------------------------------------------------------
     virtual void deleteAllTuples(bool, bool fallible = true);
 
-    void truncateTable(VoltDBEngine* engine, bool fallible = true);
+    void truncateTable(VoltDBEngine* engine, bool replicatedTable, bool fallible = true);
 
     void swapTable
            (PersistentTable* otherTable,

--- a/src/ee/structures/CompactingPool.h
+++ b/src/ee/structures/CompactingPool.h
@@ -23,6 +23,7 @@
 #include <cassert>
 #include <cstring>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace voltdb
 {
@@ -53,7 +54,7 @@ namespace voltdb
       : m_allocator(elementSize + FIXED_OVERHEAD_PER_ENTRY(), elementsPerBuffer)
     { }
 
-#ifdef VOLT_TRACE_ENABLED
+#ifdef VOLT_DEBUG_ENABLED
     ~CompactingPool();
 
     private:
@@ -121,8 +122,13 @@ namespace voltdb
 
     private:
         ContiguousAllocator m_allocator;
-#ifdef VOLT_TRACE_ENABLED
-        std::unordered_map<void *, StackTrace*> m_allocations;
+#ifdef VOLT_DEBUG_ENABLED
+#ifdef VOLT_TRACE_ALLOCATIONS
+        typedef std::unordered_map<void *, StackTrace*> AllocTraceMap_t;
+#else
+        typedef std::unordered_set<void *> AllocTraceMap_t;
+#endif
+        AllocTraceMap_t m_allocations;
 #endif
 
     /// The layout of a relocatable allocation,

--- a/tests/frontend/org/voltdb/jni/TestExecutionEngine.java
+++ b/tests/frontend/org/voltdb/jni/TestExecutionEngine.java
@@ -28,14 +28,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
 import junit.framework.TestCase;
 
 import org.voltcore.messaging.RecoveryMessageType;
-import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.LegacyHashinator;


### PR DESCRIPTION
Add a #define to debuglog.h that will optionally maintain the stacktrace of every ee managed memory allocation through compacting pool and thread  local pool.