### PR TITLE
Eng-13373. Make build-importers.xml fail if libraries are missing.

### DIFF
--- a/build-importers.xml
+++ b/build-importers.xml
@@ -68,13 +68,13 @@
             <include name="org/voltdb/importclient/kafka/*.class"/>
             <include name="org/voltdb/importclient/kafka/util/*.class"/>
             <include name="org/voltdb/importclient/ImportBaseException.class"/>
-            <zipgroupfileset dir="${base.dir}/lib/" includes="scala-library-2.11.5.jar" />
-            <zipgroupfileset dir="${base.dir}/lib/" includes="scala-parser-combinators_2.11-1.0.2.jar" />
-            <zipgroupfileset dir="${base.dir}/lib/" includes="scala-xml_2.11-1.0.2.jar" />
-            <zipgroupfileset dir="${base.dir}/lib" includes="kafka_2.11-0.8.2.2.jar" />
-            <zipgroupfileset dir="${base.dir}/lib/" includes="kafka-clients-0.8.2.2.jar" />
-            <zipgroupfileset dir="${base.dir}/lib/" includes="snappy-java-1.1.1.7.jar" />
-            <zipgroupfileset dir="${base.dir}/lib/" includes="lz4-1.2.0.jar" />
+	    <zipfileset src="${base.dir}/lib/scala-library-2.11.5.jar" />
+            <zipfileset src="${base.dir}/lib/scala-parser-combinators_2.11-1.0.2.jar" />
+            <zipfileset src="${base.dir}/lib/scala-xml_2.11-1.0.2.jar" />
+            <zipfileset src="${base.dir}/lib/kafka_2.11-0.8.2.2.jar" />
+            <zipfileset src="${base.dir}/lib/kafka-clients-0.8.2.2.jar" />
+            <zipfileset src="${base.dir}/lib/snappy-java-1.1.1.7.jar" />
+            <zipfileset src="${base.dir}/lib/lz4-1.2.0.jar" />
             <manifest>
                 <attribute name="Bundle-Activator" value="org.voltdb.importclient.kafka.KafkaStreamImporterFactory" />
                 <attribute name="Bundle-ManifestVersion" value="2" />
@@ -92,19 +92,19 @@
         <jar destfile="${bundles.dir}/kinesisstream.jar" basedir="${build.prod.dir}">
             <include name="org/voltdb/importclient/kinesis/*.class"/>
             <include name="org/voltdb/importclient/ImportBaseException.class"/>
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="amazon-kinesis-client-1.6.2.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="aws-java-sdk-1.10.72.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="jackson-dataformat-cbor-2.5.3.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="jackson-databind-2.5.3.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="jackson-core-2.5.3.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="jackson-annotations-2.5.0.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="joda-time-2.9.3.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="commons-lang-2.6.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="guava-18.0.jar" />
-            <zipgroupfileset dir="${base.dir}/lib" includes="protobuf-java-3.4.0.jar" />
-            <zipgroupfileset dir="${base.dir}/lib" includes="commons-logging-1.1.3.jar" />
-            <zipgroupfileset dir="${base.dir}/lib" includes="httpclient-4.3.6.jar" />
-            <zipgroupfileset dir="${base.dir}/lib" includes="httpcore-4.3.3.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsamazon-kinesis-client-1.6.2.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsaws-java-sdk-1.10.72.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsjackson-dataformat-cbor-2.5.3.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsjackson-databind-2.5.3.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsjackson-core-2.5.3.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsjackson-annotations-2.5.0.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsjoda-time-2.9.3.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarscommons-lang-2.6.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsguava-18.0.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsprotobuf-java-2.6.1.jar" />
+            <zipfileset src="${base.dir}/libcommons-logging-1.1.3.jar" />
+            <zipfileset src="${base.dir}/libhttpclient-4.3.6.jar" />
+            <zipfileset src="${base.dir}/libhttpcore-4.3.3.jar" />
             <manifest>
                 <attribute name="Bundle-Activator" value="org.voltdb.importclient.kinesis.KinesisStreamImporterFactory" />
                 <attribute name="Bundle-ManifestVersion" value="2" />
@@ -147,12 +147,12 @@
             <include name="org/voltdb/importclient/kafka10/*.class"/>
             <include name="org/voltdb/importclient/kafka/util/*.class"/>
             <include name="au/com/bytecode/opencsv_voltpatches/**/*.class"/>
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="kafka-clients-0.10.2.1.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="snappy-java-1.1.2.6.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="lz4-1.3.0.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="slf4j-api-1.7.21.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="slf4j-log4j12-1.7.21.jar" />
-            <zipgroupfileset dir="${base.dir}/third_party/java/jars" includes="log4j-1.2.17.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarskafka-clients-0.10.2.1.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarssnappy-java-1.1.2.6.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarslz4-1.3.0.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsslf4j-api-1.7.21.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarsslf4j-log4j12-1.7.21.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jarslog4j-1.2.17.jar" />
             <manifest>
                 <attribute name="Bundle-Activator" value="org.voltdb.importclient.kafka10.KafkaStreamImporterFactory" />
                 <attribute name="Bundle-ManifestVersion" value="2" />
@@ -187,7 +187,7 @@
             <include name="org/voltdb/importer/formatter/builtin/*.class"/>
             <include name="org/supercsv_voltpatches/tokenizer/*.class"/>
             <include name="au/com/bytecode/opencsv_voltpatches/CSVParser.class"/>
-            <zipgroupfileset dir="${base.dir}/lib" includes="super-csv-2.1.0.jar" />
+            <zipfileset src="${base.dir}/libsuper-csv-2.1.0.jar" />
             <manifest>
                 <attribute name="Bundle-Activator" value="org.voltdb.importer.formatter.builtin.VoltCSVFormatterFactory" />
                 <attribute name="Bundle-ManifestVersion" value="2" />

--- a/build-importers.xml
+++ b/build-importers.xml
@@ -68,7 +68,7 @@
             <include name="org/voltdb/importclient/kafka/*.class"/>
             <include name="org/voltdb/importclient/kafka/util/*.class"/>
             <include name="org/voltdb/importclient/ImportBaseException.class"/>
-	    <zipfileset src="${base.dir}/lib/scala-library-2.11.5.jar" />
+            <zipfileset src="${base.dir}/lib/scala-library-2.11.5.jar" />
             <zipfileset src="${base.dir}/lib/scala-parser-combinators_2.11-1.0.2.jar" />
             <zipfileset src="${base.dir}/lib/scala-xml_2.11-1.0.2.jar" />
             <zipfileset src="${base.dir}/lib/kafka_2.11-0.8.2.2.jar" />
@@ -92,19 +92,19 @@
         <jar destfile="${bundles.dir}/kinesisstream.jar" basedir="${build.prod.dir}">
             <include name="org/voltdb/importclient/kinesis/*.class"/>
             <include name="org/voltdb/importclient/ImportBaseException.class"/>
-            <zipfileset src="${base.dir}/third_party/java/jarsamazon-kinesis-client-1.6.2.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarsaws-java-sdk-1.10.72.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarsjackson-dataformat-cbor-2.5.3.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarsjackson-databind-2.5.3.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarsjackson-core-2.5.3.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarsjackson-annotations-2.5.0.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarsjoda-time-2.9.3.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarscommons-lang-2.6.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarsguava-18.0.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarsprotobuf-java-2.6.1.jar" />
-            <zipfileset src="${base.dir}/libcommons-logging-1.1.3.jar" />
-            <zipfileset src="${base.dir}/libhttpclient-4.3.6.jar" />
-            <zipfileset src="${base.dir}/libhttpcore-4.3.3.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/amazon-kinesis-client-1.6.2.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/aws-java-sdk-1.10.72.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/jackson-dataformat-cbor-2.5.3.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/jackson-databind-2.5.3.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/jackson-core-2.5.3.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/jackson-annotations-2.5.0.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/joda-time-2.9.3.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/commons-lang-2.6.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/guava-18.0.jar" />
+            <zipfileset src="${base.dir}/lib/protobuf-java-3.4.0.jar" />
+            <zipfileset src="${base.dir}/lib/commons-logging-1.1.3.jar" />
+            <zipfileset src="${base.dir}/lib/httpclient-4.3.6.jar" />
+            <zipfileset src="${base.dir}/lib/httpcore-4.3.3.jar" />
             <manifest>
                 <attribute name="Bundle-Activator" value="org.voltdb.importclient.kinesis.KinesisStreamImporterFactory" />
                 <attribute name="Bundle-ManifestVersion" value="2" />
@@ -147,12 +147,12 @@
             <include name="org/voltdb/importclient/kafka10/*.class"/>
             <include name="org/voltdb/importclient/kafka/util/*.class"/>
             <include name="au/com/bytecode/opencsv_voltpatches/**/*.class"/>
-            <zipfileset src="${base.dir}/third_party/java/jarskafka-clients-0.10.2.1.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarssnappy-java-1.1.2.6.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarslz4-1.3.0.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarsslf4j-api-1.7.21.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarsslf4j-log4j12-1.7.21.jar" />
-            <zipfileset src="${base.dir}/third_party/java/jarslog4j-1.2.17.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/kafka-clients-0.10.2.1.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/snappy-java-1.1.2.6.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/lz4-1.3.0.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/slf4j-api-1.7.21.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/slf4j-log4j12-1.7.21.jar" />
+            <zipfileset src="${base.dir}/third_party/java/jars/log4j-1.2.17.jar" />
             <manifest>
                 <attribute name="Bundle-Activator" value="org.voltdb.importclient.kafka10.KafkaStreamImporterFactory" />
                 <attribute name="Bundle-ManifestVersion" value="2" />
@@ -187,7 +187,7 @@
             <include name="org/voltdb/importer/formatter/builtin/*.class"/>
             <include name="org/supercsv_voltpatches/tokenizer/*.class"/>
             <include name="au/com/bytecode/opencsv_voltpatches/CSVParser.class"/>
-            <zipfileset src="${base.dir}/libsuper-csv-2.1.0.jar" />
+            <zipfileset src="${base.dir}/lib/super-csv-2.1.0.jar" />
             <manifest>
                 <attribute name="Bundle-Activator" value="org.voltdb.importer.formatter.builtin.VoltCSVFormatterFactory" />
                 <attribute name="Bundle-ManifestVersion" value="2" />


### PR DESCRIPTION
Change from zipgroupfileset to zipfileset. 
I've verified the new build script by building with this branch and diffing the contents of the .jar files in bundles/ against the lastest master distribution build.   All files were the same except for the MANIFEST.MF files.