### PR TITLE
sql_grammar_generator.py: added a new --find_in_log option, which allows

### DIFF
--- a/tests/sqlgrammar/run.sh
+++ b/tests/sqlgrammar/run.sh
@@ -184,11 +184,11 @@ function server() {
 
 # Start the VoltDB server, only if not already running
 function server-if-needed() {
-    if [[ -z $(ps -ef | grep -i voltdb | grep -v "grep -i voltdb") ]]; then
+    if [[ -z $(ps -ef | grep -i voltdb | grep -v SQLCommand | grep -v "grep -i voltdb") ]]; then
         server
     else
         echo -e "\nNot (re-)starting a VoltDB server, because 'ps -ef' now includes a 'voltdb' process."
-        #echo -e "   " $(ps -ef | grep -i voltdb | grep -v "grep -i voltdb")
+        #echo -e "    DEBUG:" $(ps -ef | grep -i voltdb | grep -v SQLCommand | grep -v "grep -i voltdb")
     fi
 }
 
@@ -224,8 +224,9 @@ function tests-only() {
     init-if-needed
     echo -e "\n$0 performing: tests$ARGS"
 
-    echo -e "running:\n    python sql_grammar_generator.py $DEFAULT_ARGS --minutes=$MINUTES --seed=$SEED $ARGS"
-    python $SQLGRAMMAR_DIR/sql_grammar_generator.py $DEFAULT_ARGS --minutes=$MINUTES --seed=$SEED $ARGS
+    TEST_COMMAND="python $SQLGRAMMAR_DIR/sql_grammar_generator.py $DEFAULT_ARGS --minutes=$MINUTES --seed=$SEED $ARGS"
+    echo -e "running:\n$TEST_COMMAND"
+    $TEST_COMMAND
     code[5]=$?
 }
 

--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -270,9 +270,17 @@ def print_file_tail_and_errors(from_file, to_file, number_of_lines=50):
     # listed before the more general 'ERROR' messages, and will be totaled separately
     error_types = ['NullPointerException', 'ArrayIndexOutOfBoundsException',
                    'IndexOutOfBoundsException', 'ClassCastException',
-                   'SAXParseException', 'RuntimeException',
-                   'VoltTypeException', 'Exception',
-                   'Error compiling query', 'ERROR: IN: NodeSchema', 'ERROR']
+                   'SAXParseException', 'RuntimeException', 'VoltTypeException',
+                   'Exception',
+                   'Error compiling query', 'ERROR: IN: NodeSchema',
+                   'is already defined', 'is not defined',
+                   "Attribute 'enabled' is not allowed to appear in element 'export'",
+                   'PartitionInfo specifies invalid parameter index for procedure',
+                   'unexpected token: EXEC', 'Failed to plan for statement',
+                   'Unexpected error in the SQL parser for statement', 'Could not parse reader',
+                   'No index found to support UPDATE and DELETE on some of the min() / max() columns in the materialized view',
+                   'WARN', 'ERROR']
+
     error_count = 0
     total_error_count = 0
     total_exception_count = 0
@@ -389,7 +397,8 @@ def print_file_tail_and_errors(from_file, to_file, number_of_lines=50):
 
         print >> exception_output_file, 'Exceptions found in', from_file + ':'
         for extype in sorted(exceptions_and_types, key=lambda ext: ext['count'], reverse=True):
-            print >> exception_output_file, '\nException type:', extype['exception-type'], '(total count:', str(extype['count']) + '):'
+            print >> exception_output_file, '\nException type: "' + extype['exception-type'] \
+                    + '"(total count:', str(extype['count']) + '):'
             for ex in sorted(extype['exceptions'], key=lambda e: e['count'], reverse=True):
                 times = 'times:\n'
                 if ex['count'] == 1:
@@ -398,7 +407,8 @@ def print_file_tail_and_errors(from_file, to_file, number_of_lines=50):
 
         print >> error_output_file, 'ERRORs found in', from_file + ':'
         for ertype in sorted(errors_and_types, key=lambda ert: ert['count'], reverse=True):
-            print >> error_output_file, '\nError type:', ertype['error-type'], '(total count:', str(ertype['count']) + '):'
+            print >> error_output_file, '\nError type: "' + ertype['error-type'] \
+                    + '" (total count:', str(ertype['count']) + '):'
             for er in sorted(ertype['errors'], key=lambda e: e['count'], reverse=True):
                 times = 'times:\n'
                 if er['count'] == 1:
@@ -416,11 +426,11 @@ def get_last_n_sql_statements(last_n_sql_stmnts, include_responses=True):
     sqlcmd; and, optionally, the last n responses received from sqlcmd; based on
     the current contents of last_n_sql_stmnts, where n is its size.
     """
-    result = '\n'.join(sql[0] for sql in last_n_sql_stmnts) + '\n'
+    result = '\n'.join(sql['sql'] for sql in last_n_sql_stmnts) + '\n'
     if include_responses:
         result = '\n    sql statements (or other commands):\n' + result \
                + '\n    corresponding sqlcmd output:' \
-               + ''.join(sql[1] for sql in last_n_sql_stmnts)
+               + ''.join(sql['output'] for sql in last_n_sql_stmnts)
     return result
 
 
@@ -437,7 +447,8 @@ def print_summary(error_message=''):
     sqlcmd 'hangs' are also listed.
     """
     global start_time, sql_output_file, sqlcmd_output_file, sqlcmd_summary_file, \
-        options, echo_substrings, count_sql_statements, hanging_sql_commands
+        options, echo_substrings, count_sql_statements, last_n_sql_statements, \
+        hanging_sql_commands, find_in_log_output_files
 
     # Generate the summary message (to be printed below)
     try:
@@ -491,6 +502,8 @@ def print_summary(error_message=''):
         sql_output_file.close()
     if sqlcmd_output_file and sqlcmd_output_file is not sys.stdout:
         sqlcmd_output_file.close()
+    for find in find_in_log_output_files:
+        find['output_file'].close()
     if sqlcmd_summary_file and sqlcmd_summary_file is not sys.stdout:
         if options.log_files and options.log_number:
             sys.stdout.flush()
@@ -556,7 +569,8 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
     """
     global sql_output_file, sqlcmd_output_file, echo_output_file, sqlcmd_proc, \
         last_n_sql_statements, options, echo_substrings, symbol_depth, symbol_order, \
-        known_error_messages, known_valid_show_responses, hanging_sql_commands, debug
+        known_error_messages, known_valid_show_responses, hanging_sql_commands, \
+        find_in_log_output_files, debug
 
     # Print the specified SQL statement to the specified output file
     print >> sql_output_file, sql
@@ -574,7 +588,7 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
     if sqlcmd_proc:
 
         # Save the last options.summary_number SQL statements, for the summary
-        last_n_sql_statements.append([sql,''])
+        last_n_sql_statements.append({'sql':sql, 'output':''})
         while len(last_n_sql_statements) > options.summary_number:
             last_n_sql_statements.pop(0)
         sqlLen = len(last_n_sql_statements)
@@ -619,7 +633,7 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
             else:
                 alarm(0)  # turns off the alarm
             print >> sqlcmd_output_file, output
-            last_n_sql_statements[sqlLen-1][1] += output + '\n'
+            last_n_sql_statements[sqlLen-1]['output'] += output + '\n'
 
             # Debug print, if that 'echo' substring was found
             if sql_contains_echo_substring and sql_was_echoed_as_output:
@@ -629,6 +643,9 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                 # Wait until the SQL statement has been echoed by sqlcmd,
                 # before checking whether it was considered valid or invalid
                 if output == sql:
+                    sql_was_echoed_as_output = True
+                # Kludge for ENG-13416
+                elif '--' in sql and output == sql[:sql.index('--')]+';':
                     sql_was_echoed_as_output = True
 
                 # Check if sqlcmd considered the SQL statement to be valid
@@ -690,9 +707,9 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                     previous_output = None
                     current_output  = None
                     if sqlLen > 1:
-                        previous_sql    = last_n_sql_statements[sqlLen-2][0]
-                        previous_output = last_n_sql_statements[sqlLen-2][1]
-                        current_output  = last_n_sql_statements[sqlLen-1][1]
+                        previous_sql    = last_n_sql_statements[sqlLen-2]['sql']
+                        previous_output = last_n_sql_statements[sqlLen-2]['output']
+                        current_output  = last_n_sql_statements[sqlLen-1]['output']
                     if ('show' in previous_sql and 'classes' in previous_sql
                             and 'Procedure Classes' in previous_output
                             and 'Procedure Classes' in current_output
@@ -735,6 +752,23 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                 print >> echo_output_file, "{0:1d}: {1:24s}: {2:s}".format(symbol_depth.get(symbol, 0), symbol, partial_sql)
             print >> echo_output_file, "{0:27s}: {1:s}".format('Final sql', sql)
 
+        for find in find_in_log_output_files:
+            command = 'tail -n ' + str(options.find_number) + ' ' + find['log_file']
+            if debug > 4:
+                print 'DEBUG: tail command:', command
+            tail_proc = Popen(command, shell=True, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
+            tail_of_log_file = tail_proc.communicate()[0].replace('\\n', '\n')
+            for find_string in options.find_in_log.split(','):
+                # Check if the string we're looking for is in the log file
+                if find_string in tail_of_log_file:
+                    # Make sure not to double-count something we found in the log file previously
+                    prev = find['previous_tail']
+                    if (prev not in tail_of_log_file or find_string in
+                            tail_of_log_file[tail_of_log_file.index(prev)+len(prev):]):
+                        print >> find['output_file'], 'Found "' + find_string + '" following these SQL statements:\n' \
+                                + get_last_n_sql_statements(last_n_sql_statements, False) + '\n'
+            find['previous_tail'] = tail_of_log_file[len(tail_of_log_file)/2:]
+
     else:
         increment_sql_statement_type(sql[0:num_chars_in_sql_type])
 
@@ -762,7 +796,7 @@ def generate_sql_statements(sql_statement_type, num_sql_statements=0, max_save_s
 
     for i in xrange(num_sql_statements):
         if max_time and time() > max_time:
-            if debug > 1:
+            if debug > 3:
                 print 'DEBUG: exceeded max_time, at:', formatted_time(time())
             break
         print_sql_statement(get_one_sql_statement(grammar, sql_statement_type))
@@ -802,26 +836,26 @@ if __name__ == "__main__":
                       help="a type, or comma-separated list of types, of SQL statements to generate initially; typically "
                           + "used to initialize the database using INSERT statements [default: insert-statement]")
     parser.add_option("-I", "--initial_number", dest="initial_number", default=5,
-                      help="the number of each 'initial_type' of SQL statement to generate [default: 5]")
+                      help="the number of each INITIAL_TYPE of SQL statement to generate [default: 5]")
     parser.add_option("-t", "--type", dest="type", default="sql-statement",
                       help="a type, or comma-separated list of types, of SQL statements to generate "
                          + "(after the initial ones, if any) [default: sql-statement]")
     parser.add_option("-n", "--number", dest="number", default=0,
-                      help="the number of each 'type' of SQL statement to generate; a negative value "
+                      help="the number of each TYPE of SQL statement to generate; a negative value "
                          + "means keep generating until the number of minutes is reached [default: 5; "
-                         + "but -1 if 'minutes' is nonzero]")
+                         + "but -1 if MINUTES is nonzero]")
     parser.add_option("-m", "--minutes", dest="minutes", default=0,
                       help="the number of minutes to generate all SQL statements, of all types "
-                         + "(if positive, overrides the number of SQL statements) [default: 0]")
+                         + "(if positive, overrides the NUMBER of SQL statements) [default: 0]")
     parser.add_option("-d", "--delete_type", dest="delete_type", default="truncate-statement",
                       help="a type of SQL statements used to delete data periodically, so that a VoltDB "
                          + "server's memory does not grow too large [default: truncate-statement]")
-    parser.add_option("-N", "--delete_number", dest="delete_number", default=10,
-                      help="the number of 'delete_type' SQL statements to generate, each time [default: 10]")
+    parser.add_option("-T", "--delete_number", dest="delete_number", default=10,
+                      help="the number of DELETE_TYPE SQL statements to generate, each time [default: 10]")
     parser.add_option("-x", "--max_save", dest="max_save", default=1000,
                       help="the maximum number of SQL statements (and their results, if sqlcmd is called) to save "
                          + "in the output files; after this many SQL statements, the output files are erased, and "
-                         + "'delete_type' statements are called, to clear the database and start fresh [default: 1000]")
+                         + "DELETE_TYPE statements are called, to clear the database and start fresh [default: 1000]")
     parser.add_option("-o", "--output", dest="sql_output", default="sqlcmd.in",
                       help="an output file path/name, to which to send all generated SQL statements; "
                          + "if not specified, output goes to STDOUT [default: sqlcmd.in]")
@@ -836,22 +870,39 @@ if __name__ == "__main__":
                          + "file; only applies if 'sqlcmd' and 'summary' are also specified [default: 5]")
     parser.add_option("-l", "--log", dest="log_files", default=None,
                       help="a file path/name, or comma-separated list of file paths/names, such as the VoltDB log "
-                         + "file or console output; if this and 'summary' are specified, the summary will include "
-                         + "a 'tail' of each of these files [default: None]")
+                         + "file or console output; if this and SQLCMD_SUMMARY are specified, the summary will "
+                         + "include a 'tail' of each of these files [default: None]")
     parser.add_option("-L", "--log_number", dest="log_number", default=100,
                       help="the number of lines to 'tail' from the 'log' file(s); only applies "
-                         + "if 'summary' and 'log' are also specified [default: 100]")
+                         + "if SQLCMD_SUMMARY and LOG_FILES are also specified [default: 100]")
+    parser.add_option("-f", "--find_in_log", dest="find_in_log", default=None,
+                      help="a substring, or comma-separated list of substrings, to be searched for in the 'log' "
+                         + "file(s); if this is specified, then an attempt will be made to search the FIND_FILES "
+                         + "(or LOG_FILES) for these substring(s), and determine which SQL statement (or other "
+                         + "sqlcmd command) caused the substring to appear in the log file; useful for finding "
+                         + "examples of SQL statements that cause specific Java Exceptions (e.g. NullPointerException), "
+                         + "or other errors, to appear in the log or console; any output from such searches will "
+                         + "appear in a file using the name of the log file, preceded by 'found_in_'; note that "
+                         + "this is slow, so should not be used routinely, only when tracking down specific issues "
+                         + "[default: None]")
+    parser.add_option("-F", "--find_files", dest="find_files", default=None,
+                      help="a file path/name, or comma-separated list of file paths/names, such as the VoltDB log "
+                         + "file or console output: the file(s) in which to search for the FIND_IN_LOG substring(s), "
+                         + "if specified [default: LOG_FILES]")
+    parser.add_option("-N", "--find_number", dest="find_number", default=100,
+                      help="the number of lines to 'tail' from the FIND_FILES (or LOG_FILES); only applies "
+                         + "if FIND_IN_LOG is also specified [default: 100]")
     parser.add_option("-e", "--echo", dest="echo", default=None,
                       help="a substring, or comma-separated list of substrings, to be searched for in all SQL "
                          + "statements sent to sqlcmd: if this is specified, then all SQL statements that contain "
                          + "this substring (or list of substrings), and their results, will be echoed (to "
-                         + "'echo_file'); this is useful for debugging new features, e.g., if you just added the "
+                         + "ECHO_FILE); this is useful for debugging new features, e.g., if you just added the "
                          + "LOG10 function, you can set this to 'LOG10', to see its effect [default: None]")
-    parser.add_option("-E", "--echo_file", dest="echo_file", default=None,
-                      help="a file path/name to which to send 'echo' output; if not specified, 'echo' output "
-                         + "(if any) goes to STDOUT [default: None]")
+    parser.add_option("-E", "--echo_file", dest="echo_file", default="sqlcmd.echo",
+                      help="a file path/name to which to send ECHO output; if not specified, ECHO output "
+                         + "(if any) goes to STDOUT [default: sqlcmd.echo]")
     parser.add_option("-G", "--echo_grammar", dest="echo_grammar", default=False,
-                      help="a boolean value (True or False), specifying whether to include, in the 'echo_file', "
+                      help="a boolean value (True or False), specifying whether to include, in the ECHO_FILE, "
                          + "the list of grammar symbols, and how many times each one was used, for each of the "
                          + "SQL statements that is echoed [default: False]")
     parser.add_option("-D", "--debug", dest="debug", default=2,
@@ -885,6 +936,9 @@ if __name__ == "__main__":
         print "DEBUG: options.summary_number:", options.summary_number
         print "DEBUG: options.log_files     :", options.log_files
         print "DEBUG: options.log_number    :", options.log_number
+        print "DEBUG: options.find_in_log   :", options.find_in_log
+        print "DEBUG: options.find_files    :", options.find_files
+        print "DEBUG: options.find_number   :", options.find_number
         print "DEBUG: options.echo          :", options.echo
         print "DEBUG: options.echo_file     :", options.echo_file
         print "DEBUG: options.echo_grammar  :", options.echo_grammar
@@ -948,6 +1002,7 @@ if __name__ == "__main__":
     sqlcmd_output_file = None
     sqlcmd_summary_file = None
     last_n_sql_statements = []
+    find_in_log_output_files = []
     if options.sqlcmd_output:
         if options.sqlcmd_output is "STDOUT":
             sqlcmd_output_file = sys.stdout
@@ -957,6 +1012,16 @@ if __name__ == "__main__":
         if options.sqlcmd_summary:
             sqlcmd_summary_file = open(options.sqlcmd_summary, 'w', 0)
             print >> sqlcmd_summary_file, 'Using %s seed: %d' % (seed_type, random_seed)
+
+        if options.find_in_log:
+            files = options.log_files  # default if options.find_files not specified
+            if options.find_files:
+                files = options.find_files
+            for lf in files.split(','):
+                log_file_name = lf[lf.rfind('/') + 1:]
+                output_file = open('found_in_'+log_file_name, 'w', 0)
+                find_in_log_output_files.append({'log_file':lf, 'output_file':output_file,
+                                                 'previous_tail':'INITIAL_VALUE_PRESUMABLY_NOT_IN_LOG_FILE'})
 
         command = 'sqlcmd --stop-on-error=false'
         if debug > 4:


### PR DESCRIPTION
you to search the log (and/or console) after each SQL statement (or
other command) is issued to sqlcmd, to see which statements are causing
certain phrases of interest (e.g. NullPointerException) to appear there,
and output the result in a file(s); note that this is slow, so should
not be used routinely, only when tracking down specific, known issues;
also related options --find_files, to specify the file(s) (defaults to
existing LOG_FILES option value) and --find_number, to specify the
number of lines of the log file(s) to be checked via a 'tail' command
(defaults to 100); added a bunch of new types of ERROR to grep for in
the log (& console), including 'is already defined', 'is not defined',
and 'WARN', among others; added a small kludge to workaround ENG-13416;
modified last_n_sql_statements to be dictionary rather than a list,
which is a lot clearer; tweaked the comments for a bunch of the existing
options.
run.sh: minor tweaks to checking whether a VoltDB server is already
running (don't confuse it with SQLCommand); and to running the actual
tests (make sure the command echoed is the same one that is running,
including the path).