### PR TITLE
ENG-13425. build now picks up env.CONNECTIONPOOLLIB for client classpath

### DIFF
--- a/tests/test_apps/voltkvqa/build.xml
+++ b/tests/test_apps/voltkvqa/build.xml
@@ -13,6 +13,11 @@
     <property name="voltdbroot.dir"     value="${basedir}/voltdbroot"/>
     <property name="log.dir"     value="${basedir}/log"/>
 
+    <property environment="env"/>
+    <condition property="connectionpooldir" value="${env.CONNECTIONPOOLLIB}" else="/home/opt/connection-pool">
+      <isset property="env.CONNECTIONPOOLLIB" />
+    </condition>
+
     <target name="all" depends="jars"/>
 
     <target name="clean">
@@ -33,7 +38,7 @@
            <!-- <include name="voltdbclient*.jar"/> -->
          <include name="*.jar"/>
        </fileset>
-       <fileset dir="/home/opt/connection-pool">
+       <fileset dir="${connectionpooldir}">
            <!-- <include name="voltdbclient*.jar"/> -->
          <include name="*.jar"/>
        </fileset>


### PR DESCRIPTION
Building  voltkvqa used to fail if connection-pool library wasn't in /home/opt (as it is on lab machines). Now you can override by setting CONNECTIONPOOLLIB in your environment.