### PR TITLE
ENG-13396: Sporadic failure in TestJSONInterface

### DIFF
--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -297,6 +297,8 @@ public class PlannerTool {
                 if (plan.getStatementPartitioning() != null) {
                     partitioning = plan.getStatementPartitioning();
                 }
+
+                planHasExceptionsWhenParameterized = planner.wasBadPameterized();
             }
             catch (Exception e) {
                 /*

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -59,8 +59,6 @@ public class PlannerTool {
 
     private static PlannerStatsCollector m_plannerStats;
 
-    private static final Object PLANNER_LOCK = new Object();
-
     public PlannerTool(final Database database, byte[] catalogHash)
     {
         assert(database != null);
@@ -128,232 +126,220 @@ public class PlannerTool {
     /**
      * Stripped down compile that is ONLY used to plan default procedures.
      */
-    public CompiledPlan planSqlCore(String sql, StatementPartitioning partitioning) {
-        synchronized (PLANNER_LOCK) {
-            TrivialCostModel costModel = new TrivialCostModel();
-            DatabaseEstimates estimates = new DatabaseEstimates();
-            QueryPlanner planner = new QueryPlanner(
-                    sql, "PlannerTool", "PlannerToolProc", m_database,
-                    partitioning, m_hsql, estimates, !VoltCompiler.DEBUG_MODE,
-                    costModel, null, null, DeterminismMode.FASTER, false);
+    public synchronized CompiledPlan planSqlCore(String sql, StatementPartitioning partitioning) {
+        TrivialCostModel costModel = new TrivialCostModel();
+        DatabaseEstimates estimates = new DatabaseEstimates();
+
+        CompiledPlan plan = null;
+        // This try-with-resources block acquires a global lock on all planning
+        // This is required until we figure out how to do parallel planning.
+        try (QueryPlanner planner = new QueryPlanner(
+                sql, "PlannerTool", "PlannerToolProc", m_database,
+                partitioning, m_hsql, estimates, !VoltCompiler.DEBUG_MODE,
+                costModel, null, null, DeterminismMode.FASTER, false)) {
+
+            // do the expensive full planning.
+            planner.parse();
+            plan = planner.plan();
+            assert(plan != null);
+        }
+        catch (Exception e) {
+            /*
+             * Don't log PlanningErrorExceptions or HSQLParseExceptions, as they
+             * are at least somewhat expected.
+             */
+            String loggedMsg = "";
+            if (!(e instanceof PlanningErrorException || e instanceof HSQLParseException)) {
+                logException(e, "Error compiling query");
+                loggedMsg = " (Stack trace has been written to the log.)";
+            }
+            throw new RuntimeException("Error compiling query: " + e.toString() + loggedMsg, e);
+        }
+
+        if (plan == null) {
+            throw new RuntimeException("Null plan received in PlannerTool.planSql");
+        }
+
+        return plan;
+    }
+
+    public synchronized AdHocPlannedStatement planSql(String sqlIn, StatementPartitioning partitioning,
+            boolean isExplainMode, final Object[] userParams, boolean isSwapTables, boolean isLargeQuery) {
+
+        CacheUse cacheUse = CacheUse.FAIL;
+        if (m_plannerStats != null) {
+            m_plannerStats.startStatsCollection();
+        }
+        boolean hasUserQuestionMark = false;
+        boolean wrongNumberParameters = false;
+        try {
+            if ((sqlIn == null) || (sqlIn.length() == 0)) {
+                throw new RuntimeException("Can't plan empty or null SQL.");
+            }
+            // remove any spaces or newlines
+            String sql = sqlIn.trim();
+
+            // No caching for forced single partition or forced multi partition SQL,
+            // since these options potentially get different plans that may be invalid
+            // or sub-optimal in other contexts. Likewise, plans cached from other contexts
+            // may be incompatible with these options.
+            // If this presents a planning performance problem, we could consider maintaining
+            // separate caches for the 3 cases or maintaining up to 3 plans per cache entry
+            // if the cases tended to have mostly overlapping queries.
+            //
+            // Large queries are not cached.  Their plans are different than non-large queries
+            // with the same SQL text, and in general we expect them to be slow.  If at some
+            // point it seems worthwhile to cache such plans, we can explore it.
+            if (partitioning.isInferred() && !isLargeQuery) {
+                // Check the literal cache for a match.
+                AdHocPlannedStatement cachedPlan = m_cache.getWithSQL(sqlIn);
+                if (cachedPlan != null) {
+                    cacheUse = CacheUse.HIT1;
+                    return cachedPlan;
+                }
+                else {
+                    cacheUse = CacheUse.MISS;
+                }
+            }
+
+            //////////////////////
+            // PLAN THE STMT
+            //////////////////////
 
             CompiledPlan plan = null;
-            try {
-                // do the expensive full planning.
-                // Keep this lock until we figure out how to do parallel planning
-                synchronized (QueryPlanner.class) {
+            boolean planHasExceptionsWhenParameterized = false;
+            String[] extractedLiterals = null;
+            String parsedToken = null;
+
+            TrivialCostModel costModel = new TrivialCostModel();
+            DatabaseEstimates estimates = new DatabaseEstimates();
+            // This try-with-resources block acquires a global lock on all planning
+            // This is required until we figure out how to do parallel planning.
+            try (QueryPlanner planner = new QueryPlanner(
+                    sql,
+                    "PlannerTool",
+                    "PlannerToolProc",
+                    m_database,
+                    partitioning,
+                    m_hsql,
+                    estimates,
+                    !VoltCompiler.DEBUG_MODE,
+                    costModel,
+                    null,
+                    null,
+                    DeterminismMode.FASTER,
+                    isLargeQuery)) {
+
+                if (isSwapTables) {
+                    planner.planSwapTables();
+                } else {
                     planner.parse();
-                    plan = planner.plan();
-                    assert(plan != null);
+                }
+                parsedToken = planner.parameterize();
+
+                // check the parameters count
+                // check user input question marks with input parameters
+                int inputParamsLengh = userParams == null ? 0: userParams.length;
+                if (planner.getAdhocUserParamsCount() != inputParamsLengh) {
+                    wrongNumberParameters = true;
+                    if (!isExplainMode) {
+                        throw new PlanningErrorException(String.format(
+                                "Incorrect number of parameters passed: expected %d, passed %d",
+                                planner.getAdhocUserParamsCount(), inputParamsLengh));
+                    }
+                }
+                hasUserQuestionMark  = planner.getAdhocUserParamsCount() > 0;
+
+                // do not put wrong parameter explain query into cache
+                if (!wrongNumberParameters && partitioning.isInferred() && !isLargeQuery) {
+                    // if cacheable, check the cache for a matching pre-parameterized plan
+                    // if plan found, build the full plan using the parameter data in the
+                    // QueryPlanner.
+                    assert(parsedToken != null);
+                    extractedLiterals = planner.extractedParamLiteralValues();
+                    List<BoundPlan> boundVariants = m_cache.getWithParsedToken(parsedToken);
+                    if (boundVariants != null) {
+                        assert( ! boundVariants.isEmpty());
+                        BoundPlan matched = null;
+                        for (BoundPlan boundPlan : boundVariants) {
+                            if (boundPlan.allowsParams(extractedLiterals)) {
+                                matched = boundPlan;
+                                break;
+                            }
+                        }
+                        if (matched != null) {
+                            CorePlan core = matched.m_core;
+                            ParameterSet params = null;
+                            if (planner.compiledAsParameterizedPlan()) {
+                                params = planner.extractedParamValues(core.parameterTypes);
+                            } else if (hasUserQuestionMark) {
+                                params = ParameterSet.fromArrayNoCopy(userParams);
+                            } else {
+                                // No constants AdHoc queries
+                                params = ParameterSet.emptyParameterSet();
+                            }
+
+                            AdHocPlannedStatement ahps = new AdHocPlannedStatement(sql.getBytes(Constants.UTF8ENCODING),
+                                                                                   core,
+                                                                                   params,
+                                                                                   null);
+                            ahps.setBoundConstants(matched.m_constants);
+                            // parameterized plan from the cache does not have exception
+                            m_cache.put(sql, parsedToken, ahps, extractedLiterals, hasUserQuestionMark, false);
+                            cacheUse = CacheUse.HIT2;
+                            return ahps;
+                        }
+                    }
+                }
+
+                // If not caching or there was no cache hit, do the expensive full planning.
+                plan = planner.plan();
+                if (plan.getStatementPartitioning() != null) {
+                    partitioning = plan.getStatementPartitioning();
                 }
             }
             catch (Exception e) {
                 /*
-                 * Don't log PlanningErrorExceptions or HSQLParseExceptions, as they
-                 * are at least somewhat expected.
+                 * Don't log PlanningErrorExceptions or HSQLParseExceptions, as
+                 * they are at least somewhat expected.
                  */
                 String loggedMsg = "";
-                if (!(e instanceof PlanningErrorException || e instanceof HSQLParseException)) {
+                if (!((e instanceof PlanningErrorException) || (e instanceof HSQLParseException))) {
                     logException(e, "Error compiling query");
                     loggedMsg = " (Stack trace has been written to the log.)";
                 }
-                throw new RuntimeException("Error compiling query: " + e.toString() + loggedMsg, e);
+                throw new RuntimeException("Error compiling query: " + e.toString() + loggedMsg,
+                                           e);
             }
 
-            if (plan == null) {
-                throw new RuntimeException("Null plan received in PlannerTool.planSql");
+            //////////////////////
+            // OUTPUT THE RESULT
+            //////////////////////
+            CorePlan core = new CorePlan(plan, m_catalogHash);
+            AdHocPlannedStatement ahps = new AdHocPlannedStatement(plan, core);
+
+            // Do not put wrong parameter explain query into cache.
+            // Also, do not put large query plans into the cache.
+            if (!wrongNumberParameters && partitioning.isInferred() && !isLargeQuery) {
+
+                // Note either the parameter index (per force to a user-provided parameter) or
+                // the actual constant value of the partitioning key inferred from the plan.
+                // Either or both of these two values may simply default
+                // to -1 and to null, respectively.
+                core.setPartitioningParamIndex(partitioning.getInferredParameterIndex());
+                core.setPartitioningParamValue(partitioning.getInferredPartitioningValue());
+
+
+                assert(parsedToken != null);
+                // Again, plans with inferred partitioning are the only ones supported in the cache.
+                m_cache.put(sqlIn, parsedToken, ahps, extractedLiterals, hasUserQuestionMark, planHasExceptionsWhenParameterized);
             }
-
-            return plan;
-        } // end synchronized block
-    }
-
-    public AdHocPlannedStatement planSql(String sqlIn, StatementPartitioning partitioning,
-            boolean isExplainMode, final Object[] userParams, boolean isSwapTables, boolean isLargeQuery) {
-        synchronized (PLANNER_LOCK) {
-            CacheUse cacheUse = CacheUse.FAIL;
+            return ahps;
+        }
+        finally {
             if (m_plannerStats != null) {
-                m_plannerStats.startStatsCollection();
+                m_plannerStats.endStatsCollection(m_cache.getLiteralCacheSize(), m_cache.getCoreCacheSize(), cacheUse, -1);
             }
-            boolean hasUserQuestionMark = false;
-            boolean wrongNumberParameters = false;
-            try {
-                if ((sqlIn == null) || (sqlIn.length() == 0)) {
-                    throw new RuntimeException("Can't plan empty or null SQL.");
-                }
-                // remove any spaces or newlines
-                String sql = sqlIn.trim();
-
-                // No caching for forced single partition or forced multi partition SQL,
-                // since these options potentially get different plans that may be invalid
-                // or sub-optimal in other contexts. Likewise, plans cached from other contexts
-                // may be incompatible with these options.
-                // If this presents a planning performance problem, we could consider maintaining
-                // separate caches for the 3 cases or maintaining up to 3 plans per cache entry
-                // if the cases tended to have mostly overlapping queries.
-                //
-                // Large queries are not cached.  Their plans are different than non-large queries
-                // with the same SQL text, and in general we expect them to be slow.  If at some
-                // point it seems worthwhile to cache such plans, we can explore it.
-                if (partitioning.isInferred() && !isLargeQuery) {
-                    // Check the literal cache for a match.
-                    AdHocPlannedStatement cachedPlan = m_cache.getWithSQL(sqlIn);
-                    if (cachedPlan != null) {
-                        cacheUse = CacheUse.HIT1;
-                        return cachedPlan;
-                    }
-                    else {
-                        cacheUse = CacheUse.MISS;
-                    }
-                }
-
-                //////////////////////
-                // PLAN THE STMT
-                //////////////////////
-
-                TrivialCostModel costModel = new TrivialCostModel();
-                DatabaseEstimates estimates = new DatabaseEstimates();
-                QueryPlanner planner = new QueryPlanner(
-                        sql,
-                        "PlannerTool",
-                        "PlannerToolProc",
-                        m_database,
-                        partitioning,
-                        m_hsql,
-                        estimates,
-                        !VoltCompiler.DEBUG_MODE,
-                        costModel,
-                        null,
-                        null,
-                        DeterminismMode.FASTER,
-                        isLargeQuery);
-
-                CompiledPlan plan = null;
-                String[] extractedLiterals = null;
-                String parsedToken = null;
-                try {
-                    // Keep this lock until we figure out how to do parallel planning
-                    synchronized (QueryPlanner.class) {
-                        if (isSwapTables) {
-                            planner.planSwapTables();
-                        } else {
-                            planner.parse();
-                        }
-                    }
-                    parsedToken = planner.parameterize();
-
-                    // check the parameters count
-                    // check user input question marks with input parameters
-                    int inputParamsLengh = userParams == null ? 0: userParams.length;
-                    if (planner.getAdhocUserParamsCount() != inputParamsLengh) {
-                        wrongNumberParameters = true;
-                        if (!isExplainMode) {
-                            throw new PlanningErrorException(String.format(
-                                    "Incorrect number of parameters passed: expected %d, passed %d",
-                                    planner.getAdhocUserParamsCount(), inputParamsLengh));
-                        }
-                    }
-                    hasUserQuestionMark  = planner.getAdhocUserParamsCount() > 0;
-
-                    // do not put wrong parameter explain query into cache
-                    if (!wrongNumberParameters && partitioning.isInferred() && !isLargeQuery) {
-                        // if cacheable, check the cache for a matching pre-parameterized plan
-                        // if plan found, build the full plan using the parameter data in the
-                        // QueryPlanner.
-                        assert(parsedToken != null);
-                        extractedLiterals = planner.extractedParamLiteralValues();
-                        List<BoundPlan> boundVariants = m_cache.getWithParsedToken(parsedToken);
-                        if (boundVariants != null) {
-                            assert( ! boundVariants.isEmpty());
-                            BoundPlan matched = null;
-                            for (BoundPlan boundPlan : boundVariants) {
-                                if (boundPlan.allowsParams(extractedLiterals)) {
-                                    matched = boundPlan;
-                                    break;
-                                }
-                            }
-                            if (matched != null) {
-                                CorePlan core = matched.m_core;
-                                ParameterSet params = null;
-                                if (planner.compiledAsParameterizedPlan()) {
-                                    params = planner.extractedParamValues(core.parameterTypes);
-                                } else if (hasUserQuestionMark) {
-                                    params = ParameterSet.fromArrayNoCopy(userParams);
-                                } else {
-                                    // No constants AdHoc queries
-                                    params = ParameterSet.emptyParameterSet();
-                                }
-
-                                AdHocPlannedStatement ahps = new AdHocPlannedStatement(sql.getBytes(Constants.UTF8ENCODING),
-                                        core,
-                                        params,
-                                        null);
-                                ahps.setBoundConstants(matched.m_constants);
-                                // parameterized plan from the cache does not have exception
-                                m_cache.put(sql, parsedToken, ahps, extractedLiterals, hasUserQuestionMark, false);
-                                cacheUse = CacheUse.HIT2;
-                                return ahps;
-                            }
-                        }
-                    }
-
-                    // Keep this lock until we figure out how to do parallel planning
-                    synchronized (QueryPlanner.class) {
-                        // If not caching or there was no cache hit, do the expensive full planning.
-                        plan = planner.plan();
-                        assert(plan != null);
-                    }
-                    if (plan != null && plan.getStatementPartitioning() != null) {
-                        partitioning = plan.getStatementPartitioning();
-                    }
-                }
-                catch (Exception e) {
-                    /*
-                     * Don't log PlanningErrorExceptions or HSQLParseExceptions, as
-                     * they are at least somewhat expected.
-                     */
-                    String loggedMsg = "";
-                    if (!((e instanceof PlanningErrorException) || (e instanceof HSQLParseException))) {
-                        logException(e, "Error compiling query");
-                        loggedMsg = " (Stack trace has been written to the log.)";
-                    }
-                    throw new RuntimeException("Error compiling query: " + e.toString() + loggedMsg,
-                            e);
-                }
-
-                if (plan == null) {
-                    throw new RuntimeException("Null plan received in PlannerTool.planSql");
-                }
-
-                //////////////////////
-                // OUTPUT THE RESULT
-                //////////////////////
-                CorePlan core = new CorePlan(plan, m_catalogHash);
-                AdHocPlannedStatement ahps = new AdHocPlannedStatement(plan, core);
-
-                // Do not put wrong parameter explain query into cache.
-                // Also, do not put large query plans into the cache.
-                if (!wrongNumberParameters && partitioning.isInferred() && !isLargeQuery) {
-
-                    // Note either the parameter index (per force to a user-provided parameter) or
-                    // the actual constant value of the partitioning key inferred from the plan.
-                    // Either or both of these two values may simply default
-                    // to -1 and to null, respectively.
-                    core.setPartitioningParamIndex(partitioning.getInferredParameterIndex());
-                    core.setPartitioningParamValue(partitioning.getInferredPartitioningValue());
-
-
-                    assert(parsedToken != null);
-                    // Again, plans with inferred partitioning are the only ones supported in the cache.
-                    m_cache.put(sqlIn, parsedToken, ahps, extractedLiterals, hasUserQuestionMark, planner.wasBadPameterized());
-                }
-                return ahps;
-            }
-            finally {
-                if (m_plannerStats != null) {
-                    m_plannerStats.endStatsCollection(m_cache.getLiteralCacheSize(), m_cache.getCoreCacheSize(), cacheUse, -1);
-                }
-            }
-        } // end synchronized block
+        }
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
@@ -18,6 +18,8 @@
 package org.voltdb.sysprocs;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -236,7 +238,15 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
                     "Try reducing the number of predicate expressions in the query.");
         }
         catch (AssertionError ae) {
-            throw new AdHocPlanningException("Assertion Error in Ad Hoc Planning: " + ae);
+            StringWriter stringWriter = new StringWriter();
+            PrintWriter writer = new PrintWriter(stringWriter);
+            ae.printStackTrace(writer);
+            String stackTrace = stringWriter.toString();
+
+            adhocLog.error("An unexpected internal error occurred when planning a statement issued via @AdHoc.  "
+                    + "Please contact VoltDB at support@voltdb.com with your log files.\n"
+                    + stackTrace);
+            throw new AdHocPlanningException("An unexpected internal error occurred when planning a statement issued via @AdHoc");
         }
     }
 

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
@@ -238,15 +238,15 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
                     "Try reducing the number of predicate expressions in the query.");
         }
         catch (AssertionError ae) {
+            String msg = "An unexpected internal error occurred when planning a statement issued via @AdHoc.  "
+                    + "Please contact VoltDB at support@voltdb.com with your log files.";
             StringWriter stringWriter = new StringWriter();
             PrintWriter writer = new PrintWriter(stringWriter);
             ae.printStackTrace(writer);
             String stackTrace = stringWriter.toString();
 
-            adhocLog.error("An unexpected internal error occurred when planning a statement issued via @AdHoc.  "
-                    + "Please contact VoltDB at support@voltdb.com with your log files.\n"
-                    + stackTrace);
-            throw new AdHocPlanningException("An unexpected internal error occurred when planning a statement issued via @AdHoc");
+            adhocLog.error(msg + "\n" + stackTrace);
+            throw new AdHocPlanningException(msg);
         }
     }
 


### PR DESCRIPTION
These changes fix sporadic failures in the test TestJSONInterface which were the result of planning of multiple statements happening at the same time.  This test runs a bunch of ad hoc queries in parallel with catalog updates, and so it caused a failed assertion on the expected value of a static variable used in planning, `ParameterizationInfo.curParamIndex`.

The `QueryPlanner` method `plan` was only invoked serially, but the method `parameterize`, which is called for ad hoc planning, was not guarded with a `synchronize` block.  The calls to `parameterize` and `plan` must happen with no other planning happening in between.  This caused a data race on the value of `curParamIndex`.

My fix was to force creation of an instance of `QueryPlanner` to take out a global lock to ensure that planning happens serially.  
