### PR TITLE
ENG-13359:

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.cpp
+++ b/src/ee/common/SynchronizedThreadLock.cpp
@@ -114,21 +114,13 @@ void SynchronizedDummyUndoQuantumReleaseInterest::notifyQuantumRelease() {
 void SynchronizedThreadLock::create() {
     assert(s_SITES_PER_HOST == -1);
     s_SITES_PER_HOST = 0;
-    pthread_mutex_init(&s_sharedEngineMutex, NULL);
     pthread_cond_init(&s_sharedEngineCondition, 0);
     pthread_cond_init(&s_wakeLowestEngineCondition, 0);
-#ifdef VOLT_TRACE_ENABLED
-    pthread_mutex_init(&ThreadLocalPool::s_sharedMemoryMutex, NULL);
-#endif
 }
 
 void SynchronizedThreadLock::destroy() {
     pthread_cond_destroy(&s_sharedEngineCondition);
     pthread_cond_destroy(&s_wakeLowestEngineCondition);
-    pthread_mutex_destroy(&s_sharedEngineMutex);
-#ifdef VOLT_TRACE_ENABLED
-    pthread_mutex_destroy(&ThreadLocalPool::s_sharedMemoryMutex);
-#endif
 }
 
 void SynchronizedThreadLock::init(int32_t sitesPerHost, EngineLocals& newEngineLocals) {
@@ -172,7 +164,7 @@ void SynchronizedThreadLock::resetMemory(int32_t partitionId) {
             delete s_mpEngine.enginePartitionId;
             s_mpEngine.enginePartitionId = NULL;
             s_mpEngine.context = NULL;
-#ifdef VOLT_TRACE_ENABLED
+#ifdef VOLT_DEBUG_ENABLED
             pthread_mutex_lock(&ThreadLocalPool::s_sharedMemoryMutex);
             ThreadLocalPool::SizeBucketMap_t& mapBySize = ThreadLocalPool::s_allocations[16383];
             pthread_mutex_unlock(&ThreadLocalPool::s_sharedMemoryMutex);

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -178,9 +178,9 @@ public:
     static void freeRelocatable(Sized* string);
 
 #ifdef VOLT_DEBUG_ENABLED
-    int32_t allocatingEngine;
-    int32_t allocatingThread;
-    StackTrace allocationTrace;
+    int32_t m_allocatingEngine;
+    int32_t m_allocatingThread;
+    StackTrace m_allocationTrace;
     static pthread_mutex_t s_sharedMemoryMutex;
 #ifdef VOLT_TRACE_ALLOCATIONS
     typedef std::unordered_map<void *, StackTrace*> AllocTraceMap_t;

--- a/src/ee/executors/abstractexecutor.h
+++ b/src/ee/executors/abstractexecutor.h
@@ -115,6 +115,10 @@ class AbstractExecutor {
         return true;
     }
 
+    inline void disableReplicatedFlag() {
+        m_replicatedTableOperation = false;
+    }
+
     // Compares two tuples based on the provided sets of expressions and sort directions
     struct TupleComparer
     {

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -100,7 +100,8 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
 
     int64_t modified_tuples = 0;
     {
-        assert(m_replicatedTableOperation == targetTable->isCatalogTableReplicated());
+        assert(targetTable->isCatalogTableReplicated() ==
+                (m_replicatedTableOperation || SynchronizedThreadLock::isInSingleThreadMode()));
         ConditionalExecuteWithMpMemory possiblyUseMpMemory(m_replicatedTableOperation);
 
         if (m_truncate) {

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -425,11 +425,11 @@ Java_org_voltdb_jni_ExecutionEngine_nativeLoadTable (
 
     //JNIEnv pointer can change between calls, must be updated
     updateJNILogProxy(engine);
-    VOLT_DEBUG("loading table %d in C++...", table_id);
+    VOLT_DEBUG("loading table %d in C++ on thread %d", table_id, ThreadLocalPool::getThreadPartitionId());
 
     // deserialize dependency.
     jsize length = env->GetArrayLength(serialized_table);
-    VOLT_DEBUG("deserializing %d bytes ...", (int) length);
+    VOLT_DEBUG("deserializing %d bytes on thread %d", (int) length, ThreadLocalPool::getThreadPartitionId());
     jbyte *bytes = env->GetByteArrayElements(serialized_table, NULL);
     ReferenceSerializeInputBE serialize_in(bytes, length);
     try {

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -118,7 +118,8 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
         registerSnapshotMonitor(message.getSnapshotNonce());
 
         long sinkHSId = m_dataSink.initialize(message.getSnapshotSourceCount(),
-                                              message.getSnapshotBufferPool());
+                                              message.getSnapshotDataBufferPool(),
+                                              message.getSnapshotCompressedDataBufferPool());
 
         // respond to the coordinator with the sink HSID
         RejoinMessage msg = new RejoinMessage(m_mailbox.getHSId(), -1, sinkHSId);

--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -216,7 +216,8 @@ public class RejoinProducer extends JoinProducerBase {
         // Provide a valid sink host id unless it is an empty database.
         long hsId = (m_rejoinSiteProcessor != null
                         ? m_rejoinSiteProcessor.initialize(message.getSnapshotSourceCount(),
-                                                           message.getSnapshotBufferPool())
+                                                           message.getSnapshotDataBufferPool(),
+                                                           message.getSnapshotCompressedDataBufferPool())
                         : Long.MIN_VALUE);
 
         REJOINLOG.debug(m_whoami

--- a/src/frontend/org/voltdb/messaging/RejoinMessage.java
+++ b/src/frontend/org/voltdb/messaging/RejoinMessage.java
@@ -19,9 +19,11 @@ package org.voltdb.messaging;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Queue;
 
 import org.voltcore.messaging.Subject;
 import org.voltcore.messaging.VoltMessage;
+import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.utils.FixedDBBPool;
 
 /**
@@ -48,7 +50,8 @@ public class RejoinMessage extends VoltMessage {
     private long m_snapshotTxnId = -1; // snapshot txnId
     private long m_masterHSId = -1;
     private String m_snapshotNonce = null;
-    private FixedDBBPool m_bufferPool = null;
+    private Queue<BBContainer> m_dataBufferPool = null;
+    private Queue<BBContainer> m_compressedDataBufferPool = null;
     // number of sources sending to this site
     private int m_snapshotSourceCount = 1;
     private long m_snapshotSinkHSId = -1;
@@ -75,13 +78,15 @@ public class RejoinMessage extends VoltMessage {
      * INITIATION, INITIATION_COMMUNITY pass the nonce used by the coordinator to the site.
      */
     public RejoinMessage(long sourceHSId, Type type, String snapshotNonce,
-                         int sourceCount, FixedDBBPool bufferPool,
+                         int sourceCount, Queue<BBContainer> dataBufferPool,
+                         Queue<BBContainer> compressedDataBufferPool,
                          boolean schemaHasNoTables) {
         this(sourceHSId, type);
         assert(type == Type.INITIATION || type == Type.INITIATION_COMMUNITY);
         m_snapshotNonce = snapshotNonce;
         m_snapshotSourceCount = sourceCount;
-        m_bufferPool = bufferPool;
+        m_dataBufferPool = dataBufferPool;
+        m_compressedDataBufferPool = compressedDataBufferPool;
         m_schemaHasNoTables = schemaHasNoTables;
     }
 
@@ -112,9 +117,14 @@ public class RejoinMessage extends VoltMessage {
         return m_masterHSId;
     }
 
-    public FixedDBBPool getSnapshotBufferPool()
+    public Queue<BBContainer> getSnapshotDataBufferPool()
     {
-        return m_bufferPool;
+        return m_dataBufferPool;
+    }
+
+    public Queue<BBContainer> getSnapshotCompressedDataBufferPool()
+    {
+        return m_compressedDataBufferPool;
     }
 
     public int getSnapshotSourceCount()

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -21,8 +21,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -36,13 +38,18 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DBBPool;
+import org.voltcore.utils.Pair;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.SnapshotDataTarget;
 import org.voltdb.SnapshotFormat;
 import org.voltdb.VoltDB;
+import org.voltdb.VoltTable;
+import org.voltdb.VoltType;
+import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.utils.CompressionService;
 
 import com.google_voltpatches.common.base.Preconditions;
+import com.google_voltpatches.common.primitives.Longs;
 import com.google_voltpatches.common.util.concurrent.Futures;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import com.google_voltpatches.common.util.concurrent.SettableFuture;
@@ -65,10 +72,16 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
     public final static long DEFAULT_WRITE_TIMEOUT_MS = m_rejoinDeathTestMode ? 10000 : Long.getLong("REJOIN_WRITE_TIMEOUT_MS", 60000);
     final static long WATCHDOG_PERIOS_S = 5;
 
+    // Number of bytes in the fixed header of a table data Block Type(1) + BlockIndex(4) + TableId(4) + partition id(4) + row count(4)
+    final static int ROW_COUNT_OFFSET = contentOffset + 4;
+    final static int DATA_HEADER_BYTES = contentOffset + 4 + 4;
+
     // schemas for all the tables on this partition
-    private final Map<Integer, byte[]> m_schemas = new HashMap<Integer, byte[]>();
+    private final Map<Integer, Pair<Boolean, byte[]>> m_schemas = new HashMap<>();
     // HSId of the destination mailbox
     private final long m_destHSId;
+    private final Set<Long> m_otherDestHostHSIds;
+    private boolean m_replicatedTableTarget;
     // input and output threads
     private final SnapshotSender m_sender;
     private final StreamSnapshotAckReceiver m_ackReceiver;
@@ -91,35 +104,44 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
 
     private final AtomicBoolean m_closed = new AtomicBoolean(false);
 
-    public StreamSnapshotDataTarget(long HSId, byte[] hashinatorConfig, Map<Integer, byte[]> schemas,
+    public StreamSnapshotDataTarget(long HSId, boolean lowestDestSite, Set<Long> allDestHostHSIds,
+                                    byte[] hashinatorConfig, Map<Integer, Pair<Boolean, byte[]>> schemas,
                                     SnapshotSender sender, StreamSnapshotAckReceiver ackReceiver)
     {
-        this(HSId, hashinatorConfig, schemas, DEFAULT_WRITE_TIMEOUT_MS, sender, ackReceiver);
+        this(HSId, lowestDestSite, allDestHostHSIds, hashinatorConfig, schemas, DEFAULT_WRITE_TIMEOUT_MS, sender, ackReceiver);
     }
 
-    public StreamSnapshotDataTarget(long HSId, byte[] hashinatorConfig, Map<Integer, byte[]> schemas,
+    public StreamSnapshotDataTarget(long HSId, boolean lowestDestSite, Set<Long> allDestHostHSIds,
+                                    byte[] hashinatorConfig, Map<Integer, Pair<Boolean, byte[]>> schemas,
                                     long writeTimeout, SnapshotSender sender, StreamSnapshotAckReceiver ackReceiver)
     {
         super();
         m_targetId = m_totalSnapshotTargetCount.getAndIncrement();
         m_schemas.putAll(schemas);
         m_destHSId = HSId;
+        m_replicatedTableTarget = lowestDestSite;
+        m_otherDestHostHSIds = new HashSet<>(allDestHostHSIds);
+        m_otherDestHostHSIds.remove(m_destHSId);
         m_sender = sender;
         m_sender.registerDataTarget(m_targetId);
         m_ackReceiver = ackReceiver;
         m_ackReceiver.setCallback(m_targetId, this);
 
         rejoinLog.debug(String.format("Initializing snapshot stream processor " +
-                "for source site id: %s, and with processorid: %d",
-                CoreUtils.hsIdToString(HSId), m_targetId));
+                "for source site id: %s, and with processorid: %d%s" ,
+                CoreUtils.hsIdToString(HSId), m_targetId, (lowestDestSite?" [Lowest Site]":"")));
 
         // start a periodic task to look for timed out connections
         VoltDB.instance().scheduleWork(new Watchdog(0, writeTimeout), WATCHDOG_PERIOS_S, -1, TimeUnit.SECONDS);
 
         if (hashinatorConfig != null) {
             // Send the hashinator config as  the first block
-            send(StreamSnapshotMessageType.HASHINATOR, -1, hashinatorConfig);
+            send(StreamSnapshotMessageType.HASHINATOR, -1, hashinatorConfig, false);
         }
+    }
+
+    public boolean isReplicatedTableTarget() {
+        return m_replicatedTableTarget;
     }
 
     /**
@@ -128,8 +150,11 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
      */
     public static class SendWork {
         BBContainer m_message;
+        final StreamSnapshotMessageType m_type;
         final long m_targetId;
         final long m_destHSId;
+        final Set<Long> m_otherDestHSIds;
+        AtomicInteger m_ackCounter;
         final long m_ts;
 
         final boolean m_isEmpty;
@@ -141,19 +166,23 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
          * Creates an empty send work to terminate the sender thread
          */
         SendWork() {
+            m_type = StreamSnapshotMessageType.DATA;
             m_isEmpty = true;
             m_targetId = -1;
             m_destHSId = -1;
+            m_otherDestHSIds = null;
             m_ts = -1;
             m_future = null;
         }
 
-        SendWork (long targetId, long destHSId,
-                  BBContainer message,
+        SendWork (StreamSnapshotMessageType type, long targetId, long destHSId,
+                  Set<Long> otherDestIds, BBContainer message,
                   SettableFuture<Boolean> future) {
             m_isEmpty = false;
+            m_type = type;
             m_targetId = targetId;
             m_destHSId = destHSId;
+            m_otherDestHSIds = otherDestIds;
             m_message = message;
             m_ts = System.currentTimeMillis();
             m_future = future;
@@ -203,19 +232,59 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
             }
         }
 
+        private void sendReplicatedDataToNonLowestSites(Mailbox mb, MessageFactory msgFactory, ByteBuffer message, int len) throws IOException {
+            byte[] compressedBytes;
+            if (message.isDirect()) {
+                compressedBytes = CompressionService.compressBuffer(message);
+            }
+            else {
+                compressedBytes =
+                    CompressionService.compressBytes(message.array(), 0, len);
+            }
+            mb.send(Longs.toArray(m_otherDestHSIds), msgFactory.makeDataMessage(m_targetId, compressedBytes));
+        }
+
         public synchronized int doWork(Mailbox mb, MessageFactory msgFactory) throws Exception {
             // this work has already been discarded
             if (m_message == null) {
+                m_ackCounter = new AtomicInteger(1);
                 return 0;
             }
 
             try {
-                return send(mb, msgFactory, m_message);
+                int sentBytes = send(mb, msgFactory, m_message);
+                if (m_otherDestHSIds != null) {
+                    if (m_type == StreamSnapshotMessageType.DATA) {
+                        // Copy the header from the real buffer and add a dummy table that the other non-lowest site can parse
+                        ByteBuffer dummyBuffer = ByteBuffer.allocate(DATA_HEADER_BYTES);
+                        m_message.b().get(dummyBuffer.array(), 0, ROW_COUNT_OFFSET);
+                        m_message.b().position(0);
+                        dummyBuffer.position(ROW_COUNT_OFFSET);
+                        dummyBuffer.putInt(0);  // Row Count
+                        dummyBuffer.position(0);
+                        m_ackCounter = new AtomicInteger(m_otherDestHSIds.size()+1);
+                        sendReplicatedDataToNonLowestSites(mb, msgFactory, dummyBuffer, DATA_HEADER_BYTES);
+                    }
+                    else {
+                        // Special case for sending schema for replicated table to all sites of host
+                        sendReplicatedDataToNonLowestSites(mb, msgFactory, m_message.b(), m_message.b().remaining());
+                        m_ackCounter = new AtomicInteger(m_otherDestHSIds.size()+1);
+                    }
+                }
+                else {
+                    m_ackCounter = new AtomicInteger(1);
+                }
+                rejoinLog.trace("Sent " + m_type.name() + " from " + m_targetId);
+                return sentBytes;
             } finally {
                 // Buffers are only discarded after they are acked. Discarding them here would cause the sender to
                 // generate too much work for the receiver.
                 m_future.set(true);
             }
+        }
+
+        public boolean receiveAck() {
+            return m_ackCounter.decrementAndGet() == 0;
         }
     }
 
@@ -315,13 +384,15 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
      */
     @Override
     public synchronized void receiveAck(int blockIndex) {
-        rejoinLog.trace("Received block ack for index " + String.valueOf(blockIndex));
-
-        m_outstandingWorkCount.decrementAndGet();
-        SendWork work = m_outstandingWork.remove(blockIndex);
+        SendWork work = m_outstandingWork.get(blockIndex);
 
         // releases the BBContainers and cleans up
-        work.discard();
+        if (work.receiveAck()) {
+            rejoinLog.trace("Received ack removes block for index " + String.valueOf(blockIndex));
+            m_outstandingWorkCount.decrementAndGet();
+            m_outstandingWork.remove(blockIndex);
+            work.discard();
+        }
     }
 
     /**
@@ -450,13 +521,15 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
             }
 
             // Have we seen this table before, if not, send schema
-            if (m_schemas.containsKey(tableId)) {
+            Pair<Boolean, byte[]> tableInfo = m_schemas.get(tableId);
+            if (tableInfo.getSecond() != null) {
                 // remove the schema once sent
-                byte[] schema = m_schemas.remove(tableId);
+                byte[] schema = tableInfo.getSecond();
+                m_schemas.put(tableId, Pair.of(tableInfo.getFirst(), null));
                 rejoinLog.debug("Sending schema for table " + tableId);
 
                 rejoinLog.trace("Writing schema as part of this write");
-                send(StreamSnapshotMessageType.SCHEMA, tableId, schema);
+                send(StreamSnapshotMessageType.SCHEMA, tableId, schema, tableInfo.getFirst());
             }
 
             chunk.put((byte) StreamSnapshotMessageType.DATA.ordinal());
@@ -464,14 +537,14 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
             chunk.putInt(tableId); // put table ID
 
             chunk.position(0);
-
-            return send(m_blockIndex++, chunkC);
+            return send(StreamSnapshotMessageType.DATA, m_blockIndex++, chunkC, tableInfo.getFirst());
         } finally {
             rejoinLog.trace("Finished call to write");
         }
     }
 
-    private ListenableFuture<Boolean> send(StreamSnapshotMessageType type, int tableId, byte[] content)
+    private ListenableFuture<Boolean> send(StreamSnapshotMessageType type,
+            int tableId, byte[] content, boolean replicatedTable)
     {
         // 1 byte for the type, 4 bytes for the block index, 4 bytes for table Id
         ByteBuffer buf = ByteBuffer.allocate(1 + 4 + 4 + content.length);
@@ -481,7 +554,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         buf.put(content);
         buf.flip();
 
-        return send(m_blockIndex++, DBBPool.wrapBB(buf));
+        return send(type, m_blockIndex++, DBBPool.wrapBB(buf), replicatedTable);
     }
 
     /**
@@ -494,9 +567,13 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
      * @param chunk Snapshot data to send.
      * @return return a listenable future for the caller to wait until the buffer is sent
      */
-    synchronized ListenableFuture<Boolean> send(int blockIndex, BBContainer chunk) {
+    synchronized ListenableFuture<Boolean> send(StreamSnapshotMessageType type, int blockIndex, BBContainer chunk, boolean replicatedTable) {
         SettableFuture<Boolean> sendFuture = SettableFuture.create();
-        SendWork sendWork = new SendWork(m_targetId, m_destHSId, chunk, sendFuture);
+        rejoinLog.trace("Sending block " + blockIndex + " of type " + (replicatedTable?"REPLICATED ":"PARTITIONED ") + type.name() +
+                " from targetId " + m_targetId + " to " + CoreUtils.hsIdToString(m_destHSId) +
+                (replicatedTable?", " + CoreUtils.hsIdCollectionToString(m_otherDestHostHSIds):""));
+        SendWork sendWork = new SendWork(type, m_targetId, m_destHSId,
+                replicatedTable?m_otherDestHostHSIds:null, chunk, sendFuture);
         m_outstandingWork.put(blockIndex, sendWork);
         m_outstandingWorkCount.incrementAndGet();
         m_sender.offer(sendWork);
@@ -574,7 +651,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         }
         buf.putInt(m_blockIndex);
         buf.flip();
-        send(m_blockIndex++, DBBPool.wrapBB(buf));
+        send(StreamSnapshotMessageType.END, m_blockIndex++, DBBPool.wrapBB(buf), false);
 
         // Wait for the ack of the EOS message
         waitForOutstandingWork();

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotSink.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotSink.java
@@ -20,11 +20,13 @@ package org.voltdb.rejoin;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.DBBPool.BBContainer;
+import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
 import org.voltdb.PrivateVoltTableFactory;
 import org.voltdb.SiteProcedureConnection;
@@ -33,7 +35,6 @@ import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.dtxn.UndoAction;
 import org.voltdb.utils.CachedByteBufferAllocator;
-import org.voltdb.utils.FixedDBBPool;
 
 import com.google_voltpatches.common.base.Preconditions;
 
@@ -91,6 +92,33 @@ public class StreamSnapshotSink {
         }
     }
 
+    static class DecodedContainer {
+        final long m_srcHSId;
+        final long m_dataTargetId;
+        final BBContainer m_container;
+        final int m_blockIndex;
+        final StreamSnapshotMessageType m_msgType;
+        final int m_tableId;
+
+        public DecodedContainer(long srcHSId, long dataTargetId, BBContainer container) {
+            m_srcHSId = srcHSId;
+            m_dataTargetId = dataTargetId;
+            m_container = container;
+
+            ByteBuffer block = container.b();
+            byte typeByte = block.get(StreamSnapshotDataTarget.typeOffset);
+            // Warning: for replicated tables blockIndexs can be non-sequential and from a different source site
+            m_blockIndex = block.getInt(StreamSnapshotDataTarget.blockIndexOffset);
+            m_msgType = StreamSnapshotMessageType.values()[typeByte];
+            if (m_msgType == StreamSnapshotMessageType.SCHEMA || m_msgType == StreamSnapshotMessageType.DATA) {
+                m_tableId = block.getInt(StreamSnapshotDataTarget.tableIdOffset);
+            }
+            else {
+                m_tableId = -1;
+            }
+        }
+    }
+
     /**
      * Restores a block of table data.
      */
@@ -105,6 +133,7 @@ public class StreamSnapshotSink {
 
         @Override
         public void restore(SiteProcedureConnection connection) {
+            rejoinLog.info("remaining bytes for table " + tableId + " is " + tableBlock.remaining());
             VoltTable table = PrivateVoltTableFactory.createVoltTableFromBuffer(tableBlock.duplicate(), true);
 
             // Currently, only export cares about this TXN ID.  Since we don't have one handy,
@@ -120,11 +149,11 @@ public class StreamSnapshotSink {
         m_mb = mb;
     }
 
-    public long initialize(int sourceCount, FixedDBBPool bufferPool) {
+    public long initialize(int sourceCount, Queue<BBContainer> dataPool, Queue<BBContainer> compressedDataPool) {
         // Expect sourceCount number of EOFs at the end
         m_expectedEOFs.set(sourceCount);
 
-        m_in = new StreamSnapshotDataReceiver(m_mb, bufferPool);
+        m_in = new StreamSnapshotDataReceiver(m_mb, dataPool, compressedDataPool);
         m_inThread = new Thread(m_in, "Snapshot data receiver");
         m_inThread.setDaemon(true);
         m_ack = new StreamSnapshotAckSender(m_mb);
@@ -189,7 +218,7 @@ public class StreamSnapshotSink {
 
         RestoreWork result = null;
         while (!m_EOF) {
-            Pair<Long, Pair<Long, BBContainer>> msg = m_in.take();
+            DecodedContainer msg = m_in.take();
             result = processMessage(msg, resultBufferAllocator);
             if (result != null) {
                 break;
@@ -205,7 +234,7 @@ public class StreamSnapshotSink {
             return null;
         }
 
-        Pair<Long, Pair<Long, BBContainer>> msg = m_in.poll();
+        DecodedContainer msg = m_in.poll();
         return processMessage(msg, resultBufferAllocator);
     }
 
@@ -217,22 +246,15 @@ public class StreamSnapshotSink {
      * @return The restore work, or null if there's no data block to return
      *         to the site.
      */
-    private RestoreWork processMessage(Pair<Long, Pair<Long, BBContainer>> msg,
+    private RestoreWork processMessage(DecodedContainer msg,
                                        CachedByteBufferAllocator resultBufferAllocator) {
         if (msg == null) {
             return null;
         }
 
         RestoreWork restoreWork = null;
-        long hsId = msg.getFirst();
-        long targetId = msg.getSecond().getFirst();
-        BBContainer container = msg.getSecond().getSecond();
         try {
-            ByteBuffer block = container.b();
-            byte typeByte = block.get(StreamSnapshotDataTarget.typeOffset);
-            final int blockIndex = block.getInt(StreamSnapshotDataTarget.blockIndexOffset);
-            StreamSnapshotMessageType type = StreamSnapshotMessageType.values()[typeByte];
-            if (type == StreamSnapshotMessageType.FAILURE) {
+            if (msg.m_msgType == StreamSnapshotMessageType.FAILURE) {
                 VoltDB.crashLocalVoltDB("Rejoin source sent failure message.", false, null);
 
                 // for test code only
@@ -240,9 +262,11 @@ public class StreamSnapshotSink {
                     m_EOF = true;
                 }
             }
-            else if (type == StreamSnapshotMessageType.END) {
+            else if (msg.m_msgType == StreamSnapshotMessageType.END) {
                 if (rejoinLog.isTraceEnabled()) {
-                    rejoinLog.trace("Got END message " + blockIndex);
+                    rejoinLog.trace("Got END message " + msg.m_blockIndex + " from " +
+                            CoreUtils.hsIdToString(msg.m_srcHSId) +
+                            " (TargetId " + msg.m_dataTargetId + ")");
                 }
 
                 // End of stream, no need to ack this buffer
@@ -250,16 +274,18 @@ public class StreamSnapshotSink {
                     m_EOF = true;
                 }
             }
-            else if (type == StreamSnapshotMessageType.SCHEMA) {
-                rejoinLog.trace("Got SCHEMA message");
-
+            else if (msg.m_msgType == StreamSnapshotMessageType.SCHEMA) {
+                rejoinLog.trace("Got SCHEMA message " + msg.m_blockIndex + " from " +
+                        CoreUtils.hsIdToString(msg.m_srcHSId) +
+                        " (TargetId " + msg.m_dataTargetId + ")");
+                ByteBuffer block = msg.m_container.b();
                 block.position(StreamSnapshotDataTarget.contentOffset);
                 byte[] schemaBytes = new byte[block.remaining()];
                 block.get(schemaBytes);
-                m_schemas.put(block.getInt(StreamSnapshotDataTarget.tableIdOffset),
-                              schemaBytes);
+                m_schemas.put(msg.m_tableId, schemaBytes);
             }
-            else if (type == StreamSnapshotMessageType.HASHINATOR) {
+            else if (msg.m_msgType == StreamSnapshotMessageType.HASHINATOR) {
+                ByteBuffer block = msg.m_container.b();
                 block.position(StreamSnapshotDataTarget.contentOffset);
                 long version = block.getLong();
                 byte[] hashinatorConfig = new byte[block.remaining()];
@@ -269,28 +295,31 @@ public class StreamSnapshotSink {
             }
             else {
                 // It's normal snapshot data afterwards
+                rejoinLog.trace("Got DATA message " + msg.m_blockIndex + " from " +
+                        CoreUtils.hsIdToString(msg.m_srcHSId) +
+                        " (TargetId " + msg.m_dataTargetId + ")");
 
-                final int tableId = block.getInt(StreamSnapshotDataTarget.tableIdOffset);
+                ByteBuffer block = msg.m_container.b();
 
-                if (!m_schemas.containsKey(tableId)) {
-                    VoltDB.crashLocalVoltDB("No schema for table with ID " + tableId,
+                if (!m_schemas.containsKey(msg.m_tableId)) {
+                    VoltDB.crashLocalVoltDB("No schema for table with ID " + msg.m_tableId,
                                             false, null);
                 }
 
                 // Get the byte buffer ready to be consumed
                 block.position(StreamSnapshotDataTarget.contentOffset);
-                ByteBuffer nextChunk = getNextChunk(m_schemas.get(tableId), block, resultBufferAllocator);
+                ByteBuffer nextChunk = getNextChunk(m_schemas.get(msg.m_tableId), block, resultBufferAllocator);
                 m_bytesReceived += nextChunk.remaining();
 
-                restoreWork = new TableRestoreWork(tableId, nextChunk);
+                restoreWork = new TableRestoreWork(msg.m_tableId, nextChunk);
             }
-
-            // Queue ack to this block
-            m_ack.ack(hsId, m_EOF, targetId, blockIndex);
 
             return restoreWork;
         } finally {
-            container.discard();
+            msg.m_container.discard();
+
+            // Queue ack to this block (after the container has been discarded)
+            m_ack.ack(msg.m_srcHSId, m_EOF, msg.m_dataTargetId, msg.m_blockIndex);
         }
     }
 

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotRequestConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotRequestConfig.java
@@ -48,15 +48,18 @@ public class StreamSnapshotRequestConfig extends SnapshotRequestConfig {
         // the partition the ranges associate to
         public final Integer newPartition;
 
+        public final Long lowestSiteSinkHSId;
+
         /**
          * @param streamPairs     src - > (dest1, dest2,...)
          * @param newPartition    New partition for this stream, if not null, will create a
          *                        post-snapshot task to increment the partition count
          */
-        public Stream(Multimap<Long, Long> streamPairs, Integer newPartition)
+        public Stream(Multimap<Long, Long> streamPairs, Integer newPartition, Long lowestSiteSinkHSId)
         {
             this.streamPairs = ImmutableMultimap.copyOf(streamPairs);
             this.newPartition = newPartition;
+            this.lowestSiteSinkHSId = lowestSiteSinkHSId;
         }
     }
 
@@ -103,7 +106,9 @@ public class StreamSnapshotRequestConfig extends SnapshotRequestConfig {
                 if (!streamObj.isNull("newPartition")) {
                     newPartition = Integer.parseInt(streamObj.getString("newPartition"));
                 }
-                Stream config = new Stream(parseStreamPairs(streamObj), newPartition);
+                Long lowestSiteSinkHSId = Long.parseLong(streamObj.getString("lowestSiteSinkHSId"));
+
+                Stream config = new Stream(parseStreamPairs(streamObj), newPartition, lowestSiteSinkHSId);
 
                 builder.add(config);
             }
@@ -153,6 +158,7 @@ public class StreamSnapshotRequestConfig extends SnapshotRequestConfig {
             stringer.keySymbolValuePair("newPartition", stream.newPartition == null ?
                                                null : Integer.toString(stream.newPartition));
 
+            stringer.keySymbolValuePair("lowestSiteSinkHSId", stream.lowestSiteSinkHSId);
             stringer.key("streamPairs").object();
             for (Map.Entry<Long, Collection<Long>> entry : stream.streamPairs.asMap().entrySet()) {
                 stringer.key(Long.toString(entry.getKey())).array();

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
@@ -22,17 +22,20 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.json_voltpatches.JSONObject;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
+import org.voltcore.utils.Pair;
 import org.voltdb.ExtensibleSnapshotDigestData;
 import org.voltdb.PostSnapshotTask;
 import org.voltdb.PrivateVoltTableFactory;
@@ -83,6 +86,7 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
             new StreamSnapshotRequestConfig(jsData, context.getDatabase());
         final List<StreamSnapshotRequestConfig.Stream> localStreams =
             filterRemoteStreams(config.streams, Longs.asList(tracker.getLocalSites()));
+        final Map<Integer, Set<Long>> destsByHostId = collectTargetSitesByHostId(config.streams);
         final Set<Integer> partitionsToAdd = getPartitionsToAdd(localStreams);
 
         /*
@@ -133,7 +137,7 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
                     config.tables);
 
         // table schemas for all the tables we'll snapshot on this partition
-        Map<Integer, byte[]> schemas = new HashMap<Integer, byte[]>();
+        Map<Integer, Pair<Boolean, byte[]>> schemas = new HashMap<Integer, Pair<Boolean, byte[]>>();
         for (final Table table : config.tables) {
             VoltTable schemaTable;
             if (DrRoleType.XDCR.value().equals(context.getCluster().getDrrole()) && table.getIsdred()) {
@@ -143,10 +147,10 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
                 schemaTable = CatalogUtil.getVoltTable(table);
             }
 
-            schemas.put(table.getRelativeIndex(), PrivateVoltTableFactory.getSchemaBytes(schemaTable));
+            schemas.put(table.getRelativeIndex(), Pair.of(table.getIsreplicated(), PrivateVoltTableFactory.getSchemaBytes(schemaTable)));
         }
 
-        List<DataTargetInfo> sdts = createDataTargets(localStreams, hashinatorData, schemas);
+        List<DataTargetInfo> sdts = createDataTargets(localStreams, destsByHostId, hashinatorData, schemas);
 
         // If there's no work to do on this host, just claim success, return an empty plan,
         // and things will sort themselves out properly
@@ -177,8 +181,9 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
     }
 
     private List<DataTargetInfo> createDataTargets(List<StreamSnapshotRequestConfig.Stream> localStreams,
+                                                   Map<Integer, Set<Long>> destsByHostId,
                                                    HashinatorSnapshotData hashinatorData,
-                                                   Map<Integer, byte[]> schemas)
+                                                   Map<Integer, Pair<Boolean, byte[]>> schemas)
     {
         byte[] hashinatorConfig = null;
         if (hashinatorData != null) {
@@ -207,11 +212,20 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
                     long srcHSId = entry.getKey();
                     long destHSId = entry.getValue();
 
-                    sdts.add(new DataTargetInfo(stream,
-                                                srcHSId,
-                                                destHSId,
-                                                new StreamSnapshotDataTarget(destHSId, hashinatorConfig,
-                                                                             schemas, sender, ackReceiver)));
+                    DataTargetInfo nextTarget =
+                            new DataTargetInfo(stream,
+                                               srcHSId,
+                                               destHSId,
+                                               new StreamSnapshotDataTarget(destHSId,
+                                                                            (destHSId == stream.lowestSiteSinkHSId),
+                                                                            destsByHostId.get(CoreUtils.getHostIdFromHSId(destHSId)),
+                                                                            hashinatorConfig, schemas, sender, ackReceiver));
+//                    if (destHSId == stream.lowestSiteSinkHSId) {
+//                        sdts.add(0, nextTarget);
+//                    }
+//                    else {
+                        sdts.add(nextTarget);
+//                    }
                 }
             }
         }
@@ -267,6 +281,8 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
     {
         List<StreamSnapshotRequestConfig.Stream> localStreams = Lists.newArrayList();
 
+        // This is the list of streams for a specific target partition when using ElasticJoin
+        // For Rejoin, there will only be one element in this list
         for (StreamSnapshotRequestConfig.Stream stream : streams) {
             ArrayListMultimap<Long, Long> streamPairs = ArrayListMultimap.create();
 
@@ -278,10 +294,53 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
             }
 
             localStreams.add(new StreamSnapshotRequestConfig.Stream(streamPairs,
-                                                                    stream.newPartition));
+                                                                    stream.newPartition,
+                                                                    stream.lowestSiteSinkHSId));
         }
 
         return localStreams;
+    }
+
+    private Map<Integer, Set<Long>> collectTargetSitesByHostId(List<StreamSnapshotRequestConfig.Stream> streams)
+    {
+        Map<Integer, Set<Long>> targetHSIdsByHostId = new HashMap<>();
+
+        // This is the list of streams for a specific target partition when using ElasticJoin
+        // For Rejoin, there will only be one element in this list
+        for (StreamSnapshotRequestConfig.Stream stream : streams) {
+            for (Long targetHSId : stream.streamPairs.values()) {
+                int hostId = CoreUtils.getHostIdFromHSId(targetHSId);
+                Set<Long> targetSet = targetHSIdsByHostId.get(hostId);
+                if (targetSet == null) {
+                    targetHSIdsByHostId.put(hostId, new HashSet<Long>(Arrays.asList(targetHSId)));
+                }
+                else {
+                    targetSet.add(targetHSId);
+                }
+            }
+        }
+
+        return targetHSIdsByHostId;
+    }
+
+    private SnapshotTableTask createSingleTableTask(Table table,
+                                                    DataTargetInfo targetInfo,
+                                                    AtomicInteger numTables,
+                                                    SnapshotRegistry.Snapshot snapshotRecord) {
+        final Runnable onClose = new TargetStatsClosure(targetInfo.dataTarget,
+                table.getTypeName(),
+                numTables,
+                snapshotRecord);
+        targetInfo.dataTarget.setOnCloseHandler(onClose);
+
+        final SnapshotTableTask task =
+                new SnapshotTableTask(table,
+                                      new SnapshotDataFilter[0], // This task no longer needs partition filtering
+                                      null,
+                                      false);
+        task.setTarget(targetInfo.dataTarget);
+        m_targets.add(targetInfo.dataTarget);
+        return task;
     }
 
     /**
@@ -295,21 +354,14 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
         // srcHSId -> tasks
         Multimap<Long, SnapshotTableTask> tasks = ArrayListMultimap.create();
         for (DataTargetInfo targetInfo : dataTargets) {
-            final Runnable onClose = new TargetStatsClosure(targetInfo.dataTarget,
-                                                            table.getTypeName(),
-                                                            numTables,
-                                                            snapshotRecord);
-            targetInfo.dataTarget.setOnCloseHandler(onClose);
-
-            final SnapshotTableTask task =
-                new SnapshotTableTask(table,
-                                      new SnapshotDataFilter[0], // This task no longer needs partition filtering
-                                      null,
-                                      false);
-            task.setTarget(targetInfo.dataTarget);
-
+            if (table.getIsreplicated() && !targetInfo.dataTarget.isReplicatedTableTarget()) {
+                // For replicated tables only the lowest site's dataTarget actually does any work.
+                // The other dataTargets just need to be tracked so we send EOF when all streams have finished.
+                m_targets.add(targetInfo.dataTarget);
+                continue;
+            }
+            final SnapshotTableTask task = createSingleTableTask(table, targetInfo, numTables, snapshotRecord);
             tasks.put(targetInfo.srcHSId, task);
-            m_targets.add(targetInfo.dataTarget);
         }
 
         placeTasksForTable(table, tasks);


### PR DESCRIPTION
Rejoin does not work for shared replicated tables because the partitions are snapshoted and streamed one at a time. Since Replicated table updates require the same transaction to appear on all partitions at the same time, streaming and replaying one stream at a time will not work. With this fix, all partitions are streamed at the same time.

Also flow control was removed from the Rejoin node because we can't predict how many buffers will be sent to a partition before a replicated table buffer is received that another partition is blocked on in the EE.