### PR TITLE
ENG-12820:

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.h
+++ b/src/ee/common/SynchronizedThreadLock.h
@@ -133,8 +133,8 @@ public:
     static bool isInLocalEngineContext();
 
     static void assumeMpMemoryContext();
-    static void reassumeLowestSiteContext();
-    static void reassumeLocalSiteContext();
+    static void assumeLowestSiteContext();
+    static void assumeLocalSiteContext();
     static bool isLowestSiteContext();
 
 private:
@@ -165,6 +165,17 @@ public:
 private:
     bool m_usingMpMemory;
 };
+
+
+class ConditionalExecuteOutsideMpMemory {
+public:
+    ConditionalExecuteOutsideMpMemory(bool haveMpMemory);
+    ~ConditionalExecuteOutsideMpMemory();
+
+private:
+    bool m_notUsingMpMemory;
+};
+
 }
 
 

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -856,7 +856,7 @@ VoltDBEngine::processCatalogDeletes(int64_t timestamp, bool updateReplicated)
                     ExecutorContext::assignThreadLocals(curr);
                     currEngine->m_delegatesByName.erase(table->name());
                 }
-                SynchronizedThreadLock::reassumeLowestSiteContext();
+                SynchronizedThreadLock::assumeLowestSiteContext();
             } else {
                 m_delegatesByName.erase(table->name());
             }
@@ -884,7 +884,7 @@ VoltDBEngine::processCatalogDeletes(int64_t timestamp, bool updateReplicated)
                 ExecutorContext::assignThreadLocals(curr);
                 currEngine->m_catalogDelegates.erase(path);
             }
-            SynchronizedThreadLock::reassumeLowestSiteContext();
+            SynchronizedThreadLock::assumeLowestSiteContext();
         } else {
             m_catalogDelegates.erase(path);
         }
@@ -1460,7 +1460,7 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated) {
                     currEngine->m_tables[relativeIndexOfTable] = localTable;
                     currEngine->m_tablesByName[tableName] = localTable;
                 }
-                SynchronizedThreadLock::reassumeLowestSiteContext();
+                SynchronizedThreadLock::assumeLowestSiteContext();
             }
         }
         else {
@@ -1484,7 +1484,7 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated) {
                             ExecutorContext::assignThreadLocals(curr);
                             currEngine->m_tablesBySignatureHash[hash] = persistentTable;
                         }
-                        SynchronizedThreadLock::reassumeLowestSiteContext();
+                        SynchronizedThreadLock::assumeLowestSiteContext();
                     }
                 }
                 else {
@@ -1512,7 +1512,7 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated) {
                                                                           relativeIndexOfTable,
                                                                           stats);
                     }
-                    SynchronizedThreadLock::reassumeLowestSiteContext();
+                    SynchronizedThreadLock::assumeLowestSiteContext();
                 }
             }
             else if (!updateReplicated) {

--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -724,7 +724,17 @@ TableCatalogDelegate::processSchemaChanges(catalog::Database const& catalogDatab
     ///////////////////////////////////////////////
     // Drop the old table
     ///////////////////////////////////////////////
-    existingTable->decrementRefcount();
+    if (existingPersistentTable && newPersistentTable &&
+            newPersistentTable->isCatalogTableReplicated() != existingPersistentTable->isCatalogTableReplicated()) {
+        // A table can only be modified from replicated to partitioned
+        assert(newPersistentTable->isCatalogTableReplicated());
+        // Assume the MP memory context before starting the deallocate
+        ExecuteWithMpMemory useMpMemory;
+        existingTable->decrementRefcount();
+    }
+    else {
+        existingTable->decrementRefcount();
+    }
 
     ///////////////////////////////////////////////
     // Patch up the new table as a replacement


### PR DESCRIPTION
We don't currently assume the MP Memory context when creating Join Views because replicated tables joined with partitioned tables requires us to assume other contexts. However, the statements inside the view need to be allocated in the MP memory context so we assume the memory context after the handler has been registered with all the site sources. Since we assume contexts in a very localized way with views, we may want to consider a global assignment of the MP memory context after all the tests are passing and we understand the dynamics of all the required context switches.

There was also an issue with the deconstructor of the persistent table where JoinViews of replicated tables needed to be cleaned up in the partitioned Memory context. To support this scenario, a new scoped class was introduced that assumes the localSite context if we are in the MP Memory context.