### PR TITLE
ENG-12228: SSL encrypted connections between replicated clusters

### DIFF
--- a/src/catgen/in/javasrc/CatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/CatalogDiffEngine.java
@@ -969,6 +969,8 @@ public class CatalogDiffEngine {
                 else {
                     restrictionQualifier = " from " + prevRole + " to " + newRole;
                 }
+            } else if (field.equals("drConsumerSslPropertyFile")) {
+                return null;
             }
         }
 

--- a/src/catgen/spec.txt
+++ b/src/catgen/spec.txt
@@ -15,6 +15,7 @@ begin Cluster                      "A set of connected hosts running one or more
   int drClusterId                  "Unique inter-cluster ID used to distinguish DR clusters"
   int drProducerPort               "DR port the this producer cluster will listen on (change only when !drProdEnabled)"
   string drMasterHost              "Hostname[:port] of producer cluster this consumer cluster will get transactions from"
+  string drConsumerSslPropertyFile "Path to DR consumer property file containing path to trust store and the trust store password"
   int drFlushInterval              "Time interval in milliseconds between flushing partially filled DR buffers"
   int preferredSource              "The cluster id from which this joining cluster should request snapshot"
 end
@@ -146,7 +147,7 @@ begin Function                   "A user-defined function"
   //     names will only be unique within a single procedure.
   // For example, a function which has dependers "P:S" and "Q:S" will
   // have string ",P:S,Q:S,".
-  string stmtDependers          "The set of names of statements which depend on this function" 
+  string stmtDependers          "The set of names of statements which depend on this function"
 end
 
 begin Table                                  "A table (relation) in the database"
@@ -220,7 +221,7 @@ begin Statement           "A parameterized SQL statement embedded in a stored pr
   //
   // So, the list with "a", "b" and "c" will look like ",a,b,c,".
   // The extra commas help with deduplication.
-  // 
+  //
     string functionDependees "The names of UDFs on which this statement depends"
 end
 

--- a/src/frontend/org/voltcore/network/CipherExecutor.java
+++ b/src/frontend/org/voltcore/network/CipherExecutor.java
@@ -119,7 +119,7 @@ public enum CipherExecutor {
                     es.awaitTermination(365, TimeUnit.DAYS);
                 } catch (InterruptedException e) {
                     throw new RuntimeException(
-                            "Interruped while waiting for " + name() + " cipher service shutdown",e);
+                            "Interrupted while waiting for " + name() + " cipher service shutdown",e);
                 }
             }
         }

--- a/src/frontend/org/voltcore/network/TLSNIOWriteStream.java
+++ b/src/frontend/org/voltcore/network/TLSNIOWriteStream.java
@@ -105,7 +105,7 @@ public class TLSNIOWriteStream extends VoltNIOWriteStream {
             final int partialSize = m_partialSize;
             if (partialSize > 0) {
                 assert frame.chunks == partialSize + 1
-                        : "partial frame buildup has wrong number of preceeding pieces";
+                        : "partial frame buildup has wrong number of preceding pieces";
 
                 synchronized(m_partial) {
                     for (EncryptFrame frm: m_partial) {

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -573,7 +573,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                 socket.socket().setTcpNoDelay(true);//Greatly speeds up requests hitting the wire
             }
 
-            if (remnant.hasRemaining() && remnant.remaining() <= 4 && remnant.getInt() < remnant.remaining()) {
+            if (remnant.hasRemaining() && (remnant.remaining() <= 4 || remnant.getInt() != remnant.remaining())) {
                 throw new IOException("SSL Handshake remnant is not a valid VoltDB message: " + remnant);
             }
 

--- a/src/frontend/org/voltdb/Inits.java
+++ b/src/frontend/org/voltdb/Inits.java
@@ -501,14 +501,22 @@ public class Inits {
         @Override
         public void run() {
             SslType sslType = m_deployment.getSsl();
-            if ((sslType != null && sslType.isEnabled()) || (m_config.m_sslEnable)) {
+            m_config.m_sslEnable = m_config.m_sslEnable || (sslType != null && sslType.isEnabled());
+            if (m_config.m_sslEnable) {
                 try {
                     m_config.m_sslContextFactory = getSSLContextFactory(sslType);
                     m_config.m_sslContextFactory.start();
                     hostLog.info("SSL Enabled for HTTP. Please point browser to HTTPS URL.");
-                    if ((sslType != null && sslType.isExternal()) || m_config.m_sslExternal) {
+                    m_config.m_sslExternal = m_config.m_sslExternal || (sslType != null && sslType.isExternal());
+                    m_config.m_sslDR = m_config.m_sslDR || (sslType != null && sslType.isDr());
+                    if (m_config.m_sslExternal || m_config.m_sslDR) {
                         m_config.m_sslContext = m_config.m_sslContextFactory.getSslContext();
+                    }
+                    if (m_config.m_sslExternal) {
                         hostLog.info("SSL enabled for admin and client port. Please enable SSL on client.");
+                    }
+                    if (m_config.m_sslDR) {
+                        hostLog.info("SSL enabled for DR port. Please enable SSL on consumer clusters' DR connections.");
                     }
                     CipherExecutor.SERVER.startup();
                 } catch (Exception e) {
@@ -544,7 +552,7 @@ public class Inits {
             sslContextFactory.setKeyStorePassword(keyStorePassword);
 
             String trustStorePath = getKeyTrustStoreAttribute("javax.net.ssl.trustStore", sslType.getTruststore(), "path");
-            if (sslType.isEnabled() || m_config.m_sslEnable) {
+            if (m_config.m_sslEnable) {
                 trustStorePath = null == trustStorePath  ? getResourcePath(DEFAULT_KEYSTORE_RESOURCE):getResourcePath(trustStorePath);
             }
             if (trustStorePath == null || trustStorePath.trim().isEmpty()) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -785,6 +785,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             ConfigFactory.clearProperty(Settings.CONFIG_DIR);
             ModuleManager.resetCacheRoot();
             CipherExecutor.SERVER.shutdown();
+            CipherExecutor.CLIENT.shutdown();
 
             m_isRunningWithOldVerb = config.m_startAction.isLegacy();
 
@@ -3296,6 +3297,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
                 // shutdown the cipher service
                 CipherExecutor.SERVER.shutdown();
+                CipherExecutor.CLIENT.shutdown();
 
                 //Also for test code that expects a fresh stats agent
                 if (m_opsRegistrar != null) {
@@ -4309,9 +4311,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             byte drConsumerClusterId = (byte)m_catalogContext.cluster.getDrclusterid();
             final Pair<String, Integer> drIfAndPort = VoltZK.getDRInterfaceAndPortFromMetadata(m_localMetadata);
             try {
-                if (m_config.m_sslDR) {
-                    CipherExecutor.CLIENT.startup();
-                }
                 Class<?> rdrgwClass = Class.forName("org.voltdb.dr2.ConsumerDRGatewayImpl");
                 Constructor<?> rdrgwConstructor = rdrgwClass.getConstructor(
                         ClientInterface.class,

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1362,7 +1362,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                         config.m_port,
                         adminIntf,
                         config.m_adminPort,
-                        m_config.m_sslContext);
+                        m_config.m_sslExternal ? m_config.m_sslContext : null);
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB(e.getMessage(), true, e);
             }
@@ -4309,7 +4309,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             byte drConsumerClusterId = (byte)m_catalogContext.cluster.getDrclusterid();
             final Pair<String, Integer> drIfAndPort = VoltZK.getDRInterfaceAndPortFromMetadata(m_localMetadata);
             try {
-                if (m_config.m_sslContext != null) {
+                if (m_config.m_sslDR) {
                     CipherExecutor.CLIENT.startup();
                 }
                 Class<?> rdrgwClass = Class.forName("org.voltdb.dr2.ConsumerDRGatewayImpl");

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -4309,6 +4309,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             byte drConsumerClusterId = (byte)m_catalogContext.cluster.getDrclusterid();
             final Pair<String, Integer> drIfAndPort = VoltZK.getDRInterfaceAndPortFromMetadata(m_localMetadata);
             try {
+                if (m_config.m_sslContext != null) {
+                    CipherExecutor.CLIENT.startup();
+                }
                 Class<?> rdrgwClass = Class.forName("org.voltdb.dr2.ConsumerDRGatewayImpl");
                 Constructor<?> rdrgwConstructor = rdrgwClass.getConstructor(
                         ClientInterface.class,

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -172,6 +172,8 @@ public class VoltDB {
         /** enable ssl for external (https, client and admin port*/
         public boolean m_sslExternal = Boolean.valueOf(System.getenv("ENABLE_SSL") == null ? Boolean.toString(Boolean.getBoolean("ENABLE_SSL")) : System.getenv("ENABLE_SSL"));
 
+        public boolean m_sslDR = Boolean.valueOf(System.getenv("ENABLE_DR_SSL") == null ? Boolean.toString(Boolean.getBoolean("ENABLE_DR_SSL")) : System.getenv("ENABLE_DR_SSL"));
+
         /** consistency level for reads */
         public Consistency.ReadLevel m_consistencyReadLevel = Consistency.ReadLevel.SAFE;
 
@@ -638,6 +640,8 @@ public class VoltDB {
                     m_sslEnable = true;
                 } else if (arg.equalsIgnoreCase("externalSSL")) {
                     m_sslExternal = true;
+                } else if (arg.equalsIgnoreCase("drSSL")) {
+                    m_sslDR = true;
                 } else if (arg.equalsIgnoreCase("getvoltdbroot")) {
                     //Can not use voltdbroot which creates directory we dont intend to create for get deployment etc.
                     m_voltdbRoot = new VoltFile(args[++i]);

--- a/src/frontend/org/voltdb/client/ClientConfig.java
+++ b/src/frontend/org/voltdb/client/ClientConfig.java
@@ -489,7 +489,7 @@ public class ClientConfig {
         try (FileReader fr = new FileReader(propFD)) {
             props.load(fr);
         } catch (IOException e) {
-            throw new IllegalArgumentException("Faile to read properties file " + propFN, e);
+            throw new IllegalArgumentException("Failed to read properties file " + propFN, e);
         }
         String trustStore = props.getProperty(SSLConfiguration.TRUSTSTORE_CONFIG_PROP);
         String trustStorePassword = props.getProperty(SSLConfiguration.TRUSTSTORE_PASSWORD_CONFIG_PROP);

--- a/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
+++ b/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
@@ -345,6 +345,7 @@
     </xs:sequence>
     <xs:attribute name="enabled" type="xs:boolean" default="false"/>
     <xs:attribute name="external" type="xs:boolean" default="false"/>
+    <xs:attribute name="dr" type="xs:boolean" default="false"/>
   </xs:complexType>
 
   <!-- <snapshot> -->
@@ -496,6 +497,7 @@
     </xs:attribute>
     <xs:attribute name="preferred-source" type="clusterIdType"/>
     <xs:attribute name="enabled" type="xs:boolean" default="true" />
+    <xs:attribute name="ssl" type="xs:string"/>
   </xs:complexType>
 
 </xs:schema>

--- a/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
+++ b/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
@@ -257,6 +257,7 @@ public class VoltProjectBuilder {
     boolean m_jsonApiEnabled = true;
     boolean m_sslEnabled = false;
     boolean m_sslExternal = false;
+    boolean m_sslDR = false;
 
     String m_keystore;
     String m_keystorePassword;
@@ -321,6 +322,7 @@ public class VoltProjectBuilder {
     private String m_drMasterHost;
     private Integer m_preferredSource;
     private Boolean m_drConsumerConnectionEnabled = null;
+    private String m_drConsumerSslPropertyFile = null;
     private Boolean m_drProducerEnabled = null;
     private DrRoleType m_drRole = DrRoleType.MASTER;
 
@@ -629,6 +631,10 @@ public class VoltProjectBuilder {
         m_sslExternal = enabled;
     }
 
+    public void setSslDR(final boolean enabled) {
+        m_sslDR = enabled;
+    }
+
     public void setKeyStoreInfo(final String path, final String password) {
         m_keystore = getResourcePath(path);
         m_keystorePassword = password;
@@ -762,6 +768,10 @@ public class VoltProjectBuilder {
 
     public void setDrConsumerConnectionDisabled() {
         m_drConsumerConnectionEnabled = false;
+    }
+
+    public void setDrConsumerSslPropertyFile(String sslPropertyFile) {
+        m_drConsumerSslPropertyFile = getResourcePath(sslPropertyFile);
     }
 
     public void setDrProducerEnabled()
@@ -1185,6 +1195,7 @@ public class VoltProjectBuilder {
         deployment.setSsl(ssl);
         ssl.setEnabled(m_sslEnabled);
         ssl.setExternal(m_sslExternal);
+        ssl.setDr(m_sslDR);
         if (m_keystore!=null) {
             KeyOrTrustStoreType store = factory.createKeyOrTrustStoreType();
             store.setPath(m_keystore);
@@ -1307,6 +1318,7 @@ public class VoltProjectBuilder {
             conn.setSource(m_drMasterHost);
             conn.setPreferredSource(m_preferredSource);
             conn.setEnabled(m_drConsumerConnectionEnabled);
+            conn.setSsl(m_drConsumerSslPropertyFile);
         }
 
         // Have some yummy boilerplate!

--- a/src/frontend/org/voltdb/compiler/ssl-config
+++ b/src/frontend/org/voltdb/compiler/ssl-config
@@ -1,0 +1,2 @@
+trustStore=tests/frontend/org/voltdb/keystore
+trustStorePassword=password

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2249,10 +2249,10 @@ public abstract class CatalogUtil {
             } else if (clusterType.getId() == null && dr.getId() == null) {
                 clusterId = 0;
             } else {
-                if (clusterType.getId() == dr.getId()) {
+                if (clusterType.getId().equals(dr.getId())) {
                     clusterId = clusterType.getId();
                 } else {
-                    throw new RuntimeException("Detected two conflicting cluster ids in deployement file, setting cluster id in DR tag is "
+                    throw new RuntimeException("Detected two conflicting cluster ids in deployment file, setting cluster id in DR tag is "
                             + "deprecated, please remove");
                 }
             }
@@ -2260,13 +2260,24 @@ public abstract class CatalogUtil {
             if (drConnection != null) {
                 String drSource = drConnection.getSource();
                 cluster.setDrmasterhost(drSource);
+                String sslPropertyFile = drConnection.getSsl();
+                cluster.setDrconsumersslpropertyfile(sslPropertyFile);
                 cluster.setDrconsumerenabled(drConnection.isEnabled());
                 if (drConnection.getPreferredSource() != null) {
                     cluster.setPreferredsource(drConnection.getPreferredSource());
                 } else { // reset to -1, if this is an update catalog
                     cluster.setPreferredsource(-1);
                 }
-                hostLog.info("Configured connection for DR replica role to host " + drSource);
+                String drConsumerSSLInfo = "";
+                if (sslPropertyFile != null) {
+                    if (sslPropertyFile.trim().isEmpty()) {
+                        drConsumerSSLInfo = " with SSL enabled";
+                    }
+                    else {
+                        drConsumerSSLInfo = " with SSL enabled using properties in " + sslPropertyFile;
+                    }
+                }
+                hostLog.info("Configured connection for DR replica role to host " + drSource + drConsumerSSLInfo);
             } else {
                 if (dr.getRole() == DrRoleType.XDCR) {
                     // consumer should be enabled even without connection source for XDCR


### PR DESCRIPTION
1. Added "dr" attribute in <ssl/> element in the deployment file for enabling server-side SSL for DR.
2. Added "ssl" attribute in <connection/> element in the deployment file for providing SSL property file (only needed for self-signed certificates) for client-side SSL for DR.
3. Create server-side SSL context when either external or DR SSL is enabled in the deployment file.