### PR TITLE
ENG-12820:

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.h
+++ b/src/ee/common/SynchronizedThreadLock.h
@@ -131,6 +131,9 @@ public:
 
     static bool isInSingleThreadMode();
     static bool isInLocalEngineContext();
+#ifndef  NDEBUG
+    static bool isHoldingResourceLock();
+#endif
 
     static void assumeMpMemoryContext();
     static void assumeLowestSiteContext();
@@ -140,6 +143,9 @@ public:
 private:
     static bool s_inSingleThreadMode;
     static bool s_usingMpMemory;
+#ifndef  NDEBUG
+    static bool s_holdingReplicatedTableLock;
+#endif
     static pthread_mutex_t s_sharedEngineMutex;
     static pthread_cond_t s_sharedEngineCondition;
     static pthread_cond_t s_wakeLowestEngineCondition;

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -655,8 +655,7 @@ void PersistentTable::swapTable(PersistentTable* otherTable,
     assert(hasNameIntegrity(name(), otherIndexNames));
     assert(hasNameIntegrity(otherTable->name(), theIndexNames));
 
-    // TODO: Fix this to coordinate the swap for replicated tables by the lowest site
-    ExecutorContext::getEngine()->rebuildTableCollections(true);
+    ExecutorContext::getEngine()->rebuildTableCollections(m_isReplicated);
 }
 
 void PersistentTable::swapTableState(PersistentTable* otherTable) {

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -178,6 +178,7 @@ void PersistentTable::initializeWithColumns(TupleSchema* schema,
 }
 
 PersistentTable::~PersistentTable() {
+    VOLT_DEBUG("Deleting TABLE %s as %s", m_name.c_str(), m_isReplicated?"REPLICATED":"PARTITIONED");
     for (int ii = 0; ii < TUPLE_BLOCK_NUM_BUCKETS; ii++) {
         m_blocksNotPendingSnapshotLoad[ii]->clear();
         m_blocksPendingSnapshotLoad[ii]->clear();
@@ -210,8 +211,8 @@ PersistentTable::~PersistentTable() {
         // updating other (possibly partitioned) tables
         ConditionalExecuteOutsideMpMemory getOutOfMpMemory(m_isReplicated);
         BOOST_FOREACH (auto viewHandler, m_viewHandlers) {
-            viewHandler->dropSourceTable(!m_isReplicated, this);
-    }
+            viewHandler->dropSourceTable(this);
+        }
     }
     if (m_deltaTable) {
         m_deltaTable->decrementRefcount();

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -601,7 +601,8 @@ public class TestFragmentProgressUpdate extends TestCase {
                 new HashinatorConfig(HashinatorType.LEGACY,
                                      LegacyHashinator.getConfigureBytes(1),
                                      0,
-                                     0), false);
+                                     0),
+                true);
     }
 
     @Override


### PR DESCRIPTION
There are dropping join views was not handled correctly because the replicated table wrapper was being called instead of the reeal ViewHandler. Now more ViewHandler functions are virtualized so calls like dropView are passed through correctly.