### PR TITLE
ENG-13314:

### DIFF
--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -468,7 +468,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
          */
         void executeTask(TaskType taskType, ReferenceSerializeInputBE& taskInfo);
 
-        void rebuildTableCollections(bool updateReplicated = false);
+        void rebuildTableCollections(bool updateReplicated = false, bool fromScratch = true);
         void rebuildReplicatedTableCollections() {
             rebuildTableCollections(true);
         }

--- a/src/ee/stats/StatsAgent.h
+++ b/src/ee/stats/StatsAgent.h
@@ -50,7 +50,7 @@ public:
     /**
      * Unassociate all instances of this selector type
      */
-    void unregisterStatsSource(voltdb::StatisticsSelectorType sst);
+    void unregisterStatsSource(voltdb::StatisticsSelectorType sst, int32_t relativeIndexOfTable = -1);
 
     /**
      * Get statistics for the specified resources
@@ -61,6 +61,7 @@ public:
      */
     TempTable* getStats(
             voltdb::StatisticsSelectorType sst,
+            int64_t m_siteId, int32_t m_partitionId,
             std::vector<voltdb::CatalogId> catalogIds,
             bool interval,
             int64_t now);

--- a/src/ee/stats/StatsSource.h
+++ b/src/ee/stats/StatsSource.h
@@ -83,16 +83,18 @@ public:
      * @param now Timestamp to return with each row
      * @return Pointer to a table containing the statistics.
      */
-    voltdb::Table* getStatsTable(bool interval, int64_t now);
+    voltdb::Table* getStatsTable(int64_t siteId, int32_t partitionId, bool interval, int64_t now);
 
     /*
      * Retrieve tuple containing the latest statistics available. An updated stat is requested from the derived class by calling
      * StatsSource::updateStatsTuple
+     * @param siteId for the generated tuple
+     * @param partitionId for the generated tuple
      * @param interval Whether to return counters since the beginning or since the last time this was called
      * @param Timestamp to embed in each row
      * @return Pointer to a table tuple containing the latest version of the statistics.
      */
-    voltdb::TableTuple* getStatsTuple(bool interval, int64_t now);
+    voltdb::TableTuple* getStatsTuple(int64_t siteId, int32_t partitionId, bool interval, int64_t now);
 
     /**
      * Retrieve the name of this set of statistics
@@ -152,12 +154,6 @@ private:
      */
     std::string m_name;
 
-    /**
-     * CatalogId of the partition this StatsSource is associated with.
-     */
-    voltdb::CatalogId m_partitionId;
-
-    int64_t m_siteId;
     voltdb::CatalogId m_hostId;
 
     voltdb::NValue m_hostname;

--- a/src/ee/storage/PersistentTableUndoTruncateTableAction.h
+++ b/src/ee/storage/PersistentTableUndoTruncateTableAction.h
@@ -26,10 +26,12 @@ class PersistentTableUndoTruncateTableAction: public UndoReleaseAction {
 public:
     PersistentTableUndoTruncateTableAction(TableCatalogDelegate * tcd,
             PersistentTable *originalTable,
-            PersistentTable *emptyTable)
+            PersistentTable *emptyTable,
+            bool replicatedTableAction)
         : m_tcd(tcd)
         , m_originalTable(originalTable)
         , m_emptyTable(emptyTable)
+        , m_replicatedTableAction(replicatedTableAction)
     {}
 
 private:
@@ -42,7 +44,7 @@ private:
      *
      */
     virtual void undo() {
-        m_emptyTable->truncateTableUndo(m_tcd, m_originalTable);
+        m_emptyTable->truncateTableUndo(m_tcd, m_originalTable, m_replicatedTableAction);
     }
 
     /*
@@ -65,6 +67,7 @@ private:
     TableCatalogDelegate* m_tcd;
     PersistentTable* m_originalTable;
     PersistentTable* m_emptyTable;
+    bool             m_replicatedTableAction;
 };
 
 }// namespace voltdb

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -2161,7 +2161,8 @@ void PersistentTable::addViewHandler(MaterializedViewHandler* viewHandler) {
         ConditionalExecuteWithMpMemory usingMpMemoryIfReplicated(m_isReplicated);
         TableCatalogDelegate* tcd = engine->getTableDelegate(m_name);
         m_deltaTable = tcd->createDeltaTable(*engine->getDatabase(), *engine->getCatalogTable(m_name));
-        VOLT_ERROR("Engine %p (%d) create delta table %p for table %s", engine, engine->getPartitionId(), m_deltaTable, m_name.c_str());
+        VOLT_DEBUG("Engine %p (%d) create delta table %p for table %s", engine,
+                engine->getPartitionId(), m_deltaTable, m_name.c_str());
     }
     m_viewHandlers.push_back(viewHandler);
 }
@@ -2181,7 +2182,8 @@ void PersistentTable::dropViewHandler(MaterializedViewHandler* viewHandler) {
     // The last element is now excess.
     m_viewHandlers.pop_back();
     if (m_viewHandlers.size() == 0) {
-        VOLT_ERROR("Engine %d drop delta table %p for table %s", ExecutorContext::getEngine()->getPartitionId(), m_deltaTable, m_name.c_str());
+        VOLT_DEBUG("Engine %d drop delta table %p for table %s",
+                ExecutorContext::getEngine()->getPartitionId(), m_deltaTable, m_name.c_str());
         ConditionalExecuteWithMpMemory usingMpMemoryIfReplicated(m_isReplicated);
         // If both the source and dest tables are replicated we are already in the Mp Memory Context
         m_deltaTable->decrementRefcount();

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -475,7 +475,7 @@ public:
 
     virtual int64_t validatePartitioning(TheHashinator* hashinator, int32_t partitionId);
 
-    void truncateTableUndo(TableCatalogDelegate* tcd, PersistentTable* originalTable);
+    void truncateTableUndo(TableCatalogDelegate* tcd, PersistentTable* originalTable, bool replicatedTableAction);
 
     void truncateTableRelease(PersistentTable* originalTable);
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3095,8 +3095,17 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
                 // tell the iv2 sites to stop their runloop
                 if (m_iv2Initiators != null) {
-                    for (Initiator init : m_iv2Initiators.values())
-                        init.shutdown();
+                    ArrayList<Initiator> sites = new ArrayList<>(m_iv2Initiators.values());
+                    long lastSiteId = Long.MAX_VALUE;
+                    assert(sites.get(sites.size()-1).getPartitionId() == MpInitiator.MP_INIT_PID);
+                    // do the MpIntiator last
+                    for(int ii = sites.size() - 2; ii >= 0; ii--) {
+                        Initiator site = sites.get(ii);
+                        assert(site.getInitiatorHSId() < lastSiteId);
+                        lastSiteId = site.getInitiatorHSId();
+                        site.shutdown();
+                    }
+                    sites.get(sites.size()-1).shutdown();
                 }
 
                 if (m_cartographer != null) {

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.json_voltpatches.JSONException;
@@ -37,7 +36,6 @@ import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.SnapshotFormat;
-import org.voltdb.SnapshotSiteProcessor;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
 import org.voltdb.catalog.Database;
@@ -45,7 +43,6 @@ import org.voltdb.messaging.RejoinMessage;
 import org.voltdb.messaging.RejoinMessage.Type;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 import org.voltdb.sysprocs.saverestore.StreamSnapshotRequestConfig;
-import org.voltdb.utils.FixedDBBPool;
 
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.collect.ArrayListMultimap;
@@ -71,8 +68,6 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
                                                                  .containsKey("rejoindeathtestonrejoinside");
     private static final boolean m_rejoinDeathTestCancel = System.getProperties()
                                                                  .containsKey("rejoindeathtestcancel");
-
-    private static AtomicLong m_sitesRejoinedCount = new AtomicLong(0);
 
     private Database m_catalog;
     // contains all sites that haven't started rejoin initialization
@@ -159,8 +154,8 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
         send(com.google_voltpatches.common.primitives.Longs.toArray(HSIds), msg);
 
         // For testing, exit if only one property is set...
-        if (m_rejoinDeathTestMode && !m_rejoinDeathTestCancel &&
-                (m_sitesRejoinedCount.incrementAndGet() == 2)) {
+        // Because we start all sites at the same time, we can't stop the rejoin after one site has finished anymore
+        if (m_rejoinDeathTestMode && !m_rejoinDeathTestCancel) {
             System.exit(0);
         }
     }

--- a/tests/frontend/org/voltdb/jni/TestExecutionEngine.java
+++ b/tests/frontend/org/voltdb/jni/TestExecutionEngine.java
@@ -258,7 +258,6 @@ public class TestExecutionEngine extends TestCase {
             assertEquals( STOCK_TABLEID, container.b().getInt());
 
             assertEquals( sourceEngine.tableHashCode(STOCK_TABLEID), destinationEngine.get().tableHashCode(STOCK_TABLEID));
-            terminateSourceEngine();
         } finally {
             container.discard();
             es.submit(new Runnable() {
@@ -271,6 +270,7 @@ public class TestExecutionEngine extends TestCase {
                     }
                 }
             }).get();
+            terminateSourceEngine();
             es.shutdown();
         }
     }
@@ -366,7 +366,6 @@ public class TestExecutionEngine extends TestCase {
         } finally {
             container.discard();
         }
-        terminateSourceEngine();
         es.submit(new Runnable() {
             @Override
             public void run() {
@@ -377,6 +376,7 @@ public class TestExecutionEngine extends TestCase {
                 }
             }
         }).get();
+        terminateSourceEngine();
         es.shutdown();
     }
 


### PR DESCRIPTION
Use a shared stats source for replicated tables that is installed into each partition's stats agent. When a table swap or truncate happens don't delete all the stats sources and rebuild all of them, but just delete and rebuild that table that is being swapped / truncated. Otherwise we need to synchronize partitioned table swaps and truncates to rebuild the replicated table stats.

Also reverse the order of shutting down partitions from lowest partition first to highest partition first down to lowest partition and then lastly the MP Write Site. We do this because we should delete the replicated table (and its stats sources) after all sites have shut down to avoid a tick on a higher partition from trying to get stats for a replicated table that has been deleted by the lowest site.