### PR TITLE
ENG-10421: allow multiple hosts trying to rejoin at the same time

### DIFF
--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -36,9 +36,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google_voltpatches.common.base.Charsets;
-import com.google_voltpatches.common.collect.Maps;
-import com.google_voltpatches.common.collect.Sets;
 import org.apache.zookeeper_voltpatches.CreateMode;
 import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
@@ -60,12 +57,13 @@ import org.voltcore.utils.PortGenerator;
 import org.voltcore.utils.ShutdownHooks;
 import org.voltcore.zk.CoreZK;
 import org.voltcore.zk.ZKUtil;
-import org.voltdb.VoltDB;
-import org.voltdb.utils.MiscUtils;
 
+import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableSet;
+import com.google_voltpatches.common.collect.Maps;
+import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.primitives.Longs;
 
 /**
@@ -80,6 +78,30 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     private static final VoltLogger m_hostLog = new VoltLogger("HOST");
 
     public static final CopyOnWriteArraySet<Long> VERBOTEN_THREADS = new CopyOnWriteArraySet<Long>();
+
+    /**
+     * Callback for making decision on whether a new node can join the cluster.
+     */
+    public interface MembershipAcceptor {
+        /**
+         * @param hostId     The new host trying to join the mesh
+         * @param request    The requested action from the node joining the mesh
+         * @param errMsg     Error message to send to the new host
+         * @return true if the new host can join the mesh, false otherwise.
+         */
+        boolean shouldAccept(int hostId, String request, StringBuilder errMsg);
+    }
+
+    /**
+     * Callback for watching for host failures.
+     */
+    public interface HostWatcher {
+        /**
+         * Called when host failures are detected.
+         * @param failedHosts    List of failed hosts, including hosts currently unknown to this host.
+         */
+        void hostsFailed(Set<Integer> failedHosts);
+    }
 
     /**
      * Configuration for a host messenger. The leader binds to the coordinator ip and
@@ -119,10 +141,6 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
             this(null, 3021);
             zkInterface = "127.0.0.1:" + ports.next();
             internalPort = ports.next();
-        }
-
-        public int getZKPort() {
-            return MiscUtils.getPortFromHostnameColonPort(zkInterface, VoltDB.DEFAULT_ZK_PORT);
         }
 
         private void initNetworkThreads() {
@@ -217,6 +235,9 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     private InstanceId m_instanceId = null;
     private boolean m_shuttingDown = false;
 
+    private final MembershipAcceptor m_membershipAcceptor;
+    private final HostWatcher m_hostWatcher;
+
     private final Object m_mapLock = new Object();
 
     /*
@@ -246,17 +267,14 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     }
 
     /**
-     *
-     * @param network
-     * @param coordinatorIp
-     * @param expectedHosts
-     * @param catalogCRC
-     * @param hostLog
+     * @param config
+     * @param membershipAcceptor
+     * @param m_hostWatcher
      */
-    public HostMessenger(
-            Config config)
-    {
+    public HostMessenger(Config config, MembershipAcceptor membershipAcceptor, HostWatcher hostWatcher) {
         m_config = config;
+        m_membershipAcceptor = membershipAcceptor;
+        m_hostWatcher = hostWatcher;
         m_network = new VoltNetworkPool(m_config.networkThreads, 0, m_config.coreBindIds, "Server");
         m_joiner = new SocketJoiner(
                 m_config.coordinatorIp,
@@ -298,6 +316,12 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                         // reportForeignHostFailed should print on the console once
                         m_networkLog.info(String.format("Host %d failed (DisconnectFailedHostsCallback)", hostId));
                     }
+                }
+
+                // notifying any watchers who are interested in failure -- used
+                // initially to do ZK cleanup when rejoining nodes die
+                if (m_hostWatcher != null) {
+                    m_hostWatcher.hostsFailed(failedHostIds);
                 }
             }
         }
@@ -351,8 +375,14 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     /**
      * Start the host messenger and connect to the leader, or become the leader
      * if necessary.
+     *
+     * @param request The requested action to send to other nodes when joining
+     * the mesh. This is opaque to the HostMessenger, it can be any
+     * string. HostMessenger will encode this in the request to join mesh to the
+     * live hosts. The live hosts can use this request string to make further
+     * decision on whether or not to accept the request.
      */
-    public void start() throws Exception {
+    public void start(String request) throws Exception {
         /*
          * SJ uses this barrier if this node becomes the leader to know when ZooKeeper
          * has been finished bootstrapping.
@@ -363,7 +393,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
          * If start returns true then this node is the leader, it bound to the coordinator address
          * It needs to bootstrap its agreement site so that other nodes can join
          */
-        if(m_joiner.start(zkInitBarrier)) {
+        if(m_joiner.start(zkInitBarrier, request)) {
             m_network.start();
 
             /*
@@ -434,11 +464,6 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
             m_zk.create(CoreZK.hosts_host + selectedHostId, hostInfo.toBytes(), Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
         }
         zkInitBarrier.countDown();
-    }
-
-    //For test only
-    protected HostMessenger() {
-        this(new Config());
     }
 
     /*
@@ -543,12 +568,17 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
     }
 
-    /*
+    /**
      * Any node can serve a request to join. The coordination of generating a new host id
      * is done via ZK
+     *
+     * @param request The requested action from the rejoining host. This is
+     * opaque to the HostMessenger, it can be any string. The request string can
+     * be used to make further decision on whether or not to accept the request
+     * in the MembershipAcceptor.
      */
     @Override
-    public void requestJoin(SocketChannel socket, InetSocketAddress listeningAddress) throws Exception {
+    public void requestJoin(SocketChannel socket, InetSocketAddress listeningAddress, String request) throws Exception {
         /*
          * Generate the host id via creating an ephemeral sequential node
          */
@@ -557,10 +587,22 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         ForeignHost fhost = null;
         try {
             try {
+                final boolean shouldAcceptMember;
+                final StringBuilder errMsg = new StringBuilder();
+                if (m_membershipAcceptor != null) {
+                    shouldAcceptMember = m_membershipAcceptor.shouldAccept(hostId, request, errMsg);
+                } else {
+                    shouldAcceptMember = true;
+                }
+
                 /*
                  * Write the response that advertises the cluster topology
                  */
-                writeRequestJoinResponse( hostId, socket);
+                writeRequestJoinResponse(hostId, shouldAcceptMember, errMsg.toString(), socket);
+                if (!shouldAcceptMember) {
+                    socket.close();
+                    return;
+                }
 
                 /*
                  * Wait for the a response from the joining node saying that it connected
@@ -574,6 +616,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                     int read = socket.read(finishedJoining);
                     if (read == -1) {
                         m_networkLog.info("New connection was unable to establish mesh");
+                        socket.close();
                         return;
                     } else if (read < 1) {
                         Thread.sleep(5);
@@ -590,6 +633,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                 m_networkLog.error("Error joining new node", e);
                 addFailedHost(hostId);
                 removeForeignHost(hostId);
+                socket.close();
                 return;
             }
 
@@ -622,43 +666,49 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
      * Advertise to a newly connecting node the topology of the cluster so that it can connect to
      * the rest of the nodes
      */
-    private void writeRequestJoinResponse(int hostId, SocketChannel socket) throws Exception {
+    private void writeRequestJoinResponse(int hostId, boolean shouldAccept, String errMsg, SocketChannel socket) throws Exception {
         JSONObject jsObj = new JSONObject();
 
-        /*
-         * Tell the new node what its host id is
-         */
-        jsObj.put("newHostId", hostId);
+        jsObj.put("accepted", shouldAccept);
+        if (shouldAccept) {
+            /*
+             * Tell the new node what its host id is
+             */
+            jsObj.put("newHostId", hostId);
 
-        /*
-         * Echo back the address that the node connected from
-         */
-        jsObj.put("reportedAddress",
-                ((InetSocketAddress)socket.socket().getRemoteSocketAddress()).getAddress().getHostAddress());
+            /*
+             * Echo back the address that the node connected from
+             */
+            jsObj.put("reportedAddress",
+                      ((InetSocketAddress) socket.socket().getRemoteSocketAddress()).getAddress().getHostAddress());
 
-        /*
-         * Create an array containing an ad for every node including this one
-         * even though the connection has already been made
-         */
-        JSONArray jsArray = new JSONArray();
-        JSONObject hostObj = new JSONObject();
-        hostObj.put("hostId", getHostId());
-        hostObj.put("address",
-                m_config.internalInterface.isEmpty() ?
+            /*
+             * Create an array containing an ad for every node including this one
+             * even though the connection has already been made
+             */
+            JSONArray jsArray = new JSONArray();
+            JSONObject hostObj = new JSONObject();
+            hostObj.put("hostId", getHostId());
+            hostObj.put("address",
+                        m_config.internalInterface.isEmpty() ?
                         socket.socket().getLocalAddress().getHostAddress() : m_config.internalInterface);
-        hostObj.put("port", m_config.internalPort);
-        jsArray.put(hostObj);
-        for (Map.Entry<Integer, ForeignHost>  entry : m_foreignHosts.entrySet()) {
-            if (entry.getValue() == null) continue;
-            int hsId = entry.getKey();
-            ForeignHost fh = entry.getValue();
-            hostObj = new JSONObject();
-            hostObj.put("hostId", hsId);
-            hostObj.put("address", fh.m_listeningAddress.getAddress().getHostAddress());
-            hostObj.put("port", fh.m_listeningAddress.getPort());
+            hostObj.put("port", m_config.internalPort);
             jsArray.put(hostObj);
+            for (Map.Entry<Integer, ForeignHost> entry : m_foreignHosts.entrySet()) {
+                if (entry.getValue() == null) continue;
+                int hsId = entry.getKey();
+                ForeignHost fh = entry.getValue();
+                hostObj = new JSONObject();
+                hostObj.put("hostId", hsId);
+                hostObj.put("address", fh.m_listeningAddress.getAddress().getHostAddress());
+                hostObj.put("port", fh.m_listeningAddress.getPort());
+                jsArray.put(hostObj);
+            }
+            jsObj.put("hosts", jsArray);
+        } else {
+            jsObj.put("reason", errMsg);
         }
-        jsObj.put("hosts", jsArray);
+
         byte messageBytes[] = jsObj.toString(4).getBytes("UTF-8");
         ByteBuffer message = ByteBuffer.allocate(4 + messageBytes.length);
         message.putInt(messageBytes.length);

--- a/src/frontend/org/voltcore/messaging/SocketJoiner.java
+++ b/src/frontend/org/voltcore/messaging/SocketJoiner.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
@@ -79,7 +80,7 @@ public class SocketJoiner {
         /*
          * A node wants to join the socket mesh
          */
-        public void requestJoin(SocketChannel socket, InetSocketAddress listeningAddress ) throws Exception;
+        public void requestJoin(SocketChannel socket, InetSocketAddress listeningAddress, String request) throws Exception;
 
         /*
          * A connection has been made to all of the specified hosts. Invoked by
@@ -113,7 +114,7 @@ public class SocketJoiner {
      */
     String m_reportedInternalInterface;
 
-    public boolean start(final CountDownLatch externalInitBarrier) {
+    public boolean start(final CountDownLatch externalInitBarrier, String request) {
         boolean retval = false;
 
         // Try to become leader regardless of configuration.
@@ -177,9 +178,29 @@ public class SocketJoiner {
             /*
              * Not a leader, need to connect to the primary to join the cluster.
              * Once connectToPrimary is finishes this node will be physically connected
-             * to all nodes with a working agreement site
+             * to all nodes with a working agreement site.
+             *
+             * The request to join the cluster may be rejected, e.g. multiple hosts
+             * rejoining at the same time. In this case, the code will retry.
              */
-            connectToPrimary();
+            long retryInterval = Integer.getInteger("MESH_JOIN_RETRY_INTERVAL", 10);
+            final Random salt = new Random();
+            while (true) {
+                try {
+                    connectToPrimary(request);
+                    break;
+                } catch (CoreUtils.RetryException e) {
+                    LOG.warn(String.format("Request to join cluster mesh is rejected, retrying in %d seconds. %s",
+                                           retryInterval, e.getMessage()));
+                    try { Thread.sleep(TimeUnit.SECONDS.toMillis(retryInterval)); } catch (InterruptedException e1) {}
+                    // exponential back off with a salt to avoid collision. Max is 5 minutes.
+                    retryInterval = (Math.min(retryInterval * 2, TimeUnit.MINUTES.toSeconds(5)) +
+                                     salt.nextInt(Integer.getInteger("MESH_JOIN_RETRY_INTERVAL_SALT", 30)));
+                } catch (Exception e) {
+                    hostLog.error("Failed to establish socket mesh.", e);
+                    throw new RuntimeException(e);
+                }
+            }
         }
 
         /*
@@ -379,7 +400,7 @@ public class SocketJoiner {
 
             hostLog.info("Received request type " + type);
             if (type.equals("REQUEST_HOSTID")) {
-                m_joinHandler.requestJoin( sc, listeningAddress);
+                m_joinHandler.requestJoin( sc, listeningAddress, jsObj.optString("request"));
             } else if (type.equals("PUBLISH_HOSTID")){
                 m_joinHandler.notifyOfJoin(jsObj.getInt("hostId"), sc, listeningAddress);
             } else {
@@ -476,7 +497,8 @@ public class SocketJoiner {
      * it must connect to the leader which will generate a host id and
      * advertise the rest of the cluster so that connectToPrimary can connect to it
      */
-    private void connectToPrimary() {
+    private void connectToPrimary(String request) throws Exception
+    {
         // collect clock skews from all nodes
         List<Long> skews = new ArrayList<Long>();
 
@@ -522,6 +544,7 @@ public class SocketJoiner {
 
             JSONObject jsObj = new JSONObject();
             jsObj.put("type", "REQUEST_HOSTID");
+            jsObj.put("request", request);
 
             // put the version compatibility status in the json
             jsObj.put("versionString", localVersionString);
@@ -553,6 +576,12 @@ public class SocketJoiner {
 
             // read the json response sent by HostMessenger with HostID
             JSONObject jsonObj = readJSONObjFromWire(socket, remoteAddress);
+
+            // check if the membership request is accepted
+            if (!jsonObj.optBoolean("accepted", true)) {
+                socket.close();
+                throw new CoreUtils.RetryException(jsonObj.getString("reason"));
+            }
 
             /*
              * Get the generated host id, and the interface we connected on
@@ -660,7 +689,7 @@ public class SocketJoiner {
 
             /*
              * Notify the leader that we connected to the entire cluster, it will then go
-             * and queue a txn for our agreement site to join the lcuster
+             * and queue a txn for our agreement site to join the cluster
              */
             ByteBuffer joinCompleteBuffer = ByteBuffer.allocate(1);
             while (joinCompleteBuffer.hasRemaining()) {
@@ -674,9 +703,6 @@ public class SocketJoiner {
             m_joinHandler.notifyOfHosts( m_localHostId, hostIds, hostSockets, listeningAddresses);
         } catch (ClosedByInterruptException e) {
             //This is how shutdown is done
-        } catch (Exception e) {
-            hostLog.error("Failed to establish socket mesh.", e);
-            throw new RuntimeException(e);
         }
     }
 

--- a/src/frontend/org/voltcore/utils/CoreUtils.java
+++ b/src/frontend/org/voltcore/utils/CoreUtils.java
@@ -974,10 +974,13 @@ public class CoreUtils {
         return Math.max(1, Runtime.getRuntime().availableProcessors());
     }
 
-    public static final class RetryException extends RuntimeException {
+    public static final class RetryException extends Exception {
         public RetryException() {};
         public RetryException(Throwable cause) {
             super(cause);
+        }
+        public RetryException(String errMsg) {
+            super(errMsg);
         }
     }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -152,7 +152,7 @@ import com.google_voltpatches.common.util.concurrent.SettableFuture;
  * namespace. A lot of the global namespace is described by VoltDBInterface
  * to allow test mocking.
  */
-public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
+public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostMessenger.MembershipAcceptor, HostMessenger.HostWatcher {
     private static final boolean DISABLE_JMX = Boolean.valueOf(System.getProperty("DISABLE_JMX", "false"));
 
     /** Default deployment file contents if path to deployment is null */
@@ -1024,6 +1024,53 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
         }
     }
 
+    /**
+     * This is currently used to prevent simultaneous rejoins and rejoins during network partition.
+     * It returns true for non-rejoin cases.
+     */
+    @Override
+    public boolean shouldAccept(int hostId, String request, StringBuilder errMsg)
+    {
+        Preconditions.checkNotNull(m_messenger);
+
+        StartAction action = null;
+        try {
+            action = StartAction.valueOf(request);
+        } catch (IllegalArgumentException e) {}
+
+        if (action != null && action.doesRejoin()) {
+            final int rejoiningHost = VoltZK.createRejoinNodeIndicator(m_messenger.getZK(), hostId);
+
+            if (rejoiningHost == -1) {
+                return true;
+            } else {
+                errMsg.append("Only one host can rejoin at a time. Host ")
+                      .append(rejoiningHost)
+                      .append(" is still rejoining.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public void hostsFailed(Set<Integer> failedHosts)
+    {
+        getSES(true).submit(new Runnable() {
+            @Override
+            public void run()
+            {
+                // Cleanup the rejoin blocker in case the rejoining node failed.
+                // This has to run on a separate thread because the callback is
+                // invoked on the ZooKeeper server thread.
+                for (int hostId : failedHosts) {
+                    VoltZK.removeRejoinNodeIndicatorForHost(m_messenger.getZK(), hostId);
+                }
+            }
+        });
+    }
+
     class DailyLogTask implements Runnable {
         @Override
         public void run() {
@@ -1721,12 +1768,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
         hmconfig.factory = new VoltDbMessageFactory();
         hmconfig.coreBindIds = m_config.m_networkCoreBindings;
 
-        m_messenger = new org.voltcore.messaging.HostMessenger(hmconfig);
+        m_messenger = new org.voltcore.messaging.HostMessenger(hmconfig, this, this);
 
         hostLog.info(String.format("Beginning inter-node communication on port %d.", m_config.m_internalPort));
 
         try {
-            m_messenger.start();
+            m_messenger.start(m_config.m_startAction.name());
         } catch (Exception e) {
             VoltDB.crashLocalVoltDB(e.getMessage(), true, e);
         }
@@ -2525,10 +2572,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
             // above to finish.
             if (logRecoveryCompleted || m_joining) {
                 if (m_rejoining) {
-                   final String node = VoltZK.rejoinNodesBlockerHost + m_myHostId;
-                   VoltZK.removeRejoinNodeIndicator(m_messenger.getZK(), node);
-                   m_rejoining = false;
+                    VoltZK.removeRejoinNodeIndicatorForHost(m_messenger.getZK(), m_myHostId);
+                    m_rejoining = false;
                 }
+
                 String actionName = m_joining ? "join" : "rejoin";
                 m_joining = false;
                 consoleLog.info(String.format("Node %s completed", actionName));
@@ -2721,8 +2768,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback {
             if (m_rejoinTruncationReqId.compareTo(requestId) <= 0) {
                 String actionName = m_joining ? "join" : "rejoin";
                 // remove the rejoin blocker
-                final String node = VoltZK.rejoinNodesBlockerHost+String.valueOf(m_myHostId);
-                VoltZK.removeRejoinNodeIndicator(m_messenger.getZK(),node);
+                VoltZK.removeRejoinNodeIndicatorForHost(m_messenger.getZK(), m_myHostId);
                 consoleLog.info(String.format("Node %s completed", actionName));
                 m_rejoinTruncationReqId = null;
                 m_rejoining = false;

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -18,6 +18,7 @@
 package org.voltdb;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -30,6 +31,7 @@ import org.apache.zookeeper_voltpatches.CreateMode;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.apache.zookeeper_voltpatches.data.Stat;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.voltcore.logging.VoltLogger;
@@ -116,8 +118,7 @@ public class VoltZK {
     public static final String request_truncation_snapshot_node = ZKUtil.joinZKPath(request_truncation_snapshot, "request_");
 
     // root for rejoin nodes
-    public static final String rejoinNodesBlocker = "/db/rejoin_nodes_blocker";
-    public static final String rejoinNodesBlockerHost = ZKUtil.joinZKPath(rejoinNodesBlocker, "host_");
+    public static final String rejoinNodeBlocker = "/db/rejoin_nodes_blocker";
 
     // Synchronized State Machine
     public static final String syncStateMachine = "/db/synchronized_states";
@@ -137,7 +138,6 @@ public class VoltZK {
             lastKnownLiveNodes,
             syncStateMachine,
             catalogUpdateBlockers,
-            rejoinNodesBlocker,
             request_truncation_snapshot
     };
 
@@ -286,33 +286,63 @@ public class VoltZK {
         return true;
     }
 
-    public static void createRejoinNodeIndicator(ZooKeeper zk, String node)
+    /**
+     * Creates a rejoin blocker for the given rejoining host.
+     * This prevents other hosts from rejoining at the same time.
+     *
+     * @param zk        ZooKeeper client
+     * @param hostId    The rejoining host ID
+     * @return -1 if the blocker is created successfully, or the host ID
+     * if there is already another host rejoining.
+     */
+    public static int createRejoinNodeIndicator(ZooKeeper zk, int hostId)
     {
         try {
-            zk.create(node,
-                      null,
+            zk.create(rejoinNodeBlocker,
+                      ByteBuffer.allocate(4).putInt(hostId).array(),
                       Ids.OPEN_ACL_UNSAFE,
-                      CreateMode.EPHEMERAL);
+                      CreateMode.PERSISTENT);
         } catch (KeeperException e) {
-            if (e.code() != KeeperException.Code.NODEEXISTS) {
+            if (e.code() == KeeperException.Code.NODEEXISTS) {
+                try {
+                    return ByteBuffer.wrap(zk.getData(rejoinNodeBlocker, false, null)).getInt();
+                } catch (KeeperException e1) {
+                    if (e1.code() != KeeperException.Code.NONODE) {
+                        VoltDB.crashLocalVoltDB("Unable to get the current rejoining node indicator");
+                    }
+                } catch (InterruptedException e1) {}
+            } else {
                 VoltDB.crashLocalVoltDB("Unable to create rejoin node Indicator", true, e);
             }
         } catch (InterruptedException e) {
             VoltDB.crashLocalVoltDB("Unable to create rejoin node Indicator", true, e);
         }
+
+        return -1;
     }
 
-    public static boolean removeRejoinNodeIndicator(ZooKeeper zk, String node)
+    /**
+     * Removes the rejoin blocker if the current rejoin blocker contains the given host ID.
+     * @return true if the blocker is removed successfully, false otherwise.
+     */
+    public static boolean removeRejoinNodeIndicatorForHost(ZooKeeper zk, int hostId)
     {
         try {
-            zk.delete(node, -1);
+            Stat stat = new Stat();
+            final int rejoiningHost = ByteBuffer.wrap(zk.getData(rejoinNodeBlocker, false, stat)).getInt();
+            if (hostId == rejoiningHost) {
+                zk.delete(rejoinNodeBlocker, stat.getVersion());
+                return true;
+            }
         } catch (KeeperException e) {
-            if (e.code() != KeeperException.Code.NONODE) {
-                return false;
+            if (e.code() == KeeperException.Code.NONODE ||
+                e.code() == KeeperException.Code.BADVERSION) {
+                // Okay if the rejoin blocker for the given hostId is already gone.
+                return true;
             }
         } catch (InterruptedException e) {
             return false;
         }
-        return true;
+        return false;
     }
 }

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.apache.zookeeper_voltpatches.data.Stat;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
@@ -482,9 +483,9 @@ public class Cartographer extends StatsSource
                     }
                     // check if any node still in rejoin status
                     try {
-                        List<String> children = m_zk.getChildren(VoltZK.rejoinNodesBlocker, false);
-                        if (!children.isEmpty())
+                        if (m_zk.exists(VoltZK.rejoinNodeBlocker, false) != null) {
                             return false;
+                        }
                     } catch (KeeperException.NoNodeException ignore) {} // shouldn't happen
                     //Otherwise we do check replicas for host
                     return doPartitionsHaveReplicas(hid);

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -187,8 +187,6 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
     public boolean startJoin(Database catalog) {
         m_catalog = catalog;
         boolean schemaHasNoTables = catalog.getTables().isEmpty();
-        final String node = VoltZK.rejoinNodesBlockerHost+m_hostId;
-        VoltZK.createRejoinNodeIndicator(m_messenger.getZK(),node);
         m_startTime = System.currentTimeMillis();
         if (m_liveRejoin) {
             long firstSite;

--- a/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
+++ b/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.After;
@@ -54,17 +55,18 @@ public class TestHostMessenger {
     }
 
     private HostMessenger createHostMessenger(int index, StartAction action) throws Exception {
-        return createHostMessenger(index, action, true);
+        return createHostMessenger(index, action, null, true);
     }
 
-    private HostMessenger createHostMessenger(int index, StartAction action, boolean start) throws Exception {
+    private HostMessenger createHostMessenger(int index, StartAction action, HostMessenger.MembershipAcceptor acceptor,
+                                              boolean start) throws Exception {
         HostMessenger.Config config = new HostMessenger.Config();
         config.internalPort = config.internalPort + index;
         config.zkInterface = "127.0.0.1:" + (7181 + index);
-        HostMessenger hm = new HostMessenger(config);
+        HostMessenger hm = new HostMessenger(config, acceptor, null);
         createdMessengers.add(hm);
         if (start) {
-            hm.start();
+            hm.start(action.name());
         }
         return hm;
     }
@@ -93,16 +95,16 @@ public class TestHostMessenger {
     public void testMultiHost() throws Exception {
         HostMessenger hm1 = createHostMessenger(0, StartAction.CREATE);
 
-        final HostMessenger hm2 = createHostMessenger(1, StartAction.CREATE, false);
+        final HostMessenger hm2 = createHostMessenger(1, StartAction.CREATE, null, false);
 
-        final HostMessenger hm3 = createHostMessenger(2, StartAction.CREATE, false);
+        final HostMessenger hm3 = createHostMessenger(2, StartAction.CREATE, null, false);
 
         final AtomicReference<Exception> exception = new AtomicReference<Exception>();
         Thread hm2Start = new Thread() {
             @Override
             public void run() {
                 try {
-                    hm2.start();
+                    hm2.start(null);
                 } catch (Exception e) {
                     e.printStackTrace();
                     exception.set(e);
@@ -113,7 +115,7 @@ public class TestHostMessenger {
             @Override
             public void run() {
                 try {
-                    hm3.start();
+                    hm3.start(null);
                 } catch (Exception e) {
                     e.printStackTrace();
                     exception.set(e);
@@ -168,4 +170,76 @@ public class TestHostMessenger {
         hm3.waitForGroupJoin(2);
     }
 
+    @Test
+    public void testMembershipAcceptor() throws Exception
+    {
+        // Retry immediately
+        System.setProperty("MESH_JOIN_RETRY_INTERVAL", "0");
+        System.setProperty("MESH_JOIN_RETRY_INTERVAL_SALT", "1");
+
+        final AtomicInteger hm1CallCount = new AtomicInteger(0);
+        final AtomicInteger hm2CallCount = new AtomicInteger(0);
+        HostMessenger.MembershipAcceptor acceptor = new HostMessenger.MembershipAcceptor() {
+            @Override
+            public boolean shouldAccept(int hostId, String request, StringBuilder errMsg)
+            {
+                final AtomicInteger acceptorCallCount;
+                // hack to embed the hm index in the request
+                if (request.endsWith("1")) {
+                    acceptorCallCount = hm1CallCount;
+                } else if (request.endsWith("2")) {
+                    acceptorCallCount = hm2CallCount;
+                } else {
+                    acceptorCallCount = null;
+                }
+                final int called = acceptorCallCount.getAndIncrement();
+                // reject the first time, accept the second time
+                return called != 0;
+            }
+        };
+
+        final HostMessenger hm1 = createHostMessenger(0, StartAction.CREATE, acceptor, true);
+        // Don't start hm2 and hm3 immediately, we'll start them at the same time.
+        final HostMessenger hm2 = createHostMessenger(1, null, null, false);
+        final HostMessenger hm3 = createHostMessenger(2, null, null, false);
+
+        Thread hm2Start = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    hm2.start(StartAction.LIVE_REJOIN.name()+"1");
+                } catch (Exception e) {
+                }
+            }
+        };
+        Thread hm3Start = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    hm3.start(StartAction.LIVE_REJOIN.name()+"2");
+                } catch (Exception e) {
+                }
+            }
+        };
+
+        hm2Start.start();
+        hm3Start.start();
+        hm2Start.join();
+        hm3Start.join();
+
+        assertEquals(2, hm1CallCount.get());
+        assertEquals(2, hm2CallCount.get());
+
+        List<String> root1 = hm1.getZK().getChildren("/", false );
+        List<String> root2 = hm2.getZK().getChildren("/", false );
+        List<String> root3 = hm3.getZK().getChildren("/", false );
+        assertTrue(root1.equals(root2));
+        assertTrue(root1.equals(root3));
+
+        List<String> hostids1 = hm1.getZK().getChildren(CoreZK.hostids, false );
+        List<String> hostids2 = hm2.getZK().getChildren(CoreZK.hostids, false );
+        List<String> hostids3 = hm3.getZK().getChildren(CoreZK.hostids, false );
+        assertTrue(hostids1.equals(hostids2));
+        assertTrue(hostids1.equals(hostids3));
+    }
 }

--- a/tests/frontend/org/voltcore/messaging/TestMessaging.java
+++ b/tests/frontend/org/voltcore/messaging/TestMessaging.java
@@ -151,14 +151,14 @@ public class TestMessaging extends TestCase {
                     }
                     System.out.printf("Host/Site %d/%d is creating a new HostMessenger.\n", hostId, mySiteId);
                     HostMessenger.Config config = new HostMessenger.Config(m_portGenerator);
-                    final HostMessenger messenger = new HostMessenger(config);
+                    final HostMessenger messenger = new HostMessenger(config, null, null);
                     currentMessenger = messenger;
                     messengers[hostId] = currentMessenger;
                     new Thread() {
                         @Override
                         public void run() {
                             try {
-                                messenger.start();
+                                messenger.start(null);
                             } catch (Exception e) {
                                 e.printStackTrace();
                             }
@@ -302,10 +302,10 @@ public class TestMessaging extends TestCase {
     }
 
     public void testSimple() throws Exception {
-        HostMessenger msg1 = new HostMessenger(getConfig());
-        msg1.start();
-        HostMessenger msg2 = new HostMessenger(getConfig());
-        msg2.start();
+        HostMessenger msg1 = new HostMessenger(getConfig(), null, null);
+        msg1.start(null);
+        HostMessenger msg2 = new HostMessenger(getConfig(), null, null);
+        msg2.start(null);
 
         System.out.println("Waiting for socketjoiners...");
         msg1.waitForGroupJoin(2);
@@ -360,12 +360,12 @@ public class TestMessaging extends TestCase {
     }
 
     public void testMultiMailbox() throws Exception {
-        HostMessenger msg1 = new HostMessenger(getConfig());
-        msg1.start();
-        HostMessenger msg2 = new HostMessenger(getConfig());
-        msg2.start();
-        HostMessenger msg3 = new HostMessenger(getConfig());
-        msg3.start();
+        HostMessenger msg1 = new HostMessenger(getConfig(), null, null);
+        msg1.start(null);
+        HostMessenger msg2 = new HostMessenger(getConfig(), null, null);
+        msg2.start(null);
+        HostMessenger msg3 = new HostMessenger(getConfig(), null, null);
+        msg3.start(null);
 
         System.out.println("Waiting for socketjoiners...");
         msg1.waitForGroupJoin(3);
@@ -495,8 +495,8 @@ public class TestMessaging extends TestCase {
         public void run() {
             try {
                 HostMessenger.Config config = new HostMessenger.Config(m_portGenerator);
-                HostMessenger msg = new HostMessenger(config);
-                msg.start();
+                HostMessenger msg = new HostMessenger(config, null, null);
+                msg.start(null);
                 m_ready.set(true);
                 msg.waitForGroupJoin(2);
             } catch (Exception e) {
@@ -514,10 +514,10 @@ public class TestMessaging extends TestCase {
             throw new RuntimeException(ex);
         }
 
-        HostMessenger msg1 = new HostMessenger(getConfig());
-        msg1.start();
-        HostMessenger msg2 = new HostMessenger(getConfig());
-        msg2.start();
+        HostMessenger msg1 = new HostMessenger(getConfig(), null, null);
+        msg1.start(null);
+        HostMessenger msg2 = new HostMessenger(getConfig(), null, null);
+        msg2.start(null);
         System.out.println("Waiting for socketjoiners...");
         msg1.waitForGroupJoin(2);
         System.out.println("Finished socket joiner for msg1");

--- a/tests/frontend/org/voltcore/zk/TestStateMachine.java
+++ b/tests/frontend/org/voltcore/zk/TestStateMachine.java
@@ -153,8 +153,8 @@ public class TestStateMachine extends ZKTestBase {
         m_siteIdToZKPort.put(site, clientPort);
         config.networkThreads = 1;
         config.coordinatorIp = new InetSocketAddress( recoverPort );
-        HostMessenger hm = new HostMessenger(config);
-        hm.start();
+        HostMessenger hm = new HostMessenger(config, null, null);
+        hm.start(null);
         m_messengers.set(site, hm);
         addStateMachinesFor(site);
     }

--- a/tests/frontend/org/voltcore/zk/TestZK.java
+++ b/tests/frontend/org/voltcore/zk/TestZK.java
@@ -79,8 +79,8 @@ public class TestZK extends ZKTestBase {
         m_siteIdToZKPort.put(site, clientPort);
         config.networkThreads = 1;
         config.coordinatorIp = new InetSocketAddress( recoverPort );
-        HostMessenger hm = new HostMessenger(config);
-        hm.start();
+        HostMessenger hm = new HostMessenger(config, null, null);
+        hm.start(null);
         m_messengers.set(site, hm);
     }
 

--- a/tests/frontend/org/voltcore/zk/ZKTestBase.java
+++ b/tests/frontend/org/voltcore/zk/ZKTestBase.java
@@ -35,7 +35,6 @@ import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.PortGenerator;
 
-import com.google_voltpatches.common.collect.ImmutableSet;
 import com.google_voltpatches.common.collect.Sets;
 
 /**
@@ -59,8 +58,8 @@ public class ZKTestBase {
             config.zkInterface = "127.0.0.1:" + externalPort;
             m_siteIdToZKPort.put(ii, externalPort);
             config.networkThreads = 1;
-            HostMessenger hm = new HostMessenger(config);
-            hm.start();
+            HostMessenger hm = new HostMessenger(config, null, null);
+            hm.start(null);
             m_messengers.add(hm);
         }
     }

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -71,7 +71,7 @@ public class MockVoltDB implements VoltDBInterface
     final String m_clusterName = "cluster";
     final String m_databaseName = "database";
     StatsAgent m_statsAgent = null;
-    HostMessenger m_hostMessenger = new HostMessenger(new HostMessenger.Config());
+    HostMessenger m_hostMessenger = new HostMessenger(new HostMessenger.Config(), null, null);
     private OperationMode m_mode = OperationMode.RUNNING;
     private volatile String m_localMetadata;
     final SnapshotCompletionMonitor m_snapshotCompletionMonitor = new SnapshotCompletionMonitor();
@@ -122,7 +122,7 @@ public class MockVoltDB implements VoltDBInterface
             assert(cluster != null);
 
             try {
-                m_hostMessenger.start();
+                m_hostMessenger.start(null);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/tests/frontend/org/voltdb/TestVoltZK.java
+++ b/tests/frontend/org/voltdb/TestVoltZK.java
@@ -1,0 +1,75 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb;
+
+import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.voltcore.zk.ZKTestBase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestVoltZK extends ZKTestBase {
+    private ZooKeeper m_zk = null;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        VoltDB.ignoreCrash = false;
+        VoltDB.wasCrashCalled = false;
+        setUpZK(1);
+        m_zk = getClient(0);
+        VoltZK.createPersistentZKNodes(m_zk);
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        if (m_zk != null) {
+            m_zk.close();
+        }
+        tearDownZK();
+    }
+
+    @Test
+    public void testRejoinBlocker()
+    {
+        // Create a rejoin blocker for host 0
+        assertEquals(-1, VoltZK.createRejoinNodeIndicator(m_zk, 0));
+        // Try to create a blocker for host 1 while host 0 is still in progress, should fail
+        assertEquals(0, VoltZK.createRejoinNodeIndicator(m_zk, 1));
+        // Try removing the blocker for host 1, which doesn't hold the blocker, no-op
+        assertFalse(VoltZK.removeRejoinNodeIndicatorForHost(m_zk, 1));
+        // Remove host 0's blocker
+        assertTrue(VoltZK.removeRejoinNodeIndicatorForHost(m_zk, 0));
+        // Should be able to create another blocker now
+        assertEquals(-1, VoltZK.createRejoinNodeIndicator(m_zk, 2));
+        assertTrue(VoltZK.removeRejoinNodeIndicatorForHost(m_zk, 2));
+        // Removing the same hostId twice should be okay
+        assertTrue(VoltZK.removeRejoinNodeIndicatorForHost(m_zk, 2));
+    }
+}


### PR DESCRIPTION
Backport to release-6.3.x, one customer found that simultaneous rejoin will cause missing replicas  problem during initialization.

Original commit message
---
On startup, each node sends a request to rejoin the mesh to the live node. The live node will check if the request can be accepted at the moment. For example, we only allow one node to rejoin at a time. If more than one node tries to rejoin, the first rejoning node will atomically check and set the ZK blocker. Subsequent nodes will fail to do so and be rejected to join the mesh. They will retry after a while until they can succeed.

Change-Id: I2ccced38059fdd397b11872e5d3f228d52adc31e