### PR TITLE
ENG-12823:

### DIFF
--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1567,6 +1567,9 @@ bool PersistentTable::activateStream(
      * TableStreamer object. TableStreamer enforces which multiple stream type
      * combinations are allowed. Expect the partition ID not to change.
      */
+    if (m_isReplicated) {
+        partitionId = -1;
+    }
     assert(m_tableStreamer == NULL || partitionId == m_tableStreamer->getPartitionID());
     if (m_tableStreamer == NULL) {
         m_tableStreamer.reset(new TableStreamer(partitionId, *this, tableId));

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -4385,4 +4385,14 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     public Cartographer getCartograhper() {
         return m_cartographer;
     }
+
+    @Override
+    public long getLowestSiteId() {
+        return m_iv2Initiators.firstEntry().getValue().getInitiatorHSId();
+    }
+
+    @Override
+    public int getLowestPartitionId() {
+        return m_iv2Initiators.firstKey();
+    }
 }

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -312,4 +312,6 @@ public interface VoltDBInterface
 
     public SnmpTrapSender getSnmpTrapSender();
 
+    long getLowestSiteId();
+    int getLowestPartitionId();
 }

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -117,7 +117,7 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
         m_coordinatorHsId = message.m_sourceHSId;
         registerSnapshotMonitor(message.getSnapshotNonce());
 
-        long sinkHSId = m_dataSink.initialize(message.getSnapshotSourceCount(),
+        long sinkHSId = m_dataSink.initialize(1,
                                               message.getSnapshotDataBufferPool(),
                                               message.getSnapshotCompressedDataBufferPool());
 

--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -213,9 +213,12 @@ public class RejoinProducer extends JoinProducerBase {
 
         // MUST choose the leader as the source.
         long sourceSite = m_mailbox.getMasterHsId(m_partitionId);
+        // The lowest partition has a single source for all messages whereas all other partitions have a real
+        // data source and a dummy data source for replicated tables that are used to sync up replicated table changes.
+        boolean haveTwoSources = VoltDB.instance().getLowestPartitionId() != m_partitionId;
         // Provide a valid sink host id unless it is an empty database.
         long hsId = (m_rejoinSiteProcessor != null
-                        ? m_rejoinSiteProcessor.initialize(message.getSnapshotSourceCount(),
+                        ? m_rejoinSiteProcessor.initialize(haveTwoSources?2:1,
                                                            message.getSnapshotDataBufferPool(),
                                                            message.getSnapshotCompressedDataBufferPool())
                         : Long.MIN_VALUE);

--- a/src/frontend/org/voltdb/messaging/RejoinMessage.java
+++ b/src/frontend/org/voltdb/messaging/RejoinMessage.java
@@ -53,7 +53,6 @@ public class RejoinMessage extends VoltMessage {
     private Queue<BBContainer> m_dataBufferPool = null;
     private Queue<BBContainer> m_compressedDataBufferPool = null;
     // number of sources sending to this site
-    private int m_snapshotSourceCount = 1;
     private long m_snapshotSinkHSId = -1;
     private boolean m_schemaHasNoTables = false;
 
@@ -78,13 +77,12 @@ public class RejoinMessage extends VoltMessage {
      * INITIATION, INITIATION_COMMUNITY pass the nonce used by the coordinator to the site.
      */
     public RejoinMessage(long sourceHSId, Type type, String snapshotNonce,
-                         int sourceCount, Queue<BBContainer> dataBufferPool,
+                         Queue<BBContainer> dataBufferPool,
                          Queue<BBContainer> compressedDataBufferPool,
                          boolean schemaHasNoTables) {
         this(sourceHSId, type);
         assert(type == Type.INITIATION || type == Type.INITIATION_COMMUNITY);
         m_snapshotNonce = snapshotNonce;
-        m_snapshotSourceCount = sourceCount;
         m_dataBufferPool = dataBufferPool;
         m_compressedDataBufferPool = compressedDataBufferPool;
         m_schemaHasNoTables = schemaHasNoTables;
@@ -125,11 +123,6 @@ public class RejoinMessage extends VoltMessage {
     public Queue<BBContainer> getSnapshotCompressedDataBufferPool()
     {
         return m_compressedDataBufferPool;
-    }
-
-    public int getSnapshotSourceCount()
-    {
-        return m_snapshotSourceCount;
     }
 
     public boolean schemaHasNoTables() {

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotAckReceiver.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotAckReceiver.java
@@ -59,8 +59,8 @@ public class StreamSnapshotAckReceiver implements Runnable {
         m_expectedEOFs = new AtomicInteger();
     }
 
-    public void setCallback(long targetId, AckCallback callback) {
-        m_expectedEOFs.incrementAndGet();
+    public void setCallback(long targetId, AckCallback callback, int expectedAcksForEOF) {
+        m_expectedEOFs.addAndGet(expectedAcksForEOF);
         m_callbacks.put(targetId, callback);
     }
 

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotSink.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotSink.java
@@ -269,7 +269,6 @@ public class StreamSnapshotSink {
                             " (TargetId " + msg.m_dataTargetId + ")");
                 }
 
-                // End of stream, no need to ack this buffer
                 if (m_expectedEOFs.decrementAndGet() == 0) {
                     m_EOF = true;
                 }
@@ -319,7 +318,7 @@ public class StreamSnapshotSink {
             msg.m_container.discard();
 
             // Queue ack to this block (after the container has been discarded)
-            m_ack.ack(msg.m_srcHSId, m_EOF, msg.m_dataTargetId, msg.m_blockIndex);
+            m_ack.ack(msg.m_srcHSId, msg.m_msgType == StreamSnapshotMessageType.END, msg.m_dataTargetId, msg.m_blockIndex);
         }
     }
 

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -833,4 +833,14 @@ public class MockVoltDB implements VoltDBInterface
     public SnmpTrapSender getSnmpTrapSender() {
         return new DummySnmpTrapSender();
     }
+
+    @Override
+    public long getLowestSiteId() {
+        return 0;
+    }
+
+    @Override
+    public int getLowestPartitionId() {
+        return 0;
+    }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -1276,7 +1276,7 @@ public class LocalCluster extends VoltServerConfig {
         // I have no idea why this code ignores the user's input
         // based on other state in this class except to say that whoever wrote
         // it this way originally probably eats kittens and hates cake.
-        if (rejoinHostId == null || m_hasLocalServer) {
+        if (rejoinHostId == null || (m_hasLocalServer && hostId != 0)) {
             rejoinHostId = 0;
         }
         if (isNewCli) {
@@ -1289,6 +1289,7 @@ public class LocalCluster extends VoltServerConfig {
             templateCmdLine.leaderPort(portNoToRejoin);
             try {
                 startLocalServer(rejoinHostId, false, startAction);
+                m_localServer.waitForRejoin();
             } catch (IOException ioe) {
                 throw new RuntimeException(ioe);
             }


### PR DESCRIPTION
When multiple source hosts are involved in a rejoin, knowing when a sink has received all snapshot data is more complicated because the partitioned and replicated table data for one partition can come from 2 hosts. To resolve this all rejoin partitions except the lowest site will receive 2 EOF rejoin messages (One from the replicated table source and one from the partitioned table source). When both EOFs are received, the sink for the partition is cleaned up.

Also, in some cases the source of the replicated table for a rejoin may not be the lowest site of a host. This is problematic because it was previously assumed that only the lowest site could stream the replicated table data. Now any site can stream the replicated table data, but there is an extra check to verify that a new stream is not started until the old one has been completed. This check can be used to verify that 2 partitions don't attempt to stream the replicated table data at the same time.