### PR TITLE
Eng 13436 fix rack-aware partitioning defect in v6.9 and later versions

### DIFF
--- a/src/frontend/org/voltdb/AbstractTopology.java
+++ b/src/frontend/org/voltdb/AbstractTopology.java
@@ -1636,8 +1636,6 @@ public class AbstractTopology {
     }
 
     /**
-     * THIS IS A TEST ONLY METHOD.
-     *
      * The default placement group (a.k.a. rack-aware group) is "0", if user override the setting
      * in command line configuration, we need to check whether the partition layout meets the
      * requirement (tolerate entire rack loss without shutdown the cluster). And also because we
@@ -1675,13 +1673,13 @@ public class AbstractTopology {
                 // will be distributed among racks, try in best effort to balance
                 // partition across racks.
                 if (!grp.isEmpty()) {
-                    sb.append("Partition " + p.id + " is not balanced.\n");
+                    sb.append("Partition " + p.id + " is not balanced across placement groups.\n");
                 }
             } else {
                 // When # of rack >= K+1, each rack will have at most one replica,
                 // each partition must span K+1 racks.
                 if ((topLevelGroups.size() - grp.size()) != (getReplicationFactor() + 1)) {
-                    sb.append("Partition " + p.id + " is not balanced.\n");
+                    sb.append("Partition " + p.id + " is not balanced across placement groups.\n");
                 }
             }
         }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2025,6 +2025,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             if (hostcount <= kfactor) {
                 VoltDB.crashLocalVoltDB("Not enough nodes to ensure K-Safety.", false, null);
             }
+            // Missing hosts can't be more than number of partition groups
+            int partitionGroupCount = m_clusterSettings.get().hostcount() / (kfactor + 1);
+            if (m_config.m_missingHostCount > partitionGroupCount) {
+                VoltDB.crashLocalVoltDB("Too many nodes are missing at startup. This cluster only allow up to "
+                        + partitionGroupCount + " missing hosts.");
+            }
 
             //startup or recover a cluster with missing nodes. make up the missing hosts to fool the topology
             //The topology will contain hosts which are marked as missing.The missing hosts will not host any master partitions.
@@ -2040,7 +2046,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
             int totalSites = sitesPerHostMap.values().stream().mapToInt(Number::intValue).sum();
             if (totalSites % (kfactor + 1) != 0) {
-                VoltDB.crashLocalVoltDB("Total number of sites is not divisable by the number of partitions.", false, null);
+                VoltDB.crashLocalVoltDB("Total number of sites is not divisible by the number of partitions.", false, null);
             }
             topology = AbstractTopology.getTopology(sitesPerHostMap, hostGroups, kfactor);
             String err;

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -134,12 +134,12 @@ import org.voltdb.dtxn.LatencyUncompressedHistogramStats;
 import org.voltdb.dtxn.SiteTracker;
 import org.voltdb.export.ExportManager;
 import org.voltdb.importer.ImportManager;
-import org.voltdb.iv2.MigratePartitionLeaderInfo;
 import org.voltdb.iv2.BaseInitiator;
 import org.voltdb.iv2.Cartographer;
 import org.voltdb.iv2.Initiator;
 import org.voltdb.iv2.KSafetyStats;
 import org.voltdb.iv2.LeaderAppointer;
+import org.voltdb.iv2.MigratePartitionLeaderInfo;
 import org.voltdb.iv2.MpInitiator;
 import org.voltdb.iv2.SpInitiator;
 import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
@@ -2043,6 +2043,13 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 VoltDB.crashLocalVoltDB("Total number of sites is not divisable by the number of partitions.", false, null);
             }
             topology = AbstractTopology.getTopology(sitesPerHostMap, hostGroups, kfactor);
+            String err;
+            if ((err = topology.validateLayout()) != null) {
+                hostLog.warn("Unable to find optimal replica placement layout. \n" + err);
+                hostLog.warn("If placement group is enabled, follow two rules to get better cluster availability:\n" +
+                             "   1. each placement group must have same number of nodes, and\n" +
+                             "   2. number of partition replicas (kfactor + 1) must be multiple of number of placement groups.");
+            }
             if (topology.hasMissingPartitions()) {
                 VoltDB.crashLocalVoltDB("Some partitions are missing in the topology", false, null);
             }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2051,10 +2051,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             topology = AbstractTopology.getTopology(sitesPerHostMap, hostGroups, kfactor);
             String err;
             if ((err = topology.validateLayout()) != null) {
-                hostLog.warn("Unable to find optimal replica placement layout. \n" + err);
-                hostLog.warn("If placement group is enabled, follow two rules to get better cluster availability:\n" +
-                             "   1. each placement group must have same number of nodes, and\n" +
-                             "   2. number of partition replicas (kfactor + 1) must be multiple of number of placement groups.");
+                hostLog.warn("Unable to find optimal placement layout. " + err);
+                hostLog.warn("When using placement groups, follow two rules to get better cluster availability:\n" +
+                             "   1. Each placement group must have the same number of nodes, and\n" +
+                             "   2. The number of partition replicas (kfactor + 1) must be a multiple of the number of placement groups.");
             }
             if (topology.hasMissingPartitions()) {
                 VoltDB.crashLocalVoltDB("Some partitions are missing in the topology", false, null);

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+
 import org.apache.zookeeper_voltpatches.CreateMode;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
@@ -57,6 +58,7 @@ import org.voltdb.VoltType;
 import org.voltdb.VoltZK;
 import org.voltdb.VoltZK.MailboxType;
 import org.voltdb.iv2.LeaderCache.LeaderCallBackInfo;
+
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.collect.ArrayListMultimap;
 import com.google_voltpatches.common.collect.ImmutableMap;
@@ -400,10 +402,10 @@ public class Cartographer extends StatsSource
     }
 
     /**
-     * Convenient method, given a hostId, return the hostId of its buddies (including itself) which both
-     * belong to the same partition group.
+     * Convenient method, given a set of partitionIds, return the hostId of their partition group buddies.
+     *
      * @param partitions A list of partitions that to be assigned to the newly rejoined host
-     * @return A set of host IDs (includes the given hostId) that both belong to the same partition group
+     * @return A set of host IDs that both belong to the same partition group
      */
     public Set<Integer> findPartitionGroupPeers(List<Integer> partitions) {
         Set<Integer> hostIds = Sets.newHashSet();

--- a/tests/frontend/org/voltdb/TestAbstractTopology.java
+++ b/tests/frontend/org/voltdb/TestAbstractTopology.java
@@ -36,11 +36,13 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.json_voltpatches.JSONException;
+import org.junit.Ignore;
 import org.voltdb.AbstractTopology.HAGroup;
 import org.voltdb.AbstractTopology.Host;
 import org.voltdb.AbstractTopology.HostDescription;
@@ -253,6 +255,25 @@ public class TestAbstractTopology extends TestCase {
         subTestDescription(td, false);
     }
 
+    // FIXME: For this configuration, existing algorithm can't give a answer
+    // even though the configuration is valid.
+    //
+    // Uncomment it once the problem is fixed.
+    @Ignore
+    public void testSomethingNeedsToFix() throws JSONException {
+        TestDescription td = getBoringDescription(9, 12, 3, 1, 1);
+        subTestDescription(td, true);
+
+        // Other failed configurations:
+        // Node count: 9, kfactor: 3, SPH: 12, # of racks: 1
+        // Node count: 4, kfactor: 8, SPH: 9, # of racks: 1
+        // Node count: 12, kfactor: 9, SPH: 10, # of racks: 2
+        // Node count: 32, kfactor: 7, SPH: 15, # of racks: 4
+        // Node count: 4, kfactor: 9, SPH: 20, # of racks: 2
+        // Node count: 6, kfactor: 10, SPH: 11, # of racks: 1
+        // Node count: 6, kfactor: 8, SPH: 6, # of racks: 3
+    }
+
     public void testFiveNodeK1OneRack() throws JSONException {
         TestDescription td = getBoringDescription(5, 2, 1, 1, 1);
         subTestDescription(td, true);
@@ -393,221 +414,61 @@ public class TestAbstractTopology extends TestCase {
         }
     }
 
-    public void testSixNodeK3TwoRacks() throws JSONException {
-        TestDescription td = new TestDescription();
-        int nodeCount = 6;
-        int sph = 6;
-        int k = 3;
-        td.hosts = new HostDescription[nodeCount];
-        td.hosts[0] = new HostDescription(0, sph, "0.1");
-        td.hosts[1] = new HostDescription(1, sph, "0.2");
-        td.hosts[2] = new HostDescription(2, sph, "0.3");
-        td.hosts[3] = new HostDescription(3, sph, "1.1");
-        td.hosts[4] = new HostDescription(4, sph, "1.2");
-        td.hosts[5] = new HostDescription(5, sph, "1.3");
-
-        int partitionCount = sph * nodeCount / (k + 1);
-        td.partitions = new PartitionDescription[partitionCount];
-        td.partitions[0] = new PartitionDescription(k);
-        td.partitions[1] = new PartitionDescription(k);
-        td.partitions[2] = new PartitionDescription(k);
-        td.partitions[3] = new PartitionDescription(k);
-        td.partitions[4] = new PartitionDescription(k);
-        td.partitions[5] = new PartitionDescription(k);
-        td.partitions[6] = new PartitionDescription(k);
-        td.partitions[7] = new PartitionDescription(k);
-        td.partitions[8] = new PartitionDescription(k);
-
-//        td.expectedMaxReplicationPerHAGroup = sph == 0 ? 0 : (int) Math.ceil((nodeCount / (double) (k + 1)) / leafCount);
-        td.expectedPartitionGroups = sph == 0 ? 0 : nodeCount / (k + 1);
-
-        subTestDescription(td, true);
-    }
-
-    public void testTenNodeK3TwoRacks() throws JSONException {
-        TestDescription td = new TestDescription();
-        int nodeCount = 10;
-        int sph = 6;
-        int k = 3;
-        td.hosts = new HostDescription[nodeCount];
-        td.hosts[0] = new HostDescription(0, sph, "0.1");
-        td.hosts[1] = new HostDescription(1, sph, "0.2");
-        td.hosts[2] = new HostDescription(2, sph, "0.3");
-        td.hosts[3] = new HostDescription(3, sph, "0.4");
-        td.hosts[4] = new HostDescription(4, sph, "0.5");
-        td.hosts[5] = new HostDescription(5, sph, "1.1");
-        td.hosts[6] = new HostDescription(6, sph, "1.2");
-        td.hosts[7] = new HostDescription(7, sph, "1.3");
-        td.hosts[8] = new HostDescription(8, sph, "1.4");
-        td.hosts[9] = new HostDescription(9, sph, "1.5");
-
-        int partitionCount = sph * nodeCount / (k + 1);
-        td.partitions = new PartitionDescription[partitionCount];
-        td.partitions[0] = new PartitionDescription(k);
-        td.partitions[1] = new PartitionDescription(k);
-        td.partitions[2] = new PartitionDescription(k);
-        td.partitions[3] = new PartitionDescription(k);
-        td.partitions[4] = new PartitionDescription(k);
-        td.partitions[5] = new PartitionDescription(k);
-        td.partitions[6] = new PartitionDescription(k);
-        td.partitions[7] = new PartitionDescription(k);
-        td.partitions[8] = new PartitionDescription(k);
-        td.partitions[9] = new PartitionDescription(k);
-        td.partitions[10] = new PartitionDescription(k);
-        td.partitions[11] = new PartitionDescription(k);
-        td.partitions[12] = new PartitionDescription(k);
-        td.partitions[13] = new PartitionDescription(k);
-        td.partitions[14] = new PartitionDescription(k);
-        td.expectedPartitionGroups = sph == 0 ? 0 : nodeCount / (k + 1);
-
-        subTestDescription(td, true);
-    }
-
-    public void testTenNodeK5TwoRacks() throws JSONException {
-        TestDescription td = new TestDescription();
-        int nodeCount = 10;
-        int sph = 6;
-        int k = 5;
-        td.hosts = new HostDescription[nodeCount];
-        td.hosts[0] = new HostDescription(0, sph, "0");
-        td.hosts[1] = new HostDescription(1, sph, "0");
-        td.hosts[2] = new HostDescription(2, sph, "0");
-        td.hosts[3] = new HostDescription(3, sph, "0");
-        td.hosts[4] = new HostDescription(4, sph, "0");
-        td.hosts[5] = new HostDescription(5, sph, "1");
-        td.hosts[6] = new HostDescription(6, sph, "1");
-        td.hosts[7] = new HostDescription(7, sph, "1");
-        td.hosts[8] = new HostDescription(8, sph, "1");
-        td.hosts[9] = new HostDescription(9, sph, "1");
-
-        int partitionCount = sph * nodeCount / (k + 1);
-        td.partitions = new PartitionDescription[partitionCount];
-        td.partitions[0] = new PartitionDescription(k);
-        td.partitions[1] = new PartitionDescription(k);
-        td.partitions[2] = new PartitionDescription(k);
-        td.partitions[3] = new PartitionDescription(k);
-        td.partitions[4] = new PartitionDescription(k);
-        td.partitions[5] = new PartitionDescription(k);
-        td.partitions[6] = new PartitionDescription(k);
-        td.partitions[7] = new PartitionDescription(k);
-        td.partitions[8] = new PartitionDescription(k);
-        td.partitions[9] = new PartitionDescription(k);
-        td.expectedPartitionGroups = sph == 0 ? 0 : nodeCount / (k + 1);
-
-        subTestDescription(td, true);
-    }
-
-    public void testTwelveNodeK5ThreeRacks() throws JSONException {
-        TestDescription td = new TestDescription();
-        int nodeCount = 12;
-        int sph = 12;
-        int k = 5;
-        td.hosts = new HostDescription[nodeCount];
-        // n12 k5 sph12 rack 3
-        td.hosts[0] = new HostDescription(0, sph, "0");
-        td.hosts[1] = new HostDescription(1, sph, "0");
-        td.hosts[2] = new HostDescription(2, sph, "0");
-        td.hosts[3] = new HostDescription(3, sph, "0");
-        td.hosts[4] = new HostDescription(4, sph, "1");
-        td.hosts[5] = new HostDescription(5, sph, "1");
-        td.hosts[6] = new HostDescription(6, sph, "1");
-        td.hosts[7] = new HostDescription(7, sph, "1");
-        td.hosts[8] = new HostDescription(8, sph, "2");
-        td.hosts[9] = new HostDescription(9, sph, "2");
-        td.hosts[10] = new HostDescription(10, sph, "2");
-        td.hosts[11] = new HostDescription(11, sph, "2");
-
-        int partitionCount = sph * nodeCount / (k + 1);
-        td.partitions = new PartitionDescription[partitionCount];
-        td.partitions[0] = new PartitionDescription(k);
-        td.partitions[1] = new PartitionDescription(k);
-        td.partitions[2] = new PartitionDescription(k);
-        td.partitions[3] = new PartitionDescription(k);
-        td.partitions[4] = new PartitionDescription(k);
-        td.partitions[5] = new PartitionDescription(k);
-        td.partitions[6] = new PartitionDescription(k);
-        td.partitions[7] = new PartitionDescription(k);
-        td.partitions[8] = new PartitionDescription(k);
-        td.partitions[9] = new PartitionDescription(k);
-        td.partitions[10] = new PartitionDescription(k);
-        td.partitions[11] = new PartitionDescription(k);
-        td.partitions[12] = new PartitionDescription(k);
-        td.partitions[13] = new PartitionDescription(k);
-        td.partitions[14] = new PartitionDescription(k);
-        td.partitions[15] = new PartitionDescription(k);
-        td.partitions[16] = new PartitionDescription(k);
-        td.partitions[17] = new PartitionDescription(k);
-        td.partitions[18] = new PartitionDescription(k);
-        td.partitions[19] = new PartitionDescription(k);
-        td.partitions[20] = new PartitionDescription(k);
-        td.partitions[21] = new PartitionDescription(k);
-        td.partitions[22] = new PartitionDescription(k);
-        td.partitions[23] = new PartitionDescription(k);
-        td.expectedPartitionGroups = sph == 0 ? 0 : nodeCount / (k + 1);
-
-        AbstractTopology topo = subTestDescription(td, true);
-
-        // kill and rejoin a host
-        HostDescription hostDescription = td.hosts[0];
-        try {
-            topo = AbstractTopology.mutateRemoveHost(topo, hostDescription.hostId);
-        } catch (KSafetyViolationException e) {
-            e.printStackTrace();
-            fail();
+    public void testRandomHAGroups() throws JSONException {
+        for (int i = 0; i < 100; i++) {
+            runRandomHAGroupsTest();
         }
-        //System.out.printf("TOPO MID: %s\n", topo.topologyToJSON());
-        topo = AbstractTopology.mutateRejoinHost(topo, hostDescription);
-
-        System.out.println(topo.topologyToJSON());
     }
 
-    public void testNineNodeK2ThreeRacks() throws JSONException {
+    // Generate random but valid configurations feature partition both grouping
+    // and rack-aware grouping.
+    // A valid configuration means:
+    // 1) each rack contains same number of nodes,
+    // 2) number of replica copies is divisible by number of racks.
+    private void runRandomHAGroupsTest() throws JSONException {
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        final int MAX_RACKS = 5;
+        final int MAX_RACK_NODES = 10;
+        final int MAX_K = 10;
+        final int MAX_PARTITIONS = 20;
+        int rackCount = r.nextInt(MAX_RACKS) + 1; // [1-5]
+        int rackNodeCount = r.nextInt(MAX_RACK_NODES) + 1; // [1-10]
+        int totalNodeCount = rackNodeCount * rackCount;
+        int k;
+        do {
+            k = r.nextInt(rackCount - 1, MAX_K + 1);  // [rackCount - 1, 10]
+        } while ((k + 1) % rackCount != 0);
+        int sph;
+        do {
+            sph = r.nextInt(MAX_PARTITIONS) + 1; // [1-20]
+        } while ((totalNodeCount * sph) % (k + 1) != 0);
+        //////////////////////////////////////////////////////////////////////////
+        System.out.println(
+                String.format("Node count: %d, kfactor: %d, SPH: %d, # of racks: %d",
+                              totalNodeCount, k, sph, rackCount));
+        //////////////////////////////////////////////////////////////////////////
+        // treeWidth > 1 means the group contains subgroup
+        List<String> haGroups = getHAGroupTagTree(1, rackCount);
         TestDescription td = new TestDescription();
-        int nodeCount = 9;
-        int sph = 4;
-        int k = 2;
-        td.hosts = new HostDescription[nodeCount];
-        // n9 k2 sph4 rack 3
-        td.hosts[0] = new HostDescription(0, sph, "0");
-        td.hosts[1] = new HostDescription(1, sph, "0");
-        td.hosts[2] = new HostDescription(2, sph, "0");
-        td.hosts[3] = new HostDescription(3, sph, "1");
-        td.hosts[4] = new HostDescription(4, sph, "1");
-        td.hosts[5] = new HostDescription(5, sph, "1");
-        td.hosts[6] = new HostDescription(6, sph, "2");
-        td.hosts[7] = new HostDescription(7, sph, "2");
-        td.hosts[8] = new HostDescription(8, sph, "2");
-
-        int partitionCount = sph * nodeCount / (k + 1);
-        td.partitions = new PartitionDescription[partitionCount];
-        td.partitions[0] = new PartitionDescription(k);
-        td.partitions[1] = new PartitionDescription(k);
-        td.partitions[2] = new PartitionDescription(k);
-        td.partitions[3] = new PartitionDescription(k);
-        td.partitions[4] = new PartitionDescription(k);
-        td.partitions[5] = new PartitionDescription(k);
-        td.partitions[6] = new PartitionDescription(k);
-        td.partitions[7] = new PartitionDescription(k);
-        td.partitions[8] = new PartitionDescription(k);
-        td.partitions[9] = new PartitionDescription(k);
-        td.partitions[10] = new PartitionDescription(k);
-        td.partitions[11] = new PartitionDescription(k);
-        td.expectedPartitionGroups = sph == 0 ? 0 : nodeCount / (k + 1);
-
-        AbstractTopology topo = subTestDescription(td, true);
-
-        // kill and rejoin a host
-        HostDescription hostDescription = td.hosts[0];
-        try {
-            topo = AbstractTopology.mutateRemoveHost(topo, hostDescription.hostId);
-        } catch (KSafetyViolationException e) {
-            e.printStackTrace();
-            fail();
+        td.hosts = new HostDescription[totalNodeCount];
+        for (int i = 0; i < totalNodeCount; i++) {
+            td.hosts[i] = new HostDescription(i, sph, haGroups.get(i % haGroups.size()));
         }
-        //System.out.printf("TOPO MID: %s\n", topo.topologyToJSON());
-        topo = AbstractTopology.mutateRejoinHost(topo, hostDescription);
+        int partitionCount = sph * totalNodeCount / (k + 1);
+        td.partitions = new PartitionDescription[partitionCount];
+        for (int i = 0; i < partitionCount; i++) {
+            td.partitions[i] = new PartitionDescription(k);
+        }
+        td.expectedPartitionGroups = sph == 0 ? 0 : totalNodeCount / (k + 1);
+        AbstractTopology topo = subTestDescription(td, false);
 
-        System.out.println(topo.topologyToJSON());
+        // see if partition layout is balanced
+        String err;
+        if ((err = topo.validateLayout()) != null) {
+            System.out.println(err);
+            System.out.println(topo.topologyToJSON());
+        }
+        assertTrue(err == null); // expect balanced layout
     }
 
     private List<String> getHAGroupTagTree(int treeWidth, int leafCount) {
@@ -729,7 +590,7 @@ public class TestAbstractTopology extends TestCase {
         metrics.testTimeMS = end - start;
         metrics.topoTomeMS = subEnd - start;
 
-        System.out.println(metrics.toString());
+        if (print) System.out.println(metrics.toString());
 
         //assertEquals(td.expectedMaxReplicationPerHAGroup, metrics.maxReplicationPerHAGroup);
         assertTrue(metrics.distinctPeerGroups <= td.expectedPartitionGroups);

--- a/tests/frontend/org/voltdb/TestAbstractTopology.java
+++ b/tests/frontend/org/voltdb/TestAbstractTopology.java
@@ -393,6 +393,223 @@ public class TestAbstractTopology extends TestCase {
         }
     }
 
+    public void testSixNodeK3TwoRacks() throws JSONException {
+        TestDescription td = new TestDescription();
+        int nodeCount = 6;
+        int sph = 6;
+        int k = 3;
+        td.hosts = new HostDescription[nodeCount];
+        td.hosts[0] = new HostDescription(0, sph, "0.1");
+        td.hosts[1] = new HostDescription(1, sph, "0.2");
+        td.hosts[2] = new HostDescription(2, sph, "0.3");
+        td.hosts[3] = new HostDescription(3, sph, "1.1");
+        td.hosts[4] = new HostDescription(4, sph, "1.2");
+        td.hosts[5] = new HostDescription(5, sph, "1.3");
+
+        int partitionCount = sph * nodeCount / (k + 1);
+        td.partitions = new PartitionDescription[partitionCount];
+        td.partitions[0] = new PartitionDescription(k);
+        td.partitions[1] = new PartitionDescription(k);
+        td.partitions[2] = new PartitionDescription(k);
+        td.partitions[3] = new PartitionDescription(k);
+        td.partitions[4] = new PartitionDescription(k);
+        td.partitions[5] = new PartitionDescription(k);
+        td.partitions[6] = new PartitionDescription(k);
+        td.partitions[7] = new PartitionDescription(k);
+        td.partitions[8] = new PartitionDescription(k);
+
+//        td.expectedMaxReplicationPerHAGroup = sph == 0 ? 0 : (int) Math.ceil((nodeCount / (double) (k + 1)) / leafCount);
+        td.expectedPartitionGroups = sph == 0 ? 0 : nodeCount / (k + 1);
+
+        subTestDescription(td, true);
+    }
+
+    public void testTenNodeK3TwoRacks() throws JSONException {
+        TestDescription td = new TestDescription();
+        int nodeCount = 10;
+        int sph = 6;
+        int k = 3;
+        td.hosts = new HostDescription[nodeCount];
+        td.hosts[0] = new HostDescription(0, sph, "0.1");
+        td.hosts[1] = new HostDescription(1, sph, "0.2");
+        td.hosts[2] = new HostDescription(2, sph, "0.3");
+        td.hosts[3] = new HostDescription(3, sph, "0.4");
+        td.hosts[4] = new HostDescription(4, sph, "0.5");
+        td.hosts[5] = new HostDescription(5, sph, "1.1");
+        td.hosts[6] = new HostDescription(6, sph, "1.2");
+        td.hosts[7] = new HostDescription(7, sph, "1.3");
+        td.hosts[8] = new HostDescription(8, sph, "1.4");
+        td.hosts[9] = new HostDescription(9, sph, "1.5");
+
+        int partitionCount = sph * nodeCount / (k + 1);
+        td.partitions = new PartitionDescription[partitionCount];
+        td.partitions[0] = new PartitionDescription(k);
+        td.partitions[1] = new PartitionDescription(k);
+        td.partitions[2] = new PartitionDescription(k);
+        td.partitions[3] = new PartitionDescription(k);
+        td.partitions[4] = new PartitionDescription(k);
+        td.partitions[5] = new PartitionDescription(k);
+        td.partitions[6] = new PartitionDescription(k);
+        td.partitions[7] = new PartitionDescription(k);
+        td.partitions[8] = new PartitionDescription(k);
+        td.partitions[9] = new PartitionDescription(k);
+        td.partitions[10] = new PartitionDescription(k);
+        td.partitions[11] = new PartitionDescription(k);
+        td.partitions[12] = new PartitionDescription(k);
+        td.partitions[13] = new PartitionDescription(k);
+        td.partitions[14] = new PartitionDescription(k);
+        td.expectedPartitionGroups = sph == 0 ? 0 : nodeCount / (k + 1);
+
+        subTestDescription(td, true);
+    }
+
+    public void testTenNodeK5TwoRacks() throws JSONException {
+        TestDescription td = new TestDescription();
+        int nodeCount = 10;
+        int sph = 6;
+        int k = 5;
+        td.hosts = new HostDescription[nodeCount];
+        td.hosts[0] = new HostDescription(0, sph, "0");
+        td.hosts[1] = new HostDescription(1, sph, "0");
+        td.hosts[2] = new HostDescription(2, sph, "0");
+        td.hosts[3] = new HostDescription(3, sph, "0");
+        td.hosts[4] = new HostDescription(4, sph, "0");
+        td.hosts[5] = new HostDescription(5, sph, "1");
+        td.hosts[6] = new HostDescription(6, sph, "1");
+        td.hosts[7] = new HostDescription(7, sph, "1");
+        td.hosts[8] = new HostDescription(8, sph, "1");
+        td.hosts[9] = new HostDescription(9, sph, "1");
+
+        int partitionCount = sph * nodeCount / (k + 1);
+        td.partitions = new PartitionDescription[partitionCount];
+        td.partitions[0] = new PartitionDescription(k);
+        td.partitions[1] = new PartitionDescription(k);
+        td.partitions[2] = new PartitionDescription(k);
+        td.partitions[3] = new PartitionDescription(k);
+        td.partitions[4] = new PartitionDescription(k);
+        td.partitions[5] = new PartitionDescription(k);
+        td.partitions[6] = new PartitionDescription(k);
+        td.partitions[7] = new PartitionDescription(k);
+        td.partitions[8] = new PartitionDescription(k);
+        td.partitions[9] = new PartitionDescription(k);
+        td.expectedPartitionGroups = sph == 0 ? 0 : nodeCount / (k + 1);
+
+        subTestDescription(td, true);
+    }
+
+    public void testTwelveNodeK5ThreeRacks() throws JSONException {
+        TestDescription td = new TestDescription();
+        int nodeCount = 12;
+        int sph = 12;
+        int k = 5;
+        td.hosts = new HostDescription[nodeCount];
+        // n12 k5 sph12 rack 3
+        td.hosts[0] = new HostDescription(0, sph, "0");
+        td.hosts[1] = new HostDescription(1, sph, "0");
+        td.hosts[2] = new HostDescription(2, sph, "0");
+        td.hosts[3] = new HostDescription(3, sph, "0");
+        td.hosts[4] = new HostDescription(4, sph, "1");
+        td.hosts[5] = new HostDescription(5, sph, "1");
+        td.hosts[6] = new HostDescription(6, sph, "1");
+        td.hosts[7] = new HostDescription(7, sph, "1");
+        td.hosts[8] = new HostDescription(8, sph, "2");
+        td.hosts[9] = new HostDescription(9, sph, "2");
+        td.hosts[10] = new HostDescription(10, sph, "2");
+        td.hosts[11] = new HostDescription(11, sph, "2");
+
+        int partitionCount = sph * nodeCount / (k + 1);
+        td.partitions = new PartitionDescription[partitionCount];
+        td.partitions[0] = new PartitionDescription(k);
+        td.partitions[1] = new PartitionDescription(k);
+        td.partitions[2] = new PartitionDescription(k);
+        td.partitions[3] = new PartitionDescription(k);
+        td.partitions[4] = new PartitionDescription(k);
+        td.partitions[5] = new PartitionDescription(k);
+        td.partitions[6] = new PartitionDescription(k);
+        td.partitions[7] = new PartitionDescription(k);
+        td.partitions[8] = new PartitionDescription(k);
+        td.partitions[9] = new PartitionDescription(k);
+        td.partitions[10] = new PartitionDescription(k);
+        td.partitions[11] = new PartitionDescription(k);
+        td.partitions[12] = new PartitionDescription(k);
+        td.partitions[13] = new PartitionDescription(k);
+        td.partitions[14] = new PartitionDescription(k);
+        td.partitions[15] = new PartitionDescription(k);
+        td.partitions[16] = new PartitionDescription(k);
+        td.partitions[17] = new PartitionDescription(k);
+        td.partitions[18] = new PartitionDescription(k);
+        td.partitions[19] = new PartitionDescription(k);
+        td.partitions[20] = new PartitionDescription(k);
+        td.partitions[21] = new PartitionDescription(k);
+        td.partitions[22] = new PartitionDescription(k);
+        td.partitions[23] = new PartitionDescription(k);
+        td.expectedPartitionGroups = sph == 0 ? 0 : nodeCount / (k + 1);
+
+        AbstractTopology topo = subTestDescription(td, true);
+
+        // kill and rejoin a host
+        HostDescription hostDescription = td.hosts[0];
+        try {
+            topo = AbstractTopology.mutateRemoveHost(topo, hostDescription.hostId);
+        } catch (KSafetyViolationException e) {
+            e.printStackTrace();
+            fail();
+        }
+        //System.out.printf("TOPO MID: %s\n", topo.topologyToJSON());
+        topo = AbstractTopology.mutateRejoinHost(topo, hostDescription);
+
+        System.out.println(topo.topologyToJSON());
+    }
+
+    public void testNineNodeK2ThreeRacks() throws JSONException {
+        TestDescription td = new TestDescription();
+        int nodeCount = 9;
+        int sph = 4;
+        int k = 2;
+        td.hosts = new HostDescription[nodeCount];
+        // n9 k2 sph4 rack 3
+        td.hosts[0] = new HostDescription(0, sph, "0");
+        td.hosts[1] = new HostDescription(1, sph, "0");
+        td.hosts[2] = new HostDescription(2, sph, "0");
+        td.hosts[3] = new HostDescription(3, sph, "1");
+        td.hosts[4] = new HostDescription(4, sph, "1");
+        td.hosts[5] = new HostDescription(5, sph, "1");
+        td.hosts[6] = new HostDescription(6, sph, "2");
+        td.hosts[7] = new HostDescription(7, sph, "2");
+        td.hosts[8] = new HostDescription(8, sph, "2");
+
+        int partitionCount = sph * nodeCount / (k + 1);
+        td.partitions = new PartitionDescription[partitionCount];
+        td.partitions[0] = new PartitionDescription(k);
+        td.partitions[1] = new PartitionDescription(k);
+        td.partitions[2] = new PartitionDescription(k);
+        td.partitions[3] = new PartitionDescription(k);
+        td.partitions[4] = new PartitionDescription(k);
+        td.partitions[5] = new PartitionDescription(k);
+        td.partitions[6] = new PartitionDescription(k);
+        td.partitions[7] = new PartitionDescription(k);
+        td.partitions[8] = new PartitionDescription(k);
+        td.partitions[9] = new PartitionDescription(k);
+        td.partitions[10] = new PartitionDescription(k);
+        td.partitions[11] = new PartitionDescription(k);
+        td.expectedPartitionGroups = sph == 0 ? 0 : nodeCount / (k + 1);
+
+        AbstractTopology topo = subTestDescription(td, true);
+
+        // kill and rejoin a host
+        HostDescription hostDescription = td.hosts[0];
+        try {
+            topo = AbstractTopology.mutateRemoveHost(topo, hostDescription.hostId);
+        } catch (KSafetyViolationException e) {
+            e.printStackTrace();
+            fail();
+        }
+        //System.out.printf("TOPO MID: %s\n", topo.topologyToJSON());
+        topo = AbstractTopology.mutateRejoinHost(topo, hostDescription);
+
+        System.out.println(topo.topologyToJSON());
+    }
+
     private List<String> getHAGroupTagTree(int treeWidth, int leafCount) {
         // create a set of ha group paths
         List<String> haGroupTags = new ArrayList<>();
@@ -533,10 +750,9 @@ public class TestAbstractTopology extends TestCase {
 
         k = rand.nextInt(MAX_K + 1);
 
-        do { hostCount = rand.nextInt(MAX_NODE_COUNT + 1); }
-        while (hostCount % (k + 1) != 0);
+        hostCount = rand.nextInt(MAX_NODE_COUNT) + 1;
 
-        do { sph = rand.nextInt(MAX_SPH + 1); }
+        do { sph = rand.nextInt(MAX_SPH) + 1; }
         while ((sph * hostCount) % (k + 1) != 0);
 
         ArrayList<Integer> leafOptions = new ArrayList<>();


### PR DESCRIPTION
In v6.9 and later versions partition group partitioning is the default partitioning algorithm, however it fails to generate valid partition layout for certain rack-aware group configurations. This patch fixes the issue* with two new preconditions**:

1.  each rack should contains equal number of nodes, e.g. 9-node cluster with 3 racks, each rack should have 3 nodes.
2. number of racks should be divisible to number of partition replicas (equals K + 1). For example, k=1 cluster supports at most 2 racks, k=5 cluster supports rack size 1, 2, 3, 6.

*Subgrouping is still supported but not encouraged, an unique identifier for every node belong to the same rack is enough, for example, "0" or "a" or "rack1".

**If preconditions are not met, partitioning algorithm still try its best to make a viable partition assignment, but there is no guarantee on whether rack-awareness is satisfied.

  