### PR TITLE
ENG-13543_fix_python2.7_required

### DIFF
--- a/bin/voltdb
+++ b/bin/voltdb
@@ -36,15 +36,15 @@
 import sys
 import os
 try:
-    # ensure version 2.6+ of python
-    if sys.version_info[0] == 2 and sys.version_info[1] < 6:
+    # ensure version 2.7+ of python
+    if sys.version_info[0] == 2 and sys.version_info[1] < 7:
         for dir in os.environ['PATH'].split(':'):
-            for name in ('python2.7', 'python2.6'):
+            for name in ['python2.7']:
                 path = os.path.join(dir, name)
-                if os.path.exists(path):
+                if os.path.isfile(path):
                     print 'Re-running with %s...' % path
                     os.execv(path, [path] + sys.argv)
-        sys.stderr.write("This script requires Python 2.6 or newer. Please install " +
+        sys.stderr.write("This script requires Python 2.7 or newer. Please install " +
                          "a more recent Python release and retry.\n")
         sys.exit(-1)
 


### PR DESCRIPTION
make bin/voltdb require and find python2.7 instead of python2.6. A recent change to voltdbclient.py, which is imported here, made it dependent on python2.7. I discussed with JH a few different ways around this, including, restoring the old voltdbclient.py, or shipping it along side the new one. Another way to fix all this, and maybe a better way, is just to specify #!/usr/bin/env python2.7.