### PR TITLE
Fix ENG13540 and ENG13534.

### DIFF
--- a/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
@@ -81,7 +81,7 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
         m_scalarExprType = m_valueType;
         if (m_subquery.getOutputSchema().size() == 1) {
             // potential scalar sub-query
-            m_scalarExprType = m_subquery.getOutputSchema().getColumn(0).getType();
+            m_scalarExprType = m_subquery.getOutputSchema().getColumn(0).getValueType();
         }
     }
 

--- a/src/frontend/org/voltdb/expressions/TupleValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/TupleValueExpression.java
@@ -289,8 +289,8 @@ public class TupleValueExpression extends AbstractValueExpression {
     }
 
     public void setTypeSizeAndInBytes(SchemaColumn typeSource) {
-        setValueType(typeSource.getType());
-        setValueSize(typeSource.getSize());
+        setValueType(typeSource.getValueType());
+        setValueSize(typeSource.getValueSize());
         m_inBytes = typeSource.getExpression().getInBytes();
     }
 

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtCommonTableScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtCommonTableScan.java
@@ -247,7 +247,8 @@ public class StmtCommonTableScan extends StmtEphemeralTableScan {
         if (recursiveSchema != null) {
             // Widen the current schema to the recursive
             // schema if necessary as well.
-            changedCurrent = changedCurrent || currentSchema.harmonize(recursiveSchema, "Recursive Query");
+            boolean changedRec = currentSchema.harmonize(recursiveSchema, "Recursive Query");
+            changedCurrent = changedCurrent || changedRec;
         }
         // Then change the base and current
         // schemas.

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -563,8 +563,8 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
             }
             AbstractPlanNode childProj = child.getInlinePlanNode(PlanNodeType.PROJECTION);
             if (childProj != null) {
+                AbstractPlanNode schemaSrc = null;
                 AbstractPlanNode inlineInsertNode = childProj.getInlinePlanNode(PlanNodeType.INSERT);
-                AbstractPlanNode schemaSrc;
                 if (inlineInsertNode != null) {
                     schemaSrc = inlineInsertNode;
                 } else {
@@ -585,13 +585,19 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         }
         // Trace back the chain of parents and reset the
         // output schemas of the parent.  These will all be
-        // exactly the same.
+        // exactly the same.  Note that the source of the
+        // schema may be an inline plan node.  So we need
+        // to set the child's output schema to be the answer.
+        // If the schema source is the child node itself, this will
+        // set the the output schema to itself, so no harm
+        // will be done.
         if (resetBack) {
-            for (AbstractPlanNode parent = (child.getParentCount() == 0) ? null : child.getParent(0);
-                    parent != null;
-                    parent = (parent.getParentCount() == 0) ? null : parent.getParent(0)) {
-                parent.setOutputSchema(answer);
-            }
+            do {
+                if (! child.m_hasSignificantOutputSchema) {
+                    child.setOutputSchema(answer);
+                }
+                child = (child.getParentCount() == 0) ? null : child.getParent(0);
+            } while (child != null);
         }
         return answer;
     }

--- a/src/frontend/org/voltdb/plannodes/NodeSchema.java
+++ b/src/frontend/org/voltdb/plannodes/NodeSchema.java
@@ -404,10 +404,10 @@ public class NodeSchema implements Iterable<SchemaColumn> {
         }
         boolean changedSomething = false;
         for (int idx = 0; idx < size(); idx += 1) {
-            SchemaColumn mine = getColumn(idx);
-            SchemaColumn others = otherSchema.getColumn(idx);
-            VoltType myType = mine.getType();
-            VoltType otherType = others.getType();
+            SchemaColumn myColumn = getColumn(idx);
+            SchemaColumn otherColumn = otherSchema.getColumn(idx);
+            VoltType myType = myColumn.getValueType();
+            VoltType otherType = otherColumn.getValueType();
             VoltType commonType = myType;
             if (! myType.canExactlyRepresentAnyValueOf(otherType)) {
                 if (otherType.canExactlyRepresentAnyValueOf(myType)) {
@@ -424,14 +424,26 @@ public class NodeSchema implements Iterable<SchemaColumn> {
             }
             if (myType != commonType) {
                 changedSomething = true;
-                mine.getExpression().setValueType(commonType);
+                myColumn.setValueType(commonType);
             }
-            int mySize = mine.getSize();
-            int otherSize = others.getSize();
+            int mySize;
+            int otherSize;
+            if (! myType.isVariableLength()) {
+                mySize = myType.getLengthInBytesForFixedTypesWithoutCheck();
+            }
+            else {
+                mySize = myColumn.getValueSize();
+            }
+            if (! otherType.isVariableLength()) {
+                otherSize = otherType.getLengthInBytesForFixedTypesWithoutCheck();
+            }
+            else {
+                otherSize = otherColumn.getValueSize();
+            }
             int commonSize = Math.max(mySize, otherSize);
             if (commonSize != mySize) {
                 changedSomething = true;
-                mine.getExpression().setValueSize(commonSize);
+                myColumn.setValueSize(commonSize);
             }
         }
         return changedSomething;

--- a/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
@@ -194,7 +194,7 @@ public class ProjectionPlanNode extends AbstractPlanNode {
         for (int idx = 0; idx < outputSchema.size(); idx += 1) {
             SchemaColumn col = outputSchema.getColumn(idx);
             SchemaColumn childCol = childSchema.getColumn(idx);
-            if (col.getType() != childCol.getType()) {
+            if (col.getValueType() != childCol.getValueType()) {
                 return false;
             }
             if ( ! (col.getExpression() instanceof TupleValueExpression)) {
@@ -228,7 +228,7 @@ public class ProjectionPlanNode extends AbstractPlanNode {
         for (int idx = 0; idx < childSchema.size(); idx += 1) {
             SchemaColumn cCol = childSchema.getColumn(idx);
             SchemaColumn myCol = mySchema.getColumn(idx);
-            assert(cCol.getType() == myCol.getType());
+            assert(cCol.getValueType() == myCol.getValueType());
             assert(cCol.getExpression() instanceof TupleValueExpression);
             assert(myCol.getExpression() instanceof TupleValueExpression);
             cCol.reset(myCol.getTableName(),

--- a/src/frontend/org/voltdb/plannodes/SchemaColumn.java
+++ b/src/frontend/org/voltdb/plannodes/SchemaColumn.java
@@ -240,9 +240,13 @@ public class SchemaColumn {
 
     public AbstractExpression getExpression() { return m_expression; }
 
-    public VoltType getType() { return m_expression.getValueType(); }
+    public VoltType getValueType() { return m_expression.getValueType(); }
 
-    public int getSize() { return m_expression.getValueSize(); }
+    public void setValueType(VoltType type) { m_expression.setValueType(type); }
+
+    public int getValueSize() { return m_expression.getValueSize(); }
+
+    public void setValueSize(int size) { m_expression.setValueSize(size); }
 
     /**
      * Return the differentiator that can distinguish columns with the same name.
@@ -333,7 +337,12 @@ public class SchemaColumn {
         if (m_expression != null) {
             str += " expr: (";
             if (m_expression.getValueType() != null) {
-                str += "[" + m_expression.getValueType().toSQLString() + "] ";
+                VoltType vt = m_expression.getValueType();
+                String typeStr = vt.toSQLString();
+                if (vt.isVariableLength()) {
+                    typeStr += "(" + m_expression.getValueSize() + ")";
+                }
+                str += "[" + typeStr + "] ";
             }
             else {
                 str += "[!!! value type:NULL !!!] ";

--- a/src/frontend/org/voltdb/plannodes/UnionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/UnionPlanNode.java
@@ -88,7 +88,7 @@ public class UnionPlanNode extends AbstractPlanNode {
                 throw new RuntimeException("Column number mismatch detected in rows of UNION");
             }
             for (int j = 0; j < m_outputSchema.size(); ++j) {
-                if (m_outputSchema.getColumn(j).getType() != schema.getColumn(j).getType()) {
+                if (m_outputSchema.getColumn(j).getValueType() != schema.getColumn(j).getValueType()) {
                     throw new PlanningErrorException("Incompatible data types in UNION");
                 }
             }

--- a/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
@@ -846,8 +846,8 @@ public class TestPlansInExistsSubQueries extends PlannerTestCase {
         for (int i = 0; i < ns.size(); ++i) {
             SchemaColumn col = ns.getColumn(i);
             assertEquals(columns[i], col.getColumnName());
-            assertEquals(4, col.getSize());
-            assertEquals(VoltType.INTEGER, col.getType());
+            assertEquals(4, col.getValueSize());
+            assertEquals(VoltType.INTEGER, col.getValueType());
             assertTrue(col.getExpression() instanceof TupleValueExpression);
             assertTrue(((TupleValueExpression)col.getExpression()).getColumnIndex() != -1);
         }

--- a/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
@@ -2647,7 +2647,7 @@ public class TestPlansSubQueries extends PlannerTestCase {
         String sql = "select C1 from ( select cast(a as varchar), c as c1 from r5 ) as SQ where SQ.C1 < 0;";
     AbstractPlanNode pn = compile(sql);
     assertNotNull(pn);
-    VoltType vt = pn.getOutputSchema().getColumn(0).getType();
+    VoltType vt = pn.getOutputSchema().getColumn(0).getValueType();
     assert(VoltType.INTEGER.equals(vt));
     }
 }


### PR DESCRIPTION
The logic for updating output schemas for sequential scan nodes
with CTEs was incorrect.  I also changed SchemaColumn.getType()
to be SchemaColumn.getValueType() to make the names more similar to
the names in the AbstractExpression they are based on.