### PR TITLE
ENG-13561: fix the NPE when stopping the KafkaStreamImpoter

### DIFF
--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
@@ -143,9 +143,14 @@ public class KafkaStreamImporter extends AbstractImporter {
 
     @Override
     public void stop() {
-        for (KafkaInternalConsumerRunner consumer : m_consumers) {
-            consumer.shutdown();
+        if (m_consumers != null) {
+            for (KafkaInternalConsumerRunner consumer : m_consumers) {
+                if (consumer != null) {
+                    consumer.shutdown();
+                }
+            }
         }
+
         if (m_executorService != null) {
             try {
                 m_executorService.shutdownNow();


### PR DESCRIPTION
System test see NPE with stack trace:
2018-01-11 03:44:11,494   WARN  [ImportProcessor] ImporterTypeManager: Error trying to stop importer resource ID kafka://volt14b_9092_volt14e_9092/partitioned_export_replicated_export/voltdb
java.lang.NullPointerException
	at org.voltdb.importclient.kafka10.KafkaStreamImporter.stop(KafkaStreamImporter.java:146)
	at org.voltdb.importer.AbstractImporter.stopImporter(AbstractImporter.java:129)
	at org.voltdb.importer.ImporterLifeCycleManager.stopImporters(ImporterLifeCycleManager.java:285)
	at org.voltdb.importer.ImporterLifeCycleManager.stop(ImporterLifeCycleManager.java:264)
	at org.voltdb.importer.ImportProcessor$ImporterWrapper.stop(ImportProcessor.java:84)
	at org.voltdb.importer.ImportProcessor$2.run(ImportProcessor.java:131)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
