### PR TITLE
ENG-13549 and ENG-13577: Fixes for CTE bugs

### DIFF
--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -332,14 +332,22 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
     }
 
     private void toStringHelper(String linePrefix, StringBuilder sb) {
-        String header = getExpressionNodeNameForToString() + " [" + getExpressionType().toString() + "] : ";
+        sb.append(linePrefix);
+        sb.append(getExpressionNodeNameForToString() + " [" + getExpressionType().toString() + "] : ");
         if (m_valueType != null) {
-            header += m_valueType.toSQLString();
+            sb.append(m_valueType.toSQLString());
+            if (m_valueType.isVariableLength()) {
+                sb.append("(" + m_valueSize);
+                if (m_valueType == VoltType.STRING) {
+                    sb.append(m_inBytes ? " bytes" : " chars");
+                }
+                sb.append(")");
+            }
         }
         else {
-            header += "[null type]";
+            sb.append("[null type]");
         }
-        sb.append(linePrefix + header + "\n");
+        sb.append("\n");
 
         if (m_left != null) {
             sb.append(linePrefix + "Left:\n");

--- a/src/frontend/org/voltdb/expressions/AggregateExpression.java
+++ b/src/frontend/org/voltdb/expressions/AggregateExpression.java
@@ -101,6 +101,7 @@ public class AggregateExpression extends AbstractExpression {
             assert(aggArg != null);
             expr.m_valueType = aggArg.getValueType();
             expr.m_valueSize = aggArg.getValueSize();
+            expr.m_inBytes = aggArg.getInBytes();
             // Of these aggregate functions, only AVG is
             // non-deterministic on floating point types.
             if (expr.m_valueType == VoltType.FLOAT && type == ExpressionType.AGGREGATE_AVG) {

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -2386,8 +2386,7 @@ public class PlanAssembler {
     private static AbstractPlanNode findSeqScanCandidateForGroupBy(
             AbstractPlanNode candidate) {
         if (candidate.getPlanNodeType() == PlanNodeType.SEQSCAN &&
-                ! candidate.isSubQuery() &&
-                ! ((AbstractScanPlanNode)candidate).isCommonTableScan()) {
+                ((AbstractScanPlanNode)candidate).isPersistentTableScan()) {
             // scan on sub-query does not support index, early exit here
             // In future, support sub-query edge cases.
             return candidate;
@@ -2841,8 +2840,8 @@ public class PlanAssembler {
     // Turn sequential scan to index scan for group by if possible
     private AbstractPlanNode indexAccessForGroupByExprs(SeqScanPlanNode root,
             IndexGroupByInfo gbInfo) {
-        if (root.isSubQuery()) {
-            // sub-query edge case will not be handled now
+        if (! root.isPersistentTableScan()) {
+            // subquery and common tables are not handled
             return root;
         }
 

--- a/src/frontend/org/voltdb/planner/ScanDeterminizer.java
+++ b/src/frontend/org/voltdb/planner/ScanDeterminizer.java
@@ -90,8 +90,8 @@ public class ScanDeterminizer {
         }
         SeqScanPlanNode scanNode = (SeqScanPlanNode) plan;
 
-        if (scanNode.isSubQuery()) {
-            // This is a sub-query and can't have indexes
+        if (! scanNode.isPersistentTableScan()) {
+            // This is a subquery or common table and can't have indexes
             return plan;
         }
 

--- a/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexCounter.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexCounter.java
@@ -113,8 +113,8 @@ public class ReplaceWithIndexCounter extends MicroOptimization {
 
         IndexScanPlanNode isp = (IndexScanPlanNode)child;
 
-        // Guard against (possible future?) cases of indexable subquery.
-        if (((IndexScanPlanNode)child).isSubQuery()) {
+        // Guard against (possible future?) cases of indexable subquery or common table.
+        if (! ((IndexScanPlanNode)child).isPersistentTableScan()) {
             return plan;
         }
 

--- a/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexLimit.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexLimit.java
@@ -126,7 +126,7 @@ public class ReplaceWithIndexLimit extends MicroOptimization {
                 return plan;
             }
 
-            if (((AbstractScanPlanNode)child).isSubQuery()) {
+            if (! ((AbstractScanPlanNode)child).isPersistentTableScan()) {
                 return plan;
             }
 

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -548,7 +548,7 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         NodeSchema answer = null;
         //
         // Note: This code is translated from the C++ code in
-        //       AbstractExecutor::getOutputSchema.  It's considerably
+        //       AbstractPlanNode::getOutputSchema.  It's considerably
         //       different there, but I think this has the corner
         //       cases covered correctly.
         for (child = this;
@@ -593,9 +593,18 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         // will be done.
         if (resetBack) {
             do {
+                if (child instanceof AbstractJoinPlanNode) {
+                    AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(child);
+                    if (aggNode != null) {
+                        // Workaround for ENG-13549
+                        aggNode.setOutputSchema(answer);
+                    }
+                }
+
                 if (! child.m_hasSignificantOutputSchema) {
                     child.setOutputSchema(answer);
                 }
+
                 child = (child.getParentCount() == 0) ? null : child.getParent(0);
             } while (child != null);
         }

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -279,6 +279,10 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         return (m_tableScan instanceof StmtCommonTableScan);
     }
 
+    public boolean isPersistentTableScan() {
+        return (! isCommonTableScan()) && (! isSubQuery());
+    }
+
     @Override
     public void generateOutputSchema(Database db) {
         // fill in the table schema if we haven't already

--- a/src/frontend/org/voltdb/plannodes/SchemaColumn.java
+++ b/src/frontend/org/voltdb/plannodes/SchemaColumn.java
@@ -248,6 +248,10 @@ public class SchemaColumn {
 
     public void setValueSize(int size) { m_expression.setValueSize(size); }
 
+    public boolean getInBytes() { return m_expression.getInBytes(); }
+
+    public void setInBytes(boolean inBytes) { m_expression.setInBytes(inBytes); }
+
     /**
      * Return the differentiator that can distinguish columns with the same name.
      * This value is just the ordinal position of the SchemaColumn within its NodeSchema.
@@ -340,7 +344,9 @@ public class SchemaColumn {
                 VoltType vt = m_expression.getValueType();
                 String typeStr = vt.toSQLString();
                 if (vt.isVariableLength()) {
-                    typeStr += "(" + m_expression.getValueSize() + ")";
+                    boolean inBytes = m_expression.getInBytes();
+                    typeStr += "(" + m_expression.getValueSize()
+                    + (inBytes ? " bytes" : " chars") + ")";
                 }
                 str += "[" + typeStr + "] ";
             }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/QueryExpression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/QueryExpression.java
@@ -192,7 +192,10 @@ public class QueryExpression {
     public void resolveWithClause(Session session) {
         if (withList != null) {
             for (WithExpression withExp : withList.getWithExpressions()) {
-                withExp.getBaseQuery().resolve(session);
+                if (withExp.baseQueryResolved()) {
+                    withExp.getBaseQuery().resolve(session);
+                    withExp.setBaseQueryResolved();
+                }
                 if (withList.isRecursive()) {
                     withExp.getRecursiveQuery().resolve(session);
                 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/WithExpression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/WithExpression.java
@@ -27,6 +27,7 @@ public class WithExpression {
     private QueryExpression m_baseQuery;
     private QueryExpression m_recursiveQuery;
     private Table m_table;
+    private boolean m_baseQueryResolved = false;
 
     public final boolean isRecursive() {
         return m_isRecursive;
@@ -58,4 +59,12 @@ public class WithExpression {
     public void setTable(Table table) {
         m_table = table;
     }
+    public boolean baseQueryResolved() {
+        return m_baseQueryResolved;
+    }
+    public void setBaseQueryResolved() {
+        m_baseQueryResolved = true;
+
+    }
+
 }

--- a/tests/frontend/org/voltdb/regressionsuites/TestCommonTableExpressionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCommonTableExpressionsSuite.java
@@ -428,22 +428,6 @@ public class TestCommonTableExpressionsSuite extends RegressionSuite {
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
         vt = cr.getResults()[0];
         assertContentOfTable(EMPLOYEES_EXPECTED_RECURSIVE_RESULT, vt);
-
-        // This produces a wrong answer and should have a guard.
-        //        String partitionedQuery = "WITH RECURSIVE EMP_PATH(LAST_NAME, EMP_ID, MANAGER_ID, LEVEL, PATH) AS ( "
-        //                + "  SELECT LAST_NAME, EMP_ID, MANAGER_ID, 1, LAST_NAME "
-        //                + "  FROM EMPLOYEES "
-        //                + "  WHERE PART_KEY = 0 AND MANAGER_ID IS NULL "
-        //                + "UNION ALL "
-        //                + "  SELECT E.LAST_NAME, E.EMP_ID, E.MANAGER_ID, EP.LEVEL+1, EP.PATH || '/' || E.LAST_NAME "
-        //                + "  FROM EMPLOYEES AS E JOIN EMP_PATH AS EP ON E.MANAGER_ID = EP.EMP_ID "
-        //                + ") "
-        //                + "SELECT * FROM EMP_PATH ORDER BY LEVEL, PATH; ";
-        //
-        //        cr = client.callProcedure("@AdHoc", partitionedQuery);
-        //        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
-        //        vt = cr.getResults()[0];
-        //        assertContentOfTable(EMPLOYEES_EXPECTED_RECURSIVE_RESULT, vt);
     }
 
     public void testEmployeesNonRecursive() throws Exception {


### PR DESCRIPTION
In ENG-13549, the problem was that HSQL was resolving the base query of a CTE more than once: once to determine the set of columns in the CTE so that the recursive query could be parsed, and once in the normal codepath.  HSQL maintains an "expr column list" that contains extra columns for aggregates at different stages of planning, and resolving more than once messes this up.

In ENG-13577, the "in bytes" flag was set in the base schema and not the recursive schema and the method that harmonizes these two schemas wasn't taking this into account, so we failed the "memcpy" assertion in the EE.

I also found a few places where we check if seq scan nodes are persistent table scans by calling `isSubQuery`.  This is no longer a valid way to check this, so I added a `isPersistentTableScan` method.

I also updated a bunch of unit tests.