### PR TITLE
ENG-13560 immediate shutdown of Kafka importer to avoid blocking other processes

### DIFF
--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
@@ -143,8 +143,10 @@ public class KafkaStreamImporter extends AbstractImporter {
 
     @Override
     public void stop() {
-        for (KafkaInternalConsumerRunner consumer : m_consumers) {
-            consumer.shutdown();
+        if (m_consumers != null) {
+            for (KafkaInternalConsumerRunner consumer : m_consumers) {
+                consumer.shutdown();
+            }
         }
         if (m_executorService != null) {
             try {

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
@@ -153,7 +153,7 @@ public class KafkaStreamImporter extends AbstractImporter {
 
         if (m_executorService != null) {
             try {
-                //shutdown immediately. Consumers will pick up where they left
+                //ENG-13560 shutdown immediately. Consumers will pick up where they left
                 //to avoid blocking other processes such as catalog update.
                 m_executorService.shutdownNow();
             } catch (Throwable ignore) {

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
@@ -154,7 +154,6 @@ public class KafkaStreamImporter extends AbstractImporter {
         if (m_executorService != null) {
             try {
                 m_executorService.shutdownNow();
-                m_executorService.awaitTermination(365, TimeUnit.DAYS);
             } catch (Throwable ignore) {
             } finally {
                 m_executorService = null;

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
@@ -153,6 +153,8 @@ public class KafkaStreamImporter extends AbstractImporter {
 
         if (m_executorService != null) {
             try {
+                //shutdown immediately. Consumers will pick up where they left
+                //to avoid blocking other processes such as catalog update.
                 m_executorService.shutdownNow();
             } catch (Throwable ignore) {
             } finally {

--- a/src/frontend/org/voltdb/importer/ImportManager.java
+++ b/src/frontend/org/voltdb/importer/ImportManager.java
@@ -158,7 +158,7 @@ public class ImportManager implements ChannelChangeCallback {
      * @param catalogContext new catalog context
      * @return new importer configuration
      */
-    private synchronized Map<String, ImportConfiguration> loadNewConfigAndBundles(CatalogContext catalogContext) {
+    private Map<String, ImportConfiguration> loadNewConfigAndBundles(CatalogContext catalogContext) {
         Map<String, ImportConfiguration> newProcessorConfig;
 
         ImportType importElement = catalogContext.getDeployment().getImport();

--- a/src/frontend/org/voltdb/importer/ImporterLifeCycleManager.java
+++ b/src/frontend/org/voltdb/importer/ImporterLifeCycleManager.java
@@ -268,7 +268,7 @@ public class ImporterLifeCycleManager implements ChannelChangeCallback
         }
 
         if (m_executorService != null) {
-            //shutdown right away to avoid delay. Importers should pick up where they left.
+            //ENG-13560 shutdown right away to avoid delay. Importers should pick up where they left.
             try {
                 m_executorService.shutdownNow();
             } catch (Throwable ignore) {

--- a/src/frontend/org/voltdb/importer/ImporterLifeCycleManager.java
+++ b/src/frontend/org/voltdb/importer/ImporterLifeCycleManager.java
@@ -268,12 +268,12 @@ public class ImporterLifeCycleManager implements ChannelChangeCallback
         }
 
         if (m_executorService != null) {
-            m_executorService.shutdown();
+            //shutdown right away to avoid delay. Importers should pick up where they left.
             try {
-                m_executorService.awaitTermination(365, TimeUnit.DAYS);
-            } catch (InterruptedException ex) {
-                //Should never come here.
-                s_logger.warn("Unexpected interrupted exception waiting for " + m_factory.getTypeName() + " to shutdown", ex);
+                m_executorService.shutdownNow();
+            } catch (Throwable ignore) {
+            } finally {
+                m_executorService = null;
             }
         }
     }


### PR DESCRIPTION
When cluster state changes, such as @pause, importers will  grab a lock on ImporterManager and will be shutdown. In the meantime, catalog update needs the same lock to proceed. Shutting down importers immediately to avoid blocking catalog update.