### PR TITLE
Eng 13435 v6 rackware

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -515,8 +515,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             VoltZK.createStartActionNode(m_messenger.getZK(), m_messenger.getHostId(), m_config.m_startAction);
             validateStartAction();
 
-            readDeploymentAndCreateStarterCatalogContext(config);
-            final int numberOfNodes = m_messenger.getLiveHostIds().size();
+            int numberOfNodes = readDeploymentAndCreateStarterCatalogContext();
+            if (isRejoin || m_joining) {
+                numberOfNodes = m_messenger.getLiveHostIds().size();
+            }
             if (config.m_isEnterprise && config.m_startAction == StartAction.CREATE && !config.m_forceVoltdbCreate) {
                 managedPathsEmptyCheck();
             }
@@ -1428,7 +1430,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         }
     }
 
-    void readDeploymentAndCreateStarterCatalogContext(VoltDB.Configuration config) {
+    int readDeploymentAndCreateStarterCatalogContext() {
         /*
          * Debate with the cluster what the deployment file should be
          */
@@ -1624,6 +1626,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                             new byte[] {},
                             deploymentBytes,
                             0);
+            return deployment.getCluster().getHostcount();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -140,6 +140,7 @@ import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.Multimap;
 import com.google_voltpatches.common.net.HostAndPort;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
@@ -514,16 +515,13 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             VoltZK.createStartActionNode(m_messenger.getZK(), m_messenger.getHostId(), m_config.m_startAction);
             validateStartAction();
 
-            Map<Integer, String> hostGroups = null;
-
-            final int numberOfNodes = readDeploymentAndCreateStarterCatalogContext();
+            readDeploymentAndCreateStarterCatalogContext(config);
+            final int numberOfNodes = m_messenger.getLiveHostIds().size();
             if (config.m_isEnterprise && config.m_startAction == StartAction.CREATE && !config.m_forceVoltdbCreate) {
-                    managedPathsEmptyCheck();
+                managedPathsEmptyCheck();
             }
 
-            if (!isRejoin && !m_joining) {
-                hostGroups = m_messenger.waitForGroupJoin(numberOfNodes);
-            }
+            final Map<Integer, String> hostGroups = m_messenger.waitForGroupJoin(numberOfNodes);
 
             // Create the thread pool here. It's needed by buildClusterMesh()
             m_periodicWorkThread =
@@ -620,27 +618,25 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
              * Ning: topology may not reflect the true partitions in the cluster during join. So if another node
              * is trying to rejoin, it should rely on the cartographer's view to pick the partitions to replace.
              */
+            m_configuredReplicationFactor = m_catalogContext.getDeployment().getCluster().getKfactor();
+            m_cartographer = new Cartographer(m_messenger, m_configuredReplicationFactor,
+                                              m_catalogContext.cluster.getNetworkpartition());
             JSONObject topo = getTopology(config.m_startAction, hostGroups, m_joinCoordinator);
             m_partitionsToSitesAtStartupForExportInit = new ArrayList<Integer>();
             try {
                 // IV2 mailbox stuff
                 ClusterConfig clusterConfig = new ClusterConfig(topo);
-                m_configuredReplicationFactor = clusterConfig.getReplicationFactor();
-                m_cartographer = new Cartographer(m_messenger, m_configuredReplicationFactor,
-                        m_catalogContext.cluster.getNetworkpartition());
-                List<Integer> partitions = null;
+                List<Integer> partitions;
                 if (isRejoin) {
                     m_configuredNumberOfPartitions = m_cartographer.getPartitionCount();
-                    partitions = m_cartographer.getIv2PartitionsToReplace(m_configuredReplicationFactor,
-                                                                          clusterConfig.getSitesPerHost());
+                    partitions = ClusterConfig.partitionsForHost(topo, m_messenger.getHostId());
                     if (partitions.size() == 0) {
                         VoltDB.crashLocalVoltDB("The VoltDB cluster already has enough nodes to satisfy " +
                                 "the requested k-safety factor of " +
                                 m_configuredReplicationFactor + ".\n" +
                                 "No more nodes can join.", false, null);
                     }
-                }
-                else {
+                } else {
                     m_configuredNumberOfPartitions = clusterConfig.getPartitionCount();
                     partitions = ClusterConfig.partitionsForHost(topo, m_messenger.getHostId());
                 }
@@ -1287,28 +1283,33 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                                    JoinCoordinator joinCoordinator)
     {
         JSONObject topo = null;
+        int sitesperhost = m_catalogContext.getDeployment().getCluster().getSitesperhost();
+        int kfactor = m_catalogContext.getDeployment().getCluster().getKfactor();
         if (startAction == StartAction.JOIN) {
             assert(joinCoordinator != null);
             topo = joinCoordinator.getTopology();
         }
-        else if (!startAction.doesRejoin()) {
-            int sitesperhost = m_catalogContext.getDeployment().getCluster().getSitesperhost();
-            int hostcount = m_catalogContext.getDeployment().getCluster().getHostcount();
-            int kfactor = m_catalogContext.getDeployment().getCluster().getKfactor();
+        else {
+            final Set<Integer> liveHostIds = m_messenger.getLiveHostIds();
+            Preconditions.checkArgument(hostGroups.keySet().equals(liveHostIds));
+            int hostcount = liveHostIds.size();
             ClusterConfig clusterConfig = new ClusterConfig(hostcount, sitesperhost, kfactor);
-            if (!clusterConfig.validate()) {
+            if (!startAction.doesRejoin() && !clusterConfig.validate()) {
                 VoltDB.crashLocalVoltDB(clusterConfig.getErrorMsg(), false, null);
             }
-            topo = registerClusterConfig(clusterConfig, hostGroups);
-        }
-        else {
-            Stat stat = new Stat();
+
             try {
-                topo =
-                    new JSONObject(new String(m_messenger.getZK().getData(VoltZK.topology, false, stat), "UTF-8"));
+                final Multimap<Integer, Long> replicas = m_cartographer.getReplicasForPartitions(m_cartographer.getPartitions());
+                final Map<Integer, Long> masters = m_cartographer.getHSIdsForSinglePartitionMasters();
+                replicas.removeAll(MpInitiator.MP_INIT_PID);
+                masters.remove(MpInitiator.MP_INIT_PID);
+                topo = clusterConfig.getTopology(hostGroups, replicas, masters);
+            } catch (Exception e) {
+                VoltDB.crashLocalVoltDB("Unable to calculate topology", false, e);
             }
-            catch (Exception e) {
-                VoltDB.crashLocalVoltDB("Unable to get topology from ZK", true, e);
+
+            if (!startAction.doesRejoin()) {
+                topo = registerClusterConfig(topo);
             }
         }
         return topo;
@@ -1329,16 +1330,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         return initiators;
     }
 
-    private JSONObject registerClusterConfig(ClusterConfig config, Map<Integer, String> hostGroups)
+    private JSONObject registerClusterConfig(JSONObject topo)
     {
         // First, race to write the topology to ZK using Highlander rules
         // (In the end, there can be only one)
-        JSONObject topo = null;
         try
         {
-            final Set<Integer> liveHostIds = m_messenger.getLiveHostIds();
-            Preconditions.checkArgument(hostGroups.keySet().equals(liveHostIds));
-            topo = config.getTopology(hostGroups);
             byte[] payload = topo.toString(4).getBytes("UTF-8");
             m_messenger.getZK().create(VoltZK.topology, payload,
                     Ids.OPEN_ACL_UNSAFE,
@@ -1431,7 +1428,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         }
     }
 
-    int readDeploymentAndCreateStarterCatalogContext() {
+    void readDeploymentAndCreateStarterCatalogContext(VoltDB.Configuration config) {
         /*
          * Debate with the cluster what the deployment file should be
          */
@@ -1627,8 +1624,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                             new byte[] {},
                             deploymentBytes,
                             0);
-
-            return deployment.getCluster().getHostcount();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/frontend/org/voltdb/compiler/ClusterConfig.java
+++ b/src/frontend/org/voltdb/compiler/ClusterConfig.java
@@ -18,6 +18,7 @@ package org.voltdb.compiler;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -29,15 +30,21 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import com.google_voltpatches.common.base.Preconditions;
+import com.google_voltpatches.common.collect.HashMultimap;
 import com.google_voltpatches.common.collect.Lists;
 import com.google_voltpatches.common.collect.Maps;
+import com.google_voltpatches.common.collect.Multimaps;
 import com.google_voltpatches.common.collect.Sets;
+import com.google_voltpatches.common.collect.TreeMultimap;
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltcore.logging.VoltLogger;
+import org.voltcore.utils.CoreUtils;
 import org.voltdb.VoltDB;
 
 import com.google_voltpatches.common.collect.Multimap;
@@ -203,28 +210,7 @@ public class ClusterConfig
         return true;
     }
 
-    public boolean validate(int origStartCount)
-    {
-        boolean isValid = validate();
-        if (isValid && origStartCount < m_hostCount && origStartCount > 0)
-        {
-            if ((m_hostCount - origStartCount) > m_replicationFactor + 1)
-            {
-                m_errorMsg = String.format("You can only add %d servers at a time for k=%d",
-                        m_replicationFactor + 1, m_replicationFactor);
-                return false;
-            }
-            else if ((m_hostCount - origStartCount) % (m_replicationFactor + 1) != 0)
-            {
-                m_errorMsg = String.format("Must add %d servers at a time for k=%d",
-                        m_replicationFactor + 1, m_replicationFactor);
-                return false;
-            }
-        }
-        return isValid;
-    }
-
-    private static class Partition {
+    private static class Partition implements Comparable {
         private Node m_master;
         private final Set<Node> m_replicas = new HashSet<Node>();
         private final Integer m_partitionId;
@@ -248,6 +234,10 @@ public class ClusterConfig
             m_neededReplicas--;
         }
 
+        public void incrementNeededReplicas() {
+            m_neededReplicas++;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (o instanceof Partition) {
@@ -260,19 +250,32 @@ public class ClusterConfig
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();
-            sb.append("Partition " + m_partitionId + " needing replicas " + m_neededReplicas);
-            sb.append(" with master " + m_master.m_hostId + " and replicas ");
-            for (Node n : m_replicas) {
-                sb.append(n.m_hostId).append(", ");
+            sb.append("\nP").append(m_partitionId).append(" (").append(m_neededReplicas).append(")");
+            sb.append(" [");
+            if (m_master != null) {
+                sb.append(m_master.m_hostId).append("*,");
             }
+            for (Node n : m_replicas) {
+                sb.append(n.m_hostId).append(",");
+            }
+            sb.append("]");
             return sb.toString();
+        }
+
+        @Override
+        public int compareTo(Object o)
+        {
+            if (!(o instanceof Partition)) {
+                return -1;
+            }
+            return Integer.compare(m_partitionId, ((Partition) o).m_partitionId);
         }
     }
 
     private static class Node implements Comparable {
         Set<Partition> m_masterPartitions = new HashSet<Partition>();
         Set<Partition> m_replicaPartitions = new HashSet<Partition>();
-        Map<Node, Integer> m_replicationConnections = new HashMap<Node, Integer>();
+        Multimap<Node, Integer> m_replicationConnections = HashMultimap.create();
         Integer m_hostId;
         final String[] m_group;
 
@@ -317,18 +320,18 @@ public class ClusterConfig
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();
-            sb.append("Host " + m_hostId + " master of ");
+            sb.append("\nH").append(m_hostId).append(" [");
             for (Partition p : m_masterPartitions) {
-                sb.append(p.m_partitionId).append(", ");
+                sb.append(p.m_partitionId).append("*,");
             }
-            sb.append(" replica of ");
             for (Partition p : m_replicaPartitions) {
-                sb.append(p.m_partitionId).append(", ");
+                sb.append(p.m_partitionId).append(",");
             }
-            sb.append(" connected to ");
-            for (Map.Entry<Node, Integer> entry : m_replicationConnections.entrySet()) {
-                sb.append(" host " + entry.getKey().m_hostId + " for " + entry.getValue() + " partitions");
+            sb.append("] -> [");
+            for (Map.Entry<Node, Collection<Integer>> entry : m_replicationConnections.asMap().entrySet()) {
+                sb.append(entry.getKey().m_hostId).append(",");
             }
+            sb.append("]");
             return sb.toString();
         }
 
@@ -351,11 +354,11 @@ public class ClusterConfig
         final Map<String, Group> m_children = Maps.newTreeMap();
         final Set<Node> m_hosts = Sets.newTreeSet();
 
-        public void addHost(String[] group, int host) {
-            addHost(group, 0, host);
+        public void createHost(String[] group, int host) {
+            createHost(group, 0, host);
         }
 
-        private void addHost(String[] group, int i, int host) {
+        private void createHost(String[] group, int i, int host) {
             Group nextGroup = m_children.get(group[i]);
             if (nextGroup == null) {
                 nextGroup = new Group();
@@ -365,24 +368,34 @@ public class ClusterConfig
             if (group.length == i + 1) {
                 nextGroup.m_hosts.add(new Node(host, group));
             } else {
-                nextGroup.addHost(group, i + 1, host);
+                nextGroup.createHost(group, i + 1, host);
             }
         }
 
         /**
-         * Get the nodes in the groups that are sibling to the given group,
-         * e.g. if the given group is a rack, the returned value is the servers
-         * in the neighboring racks.
+         * Get all nodes sorted in reverse distance to the given group.
          *
-         * @return A list of nodes in their groups. The list is ordered by the
+         * @return Lists of nodes in their groups. The list is ordered by the
          * reverse distance to the given group. So the first group in the list
          * is farthest away from the given group, and the last group in the list
-         * is closest to the given group.
+         * is the given group itself.
          */
-        public List<Deque<Node>> getGroupSiblingsOf(String[] group)
+        public List<Deque<Node>> sortNodesByDistance(String[] group)
         {
             List<Deque<Node>> results = Lists.newArrayList();
             getGroupSiblingsOf(group, 0, results);
+            if (group[0] != null) {
+                getHosts(findGroup(group), results);
+            }
+            return results;
+        }
+
+        public List<Deque<Node>> getDescendentsInGroup(String[] group)
+        {
+            List<Deque<Node>> results = Lists.newArrayList();
+            if (group[0] != null) {
+                getHosts(findGroup(group), results);
+            }
             return results;
         }
 
@@ -405,6 +418,14 @@ public class ClusterConfig
             }
         }
 
+        private Group findGroup(String[] group) {
+            Group found = this;
+            for (String level : group) {
+                found = found.m_children.get(level);
+            }
+            return found;
+        }
+
         public void removeHost(Node node) {
             if (m_children.isEmpty()) {
                 m_hosts.remove(node);
@@ -412,6 +433,16 @@ public class ClusterConfig
             }
             for (Group l : m_children.values()) {
                 l.removeHost(node);
+            }
+        }
+
+        public void addHost(Node node) {
+            if (m_children.isEmpty()) {
+                m_hosts.add(node);
+                return;
+            }
+            for (Group l : m_children.values()) {
+                l.addHost(node);
             }
         }
 
@@ -425,6 +456,11 @@ public class ClusterConfig
             for (Group l : group.m_children.values()) {
                 getHosts(l, hosts);
             }
+        }
+
+        public Stream<Group> flattened() {
+            return Stream.concat(Stream.of(this),
+                                 m_children.values().stream().flatMap(Group::flattened));
         }
 
         @Override
@@ -447,8 +483,15 @@ public class ClusterConfig
 
         public PhysicalTopology(Map<Integer, String> hostGroups) {
             for (Map.Entry<Integer, String> e : hostGroups.entrySet()) {
-                m_root.addHost(parseGroup(e.getValue()), e.getKey());
+                m_root.createHost(parseGroup(e.getValue()), e.getKey());
             }
+        }
+
+        /**
+         * @return The total number of distinct groups.
+         */
+        public int groupCount () {
+            return (int) m_root.flattened().filter(n -> n.m_children.isEmpty()).count();
         }
 
         /**
@@ -477,7 +520,7 @@ public class ClusterConfig
          * mean that they are no longer part of the cluster.
          */
         public List<Deque<Node>> getAllHosts() {
-            return m_root.getGroupSiblingsOf(new String[]{null});
+            return m_root.sortNodesByDistance(new String[]{null});
         }
     }
 
@@ -546,17 +589,19 @@ public class ClusterConfig
      * groups and also involve multiple nodes in replication so that the socket
      * between nodes is not a bottleneck.
      *
-     * This algorithm has three steps.
+     * This algorithm has two steps.
      * 1. Partition master assignment,
      * 2. Group partition replica assignment.
-     * 3. Remaining partition replica assignment.
      */
     JSONObject groupAwarePlacementStrategy(
             Map<Integer, String> hostGroups,
+            Multimap<Integer, Long> partitionReplicas,
+            Map<Integer, Long> partitionMasters,
             int partitionCount,
             int sitesPerHost) throws JSONException {
         final PhysicalTopology phys = new PhysicalTopology(hostGroups);
         final List<Node> allNodes = MiscUtils.zip(phys.getAllHosts());
+        final Map<Integer, Node> hostIdToNode = toHostIdNodeMap(allNodes);
 
         List<Partition> partitions = new ArrayList<Partition>();
         for (int ii = 0; ii < partitionCount; ii++) {
@@ -571,50 +616,46 @@ public class ClusterConfig
                 iter = allNodes.iterator();
                 assert iter.hasNext();
             }
-            p.m_master = iter.next();
-            p.decrementNeededReplicas();
+
+            final Long hsId = partitionMasters.get(p.m_partitionId);
+            if (hsId != null) {
+                p.m_master = hostIdToNode.get(CoreUtils.getHostIdFromHSId(hsId));
+            } else {
+                p.m_master = iter.next();
+            }
             p.m_master.m_masterPartitions.add(p);
+            p.decrementNeededReplicas();
+        }
+
+        // If there is any existing partition replicas, assign them first.
+        // e.g. rejoin would have existing nodes.
+        for (Map.Entry<Integer, Long> e : partitionReplicas.entries()) {
+            assignReplica(sitesPerHost, phys, partitions.get(e.getKey()),
+                          hostIdToNode.get(CoreUtils.getHostIdFromHSId(e.getValue())));
         }
 
         if (getReplicationFactor() > 0) {
-            // Step 2. For each partition, assign a replica to each group other
-            // than the group of the partition master. This guarantees that the
-            // replicas are spread out as much as possible. There may be more
-            // replicas than groups available, which will be handled in step 3.
+            Map<Integer, List<Node>> sortedCandidatesForPartitions = new HashMap<>();
             for (Partition p : partitions) {
-                final List<Deque<Node>> nodesInOtherGroups =
-                    sortByConnectionsToNode(p.m_master, phys.m_root.getGroupSiblingsOf(p.m_master.m_group));
-
-                List<Node> firstReplicaNodes = new ArrayList<>();
-                final Iterator<Deque<Node>> groupIter = nodesInOtherGroups.iterator();
-                int needed = p.m_neededReplicas;
-
-                // Pick one node from each other group to be the replica
-                while (needed-- > 0 && groupIter.hasNext()) {
-                    final Deque<Node> nextGroup = groupIter.next();
-                    for (Node nextNode : nextGroup) {
-                        if (nextNode.partitionCount() < sitesPerHost) {
-                            assert p.m_master != nextNode;
-                            assert !nextNode.m_replicaPartitions.contains(p);
-                            firstReplicaNodes.add(nextNode);
-                            break;
-                        }
-                    }
-                }
-
-                assignReplicas(sitesPerHost, phys, p, firstReplicaNodes);
+                sortedCandidatesForPartitions.put(p.m_partitionId,
+                                         MiscUtils.zip(sortByConnectionsToNode(p.m_master, phys.m_root.sortNodesByDistance(p.m_master.m_group))));
             }
 
-            // Step 3. Assign the remaining replicas. Make sure each partition
-            // is fully replicated.
-            for (Partition p : partitions) {
-                if (p.m_neededReplicas > 0) {
-                    final List<Node> nodesLeft = MiscUtils.zip(phys.getAllHosts());
-                    nodesLeft.remove(p.m_master);
-                    final List<Node> sortedNodesLeft =
-                        MiscUtils.zip(sortByConnectionsToNode(p.m_master, Collections.singletonList(nodesLeft)));
-                    assignReplicas(sitesPerHost, phys, p, sortedNodesLeft);
-                }
+            if (!partitionMasters.isEmpty()) {
+                partitions = sortPartitions(phys, sitesPerHost, allNodes, partitions);
+            }
+
+            // Step 2. For each partition, assign a replica to each group other
+            // than the group of the partition master. This recursively goes
+            // through permutations to try to find a feasible assignment for all
+            // partitions. For large deployments, it may take a while.
+            if (!recursivelyAssignReplicas(!partitionMasters.isEmpty(),
+                                           phys.groupCount(),
+                                           sitesPerHost,
+                                           phys,
+                                           partitions,
+                                           sortedCandidatesForPartitions)) {
+                throw new RuntimeException("Unable to find feasible partition replica assignment for the specified grouping");
             }
         }
 
@@ -622,12 +663,12 @@ public class ClusterConfig
         // partition has enough replicas.
         for (Node n : allNodes) {
             if (n.partitionCount() != sitesPerHost) {
-                throw new RuntimeException("Unable to assign partitions using the new placement algorithm");
+                throw new RuntimeException("Some nodes are missing partition replicas: " + allNodes);
             }
         }
         for (Partition p : partitions) {
-            if (p.m_neededReplicas != 0) {
-                throw new RuntimeException("Unable to assign partitions using the new placement algorithm");
+            if (p.m_neededReplicas != 0 && partitionReplicas.isEmpty() && partitionMasters.isEmpty()) {
+                throw new RuntimeException("Some partitions are missing replicas: " + partitions);
             }
         }
 
@@ -637,16 +678,16 @@ public class ClusterConfig
         stringer.key("kfactor").value(getReplicationFactor());
         stringer.key("sites_per_host").value(sitesPerHost);
         stringer.key("partitions").array();
-        for (int part = 0; part < partitionCount; part++)
+        for (Partition p : partitions)
         {
             stringer.object();
-            stringer.key("partition_id").value(part);
-            stringer.key("master").value(partitions.get(part).m_master.m_hostId);
+            stringer.key("partition_id").value(p.m_partitionId);
+            stringer.key("master").value(p.m_master.m_hostId);
             stringer.key("replicas").array();
-            for (Node n : partitions.get(part).m_replicas) {
+            for (Node n : p.m_replicas) {
                 stringer.value(n.m_hostId);
             }
-            stringer.value(partitions.get(part).m_master.m_hostId);
+            stringer.value(p.m_master.m_hostId);
             stringer.endArray();
             stringer.endObject();
         }
@@ -656,39 +697,159 @@ public class ClusterConfig
         return new JSONObject(stringer.toString());
     }
 
-    /**
-     * Given a collection of candidate nodes, try to assign the remaining
-     * replicas of the given partition to these nodes in the given order.
-     *
-     * If the given candidate nodes are more than needed, it will only use the
-     * first few. If there are less, the given partition will not be fully
-     * replicated.
-     */
-    private static void assignReplicas(int sitesPerHost, PhysicalTopology phys, Partition p, Collection<Node> nodes) {
-        final Iterator<Node> nodeIter = nodes.iterator();
-        while (p.m_neededReplicas > 0 && nodeIter.hasNext()) {
-            final Node replica = nodeIter.next();
-
-            if (replica.partitionCount() == sitesPerHost) {
-                phys.m_root.removeHost(replica);
-                continue;
-            }
-            if (p.m_master == replica || p.m_replicas.contains(replica)) {
-                continue;
-            }
-
-            p.m_replicas.add(replica);
-            p.decrementNeededReplicas();
-            replica.m_replicaPartitions.add(p);
-
-            if (p.m_master.m_replicationConnections.containsKey(replica)) {
-                final int connections = p.m_master.m_replicationConnections.get(replica);
-                p.m_master.m_replicationConnections.put(replica, connections + 1);
-                replica.m_replicationConnections.put(p.m_master, connections + 1);
+    private static List<Partition> sortPartitions(PhysicalTopology phys, int sitesPerHost,
+                                                  Collection<Node> allNodes, List<Partition> partitions)
+    {
+        Node rejoinNode = null;
+        // Find the rejoining node first, assumes one rejoin node
+        for (Node n : allNodes) {
+            if (n.partitionCount() == 0) {
+                rejoinNode = n;
+                break;
             } else {
-                p.m_master.m_replicationConnections.put(replica, 1);
-                replica.m_replicationConnections.put(p.m_master, 1);
+                assert n.partitionCount() == sitesPerHost;
             }
+        }
+
+        if (rejoinNode == null) {
+            return null;
+        }
+
+        HashMap<Partition, Integer> partitionRepCount = new HashMap<>();
+        final List<Deque<Node>> siblingsWithSelf = phys.m_root.getDescendentsInGroup(new String[]{rejoinNode.m_group[0]});
+
+        // Prime the partition replication count map with all partitions set to 0
+        partitions.forEach(p -> partitionRepCount.put(p, 0));
+
+        // Count how many replicas each partition has in the same top-level group
+        for (Deque<Node> nodes : siblingsWithSelf) {
+            for (Node n : nodes) {
+                for (Partition p : n.m_masterPartitions) {
+                    partitionRepCount.compute(p, (k, v) -> v + 1);
+                }
+                for (Partition p : n.m_replicaPartitions) {
+                    partitionRepCount.compute(p, (k, v) -> v + 1);
+                }
+            }
+        }
+
+        // Sort candidate partitions in replica count order
+        Multimap<Integer, Partition> inverse = Multimaps.invertFrom(Multimaps.forMap(partitionRepCount),
+                                                                  TreeMultimap.create());
+        return new ArrayList<>(inverse.values());
+    }
+
+    /**
+     * For each partition that needs more replicas, find a feasible candidate
+     * node and assign it. Recursively call this function until all partitions
+     * have enough replicas. If there is no feasible assignment, back up one
+     * step and try a different candidate node.
+     * @return true if a feasible global assignment has been found, false otherwise.
+     */
+    private static boolean recursivelyAssignReplicas(boolean isRejoin,
+                                                     int groupCount,
+                                                     int sitesPerHost,
+                                                     PhysicalTopology phys,
+                                                     List<Partition> partitions,
+                                                     Map<Integer, List<Node>> candidates)
+    {
+        for (Partition p : partitions) {
+            if (p.m_neededReplicas == 0) {
+                continue;
+            }
+
+            for (Node candidate : pickBestCandidates(sitesPerHost, groupCount, p, candidates.get(p.m_partitionId))) {
+                assignReplica(sitesPerHost, phys, p, candidate);
+
+                if (recursivelyAssignReplicas(isRejoin, groupCount, sitesPerHost, phys, partitions, candidates)) {
+                    break;
+                } else {
+                    // No feasible assignment with this candidate, try a different one.
+                    removeReplica(sitesPerHost, phys, p, candidate);
+                }
+            }
+
+            // If we can't find enough nodes in all the candidates to satisfy
+            // this partition, there's no feasible assignment for this partition
+            // with the current configuration, back up and try a different
+            // configuration.
+            if (!isRejoin && p.m_neededReplicas > 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static Collection<Node> pickBestCandidates(int sitesPerHost, int groupCount, Partition p, List<Node> candidates) {
+        List<Node> bestCandidates = new ArrayList<>();
+        List<Node> qualifiedCandidates = new ArrayList<>();
+
+        for (Node candidate : candidates) {
+            // The candidate has to satisfy the following,
+            // - have available sites
+            // - doesn't already contain the partition
+            // - in a different group if there are more than one group in total and there's no replicas yet
+            if (candidate.partitionCount() == sitesPerHost ||
+                candidate.m_masterPartitions.contains(p) ||
+                candidate.m_replicaPartitions.contains(p) ||
+                (groupCount > 1 && Arrays.equals(candidate.m_group, p.m_master.m_group) && p.m_replicas.isEmpty())) {
+                continue;
+            }
+
+            qualifiedCandidates.add(candidate);
+
+            // Soft requirements
+            // - If more than one group and there are replicas, pick a candidate in a group different from replicas'
+            if (groupCount == 1 ||
+                (!Arrays.equals(candidate.m_group, p.m_master.m_group) && p.m_replicas.stream().noneMatch(n -> Arrays.equals(candidate.m_group, n.m_group)))) {
+                bestCandidates.add(candidate);
+            }
+        }
+
+        return bestCandidates.isEmpty() ? qualifiedCandidates : bestCandidates;
+    }
+
+    private static Map<Integer, Node> toHostIdNodeMap(Collection<Node> nodes) {
+        Map<Integer, Node> nodeMap = new HashMap<>();
+        for (Node n : nodes) {
+            Preconditions.checkArgument(nodeMap.put(n.m_hostId, n) == null);
+        }
+        return nodeMap;
+    }
+
+    private static void assignReplica(int sitesPerHost, PhysicalTopology phys, Partition p, Node replica)
+    {
+        if (replica.partitionCount() == sitesPerHost) {
+            phys.m_root.removeHost(replica);
+            return;
+        }
+        if (p.m_master == replica || p.m_replicas.contains(replica)) {
+            return;
+        }
+
+        p.m_replicas.add(replica);
+        p.decrementNeededReplicas();
+        replica.m_replicaPartitions.add(p);
+
+        p.m_master.m_replicationConnections.put(replica, p.m_partitionId);
+        replica.m_replicationConnections.put(p.m_master, p.m_partitionId);
+    }
+
+    private static void removeReplica(int sitesPerHost, PhysicalTopology phys, Partition p, Node replica)
+    {
+        if (p.m_master == replica || !p.m_replicas.contains(replica)) {
+            return;
+        }
+
+        replica.m_replicationConnections.remove(p.m_master, p.m_partitionId);
+        p.m_master.m_replicationConnections.remove(replica, p.m_partitionId);
+        replica.m_replicaPartitions.remove(p);
+        p.m_replicas.remove(replica);
+        p.incrementNeededReplicas();
+
+        if (replica.partitionCount() < sitesPerHost) {
+            phys.m_root.addHost(replica);
         }
     }
 
@@ -698,7 +859,7 @@ public class ClusterConfig
      * that order. The sorting does not change the grouping of the nodes. It
      * favors nodes with less connections to the master node. If the connection
      * count is the same, it favors nodes with fewer replications. If the
-     * replication count is the same, it favors nodes with more master
+     * replication count is the same, it favors nodes with less master
      * partitions.
      */
     private static List<Deque<Node>> sortByConnectionsToNode(final Node master, List<? extends Collection<Node>> nodes) {
@@ -711,14 +872,14 @@ public class ClusterConfig
                 @Override
                 public int compare(Node o1, Node o2)
                 {
-                    final Integer o1Connections = master.m_replicationConnections.get(o1);
-                    final Integer o2Connections = master.m_replicationConnections.get(o2);
-                    final int connComp = Integer.compare(o1Connections == null ? 0 : o1Connections,
-                                                         o2Connections == null ? 0 : o2Connections);
+                    final Collection<Integer> o1Connections = master.m_replicationConnections.get(o1);
+                    final Collection<Integer> o2Connections = master.m_replicationConnections.get(o2);
+                    final int connComp = Integer.compare(o1Connections == null ? 0 : o1Connections.size(),
+                                                         o2Connections == null ? 0 : o2Connections.size());
                     if (connComp == 0) {
                         final int repFactorComp = Integer.compare(o1.replicationFactor(), o2.replicationFactor());
                         if (repFactorComp == 0) {
-                            return -Integer.compare(o1.m_masterPartitions.size(), o2.m_masterPartitions.size());
+                            return Integer.compare(o1.m_masterPartitions.size(), o2.m_masterPartitions.size());
                         } else {
                             return repFactorComp;
                         }
@@ -736,13 +897,15 @@ public class ClusterConfig
 
     // Statically build a topology. This only runs at startup;
     // rejoin clones this from an existing server.
-    public JSONObject getTopology(Map<Integer, String> hostGroups) throws JSONException
+    public JSONObject getTopology(Map<Integer, String> hostGroups,
+                                  Multimap<Integer, Long> partitionReplicas,
+                                  Map<Integer, Long> partitionMasters) throws JSONException
     {
         int hostCount = getHostCount();
-        int partitionCount = getPartitionCount();
+        int partitionCount = partitionMasters.isEmpty() ? getPartitionCount() : partitionMasters.size();
         int sitesPerHost = getSitesPerHost();
 
-        if (hostCount != hostGroups.size()) {
+        if (hostCount != hostGroups.size() && partitionReplicas.isEmpty() && partitionMasters.isEmpty()) {
             throw new RuntimeException("Provided " + hostGroups.size() + " host ids when host count is " + hostCount);
         }
 
@@ -752,16 +915,20 @@ public class ClusterConfig
                                              hostCount, partitionCount, sitesPerHost);
         } else {
             try {
-                topo = groupAwarePlacementStrategy(hostGroups, partitionCount, sitesPerHost);
+                topo = groupAwarePlacementStrategy(hostGroups, partitionReplicas, partitionMasters, partitionCount, sitesPerHost);
             } catch (Exception e) {
+                e.printStackTrace();
                 hostLog.error("Unable to use optimal replica placement strategy. " +
-                              "Falling back to a less optimal strategy that may result in worse performance");
+                              "Falling back to a less optimal strategy that may result in worse performance. " +
+                              "Original error was " + e.getMessage());
                 topo = fallbackPlacementStrategy(Lists.newArrayList(hostGroups.keySet()),
                                                  hostCount, partitionCount, sitesPerHost);
             }
         }
 
-        hostLog.debug("TOPO: " + topo.toString(2));
+        if (hostLog.isDebugEnabled()) {
+            hostLog.debug("TOPO: " + topo.toString(2));
+        }
         return topo;
     }
 

--- a/src/frontend/org/voltdb/compiler/ClusterConfig.java
+++ b/src/frontend/org/voltdb/compiler/ClusterConfig.java
@@ -694,9 +694,9 @@ public class ClusterConfig
             }
 
             // Step 2. For each partition, assign a replica to each group other
-            // than the group of the partition master. This recursively goes
-            // through permutations to try to find a feasible assignment for all
-            // partitions. For large deployments, it may take a while.
+            // than the group of the partition master. If there is no feasible
+            // assignment, find one full host to donate a partition to an
+            // emptier host then try to assign the partition again.
             if (!tryAssignReplicas(rejoinNode,
                                    sitesPerHost,
                                    hostGroups,

--- a/src/frontend/org/voltdb/compiler/ClusterConfig.java
+++ b/src/frontend/org/voltdb/compiler/ClusterConfig.java
@@ -1029,10 +1029,12 @@ public class ClusterConfig
             try {
                 topo = groupAwarePlacementStrategy(hostGroups, partitionReplicas, partitionMasters, partitionCount, sitesPerHost);
             } catch (Exception e) {
-                e.printStackTrace();
                 hostLog.error("Unable to use optimal replica placement strategy. " +
                               "Falling back to a less optimal strategy that may result in worse performance. " +
                               "Original error was " + e.getMessage());
+                hostLog.warn("When using placement groups, follow two rules to get better cluster availability:\n" +
+                        "   1. Each placement group must have the same number of nodes, and\n" +
+                        "   2. The number of partition replicas (kfactor + 1) must be a multiple of the number of placement groups.");
                 topo = fallbackPlacementStrategy(Lists.newArrayList(hostGroups.keySet()),
                                                  hostCount, partitionCount, sitesPerHost);
             }

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -32,6 +32,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import com.google_voltpatches.common.collect.HashMultimap;
+import com.google_voltpatches.common.collect.Multimap;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.apache.zookeeper_voltpatches.data.Stat;
@@ -233,6 +235,14 @@ public class Cartographer extends StatsSource
     }
 
     /**
+     * Get the HSID of all the partition masters
+     */
+    public Map<Integer, Long> getHSIdsForSinglePartitionMasters()
+    {
+        return new HashMap<>(m_iv2Masters.pointInTimeCache());
+    }
+
+    /**
      * Get the HSID of the single partition master for the specified partition ID
      */
     public long getHSIdForSinglePartitionMaster(int partitionId)
@@ -319,8 +329,8 @@ public class Cartographer extends StatsSource
     /**
      * Given a set of partition IDs, return a map of partition to a list of HSIDs of all the sites with copies of each partition
      */
-    public Map<Integer, List<Long>> getReplicasForPartitions(Collection<Integer> partitions) {
-        Map<Integer, List<Long>> retval = new HashMap<Integer, List<Long>>();
+    public Multimap<Integer, Long> getReplicasForPartitions(Collection<Integer> partitions) {
+        Multimap<Integer, Long> retval = HashMultimap.create();
         List<Pair<Integer,ZKUtil.ChildrenCallback>> callbacks = new ArrayList<Pair<Integer, ZKUtil.ChildrenCallback>>();
 
         for (Integer partition : partitions) {
@@ -334,11 +344,9 @@ public class Cartographer extends StatsSource
             final Integer partition = p.getFirst();
             try {
                 List<String> children = p.getSecond().getChildren();
-                List<Long> sites = new ArrayList<Long>();
                 for (String child : children) {
-                    sites.add(Long.valueOf(child.split("_")[0]));
+                    retval.put(partition, Long.valueOf(child.split("_")[0]));
                 }
-                retval.put(partition, sites);
             } catch (KeeperException.NoNodeException e) {
                 //This can happen when a partition is being removed from the system
             } catch (KeeperException ke) {
@@ -371,41 +379,6 @@ public class Cartographer extends StatsSource
             keys.add(entry.getKey());
         }
         return keys;
-    }
-
-    /**
-     * Given the current state of the cluster, compute the partitions which should be replicated on a single new host.
-     * Break this method out to be static and testable independent of ZK, JSON, other ugh.
-     */
-    static public List<Integer> computeReplacementPartitions(Map<Integer, Integer> repsPerPart, int kfactor,
-                                                             int sitesPerHost)
-    {
-        List<Integer> partitions = new ArrayList<Integer>();
-        List<Integer> partSortedByRep = sortKeysByValue(repsPerPart);
-        for (int i = 0; i < partSortedByRep.size(); i++) {
-            int leastReplicatedPart = partSortedByRep.get(i);
-            if (repsPerPart.get(leastReplicatedPart) < kfactor + 1) {
-                partitions.add(leastReplicatedPart);
-                if (partitions.size() == sitesPerHost) {
-                    break;
-                }
-            }
-        }
-        return partitions;
-    }
-
-    public List<Integer> getIv2PartitionsToReplace(int kfactor, int sitesPerHost)
-        throws JSONException
-    {
-        List<Integer> partitions = getPartitions();
-        hostLog.info("Computing partitions to replace.  Total partitions: " + partitions);
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        for (int pid : partitions) {
-            repsPerPart.put(pid, getReplicaCountForPartition(pid));
-        }
-        List<Integer> partitionsToReplace = computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        hostLog.info("IV2 Sites will replicate the following partitions: " + partitionsToReplace);
-        return partitionsToReplace;
     }
 
     /**
@@ -442,14 +415,10 @@ public class Cartographer extends StatsSource
     {
         List<MailboxNodeContent> sitesList = new ArrayList<MailboxNodeContent>();
         final Set<Integer> iv2MastersKeySet = m_iv2Masters.pointInTimeCache().keySet();
-        Map<Integer, List<Long>> hsidsForPartMap = getReplicasForPartitions(iv2MastersKeySet);
-        for (Map.Entry<Integer, List<Long>> entry : hsidsForPartMap.entrySet()) {
-            Integer partId = entry.getKey();
-            List<Long> hsidsForPart = entry.getValue();
-            for (long hsid : hsidsForPart) {
-                MailboxNodeContent mnc = new MailboxNodeContent(hsid, partId);
-                sitesList.add(mnc);
-            }
+        Multimap<Integer, Long> hsidsForPartMap = getReplicasForPartitions(iv2MastersKeySet);
+        for (Map.Entry<Integer, Long> entry : hsidsForPartMap.entries()) {
+            MailboxNodeContent mnc = new MailboxNodeContent(entry.getValue(), entry.getKey());
+            sitesList.add(mnc);
         }
         return sitesList;
     }

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -716,7 +716,7 @@ public class MiscUtils {
      * Zip the two lists up into a multimap
      * @return null if one of the lists is empty
      */
-    public static <K, V> Multimap<K, V> zipToMap(List<K> keys, List<V> values)
+    public static <K, V> Multimap<K, V> zipToMap(Collection<K> keys, Collection<V> values)
     {
         if (keys.isEmpty() || values.isEmpty()) {
             return null;
@@ -732,7 +732,7 @@ public class MiscUtils {
 
         // In case there are more values than keys, assign the rest of the
         // values to the first key
-        K firstKey = keys.get(0);
+        K firstKey = keys.iterator().next();
         while (valueIter.hasNext()) {
             result.put(firstKey, valueIter.next());
         }

--- a/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
@@ -23,10 +23,13 @@
 package org.voltdb.compiler;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.HashMultimap;
 import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.collect.Multimap;
@@ -36,6 +39,7 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 
 import junit.framework.TestCase;
+import org.voltcore.utils.CoreUtils;
 import org.voltdb.VoltDB;
 
 public class TestClusterCompiler extends TestCase
@@ -47,7 +51,7 @@ public class TestClusterCompiler extends TestCase
         topology.put(0, "0");
         topology.put(1, "0");
         topology.put(2, "0");
-        JSONObject obj = config.getTopology(topology);
+        JSONObject obj = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         config.validate();
         System.out.println(obj.toString(4));
         JSONArray partitions = obj.getJSONArray("partitions");
@@ -99,7 +103,7 @@ public class TestClusterCompiler extends TestCase
         ClusterConfig config = new ClusterConfig(1, 6, 0);
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(1, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(0, topo.getInt("kfactor"));
@@ -116,7 +120,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(0, topo.getInt("kfactor"));
@@ -135,7 +139,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(1, topo.getInt("kfactor"));
@@ -152,7 +156,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(1, topo.getInt("kfactor"));
@@ -163,6 +167,202 @@ public class TestClusterCompiler extends TestCase
             ClusterConfig.addHosts(3, topo);
             fail("Shouldn't allow adding more than ksafe + 1 node");
         } catch (AssertionError e) {}
+    }
+
+    public void testRejoinOneNode() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology =
+        ImmutableMap.of(0, "0",
+                        1, "0");
+        killAndRejoinNodes(topology, 1, 1);
+    }
+
+    public void testRejoinTwoNodes() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology =
+        ImmutableMap.of(0, "0",
+                        1, "1",
+                        2, "2");
+        killAndRejoinNodes(topology, 2, 2);
+    }
+
+    public void testRejoinTwoNodesToTwo() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
+                                                 .put(0, "0")
+                                                 .put(1, "0")
+                                                 .put(2, "1")
+                                                 .put(3, "1")
+                                                 .put(4, "2")
+                                                 .put(5, "2")
+                                                 .build();
+        killAndRejoinNodes(topology, 1, 2);
+    }
+
+    public void testRejoinThreeNodesToFour() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
+                                                 .put(0, "0")
+                                                 .put(1, "0")
+                                                 .put(2, "0")
+                                                 .put(3, "0")
+                                                 .put(4, "1")
+                                                 .put(5, "1")
+                                                 .put(6, "1")
+                                                 .build();
+        killAndRejoinNodes(topology, 2, 3);
+    }
+
+    private static void killAndRejoinNodes(ImmutableMap<Integer, String> fullHostGroup, int kfactor, int nodesToKill)
+    throws JSONException
+    {
+        final int maxSph = 20;
+        for (int sph = 1; sph < maxSph; sph++) {
+            final Map<Integer, String> rejoinHostGroup = new HashMap<>(fullHostGroup);
+            final ClusterConfig initialConfig = new ClusterConfig(rejoinHostGroup.size(), sph, kfactor);
+            if (!initialConfig.validate()) {
+                // Invalid config, skip
+                continue;
+            }
+            final JSONObject initialTopo = initialConfig.getTopology(rejoinHostGroup, HashMultimap.create(), new HashMap<>());
+
+            final Multimap<Integer, Integer> partitionToHosts = HashMultimap.create();
+            final Multimap<Integer, Integer> hostPartitions = HashMultimap.create();
+            final Multimap<Integer, Integer> hostMasters = HashMultimap.create();
+            for (int hostId : rejoinHostGroup.keySet()) {
+                for (int pid : ClusterConfig.partitionsForHost(initialTopo, hostId)) {
+                    partitionToHosts.put(pid, hostId);
+                }
+                hostPartitions.putAll(hostId, ClusterConfig.partitionsForHost(initialTopo, hostId));
+                hostMasters.putAll(hostId, ClusterConfig.partitionsForHost(initialTopo, hostId, true));
+            }
+
+            // Pick nodes to kill from different groups. if this is
+            // not a valid topology for multiple rejoins in different
+            // groups, the returned set will be empty.
+            final Set<Integer> hostIdsToKill = pickNodesInDiffGroupsToKill(fullHostGroup, hostPartitions, kfactor, nodesToKill);
+            if (hostIdsToKill.isEmpty()) {
+                System.out.println("Not a valid topology for multi node rejoin, skipping. Sites per host " + sph);
+                continue;
+            }
+            System.out.println("Running config: sites " + sph + ", host partitions: " + hostPartitions +
+                               ", nodes to kill: " + hostIdsToKill);
+
+            // Remove all partitions and masters from the failed nodes, migrate masters to remaining nodes
+            final Multimap<Integer, Integer> expectedRejoinHostPartitions = HashMultimap.create();
+            final HashSet<Integer> liveHosts = new HashSet<>(hostPartitions.keySet());
+            final Map<Integer, String> rejoinHostGroups = new HashMap<>();
+            for (int toKill : hostIdsToKill) {
+                liveHosts.remove(toKill);
+                for (int masterToRedistribute : hostMasters.get(toKill)) {
+                    for (int hostCandidate : partitionToHosts.get(masterToRedistribute)) {
+                        if (hostCandidate != toKill && liveHosts.contains(hostCandidate)) {
+                            hostMasters.put(hostCandidate, masterToRedistribute);
+                            break;
+                        }
+                    }
+                }
+                expectedRejoinHostPartitions.putAll(toKill, hostPartitions.removeAll(toKill));
+                hostMasters.removeAll(toKill);
+                rejoinHostGroups.put(toKill, rejoinHostGroup.remove(toKill));
+            }
+
+            // Fake partition to HSID mappings
+            Multimap<Integer, Long> replicas = HashMultimap.create();
+            for (Map.Entry<Integer, Integer> e : hostPartitions.entries()) {
+                replicas.put(e.getValue(), CoreUtils.getHSIdFromHostAndSite(e.getKey(), e.getValue()));
+            }
+            Map<Integer, Long> masters = new HashMap<>();
+            for (Map.Entry<Integer, Integer> e : hostMasters.entries()) {
+                masters.put(e.getValue(), CoreUtils.getHSIdFromHostAndSite(e.getKey(), e.getValue()));
+            }
+
+            // Rejoin one node at a time and verify that they have the correct partitions
+            for (Map.Entry<Integer, String> rejoin : rejoinHostGroups.entrySet()) {
+                final int rejoinHostId = rejoin.getKey() + fullHostGroup.size();
+                System.out.println("Rejoining " + rejoin.getKey() + " as " + rejoinHostId + " in group " + rejoin.getValue());
+                rejoinHostGroup.put(rejoinHostId, rejoin.getValue());
+                final JSONObject rejoinTopo = initialConfig.getTopology(rejoinHostGroup, replicas, masters);
+                final List<Integer> partitionsOnRejoinHost = ClusterConfig.partitionsForHost(rejoinTopo, rejoinHostId);
+
+                // Verify rejoined host first. Partitions on rejoined host should have
+                // at least one replica in a different group.
+                if (fullHostGroup.values().stream().distinct().count() > 1) {
+                    for (int partitionOnRejoined : partitionsOnRejoinHost) {
+                        final String rejoinedHostGroup = rejoin.getValue();
+                        boolean foundHostInOtherGroup = false;
+                        for (long hsId : replicas.get(partitionOnRejoined)) {
+                            if (!rejoinHostGroup.get(CoreUtils.getHostIdFromHSId(hsId)).equals(rejoinedHostGroup)) {
+                                foundHostInOtherGroup = true;
+                                break;
+                            }
+                        }
+                        assertTrue("Host " + rejoin.getKey() + " partition " + partitionOnRejoined + " rejoined: " +
+                                   partitionsOnRejoinHost + " current " + replicas,
+                                   foundHostInOtherGroup);
+                    }
+                }
+                assertTrue(ClusterConfig.partitionsForHost(rejoinTopo, rejoinHostId, true).isEmpty()); // No master on rejoined host
+
+                // Verify existing hosts remain the same
+                for (Map.Entry<Integer, Collection<Integer>> e : hostPartitions.asMap().entrySet()) {
+                    int hostId = e.getKey();
+                    if (rejoinHostGroups.containsKey(e.getKey())) {
+                        hostId = e.getKey() + fullHostGroup.size();
+                    }
+                    assertEquals("host " + hostId + " key " + e.getKey(), e.getValue(), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, hostId)));
+                    assertEquals(hostMasters.get(e.getKey()), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, hostId, true)));
+                }
+
+                // Now add the rejoined host to the live host maps
+                hostPartitions.putAll(rejoin.getKey(), partitionsOnRejoinHost);
+                for (int pid : partitionsOnRejoinHost) {
+                    replicas.put(pid, CoreUtils.getHSIdFromHostAndSite(rejoinHostId, pid));
+                }
+            }
+        }
+    }
+
+    private static Set<Integer> pickNodesInDiffGroupsToKill(ImmutableMap<Integer, String> topo,
+                                                            Multimap<Integer, Integer> hostPartitions,
+                                                            int kfactor,
+                                                            int nodesToKill)
+    {
+        for (Set<Integer> perm : Sets.powerSet(topo.keySet())) {
+            // Skip permutation size not equal to the node count to kill
+            if (perm.size() != nodesToKill) {
+                continue;
+            }
+            // If the nodes in the list share the group, skip
+            if (perm.stream().map(topo::get).distinct().count() != nodesToKill) {
+                continue;
+            }
+
+            // Count the occurrences of each partition in the candidate nodes
+            Map<Integer, Integer> partitionOccurrances = new HashMap<>();
+            perm.stream().map(hostPartitions::get).forEach(s -> s.forEach(a -> {
+                if (partitionOccurrances.containsKey(a)) {
+                    partitionOccurrances.put(a, partitionOccurrances.get(a) + 1);
+                } else {
+                    partitionOccurrances.put(a, 1);
+                }
+            }));
+
+            // If a partition appears k+1 times in the candidate nodes, killing
+            // them will take the cluster down, so skip this set of candidate nodes
+            boolean skip = false;
+            for (int count : partitionOccurrances.values()) {
+                if (count > kfactor) {
+                    skip = true;
+                }
+            }
+            if (skip) {
+                continue;
+            }
+
+            return new HashSet<>(perm);
+        }
+        return new HashSet<>();
     }
 
     public void testFourNodesOneGroups() throws JSONException
@@ -213,7 +413,7 @@ public class TestClusterCompiler extends TestCase
         hostGroups.put(3, "1");
         hostGroups.put(4, "2");
         hostGroups.put(5, "2");
-        runConfigAndVerifyTopology(hostGroups, 2);
+        runConfigAndVerifyTopology(hostGroups, 1);
     }
 
     public void testFiveNodesTwoGroups() throws JSONException
@@ -262,6 +462,15 @@ public class TestClusterCompiler extends TestCase
         runConfigAndVerifyTopology(hostGroups, 2);
     }
 
+    public void testFiftNodesInThreeGroups() throws JSONException
+    {
+        Map<Integer, String> hostGroups = Maps.newHashMap();
+        for (int i = 0; i < 50; i++) {
+            hostGroups.put(i, String.valueOf(i % 3));
+        }
+        runConfigAndVerifyTopology(hostGroups, 2);
+    }
+
     private static void runConfigAndVerifyTopology(Map<Integer, String> hostGroups, int kfactor) throws JSONException
     {
         final int maxSites = 20;
@@ -273,9 +482,9 @@ public class TestClusterCompiler extends TestCase
 
         for (int sites = 1; sites <= maxSites; sites++) {
             final ClusterConfig config = new ClusterConfig(hostGroups.size(), sites, kfactor);
-            System.out.println("Running config " + sites + " sitesperhost, k=" + kfactor);
+            System.out.println("Running config " + hostGroups.size() + " hosts, " + sites + " sitesperhost, k=" + kfactor);
             if (config.validate()) {
-                final JSONObject topo = config.getTopology(hostGroups);
+                final JSONObject topo = config.getTopology(hostGroups, HashMultimap.create(), new HashMap<>());
                 verifyTopology(hostGroups, topo);
             } else {
                 System.out.println(config.getErrorMsg());
@@ -320,17 +529,11 @@ public class TestClusterCompiler extends TestCase
             assertEquals(nodesWithMaxMasterCount, masterCountToHost.get(maxMasterCount).size());
         }
 
-        for (Map.Entry<String, Collection<Integer>> ghEntry : groupHosts.asMap().entrySet()) {
-            if (ghEntry.getValue().size() * sitesPerHost < partitionCount) {
-                // Non-optimal topology, no need to verify the rest
-                System.out.println("Group " + ghEntry.getKey() + " only has " + ghEntry.getValue().size() + " hosts");
-                return;
-            }
-        }
-
         // Each group should have at least one copy of all the partitions
-        for (Collection<Integer> partitions : groupPartitions.asMap().values()) {
-            assertEquals(partitionCount, Sets.newHashSet(partitions).size());
+        for (Map.Entry<String, Collection<Integer>> groupAndPids : groupPartitions.asMap().entrySet()) {
+            assertEquals(groupPartitions.toString(),
+                         Math.min(partitionCount, groupHosts.get(groupAndPids.getKey()).size() * sitesPerHost),
+                         Sets.newHashSet(groupAndPids.getValue()).size());
         }
     }
 }

--- a/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
@@ -28,19 +28,22 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
-import com.google_voltpatches.common.collect.ImmutableMap;
-import com.google_voltpatches.common.collect.HashMultimap;
-import com.google_voltpatches.common.collect.Maps;
-import com.google_voltpatches.common.collect.Multimap;
-import com.google_voltpatches.common.collect.Sets;
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
-
-import junit.framework.TestCase;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.VoltDB;
+
+import com.google_voltpatches.common.collect.HashMultimap;
+import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.Maps;
+import com.google_voltpatches.common.collect.Multimap;
+import com.google_voltpatches.common.collect.Multimaps;
+import com.google_voltpatches.common.collect.Sets;
+
+import junit.framework.TestCase;
 
 public class TestClusterCompiler extends TestCase
 {
@@ -169,6 +172,75 @@ public class TestClusterCompiler extends TestCase
         } catch (AssertionError e) {}
     }
 
+    public void testEightNodesTwoLevelsOfGroups() throws JSONException
+    {
+        Map<Integer, String> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, "0.0");
+        hostGroups.put(1, "0.0");
+        hostGroups.put(2, "0.1");
+        hostGroups.put(3, "0.1");
+        hostGroups.put(4, "1.0");
+        hostGroups.put(5, "1.0");
+        hostGroups.put(6, "1.1");
+        hostGroups.put(7, "1.1");
+        int kfactor = 3;
+        for (int sph = 1; sph <= 20; sph++) {
+            runConfiguration(true, hostGroups, sph, kfactor, true);
+        }
+    }
+
+    public void testTenNodes_ENG13435() throws JSONException
+    {
+        Map<Integer, String> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, "FC1");
+        hostGroups.put(1, "FC2");
+        hostGroups.put(2, "FC2");
+        hostGroups.put(3, "FC2");
+        hostGroups.put(4, "FC2");
+        hostGroups.put(5, "FC1");
+        hostGroups.put(6, "FC2");
+        hostGroups.put(7, "FC1");
+        hostGroups.put(8, "FC1");
+        hostGroups.put(9, "FC1");
+        int kfactor = 3;
+        for (int sph = 1; sph <= 20; sph++) {
+            runConfiguration(true, hostGroups, sph, kfactor, false);
+        }
+    }
+
+    public void testSixNodes_ENG13435() throws JSONException
+    {
+        Map<Integer, String> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, "FC1");
+        hostGroups.put(1, "FC2");
+        hostGroups.put(2, "FC2");
+        hostGroups.put(3, "FC2");
+        hostGroups.put(4, "FC1");
+        hostGroups.put(5, "FC1");
+        int kfactor = 3;
+        for (int sph = 1; sph <= 20; sph++) {
+            runConfiguration(true, hostGroups, sph, kfactor, false);
+        }
+    }
+
+    // For non-optimal but legitimate configuration, only verify that
+    // all the nodes have right number of partitions and k-safety constrain
+    // is satisfied.
+    public void testRandomNonOptimalConfig() throws JSONException
+    {
+        for (int i = 0; i < 200; i++) {
+            runRandomHAGroupTest(false);
+        }
+        System.out.println("Hooooray!!!!!!!!!!!");
+    }
+
+    public void testRandomOptimalConfig() throws JSONException
+    {
+        for (int i = 0; i < 200; i++) {
+            runRandomHAGroupTest(true);
+        }
+    }
+
     public void testRejoinOneNode() throws JSONException
     {
         ImmutableMap<Integer, String> topology =
@@ -196,7 +268,7 @@ public class TestClusterCompiler extends TestCase
                                                  .put(4, "2")
                                                  .put(5, "2")
                                                  .build();
-        killAndRejoinNodes(topology, 1, 2);
+        killAndRejoinNodes(topology, 2, 2);
     }
 
     public void testRejoinThreeNodesToFour() throws JSONException
@@ -209,8 +281,27 @@ public class TestClusterCompiler extends TestCase
                                                  .put(4, "1")
                                                  .put(5, "1")
                                                  .put(6, "1")
+                                                 .put(7, "1")
                                                  .build();
-        killAndRejoinNodes(topology, 2, 3);
+        killAndRejoinNodes(topology, 3, 3);
+    }
+
+    // Kill entire rack plus one more node on the other rack, then rejoin them back
+    public void testRejoinSixNodes() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
+                                                 .put(0, "0")
+                                                 .put(1, "1")
+                                                 .put(2, "1")
+                                                 .put(3, "1")
+                                                 .put(4, "1")
+                                                 .put(5, "0")
+                                                 .put(6, "0")
+                                                 .put(7, "1")
+                                                 .put(8, "0")
+                                                 .put(9, "0")
+                                                 .build();
+        killAndRejoinNodes(topology, 3, 6);
     }
 
     private static void killAndRejoinNodes(ImmutableMap<Integer, String> fullHostGroup, int kfactor, int nodesToKill)
@@ -240,12 +331,14 @@ public class TestClusterCompiler extends TestCase
             // Pick nodes to kill from different groups. if this is
             // not a valid topology for multiple rejoins in different
             // groups, the returned set will be empty.
-            final Set<Integer> hostIdsToKill = pickNodesInDiffGroupsToKill(fullHostGroup, hostPartitions, kfactor, nodesToKill);
+            Multimap<String, Integer> groupToHosts = Multimaps.invertFrom(Multimaps.forMap(rejoinHostGroup), HashMultimap.create());
+            final Set<Integer> hostIdsToKill = pickNodesInDiffGroupsToKill(fullHostGroup, groupToHosts, hostPartitions, kfactor, nodesToKill);
             if (hostIdsToKill.isEmpty()) {
                 System.out.println("Not a valid topology for multi node rejoin, skipping. Sites per host " + sph);
                 continue;
             }
-            System.out.println("Running config: sites " + sph + ", host partitions: " + hostPartitions +
+            System.out.println("Running config: sites " + sph + ", k-factor " + kfactor
+                    + ", host partitions: " + hostPartitions +
                                ", nodes to kill: " + hostIdsToKill);
 
             // Remove all partitions and masters from the failed nodes, migrate masters to remaining nodes
@@ -278,31 +371,16 @@ public class TestClusterCompiler extends TestCase
             }
 
             // Rejoin one node at a time and verify that they have the correct partitions
+            JSONObject rejoinTopo = null;
             for (Map.Entry<Integer, String> rejoin : rejoinHostGroups.entrySet()) {
                 final int rejoinHostId = rejoin.getKey() + fullHostGroup.size();
                 System.out.println("Rejoining " + rejoin.getKey() + " as " + rejoinHostId + " in group " + rejoin.getValue());
                 rejoinHostGroup.put(rejoinHostId, rejoin.getValue());
-                final JSONObject rejoinTopo = initialConfig.getTopology(rejoinHostGroup, replicas, masters);
+                rejoinTopo = initialConfig.getTopology(rejoinHostGroup, replicas, masters);
                 final List<Integer> partitionsOnRejoinHost = ClusterConfig.partitionsForHost(rejoinTopo, rejoinHostId);
 
-                // Verify rejoined host first. Partitions on rejoined host should have
-                // at least one replica in a different group.
-                if (fullHostGroup.values().stream().distinct().count() > 1) {
-                    for (int partitionOnRejoined : partitionsOnRejoinHost) {
-                        final String rejoinedHostGroup = rejoin.getValue();
-                        boolean foundHostInOtherGroup = false;
-                        for (long hsId : replicas.get(partitionOnRejoined)) {
-                            if (!rejoinHostGroup.get(CoreUtils.getHostIdFromHSId(hsId)).equals(rejoinedHostGroup)) {
-                                foundHostInOtherGroup = true;
-                                break;
-                            }
-                        }
-                        assertTrue("Host " + rejoin.getKey() + " partition " + partitionOnRejoined + " rejoined: " +
-                                   partitionsOnRejoinHost + " current " + replicas,
-                                   foundHostInOtherGroup);
-                    }
-                }
-                assertTrue(ClusterConfig.partitionsForHost(rejoinTopo, rejoinHostId, true).isEmpty()); // No master on rejoined host
+                // No master on rejoined host
+                assertTrue(ClusterConfig.partitionsForHost(rejoinTopo, rejoinHostId, true).isEmpty());
 
                 // Verify existing hosts remain the same
                 for (Map.Entry<Integer, Collection<Integer>> e : hostPartitions.asMap().entrySet()) {
@@ -320,22 +398,41 @@ public class TestClusterCompiler extends TestCase
                     replicas.put(pid, CoreUtils.getHSIdFromHostAndSite(rejoinHostId, pid));
                 }
             }
+            assert (rejoinTopo != null);
+            // Verify partitions are well balanced across groups
+            verifyTopology(true, true, rejoinHostGroup, rejoinTopo, kfactor);
         }
     }
 
     private static Set<Integer> pickNodesInDiffGroupsToKill(ImmutableMap<Integer, String> topo,
+                                                            Multimap<String, Integer> groupToHosts,
                                                             Multimap<Integer, Integer> hostPartitions,
                                                             int kfactor,
                                                             int nodesToKill)
     {
+        // Find minimum number of nodes in placement groups
+        int minNode = groupToHosts.asMap().values().stream()
+                .mapToInt(c -> c.size())
+                .min()
+                .orElse(Integer.MAX_VALUE);
         for (Set<Integer> perm : Sets.powerSet(topo.keySet())) {
             // Skip permutation size not equal to the node count to kill
             if (perm.size() != nodesToKill) {
                 continue;
             }
-            // If the nodes in the list share the group, skip
-            if (perm.stream().map(topo::get).distinct().count() != nodesToKill) {
-                continue;
+
+            if (nodesToKill > minNode) {
+                boolean killRack = false;
+                for (Map.Entry<String, Collection<Integer>> group : groupToHosts.asMap().entrySet()) {
+                    // Then kill entire rack
+                    if (perm.containsAll(group.getValue())) {
+                        killRack = true;
+                        break;
+                    }
+                }
+                if (!killRack) {
+                    continue;
+                }
             }
 
             // Count the occurrences of each partition in the candidate nodes
@@ -365,137 +462,69 @@ public class TestClusterCompiler extends TestCase
         return new HashSet<>();
     }
 
-    public void testFourNodesOneGroups() throws JSONException
+    // optimal means only generate configurations that
+    // 1) each placement group has same number of nodes
+    // 2) number of placement groups is divisible to (kfactor + 1)
+    private static void runRandomHAGroupTest(boolean optimal) throws JSONException
     {
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        final int MAX_RACKS = 5;
+        final int MAX_RACK_NODES = 10;
+        final int MAX_K = 10;
+        final int MAX_PARTITIONS = 20;
+        int rackCount = optimal ? (r.nextInt(MAX_RACKS) + 1 ): r.nextInt(2, MAX_RACKS + 1); // [1-5] or [2-5]
+        int rackNodeCount = r.nextInt(MAX_RACK_NODES) + 1; // [1-10]
+        int totalNodeCount = rackNodeCount * rackCount;
+        int k, sph;
+        do {
+            int lowerBound = optimal ? (rackCount - 1) : 0;
+            k = r.nextInt(lowerBound, Math.min(totalNodeCount, MAX_K));  // [rackCount - 1, 10]
+        } while (optimal ?
+                (k + 1) % rackCount != 0 : (k + 1) % rackCount == 0);
+        do {
+            sph = r.nextInt(MAX_PARTITIONS) + 1; // [1-20]
+        } while ((totalNodeCount * sph) % (k + 1) != 0 );
+        //////////////////////////////////////////////////////////////////////////
+        System.out.println(
+                String.format("Optimal=%s Node count: %d, kfactor: %d, SPH: %d, # of racks: %d",
+                              optimal ? "true" : "false", totalNodeCount, k, sph, rackCount));
+        //////////////////////////////////////////////////////////////////////////
         Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "0");
-        hostGroups.put(3, "0");
-        runConfigAndVerifyTopology(hostGroups, 1);
-    }
-
-    public void testFourNodesTwoGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "1");
-        hostGroups.put(3, "1");
-        runConfigAndVerifyTopology(hostGroups, 1);
-    }
-
-    public void testFourNodesTwoGroupsNonoptimal() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "0");
-        hostGroups.put(3, "1");
-        runConfigAndVerifyTopology(hostGroups, 1);
-    }
-
-    public void testThreeNodesThreeGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "1");
-        hostGroups.put(2, "2");
-        runConfigAndVerifyTopology(hostGroups, 2);
-    }
-
-    public void testSixNodesThreeGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "1");
-        hostGroups.put(3, "1");
-        hostGroups.put(4, "2");
-        hostGroups.put(5, "2");
-        runConfigAndVerifyTopology(hostGroups, 1);
-    }
-
-    public void testFiveNodesTwoGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "1");
-        hostGroups.put(3, "1");
-        hostGroups.put(4, "1");
-        runConfigAndVerifyTopology(hostGroups, 2);
-    }
-
-    public void testEightNodesTwoLevelsOfGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0.0");
-        hostGroups.put(1, "0.0");
-        hostGroups.put(2, "0.1");
-        hostGroups.put(3, "0.1");
-        hostGroups.put(4, "1.0");
-        hostGroups.put(5, "1.0");
-        hostGroups.put(6, "1.1");
-        hostGroups.put(7, "1.1");
-        runConfigAndVerifyTopology(hostGroups, 3);
-    }
-
-    public void testFifteenNodesTwoGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "0");
-        hostGroups.put(3, "0");
-        hostGroups.put(4, "0");
-        hostGroups.put(5, "0");
-        hostGroups.put(6, "0");
-        hostGroups.put(7, "0");
-        hostGroups.put(8, "1");
-        hostGroups.put(9, "1");
-        hostGroups.put(10, "1");
-        hostGroups.put(11, "1");
-        hostGroups.put(12, "1");
-        hostGroups.put(13, "1");
-        hostGroups.put(14, "1");
-        runConfigAndVerifyTopology(hostGroups, 2);
-    }
-
-    public void testFiftNodesInThreeGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        for (int i = 0; i < 50; i++) {
-            hostGroups.put(i, String.valueOf(i % 3));
-        }
-        runConfigAndVerifyTopology(hostGroups, 2);
-    }
-
-    private static void runConfigAndVerifyTopology(Map<Integer, String> hostGroups, int kfactor) throws JSONException
-    {
-        final int maxSites = 20;
-        int invalidConfigCount = 0;
-        int expectedInvalidConfigs = 0;
-        if (hostGroups.size() % (kfactor + 1) != 0) {
-            expectedInvalidConfigs = maxSites - (maxSites / (kfactor + 1));
+        for (int i = 0; i < totalNodeCount; i++) {
+            hostGroups.put(i, String.valueOf(i % rackCount));
         }
 
-        for (int sites = 1; sites <= maxSites; sites++) {
-            final ClusterConfig config = new ClusterConfig(hostGroups.size(), sites, kfactor);
-            System.out.println("Running config " + hostGroups.size() + " hosts, " + sites + " sitesperhost, k=" + kfactor);
-            if (config.validate()) {
-                final JSONObject topo = config.getTopology(hostGroups, HashMultimap.create(), new HashMap<>());
-                verifyTopology(hostGroups, topo);
-            } else {
-                System.out.println(config.getErrorMsg());
-                invalidConfigCount++;
+        runConfiguration(optimal, hostGroups, sph, k, true);
+    }
+
+    private static void runConfiguration(
+            boolean optimal,
+            Map<Integer, String> hostGroups,
+            int sph,
+            int kfactor,
+            boolean print) throws JSONException
+    {
+        final ClusterConfig config = new ClusterConfig(hostGroups.size(), sph, kfactor);
+        System.out.println("Running config " + hostGroups.size() + " hosts, " + sph + " sitesperhost, k=" + kfactor);
+        if (config.validate()) {
+            long start = System.currentTimeMillis();
+            final JSONObject topo = config.getTopology(hostGroups, HashMultimap.create(), new HashMap<>());
+            if (print) {
+                System.out.println("It takes " + (System.currentTimeMillis() - start) + " ms to compute the topo.");
+                System.out.println(topo);
             }
+            verifyTopology(optimal, false, hostGroups, topo, kfactor);
+        } else {
+            System.out.println(config.getErrorMsg());
         }
-
-        assertEquals(expectedInvalidConfigs, invalidConfigCount);
     }
 
-    private static void verifyTopology(Map<Integer, String> hostGroups, JSONObject topo) throws JSONException
+    private static void verifyTopology(
+            boolean optimal,
+            boolean isRejoin,
+            Map<Integer, String> hostGroups,
+            JSONObject topo,
+            int kfactor) throws JSONException
     {
         final int hostCount = new ClusterConfig(topo).getHostCount();
         final int sitesPerHost = new ClusterConfig(topo).getSitesPerHost();
@@ -506,34 +535,55 @@ public class TestClusterCompiler extends TestCase
 
         Multimap<Integer, Integer> masterCountToHost = HashMultimap.create();
         Multimap<String, Integer> groupHosts = HashMultimap.create();
-        Multimap<String, Integer> groupPartitions = HashMultimap.create();
+        Map<String, Map<Integer, Integer>> groupPartitions = new HashMap<>();   // <groupId, <pId, count>>
         for (Map.Entry<Integer, String> entry : hostGroups.entrySet()) {
             final List<Integer> hostPartitions = ClusterConfig.partitionsForHost(topo, entry.getKey());
             final List<Integer> hostMasters = ClusterConfig.partitionsForHost(topo, entry.getKey(), true);
+            // Make sure a host has exactly sitesPerHost number of partitions
             assertEquals(sitesPerHost, hostPartitions.size());
             // Make sure a host only has unique partitions
             assertEquals(hostPartitions.size(), Sets.newHashSet(hostPartitions).size());
 
             masterCountToHost.put(hostMasters.size(), entry.getKey());
             groupHosts.put(entry.getValue(), entry.getKey());
-            groupPartitions.putAll(entry.getValue(), hostPartitions);
+            Map<Integer, Integer> pidCountMap = groupPartitions.get(entry.getValue());
+            if (pidCountMap != null) {
+                for (Integer pid : hostPartitions) {
+                    if (pidCountMap.containsKey(pid)) {
+                        int count = pidCountMap.get(pid);
+                        pidCountMap.put(pid, count + 1);
+                    } else {
+                        pidCountMap.put(pid, 1);
+                    }
+                }
+            } else {
+                pidCountMap = new HashMap<Integer, Integer>();
+                groupPartitions.put(entry.getValue(), pidCountMap);
+                for (Integer pid : hostPartitions) {
+                    pidCountMap.put(pid, 1);
+                }
+            }
         }
 
-        // Make sure master partitions are spread out
-        if (nodesWithMaxMasterCount == 0) {
-            assertEquals(1, masterCountToHost.keySet().size());
-            assertTrue(masterCountToHost.containsKey(minMasterCount));
-        } else {
-            assertEquals(2, masterCountToHost.keySet().size());
-            assertTrue(masterCountToHost.containsKey(minMasterCount));
-            assertEquals(nodesWithMaxMasterCount, masterCountToHost.get(maxMasterCount).size());
-        }
+        if (optimal) {
+            if (!isRejoin) {
+                // Make sure master partitions are spread out
+                if (nodesWithMaxMasterCount == 0) {
+                    assertEquals(1, masterCountToHost.keySet().size());
+                    assertTrue(masterCountToHost.containsKey(minMasterCount));
+                } else {
+                    assertEquals(2, masterCountToHost.keySet().size());
+                    assertTrue(masterCountToHost.containsKey(minMasterCount));
+                    assertEquals(nodesWithMaxMasterCount, masterCountToHost.get(maxMasterCount).size());
+                }
+            }
+            int expectedReplicasPerGroup = (kfactor + 1) / groupPartitions.size();
 
-        // Each group should have at least one copy of all the partitions
-        for (Map.Entry<String, Collection<Integer>> groupAndPids : groupPartitions.asMap().entrySet()) {
-            assertEquals(groupPartitions.toString(),
-                         Math.min(partitionCount, groupHosts.get(groupAndPids.getKey()).size() * sitesPerHost),
-                         Sets.newHashSet(groupAndPids.getValue()).size());
+            // Each group should have equal number of copies of all the partitions
+            for (Map.Entry<String, Map<Integer, Integer>> groupAndPids : groupPartitions.entrySet()) {
+                assertTrue( groupPartitions.toString(),
+                        groupAndPids.getValue().values().stream().allMatch(c -> c == expectedReplicasPerGroup));
+            }
         }
     }
 }

--- a/tests/frontend/org/voltdb/iv2/TestCartographer.java
+++ b/tests/frontend/org/voltdb/iv2/TestCartographer.java
@@ -80,65 +80,6 @@ public class TestCartographer extends ZKTestBase {
     }
 
     @Test
-    public void testReplicateLeastReplicated()
-    {
-        // Gin up our fake replication counts to leave the last partition needing two replicas
-        // 5 hosts, 3 sites/host, k=2 is 15 sites, 5 partitions.
-        // Need 2 hosts dead, so 6 missing replicas, last one needs to miss 2
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        repsPerPart.put(0, 2);
-        repsPerPart.put(1, 2);
-        repsPerPart.put(2, 2);
-        repsPerPart.put(3, 2);
-        repsPerPart.put(4, 1);
-        int kfactor = 2;
-        int numberOfPartitions = 5;
-        int sitesPerHost = 3;
-
-        List<Integer> firstRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(3, firstRejoin.size());
-        assertEquals((Integer)4, firstRejoin.get(0));
-        assertEquals((Integer)0, firstRejoin.get(1));
-        assertEquals((Integer)1, firstRejoin.get(2));
-        // add to each of the repsPerPart from the firstRejoin results
-        for (int partition : firstRejoin) {
-            repsPerPart.put(partition, repsPerPart.get(partition) + 1);
-        }
-
-        // now do it again and make sure we fully replicate
-        List<Integer> secondRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(3, secondRejoin.size());
-        assertEquals((Integer)2, secondRejoin.get(0));
-        assertEquals((Integer)3, secondRejoin.get(1));
-        assertEquals((Integer)4, secondRejoin.get(2));
-    }
-
-    @Test
-    public void testNoOverReplication()
-    {
-        // We'll set things up to only require one more replica and then offer up a host with more sites
-        // than we need.  This particular case could never happen but should test the logic correctly.
-        // Also, test that we don't replicate the same partition twice on the same host again.
-        int kfactor = 2;
-        int numberOfPartitions = 5;
-        int sitesPerHost = 3;
-
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        repsPerPart.put(0, 3);
-        repsPerPart.put(1, 3);
-        repsPerPart.put(2, 3);
-        repsPerPart.put(3, 3);
-        repsPerPart.put(4, 1);
-
-        List<Integer> firstRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(1, firstRejoin.size());
-        assertEquals((Integer)4, firstRejoin.get(0));
-    }
-
-    @Test
     public void testSPMasterChange() throws Exception
     {
         ZooKeeper zk = getClient(0);

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -37,8 +38,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.google_voltpatches.common.collect.Maps;
-import com.google_voltpatches.common.collect.Sets;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONException;
@@ -54,7 +53,10 @@ import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
 import org.voltdb.compiler.ClusterConfig;
 
+import com.google_voltpatches.common.collect.HashMultimap;
 import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.Maps;
+import com.google_voltpatches.common.collect.Sets;
 
 public class TestLeaderAppointer extends ZKTestBase {
 
@@ -129,9 +131,10 @@ public class TestLeaderAppointer extends ZKTestBase {
     {
         KSafetyStats stats = new KSafetyStats();
         m_dut = new LeaderAppointer(m_hm, m_config.getPartitionCount(),
-                m_config.getReplicationFactor(), enablePPD,
-                null, false,
-                m_config.getTopology(m_hostGroups), m_mpi, stats, false);
+                                    m_config.getReplicationFactor(), enablePPD,
+                                    null, false,
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
+                                    m_mpi, stats, false);
         m_dut.onReplayCompletion();
     }
 
@@ -276,11 +279,14 @@ public class TestLeaderAppointer extends ZKTestBase {
         m_dut.shutdown();
         deleteReplica(0, m_cache.pointInTimeCache().get(0));
         // create a new appointer and start it up in the replay state
-        m_dut = new LeaderAppointer(m_hm, m_config.getPartitionCount(),
+        m_dut = new LeaderAppointer(m_hm,
+                                    m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(), false,
                                     null, false,
-                                    m_config.getTopology(m_hostGroups), m_mpi,
-                                    new KSafetyStats(), false);
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
+                                    m_mpi,
+                                    new KSafetyStats(),
+                                    false);
         m_newAppointee.set(false);
         VoltDB.ignoreCrash = true;
         boolean threw = false;
@@ -572,11 +578,14 @@ public class TestLeaderAppointer extends ZKTestBase {
         m_dut.shutdown();
         deleteReplica(0, m_cache.pointInTimeCache().get(0));
         // create a new appointer and start it up with expectSyncSnapshot=true
-        m_dut = new LeaderAppointer(m_hm, m_config.getPartitionCount(),
+        m_dut = new LeaderAppointer(m_hm,
+                                    m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(), false,
                                     null, false,
-                                    m_config.getTopology(m_hostGroups), m_mpi,
-                                    new KSafetyStats(), true);
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
+                                    m_mpi,
+                                    new KSafetyStats(),
+                                    true);
         m_dut.onReplayCompletion();
         m_newAppointee.set(false);
         VoltDB.ignoreCrash = true;


### PR DESCRIPTION
    ENG-13435, improve rack-aware alogrithm to generate well-balanced partitions assignment.

    The original algorithm was using greedy rack-aware algorithm to always assign partitions
    to *furthest* node. The problem is that it may not always come up with a feasible partition
    assignment even though one exists. And also it doesn't guarantte partition replicas are
    well balanced across multiple placement groups, e.g. in 2-rack K=3 configuration one group
    may have 3 or 4 replicas for some partitions.

    Rejoin may also break the rack-awareness by bring too many replicas to one of the placement
    groups.

    This patch improves the original algorithm by adding extra step after it couldn't find the
    viable solution. First it spreads partition replicas out across placement groups,
    until no more partitions can be assigned due to k-safety constraint (each host must have
    unique partitions), then it tries to move a partition from other nodes with the same placement
    group to a emptier host. Repeat above steps until all the nodes get enough partition replicas.

    This algorithm works best when following rules are met in the configuration:

    1. each placement group must have same number of nodes, and
    2. number of partition replicas (kfactor + 1) must be multiple of number of placement groups.

    When those rules aren't met, this algorithm still tries best to generate feasible solution but
    there is no further gurantee on the rack-awareness.

Companion Pro PR: https://github.com/VoltDB/pro/pull/2185