### PR TITLE
Use an unbounded wildcard to verify whether the object reference is a…

### DIFF
--- a/third_party/java/src/com/google_voltpatches/common/collect/AbstractMapBasedMultimap.java
+++ b/third_party/java/src/com/google_voltpatches/common/collect/AbstractMapBasedMultimap.java
@@ -270,11 +270,11 @@ abstract class AbstractMapBasedMultimap<K, V> extends AbstractMultimap<K, V>
   Collection<V> unmodifiableCollectionSubclass(Collection<V> collection) {
     // We don't deal with NavigableSet here yet for GWT reasons -- instead,
     // non-GWT TreeMultimap explicitly overrides this and uses NavigableSet.
-    if (collection instanceof SortedSet) {
+    if (collection instanceof SortedSet<?>) {
       return Collections.unmodifiableSortedSet((SortedSet<V>) collection);
-    } else if (collection instanceof Set) {
+    } else if (collection instanceof Set<?>) {
       return Collections.unmodifiableSet((Set<V>) collection);
-    } else if (collection instanceof List) {
+    } else if (collection instanceof List<?>) {
       return Collections.unmodifiableList((List<V>) collection);
     } else {
       return Collections.unmodifiableCollection(collection);
@@ -315,11 +315,11 @@ abstract class AbstractMapBasedMultimap<K, V> extends AbstractMultimap<K, V>
   Collection<V> wrapCollection(@Nullable K key, Collection<V> collection) {
     // We don't deal with NavigableSet here yet for GWT reasons -- instead,
     // non-GWT TreeMultimap explicitly overrides this and uses NavigableSet.
-    if (collection instanceof SortedSet) {
+    if (collection instanceof SortedSet<?>) {
       return new WrappedSortedSet(key, (SortedSet<V>) collection, null);
-    } else if (collection instanceof Set) {
+    } else if (collection instanceof Set<?>) {
       return new WrappedSet(key, (Set<V>) collection);
-    } else if (collection instanceof List) {
+    } else if (collection instanceof List<?>) {
       return wrapList(key, (List<V>) collection, null);
     } else {
       return new WrappedCollection(key, collection, null);
@@ -603,7 +603,7 @@ abstract class AbstractMapBasedMultimap<K, V> extends AbstractMultimap<K, V>
   }
 
   private Iterator<V> iteratorOrListIterator(Collection<V> collection) {
-    return (collection instanceof List)
+    return (collection instanceof List<?>)
         ? ((List<V>) collection).listIterator()
         : collection.iterator();
   }
@@ -925,7 +925,7 @@ abstract class AbstractMapBasedMultimap<K, V> extends AbstractMultimap<K, V>
   Set<K> createKeySet() {
     // TreeMultimap uses NavigableKeySet explicitly, but we don't handle that here for GWT
     // compatibility reasons
-    return (map instanceof SortedMap)
+    return (map instanceof SortedMap<?, ?>)
         ? new SortedKeySet((SortedMap<K, Collection<V>>) map)
         : new KeySet(map);
   }
@@ -1244,7 +1244,7 @@ abstract class AbstractMapBasedMultimap<K, V> extends AbstractMultimap<K, V>
   Map<K, Collection<V>> createAsMap() {
     // TreeMultimap uses NavigableAsMap explicitly, but we don't handle that here for GWT
     // compatibility reasons
-    return (map instanceof SortedMap)
+    return (map instanceof SortedMap<?, ?>)
         ? new SortedAsMap((SortedMap<K, Collection<V>>) map)
         : new AsMap(map);
   }

--- a/third_party/java/src/com/google_voltpatches/common/collect/CartesianList.java
+++ b/third_party/java/src/com/google_voltpatches/common/collect/CartesianList.java
@@ -97,7 +97,7 @@ final class CartesianList<E> extends AbstractList<List<E>> implements RandomAcce
 
   @Override
   public boolean contains(@Nullable Object o) {
-    if (!(o instanceof List)) {
+    if (!(o instanceof List<?>)) {
       return false;
     }
     List<?> list = (List<?>) o;

--- a/third_party/java/src/com/google_voltpatches/common/collect/Collections2.java
+++ b/third_party/java/src/com/google_voltpatches/common/collect/Collections2.java
@@ -84,7 +84,7 @@ public final class Collections2 {
   // TODO(kevinb): how can we omit that Iterables link when building gwt
   // javadoc?
   public static <E> Collection<E> filter(Collection<E> unfiltered, Predicate<? super E> predicate) {
-    if (unfiltered instanceof FilteredCollection) {
+    if (unfiltered instanceof FilteredCollection<?>) {
       // Support clear(), removeAll(), and retainAll() when filtering a filtered
       // collection.
       return ((FilteredCollection<E>) unfiltered).createCombined(predicate);
@@ -468,7 +468,7 @@ public final class Collections2 {
 
     @Override
     public boolean contains(@Nullable Object obj) {
-      if (obj instanceof List) {
+      if (obj instanceof List<?>) {
         List<?> list = (List<?>) obj;
         return isPermutation(inputList, list);
       }
@@ -583,7 +583,7 @@ public final class Collections2 {
 
     @Override
     public boolean contains(@Nullable Object obj) {
-      if (obj instanceof List) {
+      if (obj instanceof List<?>) {
         List<?> list = (List<?>) obj;
         return isPermutation(inputList, list);
       }

--- a/third_party/java/src/com/google_voltpatches/common/collect/Constraints.java
+++ b/third_party/java/src/com/google_voltpatches/common/collect/Constraints.java
@@ -312,11 +312,11 @@ final class Constraints {
 
   static <E> Collection<E> constrainedTypePreservingCollection(
       Collection<E> collection, Constraint<E> constraint) {
-    if (collection instanceof SortedSet) {
+    if (collection instanceof SortedSet<?>) {
       return constrainedSortedSet((SortedSet<E>) collection, constraint);
-    } else if (collection instanceof Set) {
+    } else if (collection instanceof Set<?>) {
       return constrainedSet((Set<E>) collection, constraint);
-    } else if (collection instanceof List) {
+    } else if (collection instanceof List<?>) {
       return constrainedList((List<E>) collection, constraint);
     } else {
       return constrainedCollection(collection, constraint);

--- a/third_party/java/src/com/google_voltpatches/common/collect/FluentIterable.java
+++ b/third_party/java/src/com/google_voltpatches/common/collect/FluentIterable.java
@@ -138,7 +138,7 @@ public abstract class FluentIterable<E> implements Iterable<E> {
    * {@link Collection}; {@code StreamSupport.stream(iterable.spliterator(), false)} otherwise.
    */
   public static <E> FluentIterable<E> from(final Iterable<E> iterable) {
-    return (iterable instanceof FluentIterable)
+    return (iterable instanceof FluentIterable<?>)
         ? (FluentIterable<E>) iterable
         : new FluentIterable<E>(iterable) {
           @Override
@@ -526,7 +526,7 @@ public abstract class FluentIterable<E> implements Iterable<E> {
 
     // TODO(kevinb): Support a concurrently modified collection?
     Iterable<E> iterable = getDelegate();
-    if (iterable instanceof List) {
+    if (iterable instanceof List<?>) {
       List<E> list = (List<E>) iterable;
       if (list.isEmpty()) {
         return Optional.absent();
@@ -542,7 +542,7 @@ public abstract class FluentIterable<E> implements Iterable<E> {
      * TODO(kevinb): consider whether this "optimization" is worthwhile. Users with SortedSets tend
      * to know they are SortedSets and probably would not call this method.
      */
-    if (iterable instanceof SortedSet) {
+    if (iterable instanceof SortedSet<?>) {
       SortedSet<E> sortedSet = (SortedSet<E>) iterable;
       return Optional.of(sortedSet.last());
     }
@@ -794,7 +794,7 @@ public abstract class FluentIterable<E> implements Iterable<E> {
   public final <C extends Collection<? super E>> C copyInto(C collection) {
     checkNotNull(collection);
     Iterable<E> iterable = getDelegate();
-    if (iterable instanceof Collection) {
+    if (iterable instanceof Collection<?>) {
       collection.addAll(Collections2.cast(iterable));
     } else {
       for (E item : iterable) {

--- a/third_party/java/src/com/google_voltpatches/common/collect/Iterables.java
+++ b/third_party/java/src/com/google_voltpatches/common/collect/Iterables.java
@@ -103,7 +103,7 @@ public final class Iterables {
    * Returns the number of elements in {@code iterable}.
    */
   public static int size(Iterable<?> iterable) {
-    return (iterable instanceof Collection)
+    return (iterable instanceof Collection<?>)
         ? ((Collection<?>) iterable).size()
         : Iterators.size(iterable.iterator());
   }
@@ -113,7 +113,7 @@ public final class Iterables {
    * is true.
    */
   public static boolean contains(Iterable<?> iterable, @Nullable Object element) {
-    if (iterable instanceof Collection) {
+    if (iterable instanceof Collection<?>) {
       Collection<?> collection = (Collection<?>) iterable;
       return Collections2.safeContains(collection, element);
     }
@@ -133,7 +133,7 @@ public final class Iterables {
    */
   @CanIgnoreReturnValue
   public static boolean removeAll(Iterable<?> removeFrom, Collection<?> elementsToRemove) {
-    return (removeFrom instanceof Collection)
+    return (removeFrom instanceof Collection<?>)
         ? ((Collection<?>) removeFrom).removeAll(checkNotNull(elementsToRemove))
         : Iterators.removeAll(removeFrom.iterator(), elementsToRemove);
   }
@@ -151,7 +151,7 @@ public final class Iterables {
    */
   @CanIgnoreReturnValue
   public static boolean retainAll(Iterable<?> removeFrom, Collection<?> elementsToRetain) {
-    return (removeFrom instanceof Collection)
+    return (removeFrom instanceof Collection<?>)
         ? ((Collection<?>) removeFrom).retainAll(checkNotNull(elementsToRetain))
         : Iterators.retainAll(removeFrom.iterator(), elementsToRetain);
   }
@@ -175,7 +175,7 @@ public final class Iterables {
    */
   @CanIgnoreReturnValue
   public static <T> boolean removeIf(Iterable<T> removeFrom, Predicate<? super T> predicate) {
-    if (removeFrom instanceof RandomAccess && removeFrom instanceof List) {
+    if (removeFrom instanceof RandomAccess && removeFrom instanceof List<?>) {
       return removeIfFromRandomAccessList((List<T>) removeFrom, checkNotNull(predicate));
     }
     return Iterators.removeIf(removeFrom.iterator(), predicate);
@@ -261,7 +261,7 @@ public final class Iterables {
    * {@code iterable2}.
    */
   public static boolean elementsEqual(Iterable<?> iterable1, Iterable<?> iterable2) {
-    if (iterable1 instanceof Collection && iterable2 instanceof Collection) {
+    if (iterable1 instanceof Collection<?> && iterable2 instanceof Collection<?>) {
       Collection<?> collection1 = (Collection<?>) iterable1;
       Collection<?> collection2 = (Collection<?>) iterable2;
       if (collection1.size() != collection2.size()) {
@@ -341,7 +341,7 @@ public final class Iterables {
    * created with the contents of the iterable in the same iteration order.
    */
   private static <E> Collection<E> castOrCopyToCollection(Iterable<E> iterable) {
-    return (iterable instanceof Collection)
+    return (iterable instanceof Collection<?>)
         ? (Collection<E>) iterable
         : Lists.newArrayList(iterable.iterator());
   }
@@ -354,7 +354,7 @@ public final class Iterables {
    */
   @CanIgnoreReturnValue
   public static <T> boolean addAll(Collection<T> addTo, Iterable<? extends T> elementsToAdd) {
-    if (elementsToAdd instanceof Collection) {
+    if (elementsToAdd instanceof Collection<?>) {
       Collection<? extends T> c = Collections2.cast(elementsToAdd);
       return addTo.addAll(c);
     }
@@ -369,9 +369,9 @@ public final class Iterables {
    * @see Collections#frequency
    */
   public static int frequency(Iterable<?> iterable, @Nullable Object element) {
-    if ((iterable instanceof Multiset)) {
+    if ((iterable instanceof Multiset<?>)) {
       return ((Multiset<?>) iterable).count(element);
-    } else if ((iterable instanceof Set)) {
+    } else if ((iterable instanceof Set<?>)) {
       return ((Set<?>) iterable).contains(element) ? 1 : 0;
     }
     return Iterators.frequency(iterable.iterator(), element);
@@ -701,7 +701,7 @@ public final class Iterables {
    */
   public static <T> T get(Iterable<T> iterable, int position) {
     checkNotNull(iterable);
-    return (iterable instanceof List)
+    return (iterable instanceof List<?>)
         ? ((List<T>) iterable).get(position)
         : Iterators.get(iterable.iterator(), position);
   }
@@ -723,7 +723,7 @@ public final class Iterables {
   public static <T> T get(Iterable<? extends T> iterable, int position, @Nullable T defaultValue) {
     checkNotNull(iterable);
     Iterators.checkNonnegative(position);
-    if (iterable instanceof List) {
+    if (iterable instanceof List<?>) {
       List<? extends T> list = Lists.cast(iterable);
       return (position < list.size()) ? list.get(position) : defaultValue;
     } else {
@@ -762,7 +762,7 @@ public final class Iterables {
    */
   public static <T> T getLast(Iterable<T> iterable) {
     // TODO(kevinb): Support a concurrently modified collection?
-    if (iterable instanceof List) {
+    if (iterable instanceof List<?>) {
       List<T> list = (List<T>) iterable;
       if (list.isEmpty()) {
         throw new NoSuchElementException();
@@ -784,11 +784,11 @@ public final class Iterables {
    */
   @Nullable
   public static <T> T getLast(Iterable<? extends T> iterable, @Nullable T defaultValue) {
-    if (iterable instanceof Collection) {
+    if (iterable instanceof Collection<?>) {
       Collection<? extends T> c = Collections2.cast(iterable);
       if (c.isEmpty()) {
         return defaultValue;
-      } else if (iterable instanceof List) {
+      } else if (iterable instanceof List<?>) {
         return getLastInNonemptyList(Lists.cast(iterable));
       }
     }
@@ -824,7 +824,7 @@ public final class Iterables {
     checkNotNull(iterable);
     checkArgument(numberToSkip >= 0, "number to skip cannot be negative");
 
-    if (iterable instanceof List) {
+    if (iterable instanceof List<?>) {
       final List<T> list = (List<T>) iterable;
       return new FluentIterable<T>() {
         @Override
@@ -916,7 +916,7 @@ public final class Iterables {
    * @since 2.0
    */
   public static <T> Iterable<T> consumingIterable(final Iterable<T> iterable) {
-    if (iterable instanceof Queue) {
+    if (iterable instanceof Queue<?>) {
       return new FluentIterable<T>() {
         @Override
         public Iterator<T> iterator() {
@@ -957,7 +957,7 @@ public final class Iterables {
    * @return {@code true} if the iterable contains no elements
    */
   public static boolean isEmpty(Iterable<?> iterable) {
-    if (iterable instanceof Collection) {
+    if (iterable instanceof Collection<?>) {
       return ((Collection<?>) iterable).isEmpty();
     }
     return !iterable.iterator().hasNext();


### PR DESCRIPTION
…n instance of some generic type since Java compiler erases all type parameters in the generic code as explained in this post https://docs.oracle.com/javase/tutorial/java/generics/restrictions.html#cannotCast
