### PR TITLE
sql_grammar_generator.py: when sqlcmd output includes 'Server is paused

### DIFF
--- a/tests/sqlgrammar/sql-grammar.txt
+++ b/tests/sqlgrammar/sql-grammar.txt
@@ -622,79 +622,80 @@ rec-cte-col7-alias      ::= [AS ]{rec-cte-col-alias2:rctec7}
 rec-cte-col8-alias      ::= [AS ]{rec-cte-col-alias3:rctec8}
 rec-cte-col9-alias      ::= [AS ]{rec-cte-col-alias4:rctec9}
 
-optional-1-rec-cte-col  ::=  ({rec-cte-col1:rctec1}) 8| [({rec-cte-col1:rctec1})]
-optional-2-rec-cte-cols ::=  ({rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}) 8| \
-                            [({rec-cte-col1:rctec1}, {rec-cte-col2:rctec2})]
-optional-3-rec-cte-cols ::=  ({rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col3:rctec3}) 8| \
-                            [({rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col3:rctec3})]
+# Note: DEPTH "column" added to avoid infinite loops, per ENG-13586
+optional-1-rec-cte-col  ::=  ({rec-cte-col1:rctec1}, DEPTH) 8| [({rec-cte-col1:rctec1}, DEPTH)]
+optional-2-rec-cte-cols ::=  ({rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, DEPTH) 8| \
+                            [({rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, DEPTH)]
+optional-3-rec-cte-cols ::=  ({rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col3:rctec3}, DEPTH) 8| \
+                            [({rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col3:rctec3}, DEPTH)]
 optional-9-rec-cte-cols ::=  ({rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col3:rctec3}, \
                               {rec-cte-col4:rctec4}, {rec-cte-col5:rctec5}, {rec-cte-col6:rctec6}, \
-                              {rec-cte-col7:rctec7}, {rec-cte-col8:rctec8}, {rec-cte-col9:rctec9}) 8| \
+                              {rec-cte-col7:rctec7}, {rec-cte-col8:rctec8}, {rec-cte-col9:rctec9}, DEPTH) 8| \
                             [({rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                               {rec-cte-col4:rctec4}, {rec-cte-col5:rctec5}, {rec-cte-col6:rctec6}, \
-                              {rec-cte-col7:rctec7}, {rec-cte-col8:rctec8}, {rec-cte-col9:rctec9})]
+                              {rec-cte-col7:rctec7}, {rec-cte-col8:rctec8}, {rec-cte-col9:rctec9}, DEPTH)]
 
 # Note: VALUES version not currently supported by VoltDB, so make this rare
 # TODO: change per Chris review: (add GROUP BY; also ORDER BY ???)
-basic-query-int         ::= SELECT {int-expression}[[ {rec-cte-col1-alias}]]         FROM {table-references} [{where-clause}] 199| \
+basic-query-int         ::= SELECT {int-expression}[[ {rec-cte-col1-alias}]],         1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}] 199| \
                             VALUES ({int-rarely-null-value})
-basic-query-num         ::= SELECT {numeric-expression}[[ {rec-cte-col1-alias}]]     FROM {table-references} [{where-clause}] 199| \
+basic-query-num         ::= SELECT {numeric-expression}[[ {rec-cte-col1-alias}]],     1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}] 199| \
                             VALUES ({num-rarely-null-value})
-basic-query-str         ::= SELECT {rcte-string-expression}[[ {rec-cte-col1-alias}]] FROM {table-references} [{where-clause}] 199| \
+basic-query-str         ::= SELECT {rcte-string-expression}[[ {rec-cte-col1-alias}]], 1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}] 199| \
                             VALUES ({str-rarely-null-value})
-basic-query-time        ::= SELECT {timestamp-expression}[[ {rec-cte-col1-alias}]]   FROM {table-references} [{where-clause}] 199| \
+basic-query-time        ::= SELECT {timestamp-expression}[[ {rec-cte-col1-alias}]],   1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}] 199| \
                             VALUES ({time-rarely-null-value})
-basic-query-varbin      ::= SELECT {varbinary-expression}[[ {rec-cte-col1-alias}]]   FROM {table-references} [{where-clause}] 199| \
+basic-query-varbin      ::= SELECT {varbinary-expression}[[ {rec-cte-col1-alias}]],   1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}] 199| \
                             VALUES ({varbin-rarely-null-value})
-basic-query-point       ::= SELECT {point-expression}[[ {rec-cte-col1-alias}]]       FROM {table-references} [{where-clause}] 199| \
+basic-query-point       ::= SELECT {point-expression}[[ {rec-cte-col1-alias}]],       1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}] 199| \
                             VALUES ({point-rarely-null-value})
-basic-query-polygon     ::= SELECT {polygon-expression}[[ {rec-cte-col1-alias}]]     FROM {table-references} [{where-clause}] 199| \
+basic-query-polygon     ::= SELECT {polygon-expression}[[ {rec-cte-col1-alias}]],     1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}] 199| \
                             VALUES ({poly-rarely-null-value})
-basic-query-num-str     ::= SELECT {numeric-expression},                      {rcte-string-expression}                      FROM {table-references} [{where-clause}] 150| \
-                            SELECT {numeric-expression} {rec-cte-col1-alias}, {rcte-string-expression} {rec-cte-col2-alias} FROM {table-references} [{where-clause}]  49| \
+basic-query-num-str     ::= SELECT {numeric-expression},                      {rcte-string-expression},                      1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}] 150| \
+                            SELECT {numeric-expression} {rec-cte-col1-alias}, {rcte-string-expression} {rec-cte-col2-alias}, 1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}]  49| \
                             VALUES ({num-rarely-null-value}, {str-rarely-null-value})
-basic-query-str-num     ::= SELECT {rcte-string-expression},                      {numeric-expression}                      FROM {table-references} [{where-clause}] 150| \
-                            SELECT {rcte-string-expression} {rec-cte-col1-alias}, {numeric-expression} {rec-cte-col2-alias} FROM {table-references} [{where-clause}]  49| \
+basic-query-str-num     ::= SELECT {rcte-string-expression},                      {numeric-expression},                      1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}] 150| \
+                            SELECT {rcte-string-expression} {rec-cte-col1-alias}, {numeric-expression} {rec-cte-col2-alias}, 1[[[ AS] DEPTH]] FROM {table-references} [{where-clause}]  49| \
                             VALUES ({str-rarely-null-value}, {num-rarely-null-value})
-basic-query-3-int       ::= SELECT {int-expression},                      {int-expression},                      {int-expression} \
+basic-query-3-int       ::= SELECT {int-expression},                      {int-expression},                      {int-expression}, 1 \
                             FROM {table-references} [{where-clause}] 150| \
-                            SELECT {int-expression} {rec-cte-col1-alias}, {int-expression} {rec-cte-col2-alias}, {int-expression} {rec-cte-col3-alias} \
+                            SELECT {int-expression} {rec-cte-col1-alias}, {int-expression} {rec-cte-col2-alias}, {int-expression} {rec-cte-col3-alias}, 1 \
                             FROM {table-references} [{where-clause}]  49| \
                             VALUES ({int-rarely-null-value}, {int-rarely-null-value}, {int-rarely-null-value})
-basic-query-3-str       ::= SELECT {rcte-string-expression},                      {rcte-string-expression},                      {rcte-string-expression} \
+basic-query-3-str       ::= SELECT {rcte-string-expression},                      {rcte-string-expression},                      {rcte-string-expression}, 1 \
                             FROM {table-references} [{where-clause}] 150| \
-                            SELECT {rcte-string-expression} {rec-cte-col1-alias}, {rcte-string-expression} {rec-cte-col2-alias}, {rcte-string-expression} {rec-cte-col3-alias} \
+                            SELECT {rcte-string-expression} {rec-cte-col1-alias}, {rcte-string-expression} {rec-cte-col2-alias}, {rcte-string-expression} {rec-cte-col3-alias}, 1 \
                             FROM {table-references} [{where-clause}]  49| \
                             VALUES ({str-rarely-null-value}, {str-rarely-null-value}, {str-rarely-null-value})
 basic-query-9-int       ::= SELECT {int-expression}, {int-expression}, {int-expression}, \
                                    {int-expression}, {int-expression}, {int-expression}, \
-                                   {int-expression}, {int-expression}, {int-expression}  \
+                                   {int-expression}, {int-expression}, {int-expression}, 1 \
                             FROM {table-references} [{where-clause}] 150| \
                             SELECT {int-expression} {rec-cte-col1-alias}, {int-expression} {rec-cte-col2-alias}, {int-expression} {rec-cte-col3-alias}, \
                                    {int-expression} {rec-cte-col4-alias}, {int-expression} {rec-cte-col5-alias}, {int-expression} {rec-cte-col6-alias}, \
-                                   {int-expression} {rec-cte-col7-alias}, {int-expression} {rec-cte-col8-alias}, {int-expression} {rec-cte-col9-alias}  \
+                                   {int-expression} {rec-cte-col7-alias}, {int-expression} {rec-cte-col8-alias}, {int-expression} {rec-cte-col9-alias}, 1 \
                             FROM {table-references} [{where-clause}]  49| \
                             VALUES ({int-rarely-null-value}, {int-rarely-null-value}, {int-rarely-null-value}, \
                                     {int-rarely-null-value}, {int-rarely-null-value}, {int-rarely-null-value}, \
                                     {int-rarely-null-value}, {int-rarely-null-value}, {int-rarely-null-value})
 basic-query-9-str       ::= SELECT {rcte-string-expression}, {rcte-string-expression}, {rcte-string-expression}, \
                                    {rcte-string-expression}, {rcte-string-expression}, {rcte-string-expression}, \
-                                   {rcte-string-expression}, {rcte-string-expression}, {rcte-string-expression}  \
+                                   {rcte-string-expression}, {rcte-string-expression}, {rcte-string-expression}, 1 \
                             FROM {table-references} [{where-clause}] 150| \
                             SELECT {rcte-string-expression} {rec-cte-col1-alias}, {rcte-string-expression} {rec-cte-col2-alias}, {rcte-string-expression} {rec-cte-col3-alias}, \
                                    {rcte-string-expression} {rec-cte-col4-alias}, {rcte-string-expression} {rec-cte-col5-alias}, {rcte-string-expression} {rec-cte-col6-alias}, \
-                                   {rcte-string-expression} {rec-cte-col7-alias}, {rcte-string-expression} {rec-cte-col8-alias}, {rcte-string-expression} {rec-cte-col9-alias}  \
+                                   {rcte-string-expression} {rec-cte-col7-alias}, {rcte-string-expression} {rec-cte-col8-alias}, {rcte-string-expression} {rec-cte-col9-alias}, 1 \
                             FROM {table-references} [{where-clause}]  49| \
                             VALUES ({str-rarely-null-value}, {str-rarely-null-value}, {str-rarely-null-value}, \
                                     {str-rarely-null-value}, {str-rarely-null-value}, {str-rarely-null-value}, \
                                     {str-rarely-null-value}, {str-rarely-null-value}, {str-rarely-null-value})
 basic-query-9-mixed     ::= SELECT {int-expression}, {rcte-string-expression}, {numeric-expression}, \
                                    {int-expression}, {rcte-string-expression}, {varbinary-expression}, \
-                                   {int-expression}, {rcte-string-expression}, {timestamp-expression}  \
+                                   {int-expression}, {rcte-string-expression}, {timestamp-expression}, 1 \
                             FROM {table-references} [{where-clause}] 150| \
                             SELECT {int-expression} {rec-cte-col1-alias}, {rcte-string-expression} {rec-cte-col2-alias}, {numeric-expression}   {rec-cte-col3-alias}, \
                                    {int-expression} {rec-cte-col4-alias}, {rcte-string-expression} {rec-cte-col5-alias}, {varbinary-expression} {rec-cte-col6-alias}, \
-                                   {int-expression} {rec-cte-col7-alias}, {rcte-string-expression} {rec-cte-col8-alias}, {timestamp-expression} {rec-cte-col9-alias}  \
+                                   {int-expression} {rec-cte-col7-alias}, {rcte-string-expression} {rec-cte-col8-alias}, {timestamp-expression} {rec-cte-col9-alias}, 1 \
                             FROM {table-references} [{where-clause}]  49| \
                             VALUES ({int-rarely-null-value}, {str-rarely-null-value}, {num-rarely-null-value}, \
                                     {int-rarely-null-value}, {str-rarely-null-value}, {varbin-rarely-null-value}, \
@@ -707,140 +708,196 @@ rcte-string-column-name ::= VCHAR 9| {any-string-column-name}
 
 # TODO: lots more options here (for the WHERE clause)
 # TODO: change per Chris review: (add GROUP BY; also ORDER BY ???)
-recursive-query-int     ::= SELECT {recursive-clause-int1} FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {int-rarely-null-value}
-recursive-query-num     ::= SELECT {recursive-clause-num1} FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {num-rarely-null-value}
-recursive-query-str     ::= SELECT {recursive-clause-str1} FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {str-rarely-null-value}
-recursive-query-time    ::= SELECT {recursive-clause-time1}   FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {time-rarely-null-value}
-recursive-query-varbin  ::= SELECT {recursive-clause-varbin1} FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {varbin-rarely-null-value}
-recursive-query-point   ::= SELECT {recursive-clause-point1}  FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {point-rarely-null-value}
-recursive-query-polygon ::= SELECT {recursive-clause-poly1}   FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {poly-rarely-null-value}
-recursive-query-num-str ::= SELECT {recursive-clause-num1}, {rec-cte-col2:rctec2} FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {num-rarely-null-value} | \
-                            SELECT {rec-cte-col1:rctec1}, {recursive-clause-str2} FROM rcte WHERE {rec-cte-col2:rctec2} {comparison-operator} {str-rarely-null-value}
-recursive-query-str-num ::= SELECT {recursive-clause-str1}, {rec-cte-col2:rctec2} FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {str-rarely-null-value} | \
-                            SELECT {rec-cte-col1:rctec1}, {recursive-clause-num2} FROM rcte WHERE {rec-cte-col2:rctec2} {comparison-operator} {num-rarely-null-value}
-recursive-query-3-int   ::= SELECT {recursive-clause-int1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3} \
-                            FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {int-rarely-null-value} | \
-                            SELECT {rec-cte-col1:rctec1}, {recursive-clause-int2}, {rec-cte-col2:rctec3} \
-                            FROM rcte WHERE {int-rarely-null-value} {comparison-operator} {rec-cte-col2:rctec2} | \
-                            SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {recursive-clause-int3} \
-                            FROM rcte WHERE {rec-cte-col2:rctec3} {comparison-operator} {int-rarely-null-value}
-recursive-query-3-str   ::= SELECT {recursive-clause-str1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3} \
-                            FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {str-rarely-null-value} | \
-                            SELECT {rec-cte-col1:rctec1}, {recursive-clause-str2}, {rec-cte-col2:rctec3} \
-                            FROM rcte WHERE {str-rarely-null-value} {comparison-operator} {rec-cte-col2:rctec2} | \
-                            SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {recursive-clause-str3} \
-                            FROM rcte WHERE {rec-cte-col2:rctec3} {comparison-operator} {str-rarely-null-value}
+max-depth               ::= 5 | {digit-0-to-5} | {digit}
+recursive-query-int     ::= SELECT {recursive-clause-int1},    DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col1:rctec1} {comparison-operator} {int-rarely-null-value} \
+                              AND DEPTH < {max-depth}
+recursive-query-num     ::= SELECT {recursive-clause-num1},    DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col1:rctec1} {comparison-operator} {num-rarely-null-value} \
+                              AND DEPTH < {max-depth}
+recursive-query-str     ::= SELECT {recursive-clause-str1},    DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col1:rctec1} {comparison-operator} {str-rarely-null-value} \
+                              AND DEPTH < {max-depth}
+recursive-query-time    ::= SELECT {recursive-clause-time1},   DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col1:rctec1} {comparison-operator} {time-rarely-null-value} \
+                              AND DEPTH < {max-depth}
+recursive-query-varbin  ::= SELECT {recursive-clause-varbin1}, DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col1:rctec1} {comparison-operator} {varbin-rarely-null-value} \
+                              AND DEPTH < {max-depth}
+recursive-query-point   ::= SELECT {recursive-clause-point1},  DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col1:rctec1} {comparison-operator} {point-rarely-null-value} \
+                              AND DEPTH < {max-depth}
+recursive-query-polygon ::= SELECT {recursive-clause-poly1},   DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col1:rctec1} {comparison-operator} {poly-rarely-null-value} \
+                              AND DEPTH < {max-depth}
+recursive-query-num-str ::= SELECT {recursive-clause-num1}, {rec-cte-col2:rctec2}, DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col1:rctec1} {comparison-operator} {num-rarely-null-value} \
+                              AND DEPTH < {max-depth} | \
+                            SELECT {rec-cte-col1:rctec1}, {recursive-clause-str2}, DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col2:rctec2} {comparison-operator} {str-rarely-null-value} \
+                              AND DEPTH < {max-depth}
+recursive-query-str-num ::= SELECT {recursive-clause-str1}, {rec-cte-col2:rctec2}, DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col1:rctec1} {comparison-operator} {str-rarely-null-value} \
+                              AND DEPTH < {max-depth} | \
+                            SELECT {rec-cte-col1:rctec1}, {recursive-clause-num2}, DEPTH + 1 FROM rcte \
+                            WHERE {rec-cte-col2:rctec2} {comparison-operator} {num-rarely-null-value} \
+                              AND DEPTH < {max-depth}
+recursive-query-3-int   ::= SELECT {recursive-clause-int1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
+                            SELECT {rec-cte-col1:rctec1}, {recursive-clause-int2}, {rec-cte-col2:rctec3}, DEPTH + 1 \
+                            FROM rcte WHERE {int-rarely-null-value} {comparison-operator} {rec-cte-col2:rctec2} \
+                                        AND DEPTH < {max-depth} | \
+                            SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {recursive-clause-int3}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col2:rctec3} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth}
+recursive-query-3-str   ::= SELECT {recursive-clause-str1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
+                            SELECT {rec-cte-col1:rctec1}, {recursive-clause-str2}, {rec-cte-col2:rctec3}, DEPTH + 1 \
+                            FROM rcte WHERE {str-rarely-null-value} {comparison-operator} {rec-cte-col2:rctec2} \
+                                        AND DEPTH < {max-depth} | \
+                            SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {recursive-clause-str3}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col2:rctec3} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth}
 
 recursive-query-9-int   ::= SELECT {recursive-clause-int1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {int-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {recursive-clause-int2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec2} {comparison-operator} {int-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec2} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {recursive-clause-int3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec3} {comparison-operator} {int-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec3} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {recursive-clause-int4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec4} {comparison-operator} {int-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec4} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {recursive-clause-int5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec5} {comparison-operator} {int-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec5} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {recursive-clause-int6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec6} {comparison-operator} {int-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec6} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {recursive-clause-int7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec7} {comparison-operator} {int-rarely-null-value} | \
+                                   {recursive-clause-int7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec7} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {recursive-clause-int8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec8} {comparison-operator} {int-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {recursive-clause-int8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec8} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {recursive-clause-int9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec9} {comparison-operator} {int-rarely-null-value}
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {recursive-clause-int9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec9} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth}
 
 recursive-query-9-str   ::= SELECT {recursive-clause-str1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {str-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {recursive-clause-str2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec2} {comparison-operator} {str-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec2} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {recursive-clause-str3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec3} {comparison-operator} {str-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec3} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {recursive-clause-str4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec4} {comparison-operator} {str-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec4} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {recursive-clause-str5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec5} {comparison-operator} {str-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec5} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {recursive-clause-str6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec6} {comparison-operator} {str-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec6} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {recursive-clause-str7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec7} {comparison-operator} {str-rarely-null-value} | \
+                                   {recursive-clause-str7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec7} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {recursive-clause-str8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec8} {comparison-operator} {str-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {recursive-clause-str8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec8} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {recursive-clause-str9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec9} {comparison-operator} {str-rarely-null-value}
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {recursive-clause-str9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec9} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth}
 
 recursive-query-9-mixed ::= SELECT {recursive-clause-int1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {int-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec1} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {recursive-clause-str2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec2} {comparison-operator} {str-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec2} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {recursive-clause-num3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec3} {comparison-operator} {num-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec3} {comparison-operator} {num-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {recursive-clause-int4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec4} {comparison-operator} {int-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec4} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {recursive-clause-str5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec5} {comparison-operator} {str-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec5} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {recursive-clause-varbin6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec6} {comparison-operator} {varbin-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec6} {comparison-operator} {varbin-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {recursive-clause-int7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec7} {comparison-operator} {int-rarely-null-value} | \
+                                   {recursive-clause-int7}, {rec-cte-col2:rctec8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec7} {comparison-operator} {int-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {recursive-clause-str8}, {rec-cte-col2:rctec9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec8} {comparison-operator} {str-rarely-null-value} | \
+                                   {rec-cte-col1:rctec7}, {recursive-clause-str8}, {rec-cte-col2:rctec9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec8} {comparison-operator} {str-rarely-null-value} \
+                                        AND DEPTH < {max-depth} | \
                             SELECT {rec-cte-col1:rctec1}, {rec-cte-col2:rctec2}, {rec-cte-col2:rctec3}, \
                                    {rec-cte-col1:rctec4}, {rec-cte-col2:rctec5}, {rec-cte-col2:rctec6}, \
-                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {recursive-clause-time9}  \
-                            FROM rcte WHERE {rec-cte-col1:rctec9} {comparison-operator} {time-rarely-null-value}
+                                   {rec-cte-col1:rctec7}, {rec-cte-col2:rctec8}, {recursive-clause-time9}, DEPTH + 1 \
+                            FROM rcte WHERE {rec-cte-col1:rctec9} {comparison-operator} {time-rarely-null-value} \
+                                        AND DEPTH < {max-depth}
 
 # TODO: could use functions here, etc.
 recursive-clause-int1   ::= {rec-cte-col1:rctec1} {math-operator} {int-rarely-null-value} | \
@@ -896,43 +953,56 @@ recursive-clause-point1 ::= add2GeographyPoint({rec-cte-col1:rctec1}, {point-rar
 recursive-clause-poly1  ::= addGeographyPointToGeography({rec-cte-col1:rctec1}, {point-rarely-null-value})
 
 # TODO: lots more options here
+aggregate-depth-funcs   ::=  , MIN(DEPTH) MND, MAX(DEPTH) MXD, COUNT(DEPTH) CTD, SUM(DEPTH) SMD, AVG(DEPTH) AVD 2| \
+                            [, MIN(DEPTH) MND, MAX(DEPTH) MXD, COUNT(DEPTH) CTD, SUM(DEPTH) SMD, AVG(DEPTH) AVD] | \
+                            [, MIN(DEPTH) MND][, MAX(DEPTH) MXD][, COUNT(DEPTH) CTD][, SUM(DEPTH) SMD][, AVG(DEPTH) AVD]
 final-query-1num        ::= SELECT {star} FROM rcte | \
-                            SELECT {aggregate-function}({:rctec1}) FROM rcte
+                            SELECT {aggregate-function}({:rctec1}) AG1 {aggregate-depth-funcs} FROM rcte
 final-query-1non-num    ::= SELECT {star} FROM rcte | \
-                            SELECT {non-num-arg-aggr-func}({:rctec1}) FROM rcte
+                            SELECT {non-num-arg-aggr-func}({:rctec1}) AG1 {aggregate-depth-funcs} FROM rcte
 final-query-1num-1non   ::= SELECT {star} FROM rcte | \
-                            SELECT    {aggregate-function}({:rctec1})[, {non-num-arg-aggr-func}({:rctec2})] FROM rcte | \
-                            SELECT {non-num-arg-aggr-func}({:rctec2})[,    {aggregate-function}({:rctec1})] FROM rcte
+                            SELECT    {aggregate-function}({:rctec1}) AG1[, {non-num-arg-aggr-func}({:rctec1}) AG2]\
+                                {aggregate-depth-funcs} FROM rcte | \
+                            SELECT {non-num-arg-aggr-func}({:rctec1}) AG2[,    {aggregate-function}({:rctec1}) AG1]\
+                                {aggregate-depth-funcs} FROM rcte
 final-query-1non-1num   ::= SELECT {star} FROM rcte | \
-                            SELECT {non-num-arg-aggr-func}({:rctec1})[,    {aggregate-function}({:rctec2})] FROM rcte | \
-                            SELECT    {aggregate-function}({:rctec2})[, {non-num-arg-aggr-func}({:rctec1})] FROM rcte
+                            SELECT {non-num-arg-aggr-func}({:rctec1}) AG1[,    {aggregate-function}({:rctec1}) AG2]\
+                                {aggregate-depth-funcs} FROM rcte | \
+                            SELECT    {aggregate-function}({:rctec1}) AG2[, {non-num-arg-aggr-func}({:rctec1}) AG1]\
+                                {aggregate-depth-funcs} FROM rcte
 final-query-3num        ::= SELECT {star} FROM rcte | \
-                            SELECT {aggregate-function}({:rctec1})[, {aggregate-function}({:rctec2})][, {aggregate-function}({:rctec3})] FROM rcte | \
-                            SELECT {aggregate-function}({:rctec2})[, {aggregate-function}({:rctec1})][, {aggregate-function}({:rctec3})] FROM rcte | \
-                            SELECT {aggregate-function}({:rctec3})[, {aggregate-function}({:rctec2})][, {aggregate-function}({:rctec1})] FROM rcte
+                            SELECT {aggregate-function}({:rctec1}) AG1[, {aggregate-function}({:rctec1}) AG2]\
+                                [, {aggregate-function}({:rctec1}) AG3] {aggregate-depth-funcs} FROM rcte | \
+                            SELECT {aggregate-function}({:rctec1}) AG2[, {aggregate-function}({:rctec1}) AG1]\
+                                [, {aggregate-function}({:rctec1}) AG3] {aggregate-depth-funcs} FROM rcte | \
+                            SELECT {aggregate-function}({:rctec1}) AG3[, {aggregate-function}({:rctec1}) AG2]\
+                                [, {aggregate-function}({:rctec1}) AG1] {aggregate-depth-funcs} FROM rcte
 final-query-3non-num    ::= SELECT {star} FROM rcte | \
-                            SELECT {non-num-arg-aggr-func}({:rctec1})[, {non-num-arg-aggr-func}({:rctec2})][, {non-num-arg-aggr-func}({:rctec3})] FROM rcte | \
-                            SELECT {non-num-arg-aggr-func}({:rctec2})[, {non-num-arg-aggr-func}({:rctec1})][, {non-num-arg-aggr-func}({:rctec3})] FROM rcte | \
-                            SELECT {non-num-arg-aggr-func}({:rctec3})[, {non-num-arg-aggr-func}({:rctec2})][, {non-num-arg-aggr-func}({:rctec1})] FROM rcte
+                            SELECT {non-num-arg-aggr-func}({:rctec1}) AG1[, {non-num-arg-aggr-func}({:rctec1}) AG2]\
+                                [, {non-num-arg-aggr-func}({:rctec1}) AG3]   {aggregate-depth-funcs} FROM rcte | \
+                            SELECT {non-num-arg-aggr-func}({:rctec1}) AG2[, {non-num-arg-aggr-func}({:rctec1}) AG1]\
+                                [, {non-num-arg-aggr-func}({:rctec1}) AG3]   {aggregate-depth-funcs} FROM rcte | \
+                            SELECT {non-num-arg-aggr-func}({:rctec1}) AG3[, {non-num-arg-aggr-func}({:rctec1}) AG2]\
+                                [, {non-num-arg-aggr-func}({:rctec1}) AG1]   {aggregate-depth-funcs} FROM rcte
 final-query-9num        ::= SELECT {star} FROM rcte | \
-                            SELECT {aggregate-function}({rctec1-9})[, {aggregate-function}({rctec1-9})][, {aggregate-function}({rctec1-9})] \
-                                [, {aggregate-function}({rctec1-9}),  {aggregate-function}({rctec1-9}),   {aggregate-function}({rctec1-9})] \
-                                [, {aggregate-function}({rctec1-9}),  {aggregate-function}({rctec1-9}),   {aggregate-function}({rctec1-9})] \
-                            FROM rcte
+                            SELECT {aggregate-function}({rctec1-9}) AG1[, {aggregate-function}({rctec1-9}) AG2][, {aggregate-function}({rctec1-9}) AG3] \
+                                [, {aggregate-function}({rctec1-9}) AG4,  {aggregate-function}({rctec1-9}) AG5,   {aggregate-function}({rctec1-9}) AG6] \
+                                [, {aggregate-function}({rctec1-9}) AG7,  {aggregate-function}({rctec1-9}) AG8,   {aggregate-function}({rctec1-9}) AG9] \
+                            {aggregate-depth-funcs} FROM rcte
 final-query-9non-num    ::= SELECT {star} FROM rcte | \
-                            SELECT {non-num-arg-aggr-func}({rctec1-9})[, {non-num-arg-aggr-func}({rctec1-9})][, {non-num-arg-aggr-func}({rctec1-9})] \
-                                [, {non-num-arg-aggr-func}({rctec1-9}),  {non-num-arg-aggr-func}({rctec1-9}),   {non-num-arg-aggr-func}({rctec1-9})] \
-                                [, {non-num-arg-aggr-func}({rctec1-9}),  {non-num-arg-aggr-func}({rctec1-9}),   {non-num-arg-aggr-func}({rctec1-9})] \
-                            FROM rcte
+                            SELECT {non-num-arg-aggr-func}({rctec1-9}) AG1[, {non-num-arg-aggr-func}({rctec1-9}) AG2][, {non-num-arg-aggr-func}({rctec1-9}) AG3] \
+                                [, {non-num-arg-aggr-func}({rctec1-9}) AG4,  {non-num-arg-aggr-func}({rctec1-9}) AG5,   {non-num-arg-aggr-func}({rctec1-9}) AG6] \
+                                [, {non-num-arg-aggr-func}({rctec1-9}) AG7,  {non-num-arg-aggr-func}({rctec1-9}) AG8,   {non-num-arg-aggr-func}({rctec1-9}) AG9] \
+                            {aggregate-depth-funcs} FROM rcte
 final-query-9-mixed     ::= SELECT {star} FROM rcte | \
-                            SELECT {aggregate-function}({:rctec1})[, {non-num-arg-aggr-func}({:rctec2})][,  {aggregate-function}({:rctec3})] \
-                                [, {aggregate-function}({:rctec4}),  {non-num-arg-aggr-func}({:rctec5}), {non-num-arg-aggr-func}({:rctec6})] \
-                                [, {aggregate-function}({:rctec7}),  {non-num-arg-aggr-func}({:rctec8}), {non-num-arg-aggr-func}({:rctec9})] \
-                            FROM rcte | \
-                            SELECT {non-num-arg-aggr-func}({:rctec9})[, {non-num-arg-aggr-func}({:rctec8})][, {aggregate-function}({:rctec7})] \
-                                [, {non-num-arg-aggr-func}({:rctec6}),  {non-num-arg-aggr-func}({:rctec5}),   {aggregate-function}({:rctec4})] \
-                                [,    {aggregate-function}({:rctec3}),  {non-num-arg-aggr-func}({:rctec2}),   {aggregate-function}({:rctec1})] \
-                            FROM rcte
+                            SELECT {aggregate-function}({:rctec1}) AG1[, {non-num-arg-aggr-func}({:rctec2}) AG2][,  {aggregate-function}({:rctec3}) AG3] \
+                                [, {aggregate-function}({:rctec4}) AG4,  {non-num-arg-aggr-func}({:rctec5}) AG5, {non-num-arg-aggr-func}({:rctec6}) AG6] \
+                                [, {aggregate-function}({:rctec7}) AG7,  {non-num-arg-aggr-func}({:rctec8}) AG8, {non-num-arg-aggr-func}({:rctec9}) AG9] \
+                            {aggregate-depth-funcs} FROM rcte | \
+                            SELECT {non-num-arg-aggr-func}({:rctec9}) AG9[, {non-num-arg-aggr-func}({:rctec8}) AG8][, {aggregate-function}({:rctec7}) AG7] \
+                                [, {non-num-arg-aggr-func}({:rctec6}) AG6,  {non-num-arg-aggr-func}({:rctec5}) AG5,   {aggregate-function}({:rctec4}) AG4] \
+                                [,    {aggregate-function}({:rctec3}) AG3,  {non-num-arg-aggr-func}({:rctec2}) AG2,   {aggregate-function}({:rctec1}) AG1] \
+                            {aggregate-depth-funcs} FROM rcte
 
 ################################################################################
 # Grammar rules for special non-standard SQL statements that can be used in

--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -800,12 +800,13 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                     sqlcmd_proc.communicate('exit')
                     exit(99)
 
-                # Check if sqlcmd command not found, or if sqlcmd cannot, or
-                # can no longer, reach the VoltDB server
+                # Check if the VoltDB server has been put into paused / read-only
+                # mode, usually due using too much memory (RSS), typically caused
+                # by a Recursive CTE causing an infinite loop
                 elif ('Server is paused and is available in read-only mode' in output):
                     error_message = '\n\n\nFATAL ERROR: sqlcmd responded:\n    "' + output + \
                                     '"\npossibly due to a Recursive CTE (WITH) statement that caused ' + \
-                                    'an infinite loop, consuming too much memory:\n    "' + sql + '"\n'
+                                    'an infinite loop, consuming too much memory (RSS):\n    "' + sql + '"\n'
                     print_summary(error_message)
                     sqlcmd_proc.communicate('exit')
                     exit(98)

--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -302,6 +302,7 @@ def print_file_tail_and_errors(from_file, to_file, number_of_lines=50):
                                 'Could not parse reader',
                                 'unexpected token: EXEC',
                                 'Failed to plan for statement',
+                                'Resource limit exceeded',
                                 "Attribute 'enabled' is not allowed to appear in element 'export'",
                                 'PartitionInfo specifies invalid parameter index for procedure',
                                 'Unexpected error in the SQL parser for statement']},
@@ -462,7 +463,8 @@ def print_file_tail_and_errors(from_file, to_file, number_of_lines=50):
             error_output_file.close()
 
 
-def get_last_n_sql_statements(last_n_sql_stmnts, include_responses=True):
+def get_last_n_sql_statements(last_n_sql_stmnts, include_responses=True,
+                              include_times=True, include_current_time=False):
     """Returns a (string) message, containing the last n SQL statements sent to
     sqlcmd; and, optionally, the last n responses received from sqlcmd; based on
     the current contents of last_n_sql_stmnts, where n is its size.
@@ -472,6 +474,11 @@ def get_last_n_sql_statements(last_n_sql_stmnts, include_responses=True):
         result = '\n    sql statements (or other commands):\n' + result \
                + '\n    corresponding sqlcmd output:' \
                + ''.join(sql['output'] for sql in last_n_sql_stmnts)
+        if include_times:
+            result += '\n    at times: (sql sent; output received)\n' \
+                    + '\n'.join(sql['sql-time']+'; '+sql['output-time'] for sql in last_n_sql_stmnts)
+            if include_current_time:
+                result += '\n' + formatted_time(time()) + ": timed out\n"
     return result
 
 
@@ -492,9 +499,10 @@ def print_summary(error_message=''):
         hanging_sql_commands, find_in_log_output_files
 
     # Generate the summary message (to be printed below)
+    summary_message = ''
     try:
         last_sql_message = '\n\nLast ' + str(len(last_n_sql_statements)) + ' SQL statements sent to sqlcmd:\n' \
-                         + get_last_n_sql_statements(last_n_sql_statements, False)
+                         + get_last_n_sql_statements(last_n_sql_statements, False, False)
         seconds = time() - start_time
         summary_message  = '\n\nSUMMARY: in ' + re.sub('^0:', '', str(timedelta(0, round(seconds))), 1) \
                          + ' ({0:.3f} seconds)'.format(seconds) + ', SQL statements by type:'
@@ -533,6 +541,8 @@ def print_summary(error_message=''):
             hanging_sql_message  = '\n\n\nFATAL ERROR: sqlcmd hanging due to the following set(s) of ' \
                                  + 'SQL statement(s) (or other commands) with unrecognized responses:\n' \
                                  + '\n'.join(sql for sql in hanging_sql_commands)
+            summary_message += '\n\n\nFATAL ERROR: sqlcmd hanging due to the SQL statement(s) ' \
+                             + '(or other commands) listed above, with unrecognized responses.'
     except Exception as e:
         print '\n\nCaught exception attempting to print HANGING sqlcmd message:'
         print_exc()
@@ -550,9 +560,9 @@ def print_summary(error_message=''):
             sys.stdout.flush()
             for log_file in options.log_files.split(','):
                 print_file_tail_and_errors(log_file, sqlcmd_summary_file, options.log_number)
-        print >> sqlcmd_summary_file, last_sql_message, summary_message, hanging_sql_message, error_message
+        print >> sqlcmd_summary_file, hanging_sql_message, last_sql_message, summary_message, error_message
         sqlcmd_summary_file.close()
-    print last_sql_message, summary_message, hanging_sql_message, error_message
+    print hanging_sql_message, last_sql_message, summary_message, error_message
 
 
 def increment_sql_statement_indexes(index1, index2):
@@ -602,6 +612,13 @@ def timeout_handler(signum, frame):
     raise TimeoutException
 
 
+def formatted_time(seconds_since_epoch):
+    """Takes a time representing the number of seconds since the beginning of
+    the epoch and returns that time as a nicely formatted string.
+    """
+    return strftime('%Y-%m-%d %H:%M:%S', localtime(seconds_since_epoch)) + ' (' + str(seconds_since_epoch) + ')'
+
+
 def print_sql_statement(sql, num_chars_in_sql_type=6):
     """Print the specified SQL statement (sql), to the SQL output file (which may
     be STDOUT); and, if the sqlcmd option was specified, pass that SQL statement
@@ -629,7 +646,8 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
     if sqlcmd_proc:
 
         # Save the last options.summary_number SQL statements, for the summary
-        last_n_sql_statements.append({'sql':sql, 'output':''})
+        last_n_sql_statements.append({'sql':sql, 'sql-time':formatted_time(time()),
+                                      'output':'', 'output-time':''})
         while len(last_n_sql_statements) > options.summary_number:
             last_n_sql_statements.pop(0)
         sqlLen = len(last_n_sql_statements)
@@ -665,16 +683,17 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
             try:
                 output = sqlcmd_proc.stdout.readline().rstrip('\n')
             except TimeoutException:
-                hanging_sql_commands.append(get_last_n_sql_statements(last_n_sql_statements))
+                hanging_sql_commands.append(get_last_n_sql_statements(last_n_sql_statements, include_current_time=True))
                 if debug > 1:
                         print "\nERROR: timeout waiting for (hanging?) sqlcmd, after", \
                               str(max_seconds_to_wait_for_sqlcmd), "seconds, with:\n" + \
-                              get_last_n_sql_statements(last_n_sql_statements)
+                              get_last_n_sql_statements(last_n_sql_statements, include_current_time=True)
                 break
             else:
                 alarm(0)  # turns off the alarm
             print >> sqlcmd_output_file, output
             last_n_sql_statements[sqlLen-1]['output'] += output + '\n'
+            last_n_sql_statements[sqlLen-1]['output-time'] = formatted_time(time())
 
             # Debug print, if that 'echo' substring was found
             if sql_contains_echo_substring and sql_was_echoed_as_output:
@@ -781,6 +800,16 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                     sqlcmd_proc.communicate('exit')
                     exit(99)
 
+                # Check if sqlcmd command not found, or if sqlcmd cannot, or
+                # can no longer, reach the VoltDB server
+                elif ('Server is paused and is available in read-only mode' in output):
+                    error_message = '\n\n\nFATAL ERROR: sqlcmd responded:\n    "' + output + \
+                                    '"\npossibly due to a Recursive CTE (WITH) statement that caused ' + \
+                                    'an infinite loop, consuming too much memory:\n    "' + sql + '"\n'
+                    print_summary(error_message)
+                    sqlcmd_proc.communicate('exit')
+                    exit(98)
+
         for find in find_in_log_output_files:
             command = 'tail -n ' + str(options.find_number) + ' ' + find['log_file']
             if debug > 4:
@@ -795,7 +824,7 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                     if (prev not in tail_of_log_file or find_string in
                             tail_of_log_file[tail_of_log_file.index(prev)+len(prev):]):
                         print >> find['output_file'], 'Found "' + find_string + '" following these SQL statements:\n' \
-                                + get_last_n_sql_statements(last_n_sql_statements, False) + '\n'
+                                + get_last_n_sql_statements(last_n_sql_statements, False, False) + '\n'
             find['previous_tail'] = tail_of_log_file[len(tail_of_log_file)/2:]
 
     else:
@@ -806,13 +835,6 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
         for (symbol, partial_sql) in symbol_order:
             print >> echo_output_file, "{0:1d}: {1:24s}: {2:s}".format(symbol_depth.get(symbol, 0), symbol, partial_sql)
         print >> echo_output_file, "{0:27s}: {1:s}".format('Final sql', sql)
-
-
-def formatted_time(seconds_since_epoch):
-    """Takes a time representing the number of seconds since the beginning of
-    the epoch and returns that time as a nicely formatted string.
-    """
-    return strftime('%Y-%m-%d %H:%M:%S', localtime(seconds_since_epoch)) + ' (' + str(seconds_since_epoch) + ')'
 
 
 def generate_sql_statements(sql_statement_type, num_sql_statements=0, max_save_statements=1000,
@@ -1132,4 +1154,4 @@ if __name__ == "__main__":
         sqlcmd_proc.communicate('exit')
 
     if hanging_sql_commands:
-        exit(98)
+        exit(97)


### PR DESCRIPTION
and is available in read-only mode', end execution immediately with a
fatal error; moved (in the summary file and to STDOUT) the detailed
"hanging SQL" messages to before the last-n and summary messages, with
only a single line about "hanging SQL" after them (when such messages
appear); added 'Resource limit exceeded' to the list of ERROR messages
to be searched for, in the log and in the console output; in
get_last_n_sql_statements method, added optional times (that SQL was
sent and output received) to be printed out; and added code to save
these times, when we have "hanging SQL"; and therefore moved the
formatted_time method earlier, to be used in print_sql_statement.