### PR TITLE
ENG-13633 consume the network connection exception

### DIFF
--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaLoader.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaLoader.java
@@ -273,7 +273,12 @@ public class KafkaLoader implements ImporterLifecycle {
         config.setTopologyChangeAware(true);
         final Client client = ClientFactory.createClient(config);
         for (String host : hosts) {
-            client.createConnection(host);
+            try {
+                client.createConnection(host);
+            }catch (IOException e) {
+                // Only swallow exceptions caused by Java network or connection problem
+                // Unresolved hostname exceptions will be thrown
+            }
         }
         if (client.getConnectedHostList().isEmpty()) {
             try {


### PR DESCRIPTION
When a connection to voltDB in KafkaLoader10 is refused due to network connection, ignore it (The same behavior as KafkaLoader 8).