### PR TITLE
ENG-13625:

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.h
+++ b/src/ee/common/SynchronizedThreadLock.h
@@ -129,12 +129,15 @@ public:
     static void addUndoAction(bool synchronized, UndoQuantum *uq, UndoReleaseAction* action,
             PersistentTable *interest = NULL);
 
-    static bool usingMpMemory();
     static bool isInSingleThreadMode();
     static bool isInLocalEngineContext();
 #ifndef  NDEBUG
+    static bool usingMpMemory();
     static bool isHoldingResourceLock();
 #endif
+    static void debugSimulateSingleThreadMode(bool inSingleThreadMode) {
+        s_inSingleThreadMode = inSingleThreadMode;
+    }
 
     static void assumeMpMemoryContext();
     static void assumeLowestSiteContext();
@@ -146,8 +149,8 @@ public:
 
 private:
     static bool s_inSingleThreadMode;
-    static bool s_usingMpMemory;
 #ifndef  NDEBUG
+    static bool s_usingMpMemory;
     static bool s_holdingReplicatedTableLock;
 #endif
     static pthread_mutex_t s_sharedEngineMutex;

--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -77,6 +77,16 @@ static void globalInitOrCreateOncePerProcess() {
     SynchronizedThreadLock::create();
 }
 
+void globalDestroyOncePerProcess() {
+    // Some unit tests require the re-initialization of the
+    // SynchronizedThreadLock globals. We do this here so that
+    // the next time the first executor gets created we will
+    // (re)initialize any necessary global state.
+    SynchronizedThreadLock::destroy();
+    pthread_key_delete(static_key);
+    static_keyOnce = PTHREAD_ONCE_INIT;
+}
+
 ExecutorContext::ExecutorContext(int64_t siteId,
                 CatalogId partitionId,
                 UndoQuantum *undoQuantum,

--- a/src/ee/common/executorcontext.hpp
+++ b/src/ee/common/executorcontext.hpp
@@ -50,6 +50,8 @@ struct EngineLocals;
 
 class TempTable;
 
+void globalDestroyOncePerProcess();
+
 struct ProgressStats {
     int64_t TuplesProcessedInBatch;
     int64_t TuplesProcessedInFragment;

--- a/src/ee/storage/LargeTempTable.cpp
+++ b/src/ee/storage/LargeTempTable.cpp
@@ -24,6 +24,7 @@ namespace voltdb {
 LargeTempTable::LargeTempTable()
     : AbstractTempTable(LargeTempTableBlock::BLOCK_SIZE_IN_BYTES)
     , m_blockIds()
+    , m_iter(this, m_blockIds.begin())
     , m_blockForWriting(NULL)
 {
 }
@@ -86,6 +87,15 @@ void LargeTempTable::finishInserts() {
         }
         m_blockForWriting = NULL;
     }
+}
+
+TableIterator LargeTempTable::iterator() {
+    if (m_blockForWriting != NULL) {
+        throwSerializableEEException("Attempt to iterate over large temp table before finishInserts() is called");
+    }
+
+    m_iter.reset(m_blockIds.begin());
+    return m_iter;
 }
 
 

--- a/src/ee/storage/LargeTempTable.h
+++ b/src/ee/storage/LargeTempTable.h
@@ -55,14 +55,14 @@ class LargeTempTable : public AbstractTempTable {
 public:
 
     /** return the iterator for this table */
-    TableIterator iterator() {
-        return TableIterator(this, m_blockIds.begin());
-    }
+    TableIterator iterator();
 
     /** return an iterator that will automatically delete blocks after
         they are scanned. */
     TableIterator iteratorDeletingAsWeGo() {
-        return TableIterator(this, m_blockIds.begin(), true);
+        m_iter.reset(m_blockIds.begin());
+        m_iter.setTempTableDeleteAsGo(true);
+        return m_iter;
     }
 
     /** Delete all the tuples in this table */
@@ -143,6 +143,8 @@ private:
     void getEmptyBlock();
 
     std::vector<int64_t> m_blockIds;
+
+    TableIterator m_iter;
 
     LargeTempTableBlock* m_blockForWriting;
 };

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -1826,7 +1826,6 @@ int main(int argc, char **argv) {
     // output, so keep it up to date with these printfs.
         printf("== eecount = %d ==\n", eecount);
     }
-    SynchronizedThreadLock::create();
 
     boost::shared_array<pthread_t> eeThreads(new pthread_t[eecount]);
 

--- a/tests/ee/common/tabletuple_test.cpp
+++ b/tests/ee/common/tabletuple_test.cpp
@@ -42,11 +42,8 @@ using namespace voltdb;
 
 class TableTupleTest : public Test {
 public:
-    TableTupleTest() {
-        voltdb::SynchronizedThreadLock::create();
-    }
     ~TableTupleTest() {
-        voltdb::SynchronizedThreadLock::destroy();
+        voltdb::globalDestroyOncePerProcess();
     }
 };
 

--- a/tests/ee/execution/ExecutorVectorTest.cpp
+++ b/tests/ee/execution/ExecutorVectorTest.cpp
@@ -487,6 +487,10 @@ const std::string jsonPlan =
 
 
 class ExecutorVectorTest : public Test {
+public:
+    ~ExecutorVectorTest() {
+        voltdb::globalDestroyOncePerProcess();
+    }
 };
 
 TEST_F(ExecutorVectorTest, Large) {
@@ -530,6 +534,8 @@ TEST_F(ExecutorVectorTest, Large) {
     StandAloneTupleStorage tupleWrapper(schema);
     TableTuple tuple = tupleWrapper.tuple();
 
+    SynchronizedThreadLock::debugSimulateSingleThreadMode(true);
+    SynchronizedThreadLock::assumeMpMemoryContext();
     for (int i = 0; i < 750; ++i) {
         std::ostringstream ossShort, ossLong;
         ossShort << "short " << i;
@@ -538,6 +544,8 @@ TEST_F(ExecutorVectorTest, Large) {
         Tools::setTupleValues(&tuple, i, ossShort.str(), ossLong.str());
         persTbl->insertTuple(tuple);
     }
+    SynchronizedThreadLock::assumeLowestSiteContext();
+    SynchronizedThreadLock::debugSimulateSingleThreadMode(false);
 
     tbl = engine->executePlanFragment(ev.get(), NULL);
     // Again send node has no output table.

--- a/tests/ee/execution/add_drop_table.cpp
+++ b/tests/ee/execution/add_drop_table.cpp
@@ -44,7 +44,6 @@ class AddDropTableTest : public Test {
         : m_clusterId(0), m_databaseId(0), m_siteId(0), m_partitionId(0),
           m_hostId(101), m_hostName("host101"), m_drClusterId(0)
     {
-        voltdb::SynchronizedThreadLock::create();
         m_engine = new VoltDBEngine();
 
         m_resultBuffer = new char[1024 * 1024 * 2];
@@ -89,7 +88,7 @@ class AddDropTableTest : public Test {
         delete m_engine;
         delete[] m_resultBuffer;
         delete[] m_exceptionBuffer;
-        voltdb::SynchronizedThreadLock::destroy();
+        voltdb::globalDestroyOncePerProcess();
     }
 
 

--- a/tests/ee/execution/engine_test.cpp
+++ b/tests/ee/execution/engine_test.cpp
@@ -51,6 +51,7 @@
 
 #include "harness.h"
 
+#include "common/SynchronizedThreadLock.h"
 #include "common/tabletuple.h"
 #include "common/valuevector.h"
 #include "expressions/abstractexpression.h"
@@ -384,7 +385,13 @@ public:
         ASSERT_TRUE(m_partitioned_customer_table);
         ASSERT_TRUE(voltdb::tableutil::addRandomTuples(m_partitioned_customer_table, NUM_OF_TUPLES));
         ASSERT_TRUE(m_replicated_customer_table);
+
+        // Either use the lock or execute on a single thread when adding tuples to a replicate table
+        voltdb::SynchronizedThreadLock::lockReplicatedResource();
+        voltdb::SynchronizedThreadLock::assumeMpMemoryContext();
         ASSERT_TRUE(voltdb::tableutil::addRandomTuples(m_replicated_customer_table, NUM_OF_TUPLES));
+        voltdb::SynchronizedThreadLock::assumeLocalSiteContext();
+        voltdb::SynchronizedThreadLock::unlockReplicatedResource();
     }
 
 protected:

--- a/tests/ee/indexes/index_test.cpp
+++ b/tests/ee/indexes/index_test.cpp
@@ -89,15 +89,13 @@ using namespace voltdb;
 class IndexTest : public Test {
 public:
     IndexTest() : table(NULL)
-    {
-        voltdb::SynchronizedThreadLock::create();
-    }
+    {}
     ~IndexTest()
     {
         delete table;
         delete[] m_exceptionBuffer;
         delete m_engine;
-        voltdb::SynchronizedThreadLock::destroy();
+        voltdb::globalDestroyOncePerProcess();
     }
 
     void initWideTable(string name)
@@ -181,8 +179,9 @@ public:
         m_engine = new VoltDBEngine();
         m_exceptionBuffer = new char[4096];
         m_engine->setBuffers(NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
-        int partitionCount = htonl(1);
+        int partitionCount = 1;
         m_engine->initialize(0, 0, 0, partitionCount, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, true);
+        partitionCount = htonl(partitionCount);
         m_engine->updateHashinator(HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
         table = dynamic_cast<PersistentTable*>(
             TableFactory::getPersistentTable(database_id, "test_wide_table",
@@ -317,8 +316,9 @@ public:
         m_engine = new VoltDBEngine();
         m_exceptionBuffer = new char[4096];
         m_engine->setBuffers(NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
-        int partitionCount = htonl(1);
+        int partitionCount = 1;
         m_engine->initialize(0, 0, 0, partitionCount, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, true);
+        partitionCount = htonl(partitionCount);
         m_engine->updateHashinator(HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
         table = dynamic_cast<PersistentTable*>(TableFactory::getPersistentTable(database_id, (const string)"test_table", schema, columnNames, signature));
 

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -72,10 +72,10 @@ public:
         m_tuplesDeleted = 0;
         m_tuplesInsertedInLastUndo = 0;
         m_tuplesDeletedInLastUndo = 0;
-        voltdb::SynchronizedThreadLock::create();
         m_engine = new voltdb::VoltDBEngine();
         int partitionCount = 1;
         m_engine->initialize(1, 1, 0, partitionCount, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, true);
+        partitionCount = htonl(partitionCount);
         m_engine->updateHashinator(HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
 
         m_columnNames.push_back("1");
@@ -131,7 +131,7 @@ public:
     ~CompactionTest() {
         delete m_engine;
         delete m_table;
-        voltdb::SynchronizedThreadLock::destroy();
+        voltdb::globalDestroyOncePerProcess();
     }
 
     void initTable() {

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -125,6 +125,7 @@ public:
         delete m_tuple;
         if (m_schema)
             TupleSchema::freeTupleSchema(m_schema);
+        voltdb::globalDestroyOncePerProcess();
     }
 
 protected:

--- a/tests/ee/storage/LargeTempTableTest.cpp
+++ b/tests/ee/storage/LargeTempTableTest.cpp
@@ -44,6 +44,10 @@
 using namespace voltdb;
 
 class LargeTempTableTest : public TupleComparingTest {
+public:
+    ~LargeTempTableTest() {
+        voltdb::globalDestroyOncePerProcess();
+    }
 };
 
 // Use boost::optional to represent null values

--- a/tests/ee/storage/PersistentTableMemStatsTest.cpp
+++ b/tests/ee/storage/PersistentTableMemStatsTest.cpp
@@ -78,6 +78,7 @@ public:
     ~PersistentTableMemStatsTest() {
         delete m_engine;
         delete m_table;
+        voltdb::globalDestroyOncePerProcess();
     }
 
     void initTable() {

--- a/tests/ee/storage/StreamedTable_test.cpp
+++ b/tests/ee/storage/StreamedTable_test.cpp
@@ -114,6 +114,7 @@ public:
         m_quantum->release();
         delete m_pool;
         delete m_topend;
+        voltdb::globalDestroyOncePerProcess();
     }
 
 protected:

--- a/tests/ee/storage/persistent_table_log_test.cpp
+++ b/tests/ee/storage/persistent_table_log_test.cpp
@@ -44,7 +44,6 @@ using namespace voltdb;
 class PersistentTableLogTest : public Test {
 public:
     PersistentTableLogTest() {
-        voltdb::SynchronizedThreadLock::create();
         m_engine = new voltdb::VoltDBEngine();
         int partitionCount = 1;
         m_engine->initialize(1, 1, 0, partitionCount, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, true);
@@ -119,7 +118,7 @@ public:
     ~PersistentTableLogTest() {
         delete m_engine;
         delete m_table;
-        voltdb::SynchronizedThreadLock::destroy();
+        voltdb::globalDestroyOncePerProcess();
     }
 
     void initTable(bool withPK = true) {

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -65,7 +65,6 @@ public:
         : m_undoToken(0)
         , m_uniqueId(0)
     {
-        voltdb::SynchronizedThreadLock::create();
         m_engine.reset(new VoltDBEngine());
         m_engine->initialize(1,     // clusterIndex
                              1,     // siteId
@@ -83,7 +82,7 @@ public:
     ~PersistentTableTest()
     {
         m_engine.reset();
-        voltdb::SynchronizedThreadLock::destroy();
+        voltdb::globalDestroyOncePerProcess();
     }
 
 protected:
@@ -130,8 +129,8 @@ protected:
             ""
             "set /clusters#cluster/databases#database schema \"eJwlTDkCgDAI230NDSWUtdX/f8mgAzkBeoLBkZMBEw6C59cwrDRumLJiap5O07L9rStkqd0M8ZGa36ehHXZL52rGcng4USjf1wuc0Rgz\"\n"
             "add /clusters#cluster/databases#database tables T\n"
-            "set /clusters#cluster/databases#database/tables#T isreplicated true\n"
-            "set $PREV partitioncolumn null\n"
+            "set /clusters#cluster/databases#database/tables#T isreplicated false\n"
+            "set $PREV partitioncolumn /clusters#cluster/databases#database/tables#T/columns#PK\n"
             "set $PREV estimatedtuplecount 0\n"
             "set $PREV materializer null\n"
             "set $PREV signature \"T|bv\"\n"
@@ -178,8 +177,8 @@ protected:
             "set $PREV foreignkeytable null\n"
 
             "add /clusters#cluster/databases#database tables X\n"
-            "set /clusters#cluster/databases#database/tables#X isreplicated true\n"
-            "set $PREV partitioncolumn null\n"
+            "set /clusters#cluster/databases#database/tables#X isreplicated false\n"
+            "set $PREV partitioncolumn /clusters#cluster/databases#database/tables#T/columns#PK\n"
             "set $PREV estimatedtuplecount 0\n"
             "set $PREV materializer null\n"
             "set $PREV signature \"X|bv\"\n"

--- a/tests/ee/test_utils/UniqueEngine.hpp
+++ b/tests/ee/test_utils/UniqueEngine.hpp
@@ -68,7 +68,6 @@ private:
         : m_topend(topend.release())
         , m_engine(new voltdb::VoltDBEngine(m_topend.get()))
     {
-        voltdb::SynchronizedThreadLock::create();
         m_engine->initialize(1,     // clusterIndex
                              1,     // siteId
                              0,     // partitionId


### PR DESCRIPTION
This branch fixes all CPP unit tests besides the dr binary log test. These tests are fixed by resetting the global sites per host value that is checked during engine initialization. Also, there are a few places where replicated tables are inserted into directly by unit tests and for these cases, the table first needs to be locked and the MP Memory context needs to be assumed.