### PR TITLE
Eng 13224 Large Temp Table Block Ids

### DIFF
--- a/build.py
+++ b/build.py
@@ -486,7 +486,7 @@ if whichtests in ("${eetestsuite}", "common"):
      debuglog_test
      elastic_hashinator_test
      PerFragmentStatsTest
-     lttblockid_test
+     LargeTempTableBlockIdTest
      nvalue_test
      pool_test
      serializeio_test

--- a/build.py
+++ b/build.py
@@ -486,6 +486,7 @@ if whichtests in ("${eetestsuite}", "common"):
      debuglog_test
      elastic_hashinator_test
      PerFragmentStatsTest
+     lttblockid_test
      nvalue_test
      pool_test
      serializeio_test

--- a/src/ee/common/LargeTempTableBlockCache.cpp
+++ b/src/ee/common/LargeTempTableBlockCache.cpp
@@ -31,7 +31,7 @@ LargeTempTableBlockCache::LargeTempTableBlockCache(Topend *topend, int64_t maxCa
     , m_maxCacheSizeInBytes(maxCacheSizeInBytes)
     , m_blockList()
     , m_idToBlockMap()
-    , m_nextId(0)
+    , m_nextId(int32_t(ExecutorContext::getExecutorContext()->m_siteId), 0)
     , m_totalAllocatedBytes(0)
 {
 }

--- a/src/ee/common/LargeTempTableBlockCache.cpp
+++ b/src/ee/common/LargeTempTableBlockCache.cpp
@@ -39,7 +39,7 @@ LargeTempTableBlockCache::LargeTempTableBlockCache(Topend *topend, int64_t maxCa
     , m_totalAllocatedBytes(0)
 {
     ExecutorContext *ec = ExecutorContext::getExecutorContext();
-    int32_t siteId = ec ? ec->m_siteId : 0;
+    int64_t siteId = ec ? ec->m_siteId : 0;
     m_nextId = LargeTempTableBlockId(siteId, 0);
 }
 

--- a/src/ee/common/LargeTempTableBlockCache.cpp
+++ b/src/ee/common/LargeTempTableBlockCache.cpp
@@ -31,9 +31,16 @@ LargeTempTableBlockCache::LargeTempTableBlockCache(Topend *topend, int64_t maxCa
     , m_maxCacheSizeInBytes(maxCacheSizeInBytes)
     , m_blockList()
     , m_idToBlockMap()
-    , m_nextId(int32_t(ExecutorContext::getExecutorContext()->m_siteId), 0)
+      // Sometimes for tests we don't have a site id.
+    , m_nextId(ExecutorContext::getExecutorContext()
+                 ? (ExecutorContext::getExecutorContext()->m_siteId)
+                 : 0,
+               0)
     , m_totalAllocatedBytes(0)
 {
+    ExecutorContext *ec = ExecutorContext::getExecutorContext();
+    int32_t siteId = ec ? ec->m_siteId : 0;
+    m_nextId = LargeTempTableBlockId(siteId, 0);
 }
 
 LargeTempTableBlockCache::~LargeTempTableBlockCache() {

--- a/src/ee/common/LargeTempTableBlockCache.cpp
+++ b/src/ee/common/LargeTempTableBlockCache.cpp
@@ -43,7 +43,7 @@ LargeTempTableBlockCache::~LargeTempTableBlockCache() {
 LargeTempTableBlock* LargeTempTableBlockCache::getEmptyBlock(TupleSchema* schema) {
     ensureSpaceForNewBlock();
 
-    int64_t id = getNextId();
+    LargeTempTableBlockId id = getNextId();
 
     m_blockList.emplace_front(new LargeTempTableBlock(id, schema));
     auto it = m_blockList.begin();
@@ -55,7 +55,7 @@ LargeTempTableBlock* LargeTempTableBlockCache::getEmptyBlock(TupleSchema* schema
     return m_blockList.front().get();
 }
 
-LargeTempTableBlock* LargeTempTableBlockCache::fetchBlock(int64_t blockId) {
+LargeTempTableBlock* LargeTempTableBlockCache::fetchBlock(LargeTempTableBlockId blockId) {
     auto mapIt = m_idToBlockMap.find(blockId);
     if (mapIt == m_idToBlockMap.end()) {
         throwSerializableEEException("Request for unknown block ID in LargeTempTableBlockCache (fetch)");
@@ -87,7 +87,7 @@ LargeTempTableBlock* LargeTempTableBlockCache::fetchBlock(int64_t blockId) {
     return block;
 }
 
-void LargeTempTableBlockCache::unpinBlock(int64_t blockId) {
+void LargeTempTableBlockCache::unpinBlock(LargeTempTableBlockId blockId) {
     auto mapIt = m_idToBlockMap.find(blockId);
     if (mapIt == m_idToBlockMap.end()) {
         throwSerializableEEException("Request for unknown block ID in LargeTempTableBlockCache (unpin)");
@@ -96,7 +96,7 @@ void LargeTempTableBlockCache::unpinBlock(int64_t blockId) {
     (*(mapIt->second))->unpin();
 }
 
-bool LargeTempTableBlockCache::blockIsPinned(int64_t blockId) const {
+bool LargeTempTableBlockCache::blockIsPinned(LargeTempTableBlockId blockId) const {
     auto mapIt = m_idToBlockMap.find(blockId);
     if (mapIt == m_idToBlockMap.end()) {
         throwSerializableEEException("Request for unknown block ID in LargeTempTableBlockCache (blockIsPinned)");
@@ -105,7 +105,7 @@ bool LargeTempTableBlockCache::blockIsPinned(int64_t blockId) const {
     return (*(mapIt->second))->isPinned();
 }
 
-void LargeTempTableBlockCache::releaseBlock(int64_t blockId) {
+void LargeTempTableBlockCache::releaseBlock(LargeTempTableBlockId blockId) {
     auto mapIt = m_idToBlockMap.find(blockId);
     if (mapIt == m_idToBlockMap.end()) {
         throwSerializableEEException("Request for unknown block ID in LargeTempTableBlockCache (release)");

--- a/src/ee/common/LargeTempTableBlockCache.cpp
+++ b/src/ee/common/LargeTempTableBlockCache.cpp
@@ -26,22 +26,15 @@
 
 namespace voltdb {
 
-LargeTempTableBlockCache::LargeTempTableBlockCache(Topend *topend, int64_t maxCacheSizeInBytes)
+LargeTempTableBlockCache::LargeTempTableBlockCache(Topend *topend,
+                                                   int64_t maxCacheSizeInBytes,
+                                                   LargeTempTableBlockId::siteId_t siteId)
     : m_topend(topend)
     , m_maxCacheSizeInBytes(maxCacheSizeInBytes)
     , m_blockList()
     , m_idToBlockMap()
-      // Sometimes for tests we don't have a site id.
-    , m_nextId(ExecutorContext::getExecutorContext()
-                 ? (ExecutorContext::getExecutorContext()->m_siteId)
-                 : 0,
-               0)
-    , m_totalAllocatedBytes(0)
-{
-    ExecutorContext *ec = ExecutorContext::getExecutorContext();
-    int64_t siteId = ec ? ec->m_siteId : 0;
-    m_nextId = LargeTempTableBlockId(siteId, 0);
-}
+    , m_nextId(siteId, 0)
+    , m_totalAllocatedBytes(0) { }
 
 LargeTempTableBlockCache::~LargeTempTableBlockCache() {
     assert (m_blockList.size() == 0);

--- a/src/ee/common/LargeTempTableBlockCache.h
+++ b/src/ee/common/LargeTempTableBlockCache.h
@@ -56,7 +56,9 @@ class LargeTempTableBlockCache {
      * Construct an instance of a cache containing zero large temp
      * table blocks.
      */
-    LargeTempTableBlockCache(Topend* topend, int64_t maxCacheSizeInBytes);
+    LargeTempTableBlockCache(Topend* topend,
+                             int64_t maxCacheSizeInBytes,
+                             LargeTempTableBlockId::siteId_t siteId);
 
     /**
      * A do-nothing destructor

--- a/src/ee/common/LargeTempTableBlockCache.h
+++ b/src/ee/common/LargeTempTableBlockCache.h
@@ -28,8 +28,8 @@
 #include <boost/scoped_array.hpp>
 
 #include "storage/LargeTempTableBlock.h"
+#include "common/LargeTempTableBlockId.hpp"
 #include "common/types.h"
-#include "common/lttblockid.h"
 
 class LargeTempTableTest_OverflowCache;
 

--- a/src/ee/common/LargeTempTableBlockCache.h
+++ b/src/ee/common/LargeTempTableBlockCache.h
@@ -29,6 +29,7 @@
 
 #include "storage/LargeTempTableBlock.h"
 #include "common/types.h"
+#include "common/lttblockid.h"
 
 class LargeTempTableTest_OverflowCache;
 
@@ -67,18 +68,18 @@ class LargeTempTableBlockCache {
 
     /** "Unpin" the specified block, i.e., mark it as a candidate to
         store to disk when the cache becomes full. */
-    void unpinBlock(int64_t blockId);
+    void unpinBlock(LargeTempTableBlockId blockId);
 
     /** Returns true if the block is pinned. */
-    bool blockIsPinned(int64_t blockId) const;
+    bool blockIsPinned(LargeTempTableBlockId blockId) const;
 
     /** Fetch (and pin) the specified block, loading it from disk if
         necessary.  */
-    LargeTempTableBlock* fetchBlock(int64_t blockId);
+    LargeTempTableBlock* fetchBlock(LargeTempTableBlockId blockId);
 
     /** Get the tuple count for the given block.  Does
         not fetch or pin the block. */
-    int64_t getBlockTupleCount(int64_t blockId) {
+    int64_t getBlockTupleCount(LargeTempTableBlockId blockId) {
         auto it = m_idToBlockMap.find(blockId);
         assert(it != m_idToBlockMap.end());
         return it->second->get()->activeTupleCount();
@@ -86,7 +87,7 @@ class LargeTempTableBlockCache {
 
     /** The large temp table for this block is being destroyed, so
         release all resources associated with this block. */
-    void releaseBlock(int64_t blockId);
+    void releaseBlock(LargeTempTableBlockId blockId);
 
     /** The number of pinned (blocks currently being inserted into or
         scanned) entries in the cache */
@@ -143,7 +144,7 @@ class LargeTempTableBlockCache {
         whether is stored on disk or not.  Used for debugging to show
         the state of all a table's blocks.  Does not throw if the
         specified block does not exist. */
-    LargeTempTableBlock* getBlockForDebug(int64_t id) const {
+    LargeTempTableBlock* getBlockForDebug(LargeTempTableBlockId id) const {
         auto it = m_idToBlockMap.find(id);
         if (it == m_idToBlockMap.end()) {
             return NULL;
@@ -155,8 +156,8 @@ class LargeTempTableBlockCache {
  private:
 
     // This at some point may need to be unique across the entire process
-    int64_t getNextId() {
-        int64_t nextId = m_nextId;
+    LargeTempTableBlockId getNextId() {
+        LargeTempTableBlockId nextId = m_nextId;
         ++m_nextId;
         return nextId;
     }
@@ -175,9 +176,9 @@ class LargeTempTableBlockCache {
     // The tail will be the least recently used blocks.
     // The tail of the list should have no pinned blocks.
     BlockList m_blockList;
-    std::map<int64_t, BlockList::iterator> m_idToBlockMap;
+    std::map<LargeTempTableBlockId, BlockList::iterator> m_idToBlockMap;
 
-    int64_t m_nextId;
+    LargeTempTableBlockId m_nextId;
     int64_t m_totalAllocatedBytes;
 };
 

--- a/src/ee/common/LargeTempTableBlockId.hpp
+++ b/src/ee/common/LargeTempTableBlockId.hpp
@@ -26,8 +26,8 @@ namespace voltdb {
 class LargeTempTableBlockId {
 public:
     typedef int64_t siteId_t;
-    typedef int64_t blockId_t;
-    LargeTempTableBlockId(siteId_t siteId, blockId_t blockId) : m_siteId(siteId), m_blockCounter(blockId) {}
+    typedef int64_t blockCounter_t;
+    LargeTempTableBlockId(siteId_t siteId, blockCounter_t blockCounter) : m_siteId(siteId), m_blockCounter(blockCounter) {}
     LargeTempTableBlockId(const LargeTempTableBlockId &other) : m_siteId(other.m_siteId), m_blockCounter(other.m_blockCounter) {}
     // Preincrement.
     LargeTempTableBlockId operator++() {
@@ -54,17 +54,17 @@ public:
     siteId_t getSiteId() const {
         return m_siteId;
     }
-    blockId_t getBlockCounter() const {
+    blockCounter_t getBlockCounter() const {
         return m_blockCounter;
     }
 protected:
     union {
         // For getting at the raw bits.
-        int8_t         m_data[sizeof(siteId_t ) + sizeof(blockId_t)];
+        int8_t         m_data[sizeof(siteId_t ) + sizeof(blockCounter_t)];
         // For getting at the data itself.
         struct {
             siteId_t   m_siteId;
-            blockId_t  m_blockCounter;
+            blockCounter_t  m_blockCounter;
         };
     };
 private:

--- a/src/ee/common/LargeTempTableBlockId.hpp
+++ b/src/ee/common/LargeTempTableBlockId.hpp
@@ -26,7 +26,7 @@ namespace voltdb {
 class LargeTempTableBlockId {
 public:
     typedef int64_t siteId_t;
-    typedef int32_t blockId_t;
+    typedef int64_t blockId_t;
     LargeTempTableBlockId(siteId_t siteId, blockId_t blockId) : m_siteId(siteId), m_blockCounter(blockId) {}
     LargeTempTableBlockId(const LargeTempTableBlockId &other) : m_siteId(other.m_siteId), m_blockCounter(other.m_blockCounter) {}
     // Preincrement.

--- a/src/ee/common/LargeTempTableBlockId.hpp
+++ b/src/ee/common/LargeTempTableBlockId.hpp
@@ -28,7 +28,6 @@ public:
     typedef int64_t siteId_t;
     typedef int64_t blockCounter_t;
     LargeTempTableBlockId(siteId_t siteId, blockCounter_t blockCounter) : m_siteId(siteId), m_blockCounter(blockCounter) {}
-    LargeTempTableBlockId(const LargeTempTableBlockId &other) : m_siteId(other.m_siteId), m_blockCounter(other.m_blockCounter) {}
     // Preincrement.
     LargeTempTableBlockId operator++() {
       m_blockCounter++;
@@ -44,13 +43,6 @@ public:
         return getSiteId() == other.getSiteId() && getBlockCounter() == other.getBlockCounter();
     }
 
-    LargeTempTableBlockId &operator=(const LargeTempTableBlockId &other) {
-        if (this != &other) {
-            this->m_siteId = other.getSiteId();
-            this->m_blockCounter = other.getBlockCounter();
-        }
-        return *this;
-    }
     siteId_t getSiteId() const {
         return m_siteId;
     }
@@ -67,11 +59,6 @@ protected:
             blockCounter_t  m_blockCounter;
         };
     };
-private:
-    /*
-     * Private and undefined.  This discourages people from using this.
-     */
-    LargeTempTableBlockId();
 };
 
 inline std::ostream &operator<<(std::ostream &out, LargeTempTableBlockId id) {

--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -167,7 +167,7 @@ namespace voltdb {
         return false;
     }
 
-    bool DummyTopend::releaseLargeTempTableBlock(int64_t blockId) {
+    bool DummyTopend::releaseLargeTempTableBlock(LargeTempTableBlockId blockId) {
         return false;
     }
 

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -20,6 +20,7 @@
 #include "common/ids.h"
 #include "common/FatalException.hpp"
 #include "common/types.h"
+#include "common/lttblockid.h"
 
 #include <string>
 #include <queue>
@@ -94,7 +95,7 @@ class Topend {
     virtual bool loadLargeTempTableBlock(LargeTempTableBlock* block) = 0;
 
     /** Delete any data for the specified block that is stored on disk. */
-    virtual bool releaseLargeTempTableBlock(int64_t blockId) = 0;
+    virtual bool releaseLargeTempTableBlock(LargeTempTableBlockId blockId) = 0;
 
     // Call into the Java top end to execute a user-defined function.
     // The function ID for the function to be called and the parameter data is stored in a
@@ -155,7 +156,7 @@ public:
 
     virtual bool loadLargeTempTableBlock(LargeTempTableBlock* block);
 
-    virtual bool releaseLargeTempTableBlock(int64_t blockId);
+    virtual bool releaseLargeTempTableBlock(LargeTempTableBlockId blockId);
 
     int32_t callJavaUserDefinedFunction();
     void resizeUDFBuffer(int32_t size);

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -17,16 +17,16 @@
 
 #ifndef TOPEND_H_
 #define TOPEND_H_
-#include "common/ids.h"
-#include "common/FatalException.hpp"
-#include "common/types.h"
-#include "common/lttblockid.h"
-
 #include <string>
 #include <queue>
 #include <vector>
 #include <boost/shared_ptr.hpp>
 #include <boost/shared_array.hpp>
+
+#include "common/ids.h"
+#include "common/FatalException.hpp"
+#include "common/LargeTempTableBlockId.hpp"
+#include "common/types.h"
 
 namespace voltdb {
 class Table;

--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -99,7 +99,7 @@ ExecutorContext::ExecutorContext(int64_t siteId,
     m_uniqueId(0),
     m_currentTxnTimestamp(0),
     m_currentDRTimestamp(0),
-    m_lttBlockCache(topend, engine ? engine->tempTableMemoryLimit() : 50*1024*1024), // engine may be null in unit tests
+    m_lttBlockCache(topend, engine ? engine->tempTableMemoryLimit() : 50*1024*1024, siteId), // engine may be null in unit tests
     m_traceOn(false),
     m_lastCommittedSpHandle(0),
     m_siteId(siteId),

--- a/src/ee/common/iosflagsaver.h
+++ b/src/ee/common/iosflagsaver.h
@@ -1,0 +1,52 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <ostream>
+
+namespace voltdb {
+/**
+ * This is a class to save the state of the
+ * flags of an ostream.  One uses it this way:
+ *   Here the ios flags of someStream have some state
+ *   value, say the base is decimal.
+ *   {
+ *      IosFlagSaver saver(someStream);
+ *      // Print something in hex.
+ *      someStream << hex << val;
+ *   }
+ *   ... Here someStream will have the original
+ *   state values, printing in decimal.
+ *   cf. https://stackoverflow.com/questions/2273330/restore-the-state-of-stdcout-after-manipulating-it.
+ */
+class IOSFlagSaver {
+public:
+    explicit IOSFlagSaver(std::ostream& _ios):
+        ios(_ios),
+        f(_ios.flags()) {
+    }
+    ~IOSFlagSaver() {
+        ios.flags(f);
+    }
+
+    IOSFlagSaver(const IOSFlagSaver &rhs) = delete;
+    IOSFlagSaver& operator= (const IOSFlagSaver& rhs) = delete;
+
+private:
+    std::ostream& ios;
+    std::ios::fmtflags f;
+};
+}

--- a/src/ee/common/lttblockid.h
+++ b/src/ee/common/lttblockid.h
@@ -1,0 +1,53 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef VOLTDB_LTTBLOCKID_H
+#define VOLTDB_LTTBLOCKID_H
+#include <inttypes.h>
+#include <ostream>
+
+namespace voltdb {
+class LargeTempTableBlockId {
+public:
+    LargeTempTableBlockId(int64_t id) : m_id(id) {}
+    // Preincrement.
+    LargeTempTableBlockId operator++() {
+      m_id++;
+      return *this;
+    }
+
+    explicit operator int64_t() const {
+      return m_id;
+    }
+
+    bool operator<(const LargeTempTableBlockId &other) const {
+      return m_id < other.m_id;
+    }
+
+    bool operator==(const LargeTempTableBlockId &other) const {
+        return m_id == other.m_id;
+    }
+protected:
+    int64_t       m_id;
+};
+
+inline std::ostream &operator<<(std::ostream &out, LargeTempTableBlockId id) {
+  return out << int64_t(id);
+}
+}
+#endif // VOLTDB_LTTBLOCKID_H

--- a/src/ee/common/lttblockid.h
+++ b/src/ee/common/lttblockid.h
@@ -32,10 +32,6 @@ public:
       return *this;
     }
 
-    explicit operator int64_t() const {
-      return m_id64;
-    }
-
     bool operator<(const LargeTempTableBlockId &other) const {
       return (m_siteId < other.m_siteId)
               || ((m_siteId == other.m_siteId) && (m_bid < other.m_bid));
@@ -43,6 +39,10 @@ public:
 
     bool operator==(const LargeTempTableBlockId &other) const {
         return m_id64 == other.m_id64;
+    }
+
+    int64_t getLongId() const {
+        return m_id64;
     }
 
     int32_t getSiteId() const {

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -255,7 +255,7 @@ JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecuti
 
     m_storeLargeTempTableBlockMID = m_jniEnv->GetMethodID(jniClass,
                                                           "storeLargeTempTableBlock",
-                                                          "(JJLjava/nio/ByteBuffer;)Z");
+                                                          "(JJJLjava/nio/ByteBuffer;)Z");
     if (m_storeLargeTempTableBlockMID == NULL) {
         m_jniEnv->ExceptionDescribe();
         assert(m_storeLargeTempTableBlockMID != 0);
@@ -264,7 +264,7 @@ JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecuti
 
     m_loadLargeTempTableBlockMID = m_jniEnv->GetMethodID(jniClass,
                                                          "loadLargeTempTableBlock",
-                                                          "(JLjava/nio/ByteBuffer;)J");
+                                                          "(JJLjava/nio/ByteBuffer;)J");
     if (m_loadLargeTempTableBlockMID == NULL) {
         m_jniEnv->ExceptionDescribe();
         assert(m_loadLargeTempTableBlockMID != 0);
@@ -273,7 +273,7 @@ JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecuti
 
     m_releaseLargeTempTableBlockMID = m_jniEnv->GetMethodID(jniClass,
                                                             "releaseLargeTempTableBlock",
-                                                            "(J)Z");
+                                                            "(JJ)Z");
     if (m_releaseLargeTempTableBlockMID == NULL) {
         m_jniEnv->ExceptionDescribe();
         assert(m_releaseLargeTempTableBlockMID != 0);
@@ -441,9 +441,11 @@ bool JNITopend::storeLargeTempTableBlock(LargeTempTableBlock* block) {
 
     int64_t address = reinterpret_cast<int64_t>(storage.get());
 
+    LargeTempTableBlockId blockId = block->id();
     jboolean success = m_jniEnv->CallBooleanMethod(m_javaExecutionEngine,
                                                    m_storeLargeTempTableBlockMID,
-                                                   block->id(),
+                                                   blockId.getSiteId(),
+                                                   blockId.getBlockCounter(),
                                                    address,
                                                    blockByteBuffer);
     // It's assumed that when control returns to this method the block
@@ -483,7 +485,8 @@ bool JNITopend::loadLargeTempTableBlock(LargeTempTableBlock* block) {
 bool JNITopend::releaseLargeTempTableBlock(LargeTempTableBlockId blockId) {
     jboolean success = (jboolean)m_jniEnv->CallBooleanMethod(m_javaExecutionEngine,
                                                              m_releaseLargeTempTableBlockMID,
-                                                             blockId.getLongId());
+                                                             blockId.getSiteId(),
+                                                             blockId.getBlockCounter());
     return success;
 }
 

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -483,7 +483,7 @@ bool JNITopend::loadLargeTempTableBlock(LargeTempTableBlock* block) {
 bool JNITopend::releaseLargeTempTableBlock(LargeTempTableBlockId blockId) {
     jboolean success = (jboolean)m_jniEnv->CallBooleanMethod(m_javaExecutionEngine,
                                                              m_releaseLargeTempTableBlockMID,
-                                                             int64_t(blockId));
+                                                             blockId.getLongId());
     return success;
 }
 

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -480,10 +480,10 @@ bool JNITopend::loadLargeTempTableBlock(LargeTempTableBlock* block) {
     return origAddress != 0;
 }
 
-bool JNITopend::releaseLargeTempTableBlock(int64_t blockId) {
+bool JNITopend::releaseLargeTempTableBlock(LargeTempTableBlockId blockId) {
     jboolean success = (jboolean)m_jniEnv->CallBooleanMethod(m_javaExecutionEngine,
                                                              m_releaseLargeTempTableBlockMID,
-                                                             blockId);
+                                                             int64_t(blockId));
     return success;
 }
 

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -17,12 +17,13 @@
 
 #ifndef JNITOPEND_H_
 #define JNITOPEND_H_
+#include <jni.h>
+
 #include "boost/shared_array.hpp"
 #include "common/Topend.h"
 #include "common/FatalException.hpp"
+#include "common/LargeTempTableBlockId.hpp"
 #include "common/Pool.hpp"
-#include "common/lttblockid.h"
-#include <jni.h>
 
 namespace voltdb {
 

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -21,6 +21,7 @@
 #include "common/Topend.h"
 #include "common/FatalException.hpp"
 #include "common/Pool.hpp"
+#include "common/lttblockid.h"
 #include <jni.h>
 
 namespace voltdb {
@@ -71,7 +72,7 @@ public:
 
     bool loadLargeTempTableBlock(LargeTempTableBlock* block);
 
-    bool releaseLargeTempTableBlock(int64_t blockId);
+    bool releaseLargeTempTableBlock(LargeTempTableBlockId blockId);
 
     int32_t callJavaUserDefinedFunction();
     void resizeUDFBuffer(int32_t size);

--- a/src/ee/storage/LargeTempTable.cpp
+++ b/src/ee/storage/LargeTempTable.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "common/LargeTempTableBlockCache.h"
+#include "common/lttblockid.h"
 #include "storage/LargeTempTable.h"
 #include "storage/LargeTempTableBlock.h"
 
@@ -104,7 +105,7 @@ void LargeTempTable::deleteAllTempTuples() {
 
     LargeTempTableBlockCache* lttBlockCache = ExecutorContext::getExecutorContext()->lttBlockCache();
 
-    BOOST_FOREACH(int64_t blockId, m_blockIds) {
+    BOOST_FOREACH(auto blockId, m_blockIds) {
         lttBlockCache->releaseBlock(blockId);
     }
 
@@ -112,7 +113,7 @@ void LargeTempTable::deleteAllTempTuples() {
     m_tupleCount = 0;
 }
 
-std::vector<int64_t>::iterator LargeTempTable::releaseBlock(std::vector<int64_t>::iterator it) {
+std::vector<LargeTempTableBlockId>::iterator LargeTempTable::releaseBlock(std::vector<LargeTempTableBlockId>::iterator it) {
     if (it == m_blockIds.end()) {
         // block may have already been deleted
         return it;

--- a/src/ee/storage/LargeTempTable.cpp
+++ b/src/ee/storage/LargeTempTable.cpp
@@ -15,8 +15,8 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "common/LargeTempTableBlockId.hpp"
 #include "common/LargeTempTableBlockCache.h"
-#include "common/lttblockid.h"
 #include "storage/LargeTempTable.h"
 #include "storage/LargeTempTableBlock.h"
 

--- a/src/ee/storage/LargeTempTable.h
+++ b/src/ee/storage/LargeTempTable.h
@@ -18,6 +18,7 @@
 #ifndef VOLTDB_LARGETEMPTABLE_H
 #define VOLTDB_LARGETEMPTABLE_H
 
+#include "common/lttblockid.h"
 #include "common/LargeTempTableBlockCache.h"
 #include "storage/AbstractTempTable.hpp"
 #include "storage/tableiterator.h"
@@ -88,7 +89,7 @@ public:
     /** Releases the specified block.  Called by delete-as-you-go
         iterators.  Returns an iterator pointing to the next block
         id. */
-    virtual std::vector<int64_t>::iterator releaseBlock(std::vector<int64_t>::iterator it);
+    virtual std::vector<LargeTempTableBlockId>::iterator releaseBlock(std::vector<LargeTempTableBlockId>::iterator it);
 
     /** Return the number of large temp table blocks used by this
         table */
@@ -147,7 +148,7 @@ private:
 
     void getEmptyBlock();
 
-    std::vector<int64_t> m_blockIds;
+    std::vector<LargeTempTableBlockId> m_blockIds;
 
     TableIterator m_iter;
 

--- a/src/ee/storage/LargeTempTable.h
+++ b/src/ee/storage/LargeTempTable.h
@@ -18,8 +18,8 @@
 #ifndef VOLTDB_LARGETEMPTABLE_H
 #define VOLTDB_LARGETEMPTABLE_H
 
-#include "common/lttblockid.h"
 #include "common/LargeTempTableBlockCache.h"
+#include "common/LargeTempTableBlockId.hpp"
 #include "storage/AbstractTempTable.hpp"
 #include "storage/tableiterator.h"
 

--- a/src/ee/storage/LargeTempTableBlock.cpp
+++ b/src/ee/storage/LargeTempTableBlock.cpp
@@ -131,7 +131,7 @@ std::unique_ptr<char[]> LargeTempTableBlock::releaseData() {
 
 std::string LargeTempTableBlock::debug() const {
     std::ostringstream oss;
-    oss << "Block " << int64_t(m_id) << ", " << m_activeTupleCount << " tuples, ";
+    oss << "Block " << m_id << ", " << m_activeTupleCount << " tuples, ";
 
     if (! isResident()) {
         oss << "not resident";

--- a/src/ee/storage/LargeTempTableBlock.cpp
+++ b/src/ee/storage/LargeTempTableBlock.cpp
@@ -23,7 +23,7 @@
 
 namespace voltdb {
 
-LargeTempTableBlock::LargeTempTableBlock(int64_t id, TupleSchema* schema)
+LargeTempTableBlock::LargeTempTableBlock(LargeTempTableBlockId id, TupleSchema* schema)
     : m_id(id)
     , m_schema(schema)
     , m_storage(new char [BLOCK_SIZE_IN_BYTES])
@@ -131,7 +131,7 @@ std::unique_ptr<char[]> LargeTempTableBlock::releaseData() {
 
 std::string LargeTempTableBlock::debug() const {
     std::ostringstream oss;
-    oss << "Block " << m_id << ", " << m_activeTupleCount << " tuples, ";
+    oss << "Block " << int64_t(m_id) << ", " << m_activeTupleCount << " tuples, ";
 
     if (! isResident()) {
         oss << "not resident";

--- a/src/ee/storage/LargeTempTableBlock.h
+++ b/src/ee/storage/LargeTempTableBlock.h
@@ -20,7 +20,8 @@
 
 #include <memory>
 #include <utility>
-#include "common/lttblockid.h"
+
+#include "common/LargeTempTableBlockId.hpp"
 
 namespace voltdb {
 

--- a/src/ee/storage/LargeTempTableBlock.h
+++ b/src/ee/storage/LargeTempTableBlock.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <utility>
+#include "common/lttblockid.h"
 
 namespace voltdb {
 
@@ -59,10 +60,10 @@ class LargeTempTableBlock {
     static const size_t BLOCK_SIZE_IN_BYTES = 8 * 1024 * 1024; // 8 MB
 
     /** constructor for a new block. */
-    LargeTempTableBlock(int64_t id, TupleSchema* schema);
+    LargeTempTableBlock(LargeTempTableBlockId id, TupleSchema* schema);
 
     /** Return the unique ID for this block */
-    int64_t id() const {
+    LargeTempTableBlockId id() const {
         return m_id;
     }
 
@@ -166,7 +167,7 @@ class LargeTempTableBlock {
  private:
 
     /** the ID of this block */
-    int64_t m_id;
+    LargeTempTableBlockId m_id;
 
     /** the schema for the data (owned by the table) */
     TupleSchema * m_schema;

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -47,6 +47,7 @@
 #define HSTORETABLE_H
 
 #include "common/ids.h"
+#include "common/lttblockid.h"
 #include "common/types.h"
 #include "common/TupleSchema.h"
 #include "common/Pool.hpp"
@@ -320,7 +321,7 @@ protected:
     }
 
     // Used by delete-as-you-go iterators.  Returns an iterator to the block id of the next block.
-    virtual std::vector<int64_t>::iterator releaseBlock(std::vector<int64_t>::iterator it) {
+    virtual std::vector<LargeTempTableBlockId>::iterator releaseBlock(std::vector<LargeTempTableBlockId>::iterator it) {
         throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                      "May only use releaseBlock with instances of LargeTempTable.");
     }

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -47,7 +47,7 @@
 #define HSTORETABLE_H
 
 #include "common/ids.h"
-#include "common/lttblockid.h"
+#include "common/LargeTempTableBlockId.hpp"
 #include "common/types.h"
 #include "common/TupleSchema.h"
 #include "common/Pool.hpp"

--- a/src/ee/storage/tableiterator.h
+++ b/src/ee/storage/tableiterator.h
@@ -48,6 +48,7 @@
 
 #include <cassert>
 
+#include "common/lttblockid.h"
 #include "common/LargeTempTableBlockCache.h"
 #include "common/debuglog.h"
 #include "common/tabletuple.h"
@@ -128,7 +129,7 @@ protected:
     TableIterator(Table *, std::vector<TBPtr>::iterator);
 
     /** Constructor for large temp tables */
-    TableIterator(Table *, std::vector<int64_t>::iterator);
+    TableIterator(Table *, std::vector<LargeTempTableBlockId>::iterator);
 
     /** moves iterator to beginning of table.
         (Called only for persistent tables) */
@@ -140,7 +141,7 @@ protected:
 
     /** moves iterator to beginning of table.
         (Called only for large temp tables) */
-    void reset(std::vector<int64_t>::iterator);
+    void reset(std::vector<LargeTempTableBlockId>::iterator);
 
     bool continuationPredicate();
 
@@ -229,7 +230,7 @@ private:
         }
 
         /** Construct an iterator for a large temp table */
-        TypeSpecificState(std::vector<int64_t>::iterator it, bool deleteAsGo)
+        TypeSpecificState(std::vector<LargeTempTableBlockId>::iterator it, bool deleteAsGo)
         : m_persBlockIterator()
         , m_tempBlockIterator()
         , m_largeTempBlockIterator(it)
@@ -248,7 +249,7 @@ private:
         std::vector<TBPtr>::iterator m_tempBlockIterator;
 
         /** Table block iterator for large temp tables */
-        std::vector<int64_t>::iterator m_largeTempBlockIterator;
+        std::vector<LargeTempTableBlockId>::iterator m_largeTempBlockIterator;
 
         /** "delete as you go" flag for normal and large temp tables
          * (Not used for persistent tables)
@@ -316,7 +317,7 @@ inline TableIterator::TableIterator(Table *parent, std::vector<TBPtr>::iterator 
 }
 
 //  Construct an iterator for large temp tables
-inline TableIterator::TableIterator(Table *parent, std::vector<int64_t>::iterator start)
+inline TableIterator::TableIterator(Table *parent, std::vector<LargeTempTableBlockId>::iterator start)
     : m_table(parent)
     , m_tupleLength(parent->m_tupleLength)
     , m_activeTuples((int) m_table->m_tupleCount)
@@ -390,7 +391,7 @@ inline void TableIterator::reset(std::vector<TBPtr>::iterator start) {
     m_state.m_tempTableDeleteAsGo = false;
 }
 
- inline void TableIterator::reset(std::vector<int64_t>::iterator start) {
+ inline void TableIterator::reset(std::vector<LargeTempTableBlockId>::iterator start) {
     assert(m_iteratorType == LARGE_TEMP);
 
     // Unpin the block of the previous scan before resetting.

--- a/src/ee/storage/tableiterator.h
+++ b/src/ee/storage/tableiterator.h
@@ -48,8 +48,8 @@
 
 #include <cassert>
 
-#include "common/lttblockid.h"
 #include "common/LargeTempTableBlockCache.h"
+#include "common/LargeTempTableBlockId.hpp"
 #include "common/debuglog.h"
 #include "common/tabletuple.h"
 

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -22,6 +22,11 @@
  and executes commands from Java synchronously.
  */
 
+#include <signal.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h> // for TCP_NODELAY
+
+#include "common/LargeTempTableBlockId.hpp"
 #include "common/Topend.h"
 
 #include "execution/VoltDBEngine.h"
@@ -29,15 +34,10 @@
 #include "storage/table.h"
 
 #include "common/ElasticHashinator.h"
-#include "common/lttblockid.h"
 #include "common/RecoveryProtoMessage.h"
 #include "common/serializeio.h"
 #include "common/SegvException.hpp"
 #include "common/types.h"
-
-#include <signal.h>
-#include <sys/socket.h>
-#include <netinet/tcp.h> // for TCP_NODELAY
 
 // Please don't make this different from the JNI result buffer size.
 // This determines the size of the EE results buffer and it's nice

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -33,6 +33,7 @@
 #include "common/serializeio.h"
 #include "common/SegvException.hpp"
 #include "common/types.h"
+#include "common/lttblockid.h"
 
 #include <signal.h>
 #include <sys/socket.h>
@@ -148,7 +149,7 @@ public:
 
     bool loadLargeTempTableBlock(voltdb::LargeTempTableBlock* block);
 
-    bool releaseLargeTempTableBlock(int64_t blockId);
+    bool releaseLargeTempTableBlock(LargeTempTableBlockId blockId);
 
 
 private:
@@ -1683,7 +1684,7 @@ bool VoltDBIPC::loadLargeTempTableBlock(voltdb::LargeTempTableBlock* block) {
     return false;
 }
 
-bool VoltDBIPC::releaseLargeTempTableBlock(int64_t blockId) {
+bool VoltDBIPC::releaseLargeTempTableBlock(LargeTempTableBlockId blockId) {
     return false;
 }
 

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -29,11 +29,11 @@
 #include "storage/table.h"
 
 #include "common/ElasticHashinator.h"
+#include "common/lttblockid.h"
 #include "common/RecoveryProtoMessage.h"
 #include "common/serializeio.h"
 #include "common/SegvException.hpp"
 #include "common/types.h"
-#include "common/lttblockid.h"
 
 #include <signal.h>
 #include <sys/socket.h>
@@ -149,7 +149,7 @@ public:
 
     bool loadLargeTempTableBlock(voltdb::LargeTempTableBlock* block);
 
-    bool releaseLargeTempTableBlock(LargeTempTableBlockId blockId);
+    bool releaseLargeTempTableBlock(voltdb::LargeTempTableBlockId blockId);
 
 
 private:

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -184,7 +184,7 @@ void setupSigHandler(void) {
 // Create / Destroy
 ////////////////////////////////////////////////////////////////////////////
 /**
- * Just creates a new VoltDBEngine object and retunrs it to Java.
+ * Just creates a new VoltDBEngine object and returns it to Java.
  * Never fail to destroy() for the VoltDBEngine* once you call this method
  * NOTE: Call initialize() separately for initialization.
  * This does strictly nothing so that this method never throws an exception.

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -844,12 +844,12 @@ public class ExecutionEngineJNI extends ExecutionEngine {
      * @param block        A directly-allocated ByteBuffer of the block
      * @return true if operation succeeded, false otherwise
      */
-    public boolean storeLargeTempTableBlock(long id, long origAddress, ByteBuffer block) {
+    public boolean storeLargeTempTableBlock(long siteId, long blockCounter, long origAddress, ByteBuffer block) {
         LargeBlockManager lbm = LargeBlockManager.getInstance();
         assert (lbm != null);
 
         try {
-            lbm.storeBlock(id, origAddress, block);
+            lbm.storeBlock(siteId, blockCounter, origAddress, block);
         }
         catch (IOException ioe) {
             LOG.error("Could not write large temp table block to disk: " + ioe.getMessage());
@@ -867,13 +867,13 @@ public class ExecutionEngineJNI extends ExecutionEngine {
      * @param block  The buffer to write the block to
      * @return The original address of the block (so that its internal pointers may get updated)
      */
-    public long loadLargeTempTableBlock(long id, ByteBuffer block) {
+    public long loadLargeTempTableBlock(long siteId, long blockCounter, ByteBuffer block) {
         LargeBlockManager lbm = LargeBlockManager.getInstance();
         assert (lbm != null);
         long origAddress = 0;
 
         try {
-            origAddress = lbm.loadBlock(id, block);
+            origAddress = lbm.loadBlock(siteId, blockCounter, block);
         }
         catch (IOException ioe) {
             LOG.error("Could not write large temp table block to disk: " + ioe.getMessage());
@@ -888,12 +888,12 @@ public class ExecutionEngineJNI extends ExecutionEngine {
      * @param blockId   The id of the block to release
      * @return True if the operation succeeded, and false otherwise
      */
-    public boolean releaseLargeTempTableBlock(long blockId) {
+    public boolean releaseLargeTempTableBlock(long siteId, long blockId) {
         LargeBlockManager lbm = LargeBlockManager.getInstance();
         assert (lbm != null);
 
         try {
-            lbm.releaseBlock(blockId);
+            lbm.releaseBlock(siteId, blockId);
         }
         catch (IOException ioe) {
             LOG.error("Could not release large temp table block on disk: " + ioe.getMessage());

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -39,6 +39,7 @@ import org.voltdb.common.Constants;
 import org.voltdb.exceptions.EEException;
 import org.voltdb.exceptions.SerializableException;
 import org.voltdb.iv2.DeterminismHash;
+import org.voltdb.largequery.BlockId;
 import org.voltdb.largequery.LargeBlockManager;
 import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
@@ -849,7 +850,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
         assert (lbm != null);
 
         try {
-            lbm.storeBlock(siteId, blockCounter, origAddress, block);
+            lbm.storeBlock(new BlockId(siteId, blockCounter), origAddress, block);
         }
         catch (IOException ioe) {
             LOG.error("Could not write large temp table block to disk: " + ioe.getMessage());
@@ -873,7 +874,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
         long origAddress = 0;
 
         try {
-            origAddress = lbm.loadBlock(siteId, blockCounter, block);
+            origAddress = lbm.loadBlock(new BlockId(siteId, blockCounter), block);
         }
         catch (IOException ioe) {
             LOG.error("Could not write large temp table block to disk: " + ioe.getMessage());
@@ -893,7 +894,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
         assert (lbm != null);
 
         try {
-            lbm.releaseBlock(siteId, blockId);
+            lbm.releaseBlock(new BlockId(siteId, blockId));
         }
         catch (IOException ioe) {
             LOG.error("Could not release large temp table block on disk: " + ioe.getMessage());

--- a/src/frontend/org/voltdb/largequery/BlockId.java
+++ b/src/frontend/org/voltdb/largequery/BlockId.java
@@ -1,0 +1,102 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb.largequery;
+
+import java.math.BigInteger;
+
+/**
+ * This class serves mostly as keys to the map from
+ * siteId/blockId pairs to file names.  It's also used
+ * to transmit these values to the LargeBlockManager
+ * API operations.
+ *
+ * Each BlockId object is essentially a Pair<long, long>.
+ */
+public class BlockId {
+    public BlockId(long siteId, long blockId) {
+        m_siteId = siteId;
+        m_blockId = blockId;
+    }
+
+    private final long m_siteId;
+    private final long m_blockId;
+    public final long getSiteId() {
+        return m_siteId;
+    }
+    public final long getBlockId() {
+        return m_blockId;
+    }
+
+    /**
+     * Return a string of the form "siteId::blockId".  This is
+     * used for display.
+     *
+     * @return A string of the form "SID::BLOCKID".
+     */
+    @Override
+    public String toString() {
+        return Long.toString(m_siteId) + "::" + Long.toString(m_blockId);
+    }
+    /**
+     * Return a string of the form "siteId___blockId".  This is used
+     * for file names and not for displaying in, say, error messages.
+     * It would be weird to have a file names with minus signs,
+     * so format the IDs as unsigned.
+     *
+     * @return A string of the form "SID___BLOCKID.block" where SID and BLOCKID are unsigned.
+     */
+    public String fileNameString() {
+        BigInteger bigSiteId = BigInteger.valueOf(getSiteId());
+        BigInteger bigBlockCounter = BigInteger.valueOf(getBlockId());
+        final BigInteger BIT_64 = BigInteger.ONE.shiftLeft(64);
+
+        if(bigSiteId.signum() < 0) {
+            bigSiteId = bigSiteId.add(BIT_64);
+        }
+        if(bigBlockCounter.signum() < 0) {
+            bigBlockCounter = bigBlockCounter.add(BIT_64);
+        }
+        return bigSiteId.toString() + "___" + bigBlockCounter.toString() + ".block";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if ( ! (other instanceof BlockId)) {
+            return false;
+        }
+        BlockId bOther = (BlockId)other;
+        return (m_siteId == bOther.getSiteId() && m_blockId == bOther.getBlockId());
+    }
+
+    @Override
+    public int hashCode() {
+        // Josh Bloch's recipe for hashCode values.
+        // Somewhere on StackOverflow.
+        int result = 17;
+        int sh = (int)(m_siteId ^ (m_siteId >>> 32));
+        result = 32 + result * sh;
+
+        int ch = (int)(m_blockId ^ (m_blockId >>> 32));
+        result = 32 + result * ch;
+
+        return result;
+    }
+ }
+

--- a/tests/ee/common/LargeTempTableBlockIdTest.cpp
+++ b/tests/ee/common/LargeTempTableBlockIdTest.cpp
@@ -48,8 +48,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include "common/LargeTempTableBlockId.hpp"
+
 #include "harness.h"
-#include "common/lttblockid.h"
 
 using namespace voltdb;
 
@@ -61,15 +62,15 @@ public:
 TEST_F(LargeTempTableBlockIdTest, InitializeAndTest) {
     voltdb::LargeTempTableBlockId blockId(100, 0);
     voltdb::LargeTempTableBlockId newBlockId(100, 1);
-    EXPECT_EQ(0, blockId.getBlockId());
+    EXPECT_EQ(0, blockId.getBlockCounter());
     EXPECT_EQ(100, blockId.getSiteId());
     for (int idx = 1; idx <= 100; idx += 1) {
         newBlockId = ++blockId;
         // The blockId is incremented.
-        EXPECT_EQ(idx, blockId.getBlockId());
+        EXPECT_EQ(idx, blockId.getBlockCounter());
         EXPECT_EQ(100, blockId.getSiteId());
         // newBlockId gets it.
-        EXPECT_EQ(idx, newBlockId.getBlockId());
+        EXPECT_EQ(idx, newBlockId.getBlockCounter());
         EXPECT_EQ(100, newBlockId.getSiteId());
     }
     blockId = voltdb::LargeTempTableBlockId(100, 1);

--- a/tests/ee/common/lttblockid_test.cpp
+++ b/tests/ee/common/lttblockid_test.cpp
@@ -60,11 +60,11 @@ public:
 
 TEST_F(LargeTempTableBlockIdTest, InitializeAndTest) {
     voltdb::LargeTempTableBlockId blockId(100, 0);
-
+    voltdb::LargeTempTableBlockId newBlockId(100, 1);
     EXPECT_EQ(0, blockId.getBlockId());
     EXPECT_EQ(100, blockId.getSiteId());
     for (int idx = 1; idx <= 100; idx += 1) {
-        LargeTempTableBlockId newBlockId = ++blockId;
+        newBlockId = ++blockId;
         // The blockId is incremented.
         EXPECT_EQ(idx, blockId.getBlockId());
         EXPECT_EQ(100, blockId.getSiteId());
@@ -72,6 +72,20 @@ TEST_F(LargeTempTableBlockIdTest, InitializeAndTest) {
         EXPECT_EQ(idx, newBlockId.getBlockId());
         EXPECT_EQ(100, newBlockId.getSiteId());
     }
+    blockId = voltdb::LargeTempTableBlockId(100, 1);
+    newBlockId = voltdb::LargeTempTableBlockId(110, 1);
+    EXPECT_EQ(1, (blockId < newBlockId) ? 1 : 0);
+    EXPECT_EQ(0, (blockId == newBlockId) ? 1 : 0);
+
+    blockId = voltdb::LargeTempTableBlockId(100, 1);
+    newBlockId = voltdb::LargeTempTableBlockId(100, 2);
+    EXPECT_EQ(1, (blockId < newBlockId) ? 1 : 0);
+    EXPECT_EQ(0, (blockId == newBlockId) ? 1 : 0);
+
+    blockId = voltdb::LargeTempTableBlockId(100, 1);
+    newBlockId = voltdb::LargeTempTableBlockId(100, 1);
+    EXPECT_EQ(0, (blockId < newBlockId) ? 1 : 0);
+    EXPECT_EQ(1, (blockId == newBlockId) ? 1 : 0);
 }
 
 int main() {

--- a/tests/ee/common/lttblockid_test.cpp
+++ b/tests/ee/common/lttblockid_test.cpp
@@ -1,0 +1,79 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+/* Copyright (C) 2008
+ * Evan Jones
+ * Massachusetts Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "harness.h"
+#include "common/lttblockid.h"
+
+using namespace voltdb;
+
+class LargeTempTableBlockIdTest : public Test {
+public:
+    LargeTempTableBlockIdTest() {}
+};
+
+TEST_F(LargeTempTableBlockIdTest, InitializeAndTest) {
+    voltdb::LargeTempTableBlockId blockId(100, 0);
+
+    EXPECT_EQ(0, blockId.getBlockId());
+    EXPECT_EQ(100, blockId.getSiteId());
+    for (int idx = 1; idx <= 100; idx += 1) {
+        LargeTempTableBlockId newBlockId = ++blockId;
+        // The blockId is incremented.
+        EXPECT_EQ(idx, blockId.getBlockId());
+        EXPECT_EQ(100, blockId.getSiteId());
+        // newBlockId gets it.
+        EXPECT_EQ(idx, newBlockId.getBlockId());
+        EXPECT_EQ(100, newBlockId.getSiteId());
+    }
+}
+
+int main() {
+    return TestSuite::globalInstance()->runAll();
+}

--- a/tests/ee/storage/LargeTempTableTest.cpp
+++ b/tests/ee/storage/LargeTempTableTest.cpp
@@ -34,8 +34,8 @@
 #include "test_utils/TupleComparingTest.hpp"
 #include "test_utils/UniqueTable.hpp"
 
-#include "common/lttblockid.h"
 #include "common/LargeTempTableBlockCache.h"
+#include "common/LargeTempTableBlockId.hpp"
 #include "common/TupleSchemaBuilder.h"
 #include "common/ValueFactory.hpp"
 #include "common/ValuePeeker.hpp"

--- a/tests/ee/storage/LargeTempTableTest.cpp
+++ b/tests/ee/storage/LargeTempTableTest.cpp
@@ -34,6 +34,7 @@
 #include "test_utils/TupleComparingTest.hpp"
 #include "test_utils/UniqueTable.hpp"
 
+#include "common/lttblockid.h"
 #include "common/LargeTempTableBlockCache.h"
 #include "common/TupleSchemaBuilder.h"
 #include "common/ValueFactory.hpp"
@@ -428,7 +429,7 @@ TEST_F(LargeTempTableTest, basicBlockCache) {
     ScopedTupleSchema schema(Tools::buildSchema(VALUE_TYPE_BIGINT, VALUE_TYPE_DOUBLE));
     LargeTempTableBlockCache* lttBlockCache = ExecutorContext::getExecutorContext()->lttBlockCache();
     LargeTempTableBlock* block = lttBlockCache->getEmptyBlock(schema.get());
-    int64_t blockId = block->id();
+    LargeTempTableBlockId blockId = block->id();
 
     ASSERT_NE(NULL, block);
     ASSERT_TRUE(block->isPinned());

--- a/tests/ee/test_utils/LargeTempTableTopend.hpp
+++ b/tests/ee/test_utils/LargeTempTableTopend.hpp
@@ -32,6 +32,7 @@
 #include "common/tabletuple.h"
 #include "common/Topend.h"
 
+#include "common/lttblockid.h"
 #include "storage/LargeTempTableBlock.h"
 
 namespace voltdb {
@@ -117,7 +118,7 @@ public:
         return true;
     }
 
-    bool releaseLargeTempTableBlock(int64_t blockId) {
+    bool releaseLargeTempTableBlock(voltdb::LargeTempTableBlockId blockId) {
         auto it = m_map.find(blockId);
         if (it == m_map.end()) {
             assert(false);
@@ -151,7 +152,7 @@ public:
 
 private:
 
-    std::map<int64_t, Block*> m_map;
+    std::map<voltdb::LargeTempTableBlockId, Block*> m_map;
 };
 
 #endif // LARGE_TEMP_TABLE_TOPEND_HPP

--- a/tests/ee/test_utils/LargeTempTableTopend.hpp
+++ b/tests/ee/test_utils/LargeTempTableTopend.hpp
@@ -29,10 +29,10 @@
 
 #include "harness.h"
 
+#include "common/LargeTempTableBlockId.hpp"
 #include "common/tabletuple.h"
 #include "common/Topend.h"
 
-#include "common/lttblockid.h"
 #include "storage/LargeTempTableBlock.h"
 
 namespace voltdb {

--- a/tests/frontend/org/voltdb/largequery/TestLargeBlockManagerSuite.java
+++ b/tests/frontend/org/voltdb/largequery/TestLargeBlockManagerSuite.java
@@ -43,6 +43,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.voltdb.largequery.LargeBlockManager.LargeTempTableBlockId;
 import org.voltdb.utils.VoltFile;
 
 public class TestLargeBlockManagerSuite {
@@ -81,17 +82,18 @@ public class TestLargeBlockManagerSuite {
         }
 
         // Store a block...
+        long siteId = 555;
         long blockId = 333;
         long address = 0xDEADBEEF;
-        lbm.storeBlock(blockId, address, block);
+        lbm.storeBlock(siteId, blockId, address, block);
 
-        Path blockPath = lbm.makeBlockPath(blockId);
-        assertThat(blockPath.toString(), endsWith("large_query_swap/333.block"));
+        Path blockPath = lbm.makeBlockPath(new LargeTempTableBlockId(100, blockId));
+        assertThat(blockPath.toString(), endsWith("large_query_swap/555___333.block"));
         assertTrue(Files.exists(blockPath));
 
         // Load the block back into memory
         ByteBuffer loadedBlock = ByteBuffer.allocateDirect(32);
-        long origAddress = lbm.loadBlock(blockId, loadedBlock);
+        long origAddress = lbm.loadBlock(siteId, blockId, loadedBlock);
         assertEquals(address, origAddress);
 
         // Ensure the block contains the expected data
@@ -101,7 +103,8 @@ public class TestLargeBlockManagerSuite {
         }
 
         // Release the block
-        lbm.releaseBlock(blockId);
+        lbm.releaseBlock(siteId, blockId);
+        assertTrue( ! Files.exists(blockPath));
     }
 
     @Test
@@ -116,17 +119,18 @@ public class TestLargeBlockManagerSuite {
                 block.putLong(i);
             }
 
-            lbm.storeBlock(id, address, block);
+            lbm.storeBlock(id + 100, id, address, block);
         }
 
         for (long id : ids) {
-            Path blockPath = lbm.makeBlockPath(id);
+            LargeBlockManager.LargeTempTableBlockId blockId = new LargeBlockManager.LargeTempTableBlockId(id+100, id);
+            Path blockPath = lbm.makeBlockPath(blockId);
             assertThat(blockPath.toString(), endsWith("large_query_swap/" + id + ".block"));
             assertTrue(Files.exists(blockPath));
         }
 
         // create another spurious file, just to show that shutdown will clean it up
-        Path spuriousFile = lbm.makeBlockPath(999);
+        Path spuriousFile = lbm.makeBlockPath(new LargeTempTableBlockId(0, 999));
         Files.createFile(spuriousFile);
 
         LargeBlockManager.shutdown();
@@ -153,17 +157,19 @@ public class TestLargeBlockManagerSuite {
         }
 
         // Store a block...
+        long evilSiteId = 666;
+        long siteId = 555;
         long blockId = 555;
         long address = 0xDEADBEEF;
-        lbm.storeBlock(blockId, address, block);
+        lbm.storeBlock(siteId, blockId, address, block);
 
-        Path blockPath = lbm.makeBlockPath(blockId);
+        Path blockPath = lbm.makeBlockPath(new LargeTempTableBlockId(siteId, blockId));
         assertThat(blockPath.toString(), endsWith("large_query_swap/555.block"));
         assertTrue(Files.exists(blockPath));
 
         try {
             // Redundantly store a block (should fail)
-            lbm.storeBlock(blockId, address, block);
+            lbm.storeBlock(siteId, blockId, address, block);
             fail("Expected redundant store to throw an exception");
         }
         catch (IllegalArgumentException iac) {
@@ -171,17 +177,17 @@ public class TestLargeBlockManagerSuite {
         }
 
         try {
-            // Try to load a block that does not exist
-            lbm.loadBlock(444, block);
+            // Try to load a block with a counter that does not exist
+            lbm.loadBlock(siteId, 444, block);
             fail("Expected attempted load of non-existant block to fail");
         }
         catch (IllegalArgumentException iac) {
-            assertThat(iac.getMessage(), containsString("Request to load block that is not stored: 444"));
+            assertThat(iac.getMessage(), containsString("Request to load block that is not stored: " + siteId + ":444"));
         }
 
         try {
             // Try to release a block that does not exist
-            lbm.releaseBlock(444);
+            lbm.releaseBlock(110, 444);
             fail("Expected attempted release of non-existant block to fail");
         }
         catch (IllegalArgumentException iac) {
@@ -189,7 +195,7 @@ public class TestLargeBlockManagerSuite {
         }
 
         // Clean up
-        lbm.releaseBlock(555);
+        lbm.releaseBlock(555, 555);
     }
 
     @Test
@@ -200,20 +206,20 @@ public class TestLargeBlockManagerSuite {
         // manager formats the ID as unsigned because file names starting with
         // a "-" would be weird.
 
-        Path path = lbm.makeBlockPath(0);
-        assertThat(path.toString(), endsWith("large_query_swap/0.block"));
+        Path path = lbm.makeBlockPath(new LargeTempTableBlockId(0,  0));
+        assertThat(path.toString(), endsWith("large_query_swap/0___0.block"));
 
-        path = lbm.makeBlockPath(1);
-        assertThat(path.toString(), endsWith("large_query_swap/1.block"));
+        path = lbm.makeBlockPath(new LargeTempTableBlockId(100, 1));
+        assertThat(path.toString(), endsWith("large_query_swap/100_1.block"));
 
-        path = lbm.makeBlockPath(Long.MAX_VALUE);
-        assertThat(path.toString(), endsWith("large_query_swap/" + Long.MAX_VALUE + ".block"));
+        path = lbm.makeBlockPath(new LargeTempTableBlockId(Long.MAX_VALUE, Long.MAX_VALUE));
+        assertThat(path.toString(), endsWith("large_query_swap/" + Long.MAX_VALUE + "___" + Long.MAX_VALUE + ".block"));
 
-        path = lbm.makeBlockPath(-1);
+        path = lbm.makeBlockPath(new LargeTempTableBlockId(-1, -1));
         BigInteger unsignedMinusOne = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
-        assertThat(path.toString(), endsWith("large_query_swap/" + unsignedMinusOne + ".block"));
+        assertThat(path.toString(), endsWith("large_query_swap/" + unsignedMinusOne + "___" + unsignedMinusOne + ".block"));
 
-        path = lbm.makeBlockPath(Long.MIN_VALUE);
+        path = lbm.makeBlockPath(new LargeTempTableBlockId(Long.MIN_VALUE, Long.MIN_VALUE));
         BigInteger unsignedMinLong = BigInteger.ONE.shiftLeft(63);
         assertThat(path.toString(), endsWith("large_query_swap/" + unsignedMinLong + ".block"));
     }


### PR DESCRIPTION
We change the block ids for Large Temp Tables from single int16_t values to structured values.

Objects of this class still have by-value semantics.  But they should be globally unique across
the entire cluster.
