### PR TITLE
ENG-13359:

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.cpp
+++ b/src/ee/common/SynchronizedThreadLock.cpp
@@ -209,6 +209,13 @@ void SynchronizedThreadLock::resetMemory(int32_t partitionId) {
         engine.enginePartitionId = NULL;
         engine.context = NULL;
         s_enginesByPartitionId.erase(partitionId);
+        if (s_enginesByPartitionId.empty()) {
+            // Junit Tests that use ServerThread (or LocalCluster.setHasLocalServer(true)) will use the same
+            // static ee globals from one test to the next so the last engine of the previous test should
+            // set this static to 0 so that the first engine in the next test will reinitialize the site count
+            // so that the countdown latch behaves correctly for tests with different site counts.
+            s_SITES_PER_HOST = 0;
+        }
     }
     unlockReplicatedResourceNoThreadLocals();
 }


### PR DESCRIPTION
Some JUnit tests use ServerThread repeatedly across multiple tests. In cases where the sites-per-host count changes between tests, the static globals in the EE that are used to coordinate changes across sites (the countdown latch) need to be initialized to a different value from one test to the next. By having the last engine that goes away reset, the static sites per host value to 0, the next test's first engine will use it's sites per host value to reinitialize the new engines to the correct value.