### PR TITLE
ENG-13625:

### DIFF
--- a/tests/ee/indexes/index_test.cpp
+++ b/tests/ee/indexes/index_test.cpp
@@ -393,7 +393,6 @@ protected:
     PersistentTable* table;
     char* m_exceptionBuffer;
     VoltDBEngine* m_engine;
-    ThreadLocalPool m_pool;
     char signature[20];
 };
 


### PR DESCRIPTION
There was an extra ThreadPool declaration in the Index test which made the ThreadPool get deallocated after the executor's destroy global was called. This triggers an assert in the next test. Removing the (unnecessary) ThreadPool declaration resolves this.