### PR TITLE
Eng 13407 index offset log n optimization

### DIFF
--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -260,6 +260,9 @@ class NValue {
     /* Create an NValue with the null representation for valueType */
     static NValue getNullValue(ValueType);
 
+    /* Create a max NValue with the input valueType */
+    static NValue getMaxValue(ValueType);
+
     /* Create an NValue promoted/demoted to type */
     NValue castAs(ValueType type) const;
 
@@ -3525,6 +3528,20 @@ inline void NValue::hashCombine(std::size_t &seed) const {
     throwDynamicSQLException( "NValue::hashCombine unknown type %s", getValueTypeString().c_str());
 }
 
+inline NValue NValue::getMaxValue(ValueType type) {
+    switch(type) {
+    case VALUE_TYPE_TINYINT:
+        return NValue::getTinyIntValue(INT8_MAX);
+    case VALUE_TYPE_SMALLINT:
+        return NValue::getSmallIntValue(INT16_MAX);
+    case VALUE_TYPE_INTEGER:
+        return NValue::getIntegerValue(INT32_MAX);
+    case VALUE_TYPE_BIGINT:
+        return NValue::getBigIntValue(INT64_MAX);
+    default:
+        return NValue::getNullValue(type);
+    }
+}
 
 inline NValue NValue::castAs(ValueType type) const {
     VOLT_TRACE("Converting from %s to %s",

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -260,9 +260,6 @@ class NValue {
     /* Create an NValue with the null representation for valueType */
     static NValue getNullValue(ValueType);
 
-    /* Create a max NValue with the input valueType */
-    static NValue getMaxValue(ValueType);
-
     /* Create an NValue promoted/demoted to type */
     NValue castAs(ValueType type) const;
 
@@ -3526,21 +3523,6 @@ inline void NValue::hashCombine(std::size_t &seed) const {
     }
 
     throwDynamicSQLException( "NValue::hashCombine unknown type %s", getValueTypeString().c_str());
-}
-
-inline NValue NValue::getMaxValue(ValueType type) {
-    switch(type) {
-    case VALUE_TYPE_TINYINT:
-        return NValue::getTinyIntValue(INT8_MAX);
-    case VALUE_TYPE_SMALLINT:
-        return NValue::getSmallIntValue(INT16_MAX);
-    case VALUE_TYPE_INTEGER:
-        return NValue::getIntegerValue(INT32_MAX);
-    case VALUE_TYPE_BIGINT:
-        return NValue::getBigIntValue(INT64_MAX);
-    default:
-        return NValue::getNullValue(type);
-    }
 }
 
 inline NValue NValue::castAs(ValueType type) const {

--- a/src/ee/executors/indexscanexecutor.cpp
+++ b/src/ee/executors/indexscanexecutor.cpp
@@ -507,8 +507,15 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
             return false;
         }
     } else if (m_offsetRank) {
-        assert(localSortDirection == SORT_DIRECTION_TYPE_ASC);
-        tableIndex->moveToRankTuple(offset + 1, indexCursor);
+        int rankOffset = offset + 1;
+        if (localSortDirection == SORT_DIRECTION_TYPE_DESC) {
+            rankOffset = static_cast<int>(tableIndex->getSize() - offset);
+        }
+        // when rankOffset is not greater than 0, it means there are no matching tuples
+        // then we do not need to update the IndexCursor which points to NULL tuple by default
+        if (rankOffset > 0) {
+            tableIndex->moveToRankTuple(rankOffset, indexCursor);
+        }
     } else {
         bool toStartActually = (localSortDirection != SORT_DIRECTION_TYPE_DESC);
         tableIndex->moveToEnd(toStartActually, indexCursor);

--- a/src/ee/executors/indexscanexecutor.cpp
+++ b/src/ee/executors/indexscanexecutor.cpp
@@ -506,19 +506,21 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
         else {
             return false;
         }
-    } else if (m_offsetRank) {
-        int rankOffset = offset + 1;
-        if (localSortDirection == SORT_DIRECTION_TYPE_DESC) {
-            rankOffset = static_cast<int>(tableIndex->getSize() - offset);
-        }
-        // when rankOffset is not greater than 0, it means there are no matching tuples
-        // then we do not need to update the IndexCursor which points to NULL tuple by default
-        if (rankOffset > 0) {
-            tableIndex->moveToRankTuple(rankOffset, indexCursor);
-        }
     } else {
-        bool toStartActually = (localSortDirection != SORT_DIRECTION_TYPE_DESC);
-        tableIndex->moveToEnd(toStartActually, indexCursor);
+        bool forward = (localSortDirection != SORT_DIRECTION_TYPE_DESC);
+        if (m_offsetRank) {
+            int rankOffset = offset + 1;
+            if (!forward) {
+                rankOffset = static_cast<int>(tableIndex->getSize() - offset);
+            }
+            // when rankOffset is not greater than 0, it means there are no matching tuples
+            // then we do not need to update the IndexCursor which points to NULL tuple by default
+            if (rankOffset > 0) {
+                tableIndex->moveToRankTuple(rankOffset, forward, indexCursor);
+            }
+        } else {
+            tableIndex->moveToEnd(forward, indexCursor);
+        }
     }
 
     //

--- a/src/ee/executors/indexscanexecutor.cpp
+++ b/src/ee/executors/indexscanexecutor.cpp
@@ -154,7 +154,7 @@ bool IndexScanExecutor::p_init(AbstractPlanNode *abstractNode,
     m_lookupType = m_node->getLookupType();
     m_sortDirection = m_node->getSortDirection();
 
-    m_offsetRank = m_node->hasOffsetRankOptimization();
+    m_hasOffsetRankOptimization = m_node->hasOffsetRankOptimization();
 
     VOLT_DEBUG("IndexScan: %s.%s\n", targetTable->name().c_str(), tableIndex->getName().c_str());
 
@@ -204,7 +204,7 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
 
     // Initialize the postfilter
     int postfilterOffset = offset;
-    if (m_offsetRank) {
+    if (m_hasOffsetRankOptimization) {
         postfilterOffset = CountingPostfilter::NO_OFFSET;
     }
     CountingPostfilter postfilter(m_outputTable, post_expression, limit, postfilterOffset);
@@ -508,7 +508,7 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
         }
     } else {
         bool forward = (localSortDirection != SORT_DIRECTION_TYPE_DESC);
-        if (m_offsetRank) {
+        if (m_hasOffsetRankOptimization) {
             int rankOffset = offset + 1;
             if (!forward) {
                 rankOffset = static_cast<int>(tableIndex->getSize() - offset);

--- a/src/ee/executors/indexscanexecutor.h
+++ b/src/ee/executors/indexscanexecutor.h
@@ -131,6 +131,7 @@ private:
 
     IndexLookupType m_lookupType;
     SortDirectionType m_sortDirection;
+    bool m_offsetRank;
 
     // IndexScan Information
     AbstractTempTable* m_outputTable;

--- a/src/ee/executors/indexscanexecutor.h
+++ b/src/ee/executors/indexscanexecutor.h
@@ -131,7 +131,7 @@ private:
 
     IndexLookupType m_lookupType;
     SortDirectionType m_sortDirection;
-    bool m_offsetRank;
+    bool m_hasOffsetRankOptimization;
 
     // IndexScan Information
     AbstractTempTable* m_outputTable;

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -343,7 +343,8 @@ class CompactingTreeMultiMapIndex : public TableIndex
         }
     }
 
-    bool moveToRankTuple(int64_t rank, IndexCursor& cursor) const {
+    bool moveToRankTuple(int64_t rank, bool forward, IndexCursor& cursor) const {
+        cursor.m_forward = forward;
         MapIterator &mapConstIter = castToIter(cursor);
         mapConstIter = m_entries.findRank(rank);
 

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -343,7 +343,7 @@ class CompactingTreeMultiMapIndex : public TableIndex
         }
     }
 
-    bool findRankTuple(int64_t rank, IndexCursor& cursor) const {
+    bool moveToRankTuple(int64_t rank, IndexCursor& cursor) const {
         MapIterator &mapConstIter = castToIter(cursor);
         mapConstIter = m_entries.findRank(rank);
 

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -355,24 +355,6 @@ class CompactingTreeMultiMapIndex : public TableIndex
         return true;
     }
 
-    bool isTheNextKeySame(IndexCursor& cursor) const {
-        TableTuple currentTuple = cursor.m_match;
-        TableTuple nextTuple = nextValue(cursor);
-
-        if (nextTuple.isNullTuple()) {
-            return false;
-        }
-
-        const KeyType currentKey = setKeyFromTuple(&currentTuple);
-        const KeyType nextKey = setKeyFromTuple(&nextTuple);
-
-        if (m_cmp(currentKey, nextKey) == 0) {
-            return true;
-        }
-
-        return false;
-    }
-
     size_t getSize() const { return m_entries.size(); }
 
     int64_t getMemoryEstimate() const

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -67,6 +67,7 @@ class CompactingTreeMultiMapIndex : public TableIndex
     typedef typename MapType::iterator MapIterator;
     typedef std::pair<MapIterator, MapIterator> MapRange;
 
+
     ~CompactingTreeMultiMapIndex() {};
 
     static MapIterator& castToIter(IndexCursor& cursor) {
@@ -310,7 +311,7 @@ class CompactingTreeMultiMapIndex : public TableIndex
         if (isUpper) {
             return m_entries.rankUpper(mapIter.key());
         } else {
-            return m_entries.rankAsc(mapIter.key());
+            return m_entries.rankLower(mapIter.key());
         }
     }
 
@@ -338,8 +339,38 @@ class CompactingTreeMultiMapIndex : public TableIndex
         if (isUpper) {
             return m_entries.rankUpper(mapIter.key());
         } else {
-            return m_entries.rankAsc(mapIter.key());
+            return m_entries.rankLower(mapIter.key());
         }
+    }
+
+    bool findRankTuple(int64_t rank, IndexCursor& cursor) const {
+        MapIterator &mapConstIter = castToIter(cursor);
+        mapConstIter = m_entries.findRank(rank);
+
+        if (mapConstIter.isEnd()) {
+            cursor.m_match.move(NULL);
+            return false;
+        }
+        cursor.m_match.move(const_cast<void*>(mapConstIter.value()));
+        return true;
+    }
+
+    bool isTheNextKeySame(IndexCursor& cursor) const {
+        TableTuple currentTuple = cursor.m_match;
+        TableTuple nextTuple = nextValue(cursor);
+
+        if (nextTuple.isNullTuple()) {
+            return false;
+        }
+
+        const KeyType currentKey = setKeyFromTuple(&currentTuple);
+        const KeyType nextKey = setKeyFromTuple(&nextTuple);
+
+        if (m_cmp(currentKey, nextKey) == 0) {
+            return true;
+        }
+
+        return false;
     }
 
     size_t getSize() const { return m_entries.size(); }

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -343,10 +343,10 @@ class CompactingTreeMultiMapIndex : public TableIndex
         }
     }
 
-    bool moveToRankTuple(int64_t rank, bool forward, IndexCursor& cursor) const {
+    bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const {
         cursor.m_forward = forward;
         MapIterator &mapConstIter = castToIter(cursor);
-        mapConstIter = m_entries.findRank(rank);
+        mapConstIter = m_entries.findRank(denseRank);
 
         if (mapConstIter.isEnd()) {
             cursor.m_match.move(NULL);

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -302,7 +302,7 @@ class CompactingTreeUniqueIndex : public TableIndex
         if (mapIter.isEnd()) {
             return m_entries.size() + 1;
         }
-        return m_entries.rankAsc(mapIter.key());
+        return m_entries.rankLower(mapIter.key());
     }
 
     /**
@@ -325,7 +325,23 @@ class CompactingTreeUniqueIndex : public TableIndex
                 return 0;
             }
         }
-        return m_entries.rankAsc(mapIter.key());
+        return m_entries.rankLower(mapIter.key());
+    }
+
+    bool findRankTuple(int64_t rank, IndexCursor& cursor) const {
+        MapIterator &mapConstIter = castToIter(cursor);
+        mapConstIter = m_entries.findRank(rank);
+        if (mapConstIter.isEnd()) {
+            cursor.m_match.move(NULL);
+            return false;
+        }
+        cursor.m_match.move(const_cast<void*>(mapConstIter.value()));
+        return true;
+    }
+
+    bool isTheNextKeySame(IndexCursor& cursor) const {
+        // Unique index does not have duplicate keys
+        return false;
     }
 
     size_t getSize() const { return m_entries.size(); }

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -339,11 +339,6 @@ class CompactingTreeUniqueIndex : public TableIndex
         return true;
     }
 
-    bool isTheNextKeySame(IndexCursor& cursor) const {
-        // Unique index does not have duplicate keys
-        return false;
-    }
-
     size_t getSize() const { return m_entries.size(); }
 
     int64_t getMemoryEstimate() const

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -328,10 +328,10 @@ class CompactingTreeUniqueIndex : public TableIndex
         return m_entries.rankLower(mapIter.key());
     }
 
-    bool moveToRankTuple(int64_t rank, bool forward, IndexCursor& cursor) const {
+    bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const {
         cursor.m_forward = forward;
         MapIterator &mapConstIter = castToIter(cursor);
-        mapConstIter = m_entries.findRank(rank);
+        mapConstIter = m_entries.findRank(denseRank);
         if (mapConstIter.isEnd()) {
             cursor.m_match.move(NULL);
             return false;

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -328,7 +328,7 @@ class CompactingTreeUniqueIndex : public TableIndex
         return m_entries.rankLower(mapIter.key());
     }
 
-    bool findRankTuple(int64_t rank, IndexCursor& cursor) const {
+    bool moveToRankTuple(int64_t rank, IndexCursor& cursor) const {
         MapIterator &mapConstIter = castToIter(cursor);
         mapConstIter = m_entries.findRank(rank);
         if (mapConstIter.isEnd()) {

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -328,7 +328,8 @@ class CompactingTreeUniqueIndex : public TableIndex
         return m_entries.rankLower(mapIter.key());
     }
 
-    bool moveToRankTuple(int64_t rank, IndexCursor& cursor) const {
+    bool moveToRankTuple(int64_t rank, bool forward, IndexCursor& cursor) const {
+        cursor.m_forward = forward;
         MapIterator &mapConstIter = castToIter(cursor);
         mapConstIter = m_entries.findRank(rank);
         if (mapConstIter.isEnd()) {

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -462,7 +462,7 @@ public:
      * @param denseRank rank value from 1 to N consecutively.
      * @param forward the index search direction after moving to the tuple with its rank
      * @param cursor IndexCursor object
-     * @return
+     * @return true if it finds tuple with the dense rank value, otherwise false
      */
     virtual bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const
     {

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -456,13 +456,6 @@ public:
         throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
     }
 
-    // currently unused.
-    // It can be used to check whether the current tuple key is the same with the next key in this index.
-    // This could be useful if we want to support rank other than dense rank.
-    virtual bool isTheNextKeySame(IndexCursor& cursor) const {
-        throwFatalException("Invoked TableIndex virtual method isTheNextKeySame which has no implementation");
-    }
-
     virtual size_t getSize() const = 0;
 
     // Return the amount of memory we think is allocated for this
@@ -489,37 +482,6 @@ public:
     const std::vector<AbstractExpression*>& getIndexedExpressions() const
     {
         return m_scheme.indexedExpressions;
-    }
-
-    void getIndexedTableTuple(const TableTuple *tuple, TableTuple &searchKey,
-            int numPrefix, int maxPaddingIndex = -1) const {
-        const std::vector<AbstractExpression*> &indexed_expressions = getIndexedExpressions();
-        if (indexed_expressions.size() > 0) {
-            for(int i = 0; i < indexed_expressions.size() && i < numPrefix; i++) {
-                if (maxPaddingIndex < 0 || i < maxPaddingIndex) {
-                    AbstractExpression* expr = indexed_expressions.at(i);
-                    NValue val = expr->eval(tuple, NULL);
-                    searchKey.setNValue(i, val);
-                } else if (i >= maxPaddingIndex) {
-                    ValueType type = searchKey.getSchema()->getColumnInfo(i)->getVoltType();
-                    NValue maxTypeVal = NValue::getMaxValue(type);
-                    searchKey.setNValue(i, maxTypeVal);
-                }
-            }
-        } else {
-            const std::vector<int> &column_indices_vector = getColumnIndices();
-            for(int i = 0; i < column_indices_vector.size() && i < numPrefix; i++) {
-                if (maxPaddingIndex < 0 || i < maxPaddingIndex) {
-                    int idx = column_indices_vector.at(i);
-                    NValue val = tuple->getNValue(idx);
-                    searchKey.setNValue(i, val);
-                } else if (i >= maxPaddingIndex) {
-                    ValueType type = searchKey.getSchema()->getColumnInfo(i)->getVoltType();
-                    NValue maxTypeVal = NValue::getMaxValue(type);
-                    searchKey.setNValue(i, maxTypeVal);
-                }
-            }
-        }
     }
 
     const AbstractExpression* getPredicate() const

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -451,7 +451,7 @@ public:
     }
 
     // dense rank value tuple look up
-    virtual bool moveToRankTuple(int64_t iRank, IndexCursor& cursor) const
+    virtual bool moveToRankTuple(int64_t iRank, bool forward, IndexCursor& cursor) const
     {
         throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
     }

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -451,7 +451,20 @@ public:
     }
 
     // dense rank value tuple look up
-    virtual bool moveToRankTuple(int64_t iRank, bool forward, IndexCursor& cursor) const
+
+    /**
+     * This function only supports countable tree index. It moves the @param cursor to the tuple with
+     * dense rank value @param denseRank ranging from 1 to N (the size of the index). Out of range rank
+     * look up will move the @param cursor to NULL tuple.
+     *
+     * This method is powered by the underline counting index with LogN time complexity other than doing
+     * index scan.
+     * @param denseRank rank value from 1 to N consecutively.
+     * @param forward the index search direction after moving to the tuple with its rank
+     * @param cursor IndexCursor object
+     * @return
+     */
+    virtual bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const
     {
         throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
     }

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -451,11 +451,14 @@ public:
     }
 
     // dense rank value tuple look up
-    virtual bool findRankTuple(int64_t iRank, IndexCursor& cursor) const
+    virtual bool moveToRankTuple(int64_t iRank, IndexCursor& cursor) const
     {
-        throwFatalException("Invoked non-countable TableIndex virtual method findRank which has no implementation");
+        throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
     }
 
+    // currently unused.
+    // It can be used to check whether the current tuple key is the same with the next key in this index.
+    // This could be useful if we want to support rank other than dense rank.
     virtual bool isTheNextKeySame(IndexCursor& cursor) const {
         throwFatalException("Invoked TableIndex virtual method isTheNextKeySame which has no implementation");
     }

--- a/src/ee/plannodes/indexscannode.cpp
+++ b/src/ee/plannodes/indexscannode.cpp
@@ -105,8 +105,8 @@ void IndexScanPlanNode::loadFromJSONObject(PlannerDomValue obj)
     std::string lookupTypeString = obj.valueForKey("LOOKUP_TYPE").asStr();
     m_lookup_type = stringToIndexLookup(lookupTypeString);
 
-    if (obj.hasKey("OFFSET_RANK")) {
-        m_offsetRank = obj.valueForKey("OFFSET_RANK").asBool();
+    if (obj.hasKey("HAS_OFFSET_RANK")) {
+        m_hasOffsetRank = obj.valueForKey("HAS_OFFSET_RANK").asBool();
     }
 
     std::string sortDirectionString = obj.valueForKey("SORT_DIRECTION").asStr();

--- a/src/ee/plannodes/indexscannode.cpp
+++ b/src/ee/plannodes/indexscannode.cpp
@@ -105,6 +105,10 @@ void IndexScanPlanNode::loadFromJSONObject(PlannerDomValue obj)
     std::string lookupTypeString = obj.valueForKey("LOOKUP_TYPE").asStr();
     m_lookup_type = stringToIndexLookup(lookupTypeString);
 
+    if (obj.hasKey("OFFSET_RANK")) {
+        m_offsetRank = obj.valueForKey("OFFSET_RANK").asBool();
+    }
+
     std::string sortDirectionString = obj.valueForKey("SORT_DIRECTION").asStr();
     m_sort_direction = stringToSortDirection(sortDirectionString);
 

--- a/src/ee/plannodes/indexscannode.h
+++ b/src/ee/plannodes/indexscannode.h
@@ -62,6 +62,7 @@ public:
         , m_end_expression()
         , m_initial_expression()
         , m_lookup_type(INDEX_LOOKUP_TYPE_EQ)
+        , m_offsetRank(false)
         , m_sort_direction(SORT_DIRECTION_TYPE_INVALID)
         , m_skip_null_predicate()
     {
@@ -72,6 +73,8 @@ public:
     std::string debugInfo(const std::string &spacer) const;
 
     IndexLookupType getLookupType() const { return m_lookup_type; }
+
+    bool hasOffsetRankOptimization() const { return m_offsetRank; }
 
     SortDirectionType getSortDirection() const { return m_sort_direction; }
 
@@ -111,6 +114,9 @@ protected:
 
     // Index Lookup Type
     IndexLookupType m_lookup_type;
+
+    // Offset rank
+    bool m_offsetRank;
 
     // Sorting Direction
     SortDirectionType m_sort_direction;

--- a/src/ee/plannodes/indexscannode.h
+++ b/src/ee/plannodes/indexscannode.h
@@ -62,7 +62,7 @@ public:
         , m_end_expression()
         , m_initial_expression()
         , m_lookup_type(INDEX_LOOKUP_TYPE_EQ)
-        , m_offsetRank(false)
+        , m_hasOffsetRank(false)
         , m_sort_direction(SORT_DIRECTION_TYPE_INVALID)
         , m_skip_null_predicate()
     {
@@ -74,7 +74,7 @@ public:
 
     IndexLookupType getLookupType() const { return m_lookup_type; }
 
-    bool hasOffsetRankOptimization() const { return m_offsetRank; }
+    bool hasOffsetRankOptimization() const { return m_hasOffsetRank; }
 
     SortDirectionType getSortDirection() const { return m_sort_direction; }
 
@@ -116,7 +116,7 @@ protected:
     IndexLookupType m_lookup_type;
 
     // Offset rank
-    bool m_offsetRank;
+    bool m_hasOffsetRank;
 
     // Sorting Direction
     SortDirectionType m_sort_direction;

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -1025,7 +1025,7 @@ bool CompactingMap<KeyValuePair, Compare, hasRank>::verifyRank() const
 
         if (m_unique) {
             if ((rkasc = rankLower(it.key())) != i) {
-                printf("false: unique_rankAsc expected %ld, but got %ld\n", (long)i, (long)rkasc);
+                printf("false: unique_rankLower expected %ld, but got %ld\n", (long)i, (long)rkasc);
                 return false;
             }
         }
@@ -1053,7 +1053,7 @@ bool CompactingMap<KeyValuePair, Compare, hasRank>::verifyRank() const
                     }
                 }
             }
-            // test rankAsc
+            // test rankLower
             rkasc = rankLower(k);
             int64_t nc = 0;
             it.movePrev();
@@ -1062,8 +1062,8 @@ bool CompactingMap<KeyValuePair, Compare, hasRank>::verifyRank() const
                 it.movePrev();
             }
             if (rkasc + nc != i) {
-                printf("false: multi_rankAsc %ld keys are the same", (long)nc);
-                printf("false: multi_rankAsc expected %ld, but got %ld\n", (long)i, (long)rkasc);
+                printf("false: multi_rankLower %ld keys are the same", (long)nc);
+                printf("false: multi_rankLower expected %ld, but got %ld\n", (long)i, (long)rkasc);
                 return false;
             }
         }

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -192,31 +192,6 @@ public:
         }
     };
 
-    class const_iterator {
-        friend class CompactingMap<KeyValuePair, Compare, hasRank>;
-    protected:
-        const CompactingMap *m_map;
-        const TreeNode *m_node;
-        const_iterator(const CompactingMap *m, const TreeNode* x) : m_map(m), m_node(x) {}
-        const KeyValuePair &pair() { return m_node->kv; }
-    public:
-        const_iterator() : m_map(NULL), m_node(NULL) {}
-        const_iterator(const iterator &iter) : m_map(iter.m_map), m_node(iter.m_node) {}
-        const_iterator(const const_iterator &iter) : m_map(iter.m_map), m_node(iter.m_node) {}
-        const Key &key() const { return m_node->key(); }
-        const Data &value() const { return m_node->value(); }
-        void setValue(const Data &value) { m_node->kv.setValue(value); }
-        void moveNext() { m_node = m_map->successor(m_node); }
-        void movePrev() { m_node = m_map->predecessor(m_node); }
-        bool isEnd() const { return ((!m_map) || (m_node == &(m_map->NIL))); }
-        bool equals(const iterator &iter) const {
-            if (isEnd()) {
-                return iter.isEnd();
-            }
-            return m_node == iter.m_node;
-        }
-    };
-
     CompactingMap(bool unique, Compare comper);
     ~CompactingMap();
 

--- a/src/frontend/org/voltdb/planner/microoptimizations/ImproveOffsetQueryByRankValueIndex.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/ImproveOffsetQueryByRankValueIndex.java
@@ -1,0 +1,96 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.planner.microoptimizations;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.voltdb.catalog.Index;
+import org.voltdb.planner.AbstractParsedStmt;
+import org.voltdb.plannodes.AbstractPlanNode;
+import org.voltdb.plannodes.IndexScanPlanNode;
+import org.voltdb.plannodes.LimitPlanNode;
+import org.voltdb.types.PlanNodeType;
+import org.voltdb.types.SortDirectionType;
+
+public class ImproveOffsetQueryByRankValueIndex extends MicroOptimization {
+
+    @Override
+    protected AbstractPlanNode recursivelyApply(AbstractPlanNode planNode, AbstractParsedStmt parsedStmt)
+    {
+        assert(planNode != null);
+
+        // breadth search first:
+        //     find IndexScanPlannode
+
+        Queue<AbstractPlanNode> children = new LinkedList<AbstractPlanNode>();
+        children.add(planNode);
+
+        while(!children.isEmpty()) {
+            AbstractPlanNode plan = children.remove();
+            rankIndexSearchApply(plan);
+
+            for (int i = 0; i < plan.getChildCount(); i++) {
+                children.add(plan.getChild(i));
+            }
+        }
+
+        return planNode;
+    }
+
+    void rankIndexSearchApply(AbstractPlanNode plan) {
+        // check for the index scan node of the right form
+        if ( ! (plan instanceof IndexScanPlanNode) ) {
+            return;
+        }
+        IndexScanPlanNode indexscan = (IndexScanPlanNode)plan;
+
+        if (indexscan.getPredicate() != null ||
+                indexscan.getEndExpression() != null ||
+                indexscan.getSkipNullPredicate() != null ||
+                indexscan.getInitialExpression() != null) {
+            return;
+        }
+
+        if (indexscan.getInlinePlanNodes().isEmpty()) {
+            return;
+        }
+
+        LimitPlanNode limit = (LimitPlanNode) indexscan.getInlinePlanNodes().get(PlanNodeType.LIMIT);
+        if (limit == null) {
+            return;
+        }
+
+        Index index = indexscan.getCatalogIndex();
+        if (! index.getCountable()) {
+            return;
+        }
+
+        if (! indexscan.getSearchKeyExpressions().isEmpty()) {
+            return;
+        }
+
+        // support the ascending case first, work on desending case later by using table count with offset
+        if (indexscan.getSortDirection() != SortDirectionType.ASC) {
+            return;
+        }
+
+        indexscan.setOffsetRank(true);
+    }
+
+}

--- a/src/frontend/org/voltdb/planner/microoptimizations/MicroOptimizationRunner.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/MicroOptimizationRunner.java
@@ -64,6 +64,7 @@ public class MicroOptimizationRunner {
         // at a later phase then the previous optimizations.
         addOptimization(new RemoveUnnecessaryProjectNodes());
         addOptimization(new MakeInsertNodesInlineIfPossible());
+        addOptimization(new ImproveOffsetQueryByRankValueIndex());
     }
 
     public static void applyAll(CompiledPlan plan, AbstractParsedStmt parsedStmt, Phases phase)

--- a/src/frontend/org/voltdb/planner/microoptimizations/MicroOptimizationRunner.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/MicroOptimizationRunner.java
@@ -64,7 +64,7 @@ public class MicroOptimizationRunner {
         // at a later phase then the previous optimizations.
         addOptimization(new RemoveUnnecessaryProjectNodes());
         addOptimization(new MakeInsertNodesInlineIfPossible());
-        addOptimization(new ImproveOffsetQueryByRankValueIndex());
+        addOptimization(new OffsetQueryUsingCountingIndex());
     }
 
     public static void applyAll(CompiledPlan plan, AbstractParsedStmt parsedStmt, Phases phase)

--- a/src/frontend/org/voltdb/planner/microoptimizations/OffsetQueryUsingCountingIndex.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/OffsetQueryUsingCountingIndex.java
@@ -26,9 +26,8 @@ import org.voltdb.plannodes.AbstractPlanNode;
 import org.voltdb.plannodes.IndexScanPlanNode;
 import org.voltdb.plannodes.LimitPlanNode;
 import org.voltdb.types.PlanNodeType;
-import org.voltdb.types.SortDirectionType;
 
-public class ImproveOffsetQueryByRankValueIndex extends MicroOptimization {
+public class OffsetQueryUsingCountingIndex extends MicroOptimization {
 
     @Override
     protected AbstractPlanNode recursivelyApply(AbstractPlanNode planNode, AbstractParsedStmt parsedStmt)
@@ -82,11 +81,6 @@ public class ImproveOffsetQueryByRankValueIndex extends MicroOptimization {
         }
 
         if (! indexscan.getSearchKeyExpressions().isEmpty()) {
-            return;
-        }
-
-        // support the ascending case first, work on desending case later by using table count with offset
-        if (indexscan.getSortDirection() != SortDirectionType.ASC) {
             return;
         }
 

--- a/src/frontend/org/voltdb/planner/microoptimizations/OffsetQueryUsingCountingIndex.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/OffsetQueryUsingCountingIndex.java
@@ -71,10 +71,9 @@ public class OffsetQueryUsingCountingIndex extends MicroOptimization {
         }
 
         LimitPlanNode limit = (LimitPlanNode) indexscan.getInlinePlanNodes().get(PlanNodeType.LIMIT);
-        if (limit == null) {
+        if (limit == null || !limit.hasOffset()) {
             return;
         }
-
         Index index = indexscan.getCatalogIndex();
         if (! index.getCountable()) {
             return;

--- a/src/frontend/org/voltdb/planner/microoptimizations/OffsetQueryUsingCountingIndex.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/OffsetQueryUsingCountingIndex.java
@@ -66,7 +66,7 @@ public class OffsetQueryUsingCountingIndex extends MicroOptimization {
             return;
         }
 
-        if (indexscan.getInlinePlanNodes().isEmpty()) {
+        if (indexscan.getInlinePlanNodes().size() != 1) {
             return;
         }
 

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -817,7 +817,7 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
                 usageInfo = " (for optimized grouping only)";
             }
             else if (m_hasOffsetRankOptimization) {
-                usageInfo = " (for offset rank optimisation lookup and for sort order)";
+                usageInfo = " (for offset rank lookup and for sort order)";
             }
             else {
                 usageInfo = " (for sort order only)";

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -62,7 +62,7 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
         SKIP_NULL_PREDICATE,
         KEY_ITERATE,
         LOOKUP_TYPE,
-        OFFSET_RANK,
+        HAS_OFFSET_RANK,
         PURPOSE,
         SORT_DIRECTION;
     }
@@ -108,7 +108,7 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
     protected SortDirectionType m_sortDirection = SortDirectionType.INVALID;
 
     // offset rank index
-    protected boolean m_offsetRank = false;
+    protected boolean m_hasOffsetRankOptimization = false;
 
     // A reference to the Catalog index object which defined the index which
     // this index scan is going to use
@@ -538,7 +538,7 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
     }
 
     public void setOffsetRank(boolean offsetRank) {
-        m_offsetRank = offsetRank;
+        m_hasOffsetRankOptimization = offsetRank;
     }
 
     public boolean isReverseScan() {
@@ -743,8 +743,8 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
         super.toJSONString(stringer);
         stringer.keySymbolValuePair(Members.LOOKUP_TYPE.name(), m_lookupType.toString());
         stringer.keySymbolValuePair(Members.SORT_DIRECTION.name(), m_sortDirection.toString());
-        if (m_offsetRank) {
-            stringer.keySymbolValuePair(Members.OFFSET_RANK.name(), true);
+        if (m_hasOffsetRankOptimization) {
+            stringer.keySymbolValuePair(Members.HAS_OFFSET_RANK.name(), true);
         }
         if (m_purpose != FOR_SCANNING_PERFORMANCE_OR_ORDERING) {
             stringer.keySymbolValuePair(Members.PURPOSE.name(), m_purpose);
@@ -773,8 +773,8 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
         super.loadFromJSONObject(jobj, db);
         m_lookupType = IndexLookupType.get( jobj.getString( Members.LOOKUP_TYPE.name() ) );
         m_sortDirection = SortDirectionType.get( jobj.getString( Members.SORT_DIRECTION.name() ) );
-        if (jobj.has(Members.OFFSET_RANK.name())) {
-            m_offsetRank = jobj.getBoolean(Members.OFFSET_RANK.name());
+        if (jobj.has(Members.HAS_OFFSET_RANK.name())) {
+            m_hasOffsetRankOptimization = jobj.getBoolean(Members.HAS_OFFSET_RANK.name());
         }
         m_purpose = jobj.has(Members.PURPOSE.name()) ?
                 jobj.getInt(Members.PURPOSE.name()) : FOR_SCANNING_PERFORMANCE_OR_ORDERING;
@@ -816,9 +816,10 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
             else if (m_purpose == FOR_GROUPING) {
                 usageInfo = " (for optimized grouping only)";
             }
-            else if (m_offsetRank) {
-                usageInfo = " (for offset rank lookup and for sort order)";
-            } else {
+            else if (m_hasOffsetRankOptimization) {
+                usageInfo = " (for offset rank optimisation lookup and for sort order)";
+            }
+            else {
                 usageInfo = " (for sort order only)";
             }
             // Introduce on its own indented line, any unrelated post-filter applied to the result.

--- a/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
@@ -105,6 +105,13 @@ public class LimitPlanNode extends AbstractPlanNode {
         m_offset = offset;
     }
 
+    public boolean hasOffset() {
+        if (m_offsetParameterId == -1 && m_offset == 0) {
+            return false;
+        }
+        return true;
+    }
+
     public AbstractExpression getLimitExpression() {
         return m_limitExpression;
     }

--- a/tests/ee/structures/CompactingMapIndexCountTest.cpp
+++ b/tests/ee/structures/CompactingMapIndexCountTest.cpp
@@ -154,7 +154,7 @@ TEST_F(CompactingMapTest, SimpleUniqueRank) {
 
     voltdb::CompactingMap<NormalKeyValuePair<int, int>, IntComparator, true>::iterator volti;
     bool sucess;
-    int64_t rankasc;
+    int64_t ranklower;
 
     for (int val = 1; val < 10; val++) {
         sucess = volt.insert(std::pair<int,int>(val, val));
@@ -162,10 +162,10 @@ TEST_F(CompactingMapTest, SimpleUniqueRank) {
     }
 
     sucess = volt.insert(std::pair<int,int>(3, 3)); ASSERT_TRUE(!sucess);
-    rankasc = volt.rankAsc(3);
-    if (rankasc != 3)
-        printf("false: <SimpleUniqueRank> expected %d, but got %ld\n", 3, (long)rankasc);
-    ASSERT_TRUE(rankasc == 3);
+    ranklower = volt.rankLower(3);
+    if (ranklower != 3)
+        printf("false: <SimpleUniqueRank> expected %d, but got %ld\n", 3, (long)ranklower);
+    ASSERT_TRUE(ranklower == 3);
 
     ASSERT_TRUE(volt.verify());
     ASSERT_TRUE(volt.verifyRank());
@@ -211,11 +211,11 @@ TEST_F(CompactingMapTest, RandomUniqueRank) {
                 for (it = stl.begin(); it != stli; it++) {
                         ct++;
                 }
-                int64_t rankasc = volt.rankAsc(val);
-                if (rankasc != ct)
-                    printf("false: unique_rankAsc expected %ld, but got %ld\n", (long)ct, (long)rankasc);
-                ASSERT_TRUE(rankasc == ct);
-                volti = volt.findRank(rankasc);
+                int64_t ranklower = volt.rankLower(val);
+                if (ranklower != ct)
+                    printf("false: unique_rankLower expected %ld, but got %ld\n", (long)ct, (long)ranklower);
+                ASSERT_TRUE(ranklower == ct);
+                volti = volt.findRank(ranklower);
                 ASSERT_TRUE(volti.key() == val);
 
             }
@@ -232,11 +232,11 @@ TEST_F(CompactingMapTest, RandomUniqueRank) {
                 for (it = stl.begin(); it != stli; it++) {
                         ct++;
                 }
-                int64_t rankasc= volt.rankAsc(val);
-                if (rankasc != ct)
-                    printf("false: DEPULICATE... unique_rankAsc expected %ld, but got %ld\n", (long)ct, (long)rankasc);
-                ASSERT_TRUE(rankasc == ct);
-                volti = volt.findRank(rankasc);
+                int64_t ranklower= volt.rankLower(val);
+                if (ranklower != ct)
+                    printf("false: DEPULICATE... unique_rankLower expected %ld, but got %ld\n", (long)ct, (long)ranklower);
+                ASSERT_TRUE(ranklower == ct);
+                volti = volt.findRank(ranklower);
                 ASSERT_TRUE(volti.key() == val);
 
             }
@@ -270,7 +270,7 @@ TEST_F(CompactingMapTest, SimpleMultiRank) {
     ASSERT_TRUE(volt.verify());
     voltdb::CompactingMap<NormalKeyValuePair<int, int>, IntComparator, true>::iterator volti;
     bool sucess;
-    int64_t rankasc, rankupper;
+    int64_t ranklower, rankupper;
 
     sucess = volt.insert(std::pair<int,int>(1, 1)); ASSERT_TRUE(sucess);
     sucess = volt.insert(std::pair<int,int>(2, 2)); ASSERT_TRUE(sucess);
@@ -283,16 +283,16 @@ TEST_F(CompactingMapTest, SimpleMultiRank) {
     sucess = volt.insert(std::pair<int,int>(8, 8)); ASSERT_TRUE(sucess);
     sucess = volt.insert(std::pair<int,int>(8, 8)); ASSERT_TRUE(sucess);
 
-    rankasc = volt.rankAsc(1); ASSERT_TRUE(rankasc == 1);
-    rankasc = volt.rankAsc(2); ASSERT_TRUE(rankasc == 2);
-    rankasc = volt.rankAsc(3); ASSERT_TRUE(rankasc == 3);
-    rankasc = volt.rankAsc(5); ASSERT_TRUE(rankasc == 6);
-    rankasc = volt.rankAsc(6); ASSERT_TRUE(rankasc == 7);
-    rankasc = volt.rankAsc(8); ASSERT_TRUE(rankasc == 9);
+    ranklower = volt.rankLower(1); ASSERT_TRUE(ranklower == 1);
+    ranklower = volt.rankLower(2); ASSERT_TRUE(ranklower == 2);
+    ranklower = volt.rankLower(3); ASSERT_TRUE(ranklower == 3);
+    ranklower = volt.rankLower(5); ASSERT_TRUE(ranklower == 6);
+    ranklower = volt.rankLower(6); ASSERT_TRUE(ranklower == 7);
+    ranklower = volt.rankLower(8); ASSERT_TRUE(ranklower == 9);
     // key is not in Map, return -1 always
-    rankasc = volt.rankAsc(0); ASSERT_TRUE(rankasc == -1);
-    rankasc = volt.rankAsc(7); ASSERT_TRUE(rankasc == -1);
-    rankasc = volt.rankAsc(12); ASSERT_TRUE(rankasc == -1);
+    ranklower = volt.rankLower(0); ASSERT_TRUE(ranklower == -1);
+    ranklower = volt.rankLower(7); ASSERT_TRUE(ranklower == -1);
+    ranklower = volt.rankLower(12); ASSERT_TRUE(ranklower == -1);
 
     rankupper = volt.rankUpper(1); ASSERT_TRUE(rankupper == 1);
     rankupper = volt.rankUpper(2); ASSERT_TRUE(rankupper == 2);

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
@@ -167,7 +167,8 @@ public class TestIndexOffsetSuite extends RegressionSuite {
     public void testTwoOrMoreColumnsUniqueIndex() throws Exception {
         Client client = getClient();
 
-        checkExplainPlan(client, new String[]{"TU2_BY_UNAME_POINTS", "TU2_BY_UNAME"});
+        checkExplainPlan(client, new String[]{"TU2_BY_UNAME_POINTS", "TU2_BY_UNAME",
+                "TU2_BY_UNAME_POINTS_DESC", "TU2_BY_UNAME_DESC"});
 
         client.callProcedure("TU2.insert", 1, 1, "xin");
         client.callProcedure("TU2.insert", 2, 2, "xin");
@@ -180,30 +181,36 @@ public class TestIndexOffsetSuite extends RegressionSuite {
         client.callProcedure("TU2.insert", 9, 6, "jiao");
         client.callProcedure("TU2.insert", 10, 8, "jiao");
 
-        client.callProcedure("TU2.insert", 11, null, "xin");
-        client.callProcedure("TU2.insert", 12, null, "jiao");
-
         // test order by two column with index
-        callWithExpectedTupleId(client, 12, "TU2_BY_UNAME_POINTS", 0, 0);
-        callWithExpectedTupleId(client, 6, "TU2_BY_UNAME_POINTS", 0, 1);
-        callWithExpectedTupleId(client, 7, "TU2_BY_UNAME_POINTS", 0, 2);
-        callWithExpectedTupleId(client, 8, "TU2_BY_UNAME_POINTS", 0, 3);
-        callWithExpectedTupleId(client, 9, "TU2_BY_UNAME_POINTS", 0, 4);
-        callWithExpectedTupleId(client, 10, "TU2_BY_UNAME_POINTS", 0, 5);
+        callWithExpectedTupleId(client, 6, "TU2_BY_UNAME_POINTS", 0, 0);
+        callWithExpectedTupleId(client, 7, "TU2_BY_UNAME_POINTS", 0, 1);
+        callWithExpectedTupleId(client, 8, "TU2_BY_UNAME_POINTS", 0, 2);
+        callWithExpectedTupleId(client, 9, "TU2_BY_UNAME_POINTS", 0, 3);
+        callWithExpectedTupleId(client, 10, "TU2_BY_UNAME_POINTS", 0, 4);
 
-        callWithExpectedTupleId(client, 11, "TU2_BY_UNAME_POINTS", 0, 6);
-        callWithExpectedTupleId(client, 1, "TU2_BY_UNAME_POINTS", 0, 7);
-        callWithExpectedTupleId(client, 2, "TU2_BY_UNAME_POINTS", 0, 8);
-        callWithExpectedTupleId(client, 3, "TU2_BY_UNAME_POINTS", 0, 9);
-        callWithExpectedTupleId(client, 4, "TU2_BY_UNAME_POINTS", 0, 10);
-        callWithExpectedTupleId(client, 5, "TU2_BY_UNAME_POINTS", 0, 11);
-        callWithExpectedTupleId(client, Integer.MIN_VALUE, "TU2_BY_UNAME_POINTS", 0, 12);
+        callWithExpectedTupleId(client, 1, "TU2_BY_UNAME_POINTS", 0, 5);
+        callWithExpectedTupleId(client, 2, "TU2_BY_UNAME_POINTS", 0, 6);
+        callWithExpectedTupleId(client, 3, "TU2_BY_UNAME_POINTS", 0, 7);
+        callWithExpectedTupleId(client, 4, "TU2_BY_UNAME_POINTS", 0, 8);
+        callWithExpectedTupleId(client, 5, "TU2_BY_UNAME_POINTS", 0, 9);
+        callWithExpectedTupleId(client, Integer.MIN_VALUE, "TU2_BY_UNAME_POINTS", 0, 10);
 
         // test order by one column with index, this is not a deterministic query
         callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "jiao", "TU2_BY_UNAME", 0, 0);
         callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "jiao", "TU2_BY_UNAME", 0, 1);
         callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "jiao", "TU2_BY_UNAME", 0, 2);
         callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "xin", "TU2_BY_UNAME", 0, 6);
+
+        // test descending
+        callWithExpectedTupleId(client, 5, "TU2_BY_UNAME_POINTS_DESC", 0, 0);
+        callWithExpectedTupleId(client, 4, "TU2_BY_UNAME_POINTS_DESC", 0, 1);
+        callWithExpectedTupleId(client, 10, "TU2_BY_UNAME_POINTS_DESC", 0, 5);
+        callWithExpectedTupleId(client, Integer.MIN_VALUE, "TU2_BY_UNAME_POINTS_DESC", 0, 10);
+
+        callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "xin", "TU2_BY_UNAME_DESC", 0, 0);
+        callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "xin", "TU2_BY_UNAME_DESC", 0, 1);
+        callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "xin", "TU2_BY_UNAME_DESC", 0, 3);
+        callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "jiao", "TU2_BY_UNAME_DESC", 0, 6);
     }
 
     static public Test suite() {
@@ -248,7 +255,7 @@ public class TestIndexOffsetSuite extends RegressionSuite {
                 new ProcedurePartitionData("TU2", "UNAME", "0"));
 
         project.addStmtProcedure("TU2_BY_UNAME_POINTS_DESC",
-                "SELECT ID, UNAME, CAST(? AS INTEGER) AS PARTITION FROM TU2 ORDER BY UNAME, POINTS DESC OFFSET ? LIMIT 1",
+                "SELECT ID, UNAME, CAST(? AS INTEGER) AS PARTITION FROM TU2 ORDER BY UNAME DESC, POINTS DESC OFFSET ? LIMIT 1",
                 new ProcedurePartitionData("TU2", "UNAME", "0"));
 
         // this is not a deterministic query

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
@@ -52,7 +52,6 @@ public class TestIndexOffsetSuite extends RegressionSuite {
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
         assertEquals(1, cr.getResults().length);
         VoltTable result = cr.getResults()[0];
-        System.out.println("Answer: " + result.toString());
 
         if (tupleId == Integer.MIN_VALUE) {
             assertEquals(0, result.getRowCount());
@@ -69,7 +68,6 @@ public class TestIndexOffsetSuite extends RegressionSuite {
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
         assertEquals(1, cr.getResults().length);
         VoltTable result = cr.getResults()[0];
-        System.out.println("Answer: " + result.toString());
 
         if (value == null) {
             assertEquals(0, result.getRowCount());
@@ -83,12 +81,11 @@ public class TestIndexOffsetSuite extends RegressionSuite {
     void checkExplainPlan(Client client, String[] procedures) throws NoConnectionsException, IOException, ProcCallException {
         for (String proc: procedures) {
             VoltTable vt = client.callProcedure("@ExplainProc", proc).getResults()[0];
-            System.out.println(vt);
             assertTrue(vt.toString().contains("for offset rank lookup"));
         }
     }
 
-    public void notestSingleColumnIndex() throws Exception {
+    public void testSingleColumnIndex() throws Exception {
         System.out.println("Running testOverflow");
         Client client = getClient();
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
@@ -1,0 +1,252 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.regressionsuites;
+
+import junit.framework.Test;
+import org.voltdb.BackendTarget;
+import org.voltdb.ProcedurePartitionData;
+import org.voltdb.VoltTable;
+import org.voltdb.VoltType;
+import org.voltdb.client.Client;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.client.NoConnectionsException;
+import org.voltdb.client.ProcCallException;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb_testprocs.regressionsuites.sqlfeatureprocs.BatchedMultiPartitionTest;
+
+import java.io.IOException;
+
+public class TestIndexOffsetSuite extends RegressionSuite {
+
+    /**
+     * Constructor needed for JUnit. Should just pass on parameters to superclass.
+     * @param name The name of the method to test. This is just passed to the superclass.
+     */
+    public TestIndexOffsetSuite(String name) {
+        super(name);
+    }
+
+    void callWithExpectedTupleId(Client client, int tupleId, String procName, Object... params) throws NoConnectionsException, IOException, ProcCallException {
+        ClientResponse cr = client.callProcedure(procName, params);
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+        assertEquals(1, cr.getResults().length);
+        VoltTable result = cr.getResults()[0];
+        System.out.println("Answer: " + result.toString());
+
+        if (tupleId == Integer.MIN_VALUE) {
+            assertEquals(0, result.getRowCount());
+        } else {
+            assertEquals(1, result.getRowCount());
+            assertTrue(result.advanceRow());
+            assertEquals(tupleId, result.getLong(0));
+        }
+    }
+
+    void callWithExpectedKeyValue(Client client, String columnName, VoltType type, Object value,
+            String procName, Object... params) throws NoConnectionsException, IOException, ProcCallException {
+        ClientResponse cr = client.callProcedure(procName, params);
+        assertEquals(ClientResponse.SUCCESS, cr.getStatus());
+        assertEquals(1, cr.getResults().length);
+        VoltTable result = cr.getResults()[0];
+        System.out.println("Answer: " + result.toString());
+
+        if (value == null) {
+            assertEquals(0, result.getRowCount());
+        } else {
+            assertEquals(1, result.getRowCount());
+            assertTrue(result.advanceRow());
+            assertEquals(value, result.get(columnName, type));
+        }
+    }
+
+    void checkExplainPlan(Client client, String[] procedures) throws NoConnectionsException, IOException, ProcCallException {
+        for (String proc: procedures) {
+            VoltTable vt = client.callProcedure("@ExplainProc", proc).getResults()[0];
+            System.out.println(vt);
+            assertTrue(vt.toString().contains("for offset rank lookup"));
+        }
+    }
+
+    public void notestSingleColumnIndex() throws Exception {
+        System.out.println("Running testOverflow");
+        Client client = getClient();
+
+        // check offset rank lookup plan
+        checkExplainPlan(client, new String[]{"TU1_POINTS", "TU1_ABS_POINTS", "TM1_POINTS"});
+
+        // Unique Map, Single column index
+        client.callProcedure("TU1.insert", 1, 1);
+        client.callProcedure("TU1.insert", 2, 2);
+        client.callProcedure("TU1.insert", 3, 3);
+        client.callProcedure("TU1.insert", 6, 6);
+        client.callProcedure("TU1.insert", 8, 8);
+        client.callProcedure("TU1.insert", 10, null);
+
+        // NULL value is the MIN VALUE stored in VoltDB
+        callWithExpectedTupleId(client, 10, "TU1_POINTS", 0, 0);
+        callWithExpectedTupleId(client, 1, "TU1_POINTS", 0, 1);
+        callWithExpectedTupleId(client, 8, "TU1_POINTS", 0, 5);
+        callWithExpectedTupleId(client, Integer.MIN_VALUE, "TU1_POINTS", 0, 6);
+
+        // check expression index
+        callWithExpectedTupleId(client, 10, "TU1_ABS_POINTS", 0, 0);
+        callWithExpectedTupleId(client, 1, "TU1_ABS_POINTS", 0, 1);
+        callWithExpectedTupleId(client, 8, "TU1_ABS_POINTS", 0, 5);
+        callWithExpectedTupleId(client, Integer.MIN_VALUE, "TU1_ABS_POINTS", 0, 6);
+
+        // Multi-map
+        client.callProcedure("TM1.insert", 1, 1);
+        client.callProcedure("TM1.insert", 2, 2);
+        client.callProcedure("TM1.insert", 3, 2);
+        client.callProcedure("TM1.insert", 4, 2);
+        client.callProcedure("TM1.insert", 5, 3);
+        client.callProcedure("TM1.insert", 6, 6);
+        client.callProcedure("TM1.insert", 7, 6);
+        client.callProcedure("TM1.insert", 8, 8);
+        client.callProcedure("TM1.insert", 9, null);
+        client.callProcedure("TM1.insert", 10, null);
+
+
+        // non-deterministic query, but our index is compacting index without holes
+        callWithExpectedTupleId(client, 9, "TM1_POINTS", 0, 0);
+        callWithExpectedTupleId(client, 10, "TM1_POINTS", 0, 1);
+        callWithExpectedTupleId(client, 1, "TM1_POINTS", 0, 2);
+        callWithExpectedTupleId(client, 2, "TM1_POINTS", 0, 3);
+        callWithExpectedTupleId(client, 3, "TM1_POINTS", 0, 4);
+        callWithExpectedTupleId(client, 4, "TM1_POINTS", 0, 5);
+        callWithExpectedTupleId(client, 5, "TM1_POINTS", 0, 6);
+        callWithExpectedTupleId(client, 6, "TM1_POINTS", 0, 7);
+        callWithExpectedTupleId(client, 7, "TM1_POINTS", 0, 8);
+        callWithExpectedTupleId(client, 8, "TM1_POINTS", 0, 9);
+        callWithExpectedTupleId(client, Integer.MIN_VALUE, "TM1_POINTS", 0, 10);
+    }
+
+    public void testTwoOrMoreColumnsUniqueIndex() throws Exception {
+        Client client = getClient();
+
+        checkExplainPlan(client, new String[]{"TU2_BY_UNAME_POINTS", "TU2_BY_UNAME"});
+
+        client.callProcedure("TU2.insert", 1, 1, "xin");
+        client.callProcedure("TU2.insert", 2, 2, "xin");
+        client.callProcedure("TU2.insert", 3, 3, "xin");
+        client.callProcedure("TU2.insert", 4, 6, "xin");
+        client.callProcedure("TU2.insert", 5, 8, "xin");
+        client.callProcedure("TU2.insert", 6, 1, "jiao");
+        client.callProcedure("TU2.insert", 7, 2, "jiao");
+        client.callProcedure("TU2.insert", 8, 3, "jiao");
+        client.callProcedure("TU2.insert", 9, 6, "jiao");
+        client.callProcedure("TU2.insert", 10, 8, "jiao");
+
+        client.callProcedure("TU2.insert", 11, null, "xin");
+        client.callProcedure("TU2.insert", 12, null, "jiao");
+
+        // test order by two column with index
+        callWithExpectedTupleId(client, 12, "TU2_BY_UNAME_POINTS", 0, 0);
+        callWithExpectedTupleId(client, 6, "TU2_BY_UNAME_POINTS", 0, 1);
+        callWithExpectedTupleId(client, 7, "TU2_BY_UNAME_POINTS", 0, 2);
+        callWithExpectedTupleId(client, 8, "TU2_BY_UNAME_POINTS", 0, 3);
+        callWithExpectedTupleId(client, 9, "TU2_BY_UNAME_POINTS", 0, 4);
+        callWithExpectedTupleId(client, 10, "TU2_BY_UNAME_POINTS", 0, 5);
+
+        callWithExpectedTupleId(client, 11, "TU2_BY_UNAME_POINTS", 0, 6);
+        callWithExpectedTupleId(client, 1, "TU2_BY_UNAME_POINTS", 0, 7);
+        callWithExpectedTupleId(client, 2, "TU2_BY_UNAME_POINTS", 0, 8);
+        callWithExpectedTupleId(client, 3, "TU2_BY_UNAME_POINTS", 0, 9);
+        callWithExpectedTupleId(client, 4, "TU2_BY_UNAME_POINTS", 0, 10);
+        callWithExpectedTupleId(client, 5, "TU2_BY_UNAME_POINTS", 0, 11);
+        callWithExpectedTupleId(client, Integer.MIN_VALUE, "TU2_BY_UNAME_POINTS", 0, 12);
+
+        // test order by one column with index, this is not a deterministic query
+        callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "jiao", "TU2_BY_UNAME", 0, 0);
+        callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "jiao", "TU2_BY_UNAME", 0, 1);
+        callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "jiao", "TU2_BY_UNAME", 0, 2);
+        callWithExpectedKeyValue(client, "UNAME", VoltType.STRING, "xin", "TU2_BY_UNAME", 0, 6);
+    }
+
+    static public Test suite() {
+        VoltServerConfig config = null;
+
+        // the suite made here will all be using the tests from this class
+        MultiConfigSuiteBuilder builder = new MultiConfigSuiteBuilder(TestIndexOffsetSuite.class);
+
+        // build up a project builder for the workload
+        VoltProjectBuilder project = new VoltProjectBuilder();
+        project.addSchema(BatchedMultiPartitionTest.class.getResource("sqlindex-ddl.sql"));
+
+        // this is not a deterministic query
+        project.addStmtProcedure("TU1_POINTS",
+                "SELECT ID, POINTS, CAST(? AS INTEGER) AS PARTITION FROM TU1 ORDER BY POINTS OFFSET ? LIMIT 1",
+                new ProcedurePartitionData("TU1", "ID", "0"));
+
+        project.addStmtProcedure("TU1_ABS_POINTS",
+                "SELECT ID, POINTS, CAST(? AS INTEGER) AS PARTITION FROM TU1 ORDER BY ABS(POINTS) OFFSET ? LIMIT 1",
+                new ProcedurePartitionData("TU1", "ID", "0"));
+
+        project.addStmtProcedure("TM1_POINTS",
+                "SELECT ID, POINTS, CAST(? AS INTEGER) AS PARTITION FROM TM1 ORDER BY POINTS OFFSET ? LIMIT 1",
+                new ProcedurePartitionData("TM1", "ID", "0"));
+
+        // multi-column index
+        project.addStmtProcedure("TU2_BY_UNAME_POINTS",
+                "SELECT ID, UNAME, CAST(? AS INTEGER) AS PARTITION FROM TU2 ORDER BY UNAME, POINTS OFFSET ? LIMIT 1",
+                new ProcedurePartitionData("TU2", "UNAME", "0"));
+
+        // this is not a deterministic query
+        project.addStmtProcedure("TU2_BY_UNAME",
+                "SELECT ID, UNAME, CAST(? AS INTEGER) AS PARTITION FROM TU2 ORDER BY UNAME OFFSET ? LIMIT 1",
+                new ProcedurePartitionData("TU2", "UNAME", "0"));
+
+
+        boolean success;
+
+        /////////////////////////////////////////////////////////////
+        // CONFIG #1: 1 Local Site/Partitions running on JNI backend
+        /////////////////////////////////////////////////////////////
+
+        // get a server config for the native backend with one sites/partitions
+        config = new LocalCluster("sqlOffsetIndex-onesite.jar", 1, 1, 0, BackendTarget.NATIVE_EE_JNI);
+
+        // build the jarfile
+        success = config.compile(project);
+        assert(success);
+
+        // add this config to the set of tests to run
+        builder.addServerConfig(config);
+
+        /////////////////////////////////////////////////////////////
+        // CONFIG #2: 1 Local Site/Partition running on HSQL backend
+        /////////////////////////////////////////////////////////////
+
+        config = new LocalCluster("sqlOffsetIndex-hsql.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
+        success = config.compile(project);
+        assert(success);
+        builder.addServerConfig(config);
+
+        return builder;
+    }
+
+    public static void main(String args[]) {
+        org.junit.runner.JUnitCore.runClasses(TestIndexOffsetSuite.class);
+    }
+}

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
@@ -81,7 +81,7 @@ public class TestIndexOffsetSuite extends RegressionSuite {
     void checkExplainPlan(Client client, String[] procedures) throws NoConnectionsException, IOException, ProcCallException {
         for (String proc: procedures) {
             VoltTable vt = client.callProcedure("@ExplainProc", proc).getResults()[0];
-            assertTrue(vt.toString().contains("for offset rank lookup"));
+            assertTrue(vt.toString(), vt.toString().contains("for offset rank lookup"));
         }
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestOrderBySuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestOrderBySuite.java
@@ -863,10 +863,16 @@ public class TestOrderBySuite extends RegressionSuite {
         assertTrue(vt.toString().contains("MERGE RECEIVE"));
 
         // Partitions Result sets are ordered by index with LIMIT/OFFSET
+        sql = "SELECT PKEY FROM O1 ORDER BY PKEY LIMIT 3 OFFSET 3";
+        vt = client.callProcedure("@AdHoc", sql).getResults()[0];
+        expected = new long[][] {{4}, {5}, {6}};
+        validateTableOfLongs(vt, expected);
+
         sql = "SELECT PKEY FROM O1 ORDER BY PKEY DESC LIMIT 3 OFFSET 3";
         vt = client.callProcedure("@AdHoc", sql).getResults()[0];
         expected = new long[][] {{4}, {3}, {2}};
         validateTableOfLongs(vt, expected);
+
         sql = "SELECT PKEY FROM O1 ORDER BY PKEY DESC LIMIT 3";
         vt = client.callProcedure("@AdHoc", sql).getResults()[0];
         expected = new long[][] {{7}, {6}, {5}};


### PR DESCRIPTION
This PR is to speed up offset query by using counting index, getting O(logN) look up other than sequential index scan O(N). It works for both ascending and descending order when applying offset. 

For example:
select * from t order by col offset N limit 1

If col is an indexed column of table t, EE should utilize the rank of value to find the target tuple directly. Now although the explained plan says this is index scan, EE actually performs N index scan to locate the right tuple.