### PR TITLE
Revert "ENG-12441: remove python cli voltdb old cli API (#5113)"

### DIFF
--- a/lib/python/voltcli/voltdb.d/add.py
+++ b/lib/python/voltcli/voltdb.d/add.py
@@ -27,4 +27,5 @@
     hideverb = True
 )
 def add(runner):
-    runner.abort('voltdb add is no longer supported, please use \'init\' to initialize and \'start\' to start the database.')
+    runner.warning('voltdb add is no longer supported, please use \'init\' to initialize and \'start\' to start the database.')
+    runner.go()

--- a/lib/python/voltcli/voltdb.d/create.py
+++ b/lib/python/voltcli/voltdb.d/create.py
@@ -34,4 +34,5 @@
     hideverb=True
 )
 def create(runner):
-    runner.abort('voltdb create is no longer supported, please use \'init\' to initialize and \'start\' to start the database.')
+    runner.warning('voltdb create is no longer supported, please use \'init\' to initialize and \'start\' to start the database.')
+    runner.go()

--- a/lib/python/voltcli/voltdb.d/recover.py
+++ b/lib/python/voltcli/voltdb.d/recover.py
@@ -33,4 +33,5 @@
     hideverb=True
 )
 def recover(runner):
-    runner.abort('voltdb recover is no longer supported, please use \'init\' to initialize and \'start\' to start the database.')
+    runner.warning('voltdb recover is no longer supported, please use \'init\' to initialize and \'start\' to start the database.')
+    runner.go()

--- a/lib/python/voltcli/voltdb.d/rejoin.py
+++ b/lib/python/voltcli/voltdb.d/rejoin.py
@@ -27,4 +27,5 @@
     hideverb=True
 )
 def rejoin(runner):
-    runner.abort('voltdb rejoin is no longer supported, please use \'init\' to initialize and \'start\' to start the database.')
+    runner.warning('voltdb rejoin is no longer supported, please use \'init\' to initialize and \'start\' to start the database.')
+    runner.go()


### PR DESCRIPTION
Jepsen tests got broken after deprecating the CLI. Let's revert this change and put out warning instead.