### PR TITLE
ENG-13493: performance greatly improved by balancing replicate table AdHoc read queries

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -90,16 +90,16 @@ import org.voltdb.client.ProcedureCallback;
 import org.voltdb.client.TLSHandshaker;
 import org.voltdb.common.Constants;
 import org.voltdb.dtxn.InitiatorStats.InvocationInfo;
-import org.voltdb.iv2.MigratePartitionLeaderInfo;
 import org.voltdb.iv2.Cartographer;
 import org.voltdb.iv2.Iv2Trace;
+import org.voltdb.iv2.MigratePartitionLeaderInfo;
 import org.voltdb.iv2.MpInitiator;
-import org.voltdb.messaging.MigratePartitionLeaderMessage;
 import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.messaging.InitiateResponseMessage;
 import org.voltdb.messaging.Iv2EndOfLogMessage;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.messaging.LocalMailbox;
+import org.voltdb.messaging.MigratePartitionLeaderMessage;
 import org.voltdb.security.AuthenticationRequest;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltTrace;
@@ -1045,8 +1045,9 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
 
             try {
                 ProcedurePartitionInfo ppi = (ProcedurePartitionInfo)catProc.getAttachment();
-                int partition = InvocationDispatcher.getPartitionForProcedureParameter(ppi.index,
-                        ppi.type, response.getInvocation());
+                Object invocationParameter = response.getInvocation().getParameterAtIndex(ppi.index);
+                int partition = TheHashinator.getPartitionForParameter(
+                        ppi.type, invocationParameter);
                 m_dispatcher.createTransaction(cihm.connection.connectionId(),
                         response.getInvocation(),
                         catProc.getReadonly(),

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -120,7 +120,7 @@ public final class InvocationDispatcher {
 
     // Next partition to service adhoc replicated table reads
     private static int m_nextPartition = -1;
-    // Number of partitions, will change when new node joins cluster
+    // Number of partitions, will NOT change when new node joins cluster
     private static int m_partitionCount;
     // the partition id list, which does not assume starting from 0
     private static ArrayList<Integer> m_partitionIds;

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -116,6 +117,13 @@ public final class InvocationDispatcher {
     private final AtomicBoolean m_isInitialRestore = new AtomicBoolean(true);
 
     private final NTProcedureService m_NTProcedureService;
+
+    // Next partition to service adhoc replicated table reads
+    private static int m_nextPartition = -1;
+    // Number of partitions, will change when new node joins cluster
+    private static int m_partitionCount;
+    // the partition id list, which does not assume starting from 0
+    private static ArrayList<Integer> m_partitionIds;
 
     public final static class Builder {
 
@@ -210,6 +218,9 @@ public final class InvocationDispatcher {
 
         // this kicks off the initial NT procedures being loaded
         notifyNTProcedureServiceOfCatalogUpdate();
+
+        // update the partition count and partition keys for rounting purpose
+        updatePartitionInformation();
     }
 
     /**
@@ -228,6 +239,23 @@ public final class InvocationDispatcher {
 
     LightweightNTClientResponseAdapter getInternelAdapterNT () {
         return m_NTProcedureService.m_internalNTClientAdapter;
+    }
+
+    static void updatePartitionInformation() {
+        m_partitionIds = new ArrayList<>();
+
+        VoltTable partitionKeys = TheHashinator.getPartitionKeys(VoltType.INTEGER);
+        ByteBuffer buf = ByteBuffer.allocate(partitionKeys.getSerializedSize());
+        partitionKeys.flattenToBuffer(buf);
+        buf.flip();
+        VoltTable keyCopy = PrivateVoltTableFactory.createVoltTableFromSharedBuffer(buf);
+        keyCopy.resetRowPosition();
+        while (keyCopy.advanceRow()) {
+            if (MpInitiator.MP_INIT_PID != keyCopy.getLong("PARTITION_ID")) {
+                m_partitionIds.add((int)(keyCopy.getLong("PARTITION_ID")));
+            }
+        }
+        m_partitionCount = m_partitionIds.size();
     }
 
     /*
@@ -1238,14 +1266,28 @@ public final class InvocationDispatcher {
                 (CatalogContext.ProcedurePartitionInfo) procedure.getAttachment();
         if (procedure.getSinglepartition()) {
             // break out the Hashinator and calculate the appropriate partition
-            return new int[] { getPartitionForProcedureParameter( ppi.index, ppi.type, task) };
+            Object invocationParameter = task.getParameterAtIndex(ppi.index);
+            if (invocationParameter == null && procedure.getReadonly()) {
+                // AdHoc replicated table reads are optimized as single partition,
+                // but without partition params, since replicated table reads can
+                // be done on any partition, round-robin the procedure to local
+                // partitions to spread the traffic.
+                assert (task.getProcName().equals("@AdHoc_RO_SP")): task.getProcName();
+
+                int partitionIdIndex = (Math.abs(++m_nextPartition)) % m_partitionCount;
+                int partitionId = m_partitionIds.get(partitionIdIndex);
+                return new int[] {partitionId};
+            }
+            return new int[] { TheHashinator.getPartitionForParameter(ppi.type, invocationParameter) };
         } else if (procedure.getPartitioncolumn2() != null) {
             // two-partition procedure
             VoltType partitionParamType1 = VoltType.get((byte)procedure.getPartitioncolumn().getType());
             VoltType partitionParamType2 = VoltType.get((byte)procedure.getPartitioncolumn2().getType());
+            Object invocationParameter1 = task.getParameterAtIndex(procedure.getPartitionparameter());
+            Object invocationParameter2 = task.getParameterAtIndex(procedure.getPartitionparameter2());
 
-            int p1 = getPartitionForProcedureParameter(procedure.getPartitionparameter(), partitionParamType1, task);
-            int p2 = getPartitionForProcedureParameter(procedure.getPartitionparameter2(), partitionParamType2, task);
+            int p1 = TheHashinator.getPartitionForParameter(partitionParamType1, invocationParameter1);
+            int p2 = TheHashinator.getPartitionForParameter(partitionParamType2, invocationParameter2);
 
             return new int[] { p1, p2 };
         } else {
@@ -1276,16 +1318,6 @@ public final class InvocationDispatcher {
         ClientResponseImpl clientResponse = new ClientResponseImpl(ClientResponse.UNEXPECTED_FAILURE,
                 new VoltTable[0], errorMessage, task.clientHandle);
         return clientResponse;
-    }
-
-
-    /**
-     * Identify the partition for an execution site task.
-     * @return The partition best set up to execute the procedure.
-     */
-    final static int getPartitionForProcedureParameter(int partitionIndex, VoltType partitionType, StoredProcedureInvocation task) {
-        Object invocationParameter = task.getParameterAtIndex(partitionIndex);
-        return TheHashinator.getPartitionForParameter(partitionType, invocationParameter);
     }
 
     private final static ClientResponseImpl errorResponse(Connection c, long handle, byte status, String reason, Exception e, boolean log) {

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -66,6 +66,7 @@ import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.planner.ActivePlanRepository;
 import org.voltdb.sysprocs.AdHocBase;
 import org.voltdb.sysprocs.AdHocNTBase;
+import org.voltdb.sysprocs.AdHoc_RO_SP;
 import org.voltdb.types.TimestampType;
 import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.Encoder;
@@ -533,6 +534,13 @@ public class ProcedureRunner {
                 // ClientInterface should pre-validate this param is valid
                 parameterAtIndex = invocation.getParameterAtIndex(0);
                 parameterType = VoltType.get((Byte) invocation.getParameterAtIndex(1));
+
+                if (parameterAtIndex == null && m_isReadOnly) {
+                    assert (m_procedure instanceof AdHoc_RO_SP);
+                    // Replicated table reads can run on any partition, skip check
+                    return true;
+                }
+
             } else {
                 parameterType = m_partitionColumnType;
                 parameterAtIndex = invocation.getParameterAtIndex(m_partitionColumn);

--- a/src/frontend/org/voltdb/StoredProcedureInvocation.java
+++ b/src/frontend/org/voltdb/StoredProcedureInvocation.java
@@ -424,14 +424,7 @@ public class StoredProcedureInvocation implements JSONString {
         setProcName(procNameBytes);
         clientHandle = buf.getLong();
         // do not deserialize parameters in ClientInterface context
-        serializedParams = buf.slice();
-        final ByteBuffer duplicate = serializedParams.duplicate();
-        params = new FutureTask<ParameterSet>(new Callable<ParameterSet>() {
-            @Override
-            public ParameterSet call() throws Exception {
-                return ParameterSet.fromByteBuffer(duplicate);
-            }
-        });
+        initParameters(buf);
     }
 
     private void initVersion1FromBuffer(ByteBuffer buf) throws IOException {
@@ -495,6 +488,10 @@ public class StoredProcedureInvocation implements JSONString {
         }
 
         // do not deserialize parameters in ClientInterface context
+        initParameters(buf);
+    }
+
+    private void initParameters(ByteBuffer buf) {
         serializedParams = buf.slice();
         final ByteBuffer duplicate = serializedParams.duplicate();
         params = new FutureTask<ParameterSet>(new Callable<ParameterSet>() {


### PR DESCRIPTION
AdHoc single partition replicate table read only queries currently do not have partition parameter. NULL partition value gets routed to partition 0 always. This means that all AdHoc_SP_RO queries without partition key are only executed on one partition per cluster, which can lead to performance bottleneck. This commit is to address the above performance issue by round robin routing those queries to each partition in the cluster.