### PR TITLE
ENG-13480:

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2063,7 +2063,7 @@ void VoltDBEngine::processRecoveryMessage(RecoveryProtoMsg *message) {
 }
 
 int64_t VoltDBEngine::exportAction(bool syncAction,
-                                   int64_t ackOffset,
+                                   int64_t uso,
                                    int64_t seqNo,
                                    std::string tableSignature) {
     std::map<std::string, StreamedTable*>::iterator pos = m_exportingTables.find(tableSignature);
@@ -2076,17 +2076,17 @@ int64_t VoltDBEngine::exportAction(bool syncAction,
         }
 
         m_resultOutput.writeInt(0);
-        if (ackOffset < 0) {
+        if (uso < 0) {
             return 0;
         }
         else {
-            return ackOffset;
+            return uso;
         }
     }
 
     Table *table_for_el = pos->second;
     if (syncAction) {
-        table_for_el->setExportStreamPositions(seqNo, (size_t) ackOffset);
+        table_for_el->setExportStreamPositions(seqNo, (size_t) uso);
     }
     return 0;
 }

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -219,7 +219,7 @@ public interface SiteProcedureConnection {
     public void quiesce();
 
     public void exportAction(boolean syncAction,
-                             long ackOffset,
+                             long uso,
                              Long sequenceNumber,
                              Integer partitionId,
                              String tableSignature);

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -562,7 +562,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
 
     @Override
     public void exportAction(boolean syncAction,
-                             long ackOffset,
+                             long uso,
                              Long sequenceNumber,
                              Integer partitionId, String tableSignature)
     {

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1363,11 +1363,11 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
 
     @Override
     public void exportAction(boolean syncAction,
-                             long ackOffset,
+                             long uso,
                              Long sequenceNumber,
                              Integer partitionId, String tableSignature)
     {
-        m_ee.exportAction(syncAction, ackOffset, sequenceNumber,
+        m_ee.exportAction(syncAction, uso, sequenceNumber,
                           partitionId, tableSignature);
     }
 

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -787,7 +787,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * Execute an Export action against the execution engine.
      */
     public abstract void exportAction( boolean syncAction,
-            long ackOffset, long seqNo, int partitionId, String tableSignature);
+            long uso, long seqNo, int partitionId, String tableSignature);
 
     /**
      * Get the seqNo and offset for an export table.

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -1529,12 +1529,12 @@ public class ExecutionEngineIPC extends ExecutionEngine {
 
     @Override
     public void exportAction(boolean syncAction,
-            long ackOffset, long seqNo, int partitionId, String mTableSignature) {
+            long uso, long seqNo, int partitionId, String mTableSignature) {
         try {
             m_data.clear();
             m_data.putInt(Commands.ExportAction.m_id);
             m_data.putInt(syncAction ? 1 : 0);
-            m_data.putLong(ackOffset);
+            m_data.putLong(uso);
             m_data.putLong(seqNo);
             if (mTableSignature == null) {
                 m_data.putInt(-1);
@@ -1551,8 +1551,8 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             results.flip();
             long result_offset = results.getLong();
             if (result_offset < 0) {
-                System.out.println("exportAction failed!  syncAction: " + syncAction + ", ackTxnId: " +
-                    ackOffset + ", seqNo: " + seqNo + ", partitionId: " + partitionId +
+                System.out.println("exportAction failed!  syncAction: " + syncAction + ", Uso: " +
+                    uso + ", seqNo: " + seqNo + ", partitionId: " + partitionId +
                     ", tableSignature: " + mTableSignature);
             }
         } catch (final IOException e) {

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -666,15 +666,15 @@ public class ExecutionEngineJNI extends ExecutionEngine {
      */
     @Override
     public void exportAction(boolean syncAction,
-            long ackTxnId, long seqNo, int partitionId, String tableSignature)
+            long uso, long seqNo, int partitionId, String tableSignature)
     {
         //Clear is destructive, do it before the native call
         m_nextDeserializer.clear();
         long retval = nativeExportAction(pointer,
-                                         syncAction, ackTxnId, seqNo, getStringBytes(tableSignature));
+                                         syncAction, uso, seqNo, getStringBytes(tableSignature));
         if (retval < 0) {
-            LOG.info("exportAction failed.  syncAction: " + syncAction + ", ackTxnId: " +
-                    ackTxnId + ", seqNo: " + seqNo + ", partitionId: " + partitionId +
+            LOG.info("exportAction failed.  syncAction: " + syncAction + ", uso: " +
+                    uso + ", seqNo: " + seqNo + ", partitionId: " + partitionId +
                     ", tableSignature: " + tableSignature);
         }
     }

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -198,7 +198,7 @@ public class MockExecutionEngine extends ExecutionEngine {
 
     @Override
     public void exportAction(boolean syncAction,
-            long ackOffset, long seqNo, int partitionId, String mTableSignature) {
+            long uso, long seqNo, int partitionId, String mTableSignature) {
     }
 
     @Override

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -363,6 +363,10 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         (Map<String, Map<Integer, Long>>)ois.readObject();
 
                 @SuppressWarnings("unchecked")
+                Map<String, Map<Integer, Long>> exportUsos =
+                        (Map<String, Map<Integer, Long>>)ois.readObject();
+
+                @SuppressWarnings("unchecked")
                 Map<Integer, Long> drSequenceNumbers = (Map<Integer, Long>)ois.readObject();
 
                 //Last seen unique ids from remote data centers, load each local site
@@ -370,7 +374,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> drMixedClusterSizeConsumerState =
                         (Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>>)ois.readObject();
 
-                performRestoreDigeststate(context, isRecover, snapshotTxnId, perPartitionTxnIds, exportSequenceNumbers);
+                performRestoreDigeststate(context, isRecover, snapshotTxnId, perPartitionTxnIds, exportSequenceNumbers, exportUsos);
 
                 if (isRecover) {
                     performRecoverDigestState(context, snapshotTxnId, perPartitionTxnIds, clusterCreateTime,
@@ -1138,6 +1142,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
 
         List<JSONObject> digests;
         Map<String, Map<Integer, Long>> exportSequenceNumbers;
+        Map<String, Map<Integer, Long>> exportUsos;
         Map<Integer, Long> drSequenceNumbers;
         long perPartitionTxnIds[];
         Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> remoteDCLastSeenIds;
@@ -1149,6 +1154,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                     performRestoreDigestScanWork(isRecover);
             digests = digestScanResult.digests;
             exportSequenceNumbers = digestScanResult.exportSequenceNumbers;
+            exportUsos = digestScanResult.exportUsos;
             drSequenceNumbers = digestScanResult.drSequenceNumbers;
             perPartitionTxnIds = digestScanResult.perPartitionTxnIds;
             remoteDCLastSeenIds = digestScanResult.remoteDCLastSeenIds;
@@ -1325,6 +1331,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ObjectOutputStream oos = new ObjectOutputStream(baos);
             oos.writeObject(exportSequenceNumbers);
+            oos.writeObject(exportUsos);
             oos.writeObject(drSequenceNumbers);
             oos.writeObject(remoteDCLastSeenIds);
             oos.flush();
@@ -1498,7 +1505,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
             boolean isRecover,
             long snapshotTxnId,
             long perPartitionTxnIds[],
-            Map<String, Map<Integer, Long>> exportSequenceNumbers) {
+            Map<String, Map<Integer, Long>> exportSequenceNumbers,
+            Map<String, Map<Integer, Long>> exportUsos) {
 
         // Choose the lowest site ID on this host to truncate export data
         if (isRecover && context.isLowestSiteId()) {
@@ -1539,10 +1547,32 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         " are reset to 0");
                 continue;
             }
+
+            //Usos for this table for every partition
+            Map<Integer, Long> usosPerPartition = exportUsos.get(name);
+            if (usosPerPartition == null) {
+                SNAP_LOG.warn("Could not find export USO for table " + name +
+                        ". This warning is safe to ignore if you are loading a pre 8.1 snapshot" +
+                        " which would not contain these USOs (added in 8.1)." +
+                        " If this is a post 8.1 snapshot then the restore has failed and export USOs " +
+                        " are reset to 0");
+                continue;
+            }
+
+            Long uso = usosPerPartition.get(myPartitionId);
+            if (uso == null) {
+                SNAP_LOG.warn("Could not find an export USO for table " + name +
+                        " partition " + myPartitionId +
+                        ". This warning is safe to ignore if you are loading a pre 8.1 snapshot " +
+                        " which would not contain these USOs (added in 8.1)." +
+                        " If this is a post 8.1 snapshot then the restore has failed and export USO " +
+                        " is reset to 0");
+                continue;
+            }
             //Forward the sequence number to the EE
             context.getSiteProcedureConnection().exportAction(
                     true,
-                    0,
+                    uso,
                     sequenceNumber,
                     myPartitionId,
                     signature);
@@ -1731,6 +1761,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
     private static class DigestScanResult {
         List<JSONObject> digests;
         Map<String, Map<Integer, Long>> exportSequenceNumbers;
+        Map<String, Map<Integer, Long>> exportUsos;
         Map<Integer, Long> drSequenceNumbers;
         long perPartitionTxnIds[];
         Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> remoteDCLastSeenIds;
@@ -1763,6 +1794,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
         results = executeSysProcPlanFragments(pfs, DEP_restoreDigestScanResults);
 
         HashMap<String, Map<Integer, Long>> exportSequenceNumbers =
+                new HashMap<String, Map<Integer, Long>>();
+        HashMap<String, Map<Integer, Long>> exportUsos =
                 new HashMap<String, Map<Integer, Long>>();
         Map<Integer, Long> drSequenceNumbers = new HashMap<>();
 
@@ -1820,11 +1853,11 @@ public class SnapshotRestore extends VoltSystemProcedure {
                  * Snapshots from pre 1.3 VoltDB won't have sequence numbers
                  * Doing nothing will default it to zero.
                  */
-                if (digest.has("exportSequenceNumbers")) {
+                if (digest.has(ExtensibleSnapshotDigestData.EXPORT_SEQUENCE_NUMBERS)) {
                     /*
                      * An array of entries for each table
                      */
-                    JSONArray sequenceNumbers = digest.getJSONArray("exportSequenceNumbers");
+                    JSONArray sequenceNumbers = digest.getJSONArray(ExtensibleSnapshotDigestData.EXPORT_SEQUENCE_NUMBERS);
                     for (int ii = 0; ii < sequenceNumbers.length(); ii++) {
                         /*
                          * An object containing all the sequence numbers for its partitions
@@ -1850,6 +1883,31 @@ public class SnapshotRestore extends VoltSystemProcedure {
                             long sequenceNumber =
                                     sourcePartitionSequenceNumbers.getJSONObject(zz).getInt("exportSequenceNumber");
                             partitionSequenceNumbers.put(partition, sequenceNumber);
+                        }
+                    }
+                }
+                // Snapshots didn't save export USOs pre-8.1
+                if (digest.has(ExtensibleSnapshotDigestData.EXPORT_USOS)) {
+                    JSONArray allUsos = digest.getJSONArray(ExtensibleSnapshotDigestData.EXPORT_USOS);
+                    for (int ii = 0; ii < allUsos.length(); ii++) {
+                        /*
+                         * An object containing all the sequence numbers for its partitions
+                         * in this table. This will be a subset since it is from a single digest
+                         */
+                        JSONObject tableUsos = allUsos.getJSONObject(ii);
+                        String tableName = tableUsos.getString("exportTableName");
+
+                        Map<Integer,Long> partitionUsos = exportUsos.get(tableName);
+                        if (partitionUsos == null) {
+                            partitionUsos = new HashMap<Integer,Long>();
+                            exportUsos.put(tableName, partitionUsos);
+                        }
+
+                        JSONArray sourcePartitionUsos = tableUsos.getJSONArray("usoPerPartition");
+                        for (int zz = 0; zz < sourcePartitionUsos.length(); zz++) {
+                            int partition = sourcePartitionUsos.getJSONObject(zz).getInt("partition");
+                            long uso = sourcePartitionUsos.getJSONObject(zz).getInt("exportUso");
+                            partitionUsos.put(partition, uso);
                         }
                     }
                 }
@@ -1904,6 +1962,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
         DigestScanResult result = new DigestScanResult();
         result.digests = digests;
         result.exportSequenceNumbers = exportSequenceNumbers;
+        result.exportUsos = exportUsos;
         result.drSequenceNumbers = drSequenceNumbers;
         result.perPartitionTxnIds = Longs.toArray(perPartitionTxnIds);
         result.remoteDCLastSeenIds = remoteDCLastSeenIds;

--- a/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
+++ b/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
@@ -88,7 +88,7 @@ public class TestStreamBlockQueue {
         assertEquals(m_sbq.sizeInBytes(), 1024 * 1024 * 2);//USO and length prefix on disk
         assertEquals(sb, m_sbq.poll());
         assertTrue(sb.uso() == g_uso);
-        assertEquals(sb.totalUso(), 1024 * 1024 * 2);
+        assertEquals(sb.totalSize(), 1024 * 1024 * 2);
         assertTrue(m_sbq.isEmpty());
         assertNull(m_sbq.peek());
         assertNull(m_sbq.peek());
@@ -181,7 +181,7 @@ public class TestStreamBlockQueue {
             blocks.add(sb);
             assertEquals(sb.uso(), uso);
             uso += 1024 * 1024 * 2;
-            assertEquals(sb.totalUso(), 1024 * 1024 * 2);
+            assertEquals(sb.totalSize(), 1024 * 1024 * 2);
             BBContainer cont = sb.unreleasedContainer();
             ByteBuffer buf = cont.b();
             try {
@@ -243,7 +243,7 @@ public class TestStreamBlockQueue {
             blocks.add(sb);
             assertEquals(sb.uso(), uso);
             uso += 1024 * 1024 * 2;
-            assertEquals(sb.totalUso(), 1024 * 1024 * 2);
+            assertEquals(sb.totalSize(), 1024 * 1024 * 2);
             BBContainer cont = sb.unreleasedContainer();
             ByteBuffer buf = cont.b();
             try {
@@ -309,7 +309,7 @@ public class TestStreamBlockQueue {
             blocks.add(sb);
             assertEquals(sb.uso(), uso);
             uso += 1024 * 1024 * 2;
-            assertEquals(sb.totalUso(), 1024 * 1024 * 2);
+            assertEquals(sb.totalSize(), 1024 * 1024 * 2);
             BBContainer cont = sb.unreleasedContainer();
             ByteBuffer buf = cont.b();
             try {
@@ -379,7 +379,7 @@ public class TestStreamBlockQueue {
             blocks.add(sb);
             assertEquals(sb.uso(), uso);
             uso += 1024 * 1024 * 2;
-            assertEquals(sb.totalUso(), 1024 * 1024 * 2);
+            assertEquals(sb.totalSize(), 1024 * 1024 * 2);
             BBContainer cont = sb.unreleasedContainer();
             ByteBuffer buf = cont.b();
             try {
@@ -437,7 +437,7 @@ public class TestStreamBlockQueue {
             blocks.add(sb);
             assertEquals(sb.uso(), uso);
             uso += 1024 * 1024 * 2;
-            assertEquals(sb.totalUso(), 1024 * 1024 * 2);
+            assertEquals(sb.totalSize(), 1024 * 1024 * 2);
             BBContainer cont = sb.unreleasedContainer();
             ByteBuffer buf = cont.b();
             try {
@@ -496,7 +496,7 @@ public class TestStreamBlockQueue {
             blocks.add(sb);
             assertEquals(sb.uso(), uso);
             uso += 1024 * 1024 * 2;
-            assertEquals(sb.totalUso(), 1024 * 1024 * 2);
+            assertEquals(sb.totalSize(), 1024 * 1024 * 2);
             BBContainer cont = sb.unreleasedContainer();
             ByteBuffer buf = cont.b();
             try {


### PR DESCRIPTION
- Save export USOs in snapshot and use it restart from where we left off on snapshot restore.
- Reopen PBD after truncate.
- Stop using PBD.push. Always write to PBD, so that we never need to do a push.
  PBD.push doesn't do the correct thing after some blocks are deleted.
- Changed totalUso to totalSize because that is what it actually is.