### PR TITLE
ENG-13701:

### DIFF
--- a/src/ee/storage/TupleBlock.cpp
+++ b/src/ee/storage/TupleBlock.cpp
@@ -33,7 +33,7 @@ TupleBlock::TupleBlock(Table *table, TBBucketPtr bucket) :
         m_nextFreeTuple(0),
         m_lastCompactionOffset(0),
         m_bucket(bucket),
-        m_bucketIndex(0)
+        m_bucketIndex(bucket.get() == NULL ? -1 : 0)
 {
 #ifdef USE_MMAP
     size_t tableAllocationSize = static_cast<size_t> (m_tupleLength * m_tuplesPerBlock);

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -237,6 +237,10 @@ void PersistentTable::nextFreeTuple(TableTuple* tuple) {
         VOLT_TRACE("GRABBED FREE TUPLE!\n");
         stx::btree_set<TBPtr >::iterator begin = m_blocksWithSpace.begin();
         TBPtr block = (*begin);
+        if (m_tupleCount == 0) {
+            assert(m_blocksNotPendingSnapshot.find(block) == m_blocksNotPendingSnapshot.end());
+            m_blocksNotPendingSnapshot.insert(block);
+        }
         std::pair<char*, int> retval = block->nextFreeTuple();
 
         /**

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -568,7 +568,8 @@ private:
     }
 
     bool blockCountConsistent() const {
-        return m_blocksNotPendingSnapshot.size() == m_data.size();
+        // if the table is empty, the empty cache block will not be present in m_blocksNotPendingSnapshot
+        return isPersistentTableEmpty() || m_blocksNotPendingSnapshot.size() == m_data.size();
     }
 
     void snapshotFinishedScanningBlock(TBPtr finishedBlock, TBPtr nextBlock) {
@@ -652,6 +653,8 @@ private:
     };
 
     TableTuple lookupTuple(TableTuple tuple, LookupType lookupType);
+
+    TBPtr allocateFirstBlock();
 
     TBPtr allocateNextBlock();
 
@@ -1032,11 +1035,19 @@ inline void PersistentTable::deleteTupleStorage(TableTuple& tuple, TBPtr block,
         }
     }
 
-    if (block->isEmpty() && (m_data.size() > 1 || deleteLastEmptyBlock)) {
-        // Release the empty block unless it's the only remaining block and caller has requested not to do so.
-        // The intent of doing so is to avoid block allocation cost at time tuple insertion into the table
-        m_data.erase(block->address());
-        m_blocksWithSpace.erase(block);
+    if (block->isEmpty()) {
+        if (m_data.size() > 1 || deleteLastEmptyBlock) {
+            // Release the empty block unless it's the only remaining block and caller has requested not to do so.
+            // The intent of doing so is to avoid block allocation cost at time tuple insertion into the table
+            m_data.erase(block->address());
+            m_blocksWithSpace.erase(block);
+        }
+        else {
+            // In the unlikely event that tuplesPerBlock == 1
+            if (transitioningToBlockWithSpace) {
+                m_blocksWithSpace.insert(block);
+            }
+        }
         m_blocksNotPendingSnapshot.erase(block);
         assert(m_blocksPendingSnapshot.find(block) == m_blocksPendingSnapshot.end());
         //Eliminates circular reference
@@ -1067,6 +1078,12 @@ inline TBPtr PersistentTable::findBlock(char* tuple, TBMap& blocks, int blockSiz
     }
 
     return TBPtr(NULL);
+}
+
+inline TBPtr PersistentTable::allocateFirstBlock() {
+    TBPtr block(new TupleBlock(this, TBBucketPtr()));
+    m_data.insert(block->address(), block);
+    return block;
 }
 
 inline TBPtr PersistentTable::allocateNextBlock() {

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -106,7 +106,7 @@ Table* TableFactory::getPersistentTable(
         // Allocate and assign the tuple storage block to the persistent table ahead of time instead
         // of doing so at time of first tuple insertion. The intent of block allocation ahead of time
         // is to avoid allocation cost at time of tuple insertion
-        TBPtr block = persistentTable->allocateNextBlock();
+        TBPtr block = persistentTable->allocateFirstBlock();
         assert(block->hasFreeTuples());
         persistentTable->m_blocksWithSpace.insert(block);
     }


### PR DESCRIPTION
There are two maps which track the set of blocks that are non-empty. These maps are used to determine if a block is in a bucket. However, an optimization to keep a cache block around when the table's tuple count goes to zero does not cleanly track this buffer either when the last tuple is deallocated nor subsequently when the first tuple is allocated. Therefore, this block may not participate in subsequent compactions.

This branch adds special checks to ensure that the last empty block is correctly tracked when the last tuple is deleted and when this block is used by the first tuple that is subsequently inserted.