### PR TITLE
ENG-13652, fix a issue that when MPI failover NT procedure that currently running will receive premature failure response.

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -176,6 +176,9 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
 
     private static final RateLimitedLogger m_rateLimitedLogger =  new RateLimitedLogger(TimeUnit.MINUTES.toMillis(60), authLog, Level.WARN);
 
+    // Used by NT procedure to generate handle, don't use elsewhere.
+    public static final int NTPROC_JUNK_ID = -2;
+
     /** Ad hoc async work is either regular planning, ad hoc explain, or default proc explain. */
     public enum ExplainMode {
         NONE, EXPLAIN_ADHOC, EXPLAIN_DEFAULT_PROC, EXPLAIN_JSON;

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -723,23 +723,18 @@ public final class InvocationDispatcher {
                     task.clientHandle);
         }
 
-        // used below, but never really matters
-        final int NTPROC_JUNK_ID = -2;
-
         // This handle is needed for backpressure. It identifies this transaction to the ACG and
         // increments backpressure. When the response is sent (by sending an InitiateResponseMessage
         // to the CI mailbox, the backpressure associated with this handle will go away.
         // Sadly, many of the value's here are junk.
         long handle = cihm.getHandle(true,
-                                     NTPROC_JUNK_ID,
+                                     ClientInterface.NTPROC_JUNK_ID,
                                      task.clientHandle,
                                      task.getSerializedSize(),
                                      nowNanos,
                                      task.getProcName(),
-                                     NTPROC_JUNK_ID,
-                                     true); // We are using shortcut read here on purpose
-                                            // it's the simplest place to keep the handle because it
-                                            // doesn't do as much work with partitions.
+                                     ClientInterface.NTPROC_JUNK_ID,
+                                     false);
 
         // note, once we get the handle above, any response to the client MUST be done
         // by sending an InitiateResponseMessage to the CI mailbox. Writing bytes to the wire, like we


### PR DESCRIPTION
This pull request creates a separate bucket at CIHM for client handle of NT procedure. When mastership changes, for any inflight transaction send to the down node/partition, its client interface handle will be cleared and send an error response back to the client (or internal client). But so far all NT procedures run locally, even for the runOnAllNode NT procedure, so it means mastership change doesn't necessarily require NT procedure client interface handle cleanup.