### PR TITLE
ENG-13723: shared replicated: valgrind reports invalid reads during shutdown

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -303,7 +303,7 @@ VoltDBEngine::~VoltDBEngine() {
             }
             else {
                 deleteWithMpPool = true;
-                VOLT_TRACE("Partition %d Deallocating replicated table %s", m_partitionId, eraseThis->second->getTable()->name().c_str());
+                VOLT_DEBUG("Partition %d Deallocating replicated table %s", m_partitionId, eraseThis->second->getTable()->name().c_str());
             }
 
             if (deleteWithMpPool) {

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -301,21 +301,6 @@ VoltDBEngine::~VoltDBEngine() {
             }
             else {
                 deleteWithMpPool = true;
-//                // It is assumed that the lowest site will always be the first site to perform a cleanup and remove the replicated tables
-//                assert(m_isLowestSite && SynchronizedThreadLock::isLowestSiteContext());
-//                BOOST_FOREACH (SharedEngineLocalsType::value_type& enginePair, SynchronizedThreadLock::s_enginesByPartitionId) {
-//                    if (enginePair.first == m_partitionId) {
-//                        continue;
-//                    }
-//                    EngineLocals& curr = enginePair.second;
-//                    VoltDBEngine* currEngine = curr.context->getContextEngine();
-//                    ExecutorContext::assignThreadLocals(curr);
-//                    auto extTcdIter = currEngine->m_catalogDelegates.find(eraseThis->first);
-//                    if (extTcdIter != currEngine->m_catalogDelegates.end()) {
-//                        currEngine->m_catalogDelegates.erase(extTcdIter);
-//                    }
-//                }
-//                ExecutorContext::assignThreadLocals(SynchronizedThreadLock::s_enginesByPartitionId.find(m_partitionId)->second);
                 VOLT_TRACE("Partition %d Deallocating replicated table %s", m_partitionId, eraseThis->second->getTable()->name().c_str());
             }
 

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -442,7 +442,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
 
         Topend* getTopend() { return m_topend; }
 
-        bool isLowestSite() { return m_isLowestSite; }
+        bool isLowestSite() const { return m_isLowestSite; }
 
         void setLowestSiteForTest() { m_isLowestSite = true; }
 

--- a/src/ee/storage/MaterializedViewHandler.h
+++ b/src/ee/storage/MaterializedViewHandler.h
@@ -25,7 +25,7 @@
 #include "catalog/materializedviewhandlerinfo.h"
 #include "common/tabletuple.h"
 #include "execution/ExecutorVector.h"
-#include "persistenttable.h"
+#include "storage/persistenttable.h"
 
 namespace voltdb {
 

--- a/src/ee/storage/MaterializedViewHandler.h
+++ b/src/ee/storage/MaterializedViewHandler.h
@@ -122,7 +122,7 @@ private:
     // aggregated columns, but there might be some other mostly harmless ones in there that are based
     // solely on the immutable primary key (GROUP BY columns).
     std::vector<TableIndex*> m_updatableIndexList;
-    ReplicatedMaterializedViewHandler* m_replicatedWrapper;
+    std::unique_ptr<ReplicatedMaterializedViewHandler> m_replicatedWrapper;
 
     // We maintain the source table list here to register / de-register the view handler on the source tables.
     void addSourceTable(bool viewHandlerPartitioned, PersistentTable *sourceTable,

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -441,6 +441,7 @@ VoltDBIPC::VoltDBIPC(int fd)
     , m_tupleBuffer(NULL)
     , m_tupleBufferSize(0)
 {
+    currentVolt = this;
     setupSigHandler();
 }
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
@@ -124,7 +124,7 @@ public class TestIndexOffsetSuite extends RegressionSuite {
         // check expression index
 
         // non-deterministic query, but our index is compacting index without holes
-        if (!isHSQL()) {
+        if (!isHSQL() && !isValgrind()) {
             callWithExpectedTupleId(client, 10, "TU1_ABS_POINTS", 0, 0);
             callWithExpectedTupleId(client, 1, "TU1_ABS_POINTS", 0, 1);
             callWithExpectedTupleId(client, 8, "TU1_ABS_POINTS", 0, 5);
@@ -137,31 +137,35 @@ public class TestIndexOffsetSuite extends RegressionSuite {
             callWithExpectedTupleId(client, Integer.MIN_VALUE, "TU1_ABS_POINTS_DESC", 0, 6);
         }
 
-        // Multi-map
-        client.callProcedure("TM1.insert", 1, 1);
-        client.callProcedure("TM1.insert", 2, 2);
-        client.callProcedure("TM1.insert", 3, 2);
-        client.callProcedure("TM1.insert", 4, 2);
-        client.callProcedure("TM1.insert", 5, 3);
-        client.callProcedure("TM1.insert", 6, 6);
-        client.callProcedure("TM1.insert", 7, 6);
-        client.callProcedure("TM1.insert", 8, 8);
-        client.callProcedure("TM1.insert", 9, null);
-        client.callProcedure("TM1.insert", 10, null);
+        if (!isValgrind()) {
+            // Non-deterministic storage makes this fail in MEMCHECK builds
+
+            // Multi-map
+            client.callProcedure("TM1.insert", 1, 1);
+            client.callProcedure("TM1.insert", 2, 2);
+            client.callProcedure("TM1.insert", 3, 2);
+            client.callProcedure("TM1.insert", 4, 2);
+            client.callProcedure("TM1.insert", 5, 3);
+            client.callProcedure("TM1.insert", 6, 6);
+            client.callProcedure("TM1.insert", 7, 6);
+            client.callProcedure("TM1.insert", 8, 8);
+            client.callProcedure("TM1.insert", 9, null);
+            client.callProcedure("TM1.insert", 10, null);
 
 
-        // non-deterministic query, but our index is compacting index without holes
-        callWithExpectedTupleId(client, 9, "TM1_POINTS", 0, 0);
-        callWithExpectedTupleId(client, 10, "TM1_POINTS", 0, 1);
-        callWithExpectedTupleId(client, 1, "TM1_POINTS", 0, 2);
-        callWithExpectedTupleId(client, 2, "TM1_POINTS", 0, 3);
-        callWithExpectedTupleId(client, 3, "TM1_POINTS", 0, 4);
-        callWithExpectedTupleId(client, 4, "TM1_POINTS", 0, 5);
-        callWithExpectedTupleId(client, 5, "TM1_POINTS", 0, 6);
-        callWithExpectedTupleId(client, 6, "TM1_POINTS", 0, 7);
-        callWithExpectedTupleId(client, 7, "TM1_POINTS", 0, 8);
-        callWithExpectedTupleId(client, 8, "TM1_POINTS", 0, 9);
-        callWithExpectedTupleId(client, Integer.MIN_VALUE, "TM1_POINTS", 0, 10);
+            // non-deterministic query, but our index is compacting index without holes
+            callWithExpectedTupleId(client, 9, "TM1_POINTS", 0, 0);
+            callWithExpectedTupleId(client, 10, "TM1_POINTS", 0, 1);
+            callWithExpectedTupleId(client, 1, "TM1_POINTS", 0, 2);
+            callWithExpectedTupleId(client, 2, "TM1_POINTS", 0, 3);
+            callWithExpectedTupleId(client, 3, "TM1_POINTS", 0, 4);
+            callWithExpectedTupleId(client, 4, "TM1_POINTS", 0, 5);
+            callWithExpectedTupleId(client, 5, "TM1_POINTS", 0, 6);
+            callWithExpectedTupleId(client, 6, "TM1_POINTS", 0, 7);
+            callWithExpectedTupleId(client, 7, "TM1_POINTS", 0, 8);
+            callWithExpectedTupleId(client, 8, "TM1_POINTS", 0, 9);
+            callWithExpectedTupleId(client, Integer.MIN_VALUE, "TM1_POINTS", 0, 10);
+        }
     }
 
     public void testTwoOrMoreColumnsUniqueIndex() throws Exception {


### PR DESCRIPTION
Fix was to explicitly shutdown the IPC EEs from Java class ExecutionEngineIPC.  This forces synchronous shutdown of all the engines (lowest site last).