### PR TITLE
ENG-13736:

### DIFF
--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -215,13 +215,13 @@ public class SnapshotSiteProcessor {
                 m_exportSequenceNumbers.put(t.getTypeName(), sequenceNumbers);
             }
 
-            long[] ackOffSetAndSequenceNumber =
+            long[] usoAndSequenceNumber =
                     context.getSiteProcedureConnection().getUSOForExportTable(t.getSignature());
             sequenceNumbers.put(
                             context.getPartitionId(),
                             Pair.of(
-                                ackOffSetAndSequenceNumber[0],
-                                ackOffSetAndSequenceNumber[1]));
+                                usoAndSequenceNumber[0],
+                                usoAndSequenceNumber[1]));
         }
         TupleStreamStateInfo drStateInfo = context.getSiteProcedureConnection().getDRTupleStreamStateInfo();
         m_drTupleStreamInfo.put(context.getPartitionId(), drStateInfo);

--- a/src/frontend/org/voltdb/export/StreamBlock.java
+++ b/src/frontend/org/voltdb/export/StreamBlock.java
@@ -106,7 +106,8 @@ public class StreamBlock {
     {
         assert(releaseUso >= m_uso);
         m_releaseOffset = releaseUso - m_uso;
-        assert(m_releaseOffset < totalSize());
+        // if it is fully released, we will discard the block
+        assert(m_releaseOffset < totalSize()-1);
     }
 
     boolean isPersisted() {

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -203,7 +203,8 @@ public class StreamBlockQueue {
         long unreleasedUso = streamBlock.unreleasedUso();
         if (m_memoryDeque.size() < 2) {
             StreamBlock fromPBD = pollPersistentDeque(false);
-            if (unreleasedUso > streamBlock.uso()) {
+            assert((m_memoryDeque.size() == 2) || (streamBlock.uso() == fromPBD.uso()));
+            if ((streamBlock.uso() == fromPBD.uso()) && (unreleasedUso > streamBlock.uso())) {
                 fromPBD.releaseUso(unreleasedUso - 1);
                 assert(fromPBD.unreleasedUso() < fromPBD.uso() + fromPBD.totalSize() - 1);
             }

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -203,7 +203,6 @@ public class StreamBlockQueue {
         long unreleasedUso = streamBlock.unreleasedUso();
         if (m_memoryDeque.size() < 2) {
             StreamBlock fromPBD = pollPersistentDeque(false);
-            assert((m_memoryDeque.size() == 2) || (streamBlock.uso() == fromPBD.uso()));
             if ((streamBlock.uso() == fromPBD.uso()) && (unreleasedUso > streamBlock.uso())) {
                 fromPBD.releaseUso(unreleasedUso - 1);
                 assert(fromPBD.unreleasedUso() < fromPBD.uso() + fromPBD.totalSize() - 1);

--- a/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExport.java
+++ b/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExport.java
@@ -300,7 +300,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         client.drain();
         waitForStreamedAllocatedMemoryZero(client);
         //After recovery make sure we get exact 2 of each.
-        exportVerify(true, 100);
+        exportVerify(false, 100);
 
         config.killSingleHost(2);
         config.recoverOne(2, 0, "");
@@ -313,7 +313,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         client.drain();
         waitForStreamedAllocatedMemoryZero(client);
         //After recovery make sure we get exact 2 of each.
-        exportVerify(true, 150);
+        exportVerify(false, 150);
 
         //Kill host with all masters now.
         config.killSingleHost(0);
@@ -329,7 +329,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         client.drain();
         waitForStreamedAllocatedMemoryZero(client);
         //After recovery make sure we get exact 2 of each.
-        exportVerify(true, 2000);
+        exportVerify(false, 2000);
     }
 
     public TestExportSuiteReplicatedSocketExport(final String name) {

--- a/tests/frontend/org/voltdb/TestSnapshotWithViews.java
+++ b/tests/frontend/org/voltdb/TestSnapshotWithViews.java
@@ -258,6 +258,7 @@ public class TestSnapshotWithViews extends TestExportBase {
          */
         config = new LocalCluster("export-ddl-cluster-rep.jar", 8, 3, 1,
                 BackendTarget.NATIVE_EE_JNI, LocalCluster.FailureState.ALL_RUNNING, true, false, additionalEnv);
+        ((LocalCluster) config).setHasLocalServer(false);
         //TODO: Snapshot test to use old CLI
         ((LocalCluster)config).setNewCli(false);
         config.setMaxHeap(1024);


### PR DESCRIPTION
- Fixed off by one error when deciding to discard versus set release offset on a push.
- SBQ.offer now checks if the newly polled value is the same one that was just offered
  before setting the release offset.