### PR TITLE
Eng 13693 gram shared repl 2m

### DIFF
--- a/tests/sqlgrammar/run.sh
+++ b/tests/sqlgrammar/run.sh
@@ -57,7 +57,6 @@ function find-directories-if-needed() {
 
 # Build VoltDB: 'community', open-source version
 function build() {
-    BUILD_ARGS=$ARGS
     echo -e "\n$0 performing: build$BUILD_ARGS"
     test-tools-build
     code[0]=$code_tt_build
@@ -65,7 +64,6 @@ function build() {
 
 # Build VoltDB: 'pro' version
 function build-pro() {
-    BUILD_ARGS=$ARGS
     echo -e "\n$0 performing: build-pro$BUILD_ARGS"
     test-tools-build-pro
     code[0]=$code_tt_build
@@ -73,14 +71,12 @@ function build-pro() {
 
 # Build VoltDB, only if not built already
 function build-if-needed() {
-    BUILD_ARGS=$ARGS
     test-tools-build-if-needed
     code[0]=$code_tt_build
 }
 
 # Build VoltDB 'pro' version, only if not built already
 function build-pro-if-needed() {
-    BUILD_ARGS=$ARGS
     test-tools-build-pro-if-needed
     code[0]=$code_tt_build
 }
@@ -122,6 +118,7 @@ function debug() {
     echo "UDF_TEST_DIR   :" $UDF_TEST_DIR
     echo "UDF_TEST_DDL   :" $UDF_TEST_DDL
     echo "BUILD_ARGS     :" $BUILD_ARGS
+    echo "BUILD_UDF_ARGS :" $BUILD_UDF_ARGS
     echo "DEFAULT_ARGS   :" $DEFAULT_ARGS
     echo "ARGS           :" $ARGS
     echo "SEED           :" $SEED
@@ -142,8 +139,12 @@ function jars() {
     code2b=$?
 
     # Compile the classes and build the jar files for the UDF tests
+    BUILD_UDF_ARGS=
+    if [[ "$BUILD_ARGS" == *-Dbuild=debug*  ]]; then
+        BUILD_UDF_ARGS="--build=debug"
+    fi
     cd $UDF_TEST_DIR
-    ./build_udf_jar.sh
+    ./build_udf_jar.sh $BUILD_UDF_ARGS
     code2c=$?
     mv testfuncs*.jar $HOME_DIR
     code2d=$?
@@ -173,7 +174,7 @@ function server-pro() {
     code[3]=${code_tt_server}
 }
 
-# Start the VoltDB server, only if not already running
+# Start the VoltDB 'community' server, only if not already running
 function server-if-needed() {
     test-tools-server-if-needed
     code[3]=${code_tt_server}
@@ -392,6 +393,7 @@ fi
 # Run the options passed on the command line
 run-test-tools
 SUFFIX=
+BUILD_ARGS=
 while [[ -n "$1" ]]; do
     CMD="$1"
     ARGS=
@@ -411,6 +413,9 @@ while [[ -n "$1" ]]; do
             fi
             shift
         done
+        if [[ "$CMD" == build* ]]; then
+            BUILD_ARGS=$ARGS
+        fi
     fi
     $CMD
     shift

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -29,7 +29,7 @@ function test-tools-find-directories() {
         VOLTDB_COM_DIR=$(cd $TT_HOME_DIR/../../..; pwd)
     elif [[ $TT_HOME_DIR == */tests/*/*/* ]] && [[ -e $TT_HOME_DIR/../../../test-tools.sh ]]; then
         # It looks like we're running from a <voltdb>/tests/FOO/BAR/BAZ/ directory,
-        # e.g., from <voltdb>/tests/geb/vmc/server/
+        # e.g., from <voltdb>/tests/geb/vmc/src/
         VOLTDB_COM_DIR=$(cd $TT_HOME_DIR/../../../..; pwd)
     elif [[ -n "$(which voltdb 2> /dev/null)" ]]; then
         # It looks like we're using VoltDB from the PATH
@@ -66,12 +66,13 @@ function test-tools-find-directories-if-needed() {
 }
 
 # Build VoltDB: 'community', open-source version
+# Optionally, you may specify BUILD_ARGS
 function test-tools-build() {
     test-tools-find-directories-if-needed
-    echo -e "\n$0 performing: [test-tools-]build"
+    echo -e "\n$0 performing: [test-tools-]build $BUILD_ARGS"
 
     cd $VOLTDB_COM_DIR
-    ant clean dist
+    ant clean dist $BUILD_ARGS
     code_tt_build=$?
     cd -
 
@@ -81,12 +82,13 @@ function test-tools-build() {
 }
 
 # Build VoltDB: 'pro' version
+# Optionally, you may specify BUILD_ARGS
 function test-tools-build-pro() {
     test-tools-find-directories-if-needed
-    echo -e "\n$0 performing: [test-tools-]build-pro"
+    echo -e "\n$0 performing: [test-tools-]build-pro $BUILD_ARGS"
 
     cd $VOLTDB_PRO_DIR
-    ant -f mmt.xml dist.pro
+    ant -f mmt.xml dist.pro $BUILD_ARGS
     code_tt_build=$?
     cd -
     VOLTDB_PRO_BIN=$(cd $VOLTDB_PRO_DIR/obj/pro/voltdb-ent-*/bin; pwd)
@@ -98,6 +100,7 @@ function test-tools-build-pro() {
 }
 
 # Build VoltDB ('community'), only if not built already
+# Optionally, you may specify BUILD_ARGS
 function test-tools-build-if-needed() {
     test-tools-find-directories-if-needed
     VOLTDB_COM_JAR=$(ls $VOLTDB_COM_DIR/voltdb/voltdb-*.jar)
@@ -107,6 +110,7 @@ function test-tools-build-if-needed() {
 }
 
 # Build VoltDB 'pro' version, only if not built already
+# Optionally, you may specify BUILD_ARGS
 function test-tools-build-pro-if-needed() {
     test-tools-find-directories-if-needed
     VOLTDB_PRO_TAR=$(ls $VOLTDB_PRO_DIR/obj/pro/voltdb-ent-*.tar.gz)


### PR DESCRIPTION
ENG-13693: SQL-grammar-gen: modified the run.sh script (and related test-tools.sh), adding build-pro[-if-needed], server-pro[-if-needed], and all-pro options/functions, and now allow all of the build... options to accept arguments (e.g. -Dbuild=debug and/or -DVOLT_POOL_CHECKING=true, which are needed for ENG-13693. [This is already on the ENG-13611-shared-replicated-tables branch; now merging to master.]