### PR TITLE
ENG-13752: It is possible for an export message to be smaller than 8 …

### DIFF
--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -226,7 +226,9 @@ public abstract class PBDSegment {
                         final long partialEntryBeginOffset = reader.readOffset();
                         m_fc.position(partialEntryBeginOffset);
 
-                        final int written = writeTruncatedEntry(retval, compressedLength);
+                        // It is conceivable that a truncated buffer uses up more compressed space than the original
+                        // compressed buffer, but we won't worry about that until it happens.
+                        final int written = writeTruncatedEntry(retval, compressedLength + OBJECT_HEADER_BYTES);
                         sizeInBytes += written;
 
                         initNumEntries(reader.readIndex(), sizeInBytes);


### PR DESCRIPTION
…bytes, in which case when it is truncated, the required buffer will be larger than original data because of the 8 byte header that is prepended to each buffer. This fix addresses this rare condition by ensuring that the allocated buffer accounts for the extra 8 bytes needed at the beginning of the buffer.