### PR TITLE
ENG-13468 ZooKeeper client xid overflow handling

### DIFF
--- a/third_party/java/src/org/apache/zookeeper_voltpatches/ClientCnxn.java
+++ b/third_party/java/src/org/apache/zookeeper_voltpatches/ClientCnxn.java
@@ -1349,8 +1349,16 @@ public class ClientCnxn {
     synchronized private int getXid() {
         int currentXid = xid;
         xid++;
-        //wrap xid around if int overflow.
-        if (xid < 0) xid = 1;
+
+        //xids are assumed to be non-negative, except as special xids, -2 for ping, and -4 for auth.
+        //If the xid overflows, the system could hang when a non-auth packet uses -4 for xid.
+        //xids are only used to match requests and responses. So resetting it to 1 as it overflows
+        //should be safe. The odds of an existing in-flight operation that happened 2147483647 operations ago still
+        //lingering around or causing any confusion seems beyond unlikely.
+        if (xid < 0) {
+            xid = 1;
+        }
+
         return currentXid;
     }
 

--- a/third_party/java/src/org/apache/zookeeper_voltpatches/ClientCnxn.java
+++ b/third_party/java/src/org/apache/zookeeper_voltpatches/ClientCnxn.java
@@ -1347,7 +1347,11 @@ public class ClientCnxn {
     private int xid = 1;
 
     synchronized private int getXid() {
-        return xid++;
+        int currentXid = xid;
+        xid++;
+        //wrap xid around if int overflow.
+        if (xid < 0) xid = 1;
+        return currentXid;
     }
 
     public ReplyHeader submitRequest(RequestHeader h, Record request,


### PR DESCRIPTION
Client uses signed 32-int as xids which are assumed to be non-negative. Zookeeper uses some negative values as special XIDs (e.g. -2 for ping, -4 for auth). However, ZK client does not ensure the xids it generates are non-negative, and the server doesn't reject negative xids. If signed 32-int overflows, xids become negative, which will break the system.

The solution is to reset xid to 1 when it overflows.
