### PR TITLE
ENG-13611:

### DIFF
--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1543,6 +1543,7 @@ bool PersistentTable::equals(PersistentTable* other) {
 std::string PersistentTable::debug(const std::string& spacer) const {
     std::ostringstream buffer;
     buffer << Table::debug(spacer);
+#ifdef VOLT_TRACE_ENABLED
     std::string infoSpacer = spacer + "  |";
     buffer << infoSpacer << "\tINDEXES: " << m_indexes.size() << "\n";
 
@@ -1560,6 +1561,7 @@ std::string PersistentTable::debug(const std::string& spacer) const {
             buffer << "\n";
         }
     }
+#endif
 
     return buffer.str();
 }

--- a/src/ee/storage/table.cpp
+++ b/src/ee/storage/table.cpp
@@ -206,6 +206,7 @@ std::string Table::debug(const std::string &spacer) const {
     buffer << infoSpacer << m_schema->debug();
     //buffer << infoSpacer << " - TupleSchema needs a \"debug\" method. Add one for output here.\n";
 
+#ifdef VOLT_TRACE_ENABLED
     //
     // Tuples
     //
@@ -227,6 +228,7 @@ std::string Table::debug(const std::string &spacer) const {
         }
         buffer << infoSpacer << "===========================================================\n";
     }
+#endif
     std::string ret(buffer.str());
     VOLT_DEBUG("tabledebug end");
 


### PR DESCRIPTION
There is a great deal of extraneous output generated by the EE from table data particularly for large tables with many indexes. The Table Data and Table Index data will now only generated in the log message when the TRACE log level is enabled.