### PR TITLE
ENG-13611:

### DIFF
--- a/src/ee/common/debuglog.cpp
+++ b/src/ee/common/debuglog.cpp
@@ -15,6 +15,7 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "debuglog.h"
+#include "common/ThreadLocalPool.h"
 #include <execinfo.h>
 #include <cstring>
 #include <cxxabi.h>   // for abi
@@ -22,6 +23,39 @@
 #include <sstream> // for std::ostringstream
 
 namespace voltdb {
+
+// Output log message header in this format: [type] [threadPartition:enginePartition] [file:line:function] time -
+// ex: [ERROR] [1:1] [somefile.cpp:123:doSome()] 2008/07/06 10:00:00 -
+void outputLogHeader(const char *file, int line, const char *func, int level) {
+    time_t t = ::time(NULL) ;
+    tm *curTime = localtime(&t);
+    char time_str[32]; // FIXME
+    ::strftime(time_str, 32, VOLT_LOG_TIME_FORMAT, curTime);
+    const int32_t tPartId = ThreadLocalPool::getThreadPartitionId();
+    const int32_t ePartId = ThreadLocalPool::getEnginePartitionId();
+    const char* type;
+    switch (level) {
+        case VOLT_LEVEL_ERROR:
+            type = "ERROR";
+            break;
+        case VOLT_LEVEL_WARN:
+            type = "WARN ";
+            break;
+        case VOLT_LEVEL_INFO:
+            type = "INFO ";
+            break;
+        case VOLT_LEVEL_DEBUG:
+            type = "DEBUG";
+            break;
+        case VOLT_LEVEL_TRACE:
+            type = "TRACE";
+            break;
+        default:
+            type = "UNKWN";
+    }
+    printf("[%s] [%d:%d] [%s:%d:%s()] %s - ", type, tPartId, ePartId, file, line, func, time_str);
+}
+
 StackTrace::StackTrace() {
     /**
      * Stack trace code from http://tombarta.wordpress.com/2008/08/01/c-stack-traces-with-gcc/

--- a/src/ee/common/debuglog.h
+++ b/src/ee/common/debuglog.h
@@ -166,36 +166,6 @@ void outputLogHeader(const char *file, int line, const char *func, int level);
     #define VOLT_TRACE_STACK() ((void)0)
 #endif
 
-// Output log message header in this format: [type] [file:line:function] time -
-// ex: [ERROR] [somefile.cpp:123:doSome()] 2008/07/06 10:00:00 -
-inline void outputLogHeader(const char *file, int line, const char *func, int level) {
-    time_t t = ::time(NULL) ;
-    tm *curTime = localtime(&t);
-    char time_str[32]; // FIXME
-    ::strftime(time_str, 32, VOLT_LOG_TIME_FORMAT, curTime);
-    const char* type;
-    switch (level) {
-        case VOLT_LEVEL_ERROR:
-            type = "ERROR";
-            break;
-        case VOLT_LEVEL_WARN:
-            type = "WARN ";
-            break;
-        case VOLT_LEVEL_INFO:
-            type = "INFO ";
-            break;
-        case VOLT_LEVEL_DEBUG:
-            type = "DEBUG";
-            break;
-        case VOLT_LEVEL_TRACE:
-            type = "TRACE";
-            break;
-        default:
-            type = "UNKWN";
-    }
-    printf("[%s] [%s:%d:%s()] %s - ", type, file, line, func, time_str);
-}
-
 class StackTrace {
 public:
     StackTrace();


### PR DESCRIPTION
For debug logging from the EE it is now valuable to know what thread and engine the log message is coming from. This now added to all trace messages after the log type.