### PR TITLE
Make MP Repair Sequence More deterministic

### DIFF
--- a/src/frontend/org/voltdb/dtxn/TransactionState.java
+++ b/src/frontend/org/voltdb/dtxn/TransactionState.java
@@ -27,6 +27,7 @@ import org.voltdb.ClientResponseImpl;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.VoltTable;
+import org.voltdb.iv2.ProcedureTask;
 import org.voltdb.iv2.Site;
 import org.voltdb.messaging.FragmentTaskMessage;
 
@@ -52,6 +53,9 @@ public abstract class TransactionState extends OrderableTransaction  {
     // IZZY: make me protected/private
     public final long m_spHandle;
     private ArrayList<UndoAction> m_undoLog;
+
+    // reference back to owner of this transactionState
+    private ProcedureTask m_procedureTask;
 
     /**
      * Set up the final member variables from the parameters. This will
@@ -150,6 +154,10 @@ public abstract class TransactionState extends OrderableTransaction  {
     {
         return m_needsRollback;
     }
+
+    public void setProcedureTask(ProcedureTask mpProcedureTask) { m_procedureTask = mpProcedureTask;}
+
+    public ProcedureTask getProcedureTask() { return m_procedureTask; }
 
     public abstract StoredProcedureInvocation getInvocation();
 

--- a/src/frontend/org/voltdb/exceptions/SerializableException.java
+++ b/src/frontend/org/voltdb/exceptions/SerializableException.java
@@ -86,6 +86,12 @@ public class SerializableException extends VoltProcedure.VoltAbortException impl
                 return new TransactionRestartException(b);
             }
         },
+        TransactionMisroutedException() {
+            @Override
+            protected SerializableException deserializeException(ByteBuffer b) {
+                return new TransactionMisroutedException(b);
+            }
+        },
         TransactionTerminationException() {
             @Override
             protected SerializableException deserializeException(ByteBuffer b) {

--- a/src/frontend/org/voltdb/exceptions/TransactionMisroutedException.java
+++ b/src/frontend/org/voltdb/exceptions/TransactionMisroutedException.java
@@ -19,8 +19,13 @@ package org.voltdb.exceptions;
 
 import com.google_voltpatches.common.collect.Maps;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -31,25 +36,17 @@ import java.util.Map;
  * procedure can determine whether or not it is being restarted or whether it
  * completed successfully.
  */
-public class TransactionRestartException extends SerializableException {
+public class TransactionMisroutedException extends SerializableException {
     public static final long serialVersionUID = 0L;
     private long m_txnId;
-    // This exception is local to the host has MPI, don't need to serializable
-    private final List<Long> m_masters;
-    private final Map<Integer, Long> m_partitionMasters;
-
-    public TransactionRestartException(String message, long txnId, List<Long> masters, Map<Integer, Long> partitionMasters) {
+    public TransactionMisroutedException(String message, long txnId) {
         super(message);
         m_txnId = txnId;
-        m_masters = new ArrayList<>(masters);
-        m_partitionMasters = Maps.newHashMap(partitionMasters);
     }
 
-    public TransactionRestartException(ByteBuffer b) {
+    public TransactionMisroutedException(ByteBuffer b) {
         super(b);
         m_txnId = b.getLong();
-        m_masters = new ArrayList<>();
-        m_partitionMasters = Maps.newHashMap();
     }
 
     public long getTxnId()
@@ -57,19 +54,9 @@ public class TransactionRestartException extends SerializableException {
         return m_txnId;
     }
 
-    public List<Long> getMasters()
-    {
-        return m_masters;
-    }
-
-    public Map<Integer, Long> getPartitionMasters()
-    {
-        return m_partitionMasters;
-    }
-
     @Override
     protected SerializableExceptions getExceptionType() {
-        return SerializableExceptions.TransactionRestartException;
+        return SerializableExceptions.TransactionMisroutedException;
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
@@ -33,7 +33,7 @@ import org.voltcore.utils.CoreUtils;
 import org.voltdb.RealVoltDB;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
-import org.voltdb.exceptions.TransactionRestartException;
+import org.voltdb.exceptions.TransactionMisroutedException;
 import org.voltdb.messaging.MigratePartitionLeaderMessage;
 import org.voltdb.messaging.CompleteTransactionMessage;
 import org.voltdb.messaging.DummyTransactionTaskMessage;
@@ -452,9 +452,8 @@ public class InitiatorMailbox implements Mailbox
         // If a fragment is part of a transaction which have not been seen on this site, restart it.
         if (!seenTheTxn) {
             FragmentResponseMessage response = new FragmentResponseMessage(message, getHSId());
-            TransactionRestartException restart = new TransactionRestartException(
+            TransactionMisroutedException restart = new TransactionMisroutedException(
                     "Transaction being restarted due to MigratePartitionLeader.", message.getTxnId());
-            restart.setMisrouted(true);
             response.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, restart);
             response.m_sourceHSId = getHSId();
             response.setPartitionId(m_partitionId);

--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -75,6 +75,7 @@ public class MpProcedureTask extends ProcedureTask
         m_initiatorHSIds.addAll(pInitiators);
         m_restartMasters.set(new ArrayList<Long>());
         m_restartMastersMap.set(new HashMap<Integer, Long>());
+        m_txnState.setProcedureTask(this);
     }
 
     /**
@@ -209,31 +210,7 @@ public class MpProcedureTask extends ProcedureTask
                     hostLog.debug("[MpProcedureTask] COMPLETE: " + this);
                 }
             } else {
-                String respStr = response.getClientResponseData().getStatusString();
-                int ind = respStr.indexOf("RestartMasters Info:");
-                boolean isFound = ind != -1;
-                restartTransaction(!isFound);
-                if (isFound) {
-                    try {
-                        JSONObject jsObj = new JSONObject(respStr.substring(ind + "RestartMasters Info:".length()));
-                        List<Long> restartMasters = new ArrayList<>();
-                        JSONArray restartMastersIds = jsObj.getJSONArray("masters");
-                        for (int ii = 0; ii < restartMastersIds.length(); ii++) {
-                            restartMasters.add(restartMastersIds.getLong(ii));
-                        }
-                        Map<Integer, Long> restartMastersMap = new HashMap<>();
-                        JSONObject restartMasterEntries = jsObj.getJSONObject("partitionMasters");
-                        Iterator<String> it = restartMasterEntries.keys();
-                        while (it.hasNext()) {
-                            String key = it.next();
-                            Long val = Long.valueOf(restartMasterEntries.getString(key));
-                            restartMastersMap.put(Integer.valueOf(key), val);
-                        }
-                        updateMasters(restartMasters, restartMastersMap);
-                    } catch (JSONException e) {
-                        e.printStackTrace();
-                    }
-                }
+                restartTransaction(false);
                 if (hostLog.isDebugEnabled()) {
                     hostLog.debug("[MpProcedureTask] RESTART: " + this);
                 }

--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -275,7 +275,9 @@ public class MpPromoteAlgo implements RepairAlgo
                 tmLog.debug(m_whoami + "repairing: " + CoreUtils.hsIdCollectionToString(m_survivors) + " with: " + TxnEgo.txnIdToString(li.getTxnId()) +
                         " " + repairMsg);
             }
-            m_mailbox.repairReplicasWith(m_survivors, repairMsg);
+            if (repairMsg != null) {
+                m_mailbox.repairReplicasWith(m_survivors, repairMsg);
+            }
         }
 
         m_promotionResult.set(new RepairResult(m_maxSeenTxnId));
@@ -337,6 +339,10 @@ public class MpPromoteAlgo implements RepairAlgo
                 assert(ftm.getInitiateTask() != null);
                 m_interruptedTxns.add(ftm.getInitiateTask());
             }
+
+            // since the restartingTxn could be coordinated by the poison to MPTransactionState
+            // don't rollback here
+            /*
             CompleteTransactionMessage rollback =
                 new CompleteTransactionMessage(
                         ftm.getInitiatorHSId(),
@@ -349,6 +355,8 @@ public class MpPromoteAlgo implements RepairAlgo
                         restart,   // Indicate rollback for repair as appropriate
                         ftm.isForReplay());
             return rollback;
+            */
+            return null;
         }
     }
 }

--- a/src/frontend/org/voltdb/iv2/MpRepairTask.java
+++ b/src/frontend/org/voltdb/iv2/MpRepairTask.java
@@ -49,7 +49,6 @@ public class MpRepairTask extends SiteTasker
     static VoltLogger tmLog = new VoltLogger("TM");
 
     private InitiatorMailbox m_mailbox;
-    private List<Long> m_spMasters;
     private Object m_lock = new Object();
     private boolean m_repairRan = false;
     private final String whoami;
@@ -58,10 +57,9 @@ public class MpRepairTask extends SiteTasker
     public MpRepairTask(InitiatorMailbox mailbox, List<Long> spMasters, boolean balanceSPI)
     {
         m_mailbox = mailbox;
-        m_spMasters = new ArrayList<Long>(spMasters);
         whoami = "MP leader repair " +
                 CoreUtils.hsIdToString(m_mailbox.getHSId()) + " ";
-        algo = mailbox.constructRepairAlgo(Suppliers.ofInstance(m_spMasters), whoami, balanceSPI);
+        algo = mailbox.constructRepairAlgo(Suppliers.ofInstance(spMasters), whoami, balanceSPI);
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
@@ -140,8 +140,9 @@ public class MpTransactionTaskQueue extends TransactionTaskQueue
                     // into a ClientResponse.RESTART, so that the MpProcedureTask can
                     // detect the restart and take the appropriate actions.
                     TransactionRestartException restart = new TransactionRestartException(
-                            "Transaction being restarted due to fault recovery or shutdown.", next.getTxnId());
-                    restart.setMisrouted(false);
+                            "Transaction being restarted due to fault recovery or shutdown.",
+                            next.getTxnId(),
+                            masters, partitionMasters);
                     poison.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, restart);
                     txn.offerReceivedFragmentResponse(poison);
                     if (tmLog.isDebugEnabled()) {

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -49,6 +49,7 @@ import org.voltdb.VoltTable;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.dtxn.TransactionState;
 import org.voltdb.exceptions.SerializableException;
+import org.voltdb.exceptions.TransactionMisroutedException;
 import org.voltdb.exceptions.TransactionRestartException;
 import org.voltdb.iv2.SiteTasker.SiteTaskerRunnable;
 import org.voltdb.messaging.BorrowTaskMessage;
@@ -1118,10 +1119,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 
     private boolean isFragmentMisrouted(FragmentResponseMessage message) {
         SerializableException ex = message.getException();
-        if (ex != null && ex instanceof TransactionRestartException) {
-            return (((TransactionRestartException)ex).isMisrouted());
-        }
-        return false;
+        return ex instanceof TransactionMisroutedException;
     }
 
     // Eventually, the master for a partition set will need to be able to dedupe


### PR DESCRIPTION
This Commit try to solve following two issues:
1. the duplicate rollback messages: 
    During the execution of RepairTask, if none of sites receives CompletionTransactionMessage, rollback was sent. 
    During the restart the txn, another Rollback also been send.
    To remove dubious  race of the rollback with in-flight commit messages, the RepairTask rollback message has been removed.

2.  indeterministic master list the restart txn has seen:
    Previously restart txn would refresh the master list from Leader Cache at the time it been requeued (after it consume the Posion fragment messages).
   Meanwhile there could be other Leader Changes happened so it's possible this txn would see a more "recent" master list then the repairTask ahead of it. This add a chance it would conflict the txn state with previous repair. 
   Current solution is persistent a master list into the Posion's TransactionRestartExecption so it will always see a same version with repairTask.
   When ProcedureRunner transfer the TransactionRestartExecption into ClientResponse.TXN_RESTART, currently has to stash the master list info to message string. 
  