### PR TITLE
ENG-13778-srt-swap-drop

### DIFF
--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -3526,9 +3526,6 @@ inline void NValue::hashCombine(std::size_t &seed) const {
 }
 
 inline NValue NValue::castAs(ValueType type) const {
-    VOLT_TRACE("Converting from %s to %s",
-            voltdb::getTypeName(getValueType()).c_str(),
-            voltdb::getTypeName(type).c_str());
     if (getValueType() == type) {
         return *this;
     }

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -907,8 +907,6 @@ VoltDBEngine::processCatalogDeletes(int64_t timestamp, bool updateReplicated,
     // delete tables in the set
     bool isReplicatedTable;
     BOOST_FOREACH (auto path, deletions) {
-        VOLT_TRACE("delete path:");
-
         // If the delete path is under the catalog functions item, drop the user-defined function.
         if (startsWith(path, catalogFunctions.path())) {
             catalog::Function* catalogFunction =
@@ -1628,14 +1626,17 @@ VoltDBEngine::loadTable(int32_t tableId,
 }
 
 /*
- * Delete and rebuild id based table collections. Does not affect
- * any currently stored tuples.
+ * Delete and rebuild the relativeIndex based table collections.
+ * It does not affect any currently stored tuples.
  */
 void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScratch) {
+    VOLT_DEBUG("UpdateReplicated = %s,%s from scratch",
+               updateReplicated ? "true" : "false",
+               fromScratch ? "" : " not");
     // 1. See header comments explaining m_snapshottingTables.
     // 2. Don't clear m_exportTables. They are still exporting, even if deleted.
     // 3. Clear everything else.
-    if (!updateReplicated && fromScratch) {
+    if (! updateReplicated && fromScratch) {
         m_tables.clear();
         m_tablesByName.clear();
         m_tablesBySignatureHash.clear();
@@ -1645,18 +1646,17 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
         getStatsManager().unregisterStatsSource(STATISTICS_SELECTOR_TYPE_INDEX);
     }
 
-    // walk the table delegates and update local table collections
+    // Walk through table delegates and update local table collections
     BOOST_FOREACH (LabeledTCD cd, m_catalogDelegates) {
         auto tcd = cd.second;
         assert(tcd);
-        if (!tcd) {
+        if (! tcd) {
             continue;
         }
         Table* localTable = tcd->getTable();
         assert(localTable);
-        if (!localTable) {
-            VOLT_ERROR("DEBUG-NULL");//:%s", cd.first.c_str());
-            std::cout << "DEBUG-NULL:" << cd.first << std::endl;
+        if (! localTable) {
+            VOLT_ERROR("DEBUG-NULL: %s", cd.first.c_str());
             continue;
         }
         assert(m_database);
@@ -1665,7 +1665,7 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
         const std::string& tableName = tcd->getTable()->name();
         if (catTable->isreplicated()) {
             if (updateReplicated) {
-                // Update catalog table map for other sites
+                // This engine is responsible for updating the catalog table maps for all sites.
                 ExecuteWithAllSitesMemory execAllSites;
                 for (auto engineIt = execAllSites.begin(); engineIt != execAllSites.end(); ++engineIt) {
                     EngineLocals& curr = engineIt->second;
@@ -1676,17 +1676,16 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
                 }
             }
         }
-        else {
-            if (!updateReplicated) {
-                m_tables[relativeIndexOfTable] = localTable;
-                m_tablesByName[tableName] = localTable;
-            }
+        else if (! updateReplicated) {
+            m_tables[relativeIndexOfTable] = localTable;
+            m_tablesByName[tableName] = localTable;
         }
+
         TableStats* stats = NULL;
         PersistentTable* persistentTable = tcd->getPersistentTable();
         if (persistentTable) {
             stats = persistentTable->getTableStats();
-            if (!tcd->materialized()) {
+            if (! tcd->materialized()) {
                 int64_t hash = *reinterpret_cast<const int64_t*>(tcd->signatureHash());
                 if (catTable->isreplicated()) {
                     if (updateReplicated) {
@@ -1699,7 +1698,7 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
                         }
                     }
                 }
-                else {
+                else if (! updateReplicated) {
                     m_tablesBySignatureHash[hash] = persistentTable;
                 }
             }
@@ -1713,8 +1712,8 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
                         EngineLocals& curr = engineIt->second;
                         VoltDBEngine* currEngine = curr.context->getContextEngine();
                         SynchronizedThreadLock::assumeSpecificSiteContext(curr);
-                        if (!fromScratch) {
-                            // This is a swap or truncate and we need to clear the old index stats sources for this this table
+                        if (! fromScratch) {
+                            // This is a swap or truncate and we need to clear the old index stats sources for this table
                             currEngine->getStatsManager().unregisterStatsSource(STATISTICS_SELECTOR_TYPE_TABLE,
                                                                                 relativeIndexOfTable);
                             currEngine->getStatsManager().unregisterStatsSource(STATISTICS_SELECTOR_TYPE_INDEX,
@@ -1725,17 +1724,15 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
                                                                               relativeIndexOfTable,
                                                                               index->getIndexStats());
                         }
-                        VOLT_DEBUG("VoltDBEngine %d register stats source %p for table %s at index %d",
-                                ThreadLocalPool::getEnginePartitionId(), stats, localTable->name().c_str(), relativeIndexOfTable);
                         currEngine->getStatsManager().registerStatsSource(STATISTICS_SELECTOR_TYPE_TABLE,
                                                                           relativeIndexOfTable,
                                                                           stats);
                     }
                 }
             }
-            else if (!updateReplicated) {
-                if (!fromScratch) {
-                    // This is a swap or truncate and we need to clear the old index stats sources for this this table
+            else if (! updateReplicated) {
+                if (! fromScratch) {
+                    // This is a swap or truncate and we need to clear the old index stats sources for this table
                     getStatsManager().unregisterStatsSource(STATISTICS_SELECTOR_TYPE_TABLE, relativeIndexOfTable);
                     getStatsManager().unregisterStatsSource(STATISTICS_SELECTOR_TYPE_INDEX, relativeIndexOfTable);
                 }
@@ -1744,22 +1741,20 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
                                                           relativeIndexOfTable,
                                                           index->getIndexStats());
                 }
-                VOLT_DEBUG("VoltDBEngine %d register stats source %p for table %s at index %d",
-                        ThreadLocalPool::getEnginePartitionId(), stats, localTable->name().c_str(), relativeIndexOfTable);
                 getStatsManager().registerStatsSource(STATISTICS_SELECTOR_TYPE_TABLE,
                                                       relativeIndexOfTable,
                                                       stats);
             }
         }
         else {
-            VOLT_DEBUG("VoltDBEngine %d register stats source %p for table %s at index %d, updateReplicated %s, fromScratch %s",
-                                ThreadLocalPool::getEnginePartitionId(), stats, localTable->name().c_str(), relativeIndexOfTable,
-                                (updateReplicated ? "true" : "false"), (fromScratch ? "true" : "false"));
-            if (updateReplicated) continue;
-            // stream table could not be truncated or swapped, but pre-built DR conflict table should has already been registered the stats already.
+            // Streamed tables are all partitioned.
+            if (updateReplicated) {
+                continue;
+            }
+            // Streamed table could not be truncated or swapped, but pre-built DR conflict table
+            // should have already been registered in the stats already.
             if (fromScratch) {
                 stats = tcd->getStreamedTable()->getTableStats();
-
                 getStatsManager().registerStatsSource(STATISTICS_SELECTOR_TYPE_TABLE,
                                                       relativeIndexOfTable,
                                                       stats);

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1691,7 +1691,7 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
                 if (catTable->isreplicated()) {
                     if (updateReplicated) {
                         ExecuteWithAllSitesMemory execAllSites;
-                        for (auto engineIt = execAllSites.begin(); engineIt != execAllSites.end(); ++ engineIt) {
+                        for (auto engineIt = execAllSites.begin(); engineIt != execAllSites.end(); ++engineIt) {
                             EngineLocals& curr = engineIt->second;
                             VoltDBEngine* currEngine = curr.context->getContextEngine();
                             SynchronizedThreadLock::assumeSpecificSiteContext(curr);

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1751,8 +1751,10 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
             if (updateReplicated) {
                 continue;
             }
-            // Streamed table could not be truncated or swapped, but pre-built DR conflict table
-            // should have already been registered in the stats already.
+            // Streamed tables could not be truncated or swapped, so we will never change this
+            // table stats map in a not-from-scratch mode.
+            // Before this rebuildTableCollections() is called, pre-built DR conflict tables
+            // (which are also streamed tables) should have already been instantiated.
             if (fromScratch) {
                 stats = tcd->getStreamedTable()->getTableStats();
                 getStatsManager().registerStatsSource(STATISTICS_SELECTOR_TYPE_TABLE,

--- a/src/ee/indexes/IndexStats.cpp
+++ b/src/ee/indexes/IndexStats.cpp
@@ -129,16 +129,10 @@ IndexStats::IndexStats(TableIndex* index)
  * Configure a StatsSource superclass for a set of statistics. Since this class is only used in
  * the EE it can be assumed that it is part of an Execution Site and that there is a site Id.
  * @parameter name Name of this set of statistics
- * @parameter hostId id of the host this partition is on
- * @parameter hostname name of the host this partition is on
- * @parameter siteId this stat source is associated with
- * @parameter partitionId this stat source is associated with
- * @parameter databaseId Database this source is associated with
+ * @parameter tableName Name of the indexed table
  */
-void IndexStats::configure(
-        string name,
-        string tableName) {
-    VOLT_TRACE("Configuring stats for index %s in Table %s", name.c_str(), tableName.c_str());
+void IndexStats::configure(string name, string tableName) {
+    VOLT_TRACE("Configuring stats for index %s in table %s.", name.c_str(), tableName.c_str());
     StatsSource::configure(name);
     m_indexName = ValueFactory::getStringValue(m_index->getName());
     m_tableName = ValueFactory::getStringValue(tableName);

--- a/src/ee/indexes/IndexStats.cpp
+++ b/src/ee/indexes/IndexStats.cpp
@@ -146,6 +146,10 @@ void IndexStats::rename(std::string name) {
     m_indexName = ValueFactory::getStringValue(name);
 }
 
+void IndexStats::updateTableName(std::string tableName) {
+    m_tableName = ValueFactory::getStringValue(tableName);
+}
+
 /**
  * Generates the list of column names that will be in the statTable_. Derived classes must override
  * this method and call the parent class's version to obtain the list of columns contributed by

--- a/src/ee/indexes/IndexStats.cpp
+++ b/src/ee/indexes/IndexStats.cpp
@@ -146,10 +146,6 @@ void IndexStats::rename(std::string name) {
     m_indexName = ValueFactory::getStringValue(name);
 }
 
-void IndexStats::updateTableName(std::string tableName) {
-    m_tableName = ValueFactory::getStringValue(tableName);
-}
-
 /**
  * Generates the list of column names that will be in the statTable_. Derived classes must override
  * this method and call the parent class's version to obtain the list of columns contributed by

--- a/src/ee/indexes/IndexStats.h
+++ b/src/ee/indexes/IndexStats.h
@@ -92,7 +92,6 @@ private:
     voltdb::TableIndex *m_index;
 
     voltdb::NValue m_indexName;
-    voltdb::NValue m_tableName;
     voltdb::NValue m_indexType;
 
     int8_t m_isUnique;

--- a/src/ee/indexes/IndexStats.h
+++ b/src/ee/indexes/IndexStats.h
@@ -64,8 +64,6 @@ public:
 
     void rename(std::string name);
 
-    void updateTableName(std::string tableName);
-
 protected:
 
     /**

--- a/src/ee/indexes/IndexStats.h
+++ b/src/ee/indexes/IndexStats.h
@@ -64,6 +64,8 @@ public:
 
     void rename(std::string name);
 
+    void updateTableName(std::string tableName);
+
 protected:
 
     /**

--- a/src/ee/stats/StatsAgent.cpp
+++ b/src/ee/stats/StatsAgent.cpp
@@ -65,7 +65,7 @@ void StatsAgent::registerStatsSource(StatisticsSelectorType sst,
     VOLT_DEBUG("Partition %d registered %s stats source (%p) for table %s at index %d.",
                ThreadLocalPool::getEnginePartitionId(),
                sst == StatisticsSelectorType::STATISTICS_SELECTOR_TYPE_TABLE ? "a table" : "an index",
-               statsSource, statsSource->getTableName(), catalogId);
+               statsSource, statsSource->getTableName().c_str(), catalogId);
 }
 
 void StatsAgent::unregisterStatsSource(StatisticsSelectorType sst, int32_t relativeIndexOfTable) {

--- a/src/ee/stats/StatsAgent.cpp
+++ b/src/ee/stats/StatsAgent.cpp
@@ -61,7 +61,7 @@ void StatsAgent::registerStatsSource(StatisticsSelectorType sst,
                                      CatalogId catalogId,
                                      StatsSource* statsSource) {
     assert(statsSource != NULL);
-    m_statsCategoryByStatsSelector[sst].insert(pair<CatalogId, StatsSource*>(catalogId, statsSource));
+    m_statsCategoryByStatsSelector[sst].insert(make_pair(catalogId, statsSource));
     VOLT_DEBUG("Partition %d registered %s stats source (%p) for table %s at index %d.",
                ThreadLocalPool::getEnginePartitionId(),
                sst == StatisticsSelectorType::STATISTICS_SELECTOR_TYPE_TABLE ? "a table" : "an index",

--- a/src/ee/stats/StatsAgent.cpp
+++ b/src/ee/stats/StatsAgent.cpp
@@ -61,8 +61,11 @@ void StatsAgent::registerStatsSource(StatisticsSelectorType sst,
                                      CatalogId catalogId,
                                      StatsSource* statsSource) {
     assert(statsSource != NULL);
-    m_statsCategoryByStatsSelector[sst].insert(
-        pair<CatalogId, StatsSource*>(catalogId, statsSource));
+    m_statsCategoryByStatsSelector[sst].insert(pair<CatalogId, StatsSource*>(catalogId, statsSource));
+    VOLT_DEBUG("Partition %d registered %s stats source (%p) for table %s at index %d.",
+               ThreadLocalPool::getEnginePartitionId(),
+               sst == StatisticsSelectorType::STATISTICS_SELECTOR_TYPE_TABLE ? "a table" : "an index",
+               statsSource, statsSource->getTableName(), catalogId);
 }
 
 void StatsAgent::unregisterStatsSource(StatisticsSelectorType sst, int32_t relativeIndexOfTable) {
@@ -76,9 +79,16 @@ void StatsAgent::unregisterStatsSource(StatisticsSelectorType sst, int32_t relat
     }
     if (relativeIndexOfTable == -1) {
         it1->second.clear();
+        VOLT_DEBUG("Partition %d unregistered all %s stats sources.",
+                   ThreadLocalPool::getEnginePartitionId(),
+                   sst == StatisticsSelectorType::STATISTICS_SELECTOR_TYPE_TABLE ? "table" : "index");
     }
     else {
         it1->second.erase(relativeIndexOfTable);
+        VOLT_DEBUG("Partition %d unregistered %s stats source for table at index %d.",
+                   ThreadLocalPool::getEnginePartitionId(),
+                   sst == StatisticsSelectorType::STATISTICS_SELECTOR_TYPE_TABLE ? "a table" : "an index",
+                   relativeIndexOfTable);
     }
 }
 

--- a/src/ee/stats/StatsSource.cpp
+++ b/src/ee/stats/StatsSource.cpp
@@ -83,7 +83,7 @@ void StatsSource::configure(string name) {
     m_statsTuple = m_statsTable->tempTuple();
 }
 
-void StatsSource::updateTableName(std::string tableName) {
+void StatsSource::updateTableName(const std::string& tableName) {
     m_tableName = ValueFactory::getStringValue(tableName);
 }
 

--- a/src/ee/stats/StatsSource.cpp
+++ b/src/ee/stats/StatsSource.cpp
@@ -91,8 +91,8 @@ StatsSource::~StatsSource() {
     m_hostname.free();
 }
 
-const char* StatsSource::getTableName() {
-    return ValuePeeker::peekObjectValue(m_tableName);
+const string StatsSource::getTableName() {
+    return m_tableName.toString();
 }
 
 /**

--- a/src/ee/stats/StatsSource.cpp
+++ b/src/ee/stats/StatsSource.cpp
@@ -87,12 +87,8 @@ StatsSource::~StatsSource() {
     m_hostname.free();
 }
 
-/**
- * Retrieve the name of this set of statistics
- * @return Name of statistics
- */
-string StatsSource::getName() {
-    return m_name;
+const char* StatsSource::getTableName() {
+    return ValuePeeker::peekObjectValue(m_tableName);
 }
 
 /**

--- a/src/ee/stats/StatsSource.cpp
+++ b/src/ee/stats/StatsSource.cpp
@@ -83,6 +83,10 @@ void StatsSource::configure(string name) {
     m_statsTuple = m_statsTable->tempTuple();
 }
 
+void StatsSource::updateTableName(std::string tableName) {
+    m_tableName = ValueFactory::getStringValue(tableName);
+}
+
 StatsSource::~StatsSource() {
     m_hostname.free();
 }

--- a/src/ee/stats/StatsSource.h
+++ b/src/ee/stats/StatsSource.h
@@ -102,7 +102,7 @@ public:
      * Retrieve the name of the table that this set of statistics is associated with.
      * @return Table name.
      */
-    const char* getTableName();
+    const string getTableName();
 
     /**
      * String representation of the statistics. Default implementation is to print the stats table.

--- a/src/ee/stats/StatsSource.h
+++ b/src/ee/stats/StatsSource.h
@@ -71,7 +71,7 @@ public:
      */
     void configure(std::string name);
 
-    void updateTableName(std::string tableName);
+    void updateTableName(const std::string& tableName);
 
     /*
      * Destructor that frees tupleSchema_, and statsTable_

--- a/src/ee/stats/StatsSource.h
+++ b/src/ee/stats/StatsSource.h
@@ -97,10 +97,10 @@ public:
     voltdb::TableTuple* getStatsTuple(int64_t siteId, int32_t partitionId, bool interval, int64_t now);
 
     /**
-     * Retrieve the name of this set of statistics
-     * @return Name of statistics
+     * Retrieve the name of the table that this set of statistics is associated with.
+     * @return Table name.
      */
-    std::string getName();
+    const char* getTableName();
 
     /**
      * String representation of the statistics. Default implementation is to print the stats table.
@@ -135,6 +135,8 @@ protected:
      */
     std::map<std::string, int> m_columnName2Index;
 
+    NValue m_tableName;
+
     bool interval() { return m_interval; }
 
 private:
@@ -148,11 +150,6 @@ private:
      * Tuple used to modify the stat table.
      */
     voltdb::TableTuple m_statsTuple;
-
-    /**
-     * Name of this set of statistics.
-     */
-    std::string m_name;
 
     voltdb::CatalogId m_hostId;
 

--- a/src/ee/stats/StatsSource.h
+++ b/src/ee/stats/StatsSource.h
@@ -71,6 +71,8 @@ public:
      */
     void configure(std::string name);
 
+    void updateTableName(std::string tableName);
+
     /*
      * Destructor that frees tupleSchema_, and statsTable_
      */

--- a/src/ee/storage/TableStats.h
+++ b/src/ee/storage/TableStats.h
@@ -28,7 +28,7 @@ class TempTable;
 /**
  * StatsSource extension for tables.
  */
-class TableStats : public voltdb::StatsSource {
+class TableStats : public StatsSource {
 public:
     /**
      * Static method to generate the column names for the tables which
@@ -90,8 +90,6 @@ private:
      * Table whose stats are being collected.
      */
     voltdb::Table* m_table;
-
-    voltdb::NValue m_tableName;
 
     voltdb::NValue m_tableType;
 

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -748,7 +748,10 @@ void PersistentTable::swapTableIndexes(PersistentTable* otherTable,
 
         auto heldName = theIndex->getName();
         theIndex->rename(otherIndex->getName());
+        // The table names are already swapped before we swap the indexes.
+        theIndex->getIndexStats()->updateTableName(m_name);
         otherIndex->rename(heldName);
+        otherIndex->getIndexStats()->updateTableName(otherTable->m_name);
     }
 }
 

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -711,8 +711,8 @@ void PersistentTable::swapTableState(PersistentTable* otherTable) {
     // instead of PersistentTable?
 
     std::swap(m_name, otherTable->m_name);
-    TableFactory::configureStats(m_name, &m_stats);
-    TableFactory::configureStats(otherTable->m_name, &otherTable->m_stats);
+    m_stats.updateTableName(m_name);
+    otherTable->m_stats.updateTableName(otherTable->m_name);
 
     if (m_tableStreamer &&
             m_tableStreamer->hasStreamType(TABLE_STREAM_ELASTIC_INDEX)) {

--- a/src/ee/storage/tablefactory.h
+++ b/src/ee/storage/tablefactory.h
@@ -143,10 +143,6 @@ public:
         const std::string &name,
         const Table* templateTable);
 
-    static void configureStats(
-        std::string name,
-        TableStats *tableStats);
-
 private:
     static void initCommon(
         voltdb::CatalogId databaseId,
@@ -156,6 +152,10 @@ private:
         const std::vector<std::string> &columnNames,
         const bool ownsTupleSchema,
         const int32_t compactionThreshold = 95);
+
+    static void configureStats(
+        std::string name,
+        TableStats *tableStats);
 };
 
 }// namespace voltdb

--- a/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
@@ -3073,6 +3073,19 @@ public class TestFixedSQLSuite extends RegressionSuite {
         client.callProcedure("@SwapTables", "Swapper_Table_Foo", "Swapper_Table_BAR");
         client.callProcedure("@AdHoc", "drop table swapper_table_foo;");
         client.callProcedure("@AdHoc", "drop table swapper_table_bar;");
+
+        // Restore the catalog so that the junit re-init optimization won't complain.
+        client.callProcedure("@AdHoc", "create table swapper_table_foo (\n" +
+                                       "       i integer,\n" +
+                                       "       j varchar(32),\n" +
+                                       "       primary key (i)\n" +
+                                       ");\n" +
+                                       "\n" +
+                                       "create table swapper_table_bar (\n" +
+                                       "       i integer,\n" +
+                                       "       j varchar(32),\n" +
+                                       "       primary key (i)\n" +
+                                       ");");
     }
 
     //

--- a/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
@@ -63,7 +63,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
 
     static final int VARCHAR_VARBINARY_THRESHOLD = 100;
 
-    public void notestSmallFixedTests() throws IOException, ProcCallException
+    public void testSmallFixedTests() throws IOException, ProcCallException
     {
         subTestInsertNullPartitionString();
         subTestAndExpressionComparingSameTableColumns();
@@ -859,7 +859,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         truncateTables(client, tables);
     }
 
-    public void notestFixedTickets() throws Exception
+    public void testFixedTickets() throws Exception
     {
         subTestTicketEng2250_IsNull();
         subTestTicketEng1850_WhereOrderBy();
@@ -1073,7 +1073,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         truncateTables(client, tables);
     }
 
-    //public void notestTicket205() throws IOException, ProcCallException
+    //public void testTicket205() throws IOException, ProcCallException
     //{
     //    String[] tables = {"P1", "R1", "P2", "R2"};
     //    Client client = getClient();
@@ -1832,7 +1832,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         truncateTable(client, "P3");
     }
 
-    public void notestVarchar() throws IOException, ProcCallException {
+    public void testVarchar() throws IOException, ProcCallException {
         subTestVarcharByBytes();
         subTestVarcharByCharacter();
         subTestInlineVarcharAggregation();
@@ -2340,7 +2340,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         }
     }
 
-    public void notestInWithString() throws IOException, ProcCallException, InterruptedException {
+    public void testInWithString() throws IOException, ProcCallException, InterruptedException {
         subTestInWithIntParams();
         subTestInWithStringParams();
         subTestInWithStringParamsAdHoc();
@@ -3004,7 +3004,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         truncateTables(client, new String[]{"P1", "R1"});
     }
 
-    public void notestExistsBugEng12204() throws Exception {
+    public void testExistsBugEng12204() throws Exception {
         Client client = getClient();
 
         client.callProcedure("@AdHoc", "insert into p1 values (0, 'foo', 0, 0.1);");
@@ -3064,8 +3064,10 @@ public class TestFixedSQLSuite extends RegressionSuite {
     }
 
     public void testSwapTablesTruncateReplicated() throws Exception {
+        if (isHSQL()) {
+            return;
+        }
         Client client = getClient();
-
         client.callProcedure("@AdHoc", "insert into swapper_table_foo values (0, 'dog');");
         client.callProcedure("@AdHoc", "insert into swapper_table_foo values (1, 'cat');");
         client.callProcedure("@SwapTables", "Swapper_Table_Foo", "Swapper_Table_BAR");
@@ -3120,10 +3122,10 @@ public class TestFixedSQLSuite extends RegressionSuite {
         // end of normally disabled section */
 
         //* CONFIG #2: HSQL
-//        config = new LocalCluster("fixedsql-hsql.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
-//        success = config.compile(project);
-//        assertTrue(success);
-//        builder.addServerConfig(config);
+        config = new LocalCluster("fixedsql-hsql.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
+        success = config.compile(project);
+        assertTrue(success);
+        builder.addServerConfig(config);
         // end of HSQDB config */
         return builder;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
@@ -63,7 +63,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
 
     static final int VARCHAR_VARBINARY_THRESHOLD = 100;
 
-    public void testSmallFixedTests() throws IOException, ProcCallException
+    public void notestSmallFixedTests() throws IOException, ProcCallException
     {
         subTestInsertNullPartitionString();
         subTestAndExpressionComparingSameTableColumns();
@@ -859,7 +859,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         truncateTables(client, tables);
     }
 
-    public void testFixedTickets() throws Exception
+    public void notestFixedTickets() throws Exception
     {
         subTestTicketEng2250_IsNull();
         subTestTicketEng1850_WhereOrderBy();
@@ -1073,7 +1073,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         truncateTables(client, tables);
     }
 
-    //public void testTicket205() throws IOException, ProcCallException
+    //public void notestTicket205() throws IOException, ProcCallException
     //{
     //    String[] tables = {"P1", "R1", "P2", "R2"};
     //    Client client = getClient();
@@ -1832,7 +1832,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         truncateTable(client, "P3");
     }
 
-    public void testVarchar() throws IOException, ProcCallException {
+    public void notestVarchar() throws IOException, ProcCallException {
         subTestVarcharByBytes();
         subTestVarcharByCharacter();
         subTestInlineVarcharAggregation();
@@ -2340,7 +2340,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         }
     }
 
-    public void testInWithString() throws IOException, ProcCallException, InterruptedException {
+    public void notestInWithString() throws IOException, ProcCallException, InterruptedException {
         subTestInWithIntParams();
         subTestInWithStringParams();
         subTestInWithStringParamsAdHoc();
@@ -3004,7 +3004,7 @@ public class TestFixedSQLSuite extends RegressionSuite {
         truncateTables(client, new String[]{"P1", "R1"});
     }
 
-    public void testExistsBugEng12204() throws Exception {
+    public void notestExistsBugEng12204() throws Exception {
         Client client = getClient();
 
         client.callProcedure("@AdHoc", "insert into p1 values (0, 'foo', 0, 0.1);");
@@ -3063,6 +3063,16 @@ public class TestFixedSQLSuite extends RegressionSuite {
         assertContentOfTable(new Object[][] {}, vt);
     }
 
+    public void testSwapTablesTruncateReplicated() throws Exception {
+        Client client = getClient();
+
+        client.callProcedure("@AdHoc", "insert into swapper_table_foo values (0, 'dog');");
+        client.callProcedure("@AdHoc", "insert into swapper_table_foo values (1, 'cat');");
+        client.callProcedure("@SwapTables", "Swapper_Table_Foo", "Swapper_Table_BAR");
+        client.callProcedure("@AdHoc", "drop table swapper_table_foo;");
+        client.callProcedure("@AdHoc", "drop table swapper_table_bar;");
+    }
+
     //
     // JUnit / RegressionSuite boilerplate
     //
@@ -3094,6 +3104,8 @@ public class TestFixedSQLSuite extends RegressionSuite {
         project.addStmtProcedure("Eng1316Insert_P1", "insert into P1 values (?, ?, ?, ?);", "P1.ID: 0");
         project.addStmtProcedure("Eng1316Update_P1", "update P1 set num = num + 1 where id = ?", "P1.ID: 0");
 
+        project.setUseDDLSchema(true);
+
         //* CONFIG #1: JNI -- keep this enabled by default with / / vs. / *
         config = new LocalCluster("fixedsql-threesite.jar", 3, 1, 0, BackendTarget.NATIVE_EE_JNI);
         success = config.compile(project);
@@ -3108,10 +3120,10 @@ public class TestFixedSQLSuite extends RegressionSuite {
         // end of normally disabled section */
 
         //* CONFIG #2: HSQL
-        config = new LocalCluster("fixedsql-hsql.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
-        success = config.compile(project);
-        assertTrue(success);
-        builder.addServerConfig(config);
+//        config = new LocalCluster("fixedsql-hsql.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
+//        success = config.compile(project);
+//        assertTrue(success);
+//        builder.addServerConfig(config);
         // end of HSQDB config */
         return builder;
     }

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/fixed-sql-ddl.sql
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/fixed-sql-ddl.sql
@@ -410,3 +410,15 @@ CREATE TABLE ENG_539 (
   BIG     BIGINT,
   PRIMARY KEY (ID)
 );
+
+create table swapper_table_foo (
+       i integer,
+       j varchar(32),
+       primary key (i)
+);
+
+create table swapper_table_bar (
+       i integer,
+       j varchar(32),
+       primary key (i)
+);


### PR DESCRIPTION
This is an old problem that manifested recently with the shared replicated table commit.
In EE, there are two types of `StatsSource`: one for tables and one for indexes. Both of them cache the table name in an `NValue` so they don't have to construct one every time when they produce a stats temp table.
Before we have the @SwapTables procedure, a table's name cannot be changed once it is created because we do not support `ALTER TABLE RENAME`. But when you swap two tables, the table names are also swapped. Previously, we forgot to update the cached `NValue` in the index and table stats to reflect the new table name. So the statistics that we have been providing, in this case, is always wrong.

In the shared replicated table work, we have a new change in Java where, before returning the stats, we retrieve the table name from the stats table and get the catalog table object to see if it is replicated. If you swap A and B, then drop A, B's stats still show A's name, but A does not exist in the catalog anymore. That's how the NPE is resulted from.

The fix for this problem is to update the table name cached in the index or table stats when swapping two tables.

In this fix, I moved the table name NValue from IndexStats and TableStats to the base class because both index and table stats need it.
I also removed the unused `m_name` string in the base class. In addition, I found the previous bug ENG-13798 I fixed can also be rewritten using the new `getTableName()` I added to the StatsSource base class. So I updated the fix.