### PR TITLE
ENG-13802. Cleanup .dylib files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -954,7 +954,7 @@ CLEANING
     <arg line="-c 'rm -rf voltdb/*.jar'"/>
   </exec>
   <exec dir='.' executable='/bin/sh'>
-    <arg line="-c 'rm -rf voltdb/*.so voltdb/*.jnilib'"/>
+    <arg line="-c 'rm -rf voltdb/*.so voltdb/*.jnilib voltdb/*.dylib'"/>
   </exec>
   <exec dir='.' executable='/bin/sh'>
     <arg line="-c 'rm -rf src/ee/catalog/*'"/>


### PR DESCRIPTION
For a brief period cmake produced .dylib.  This change cleans them up if they are still present in the voltdb/ directory.