### PR TITLE
Eng 1376 nibble delete st

### DIFF
--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/NibbleDeleteLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/NibbleDeleteLoader.java
@@ -24,8 +24,11 @@
 package txnIdSelfCheck;
 
 import org.voltdb.ClientResponseImpl;
+import org.voltdb.VoltTable;
+import org.voltdb.VoltTableRow;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.client.ProcCallException;
 import org.voltdb.client.ProcedureCallback;
 
 import java.io.InterruptedIOException;
@@ -35,7 +38,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class BigTableLoader extends BenchmarkThread {
+public class NibbleDeleteLoader extends BenchmarkThread {
 
     final Client client;
     final long targetCount;
@@ -48,10 +51,13 @@ public class BigTableLoader extends BenchmarkThread {
     final Semaphore m_permits;
     long insertsTried = 0;
     long rowsLoaded = 0;
-    long nTruncates = 0;
+    long deletesTried = 0;
+    long deletesSucceeded = 0;
+    NibbleDeleter deleter = null;
+    long rowsDeletedTotal = 0;
 
-    BigTableLoader(Client client, String tableName, long targetCount, int rowSize, int batchSize, Semaphore permits, int partitionCount) {
-        setName("BigTableLoader-"+tableName);
+    NibbleDeleteLoader(Client client, String tableName, long targetCount, int rowSize, int batchSize, Semaphore permits, int partitionCount) {
+        setName("NibbleDeleteLoader-"+tableName);
         this.client = client;
         this.tableName = tableName;
         this.targetCount = targetCount;
@@ -62,21 +68,19 @@ public class BigTableLoader extends BenchmarkThread {
 
         // make this run more than other threads
         setPriority(getPriority() + 1);
-        log.info("BigTableLoader table: "+ tableName + " targetCount: " + targetCount + " storage required: " + targetCount*rowSize + " bytes");
+        log.info("NibbleDeleteLoader table: "+ tableName + " targetCount: " + targetCount + " storage required: " + targetCount*rowSize + " bytes");
+        this.deleter = new NibbleDeleter(this.tableName, "ts", "75", ">", 1000, 2000);
     }
 
     void shutdown() {
         m_shouldContinue.set(false);
-        log.info("BigTableLoader " + tableName + " shutdown: inserts tried " + insertsTried + " rows loaded " + rowsLoaded +
-                    " truncates " + nTruncates);
+        log.info("NibbleDeleteLoader " + tableName + " shutdown: inserts tried: " + insertsTried + " rows loaded: " + rowsLoaded +
+                " deletes tried: " + deletesTried + " deletes succeeded: " + deletesSucceeded);
         this.interrupt();
     }
 
-    public int getPercentLoadComplete() {
-        Double d = ((double)rowsLoaded / targetCount) * 100.;
-        return d.intValue();
-
-    }
+    //"@LowImpactDelete", [FastSerializer.VOLTTYPE_STRING,FastSerializer.VOLTTYPE_STRING,FastSerializer.VOLTTYPE_STRING,FastSerializer.VOLTTYPE_STRING,FastSerializer.VOLTTYPE_BIGINT,FastSerializer.VOLTTYPE_BIGINT],
+    //        [tablename,columnName,columnThresholdInMicros,comparisonOp,chunksize,timeoutms]
 
     class InsertCallback implements ProcedureCallback {
 
@@ -92,11 +96,11 @@ public class BigTableLoader extends BenchmarkThread {
             if (status == ClientResponse.GRACEFUL_FAILURE ||
                     status == ClientResponse.USER_ABORT) {
                 // log what happened
-                hardStop("BigTableLoader gracefully failed to insert into table " + tableName + " and this shoudn't happen. Exiting.");
+                hardStop("NibbleDeleteLoader gracefully failed to insert into table " + tableName + " and this shoudn't happen. Exiting.");
             }
             if (status != ClientResponse.SUCCESS) {
                 // log what happened
-                log.warn("BigTableLoader ungracefully failed to insert into table " + tableName);
+                log.warn("NibbleDeleteLoader ungracefully failed to insert into table " + tableName);
                 log.warn(((ClientResponseImpl) clientResponse).toJSONString());
             }
             else {
@@ -107,13 +111,77 @@ public class BigTableLoader extends BenchmarkThread {
         }
     }
 
+
+    class NibbleDeleter extends Thread {
+
+        final String columnName;
+        final String tableName;
+        final String columnThresholdInMicros;
+        final String comparisonOp;
+        final int chunksize;
+        final int timeoutms;
+
+        NibbleDeleter(String tableName, String columnName, String columnThresholdInMicros, String comparisonOp, int chunksize, int timeoutms) {
+            this.tableName = tableName;
+            this.columnName = columnName;
+            this.columnThresholdInMicros = columnThresholdInMicros;
+            this.comparisonOp = comparisonOp;
+            this.chunksize = chunksize;
+            this.timeoutms = timeoutms;
+        }
+
+        @Override
+        public void run() {
+            while (m_shouldContinue.get()) {
+                try { Thread.sleep(1000); } catch (Exception e) { }
+                try {
+                    m_permits.acquire(1000);
+                } catch (InterruptedException e) {
+                    if (!m_shouldContinue.get()) {
+                        return;
+                    }
+                    log.error("NibbleDeleter thread interrupted while waiting for permits. " + e.getMessage());
+                }
+                try {
+                    deletesTried++;
+                    // this sysproc is synchronous
+                    ClientResponse response = TxnId2Utils.doProcCall(client, "@LowImpactDelete", tableName, columnName, columnThresholdInMicros, comparisonOp, chunksize, timeoutms);
+                    if (response.getStatus() == ClientResponse.SUCCESS) {
+                        VoltTable[] t = response.getResults();
+                        VoltTable data = t[0];
+                        if (data.getRowCount() <= 0) {
+                            hardStop("No rows");
+                        }
+                        VoltTableRow row = data.fetchRow(0);
+                        long rowsDeleted = row.getLong(0);
+                        long rowsLeft = row.getLong(1);
+                        long rounds = row.getLong(2);
+                        long deletedLastRound = row.getLong(3);
+                        String note = row.getString(4);
+                        deletesSucceeded++;
+                        rowsDeletedTotal += rowsDeleted;
+                    } else {
+
+                    }
+                } catch (ProcCallException e) {
+                    if (! m_shouldContinue.get())
+                        return;
+                    hardStop("NibbleDeleter failed a '@LowImpactDelete' procedure call for table '" + tableName + "' " + e.getMessage());
+                } catch (Exception e) {
+                    hardStop("NibbleDeleter failed a '@LowImpactDelete' for table '" + tableName + "' " + e.getMessage());
+                }
+            }
+        }
+    }
+
+
     @Override
     public void run() {
+        this.deleter.start();  // start the nibbler
         byte[] data = new byte[rowSize];
         long currentRowCount;
         while (m_shouldContinue.get()) {
             r.nextBytes(data);
-
             try {
                 currentRowCount = TxnId2Utils.getRowCount(client, tableName);
                 // insert some batches...
@@ -129,7 +197,7 @@ public class BigTableLoader extends BenchmarkThread {
                             if (!m_shouldContinue.get()) {
                                 return;
                             }
-                            log.error("BigTableLoader thread interrupted while waiting for permit. " + e.getMessage());
+                            log.error("NibbleDeleteLoader thread interrupted while waiting for permit. " + e.getMessage());
                         }
                         insertsTried++;
                         client.callProcedure(new InsertCallback(latch), tableName.toUpperCase() + "TableInsert", p, data);
@@ -140,7 +208,7 @@ public class BigTableLoader extends BenchmarkThread {
                         if (!m_shouldContinue.get()) {
                             return;
                         }
-                        log.error("BigTableLoader thread interrupted while waiting." + e.getMessage());
+                        log.error("NibbleDeleteLoader thread interrupted while waiting." + e.getMessage());
                     }
                     long nextRowCount = TxnId2Utils.getRowCount(client, tableName);
                     // if no progress, throttle a bit
@@ -148,7 +216,7 @@ public class BigTableLoader extends BenchmarkThread {
                         try { Thread.sleep(1000); } catch (Exception e2) {}
                     }
                     currentRowCount = nextRowCount;
-                    log.debug("BigTableLoader " + tableName.toUpperCase() + " count " + currentRowCount);
+                    log.info("NibbleDeleteLoader " + tableName.toUpperCase() + " current count: " + currentRowCount + " rows deleted: " + rowsDeletedTotal);
                 }
             }
             catch (Exception e) {
@@ -156,11 +224,11 @@ public class BigTableLoader extends BenchmarkThread {
                     continue;
                 }
                 // on exception, log and end the thread, but don't kill the process
-                log.error("BigTableLoader failed a TableInsert procedure call for table '" + tableName + "' " + e.getMessage());
+                hardStop("NibbleDeleteLoader failed a 'TableInsert' procedure call for table '" + tableName + "' " + e.getMessage());
                 try { Thread.sleep(3000); } catch (Exception e2) {}
             }
         }
-        log.info("BigTableLoader normal exit for table " + tableName + " rows sent: " + insertsTried + " inserted: " + rowsLoaded + " truncates: " + nTruncates);
+        log.info("NibbleDeleteLoader exit for table " + tableName + " rows sent: " + insertsTried + " inserted: " + rowsLoaded);
+        hardStop("NibbleDeleteLoader exit");
     }
-
 }

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/NibbleDeleteLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/NibbleDeleteLoader.java
@@ -129,9 +129,9 @@ public class NibbleDeleteLoader extends BenchmarkThread {
             try {
             while ( true ) {
                 // give a little wiggle room when checking if rows shoul've been deleted.
-                long ttl = new Double(Math.ceil(TTL*1.2)).longValue();
+                long ttl = new Double(Math.ceil(TTL*1.5)).longValue();
 
-                ClientResponse response = TxnId2Utils.doProcCall(client, "@AdHoc", "select *,now from "+tableName+" where DATEADD(SECOND,"+ttl+","+tsColumnName+") < NOW");
+                ClientResponse response = TxnId2Utils.doProcCall(client, "@AdHoc", "select *,now from "+tableName+" where "+tsColumnName+" < DATEADD(SECOND,-"+ttl+",NOW) ");
 
                 if (response.getStatus() == ClientResponse.SUCCESS ) {
                     VoltTable[] t = response.getResults();

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl.sql
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl.sql
@@ -130,6 +130,29 @@ CREATE TABLE bigp
 );
 PARTITION TABLE bigp ON COLUMN p;
 
+--  nibble delete replicated table
+CREATE TABLE nibdr
+(
+  p          bigint             NOT NULL
+, id         bigint             NOT NULL
+, ts         timestamp          DEFAULT NOW
+, value      varbinary(1048576) NOT NULL
+, CONSTRAINT PK_id_nr PRIMARY KEY (p,id)
+);
+CREATE INDEX NIBR_TSINDEX ON nibdr (ts);
+
+-- nibble delete partitioned table
+CREATE TABLE nibdp
+(
+  p          bigint             NOT NULL
+, id         bigint             NOT NULL
+, ts         timestamp          DEFAULT NOW
+, value      varbinary(1048576) NOT NULL
+, CONSTRAINT PK_id_np PRIMARY KEY (p,id)
+);
+PARTITION TABLE nibdp ON COLUMN p;
+CREATE INDEX NIBP_TSINDEX ON nibdp (ts);
+
 CREATE TABLE forDroppedProcedure
 (
   p          integer             NOT NULL
@@ -465,9 +488,15 @@ CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.ImportInsertP;
 PARTITION PROCEDURE ImportInsertP ON TABLE importp COLUMN cid PARAMETER 3;
 PARTITION PROCEDURE ImportInsertP ON TABLE importbp COLUMN cid PARAMETER 3;
 CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.ImportInsertR;
+CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.exceptionUDF;
+CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.NIBDPTableInsert;
+PARTITION PROCEDURE NIBDPTableInsert ON TABLE nibdp COLUMN p;
+CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.NIBDRTableInsert;
+
+-- functions
 CREATE FUNCTION add2Bigint    FROM METHOD txnIdSelfCheck.procedures.udfs.add2Bigint;
 CREATE FUNCTION identityVarbin    FROM METHOD txnIdSelfCheck.procedures.udfs.identityVarbin;
-CREATE PROCEDURE FROM CLASS txnIdSelfCheck.procedures.exceptionUDF;
 CREATE FUNCTION excUDF    FROM METHOD txnIdSelfCheck.procedures.udfs.badUDF;
+
 
 END_OF_BATCH

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl.sql
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl.sql
@@ -135,10 +135,10 @@ CREATE TABLE nibdr
 (
   p          bigint             NOT NULL
 , id         bigint             NOT NULL
-, ts         timestamp          DEFAULT NOW
+, ts         timestamp          DEFAULT NOW NOT NULL
 , value      varbinary(1048576) NOT NULL
 , CONSTRAINT PK_id_nr PRIMARY KEY (p,id)
-);
+) USING TTL 30 Second on column ts ;
 CREATE INDEX NIBR_TSINDEX ON nibdr (ts);
 
 -- nibble delete partitioned table
@@ -146,10 +146,10 @@ CREATE TABLE nibdp
 (
   p          bigint             NOT NULL
 , id         bigint             NOT NULL
-, ts         timestamp          DEFAULT NOW
+, ts         timestamp          DEFAULT NOW NOT NULL
 , value      varbinary(1048576) NOT NULL
 , CONSTRAINT PK_id_np PRIMARY KEY (p,id)
-);
+) USING TTL 30 Second on column ts ;
 PARTITION TABLE nibdp ON COLUMN p;
 CREATE INDEX NIBP_TSINDEX ON nibdp (ts);
 

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/NIBDPTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/NIBDPTableInsert.java
@@ -1,0 +1,37 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package txnIdSelfCheck.procedures;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+
+public class NIBDPTableInsert extends VoltProcedure {
+    final SQLStmt insert = new SQLStmt("insert into nibdp (p, id, value) values (?,?,?);");
+
+    public VoltTable[] run(long p, byte[] data) {
+        voltQueueSQL(insert, EXPECT_SCALAR_MATCH(1), p, getUniqueId(), data);
+        return voltExecuteSQL(true);
+    }
+}

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/NIBDRTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/NIBDRTableInsert.java
@@ -1,0 +1,37 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package txnIdSelfCheck.procedures;
+
+import org.voltdb.SQLStmt;
+import org.voltdb.VoltProcedure;
+import org.voltdb.VoltTable;
+
+public class NIBDRTableInsert extends VoltProcedure {
+    final SQLStmt insert = new SQLStmt("insert into nibdr (p, id, value) values (?,?,?);");
+
+    public VoltTable[] run(long p, byte[] data) {
+        voltQueueSQL(insert, EXPECT_SCALAR_MATCH(1), p, getUniqueId(), data);
+        return voltExecuteSQL(true);
+    }
+}


### PR DESCRIPTION
This adds two seperate threads to TxnId2, a loader and a monitor.  The loader thread (NibbleDeleteLoader) can populate one of two new tables 'NIBDP' and 'NIBDR'  who have a TTL set on a Timestamp column.  The NibbleDeleteMonitor thread monitors the data in those tables and fails the test if any data remains in the table past it's TTL plus a little wiggle room - since not all of the data may be deletable in a single Tick.