### PR TITLE
Adjust testAdHocLengthLimit

### DIFF
--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -461,7 +461,7 @@ public class TestAdHocQueries extends AdHocQueryTester {
         try {
             StringBuffer adHocQueryTemp = new StringBuffer("SELECT * FROM VOTES WHERE PHONE_NUMBER IN (");
             int i = 0;
-            while (adHocQueryTemp.length() <= Short.MAX_VALUE*10) {
+            while (adHocQueryTemp.length() <= Short.MAX_VALUE * 2) {
                 String randPhone = RandomStringUtils.randomNumeric(10);
                 VoltTable result = env.m_client.callProcedure("@AdHoc", "INSERT INTO VOTES VALUES(?, ?, ?);", randPhone, "MA", i).getResults()[0];
                 assertEquals(1, result.getRowCount());


### PR DESCRIPTION
The length prefix was expanded from a 2-byte integer to a 4-byte integer (signed).
Obviously, it now can support way more than 10x longer query string.

Getting a `10 * Short.MAX_VALUE` long query string does not cover that much of this length range, and it brings the timeout issue in the test itself.

Change to the loop condition below, so that it just verifies you can go beyond 2^15 in query string, which is enough for the scope of [ENG-9560](https://issues.voltdb.com/browse/ENG-9560).
