### PR TITLE
ENG-13816: refactor exception handling for VoltDBEngine::loadTable

### DIFF
--- a/src/ee/common/ExecuteWithMpMemory.cpp
+++ b/src/ee/common/ExecuteWithMpMemory.cpp
@@ -60,18 +60,14 @@ ConditionalExecuteOutsideMpMemory::~ConditionalExecuteOutsideMpMemory() {
 }
 
 ConditionalSynchronizedExecuteWithMpMemory::ConditionalSynchronizedExecuteWithMpMemory(bool needMpMemoryOnLowestThread,
-                                                                                       bool isLowestSite,
-                                                                                       int64_t& exceptionTracker) :
-        m_usingMpMemoryOnLowestThread(needMpMemoryOnLowestThread && isLowestSite),
-        m_okToExecute(!needMpMemoryOnLowestThread || m_usingMpMemoryOnLowestThread)
+                                                                                       bool isLowestSite)
+        : m_usingMpMemoryOnLowestThread(needMpMemoryOnLowestThread && isLowestSite)
+        , m_okToExecute(!needMpMemoryOnLowestThread || m_usingMpMemoryOnLowestThread)
 {
     if (needMpMemoryOnLowestThread) {
         if (SynchronizedThreadLock::countDownGlobalTxnStartCount(isLowestSite)) {
-            // Call the execute method to actually perform whatever action
             VOLT_DEBUG("Entering UseMPmemory");
             SynchronizedThreadLock::assumeMpMemoryContext();
-            // Trap exceptions for replicated tables by initializing to an invalid value
-            exceptionTracker = -1;
         }
     }
 }

--- a/src/ee/common/ExecuteWithMpMemory.cpp
+++ b/src/ee/common/ExecuteWithMpMemory.cpp
@@ -59,21 +59,9 @@ ConditionalExecuteOutsideMpMemory::~ConditionalExecuteOutsideMpMemory() {
     }
 }
 
-ConditionalSynchronizedExecuteWithMpMemory::ConditionalSynchronizedExecuteWithMpMemory(bool needMpMemoryOnLowestThread,
-                                                                                       bool isLowestSite)
-        : m_usingMpMemoryOnLowestThread(needMpMemoryOnLowestThread && isLowestSite)
-        , m_okToExecute(!needMpMemoryOnLowestThread || m_usingMpMemoryOnLowestThread)
-{
-    if (needMpMemoryOnLowestThread) {
-        if (SynchronizedThreadLock::countDownGlobalTxnStartCount(isLowestSite)) {
-            VOLT_DEBUG("Entering UseMPmemory");
-            SynchronizedThreadLock::assumeMpMemoryContext();
-        }
-    }
-}
 ConditionalSynchronizedExecuteWithMpMemory::~ConditionalSynchronizedExecuteWithMpMemory() {
     if (m_usingMpMemoryOnLowestThread) {
-        VOLT_DEBUG("Exiting UseMPmemory");
+        VOLT_DEBUG("Switching to local site context and waking other threads...");
         SynchronizedThreadLock::assumeLocalSiteContext();
         SynchronizedThreadLock::signalLowestSiteFinished();
     }

--- a/src/ee/common/ExecuteWithMpMemory.h
+++ b/src/ee/common/ExecuteWithMpMemory.h
@@ -54,8 +54,23 @@ private:
 
 class ConditionalSynchronizedExecuteWithMpMemory {
 public:
+    template<class ExceptionTracker>
     ConditionalSynchronizedExecuteWithMpMemory(bool needMpMemoryOnLowestThread,
-                                               bool isLowestSite);
+                                               bool isLowestSite,
+                                               ExceptionTracker* tracker,
+                                               const ExceptionTracker& initValue)
+    : m_usingMpMemoryOnLowestThread(needMpMemoryOnLowestThread && isLowestSite)
+    , m_okToExecute(!needMpMemoryOnLowestThread || m_usingMpMemoryOnLowestThread)
+    {
+        if (needMpMemoryOnLowestThread) {
+            if (SynchronizedThreadLock::countDownGlobalTxnStartCount(isLowestSite)) {
+                VOLT_DEBUG("Entering UseMPmemory");
+                SynchronizedThreadLock::assumeMpMemoryContext();
+                // This must be done in here to avoid a race with the non-MP path.
+                *tracker = initValue;
+            }
+        }
+    }
 
     ~ConditionalSynchronizedExecuteWithMpMemory();
 

--- a/src/ee/common/ExecuteWithMpMemory.h
+++ b/src/ee/common/ExecuteWithMpMemory.h
@@ -55,7 +55,7 @@ private:
 class ConditionalSynchronizedExecuteWithMpMemory {
 public:
     ConditionalSynchronizedExecuteWithMpMemory(bool needMpMemoryOnLowestThread,
-                                               bool isLowestSite, int64_t &exceptionTracker);
+                                               bool isLowestSite);
 
     ~ConditionalSynchronizedExecuteWithMpMemory();
 

--- a/src/ee/common/SynchronizedThreadLock.cpp
+++ b/src/ee/common/SynchronizedThreadLock.cpp
@@ -186,7 +186,9 @@ void SynchronizedThreadLock::resetMemory(int32_t partitionId) {
 }
 
 bool SynchronizedThreadLock::countDownGlobalTxnStartCount(bool lowestSite) {
+    VOLT_DEBUG("Entering countdown latch...");
     assert(s_globalTxnStartCountdownLatch > 0);
+    assert(ThreadLocalPool::getEnginePartitionId() != 16383);
     assert(!isInSingleThreadMode());
     if (lowestSite) {
         pthread_mutex_lock(&s_sharedEngineMutex);
@@ -206,8 +208,8 @@ bool SynchronizedThreadLock::countDownGlobalTxnStartCount(bool lowestSite) {
         }
         pthread_cond_wait(&s_sharedEngineCondition, &s_sharedEngineMutex);
         pthread_mutex_unlock(&s_sharedEngineMutex);
-        assert(!isInSingleThreadMode());
         VOLT_DEBUG("Other SP partition thread released on thread %d", ThreadLocalPool::getThreadPartitionId());
+        assert(!isInSingleThreadMode());
         return false;
     }
 }

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1650,8 +1650,8 @@ VoltDBEngine::loadTable(int32_t tableId,
         // This is fatal.
         std::ostringstream oss;
         oss << "An unknown exception occurred on another thread when loading table \"" << table->name() << "\".";
-        throwFatalException("An unknown exception occurred on another thread when loading table \"%s\".",
-                            table->name().c_str());
+        VOLT_DEBUG("%s", oss.str().c_str());
+        throwFatalException("%s", oss.str().c_str());
     }
 
     return true;

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1597,10 +1597,9 @@ VoltDBEngine::loadTable(int32_t tableId,
     //   For all other kinds of exceptions, throw a FatalException.  This is legacy behavior.
     //   Perhaps we cannot be ensured of data integrity for other kinds of exceptions?
 
-    ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(table->isCatalogTableReplicated(),
-                                                                               isLowestSite());
+    ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory
+            (table->isCatalogTableReplicated(), isLowestSite(), &s_loadTableException, VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
     if (possiblySynchronizedUseMpMemory.okToExecute()) {
-        s_loadTableException = VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE;
         try {
             table->loadTuplesForLoadTable(serializeIn,
                                           NULL,

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -270,7 +270,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
                        int64_t spHandle,
                        int64_t lastCommittedSpHandle,
                        int64_t uniqueId,
-                       bool returnUniqueViolations,
+                       bool throwUniqueViolations,
                        bool shouldDRStream,
                        int64_t undoToken);
 

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -796,7 +796,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         ThreadLocalPool m_tlPool;
 
         // static variable for sharing loadTable result (and exception) across VoltDBEngines
-        static int64_t s_loadTableResult;
+        static VoltEEExceptionType s_loadTableException;
 };
 
 inline bool startsWith(const string& s1, const string& s2) {

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -98,8 +98,8 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
                 m_replicatedTableOperation, m_engine->isLowestSite());
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
+            s_modifiedTuples = -1;
             if (m_truncate) {
-                s_modifiedTuples = -1;
                 VOLT_TRACE("truncating table %s...", targetTable->name().c_str());
                 // count the truncated tuples as deleted
                 modified_tuples = targetTable->visibleTupleCount();

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -96,9 +96,10 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
         assert(targetTable->isCatalogTableReplicated() ==
                 (m_replicatedTableOperation || SynchronizedThreadLock::isInSingleThreadMode()));
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                m_replicatedTableOperation, m_engine->isLowestSite(), s_modifiedTuples);
+                m_replicatedTableOperation, m_engine->isLowestSite());
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
             if (m_truncate) {
+                s_modifiedTuples = -1;
                 VOLT_TRACE("truncating table %s...", targetTable->name().c_str());
                 // count the truncated tuples as deleted
                 modified_tuples = targetTable->visibleTupleCount();

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -96,9 +96,8 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
         assert(targetTable->isCatalogTableReplicated() ==
                 (m_replicatedTableOperation || SynchronizedThreadLock::isInSingleThreadMode()));
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                m_replicatedTableOperation, m_engine->isLowestSite());
+                m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
-            s_modifiedTuples = -1;
             if (m_truncate) {
                 VOLT_TRACE("truncating table %s...", targetTable->name().c_str());
                 // count the truncated tuples as deleted

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -355,8 +355,9 @@ void InsertExecutor::p_execute_tuple_internal(TableTuple &tuple) {
 void InsertExecutor::p_execute_tuple(TableTuple &tuple) {
     // This should only be called from inlined insert executors because we have to change contexts every time
     ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-            m_replicatedTableOperation, m_engine->isLowestSite(), s_modifiedTuples);
+            m_replicatedTableOperation, m_engine->isLowestSite());
     if (possiblySynchronizedUseMpMemory.okToExecute()) {
+        s_modifiedTuples = -1;
         p_execute_tuple_internal(tuple);
         s_modifiedTuples = m_modifiedTuples;
     }
@@ -403,8 +404,9 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
     {
         if (p_execute_init_internal(inputSchema, m_tmpOutputTable, inputTuple)) {
             ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                    m_replicatedTableOperation, m_engine->isLowestSite(), s_modifiedTuples);
+                    m_replicatedTableOperation, m_engine->isLowestSite());
             if (possiblySynchronizedUseMpMemory.okToExecute()) {
+                s_modifiedTuples = -1;
                 //
                 // An insert is quite simple really. We just loop through our m_inputTable
                 // and insert any tuple that we find into our targetTable. It doesn't get any easier than that!

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -216,6 +216,9 @@ bool InsertExecutor::p_execute_init_internal(const TupleSchema *inputSchema,
         m_templateTuple.setNValue(*it, NValue::callConstant<FUNC_CURRENT_TIMESTAMP>());
     }
 
+    VOLT_DEBUG("Initializing insert executor to insert into %s table %s",
+               static_cast<PersistentTable*>(m_targetTable)->isCatalogTableReplicated() ? "replicated" : "partitioned",
+               m_targetTable->name().c_str());
     VOLT_DEBUG("This is a %s insert on partition with id %d",
                m_node->isInline() ? "inline"
                        : (m_node->getChildren()[0]->getPlanNodeType() == PLAN_NODE_TYPE_MATERIALIZE ?
@@ -346,7 +349,7 @@ void InsertExecutor::p_execute_tuple_internal(TableTuple &tuple) {
         m_targetTable = m_persistentTable;
     }
     m_targetTable->insertTuple(m_templateTuple);
-    VOLT_DEBUG("Target table:\n%s\n", m_targetTable->debug().c_str());
+    VOLT_TRACE("Target table:\n%s\n", m_targetTable->debug().c_str());
     // successfully inserted
     ++m_modifiedTuples;
     return;
@@ -355,9 +358,8 @@ void InsertExecutor::p_execute_tuple_internal(TableTuple &tuple) {
 void InsertExecutor::p_execute_tuple(TableTuple &tuple) {
     // This should only be called from inlined insert executors because we have to change contexts every time
     ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-            m_replicatedTableOperation, m_engine->isLowestSite());
+            m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
     if (possiblySynchronizedUseMpMemory.okToExecute()) {
-        s_modifiedTuples = -1;
         p_execute_tuple_internal(tuple);
         s_modifiedTuples = m_modifiedTuples;
     }
@@ -388,8 +390,8 @@ void InsertExecutor::p_execute_finish() {
     // add to the planfragments count of modified tuples
     m_engine->addToTuplesModified(m_modifiedTuples);
     VOLT_DEBUG("Finished inserting %" PRId64 " tuples", m_modifiedTuples);
-    VOLT_DEBUG("InsertExecutor output table:\n%s\n", m_tmpOutputTable->debug().c_str());
-    VOLT_DEBUG("InsertExecutor target table:\n%s\n", m_targetTable->debug().c_str());
+    VOLT_TRACE("InsertExecutor output table:\n%s\n", m_tmpOutputTable->debug().c_str());
+    VOLT_TRACE("InsertExecutor target table:\n%s\n", m_targetTable->debug().c_str());
 }
 
 bool InsertExecutor::p_execute(const NValueArray &params) {
@@ -404,9 +406,8 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
     {
         if (p_execute_init_internal(inputSchema, m_tmpOutputTable, inputTuple)) {
             ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                    m_replicatedTableOperation, m_engine->isLowestSite());
+                    m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
             if (possiblySynchronizedUseMpMemory.okToExecute()) {
-                s_modifiedTuples = -1;
                 //
                 // An insert is quite simple really. We just loop through our m_inputTable
                 // and insert any tuple that we find into our targetTable. It doesn't get any easier than that!

--- a/src/ee/executors/sendexecutor.cpp
+++ b/src/ee/executors/sendexecutor.cpp
@@ -66,11 +66,11 @@ bool SendExecutor::p_execute(const NValueArray &params) {
 
     Table* inputTable = m_abstractNode->getInputTable();
     assert(inputTable);
-    VOLT_DEBUG("send input:\n%s\n", inputTable->debug().c_str());
+    VOLT_TRACE("send input:\n%s\n", inputTable->debug().c_str());
     //inputTable->setDependencyId(m_dependencyId);//Multiple send executors sharing the same input table apparently.
     // Just blast the input table on through VoltDBEngine!
     m_engine->send(inputTable);
-    VOLT_DEBUG("SEND TABLE: %s", inputTable->debug().c_str());
+    VOLT_TRACE("SEND TABLE: %s", inputTable->debug().c_str());
 
     return true;
 }

--- a/src/ee/executors/swaptablesexecutor.cpp
+++ b/src/ee/executors/swaptablesexecutor.cpp
@@ -88,8 +88,9 @@ bool SwapTablesExecutor::p_execute(NValueArray const& params) {
     {
         assert(m_replicatedTableOperation == theTargetTable->isCatalogTableReplicated());
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                m_replicatedTableOperation, m_engine->isLowestSite(), s_modifiedTuples);
+                m_replicatedTableOperation, m_engine->isLowestSite());
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
+            s_modifiedTuples = -1;
             // count the active tuples in both tables as modified
             modified_tuples = theTargetTable->visibleTupleCount() +
                     otherTargetTable->visibleTupleCount();

--- a/src/ee/executors/swaptablesexecutor.cpp
+++ b/src/ee/executors/swaptablesexecutor.cpp
@@ -88,9 +88,8 @@ bool SwapTablesExecutor::p_execute(NValueArray const& params) {
     {
         assert(m_replicatedTableOperation == theTargetTable->isCatalogTableReplicated());
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                m_replicatedTableOperation, m_engine->isLowestSite());
+                m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
-            s_modifiedTuples = -1;
             // count the active tuples in both tables as modified
             modified_tuples = theTargetTable->visibleTupleCount() +
                     otherTargetTable->visibleTupleCount();

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -141,8 +141,9 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
     {
         assert(m_replicatedTableOperation == targetTable->isCatalogTableReplicated());
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                m_replicatedTableOperation, m_engine->isLowestSite(), s_modifiedTuples);
+                m_replicatedTableOperation, m_engine->isLowestSite());
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
+            s_modifiedTuples = -1;
             // determine which indices are updated by this executor
             // iterate through all target table indices and see if they contain
             // columns mutated by this executor

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -141,9 +141,8 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
     {
         assert(m_replicatedTableOperation == targetTable->isCatalogTableReplicated());
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                m_replicatedTableOperation, m_engine->isLowestSite());
+                m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
-            s_modifiedTuples = -1;
             // determine which indices are updated by this executor
             // iterate through all target table indices and see if they contain
             // columns mutated by this executor

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -872,7 +872,12 @@ public class ProcedureRunner {
                     clusterName, databaseName,
                     tableName, data, returnUniqueViolations, shouldDRStream, undo);
         } catch (EEException e) {
-            throw new VoltAbortException("Failed to load table: " + tableName);
+            String msg = "Failed to load table \"" + tableName + "\"";
+            if (e.getMessage() != null) {
+                msg += ": " + e.getMessage();
+            }
+
+            throw new VoltAbortException(msg);
         }
     }
 

--- a/tests/ee/test_utils/plan_testing_baseclass.h
+++ b/tests/ee/test_utils/plan_testing_baseclass.h
@@ -253,9 +253,7 @@ public:
             throw std::logic_error(oss.str());
         }
         assert(pTable != NULL);
-        int64_t dummyTrackerForExceptions = 0;
-        voltdb::ConditionalSynchronizedExecuteWithMpMemory
-                setMpMemoryIfNeeded(pTable->isCatalogTableReplicated(), true, dummyTrackerForExceptions);
+        voltdb::ConditionalSynchronizedExecuteWithMpMemory setMpMemoryIfNeeded(pTable->isCatalogTableReplicated(), true);
         for (int row = 0; row < nRows; row += 1) {
             if (row > 0 && (row % 100 == 0)) {
                 std::cout << '.';

--- a/tests/ee/test_utils/plan_testing_baseclass.h
+++ b/tests/ee/test_utils/plan_testing_baseclass.h
@@ -253,7 +253,9 @@ public:
             throw std::logic_error(oss.str());
         }
         assert(pTable != NULL);
-        voltdb::ConditionalSynchronizedExecuteWithMpMemory setMpMemoryIfNeeded(pTable->isCatalogTableReplicated(), true);
+        int dummyExceptionTracker;
+        voltdb::ConditionalSynchronizedExecuteWithMpMemory setMpMemoryIfNeeded
+                (pTable->isCatalogTableReplicated(), true, &dummyExceptionTracker, -1);
         for (int row = 0; row < nRows; row += 1) {
             if (row > 0 && (row % 100 == 0)) {
                 std::cout << '.';

--- a/tests/frontend/org/voltdb/regressionsuites/TestLoadingSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestLoadingSuite.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 
 import junit.framework.Test;
 
-import org.junit.Ignore;
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
@@ -82,12 +81,12 @@ public class TestLoadingSuite extends RegressionSuite {
 
         // test failure to load replicated table from SP proc
         try {
-            r = client.callProcedure("@LoadSinglepartitionTable", VoltType.valueToBytes(1),
+            client.callProcedure("@LoadSinglepartitionTable", VoltType.valueToBytes(1),
                     "REPLICATED", upsertMode, table);
             fail(); // prev stmt should throw exception
         } catch (ProcCallException e) {
-            e.printStackTrace();
         }
+
         assertEquals(0, countReplicatedRows(client));
 
         // test rollback for constraint
@@ -95,17 +94,20 @@ public class TestLoadingSuite extends RegressionSuite {
         table.addRow(3, 2, 3, "3", 3.0);
         table.addRow(3, 2, 3, "3", 3.0);
         try {
-            r = client.callProcedure("@LoadSinglepartitionTable", VoltType.valueToBytes(2),
+            client.callProcedure("@LoadSinglepartitionTable", VoltType.valueToBytes(2),
                     "PARTITIONED", upsertMode, table);
             fail(); // prev stmt should throw exception
         } catch (ProcCallException e) {
             e.printStackTrace();
         }
+
         // 2 rows in the db from the previous test (3 for hsql)
-        if (isHSQL()) // sadly, hsql is not super transactional as a backend
+        if (isHSQL()) { // sadly, hsql is not super transactional as a backend
             assertEquals(3, countPartitionedRows(client));
-        else
+        }
+        else {
             assertEquals(2, countPartitionedRows(client));
+        }
     }
 
     public void testMultiPartitionLoad() throws Exception {
@@ -139,7 +141,9 @@ public class TestLoadingSuite extends RegressionSuite {
         try {
             r = client.callProcedure("@LoadMultipartitionTable", "PARTITIONED", upsertMode, table);
             fail();
-        } catch (ProcCallException e) {}
+        }
+        catch (ProcCallException e) {
+        }
 
         // test rollback to a replicated table (constraint)
         table = m_template.clone(100);
@@ -148,8 +152,8 @@ public class TestLoadingSuite extends RegressionSuite {
         try {
             r = client.callProcedure("@LoadMultipartitionTable", "REPLICATED", upsertMode, table);
             fail(); // prev stmt should throw exception
-        } catch (ProcCallException e) {
-            e.printStackTrace();
+        }
+        catch (ProcCallException e) {
         }
         // 4 rows in the db from the previous test
         assertEquals(4, countReplicatedRows(client));


### PR DESCRIPTION
TestLoadingSuite was failing in memcheck mode because of subtle differences in exception handling between the IPC and JNI back ends.  It turns out we were throwing a fatal exception in some cases from non-lowest site threads when encountering a unique constraint violation when loading a replicated table.