### PR TITLE
ENG-13769:

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -59,7 +59,7 @@ public class MpProcedureTask extends ProcedureTask
     final Iv2InitiateTaskMessage m_msg;
     // Generator uses node id under ZK.leaders_globalservice directory, not host id.
     // Only used for MP scoreboard at TransactionTaskQueue to track restarted MP transactions.
-    final private MpRestartSequenceGenerator m_resartSeqGenerator;
+    final private MpRestartSequenceGenerator m_restartSeqGenerator;
 
     MpProcedureTask(Mailbox mailbox, String procName, TransactionTaskQueue queue,
                   Iv2InitiateTaskMessage msg, List<Long> pInitiators, Map<Integer, Long> partitionMasters,
@@ -74,7 +74,7 @@ public class MpProcedureTask extends ProcedureTask
         m_initiatorHSIds.addAll(pInitiators);
         m_restartMasters.set(new ArrayList<Long>());
         m_restartMastersMap.set(new HashMap<Integer, Long>());
-        m_resartSeqGenerator = new MpRestartSequenceGenerator(leaderNodeId);
+        m_restartSeqGenerator = new MpRestartSequenceGenerator(leaderNodeId);
     }
 
     /**
@@ -163,7 +163,7 @@ public class MpProcedureTask extends ProcedureTask
                     !m_txnState.isReadOnly(),
                     m_msg.isForReplay());
             // TransactionTaskQueue uses it to find matching CompleteTransactionMessage
-            long ts = m_resartSeqGenerator.getNextSeqNum();
+            long ts = m_restartSeqGenerator.getNextSeqNum();
             restart.setTimestamp(ts);
             // Update the timestamp to txnState so following restarted fragments could use it
             m_txnState.setTimestamp(ts);

--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -55,6 +55,8 @@ public class MpPromoteAlgo implements RepairAlgo
     // a new Term and try again (if that's your big plan...)
     private final SettableFuture<RepairResult> m_promotionResult = SettableFuture.create();
     private final boolean m_isMigratePartitionLeader;
+    private final MpRestartSequenceGenerator m_restartSeqGenerator;
+
     long getRequestId()
     {
         return m_requestId;
@@ -116,6 +118,7 @@ public class MpPromoteAlgo implements RepairAlgo
         m_mailbox = mailbox;
         m_isMigratePartitionLeader = false;
         m_whoami = whoami;
+        m_restartSeqGenerator = new MpRestartSequenceGenerator(((MpScheduler)m_mailbox.m_scheduler).getLeaderNodeId());
     }
 
     /**
@@ -128,6 +131,7 @@ public class MpPromoteAlgo implements RepairAlgo
         m_mailbox = mailbox;
         m_isMigratePartitionLeader = migratePartitionLeader;
         m_whoami = whoami;
+        m_restartSeqGenerator = new MpRestartSequenceGenerator(((MpScheduler)m_mailbox.m_scheduler).getLeaderNodeId());
     }
 
     @Override
@@ -322,6 +326,7 @@ public class MpPromoteAlgo implements RepairAlgo
             CompleteTransactionMessage message = (CompleteTransactionMessage)msg.getPayload();
             message.setForReplica(false);
             message.setRequireAck(false);
+            message.setTimestamp(m_restartSeqGenerator.getNextSeqNum());
             return message;
         } else {
             FragmentTaskMessage ftm = (FragmentTaskMessage)msg.getPayload();

--- a/src/frontend/org/voltdb/iv2/MpRestartSequenceGenerator.java
+++ b/src/frontend/org/voltdb/iv2/MpRestartSequenceGenerator.java
@@ -17,8 +17,6 @@
 
 package org.voltdb.iv2;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 public class MpRestartSequenceGenerator {
     // bit sizes for each of the fields in the 64-bit id
     // note, these add up to 63 bits to make dealing with
@@ -30,14 +28,15 @@ public class MpRestartSequenceGenerator {
     static final long NODEID_MAX_VALUE = (1L << NODEID_BITS) - 1L;
     static final long COUNTER_MAX_VALUE = (1L << COUNTER_BITS) - 1L;
     private int m_leaderElectorId;
-    private AtomicLong m_counter = new AtomicLong(0);
+    private long m_counter = 0;
 
     public MpRestartSequenceGenerator(int nodeId) {
         m_leaderElectorId = nodeId;
     }
 
     public long getNextSeqNum() {
-        long counter = m_counter.incrementAndGet();
+        m_counter++;
+        long counter = m_counter;
         return makeSequenceNumber(m_leaderElectorId, counter);
     }
 

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -595,4 +595,8 @@ public class MpScheduler extends Scheduler
         }
         return null;
     }
+
+    public int getLeaderNodeId() {
+        return m_leaderNodeId;
+    }
 }

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -63,7 +63,9 @@ public class TransactionTaskQueue
         public TransactionTask m_lastFragTask;
 
         public void addCompletedTransactionTask(CompleteTransactionTask task, Boolean missingTxn) {
-            if (task.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP) {
+            if (task.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP ||
+                    (m_lastCompleteTxnTasks.peekFirst() != null &&
+                     m_lastCompleteTxnTasks.peekFirst().getFirst().getMsgTxnId() == task.getMsgTxnId())) {
                 // This is a submission of a completion. In case this is a resubmission of a completion that not
                 // all sites received clear the whole queue. The Completion may or may not be for a transaction
                 // that has already been completed (if it was completed missingTxn will be true)
@@ -227,17 +229,7 @@ public class TransactionTaskQueue
 
             } else if (task instanceof FragmentTask ||
                        task instanceof SysprocFragmentTask) {
-//                if (queuedTask.m_lastCompleteTxnTasks.isEmpty() ||
-//                        queuedTask.m_lastCompleteTxnTasks.peekLast().getFirst().getMsgTxnId() == task.getTxnId()) {
-//                    // Queue Fragment task if there is no queued CompleteTxn task.
-//                    // If CompleteTxn exists, only queue fragment task newer than CompleteTxn.
-                    queuedTask.addFragmentTask(task);
-//                }
-//                else {
-//                    if (hostLog.isDebugEnabled()) {
-//                        hostLog.debug("MP Write Scoreboard ignored task:\n" + task);
-//                    }
-//                }
+                queuedTask.addFragmentTask(task);
             }
 
             int receivedFrags = 0;


### PR DESCRIPTION
When some completions were received by sites and repair completions arrive on other sites, the completions won't match up and the scoreboard advances the Release before all the resubmitted completions arrive. Timestamps need to be added to resubmitted completions to match them up correctly.