### PR TITLE
ENG-13769:

### DIFF
--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -105,8 +105,13 @@ public class TransactionTaskQueue
         m_taskQueue = queue;
         m_siteCount = VoltDB.instance().getCatalogContext().getNodeSettings().getLocalSitesCount();
         synchronized (s_lock) {
-            m_scoreboard =  new ScoreboardTasks();
-            s_stashedMpWrites.put(m_taskQueue, m_scoreboard);
+            if (queue.getPartitionId() != MpInitiator.MP_INIT_PID) {
+                m_scoreboard = new ScoreboardTasks();
+                s_stashedMpWrites.put(m_taskQueue, m_scoreboard);
+            }
+            else {
+                m_scoreboard = null;
+            }
         }
     }
 


### PR DESCRIPTION
Don't generate a ScoreboardTasks Queue in the Mp Site because the MpScheduler does not participate in the scoreboard tracking of fragment tasks or completions.