### PR TITLE
ENG-13769:

### DIFF
--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -446,7 +446,8 @@ public class FragmentTask extends FragmentTaskBase
         sb.append("  TXN ID: ").append(TxnEgo.txnIdToString(getTxnId()));
         sb.append("  SP HANDLE ID: ").append(TxnEgo.txnIdToString(getSpHandle()));
         sb.append("  ON HSID: ").append(CoreUtils.hsIdToString(m_initiator.getHSId()));
-        sb.append("  TIMESTAMP: ").append(getTimestamp());
+        sb.append("  TIMESTAMP: ");
+        MpRestartSequenceGenerator.restartSeqIdToString(getTimestamp(), sb);
         return sb.toString();
     }
 

--- a/src/frontend/org/voltdb/iv2/MpRestartSequenceGenerator.java
+++ b/src/frontend/org/voltdb/iv2/MpRestartSequenceGenerator.java
@@ -48,4 +48,22 @@ public class MpRestartSequenceGenerator {
         return seq;
     }
 
+    public static long getSequence(long restartSeqId) {
+        return restartSeqId & COUNTER_MAX_VALUE;
+    }
+
+    public static int getNodeId(long restartSeqId) {
+        return (int) (restartSeqId >> COUNTER_BITS);
+    }
+
+    public static String restartSeqIdToString(long restartSeqId)
+    {
+        return "(" + MpRestartSequenceGenerator.getNodeId(restartSeqId) + ":" +
+                MpRestartSequenceGenerator.getSequence(restartSeqId) + ")";
+    }
+    public static void restartSeqIdToString(long restartSeqId, StringBuilder sb)
+    {
+        sb.append("(").append(MpRestartSequenceGenerator.getNodeId(restartSeqId)).append(":");
+        sb.append(MpRestartSequenceGenerator.getSequence(restartSeqId)).append(")");
+    }
 }

--- a/src/frontend/org/voltdb/iv2/ReplaySequencer.java
+++ b/src/frontend/org/voltdb/iv2/ReplaySequencer.java
@@ -73,7 +73,7 @@ import org.voltdb.messaging.MultiPartitionParticipantMessage;
  */
 public class ReplaySequencer
 {
-    static final VoltLogger tmLog = new VoltLogger("TM");
+    static final VoltLogger hostLog = new VoltLogger("HOST");
 
     // place holder that associates sentinel, first fragment and
     // work that follows in the transaction sequence.
@@ -367,14 +367,14 @@ public class ReplaySequencer
     public void dump(long hsId)
     {
         final String who = CoreUtils.hsIdToString(hsId);
-        tmLog.info(String.format("%s: REPLAY SEQUENCER DUMP, LAST POLLED FRAGMENT %d (%s), LAST SEEN TXNID %d (%s), %s%s",
+        hostLog.warn(String.format("%s: REPLAY SEQUENCER DUMP, LAST POLLED FRAGMENT %d (%s), LAST SEEN TXNID %d (%s), %s%s",
                                  who,
                                  m_lastPolledFragmentUniqueId, TxnEgo.txnIdToString(m_lastPolledFragmentUniqueId),
                                  m_lastSeenUniqueId, TxnEgo.txnIdToString(m_lastSeenUniqueId),
                                  m_mpiEOLReached ? "MPI EOL, " : "",
                                  m_mustDrain ? "MUST DRAIN" : ""));
         for (Entry<Long, ReplayEntry> e : m_replayEntries.entrySet()) {
-            tmLog.info(String.format("%s: REPLAY ENTRY %s: %s", who, e.getKey(), e.getValue()));
+            hostLog.warn(String.format("%s: REPLAY ENTRY %s: %s", who, e.getKey(), e.getValue()));
         }
     }
 }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1580,8 +1580,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     public void dump()
     {
         m_replaySequencer.dump(m_mailbox.getHSId());
-        tmLog.info(String.format("%s: %s", CoreUtils.hsIdToString(m_mailbox.getHSId()), m_pendingTasks));
-        tmLog.info("[dump] current truncation handle: " + TxnEgo.txnIdToString(m_repairLogTruncationHandle) + " "
+        hostLog.warn("[dump] current truncation handle: " + TxnEgo.txnIdToString(m_repairLogTruncationHandle) + " "
                 + m_bufferedReadLog.toString());
     }
 

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -306,7 +306,8 @@ public class SysprocFragmentTask extends FragmentTaskBase
         sb.append("  TXN ID: ").append(TxnEgo.txnIdToString(getTxnId()));
         sb.append("  SP HANDLE ID: ").append(TxnEgo.txnIdToString(getSpHandle()));
         sb.append("  ON HSID: ").append(CoreUtils.hsIdToString(m_initiator.getHSId()));
-        sb.append("  TIMESTAMP: ").append(getTimestamp());
+        sb.append("  TIMESTAMP: ");
+        MpRestartSequenceGenerator.restartSeqIdToString(getTimestamp(), sb);
         return sb.toString();
     }
 

--- a/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
+++ b/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.utils.CoreUtils;
+import org.voltdb.iv2.MpRestartSequenceGenerator;
 import org.voltdb.iv2.TxnEgo;
 
 public class CompleteTransactionMessage extends TransactionInfoBaseMessage
@@ -161,10 +162,10 @@ public class CompleteTransactionMessage extends TransactionInfoBaseMessage
         sb.append("\n SP HANDLE: ");
         sb.append(TxnEgo.txnIdToString(getSpHandle()));
         sb.append("\n  FLAGS: ").append(m_flags);
-        sb.append("\n  TIMESTAMP: ").append(m_timestamp);
+        sb.append("\n  TIMESTAMP: ");
+        MpRestartSequenceGenerator.restartSeqIdToString(m_timestamp, sb);
         sb.append("\n  TRUNCATION HANDLE:" + getTruncationHandle());
         sb.append("\n  HASH: " + String.valueOf(m_hash));
-        sb.append("\n  TIMESTAMP: " + getTimestamp());
 
         if (isRollback())
             sb.append("\n  THIS IS AN ROLLBACK REQUEST");


### PR DESCRIPTION
The dump log generated after a MP deadlock logs the transactiontaskqueue twice. Also some of the dump messages are written to the tmlog while others are written to the host log. Finally, the timestamp added to restarted fragments and completions is encoded so we print out the details so it is easy to figure out which restart this is.