### PR TITLE
ENG-13769:

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -144,6 +144,7 @@ import org.voltdb.iv2.MigratePartitionLeaderInfo;
 import org.voltdb.iv2.MpInitiator;
 import org.voltdb.iv2.SpInitiator;
 import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
+import org.voltdb.iv2.TransactionTaskQueue;
 import org.voltdb.iv2.TxnEgo;
 import org.voltdb.jni.ExecutionEngine;
 import org.voltdb.join.BalancePartitionsStatistics;
@@ -2083,6 +2084,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                                                 List<Integer> m_partitionsToSitesAtStartupForExportInit)
     {
         TreeMap<Integer, Initiator> initiators = new TreeMap<>();
+        // Needed when static is reused by ServerThread
+        TransactionTaskQueue.resetScoreboards();
         for (Integer partition : partitions)
         {
             Initiator initiator = new SpInitiator(m_messenger, partition, getStatsAgent(),

--- a/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
@@ -93,7 +93,8 @@ public class MpInitiatorMailbox extends InitiatorMailbox
             FutureTask<RepairAlgo> ft = new FutureTask<RepairAlgo>(new Callable<RepairAlgo>() {
                 @Override
                 public RepairAlgo call() throws Exception {
-                    RepairAlgo ra = new MpPromoteAlgo( survivors.get(), MpInitiatorMailbox.this, whoami, balanceSPI);
+                    RepairAlgo ra = new MpPromoteAlgo(survivors.get(), MpInitiatorMailbox.this,
+                            ((MpScheduler)MpInitiatorMailbox.this.m_scheduler).getLeaderNodeId(), whoami, balanceSPI);
                     setRepairAlgoInternal(ra);
                     return ra;
                 }
@@ -105,7 +106,8 @@ public class MpInitiatorMailbox extends InitiatorMailbox
                 Throwables.propagate(e);
             }
         } else {
-            ra = new MpPromoteAlgo( survivors.get(), this, whoami, balanceSPI);
+            ra = new MpPromoteAlgo(survivors.get(), this, ((MpScheduler)this.m_scheduler).getLeaderNodeId(),
+                    whoami, balanceSPI);
             setRepairAlgoInternal(ra);
         }
         return ra;

--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -111,27 +111,27 @@ public class MpPromoteAlgo implements RepairAlgo
     /**
      * Setup a new RepairAlgo but don't take any action to take responsibility.
      */
-    public MpPromoteAlgo(List<Long> survivors, InitiatorMailbox mailbox,
+    public MpPromoteAlgo(List<Long> survivors, InitiatorMailbox mailbox, int zkNodeId,
             String whoami)
     {
         m_survivors = new ArrayList<Long>(survivors);
         m_mailbox = mailbox;
         m_isMigratePartitionLeader = false;
         m_whoami = whoami;
-        m_restartSeqGenerator = new MpRestartSequenceGenerator(((MpScheduler)m_mailbox.m_scheduler).getLeaderNodeId(), false);
+        m_restartSeqGenerator = new MpRestartSequenceGenerator(zkNodeId, false);
     }
 
     /**
      * Setup a new RepairAlgo but don't take any action to take responsibility.
      */
-    public MpPromoteAlgo(List<Long> survivors, InitiatorMailbox mailbox,
+    public MpPromoteAlgo(List<Long> survivors, InitiatorMailbox mailbox, int zkNodeId,
             String whoami, boolean migratePartitionLeader)
     {
         m_survivors = new ArrayList<Long>(survivors);
         m_mailbox = mailbox;
         m_isMigratePartitionLeader = migratePartitionLeader;
         m_whoami = whoami;
-        m_restartSeqGenerator = new MpRestartSequenceGenerator(((MpScheduler)m_mailbox.m_scheduler).getLeaderNodeId(), false);
+        m_restartSeqGenerator = new MpRestartSequenceGenerator(zkNodeId, false);
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/MpRestartSequenceGenerator.java
+++ b/src/frontend/org/voltdb/iv2/MpRestartSequenceGenerator.java
@@ -23,11 +23,11 @@ public class MpRestartSequenceGenerator {
     // bit sizes for each of the fields in the 64-bit id
     // note, these add up to 63 bits to make dealing with
     // signed / unsigned conversions easier.
-    // having up to 1,000,000 MPI promotions, should be enough for now.
-    // Restart flag reset means that this came from a SPI leader promotion
+    // having MPI promotions for up to 1,000,000 Rejoined nodes, should be enough
+    // for now. Restart flag reset means that this came from a SPI leader promotion
     static final long NODEID_BITS = 20;
     static final long RESTART_BITS = 1;
-    static final long COUNTER_BITS = 22;
+    static final long COUNTER_BITS = 42;
 
     static final long NODEID_MAX_VALUE = (1L << NODEID_BITS) - 1L;
     static final long RESTART_MAX_VALUE = (1L << RESTART_BITS) - 1L;
@@ -37,7 +37,7 @@ public class MpRestartSequenceGenerator {
 
     public MpRestartSequenceGenerator(int nodeId, boolean forRestart) {
         assert (nodeId <= NODEID_MAX_VALUE);
-        m_highOrderFields = nodeId << (COUNTER_BITS + RESTART_BITS)
+        m_highOrderFields = ((long)nodeId << (COUNTER_BITS + RESTART_BITS))
                           | (forRestart ? (1 << COUNTER_BITS) : 0);
     }
 

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -269,18 +269,22 @@ public class TransactionTaskQueue
             int receivedCompleteTxns = 0;
             boolean missingTxn = false;
             for (Pair<SiteTaskerQueue, ScoreboardTasks> p : s_stashedMpWrites) {
-                if (!p.getSecond().m_lastCompleteTxnTasks.isEmpty()) {
-                    if (matchingCompletionTime != p.getSecond().m_lastCompleteTxnTasks.peekFirst().getFirst().getTimestamp()) {
+                ScoreboardTasks st = p.getSecond();
+                if (st.m_lastFragTask == null && st.m_lastCompleteTxnTasks.isEmpty()) {
+                    break;
+                }
+                if (st.m_lastFragTask != null) {
+                    receivedFrags++;
+                }
+                if (!st.m_lastCompleteTxnTasks.isEmpty()) {
+                    if (matchingCompletionTime != st.m_lastCompleteTxnTasks.peekFirst().getFirst().getTimestamp()) {
                         continue;
                     }
-                    missingTxn |= p.getSecond().m_lastCompleteTxnTasks.peekFirst().getSecond();
+                    missingTxn |= st.m_lastCompleteTxnTasks.peekFirst().getSecond();
                     // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
                     // many SPI leaders are promoted, each round of CompleteTxnMessages share the same
                     // timestamp, so at TransactionTaskQueue level it only counts messages from the same round.
                     receivedCompleteTxns++;
-                }
-                if (p.getSecond().m_lastFragTask != null) {
-                    receivedFrags++;
                 }
             }
 
@@ -306,9 +310,10 @@ public class TransactionTaskQueue
             m_scoreboard.addCompletedTransactionTask(missingTxnCompletion, true);
             int receivedCompleteTxns = 0;
             for (Pair<SiteTaskerQueue, ScoreboardTasks> p : s_stashedMpWrites) {
-                if (!p.getSecond().m_lastCompleteTxnTasks.isEmpty()) {
-                    if (matchingCompletionTime != p.getSecond().m_lastCompleteTxnTasks.peekFirst().getFirst().getTimestamp()) {
-                        continue;
+                ScoreboardTasks st = p.getSecond();
+                if (!st.m_lastCompleteTxnTasks.isEmpty()) {
+                    if (matchingCompletionTime != st.m_lastCompleteTxnTasks.peekFirst().getFirst().getTimestamp()) {
+                        break;
                     }
                     // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
                     // many SPI leaders are promoted, each round of CompleteTxnMessages share the same

--- a/src/frontend/org/voltdb/messaging/FragmentTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/FragmentTaskMessage.java
@@ -645,7 +645,7 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
         int msgsize = super.getSerializedSize();
 
         // Fixed header
-        msgsize += 2 + 2 + 1 + 1 + 1 + 1 + 1 + 2;
+        msgsize += 2 + 2 + 1 + 1 + 1 + 1 + 1 + 2 + 8;
 
         // procname to load str if any
         if (m_procNameToLoad != null) {
@@ -729,8 +729,6 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
                 msgsize += 4 + item.m_stmtText.length;
             }
         }
-        // For the restarted transaction timestamp
-        msgsize += 8;
 
         return msgsize;
     }
@@ -791,6 +789,8 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
         }
         buf.put(m_perFragmentStatsRecording ? (byte) 1 : (byte) 0);
         buf.put(m_coordinatorTask ? (byte) 1 : (byte) 0);
+        // timestamp for restarted transaction
+        buf.putLong(m_restartTimestamp);
 
         // Plan Hash block
         for (FragmentData item : m_items) {
@@ -889,8 +889,6 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
                 buf.put(item.m_stmtText);
             }
         }
-        // timestamp for restarted transaction
-        buf.putLong(m_restartTimestamp);
     }
 
     @Override
@@ -927,6 +925,8 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
         }
         m_perFragmentStatsRecording = buf.get() != 0;
         m_coordinatorTask = buf.get() != 0;
+        // timestamp for restarted transaction
+        m_restartTimestamp = buf.getLong();
 
         m_items = new ArrayList<FragmentData>(fragCount);
 
@@ -1056,8 +1056,6 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
                 buf.get(item.m_stmtText);
             }
         }
-        // timestamp for restarted transaction
-        m_restartTimestamp = buf.getLong();
     }
 
     @Override

--- a/tests/frontend/org/voltdb/iv2/TestMpPromoteAlgo.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpPromoteAlgo.java
@@ -152,7 +152,7 @@ public class TestMpPromoteAlgo
         masters.add(2L);
         masters.add(3L);
 
-        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, "Test");
+        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, 0, "Test");
         long requestId = algo.getRequestId();
         Future<RepairResult> result = algo.start();
         verify(mailbox, times(1)).send(any(long[].class), any(Iv2RepairLogRequestMessage.class));
@@ -202,7 +202,7 @@ public class TestMpPromoteAlgo
         masters.add(2L);
         masters.add(3L);
 
-        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, "Test");
+        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, 0, "Test");
         long requestId = algo.getRequestId();
         Future<RepairResult> result = algo.start();
 
@@ -267,7 +267,7 @@ public class TestMpPromoteAlgo
         masters.add(2L);
         masters.add(3L);
 
-        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, "Test");
+        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, 0, "Test");
         long requestId = algo.getRequestId();
         Future<RepairResult> result = algo.start();
         verify(mailbox, times(1)).send(any(long[].class), any(Iv2RepairLogRequestMessage.class));
@@ -301,7 +301,7 @@ public class TestMpPromoteAlgo
         masters.add(1L);
         masters.add(2L);
 
-        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, "Test");
+        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, 0, "Test");
         long requestId = algo.getRequestId();
         Future<RepairResult> result = algo.start();
         verify(mailbox, times(1)).send(any(long[].class), any(Iv2RepairLogRequestMessage.class));
@@ -377,7 +377,7 @@ public class TestMpPromoteAlgo
         survivors.add(0l);
         survivors.add(1l);
         survivors.add(2l);
-        MpPromoteAlgo dut = new MpPromoteAlgo(survivors, mbox, "bleh ");
+        MpPromoteAlgo dut = new MpPromoteAlgo(survivors, mbox, 0, "bleh ");
         Future<RepairResult> result = dut.start();
         for (int i = 0; i < 3; i++) {
             List<Iv2RepairLogResponseMessage> stuff = logs[i].contents(dut.getRequestId(), true);


### PR DESCRIPTION
Some of the unit tests were failing because the static in the scoreboard was being reused by local serverthread. Also the RestartSequence generator uses the zkzeeper node id of the MPI to create unique sequence numbers, but some unit tests use mock which does not expose the nodeId.