### PR TITLE
ENG-13752:

### DIFF
--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -152,6 +152,11 @@ public interface BinaryDeque {
         public TruncatorResponse(Status status) {
             this.status = status;
         }
+
+        public int getTruncatedBuffSize() throws IOException {
+            throw new UnsupportedOperationException("Must implement this for partial object truncation");
+        }
+
         public int writeTruncatedObject(ByteBuffer output) throws IOException {
             throw new UnsupportedOperationException("Must implement this for partial object truncation");
         }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -339,10 +339,10 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry, int length) throws IOException
+    protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry, int hdrLength) throws IOException
     {
         int written = 0;
-        final DBBPool.BBContainer partialCont = DBBPool.allocateDirect(length);
+        final DBBPool.BBContainer partialCont = DBBPool.allocateDirect(hdrLength + entry.getTruncatedBuffSize());
         try {
             written += entry.writeTruncatedObject(partialCont.b());
             partialCont.b().flip();

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -165,7 +165,7 @@ public abstract class PBDSegment {
     // TODO: javadoc
     abstract int size();
 
-    abstract protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry, int length) throws IOException;
+    abstract protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry, int hdrLength) throws IOException;
 
     /**
      * Parse the segment and truncate the file if necessary.
@@ -226,9 +226,7 @@ public abstract class PBDSegment {
                         final long partialEntryBeginOffset = reader.readOffset();
                         m_fc.position(partialEntryBeginOffset);
 
-                        // It is conceivable that a truncated buffer uses up more compressed space than the original
-                        // compressed buffer, but we won't worry about that until it happens.
-                        final int written = writeTruncatedEntry(retval, compressedLength + OBJECT_HEADER_BYTES);
+                        final int written = writeTruncatedEntry(retval, OBJECT_HEADER_BYTES);
                         sizeInBytes += written;
 
                         initNumEntries(reader.readIndex(), sizeInBytes);

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -816,6 +816,11 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         @Override
+        public int getTruncatedBuffSize() {
+            return m_retval.remaining();
+        }
+
+        @Override
         public int writeTruncatedObject(ByteBuffer output) {
             int objectSize = m_retval.remaining();
             output.putInt(objectSize);
@@ -837,6 +842,11 @@ public class PersistentBinaryDeque implements BinaryDeque {
             super(Status.PARTIAL_TRUNCATE);
             m_ds = ds;
             m_truncationCallback = truncationCallback;
+        }
+
+        @Override
+        public int getTruncatedBuffSize() throws IOException {
+            return m_ds.getSerializedSize();
         }
 
         @Override


### PR DESCRIPTION
Previously it was assumed that a trucated PBD buffer would use less space than the original buffer. However, when compression is involved, this is not necessarily the case. To protect against this case, we get the necessary length from the truncation response rather than assuming that the original compressed buffer size will be enough.