### PR TITLE
Eng-13769 cherry-pick to 8.1

### DIFF
--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1479,6 +1479,10 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
     }
 
+    public int getNextSiteId() {
+        return m_nextSiteId.get();
+    }
+
     /**
      * Discard a mailbox
      */

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1222,7 +1222,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 for (Initiator ii : m_iv2Initiators.values()) {
                     localHSIds.add(ii.getInitiatorHSId());
                 }
-                m_MPI = new MpInitiator(m_messenger, localHSIds, getStatsAgent(), m_globalServiceElector.getLeaderElectorNode(), m_nodeSettings.getLocalSitesCount());
+                m_MPI = new MpInitiator(m_messenger, localHSIds, getStatsAgent(), m_globalServiceElector.getLeaderElectorNode());
                 m_iv2Initiators.put(MpInitiator.MP_INIT_PID, m_MPI);
 
                 // Make a list of HDIds to join
@@ -2085,11 +2085,11 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     {
         TreeMap<Integer, Initiator> initiators = new TreeMap<>();
         // Needed when static is reused by ServerThread
-        TransactionTaskQueue.resetScoreboards();
+        TransactionTaskQueue.resetScoreboards(m_messenger.getNextSiteId(), m_nodeSettings.getLocalSitesCount());
         for (Integer partition : partitions)
         {
             Initiator initiator = new SpInitiator(m_messenger, partition, getStatsAgent(),
-                    m_snapshotCompletionMonitor, startAction, m_nodeSettings.getLocalSitesCount());
+                    m_snapshotCompletionMonitor, startAction);
             initiators.put(partition, initiator);
             m_partitionsToSitesAtStartupForExportInit.add(partition);
         }

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -61,6 +61,7 @@ public abstract class BaseInitiator implements Initiator
     protected Thread m_siteThread = null;
     protected final RepairLog m_repairLog = new RepairLog();
 
+
     public BaseInitiator(String zkMailboxNode, HostMessenger messenger, Integer partition,
             Scheduler scheduler, String whoamiPrefix, StatsAgent agent,
             StartAction startAction)
@@ -70,6 +71,7 @@ public abstract class BaseInitiator implements Initiator
         m_partitionId = partition;
         m_scheduler = scheduler;
         JoinProducerBase joinProducer;
+
 
         if (startAction == StartAction.JOIN) {
             joinProducer = new ElasticJoinProducer(m_partitionId, scheduler.m_tasks);

--- a/src/frontend/org/voltdb/iv2/BorrowTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/BorrowTransactionState.java
@@ -17,7 +17,7 @@
 
 package org.voltdb.iv2;
 
-import org.voltcore.messaging.TransactionInfoBaseMessage;
+import org.voltdb.messaging.BorrowTaskMessage;
 
 /**
  * BorrowTransactionState represents the execution of a borrowed
@@ -29,9 +29,9 @@ import org.voltcore.messaging.TransactionInfoBaseMessage;
  */
 public class BorrowTransactionState extends ParticipantTransactionState
 {
-    BorrowTransactionState(long txnId, TransactionInfoBaseMessage notice)
+    BorrowTransactionState(long txnId, BorrowTaskMessage notice)
     {
-        super(txnId, notice, true);
+        super(txnId, notice, true, false);
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -48,7 +48,7 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
     private boolean m_firstFragResponseSent = false;
 
     // a snapshot sink used to stream table data from multiple sources
-    private final StreamSnapshotSink m_dataSink;
+    private StreamSnapshotSink m_dataSink = null;
     private Mailbox m_streamSnapshotMb;
 
     private class CompletionAction extends JoinCompletionAction {
@@ -65,8 +65,9 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
     {
         super(partitionId, "Elastic join producer:" + partitionId + " ", taskQueue);
         m_completionAction = new CompletionAction();
-        m_streamSnapshotMb = VoltDB.instance().getHostMessenger().createMailbox();
-        m_dataSink = new StreamSnapshotSink(m_streamSnapshotMb);
+        if (JOINLOG.isDebugEnabled()) {
+            JOINLOG.debug(m_whoami + "created");
+        }
     }
 
     /*
@@ -112,9 +113,16 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
         connection.setPerPartitionTxnIds(partitionTxnIds, true);
     }
 
+    private void initMailBox() {
+        m_streamSnapshotMb = VoltDB.instance().getHostMessenger().createMailbox();
+        m_dataSink = new StreamSnapshotSink(m_streamSnapshotMb);
+    }
+
     private void doInitiation(RejoinMessage message)
     {
         m_coordinatorHsId = message.m_sourceHSId;
+        initMailBox();
+
         registerSnapshotMonitor(message.getSnapshotNonce());
 
         // The lowest partition has a single source for all messages whereas all other partitions have a real

--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -452,7 +452,7 @@ public class FragmentTask extends FragmentTaskBase
     }
 
     public boolean needCoordination() {
-        return !m_txnState.isReadOnly() && !isBorrowedTask();
+        return !(m_txnState.isReadOnly() || isBorrowedTask() || m_isNPartition);
     }
 
     public boolean isBorrowedTask() {

--- a/src/frontend/org/voltdb/iv2/FragmentTaskBase.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTaskBase.java
@@ -17,12 +17,12 @@
 
 package org.voltdb.iv2;
 
-import org.voltdb.dtxn.TransactionState;
-
 public abstract class FragmentTaskBase extends TransactionTask {
+    final protected boolean m_isNPartition;
 
-    public FragmentTaskBase(TransactionState txnState, TransactionTaskQueue queue) {
+    public FragmentTaskBase(ParticipantTransactionState txnState, TransactionTaskQueue queue) {
         super(txnState, queue);
+        m_isNPartition = txnState.m_npTransaction;
     }
 
     // Used for FragmentTask and SysprocFragmentTask to match restarted messages

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -48,8 +48,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
 {
     public static final int MP_INIT_PID = TxnEgo.PARTITIONID_MAX_VALUE;
 
-    public MpInitiator(HostMessenger messenger, List<Long> buddyHSIds, StatsAgent agent,
-            int leaderNodeId, int localSitesCount)
+    public MpInitiator(HostMessenger messenger, List<Long> buddyHSIds, StatsAgent agent, int leaderNodeId)
     {
         super(VoltZK.iv2mpi,
                 messenger,
@@ -58,8 +57,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
                     MP_INIT_PID,
                     buddyHSIds,
                     new SiteTaskerQueue(MP_INIT_PID),
-                    leaderNodeId,
-                    localSitesCount),
+                    leaderNodeId),
                 "MP",
                 agent,
                 StartAction.CREATE /* never for rejoin */);

--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -111,27 +111,27 @@ public class MpPromoteAlgo implements RepairAlgo
     /**
      * Setup a new RepairAlgo but don't take any action to take responsibility.
      */
-    public MpPromoteAlgo(List<Long> survivors, InitiatorMailbox mailbox, int zkNodeId,
+    public MpPromoteAlgo(List<Long> survivors, InitiatorMailbox mailbox, MpRestartSequenceGenerator seqGen,
             String whoami)
     {
         m_survivors = new ArrayList<Long>(survivors);
         m_mailbox = mailbox;
         m_isMigratePartitionLeader = false;
         m_whoami = whoami;
-        m_restartSeqGenerator = new MpRestartSequenceGenerator(zkNodeId, false);
+        m_restartSeqGenerator = seqGen;
     }
 
     /**
      * Setup a new RepairAlgo but don't take any action to take responsibility.
      */
-    public MpPromoteAlgo(List<Long> survivors, InitiatorMailbox mailbox, int zkNodeId,
+    public MpPromoteAlgo(List<Long> survivors, InitiatorMailbox mailbox, MpRestartSequenceGenerator seqGen,
             String whoami, boolean migratePartitionLeader)
     {
         m_survivors = new ArrayList<Long>(survivors);
         m_mailbox = mailbox;
         m_isMigratePartitionLeader = migratePartitionLeader;
         m_whoami = whoami;
-        m_restartSeqGenerator = new MpRestartSequenceGenerator(zkNodeId, false);
+        m_restartSeqGenerator = seqGen;
     }
 
     @Override
@@ -329,6 +329,10 @@ public class MpPromoteAlgo implements RepairAlgo
             message.setForReplica(false);
             message.setRequireAck(false);
             message.setTimestamp(m_restartSeqGenerator.getNextSeqNum());
+            if (tmLog.isDebugEnabled()) {
+                tmLog.debug(m_whoami + "sending completion for txn " + TxnEgo.txnIdToString(message.getTxnId()) +
+                        ", ts " + MpRestartSequenceGenerator.restartSeqIdToString(message.getTimestamp()));
+            }
             return message;
         } else {
             FragmentTaskMessage ftm = (FragmentTaskMessage)msg.getPayload();

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -84,10 +84,10 @@ public class MpScheduler extends Scheduler
     // Let the one we can't be sure about linger here.  See ENG-4211 for more.
     long m_repairLogAwaitingCommit = Long.MIN_VALUE;
 
-    MpScheduler(int partitionId, List<Long> buddyHSIds, SiteTaskerQueue taskQueue, int leaderNodeId, int localSitesCount)
+    MpScheduler(int partitionId, List<Long> buddyHSIds, SiteTaskerQueue taskQueue, int leaderNodeId)
     {
         super(partitionId, taskQueue);
-        m_pendingTasks = new MpTransactionTaskQueue(m_tasks, localSitesCount);
+        m_pendingTasks = new MpTransactionTaskQueue(m_tasks);
         m_buddyHSIds = buddyHSIds;
         m_iv2Masters = new ArrayList<Long>();
         m_partitionMasters = Maps.newHashMap();

--- a/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
@@ -49,9 +49,9 @@ public class MpTransactionTaskQueue extends TransactionTaskQueue
 
     private MpRoSitePool m_sitePool = null;
 
-    MpTransactionTaskQueue(SiteTaskerQueue queue, int localSitesCount)
+    MpTransactionTaskQueue(SiteTaskerQueue queue)
     {
-        super(queue, localSitesCount);
+        super(queue);
     }
 
     void setMpRoSitePool(MpRoSitePool sitePool)

--- a/src/frontend/org/voltdb/iv2/ParticipantTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/ParticipantTransactionState.java
@@ -20,12 +20,16 @@ package org.voltdb.iv2;
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.dtxn.TransactionState;
+import org.voltdb.messaging.FragmentTaskMessage;
 
 public class ParticipantTransactionState extends TransactionState
 {
-    ParticipantTransactionState(long txnId, TransactionInfoBaseMessage notice)
+    final boolean m_npTransaction;
+
+    ParticipantTransactionState(long txnId, FragmentTaskMessage notice)
     {
         super(null, notice);
+        m_npTransaction = notice.getInitiateTask().isN_Partition();
     }
 
     /**
@@ -34,9 +38,10 @@ public class ParticipantTransactionState extends TransactionState
      * @param notice
      * @param readOnly
      */
-    ParticipantTransactionState(long txnId, TransactionInfoBaseMessage notice, boolean readOnly)
+    ParticipantTransactionState(long txnId, TransactionInfoBaseMessage notice, boolean readOnly, boolean npTransaction)
     {
         super(null, notice, readOnly);
+        m_npTransaction = npTransaction;
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -138,7 +138,9 @@ public class RejoinProducer extends JoinProducerBase {
         super(partitionId, "Rejoin producer:" + partitionId + " ", taskQueue);
         m_currentlyRejoining = new AtomicBoolean(true);
         m_completionAction = new ReplayCompletionAction();
-        REJOINLOG.debug(m_whoami + "created.");
+        if (REJOINLOG.isDebugEnabled()) {
+            REJOINLOG.debug(m_whoami + "created.");
+        }
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -97,11 +97,10 @@ public class SpInitiator extends BaseInitiator implements Promotable
 
     public SpInitiator(HostMessenger messenger, Integer partition, StatsAgent agent,
             SnapshotCompletionMonitor snapMonitor,
-            StartAction startAction,
-            int localSitesCount)
+            StartAction startAction)
     {
         super(VoltZK.iv2masters, messenger, partition,
-                new SpScheduler(partition, new SiteTaskerQueue(partition), snapMonitor, localSitesCount),
+                new SpScheduler(partition, new SiteTaskerQueue(partition), snapMonitor),
                 "SP", agent, startAction);
         ((SpScheduler)m_scheduler).initializeScoreboard(CoreUtils.getSiteIdFromHSId(getInitiatorHSId()));
         m_leaderCache = new LeaderCache(messenger.getZK(), VoltZK.iv2appointees, m_leadersChangeHandler);

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -184,10 +184,10 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 
     private final boolean IS_KSAFE_CLUSTER;
 
-    SpScheduler(int partitionId, SiteTaskerQueue taskQueue, SnapshotCompletionMonitor snapMonitor, int localSitesCount)
+    SpScheduler(int partitionId, SiteTaskerQueue taskQueue, SnapshotCompletionMonitor snapMonitor)
     {
         super(partitionId, taskQueue);
-        m_pendingTasks = new TransactionTaskQueue(m_tasks, localSitesCount);
+        m_pendingTasks = new TransactionTaskQueue(m_tasks);
         m_snapMonitor = snapMonitor;
         m_durabilityListener = new SpDurabilityListener(this, m_pendingTasks);
         m_uniqueIdGenerator = new UniqueIdGenerator(partitionId, 0);
@@ -1036,7 +1036,8 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         // offer FragmentTasks for txn ids that don't match if we have
         // something in progress already
         if (txn == null) {
-            txn = new ParticipantTransactionState(msg.getSpHandle(), msg, msg.isReadOnly());
+            txn = new ParticipantTransactionState(msg.getSpHandle(), msg, msg.isReadOnly(),
+                    msg.getInitiateTask().isN_Partition());
             m_outstandingTxns.put(msg.getTxnId(), txn);
             // Only want to send things to the command log if it satisfies this predicate
             // AND we've never seen anything for this transaction before.  We can't

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -312,7 +312,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
     }
 
     public boolean needCoordination() {
-        return !m_txnState.isReadOnly() && !isBorrowedTask();
+        return !(m_txnState.isReadOnly() || isBorrowedTask() || m_isNPartition);
     }
 
     public boolean isBorrowedTask() {

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -34,8 +34,89 @@ public class TransactionTaskQueue
 
     final protected SiteTaskerQueue m_taskQueue;
 
-    final private int m_siteCount;
     final private Scoreboard m_scoreboard;
+
+    private static class RelativeSiteOffset {
+        private SiteTaskerQueue[] m_stashedMpQueues;
+        private Scoreboard[] m_stashedMpScoreboards;
+        private int m_lowestSiteId = Integer.MIN_VALUE;
+        private int m_siteCount = 0;
+
+        void resetScoreboards(int firstSiteId, int siteCount) {
+            m_stashedMpQueues = null;
+            m_stashedMpScoreboards = null;
+            m_lowestSiteId = firstSiteId;
+            m_siteCount = siteCount;
+        }
+
+        void initializeScoreboard(int siteId, SiteTaskerQueue queue, Scoreboard scoreboard) {
+            hostLog.debug("Initializing scoreboard for site " + siteId + " out of " + m_siteCount + " (lowest expected is " + m_lowestSiteId + ")");
+            assert(m_lowestSiteId != Integer.MIN_VALUE);
+            assert(siteId >= m_lowestSiteId && siteId-m_lowestSiteId < m_siteCount);
+            if (m_stashedMpQueues == null) {
+                m_stashedMpQueues = new SiteTaskerQueue[m_siteCount];
+                m_stashedMpScoreboards = new Scoreboard[m_siteCount];
+            }
+            m_stashedMpQueues[siteId-m_lowestSiteId] = queue;
+            m_stashedMpScoreboards[siteId-m_lowestSiteId] = scoreboard;
+        }
+
+        // All sites receives FragmentTask messages, time to fire the task.
+        void releaseStashedFragments(long txnId) {
+            if (hostLog.isDebugEnabled()) {
+                hostLog.debug("release stashed fragment messages:" + TxnEgo.txnIdToString(txnId));
+            }
+            long lastTxnId = 0;
+            for (int ii = m_siteCount-1; ii >= 0; ii--) {
+                TransactionTask task = m_stashedMpScoreboards[ii].getFragmentTask();
+                assert(lastTxnId == 0 || lastTxnId == task.getTxnId());
+                lastTxnId = task.getTxnId();
+                Iv2Trace.logSiteTaskerQueueOffer(task);
+                m_stashedMpQueues[ii].offer(task);
+                m_stashedMpScoreboards[ii].clearFragment();
+            }
+
+        }
+
+        // All sites receives CompletedTransactionTask messages, time to fire the task.
+        void releaseStashedComleteTxns(boolean missingTxn, long txnId)
+        {
+            if (hostLog.isDebugEnabled()) {
+                if (missingTxn) {
+                    hostLog.debug("skipped incomplete rollback transaction message:" + TxnEgo.txnIdToString(txnId));
+                }
+                else {
+                    hostLog.debug("release stashed complete transaction message:" + TxnEgo.txnIdToString(txnId));
+                }
+            }
+            long lastTxnId = 0;
+            for (int ii = m_siteCount-1; ii >= 0; ii--) {
+                CompleteTransactionTask completion = m_stashedMpScoreboards[ii].getCompletionTasks().poll().getFirst();
+                assert(lastTxnId == 0 || lastTxnId == completion.getMsgTxnId());
+                lastTxnId = completion.getMsgTxnId();
+                if (!missingTxn) {
+                    Iv2Trace.logSiteTaskerQueueOffer(completion);
+                    m_stashedMpQueues[ii].offer(completion);
+                }
+            }
+        }
+
+        Scoreboard[] getScoreboards() {
+            return m_stashedMpScoreboards;
+        }
+
+        int getSiteCount() {
+            return m_siteCount;
+        }
+
+        // should only be used for debugging purpose
+        private void dumpStashedMpWrites(StringBuilder builder) {
+            for (int ii = 0; ii < m_siteCount; ii++) {
+                builder.append("\nQueue " + m_stashedMpQueues[ii].getPartitionId() + ":" + m_stashedMpScoreboards[ii]);
+            }
+        }
+
+    }
 
     /*
      * Multi-part transactions create a backlog of tasks behind them. A queue is
@@ -44,13 +125,12 @@ public class TransactionTaskQueue
      */
     private Deque<TransactionTask> m_backlog = new ArrayDeque<TransactionTask>();
 
-    final static ArrayList<Pair<SiteTaskerQueue, Scoreboard>> s_stashedMpWrites = new ArrayList<>(0);
-    static Object s_lock = new Object();
+    final private static RelativeSiteOffset s_stashedMpWrites = new RelativeSiteOffset();
+    private static Object s_lock = new Object();
 
-    TransactionTaskQueue(SiteTaskerQueue queue, int localSitesCount)
+    TransactionTaskQueue(SiteTaskerQueue queue)
     {
         m_taskQueue = queue;
-        m_siteCount = localSitesCount;
         if (queue.getPartitionId() == MpInitiator.MP_INIT_PID) {
             m_scoreboard = null;
         }
@@ -59,20 +139,16 @@ public class TransactionTaskQueue
         }
     }
 
-    public static void resetScoreboards() {
+    public static void resetScoreboards(int firstSiteId, int siteCount) {
         synchronized (s_lock) {
-            s_stashedMpWrites.clear();
+            s_stashedMpWrites.resetScoreboards(firstSiteId, siteCount);
         }
     }
 
     void initializeScoreboard(int siteId) {
         synchronized (s_lock) {
             if (m_taskQueue.getPartitionId() != MpInitiator.MP_INIT_PID) {
-                if (s_stashedMpWrites.isEmpty()) {
-                    s_stashedMpWrites.ensureCapacity(m_siteCount);
-                }
-                s_stashedMpWrites.add(siteId, Pair.of(m_taskQueue, m_scoreboard));
-                assert(s_stashedMpWrites.size() <= m_siteCount);
+                s_stashedMpWrites.initializeScoreboard(siteId, m_taskQueue, m_scoreboard);
             }
         }
     }
@@ -146,46 +222,6 @@ public class TransactionTaskQueue
         m_taskQueue.offer(task);
     }
 
-    // All sites receives FragmentTask messages, time to fire the task.
-    static private void releaseStashedFragments(long txnId)
-    {
-        if (hostLog.isDebugEnabled()) {
-            hostLog.debug("release stashed fragment messages:" + TxnEgo.txnIdToString(txnId));
-        }
-        long lastTxnId = 0;
-        for (Pair<SiteTaskerQueue, Scoreboard> p : s_stashedMpWrites) {
-            TransactionTask task = p.getSecond().getFragmentTask();
-            assert(lastTxnId == 0 || lastTxnId == task.getTxnId());
-            lastTxnId = task.getTxnId();
-            Iv2Trace.logSiteTaskerQueueOffer(task);
-            p.getFirst().offer(task);
-            p.getSecond().clearFragment();
-        }
-    }
-
-    // All sites receives CompletedTransactionTask messages, time to fire the task.
-    static private void releaseStashedComleteTxns(boolean missingTxn, long txnId)
-    {
-        if (hostLog.isDebugEnabled()) {
-            if (missingTxn) {
-                hostLog.debug("skipped incomplete rollback transaction message:" + TxnEgo.txnIdToString(txnId));
-            }
-            else {
-                hostLog.debug("release stashed complete transaction message:" + TxnEgo.txnIdToString(txnId));
-            }
-        }
-        long lastTxnId = 0;
-        for (Pair<SiteTaskerQueue, Scoreboard> p : s_stashedMpWrites) {
-            CompleteTransactionTask completion = p.getSecond().getCompletionTasks().poll().getFirst();
-            assert(lastTxnId == 0 || lastTxnId == completion.getMsgTxnId());
-            lastTxnId = completion.getMsgTxnId();
-            if (!missingTxn) {
-                Iv2Trace.logSiteTaskerQueueOffer(completion);
-                p.getFirst().offer(completion);
-            }
-        }
-    }
-
     private void coordinatedTaskQueueOffer(TransactionTask task) {
         synchronized (s_lock) {
             long matchingCompletionTime = -1;
@@ -201,19 +237,18 @@ public class TransactionTaskQueue
             int fragmentScore = 0;
             int completionScore = 0;
             boolean missingTxn = false;
-            for (Pair<SiteTaskerQueue, Scoreboard> p : s_stashedMpWrites) {
-                Scoreboard st = p.getSecond();
-                if (st.getFragmentTask() == null && st.getCompletionTasks().isEmpty()) {
+            for (Scoreboard sb : s_stashedMpWrites.getScoreboards()) {
+                if (sb.getFragmentTask() == null && sb.getCompletionTasks().isEmpty()) {
                     break;
                 }
-                if (st.getFragmentTask() != null) {
+                if (sb.getFragmentTask() != null) {
                     fragmentScore++;
                 }
-                if (!st.getCompletionTasks().isEmpty()) {
-                    if (matchingCompletionTime != st.getCompletionTasks().peekFirst().getFirst().getTimestamp()) {
+                if (!sb.getCompletionTasks().isEmpty()) {
+                    if (matchingCompletionTime != sb.getCompletionTasks().peekFirst().getFirst().getTimestamp()) {
                         continue;
                     }
-                    missingTxn |= st.getCompletionTasks().peekFirst().getSecond();
+                    missingTxn |= sb.getCompletionTasks().peekFirst().getSecond();
                     // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
                     // many SPI leaders are promoted, each round of CompleteTxnMessages share the same
                     // timestamp, so at TransactionTaskQueue level it only counts messages from the same round.
@@ -222,17 +257,18 @@ public class TransactionTaskQueue
             }
 
             if (hostLog.isDebugEnabled()) {
-                StringBuilder sb = new StringBuilder("MP Write Scoreboard Received " + task + "\nFrags: " + fragmentScore + "/" + m_siteCount +
-                        " Comps: " + completionScore + "/" + m_siteCount + ".\n");
-                dumpStashedMpWrites(sb);
+                StringBuilder sb = new StringBuilder("MP Write Scoreboard Received " + task +
+                        "\nFrags: " + fragmentScore + "/" + s_stashedMpWrites.getSiteCount() +
+                        " Comps: " + completionScore + "/" + s_stashedMpWrites.getSiteCount() + ".\n");
+                s_stashedMpWrites.dumpStashedMpWrites(sb);
                 hostLog.debug(sb.toString());
             }
-            if (completionScore == m_siteCount) {
-                releaseStashedComleteTxns(missingTxn, task.getTxnId());
+            if (completionScore == s_stashedMpWrites.getSiteCount()) {
+                s_stashedMpWrites.releaseStashedComleteTxns(missingTxn, task.getTxnId());
             }
             else
-            if (fragmentScore == m_siteCount && completionScore == 0) {
-                releaseStashedFragments(task.getTxnId());
+            if (fragmentScore == s_stashedMpWrites.getSiteCount() && completionScore == 0) {
+                s_stashedMpWrites.releaseStashedFragments(task.getTxnId());
             }
         }
     }
@@ -242,10 +278,9 @@ public class TransactionTaskQueue
             long matchingCompletionTime = missingTxnCompletion.getTimestamp();
             m_scoreboard.addCompletedTransactionTask(missingTxnCompletion, true);
             int completionScore = 0;
-            for (Pair<SiteTaskerQueue, Scoreboard> p : s_stashedMpWrites) {
-                Scoreboard st = p.getSecond();
-                if (!st.getCompletionTasks().isEmpty()) {
-                    if (matchingCompletionTime != st.getCompletionTasks().peekFirst().getFirst().getTimestamp()) {
+            for (Scoreboard sb : s_stashedMpWrites.getScoreboards()) {
+                if (!sb.getCompletionTasks().isEmpty()) {
+                    if (matchingCompletionTime != sb.getCompletionTasks().peekFirst().getFirst().getTimestamp()) {
                         break;
                     }
                     // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
@@ -257,20 +292,13 @@ public class TransactionTaskQueue
 
             if (hostLog.isDebugEnabled()) {
                 StringBuilder sb = new StringBuilder("MP Write Scoreboard Received unmatched " + missingTxnCompletion +
-                        "\nComps: " + completionScore + "/" + m_siteCount);
-                dumpStashedMpWrites(sb);
+                        "\nComps: " + completionScore + "/" + s_stashedMpWrites.getSiteCount());
+                s_stashedMpWrites.dumpStashedMpWrites(sb);
                 hostLog.debug(sb.toString());
             }
-            if (completionScore == m_siteCount) {
-                releaseStashedComleteTxns(true, missingTxnCompletion.getMsgTxnId());
+            if (completionScore == s_stashedMpWrites.getSiteCount()) {
+                s_stashedMpWrites.releaseStashedComleteTxns(true, missingTxnCompletion.getMsgTxnId());
             }
-        }
-    }
-
-    // should only be used for debugging purpose
-    private void dumpStashedMpWrites(StringBuilder builder) {
-        for (Pair<SiteTaskerQueue, Scoreboard> p : s_stashedMpWrites) {
-            builder.append("\nQueue " + p.getFirst().getPartitionId() + ":" + p.getSecond());
         }
     }
 

--- a/src/frontend/org/voltdb/messaging/Iv2InitiateTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/Iv2InitiateTaskMessage.java
@@ -164,6 +164,10 @@ public class Iv2InitiateTaskMessage extends TransactionInfoBaseMessage {
         return m_isSinglePartition;
     }
 
+    public boolean isN_Partition() {
+        return m_nPartitions != null;
+    }
+
     public boolean shouldReturnResultTables() {
         return m_shouldReturnResultTables;
     }

--- a/tests/frontend/org/voltdb/iv2/TestDurabilityListener.java
+++ b/tests/frontend/org/voltdb/iv2/TestDurabilityListener.java
@@ -164,7 +164,7 @@ public class TestDurabilityListener {
     {
         SiteTaskerQueue stq = mock(SiteTaskerQueue.class);
         SnapshotCompletionMonitor scm = mock(SnapshotCompletionMonitor.class);
-        SpScheduler sched = spy(new SpScheduler(1, stq, scm, 2));
+        SpScheduler sched = spy(new SpScheduler(1, stq, scm));
         sched.setLock(new Object());
 
         TransactionTaskQueue taskQueue = mock(TransactionTaskQueue.class);

--- a/tests/frontend/org/voltdb/iv2/TestMpPromoteAlgo.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpPromoteAlgo.java
@@ -152,7 +152,8 @@ public class TestMpPromoteAlgo
         masters.add(2L);
         masters.add(3L);
 
-        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, 0, "Test");
+        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox,
+                new MpRestartSequenceGenerator(0, false), "Test");
         long requestId = algo.getRequestId();
         Future<RepairResult> result = algo.start();
         verify(mailbox, times(1)).send(any(long[].class), any(Iv2RepairLogRequestMessage.class));
@@ -202,7 +203,8 @@ public class TestMpPromoteAlgo
         masters.add(2L);
         masters.add(3L);
 
-        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, 0, "Test");
+        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox,
+                new MpRestartSequenceGenerator(0, false), "Test");
         long requestId = algo.getRequestId();
         Future<RepairResult> result = algo.start();
 
@@ -267,7 +269,8 @@ public class TestMpPromoteAlgo
         masters.add(2L);
         masters.add(3L);
 
-        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, 0, "Test");
+        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox,
+                new MpRestartSequenceGenerator(0, false), "Test");
         long requestId = algo.getRequestId();
         Future<RepairResult> result = algo.start();
         verify(mailbox, times(1)).send(any(long[].class), any(Iv2RepairLogRequestMessage.class));
@@ -301,7 +304,8 @@ public class TestMpPromoteAlgo
         masters.add(1L);
         masters.add(2L);
 
-        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox, 0, "Test");
+        MpPromoteAlgo algo = new MpPromoteAlgo(masters, mailbox,
+                new MpRestartSequenceGenerator(0, false), "Test");
         long requestId = algo.getRequestId();
         Future<RepairResult> result = algo.start();
         verify(mailbox, times(1)).send(any(long[].class), any(Iv2RepairLogRequestMessage.class));
@@ -377,7 +381,8 @@ public class TestMpPromoteAlgo
         survivors.add(0l);
         survivors.add(1l);
         survivors.add(2l);
-        MpPromoteAlgo dut = new MpPromoteAlgo(survivors, mbox, 0, "bleh ");
+        MpPromoteAlgo dut = new MpPromoteAlgo(survivors, mbox,
+                new MpRestartSequenceGenerator(0, false), "bleh ");
         Future<RepairResult> result = dut.start();
         for (int i = 0; i < 3; i++) {
             List<Iv2RepairLogResponseMessage> stuff = logs[i].contents(dut.getRequestId(), true);

--- a/tests/frontend/org/voltdb/iv2/TestMpTransactionTaskQueue.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpTransactionTaskQueue.java
@@ -64,7 +64,7 @@ public class TestMpTransactionTaskQueue extends TestCase
         m_MPpool = mock(MpRoSitePool.class);
         // Accept work for a while
         when(m_MPpool.canAcceptWork()).thenReturn(true);
-        m_dut = new MpTransactionTaskQueue(m_writeQueue, 2);
+        m_dut = new MpTransactionTaskQueue(m_writeQueue);
         m_dut.setMpRoSitePool(m_MPpool);
     }
 

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
@@ -111,7 +111,7 @@ public class TestSpSchedulerDedupe
                                                           any(CommandLog.DurabilityListener.class),
                                                           any(TransactionTask.class));
 
-        dut = new SpScheduler(0, getSiteTaskerQueue(), snapMonitor, 2);
+        dut = new SpScheduler(0, getSiteTaskerQueue(), snapMonitor);
         dut.setMailbox(mbox);
         dut.setCommandLog(cl);
         dut.setLock(mbox);

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerSpHandle.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerSpHandle.java
@@ -104,7 +104,7 @@ public class TestSpSchedulerSpHandle extends TestCase
                                                           any(CommandLog.DurabilityListener.class),
                                                           any(TransactionTask.class));
 
-        dut = new SpScheduler(0, getSiteTaskerQueue(), snapMonitor, 2);
+        dut = new SpScheduler(0, getSiteTaskerQueue(), snapMonitor);
         dut.setMailbox(mbox);
         dut.setCommandLog(cl);
         dut.setLock(mbox);

--- a/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
+++ b/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
@@ -86,8 +86,11 @@ public class TestTransactionTaskQueue extends TestCase
                                     boolean forReplay)
     {
         FragmentTaskMessage msg = mock(FragmentTaskMessage.class);
+        Iv2InitiateTaskMessage itMsg = mock(Iv2InitiateTaskMessage.class);
+        when(itMsg.isN_Partition()).thenReturn(false);
         when(msg.getTxnId()).thenReturn(mpTxnId);
         when(msg.isForReplay()).thenReturn(forReplay);
+        when(msg.getInitiateTask()).thenReturn(itMsg);
         InitiatorMailbox mbox = mock(InitiatorMailbox.class);
         when(mbox.getHSId()).thenReturn(1337l);
         ParticipantTransactionState pft =
@@ -203,10 +206,11 @@ public class TestTransactionTaskQueue extends TestCase
 
     @Override
     public void setUp() {
+        TransactionTaskQueue.resetScoreboards(0, SITE_COUNT);
         for (int i = 0; i < SITE_COUNT; i++) {
             SiteTaskerQueue siteTaskQueue = getSiteTaskerQueue();
             m_siteTaskQueues.add(siteTaskQueue);
-            TransactionTaskQueue txnTaskQueue = new TransactionTaskQueue(siteTaskQueue, SITE_COUNT);
+            TransactionTaskQueue txnTaskQueue = new TransactionTaskQueue(siteTaskQueue);
             txnTaskQueue.initializeScoreboard(i);
             m_txnTaskQueues.add(txnTaskQueue);
             Deque<TransactionTask> expectedOrder = new ArrayDeque<>();
@@ -224,7 +228,6 @@ public class TestTransactionTaskQueue extends TestCase
             m_localTxnId[i] = 0;
         }
         m_mpTxnId = 0;
-        TransactionTaskQueue.resetScoreboards();
     }
 
     // This is the most common case

--- a/tests/log4j-allconsole.xml
+++ b/tests/log4j-allconsole.xml
@@ -24,7 +24,7 @@
         <level value="INFO"/>
     </logger -->
 
-    <!-- logger name="HOST">
+    <!--logger name="HOST">
         <level value="INFO"/>
     </logger -->
 
@@ -72,9 +72,9 @@
         <level value="TRACE"/>
     </logger -->
 
-    <logger name="TM">
+    <!-- logger name="TM">
         <level value="INFO"/>
-    </logger>
+    </logger -->
 
     <root>
         <priority value="info" />


### PR DESCRIPTION
…iteId fix (#5279)

* ENG-13769:
The scoreboard now coordinates all fragment tasks across all sites. However, NP transactions such as @BalancePartitions does not need to be coordinated because it does not modify replicated tables. This change will resolve join failures that currently get blocked by the scoreboard.

* ENG-13769:
Fix some unit tests and use an array instead of an arraylist for the scoreboard so that contiguous siteIds higher then 0 (happens when local serverthread is reused) are tolerated.

* ENG-12628: Pospone ElasticJoinProducer Mailbox initilzation till sp
initors creation

* ENG-12628:
MP Repair algo creates a new timestamp every time the repair is restarted so the same timestamp will be used repeatedly. We now create the timesamp once in the mpinitiator and pass it in every time we create a new MP Repair algo.

* remove duplicated kFactor method because of rebase

* address the review