### PR TITLE
ENG-13769 check both entries for task completion match in scoreboard

### DIFF
--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -101,4 +101,42 @@ public class Scoreboard {
     public void clearFragment() {
         m_fragTask = null;
     }
+
+    //There could be two transactions in the queue.
+    public boolean matchCompleteTransactionTask(long matchingCompletionTime) {
+        if (m_compTasks.isEmpty()) {
+            return false;
+        }
+        if (matchingCompletionTime == m_compTasks.peekFirst().getFirst().getTimestamp()) {
+            return true;
+        }
+
+        if (m_compTasks.size() == 2) {
+            return (matchingCompletionTime == m_compTasks.peekLast().getFirst().getTimestamp());
+        }
+        return false;
+    }
+
+    //Find the CompleteTransactionTask to be released. The task could be in header or tail
+    //If the released one has the latest time stamp, then remove txn before the released one.
+    public CompleteTransactionTask releaseCompleteTransactionTaskAndRemoveStaleTxn(long txnId) {
+        Pair<CompleteTransactionTask, Boolean> header = m_compTasks.pollFirst();
+        if (m_compTasks.isEmpty()) {
+            return header.getFirst();
+        }
+
+        Pair<CompleteTransactionTask, Boolean> tail = m_compTasks.pollFirst();
+        //match in the header
+        if (header.getFirst().getMsgTxnId() == txnId) {
+            if (header.getFirst().getTimestamp() < tail.getFirst().getTimestamp()) {
+                m_compTasks.addLast(tail);
+            }
+            return header.getFirst();
+        } else { //match in the tail
+            if (header.getFirst().getTimestamp() > tail.getFirst().getTimestamp()) {
+                m_compTasks.addLast(header);
+            }
+            return tail.getFirst();
+        }
+    }
 }

--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -128,12 +128,12 @@ public class Scoreboard {
         Pair<CompleteTransactionTask, Boolean> tail = m_compTasks.pollFirst();
         //match in the header
         if (header.getFirst().getMsgTxnId() == txnId) {
-            if (header.getFirst().getTimestamp() < tail.getFirst().getTimestamp()) {
+            if (txnId < tail.getFirst().getMsgTxnId()) {
                 m_compTasks.addLast(tail);
             }
             return header.getFirst();
         } else { //match in the tail
-            if (header.getFirst().getTimestamp() > tail.getFirst().getTimestamp()) {
+            if (header.getFirst().getMsgTxnId() > txnId) {
                 m_compTasks.addLast(header);
             }
             return tail.getFirst();

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -176,7 +176,8 @@ public class TransactionTaskQueue
         }
         long lastTxnId = 0;
         for (Pair<SiteTaskerQueue, Scoreboard> p : s_stashedMpWrites) {
-            CompleteTransactionTask completion = p.getSecond().getCompletionTasks().poll().getFirst();
+            CompleteTransactionTask completion = p.getSecond().releaseCompleteTransactionTaskAndRemoveStaleTxn(txnId);
+            assert(completion != null);
             assert(lastTxnId == 0 || lastTxnId == completion.getMsgTxnId());
             lastTxnId = completion.getMsgTxnId();
             if (!missingTxn) {
@@ -209,16 +210,14 @@ public class TransactionTaskQueue
                 if (st.getFragmentTask() != null) {
                     fragmentScore++;
                 }
-                if (!st.getCompletionTasks().isEmpty()) {
-                    if (matchingCompletionTime != st.getCompletionTasks().peekFirst().getFirst().getTimestamp()) {
-                        continue;
-                    }
-                    missingTxn |= st.getCompletionTasks().peekFirst().getSecond();
-                    // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
-                    // many SPI leaders are promoted, each round of CompleteTxnMessages share the same
-                    // timestamp, so at TransactionTaskQueue level it only counts messages from the same round.
-                    completionScore++;
+                if (!st.matchCompleteTransactionTask(matchingCompletionTime)) {
+                    continue;
                 }
+                missingTxn |= st.getCompletionTasks().peekFirst().getSecond();
+                // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
+                // many SPI leaders are promoted, each round of CompleteTxnMessages share the same
+                // timestamp, so at TransactionTaskQueue level it only counts messages from the same round.
+                completionScore++;
             }
 
             if (hostLog.isDebugEnabled()) {
@@ -244,15 +243,13 @@ public class TransactionTaskQueue
             int completionScore = 0;
             for (Pair<SiteTaskerQueue, Scoreboard> p : s_stashedMpWrites) {
                 Scoreboard st = p.getSecond();
-                if (!st.getCompletionTasks().isEmpty()) {
-                    if (matchingCompletionTime != st.getCompletionTasks().peekFirst().getFirst().getTimestamp()) {
-                        break;
-                    }
-                    // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
-                    // many SPI leaders are promoted, each round of CompleteTxnMessages share the same
-                    // timestamp, so at TransactionTaskQueue level it only counts messages from the same round.
-                    completionScore++;
+                if (!st.matchCompleteTransactionTask(matchingCompletionTime)) {
+                    continue;
                 }
+                // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
+                // many SPI leaders are promoted, each round of CompleteTxnMessages share the same
+                // timestamp, so at TransactionTaskQueue level it only counts messages from the same round.
+                completionScore++;
             }
 
             if (hostLog.isDebugEnabled()) {

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -90,7 +90,7 @@ public class TransactionTaskQueue
             }
             long lastTxnId = 0;
             for (int ii = m_siteCount-1; ii >= 0; ii--) {
-                CompleteTransactionTask completion = m_stashedMpScoreboards[ii].getCompletionTasks().poll().getFirst();
+                CompleteTransactionTask completion = m_stashedMpScoreboards[ii].releaseCompleteTransactionTaskAndRemoveStaleTxn(txnId);
                 assert(lastTxnId == 0 || lastTxnId == completion.getMsgTxnId());
                 lastTxnId = completion.getMsgTxnId();
                 if (!missingTxn) {

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -280,7 +280,7 @@ public class TransactionTaskQueue
             for (Scoreboard sb : s_stashedMpWrites.getScoreboards()) {
                 if (!sb.getCompletionTasks().isEmpty()) {
                     if (!sb.matchCompleteTransactionTask(matchingCompletionTime)) {
-                        continue;
+                        break;
                     }                    // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
                     // many SPI leaders are promoted, each round of CompleteTxnMessages share the same
                     // timestamp, so at TransactionTaskQueue level it only counts messages from the same round.


### PR DESCRIPTION
A stale txn may get into scoreboard in random order.  Check both entries for a completion match and release the completion tasks to avoid transaction lockup.