### PR TITLE
Only allow at most two messages in MP repair log, that is, complete m…

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -49,6 +49,7 @@ public class MpPromoteAlgo implements RepairAlgo
     private final long m_requestId = System.nanoTime();
     private final List<Long> m_survivors;
     private long m_maxSeenTxnId = TxnEgo.makeZero(MpInitiator.MP_INIT_PID).getTxnId();
+    private long m_maxSeenCompleteTxnId = TxnEgo.makeZero(MpInitiator.MP_INIT_PID).getTxnId();
     private final List<Iv2InitiateTaskMessage> m_interruptedTxns = new ArrayList<Iv2InitiateTaskMessage>();
     private Pair<Long, byte[]> m_newestHashinatorConfig = Pair.of(Long.MIN_VALUE,new byte[0]);
     // Each Term can process at most one promotion; if promotion fails, make
@@ -307,6 +308,11 @@ public class MpPromoteAlgo implements RepairAlgo
         if (msg.getPayload() == null) {
             return;
         }
+        // MP repair log has at most two messages, complete message for prior transaction
+        // and fragment message for current transaction, don't add message before prior completion
+        if (msg.getTxnId() <= m_maxSeenCompleteTxnId) {
+            return;
+        }
         Iv2RepairLogResponseMessage prev = m_repairLogUnion.floor(msg);
         if (prev != null && (prev.getTxnId() != msg.getTxnId())) {
             prev = null;
@@ -316,6 +322,7 @@ public class MpPromoteAlgo implements RepairAlgo
             // prefer complete messages to fragment tasks. Completion message also erases prior staled messages
             m_repairLogUnion.removeIf((p) -> p.getTxnId() <= msg.getTxnId());
             m_repairLogUnion.add(msg);
+            m_maxSeenCompleteTxnId = msg.getTxnId();
         }
         else if (prev == null) {
            m_repairLogUnion.add(msg);

--- a/tests/frontend/org/voltdb/iv2/TestMpPromoteAlgo.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpPromoteAlgo.java
@@ -252,7 +252,7 @@ public class TestMpPromoteAlgo
         needsRepair.add(1L);
         needsRepair.add(2L);
         needsRepair.add(3L);
-        inOrder.verify(mailbox, times(4)).repairReplicasWith(eq(needsRepair), any(Iv2RepairLogResponseMessage.class));
+        inOrder.verify(mailbox, times(1)).repairReplicasWith(eq(needsRepair), any(Iv2RepairLogResponseMessage.class));
 
         assertEquals(txnEgo(1003L), result.get().m_txnId);
     }


### PR DESCRIPTION
…essage for prior transaction and fragment message for current transaction.

Also fix TestMpPromoteAlgo.testSlowDieOff.

Change-Id: If5c45e6fa0e63088e1e3627a8084dc979bcd8005