### PR TITLE
ENG-13865, mp transaction in replay also doesn't have initiate task, …

### DIFF
--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1036,8 +1036,9 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         // offer FragmentTasks for txn ids that don't match if we have
         // something in progress already
         if (txn == null) {
+            //FIXME: replay transaction doesn't have initiate task,
             txn = new ParticipantTransactionState(msg.getSpHandle(), msg, msg.isReadOnly(),
-                    msg.isReadOnly() ? false : msg.getInitiateTask().isN_Partition());
+                    msg.getInitiateTask() != null ? msg.getInitiateTask().isN_Partition() : false);
             m_outstandingTxns.put(msg.getTxnId(), txn);
             // Only want to send things to the command log if it satisfies this predicate
             // AND we've never seen anything for this transaction before.  We can't

--- a/src/frontend/org/voltdb/messaging/FragmentTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/FragmentTaskMessage.java
@@ -527,6 +527,7 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
     }
 
     // Can be null for non-first fragment task message or read-only transaction
+    // or in replay
     public Iv2InitiateTaskMessage getInitiateTask() {
         return m_initiateTask;
     }


### PR DESCRIPTION
…which is another cause of the NPE.

Change-Id: Ie1825aabcdef2528fa0be0190ba879e5a1e3b0fe