### PR TITLE
Fix another corner case that non-restartable sysproc abort will gener…

### DIFF
--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -38,6 +38,14 @@ public class Scoreboard {
     private FragmentTaskBase m_fragTask;
 
     public void addCompletedTransactionTask(CompleteTransactionTask task, Boolean missingTxn) {
+        // This happens when a non-restartable sysproc was aborted, since MPI doesn't send repair message for this transaction
+        // we must allow the rollback completion to go through scoreboard.
+        boolean isTxnRollback = (task.getCompleteMessage().isRollback() && task.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP);
+        // Dont' treat rollback transaction as missing
+        if (isTxnRollback) {
+            missingTxn = false;
+        }
+
         // This is an extremely rare case were a MPI restart completion arrives before the dead MPI's completion
         // Ignore this message because the restart completion is more recent and should step on the initial completion
         if (task.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP &&

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -71,7 +71,6 @@ import org.voltdb.messaging.RepairLogTruncationMessage;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltTrace;
 
-import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.primitives.Ints;
 import com.google_voltpatches.common.primitives.Longs;
@@ -146,7 +145,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         public void lastUniqueIdsMadeDurable(long spUniqueId, long mpUniqueId);
     }
 
-    private ImmutableList<Long> m_replicaHSIds = ImmutableList.of();
+    private List<Long> m_replicaHSIds = new ArrayList<>();
     long m_sendToHSIds[] = new long[0];
     private final TransactionTaskQueue m_pendingTasks;
     private final Map<Long, TransactionState> m_outstandingTxns =
@@ -258,7 +257,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             replicasAdded = Longs.toArray(rejoinHSIds);
         }
         // First - correct the official replica set.
-        m_replicaHSIds = ImmutableList.copyOf(replicas);
+        m_replicaHSIds = replicas;
         // Update the list of remote replicas that we'll need to send to
         List<Long> sendToHSIds = new ArrayList<Long>(m_replicaHSIds);
         sendToHSIds.remove(m_mailbox.getHSId());


### PR DESCRIPTION
…ate rollback completion instead of repair or restart completion, scorebaord should allow rollback completion to run no matter it is an missing completion or not.

Change-Id: I72837e8a79b483964817ee011b760497961a6059