### PR TITLE
Eng 13891: Ignore np missingTxnCompletion for Scoreboard

### DIFF
--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1285,7 +1285,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
                 new CompleteTransactionTask(m_mailbox, txn, m_pendingTasks, msg);
             queueOrOfferMPTask(task);
         } else {
-            if (!msg.isReadOnly()) {
+            if (msg.needsCoordination()) {
                 final CompleteTransactionTask missingTxnCompletion =
                         new CompleteTransactionTask(m_mailbox, null, m_pendingTasks, msg);
                 m_pendingTasks.handleCompletionForMissingTxn(missingTxnCompletion);


### PR DESCRIPTION
If repair has receiving the completion Message for a missing np transaction, that txn should already been commit or never seen. We should not put a completeTransactionTask to the scoreboard since it don't need to be coordination.