### PR TITLE
ENG-13854, When MPI fails over, since repair log doesn't include any …

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -117,7 +117,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
             m_term.start();
             while (!success) {
                 final RepairAlgo repair =
-                        m_initiatorMailbox.constructRepairAlgo(m_term.getInterestingHSIds(), m_whoami);
+                        m_initiatorMailbox.constructRepairAlgo(m_term.getInterestingHSIds(), m_whoami, false, true);
 
                 // term syslogs the start of leader promotion.
                 long txnid = Long.MIN_VALUE;

--- a/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
@@ -85,17 +85,17 @@ public class MpInitiatorMailbox extends InitiatorMailbox
 
     @Override
     public RepairAlgo constructRepairAlgo(final Supplier<List<Long>> survivors, final String whoami) {
-        return constructRepairAlgo(survivors, whoami , false);
+        return constructRepairAlgo(survivors, whoami , false, false);
     }
 
-    public RepairAlgo constructRepairAlgo(final Supplier<List<Long>> survivors, final String whoami, boolean balanceSPI) {
+    public RepairAlgo constructRepairAlgo(final Supplier<List<Long>> survivors, final String whoami, boolean balanceSPI, boolean isMPIFailover) {
         RepairAlgo ra = null;
         if (Thread.currentThread().getId() != m_taskThreadId) {
             FutureTask<RepairAlgo> ft = new FutureTask<RepairAlgo>(new Callable<RepairAlgo>() {
                 @Override
                 public RepairAlgo call() throws Exception {
                     RepairAlgo ra = new MpPromoteAlgo(survivors.get(), MpInitiatorMailbox.this,
-                            m_restartSeqGenerator, whoami, balanceSPI);
+                            m_restartSeqGenerator, whoami, balanceSPI, isMPIFailover);
                     setRepairAlgoInternal(ra);
                     return ra;
                 }
@@ -107,7 +107,7 @@ public class MpInitiatorMailbox extends InitiatorMailbox
                 Throwables.propagate(e);
             }
         } else {
-            ra = new MpPromoteAlgo(survivors.get(), this, m_restartSeqGenerator, whoami, balanceSPI);
+            ra = new MpPromoteAlgo(survivors.get(), this, m_restartSeqGenerator, whoami, balanceSPI, isMPIFailover);
             setRepairAlgoInternal(ra);
         }
         return ra;

--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -46,7 +46,8 @@ public class MpPromoteAlgo implements RepairAlgo
     private final String m_whoami;
 
     private final InitiatorMailbox m_mailbox;
-    private final long m_requestId = System.nanoTime();
+    // The last bit is isMPIFailover flag, 1 means true, 0 means false.
+    private final long m_requestId;
     private final List<Long> m_survivors;
     private long m_maxSeenTxnId = TxnEgo.makeZero(MpInitiator.MP_INIT_PID).getTxnId();
     private long m_maxSeenCompleteTxnId = TxnEgo.makeZero(MpInitiator.MP_INIT_PID).getTxnId();
@@ -120,19 +121,22 @@ public class MpPromoteAlgo implements RepairAlgo
         m_isMigratePartitionLeader = false;
         m_whoami = whoami;
         m_restartSeqGenerator = seqGen;
+        m_requestId = System.nanoTime() << 1;
     }
 
     /**
      * Setup a new RepairAlgo but don't take any action to take responsibility.
      */
     public MpPromoteAlgo(List<Long> survivors, InitiatorMailbox mailbox, MpRestartSequenceGenerator seqGen,
-            String whoami, boolean migratePartitionLeader)
+            String whoami, boolean migratePartitionLeader, boolean isMPIFailover)
     {
         m_survivors = new ArrayList<Long>(survivors);
         m_mailbox = mailbox;
         m_isMigratePartitionLeader = migratePartitionLeader;
         m_whoami = whoami;
         m_restartSeqGenerator = seqGen;
+        // use the last bit to mark whether the repair request message is from newly promoted MPI (MPI failover)
+        m_requestId = (isMPIFailover? 1L : 0L) | System.nanoTime() << 1;
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/MpRepairTask.java
+++ b/src/frontend/org/voltdb/iv2/MpRepairTask.java
@@ -61,7 +61,7 @@ public class MpRepairTask extends SiteTasker
         m_spMasters = new ArrayList<Long>(spMasters);
         whoami = "MP leader repair " +
                 CoreUtils.hsIdToString(m_mailbox.getHSId()) + " ";
-        algo = mailbox.constructRepairAlgo(Suppliers.ofInstance(m_spMasters), whoami, balanceSPI);
+        algo = mailbox.constructRepairAlgo(Suppliers.ofInstance(m_spMasters), whoami, balanceSPI, false);
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/Scheduler.java
+++ b/src/frontend/org/voltdb/iv2/Scheduler.java
@@ -215,4 +215,6 @@ abstract public class Scheduler implements InitiatorMessageHandler
     abstract public void enableWritingIv2FaultLog();
 
     abstract public boolean sequenceForReplay(VoltMessage m);
+
+    public void handleMPIFailoverMessage() {}
 }

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -210,7 +210,7 @@ public class SpInitiator extends BaseInitiator implements Promotable
                 // term syslogs the start of leader promotion.
                 long txnid = Long.MIN_VALUE;
                 RepairAlgo repair =
-                        m_initiatorMailbox.constructRepairAlgo(m_term.getInterestingHSIds(), m_whoami, migratePartitionLeader);
+                        m_initiatorMailbox.constructRepairAlgo(m_term.getInterestingHSIds(), m_whoami, migratePartitionLeader, false);
                 try {
                     RepairResult res = repair.start().get();
                     txnid = res.m_txnId;

--- a/src/frontend/org/voltdb/iv2/SpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/SpPromoteAlgo.java
@@ -40,7 +40,7 @@ public class SpPromoteAlgo implements RepairAlgo
     private final String m_whoami;
 
     private final InitiatorMailbox m_mailbox;
-    private final long m_requestId = System.nanoTime();
+    private final long m_requestId;
     private final List<Long> m_survivors;
     private long m_maxSeenTxnId;
     private final boolean m_isMigratePartitionLeader;
@@ -118,6 +118,8 @@ public class SpPromoteAlgo implements RepairAlgo
         m_whoami = whoami;
         m_maxSeenTxnId = TxnEgo.makeZero(partitionId).getTxnId();
         m_isMigratePartitionLeader = isMigratePartitionLeader;
+        // last bit of request id is reserved for MpPromoteAlgo
+        m_requestId = System.nanoTime() << 1L;
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1796,7 +1796,8 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
                 }
             }
         }
-        if (maxSeenMpTxnId != -1 && m_pendingTasks.peekFirstBacklogTask().getTransactionState().isReadOnly()) {
+        if (maxSeenMpTxnId != -1 && m_pendingTasks.peekFirstBacklogTask() != null &&
+                m_pendingTasks.peekFirstBacklogTask().getTransactionState().isReadOnly()) {
             m_pendingTasks.flush(maxSeenMpTxnId);
         }
     }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1798,6 +1798,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         }
         if (maxSeenMpTxnId != -1 && m_pendingTasks.peekFirstBacklogTask() != null &&
                 m_pendingTasks.peekFirstBacklogTask().getTransactionState().isReadOnly()) {
+            assert (maxSeenMpTxnId == m_pendingTasks.peekFirstBacklogTask().getTxnId());
             m_pendingTasks.flush(maxSeenMpTxnId);
         }
     }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,7 @@ import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.messaging.InitiateResponseMessage;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.messaging.Iv2LogFaultMessage;
+import org.voltdb.messaging.MPIFailoverMessage;
 import org.voltdb.messaging.MultiPartitionParticipantMessage;
 import org.voltdb.messaging.RepairLogTruncationMessage;
 import org.voltdb.utils.MiscUtils;
@@ -458,6 +460,9 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         }
         else if (message instanceof DummyTransactionResponseMessage) {
             handleDummyTransactionResponseMessage((DummyTransactionResponseMessage)message);
+        }
+        else if (message instanceof MPIFailoverMessage) {
+            handleMPIFailoverMessage();
         }
         else {
             throw new RuntimeException("UNKNOWN MESSAGE TYPE, BOOM!");
@@ -1762,4 +1767,38 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             }
         }
     }
+
+    // When MPI fails over, since repair log doesn't include any MP RO transaction, new MPI needs to clean up the
+    // possibly in-progress RO transaction. Note that if RO transaction is a multi-fragment read, some sites may have
+    // not received the fragment while some others have received it when the MPI failover occurs. If new MPI starts
+    // the next transaction without cleaning up prior RO transaction, on the sites that have received fragment, the
+    // backlogs of transaction task queue are still blocked on the fragment, it causes MP deadlock for the next transaction.
+    //
+    // Fix of this issue is to ask site leaders to clean their backlogs and duplicate counters when they receives repair log request
+    // from new MPI, site leaders also forward the message to its replicas.
+    @Override
+    public void handleMPIFailoverMessage() {
+        if (m_isLeader && m_sendToHSIds.length > 0) {
+            m_mailbox.send(m_sendToHSIds, new MPIFailoverMessage());
+        }
+
+        long maxSeenMpTxnId = -1;
+        Iterator<Entry<Long, TransactionState>> iter = m_outstandingTxns.entrySet().iterator();
+        while (iter.hasNext()) {
+            Entry<Long, TransactionState> entry = iter.next();
+            TransactionState txnState = entry.getValue();
+            if (TxnEgo.getPartitionId(entry.getKey()) == MpInitiator.MP_INIT_PID ) {
+                maxSeenMpTxnId = Math.max(entry.getKey(), maxSeenMpTxnId);
+                if (txnState.isReadOnly()) {
+                    txnState.setDone();
+                    m_duplicateCounters.entrySet().removeIf((e) -> e.getKey().m_txnId == entry.getKey());
+                    iter.remove();
+                }
+            }
+        }
+        if (maxSeenMpTxnId != -1 && m_pendingTasks.peekFirstBacklogTask().getTransactionState().isReadOnly()) {
+            m_pendingTasks.flush(maxSeenMpTxnId);
+        }
+    }
+
 }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1768,8 +1768,8 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         }
     }
 
-    // When MPI fails over, since repair log doesn't include any MP RO transaction, new MPI needs to clean up the
-    // possibly in-progress RO transaction. Note that if RO transaction is a multi-fragment read, some sites may have
+    // When MPI fails over, since repair log doesn't include any MP RO transaction, the new MPI needs to clean up
+    // possible in-progress RO transaction. Note that if RO transaction is a multi-fragment read, some sites may have
     // not received the fragment while some others have received it when the MPI failover occurs. If new MPI starts
     // the next transaction without cleaning up prior RO transaction, on the sites that have received fragment, the
     // backlogs of transaction task queue are still blocked on the fragment, it causes MP deadlock for the next transaction.

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -471,5 +471,11 @@ public class TransactionTaskQueue
         return pendingTasks;
     }
 
+    public TransactionTask peekFirstBacklogTask() {
+        if (m_backlog.isEmpty()) {
+            return null;
+        }
+        return m_backlog.getFirst();
+    }
 
 }

--- a/src/frontend/org/voltdb/messaging/MPIFailoverMessage.java
+++ b/src/frontend/org/voltdb/messaging/MPIFailoverMessage.java
@@ -1,0 +1,63 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.messaging;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.voltcore.messaging.VoltMessage;
+import org.voltcore.utils.CoreUtils;
+
+public class MPIFailoverMessage extends VoltMessage {
+
+    public MPIFailoverMessage()
+    {
+        super();
+    }
+
+    @Override
+    public int getSerializedSize()
+    {
+        int msgsize = super.getSerializedSize();
+        return msgsize;
+    }
+
+    @Override
+    public void flattenToBuffer(ByteBuffer buf) throws IOException
+    {
+        buf.put(VoltDbMessageFactory.MPI_FAILOVER_MESSAGE_ID);
+
+        assert(buf.capacity() == buf.position());
+        buf.limit(buf.position());
+    }
+
+    @Override
+    public void initFromBuffer(ByteBuffer buf) throws IOException {
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("MPI_FAILOVER (FROM ")
+          .append(CoreUtils.hsIdToString(m_sourceHSId))
+          .append(")");
+        return sb.toString();
+    }
+
+}

--- a/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
+++ b/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
@@ -53,6 +53,7 @@ public class VoltDbMessageFactory extends VoltMessageFactory
     final public static byte DUMMY_TRANSACTION_RESPONSE_ID = VOLTCORE_MESSAGE_ID_MAX + 27;
     final public static byte DUMP_PLAN_ID = VOLTCORE_MESSAGE_ID_MAX + 28;
     final public static byte Migrate_Partition_Leader_MESSAGE_ID = VOLTCORE_MESSAGE_ID_MAX + 29;
+    final public static byte MPI_FAILOVER_MESSAGE_ID = VOLTCORE_MESSAGE_ID_MAX + 30;
 
     /**
      * Overridden by subclasses to create message types unknown by voltcore
@@ -152,6 +153,9 @@ public class VoltDbMessageFactory extends VoltMessageFactory
             break;
         case DUMP_PLAN_ID:
             message = new DumpPlanThenExitMessage();
+            break;
+        case MPI_FAILOVER_MESSAGE_ID:
+            message = new MPIFailoverMessage();
             break;
         default:
             message = null;


### PR DESCRIPTION
…MP RO transaction, new MPI needs to clean up the possibly in-progress RO transaction. Note that if RO transaction is a multi-fragment read, some sites may have not received the fragment while some others have received it when the MPI failover occurs. If new MPI starts the next transaction without cleaning up prior RO transaction, on the sites that have received fragment, the backlogs of transaction task queue are still blocked on the fragment, it causes MP deadlock for the next transaction.

Fix of this issue is to ask site leaders to clean their backlogs and duplicate counters when they receives repair log request from new MPI, site leaders also forward the message to its replicas.

Change-Id: I009386d189cb69a0292e5b1fd8d49102e1017395