### PR TITLE
ENG-13844: Disable/Reenable Scoreboard for join Nodes

### DIFF
--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -505,7 +505,6 @@ public class VoltZK {
                 return false;
             }
         } catch (InterruptedException e) {
-            log.error("Failed to remove action blocker: " + node + "\n" + e.getMessage(), e);
             return false;
         }
         return true;

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -500,11 +500,12 @@ public class VoltZK {
         } catch (KeeperException e) {
             if (e.code() != KeeperException.Code.NONODE) {
                 if (log != null) {
-                    log.error("Failed to remove action blocker: " + e.getMessage(), e);
+                    log.error("Failed to remove action blocker: " + node + "\n" + e.getMessage(), e);
                 }
                 return false;
             }
         } catch (InterruptedException e) {
+            log.error("Failed to remove action blocker: " + node + "\n" + e.getMessage(), e);
             return false;
         }
         return true;

--- a/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
@@ -51,7 +51,7 @@ public class MpTransactionTaskQueue extends TransactionTaskQueue
 
     MpTransactionTaskQueue(SiteTaskerQueue queue)
     {
-        super(queue);
+        super(queue, false);
     }
 
     void setMpRoSitePool(MpRoSitePool sitePool)

--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -91,13 +91,7 @@ public class Scoreboard {
             Pair<CompleteTransactionTask, Boolean> head = m_compTasks.peekFirst();
             Pair<CompleteTransactionTask, Boolean> tail = m_compTasks.peekLast();
             // scoreboard can take completions from two transactions at most
-            if (!(task.getMsgTxnId() == head.getFirst().getMsgTxnId() || task.getMsgTxnId() == tail.getFirst().getMsgTxnId())) {
-                tmLog.error("Received an unexpected completion task: " + task +
-                            "\n head: " + head.getFirst() +
-                            "\n tail: " + tail.getFirst());
-                assert (false);
-            }
-
+            assert (task.getMsgTxnId() == head.getFirst().getMsgTxnId() || task.getMsgTxnId() == tail.getFirst().getMsgTxnId());
 
             // Keep newer completion, discard the older one
             if ( task.getTimestamp() > head.getFirst().getTimestamp() && isComparable(head.getFirst(), task)) {

--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -20,6 +20,7 @@ package org.voltdb.iv2;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
+import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.Pair;
 import org.voltdb.messaging.CompleteTransactionMessage;
 
@@ -36,6 +37,7 @@ import org.voltdb.messaging.CompleteTransactionMessage;
 public class Scoreboard {
     private Deque<Pair<CompleteTransactionTask, Boolean>> m_compTasks = new ArrayDeque<>(2);
     private FragmentTaskBase m_fragTask;
+    protected static final VoltLogger tmLog = new VoltLogger("TM");
 
     public void addCompletedTransactionTask(CompleteTransactionTask task, Boolean missingTxn) {
         // This happens when a non-restartable sysproc was aborted, since MPI doesn't send repair message for this transaction
@@ -88,8 +90,14 @@ public class Scoreboard {
             // scoreboard has two completions
             Pair<CompleteTransactionTask, Boolean> head = m_compTasks.peekFirst();
             Pair<CompleteTransactionTask, Boolean> tail = m_compTasks.peekLast();
-            // scorebaord can take completions from two transactions at most
-            assert (task.getMsgTxnId() == head.getFirst().getMsgTxnId() || task.getMsgTxnId() == tail.getFirst().getMsgTxnId());
+            // scoreboard can take completions from two transactions at most
+            if (!(task.getMsgTxnId() == head.getFirst().getMsgTxnId() || task.getMsgTxnId() == tail.getFirst().getMsgTxnId())) {
+                tmLog.error("Received an unexpected completion task: " + task +
+                            "\n head: " + head.getFirst() +
+                            "\n tail: " + tail.getFirst());
+                assert (false);
+            }
+
 
             // Keep newer completion, discard the older one
             if ( task.getTimestamp() > head.getFirst().getTimestamp() && isComparable(head.getFirst(), task)) {

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -844,7 +844,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                         }
                     } else {
                         //If there are no tasks, do task log work
-                        didWork |= replayFromTaskLog(mrm);
+                        didWork = replayFromTaskLog(mrm);
                     }
                     if (!didWork) Thread.yield();
                 } else {

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -100,7 +100,7 @@ public class SpInitiator extends BaseInitiator implements Promotable
             StartAction startAction)
     {
         super(VoltZK.iv2masters, messenger, partition,
-                new SpScheduler(partition, new SiteTaskerQueue(partition), snapMonitor),
+                new SpScheduler(partition, new SiteTaskerQueue(partition), snapMonitor, startAction != StartAction.JOIN),
                 "SP", agent, startAction);
         ((SpScheduler)m_scheduler).initializeScoreboard(CoreUtils.getSiteIdFromHSId(getInitiatorHSId()), m_initiatorMailbox);
         m_leaderCache = new LeaderCache(messenger.getZK(), VoltZK.iv2appointees, m_leadersChangeHandler);

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -46,6 +46,7 @@ import org.voltdb.CommandLog.DurabilityListener;
 import org.voltdb.RealVoltDB;
 import org.voltdb.SnapshotCompletionInterest;
 import org.voltdb.SnapshotCompletionMonitor;
+import org.voltdb.StartAction;
 import org.voltdb.SystemProcedureCatalog;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
@@ -184,10 +185,10 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 
     private final boolean IS_KSAFE_CLUSTER;
 
-    SpScheduler(int partitionId, SiteTaskerQueue taskQueue, SnapshotCompletionMonitor snapMonitor)
+    SpScheduler(int partitionId, SiteTaskerQueue taskQueue, SnapshotCompletionMonitor snapMonitor, boolean scoreboardEnabled)
     {
         super(partitionId, taskQueue);
-        m_pendingTasks = new TransactionTaskQueue(m_tasks);
+        m_pendingTasks = new TransactionTaskQueue(m_tasks, scoreboardEnabled);
         m_snapMonitor = snapMonitor;
         m_durabilityListener = new SpDurabilityListener(this, m_pendingTasks);
         m_uniqueIdGenerator = new UniqueIdGenerator(partitionId, 0);

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -167,6 +167,18 @@ public class SysprocFragmentTask extends FragmentTaskBase
                     "The rejoining node's VoltDB process will now exit.", false, null);
         }
 
+        // special case for @PingPartitions for re-enabling scoreboard
+        if (SysProcFragmentId.isEnableScoreboardFragment(m_fragmentMsg.getPlanHash(0)) &&
+                ! m_queue.scoreboardEnabled()) {
+            // enable scoreboard
+            // TODO: For handling the rare corner case of MP Failover during handling the last @PingPartitions,
+            // We would better to enable the scoreboard atomic for. This requires a barrier for ensuring all sites has seen this last fragments.
+            m_queue.setScoreboard(true);
+            // queue to the scoreboard
+            m_queue.offer(this);
+            return;
+        }
+
         taskLog.logTask(m_fragmentMsg);
 
         respondWithDummy();

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -171,9 +171,9 @@ public class SysprocFragmentTask extends FragmentTaskBase
         if (SysProcFragmentId.isEnableScoreboardFragment(m_fragmentMsg.getPlanHash(0)) &&
                 ! m_queue.scoreboardEnabled()) {
             // enable scoreboard
-            // TODO: For handling the rare corner case of MP Failover during handling the last @PingPartitions,
+            // TODO: For handling the rare corner case of MPI Failover during handling the last @PingPartitions,
             // We would better to enable the scoreboard atomic for. This requires a barrier for ensuring all sites has seen this last fragments.
-            m_queue.setScoreboard(true);
+            m_queue.enableScoreboard();
             // queue to the scoreboard
             m_queue.offer(this);
             return;

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -329,6 +329,7 @@ public class TransactionTaskQueue
     }
 
     public void handleCompletionForMissingTxn(CompleteTransactionTask missingTxnCompletion) {
+        if (!m_scoreboardEnabled) return;
         synchronized (s_lock) {
             long taskTxnId = missingTxnCompletion.getMsgTxnId();
             long taskTimestamp = missingTxnCompletion.getTimestamp();

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -37,6 +37,7 @@ public class TransactionTaskQueue
     final protected SiteTaskerQueue m_taskQueue;
 
     final private Scoreboard m_scoreboard;
+    private boolean m_scoreboardEnabled;
 
     private static class RelativeSiteOffset {
         private SiteTaskerQueue[] m_stashedMpQueues;
@@ -87,7 +88,7 @@ public class TransactionTaskQueue
 
         // All sites receives CompletedTransactionTask messages, time to fire the task.
         // If there are enough completeTransactionTask messages to fire another round of release, return false, otherwise true.
-        boolean releaseStashedComleteTxns(boolean missingTxn, long txnId)
+        boolean releaseStashedCompleteTxns(boolean missingTxn, long txnId)
         {
             boolean missingTask = missingTxn ? true : hasMissingTxn(txnId);
             if (hostLog.isDebugEnabled()) {
@@ -160,7 +161,8 @@ public class TransactionTaskQueue
     final private static RelativeSiteOffset s_stashedMpWrites = new RelativeSiteOffset();
     private static Object s_lock = new Object();
 
-    TransactionTaskQueue(SiteTaskerQueue queue)
+
+    TransactionTaskQueue(SiteTaskerQueue queue, boolean scoreboardEnabled)
     {
         m_taskQueue = queue;
         if (queue.getPartitionId() == MpInitiator.MP_INIT_PID) {
@@ -169,6 +171,18 @@ public class TransactionTaskQueue
         else {
             m_scoreboard = new Scoreboard();
         }
+        m_scoreboardEnabled = scoreboardEnabled;
+    }
+
+    public void setScoreboard(boolean enabled) {
+        if (hostLog.isDebugEnabled()) {
+            hostLog.debug("Scoreboard being enabled " + enabled);
+        }
+        m_scoreboardEnabled = enabled;
+    }
+
+    public boolean scoreboardEnabled() {
+        return m_scoreboardEnabled;
     }
 
     public static void resetScoreboards(int firstSiteId, int siteCount) {
@@ -214,7 +228,7 @@ public class TransactionTaskQueue
              * holds the tasks until all the sites on the node receive the task.
              * Task with newer spHandle will
              */
-            else if (task.needCoordination()) {
+            else if (task.needCoordination() && m_scoreboardEnabled) {
                 coordinatedTaskQueueOffer(task);
             }
             else {
@@ -237,7 +251,7 @@ public class TransactionTaskQueue
              * holds the tasks until all the sites on the node receive the task.
              * Task with newer spHandle will
              */
-            if (task.needCoordination()) {
+            if (task.needCoordination() && m_scoreboardEnabled) {
                 coordinatedTaskQueueOffer(task);
             } else {
                 taskQueueOffer(task);
@@ -302,7 +316,7 @@ public class TransactionTaskQueue
                     hostLog.debug(sb.toString());
                 }
                 if (completionScore == s_stashedMpWrites.getSiteCount()) {
-                    done = s_stashedMpWrites.releaseStashedComleteTxns(missingTxn, task.getTxnId());
+                    done = s_stashedMpWrites.releaseStashedCompleteTxns(missingTxn, task.getTxnId());
                 }
                 else if (fragmentScore == s_stashedMpWrites.getSiteCount() && completionScore == 0) {
                     s_stashedMpWrites.releaseStashedFragments(task.getTxnId());
@@ -341,7 +355,7 @@ public class TransactionTaskQueue
                     hostLog.debug(sb.toString());
                 }
                 if (completionScore == s_stashedMpWrites.getSiteCount()) {
-                    done = s_stashedMpWrites.releaseStashedComleteTxns(true, missingTxnCompletion.getMsgTxnId());
+                    done = s_stashedMpWrites.releaseStashedCompleteTxns(true, missingTxnCompletion.getMsgTxnId());
                 } else {
                     done = true;
                 }
@@ -384,7 +398,7 @@ public class TransactionTaskQueue
         while (iter.hasNext()) {
             TransactionTask task = iter.next();
             long lastQueuedTxnId = task.getTxnId();
-            if (task.needCoordination()) {
+            if (task.needCoordination() && m_scoreboardEnabled) {
                 coordinatedTaskQueueOffer(task);
             } else {
                 taskQueueOffer(task);
@@ -402,7 +416,7 @@ public class TransactionTaskQueue
                     task = iter.next();
                     if (task.getTxnId() == lastQueuedTxnId) {
                         iter.remove();
-                        if (task.needCoordination()) {
+                        if (task.needCoordination() && m_scoreboardEnabled) {
                             coordinatedTaskQueueOffer(task);
                         } else {
                             taskQueueOffer(task);
@@ -424,7 +438,7 @@ public class TransactionTaskQueue
     synchronized void restart()
     {
         TransactionTask task = m_backlog.getFirst();
-        if (task.needCoordination()) {
+        if (task.needCoordination() && m_scoreboardEnabled) {
             coordinatedTaskQueueOffer(task);
         } else {
             taskQueueOffer(task);

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -174,11 +174,14 @@ public class TransactionTaskQueue
         m_scoreboardEnabled = scoreboardEnabled;
     }
 
-    public void setScoreboard(boolean enabled) {
+
+    // We start joining nodes with scoreboard disabled
+    // After all sites has been fully initilized and ready for snapshot, we should enable the scoreboard.
+    void enableScoreboard() {
         if (hostLog.isDebugEnabled()) {
-            hostLog.debug("Scoreboard being enabled " + enabled);
+            hostLog.debug("Scoreboard has been enabled.");
         }
-        m_scoreboardEnabled = enabled;
+        m_scoreboardEnabled = true;
     }
 
     public boolean scoreboardEnabled() {

--- a/src/frontend/org/voltdb/sysprocs/PingPartitions.java
+++ b/src/frontend/org/voltdb/sysprocs/PingPartitions.java
@@ -37,15 +37,21 @@ import java.util.Map;
 public class PingPartitions extends VoltSystemProcedure {
     private static final VoltLogger hostLog = new VoltLogger("HOST");
 
-    static final int DEP_DISTRIBUTE = (int)
+    static final int DEP_PingPartitionDistribute = (int)
             SysProcFragmentId.PF_pingPartitions | DtxnConstants.MULTIPARTITION_DEPENDENCY;
-    static final int DEP_AGGREGATE = (int) SysProcFragmentId.PF_pingPartitionsAggregate;
+    static final int DEP_PingPartitionAggregate= (int) SysProcFragmentId.PF_pingPartitionsAggregate;
+
+    static final int DEP_EnableScoreboardDistribute = (int)
+            SysProcFragmentId.PF_enableScoreboard  | DtxnConstants.MULTIPARTITION_DEPENDENCY;
+    static final int DEP_EnableScoreboardAggregate = (int) SysProcFragmentId.PF_enableScoreboardAggregate;
 
     @Override
     public long[] getPlanFragmentIds() {
         return new long[]{
                 SysProcFragmentId.PF_pingPartitions,
-                SysProcFragmentId.PF_pingPartitionsAggregate
+                SysProcFragmentId.PF_pingPartitionsAggregate,
+                SysProcFragmentId.PF_enableScoreboard,
+                SysProcFragmentId.PF_enableScoreboardAggregate
         };
     }
 
@@ -58,31 +64,60 @@ public class PingPartitions extends VoltSystemProcedure {
         dummy.addRow(STATUS_OK);
 
         if (fragmentId == SysProcFragmentId.PF_pingPartitions) {
-            return new DependencyPair.TableDependencyPair(DEP_DISTRIBUTE, dummy);
+            return new DependencyPair.TableDependencyPair(DEP_PingPartitionDistribute, dummy);
         } else if (fragmentId == SysProcFragmentId.PF_pingPartitionsAggregate) {
-            return new DependencyPair.TableDependencyPair(DEP_AGGREGATE, dummy);
+            return new DependencyPair.TableDependencyPair(DEP_PingPartitionAggregate, dummy);
+        } else if (fragmentId == SysProcFragmentId.PF_enableScoreboard) {
+            return new DependencyPair.TableDependencyPair(DEP_EnableScoreboardDistribute, dummy);
+        } else if (fragmentId == SysProcFragmentId.PF_enableScoreboardAggregate) {
+            return new DependencyPair.TableDependencyPair(DEP_EnableScoreboardAggregate, dummy);
         }
+
         assert (false);
         return null;
     }
 
-    public VoltTable[] run(SystemProcedureExecutionContext ctx) throws VoltAbortException {
+    public VoltTable[] run(SystemProcedureExecutionContext ctx, byte enableScoreboard) throws VoltAbortException {
+        if (enableScoreboard == (byte) 1) {
+            return runPingAndEnableScoreboard();
+        }
+        return runDummyPings();
+    }
+
+    private VoltTable[] runDummyPings() {
         SynthesizedPlanFragment spf[] = new SynthesizedPlanFragment[2];
         spf[0] = new SynthesizedPlanFragment();
         spf[0].fragmentId = SysProcFragmentId.PF_pingPartitions;
-        spf[0].outputDepId = DEP_DISTRIBUTE;
+        spf[0].outputDepId = DEP_PingPartitionDistribute;
         spf[0].inputDepIds = new int[] {};
         spf[0].multipartition = true;
         spf[0].parameters = ParameterSet.emptyParameterSet();
 
         spf[1] = new SynthesizedPlanFragment();
-        spf[1] = new SynthesizedPlanFragment();
         spf[1].fragmentId = SysProcFragmentId.PF_pingPartitionsAggregate;
-        spf[1].outputDepId = DEP_AGGREGATE;
-        spf[1].inputDepIds = new int[] { DEP_DISTRIBUTE };
+        spf[1].outputDepId = DEP_PingPartitionAggregate;
+        spf[1].inputDepIds = new int[] {DEP_PingPartitionDistribute};
         spf[1].multipartition = false;
         spf[1].parameters = ParameterSet.emptyParameterSet();
-        return executeSysProcPlanFragments(spf, DEP_AGGREGATE);
+        return executeSysProcPlanFragments(spf, DEP_PingPartitionAggregate);
+    }
+
+    private VoltTable[] runPingAndEnableScoreboard() {
+        SynthesizedPlanFragment spf[] = new SynthesizedPlanFragment[2];
+        spf[0] = new SynthesizedPlanFragment();
+        spf[0].fragmentId = SysProcFragmentId.PF_enableScoreboard;
+        spf[0].outputDepId = DEP_EnableScoreboardDistribute;
+        spf[0].inputDepIds = new int[] {};
+        spf[0].multipartition = true;
+        spf[0].parameters = ParameterSet.emptyParameterSet();
+
+        spf[1] = new SynthesizedPlanFragment();
+        spf[1].fragmentId = SysProcFragmentId.PF_enableScoreboardAggregate;
+        spf[1].outputDepId = DEP_EnableScoreboardAggregate;
+        spf[1].inputDepIds = new int[] {DEP_EnableScoreboardDistribute};
+        spf[1].multipartition = false;
+        spf[1].parameters = ParameterSet.emptyParameterSet();
+        return executeSysProcPlanFragments(spf, DEP_EnableScoreboardAggregate);
     }
 
 }

--- a/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
+++ b/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
@@ -225,4 +225,13 @@ public class SysProcFragmentId
     // @PingPartitions
     public static final long PF_pingPartitions = 330;
     public static final long PF_pingPartitionsAggregate = 331;
+    public static final long PF_enableScoreboard = 332;
+    public static final long PF_enableScoreboardAggregate = 333;
+
+
+    public static boolean isEnableScoreboardFragment(byte[] planHash) {
+        long fragId = VoltSystemProcedure.hashToFragId(planHash);
+
+        return (fragId == PF_enableScoreboard);
+    }
 }

--- a/tests/frontend/org/voltdb/iv2/TestDurabilityListener.java
+++ b/tests/frontend/org/voltdb/iv2/TestDurabilityListener.java
@@ -164,7 +164,7 @@ public class TestDurabilityListener {
     {
         SiteTaskerQueue stq = mock(SiteTaskerQueue.class);
         SnapshotCompletionMonitor scm = mock(SnapshotCompletionMonitor.class);
-        SpScheduler sched = spy(new SpScheduler(1, stq, scm));
+        SpScheduler sched = spy(new SpScheduler(1, stq, scm, true));
         sched.setLock(new Object());
 
         TransactionTaskQueue taskQueue = mock(TransactionTaskQueue.class);

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
@@ -112,7 +112,7 @@ public class TestSpSchedulerDedupe
                                                           any(CommandLog.DurabilityListener.class),
                                                           any(TransactionTask.class));
 
-        dut = new SpScheduler(0, getSiteTaskerQueue(), snapMonitor);
+        dut = new SpScheduler(0, getSiteTaskerQueue(), snapMonitor, true);
         dut.setMailbox(mbox);
         dut.setCommandLog(cl);
         dut.setLock(mbox);

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerSpHandle.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerSpHandle.java
@@ -104,7 +104,7 @@ public class TestSpSchedulerSpHandle extends TestCase
                                                           any(CommandLog.DurabilityListener.class),
                                                           any(TransactionTask.class));
 
-        dut = new SpScheduler(0, getSiteTaskerQueue(), snapMonitor);
+        dut = new SpScheduler(0, getSiteTaskerQueue(), snapMonitor, true);
         dut.setMailbox(mbox);
         dut.setCommandLog(cl);
         dut.setLock(mbox);

--- a/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
+++ b/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
@@ -223,7 +223,7 @@ public class TestTransactionTaskQueue extends TestCase
         for (int i = 0; i < SITE_COUNT; i++) {
             SiteTaskerQueue siteTaskQueue = getSiteTaskerQueue();
             m_siteTaskQueues.add(siteTaskQueue);
-            TransactionTaskQueue txnTaskQueue = new TransactionTaskQueue(siteTaskQueue);
+            TransactionTaskQueue txnTaskQueue = new TransactionTaskQueue(siteTaskQueue, true);
             txnTaskQueue.initializeScoreboard(i, new MockMailbox());
             m_txnTaskQueues.add(txnTaskQueue);
             Deque<TransactionTask> expectedOrder = new ArrayDeque<>();


### PR DESCRIPTION
1. Disable scoreboard for Join Nodes when initiated
2. Still updateReplicas for new Partititions on join nodes
3. Once all new sites has been initialized, queue one addition @PingPartiton for reenable Scoreboard and queue this very @PingPartitions as first task to the scoreboard. 