### PR TITLE
ENG-13894:

### DIFF
--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -270,7 +270,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
                        int64_t spHandle,
                        int64_t lastCommittedSpHandle,
                        int64_t uniqueId,
-                       bool throwUniqueViolations,
+                       bool returnConflictRows,
                        bool shouldDRStream,
                        int64_t undoToken);
 

--- a/tests/frontend/org/voltdb/benchmark/tpcc/TPCCProjectBuilder.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/TPCCProjectBuilder.java
@@ -175,7 +175,7 @@ public class TPCCProjectBuilder extends VoltProjectBuilder {
     /**
      * Get a pointer to a compiled catalog for TPCC with all the procedures.
      */
-    public Catalog createTPCCSchemaCatalog() throws IOException {
+    public Catalog createTPCCSchemaCatalog(int sitesPerHost) throws IOException {
         // compile a catalog
         String testDir = BuildDirectoryUtils.getBuildDirectoryPath();
         String catalogJar = testDir + File.separator + "tpcc-jni.jar";
@@ -184,7 +184,7 @@ public class TPCCProjectBuilder extends VoltProjectBuilder {
         addDefaultPartitioning();
         addDefaultProcedures();
 
-        Catalog catalog = compile(catalogJar, 1, 1, 0, null);
+        Catalog catalog = compile(catalogJar, sitesPerHost, 1, 0, null);
         assert(catalog != null);
         return catalog;
     }
@@ -194,6 +194,10 @@ public class TPCCProjectBuilder extends VoltProjectBuilder {
      * This can be run without worrying about setting up anything else in this class.
      */
     static public Catalog getTPCCSchemaCatalog() throws IOException {
-        return (new TPCCProjectBuilder().createTPCCSchemaCatalog());
+        return (new TPCCProjectBuilder().createTPCCSchemaCatalog(1));
+    }
+
+    static public Catalog getTPCCSchemaCatalogMultiSite(int sitesPerHost) throws IOException {
+        return (new TPCCProjectBuilder().createTPCCSchemaCatalog(sitesPerHost));
     }
 }

--- a/tests/frontend/org/voltdb/compiler/TestDDLCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestDDLCompiler.java
@@ -635,7 +635,7 @@ public class TestDDLCompiler extends TestCase {
 
     public void testNullAnnotation() throws IOException {
 
-        Catalog catalog  = new TPCCProjectBuilder().createTPCCSchemaCatalog();
+        Catalog catalog  = TPCCProjectBuilder.getTPCCSchemaCatalog();
         Database catalog_db = catalog.getClusters().get("cluster").getDatabases().get("database");
 
         for(Table t : catalog_db.getTables()) {

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -598,8 +598,7 @@ public class TestFragmentProgressUpdate extends TestCase {
                 new VoltTable.ColumnInfo("I_PRICE", VoltType.FLOAT),
                 new VoltTable.ColumnInfo("I_DATA", VoltType.STRING)
                 );
-        TPCCProjectBuilder builder = new TPCCProjectBuilder();
-        m_catalog = builder.createTPCCSchemaCatalog();
+        m_catalog = TPCCProjectBuilder.getTPCCSchemaCatalog();
         Cluster cluster = m_catalog.getClusters().get("cluster");
         WAREHOUSE_TABLEID = m_catalog.getClusters().get("cluster").getDatabases().
                 get("database").getTables().get("WAREHOUSE").getRelativeIndex();


### PR DESCRIPTION
Load table was not generating consistent results on all sites in the event of a failure. While this failure should not happen, it would generate a Hash Mismatch if it does, so this code fixes this path and addes unit tests for both this failure scenario and the exception failure scenario.