### PR TITLE
ENG-13854, add restart timestamp for fragment response, used by MPI t…

### DIFF
--- a/src/frontend/org/voltdb/dtxn/TransactionState.java
+++ b/src/frontend/org/voltdb/dtxn/TransactionState.java
@@ -53,7 +53,7 @@ public abstract class TransactionState extends OrderableTransaction  {
     public final long m_spHandle;
     private ArrayList<UndoAction> m_undoLog;
     // This timestamp is only used for restarted transactions
-    protected long m_restartTimestamp;
+    protected long m_restartTimestamp = TransactionInfoBaseMessage.INITIAL_TIMESTAMP;
 
     /**
      * Set up the final member variables from the parameters. This will

--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -153,6 +153,7 @@ public class FragmentTask extends FragmentTaskBase
             //The fragment is not misrouted and the site may have been marked as non-leader via @MigratePartitionLeader
             //but it should be processed by the same site, act like a leader.
             response.setForOldLeader(m_fragmentMsg.isForOldLeader());
+            response.setRestartTimestamp(m_fragmentMsg.getTimestamp());
             deliverResponse(response);
         } finally {
             if (BatchTimeoutOverrideType.isUserSetTimeout(individualTimeout)) {
@@ -200,6 +201,7 @@ public class FragmentTask extends FragmentTaskBase
                     m_rawDummyResponse, 0, m_rawDummyResponse.length));
         }
 
+        response.setRestartTimestamp(m_fragmentMsg.getTimestamp());
         deliverResponse(response);
         completeFragment();
     }

--- a/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
@@ -463,6 +463,7 @@ public class InitiatorMailbox implements Mailbox
             if (tmLog.isDebugEnabled()) {
                 tmLog.debug("misRoutedFragMsg on site:" + CoreUtils.hsIdToString(getHSId()) + "\n" + message);
             }
+            response.setRestartTimestamp(message.getTimestamp());
             deliver(response);
             return true;
         }

--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -171,7 +171,8 @@ public class MpProcedureTask extends ProcedureTask
             restart.setTruncationHandle(m_msg.getTruncationHandle());
             //restart.setForReplica(false);
             if (hostLog.isDebugEnabled()) {
-                hostLog.debug("MP restart cleanup CompleteTransactionMessage to: " + CoreUtils.hsIdCollectionToString(m_initiatorHSIds));
+                hostLog.debug("MP restart cleanup CompleteTransactionMessage "+ MpRestartSequenceGenerator.restartSeqIdToString(ts) +
+                        " to: " + CoreUtils.hsIdCollectionToString(m_initiatorHSIds));
             }
             m_initiator.send(com.google_voltpatches.common.primitives.Longs.toArray(m_initiatorHSIds), restart);
         }

--- a/src/frontend/org/voltdb/iv2/MpTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionState.java
@@ -277,6 +277,14 @@ public class MpTransactionState extends TransactionState
                                                           MiscUtils.hsIdPairTxnIdToString(m_mbox.getHSId(), msg.m_sourceHSId, txnId, batchIdx),
                                                           "status", Byte.toString(msg.getStatusCode())));
                 }
+                // Filter out stale responses due to the transaction restart, normally the timestamp is Long.MIN_VALUE
+                if (m_restartTimestamp != msg.getRestartTimestamp()) {
+                    if (tmLog.isDebugEnabled()) {
+                        tmLog.debug("Receives unmatched fragment response, expect timestamp " + MpRestartSequenceGenerator.restartSeqIdToString(m_restartTimestamp) +
+                                " actually receives: " + msg);
+                    }
+                    continue;
+                }
                 boolean expectedMsg = handleReceivedFragResponse(msg);
                 if (expectedMsg) {
                     // Will roll-back and throw if this message has an exception

--- a/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
@@ -144,6 +144,7 @@ public class MpTransactionTaskQueue extends TransactionTaskQueue
                             "Transaction being restarted due to fault recovery or shutdown.", next.getTxnId());
                     restart.setMisrouted(false);
                     poison.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, restart);
+                    poison.setRestartTimestamp(txn.getTimetamp());
                     txn.offerReceivedFragmentResponse(poison);
                     if (tmLog.isDebugEnabled()) {
                         tmLog.debug("MpTTQ: restarting:" + next);

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -109,6 +109,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
                     m_rawDummyResponse, 0, m_rawDummyResponse.length));
         }
         response.setRespBufferable(m_respBufferable);
+        response.setRestartTimestamp(m_fragmentMsg.getTimestamp());
         m_initiator.deliver(response);
     }
 
@@ -148,6 +149,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
         response.m_sourceHSId = m_initiator.getHSId();
         response.setRespBufferable(m_respBufferable);
         response.setForOldLeader(m_fragmentMsg.isForOldLeader());
+        response.setRestartTimestamp(m_fragmentMsg.getTimestamp());
         m_initiator.deliver(response);
         if (hostLog.isDebugEnabled()) {
             hostLog.debug("COMPLETE: " + this);

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -716,6 +716,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                                     ftm.getParameterSetForFragment(0));
                     FragmentResponseMessage frm = new FragmentResponseMessage(ftm, m.getHSId());
                     frm.addDependency(dp);
+                    frm.setRestartTimestamp(m_runner.getTxnState().getTimetamp());
                     m.send(ftm.getCoordinatorHSId(), frm);
                 } else if (vm instanceof BinaryPayloadMessage) {
                     if (context.isLowestSiteId() && m_duplicateRowHandler != null) {
@@ -2851,6 +2852,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                                 ftm.getParameterSetForFragment(0));
                 FragmentResponseMessage frm = new FragmentResponseMessage(ftm, m.getHSId());
                 frm.addDependency(dp);
+                frm.setRestartTimestamp(m_runner.getTxnState().getTimetamp());
                 m.send(ftm.getCoordinatorHSId(), frm);
 
                 if (!m_unexpectedDependencies.isEmpty()) {


### PR DESCRIPTION
…o match response due to the fact that restarted transaction generates new set of fragments.

Change-Id: Ifddc0f1af30e7c60559cf8a840831df1b65a4202