### PR TITLE
ENG-13900: fix the race partition table change override the modifiedT…

### DIFF
--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -140,7 +140,9 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
                            (int)targetTable->allocatedTupleCount());
 
             }
-            s_modifiedTuples = modified_tuples;
+            if (m_replicatedTableOperation) {
+                s_modifiedTuples = modified_tuples;
+            }
         }
         else {
             if (s_modifiedTuples == -1) {

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -361,7 +361,9 @@ void InsertExecutor::p_execute_tuple(TableTuple &tuple) {
             m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
     if (possiblySynchronizedUseMpMemory.okToExecute()) {
         p_execute_tuple_internal(tuple);
-        s_modifiedTuples = m_modifiedTuples;
+        if (m_replicatedTableOperation) {
+            s_modifiedTuples = m_modifiedTuples;
+        }
     }
     else {
         if (s_modifiedTuples == -1) {
@@ -416,7 +418,9 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
                 while (iterator.next(inputTuple)) {
                     p_execute_tuple_internal(inputTuple);
                 }
-                s_modifiedTuples = m_modifiedTuples;
+                if (m_replicatedTableOperation) {
+                    s_modifiedTuples = m_modifiedTuples;
+                }
             }
             else {
                 if (s_modifiedTuples == -1) {

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -215,7 +215,9 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
                                                             indexesToUpdate);
             }
             modified_tuples = m_inputTable->tempTableTupleCount();
-            s_modifiedTuples = modified_tuples;
+            if (m_replicatedTableOperation) {
+                s_modifiedTuples = modified_tuples;
+            }
         }
         else {
             if (s_modifiedTuples == -1) {


### PR DESCRIPTION
…uples for previous replicated table change



In Update/Insert/Delete Executors, we have being using a static variable s_modifiedTuples for serving the dual purposes of propagating the modifiied rows and exceptions from lowest site to all the other sites.

This should only be used for replicated table modification path. 

However partition table modification now also change it. A back to back replicated table change with a partition table change would raise the issue of racing changing that static variable. If the later partition table change happens before other site propagate that value, the tuple changed value for the replicated table would be corrupted.

So we have to check and skip setting the static value if it is not replicate table change.
