### PR TITLE
ENG-13856:

### DIFF
--- a/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
+++ b/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
@@ -20,9 +20,11 @@ package org.voltdb;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
@@ -30,6 +32,7 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.Pair;
 import org.voltdb.DRConsumerDrIdTracker.DRSiteDrIdTracker;
 import org.voltdb.iv2.MpInitiator;
+import org.voltdb.iv2.TxnEgo;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 
 public class ExtensibleSnapshotDigestData {
@@ -40,6 +43,8 @@ public class ExtensibleSnapshotDigestData {
     public static final String PARTITION = "partition";
     public static final String EXPORT_SEQUENCE_NUMBER = "exportSequenceNumber";
     public static final String EXPORT_USO = "exportUso";
+
+    private final List<Long> m_snapshotPartitionTxnIds;
 
     /**
      * This field is the same values as m_exportSequenceNumbers once they have been extracted
@@ -69,10 +74,12 @@ public class ExtensibleSnapshotDigestData {
     private long m_terminus;
 
     public ExtensibleSnapshotDigestData(
+            List<Long> snapshotPartitionTxnIds,
             Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
             Map<Integer, TupleStreamStateInfo> drTupleStreamInfo,
             Map<Integer, JSONObject> drMixedClusterSizeConsumerState,
             final JSONObject jsData) {
+        m_snapshotPartitionTxnIds = snapshotPartitionTxnIds;
         m_exportSequenceNumbers = exportSequenceNumbers;
         m_drTupleStreamInfo = drTupleStreamInfo;
         m_drMixedClusterSizeConsumerState = drMixedClusterSizeConsumerState;
@@ -165,6 +172,38 @@ public class ExtensibleSnapshotDigestData {
         long jsTerminus = jsonObj.optLong(SnapshotUtil.JSON_TERMINUS, 0L);
         m_terminus = Math.max(jsTerminus, m_terminus);
         jsonObj.put(SnapshotUtil.JSON_TERMINUS, m_terminus);
+    }
+
+    private void mergeSnapshotPartitionTxnIdsToZK(JSONObject jsonObj) throws JSONException {
+        JSONArray partitionList = jsonObj.optJSONArray("snapshotPartitionTxnIds");
+        Map<Integer, Long> remoteTxnIds = null;
+        if (partitionList == null) {
+            remoteTxnIds = new HashMap<>();
+            partitionList = new JSONArray();
+            jsonObj.put("snapshotPartitionTxnIds", partitionList);
+        }
+        else {
+            remoteTxnIds = new HashMap<>(partitionList.length()*2);
+            for (int ii = 0; ii < partitionList.length(); ii++) {
+                Long txnId = partitionList.getLong(ii);
+                remoteTxnIds.put(TxnEgo.getPartitionId(txnId), txnId);
+            }
+        }
+
+        for (Long localTxnId : m_snapshotPartitionTxnIds) {
+            Long remoteTxnId = remoteTxnIds.get(TxnEgo.getPartitionId(localTxnId));
+            if (remoteTxnId == null) {
+                partitionList.put(localTxnId);
+            }
+            else {
+                if (remoteTxnId != localTxnId) {
+                    VoltDB.crashLocalVoltDB(
+                            "Snapshot Transaction Ids for partition " + TxnEgo.getPartitionId(localTxnId) +
+                            " not consistent in snapshot between remote Host (" + TxnEgo.txnIdToString(remoteTxnId) +
+                            " and local host (" + TxnEgo.txnIdSeqToString(localTxnId) + ")", true, null);
+                }
+            }
+        }
     }
 
     private void writeDRTupleStreamInfoToSnapshot(JSONStringer stringer) throws IOException {
@@ -329,6 +368,7 @@ public class ExtensibleSnapshotDigestData {
     }
 
     public void mergeToZooKeeper(JSONObject jsonObj, VoltLogger log) throws JSONException {
+        mergeSnapshotPartitionTxnIdsToZK(jsonObj);
         mergeExportSequenceNumbersToZK(jsonObj, log);
         mergeDRTupleStreamInfoToZK(jsonObj, log);
         mergeConsumerDrIdTrackerToZK(jsonObj);

--- a/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
+++ b/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
@@ -196,11 +196,11 @@ public class ExtensibleSnapshotDigestData {
                 partitionList.put(localTxnId);
             }
             else {
-                if (remoteTxnId != localTxnId) {
+                if (!remoteTxnId.equals(localTxnId)) {
                     VoltDB.crashLocalVoltDB(
                             "Snapshot Transaction Ids for partition " + TxnEgo.getPartitionId(localTxnId) +
-                            " not consistent in snapshot between remote Host (" + TxnEgo.txnIdToString(remoteTxnId) +
-                            " and local host (" + TxnEgo.txnIdSeqToString(localTxnId) + ")", true, null);
+                            " not consistent in snapshot between remote Host " + TxnEgo.txnIdToString(remoteTxnId) +
+                            " and local host " + TxnEgo.txnIdToString(localTxnId), true, null);
                 }
             }
         }

--- a/src/frontend/org/voltdb/RestoreAgent.java
+++ b/src/frontend/org/voltdb/RestoreAgent.java
@@ -1411,7 +1411,7 @@ SnapshotCompletionInterest, Promotable
                                      false, null);
         } else {
             m_truncationSnapshot = event.multipartTxnId;
-            m_truncationSnapshotPerPartition = event.partitionTxnIds;
+            m_truncationSnapshotPerPartition = event.localPartitionTxnIds;
             m_replayAgent.returnAllSegments();
             changeState();
         }

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -200,6 +200,7 @@ public interface SiteProcedureConnection {
      */
     public void setRejoinComplete(
             JoinProducerBase.JoinCompletionAction action,
+            Map<Integer, Long> partitionTxnIds,
             Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
             Map<Integer, Long> drSequenceNumbers,
             Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -200,7 +200,7 @@ public interface SiteProcedureConnection {
      */
     public void setRejoinComplete(
             JoinProducerBase.JoinCompletionAction action,
-            Map<Integer, Long> partitionTxnIds,
+            List<Long> allPartitionTxnIds,
             Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
             Map<Integer, Long> drSequenceNumbers,
             Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,

--- a/src/frontend/org/voltdb/SnapshotCompletionInterest.java
+++ b/src/frontend/org/voltdb/SnapshotCompletionInterest.java
@@ -17,6 +17,7 @@
 package org.voltdb;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
@@ -32,7 +33,8 @@ public interface SnapshotCompletionInterest {
         // multipartTxnId is the txnId of the snapshot itself.
         // as well as the last snapshotted MP transaction.
         public final long multipartTxnId;
-        public final Map<Integer, Long> partitionTxnIds;
+        public final Map<Integer, Long> localPartitionTxnIds;
+        public final List<Long> allPartitionTxnIds;
         public final boolean truncationSnapshot;
         public final boolean didSucceed;
         public final String requestId;
@@ -47,7 +49,8 @@ public interface SnapshotCompletionInterest {
                 SnapshotPathType stype,
                 String nonce,
                 final long multipartTxnId,
-                final Map<Integer, Long> partitionTxnIds,
+                final Map<Integer, Long> localPartitionTxnIds,
+                final List<Long> allPartitionTxnIds,
                 final boolean truncationSnapshot,
                 final boolean didSucceed,
                 final String requestId,
@@ -59,7 +62,8 @@ public interface SnapshotCompletionInterest {
             this.path = path;
             this.nonce = nonce;
             this.multipartTxnId = multipartTxnId;
-            this.partitionTxnIds = partitionTxnIds;
+            this.localPartitionTxnIds = localPartitionTxnIds;
+            this.allPartitionTxnIds = allPartitionTxnIds;
             this.truncationSnapshot = truncationSnapshot;
             this.didSucceed = didSucceed;
             this.requestId = requestId;
@@ -77,13 +81,14 @@ public interface SnapshotCompletionInterest {
                 SnapshotPathType stype,
                 String nonce,
                 long multipartTxnId,
-                Map<Integer, Long> partitionTxnIds,
+                Map<Integer, Long> localPartitionTxnIds,
+                List<Long> allPartitionTxnIds,
                 boolean truncationSnapshot,
                 int drVersion,
                 long clusterCreateTime) {
             return new SnapshotCompletionEvent(
-                    path, stype, nonce, multipartTxnId, partitionTxnIds, truncationSnapshot,
-                    true, "", null, null, new HashMap<>(), drVersion, clusterCreateTime);
+                    path, stype, nonce, multipartTxnId, localPartitionTxnIds, allPartitionTxnIds,
+                    truncationSnapshot, true, "", null, null, new HashMap<>(), drVersion, clusterCreateTime);
         }
     }
 

--- a/src/frontend/org/voltdb/SnapshotSaveAPI.java
+++ b/src/frontend/org/voltdb/SnapshotSaveAPI.java
@@ -18,9 +18,11 @@
 package org.voltdb;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.Callable;
@@ -150,6 +152,7 @@ public class SnapshotSaveAPI
                 @Override
                 public void run() {
                     Map<Integer, Long> partitionTransactionIds = m_partitionLastSeenTransactionIds;
+                    List<Long> snapshotPartitionTxnIds = new ArrayList<Long>(partitionTransactionIds.values());
 
                     SNAP_LOG.debug("Last seen partition transaction ids " + partitionTransactionIds);
                     m_partitionLastSeenTransactionIds = new HashMap<Integer, Long>();
@@ -175,6 +178,7 @@ public class SnapshotSaveAPI
                     }
 
                     m_allLocalSiteSnapshotDigestData = new ExtensibleSnapshotDigestData(
+                            snapshotPartitionTxnIds,
                             SnapshotSiteProcessor.getExportSequenceNumbers(),
                             SnapshotSiteProcessor.getDRTupleStreamStateInfo(),
                             remoteDataCenterLastIds, finalJsData);

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -190,6 +190,7 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
                     m_completionAction.setSnapshotTxnId(event.multipartTxnId);
 
                     setJoinComplete(siteConnection,
+                                    event.partitionTxnIds,
                                     event.exportSequenceNumbers,
                                     event.drSequenceNumbers,
                                     event.drMixedClusterSizeConsumerState,

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -190,7 +190,7 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
                     m_completionAction.setSnapshotTxnId(event.multipartTxnId);
 
                     setJoinComplete(siteConnection,
-                                    event.partitionTxnIds,
+                                    event.allPartitionTxnIds,
                                     event.exportSequenceNumbers,
                                     event.drSequenceNumbers,
                                     event.drMixedClusterSizeConsumerState,

--- a/src/frontend/org/voltdb/iv2/JoinProducerBase.java
+++ b/src/frontend/org/voltdb/iv2/JoinProducerBase.java
@@ -172,13 +172,14 @@ public abstract class JoinProducerBase extends SiteTasker {
 
     // Completed all criteria: Kill the watchdog and inform the site.
     protected void setJoinComplete(SiteProcedureConnection siteConnection,
+                                   Map<Integer, Long> partitionTxnIds,
                                    Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
                                    Map<Integer, Long> drSequenceNumbers,
                                    Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,
                                    boolean requireExistingSequenceNumbers,
                                    long clusterCreateTime)
     {
-        siteConnection.setRejoinComplete(m_completionAction, exportSequenceNumbers, drSequenceNumbers,
+        siteConnection.setRejoinComplete(m_completionAction, partitionTxnIds, exportSequenceNumbers, drSequenceNumbers,
                 allConsumerSiteTrackers, requireExistingSequenceNumbers, clusterCreateTime);
     }
 

--- a/src/frontend/org/voltdb/iv2/JoinProducerBase.java
+++ b/src/frontend/org/voltdb/iv2/JoinProducerBase.java
@@ -20,6 +20,7 @@ package org.voltdb.iv2;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -172,15 +173,15 @@ public abstract class JoinProducerBase extends SiteTasker {
 
     // Completed all criteria: Kill the watchdog and inform the site.
     protected void setJoinComplete(SiteProcedureConnection siteConnection,
-                                   Map<Integer, Long> partitionTxnIds,
+                                   List<Long> allpartitionTxnIds,
                                    Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
                                    Map<Integer, Long> drSequenceNumbers,
                                    Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,
                                    boolean requireExistingSequenceNumbers,
                                    long clusterCreateTime)
     {
-        siteConnection.setRejoinComplete(m_completionAction, partitionTxnIds, exportSequenceNumbers, drSequenceNumbers,
-                allConsumerSiteTrackers, requireExistingSequenceNumbers, clusterCreateTime);
+        siteConnection.setRejoinComplete(m_completionAction, allpartitionTxnIds, exportSequenceNumbers,
+                drSequenceNumbers, allConsumerSiteTrackers, requireExistingSequenceNumbers, clusterCreateTime);
     }
 
     protected void registerSnapshotMonitor(String nonce) {

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -585,6 +585,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     @Override
     public void setRejoinComplete(
             JoinProducerBase.JoinCompletionAction replayComplete,
+            Map<Integer, Long> partitionTxnIds,
             Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
             Map<Integer, Long> drSequenceNumbers,
             Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -585,7 +585,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     @Override
     public void setRejoinComplete(
             JoinProducerBase.JoinCompletionAction replayComplete,
-            Map<Integer, Long> partitionTxnIds,
+            List<Long> allPartitionTxnIds,
             Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
             Map<Integer, Long> drSequenceNumbers,
             Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,

--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -19,6 +19,7 @@ package org.voltdb.iv2;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
@@ -325,11 +326,11 @@ public class RejoinProducer extends JoinProducerBase {
                 Map<String, Map<Integer, Pair<Long,Long>>> exportSequenceNumbers = null;
                 Map<Integer, Long> drSequenceNumbers = null;
                 Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers = null;
-                Map<Integer, Long> partitionTxnIds = null;
+                List<Long> allPartitionTxnIds = null;
                 long clusterCreateTime = -1;
                 try {
                     event = m_snapshotCompletionMonitor.get();
-                    partitionTxnIds = event.partitionTxnIds;
+                    allPartitionTxnIds = event.allPartitionTxnIds;
                     if (!m_schemaHasNoTables) {
                         REJOINLOG.debug(m_whoami + "waiting on snapshot completion monitor.");
                         exportSequenceNumbers = event.exportSequenceNumbers;
@@ -362,7 +363,7 @@ public class RejoinProducer extends JoinProducerBase {
                 }
                 setJoinComplete(
                         siteConnection,
-                        partitionTxnIds,
+                        allPartitionTxnIds,
                         exportSequenceNumbers,
                         drSequenceNumbers,
                         allConsumerSiteTrackers,

--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -325,9 +325,11 @@ public class RejoinProducer extends JoinProducerBase {
                 Map<String, Map<Integer, Pair<Long,Long>>> exportSequenceNumbers = null;
                 Map<Integer, Long> drSequenceNumbers = null;
                 Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers = null;
+                Map<Integer, Long> partitionTxnIds = null;
                 long clusterCreateTime = -1;
                 try {
                     event = m_snapshotCompletionMonitor.get();
+                    partitionTxnIds = event.partitionTxnIds;
                     if (!m_schemaHasNoTables) {
                         REJOINLOG.debug(m_whoami + "waiting on snapshot completion monitor.");
                         exportSequenceNumbers = event.exportSequenceNumbers;
@@ -360,6 +362,7 @@ public class RejoinProducer extends JoinProducerBase {
                 }
                 setJoinComplete(
                         siteConnection,
+                        partitionTxnIds,
                         exportSequenceNumbers,
                         drSequenceNumbers,
                         allConsumerSiteTrackers,

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1410,6 +1410,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     @Override
     public void setRejoinComplete(
             JoinProducerBase.JoinCompletionAction replayComplete,
+            Map<Integer, Long> partitionTxnIds,
             Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
             Map<Integer, Long> drSequenceNumbers,
             Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,
@@ -1420,6 +1421,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         // live rejoin, will transfer to kStateRunning as usual
         // as the rejoin task log will be empty.
         assert(m_rejoinState == kStateRejoining);
+        Long snapshotSpHandle = partitionTxnIds.get(m_partitionId);
+        assert(snapshotSpHandle != null);
+        setSpHandleForSnapshotDigest(snapshotSpHandle);
 
         if (replayComplete == null) {
             throw new RuntimeException("Null Replay Complete Action.");

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1410,7 +1410,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     @Override
     public void setRejoinComplete(
             JoinProducerBase.JoinCompletionAction replayComplete,
-            Map<Integer, Long> partitionTxnIds,
+            List<Long> allPartitionTxnIds,
             Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
             Map<Integer, Long> drSequenceNumbers,
             Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,
@@ -1421,9 +1421,15 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         // live rejoin, will transfer to kStateRunning as usual
         // as the rejoin task log will be empty.
         assert(m_rejoinState == kStateRejoining);
-        Long snapshotSpHandle = partitionTxnIds.get(m_partitionId);
-        assert(snapshotSpHandle != null);
-        setSpHandleForSnapshotDigest(snapshotSpHandle);
+        long foundTxnId = -1;
+        for (Long txnId: allPartitionTxnIds) {
+            if (TxnEgo.getPartitionId(txnId) == m_partitionId) {
+                foundTxnId = txnId;
+                break;
+            }
+        }
+        assert(foundTxnId != -1);
+        setSpHandleForSnapshotDigest(foundTxnId);
 
         if (replayComplete == null) {
             throw new RuntimeException("Null Replay Complete Action.");

--- a/tests/frontend/org/voltdb/TestSnapshotDaemonLeaderElection.java
+++ b/tests/frontend/org/voltdb/TestSnapshotDaemonLeaderElection.java
@@ -117,6 +117,7 @@ public class TestSnapshotDaemonLeaderElection extends TestSnapshotDaemon {
                         "",
                         32,
                         Collections.<Integer, Long>emptyMap(),
+                        Collections.<Long>emptyList(),
                         true, /*DRProducerProtocol.PROTOCOL_VERSION*/0,
                         VoltDB.instance().getClusterCreateTime())).await();
         assertTrue(m_initiator.procedureName.equals("@SnapshotDelete"));

--- a/tests/frontend/org/voltdb/regressionsuites/TestSnapshotSaveTruncation.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSnapshotSaveTruncation.java
@@ -59,7 +59,7 @@ public class TestSnapshotSaveTruncation extends SaveRestoreBase {
         public CountDownLatch snapshotCompleted(SnapshotCompletionEvent event) {
             this.txnId = event.multipartTxnId;
             this.truncationSnapshot = event.truncationSnapshot;
-            this.partitionTxnIds = event.partitionTxnIds;
+            this.partitionTxnIds = event.localPartitionTxnIds;
             snapshotCompleted.release();
             return null;
         }

--- a/tests/frontend/org/voltdb/rejoin/TestPauselessRejoinEndToEnd.java
+++ b/tests/frontend/org/voltdb/rejoin/TestPauselessRejoinEndToEnd.java
@@ -99,7 +99,7 @@ public class TestPauselessRejoinEndToEnd extends RejoinTestBase {
         boolean success = cluster.compile(builder);
         assertTrue(success);
         MiscUtils.copyFile(builder.getPathToDeployment(), Configuration.getPathToCatalogForTest("rejoin.xml"));
-        cluster.setHasLocalServer(false);
+        cluster.setHasLocalServer(true);
 
         cluster.startUp();
 


### PR DESCRIPTION
A rejoined node can participate in a snapshot as it's first transaction but does not appear to have the latest txnId because that is normally assigned as part of fragment processing. Therefore the digest of a rejoin node can contain incorrect txnIds. By assigning the TxnId from the rejoin snapshot, the value will be correctly initialized.