### PR TITLE
ENG-13856, fix various issues found in system tests.

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -357,28 +357,27 @@ public class MpPromoteAlgo implements RepairAlgo
                 m_interruptedTxns.add(ftm.getInitiateTask());
             }
             CompleteTransactionMessage rollback = null;
-            if (ftm.isSysProcTask()) {
-                //A response for non-restartable proc will be sent to client immediately if it is restarted. Thus
-                //the transaction is marked as done and the state is removed. But sites may still have fragments in the backlog or site queue
-                //which may block Scoreboard to release downstream transactions. The message would help clean the transaction state.
-                String procName = ftm.getProcedureName();
-                if (procName != null) {
-                    final SystemProcedureCatalog.Config proc = SystemProcedureCatalog.listing.get(procName);
-                    if (proc != null && !proc.isRestartable()) {
-                        rollback = new CompleteTransactionMessage(
-                                ftm.getInitiatorHSId(),
-                                ftm.getCoordinatorHSId(),
-                                ftm.getTxnId(),
-                                ftm.isReadOnly(),
-                                0,
-                                true,       // Force rollback as our repair operation.
-                                false,      // no acks in iv2.
-                                restart,    // Indicate rollback for repair as appropriate
-                                ftm.isForReplay(),
-                                ftm.isNPartTxn());
-                    }
+            //A response for non-restartable proc will be sent to client immediately if it is restarted. Thus
+            //the transaction is marked as done and the state is removed. But sites may still have fragments in the backlog or site queue
+            //which may block Scoreboard to release downstream transactions. The message would help clean the transaction state.
+            String procName = ftm.getProcedureName();
+            if (procName != null) {
+                final SystemProcedureCatalog.Config proc = SystemProcedureCatalog.listing.get(procName);
+                if (proc != null && !proc.isRestartable()) {
+                    rollback = new CompleteTransactionMessage(
+                            ftm.getInitiatorHSId(),
+                            ftm.getCoordinatorHSId(),
+                            ftm.getTxnId(),
+                            ftm.isReadOnly(),
+                            0,
+                            true,       // Force rollback as our repair operation.
+                            false,      // no acks in iv2.
+                            restart,    // Indicate rollback for repair as appropriate
+                            ftm.isForReplay(),
+                            ftm.isNPartTxn());
                 }
             }
+
             return rollback;
         }
     }

--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -55,18 +55,19 @@ public class Scoreboard {
             return;
         }
 
-        // special case, scoreboard is empty
-        if (m_compTasks.peekFirst() == null) {
-            m_compTasks.addFirst(Pair.of(task, missingTxn));
-            return;
-        }
-
         // Restart completion steps on any pending prior fragment of the same transaction
         if (task.getTimestamp() != CompleteTransactionMessage.INITIAL_TIMESTAMP &&
                 MpRestartSequenceGenerator.isForRestart(task.getTimestamp()) &&
                 m_fragTask != null && m_fragTask.getTxnId() == task.getMsgTxnId()) {
             m_fragTask = null;
         }
+
+        // special case, scoreboard is empty
+        if (m_compTasks.peekFirst() == null) {
+            m_compTasks.addFirst(Pair.of(task, missingTxn));
+            return;
+        }
+
         // scoreboard has one completion
         if (m_compTasks.size() == 1) {
             Pair<CompleteTransactionTask, Boolean> head = m_compTasks.peekFirst();

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -47,7 +47,6 @@ import org.voltdb.CommandLog.DurabilityListener;
 import org.voltdb.RealVoltDB;
 import org.voltdb.SnapshotCompletionInterest;
 import org.voltdb.SnapshotCompletionMonitor;
-import org.voltdb.StartAction;
 import org.voltdb.SystemProcedureCatalog;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;

--- a/tests/frontend/org/voltdb/iv2/TestScoreboard.java
+++ b/tests/frontend/org/voltdb/iv2/TestScoreboard.java
@@ -24,6 +24,7 @@
 package org.voltdb.iv2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -84,6 +85,19 @@ public class TestScoreboard {
         assertEquals(expectedTimestamp, scoreboard.getCompletionTasks().peekFirst().getFirst().getTimestamp());
         assertEquals(2000L, scoreboard.getCompletionTasks().peekLast().getFirst().getMsgTxnId());
         assertEquals(CompleteTransactionMessage.INITIAL_TIMESTAMP, scoreboard.getCompletionTasks().peekLast().getFirst().getTimestamp());
+    }
+
+    @Test
+    public void testRestartCompletionStepsOnFragment() {
+        Scoreboard scoreboard = new Scoreboard();
+        MpRestartSequenceGenerator repairGen = new MpRestartSequenceGenerator(1, true);
+        FragmentTask ft1 = createFrag(1000L, CompleteTransactionMessage.INITIAL_TIMESTAMP);
+        scoreboard.addFragmentTask(ft1);
+        long expectedTimestamp = repairGen.getNextSeqNum();
+        CompleteTransactionTask comp1 = createComp(1000L, expectedTimestamp);
+        scoreboard.addCompletedTransactionTask(comp1, false);
+        assertEquals(1000L, scoreboard.getCompletionTasks().peekFirst().getFirst().getMsgTxnId());
+        assertNull(scoreboard.getFragmentTask());
     }
 
     @Test


### PR DESCRIPTION
fix thread-safe issue when we touching transaction backlog,
fix a corner case that fragment message doesn't get cleaned by restart completion message,
fix an issue that we don't flush backlog for certain non-restartable MP sysprocs (e.g. @SwapTablesCore)

Change-Id: I39419514a474bc837c3f9e0f61f8317c5b912fb7