### PR TITLE
ENG-13854 CompleteTransactionMessage for non-restartable 

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -271,9 +271,15 @@ public class MpProcedureTask extends ProcedureTask
                     m_msg.isForReplay(),
                     txnState.isNPartTxn());
             complete.setTruncationHandle(m_msg.getTruncationHandle());
+            if (!restartable) {
+             // Update the timestamp to txnState so following restarted fragments could use it
+                long ts = m_restartSeqGenerator.getNextSeqNum();
+                complete.setTimestamp(ts);
+                m_txnState.setTimestamp(ts);
+                //A flag for Scoreboard to determine if it is necessary to flush transaction queue.
+                complete.setRestartable(restartable);
+            }
 
-            //A flag for Scoreboard to determine if it is necessary to flush transaction queue.
-            complete.setRestartable(restartable);
             //If there are misrouted fragments, send message to current masters.
             final List<Long> initiatorHSIds = new ArrayList<Long>();
             if (txnState.isFragmentRestarted()) {

--- a/src/frontend/org/voltdb/iv2/MpTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionState.java
@@ -33,6 +33,7 @@ import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.StoredProcedureInvocation;
+import org.voltdb.SystemProcedureCatalog;
 import org.voltdb.VoltTable;
 import org.voltdb.dtxn.TransactionState;
 import org.voltdb.exceptions.ReplicatedTableException;
@@ -126,6 +127,14 @@ public class MpTransactionState extends TransactionState
         // since some masters may not have seen it.
         m_haveDistributedInitTask = false;
         m_isRestart = true;
+        //do not set m_haveSentfragment to false if a proc is non-restartable.
+        if (!isReadOnly() && m_haveSentfragment && m_initiationMsg != null
+                && m_initiationMsg.getStoredProcedureName() != null) {
+            SystemProcedureCatalog.Config sysproc = SystemProcedureCatalog.listing.get(m_initiationMsg.getStoredProcedureName());
+            if (sysproc != null && !sysproc.isRestartable()) {
+                return;
+            }
+        }
         m_haveSentfragment = false;
     }
 

--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -44,7 +44,7 @@ public class Scoreboard {
         // we must allow the rollback completion to go through scoreboard.
         boolean isTxnRollback = (task.getCompleteMessage().isRollback() && task.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP);
         // Dont' treat rollback transaction as missing
-        if (isTxnRollback  && !task.isRestartable()) {
+        if (isTxnRollback) {
             missingTxn = false;
         }
 

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1401,24 +1401,26 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     private void handleDumpMessage()
     {
         String who = CoreUtils.hsIdToString(m_mailbox.getHSId());
-        hostLog.warn("State dump for site: " + who);
-        hostLog.warn(who + ": partition: " + m_partitionId + ", isLeader: " + m_isLeader);
+        StringBuilder builder = new StringBuilder();
+        builder.append("State dump for site: " + who);
+        builder.append("\npartition: " + m_partitionId + ", isLeader: " + m_isLeader);
         if (m_isLeader) {
-            hostLog.warn(who + ": replicas: " + CoreUtils.hsIdCollectionToString(m_replicaHSIds));
+            builder.append("\nreplicas: " + CoreUtils.hsIdCollectionToString(m_replicaHSIds));
             if (m_sendToHSIds.length > 0) {
                 m_mailbox.send(m_sendToHSIds, new DumpMessage());
             }
         }
-        hostLog.warn(who + ": most recent SP handle: " + TxnEgo.txnIdToString(getCurrentTxnId()));
-        hostLog.warn(who + ": outstanding txns: " + m_outstandingTxns.keySet() + " " +
+        builder.append("\nmost recent SP handle: " + TxnEgo.txnIdToString(getCurrentTxnId()));
+        builder.append("\noutstanding txns: " + m_outstandingTxns.keySet() + " " +
                 TxnEgo.txnIdCollectionToString(m_outstandingTxns.keySet()));
-        hostLog.warn(who + ": " + m_pendingTasks.toString());
+        builder.append("\n" + m_pendingTasks.toString());
         if (m_duplicateCounters.size() > 0) {
-            hostLog.warn(who + ": duplicate counters: ");
+            builder.append("\nduplicate counters: ");
             for (Entry<DuplicateCounterKey, DuplicateCounter> e : m_duplicateCounters.entrySet()) {
-                hostLog.warn("\t" + who + ": " + e.getKey().toString() + ": " + e.getValue().toString());
+                builder.append("\t" + who + ": " + e.getKey().toString() + ": " + e.getValue().toString());
             }
         }
+        hostLog.warn(builder.toString());
     }
 
     private void handleDummyTransactionTaskMessage(DummyTransactionTaskMessage message)


### PR DESCRIPTION
Set restart timestamp for final CompleteTransactionMessage with non-restartable proc.
avoid reset a flag for fragment sent with non-restartable proc restart so that CompleteTransactionMessage can be sent to all sites.
