### PR TITLE
ENG-13854:

### DIFF
--- a/src/frontend/org/voltdb/iv2/CompleteTransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/CompleteTransactionTask.java
@@ -148,8 +148,8 @@ public class CompleteTransactionTask extends TransactionTask
         return m_completeMsg.getTxnId();
     }
 
-    public boolean isRestartable() {
-        return m_completeMsg.isRestartable();
+    public boolean isAbortDuringRepair() {
+        return m_completeMsg.isAbortDuringRepair();
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -138,8 +138,6 @@ public class MpProcedureTask extends ProcedureTask
                         new VoltTable[] {},
                         "Failure while running system procedure " + txn.m_initiationMsg.getStoredProcedureName() +
                         ", and system procedures can not be restarted."));
-            txn.setNeedsRollback(true);
-            completeInitiateTask(siteConnection, false);
             errorResp.m_sourceHSId = m_initiator.getHSId();
             m_initiator.deliver(errorResp);
 
@@ -162,7 +160,8 @@ public class MpProcedureTask extends ProcedureTask
                     false,  // really don't want to have ack the ack.
                     !m_txnState.isReadOnly(),
                     m_msg.isForReplay(),
-                    txn.isNPartTxn());
+                    txn.isNPartTxn(),
+                    false);
             // TransactionTaskQueue uses it to find matching CompleteTransactionMessage
             long ts = m_restartSeqGenerator.getNextSeqNum();
             restart.setTimestamp(ts);
@@ -245,10 +244,6 @@ public class MpProcedureTask extends ProcedureTask
 
     @Override
     void completeInitiateTask(SiteProcedureConnection siteConnection) {
-        completeInitiateTask(siteConnection, true);
-    }
-
-    void completeInitiateTask(SiteProcedureConnection siteConnection, boolean restartable){
         final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.MPSITE);
         if (traceLog != null) {
             traceLog.add(() -> VoltTrace.instant("sendcomplete",
@@ -269,11 +264,10 @@ public class MpProcedureTask extends ProcedureTask
                     false,  // really don't want to have ack the ack.
                     false,
                     m_msg.isForReplay(),
-                    txnState.isNPartTxn());
+                    txnState.isNPartTxn(),
+                    false);
             complete.setTruncationHandle(m_msg.getTruncationHandle());
 
-            //A flag for Scoreboard to determine if it is necessary to flush transaction queue.
-            complete.setRestartable(restartable);
             //If there are misrouted fragments, send message to current masters.
             final List<Long> initiatorHSIds = new ArrayList<Long>();
             if (txnState.isFragmentRestarted()) {

--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -374,7 +374,9 @@ public class MpPromoteAlgo implements RepairAlgo
                             false,      // no acks in iv2.
                             restart,    // Indicate rollback for repair as appropriate
                             ftm.isForReplay(),
-                            ftm.isNPartTxn());
+                            ftm.isNPartTxn(),
+                            true);
+                    rollback.setTimestamp(m_restartSeqGenerator.getNextSeqNum());
                 }
             }
 

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -480,7 +480,7 @@ public class MpScheduler extends Scheduler
             // even if all the masters somehow die before forwarding Complete on to their replicas.
             CompleteTransactionMessage ctm = new CompleteTransactionMessage(m_mailbox.getHSId(),
                     message.m_sourceHSId, message.getTxnId(), message.isReadOnly(), 0,
-                    !message.shouldCommit(), false, false, false, txn.isNPartTxn());
+                    !message.shouldCommit(), false, false, false, txn.isNPartTxn(), false);
             ctm.setTruncationHandle(m_repairLogTruncationHandle);
             // dump it in the repair log
             // hacky castage

--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -40,14 +40,6 @@ public class Scoreboard {
     protected static final VoltLogger tmLog = new VoltLogger("TM");
 
     public void addCompletedTransactionTask(CompleteTransactionTask task, Boolean missingTxn) {
-//        // This happens when a non-restartable sysproc was aborted, since MPI doesn't send repair message for this transaction
-//        // we must allow the rollback completion to go through scoreboard.
-//        boolean isTxnRollback = (task.getCompleteMessage().isRollback() && task.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP);
-//        // Dont' treat rollback transaction as missing
-//        if (isTxnRollback  && !task.isRestartable()) {
-//            missingTxn = false;
-//        }
-
         // This is an extremely rare case were a MPI restart completion arrives before the dead MPI's completion
         // Ignore this message because the restart completion is more recent and should step on the initial completion
         if (task.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP &&

--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -40,24 +40,23 @@ public class Scoreboard {
     protected static final VoltLogger tmLog = new VoltLogger("TM");
 
     public void addCompletedTransactionTask(CompleteTransactionTask task, Boolean missingTxn) {
-        // This happens when a non-restartable sysproc was aborted, since MPI doesn't send repair message for this transaction
-        // we must allow the rollback completion to go through scoreboard.
-        boolean isTxnRollback = (task.getCompleteMessage().isRollback() && task.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP);
-        // Dont' treat rollback transaction as missing
-        if (isTxnRollback  && !task.isRestartable()) {
-            missingTxn = false;
-        }
+//        // This happens when a non-restartable sysproc was aborted, since MPI doesn't send repair message for this transaction
+//        // we must allow the rollback completion to go through scoreboard.
+//        boolean isTxnRollback = (task.getCompleteMessage().isRollback() && task.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP);
+//        // Dont' treat rollback transaction as missing
+//        if (isTxnRollback  && !task.isRestartable()) {
+//            missingTxn = false;
+//        }
 
         // This is an extremely rare case were a MPI restart completion arrives before the dead MPI's completion
         // Ignore this message because the restart completion is more recent and should step on the initial completion
         if (task.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP &&
-                ( hasRestartCompletion(task) || missingTxn)) {
+                (hasRestartCompletion(task) || missingTxn)) {
             return;
         }
 
         // Restart completion steps on any pending prior fragment of the same transaction
         if (task.getTimestamp() != CompleteTransactionMessage.INITIAL_TIMESTAMP &&
-                MpRestartSequenceGenerator.isForRestart(task.getTimestamp()) &&
                 m_fragTask != null && m_fragTask.getTxnId() == task.getMsgTxnId()) {
             m_fragTask = null;
         }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1303,7 +1303,6 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             queueOrOfferMPTask(task);
         } else {
             if (msg.needsCoordination()) {
-                msg.setRestartable(message.isRestartable());
                 final CompleteTransactionTask missingTxnCompletion =
                         new CompleteTransactionTask(m_mailbox, null, m_pendingTasks, msg);
                 m_pendingTasks.handleCompletionForMissingTxn(missingTxnCompletion);

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -107,7 +107,6 @@ public class TransactionTaskQueue
                 // only release completions at head of queue
                 CompleteTransactionTask completion = m_stashedMpScoreboards[ii].getCompletionTasks().pollFirst().getFirst();
                 if (missingTask) {
-
                     //flush the backlog to avoid no task is pushed to site queue
                     if (completion.isAbortDuringRepair()) {
                         if (hostLog.isDebugEnabled()) {

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -109,11 +109,11 @@ public class TransactionTaskQueue
                 if (missingTask) {
 
                     //flush the backlog to avoid no task is pushed to site queue
-                    if (!completion.isRestartable()) {
+                    if (completion.isAbortDuringRepair()) {
                         if (hostLog.isDebugEnabled()) {
                             hostLog.debug("releaseStashedComleteTxns: flush non-restartable logs at " + TxnEgo.txnIdToString(txnId));
                         }
-                        m_txnTaskQueues[ii].flush(txnId);
+                        completion.doCommonSPICompleteActions();
                     }
                     //Some sites may have processed CompleteTransactionResponseMessage, re-deliver this message to all sites and clear
                     //up the site outstanding transaction queue and duplicate counter

--- a/tests/frontend/org/voltdb/iv2/RandomMsgGenerator.java
+++ b/tests/frontend/org/voltdb/iv2/RandomMsgGenerator.java
@@ -95,7 +95,7 @@ public class RandomMsgGenerator
     {
         CompleteTransactionMessage msg =
             new CompleteTransactionMessage(0l, 0l, m_mpiTxnEgo.getTxnId(), readOnly, 0, isRollback,
-                    false, isRestart, false, false);
+                    false, isRestart, false, false, false);
         return msg;
     }
 

--- a/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
+++ b/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
@@ -373,7 +373,7 @@ public class TestVoltMessageSerialization extends TestCase {
     {
         CompleteTransactionMessage ctm =
             new CompleteTransactionMessage(12345, 54321, 67890, false, 77, false,
-                                           true, false, true, false);
+                                           true, false, true, false, false);
 
         CompleteTransactionMessage ctm2 = (CompleteTransactionMessage) checkVoltMessage(ctm);
         assertEquals(ctm.m_isRollback, ctm2.m_isRollback);
@@ -386,7 +386,7 @@ public class TestVoltMessageSerialization extends TestCase {
     {
         CompleteTransactionMessage ctm =
             new CompleteTransactionMessage(12345, 54321, 67890, false, 0, false,
-                                           true, false, true, false);
+                                           true, false, true, false, false);
 
         CompleteTransactionResponseMessage ctrm =
             new CompleteTransactionResponseMessage(ctm);


### PR DESCRIPTION
Rename restartable in the completion message to indicate that this is a repair completion with an abort.

Also use and advance the timestamp for this use of completions.

Also make sure that abort completions for txns where some sites have the first fragment and some don't, mark the txn state complete in those sites that receive the txn. Otherwise the backlog.flush won't advance the backlog.

Clean up unit tests that flush the backlog at the time the txn is added rather than waiting until the txn has been released by the scoreboard.