### PR TITLE
Eng 11896 pi function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ tools/meshmonitor/dist/
 # IntelliJ excluded files.
 .idea/workspace.xml
 .idea/tasks.xml
+.idea/modules.xml
+

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionCustom.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionCustom.java
@@ -242,7 +242,6 @@ public class FunctionCustom extends FunctionSQL {
         customValueFuncMap.put(Tokens.SYSDATE, FUNC_SYSDATE);
         customValueFuncMap.put(Tokens.TODAY, FUNC_CURRENT_DATE);
         customValueFuncMap.put(Tokens.NOW, FUNC_CURRENT_TIMESTAMP);
-        customValueFuncMap.put(Tokens.PI, FUNC_PI);
     }
 
     private int extractSpec;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionCustom.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionCustom.java
@@ -271,7 +271,6 @@ public class FunctionCustom extends FunctionSQL {
 
             // A VoltDB extension to customize the SQL function set support
             case Tokens.LOG :
-            case Tokens.PI :
             /* disable 1 line
             case Tokens.LN :
              ... disabled 1 line */
@@ -499,6 +498,7 @@ public class FunctionCustom extends FunctionSQL {
             case FUNC_PI :
                 name = Tokens.T_PI;
                 parseList = emptyParamList;
+                parseListAlt = noParamList;
                 break;
             case FUNC_SIN :
                 name = Tokens.T_SIN;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionCustom.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionCustom.java
@@ -242,6 +242,7 @@ public class FunctionCustom extends FunctionSQL {
         customValueFuncMap.put(Tokens.SYSDATE, FUNC_SYSDATE);
         customValueFuncMap.put(Tokens.TODAY, FUNC_CURRENT_DATE);
         customValueFuncMap.put(Tokens.NOW, FUNC_CURRENT_TIMESTAMP);
+        customValueFuncMap.put(Tokens.PI, FUNC_PI);
     }
 
     private int extractSpec;
@@ -271,6 +272,7 @@ public class FunctionCustom extends FunctionSQL {
 
             // A VoltDB extension to customize the SQL function set support
             case Tokens.LOG :
+            case Tokens.PI :
             /* disable 1 line
             case Tokens.LN :
              ... disabled 1 line */

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQL.java
@@ -932,6 +932,9 @@ public class FunctionSQL extends Expression {
             case FUNC_WIDTH_BUCKET : {
                 return null;
             }
+            case FUNC_PI : {
+                return Double.valueOf(Math.PI);
+            }
             case FUNC_SUBSTRING_CHAR : {
                 if (data[0] == null || data[1] == null) {
                     return null;
@@ -1920,6 +1923,10 @@ public class FunctionSQL extends Expression {
                 sb.append(Tokens.T_CEILING).append('(').                 //
                     append(nodes[0].getSQL()).append(')');
 
+                break;
+            }
+            case FUNC_PI : {
+                sb.append(Tokens.T_PI).append("()");                     //
                 break;
             }
             case FUNC_WIDTH_BUCKET : {

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQL.java
@@ -101,6 +101,7 @@ public class FunctionSQL extends Expression {
     private final static int   FUNC_SYSTEM_USER                      = 59;
     protected final static int FUNC_USER                             = 60;
     private final static int   FUNC_VALUE                            = 61;
+    private final static int   FUNC_PI                               = 111;
 
     //
     static final short[] noParamList              = new short[]{};
@@ -633,8 +634,9 @@ public class FunctionSQL extends Expression {
                 // End of VoltDB extension
                 break;
 
+            case FUNC_PI:
             case FUNC_CURRENT_TIMESTAMP :
-                name            = Tokens.T_CURRENT_TIMESTAMP;
+                name            = id == FUNC_CURRENT_TIMESTAMP ? Tokens.T_CURRENT_TIMESTAMP : Tokens.T_PI;
                 parseList       = emptyParamList;
                 parseListAlt    = noParamList;
                 isValueFunction = true;
@@ -1752,6 +1754,9 @@ public class FunctionSQL extends Expression {
 
                 break;
             }
+            case FUNC_PI :
+                dataType = Type.SQL_DOUBLE;
+                break;
             case FUNC_CURRENT_TIMESTAMP : {
                 // A VoltDB extension to disable TIME ZONE support
                 dataType = Type.SQL_TIMESTAMP;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionSQL.java
@@ -101,7 +101,6 @@ public class FunctionSQL extends Expression {
     private final static int   FUNC_SYSTEM_USER                      = 59;
     protected final static int FUNC_USER                             = 60;
     private final static int   FUNC_VALUE                            = 61;
-    private final static int   FUNC_PI                               = 111;
 
     //
     static final short[] noParamList              = new short[]{};
@@ -634,9 +633,8 @@ public class FunctionSQL extends Expression {
                 // End of VoltDB extension
                 break;
 
-            case FUNC_PI:
             case FUNC_CURRENT_TIMESTAMP :
-                name            = id == FUNC_CURRENT_TIMESTAMP ? Tokens.T_CURRENT_TIMESTAMP : Tokens.T_PI;
+                name            = Tokens.T_CURRENT_TIMESTAMP;
                 parseList       = emptyParamList;
                 parseListAlt    = noParamList;
                 isValueFunction = true;
@@ -931,9 +929,6 @@ public class FunctionSQL extends Expression {
             }
             case FUNC_WIDTH_BUCKET : {
                 return null;
-            }
-            case FUNC_PI : {
-                return Double.valueOf(Math.PI);
             }
             case FUNC_SUBSTRING_CHAR : {
                 if (data[0] == null || data[1] == null) {
@@ -1757,9 +1752,6 @@ public class FunctionSQL extends Expression {
 
                 break;
             }
-            case FUNC_PI :
-                dataType = Type.SQL_DOUBLE;
-                break;
             case FUNC_CURRENT_TIMESTAMP : {
                 // A VoltDB extension to disable TIME ZONE support
                 dataType = Type.SQL_TIMESTAMP;
@@ -1923,10 +1915,6 @@ public class FunctionSQL extends Expression {
                 sb.append(Tokens.T_CEILING).append('(').                 //
                     append(nodes[0].getSQL()).append(')');
 
-                break;
-            }
-            case FUNC_PI : {
-                sb.append(Tokens.T_PI).append("()");                     //
                 break;
             }
             case FUNC_WIDTH_BUCKET : {

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -3705,13 +3705,16 @@ public class TestFunctionsSuite extends RegressionSuite {
          */
         ClientResponse cr = null;
         VoltTable vt = null;
-        double pi = 3.1415926535897932384;
 
         cr = client.callProcedure("@AdHoc","INSERT INTO P1 (ID) VALUES(1)");
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
         vt = client.callProcedure("@AdHoc", "SELECT PI() * ID FROM P1 WHERE ID = 1;").getResults()[0];
         assertTrue(vt.advanceRow());
-        assertTrue(Math.abs(vt.getDouble(0) - pi) <= 1.0e-16);
+        assertTrue(Math.abs(vt.getDouble(0) - Math.PI) <= 1.0e-16);
+
+        vt = client.callProcedure("@AdHoc", "SELECT PI * ID FROM P1 WHERE ID = 1;").getResults()[0];
+        assertTrue(vt.advanceRow());
+        assertTrue(Math.abs(vt.getDouble(0) - Math.PI) <= 1.0e-16);
 
         cr = client.callProcedure("@AdHoc", "TRUNCATE TABLE P1");
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());


### PR DESCRIPTION
Makes query `SELECT PI FROM T;` work the way as `SELECT PI() FROM T;`.

See [Jenkins](http://ci.voltdb.lan/view/Branch-jobs/view/branch-ENG-11896-pi-function/). Not totally sure if failed ones were ok, but a few, e.g. TestTopologyAwareClient fails both on master branch and this branch on my local machine.