### PR TITLE
ENG-13857, another corner case for non-restartable MP sysproc, when t…

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -138,6 +138,7 @@ public class MpProcedureTask extends ProcedureTask
                         new VoltTable[] {},
                         "Failure while running system procedure " + txn.m_initiationMsg.getStoredProcedureName() +
                         ", and system procedures can not be restarted."));
+            errorResp.m_isFromNonRestartableSysproc = true;
             errorResp.m_sourceHSId = m_initiator.getHSId();
             m_txnState.setDone();
             m_queue.flush(getTxnId());

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -481,7 +481,7 @@ public class MpScheduler extends Scheduler
             // even if all the masters somehow die before forwarding Complete on to their replicas.
             CompleteTransactionMessage ctm = new CompleteTransactionMessage(m_mailbox.getHSId(),
                     message.m_sourceHSId, message.getTxnId(), message.isReadOnly(), 0,
-                    !message.shouldCommit(), false, false, false, txn.isNPartTxn(), false);
+                    !message.shouldCommit(), false, false, false, txn.isNPartTxn(), message.m_isFromNonRestartableSysproc);
             ctm.setTruncationHandle(m_repairLogTruncationHandle);
             // dump it in the repair log
             // hacky castage

--- a/src/frontend/org/voltdb/messaging/InitiateResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/InitiateResponseMessage.java
@@ -58,6 +58,9 @@ public class InitiateResponseMessage extends VoltMessage {
     //when the site was leader partition
     boolean m_isForOldLeader = false;
 
+    // No need to serialize it
+    public boolean m_isFromNonRestartableSysproc = false;
+
     /** Empty constructor for de-serialization */
     public InitiateResponseMessage()
     {


### PR DESCRIPTION
…his kind of sysprocs are interrupted by SP leader promotion, we generates an error response to MpScheduler. In MpScheduler, we fake a CompleteTransactionMessage to repair log, but in this case, we mark it as a normal CTM, it should be a CTM with abortDuringRepair flag on.

Change-Id: Ic914ecaf38ab9ece24d777ae0a0434d54e384f4c