### PR TITLE
ENG-13854:

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -333,7 +333,11 @@ public class MpPromoteAlgo implements RepairAlgo
     VoltMessage createRepairMessage(Iv2RepairLogResponseMessage msg)
     {
         if (msg.getPayload() instanceof CompleteTransactionMessage) {
-            CompleteTransactionMessage message = (CompleteTransactionMessage)msg.getPayload();
+            CompleteTransactionMessage ctm = (CompleteTransactionMessage)msg.getPayload();
+            // Repair log messages that originated from this host may still be in the scoreboard,
+            // so build a new message to avoid corrupting the scoreboard's reference.
+            CompleteTransactionMessage message = new CompleteTransactionMessage(ctm.getInitiatorHSId(),
+                    ctm.getCoordinatorHSId(), ctm);
             message.setForReplica(false);
             message.setRequireAck(false);
             message.setTimestamp(m_restartSeqGenerator.getNextSeqNum());


### PR DESCRIPTION
The SP RepairLog and the ScoreBoard share the same message. When a local repairlog is sent to a local MPI, the MPI will modify any found completion messages before resending them back to site leaders, these modifications alter the scoreboard message causing the scoreboard to treat the original, modified completion message as a repair message before the actual repair message arrives. To prevent this, we need to make new completion messages from the original repair messages rather than reusing the message we received.