### PR TITLE
ENG-13854:

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -161,7 +161,7 @@ public class MpProcedureTask extends ProcedureTask
                     0,
                     true,
                     false,  // really don't want to have ack the ack.
-                    !m_txnState.isReadOnly(),
+                    true,   // Don't clear/flush the txn because we are restarting it
                     m_msg.isForReplay(),
                     txn.isNPartTxn(),
                     false);

--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -372,7 +372,7 @@ public class MpPromoteAlgo implements RepairAlgo
                             0,
                             true,       // Force rollback as our repair operation.
                             false,      // no acks in iv2.
-                            restart,    // Indicate rollback for repair as appropriate
+                            false,      // Indicate because this will not be restarted, the txn should be cleaned up
                             ftm.isForReplay(),
                             ftm.isNPartTxn(),
                             true);

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1343,6 +1343,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             DuplicateCounterKey staleMatch = m_duplicateCounters.ceilingKey(lowestPossible);
             while (staleMatch != null && staleMatch.compareTo(duplicateCounterKey) == -1) {
                 m_duplicateCounters.remove(staleMatch);
+                staleMatch = m_duplicateCounters.ceilingKey(lowestPossible);
             };
         }
 

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1336,6 +1336,15 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             // Don't mark txn done for restarts
             txnDone = false;
         }
+        if (msg.isAborted() && counter != null) {
+            // The last completion was an abort due to a repair/abort or restart/abort so we need to remove duplicate counters
+            // for stale versions of the restarted Txn that never made it past the scoreboard
+            final DuplicateCounterKey lowestPossible = new DuplicateCounterKey(msg.getTxnId(), 0);
+            DuplicateCounterKey staleMatch = m_duplicateCounters.ceilingKey(lowestPossible);
+            while (staleMatch != null && staleMatch.compareTo(duplicateCounterKey) == -1) {
+                m_duplicateCounters.remove(staleMatch);
+            };
+        }
 
         if (counter != null) {
             txnDone = counter.offer(msg) == DuplicateCounter.DONE;

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -45,7 +45,6 @@ public class TransactionTaskQueue
     private static class RelativeSiteOffset {
         private SiteTaskerQueue[] m_stashedMpQueues;
         private Scoreboard[] m_stashedMpScoreboards;
-        private TransactionTaskQueue[] m_txnTaskQueues;
         private int m_lowestSiteId = Integer.MIN_VALUE;
         private int m_siteCount = 0;
         private Mailbox[] m_mailBoxes;
@@ -54,22 +53,19 @@ public class TransactionTaskQueue
             m_stashedMpScoreboards = null;
             m_lowestSiteId = firstSiteId;
             m_siteCount = siteCount;
-            m_txnTaskQueues = null;
         }
 
-        void initializeScoreboard(int siteId, SiteTaskerQueue queue, Scoreboard scoreboard, Mailbox mailBox, TransactionTaskQueue taskQueue) {
+        void initializeScoreboard(int siteId, SiteTaskerQueue queue, Scoreboard scoreboard, Mailbox mailBox) {
             assert(m_lowestSiteId != Integer.MIN_VALUE);
             assert(siteId >= m_lowestSiteId && siteId-m_lowestSiteId < m_siteCount);
             if (m_stashedMpQueues == null) {
                 m_stashedMpQueues = new SiteTaskerQueue[m_siteCount];
                 m_stashedMpScoreboards = new Scoreboard[m_siteCount];
                 m_mailBoxes = new Mailbox[m_siteCount];
-                m_txnTaskQueues = new TransactionTaskQueue[m_siteCount];
             }
             m_stashedMpQueues[siteId-m_lowestSiteId] = queue;
             m_stashedMpScoreboards[siteId-m_lowestSiteId] = scoreboard;
             m_mailBoxes[siteId-m_lowestSiteId] = mailBox;
-            m_txnTaskQueues[siteId-m_lowestSiteId] = taskQueue;
         }
 
         // All sites receives FragmentTask messages, time to fire the task.
@@ -204,7 +200,7 @@ public class TransactionTaskQueue
     void initializeScoreboard(int siteId, Mailbox mailBox) {
         synchronized (s_lock) {
             if (m_taskQueue.getPartitionId() != MpInitiator.MP_INIT_PID) {
-                s_stashedMpWrites.initializeScoreboard(siteId, m_taskQueue, m_scoreboard, mailBox, this);
+                s_stashedMpWrites.initializeScoreboard(siteId, m_taskQueue, m_scoreboard, mailBox);
             }
         }
     }

--- a/src/frontend/org/voltdb/messaging/CompleteTransactionResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/CompleteTransactionResponseMessage.java
@@ -31,6 +31,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
     boolean m_isRestart;
     boolean m_isRecovering = false;
     boolean m_ackRequired = false;
+    boolean m_isAborted;
 
     /** Empty constructor for de-serialization */
     CompleteTransactionResponseMessage() {
@@ -44,6 +45,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
         m_isRestart = msg.isRestart();
         m_spiHSId = msg.getCoordinatorHSId();
         m_ackRequired = msg.requiresAck();
+        m_isAborted = msg.isRestart() || msg.m_isAbortDuringRepair;
     }
 
     public long getTxnId()
@@ -66,6 +68,11 @@ public class CompleteTransactionResponseMessage extends VoltMessage
         return m_isRestart;
     }
 
+    public boolean isAborted()
+    {
+        return m_isAborted;
+    }
+
     public boolean isRecovering()
     {
         return m_isRecovering;
@@ -85,7 +92,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
     public int getSerializedSize()
     {
         int msgsize = super.getSerializedSize();
-        msgsize += 8 + 8 + 8 + 1 + 1 + 1;
+        msgsize += 8 + 8 + 8 + 1 + 1 + 1 + 1;
         return msgsize;
     }
 
@@ -99,6 +106,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
         buf.put((byte) (m_isRestart ? 1 : 0));
         buf.put((byte) (m_isRecovering ? 1 : 0));
         buf.put((byte) (m_ackRequired ? 1 : 0));
+        buf.put((byte) (m_isAborted ? 1 : 0));
         assert(buf.capacity() == buf.position());
         buf.limit(buf.position());
     }
@@ -112,6 +120,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
         m_isRestart = buf.get() == 1;
         m_isRecovering = buf.get() == 1;
         m_ackRequired = buf.get() == 1;
+        m_isAborted = buf.get() == 1;
         assert(buf.capacity() == buf.position());
     }
 
@@ -131,6 +140,8 @@ public class CompleteTransactionResponseMessage extends VoltMessage
         sb.append(CoreUtils.hsIdToString(m_spiHSId));
         sb.append(" ISRESTART: ");
         sb.append(m_isRestart);
+        sb.append(" ISABORTED: ");
+        sb.append(m_isAborted);
         sb.append(" RECOVERING ");
         sb.append(m_isRecovering);
 


### PR DESCRIPTION
All completion handling (even for aborted txns) need to be done on the correct site thread to avoid a locking deadlock between the TransactionTaskQueue and the Scoreboard locks.

Also make sure that abort repair messages for non-restartable txns do not have the restart flag set (for non-restartables) because otherwise the txn will not be cleaned up by the SPs.

Lastly clean up duplicate counters for all abort completions that never made it past the scoreboard because a newer abort completion (with more valid SP leaders) arrived.