### PR TITLE
ENG-13816: Catch Serilized EE exception in IPC for loadTable; non low…

### DIFF
--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -978,7 +978,10 @@ int8_t VoltDBIPC::loadTable(struct ipc_command *cmd) {
         } else {
             return kErrorCode_Error;
         }
-    } catch (const FatalException &e) {
+    } catch (const SerializableEEException &see) {
+        return kErrorCode_Error;
+    }
+    catch (const FatalException &e) {
         crashVoltDB(e);
     }
     return kErrorCode_Error;


### PR DESCRIPTION
…est site for replicatedTable changes can throw it if lowest site hit exception