### PR TITLE
ENG-13654: in VoltDBManagementCenterPage.groovy's 'getTableContents',

### DIFF
--- a/tests/geb/vmc/src/pages/VoltDBManagementCenterPage.groovy
+++ b/tests/geb/vmc/src/pages/VoltDBManagementCenterPage.groovy
@@ -203,13 +203,16 @@ class VoltDBManagementCenterPage extends Page {
         }
         if (columnWise) {
             result = [:]
-            def makeColumn = { index,rowset -> rowset.collect { row -> row.find('td',index).text() } }
+            // Note: need to use '@innerHTML' rather than 'text()' here,
+            // because the latter removes leading and trailing whitespace
+            def makeColumn = { index,rowset -> rowset.collect { row -> row.find('td',index).@innerHTML } }
             def colNum = 0
             columnHeaders.each { result.put(it, makeColumn(colNum++, rows)) }
             return result
         } else {
             result.add(columnHeaders)
-            rows.each { result.add(it.find('td')*.text()) }
+            // Same comment as above (use '@innerHTML', not 'text()')
+            rows.each { result.add(it.find('td')*.@innerHTML) }
         }
         return result
     }

--- a/tests/geb/vmc/src/resources/sqlQueries.txt
+++ b/tests/geb/vmc/src/resources/sqlQueries.txt
@@ -218,19 +218,18 @@
                        "type_null_varchar1024":["  x"],"type_not_null_varchar1024":["y z"],"type_null_point":["POINT (-23.0 23.0)"],"type_not_null_point":["POINT (24.0 -24.0)"],
                        "type_null_polygon":["POLYGON ((25.0 22.0, 25.0 21.0, 26.0 22.0, 25.0 22.0))"],"type_not_null_polygon":["POLYGON ((26.0 22.0, 25.0 23.0, 25.0 22.0, 26.0 22.0))"]},
             "status":"SUCCESS"}}
-# Note: we pass '\\t' to JSON, to pass '\t' to the VMC, which it interprets (correctly) as a tab character
-# TODO: this test is commented out until ENG-13003 is truly fixed:
-#{"testName":"SelectInsertedEmbeddedWhitespace",
-#   "sqlCmd":"INSERT INTO partitioned_table VALUES(__standard_num_values ' ', '\\t', '  ', 'w ', '\\t x', 'y z',\n  __standard_geo_values);\n
-#             SELECT * FROM partitioned_table WHERE type_null_varchar25 = ' '",
-# "response":{"result":{"rowid":["1"],"rowid_group":["2"],"type_null_tinyint":["3"],"type_not_null_tinyint":["4"],"type_null_smallint":["5"],"type_not_null_smallint":["6"],
-#                       "type_null_integer":["7"],"type_not_null_integer":["8"],"type_null_bigint":["9"],"type_not_null_bigint":["10"],
-#                       "type_null_timestamp":["2010-07-31 16:08:11.000011"],"type_not_null_timestamp":["2012-07-19 01:02:12.000012"],
-#                       "type_null_float":["13.3"],"type_not_null_float":["14.4"],"type_null_decimal":["15.500000000000"],"type_not_null_decimal":["16.600000000000"],
-#                       "type_null_varchar25":[" "],"type_not_null_varchar25":["\t"],"type_null_varchar128":["  "],"type_not_null_varchar128":["w "],
-#                       "type_null_varchar1024":["\t x"],"type_not_null_varchar1024":["y z"],"type_null_point":["POINT (-23.0 23.0)"],"type_not_null_point":["POINT (24.0 -24.0)"],
-#                       "type_null_polygon":["POLYGON ((25.0 22.0, 25.0 21.0, 26.0 22.0, 25.0 22.0))"],"type_not_null_polygon":["POLYGON ((26.0 22.0, 25.0 23.0, 25.0 22.0, 26.0 22.0))"]},
-#            "status":"SUCCESS"}}
+# Note: we pass '\t' to JSON, which it interprets (correctly) as a tab character
+{"testName":"SelectInsertedEmbeddedWhitespace",
+   "sqlCmd":"INSERT INTO partitioned_table VALUES(__standard_num_values ' ', '\t', '  ', 'w ', '\t x', 'y z',\n  __standard_geo_values);\n
+             SELECT * FROM partitioned_table WHERE type_null_varchar25 = ' '",
+ "response":{"result":{"rowid":["1"],"rowid_group":["2"],"type_null_tinyint":["3"],"type_not_null_tinyint":["4"],"type_null_smallint":["5"],"type_not_null_smallint":["6"],
+                       "type_null_integer":["7"],"type_not_null_integer":["8"],"type_null_bigint":["9"],"type_not_null_bigint":["10"],
+                       "type_null_timestamp":["2010-07-31 16:08:11.000011"],"type_not_null_timestamp":["2012-07-19 01:02:12.000012"],
+                       "type_null_float":["13.3"],"type_not_null_float":["14.4"],"type_null_decimal":["15.500000000000"],"type_not_null_decimal":["16.600000000000"],
+                       "type_null_varchar25":[" "],"type_not_null_varchar25":["\t"],"type_null_varchar128":["  "],"type_not_null_varchar128":["w "],
+                       "type_null_varchar1024":["\t x"],"type_not_null_varchar1024":["y z"],"type_null_point":["POINT (-23.0 23.0)"],"type_not_null_point":["POINT (24.0 -24.0)"],
+                       "type_null_polygon":["POLYGON ((25.0 22.0, 25.0 21.0, 26.0 22.0, 25.0 22.0))"],"type_not_null_polygon":["POLYGON ((26.0 22.0, 25.0 23.0, 25.0 22.0, 26.0 22.0))"]},
+            "status":"SUCCESS"}}
 {"testName":"SelectInsertedEmbeddedQuotes",
    "sqlCmd":"INSERT INTO partitioned_table VALUES(__standard_num_values '''', '''b''', 'can''t', 'doin''', '''\"''', '''''''',\n  __standard_geo_values);\n
              SELECT * FROM partitioned_table WHERE type_null_varchar25 = ''''",
@@ -576,19 +575,18 @@
                        "type_null_varchar1024":["  x"],"type_not_null_varchar1024":["y z"],"type_null_point":["POINT (-23.0 23.0)"],"type_not_null_point":["POINT (24.0 -24.0)"],
                        "type_null_polygon":["POLYGON ((25.0 22.0, 25.0 21.0, 26.0 22.0, 25.0 22.0))"],"type_not_null_polygon":["POLYGON ((26.0 22.0, 25.0 23.0, 25.0 22.0, 26.0 22.0))"]},
              "status":"SUCCESS"}}
-# Note: we pass '\\t' to JSON, to pass '\t' to the VMC, which it interprets (correctly) as a tab character
-# TODO: this test is commented out until ENG-13003 is truly fixed:
-#{"testName":"CrudRoundTripEmbeddedWhitespace",
-#   "sqlCmd":"exec PARTITIONED_TABLE.insert __standard_num_values ' ', '\\t', '  ', 'w ', '\\t x', 'y z',\n  __stored_proc_geo_values;\n
-#             exec PARTITIONED_TABLE.select 1",
-# "response":{"result":{"rowid":["1"],"rowid_group":["2"],"type_null_tinyint":["3"],"type_not_null_tinyint":["4"],"type_null_smallint":["5"],"type_not_null_smallint":["6"],
-#                       "type_null_integer":["7"],"type_not_null_integer":["8"],"type_null_bigint":["9"],"type_not_null_bigint":["10"],
-#                       "type_null_timestamp":["2010-07-31 16:08:11.000011"],"type_not_null_timestamp":["2012-07-19 01:02:12.000012"],
-#                       "type_null_float":["13.3"],"type_not_null_float":["14.4"],"type_null_decimal":["15.500000000000"],"type_not_null_decimal":["16.600000000000"],
-#                       "type_null_varchar25":[" "],"type_not_null_varchar25":["\t"],"type_null_varchar128":["  "],"type_not_null_varchar128":["w "],
-#                       "type_null_varchar1024":["\t x"],"type_not_null_varchar1024":["y z"],"type_null_point":["POINT (-23.0 23.0)"],"type_not_null_point":["POINT (24.0 -24.0)"],
-#                       "type_null_polygon":["POLYGON ((25.0 22.0, 25.0 21.0, 26.0 22.0, 25.0 22.0))"],"type_not_null_polygon":["POLYGON ((26.0 22.0, 25.0 23.0, 25.0 22.0, 26.0 22.0))"]},
-#             "status":"SUCCESS"}}
+# Note: we pass '\t' to JSON, which it interprets (correctly) as a tab character
+{"testName":"CrudRoundTripEmbeddedWhitespace",
+   "sqlCmd":"exec PARTITIONED_TABLE.insert __standard_num_values ' ', '\t', '  ', 'w ', '\t x', 'y z',\n  __stored_proc_geo_values;\n
+             exec PARTITIONED_TABLE.select 1",
+ "response":{"result":{"rowid":["1"],"rowid_group":["2"],"type_null_tinyint":["3"],"type_not_null_tinyint":["4"],"type_null_smallint":["5"],"type_not_null_smallint":["6"],
+                       "type_null_integer":["7"],"type_not_null_integer":["8"],"type_null_bigint":["9"],"type_not_null_bigint":["10"],
+                       "type_null_timestamp":["2010-07-31 16:08:11.000011"],"type_not_null_timestamp":["2012-07-19 01:02:12.000012"],
+                       "type_null_float":["13.3"],"type_not_null_float":["14.4"],"type_null_decimal":["15.500000000000"],"type_not_null_decimal":["16.600000000000"],
+                       "type_null_varchar25":[" "],"type_not_null_varchar25":["\t"],"type_null_varchar128":["  "],"type_not_null_varchar128":["w "],
+                       "type_null_varchar1024":["\t x"],"type_not_null_varchar1024":["y z"],"type_null_point":["POINT (-23.0 23.0)"],"type_not_null_point":["POINT (24.0 -24.0)"],
+                       "type_null_polygon":["POLYGON ((25.0 22.0, 25.0 21.0, 26.0 22.0, 25.0 22.0))"],"type_not_null_polygon":["POLYGON ((26.0 22.0, 25.0 23.0, 25.0 22.0, 26.0 22.0))"]},
+             "status":"SUCCESS"}}
 {"testName":"CrudRoundTripEmbeddedQuotes",
    "sqlCmd":"exec PARTITIONED_TABLE.insert __standard_num_values '''', '''b''', 'can''t', 'doin''', '''\"''', '''''''',\n  __stored_proc_geo_values;\n
              exec PARTITIONED_TABLE.select 1",


### PR DESCRIPTION
use '@innerHTML' rather than 'text()', because the latter removes
leading and trailing whitespace. In sqlQueries.txt, use '\t' to pass a
tab character to JSON, but not '\\t', since the VMC no longer interprets
'\t' as a tab character, but does work with a literal tab character; and
uncomment the 2 '...EmbeddedWhitespace' tests, since they now work, with
the above changes.