### PR TITLE
ENG-13880:

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -59,6 +59,8 @@ public interface ConsumerDRGateway extends Promotable {
 
     void restart(final boolean blocking) throws InterruptedException, ExecutionException;
 
+    void shutdownPartitions(final int consumerPartitionId) throws InterruptedException, ExecutionException;
+
     DRConsumerMpCoordinator getDRConsumerMpCoordinator();
 
     void clusterUnrecoverable(byte clusterId, Throwable t);

--- a/src/frontend/org/voltdb/messaging/Dr2MultipartResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/Dr2MultipartResponseMessage.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 public class Dr2MultipartResponseMessage extends VoltMessage {
 
     private boolean m_drain;
+    private boolean m_reneg;
     private byte m_producerClusterId;
     private int m_producerPID;
     private ClientResponseImpl m_response;
@@ -36,14 +37,17 @@ public class Dr2MultipartResponseMessage extends VoltMessage {
 
     public Dr2MultipartResponseMessage(byte producerClusterId, int producerPID, ClientResponseImpl response)  {
         m_drain = false;
+        m_reneg = false;
         m_producerClusterId = producerClusterId;
         m_producerPID = producerPID;
         m_response = response;
     }
 
-    public static Dr2MultipartResponseMessage createDrainMessage(byte producerClusterId, int producerPID) {
+    public static Dr2MultipartResponseMessage createDrainOrRenegMessage(byte producerClusterId, int producerPID,
+            boolean withDrainFlag, boolean withRenegFlag) {
         final Dr2MultipartResponseMessage msg = new Dr2MultipartResponseMessage();
-        msg.m_drain = true;
+        msg.m_drain = withDrainFlag;
+        msg.m_reneg = withRenegFlag;
         msg.m_producerClusterId = producerClusterId;
         msg.m_producerPID = producerPID;
         msg.m_response = null;
@@ -66,9 +70,14 @@ public class Dr2MultipartResponseMessage extends VoltMessage {
         return m_drain;
     }
 
+    public boolean isReneg() {
+        return m_reneg;
+    }
+
     @Override
     protected void initFromBuffer(ByteBuffer buf) throws IOException {
         m_drain = buf.get() == 1;
+        m_reneg = buf.get() == 1;
         m_producerClusterId = buf.get();
         m_producerPID = buf.getInt();
         if (buf.remaining() > 0) {
@@ -81,6 +90,7 @@ public class Dr2MultipartResponseMessage extends VoltMessage {
     public void flattenToBuffer(ByteBuffer buf) throws IOException {
         buf.put(VoltDbMessageFactory.DR2_MULTIPART_RESPONSE_ID);
         buf.put((byte) (m_drain ? 1 : 0));
+        buf.put((byte) (m_reneg ? 1 : 0));
         buf.put(m_producerClusterId);
         buf.putInt(m_producerPID);
 
@@ -96,6 +106,7 @@ public class Dr2MultipartResponseMessage extends VoltMessage {
     public int getSerializedSize() {
         int size = super.getSerializedSize()
                    + 1  // drain or not
+                   + 1  // reneg or not
                    + 1  // producer cluster ID
                    + 4; // producer partition ID
         if (!m_drain) {

--- a/src/frontend/org/voltdb/messaging/Dr2MultipartTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/Dr2MultipartTaskMessage.java
@@ -27,6 +27,7 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
 
     private int m_producerPID;
     private boolean m_drain;
+    private boolean m_reneg;
     private byte m_producerClusterId;
     private short m_producerPartitionCnt;
 
@@ -46,6 +47,7 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
         m_lastExecutedMPUniqueID = lastExecutedMPUniqueID;
         m_producerPID = producerPID;
         m_drain = false;
+        m_reneg = false;
     }
 
     public static Dr2MultipartTaskMessage createDrainMessage(byte producerClusterId, int producerPID) {
@@ -54,6 +56,19 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
         msg.m_producerClusterId = producerClusterId;
         msg.m_producerPartitionCnt = -1;
         msg.m_drain = true;
+        msg.m_reneg = false;
+        msg.m_invocation = null;
+        msg.m_lastExecutedMPUniqueID = Long.MIN_VALUE;
+        return msg;
+    }
+
+    public static Dr2MultipartTaskMessage createRenegMessage(byte producerClusterId, int producerPID) {
+        final Dr2MultipartTaskMessage msg = new Dr2MultipartTaskMessage();
+        msg.m_producerPID = producerPID;
+        msg.m_producerClusterId = producerClusterId;
+        msg.m_producerPartitionCnt = -1;
+        msg.m_drain = false;
+        msg.m_reneg = true;
         msg.m_invocation = null;
         msg.m_lastExecutedMPUniqueID = Long.MIN_VALUE;
         return msg;
@@ -69,6 +84,10 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
 
     public boolean isDrain() {
         return m_drain;
+    }
+
+    public boolean isReneg() {
+        return m_reneg;
     }
 
     public byte getProducerClusterId() {
@@ -87,6 +106,7 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
     protected void initFromBuffer(ByteBuffer buf) throws IOException {
         m_producerPID = buf.getInt();
         m_drain = buf.get() == 1;
+        m_reneg = buf.get() == 1;
         m_producerClusterId = buf.get();
         m_producerPartitionCnt = buf.getShort();
         m_lastExecutedMPUniqueID = buf.getLong();
@@ -103,6 +123,7 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
         buf.put(VoltDbMessageFactory.DR2_MULTIPART_TASK_ID);
         buf.putInt(m_producerPID);
         buf.put((byte) (m_drain ? 1 : 0));
+        buf.put((byte) (m_reneg ? 1 : 0));
         buf.put(m_producerClusterId);
         buf.putShort(m_producerPartitionCnt);
         buf.putLong(m_lastExecutedMPUniqueID);
@@ -120,6 +141,7 @@ public class Dr2MultipartTaskMessage extends VoltMessage {
         int size = super.getSerializedSize()
                    + 4  // producer partition ID
                    + 1  // is drain or not
+                   + 1  // is reneg or not
                    + 1  // producer clusterId
                    + 2  // producer partition count
                    + 8; // last executed MP unique ID


### PR DESCRIPTION
In order to migrate an SPI on a DR Consumer, the BufferReceivers associated with that Consumer must be migrated as well. The first step in the process is to shutdown the PartitionBufferReceivers pinned to that consumer partition.

While the shutdown process is straightforward, the problem is that the DRConsumerMpCoordinator may not have any transaction in process from this PartitionBufferReceiver. To enable this a new mechanism has been added to reneg (take back) a pending message from the DRConsumerMpCoordinator. A response will be provided by the DRConsumerMpCoordinator when either, the message (if any) was successfully reneged, or the transaction associated with the message (and is currently in progress), has been completed.