### PR TITLE
ENG-13854 matched complete transaction

### DIFF
--- a/src/frontend/org/voltdb/iv2/CompleteTransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/CompleteTransactionTask.java
@@ -55,9 +55,11 @@ public class CompleteTransactionTask extends TransactionTask
     public void setRepairCompletionMatched() {
         // In the repair process, some sites many have received CompleteTransactionResposneMessage so
         // the TransactionTaskQueue and outstandingTxn are cleaned on these sites. When a repair CompleteTransactionMessage reaches
-        // these sites, a CompelteTransactionTask will be placed on ScoreBoard as unmatched. However, if a site still has the transaction state
-        // (in outstanding transaction and TransactionTaskQueue, a CompelteTransactionTask will be placed on ScoreBoard as matched.
-        // The flag is used to flush the TransactionTaskQueue for the matched.
+        // these sites, a CompelteTransactionTask will be placed on ScoreBoard as unmatched (missing).
+        //
+        // However, if a site still has the transaction state, i.e.in outstanding transaction and TransactionTaskQueue, a CompelteTransactionTask
+        // is placed on ScoreBoard as matched. The heads of TransactionTaskQueues for these matched sites may still have the CompelteTransactionTask
+        // of the transaction. The flag is used to flush these TransactionTaskQueues to unblock these sites.
         m_repaireCompletionMatched = true;
     }
     private void doUnexecutedFragmentCleanup()

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -103,7 +103,7 @@ public class TransactionTaskQueue
                 CompleteTransactionTask completion = task.getFirst();
                 if (missingTxn) {
                     completion.setFragmentNotExecuted();
-                    if (task.getSecond()) {
+                    if (!task.getSecond()) {
                         completion.setRepairCompletionMatched();
                     }
                 }

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -89,9 +89,8 @@ public class TransactionTaskQueue
         // If there are enough completeTransactionTask messages to fire another round of release, return false, otherwise true.
         boolean releaseStashedCompleteTxns(boolean missingTxn, long txnId)
         {
-            boolean missingTask = missingTxn ? true : hasMissingTxn(txnId);
             if (hostLog.isDebugEnabled()) {
-                if (missingTask) {
+                if (missingTxn) {
                     hostLog.debug("skipped incomplete rollback transaction message:" + TxnEgo.txnIdToString(txnId));
                 } else {
                     hostLog.debug("release stashed complete transaction message:" + TxnEgo.txnIdToString(txnId));
@@ -102,14 +101,14 @@ public class TransactionTaskQueue
                 // only release completions at head of queue
                 Pair<CompleteTransactionTask, Boolean> task = m_stashedMpScoreboards[ii].getCompletionTasks().pollFirst();
                 CompleteTransactionTask completion = task.getFirst();
-                if (missingTask) {
+                if (missingTxn) {
                     completion.setFragmentNotExecuted();
                     if (task.getSecond()) {
                         completion.setRepairCompletionMatched();
                     }
                 }
                 Iv2Trace.logSiteTaskerQueueOffer(completion);
-                m_stashedMpQueues[ii].offer( completion);
+                m_stashedMpQueues[ii].offer(completion);
                 Pair<CompleteTransactionTask, Boolean> tail = m_stashedMpScoreboards[ii].getCompletionTasks().pollLast();
                 if (tail != null) {
                     m_stashedMpScoreboards[ii].getCompletionTasks().addFirst(tail);
@@ -132,15 +131,6 @@ public class TransactionTaskQueue
             for (int ii = 0; ii < m_siteCount; ii++) {
                 builder.append("\nQueue " + m_stashedMpQueues[ii].getPartitionId() + ":" + m_stashedMpScoreboards[ii]);
             }
-        }
-
-        boolean hasMissingTxn(long txnId) {
-            for (int ii = m_siteCount-1; ii >= 0; ii--) {
-                if (m_stashedMpScoreboards[ii].isTransactionMissing(txnId)) {
-                    return true;
-                }
-            }
-            return false;
         }
     }
 
@@ -348,11 +338,14 @@ public class TransactionTaskQueue
 
             while (!done) {
                 int completionScore = 0;
+                boolean missingTxn = false;
                 for (Scoreboard sb : s_stashedMpWrites.getScoreboards()) {
                     if (!sb.getCompletionTasks().isEmpty()) {
                         if (!sb.matchCompleteTransactionTask(taskTxnId, taskTimestamp)) {
                             break;
-                        }                    // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
+                        }
+                        missingTxn |= sb.getCompletionTasks().peekFirst().getSecond();
+                        // At repair time MPI may send many rounds of CompleteTxnMessage due to the fact that
                         // many SPI leaders are promoted, each round of CompleteTxnMessages share the same
                         // timestamp, so at TransactionTaskQueue level it only counts messages from the same round.
                         completionScore++;
@@ -366,7 +359,7 @@ public class TransactionTaskQueue
                     hostLog.debug(sb.toString());
                 }
                 if (completionScore == s_stashedMpWrites.getSiteCount()) {
-                    done = s_stashedMpWrites.releaseStashedCompleteTxns(true, missingTxnCompletion.getMsgTxnId());
+                    done = s_stashedMpWrites.releaseStashedCompleteTxns(missingTxn, missingTxnCompletion.getMsgTxnId());
                 } else {
                     done = true;
                 }

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -100,12 +100,16 @@ public class TransactionTaskQueue
             int tasksAtTail = 0;
             for (int ii = m_siteCount-1; ii >= 0; ii--) {
                 // only release completions at head of queue
-                CompleteTransactionTask completion = m_stashedMpScoreboards[ii].getCompletionTasks().pollFirst().getFirst();
+                Pair<CompleteTransactionTask, Boolean> task = m_stashedMpScoreboards[ii].getCompletionTasks().pollFirst();
+                CompleteTransactionTask completion = task.getFirst();
                 if (missingTask) {
                     completion.setFragmentNotExecuted();
+                    if (task.getSecond()) {
+                        completion.setRepairCompletionMatched();
+                    }
                 }
                 Iv2Trace.logSiteTaskerQueueOffer(completion);
-                m_stashedMpQueues[ii].offer(completion);
+                m_stashedMpQueues[ii].offer( completion);
                 Pair<CompleteTransactionTask, Boolean> tail = m_stashedMpScoreboards[ii].getCompletionTasks().pollLast();
                 if (tail != null) {
                     m_stashedMpScoreboards[ii].getCompletionTasks().addFirst(tail);


### PR DESCRIPTION
In the repair process, some sites many have received CompleteTransactionResposneMessage so
the TransactionTaskQueue and outstandingTxn are cleaned on these sites. When a repair CompleteTransactionMessage reache these sites, a CompelteTransactionTask will be placed on ScoreBoard as unmatched (missing). However, if a site still has the transaction state, i.e.in outstanding transaction and TransactionTaskQueue, a CompelteTransactionTask is placed on ScoreBoard as matched, the TransactionTaskQueues on these sites need be flushed to unblock these sites.