### PR TITLE
ENG-14154 wait leader promotions completed before rejoining moves forward

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1160,9 +1160,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
 
             if (m_rejoining) {
-                // check if any partition leader promotions are in progress to upon node failures.
+                // check if any partition leader promotions are in progress upon node failures.
                 // avoid rejoining while partition leader promotions and transaction repairs are not done
-                VoltZK.checkPromotingPartitions(m_messenger.getZK());
+                VoltZK.checkPartitionLeaderPromotion(m_messenger.getZK());
             }
 
             /*

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1159,6 +1159,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 }
             }
 
+            if (m_rejoining) {
+                // check if any partition leader promotions are in progress to upon node failures.
+                // avoid rejoining while partition leader promotions and transaction repairs are not done
+                VoltZK.checkPromotingPartitions(m_messenger.getZK());
+            }
+
             /*
              * Construct all the mailboxes for things that need to be globally addressable so they can be published
              * in one atomic shot.

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -202,6 +202,9 @@ public class VoltZK {
 
     public static final String actionLock = "/db/action_lock";
 
+    //register partition while the partition elects a new leader upon node failure
+    public static final String promotingLeaders = "/db/promotingLeaders";
+
     // Persistent nodes (mostly directories) to create on startup
     public static final String[] ZK_HIERARCHY = {
             root,
@@ -221,7 +224,8 @@ public class VoltZK {
             actionBlockers,
             request_truncation_snapshot,
             host_ids_be_stopped,
-            actionLock
+            actionLock,
+            promotingLeaders
     };
 
     /**
@@ -511,6 +515,57 @@ public class VoltZK {
         }
         log.info("Remove action blocker " + node + " successfully.");
         return true;
+    }
+
+    //add partition id under /db/promotingLeaders when the partition elects a new leader upon node failure
+    public static void registerPromotingPartition(ZooKeeper zk, int partitionId, VoltLogger log) {
+        String node = ZKUtil.joinZKPath(promotingLeaders, Integer.toString(partitionId));
+        try {
+            zk.create(node,
+                      null,
+                      Ids.OPEN_ACL_UNSAFE,
+                      CreateMode.EPHEMERAL);
+            log.info("Register promoting partition " + partitionId);
+        } catch (KeeperException e) {
+            if (e.code() != KeeperException.Code.NODEEXISTS) {
+                VoltDB.crashLocalVoltDB("Unable to register promoting partition " + partitionId, true, e);
+            }
+        } catch (InterruptedException e) {
+            VoltDB.crashLocalVoltDB("Unable to register promoting partition " + partitionId, true, e);
+        }
+    }
+
+    //remove the partition under /db/promotion when the new leader has accepted promotion
+    public static void unregisterPromotingPartition(ZooKeeper zk, int partitionId, VoltLogger log) {
+        String node = ZKUtil.joinZKPath(promotingLeaders, Integer.toString(partitionId));
+        try {
+            zk.delete(node, -1);
+        } catch (KeeperException e) {
+            if (e.code() != KeeperException.Code.NONODE) {
+                if (log != null) {
+                    log.error("Failed to remove promoting partition: " + partitionId + "\n" + e.getMessage(), e);
+                }
+            }
+        } catch (InterruptedException e) {
+        }
+        log.info("Unregister promoting partition " + partitionId + " successfully.");
+    }
+
+    //Upon node failures, new partition leaders, including MPI, will be registered right before they
+    //are promoted and unregistered after their promotion are done. Let rejoining nodes wait until
+    //all the partition leader promotions have finished to avoid any
+    //interference in the transaction repair process and score board.
+    public static void checkPromotingPartitions(ZooKeeper zk) {
+        try {
+            List<String> partitions = zk.getChildren(VoltZK.promotingLeaders, false);
+            long maxWait = TimeUnit.SECONDS.toNanos(10);
+            long start = System.nanoTime();
+            while(!partitions.isEmpty() && (System.nanoTime() - start < maxWait)) {
+                partitions = zk.getChildren(VoltZK.promotingLeaders, false);
+            }
+        } catch (KeeperException | InterruptedException e) {
+            VoltDB.crashLocalVoltDB("Failed to validate promoting partitions ", true, e);
+        }
     }
 
     /**

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -517,7 +517,7 @@ public class VoltZK {
         return true;
     }
 
-    //add partition id under /db/promotingLeaders when the partition elects a new leader upon node failure
+    // add partition under /db/promotingLeaders when the partition elects a new leader upon node failure
     public static void registerPromotingPartition(ZooKeeper zk, int partitionId, VoltLogger log) {
         String node = ZKUtil.joinZKPath(promotingLeaders, Integer.toString(partitionId));
         try {
@@ -535,7 +535,7 @@ public class VoltZK {
         }
     }
 
-    //remove the partition under /db/promotion when the new leader has accepted promotion
+    // remove the partition under /db/promotion when the new leader has accepted promotion
     public static void unregisterPromotingPartition(ZooKeeper zk, int partitionId, VoltLogger log) {
         String node = ZKUtil.joinZKPath(promotingLeaders, Integer.toString(partitionId));
         try {
@@ -551,11 +551,11 @@ public class VoltZK {
         log.info("Unregister promoting partition " + partitionId + " successfully.");
     }
 
-    //Upon node failures, new partition leaders, including MPI, will be registered right before they
-    //are promoted and unregistered after their promotion are done. Let rejoining nodes wait until
-    //all the partition leader promotions have finished to avoid any
-    //interference in the transaction repair process and score board.
-    public static void checkPromotingPartitions(ZooKeeper zk) {
+    // Upon node failures, new partition leaders, including MPI, will be registered right before they
+    // are promoted and unregistered after their promotions are done. Let rejoining nodes wait until
+    // all the partition leader promotions have finished to avoid any
+    // interference with the transaction repair process and score board.
+    public static void checkPartitionLeaderPromotion(ZooKeeper zk) {
         try {
             List<String> partitions = zk.getChildren(VoltZK.promotingLeaders, false);
             long maxWait = TimeUnit.SECONDS.toNanos(10);
@@ -564,7 +564,7 @@ public class VoltZK {
                 partitions = zk.getChildren(VoltZK.promotingLeaders, false);
             }
         } catch (KeeperException | InterruptedException e) {
-            VoltDB.crashLocalVoltDB("Failed to validate promoting partitions ", true, e);
+            VoltDB.crashLocalVoltDB("Failed to validate partition leader promotions.", true, e);
         }
     }
 

--- a/src/frontend/org/voltdb/iv2/LeaderAppointer.java
+++ b/src/frontend/org/voltdb/iv2/LeaderAppointer.java
@@ -278,6 +278,7 @@ public class LeaderAppointer implements Promotable
                         partitionId);
             try {
                 m_iv2appointees.put(partitionId, masterHSId);
+                VoltZK.registerPromotingPartition(m_zk, partitionId, tmLog);
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("Unable to appoint new master for partition " + partitionId, true, e);
             }
@@ -528,6 +529,7 @@ public class LeaderAppointer implements Promotable
             m_removedPartitionsAtPromotionTime = null;
             // just go ahead and promote our MPI
             m_MPI.acceptPromotion();
+            VoltZK.registerPromotingPartition(m_zk, MpInitiator.MP_INIT_PID, tmLog);
             // set up a watcher on the partitions dir so that new partitions will be picked up
             m_zk.getChildren(VoltZK.leaders_initiators, m_partitionCallback);
             blocker.set(null);

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -160,7 +160,6 @@ public class MpInitiator extends BaseInitiator implements Promotable
                     LeaderCacheWriter iv2masters = new LeaderCache(m_messenger.getZK(),
                             m_zkMailboxNode);
                     iv2masters.put(m_partitionId, m_initiatorMailbox.getHSId());
-                    VoltZK.unregisterPromotingPartition(m_messenger.getZK(), MP_INIT_PID, tmLog);
                     TTLManager.instance().scheduleTTLTasks();
                 }
                 else {

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -160,6 +160,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
                     LeaderCacheWriter iv2masters = new LeaderCache(m_messenger.getZK(),
                             m_zkMailboxNode);
                     iv2masters.put(m_partitionId, m_initiatorMailbox.getHSId());
+                    VoltZK.unregisterPromotingPartition(m_messenger.getZK(), MP_INIT_PID, tmLog);
                     TTLManager.instance().scheduleTTLTasks();
                 }
                 else {

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -235,7 +235,7 @@ public class SpInitiator extends BaseInitiator implements Promotable
                     } else {
                         iv2masters.put(m_partitionId, m_initiatorMailbox.getHSId());
                     }
-
+                    VoltZK.unregisterPromotingPartition(m_messenger.getZK(), getPartitionId(), tmLog);
                     m_initiatorMailbox.setMigratePartitionLeaderStatus(migratePartitionLeader);
                 }
                 else {


### PR DESCRIPTION
When a node is down, partitions will promote their new leaders. Before new leaders are fully promoted, the failed node may join back to the cluster, which will interference the partition replica calculations.  A partition replica from the rejoining node may be prematurely added to the partition replica list.  Transaction fragments may be forwarded to the partition replica on the rejoining node which may  fail to complete the scoreboard. And the repair process may hang on the new partition leader. The pull request  will make the rejoining wait until partition leader promotions are finished.