### PR TITLE
ENG-14186 update DDL syntax for TTL

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -2317,8 +2317,8 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
         }
     }
 
-    public void runTimeToLive(String tableName, String columnName, long ttlValue, int chunkSize, int timeout,
-            TTLManager.TTLStats stats, TTLManager.TTLTask task) {
+    public void runTimeToLive(String columnName, long ttlValue, int chunkSize, int timeout,
+             TTLManager.TTLTask task) {
 
         CountDownLatch latch = new CountDownLatch(1);
         final ProcedureCallback cb = new ProcedureCallback() {
@@ -2326,26 +2326,26 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
             public void clientCallback(ClientResponse resp) throws Exception {
                 if (resp.getStatus() != ClientResponse.SUCCESS) {
                     hostLog.warn(String.format("Fail to execute TTL on table:%s, column:%s, status:s%",
-                            tableName, columnName, resp.getStatusString()));
+                            task.tableName, columnName, resp.getStatusString()));
                 }
                 VoltTable t = resp.getResults()[0];
                 t.advanceRow();
                 String error = t.getString("MESSAGE");
                 if (!error.isEmpty()) {
-                    hostLog.warn("Errors occured when running TTL on table " + tableName + ":" +  error);
+                    hostLog.warn("Errors occured when running TTL on table " + task.tableName + ":" +  error);
                     if (error.indexOf(TTLManager.DR_LIMIT_MSG) > -1) {
                         //over DR limit
-                        hostLog.warn("TTL is disabled for table " + tableName);
+                        hostLog.warn("TTL is disabled for table " + task.tableName);
                         task.cancel();
                     }
                 } else {
-                    stats.update(t.getLong("ROWS_DELETED"), t.getLong("ROWS_LEFT"), t.getLong("LAST_DELETE_TIMESTAMP"));
+                    task.stats.update(t.getLong("ROWS_DELETED"), t.getLong("ROWS_LEFT"), t.getLong("LAST_DELETE_TIMESTAMP"));
                 }
                 latch.countDown();
             }
         };
         m_dispatcher.getInternelAdapterNT().callProcedure(m_catalogContext.get().authSystem.getInternalAdminUser(),
-                true, 1000 * 120, cb, "@LowImpactDelete", new Object[] {tableName, columnName, ttlValue, "<", chunkSize, timeout});
+                true, 1000 * 120, cb, "@LowImpactDelete", new Object[] {task.tableName, columnName, ttlValue, "<", chunkSize, timeout});
         try {
             latch.await(1, TimeUnit.MINUTES);
         } catch (InterruptedException e) {

--- a/src/frontend/org/voltdb/TTLManager.java
+++ b/src/frontend/org/voltdb/TTLManager.java
@@ -89,9 +89,9 @@ public class TTLManager extends StatsSource{
         @Override
         public void run() {
 
-            //do not run TTL when cluster is paused to allow proper draini of stream and dr buffer
+            //do not run TTL when cluster is paused to allow proper draining of stream and dr buffer
             final VoltDBInterface voltdb = VoltDB.instance();
-            if (voltdb.getMode() == OperationMode.PAUSED) {
+            if (voltdb.getMode() != OperationMode.RUNNING) {
                 return;
             }
             ClientInterface cl = voltdb.getClientInterface();

--- a/src/frontend/org/voltdb/TTLManager.java
+++ b/src/frontend/org/voltdb/TTLManager.java
@@ -119,13 +119,24 @@ public class TTLManager extends StatsSource{
             if (VoltType.get((byte)ttl.getTtlcolumn().getType()) != VoltType.TIMESTAMP) {
                 return ttl.getTtlvalue();
             }
-            TimeUnit timeUnit = TimeUnit.SECONDS;
-            if ("MINUTE".equalsIgnoreCase(ttl.getTtlunit())) {
-                timeUnit = TimeUnit.MINUTES;
-            } else if ("HOUR".equalsIgnoreCase(ttl.getTtlunit())) {
-                timeUnit = TimeUnit.HOURS;
-            }else if ("DAY".equalsIgnoreCase(ttl.getTtlunit())) {
-                timeUnit = TimeUnit.DAYS;
+            TimeUnit timeUnit;
+            if(ttl.getTtlunit().isEmpty()) {
+                timeUnit = TimeUnit.SECONDS;
+            } else {
+                final char frequencyUnit = ttl.getTtlunit().toLowerCase().charAt(0);
+                switch (frequencyUnit) {
+                case 'm':
+                    timeUnit = TimeUnit.MINUTES;
+                    break;
+                case 'h':
+                    timeUnit = TimeUnit.HOURS;
+                    break;
+                case 'd':
+                    timeUnit = TimeUnit.DAYS;
+                    break;
+                default:
+                    timeUnit = TimeUnit.SECONDS;
+                }
             }
             return ((System.currentTimeMillis() - timeUnit.toMillis(ttl.getTtlvalue())) * 1000);
         }

--- a/src/frontend/org/voltdb/TTLManager.java
+++ b/src/frontend/org/voltdb/TTLManager.java
@@ -88,11 +88,17 @@ public class TTLManager extends StatsSource{
         }
         @Override
         public void run() {
-            ClientInterface cl = VoltDB.instance().getClientInterface();
+
+            //do not run TTL when paused.
+            final VoltDBInterface voltdb = VoltDB.instance();
+            if (voltdb.getMode() == OperationMode.PAUSED) {
+                return;
+            }
+            ClientInterface cl = voltdb.getClientInterface();
             if (!canceled.get() && cl != null && cl.isAcceptingConnections()) {
                 TimeToLive ttl = ttlRef.get();
-                cl.runTimeToLive(tableName, ttl.getTtlcolumn().getName(),
-                        transformValue(ttl), CHUNK_SIZE, TIMEOUT, stats, this);
+                cl.runTimeToLive(ttl.getTtlcolumn().getName(),
+                        transformValue(ttl), CHUNK_SIZE, TIMEOUT, this);
             }
         }
 

--- a/src/frontend/org/voltdb/TTLManager.java
+++ b/src/frontend/org/voltdb/TTLManager.java
@@ -89,7 +89,7 @@ public class TTLManager extends StatsSource{
         @Override
         public void run() {
 
-            //do not run TTL when paused.
+            //do not run TTL when cluster is paused to allow proper draini of stream and dr buffer
             final VoltDBInterface voltdb = VoltDB.instance();
             if (voltdb.getMode() == OperationMode.PAUSED) {
                 return;
@@ -119,10 +119,8 @@ public class TTLManager extends StatsSource{
             if (VoltType.get((byte)ttl.getTtlcolumn().getType()) != VoltType.TIMESTAMP) {
                 return ttl.getTtlvalue();
             }
-            TimeUnit timeUnit;
-            if(ttl.getTtlunit().isEmpty()) {
-                timeUnit = TimeUnit.SECONDS;
-            } else {
+            TimeUnit timeUnit = TimeUnit.SECONDS;
+            if(!ttl.getTtlunit().isEmpty()) {
                 final char frequencyUnit = ttl.getTtlunit().toLowerCase().charAt(0);
                 switch (frequencyUnit) {
                 case 'm':

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -1009,7 +1009,7 @@ public class ParserDDL extends ParserRoutine {
             return null;
         }
         int timeLiveValue = 0;
-        String ttlUnit = "SECOND";
+        String ttlUnit = "SECONDS";
         String ttlColumn = "";
         int tokenCount = 0;
         while (tokenCount <= 5) {
@@ -1028,10 +1028,10 @@ public class ParserDDL extends ParserRoutine {
                 tokenCount++;
                 timeLiveValue = (Integer)(token.tokenValue);
                 break;
-            case Tokens.SECOND:
-            case Tokens.MINUTE:
-            case Tokens.HOUR:
-            case Tokens.DAY:
+            case Tokens.SECONDS:
+            case Tokens.MINUTES:
+            case Tokens.HOURS:
+            case Tokens.DAYS:
                 if (tokenCount != 2) {
                     throw unexpectedToken();
                 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Tokens.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Tokens.java
@@ -819,7 +819,7 @@ public class Tokens {
     static final String        T_DATEDIFF         = "DATEDIFF";
     public static final String T_SECONDS_MIDNIGHT = "SECONDS_SINCE_MIDNIGHT";
 
-    //VOLTDB EXENSION
+    //VoltDB extension for TTL
     public static final String T_MINUTES          = "MINUTES";
     public static final String T_SECONDS          = "SECONDS";
     public static final String T_HOURS            = "HOURS";
@@ -1619,7 +1619,7 @@ public class Tokens {
     static final int HOURS         = 1006;
     static final int DAYS          = 1007;
     // End of VoltDB extension
-    //
+
     public static final int X_UNKNOWN_TOKEN = -1;
     private static final IntValueHashMap reservedKeys =
         new IntValueHashMap(351);

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Tokens.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Tokens.java
@@ -819,6 +819,12 @@ public class Tokens {
     static final String        T_DATEDIFF         = "DATEDIFF";
     public static final String T_SECONDS_MIDNIGHT = "SECONDS_SINCE_MIDNIGHT";
 
+    //VOLTDB EXENSION
+    public static final String T_MINUTES          = "MINUTES";
+    public static final String T_SECONDS          = "SECONDS";
+    public static final String T_HOURS            = "HOURS";
+    public static final String T_DAYS             = "DAYS";
+
     //
     //
     //SQL 200n Standard reserved keywords - full set
@@ -1608,6 +1614,10 @@ public class Tokens {
 
     // A VoltDB extension to support TTL
     static final int TTL           = 1003;
+    static final int SECONDS       = 1004;
+    static final int MINUTES       = 1005;
+    static final int HOURS         = 1006;
+    static final int DAYS          = 1007;
     // End of VoltDB extension
     //
     public static final int X_UNKNOWN_TOKEN = -1;
@@ -1960,6 +1970,10 @@ public class Tokens {
         // A VoltDB extension to support WEEKOFYEAR and WEEKDAY function
         reservedKeys.put(Tokens.T_WEEKOFYEAR, WEEKOFYEAR);    // For compliant with MySQL
         reservedKeys.put(Tokens.T_WEEKDAY, WEEKDAY);          // For compliant with MySQL
+        reservedKeys.put(Tokens.T_SECONDS, SECONDS);
+        reservedKeys.put(Tokens.T_MINUTES, MINUTES);
+        reservedKeys.put(Tokens.T_HOURS, HOURS);
+        reservedKeys.put(Tokens.T_DAYS, DAYS);
         // End of VoltDB extension
     }
 

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -90,8 +90,8 @@ public class TestVoltCompiler extends TestCase {
     }
 
     public void testDDLCompilerTTL() throws Exception {
-        String ddl = "create table ttl (a integer, b integer, PRIMARY KEY(a)) USING TTL 10 SECOND ON COLUMN a;\n" +
-                     "alter table ttl USING TTL 20 MINUTE ON COLUMN a;\n" +
+        String ddl = "create table ttl (a integer, b integer, PRIMARY KEY(a)) USING TTL 10 SECONDS ON COLUMN a;\n" +
+                     "alter table ttl USING TTL 20 MINUTES ON COLUMN a;\n" +
                      "alter table ttl drop TTL;\n";
         VoltProjectBuilder pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);

--- a/tests/frontend/org/voltdb/fullddlfeatures/fullDDL.sql
+++ b/tests/frontend/org/voltdb/fullddlfeatures/fullDDL.sql
@@ -1075,6 +1075,17 @@ CREATE INDEX partial_idx_4 ON T62 (C1) WHERE ABS(C1) > 5;
 CREATE INDEX partial_idx_5 ON T62 (C1,C2) WHERE ABS(C3) = 5;
 CREATE INDEX partial_idx_6 ON T62 (C1) WHERE C2 > 5 and C2 < 100;
 
+-- TTL
+CREATE TABLE T63
+(
+   C1 INTEGER,
+   C2 INTEGER,
+   C3 INTEGER NOT NULL,
+   PRIMARY KEY (C3)
+) USING TTL 10 ON COLUMN C3;
+PARTITION TABLE T63 ON COLUMN C3;
+CREATE INDEX ttl_idx ON T63 (C3);
+
 -- These statements were added when use of some Volt-specific functions or ||
 -- or NULL in indexed expressions was discovered to be mishandled (ENG-7792).
 -- They showed that views and procs did NOT share these problems,

--- a/tests/frontend/org/voltdb/sysprocs/TestLowImpactDelete.java
+++ b/tests/frontend/org/voltdb/sysprocs/TestLowImpactDelete.java
@@ -69,7 +69,7 @@ public class TestLowImpactDelete extends TestCase {
               + "    id BIGINT not null, \n"
               + "    ts TIMESTAMP not null, "
               + "    PRIMARY KEY (id) \n"
-              + " ) USING TTL 10 SECOND ON COLUMN TS; \n"
+              + " ) USING TTL 10 SECONDS ON COLUMN TS; \n"
               + "PARTITION TABLE ttl ON COLUMN id;"
               + "CREATE INDEX ttlindex ON ttl (ts);"
 

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl.sql
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ddl.sql
@@ -138,7 +138,7 @@ CREATE TABLE nibdr
 , ts         timestamp          DEFAULT NOW NOT NULL
 , value      varbinary(1048576) NOT NULL
 , CONSTRAINT PK_id_nr PRIMARY KEY (p,id)
-) USING TTL 30 Second on column ts ;
+) USING TTL 30 Seconds on column ts ;
 CREATE INDEX NIBR_TSINDEX ON nibdr (ts);
 
 -- nibble delete partitioned table
@@ -149,7 +149,7 @@ CREATE TABLE nibdp
 , ts         timestamp          DEFAULT NOW NOT NULL
 , value      varbinary(1048576) NOT NULL
 , CONSTRAINT PK_id_np PRIMARY KEY (p,id)
-) USING TTL 30 Second on column ts ;
+) USING TTL 30 Seconds on column ts ;
 PARTITION TABLE nibdp ON COLUMN p;
 CREATE INDEX NIBP_TSINDEX ON nibdp (ts);
 


### PR DESCRIPTION
also do not execute nibble deletes when cluster is paused to allow buffers to be drained for export and dr