### PR TITLE
ENG-14155: With generationless export we keep track of streams in the…

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1532,7 +1532,9 @@ void
 VoltDBEngine::markAllExportingStreamsNew() {
     //Mark all streams new so that schema is sent on next tuple.
     BOOST_FOREACH (LabeledStreamWrapper entry, m_exportingStreams) {
-        entry.second->setNew();
+        if (entry.second != NULL) {
+            entry.second->setNew();
+        }
     }
 }
 

--- a/tests/frontend/org/voltdb/TestAdhocExportTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocExportTable.java
@@ -78,6 +78,17 @@ public class TestAdhocExportTable extends AdhocDDLTestBase {
                 fail("Should be able to drop a stream table");
             }
             assertFalse(findTableInSystemCatalogResults("FOO"));
+            // ENG-14155: add stream after drop stream causes SIGSEGV in ee
+            try {
+                m_client.callProcedure("@AdHoc",
+                        "create stream FOO (ID int default 0, VAL varchar(64 bytes));");
+            }
+            catch (ProcCallException pce) {
+                pce.printStackTrace();
+                fail("Should be able to add a stream table after the drop");
+            }
+            assertTrue(findTableInSystemCatalogResults("FOO"));
+
         }
         finally {
             teardownSystem();


### PR DESCRIPTION
… ee even after they are deleted. However when we iterate through the streams for the next generation we don't account for removed streams causing a SIGSEGV.