### PR TITLE
ENG-14207 skip TransactionTaskQueue flush with restart

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -2325,7 +2325,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
             @Override
             public void clientCallback(ClientResponse resp) throws Exception {
                 if (resp.getStatus() != ClientResponse.SUCCESS) {
-                    hostLog.warn(String.format("Fail to execute TTL on table: %s, column: %s, status: s%",
+                    hostLog.warn(String.format("Fail to execute TTL on table: %s, column: %s, status: %s",
                             task.tableName, columnName, resp.getStatusString()));
                 }
                 VoltTable t = resp.getResults()[0];

--- a/src/frontend/org/voltdb/iv2/CompleteTransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/CompleteTransactionTask.java
@@ -67,9 +67,12 @@ public class CompleteTransactionTask extends TransactionTask
     }
     private void doUnexecutedFragmentCleanup()
     {
-        if (m_completeMsg.isAbortDuringRepair() || m_repairCompletionMatched) {
+        // If the task is for restart, FragmentTasks could be at head of the TransactionTaskQueue.
+        // The transaction should not be flushed at this moment.
+        if (m_completeMsg.isAbortDuringRepair() || (m_repairCompletionMatched && !m_completeMsg.isRestart())) {
+
             if (hostLog.isDebugEnabled()) {
-                hostLog.debug("releaseStashedComleteTxns: flush non-restartable logs at " + TxnEgo.txnIdToString(getTxnId()));
+                hostLog.debug("doUnexecutedFragmentCleanup: flush non-restartable logs at " + TxnEgo.txnIdToString(getTxnId()));
             }
             // Mark the transaction state as DONE
             // Transaction state could be null when a CompleteTransactionTask is added to scoreboard.


### PR DESCRIPTION
When a CompleteTransactionTask for restart is processed, skip TransactionTaskQueue flush since  the transaction is not done yet.
