### PR TITLE
ENG-14213 do not replay logged tasks before snapshotting in join path

### DIFF
--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -235,6 +235,7 @@ public interface SiteProcedureConnection {
     public void updateHashinator(TheHashinator hashinator);
     public void setViewsEnabled(String viewNames, boolean enabled);
     public long[] validatePartitioning(long tableIds[], byte hashinatorConfig[]);
+    public void notifyOfSnapshotNonce(String nonce, long snapshotSpHandle);
     public long applyBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, int remotePartitionId, byte logData[]);
     public void setDRProtocolVersion(int drVersion);
     /*

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -297,4 +297,9 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
     {
         m_taskLog.close();
     }
+
+    @Override
+    public void enableRecording(long snapshotSpHandle) {
+        //Implemented by the nest task log, it is enabled immediately on construction
+    }
 }

--- a/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
@@ -606,6 +606,11 @@ public class InitiatorMailbox implements Mailbox
         }
     }
 
+    public void notifyOfSnapshotNonce(String nonce, long snapshotSpHandle) {
+        if (m_joinProducer == null) return;
+        m_joinProducer.notifyOfSnapshotNonce(nonce, snapshotSpHandle);
+    }
+
     //The new partition leader is notified by previous partition leader
     //that previous partition leader has drained its txns
     private void setMigratePartitionLeaderStatus(MigratePartitionLeaderMessage message) {

--- a/src/frontend/org/voltdb/iv2/Iv2Trace.java
+++ b/src/frontend/org/voltdb/iv2/Iv2Trace.java
@@ -297,7 +297,7 @@ public class Iv2Trace
             String logmsg = "txnQOffer txnId %s spHandle %s type %s";
             iv2queuelog.trace(String.format(logmsg, txnIdToString(task.getTxnId()),
                         txnIdToString(task.getSpHandle()),
-                    task.m_txnState.isSinglePartition() ? "SP" : "MP"));
+                    (task.m_txnState != null && task.m_txnState.isSinglePartition()) ? "SP" : "MP"));
         }
     }
 
@@ -307,7 +307,7 @@ public class Iv2Trace
             String logmsg = "tskQOffer txnId %s spHandle %s type %s";
             iv2queuelog.trace(String.format(logmsg, txnIdToString(task.getTxnId()),
                             txnIdToString(task.getSpHandle()),
-                    task.m_txnState.isSinglePartition() ? "SP" : "MP"));
+                   (task.m_txnState != null &&  task.m_txnState.isSinglePartition()) ? "SP" : "MP"));
         }
     }
 }

--- a/src/frontend/org/voltdb/iv2/JoinProducerBase.java
+++ b/src/frontend/org/voltdb/iv2/JoinProducerBase.java
@@ -199,6 +199,15 @@ public abstract class JoinProducerBase extends SiteTasker {
 
     protected abstract VoltLogger getLogger();
 
+    public void notifyOfSnapshotNonce(String nonce, long snapshotSpHandle) {
+        if (nonce.equals(m_snapshotNonce)) {
+            getLogger().debug("Started recording transactions after snapshot nonce " + nonce);
+            if (m_taskLog != null) {
+                m_taskLog.enableRecording(snapshotSpHandle);
+            }
+        }
+    }
+
     // Based on whether or not we just did real work, return ourselves to the task queue either now
     // or after waiting a few milliseconds
     protected void returnToTaskQueue(boolean sourcesReady)

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -728,4 +728,9 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     public SystemProcedureExecutionContext getSystemProcedureExecutionContext() {
         return m_sysprocContext;
     }
+
+    @Override
+    public void notifyOfSnapshotNonce(String nonce, long snapshotSpHandle) {
+        // TODO Auto-generated method stub
+    }
 }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1728,6 +1728,11 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
+    public void notifyOfSnapshotNonce(String nonce, long snapshotSpHandle) {
+        m_initiatorMailbox.notifyOfSnapshotNonce(nonce, snapshotSpHandle);
+    }
+
+    @Override
     public long applyBinaryLog(long txnId, long spHandle,
                                long uniqueId, int remoteClusterId, int remotePartitionId,
                                byte log[]) throws EEException {

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -167,6 +167,14 @@ public class SysprocFragmentTask extends FragmentTaskBase
                     "The rejoining node's VoltDB process will now exit.", false, null);
         }
 
+        //If this is a snapshot creation we have the nonce of the snapshot
+        //Provide it to the site so it can decide to enable recording in the task log
+        //if it is our rejoin snapshot start
+        if (SysProcFragmentId.isFirstSnapshotFragment(m_fragmentMsg.getPlanHash(0))) {
+            siteConnection.notifyOfSnapshotNonce((String)m_fragmentMsg.getParameterSetForFragment(0).toArray()[1],
+                    m_fragmentMsg.getSpHandle());
+        }
+
         // special case for @PingPartitions for re-enabling scoreboard
         if (SysProcFragmentId.isEnableScoreboardFragment(m_fragmentMsg.getPlanHash(0)) &&
                 ! m_queue.scoreboardEnabled()) {

--- a/src/frontend/org/voltdb/rejoin/TaskLog.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLog.java
@@ -51,4 +51,21 @@ public interface TaskLog {
      * @throws IOException
      */
     public void close() throws IOException;
+
+    /**
+     * Default policy at startup is to drop invocations until recording is necessary
+     * When used for live rejoin the first SnapshotSave plan fragment triggers the start
+     * of recording of transactions for the live rejoin.
+     *
+     * @param snapshotSpHandle    Note that it is possible that this may be called
+     *                            multiple times with different snapshotSpHandles during
+     *                            live rejoin. There may be multiple snapshot fragments
+     *                            with the same snapshot nonce due to snapshot collisions.
+     *                            At the time this is called, we don't know if the
+     *                            snapshot will succeed or not. If it collides with an
+     *                            snapshot in progress, it will be retried later. The task
+     *                            log implementation should update the snapshotSpHandle
+     *                            with the latest one.
+     */
+    public void enableRecording(long snapshotSpHandle);
 }

--- a/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
@@ -52,6 +52,7 @@ public class TaskLogImpl implements TaskLog {
     // The number of tasks in the current buffer
     private int m_taskCount = 0;
     private int m_tasksPendingInCurrentTail = 0;
+    private long m_snapshotSpHandle = Long.MAX_VALUE;
     private int m_bufferHeadroom = RejoinTaskBuffer.DEFAULT_BUFFER_SIZE;
 
     private final ExecutorService m_es;
@@ -129,6 +130,7 @@ public class TaskLogImpl implements TaskLog {
 
     @Override
     public void logTask(TransactionInfoBaseMessage message) throws IOException {
+        if (message.getSpHandle() <= m_snapshotSpHandle) return;
         if (m_closed) throw new IOException("Closed");
 
         assert(message != null);
@@ -216,7 +218,14 @@ public class TaskLogImpl implements TaskLog {
             nextTask = getNextMessage();
         }
 
-        return nextTask;
+        // SPs or fragments that's before the actual snapshot fragment may end up in the task log,
+        // because there can be multiple snapshot fragments enabling the task log due to snapshot
+        // collision. Need to filter tasks here based on their spHandles.
+        if (nextTask != null && nextTask.getSpHandle() > m_snapshotSpHandle) {
+            return nextTask;
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -254,4 +263,10 @@ public class TaskLogImpl implements TaskLog {
             buf.discard();
         }
     }
+
+    @Override
+    public void enableRecording(long snapshotSpHandle) {
+        m_snapshotSpHandle = snapshotSpHandle;
+    }
+
 }


### PR DESCRIPTION
When tasks in task log before stream snapshotting are replayed  in join path, EE could hang since these tasks are not synchronized via score board. Filter out these tasks during replay.