### PR TITLE
ENG-14213 prevent multiple mp reads from coexisting in the same site …

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
@@ -84,12 +84,11 @@ public class MpTransactionTaskQueue extends TransactionTaskQueue
      * TransactionTaskQueue.
      */
     @Override
-    synchronized boolean offer(TransactionTask task)
+    synchronized void offer(TransactionTask task)
     {
         Iv2Trace.logTransactionTaskQueueOffer(task);
         m_backlog.addLast(task);
         taskQueueOffer();
-        return true;
     }
 
     // repair is used by MPI repair to inject a repair task into the

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -204,13 +204,11 @@ public class TransactionTaskQueue
      * Many network threads may be racing to reach here, synchronize to
      * serialize queue order
      * @param task
-     * @return true if this task was stored, false if not
      */
-    synchronized boolean offer(TransactionTask task)
+    synchronized void offer(TransactionTask task)
     {
         Iv2Trace.logTransactionTaskQueueOffer(task);
         TransactionState txnState = task.getTransactionState();
-        boolean retval = false;
         if (!m_backlog.isEmpty()) {
             /*
              * This branch happens during regular execution when a multi-part is in progress.
@@ -219,23 +217,29 @@ public class TransactionTaskQueue
              * and immediately queues them for execution. If any multi-part txn with smaller txnId shows up,
              * it must from repair process, just let it through.
              */
-            if (txnState.isSinglePartition() || TxnEgo.getSequence(task.getTxnId()) > TxnEgo.getSequence(m_backlog.getFirst().getTxnId())) {
+            if (txnState.isSinglePartition() ){
                 m_backlog.addLast(task);
-                retval = true;
+                return;
             }
-            /*
-             * This branch coordinates FragmentTask or CompletedTransactionTask,
-             * holds the tasks until all the sites on the node receive the task.
-             * Task with newer spHandle will
-             */
-            else if (task.needCoordination() && m_scoreboardEnabled) {
+
+            //It is possible a RO MP read with higher TxnId could be executed before a RO MP reader with lower TxnId
+            //so do not offer them to the site task queue in the same time, place it in the backlog instead.
+            TransactionTask headTask = m_backlog.getFirst();
+            if ((txnState.isReadOnly()) && headTask.getTransactionState().isReadOnly() &&
+                    TxnEgo.getSequence(task.getTxnId()) != TxnEgo.getSequence(headTask.getTxnId())
+                       || (TxnEgo.getSequence(task.getTxnId()) > TxnEgo.getSequence(headTask.getTxnId()))) {
+                m_backlog.addLast(task);
+            } else if (task.needCoordination() && m_scoreboardEnabled) {
+                /*
+                 * This branch coordinates FragmentTask or CompletedTransactionTask,
+                 * holds the tasks until all the sites on the node receive the task.
+                 * Task with newer spHandle will
+                 */
                 coordinatedTaskQueueOffer(task);
-            }
-            else {
+            } else {
                 taskQueueOffer(task);
             }
-        }
-        else {
+        } else {
             /*
              * Base case nothing queued nothing in progress
              * If the task is a multipart then put an entry in the backlog which
@@ -244,7 +248,6 @@ public class TransactionTaskQueue
              */
             if (!txnState.isSinglePartition()) {
                 m_backlog.addLast(task);
-                retval = true;
             }
             /*
              * This branch coordinates FragmentTask or CompletedTransactionTask,
@@ -257,7 +260,6 @@ public class TransactionTaskQueue
                 taskQueueOffer(task);
             }
         }
-        return retval;
     }
 
     // Add a local method to offer to the SiteTaskerQueue so we have


### PR DESCRIPTION
…task queue

Multiple MP reads can be executed in parallel but the order of execution is not determined. Example, for MP Read Txns 1,2,3, Txn 2 may be processed before Txn 1. The fragments of both txn 2 and 1 will be sent to all partition leaders. When fragments from Txn 2 arrive, a site will put it to backlog and move it to SiteTaskQueue. When fragments from Txn 1 arrive, the site will also put it the backlog and then move it to the SiteTaskQueue. So the header of backlog is a fragment from Txn 2. Since the fragments from both Txn 2 and Txn 1 are on the SiteTaskQueue, they can be processed sequentially. Unfortunately if the final fragment from Txn 1 processed before the final fragment from Txn 2, Txn 1 will try to flush the backlog but fails since Txn 1 is not in the header. The backlog will be blocked under this circumstance. The pull request is to address this corner case: do not allow the fragments from different MP read transactions in the SiteTaskQueue at the same time.

