### PR TITLE
ENG-13765, export data source send out MIGRATE_MASTER event when part…

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -284,6 +284,10 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     }
 
     public synchronized void updateAckMailboxes(final Pair<Mailbox, ImmutableList<Long>> ackMailboxes) {
+        if (exportLog.isDebugEnabled()) {
+            exportLog.debug("Mailbox " + CoreUtils.hsIdToString(ackMailboxes.getFirst().getHSId()) + " is registered for " + this.toString() +
+                    " : replicas " + CoreUtils.hsIdCollectionToString(ackMailboxes.getSecond()) );
+        }
         m_ackMailboxRefs.set( ackMailboxes);
     }
 
@@ -833,6 +837,11 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
             for( Long siteId: p.getSecond()) {
                 mbx.send(siteId, bpm);
+            }
+            if (exportLog.isDebugEnabled()) {
+                exportLog.debug("Send RELEASE_BUFFER for partition " + m_partitionId + "source signature " + m_tableName + " with uso " + uso
+                        + " from " + CoreUtils.hsIdToString(mbx.getHSId())
+                        + " to " + CoreUtils.hsIdCollectionToString(p.getSecond()));
             }
         }
     }

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -56,6 +56,7 @@ import org.voltdb.messaging.LocalMailbox;
 
 import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.collect.ImmutableList;
+import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.util.concurrent.Futures;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
@@ -72,6 +73,8 @@ public class ExportGeneration implements Generation {
 
     public final File m_directory;
 
+    private ExportManager m_manager;
+
     private String m_mailboxesZKPath;
 
     /**
@@ -82,12 +85,9 @@ public class ExportGeneration implements Generation {
      */
     private final Map<Integer, Map<String, ExportDataSource>> m_dataSourcesByPartition
             =        new HashMap<Integer, Map<String, ExportDataSource>>();
-    @Override
-    public Map<Integer, Map<String, ExportDataSource>> getDataSourceByPartition() {
-        return m_dataSourcesByPartition;
-    }
 
-    private ImmutableList<Long> m_replicasHSIds = null;
+    // Export generation mailboxes under the same partition id, excludes the local one.
+    private Map<Integer, ImmutableList<Long>> m_replicasHSIds = new HashMap<>();
 
     private Mailbox m_mbox = null;
 
@@ -101,8 +101,9 @@ public class ExportGeneration implements Generation {
      * @param exportOverflowDirectory
      * @throws IOException
      */
-    public ExportGeneration(File exportOverflowDirectory) throws IOException {
+    public ExportGeneration(File exportOverflowDirectory, ExportManager manager) throws IOException {
         m_directory = exportOverflowDirectory;
+        m_manager = manager;
         if (!m_directory.canWrite()) {
             if (!m_directory.mkdirs()) {
                 throw new IOException("Could not create " + m_directory);
@@ -114,8 +115,29 @@ public class ExportGeneration implements Generation {
         }
     }
 
-    void initializeGenerationFromDisk(HostMessenger messenger) {
-        Set<Integer> partitions = new HashSet<Integer>();
+    void initialize(HostMessenger messenger,
+            int hostId,
+            CatalogContext catalogContext,
+            final CatalogMap<Connector> connectors,
+            List<Integer> partitions,
+            File exportOverflowDirectory)
+    {
+        List<Integer> allLocalPartitions = new ArrayList<>(partitions);
+        File files[] = exportOverflowDirectory.listFiles();
+        if (files != null) {
+            List<Integer> onDiskPartitions = initializeGenerationFromDisk(messenger);
+            // Add new unique partitions from on disk list.
+            onDiskPartitions.removeAll(allLocalPartitions);
+            allLocalPartitions.addAll(onDiskPartitions);
+        }
+        initializeGenerationFromCatalog(catalogContext, connectors, hostId, messenger, partitions);
+
+        // One export mailbox per node, since we only keep one generation
+        createAckMailboxesIfNeeded(messenger, allLocalPartitions);
+    }
+
+    List<Integer> initializeGenerationFromDisk(HostMessenger messenger) {
+        List<Integer> partitions = new ArrayList<Integer>();
 
         /*
          * Find all the data files. Once one is found, extract the nonce
@@ -146,7 +168,7 @@ public class ExportGeneration implements Generation {
                 }
             }
         }
-        createAndRegisterAckMailboxes(partitions, messenger);
+        return partitions;
     }
 
     void initializeGenerationFromCatalog(CatalogContext catalogContext,
@@ -155,27 +177,26 @@ public class ExportGeneration implements Generation {
             HostMessenger messenger,
             List<Integer> partitions)
     {
-        //Only populate partitions in use if export is actually happening
-        Set<Integer> partitionsInUse = new HashSet<Integer>();
-        final long genId = catalogContext.m_genId;
-        /*
-         * Now create datasources based on the catalog
-         */
+        // Now create datasources based on the catalog
         for (Connector conn : connectors) {
             if (conn.getEnabled()) {
                 for (ConnectorTableInfo ti : conn.getTableinfo()) {
                     Table table = ti.getTable();
-                    addDataSources(genId, table, hostId, partitions);
-                    partitionsInUse.addAll(partitions);
+                    addDataSources(table, hostId, partitions);
                 }
             }
         }
-
-        createAndRegisterAckMailboxes(partitionsInUse, messenger);
     }
 
-    private void createAndRegisterAckMailboxes(final Set<Integer> localPartitions, HostMessenger messenger) {
-
+    /**
+     * Create export ack mailbox during generation initialization, do nothing if generation has already initialized.
+     * @param messenger  HostMessenger
+     * @param localPartitions  locally covered partitions
+     */
+    public void createAckMailboxesIfNeeded(HostMessenger messenger, final List<Integer> localPartitions) {
+        if (m_mbox != null) {
+            return;
+        }
         m_mailboxesZKPath = VoltZK.exportGenerations + "/" + "mailboxes";
 
         m_mbox = new LocalMailbox(messenger) {
@@ -209,7 +230,9 @@ public class ExportGeneration implements Generation {
                         try {
                             if (exportLog.isDebugEnabled()) {
                                 exportLog.debug("Received RELEASE_BUFFER message for partition " + partition +
-                                        " source signature " + signature + " with uso: " + ackUSO);
+                                        " source signature " + signature + " with uso: " + ackUSO +
+                                        " from " + CoreUtils.hsIdToString(message.m_sourceHSId) +
+                                        " to " + CoreUtils.hsIdToString(m_mbox.getHSId()));
                             }
                             eds.ack(ackUSO);
                         } catch (RejectedExecutionException ignoreIt) {
@@ -228,6 +251,10 @@ public class ExportGeneration implements Generation {
                         }
                         for (Entry<String, ExportDataSource> e : partitionSources.entrySet()) {
                             if (e.getValue().readyForMastership()) {
+                                if (exportLog.isDebugEnabled()) {
+                                    exportLog.debug("Received MIGRATE_MASTER message for partition " + partition +
+                                            " table " + e.getValue().getTableName() + ", this stream is ready to be master.");
+                                }
                                 e.getValue().acceptMastership();
                             } else {
                                 Long uso = perDataSourceUso.get(e.getKey());
@@ -252,7 +279,23 @@ public class ExportGeneration implements Generation {
             }
         };
         messenger.createMailbox(null, m_mbox);
+        // Update latest replica list to each data source.
+        updateReplicaList(messenger, localPartitions);
+    }
 
+    // Access by multiple threads
+    public void updateAckMailboxes(int partition) {
+        synchronized (m_dataSourcesByPartition) {
+            for( ExportDataSource eds: m_dataSourcesByPartition.get(partition).values()) {
+                ImmutableList<Long> replicaHSIds = m_replicasHSIds.get(partition);
+                if (replicaHSIds != null) {
+                    eds.updateAckMailboxes(Pair.of(m_mbox, replicaHSIds));
+                }
+            }
+        }
+    }
+
+    private void updateReplicaList(HostMessenger messenger, List<Integer> localPartitions) {
         //If we have new partitions create mailbox paths.
         for (Integer partition : localPartitions) {
             final String partitionDN =  m_mailboxesZKPath + "/" + partition;
@@ -299,13 +342,8 @@ public class ExportGeneration implements Generation {
                         mailboxes.add(Long.valueOf(child));
                     }
                     ImmutableList<Long> mailboxHsids = mailboxes.build();
-                    m_replicasHSIds = mailboxHsids;
-                    synchronized (m_dataSourcesByPartition) {
-                        for( ExportDataSource eds:
-                            m_dataSourcesByPartition.get( partition).values()) {
-                            eds.updateAckMailboxes(Pair.of(m_mbox, mailboxHsids));
-                        }
-                    }
+                    m_replicasHSIds.put(partition, mailboxHsids);
+                    updateAckMailboxes(partition);
                 }
             }
         });
@@ -315,7 +353,6 @@ public class ExportGeneration implements Generation {
         } catch (Throwable t) {
             Throwables.propagate(t);
         }
-
     }
 
     private Watcher constructMailboxChildWatcher(final HostMessenger messenger) {
@@ -369,7 +406,6 @@ public class ExportGeneration implements Generation {
                             } else if (code != KeeperException.Code.OK) {
                                 throw KeeperException.create(code);
                             }
-
                             final String split[] = path.split("/");
                             final int partition = Integer.valueOf(split[split.length - 1]);
                             ImmutableList.Builder<Long> mailboxes = ImmutableList.builder();
@@ -378,12 +414,16 @@ public class ExportGeneration implements Generation {
                                 mailboxes.add(Long.valueOf(child));
                             }
                             ImmutableList<Long> mailboxHsids = mailboxes.build();
-                            m_replicasHSIds = mailboxHsids;
-                            synchronized (m_dataSourcesByPartition) {
-                                for( ExportDataSource eds: m_dataSourcesByPartition.get( partition).values()) {
-                                    eds.updateAckMailboxes(Pair.of(m_mbox, mailboxHsids));
-                                }
+                            if (exportLog.isDebugEnabled()) {
+                                Set<Long> newHSIds = Sets.difference(new HashSet<Long>(mailboxHsids),
+                                        new HashSet<Long>(m_replicasHSIds.get(partition)));
+                                Set<Long> removedHSIds = Sets.difference(new HashSet<Long>(m_replicasHSIds.get(partition)),
+                                        new HashSet<Long>(mailboxHsids));
+                                exportLog.debug("Current export generation added mailbox: " + CoreUtils.hsIdCollectionToString(newHSIds) +
+                                        ", removed mailbox: " + CoreUtils.hsIdCollectionToString(removedHSIds));
                             }
+                            m_replicasHSIds.put(partition, mailboxHsids);
+                            updateAckMailboxes(partition);
                         } catch (Throwable t) {
                             VoltDB.crashLocalVoltDB("Error in export ack handling", true, t);
                         }
@@ -449,7 +489,7 @@ public class ExportGeneration implements Generation {
     /*
      * Create a datasource based on an ad file
      */
-    private void addDataSource(File adFile, Set<Integer> partitions) throws IOException {
+    private void addDataSource(File adFile, List<Integer> partitions) throws IOException {
         ExportDataSource source = new ExportDataSource(this, adFile);
         partitions.add(source.getPartitionId());
         if (exportLog.isDebugEnabled()) {
@@ -471,7 +511,7 @@ public class ExportGeneration implements Generation {
     }
 
     // silly helper to add datasources for a table catalog object
-    private void addDataSources(final long genId, Table table, int hostId, List<Integer> partitions)
+    private void addDataSources(Table table, int hostId, List<Integer> partitions)
     {
         for (Integer partition : partitions) {
 
@@ -661,7 +701,6 @@ public class ExportGeneration implements Generation {
                 source.unacceptMastership();
             }
         }
-
     }
 
     /**
@@ -680,13 +719,14 @@ public class ExportGeneration implements Generation {
             eds.prepareUnacceptMastership();
         }
     }
+
     /**
-     * Indicate to all associated {@link ExportDataSource}to assume
+     * Indicate to all associated {@link ExportDataSource} to assume
      * mastership role for the given partition id
      * @param partitionId
      */
     @Override
-    public void acceptMastershipTask( int partitionId) {
+    public void acceptMastership(int partitionId) {
         Map<String, ExportDataSource> partitionDataSourceMap = m_dataSourcesByPartition.get(partitionId);
 
         // this case happens when there are no export tables
@@ -740,6 +780,11 @@ public class ExportGeneration implements Generation {
     }
 
     @Override
+    public Map<Integer, Map<String, ExportDataSource>> getDataSourceByPartition() {
+        return m_dataSourcesByPartition;
+    }
+
+    @Override
     public String toString() {
         return "Export Generation";
     }
@@ -767,14 +812,14 @@ public class ExportGeneration implements Generation {
 
             BinaryPayloadMessage bpm = new BinaryPayloadMessage(new byte[0], buf.array());
 
-            for( Long siteId: m_replicasHSIds) {
+            for( Long siteId: m_replicasHSIds.get(partitionId)) {
                 m_mbox.send(siteId, bpm);
             }
 
             if (exportLog.isDebugEnabled()) {
                 exportLog.debug("Partition " + partitionId + " mailbox hsid (" +
                         CoreUtils.hsIdToString(m_mbox.getHSId()) + ") send MIGRATE_MASTER message to " +
-                        CoreUtils.hsIdCollectionToString(m_replicasHSIds));
+                        CoreUtils.hsIdCollectionToString(m_replicasHSIds.get(partitionId)));
             }
         }
     }
@@ -789,6 +834,8 @@ public class ExportGeneration implements Generation {
 
         int drainedTables = (int)partitionDataSourceMap.values().stream().filter(eds -> eds.streamHasNoMaster()).count();
         if (partitionDataSourceMap.values().size() == drainedTables) {
+            // This host is no longer the export master of given partition.
+            m_manager.removeMasterPartition(source.getPartitionId());
             sendMigrateMastershipEvent(source.getPartitionId(), partitionDataSourceMap);
         }
     }

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -85,6 +85,10 @@ public class ExportManager
      */
     private final Set<Integer> m_masterOfPartitions = new HashSet<Integer>();
 
+    public static final byte RELEASE_BUFFER = 1;
+
+    public static final byte MIGRATE_MASTER = 2;
+
     /**
      * Thrown if the initial setup of the loader fails
      */

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -27,7 +27,7 @@ import org.voltcore.messaging.HostMessenger;
  */
 public interface Generation {
 
-    public void acceptMastershipTask(int partitionId);
+    public void acceptMastership(int partitionId);
     public void close(final HostMessenger messenger);
 
     public long getQueuedExportBytes(int partitionId, String signature);

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -38,6 +38,4 @@ public interface Generation {
     public void truncateExportToTxnId(long snapshotTxnId, long[] perPartitionTxnIds);
 
     public Map<Integer, Map<String, ExportDataSource>> getDataSourceByPartition();
-
-    public void migrateDataSource(ExportDataSource source);
 }

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -18,6 +18,7 @@ package org.voltdb.export;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
+
 import org.voltcore.messaging.HostMessenger;
 
 /**
@@ -37,4 +38,6 @@ public interface Generation {
     public void truncateExportToTxnId(long snapshotTxnId, long[] perPartitionTxnIds);
 
     public Map<Integer, Map<String, ExportDataSource>> getDataSourceByPartition();
+
+    public void migrateDataSource(ExportDataSource source);
 }

--- a/src/frontend/org/voltdb/export/StandaloneExportGeneration.java
+++ b/src/frontend/org/voltdb/export/StandaloneExportGeneration.java
@@ -298,7 +298,4 @@ public class StandaloneExportGeneration implements Generation {
     public String toString() {
         return "Standalone Export Generation";
     }
-
-    public void migrateDataSource(ExportDataSource source) {
-    }
 }

--- a/src/frontend/org/voltdb/export/StandaloneExportGeneration.java
+++ b/src/frontend/org/voltdb/export/StandaloneExportGeneration.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.voltcore.logging.VoltLogger;
@@ -33,7 +34,6 @@ import org.voltdb.utils.VoltFile;
 import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.util.concurrent.Futures;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
-import java.util.Map;
 
 /**
  * Export data from a single catalog version and database instance.
@@ -298,5 +298,8 @@ public class StandaloneExportGeneration implements Generation {
     @Override
     public String toString() {
         return "Standalone Export Generation";
+    }
+
+    public void migrateDataSource(ExportDataSource source) {
     }
 }

--- a/src/frontend/org/voltdb/export/StandaloneExportGeneration.java
+++ b/src/frontend/org/voltdb/export/StandaloneExportGeneration.java
@@ -277,7 +277,7 @@ public class StandaloneExportGeneration implements Generation {
      * @param partitionId
      */
     @Override
-    public void acceptMastershipTask( int partitionId) {
+    public void acceptMastership( int partitionId) {
         Map<String, ExportDataSource> partitionDataSourceMap = m_dataSourcesByPartition.get(partitionId);
 
         // this case happens when there are no export tables
@@ -285,7 +285,6 @@ public class StandaloneExportGeneration implements Generation {
             return;
         }
 
-        exportLog.info("Export accepting mastership for partition " + partitionId);
         for( ExportDataSource eds: partitionDataSourceMap.values()) {
             try {
                 eds.acceptMastership();

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -18,6 +18,7 @@
 package org.voltdb.export.processors;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
 import org.voltdb.VoltDB;
+import org.voltdb.VoltType;
 import org.voltdb.export.AdvertisedDataSource;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.export.ExportDataSource;
@@ -45,8 +47,6 @@ import org.voltdb.exportclient.ExportRow;
 
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
-import java.lang.reflect.Method;
-import org.voltdb.VoltType;
 
 public class GuestProcessor implements ExportDataProcessor {
 
@@ -219,8 +219,7 @@ public class GuestProcessor implements ExportDataProcessor {
             detectDecoder(m_client, edb);
             Pair<ExportDecoderBase, AdvertisedDataSource> pair = Pair.of(edb, ads);
             m_decoders.add(pair);
-            final ListenableFuture<BBContainer> fut = m_source.poll();
-            addBlockListener(m_source, fut, edb);
+            addBlockListener(m_source, m_source.poll(), edb);
         }
 
         private void runDataSource() {

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -184,7 +184,7 @@ public class Cartographer extends StatsSource
                         } else {
                             // this host *could* contain old master
                             // inform the export manager to prepare mastership migration (drain existing PBD and notify new leader)
-                            ExportManager.instance().prepareUnacceptMastership(partitionId);
+                            ExportManager.instance().prepareTransferMastership(partitionId, hostId);
                         }
                     }
                 }

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -178,6 +178,8 @@ public class Cartographer extends StatsSource
                         if (isHostIdLocal(hostId)) {
                             // this is a host contain newly promoted partition
                             // inform the export manager to prepare mastership promotion
+                            // Cartographer is initialized before ExportManager, ignore callbacks
+                            // before export is initialized
                             ExportManager.instance().prepareAcceptMastership(partitionId);
                         } else {
                             // this host *could* contain old master

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -253,6 +253,8 @@ public class SpInitiator extends BaseInitiator implements Promotable
             // leave the export on the former leader, now a replica
             if (!migratePartitionLeader) {
                 ExportManager.instance().acceptMastership(m_partitionId);
+                // notify Export subsystem in host failure case
+//                ExportManager.instance().handlePartitionFailure(m_partitionId);
             }
         } catch (Exception e) {
             VoltDB.crashLocalVoltDB("Terminally failed leader promotion.", true, e);

--- a/src/frontend/org/voltdb/iv2/SpTerm.java
+++ b/src/frontend/org/voltdb/iv2/SpTerm.java
@@ -29,14 +29,12 @@ import org.voltcore.utils.Pair;
 import org.voltcore.zk.BabySitter;
 import org.voltcore.zk.BabySitter.Callback;
 import org.voltcore.zk.LeaderElector;
-import org.voltdb.StartAction;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
 
 import com.google_voltpatches.common.base.Supplier;
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.Sets;
-import org.voltdb.export.ExportManager;
 
 public class SpTerm implements Term
 {
@@ -87,14 +85,11 @@ public class SpTerm implements Term
                 }
                 m_mailbox.updateReplicas(replicas, null);
                 m_replicasUpdatedRequired = false;
-                // TODO ? JOIN case for export
             }
             if (m_replicas.isEmpty() || replicas.size() <= m_replicas.size()) {
                 //The cases for startup or host failure
                 m_mailbox.updateReplicas(replicas, null);
                 m_replicasUpdatedRequired = false;
-                // notify Export subsystem in host failure case
-                ExportManager.instance().handlePartitionFailure(m_partitionId);
             } else {
                 //The case for rejoin
                 m_replicasUpdatedRequired = true;

--- a/tests/frontend/org/voltdb/export/ExportMatchers.java
+++ b/tests/frontend/org/voltdb/export/ExportMatchers.java
@@ -116,6 +116,7 @@ public class ExportMatchers {
 
         AckPayloadMessage(BinaryPayloadMessage p) {
             ByteBuffer buf = ByteBuffer.wrap(p.m_payload);
+            buf.get(); // skip message type
 
             partitionId = buf.getInt();
 
@@ -150,12 +151,12 @@ public class ExportMatchers {
 
         VoltMessage asVoltMessage() {
             byte [] signatureBytes = signature.getBytes(Constants.UTF8ENCODING);
-            ByteBuffer buf = ByteBuffer.allocate(18 + signatureBytes.length);
+            ByteBuffer buf = ByteBuffer.allocate(17 + signatureBytes.length);
+            buf.put((byte)0);
             buf.putInt(partitionId);
             buf.putInt(signatureBytes.length);
             buf.put(signatureBytes);
             buf.putLong(uso);
-            buf.putShort((short )0);
 
             return new BinaryPayloadMessage(new byte[0], buf.array());
         }

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -95,7 +95,7 @@ public class TestExportDataSource extends TestCase {
     class TestGeneration implements Generation {
 
         @Override
-        public void acceptMastershipTask(int partitionId) {
+        public void acceptMastership(int partitionId) {
         }
 
         @Override

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -127,10 +127,6 @@ public class TestExportDataSource extends TestCase {
         public Map<Integer, Map<String, ExportDataSource>> getDataSourceByPartition() {
             throw new UnsupportedOperationException("Not supported yet.");
         }
-
-        public void migrateDataSource(ExportDataSource source) {
-        }
-
     }
 
     @Override

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -23,9 +23,12 @@
 
 package org.voltdb.export;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.voltdb.export.ExportMatchers.ackPayloadIs;
 
 import java.io.File;
@@ -33,6 +36,7 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Map;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -43,6 +47,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.voltcore.messaging.BinaryPayloadMessage;
+import org.voltcore.messaging.HostMessenger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DBBPool.BBContainer;
@@ -56,13 +61,8 @@ import org.voltdb.utils.VoltFile;
 
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
-import java.util.Map;
 
 import junit.framework.TestCase;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import org.voltcore.messaging.HostMessenger;
 
 public class TestExportDataSource extends TestCase {
 
@@ -126,6 +126,9 @@ public class TestExportDataSource extends TestCase {
         @Override
         public Map<Integer, Map<String, ExportDataSource>> getDataSourceByPartition() {
             throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        public void migrateDataSource(ExportDataSource source) {
         }
 
     }
@@ -393,7 +396,7 @@ public class TestExportDataSource extends TestCase {
         try {
 
             //Ack before push
-            s.ack(100, false);
+            s.ack(100);
             TreeSet<String> listing = getSortedDirectoryListingSegments();
             assertEquals(listing.size(), 1);
 
@@ -407,7 +410,7 @@ public class TestExportDataSource extends TestCase {
             assertEquals(listing.size(), 1);
 
             //Ack after push beyond size...last segment kept.
-            s.ack(1000, false);
+            s.ack(1000);
             sz = s.sizeInBytes();
             assertEquals(sz, 0);
             listing = getSortedDirectoryListingSegments();
@@ -423,7 +426,7 @@ public class TestExportDataSource extends TestCase {
             assertEquals(listing.size(), 1);
 
             //Low ack should have no effect.
-            s.ack(100, false);
+            s.ack(100);
             sz = s.sizeInBytes();
             assertEquals(sz, 802);
             listing = getSortedDirectoryListingSegments();
@@ -438,7 +441,7 @@ public class TestExportDataSource extends TestCase {
             assertEquals(listing.size(), 1);
 
             //Last segment is always kept.
-            s.ack(2000, false);
+            s.ack(2000);
             sz = s.sizeInBytes();
             assertEquals(sz, 0);
             listing = getSortedDirectoryListingSegments();

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.voltdb.export.ExportMatchers.ackMbxMessageIs;
 
 import java.io.File;
@@ -138,7 +137,7 @@ public class TestExportGeneration {
 
         VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
 
-        m_exportGeneration = new ExportGeneration(m_dataDirectory, mock(ExportManager.class));
+        m_exportGeneration = new ExportGeneration(m_dataDirectory);
 
         m_exportGeneration.initializeGenerationFromCatalog(m_mockVoltDB.getCatalogContext(),
                 m_connectors, m_mockVoltDB.m_hostId, m_mockVoltDB.getHostMessenger(),

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -23,6 +23,11 @@
 
 package org.voltdb.export;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.voltdb.export.ExportMatchers.ackMbxMessageIs;
 
 import java.io.File;
@@ -57,10 +62,6 @@ import org.voltdb.utils.MiscUtils;
 
 import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.collect.ImmutableList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class TestExportGeneration {
 
@@ -137,7 +138,7 @@ public class TestExportGeneration {
 
         VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
 
-        m_exportGeneration = new ExportGeneration(m_dataDirectory);
+        m_exportGeneration = new ExportGeneration(m_dataDirectory, mock(ExportManager.class));
 
         m_exportGeneration.initializeGenerationFromCatalog(m_mockVoltDB.getCatalogContext(),
                 m_connectors, m_mockVoltDB.m_hostId, m_mockVoltDB.getHostMessenger(),
@@ -187,7 +188,7 @@ public class TestExportGeneration {
         final CountDownLatch promoted = new CountDownLatch(1);
         // Promote the data source to be master first, otherwise it won't send acks.
         m_exportGeneration.getDataSourceByPartition().get(m_part).get(m_tableSignature).setOnMastership(promoted::countDown, false);
-        m_exportGeneration.acceptMastershipTask(m_part);
+        m_exportGeneration.acceptMastership(m_part);
         promoted.await(5, TimeUnit.SECONDS);
 
         int retries = 4000;

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -142,6 +142,7 @@ public class TestExportGeneration {
         m_exportGeneration.initializeGenerationFromCatalog(m_mockVoltDB.getCatalogContext(),
                 m_connectors, m_mockVoltDB.m_hostId, m_mockVoltDB.getHostMessenger(),
                 ImmutableList.of(m_part));
+        m_exportGeneration.createAckMailboxesIfNeeded(m_mockVoltDB.getHostMessenger(), ImmutableList.of(m_part));
 
         m_mbox = new LocalMailbox(m_mockVoltDB.getHostMessenger()) {
             @Override

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -64,9 +64,9 @@
         <level value="INFO"/>
     </logger -->
 
-    <!-- logger name="EXPORT">
-        <level value="INFO"/>
-    </logger -->
+    <logger name="EXPORT">
+        <level value="DEBUG"/>
+    </logger>
 
     <!-- logger name="IMPORT">
         <level value="INFO"/>

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -64,9 +64,9 @@
         <level value="INFO"/>
     </logger -->
 
-    <logger name="EXPORT">
-        <level value="DEBUG"/>
-    </logger>
+    <!--logger name="EXPORT">
+        <level value="INFO"/>
+    </logger -->
 
     <!-- logger name="IMPORT">
         <level value="INFO"/>


### PR DESCRIPTION
…ition leader migrates to different host.

Cartographer notifies export data sources that partition leader is migrated. Export generation holds the
event until all streams of the same partition are ready to migrate. On receiver side, receiver picks up from
where prior master left and continue exporting.

Change-Id: I5280236e395964a1e2f6be62dfa266d3dc100db2