### PR TITLE
ENG-14315: Update JUnit auto-filer Jira ticket design

### DIFF
--- a/tools/jenkins/jenkinsbot.py
+++ b/tools/jenkins/jenkinsbot.py
@@ -833,7 +833,7 @@ tr:hover{
             #self.logger.info('NEW: Reported issue with summary "' + summary + '"')
             if self.connect_to_slack():
                 self.post_message(channel, 'Opened issue at https://issues.voltdb.com/browse/' + new_issue.key)
-            suite = summary.split('.')[-2]
+            suite = summary.split('.')[-3]
             # Find all tickets within same test suite and link them
             link_tickets = jira.search_issues('summary ~ \'%s\' and labels = automatic and status != Closed and reporter in (voltdbci)' % suite)
             for ticket in link_tickets:

--- a/tools/jenkins/jenkinsbot.py
+++ b/tools/jenkins/jenkinsbot.py
@@ -18,6 +18,7 @@ from logging import handlers
 from mysql.connector.errors import Error as MySQLError
 from slackclient import SlackClient
 from tabulate import tabulate  # Used for pretty printing tables
+from urllib import urlretrieve
 
 # Get job names from environment variables
 COMMUNITY = os.environ.get('community', None)
@@ -735,7 +736,7 @@ tr:hover{
         else:
             self.response_html()
 
-    def create_bug_issue(self, channel, summary, description, component, version, labels,
+    def create_bug_issue(self, channel, summary, description, component, version, labels, attachments={},
                          user=JIRA_USER, passwd=JIRA_PASS, project=JIRA_PROJECT, DRY_RUN=False):
         """
         Creates a bug issue on Jira
@@ -765,6 +766,12 @@ tr:hover{
         if len(existing) > 0:
             # Already reported
             self.logger.info('Found open issue(s) for "' + test_case + '" ' + ' '.join([k.key for k in existing]))
+            # If failing on different job, comment about new failure on previous ticket
+            reported_ticket = jira.issue(existing[0].id)
+            reported_job = reported_ticket.fields.summary.split('(')[0].split()[-1]
+            if reported_job not in summary and not DRY_RUN:
+                self.logger.info('Commenting about separate job failure for %s on open issue' % test_case)
+                jira.add_comment(existing[0].id, summary)
             return
 
         issue_dict = {
@@ -814,6 +821,10 @@ tr:hover{
         self.logger.info("Filing ticket: %s" % summary)
         if not DRY_RUN:
             new_issue = jira.create_issue(fields=issue_dict)
+            for filename in attachments:
+                urlretrieve(attachments[filename], filename)
+                jira.add_attachment(new_issue.id, os.getcwd() + '/' + filename, filename)
+                os.unlink(filename)
             #self.logger.info('NEW: Reported issue with summary "' + summary + '"')
             if self.connect_to_slack():
                 self.post_message(channel, 'Opened issue at https://issues.voltdb.com/browse/' + new_issue.key)

--- a/tools/jenkins/jenkinsbot.py
+++ b/tools/jenkins/jenkinsbot.py
@@ -837,7 +837,7 @@ tr:hover{
             # Find all tickets within same test suite and link them
             link_tickets = jira.search_issues('summary ~ \'%s\' and labels = automatic and status != Closed and reporter in (voltdbci)' % suite)
             for ticket in link_tickets:
-                jira.create_issue_link('Related', new_issue.id, ticket.id)
+                jira.create_issue_link('Related', new_issue.key, ticket)
         else:
             new_issue = None
 

--- a/tools/jenkins/junit-stats.py
+++ b/tools/jenkins/junit-stats.py
@@ -22,7 +22,7 @@ from urllib2 import HTTPError, URLError, urlopen
 JUNIT = os.environ.get('junit', None)
 
 # set to True if you need to suppress updating the database or JIRA
-DRY_RUN = True
+DRY_RUN = False
 
 # set threshold (greater than or equal to) of failures in a row to be significant
 FAIL_THRESHOLD = 2
@@ -185,8 +185,6 @@ class Stats(object):
             # filename : location
             job + 'CountGraph.png' : error_url + '/history/countGraph/png?start=0&amp;end=25'
         }
-        print(summary)
-        print(description)
 
         try:
             new_issue = jenkinsbot.create_bug_issue(JUNIT, summary, description, 'Core', current_version,

--- a/tools/jenkins/junit-stats.py
+++ b/tools/jenkins/junit-stats.py
@@ -161,7 +161,7 @@ class Stats(object):
 
         failed_since = error_report['failedSince']
         summary = issue['name'] + ' is failing on ' + job + ' (' + issue['reason'] + ')'
-        description = error_url + '\n\n------------------stack trace----------------------------\n\n' \
+        description = error_url + '\n\n-----------------\-stack trace\----------------------------\n\n' \
                       + str(error_report['errorStackTrace']) \
                       + '\n\n----------------------------------------------\n\n' \
                       + 'Failing since build ' + str(failed_since) + '\n' \
@@ -511,7 +511,7 @@ class Stats(object):
                                 values = [int(v[3]) for v in results]
                                 current = results[0][4]
 
-                                if (current < mean(values) - 2*std(values) or current > mean(values) + 2*std(values)):
+                                if (current > mean(values) + 2*std(values)):
                                     logging.info("will file: %s %s %s %s" % (job, build, name, testcase_url))
                                     test_data['reason'] = "CONSISTENT"
                                     try:
@@ -638,7 +638,7 @@ class Tests(unittest.TestCase):
         values = [int(v[3]) for v in results]
         current = results[0][4]
 
-        if (current < mean(values) - 2*std(values) or current > mean(values) + 2*std(values)):
+        if (current > mean(values) + 2*std(values)):
             print("FILE TICKET")
             return
 

--- a/tools/jenkins/junit-stats.py
+++ b/tools/jenkins/junit-stats.py
@@ -505,7 +505,6 @@ class Stats(object):
                                 current = results[0][4]
 
                                 if (current < mean(values) - 2*std(values) or current > mean(values) + 2*std(values)):
-                                    logging.info(str(mean(values)) + ' ' + str(std(values)) + ' ' + str(current))
                                     logging.info("will file: %s %s %s %s" % (job, build, name, testcase_url))
                                     test_data['reason'] = "FLAKY"
                                     try:

--- a/tools/jenkins/junit-stats.py
+++ b/tools/jenkins/junit-stats.py
@@ -535,7 +535,6 @@ class Stats(object):
                                         test_data['type'] = "CONSISTENT"
                                         try:
                                             test_data['new_issue_url'] = self.file_jira_issue(test_data, DRY_RUN=(not file_jira_ticket))
-                                            pass
                                         except:
                                             logging.exception("failed to file a jira ticket")
 

--- a/tools/jenkins/junit-stats.py
+++ b/tools/jenkins/junit-stats.py
@@ -22,7 +22,7 @@ from urllib2 import HTTPError, URLError, urlopen
 JUNIT = os.environ.get('junit', None)
 
 # set to True if you need to suppress updating the database or JIRA
-DRY_RUN = True
+DRY_RUN = False
 
 # set threshold (greater than or equal to) of failures in a row to be significant
 FAIL_THRESHOLD = 2

--- a/tools/jenkins/junit-stats.py
+++ b/tools/jenkins/junit-stats.py
@@ -166,7 +166,7 @@ class Stats(object):
                       + '\n\n----------------------------------------------\n\n' \
                       + 'Failing since build ' + str(failed_since) + '\n' \
                       + '[query history|' + note + '] | [jenkins history|' + history + ']\n' \
-                      + '!' + history + 'durationGraph/png!'
+                      + '!durationGraph.png!'
 
         current_version = str(self.read_url('https://raw.githubusercontent.com/VoltDB/voltdb/'
                                     'master/version.txt'))
@@ -174,7 +174,9 @@ class Stats(object):
 
         try:
             new_issue = jenkinsbot.create_bug_issue(JUNIT, summary, description, 'Core', current_version,
-                                                        ['junit-consistent-failure', 'automatic'], DRY_RUN=DRY_RUN)
+                                                        ['junit-consistent-failure', 'automatic'],
+                                                        {'durationGraph.png' : error_url + '/history/durationGraph/png'},
+                                                        DRY_RUN=DRY_RUN)
 
             if new_issue:
                 new_issue_url = "https://issues.voltdb.com/browse/" + new_issue.key

--- a/tools/jenkins/sql_coverage_reporter.py
+++ b/tools/jenkins/sql_coverage_reporter.py
@@ -10,11 +10,6 @@ from jenkinsbot import JenkinsBot
 from jira import JIRA
 from sql_grammar_reporter import Issues # using symlink alias to reference file
 
-JIRA_USER = os.environ.get('jirauser', None)
-JIRA_PASS = os.environ.get('jirapass', None)
-JIRA_PROJECT = os.environ.get('jiraproject', None)
-JUNIT = os.environ.get('junit', None)
-
 # Set to true to avoid updating Jira
 DRY_RUN = False
 
@@ -76,7 +71,7 @@ class Reporter(Issues):
 
         jenkinsbot = JenkinsBot()
         jenkinsbot.create_bug_issue(JUNIT, summary, description, 'Core', current_version, ['sqlcoverage-failure', 'automatic'],
-                                    JIRA_USER, JIRA_PASS, JIRA_PROJECT, DRY_RUN)
+                                    DRY_RUN=DRY_RUN)
 
 if __name__ == '__main__':
     job = os.environ.get('job', None)


### PR DESCRIPTION
Ready for review
 - includes failure % and type (Intermittent, Consistent) in summary
 - now supports including attachments to tickets for uploading countGraphs
 - now supports linking tickets on same job
 - displays countGraphs and adds link to Jenkins updatedGraph
 - if test failing (but tickets already exists) on different job, will comment on existing ticket
 - only counts failures that exceed threshold (default 2)
 - for Consistent failure cases, only significant if 2SD above mean (not below)