### PR TITLE
ENG-13766, fault handling of export stream migration.

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -227,6 +227,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
     private static final VoltLogger hostLog = new VoltLogger("HOST");
     private static final VoltLogger consoleLog = new VoltLogger("CONSOLE");
+    private static final VoltLogger exportLog = new VoltLogger("EXPORT");
 
     private VoltDB.Configuration m_config = new VoltDB.Configuration();
     int m_configuredNumberOfPartitions;
@@ -1780,6 +1781,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             if (initiator.getPartitionId() != MpInitiator.MP_INIT_PID) {
                 SpInitiator spInitiator = (SpInitiator)initiator;
                 if (spInitiator.isLeader()) {
+                    if (exportLog.isDebugEnabled()) {
+                        exportLog.debug("Export Manager has been notified that local partition " +
+                                  spInitiator.getPartitionId() + " to reevaluate export stream master.");
+                    }
                     ExportManager.instance().acceptMastership(spInitiator.getPartitionId());
                 }
             }

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -25,7 +25,9 @@ import java.lang.management.ManagementFactory;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
@@ -41,6 +43,7 @@ import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.BinaryPayloadMessage;
 import org.voltcore.messaging.Mailbox;
+import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
@@ -92,6 +95,8 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     private volatile AtomicBoolean m_mastershipAccepted = new AtomicBoolean(false);
     // This is set when mastership is going to transfer to another node.
     private Integer m_newLeaderHostId = null;
+    // HSIds that send query response back
+    private Set<Long> m_responseHSIds = new HashSet<>();
 
     private volatile boolean m_closed = false;
     private final StreamBlockQueue m_committedBuffers;
@@ -959,6 +964,61 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
     }
 
+    private void queryExportMembership() {
+        Pair<Mailbox, ImmutableList<Long>> p = m_ackMailboxRefs.get();
+        Mailbox mbx = p.getFirst();
+        if (mbx != null && p.getSecond().size() > 0) {
+            m_responseHSIds.clear();
+            // msg type(1) + partition:int(4) + length:int(4) +
+            // signaturesBytes.length + ackUSO:long(8).
+            final int msgLen = 1 + 4 + 4 + m_signatureBytes.length;
+
+            ByteBuffer buf = ByteBuffer.allocate(msgLen);
+            buf.put(ExportManager.QUERY_MEMBERSHIP);
+            buf.putInt(m_partitionId);
+            buf.putInt(m_signatureBytes.length);
+            buf.put(m_signatureBytes);
+
+            BinaryPayloadMessage bpm = new BinaryPayloadMessage(new byte[0], buf.array());
+
+            for( Long siteId: p.getSecond()) {
+                mbx.send(siteId, bpm);
+            }
+            if (exportLog.isDebugEnabled()) {
+                exportLog.debug("Send QUERY_MEMBERSHIP for partition " + m_partitionId + "source signature " + m_tableName
+                        + " from " + CoreUtils.hsIdToString(mbx.getHSId())
+                        + " to " + CoreUtils.hsIdCollectionToString(p.getSecond()));
+            }
+        } else {
+            // If there is no other replica, promote current stream as master
+            acceptMastership();
+        }
+    }
+
+    private void sendQueryResponse(long newLeaderHSId) {
+        Pair<Mailbox, ImmutableList<Long>> p = m_ackMailboxRefs.get();
+        Mailbox mbx = p.getFirst();
+        if (mbx != null && p.getSecond().size() > 0 && p.getSecond().contains(newLeaderHSId)) {
+            // msg type(1) + partition:int(4) + length:int(4) +
+            // signaturesBytes.length + ackUSO:long(8).
+            final int msgLen = 1 + 4 + 4 + m_signatureBytes.length;
+
+            ByteBuffer buf = ByteBuffer.allocate(msgLen);
+            buf.put(ExportManager.QUERY_RESPONSE);
+            buf.putInt(m_partitionId);
+            buf.putInt(m_signatureBytes.length);
+            buf.put(m_signatureBytes);
+
+            BinaryPayloadMessage bpm = new BinaryPayloadMessage(new byte[0], buf.array());
+            mbx.send(newLeaderHSId, bpm);
+            if (exportLog.isDebugEnabled()) {
+                exportLog.debug("Partition " + m_partitionId + " mailbox hsid (" +
+                        CoreUtils.hsIdToString(mbx.getHSId()) + ") send QUERY_RESPONSE message to " +
+                        CoreUtils.hsIdToString(newLeaderHSId));
+            }
+        }
+    }
+
     public synchronized void unacceptMastership() {
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("Export table " + getTableName() + " for partition " + getPartitionId() + " mailbox hsid (" +
@@ -1004,6 +1064,8 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                         }
                         if (m_onMastership != null) {
                             if (m_mastershipAccepted.compareAndSet(false, true)) {
+                                // Either get enough responses or have received TRANSFER_MASTER event, clear the response sender HSids.
+                                m_responseHSIds.clear();
                                 m_onMastership.run();
                             }
                         }
@@ -1048,12 +1110,56 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
      * prepare to assume the mastership,
      * still has to wait for the old leader to give up mastership (through ack)
      */
-    synchronized void handlePartitionFailure() {
+    void reassignExportStreamMaster() {
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("Export table " + getTableName() + " mastership for partition " + getPartitionId() + " needs to be reevaluated.");
         }
-        // TODO
-        // Query all other node for current mastership
+        if (!m_mastershipAccepted.get()) {
+            m_es.execute(new Runnable() {
+                public void run() {
+                    // Query export membership if current stream is not the master
+                    queryExportMembership();
+                }
+            });
+        }
+    }
+
+    public void handleQueryMessage(final long newLeaderHSId) {
+        if (m_mastershipAccepted.get()) {
+            m_es.execute(new Runnable() {
+                public void run() {
+                    m_newLeaderHostId = CoreUtils.getHostIdFromHSId(newLeaderHSId);
+                    // memorize end USO of the most recently pushed buffer from EE
+                    m_usoToDrain = m_lastPushedUso;
+                    // if no new buffer to be drained, send the migrate event right away
+                    if (m_usoToDrain == m_lastReleasedUso) {
+                        unacceptMastership();
+                        sendTakeMastershipEvent(m_usoToDrain);
+                    }
+                }
+            });
+        } else {
+            m_es.execute(new Runnable() {
+                public void run() {
+                    sendQueryResponse(newLeaderHSId);
+                }
+            });
+        }
+    }
+
+    public void handleQueryResponse(VoltMessage message) {
+        if (!m_mastershipAccepted.get()) {
+            m_es.execute(new Runnable() {
+                public void run() {
+                    m_responseHSIds.add(message.m_sourceHSId);
+                    Pair<Mailbox, ImmutableList<Long>> p = m_ackMailboxRefs.get();
+                    if (p.getSecond().stream().allMatch(hsid -> m_responseHSIds.contains(hsid))) {
+                        // No one is master, promote current stream as master.
+                        acceptMastership();
+                    }
+                }
+            });
+        }
     }
 
     public byte[] getTableSignature() {

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -174,9 +174,6 @@ public class ExportManager
      * @param partitionId
      */
     synchronized public void acceptMastership(int partitionId) {
-        if (exportLog.isDebugEnabled()) {
-            exportLog.debug("Export Manager has been notified that local partition " + partitionId + " to accept export mastership.");
-        }
         m_masterOfPartitions.add(partitionId);
         /*
          * Only the first generation will have a processor which
@@ -200,7 +197,7 @@ public class ExportManager
             return;
         }
         if (exportLog.isDebugEnabled()) {
-            exportLog.debug("Export Manager has been notified that local partition " + partitionId + " has became leader.");
+            exportLog.debug("Export streams on local partition " + partitionId + " will become master.");
         }
     }
 
@@ -215,7 +212,7 @@ public class ExportManager
         m_masterOfPartitions.remove(partitionId);
 
         if (exportLog.isDebugEnabled()) {
-            exportLog.debug("ExportManager has been notified the sp leader for " + partitionId + " has been migrated away");
+            exportLog.debug("Export stream masters on " + partitionId + " are going to migrate away");
         }
         ExportGeneration generation = m_generation.get();
         if (generation == null) {
@@ -496,7 +493,7 @@ public class ExportManager
         //Load any missing tables.
         generation.initializeGenerationFromCatalog(catalogContext, connectors, m_hostId, m_messenger, partitions);
         for (int partition : partitions) {
-            generation.updateAckMailboxes(partition);
+            generation.updateAckMailboxes(partition, null);
         }
 
         //We create processor even if we dont have any streams.

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -89,6 +89,10 @@ public class ExportManager
 
     public static final byte TAKE_MASTERSHIP = 2;
 
+    public static final byte QUERY_MEMBERSHIP = 3;
+
+    public static final byte QUERY_RESPONSE = 4;
+
     /**
      * Thrown if the initial setup of the loader fails
      */
@@ -173,12 +177,7 @@ public class ExportManager
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("Export Manager has been notified that local partition " + partitionId + " to accept export mastership.");
         }
-
-        // can't acquire mastership twice for the same partition id
-        if (! m_masterOfPartitions.add(partitionId)) {
-            return;
-        }
-
+        m_masterOfPartitions.add(partitionId);
         /*
          * Only the first generation will have a processor which
          * makes it safe to accept mastership.
@@ -187,7 +186,7 @@ public class ExportManager
         if (generation == null) {
             return;
         }
-        generation.acceptMastership(partitionId);
+        generation.reassignExportStreamMaster(partitionId);
     }
 
     /**
@@ -203,27 +202,6 @@ public class ExportManager
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("Export Manager has been notified that local partition " + partitionId + " has became leader.");
         }
-    }
-
-    /**
-     * Indicate local partition has saw node failure
-     * Could be leader failover or replica fail
-     * Need to query the replica for verify ExportMastership
-     * @param partitionId
-     */
-    synchronized public void handlePartitionFailure(int partitionId) {
-        // ? if is already export master, don't need query
-        if (m_masterOfPartitions.contains(partitionId)) {
-            return;
-        }
-        if (exportLog.isDebugEnabled()) {
-            exportLog.debug("Export Manager has been notified that local partition " + partitionId + "  has encountered node failure.");
-        }
-        ExportGeneration generation = m_generation.get();
-        if (generation == null) {
-            return;
-        }
-        generation.handlePartitionFailure(partitionId);
     }
 
     /**

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.zk.LeaderElector;
@@ -59,6 +60,9 @@ public class SpInitiator extends BaseInitiator implements Promotable
     final private LeaderCache m_leaderCache;
     private final TickProducer m_tickProducer;
     private boolean m_promoted = false;
+
+    private static final VoltLogger exportLog = new VoltLogger("EXPORT");
+
     LeaderCache.Callback m_leadersChangeHandler = new LeaderCache.Callback()
     {
         @Override
@@ -252,6 +256,10 @@ public class SpInitiator extends BaseInitiator implements Promotable
             // Tag along and become the export master too
             // leave the export on the former leader, now a replica
             if (!migratePartitionLeader) {
+                if (exportLog.isDebugEnabled()) {
+                    exportLog.debug("Export Manager has been notified that local partition " +
+                            m_partitionId + " to accept export stream mastership.");
+                }
                 ExportManager.instance().acceptMastership(m_partitionId);
             }
         } catch (Exception e) {

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -253,8 +253,6 @@ public class SpInitiator extends BaseInitiator implements Promotable
             // leave the export on the former leader, now a replica
             if (!migratePartitionLeader) {
                 ExportManager.instance().acceptMastership(m_partitionId);
-                // notify Export subsystem in host failure case
-//                ExportManager.instance().handlePartitionFailure(m_partitionId);
             }
         } catch (Exception e) {
             VoltDB.crashLocalVoltDB("Terminally failed leader promotion.", true, e);

--- a/src/frontend/org/voltdb/sysprocs/MigratePartitionLeader.java
+++ b/src/frontend/org/voltdb/sysprocs/MigratePartitionLeader.java
@@ -61,6 +61,9 @@ public class MigratePartitionLeader extends VoltSystemProcedure {
             return (new VoltTable[] {t});
         }
 
+        // before starting the migration, give some time for old leader to drain any pending tasks
+        ctx.getSiteProcedureConnection().quiesce();
+
         RealVoltDB db = (RealVoltDB)VoltDB.instance();
         Long targetHsid = db.getCartograhper().getHSIDForPartitionHost(hostId, partitionId);
         if (targetHsid == null) {

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -64,7 +64,7 @@
         <level value="INFO"/>
     </logger -->
 
-    <!--logger name="EXPORT">
+    <!-- logger name="EXPORT">
         <level value="INFO"/>
     </logger -->
 


### PR DESCRIPTION
On host failure, every partition leader sends QUERY message to collect whether the local stream has an remote
master, if none of the replicas has master, promote the local stream as master. If one of the replicas is master,
ask that stream to transfer mastership back when export buffer is drained.

Change-Id: I104f78aa78563f85d3dd406a398b437af80e3a35