### PR TITLE
Fix help and code for voltadmin update to only accept config file

### DIFF
--- a/lib/python/voltcli/voltadmin.d/update.py
+++ b/lib/python/voltcli/voltadmin.d/update.py
@@ -19,38 +19,23 @@ from voltcli import utility
 
 @VOLT.Command(
     bundles=VOLT.AdminBundle(),
-    description='Update the schema of a running database.',
-    description2='Either a catalog (extension .jar), a deployment file (extension .xml), or both, must be provided.',
+    description='Update the configuration of a running database.',
+    #description2='Either a catalog (extension .jar), a deployment file (extension .xml), or both, must be provided.',
     arguments=(
         VOLT.StringArgument(
-            'catalog_or_deployment',
-            'application catalog (extension .jar) and/or deployment configuration (extension .xml) file path(s)',
-            min_count=1, max_count=2),
+            'configuration',
+            'database configuration file (extension .xml)',
+            min_count=1, max_count=1),
     )
 )
 def update(runner):
     columns = [VOLT.FastSerializer.VOLTTYPE_NULL, VOLT.FastSerializer.VOLTTYPE_NULL]
     catalog = None
     deployment = None
-    for catalog_or_deployment in runner.opts.catalog_or_deployment:
-        extension = os.path.splitext(catalog_or_deployment)[1].lower()
-        if extension == '.jar':
-            if not catalog is None:
-                runner.abort('More than one catalog .jar file was specified.')
-            catalog = VOLT.utility.File(catalog_or_deployment).read_hex()
-            columns[0] = VOLT.FastSerializer.VOLTTYPE_STRING
-        elif extension == '.xml':
-            if not deployment is None:
-                runner.abort('More than one deployment .xml file was specified.')
-            deployment = VOLT.utility.File(catalog_or_deployment).read()
-            columns[1] = VOLT.FastSerializer.VOLTTYPE_STRING
-        else:
-            runner.abort(
-                'The "%s" extension is not recognized as either a catalog or a deployment file'
-                    % extension)
-    if catalog is None and deployment is None:
-        runner.abort('At least one catalog .jar or deployment .xml file is required.')
+    configuration = runner.opts.configuration
+    deployment = VOLT.utility.File(configuration).read()
+    columns[1] = VOLT.FastSerializer.VOLTTYPE_STRING
     params = [catalog, deployment]
     # call_proc() aborts with an error if the update failed.
     runner.call_proc('@UpdateApplicationCatalog', columns, params)
-    runner.info('The catalog update succeeded.')
+    runner.info('The configuration update succeeded.')


### PR DESCRIPTION
The original request was to fix the help. But since I was in there, it seemed better
to actually correct the processing to only accept one file, a deployment/config file.

Since I changed the actual code, thought it would be good to have it reviewed before merging.

--Andrew