### PR TITLE
ENG-14347, master stream forwards an ACK to newly rejoined streams.

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -227,6 +227,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
     private static final VoltLogger hostLog = new VoltLogger("HOST");
     private static final VoltLogger consoleLog = new VoltLogger("CONSOLE");
+    private static final VoltLogger exportLog = new VoltLogger("EXPORT");
 
     private VoltDB.Configuration m_config = new VoltDB.Configuration();
     int m_configuredNumberOfPartitions;
@@ -1780,6 +1781,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             if (initiator.getPartitionId() != MpInitiator.MP_INIT_PID) {
                 SpInitiator spInitiator = (SpInitiator)initiator;
                 if (spInitiator.isLeader()) {
+                    if (exportLog.isDebugEnabled()) {
+                        exportLog.debug("Export Manager has been notified that local partition " +
+                                  spInitiator.getPartitionId() + " to reevaluate export stream master.");
+                    }
                     ExportManager.instance().acceptMastership(spInitiator.getPartitionId());
                 }
             }

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -174,9 +174,6 @@ public class ExportManager
      * @param partitionId
      */
     synchronized public void acceptMastership(int partitionId) {
-        if (exportLog.isDebugEnabled()) {
-            exportLog.debug("Export Manager has been notified that local partition " + partitionId + " to accept export mastership.");
-        }
         m_masterOfPartitions.add(partitionId);
         /*
          * Only the first generation will have a processor which
@@ -200,7 +197,7 @@ public class ExportManager
             return;
         }
         if (exportLog.isDebugEnabled()) {
-            exportLog.debug("Export Manager has been notified that local partition " + partitionId + " has became leader.");
+            exportLog.debug("Export streams on local partition " + partitionId + " will become master.");
         }
     }
 
@@ -215,7 +212,7 @@ public class ExportManager
         m_masterOfPartitions.remove(partitionId);
 
         if (exportLog.isDebugEnabled()) {
-            exportLog.debug("ExportManager has been notified the sp leader for " + partitionId + " has been migrated away");
+            exportLog.debug("Export stream masters on " + partitionId + " are going to migrate away");
         }
         ExportGeneration generation = m_generation.get();
         if (generation == null) {
@@ -496,7 +493,7 @@ public class ExportManager
         //Load any missing tables.
         generation.initializeGenerationFromCatalog(catalogContext, connectors, m_hostId, m_messenger, partitions);
         for (int partition : partitions) {
-            generation.updateAckMailboxes(partition);
+            generation.updateAckMailboxes(partition, null);
         }
 
         //We create processor even if we dont have any streams.

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.zk.LeaderElector;
@@ -59,6 +60,9 @@ public class SpInitiator extends BaseInitiator implements Promotable
     final private LeaderCache m_leaderCache;
     private final TickProducer m_tickProducer;
     private boolean m_promoted = false;
+
+    private static final VoltLogger exportLog = new VoltLogger("EXPORT");
+
     LeaderCache.Callback m_leadersChangeHandler = new LeaderCache.Callback()
     {
         @Override
@@ -252,6 +256,10 @@ public class SpInitiator extends BaseInitiator implements Promotable
             // Tag along and become the export master too
             // leave the export on the former leader, now a replica
             if (!migratePartitionLeader) {
+                if (exportLog.isDebugEnabled()) {
+                    exportLog.debug("Export Manager has been notified that local partition " +
+                            m_partitionId + " to accept export stream mastership.");
+                }
                 ExportManager.instance().acceptMastership(m_partitionId);
             }
         } catch (Exception e) {

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -44,7 +44,7 @@
         <level value="INFO"/>
     </logger -->
 
-    <!-- logger name="HOST">
+    <!--logger name="HOST">
         <level value="INFO"/>
     </logger -->
 
@@ -64,7 +64,7 @@
         <level value="INFO"/>
     </logger -->
 
-    <!--logger name="EXPORT">
+    <!-- logger name="EXPORT">
         <level value="INFO"/>
     </logger -->
 

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -44,7 +44,7 @@
         <level value="INFO"/>
     </logger -->
 
-    <!--logger name="HOST">
+    <!-- logger name="HOST">
         <level value="INFO"/>
     </logger -->
 


### PR DESCRIPTION
When newly joined or rejoined streams miss any RELEASE_BUFFER event, and client is stopped, it causes
export buffers on rejoined nodes never get drained. Forwarding an ACK from master stream fixes the edge case.

Change-Id: If14d0a2a36e8835f7ad3e6b660af19d0ee5d9118