### PR TITLE
ENG-14334-The vmc "Import" tab is missing

### DIFF
--- a/src/frontend/org/voltdb/ImporterServerAdapterImpl.java
+++ b/src/frontend/org/voltdb/ImporterServerAdapterImpl.java
@@ -61,4 +61,9 @@ public class ImporterServerAdapterImpl implements ImporterServerAdapter {
     public void reportQueued(String importerName, String procName) {
         m_statsCollector.reportQueued(importerName, procName);
     }
+
+    @Override
+    public void reportInitialized(String importerName, String procName) {
+        m_statsCollector.reportInitialized(importerName, procName);
+    }
 }

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
@@ -146,8 +146,8 @@ public class KafkaStreamImporter extends AbstractImporter {
 
         LOGGER.info("Number of Kafka Consumers on this host:" + consumerCount);
         // After the importer is initialized, insert records in @Statistics IMPORTER to make sure VMC can keep track of the import progress
-        for (String procedureName : m_config.getTopics().split("\\s*,\\s*")) {
-            reportStat(m_config.getProcedure(procedureName));
+        for (String topicName : m_config.getTopics().split("\\s*,\\s*")) {
+            reportInitializedStat(m_config.getProcedure(topicName));
         }
     }
 

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
@@ -145,6 +145,8 @@ public class KafkaStreamImporter extends AbstractImporter {
         }
 
         LOGGER.info("Number of Kafka Consumers on this host:" + consumerCount);
+        // When the importer is initialized, insert a record in @Statistics IMPORTER to make sure VMC can keep track of the import progress
+        reportStat(m_config.getProcedure(m_config.getTopics()));
     }
 
     @Override

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
@@ -145,8 +145,10 @@ public class KafkaStreamImporter extends AbstractImporter {
         }
 
         LOGGER.info("Number of Kafka Consumers on this host:" + consumerCount);
-        // When the importer is initialized, insert a record in @Statistics IMPORTER to make sure VMC can keep track of the import progress
-        reportStat(m_config.getProcedure(m_config.getTopics()));
+        // After the importer is initialized, insert records in @Statistics IMPORTER to make sure VMC can keep track of the import progress
+        for (String procedureName : m_config.getTopics().split("\\s*,\\s*")) {
+            reportStat(m_config.getProcedure(procedureName));
+        }
     }
 
     @Override

--- a/src/frontend/org/voltdb/importer/AbstractImporter.java
+++ b/src/frontend/org/voltdb/importer/AbstractImporter.java
@@ -137,6 +137,10 @@ public abstract class AbstractImporter
         }
     }
 
+    public void reportStat(String procName){
+        m_importServerAdapter.reportInitialized(getName(), procName);
+    }
+
     private void reportFailureStat(String procName) {
         m_importServerAdapter.reportFailure(getName(), procName, false);
     }

--- a/src/frontend/org/voltdb/importer/AbstractImporter.java
+++ b/src/frontend/org/voltdb/importer/AbstractImporter.java
@@ -137,7 +137,7 @@ public abstract class AbstractImporter
         }
     }
 
-    public void reportStat(String procName){
+    public void reportInitializedStat(String procName){
         m_importServerAdapter.reportInitialized(getName(), procName);
     }
 

--- a/src/frontend/org/voltdb/importer/ImporterServerAdapter.java
+++ b/src/frontend/org/voltdb/importer/ImporterServerAdapter.java
@@ -69,7 +69,7 @@ public interface ImporterServerAdapter {
      */
     public void reportQueued(String importerName, String procName);
 
-    /** This should be used by importer to report that the imported was successfully initialized.
+    /** This should be used by importer to report that the importer was successfully initialized.
      *
      * @param importerName the name of the importer
      * @param procName the name of the procedure that the importer was trying to execute

--- a/src/frontend/org/voltdb/importer/ImporterServerAdapter.java
+++ b/src/frontend/org/voltdb/importer/ImporterServerAdapter.java
@@ -68,4 +68,11 @@ public interface ImporterServerAdapter {
      * @param procName the name of the procedure that the importer was trying to execute
      */
     public void reportQueued(String importerName, String procName);
+
+    /** This should be used by importer to report that the imported was successfully initialized.
+     *
+     * @param importerName the name of the importer
+     * @param procName the name of the procedure that the importer was trying to execute
+     */
+    public void reportInitialized(String importerName, String procName);
 }

--- a/src/frontend/org/voltdb/importer/ImporterStatsCollector.java
+++ b/src/frontend/org/voltdb/importer/ImporterStatsCollector.java
@@ -90,7 +90,7 @@ public class ImporterStatsCollector extends SiteStatsSource
         statsInfo.m_failureCount.incrementAndGet();
     }
 
-    // Report that the imported was successfully initialized
+    // Report that the importer was successfully initialized
     public void reportInitialized(String importerName, String procName) {
         getStatsInfo(importerName, procName);
     }

--- a/src/frontend/org/voltdb/importer/ImporterStatsCollector.java
+++ b/src/frontend/org/voltdb/importer/ImporterStatsCollector.java
@@ -90,6 +90,11 @@ public class ImporterStatsCollector extends SiteStatsSource
         statsInfo.m_failureCount.incrementAndGet();
     }
 
+    // Report that the imported was successfully initialized
+    public void reportInitialized(String importerName, String procName) {
+        getStatsInfo(importerName, procName);
+    }
+
     // One insert succeeded
     private void reportSuccess(String importerName, String procName) {
         StatsInfo statsInfo = getStatsInfo(importerName, procName);


### PR DESCRIPTION
This issue is related to the behavior of `@Statistics IMPORTER`

We won't have anything in `Statistics` until we successfully insert a record from Kafka into the target table, which is  considered as a bug.

This PR fix this behavior, once we have the Kafka importer successfully initialized (Kafka server is started and the target table is existed), we will have a record in `@Statistics IMPORTER`, and the "import tab" will appear.