### PR TITLE
ENG-13929: don't allow queries with no GB clause to order by aggregates

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/QuerySpecification.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/QuerySpecification.java
@@ -1084,6 +1084,12 @@ public class QuerySpecification extends QueryExpression {
             if (e.getLeftNode().isAggregate) {
                 e.isAggregate = true;
             }
+
+            if (e.isAggregate && ! isGrouped) {
+                // Don't allow ordering by aggregate functions
+                // in ungrouped queries...
+                throw Error.error(ErrorCode.X_42576);
+            }
         }
 
         for (int i = indexStartOrderBy; i < indexStartAggregates; i++) {


### PR DESCRIPTION
Dummy PR for Chirs' work on HSQL to disallow OBY aggregate without GBY clause.

Synced to latest master and resolved conflicts.