### PR TITLE
Fixed bug on nested optimized query

### DIFF
--- a/src/frontend/org/voltdb/planner/MVQueryRewriter.java
+++ b/src/frontend/org/voltdb/planner/MVQueryRewriter.java
@@ -174,9 +174,6 @@ final class MVQueryRewriter {
      * match.
      * \pre both SELECT stmt and candidate MV has a single table source. This is guaranteed in the constructor logic.
      *
-     * TODO: 1. Verify the case that GBY complex expressions ordering mismatch should actually be optimized/matched
-     * TODO: 2. Verify that the combination of complex and simple GBY expressions from different tables should *NOT* be matched.
-     *
      * @param mv candidate materialized view
      * @return whether given candidate MV might match SELECT stmt, by looking only at the group-by expressions.
      */

--- a/src/frontend/org/voltdb/planner/QueryPlanner.java
+++ b/src/frontend/org/voltdb/planner/QueryPlanner.java
@@ -403,11 +403,14 @@ public class QueryPlanner implements AutoCloseable {
             }
         }
         if(parsedStmt instanceof ParsedSelectStmt || parsedStmt instanceof ParsedUnionStmt) {
-            final MVQueryRewriter rewriter = parsedStmt instanceof ParsedSelectStmt ?
-                    new MVQueryRewriter((ParsedSelectStmt) parsedStmt) :
-                    new MVQueryRewriter((ParsedUnionStmt) parsedStmt);
-            if(rewriter.rewrite() && m_paramzInfo != null) {
-                m_paramzInfo.setParamLiteralValues(new String[0]);
+            final MVQueryRewriter rewriter;
+            if (parsedStmt instanceof ParsedSelectStmt) {
+                rewriter = new MVQueryRewriter((ParsedSelectStmt) parsedStmt);
+            } else {
+                rewriter = new MVQueryRewriter((ParsedUnionStmt) parsedStmt);
+            }
+            if (rewriter.rewrite() && m_paramzInfo != null) { // if query is rewritten the #parameters is likely reduced.
+                m_paramzInfo.rewrite();
             }
         }
         m_planSelector.outputParsedStatement(parsedStmt);


### PR DESCRIPTION
The parameter number decreases when MV optimization rewrites a query. In that case, the assertion check needs updated.