### PR TITLE
ENG-14371, in partition leader migration read-only MP transaction sho…

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
@@ -131,7 +131,7 @@ public class MpTransactionTaskQueue extends TransactionTaskQueue
                 }
                 next.doRestart(masters, partitionMasters);
 
-                if (!balanceSPI || readonly) {
+                if (!balanceSPI) {
                     MpTransactionState txn = (MpTransactionState)next.getTransactionState();
                     // inject poison pill
                     FragmentTaskMessage dummy = new FragmentTaskMessage(0L, 0L, 0L, 0L,


### PR DESCRIPTION
…uld be restarted and reroute to right partition leader, currently server returns a ProcCallException with the reason "VOLTDB ERROR: TRANSACTION RESTART", it's unpleasant to user since there's no node loss and transaction is actually aborted instead of being restarted.

Change-Id: I8fc06cfd2f2702fe6981e81accd148bd3e516031

Pro PR: https://github.com/VoltDB/pro/pull/2305