### PR TITLE
Refactory ee topend and exceptions

### DIFF
--- a/src/ee/CMakeLists.txt
+++ b/src/ee/CMakeLists.txt
@@ -264,6 +264,7 @@ SET (VOLTDB_SRC
   storage/StreamedTableStats.cpp
   storage/TableCatalogDelegate.cpp
   storage/table.cpp
+  storage/tableiterator.cpp
   storage/tablefactory.cpp
   storage/TableStats.cpp
   storage/TableStreamerContext.cpp

--- a/src/ee/common/SegvException.cpp
+++ b/src/ee/common/SegvException.cpp
@@ -116,7 +116,7 @@ SegvException::SegvException(
     }
 
     if (!bp || !ip) {
-        m_traces = traces;
+        setTraces(traces);
     }
 #endif
 #endif

--- a/src/ee/common/SerializableEEException.cpp
+++ b/src/ee/common/SerializableEEException.cpp
@@ -20,40 +20,50 @@
 #include "common/serializeio.h"
 #include "execution/VoltDBEngine.h"
 
-namespace voltdb {
+using namespace voltdb;
 
 #ifdef VOLT_DEBUG_ENABLED
-static const char* translateVoltEEExceptionTypeToString(VoltEEExceptionType exceptionType)
-{
-    switch(exceptionType) {
-    case VOLT_EE_EXCEPTION_TYPE_NONE: return "VOLT_EE_EXCEPTION_TYPE_NONE";
-    case VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION: return "VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION";
-    case VOLT_EE_EXCEPTION_TYPE_SQL: return "VOLT_EE_EXCEPTION_TYPE_SQL";
-    case VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION: return "VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION";
-    case VOLT_EE_EXCEPTION_TYPE_INTERRUPT: return "VOLT_EE_EXCEPTION_TYPE_INTERRUPT";
-    case VOLT_EE_EXCEPTION_TYPE_TXN_RESTART: return "VOLT_EE_EXCEPTION_TYPE_TXN_RESTART";
-    case VOLT_EE_EXCEPTION_TYPE_TXN_TERMINATION: return "VOLT_EE_EXCEPTION_TYPE_TXN_TERMINATION";
-    case VOLT_EE_EXCEPTION_TYPE_SPECIFIED: return "VOLT_EE_EXCEPTION_TYPE_SPECIFIED";
-    case VOLT_EE_EXCEPTION_TYPE_GENERIC: return "VOLT_EE_EXCEPTION_TYPE_GENERIC";
-    case VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED: return "VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED";
-    case VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE: return "VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE";
-    default: return "UNKNOWN";
-    }
+static const char* translateVoltEEExceptionTypeToString(VoltEEExceptionType exceptionType) {
+   switch(exceptionType) {
+      case VOLT_EE_EXCEPTION_TYPE_NONE:
+         return "VOLT_EE_EXCEPTION_TYPE_NONE";
+      case VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION:
+         return "VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION";
+      case VOLT_EE_EXCEPTION_TYPE_SQL:
+         return "VOLT_EE_EXCEPTION_TYPE_SQL";
+      case VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION:
+         return "VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION";
+      case VOLT_EE_EXCEPTION_TYPE_INTERRUPT:
+         return "VOLT_EE_EXCEPTION_TYPE_INTERRUPT";
+      case VOLT_EE_EXCEPTION_TYPE_TXN_RESTART:
+         return "VOLT_EE_EXCEPTION_TYPE_TXN_RESTART";
+      case VOLT_EE_EXCEPTION_TYPE_TXN_TERMINATION:
+         return "VOLT_EE_EXCEPTION_TYPE_TXN_TERMINATION";
+      case VOLT_EE_EXCEPTION_TYPE_SPECIFIED:
+         return "VOLT_EE_EXCEPTION_TYPE_SPECIFIED";
+      case VOLT_EE_EXCEPTION_TYPE_GENERIC:
+         return "VOLT_EE_EXCEPTION_TYPE_GENERIC";
+      case VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED:
+         return "VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED";
+      case VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE:
+         return "VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE";
+      default:
+         return "UNKNOWN";
+   }
 }
 #endif
 
-SerializableEEException::SerializableEEException(VoltEEExceptionType exceptionType, std::string message) :
-    m_exceptionType(exceptionType), m_message(message)
-{
+SerializableEEException::SerializableEEException(VoltEEExceptionType exceptionType,
+      const std::string& message) :
+    std::runtime_error(message), m_exceptionType(exceptionType), m_message(message) {
     VOLT_DEBUG("Created SerializableEEException: type: %s message: %s",
                translateVoltEEExceptionTypeToString(exceptionType), message.c_str());
 }
 
-SerializableEEException::SerializableEEException(std::string message) :
-    m_exceptionType(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION), m_message(message)
-{
-    VOLT_DEBUG("Created SerializableEEException: default type, %s",
-               message.c_str());
+SerializableEEException::SerializableEEException(std::string const& message) :
+    std::runtime_error(message),
+    m_exceptionType(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION), m_message(message) {
+    VOLT_DEBUG("Created SerializableEEException: default type, %s", message.c_str());
 }
 
 void SerializableEEException::serialize(ReferenceSerializeOutput *output) const {
@@ -66,12 +76,7 @@ void SerializableEEException::serialize(ReferenceSerializeOutput *output) const 
     p_serialize(output);
     if (m_exceptionType == VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION)
         output->writeInt(ENGINE_ERRORCODE_ERROR);
-    const int32_t length = static_cast<int32_t>(output->position() - (lengthPosition + sizeof(int32_t)));
-    output->writeIntAt( lengthPosition, length);
+    const int32_t len = static_cast<int32_t>(output->position() - (lengthPosition + sizeof(int32_t)));
+    output->writeIntAt( lengthPosition, len);
 }
 
-SerializableEEException::~SerializableEEException() {
-    // TODO Auto-generated destructor stub
-}
-
-}

--- a/src/ee/common/SerializableEEException.h
+++ b/src/ee/common/SerializableEEException.h
@@ -15,12 +15,15 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SERIALIZABLEEEEXCEPTION_H_
-#define SERIALIZABLEEEEXCEPTION_H_
+#pragma once
 
 #include <string>
+#include <stdexcept>
 
-#define throwSerializableEEException(...) do { char msg[8192]; snprintf(msg, 8192, __VA_ARGS__); throw voltdb::SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg); } while (false)
+#define throwSerializableEEException(...) do {                                     \
+   char msg[8192]; snprintf(msg, 8192, __VA_ARGS__);                               \
+   throw voltdb::SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg); \
+} while (false)
 
 namespace voltdb {
 
@@ -51,35 +54,32 @@ enum VoltEEExceptionType {
  * used to determine what exception class will be used to deserialize
  * this exception.
  */
-class SerializableEEException {
+class SerializableEEException : public std::runtime_error {
 public:
     /*
      * Constructor that performs the serialization to the engines
      * exception buffer.
      */
-    SerializableEEException(VoltEEExceptionType exceptionType, std::string message);
-    SerializableEEException(std::string message);
-    virtual ~SerializableEEException();
+    SerializableEEException(VoltEEExceptionType exceptionType, std::string const& message);
+    SerializableEEException(std::string const& message);
+    virtual ~SerializableEEException() {}
 
     void serialize (ReferenceSerializeOutput *output) const;
-    virtual const std::string message() const { return m_message; }
-    VoltEEExceptionType getType() const { return m_exceptionType; }
-    void appendContextToMessage(const std::string& more) { m_message += more; }
-protected:
-    virtual void p_serialize(ReferenceSerializeOutput *output) const {};
-
+    const char* what() const noexcept override {
+       return m_message.c_str();
+    }
+    VoltEEExceptionType getType() const {
+       return m_exceptionType;
+    }
+    void appendContextToMessage(const std::string& more) {
+       m_message += more;
+    }
 private:
+    virtual void p_serialize(ReferenceSerializeOutput *output) const {};
     const VoltEEExceptionType m_exceptionType;
+protected:
     std::string m_message;
-
 };
-
-class UnexpectedEEException : public SerializableEEException {
-public:
-    UnexpectedEEException(std::string message)
-      : SerializableEEException(message)
-    { }
-};
+using UnexpectedEEException = SerializableEEException;
 
 } // end namespace voltdb
-#endif /* SERIALIZABLEEEEXCEPTION_H_ */

--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -14,170 +14,142 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "common/LargeTempTableBlockId.hpp"
 #include "common/Topend.h"
 #include "common/StreamBlock.h"
 #include "storage/table.h"
 #include "storage/persistenttable.h"
 #include "storage/tablefactory.h"
 
-namespace voltdb {
-    static Table* copyTable(const std::string &name, Table* template_table, char *signature)
-    {
-        Table* t = TableFactory::getPersistentTable(0,
-                                                    name,
-                                                    TupleSchema::createTupleSchema(template_table->schema()),
-                                                    template_table->getColumnNames(),
-                                                    signature);
-        TableTuple tuple(template_table->schema());
-        TableIterator iterator = template_table->iterator();
-        while (iterator.next(tuple)) {
-            t->insertTuple(tuple);
-        }
-        return t;
+using namespace voltdb;
+static Table* copyTable(const std::string &name, Table* template_table, char *signature) {
+   Table* t = TableFactory::getPersistentTable(0, name,
+         TupleSchema::createTupleSchema(template_table->schema()),
+         template_table->getColumnNames(), signature);
+    TableTuple tuple(template_table->schema());
+    TableIterator iterator = template_table->iterator();
+    while (iterator.next(tuple)) {
+        t->insertTuple(tuple);
+    }
+    return t;
+}
+
+int DummyTopend::loadNextDependency(
+    int32_t dependencyId, Pool *pool, Table* destination) {
+    return 0;
+}
+
+int64_t DummyTopend::fragmentProgressUpdate(int32_t batchIndex, PlanNodeType planNodeType,
+        int64_t tuplesFound, int64_t currMemoryInBytes, int64_t peakMemoryInBytes) {
+    return 1000000000; // larger means less likely/frequent callbacks to ignore
+}
+
+std::string DummyTopend::planForFragmentId(int64_t fragmentId) {
+    return "";
+}
+
+void DummyTopend::crashVoltDB(FatalException const& e) {
+}
+
+int64_t DummyTopend::getQueuedExportBytes(int32_t partitionId, std::string const& signature) {
+    int64_t bytes = 0;
+    for (int ii = 0; ii < m_blocks.size(); ii++) {
+        bytes += m_blocks[ii]->rawLength();
+    }
+    return bytes;
+}
+
+void DummyTopend::pushExportBuffer(int32_t partitionId, std::string const& signature, StreamBlock *block, bool sync) {
+    if (sync) {
+        return;
+    }
+    m_partitionIds.push(partitionId);
+    m_signatures.push(signature);
+    m_blocks.push_back(std::unique_ptr<StreamBlock>(new StreamBlock(block)));
+    m_data.push_back(boost::shared_array<char>(block->rawPtr()));
+    m_receivedExportBuffer = true;
+}
+
+void DummyTopend::pushEndOfStream(int32_t partitionId, std::string const& signature) {
+    m_partitionIds.push(partitionId);
+    m_signatures.push(signature);
+    m_receivedExportBuffer = true;
+}
+
+int64_t DummyTopend::pushDRBuffer(int32_t partitionId, StreamBlock *block) {
+    m_receivedDRBuffer = true;
+    m_partitionIds.push(partitionId);
+    m_blocks.push_back(std::unique_ptr<StreamBlock>(new StreamBlock(block)));
+    m_data.push_back(boost::shared_array<char>(block->rawPtr()));
+    return m_pushDRBufferRetval;
+}
+
+
+void DummyTopend::pushPoisonPill(int32_t partitionId, std::string& reason, StreamBlock *block) {
+    m_partitionIds.push(partitionId);
+    m_blocks.push_back(std::unique_ptr<StreamBlock>(new StreamBlock(block)));
+    m_data.push_back(boost::shared_array<char>(block->rawPtr()));
+}
+
+
+int DummyTopend::reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName,
+      DRRecordType action, DRConflictType deleteConflict, Table* existingMetaTableForDelete, Table* existingTupleTableForDelete,
+        Table* expectedMetaTableForDelete, Table* expectedTupleTableForDelete, DRConflictType insertConflict,
+        Table* existingMetaTableForInsert, Table* existingTupleTableForInsert, Table* newMetaTableForInsert,
+        Table* newTupleTableForInsert) {
+    m_actionType = action;
+    m_deleteConflictType = deleteConflict;
+    m_insertConflictType = insertConflict;
+    m_remoteClusterId = remoteClusterId;
+    m_remoteTimestamp = remoteTimestamp;
+    char signature[20];
+
+    if (existingMetaTableForDelete) {
+        m_existingMetaRowsForDelete = table_ptr_t(copyTable("existingMeta", existingMetaTableForDelete, signature));
+        m_existingTupleRowsForDelete = table_ptr_t(copyTable("existing", existingTupleTableForDelete, signature));
     }
 
-    DummyTopend::DummyTopend() : receivedDRBuffer(false), receivedExportBuffer(false), pushDRBufferRetval(-1) {
-
+    if (expectedMetaTableForDelete) {
+        m_expectedMetaRowsForDelete = table_ptr_t(copyTable("expectedMeta", expectedMetaTableForDelete, signature));
+        m_expectedTupleRowsForDelete = table_ptr_t(copyTable("expected", expectedTupleTableForDelete, signature));
     }
 
-    int DummyTopend::loadNextDependency(
-        int32_t dependencyId, voltdb::Pool *pool, Table* destination) {
-        return 0;
+    if (existingMetaTableForInsert) {
+        m_existingMetaRowsForInsert = table_ptr_t(copyTable("existingMeta", existingMetaTableForInsert, signature));
+        m_existingTupleRowsForInsert = table_ptr_t(copyTable("existing", existingTupleTableForInsert, signature));
     }
 
-    int64_t DummyTopend::fragmentProgressUpdate(
-            int32_t batchIndex,
-            PlanNodeType planNodeType,
-            int64_t tuplesFound,
-            int64_t currMemoryInBytes,
-            int64_t peakMemoryInBytes) {
-        return 1000000000; // larger means less likely/frequent callbacks to ignore
+    if (newMetaTableForInsert) {
+        m_newMetaRowsForInsert = table_ptr_t(copyTable("newMeta", newMetaTableForInsert, signature));
+        m_newTupleRowsForInsert = table_ptr_t(copyTable("new", newTupleTableForInsert, signature));
     }
+    return 2; /*resolved but not apply remote change*/
+}
 
-    std::string DummyTopend::planForFragmentId(int64_t fragmentId) {
-        return "";
-    }
+void DummyTopend::fallbackToEEAllocatedBuffer(char *buffer, size_t length) {}
 
-    void DummyTopend::crashVoltDB(voltdb::FatalException e) {
-    }
+std::string DummyTopend::decodeBase64AndDecompress(const std::string& buffer) {
+    return "";
+}
 
-    int64_t DummyTopend::getQueuedExportBytes(int32_t partitionId, std::string signature) {
-        int64_t bytes = 0;
-        for (int ii = 0; ii < blocks.size(); ii++) {
-            bytes += blocks[ii]->rawLength();
-        }
-        return bytes;
-    }
+bool DummyTopend::storeLargeTempTableBlock(LargeTempTableBlock* block) {
+    return false;
+}
 
-    void DummyTopend::pushExportBuffer(int32_t partitionId, std::string signature, StreamBlock *block, bool sync) {
-        if (sync) {
-            return;
-        }
-        partitionIds.push(partitionId);
-        signatures.push(signature);
-        blocks.push_back(boost::shared_ptr<StreamBlock>(new StreamBlock(block)));
-        data.push_back(boost::shared_array<char>(block->rawPtr()));
-        receivedExportBuffer = true;
-    }
+bool DummyTopend::loadLargeTempTableBlock(LargeTempTableBlock* block) {
+    return false;
+}
 
-    void DummyTopend::pushEndOfStream(int32_t partitionId, std::string signature) {
-        partitionIds.push(partitionId);
-        signatures.push(signature);
-        receivedExportBuffer = true;
-    }
+bool DummyTopend::releaseLargeTempTableBlock(LargeTempTableBlockId const& blockId) {
+    return false;
+}
 
-    int64_t DummyTopend::pushDRBuffer(int32_t partitionId, voltdb::StreamBlock *block) {
-        receivedDRBuffer = true;
-        partitionIds.push(partitionId);
-        blocks.push_back(boost::shared_ptr<StreamBlock>(new StreamBlock(block)));
-        data.push_back(boost::shared_array<char>(block->rawPtr()));
-        return pushDRBufferRetval;
-    }
+int32_t DummyTopend::callJavaUserDefinedFunction() {
+    // We do not call any UDF here, directly return zero which means success.
+    return 0;
+}
 
+void DummyTopend::resizeUDFBuffer(int32_t size) {
+    // We do nothing here.
+}
 
-    void DummyTopend::pushPoisonPill(int32_t partitionId, std::string& reason, StreamBlock *block) {
-        partitionIds.push(partitionId);
-        blocks.push_back(boost::shared_ptr<StreamBlock>(new StreamBlock(block)));
-        data.push_back(boost::shared_array<char>(block->rawPtr()));
-    }
-
-
-    int DummyTopend::reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, DRRecordType action,
-            DRConflictType deleteConflict, Table *existingMetaTableForDelete, Table *existingTupleTableForDelete,
-            Table *expectedMetaTableForDelete, Table *expectedTupleTableForDelete,
-            DRConflictType insertConflict, Table *existingMetaTableForInsert, Table *existingTupleTableForInsert,
-            Table *newMetaTableForInsert, Table *newTupleTableForInsert) {
-        this->actionType = action;
-        this->deleteConflictType = deleteConflict;
-        this->insertConflictType = insertConflict;
-        this->remoteClusterId = remoteClusterId;
-        this->remoteTimestamp = remoteTimestamp;
-        char signature[20];
-
-        if (existingMetaTableForDelete) {
-            this->existingMetaRowsForDelete = boost::shared_ptr<Table>(copyTable("existingMeta",
-                                                                                 existingMetaTableForDelete,
-                                                                                 signature));
-            this->existingTupleRowsForDelete = boost::shared_ptr<Table>(copyTable("existing",
-                                                                                  existingTupleTableForDelete,
-                                                                                  signature));
-        }
-
-        if (expectedMetaTableForDelete) {
-            this->expectedMetaRowsForDelete = boost::shared_ptr<Table>(copyTable("expectedMeta",
-                                                                                 expectedMetaTableForDelete,
-                                                                                 signature));
-            this->expectedTupleRowsForDelete = boost::shared_ptr<Table>(copyTable("expected",
-                                                                                  expectedTupleTableForDelete,
-                                                                                  signature));
-        }
-
-        if (existingMetaTableForInsert) {
-            this->existingMetaRowsForInsert = boost::shared_ptr<Table>(copyTable("existingMeta",
-                                                                                 existingMetaTableForInsert,
-                                                                                 signature));
-            this->existingTupleRowsForInsert = boost::shared_ptr<Table>(copyTable("existing",
-                                                                                  existingTupleTableForInsert,
-                                                                                  signature));
-        }
-
-        if (newMetaTableForInsert) {
-            this->newMetaRowsForInsert = boost::shared_ptr<Table>(copyTable("newMeta",
-                                                                            newMetaTableForInsert,
-                                                                            signature));
-            this->newTupleRowsForInsert = boost::shared_ptr<Table>(copyTable("new",
-                                                                             newTupleTableForInsert,
-                                                                             signature));
-        }
-
-        return 2; /*resolved but not apply remote change*/
-    }
-
-    void DummyTopend::fallbackToEEAllocatedBuffer(char *buffer, size_t length) {}
-
-    std::string DummyTopend::decodeBase64AndDecompress(const std::string& buffer) {
-        return "";
-    }
-
-    bool DummyTopend::storeLargeTempTableBlock(LargeTempTableBlock* block) {
-        return false;
-    }
-
-    bool DummyTopend::loadLargeTempTableBlock(LargeTempTableBlock* block) {
-        return false;
-    }
-
-    bool DummyTopend::releaseLargeTempTableBlock(LargeTempTableBlockId blockId) {
-        return false;
-    }
-
-    int32_t DummyTopend::callJavaUserDefinedFunction() {
-        // We do not call any UDF here, directly return zero which means success.
-        return 0;
-    }
-
-    void DummyTopend::resizeUDFBuffer(int32_t size) {
-        // We do nothing here.
-    }
-
-} // end namespace voltdb

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -120,46 +120,46 @@ public:
     DummyTopend();
 
     int loadNextDependency(
-        int32_t dependencyId, voltdb::Pool *pool, Table* destination);
+        int32_t dependencyId, voltdb::Pool *pool, Table* destination) override;
 
     virtual int64_t fragmentProgressUpdate(
             int32_t batchIndex,
             PlanNodeType planNodeType,
             int64_t tuplesFound,
             int64_t currMemoryInBytes,
-            int64_t peakMemoryInBytes);
+            int64_t peakMemoryInBytes) override;
 
-    std::string planForFragmentId(int64_t fragmentId);
+    std::string planForFragmentId(int64_t fragmentId) override;
 
-    void crashVoltDB(voltdb::FatalException e);
+    void crashVoltDB(voltdb::FatalException e) override;
 
-    int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);
+    int64_t getQueuedExportBytes(int32_t partitionId, std::string signature) override;
 
-    virtual void pushExportBuffer(int32_t partitionId, std::string signature, StreamBlock *block, bool sync);
-    virtual void pushEndOfStream(int32_t partitionId, std::string signature);
+    virtual void pushExportBuffer(int32_t partitionId, std::string signature, StreamBlock *block, bool sync) override;
+    virtual void pushEndOfStream(int32_t partitionId, std::string signature) override;
 
-    int64_t pushDRBuffer(int32_t partitionId, voltdb::StreamBlock *block);
+    int64_t pushDRBuffer(int32_t partitionId, voltdb::StreamBlock *block) override;
 
-    void pushPoisonPill(int32_t partitionId, std::string& reason, StreamBlock *block);
+    void pushPoisonPill(int32_t partitionId, std::string& reason, StreamBlock *block) override;
 
     int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, DRRecordType action,
             DRConflictType deleteConflict, Table *existingMetaTableForDelete, Table *existingTupleTableForDelete,
             Table *expectedMetaTableForDelete, Table *expectedTupleTableForDelete,
             DRConflictType insertConflict, Table *existingMetaTableForInsert, Table *existingTupleTableForInsert,
-            Table *newMetaTableForInsert, Table *newTupleTableForInsert);
+            Table *newMetaTableForInsert, Table *newTupleTableForInsert) override;
 
-    void fallbackToEEAllocatedBuffer(char *buffer, size_t length);
+    void fallbackToEEAllocatedBuffer(char *buffer, size_t length) override;
 
-    std::string decodeBase64AndDecompress(const std::string& buffer);
+    std::string decodeBase64AndDecompress(const std::string& buffer) override;
 
-    virtual bool storeLargeTempTableBlock(LargeTempTableBlock* block);
+    virtual bool storeLargeTempTableBlock(LargeTempTableBlock* block) override;
 
-    virtual bool loadLargeTempTableBlock(LargeTempTableBlock* block);
+    virtual bool loadLargeTempTableBlock(LargeTempTableBlock* block) override;
 
-    virtual bool releaseLargeTempTableBlock(LargeTempTableBlockId blockId);
+    virtual bool releaseLargeTempTableBlock(LargeTempTableBlockId blockId) override;
 
-    int32_t callJavaUserDefinedFunction();
-    void resizeUDFBuffer(int32_t size);
+    int32_t callJavaUserDefinedFunction() override;
+    void resizeUDFBuffer(int32_t size) override;
 
     std::queue<int32_t> partitionIds;
     std::queue<std::string> signatures;

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -15,526 +15,105 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "JNITopend.h"
-
 #include "common/StreamBlock.h"
 #include "storage/table.h"
+#include "common/LargeTempTableBlockId.hpp"
 
 using namespace std;
+using namespace voltdb;
 
-namespace voltdb{
+jclass JNITopend::getJClass(JNIEnv& env, const jobject& engine) {
+   const jclass jniClass = env.GetObjectClass(engine);
+   VOLT_TRACE("found class: %d", jniClass == nullptr);
+   if (jniClass == nullptr) {
+      env.ExceptionDescribe();
+      throw std::invalid_argument("Failed to call GetObjectClass() method on jobject engine");
+   } else {
+      return jniClass;
+   }
+}
 
-// Create an instance of this class on the stack to release all local
-// references created during its lifetime.
-class JNILocalFrameBarrier {
-  private:
-    JNIEnv * m_env;
-    int32_t m_refs;
-    int32_t m_result;
+jmethodID JNITopend::createJniMethod(JNIEnv& env, const jclass jClass,
+      const char* name, const char* signature) {
+   return checked(env.GetMethodID(jClass, name, signature),
+         env, name, signature);
+}
 
-    jboolean m_isCopy;
-    jbyteArray m_jbuf;
-    jbyte* m_bytes;
+jmethodID JNITopend::createJniStaticMethod(JNIEnv& env, const jclass jClass,
+      const char* name, const char* signature) {
+   return checked(env.GetStaticMethodID(jClass, name, signature),
+         env, name, signature);
+}
 
-  public:
-    JNILocalFrameBarrier(JNIEnv* env, int32_t numReferences) {
-        m_env = env;
-        m_refs = numReferences;
-        m_result = m_env->PushLocalFrame(m_refs);
-        m_isCopy = JNI_FALSE;
-        m_jbuf = 0;
-        m_bytes = NULL;
-    }
+template<typename jptr_type>
+jptr_type JNITopend::checked(jptr_type id, JNIEnv& env, const char* name, const char* signature) {
+   if (id == nullptr) {
+      env.ExceptionDescribe();
+      throw std::invalid_argument(
+            std::string("Failed to set JNI method ")
+            .append(name).append(" @ ").append(signature));
+   } else {
+      return id;
+   }
+}
 
-    void addDependencyRef(jboolean isCopy, jbyteArray jbuf, jbyte* bytes)
-    {
-        m_isCopy = isCopy;
-        m_jbuf = jbuf;
-        m_bytes = bytes;
-    }
-
-    ~JNILocalFrameBarrier() {
-        if (m_isCopy == JNI_TRUE)
-        {
-            m_env->ReleaseByteArrayElements(m_jbuf, m_bytes, 0);
-        }
-        // pass jobject* to get pointer to previous frame?
-        m_env->PopLocalFrame(NULL);
-    }
-
-    int32_t checkResult() {
-        return m_result;
-    }
-};
-
-JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecutionEngine(caller) {
-    // Cache the method id for better performance. It is valid until the JVM unloads the class:
-    // http://java.sun.com/javase/6/docs/technotes/guides/jni/spec/design.html#wp17074
-    jclass jniClass = m_jniEnv->GetObjectClass(m_javaExecutionEngine);
-    VOLT_TRACE("found class: %d", jniClass == NULL);
-    if (jniClass == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(jniClass != 0);
-        throw std::exception();
-    }
-
-    m_fallbackToEEAllocatedBufferMID =
-            m_jniEnv->GetMethodID(
-                    jniClass,
-                    "fallbackToEEAllocatedBuffer",
-                    "(Ljava/nio/ByteBuffer;)V");
-    if (m_fallbackToEEAllocatedBufferMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_fallbackToEEAllocatedBufferMID != 0);
-        throw std::exception();
-    }
-
-    m_callJavaUserDefinedFunctionMID = m_jniEnv->GetMethodID(
-            jniClass, "callJavaUserDefinedFunction", "()I");
-    if (m_callJavaUserDefinedFunctionMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_callJavaUserDefinedFunctionMID != 0);
-        throw std::exception();
-    }
-
-    m_resizeUDFBufferMID = m_jniEnv->GetMethodID(
-            jniClass, "resizeUDFBuffer", "(I)V");
-    if (m_resizeUDFBufferMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_resizeUDFBufferMID != 0);
-        throw std::exception();
-    }
-
-    m_nextDependencyMID = m_jniEnv->GetMethodID(jniClass, "nextDependencyAsBytes", "(I)[B");
-    if (m_nextDependencyMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_nextDependencyMID != 0);
-        throw std::exception();
-    }
-
-    m_traceLogMID = m_jniEnv->GetMethodID(jniClass, "traceLog", "(ZLjava/lang/String;Ljava/lang/String;)V");
-    if (m_traceLogMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_traceLogMID != 0);
-        throw std::exception();
-    }
-
-    m_fragmentProgressUpdateMID = m_jniEnv->GetMethodID(jniClass, "fragmentProgressUpdate", "(IIJJJ)J");
-    if (m_fragmentProgressUpdateMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_fragmentProgressUpdateMID != 0);
-        throw std::exception();
-    }
-
-    m_planForFragmentIdMID = m_jniEnv->GetMethodID(jniClass, "planForFragmentId", "(J)[B");
-    if (m_planForFragmentIdMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_planForFragmentIdMID != 0);
-        throw std::exception();
-    }
-
-    m_crashVoltDBMID =
-        m_jniEnv->GetStaticMethodID(
-            jniClass,
-            "crashVoltDB",
-            "(Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;I)V");
-    if (m_crashVoltDBMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_crashVoltDBMID != NULL);
-        throw std::exception();
-    }
-
-    m_exportManagerClass = m_jniEnv->FindClass("org/voltdb/export/ExportManager");
-    if (m_exportManagerClass == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_exportManagerClass != NULL);
-        throw std::exception();
-    }
-
-    m_exportManagerClass = static_cast<jclass>(m_jniEnv->NewGlobalRef(m_exportManagerClass));
-    if (m_exportManagerClass == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_exportManagerClass != NULL);
-        throw std::exception();
-    }
-
-    m_pushExportBufferMID = m_jniEnv->GetStaticMethodID(
-            m_exportManagerClass,
-            "pushExportBuffer",
-            "(ILjava/lang/String;JJLjava/nio/ByteBuffer;Z)V");
-    if (m_pushExportBufferMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_pushExportBufferMID != NULL);
-        throw std::exception();
-    }
-    m_pushExportEOFMID = m_jniEnv->GetStaticMethodID(
-            m_exportManagerClass,
-            "pushEndOfStream",
-            "(ILjava/lang/String;)V");
-    if (m_pushExportEOFMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_pushExportEOFMID != NULL);
-        throw std::exception();
-    }
-
-    m_getQueuedExportBytesMID = m_jniEnv->GetStaticMethodID(
-            m_exportManagerClass,
-            "getQueuedExportBytes",
-            "(ILjava/lang/String;)J");
-    if (m_getQueuedExportBytesMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_getQueuedExportBytesMID != NULL);
-        throw std::exception();
-    }
-
-    m_partitionDRGatewayClass = m_jniEnv->FindClass("org/voltdb/PartitionDRGateway");
-    if (m_partitionDRGatewayClass == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_partitionDRGatewayClass != NULL);
-        throw std::exception();
-    }
-
-    m_partitionDRGatewayClass = static_cast<jclass>(m_jniEnv->NewGlobalRef(m_partitionDRGatewayClass));
-    if (m_partitionDRGatewayClass == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_partitionDRGatewayClass != NULL);
-        throw std::exception();
-    }
-
-    m_pushDRBufferMID = m_jniEnv->GetStaticMethodID(
-            m_partitionDRGatewayClass,
-            "pushDRBuffer",
-            "(IJJJJILjava/nio/ByteBuffer;)J");
-
-    m_pushPoisonPillMID = m_jniEnv->GetStaticMethodID(
-            m_partitionDRGatewayClass,
-            "pushPoisonPill",
-            "(ILjava/lang/String;Ljava/nio/ByteBuffer;)V");
-
-    if (m_pushDRBufferMID == NULL || m_pushPoisonPillMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_pushDRBufferMID != NULL && m_pushPoisonPillMID != NULL);
-        throw std::exception();
-    }
-
-    m_reportDRConflictMID = m_jniEnv->GetStaticMethodID(
-            m_partitionDRGatewayClass,
+JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecutionEngine(caller),
+   // classes
+   m_jniClass(getJClass(*m_jniEnv, m_javaExecutionEngine)),
+   m_exportManagerClass(checked(m_jniEnv->FindClass("org/voltdb/export/ExportManager"),
+            *m_jniEnv, "org/voltdb/export/ExportManager")),
+   m_partitionDRGatewayClass(checked(
+            static_cast<jclass>(
+               m_jniEnv->NewGlobalRef(     // Class created from global ref based on
+                  checked(m_jniEnv->FindClass("org/voltdb/PartitionDRGateway"),    // finding the class
+                     *m_jniEnv, "org/voltdb/PartitionDRGateway"))),
+            *m_jniEnv, "org/voltdb/PartitionDRGateway")),
+    m_decompressionClass(checked(m_jniEnv->FindClass("org/voltdb/utils/CompressionService"),
+             *m_jniEnv, "org/voltdb/utils/CompressionService")),
+   // JNI class' methods
+   m_fallbackToEEAllocatedBufferMID(createJniMethod(*m_jniEnv, m_jniClass,
+            "fallbackToEEAllocatedBuffer", "(Ljava/nio/ByteBuffer;)V")),
+   m_callJavaUserDefinedFunctionMID(createJniMethod(*m_jniEnv, m_jniClass,
+            "callJavaUserDefinedFunction", "()I")),
+   m_resizeUDFBufferMID(createJniMethod(*m_jniEnv, m_jniClass,
+            "resizeUDFBuffer", "(I)V")),
+   m_nextDependencyMID(createJniMethod(*m_jniEnv, m_jniClass,
+            "nextDependencyAsBytes", "(I)[B")),
+   m_traceLogMID(createJniMethod(*m_jniEnv, m_jniClass,
+            "traceLog", "(ZLjava/lang/String;Ljava/lang/String;)V")),
+   m_fragmentProgressUpdateMID(createJniMethod(*m_jniEnv, m_jniClass,
+            "fragmentProgressUpdate", "(IIJJJ)J")),
+   m_planForFragmentIdMID(createJniMethod(*m_jniEnv, m_jniClass,
+            "planForFragmentId", "(J)[B")),
+   m_crashVoltDBMID(createJniStaticMethod(*m_jniEnv, m_jniClass,
+            "crashVoltDB", "(Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;I)V")),
+   m_storeLargeTempTableBlockMID(createJniMethod(*m_jniEnv, m_jniClass,
+            "storeLargeTempTableBlock", "(JJLjava/nio/ByteBuffer;)Z")),
+   m_loadLargeTempTableBlockMID(createJniMethod(*m_jniEnv, m_jniClass,
+            "loadLargeTempTableBlock", "(JJLjava/nio/ByteBuffer;)Z")),
+   m_releaseLargeTempTableBlockMID(createJniMethod(*m_jniEnv, m_jniClass,
+            "releaseLargeTempTableBlock", "(JJ)Z")),
+   // export class' methods
+   m_pushExportBufferMID(createJniStaticMethod(*m_jniEnv, m_exportManagerClass,
+            "pushExportBuffer", "(ILjava/lang/String;JJLjava/nio/ByteBuffer;Z)V")),
+   m_pushExportEOFMID(createJniStaticMethod(*m_jniEnv, m_exportManagerClass,
+            "pushEndOfStream", "(ILjava/lang/String;)V")),
+   m_getQueuedExportBytesMID(createJniStaticMethod(*m_jniEnv, m_exportManagerClass,
+            "getQueuedExportBytes", "(ILjava/lang/String;)J")),
+   // DRGateway class' methods
+   m_pushDRBufferMID(createJniStaticMethod(*m_jniEnv, m_partitionDRGatewayClass,
+            "pushDRBuffer", "(IJJJJILjava/nio/ByteBuffer;)J")),
+   m_pushPoisonPillMID(createJniStaticMethod(*m_jniEnv, m_partitionDRGatewayClass,
+            "pushPoisonPill", "(ILjava/lang/String;Ljava/nio/ByteBuffer;)V")),
+   m_reportDRConflictMID(createJniStaticMethod(*m_jniEnv, m_partitionDRGatewayClass,
             "reportDRConflict",
-            "(IIJLjava/lang/String;IILjava/nio/ByteBuffer;Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;ILjava/nio/ByteBuffer;Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)I");
-    if (m_reportDRConflictMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_reportDRConflictMID != NULL);
-        throw std::exception();
-    }
-
-    m_decompressionClass = m_jniEnv->FindClass("org/voltdb/utils/CompressionService");
-    if (m_decompressionClass == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_decompressionClass != NULL);
-        throw std::exception();
-    }
-
-    m_decompressionClass = static_cast<jclass>(m_jniEnv->NewGlobalRef(m_decompressionClass));
-    if (m_decompressionClass == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_decompressionClass != NULL);
-        throw std::exception();
-    }
-
-    m_decodeBase64AndDecompressToBytesMID = m_jniEnv->GetStaticMethodID(
-            m_decompressionClass,
-            "decodeBase64AndDecompressToBytes",
-            "(Ljava/lang/String;)[B");
-    if (m_decodeBase64AndDecompressToBytesMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_decodeBase64AndDecompressToBytesMID != NULL);
-        throw std::exception();
-    }
-
-    m_storeLargeTempTableBlockMID = m_jniEnv->GetMethodID(jniClass,
-                                                          "storeLargeTempTableBlock",
-                                                          "(JJLjava/nio/ByteBuffer;)Z");
-    if (m_storeLargeTempTableBlockMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_storeLargeTempTableBlockMID != 0);
-        throw std::exception();
-    }
-
-    m_loadLargeTempTableBlockMID = m_jniEnv->GetMethodID(jniClass,
-                                                         "loadLargeTempTableBlock",
-                                                          "(JJLjava/nio/ByteBuffer;)Z");
-    if (m_loadLargeTempTableBlockMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_loadLargeTempTableBlockMID != 0);
-        throw std::exception();
-    }
-
-    m_releaseLargeTempTableBlockMID = m_jniEnv->GetMethodID(jniClass,
-                                                            "releaseLargeTempTableBlock",
-                                                            "(JJ)Z");
-    if (m_releaseLargeTempTableBlockMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        assert(m_releaseLargeTempTableBlockMID != 0);
-        throw std::exception();
-    }
-}
-
-
-void JNITopend::fallbackToEEAllocatedBuffer(char *buffer, size_t length) {
-    JNILocalFrameBarrier jni_frame = JNILocalFrameBarrier(m_jniEnv, 1);
-    if (jni_frame.checkResult() < 0) {
-        VOLT_ERROR("Unable to load dependency: jni frame error.");
-        throw std::exception();
-    }
-
-    jobject jbuffer = m_jniEnv->NewDirectByteBuffer(buffer, length);
-    if (jbuffer == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
-
-    m_jniEnv->CallVoidMethod(m_javaExecutionEngine, m_fallbackToEEAllocatedBufferMID, jbuffer);
-    if (m_jniEnv->ExceptionCheck()) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
-}
-
-int JNITopend::loadNextDependency(int32_t dependencyId, voltdb::Pool *stringPool, Table* destination) {
-    VOLT_DEBUG("iterating java dependency for id %d", dependencyId);
-
-    JNILocalFrameBarrier jni_frame = JNILocalFrameBarrier(m_jniEnv, 10);
-    if (jni_frame.checkResult() < 0) {
-        VOLT_ERROR("Unable to load dependency: jni frame error.");
-        throw std::exception();
-    }
-
-    jbyteArray jbuf = (jbyteArray)(m_jniEnv->CallObjectMethod(m_javaExecutionEngine,
-                                                              m_nextDependencyMID,
-                                                              dependencyId));
-
-    if (!jbuf) {
-        return 0;
-    }
-
-    jsize length = m_jniEnv->GetArrayLength(jbuf);
-    if (length > 0) {
-        jboolean is_copy;
-        jbyte *bytes = m_jniEnv->GetByteArrayElements(jbuf, &is_copy);
-        // Add the dependency buffer info to the stack object
-        // so it'll get cleaned up if loadTuplesFrom throws
-        jni_frame.addDependencyRef(is_copy, jbuf, bytes);
-        ReferenceSerializeInputBE serialize_in(bytes, length);
-        destination->loadTuplesFrom(serialize_in, stringPool);
-        return 1;
-    }
-    else {
-        return 0;
-    }
-}
-
-void JNITopend::traceLog(bool isBegin, const char *name, const char *args) {
-    jstring nameStr = m_jniEnv->NewStringUTF(name);
-    jstring argsStr = m_jniEnv->NewStringUTF(args);
-
-    m_jniEnv->CallVoidMethod(m_javaExecutionEngine, m_traceLogMID,
-                             isBegin ? JNI_TRUE : JNI_FALSE, nameStr, argsStr);
-
-    m_jniEnv->DeleteLocalRef(nameStr);
-    m_jniEnv->DeleteLocalRef(argsStr);
-
-    if (m_jniEnv->ExceptionCheck()) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
-}
-
-int64_t JNITopend::fragmentProgressUpdate(
-                int32_t batchIndex,
-                PlanNodeType planNodeType,
-                int64_t tuplesProcessed,
-                int64_t currMemoryInBytes,
-                int64_t peakMemoryInBytes) {
-    jlong nextStep = m_jniEnv->CallLongMethod(m_javaExecutionEngine,
-                                              m_fragmentProgressUpdateMID,
-                                              batchIndex,
-                                              static_cast<int32_t>(planNodeType),
-                                              tuplesProcessed,
-                                              currMemoryInBytes,
-                                              peakMemoryInBytes);
-    return (int64_t)nextStep;
-}
-
-// A local helper to convert a jbyteArray to an std::string.
-// Callers should be aware that an empty string may be returned if
-// jbuf is null.
-static std::string jbyteArrayToStdString(JNIEnv* jniEnv,
-                                         JNILocalFrameBarrier& jniFrame,
-                                         jbyteArray jbuf) {
-
-    if (!jbuf)
-        return "";
-
-    jsize length = jniEnv->GetArrayLength(jbuf);
-    if (length > 0) {
-        jboolean isCopy;
-        jbyte *bytes = jniEnv->GetByteArrayElements(jbuf, &isCopy);
-        jniFrame.addDependencyRef(isCopy, jbuf, bytes);
-        return std::string(reinterpret_cast<char*>(bytes), length);
-    }
-
-    return "";
- }
-
-std::string JNITopend::planForFragmentId(int64_t fragmentId) {
-    VOLT_DEBUG("fetching plan for id %d", (int) fragmentId);
-
-    JNILocalFrameBarrier jni_frame = JNILocalFrameBarrier(m_jniEnv, 10);
-    if (jni_frame.checkResult() < 0) {
-        VOLT_ERROR("Unable to load dependency: jni frame error.");
-        throw std::exception();
-    }
-
-    jbyteArray jbuf = (jbyteArray)(m_jniEnv->CallObjectMethod(m_javaExecutionEngine,
-                                                              m_planForFragmentIdMID,
-                                                              fragmentId));
-    // jbuf might be NULL or might have 0 length here.  In that case
-    // we'll return a 0-length string to the caller, who will return
-    // an appropriate error.
-    return jbyteArrayToStdString(m_jniEnv, jni_frame, jbuf);
-}
-
-std::string JNITopend::decodeBase64AndDecompress(const std::string& base64Str) {
-    JNILocalFrameBarrier jni_frame = JNILocalFrameBarrier(m_jniEnv, 2);
-    if (jni_frame.checkResult() < 0) {
-        VOLT_ERROR("Unable to load dependency: jni frame error.");
-        throw std::exception();
-    }
-
-    jstring jBase64Str = m_jniEnv->NewStringUTF(base64Str.c_str());
-    if (m_jniEnv->ExceptionCheck()) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
-
-    jbyteArray jbuf = (jbyteArray)m_jniEnv->CallStaticObjectMethod(m_decompressionClass,
-                                                                   m_decodeBase64AndDecompressToBytesMID,
-                                                                   jBase64Str);
-    return jbyteArrayToStdString(m_jniEnv, jni_frame, jbuf);
-}
-
-bool JNITopend::storeLargeTempTableBlock(LargeTempTableBlock* block) {
-    JNILocalFrameBarrier jni_frame = JNILocalFrameBarrier(m_jniEnv, 1);
-    if (jni_frame.checkResult() < 0) {
-        VOLT_ERROR("JNI frame error");
-        throw std::exception();
-    }
-
-    std::unique_ptr<char[]> storage = block->releaseData();
-    jobject blockByteBuffer = m_jniEnv->NewDirectByteBuffer(storage.get(), LargeTempTableBlock::BLOCK_SIZE_IN_BYTES);
-    if (blockByteBuffer == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
-
-    LargeTempTableBlockId blockId = block->id();
-    jboolean success = m_jniEnv->CallBooleanMethod(m_javaExecutionEngine,
-                                                   m_storeLargeTempTableBlockMID,
-                                                   blockId.getSiteId(),
-                                                   blockId.getBlockCounter(),
-                                                   blockByteBuffer);
-    // It's assumed that when control returns to this method the block
-    // will have been persisted to disk.  The memory for the block
-    // will be returned to the OS when above unique_ptr goes out of
-    // scope.
-    return success;
-}
-
-bool JNITopend::loadLargeTempTableBlock(LargeTempTableBlock* block) {
-    JNILocalFrameBarrier jni_frame = JNILocalFrameBarrier(m_jniEnv, 1);
-    if (jni_frame.checkResult() < 0) {
-        VOLT_ERROR("JNI frame error");
-        throw std::exception();
-    }
-
-    // Memory allocation should really be done by LargeTempTableBLock
-    // cache, and it should pass in the storage for the loaded block.
-    std::unique_ptr<char[]> storage(new char[LargeTempTableBlock::BLOCK_SIZE_IN_BYTES]);
-    jobject blockByteBuffer = m_jniEnv->NewDirectByteBuffer(storage.get(), LargeTempTableBlock::BLOCK_SIZE_IN_BYTES);
-    if (blockByteBuffer == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
-
-    bool success = m_jniEnv->CallBooleanMethod(m_javaExecutionEngine,
-                                               m_loadLargeTempTableBlockMID,
-                                               block->id(),
-                                               blockByteBuffer);
-    if (success) {
-        block->setData(std::move(storage));
-    }
-
-    return success;
-}
-
-bool JNITopend::releaseLargeTempTableBlock(LargeTempTableBlockId blockId) {
-    jboolean success = (jboolean)m_jniEnv->CallBooleanMethod(m_javaExecutionEngine,
-                                                             m_releaseLargeTempTableBlockMID,
-                                                             blockId.getSiteId(),
-                                                             blockId.getBlockCounter());
-    return success;
-}
-
-int32_t JNITopend::callJavaUserDefinedFunction() {
-    return (int32_t)m_jniEnv->CallIntMethod(m_javaExecutionEngine,
-                                            m_callJavaUserDefinedFunctionMID);
-}
-
-void JNITopend::resizeUDFBuffer(int32_t size) {
-    m_jniEnv->CallVoidMethod(m_javaExecutionEngine, m_resizeUDFBufferMID, size);
-}
-
-void JNITopend::crashVoltDB(FatalException e) {
-    //Enough references for the reason string, traces array, and traces strings
-    JNILocalFrameBarrier jni_frame =
-            JNILocalFrameBarrier(
-                    m_jniEnv,
-                    static_cast<int32_t>(e.m_traces.size()) + 4);
-    if (jni_frame.checkResult() < 0) {
-        VOLT_ERROR("Unable to load dependency: jni frame error.");
-        throw std::exception();
-    }
-    jstring jReason = m_jniEnv->NewStringUTF(e.m_reason.c_str());
-    if (m_jniEnv->ExceptionCheck()) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
-    jstring jFilename = m_jniEnv->NewStringUTF(e.m_filename);
-    if (m_jniEnv->ExceptionCheck()) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
-    jobjectArray jTracesArray =
-            m_jniEnv->NewObjectArray(
-                    static_cast<jsize>(e.m_traces.size()),
-                    m_jniEnv->FindClass("java/lang/String"),
-                    NULL);
-    if (m_jniEnv->ExceptionCheck()) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
-    for (int ii = 0; ii < e.m_traces.size(); ii++) {
-        jstring traceString = m_jniEnv->NewStringUTF(e.m_traces[ii].c_str());
-        m_jniEnv->SetObjectArrayElement( jTracesArray, ii, traceString);
-    }
-    m_jniEnv->CallStaticVoidMethod(
-            m_jniEnv->GetObjectClass(m_javaExecutionEngine),
-            m_crashVoltDBMID,
-            jReason,
-            jTracesArray,
-            jFilename,
-            static_cast<int32_t>(e.m_lineno));
-    throw std::exception();
-}
+            "(IIJLjava/lang/String;IILjava/nio/ByteBuffer;Ljava/nio/ByteBuffer;"
+            "Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;ILjava/nio/ByteBuffer;"
+            "Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)I")),
+   // CompressionService class' methods
+   m_decodeBase64AndDecompressToBytesMID(
+         createJniStaticMethod(*m_jniEnv, m_decompressionClass,
+            "decodeBase64AndDecompressToBytes", "(Ljava/lang/String;)[B")) { }
 
 JNITopend::~JNITopend() {
     m_jniEnv->DeleteGlobalRef(m_javaExecutionEngine);
@@ -543,215 +122,263 @@ JNITopend::~JNITopend() {
     m_jniEnv->DeleteGlobalRef(m_decompressionClass);
 }
 
-int64_t JNITopend::getQueuedExportBytes(int32_t partitionId, string signature) {
-    jstring signatureString = m_jniEnv->NewStringUTF(signature.c_str());
-    int64_t retval = m_jniEnv->CallStaticLongMethod(
-            m_exportManagerClass,
-            m_getQueuedExportBytesMID,
-            partitionId,
-            signatureString);
+void JNITopend::fallbackToEEAllocatedBuffer(char *buffer, size_t length) {
+    checkFrameBarrier(JNILocalFrameBarrier(m_jniEnv, 1));
+    jobject jbuffer = m_jniEnv->NewDirectByteBuffer(buffer, length);
+    checkJobject(jbuffer);
+    m_jniEnv->CallVoidMethod(m_javaExecutionEngine, m_fallbackToEEAllocatedBufferMID, jbuffer);
+    checkException();
+}
+
+int JNITopend::loadNextDependency(int32_t dependencyId, Pool *stringPool, Table* destination) {
+   VOLT_DEBUG("iterating java dependency for id %d", dependencyId);
+   JNILocalFrameBarrier jni_frame = JNILocalFrameBarrier(m_jniEnv, 10);
+   checkFrameBarrier(jni_frame);
+   const jbyteArray jbuf = reinterpret_cast<jbyteArray>(
+         m_jniEnv->CallObjectMethod(m_javaExecutionEngine, m_nextDependencyMID, dependencyId));
+   const jsize len = jbuf ? m_jniEnv->GetArrayLength(jbuf) : 0;
+   if (len > 0) {
+      jboolean is_copy;
+      jbyte *bytes = m_jniEnv->GetByteArrayElements(jbuf, &is_copy);
+      // Add the dependency buffer info to the stack object
+      // so it'll get cleaned up if loadTuplesFrom throws
+      jni_frame.addDependencyRef(is_copy, jbuf, bytes);
+      ReferenceSerializeInputBE serialize_in(bytes, len);
+      destination->loadTuplesFrom(serialize_in, stringPool);
+      return 1;
+   } else {
+      return 0;
+   }
+}
+
+void JNITopend::traceLog(bool isBegin, const char *name, const char *args) {
+    const jstring nameStr = m_jniEnv->NewStringUTF(name),
+          argsStr = m_jniEnv->NewStringUTF(args);
+    m_jniEnv->CallVoidMethod(m_javaExecutionEngine, m_traceLogMID,
+          isBegin ? JNI_TRUE : JNI_FALSE, nameStr, argsStr);
+    m_jniEnv->DeleteLocalRef(nameStr);
+    m_jniEnv->DeleteLocalRef(argsStr);
+    checkException();
+}
+
+int64_t JNITopend::fragmentProgressUpdate(int32_t batchIndex, PlanNodeType planNodeType,
+      int64_t tuplesProcessed, int64_t currMemoryInBytes, int64_t peakMemoryInBytes) {
+   return m_jniEnv->CallLongMethod(m_javaExecutionEngine, m_fragmentProgressUpdateMID,
+            batchIndex, static_cast<int32_t>(planNodeType), tuplesProcessed,
+            currMemoryInBytes, peakMemoryInBytes);
+}
+
+// A local helper to convert a jbyteArray to an std::string.
+// Callers should be aware that an empty string may be returned if
+// jbuf is null.
+static std::string jbyteArrayToStdString(JNIEnv* jniEnv, JNILocalFrameBarrier& jniFrame, jbyteArray jbuf) {
+   const jsize len = jbuf ? jniEnv->GetArrayLength(jbuf) : 0;
+   if (len > 0) {
+      jboolean isCopy;
+      jbyte *bytes = jniEnv->GetByteArrayElements(jbuf, &isCopy);
+      jniFrame.addDependencyRef(isCopy, jbuf, bytes);
+      return std::string(reinterpret_cast<char*>(bytes), len);
+   } else {
+      return "";
+   }
+}
+
+std::string JNITopend::planForFragmentId(int64_t fragmentId) {
+   VOLT_DEBUG("fetching plan for id %l", fragmentId);
+   JNILocalFrameBarrier jni_frame = JNILocalFrameBarrier(m_jniEnv, 10);
+   checkFrameBarrier(jni_frame);
+   // jbuf might be NULL or might have 0 length here.  In that case
+   // we'll return a 0-length string to the caller, who will return
+   // an appropriate error.
+   return jbyteArrayToStdString(m_jniEnv, jni_frame,
+         static_cast<jbyteArray>(m_jniEnv->CallObjectMethod(
+               m_javaExecutionEngine, m_planForFragmentIdMID, fragmentId)));
+}
+
+std::string JNITopend::decodeBase64AndDecompress(const std::string& base64Str) {
+   JNILocalFrameBarrier jni_frame = JNILocalFrameBarrier(m_jniEnv, 2);
+   checkFrameBarrier(jni_frame);
+   const jstring jBase64Str = m_jniEnv->NewStringUTF(base64Str.c_str());
+   checkException();
+   return jbyteArrayToStdString(m_jniEnv, jni_frame,
+         reinterpret_cast<jbyteArray>(m_jniEnv->CallStaticObjectMethod(m_decompressionClass,
+               m_decodeBase64AndDecompressToBytesMID, jBase64Str)));
+}
+
+bool JNITopend::storeLargeTempTableBlock(LargeTempTableBlock* block) {
+    checkFrameBarrier(JNILocalFrameBarrier(m_jniEnv, 1));
+    std::unique_ptr<char[]> storage = block->releaseData();
+    const jobject blockByteBuffer = m_jniEnv->NewDirectByteBuffer(
+          storage.get(), LargeTempTableBlock::BLOCK_SIZE_IN_BYTES);
+    checkJobject(blockByteBuffer);
+    const LargeTempTableBlockId blockId = block->id();
+    // It's assumed that when control returns to this method the block
+    // will have been persisted to disk.  The memory for the block
+    // will be returned to the OS when above unique_ptr goes out of
+    // scope.
+    return m_jniEnv->CallBooleanMethod(m_javaExecutionEngine, m_storeLargeTempTableBlockMID,
+          blockId.getSiteId(), blockId.getBlockCounter(), blockByteBuffer);
+}
+
+bool JNITopend::loadLargeTempTableBlock(LargeTempTableBlock* block) {
+    checkFrameBarrier(JNILocalFrameBarrier(m_jniEnv, 1));
+    // Memory allocation should really be done by LargeTempTableBLock
+    // cache, and it should pass in the storage for the loaded block.
+    std::unique_ptr<char[]> storage(new char[LargeTempTableBlock::BLOCK_SIZE_IN_BYTES]);
+    const jobject blockByteBuffer = m_jniEnv->NewDirectByteBuffer(
+          storage.get(), LargeTempTableBlock::BLOCK_SIZE_IN_BYTES);
+    checkJobject(blockByteBuffer);
+    const bool success = m_jniEnv->CallBooleanMethod(m_javaExecutionEngine,
+          m_loadLargeTempTableBlockMID, block->id(), blockByteBuffer);
+    if (success) {
+        block->setData(std::move(storage));
+    }
+    return success;
+}
+
+bool JNITopend::releaseLargeTempTableBlock(LargeTempTableBlockId const& blockId) {
+   return m_jniEnv->CallBooleanMethod(m_javaExecutionEngine,
+         m_releaseLargeTempTableBlockMID, blockId.getSiteId(),
+         blockId.getBlockCounter());
+}
+
+int32_t JNITopend::callJavaUserDefinedFunction() {
+   return m_jniEnv->CallIntMethod(m_javaExecutionEngine,
+         m_callJavaUserDefinedFunctionMID);
+}
+
+void JNITopend::resizeUDFBuffer(int32_t size) {
+    m_jniEnv->CallVoidMethod(m_javaExecutionEngine, m_resizeUDFBufferMID, size);
+}
+
+void JNITopend::crashVoltDB(FatalException const& e) {
+   //Enough references for the reason string, traces array, and traces strings
+   checkFrameBarrier(JNILocalFrameBarrier(m_jniEnv, e.traces().size() + 4));
+   const jstring jReason = m_jniEnv->NewStringUTF(e.what());
+   checkException();
+   const jstring jFilename = m_jniEnv->NewStringUTF(e.filename());
+   checkException();
+   const jobjectArray jTracesArray =
+      m_jniEnv->NewObjectArray(static_cast<jsize>(e.traces().size()),
+            m_jniEnv->FindClass("java/lang/String"), nullptr);
+   checkException();
+   for (int ii = 0; ii < e.traces().size(); ii++) {
+      const jstring traceString = m_jniEnv->NewStringUTF(e.traces()[ii].c_str());
+      m_jniEnv->SetObjectArrayElement(jTracesArray, ii, traceString);
+   }
+   m_jniEnv->CallStaticVoidMethod(m_jniEnv->GetObjectClass(m_javaExecutionEngine), m_crashVoltDBMID,
+         jReason, jTracesArray, jFilename, e.lineno());
+   throw e;
+}
+
+int64_t JNITopend::getQueuedExportBytes(int32_t partitionId, string const& signature) {
+    const jstring signatureString = m_jniEnv->NewStringUTF(signature.c_str());
+    const int64_t retval = m_jniEnv->CallStaticLongMethod(m_exportManagerClass, m_getQueuedExportBytesMID,
+          partitionId, signatureString);
     m_jniEnv->DeleteLocalRef(signatureString);
     return retval;
 }
 
-void JNITopend::pushExportBuffer(
-        int32_t partitionId,
-        string signature,
-        StreamBlock *block,
-        bool sync) {
-    jstring signatureString = m_jniEnv->NewStringUTF(signature.c_str());
-    if (block != NULL) {
-        jobject buffer = m_jniEnv->NewDirectByteBuffer( block->rawPtr(), block->rawLength());
-        if (buffer == NULL) {
-            m_jniEnv->ExceptionDescribe();
-            throw std::exception();
-        }
-
-        m_jniEnv->CallStaticVoidMethod(
-                m_exportManagerClass,
-                m_pushExportBufferMID,
-                partitionId,
-                signatureString,
-                block->uso(),
+void JNITopend::pushExportBuffer(int32_t partitionId, string const& signature,
+        StreamBlock *block, bool sync) {
+    const jstring signatureString = m_jniEnv->NewStringUTF(signature.c_str());
+    if (block != nullptr) {
+        const jobject buffer = m_jniEnv->NewDirectByteBuffer(block->rawPtr(), block->rawLength());
+        checkJobject(buffer);
+        m_jniEnv->CallStaticVoidMethod(m_exportManagerClass, m_pushExportBufferMID,
+                partitionId, signatureString, block->uso(),
                 reinterpret_cast<jlong>(block->rawPtr()),
-                buffer,
-                sync ? JNI_TRUE : JNI_FALSE);
+                buffer, sync ? JNI_TRUE : JNI_FALSE);
         m_jniEnv->DeleteLocalRef(buffer);
     } else {
-
-        m_jniEnv->CallStaticVoidMethod(
-                        m_exportManagerClass,
-                        m_pushExportBufferMID,
-                        partitionId,
-                        signatureString,
-                        static_cast<int64_t>(0),
-                        NULL,
-                        NULL,
-                        sync ? JNI_TRUE : JNI_FALSE);
+       m_jniEnv->CallStaticVoidMethod(m_exportManagerClass, m_pushExportBufferMID,
+             partitionId, signatureString, 0l, nullptr, nullptr,
+             sync ? JNI_TRUE : JNI_FALSE);
     }
     m_jniEnv->DeleteLocalRef(signatureString);
-    if (m_jniEnv->ExceptionCheck()) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
+    checkException();
 }
 
-void JNITopend::pushEndOfStream(
-        int32_t partitionId,
-        string signature) {
-    jstring signatureString = m_jniEnv->NewStringUTF(signature.c_str());
+void JNITopend::pushEndOfStream(int32_t partitionId, string const& signature) {
+    const jstring signatureString = m_jniEnv->NewStringUTF(signature.c_str());
     //std::cout << "Block is null" << std::endl;
-    m_jniEnv->CallStaticVoidMethod(
-                    m_exportManagerClass,
-                    m_pushExportEOFMID,
-                    partitionId,
-                    signatureString);
+    m_jniEnv->CallStaticVoidMethod(m_exportManagerClass, m_pushExportEOFMID,
+          partitionId, signatureString);
     m_jniEnv->DeleteLocalRef(signatureString);
-    if (m_jniEnv->ExceptionCheck()) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
+    checkException();
 }
 
 int64_t JNITopend::pushDRBuffer(int32_t partitionId, StreamBlock *block) {
-    int64_t retval = -1;
-    if (block != NULL) {
-        jobject buffer = m_jniEnv->NewDirectByteBuffer( block->rawPtr(), block->rawLength());
-        if (buffer == NULL) {
-            m_jniEnv->ExceptionDescribe();
-            throw std::exception();
-        }
-
-        retval = m_jniEnv->CallStaticLongMethod(
-                m_partitionDRGatewayClass,
-                m_pushDRBufferMID,
-                partitionId,
-                block->startDRSequenceNumber(),
-                block->lastDRSequenceNumber(),
-                block->lastSpUniqueId(),
-                block->lastMpUniqueId(),
-                block->drEventType(),
-                buffer);
-        m_jniEnv->DeleteLocalRef(buffer);
+    if (block == nullptr) {
+       return -1l;
+    } else {
+       const jobject buffer = m_jniEnv->NewDirectByteBuffer(block->rawPtr(), block->rawLength());
+       checkJobject(buffer);
+       int64_t retVal = m_jniEnv->CallStaticLongMethod(m_partitionDRGatewayClass, m_pushDRBufferMID, partitionId,
+             block->startDRSequenceNumber(), block->lastDRSequenceNumber(), block->lastSpUniqueId(),
+             block->lastMpUniqueId(), block->drEventType(), buffer);
+       m_jniEnv->DeleteLocalRef(buffer);
+       return retVal;
     }
-    return retval;
 }
 
 void JNITopend::pushPoisonPill(int32_t partitionId, std::string& reason, StreamBlock *block) {
-    jstring jReason = m_jniEnv->NewStringUTF(reason.c_str());
-
-    if (block != NULL) {
-        jobject buffer = m_jniEnv->NewDirectByteBuffer( block->rawPtr(), block->rawLength());
-        if (buffer == NULL) {
-            m_jniEnv->ExceptionDescribe();
-            throw std::exception();
-        }
-
-        m_jniEnv->CallStaticLongMethod(
-                m_partitionDRGatewayClass,
-                m_pushPoisonPillMID,
-                partitionId,
-                jReason,
-                buffer);
+    const jstring jReason = m_jniEnv->NewStringUTF(reason.c_str());
+    if (block != nullptr) {
+        const jobject buffer = m_jniEnv->NewDirectByteBuffer( block->rawPtr(), block->rawLength());
+        checkJobject(buffer);
+        m_jniEnv->CallStaticLongMethod(m_partitionDRGatewayClass, m_pushPoisonPillMID,
+              partitionId, jReason, buffer);
         m_jniEnv->DeleteLocalRef(buffer);
     }
     m_jniEnv->DeleteLocalRef(jReason);
 }
 
-static boost::shared_array<char> serializeToDirectByteBuffer(JNIEnv *jniEngine, Table *table, jobject &byteBuffer) {
+static std::unique_ptr<char[]> serializeToDirectByteBuffer(JNIEnv *jniEngine, Table* table, jobject& byteBuffer) {
     if (table) {
-        size_t serializeSize = table->getAccurateSizeToSerialize();
-        boost::shared_array<char> backingArray(new char[serializeSize]);
+        const size_t serializeSize = table->getAccurateSizeToSerialize();
+        std::unique_ptr<char[]> backingArray(new char[serializeSize]);
         ReferenceSerializeOutput conflictSerializeOutput(backingArray.get(), serializeSize);
         table->serializeToWithoutTotalSize(conflictSerializeOutput);
         byteBuffer = jniEngine->NewDirectByteBuffer(static_cast<void*>(backingArray.get()),
-                                                            static_cast<int32_t>(serializeSize));
-        if (byteBuffer == NULL) {
-            jniEngine->ExceptionDescribe();
-            throw std::exception();
+              static_cast<int32_t>(serializeSize));
+       if (byteBuffer == nullptr) {
+           jniEngine->ExceptionDescribe();
+           throw std::runtime_error("serializeToDirectByteBuffer");
+        } else {
+           return backingArray;
         }
-        return backingArray;
+    } else {
+       return std::unique_ptr<char[]>();
     }
-    return boost::shared_array<char>();
 }
 
 int JNITopend::reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, DRRecordType action,
-        DRConflictType deleteConflict, Table *existingMetaTableForDelete, Table *existingTupleTableForDelete,
-        Table *expectedMetaTableForDelete, Table *expectedTupleTableForDelete,
-        DRConflictType insertConflict, Table *existingMetaTableForInsert, Table *existingTupleTableForInsert,
-        Table *newMetaTableForInsert, Table *newTupleTableForInsert) {
-    // prepare tablename
-    jstring tableNameString = m_jniEnv->NewStringUTF(tableName.c_str());
-
-    // prepare input buffer for delete conflict
-    jobject existingMetaRowsBufferForDelete = NULL;
-    boost::shared_array<char> existingMetaArrayForDelete = serializeToDirectByteBuffer(m_jniEnv,
-                                                                                       existingMetaTableForDelete,
-                                                                                       existingMetaRowsBufferForDelete);
-
-    jobject existingTupleRowsBufferForDelete = NULL;
-    boost::shared_array<char> existingTupleArrayForDelete = serializeToDirectByteBuffer(m_jniEnv,
-                                                                                        existingTupleTableForDelete,
-                                                                                        existingTupleRowsBufferForDelete);
-
-    jobject expectedMetaRowsBufferForDelete = NULL;
-    boost::shared_array<char> expectedMetaArrayForDelete = serializeToDirectByteBuffer(m_jniEnv,
-                                                                                       expectedMetaTableForDelete,
-                                                                                       expectedMetaRowsBufferForDelete);
-
-    jobject expectedTupleRowsBufferForDelete = NULL;
-    boost::shared_array<char> expectedTupleArrayForDelete = serializeToDirectByteBuffer(m_jniEnv,
-                                                                                        expectedTupleTableForDelete,
-                                                                                        expectedTupleRowsBufferForDelete);
-
-    jobject existingMetaRowsBufferForInsert = NULL;
-    boost::shared_array<char> existingMetaArrayForInsert = serializeToDirectByteBuffer(m_jniEnv,
-                                                                                       existingMetaTableForInsert,
-                                                                                       existingMetaRowsBufferForInsert);
-
-    jobject existingTupleRowsBufferForInsert = NULL;
-    boost::shared_array<char> existingTupleArrayForInsert = serializeToDirectByteBuffer(m_jniEnv,
-                                                                                        existingTupleTableForInsert,
-                                                                                        existingTupleRowsBufferForInsert);
-
-    jobject newMetaRowsBufferForInsert = NULL;
-    boost::shared_array<char> newMetaArrayForInsert = serializeToDirectByteBuffer(m_jniEnv,
-                                                                                  newMetaTableForInsert,
-                                                                                  newMetaRowsBufferForInsert);
-
-    jobject newTupleRowsBufferForInsert = NULL;
-    boost::shared_array<char> newTupleArrayForInsert = serializeToDirectByteBuffer(m_jniEnv,
-                                                                                   newTupleTableForInsert,
-                                                                                   newTupleRowsBufferForInsert);
-
-    int32_t retval = m_jniEnv->CallStaticIntMethod(m_partitionDRGatewayClass,
-                                            m_reportDRConflictMID,
-                                            partitionId,
-                                            remoteClusterId,
-                                            remoteTimestamp,
-                                            tableNameString,
-                                            action,
-                                            deleteConflict,
-                                            existingMetaRowsBufferForDelete,
-                                            existingTupleRowsBufferForDelete,
-                                            expectedMetaRowsBufferForDelete,
-                                            expectedTupleRowsBufferForDelete,
-                                            insertConflict,
-                                            existingMetaRowsBufferForInsert,
-                                            existingTupleRowsBufferForInsert,
-                                            newMetaRowsBufferForInsert,
-                                            newTupleRowsBufferForInsert);
-
-    m_jniEnv->DeleteLocalRef(tableNameString);
-    m_jniEnv->DeleteLocalRef(existingMetaRowsBufferForDelete);
-    m_jniEnv->DeleteLocalRef(existingTupleRowsBufferForDelete);
-    m_jniEnv->DeleteLocalRef(expectedMetaRowsBufferForDelete);
-    m_jniEnv->DeleteLocalRef(expectedTupleRowsBufferForDelete);
-    m_jniEnv->DeleteLocalRef(existingMetaRowsBufferForInsert);
-    m_jniEnv->DeleteLocalRef(existingTupleRowsBufferForInsert);
-    m_jniEnv->DeleteLocalRef(newMetaRowsBufferForInsert);
-    m_jniEnv->DeleteLocalRef(newTupleRowsBufferForInsert);
-
-    return retval;
+        DRConflictType deleteConflict, Table* existingMetaTableForDelete, Table* existingTupleTableForDelete,
+        Table* expectedMetaTableForDelete, Table* expectedTupleTableForDelete,
+        DRConflictType insertConflict, Table* existingMetaTableForInsert, Table* existingTupleTableForInsert,
+        Table* newMetaTableForInsert, Table* newTupleTableForInsert) {
+   // prepare tablename
+   const jstring tableNameString = m_jniEnv->NewStringUTF(tableName.c_str());
+   // prepare input buffer for delete conflict
+   std::array<Table*, 8> tbls {
+      existingMetaTableForDelete, existingTupleTableForDelete, expectedMetaTableForDelete,
+         expectedTupleTableForDelete, existingMetaTableForInsert, existingTupleTableForInsert,
+         newMetaTableForInsert, newTupleTableForInsert
+   };
+   std::array<jobject, 8> buffers{nullptr};
+   std::array<std::unique_ptr<char[]>, 8> expected{};
+   for (int index = 0; index < 8; ++index) {
+      expected[index] = serializeToDirectByteBuffer(m_jniEnv, tbls[index], buffers[index]);
+   }
+   const int retval = m_jniEnv->CallStaticIntMethod(m_partitionDRGatewayClass, m_reportDRConflictMID,
+         partitionId, remoteClusterId, remoteTimestamp, tableNameString, action, deleteConflict,
+         buffers[0], buffers[1], buffers[2], buffers[3], insertConflict,
+         buffers[4], buffers[5], buffers[6], buffers[7]);
+   m_jniEnv->DeleteLocalRef(tableNameString);
+   for (jobject obj : buffers) {
+      m_jniEnv->DeleteLocalRef(obj);
+   }
+   return retval;
 }
-}
+

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -15,97 +15,142 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef JNITOPEND_H_
-#define JNITOPEND_H_
+#pragma once
 #include <jni.h>
 
-#include "boost/shared_array.hpp"
-#include "common/Topend.h"
 #include "common/FatalException.hpp"
-#include "common/LargeTempTableBlockId.hpp"
-#include "common/Pool.hpp"
+#include "common/Topend.h"
 
 namespace voltdb {
+   class Pool;
+   class LargeTempTableBlockId;
+   // Create an instance of this class on the stack to release all local
+   // references created during its lifetime.
+   class JNILocalFrameBarrier {
+      JNIEnv * m_env;
+      const int32_t m_refs;
+      const int32_t m_result;
+      jboolean m_isCopy = JNI_FALSE;
+      jbyteArray m_jbuf = nullptr;
+      jbyte* m_bytes = nullptr;
+   public:
+      JNILocalFrameBarrier(JNIEnv* env, int32_t numReferences) :
+         m_env(env), m_refs(numReferences), m_result(m_env->PushLocalFrame(m_refs)) {}
+      ~JNILocalFrameBarrier() {
+         if (m_isCopy == JNI_TRUE) {
+            m_env->ReleaseByteArrayElements(m_jbuf, m_bytes, 0);
+         }
+         // pass jobject* to get pointer to previous frame?
+         m_env->PopLocalFrame(nullptr);
+      }
+      void addDependencyRef(jboolean isCopy, jbyteArray jbuf, jbyte* bytes) {
+         m_isCopy = isCopy;
+         m_jbuf = jbuf;
+         m_bytes = bytes;
+      }
+      int32_t checkResult() const {
+         return m_result;
+      }
+   };
 
-class JNITopend : public Topend {
-    JNIEnv *m_jniEnv;
+   class JNITopend : public Topend {
+      JNIEnv *m_jniEnv;
 
-    /**
-     * JNI object corresponding to this engine. for callback functions.
-     * if this is NULL, VoltDBEngine will fail to call sendDependency().
-    */
-    jobject m_javaExecutionEngine;
-    jmethodID m_fallbackToEEAllocatedBufferMID;
-    jmethodID m_nextDependencyMID;
-    jmethodID m_traceLogMID;
-    jmethodID m_fragmentProgressUpdateMID;
-    jmethodID m_planForFragmentIdMID;
-    jmethodID m_crashVoltDBMID;
-    jmethodID m_pushExportBufferMID;
-    jmethodID m_pushExportEOFMID;
-    jmethodID m_getQueuedExportBytesMID;
-    jmethodID m_pushDRBufferMID;
-    jmethodID m_pushPoisonPillMID;
-    jmethodID m_reportDRConflictMID;
-    jmethodID m_decodeBase64AndDecompressToBytesMID;
-    jmethodID m_callJavaUserDefinedFunctionMID;
-    jmethodID m_resizeUDFBufferMID;
-    jmethodID m_storeLargeTempTableBlockMID;
-    jmethodID m_loadLargeTempTableBlockMID;
-    jmethodID m_releaseLargeTempTableBlockMID;
-    jclass m_exportManagerClass;
-    jclass m_partitionDRGatewayClass;
-    jclass m_decompressionClass;
-public:
-    JNITopend(JNIEnv *env, jobject caller);
-    ~JNITopend();
+      /**
+       * JNI object corresponding to this engine. for callback functions.
+       * if this is NULL, VoltDBEngine will fail to call sendDependency().
+       */
+      const jobject m_javaExecutionEngine;
+      const jclass m_jniClass,
+            m_exportManagerClass,
+            m_partitionDRGatewayClass,
+            m_decompressionClass;
+      /**
+       * Cache the method id for better performance. It is valid until the JVM unloads the class:
+       * http://java.sun.com/javase/6/docs/technotes/guides/jni/spec/design.html#wp17074
+       *
+       * The jmethodID, jclass, etc. are all typedefs of raw pointer.
+       */
 
-    inline JNITopend* updateJNIEnv(JNIEnv *env) { m_jniEnv = env; return this; }
-    int loadNextDependency(int32_t dependencyId, Pool *stringPool, Table* destination) override;
-    void traceLog(bool isBegin,
-                  const char *name,
-                  const char *args);
-    int64_t fragmentProgressUpdate(
-                int32_t batchIndex,
-                PlanNodeType planNodeType,
-                int64_t tuplesProcessed,
-                int64_t currMemoryInBytes,
-                int64_t peakMemoryInBytes) override;
-    std::string planForFragmentId(int64_t fragmentId) override;
-    void crashVoltDB(FatalException e) override;
-    int64_t getQueuedExportBytes(int32_t partitionId, std::string signature) override;
-    void pushExportBuffer(
-            int32_t partitionId,
-            std::string signature,
-            StreamBlock *block,
-            bool sync) override;
-    void pushEndOfStream(
-            int32_t partitionId,
-            std::string signature) override;
+      const jmethodID m_fallbackToEEAllocatedBufferMID,   // from class of m_javaExecutionEngine
+            m_callJavaUserDefinedFunctionMID,
+            m_resizeUDFBufferMID,
+            m_nextDependencyMID,
+            m_traceLogMID,
+            m_fragmentProgressUpdateMID,
+            m_planForFragmentIdMID,
+            m_crashVoltDBMID,
+            m_storeLargeTempTableBlockMID,
+            m_loadLargeTempTableBlockMID,
+            m_releaseLargeTempTableBlockMID;
 
-    int64_t pushDRBuffer(int32_t partitionId, StreamBlock *block) override;
+      const jmethodID m_pushExportBufferMID,              // from class m_exportManagerClass
+            m_pushExportEOFMID,
+            m_getQueuedExportBytesMID;
 
-    void pushPoisonPill(int32_t partitionId, std::string& reason, StreamBlock *block) override;
+      const jmethodID m_pushDRBufferMID,                  // from class m_partitionDRGatewayClass
+            m_pushPoisonPillMID,
+            m_reportDRConflictMID;
 
-    int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, DRRecordType action,
-            DRConflictType deleteConflict, Table *existingMetaTableForDelete, Table *existingTupleTableForDelete,
-            Table *expectedMetaTableForDelete, Table *expectedTupleTableForDelete,
-            DRConflictType insertConflict, Table *existingMetaTableForInsert, Table *existingTupleTableForInsert,
-            Table *newMetaTableForInsert, Table *newTupleTableForInsert) override;
+      const jmethodID m_decodeBase64AndDecompressToBytesMID;    // from class m_decompressionClass
+      // Helper methods for the constructor
+      static jclass getJClass(JNIEnv& env, const jobject& engine);
+      static jmethodID createJniMethod(JNIEnv& env, const jclass jClass, const char* name, const char* signature);
+      static jmethodID createJniStaticMethod(JNIEnv& env, const jclass jClass,
+            const char* name, const char* signature);
+      template<typename jptr_type> static jptr_type checked(jptr_type id, JNIEnv& env,
+            const char* name, const char* signature = "");
 
-    void fallbackToEEAllocatedBuffer(char *buffer, size_t length) override;
+      void checkJobject(jobject const ptr) const {
+         if (ptr == NULL) {
+            m_jniEnv->ExceptionDescribe();
+            throw std::runtime_error("jobject is null");
+         }
+      }
+      void checkException() const {
+         if (m_jniEnv->ExceptionCheck()) {
+            m_jniEnv->ExceptionDescribe();
+            throw std::runtime_error("Failed JNI Env exception check");
+         }
+      }
+      void checkFrameBarrier(JNILocalFrameBarrier const& barrier) const {
+         if (barrier.checkResult() < 0) {
+            VOLT_ERROR("Unable to load dependency: jni frame error.");
+            throw std::runtime_error("Unable to load dependency: jni frame error.");
+         }
+      }
+   public:
+      JNITopend(JNIEnv *env, jobject caller);
+      ~JNITopend();
 
-    std::string decodeBase64AndDecompress(const std::string& buffer) override;
-
-    bool storeLargeTempTableBlock(LargeTempTableBlock* block) override;
-
-    bool loadLargeTempTableBlock(LargeTempTableBlock* block) override;
-
-    bool releaseLargeTempTableBlock(LargeTempTableBlockId blockId) override;
-
-    int32_t callJavaUserDefinedFunction() override;
-    void resizeUDFBuffer(int32_t size) override;
-};
-
+      JNITopend& updateJNIEnv(JNIEnv *env) {
+         m_jniEnv = env;
+         return *this;
+      }
+      int loadNextDependency(int32_t dependencyId, Pool *stringPool, Table* destination) override;
+      void traceLog(bool isBegin, const char *name, const char *args);
+      int64_t fragmentProgressUpdate(int32_t batchIndex, PlanNodeType planNodeType,
+            int64_t tuplesProcessed, int64_t currMemoryInBytes, int64_t peakMemoryInBytes) override;
+      std::string planForFragmentId(int64_t fragmentId) override;
+      void crashVoltDB(FatalException const& e) override;
+      int64_t getQueuedExportBytes(int32_t partitionId, std::string const& signature) override;
+      void pushExportBuffer(int32_t partitionId, std::string const& signature,
+            StreamBlock *block, bool sync) override;
+      void pushEndOfStream( int32_t partitionId, std::string const& signature) override;
+      int64_t pushDRBuffer(int32_t partitionId, StreamBlock *block) override;
+      void pushPoisonPill(int32_t partitionId, std::string& reason, StreamBlock *block) override;
+      int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, DRRecordType action,
+            DRConflictType deleteConflict, Table* existingMetaTableForDelete, Table* existingTupleTableForDelete,
+            Table* expectedMetaTableForDelete, Table* expectedTupleTableForDelete,
+            DRConflictType insertConflict, Table* existingMetaTableForInsert, Table* existingTupleTableForInsert,
+            Table* newMetaTableForInsert, Table* newTupleTableForInsert) override;
+      void fallbackToEEAllocatedBuffer(char *buffer, size_t length) override;
+      std::string decodeBase64AndDecompress(const std::string& buffer) override;
+      bool storeLargeTempTableBlock(LargeTempTableBlock* block) override;
+      bool loadLargeTempTableBlock(LargeTempTableBlock* block) override;
+      bool releaseLargeTempTableBlock(LargeTempTableBlockId const& blockId) override;
+      int32_t callJavaUserDefinedFunction() override;
+      void resizeUDFBuffer(int32_t size) override;
+   };
 }
-#endif /* JNITOPEND_H_ */
+

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -28,57 +28,6 @@
 namespace voltdb {
 
 class JNITopend : public Topend {
-public:
-    JNITopend(JNIEnv *env, jobject caller);
-    ~JNITopend();
-
-    inline JNITopend* updateJNIEnv(JNIEnv *env) { m_jniEnv = env; return this; }
-    int loadNextDependency(int32_t dependencyId, Pool *stringPool, Table* destination);
-    void traceLog(bool isBegin,
-                  const char *name,
-                  const char *args);
-    int64_t fragmentProgressUpdate(
-                int32_t batchIndex,
-                PlanNodeType planNodeType,
-                int64_t tuplesProcessed,
-                int64_t currMemoryInBytes,
-                int64_t peakMemoryInBytes);
-    std::string planForFragmentId(int64_t fragmentId);
-    void crashVoltDB(FatalException e);
-    int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);
-    void pushExportBuffer(
-            int32_t partitionId,
-            std::string signature,
-            StreamBlock *block,
-            bool sync);
-    void pushEndOfStream(
-            int32_t partitionId,
-            std::string signature);
-
-    int64_t pushDRBuffer(int32_t partitionId, StreamBlock *block);
-
-    void pushPoisonPill(int32_t partitionId, std::string& reason, StreamBlock *block);
-
-    int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, DRRecordType action,
-            DRConflictType deleteConflict, Table *existingMetaTableForDelete, Table *existingTupleTableForDelete,
-            Table *expectedMetaTableForDelete, Table *expectedTupleTableForDelete,
-            DRConflictType insertConflict, Table *existingMetaTableForInsert, Table *existingTupleTableForInsert,
-            Table *newMetaTableForInsert, Table *newTupleTableForInsert);
-
-    void fallbackToEEAllocatedBuffer(char *buffer, size_t length);
-
-    std::string decodeBase64AndDecompress(const std::string& buffer);
-
-    bool storeLargeTempTableBlock(LargeTempTableBlock* block);
-
-    bool loadLargeTempTableBlock(LargeTempTableBlock* block);
-
-    bool releaseLargeTempTableBlock(LargeTempTableBlockId blockId);
-
-    int32_t callJavaUserDefinedFunction();
-    void resizeUDFBuffer(int32_t size);
-
-private:
     JNIEnv *m_jniEnv;
 
     /**
@@ -107,6 +56,55 @@ private:
     jclass m_exportManagerClass;
     jclass m_partitionDRGatewayClass;
     jclass m_decompressionClass;
+public:
+    JNITopend(JNIEnv *env, jobject caller);
+    ~JNITopend();
+
+    inline JNITopend* updateJNIEnv(JNIEnv *env) { m_jniEnv = env; return this; }
+    int loadNextDependency(int32_t dependencyId, Pool *stringPool, Table* destination) override;
+    void traceLog(bool isBegin,
+                  const char *name,
+                  const char *args);
+    int64_t fragmentProgressUpdate(
+                int32_t batchIndex,
+                PlanNodeType planNodeType,
+                int64_t tuplesProcessed,
+                int64_t currMemoryInBytes,
+                int64_t peakMemoryInBytes) override;
+    std::string planForFragmentId(int64_t fragmentId) override;
+    void crashVoltDB(FatalException e) override;
+    int64_t getQueuedExportBytes(int32_t partitionId, std::string signature) override;
+    void pushExportBuffer(
+            int32_t partitionId,
+            std::string signature,
+            StreamBlock *block,
+            bool sync) override;
+    void pushEndOfStream(
+            int32_t partitionId,
+            std::string signature) override;
+
+    int64_t pushDRBuffer(int32_t partitionId, StreamBlock *block) override;
+
+    void pushPoisonPill(int32_t partitionId, std::string& reason, StreamBlock *block) override;
+
+    int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, DRRecordType action,
+            DRConflictType deleteConflict, Table *existingMetaTableForDelete, Table *existingTupleTableForDelete,
+            Table *expectedMetaTableForDelete, Table *expectedTupleTableForDelete,
+            DRConflictType insertConflict, Table *existingMetaTableForInsert, Table *existingTupleTableForInsert,
+            Table *newMetaTableForInsert, Table *newTupleTableForInsert) override;
+
+    void fallbackToEEAllocatedBuffer(char *buffer, size_t length) override;
+
+    std::string decodeBase64AndDecompress(const std::string& buffer) override;
+
+    bool storeLargeTempTableBlock(LargeTempTableBlock* block) override;
+
+    bool loadLargeTempTableBlock(LargeTempTableBlock* block) override;
+
+    bool releaseLargeTempTableBlock(LargeTempTableBlockId blockId) override;
+
+    int32_t callJavaUserDefinedFunction() override;
+    void resizeUDFBuffer(int32_t size) override;
 };
 
 }

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1650,7 +1650,7 @@ VoltDBEngine::loadTable(int32_t tableId,
             // This is legacy behavior.  Perhaps we cannot be ensured of data integrity for some mysterious
             // other kind of exception?
             s_loadTableException = serializableExc.getType();
-            throwFatalException("%s", serializableExc.message().c_str());
+            throwFatalException("%s", serializableExc.what());
         }
 
         if (table->isCatalogTableReplicated() && returnConflictRows) {

--- a/src/ee/executors/materializeexecutor.cpp
+++ b/src/ee/executors/materializeexecutor.cpp
@@ -130,9 +130,8 @@ bool MaterializeExecutor::p_execute(const NValueArray &params) {
             try {
                 temp_tuple.setNValue(ctr, params[m_allParamArray[ctr]]);
             } catch (SQLException& ex) {
-                std::string errorMsg = ex.message()
-                                    + " '" + (m_outputTable -> getColumnNames()).at(ctr) + "'";
-
+                std::string errorMsg(ex.what());
+                errorMsg.append(" '").append(m_outputTable -> getColumnNames().at(ctr)).append("'");
                 throw SQLException(ex.getSqlState(), errorMsg, ex.getInternalFlags());
             }
         }
@@ -145,9 +144,8 @@ bool MaterializeExecutor::p_execute(const NValueArray &params) {
             try {
                 temp_tuple.setNValue(ctr, m_expressionArray[ctr]->eval(&dummy, NULL));
             } catch (SQLException& ex) {
-                std::string errorMsg = ex.message()
-                                    + " '" + (m_outputTable -> getColumnNames()).at(ctr) + "'";
-
+                std::string errorMsg(ex.what());
+                errorMsg.append(" '").append(m_outputTable -> getColumnNames().at(ctr)).append("'");
                 throw SQLException(ex.getSqlState(), errorMsg, ex.getInternalFlags());
             }
         }

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -191,9 +191,11 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
                         tempTuple.setNValue(m_inputTargetMap[map_ctr].second,
                                         m_inputTuple.getNValue(m_inputTargetMap[map_ctr].first));
                     } catch (SQLException& ex) {
-                        std::string errorMsg = ex.message()
-                                + " '" + (targetTable->getColumnNames()).at(m_inputTargetMap[map_ctr].second) + "'";
-                        throw SQLException(ex.getSqlState(), errorMsg, ex.getInternalFlags());
+                       std::string errorMsg(ex.what());
+                       errorMsg.append(" '")
+                          .append(targetTable->getColumnNames().at(m_inputTargetMap[map_ctr].second))
+                          .append("'");
+                       throw SQLException(ex.getSqlState(), errorMsg, ex.getInternalFlags());
                     }
                 }
 

--- a/src/ee/logging/StdoutLogProxy.h
+++ b/src/ee/logging/StdoutLogProxy.h
@@ -26,7 +26,7 @@ namespace voltdb {
  * A log proxy implementation that logs all messages to stdout.
  */
 class StdoutLogProxy : public LogProxy {
-
+public:
     /**
      * Log a statement on behalf of the specified logger at the specified log level
      * @param LoggerId ID of the logger that received this statement

--- a/src/ee/storage/ConstraintFailureException.h
+++ b/src/ee/storage/ConstraintFailureException.h
@@ -34,6 +34,15 @@ class VoltDBEngine;
  * A constraint exception is generated when an update or an insert on a table violates a constraint
  */
 class ConstraintFailureException: public SQLException {
+    Table *m_table;
+    TableTuple m_tuple;
+    TableTuple m_otherTuple;
+    ConstraintType m_type;
+    PersistentTableSurgeon *m_surgeon;
+
+    static std::string enrichedMessage(ConstraintType const& type,
+          std::string const& tblName, TableTuple const& curTuple,
+          TableTuple const& otherTuple);
 public:
     /**
      * General constructor for for CFE
@@ -43,7 +52,9 @@ public:
      * @param otherTuple updated tuple values or a null tuple.
      * @param type Type of constraint that was violated
      */
-    ConstraintFailureException(Table *table, TableTuple tuple, TableTuple otherTuple, ConstraintType type, PersistentTableSurgeon *surgeon =  NULL);
+    ConstraintFailureException(Table *table, TableTuple const& tuple,
+          TableTuple const& otherTuple, ConstraintType const& type,
+          PersistentTableSurgeon *surgeon =  NULL);
 
     /**
      * Special constructor for partitioning error CFEs only
@@ -52,21 +63,17 @@ public:
      * @param tuple Tuple that was being inserted or updated
      * @param message Description of the partitioning failure.
      */
-    ConstraintFailureException(Table *table, TableTuple tuple, std::string message, PersistentTableSurgeon *surgeon =  NULL);
-
-    virtual const std::string message() const;
+    ConstraintFailureException(Table *table, TableTuple const& tuple,
+          std::string const& message, PersistentTableSurgeon *surgeon =  NULL);
     virtual ~ConstraintFailureException();
-
-    const TableTuple* getConflictTuple() const { return &m_tuple; }
-    const TableTuple* getOriginalTuple() const { return &m_otherTuple; }
+    const TableTuple* getConflictTuple() const {
+       return &m_tuple;
+    }
+    const TableTuple* getOriginalTuple() const {
+       return &m_otherTuple;
+    }
 protected:
     void p_serialize(ReferenceSerializeOutput *output) const;
-
-    Table *m_table;
-    TableTuple m_tuple;
-    TableTuple m_otherTuple;
-    ConstraintType m_type;
-    PersistentTableSurgeon *m_surgeon;
 };
 
 }

--- a/src/ee/storage/tableiterator.cpp
+++ b/src/ee/storage/tableiterator.cpp
@@ -1,0 +1,313 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This file contains original code and/or modifications of original code.
+ * Any modifications made by VoltDB Inc. are licensed under the following
+ * terms and conditions:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* Copyright (C) 2008 by H-Store Project
+ * Brown University
+ * Massachusetts Institute of Technology
+ * Yale University
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "tableiterator.h"
+using namespace voltdb;
+
+// Construct iterator for persistent tables
+TableIterator::TableIterator(Table *parent, TBMapI start)
+    : m_table(parent)
+    , m_tupleLength(parent->m_tupleLength)
+    , m_activeTuples((int) m_table->m_tupleCount)
+    , m_iteratorType(PERSISTENT)
+    , m_state(start)
+{
+}
+
+// Construct iterator for temp tables
+TableIterator::TableIterator(Table *parent, std::vector<TBPtr>::iterator start, bool deleteAsGo)
+    : m_table(parent)
+    , m_tupleLength(parent->m_tupleLength)
+    , m_activeTuples((int) m_table->m_tupleCount)
+    , m_iteratorType(TEMP)
+    , m_state(start, deleteAsGo)
+{
+}
+
+//  Construct an iterator for large temp tables
+TableIterator::TableIterator(Table *parent, std::vector<LargeTempTableBlockId>::iterator start, bool deleteAsGo)
+    : m_table(parent)
+    , m_tupleLength(parent->m_tupleLength)
+    , m_activeTuples((int) m_table->m_tupleCount)
+    , m_iteratorType(LARGE_TEMP)
+    , m_state(start, deleteAsGo)
+{
+}
+
+// Construct an iterator from another iterator
+TableIterator::TableIterator(const TableIterator &that)
+    : m_table(that.m_table)
+    , m_tupleLength(that.m_tupleLength)
+    , m_activeTuples(that.m_activeTuples)
+    , m_foundTuples(that.m_foundTuples)
+    , m_dataPtr(that.m_dataPtr)
+    , m_dataEndPtr(that.m_dataEndPtr)
+    , m_iteratorType(that.m_iteratorType)
+    , m_state(that.m_state)
+{
+    // This assertion could fail if we are copying an invalid iterator
+    // (table changed after iterator was created)
+    assert (that.m_table->m_tupleCount == that.m_activeTuples);
+}
+
+TableIterator& TableIterator::operator=(const TableIterator& that) {
+    // This assertion could fail if we are copying an invalid iterator
+    // (table changed after iterator was created)
+    assert (that.m_table->m_tupleCount == that.m_activeTuples);
+
+    if (*this != that) {
+        if (m_iteratorType == LARGE_TEMP) {
+            finishLargeTempTableScan();
+        }
+
+        m_table = that.m_table;
+        m_tupleLength = that.m_tupleLength;
+        m_activeTuples = that.m_activeTuples;
+        m_foundTuples = that.m_foundTuples;
+        m_dataPtr = that.m_dataPtr;
+        m_dataEndPtr = that.m_dataEndPtr;
+        m_iteratorType = that.m_iteratorType;
+        m_state = that.m_state;
+    }
+
+    return *this;
+}
+
+void TableIterator::reset(TBMapI start) {
+    assert(m_iteratorType == PERSISTENT);
+
+    m_tupleLength = m_table->m_tupleLength;
+    m_activeTuples = (int) m_table->m_tupleCount;
+    m_foundTuples = 0;
+    m_dataPtr = NULL;
+    m_dataEndPtr = NULL;
+    m_state.m_persBlockIterator = start;
+}
+
+void TableIterator::reset(std::vector<TBPtr>::iterator start) {
+    assert(m_iteratorType == TEMP);
+
+    m_tupleLength = m_table->m_tupleLength;
+    m_activeTuples = (int) m_table->m_tupleCount;
+    m_foundTuples = 0;
+    m_dataPtr = NULL;
+    m_dataEndPtr = NULL;
+    m_state.m_tempBlockIterator = start;
+    m_state.m_tempTableDeleteAsGo = false;
+}
+
+ void TableIterator::reset(std::vector<LargeTempTableBlockId>::iterator start) {
+    assert(m_iteratorType == LARGE_TEMP);
+
+    // Unpin the block of the previous scan before resetting.
+    finishLargeTempTableScan();
+
+    m_tupleLength = m_table->m_tupleLength;
+    m_activeTuples = (int) m_table->m_tupleCount;
+    m_foundTuples = 0;
+    m_dataPtr = NULL;
+    m_dataEndPtr = NULL;
+    m_state.m_largeTempBlockIterator = start;
+    m_state.m_tempTableDeleteAsGo = false;
+}
+
+bool TableIterator::hasNext() const {
+    return m_foundTuples < m_activeTuples;
+}
+
+// This function should be replaced by specific iteration functions
+// when the caller knows the table type.
+bool TableIterator::next(TableTuple &out) {
+    switch (m_iteratorType) {
+    case TEMP:
+        return tempNext(out);
+    case PERSISTENT:
+        return persistentNext(out);
+    case LARGE_TEMP:
+    default:
+        assert(m_iteratorType == LARGE_TEMP);
+        return largeTempNext(out);
+    }
+}
+
+bool TableIterator::persistentNext(TableTuple &out) {
+    while (m_foundTuples < m_activeTuples) {
+
+        if (m_dataPtr != NULL) {
+            m_dataPtr += m_tupleLength;
+        }
+
+        if (m_dataPtr == NULL || m_dataPtr >= m_dataEndPtr) {
+            // We are either before first tuple (m_dataPtr is null)
+            // or at the end of a block.
+            m_dataPtr = m_state.m_persBlockIterator.key();
+
+            uint32_t unusedTupleBoundary = m_state.m_persBlockIterator.data()->unusedTupleBoundary();
+            m_dataEndPtr = m_dataPtr + (unusedTupleBoundary * m_tupleLength);
+
+            m_state.m_persBlockIterator++;
+        }
+
+        assert (out.columnCount() == m_table->columnCount());
+        out.move(m_dataPtr);
+
+        const bool active = out.isActive();
+        const bool pendingDelete = out.isPendingDelete();
+        const bool isPendingDeleteOnUndoRelease = out.isPendingDeleteOnUndoRelease();
+
+        // Return this tuple only when this tuple is not marked as deleted.
+        if (active) {
+            ++m_foundTuples;
+            if (!(pendingDelete || isPendingDeleteOnUndoRelease)) {
+                return true;
+            }
+        }
+    } // end while found tuples is less than active tuples
+
+    return false;
+}
+
+bool TableIterator::tempNext(TableTuple &out) {
+    if (m_foundTuples < m_activeTuples) {
+
+        if (m_dataPtr != NULL) {
+            m_dataPtr += m_tupleLength;
+        }
+
+        if (m_dataPtr == NULL || m_dataPtr >= m_dataEndPtr) {
+
+            // delete the last block of tuples in this temp table when they will never be used
+            if (m_state.m_tempTableDeleteAsGo) {
+                m_table->freeLastScannedBlock(m_state.m_tempBlockIterator);
+            }
+
+            m_dataPtr = (*m_state.m_tempBlockIterator)->address();
+
+            uint32_t unusedTupleBoundary = (*m_state.m_tempBlockIterator)->unusedTupleBoundary();
+            m_dataEndPtr = m_dataPtr + (unusedTupleBoundary * m_tupleLength);
+
+            ++m_state.m_tempBlockIterator;
+        }
+
+        assert (out.columnCount() == m_table->columnCount());
+        out.move(m_dataPtr);
+
+        ++m_foundTuples;
+        return true;
+    }
+
+    return false;
+}
+
+bool TableIterator::largeTempNext(TableTuple &out) {
+    if (m_foundTuples < m_activeTuples) {
+
+        if (m_dataPtr != NULL) {
+            m_dataPtr += m_tupleLength;
+        }
+
+        if (m_dataPtr == NULL || m_dataPtr >= m_dataEndPtr) {
+            LargeTempTableBlockCache* lttCache = ExecutorContext::getExecutorContext()->lttBlockCache();
+            auto& blockIdIterator = m_state.m_largeTempBlockIterator;
+
+            if (m_dataPtr != NULL) {
+                lttCache->unpinBlock(*blockIdIterator);
+
+                if (m_state.m_tempTableDeleteAsGo) {
+                    blockIdIterator = m_table->releaseBlock(blockIdIterator);
+                }
+                else {
+                    ++blockIdIterator;
+                }
+            }
+
+            LargeTempTableBlock* block = lttCache->fetchBlock(*blockIdIterator);
+            m_dataPtr = block->tupleStorage();
+
+            uint32_t unusedTupleBoundary = block->unusedTupleBoundary();
+            m_dataEndPtr = m_dataPtr + (unusedTupleBoundary * m_tupleLength);
+        }
+
+        out.move(m_dataPtr);
+
+        ++m_foundTuples;
+
+        return true;
+    } // end if there are still more tuples
+
+    // Unpin (and release, if delete-as-you-go) the last block
+    finishLargeTempTableScan();
+    return false;
+}
+
+void TableIterator::finishLargeTempTableScan() {
+    if (m_foundTuples == 0) {
+        return;
+    }
+
+    LargeTempTableBlockCache* lttCache = ExecutorContext::getExecutorContext()->lttBlockCache();
+    auto& blockIdIterator = m_state.m_largeTempBlockIterator;
+
+    if (lttCache->blockIsPinned(*blockIdIterator)) {
+        lttCache->unpinBlock(*blockIdIterator);
+    }
+
+    if (m_foundTuples == m_activeTuples
+        && m_state.m_tempTableDeleteAsGo) {
+
+        blockIdIterator = m_table->releaseBlock(blockIdIterator);
+        m_activeTuples = 0;
+        m_foundTuples = 0;
+        m_dataPtr = NULL;
+        m_dataEndPtr = NULL;
+    }
+}
+
+TableIterator::~TableIterator() {
+    if (m_iteratorType == LARGE_TEMP) {
+        finishLargeTempTableScan();
+    }
+}
+

--- a/src/ee/storage/tableiterator.h
+++ b/src/ee/storage/tableiterator.h
@@ -43,8 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef HSTORETABLEITERATOR_H
-#define HSTORETABLEITERATOR_H
+#pragma once
 
 #include <cassert>
 
@@ -74,7 +73,6 @@ class PersistentTable;
  *
  */
 class TableIterator : public TupleIterator {
-
     friend class TempTable;
     friend class PersistentTable;
     friend class LargeTempTable;
@@ -291,15 +289,15 @@ private:
     /** The number of tuples returned so far by this iterator, since
         it was constructed or reset.  Scan is complete when
         m_foundTuples == m_activeTuples. */
-    uint32_t m_foundTuples;
+    uint32_t m_foundTuples = 0;
 
     /** Pointer to our current position in the current block. */
-    char *m_dataPtr;
+    char *m_dataPtr = nullptr;
 
     /** Pointer to the first tuple after the last valid tuple in the
         current block.  Scan of current block is complete when
         m_dataPtr == m_dataEndPtr. */
-    char *m_dataEndPtr;
+    char *m_dataEndPtr = nullptr;
 
     /** The type of iterator based on the kind of table that we're scanning. */
     IteratorType m_iteratorType;
@@ -308,280 +306,5 @@ private:
         over: */
     TypeSpecificState m_state;
 };
-
-// Construct iterator for persistent tables
-inline TableIterator::TableIterator(Table *parent, TBMapI start)
-    : m_table(parent)
-    , m_tupleLength(parent->m_tupleLength)
-    , m_activeTuples((int) m_table->m_tupleCount)
-    , m_foundTuples(0)
-    , m_dataPtr(NULL)
-    , m_dataEndPtr(NULL)
-    , m_iteratorType(PERSISTENT)
-    , m_state(start)
-{
 }
 
-// Construct iterator for temp tables
-inline TableIterator::TableIterator(Table *parent, std::vector<TBPtr>::iterator start, bool deleteAsGo)
-    : m_table(parent)
-    , m_tupleLength(parent->m_tupleLength)
-    , m_activeTuples((int) m_table->m_tupleCount)
-    , m_foundTuples(0)
-    , m_dataPtr(NULL)
-    , m_dataEndPtr(NULL)
-    , m_iteratorType(TEMP)
-    , m_state(start, deleteAsGo)
-{
-}
-
-//  Construct an iterator for large temp tables
-inline TableIterator::TableIterator(Table *parent, std::vector<LargeTempTableBlockId>::iterator start, bool deleteAsGo)
-    : m_table(parent)
-    , m_tupleLength(parent->m_tupleLength)
-    , m_activeTuples((int) m_table->m_tupleCount)
-    , m_foundTuples(0)
-    , m_dataPtr(NULL)
-    , m_dataEndPtr(NULL)
-    , m_iteratorType(LARGE_TEMP)
-    , m_state(start, deleteAsGo)
-{
-}
-
-// Construct an iterator from another iterator
-inline TableIterator::TableIterator(const TableIterator &that)
-    : m_table(that.m_table)
-    , m_tupleLength(that.m_tupleLength)
-    , m_activeTuples(that.m_activeTuples)
-    , m_foundTuples(that.m_foundTuples)
-    , m_dataPtr(that.m_dataPtr)
-    , m_dataEndPtr(that.m_dataEndPtr)
-    , m_iteratorType(that.m_iteratorType)
-    , m_state(that.m_state)
-{
-    // This assertion could fail if we are copying an invalid iterator
-    // (table changed after iterator was created)
-    assert (that.m_table->m_tupleCount == that.m_activeTuples);
-}
-
-inline TableIterator& TableIterator::operator=(const TableIterator& that) {
-    // This assertion could fail if we are copying an invalid iterator
-    // (table changed after iterator was created)
-    assert (that.m_table->m_tupleCount == that.m_activeTuples);
-
-    if (*this != that) {
-        if (m_iteratorType == LARGE_TEMP) {
-            finishLargeTempTableScan();
-        }
-
-        m_table = that.m_table;
-        m_tupleLength = that.m_tupleLength;
-        m_activeTuples = that.m_activeTuples;
-        m_foundTuples = that.m_foundTuples;
-        m_dataPtr = that.m_dataPtr;
-        m_dataEndPtr = that.m_dataEndPtr;
-        m_iteratorType = that.m_iteratorType;
-        m_state = that.m_state;
-    }
-
-    return *this;
-}
-
-inline void TableIterator::reset(TBMapI start) {
-    assert(m_iteratorType == PERSISTENT);
-
-    m_tupleLength = m_table->m_tupleLength;
-    m_activeTuples = (int) m_table->m_tupleCount;
-    m_foundTuples = 0;
-    m_dataPtr = NULL;
-    m_dataEndPtr = NULL;
-    m_state.m_persBlockIterator = start;
-}
-
-inline void TableIterator::reset(std::vector<TBPtr>::iterator start) {
-    assert(m_iteratorType == TEMP);
-
-    m_tupleLength = m_table->m_tupleLength;
-    m_activeTuples = (int) m_table->m_tupleCount;
-    m_foundTuples = 0;
-    m_dataPtr = NULL;
-    m_dataEndPtr = NULL;
-    m_state.m_tempBlockIterator = start;
-    m_state.m_tempTableDeleteAsGo = false;
-}
-
- inline void TableIterator::reset(std::vector<LargeTempTableBlockId>::iterator start) {
-    assert(m_iteratorType == LARGE_TEMP);
-
-    // Unpin the block of the previous scan before resetting.
-    finishLargeTempTableScan();
-
-    m_tupleLength = m_table->m_tupleLength;
-    m_activeTuples = (int) m_table->m_tupleCount;
-    m_foundTuples = 0;
-    m_dataPtr = NULL;
-    m_dataEndPtr = NULL;
-    m_state.m_largeTempBlockIterator = start;
-    m_state.m_tempTableDeleteAsGo = false;
-}
-
-inline bool TableIterator::hasNext() const {
-    return m_foundTuples < m_activeTuples;
-}
-
-// This function should be replaced by specific iteration functions
-// when the caller knows the table type.
-inline bool TableIterator::next(TableTuple &out) {
-    switch (m_iteratorType) {
-    case TEMP:
-        return tempNext(out);
-    case PERSISTENT:
-        return persistentNext(out);
-    case LARGE_TEMP:
-    default:
-        assert(m_iteratorType == LARGE_TEMP);
-        return largeTempNext(out);
-    }
-}
-
-inline bool TableIterator::persistentNext(TableTuple &out) {
-    while (m_foundTuples < m_activeTuples) {
-
-        if (m_dataPtr != NULL) {
-            m_dataPtr += m_tupleLength;
-        }
-
-        if (m_dataPtr == NULL || m_dataPtr >= m_dataEndPtr) {
-            // We are either before first tuple (m_dataPtr is null)
-            // or at the end of a block.
-            m_dataPtr = m_state.m_persBlockIterator.key();
-
-            uint32_t unusedTupleBoundary = m_state.m_persBlockIterator.data()->unusedTupleBoundary();
-            m_dataEndPtr = m_dataPtr + (unusedTupleBoundary * m_tupleLength);
-
-            m_state.m_persBlockIterator++;
-        }
-
-        assert (out.columnCount() == m_table->columnCount());
-        out.move(m_dataPtr);
-
-        const bool active = out.isActive();
-        const bool pendingDelete = out.isPendingDelete();
-        const bool isPendingDeleteOnUndoRelease = out.isPendingDeleteOnUndoRelease();
-
-        // Return this tuple only when this tuple is not marked as deleted.
-        if (active) {
-            ++m_foundTuples;
-            if (!(pendingDelete || isPendingDeleteOnUndoRelease)) {
-                return true;
-            }
-        }
-    } // end while found tuples is less than active tuples
-
-    return false;
-}
-
-inline bool TableIterator::tempNext(TableTuple &out) {
-    if (m_foundTuples < m_activeTuples) {
-
-        if (m_dataPtr != NULL) {
-            m_dataPtr += m_tupleLength;
-        }
-
-        if (m_dataPtr == NULL || m_dataPtr >= m_dataEndPtr) {
-
-            // delete the last block of tuples in this temp table when they will never be used
-            if (m_state.m_tempTableDeleteAsGo) {
-                m_table->freeLastScannedBlock(m_state.m_tempBlockIterator);
-            }
-
-            m_dataPtr = (*m_state.m_tempBlockIterator)->address();
-
-            uint32_t unusedTupleBoundary = (*m_state.m_tempBlockIterator)->unusedTupleBoundary();
-            m_dataEndPtr = m_dataPtr + (unusedTupleBoundary * m_tupleLength);
-
-            ++m_state.m_tempBlockIterator;
-        }
-
-        assert (out.columnCount() == m_table->columnCount());
-        out.move(m_dataPtr);
-
-        ++m_foundTuples;
-        return true;
-    }
-
-    return false;
-}
-
-inline bool TableIterator::largeTempNext(TableTuple &out) {
-    if (m_foundTuples < m_activeTuples) {
-
-        if (m_dataPtr != NULL) {
-            m_dataPtr += m_tupleLength;
-        }
-
-        if (m_dataPtr == NULL || m_dataPtr >= m_dataEndPtr) {
-            LargeTempTableBlockCache* lttCache = ExecutorContext::getExecutorContext()->lttBlockCache();
-            auto& blockIdIterator = m_state.m_largeTempBlockIterator;
-
-            if (m_dataPtr != NULL) {
-                lttCache->unpinBlock(*blockIdIterator);
-
-                if (m_state.m_tempTableDeleteAsGo) {
-                    blockIdIterator = m_table->releaseBlock(blockIdIterator);
-                }
-                else {
-                    ++blockIdIterator;
-                }
-            }
-
-            LargeTempTableBlock* block = lttCache->fetchBlock(*blockIdIterator);
-            m_dataPtr = block->tupleStorage();
-
-            uint32_t unusedTupleBoundary = block->unusedTupleBoundary();
-            m_dataEndPtr = m_dataPtr + (unusedTupleBoundary * m_tupleLength);
-        }
-
-        out.move(m_dataPtr);
-
-        ++m_foundTuples;
-
-        return true;
-    } // end if there are still more tuples
-
-    // Unpin (and release, if delete-as-you-go) the last block
-    finishLargeTempTableScan();
-    return false;
-}
-
-inline void TableIterator::finishLargeTempTableScan() {
-    if (m_foundTuples == 0) {
-        return;
-    }
-
-    LargeTempTableBlockCache* lttCache = ExecutorContext::getExecutorContext()->lttBlockCache();
-    auto& blockIdIterator = m_state.m_largeTempBlockIterator;
-
-    if (lttCache->blockIsPinned(*blockIdIterator)) {
-        lttCache->unpinBlock(*blockIdIterator);
-    }
-
-    if (m_foundTuples == m_activeTuples
-        && m_state.m_tempTableDeleteAsGo) {
-
-        blockIdIterator = m_table->releaseBlock(blockIdIterator);
-        m_activeTuples = 0;
-        m_foundTuples = 0;
-        m_dataPtr = NULL;
-        m_dataEndPtr = NULL;
-    }
-}
-
-inline TableIterator::~TableIterator() {
-    if (m_iteratorType == LARGE_TEMP) {
-        finishLargeTempTableScan();
-    }
-}
-
-}
-#endif

--- a/src/ee/voltdbipc.h
+++ b/src/ee/voltdbipc.h
@@ -39,7 +39,7 @@ namespace voltdb {
    class Table;
    struct ipc_command;
 
-   class VoltDBIPC : public voltdb::Topend {
+   class VoltDBIPC : public Topend {
       public:
          // must match ERRORCODE_SUCCESS|ERROR in ExecutionEngine.java
          enum {
@@ -69,11 +69,11 @@ namespace voltdb {
 
          ~VoltDBIPC();
 
-         const voltdb::VoltDBEngine* getEngine() const {
+         const VoltDBEngine* getEngine() const {
             return m_engine.get();
          }
 
-         int loadNextDependency(int32_t dependencyId, voltdb::Pool *stringPool, voltdb::Table* destination) override;
+         int loadNextDependency(int32_t dependencyId, Pool *stringPool, Table* destination) override;
          void fallbackToEEAllocatedBuffer(char *buffer, size_t length) override { }
 
          /**
@@ -89,7 +89,7 @@ namespace voltdb {
 
          int64_t fragmentProgressUpdate(
                int32_t batchIndex,
-               voltdb::PlanNodeType planNodeType,
+               PlanNodeType planNodeType,
                int64_t tuplesProcessed,
                int64_t currMemoryInBytes,
                int64_t peakMemoryInBytes) override;
@@ -105,9 +105,9 @@ namespace voltdb {
 
          bool execute(ipc_command *cmd);
 
-         int64_t pushDRBuffer(int32_t partitionId, voltdb::StreamBlock *block) override;
+         int64_t pushDRBuffer(int32_t partitionId, StreamBlock *block) override;
 
-         void pushPoisonPill(int32_t partitionId, std::string& reason, voltdb::StreamBlock *block) override;
+         void pushPoisonPill(int32_t partitionId, std::string& reason, StreamBlock *block) override;
 
          /**
           * Log a statement on behalf of the IPC log proxy at the specified log level
@@ -115,9 +115,9 @@ namespace voltdb {
           * @param level Log level of the statement
           * @param statement null terminated UTF-8 string containing the statement to log
           */
-         void log(voltdb::LoggerId loggerId, voltdb::LogLevel level, const char *statement) const;
+         void log(LoggerId loggerId, LogLevel level, const char *statement) const;
 
-         void crashVoltDB(voltdb::FatalException e) override;
+         void crashVoltDB(FatalException const& e) override;
 
          /*
           * Cause the engine to terminate gracefully after finishing execution of the current command.
@@ -127,21 +127,22 @@ namespace voltdb {
           */
          void terminate();
 
-         int64_t getQueuedExportBytes(int32_t partitionId, std::string signature) override;
-         void pushExportBuffer(int32_t partitionId, std::string signature, voltdb::StreamBlock *block, bool sync) override;
-         void pushEndOfStream(int32_t partitionId, std::string signature) override;
+         int64_t getQueuedExportBytes(int32_t partitionId, std::string const& signature) override;
+         void pushExportBuffer(int32_t partitionId, std::string const& signature, StreamBlock *block, bool sync) override;
+         void pushEndOfStream(int32_t partitionId, std::string const& signature) override;
 
-         int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, voltdb::DRRecordType action,
-               voltdb::DRConflictType deleteConflict, voltdb::Table *existingMetaTableForDelete, voltdb::Table *existingTupleTableForDelete,
-               voltdb::Table *expectedMetaTableForDelete, voltdb::Table *expectedTupleTableForDelete,
-               voltdb::DRConflictType insertConflict, voltdb::Table *existingMetaTableForInsert, voltdb::Table *existingTupleTableForInsert,
-               voltdb::Table *newMetaTableForInsert, voltdb::Table *newTupleTableForInsert) override;
+         int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName,
+               DRRecordType action, DRConflictType deleteConflict, Table* existingMetaTableForDelete,
+               Table* existingTupleTableForDelete, Table* expectedMetaTableForDelete,
+               Table* expectedTupleTableForDelete, DRConflictType insertConflict,
+               Table* existingMetaTableForInsert, Table* existingTupleTableForInsert,
+               Table* newMetaTableForInsert, Table* newTupleTableForInsert) override;
 
-         bool storeLargeTempTableBlock(voltdb::LargeTempTableBlock* block) override;
+         bool storeLargeTempTableBlock(LargeTempTableBlock* block) override;
 
-         bool loadLargeTempTableBlock(voltdb::LargeTempTableBlock* block) override;
+         bool loadLargeTempTableBlock(LargeTempTableBlock* block) override;
 
-         bool releaseLargeTempTableBlock(voltdb::LargeTempTableBlockId blockId) override;
+         bool releaseLargeTempTableBlock(LargeTempTableBlockId const& blockId) override;
 
 
       private:
@@ -211,7 +212,7 @@ namespace voltdb {
          static void signalDispatcher(int signum, siginfo_t *info, void *context);
          void setupSigHandler(void) const;
 
-         std::unique_ptr<voltdb::VoltDBEngine> m_engine{};
+         std::unique_ptr<VoltDBEngine> m_engine{};
          long int m_counter = 0;
 
          int m_fd;
@@ -294,8 +295,8 @@ namespace voltdb {
     */
    struct activate_tablestream {
       ipc_command cmd;
-      voltdb::CatalogId tableId;
-      voltdb::TableStreamType streamType;
+      CatalogId tableId;
+      TableStreamType streamType;
       int64_t undoToken;
       char data[0];
    }__attribute__((packed));
@@ -305,8 +306,8 @@ namespace voltdb {
     */
    struct tablestream_serialize_more {
       ipc_command cmd;
-      voltdb::CatalogId tableId;
-      voltdb::TableStreamType streamType;
+      CatalogId tableId;
+      TableStreamType streamType;
       int bufferCount;
       char data[0];
    }__attribute__((packed));
@@ -388,13 +389,4 @@ namespace voltdb {
       char enabled;
       char viewNameBytes[0];
    }__attribute__((packed));
-
-   /**
-    * Utility used for deserializing ParameterSet passed from Java.
-    */
-   void deserializeParameterSetCommon(int cnt, ReferenceSerializeInputBE &serialize_in,
-         NValueArray &params, Pool *stringPool);
-
-   void *eethread(void *ptr);
-   void checkBytesRead(ssize_t byteCountExpected, ssize_t byteCountRead, std::string description);
 }

--- a/src/ee/voltdbipc.h
+++ b/src/ee/voltdbipc.h
@@ -1,0 +1,400 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ Implement the Java ExecutionEngine interface using IPC to a standalone EE
+ process. This allows the backend to run without a JVM - useful for many
+ debugging tasks.  Represents a single EE in a single process. Accepts
+ and executes commands from Java synchronously.
+ */
+#pragma once
+
+#include "common/Topend.h"
+#include "execution/VoltDBEngine.h"
+#include "storage/table.h"
+#include "logging/StdoutLogProxy.h"
+
+// Please don't make this different from the JNI result buffer size.
+// This determines the size of the EE results buffer and it's nice
+// if IPC and JNI are matched.
+#define MAX_MSG_SZ (1024*1024*10)
+
+namespace voltdb {
+   class Pool;
+   class StreamBlock;
+   class Table;
+   struct ipc_command;
+
+   class VoltDBIPC : public voltdb::Topend {
+      public:
+         // must match ERRORCODE_SUCCESS|ERROR in ExecutionEngine.java
+         enum {
+            kErrorCode_None = -1, // not in the java
+            kErrorCode_Success = 0,
+            kErrorCode_Error = 1,
+            /*
+             * The following are not error codes but requests for information or functionality
+             * from Java. These do not exist in ExecutionEngine.java since they are IPC specific.
+             * These constants are mirrored in ExecutionEngine.java.
+             */
+            kErrorCode_RetrieveDependency = 100,           // Request for dependency
+            kErrorCode_DependencyFound = 101,              // Response to 100
+            kErrorCode_DependencyNotFound = 102,           // Also response to 100
+            kErrorCode_pushExportBuffer = 103,             // Indication that export buffer is next
+            kErrorCode_CrashVoltDB = 104,                  // Crash with reason string
+            kErrorCode_getQueuedExportBytes = 105,         // Retrieve value for stats
+            kErrorCode_pushPerFragmentStatsBuffer = 106,   // Indication that per-fragment statistics buffer is next
+            kErrorCode_callJavaUserDefinedFunction = 107,  // Notify the frontend to call a Java user-defined function.
+            kErrorCode_needPlan = 110,                     // fetch a plan from java for a fragment
+            kErrorCode_progressUpdate = 111,               // Update Java on execution progress
+            kErrorCode_decodeBase64AndDecompress = 112,    // Decode base64, compressed data
+            kErrorCode_pushEndOfStream = 113               // Push EOF for dropped stream.
+         };
+
+         VoltDBIPC(int fd);
+
+         ~VoltDBIPC();
+
+         const voltdb::VoltDBEngine* getEngine() const {
+            return m_engine.get();
+         }
+
+         int loadNextDependency(int32_t dependencyId, voltdb::Pool *stringPool, voltdb::Table* destination);
+         void fallbackToEEAllocatedBuffer(char *buffer, size_t length) { }
+
+         /**
+          * Retrieve a dependency from Java via the IPC connection.
+          * This method returns null if there are no more dependency tables. Otherwise
+          * it returns a pointer to a buffer containing the dependency. The first four bytes
+          * of the buffer is an int32_t length prefix.
+          *
+          * The returned allocated memory must be freed by the caller.
+          * Returns dependency size with out parameter.
+          */
+         char *retrieveDependency(int32_t dependencyId, size_t *dependencySz);
+
+         int64_t fragmentProgressUpdate(
+               int32_t batchIndex,
+               voltdb::PlanNodeType planNodeType,
+               int64_t tuplesProcessed,
+               int64_t currMemoryInBytes,
+               int64_t peakMemoryInBytes);
+
+         std::string decodeBase64AndDecompress(const std::string& base64Data);
+
+         /**
+          * Retrieve a plan from Java via the IPC connection for a fragment id.
+          * Plan is JSON. Returns the empty string on failure, but failure is
+          * probably going to be detected somewhere else.
+          */
+         std::string planForFragmentId(int64_t fragmentId);
+
+         bool execute(ipc_command *cmd);
+
+         int64_t pushDRBuffer(int32_t partitionId, voltdb::StreamBlock *block);
+
+         void pushPoisonPill(int32_t partitionId, std::string& reason, voltdb::StreamBlock *block);
+
+         /**
+          * Log a statement on behalf of the IPC log proxy at the specified log level
+          * @param LoggerId ID of the logger that received this statement
+          * @param level Log level of the statement
+          * @param statement null terminated UTF-8 string containing the statement to log
+          */
+         void log(voltdb::LoggerId loggerId, voltdb::LogLevel level, const char *statement) const;
+
+         void crashVoltDB(voltdb::FatalException e);
+
+         /*
+          * Cause the engine to terminate gracefully after finishing execution of the current command.
+          * Useful when running Valgrind because you can terminate at the point where you think memory has leaked
+          * and this method will make sure that the VoltDBEngine is deleted and that the program will attempt
+          * to free all memory allocated on the heap.
+          */
+         void terminate();
+
+         int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);
+         void pushExportBuffer(int32_t partitionId, std::string signature, voltdb::StreamBlock *block, bool sync);
+         void pushEndOfStream(int32_t partitionId, std::string signature);
+
+         int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, voltdb::DRRecordType action,
+               voltdb::DRConflictType deleteConflict, voltdb::Table *existingMetaTableForDelete, voltdb::Table *existingTupleTableForDelete,
+               voltdb::Table *expectedMetaTableForDelete, voltdb::Table *expectedTupleTableForDelete,
+               voltdb::DRConflictType insertConflict, voltdb::Table *existingMetaTableForInsert, voltdb::Table *existingTupleTableForInsert,
+               voltdb::Table *newMetaTableForInsert, voltdb::Table *newTupleTableForInsert);
+
+         bool storeLargeTempTableBlock(voltdb::LargeTempTableBlock* block);
+
+         bool loadLargeTempTableBlock(voltdb::LargeTempTableBlock* block);
+
+         bool releaseLargeTempTableBlock(voltdb::LargeTempTableBlockId blockId);
+
+
+      private:
+
+         int8_t stub(ipc_command *cmd);
+
+         int8_t loadCatalog(ipc_command *cmd);
+
+         int8_t updateCatalog(ipc_command *cmd);
+
+         int8_t initialize(ipc_command *cmd);
+
+         int8_t toggleProfiler(ipc_command *cmd);
+
+         int8_t releaseUndoToken(ipc_command *cmd);
+
+         int8_t undoUndoToken(ipc_command *cmd);
+
+         int8_t tick(ipc_command *cmd);
+
+         int8_t quiesce(ipc_command *cmd);
+
+         int8_t shutDown();
+
+         int8_t setLogLevels(ipc_command *cmd);
+
+         void executePlanFragments(ipc_command *cmd);
+
+         void getStats(ipc_command *cmd);
+
+         int8_t loadTable(ipc_command *cmd);
+
+         int8_t processRecoveryMessage( ipc_command *cmd);
+
+         void tableHashCode( ipc_command *cmd);
+
+         void hashinate(ipc_command* cmd);
+
+         void updateHashinator(ipc_command *cmd);
+
+         void threadLocalPoolAllocations();
+
+         void applyBinaryLog(ipc_command*);
+
+         void executeTask(ipc_command*);
+
+         void sendPerFragmentStatsBuffer();
+
+         int callJavaUserDefinedFunction();
+
+         void setViewsEnabled(ipc_command*);
+
+         // We do not adjust the UDF buffer size in the IPC mode.
+         // The buffer sizes are always MAX_MSG_SZ (10M)
+         void resizeUDFBuffer(int32_t size) {
+            return;
+         }
+
+         void sendException( int8_t errorCode);
+
+         int8_t activateTableStream(ipc_command *cmd);
+         void tableStreamSerializeMore(ipc_command *cmd);
+         void exportAction(ipc_command *cmd);
+         void getUSOForExportTable(ipc_command *cmd);
+
+         void signalHandler(int signum, siginfo_t *info, void *context);
+         static void signalDispatcher(int signum, siginfo_t *info, void *context);
+         void setupSigHandler(void) const;
+
+         std::unique_ptr<voltdb::VoltDBEngine> m_engine{};
+         long int m_counter = 0;
+
+         int m_fd;
+         std::unique_ptr<char[]> m_perFragmentStatsBuffer{new char[MAX_MSG_SZ]},
+            m_reusedResultBuffer{new char[MAX_MSG_SZ]},
+            m_exceptionBuffer{new char[MAX_MSG_SZ]},
+            m_udfBuffer{new char[MAX_MSG_SZ]},
+            m_tupleBuffer{new char[MAX_MSG_SZ]};
+         bool m_terminate = false;
+
+         // The tuple buffer gets expanded (doubled) as needed, but never compacted.
+         size_t m_tupleBufferSize = 0;
+         StdoutLogProxy m_logProxy{};
+   };
+
+   /* java sends all data with this header */
+   struct ipc_command {
+      int32_t msgsize;
+      int32_t command;
+      char data[0];
+   }__attribute__((packed));
+
+   /*
+    * Structure describing an executePlanFragments message header.
+    */
+   struct querypfs {
+      ipc_command cmd;
+      int64_t txnId;
+      int64_t spHandle;
+      int64_t lastCommittedSpHandle;
+      int64_t uniqueId;
+      int64_t undoToken;
+      int8_t perFragmentTimingEnabled;
+      int32_t numFragmentIds;
+      char data[0];
+   }__attribute__((packed));
+
+   struct loadfrag {
+      ipc_command cmd;
+      int32_t planFragLength;
+      char data[0];
+   }__attribute__((packed));
+
+   /*
+    * Header for a load table request.
+    */
+   struct load_table_cmd {
+      ipc_command cmd;
+      int32_t tableId;
+      int64_t txnId;
+      int64_t spHandle;
+      int64_t lastCommittedSpHandle;
+      int64_t uniqueId;
+      int64_t undoToken;
+      int32_t returnUniqueViolations;
+      int32_t shouldDRStream;
+      char data[0];
+   }__attribute__((packed));
+
+   /*
+    * Header for a stats table request.
+    */
+   struct get_stats_cmd {
+      ipc_command cmd;
+      int32_t selector;
+      int8_t  interval;
+      int64_t now;
+      int32_t num_locators;
+      int32_t locators[0];
+   }__attribute__((packed));
+
+   struct undo_token {
+      ipc_command cmd;
+      int64_t token;
+      char isEmptyDRTxn;
+   }__attribute__((packed));
+
+   /*
+    * Header for a ActivateCopyOnWrite request
+    */
+   struct activate_tablestream {
+      ipc_command cmd;
+      voltdb::CatalogId tableId;
+      voltdb::TableStreamType streamType;
+      int64_t undoToken;
+      char data[0];
+   }__attribute__((packed));
+
+   /*
+    * Header for a Copy On Write Serialize More request
+    */
+   struct tablestream_serialize_more {
+      ipc_command cmd;
+      voltdb::CatalogId tableId;
+      voltdb::TableStreamType streamType;
+      int bufferCount;
+      char data[0];
+   }__attribute__((packed));
+
+   /*
+    * Header for an incoming recovery message
+    */
+   struct recovery_message {
+      ipc_command cmd;
+      int32_t messageLength;
+      char message[0];
+   }__attribute__((packed));
+
+   /*
+    * Header for a request for a table hash code
+    */
+   struct table_hash_code {
+      ipc_command cmd;
+      int32_t tableId;
+   }__attribute__((packed));
+
+   struct hashinate_msg {
+      ipc_command cmd;
+      int32_t configLength;
+      char data[0];
+   }__attribute__((packed));
+
+   /*
+    * Header for an Export action.
+    */
+   struct export_action {
+      ipc_command cmd;
+      int32_t isSync;
+      int64_t offset;
+      int64_t seqNo;
+      int32_t tableSignatureLength;
+      char tableSignature[0];
+   }__attribute__((packed));
+
+   struct get_uso {
+      ipc_command cmd;
+      int32_t tableSignatureLength;
+      char tableSignature[0];
+   }__attribute__((packed));
+
+   struct catalog_load {
+      ipc_command cmd;
+      int64_t timestamp;
+      char data[0];
+   }__attribute__((packed));
+
+   struct execute_task {
+      ipc_command cmd;
+      int64_t taskId;
+      char task[0];
+   }__attribute__((packed));
+
+   struct apply_binary_log {
+      ipc_command cmd;
+      int64_t txnId;
+      int64_t spHandle;
+      int64_t lastCommittedSpHandle;
+      int64_t uniqueId;
+      int32_t remoteClusterId;
+      int32_t remotePartitionId;
+      int64_t undoToken;
+      char log[0];
+   }__attribute__((packed));
+
+   struct update_catalog_cmd {
+      ipc_command cmd;
+      int64_t timestamp;
+      int32_t isStreamChange;
+      char data[0];
+   }__attribute__((packed));
+
+   struct set_views_enabled {
+      ipc_command cmd;
+      char enabled;
+      char viewNameBytes[0];
+   }__attribute__((packed));
+
+   /**
+    * Utility used for deserializing ParameterSet passed from Java.
+    */
+   void deserializeParameterSetCommon(int cnt, ReferenceSerializeInputBE &serialize_in,
+         NValueArray &params, Pool *stringPool);
+
+   void *eethread(void *ptr);
+   void checkBytesRead(ssize_t byteCountExpected, ssize_t byteCountRead, std::string description);
+}

--- a/src/ee/voltdbipc.h
+++ b/src/ee/voltdbipc.h
@@ -73,8 +73,8 @@ namespace voltdb {
             return m_engine.get();
          }
 
-         int loadNextDependency(int32_t dependencyId, voltdb::Pool *stringPool, voltdb::Table* destination);
-         void fallbackToEEAllocatedBuffer(char *buffer, size_t length) { }
+         int loadNextDependency(int32_t dependencyId, voltdb::Pool *stringPool, voltdb::Table* destination) override;
+         void fallbackToEEAllocatedBuffer(char *buffer, size_t length) override { }
 
          /**
           * Retrieve a dependency from Java via the IPC connection.
@@ -92,22 +92,22 @@ namespace voltdb {
                voltdb::PlanNodeType planNodeType,
                int64_t tuplesProcessed,
                int64_t currMemoryInBytes,
-               int64_t peakMemoryInBytes);
+               int64_t peakMemoryInBytes) override;
 
-         std::string decodeBase64AndDecompress(const std::string& base64Data);
+         std::string decodeBase64AndDecompress(const std::string& base64Data) override;
 
          /**
           * Retrieve a plan from Java via the IPC connection for a fragment id.
           * Plan is JSON. Returns the empty string on failure, but failure is
           * probably going to be detected somewhere else.
           */
-         std::string planForFragmentId(int64_t fragmentId);
+         std::string planForFragmentId(int64_t fragmentId) override;
 
          bool execute(ipc_command *cmd);
 
-         int64_t pushDRBuffer(int32_t partitionId, voltdb::StreamBlock *block);
+         int64_t pushDRBuffer(int32_t partitionId, voltdb::StreamBlock *block) override;
 
-         void pushPoisonPill(int32_t partitionId, std::string& reason, voltdb::StreamBlock *block);
+         void pushPoisonPill(int32_t partitionId, std::string& reason, voltdb::StreamBlock *block) override;
 
          /**
           * Log a statement on behalf of the IPC log proxy at the specified log level
@@ -117,7 +117,7 @@ namespace voltdb {
           */
          void log(voltdb::LoggerId loggerId, voltdb::LogLevel level, const char *statement) const;
 
-         void crashVoltDB(voltdb::FatalException e);
+         void crashVoltDB(voltdb::FatalException e) override;
 
          /*
           * Cause the engine to terminate gracefully after finishing execution of the current command.
@@ -127,21 +127,21 @@ namespace voltdb {
           */
          void terminate();
 
-         int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);
-         void pushExportBuffer(int32_t partitionId, std::string signature, voltdb::StreamBlock *block, bool sync);
-         void pushEndOfStream(int32_t partitionId, std::string signature);
+         int64_t getQueuedExportBytes(int32_t partitionId, std::string signature) override;
+         void pushExportBuffer(int32_t partitionId, std::string signature, voltdb::StreamBlock *block, bool sync) override;
+         void pushEndOfStream(int32_t partitionId, std::string signature) override;
 
          int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, voltdb::DRRecordType action,
                voltdb::DRConflictType deleteConflict, voltdb::Table *existingMetaTableForDelete, voltdb::Table *existingTupleTableForDelete,
                voltdb::Table *expectedMetaTableForDelete, voltdb::Table *expectedTupleTableForDelete,
                voltdb::DRConflictType insertConflict, voltdb::Table *existingMetaTableForInsert, voltdb::Table *existingTupleTableForInsert,
-               voltdb::Table *newMetaTableForInsert, voltdb::Table *newTupleTableForInsert);
+               voltdb::Table *newMetaTableForInsert, voltdb::Table *newTupleTableForInsert) override;
 
-         bool storeLargeTempTableBlock(voltdb::LargeTempTableBlock* block);
+         bool storeLargeTempTableBlock(voltdb::LargeTempTableBlock* block) override;
 
-         bool loadLargeTempTableBlock(voltdb::LargeTempTableBlock* block);
+         bool loadLargeTempTableBlock(voltdb::LargeTempTableBlock* block) override;
 
-         bool releaseLargeTempTableBlock(voltdb::LargeTempTableBlockId blockId);
+         bool releaseLargeTempTableBlock(voltdb::LargeTempTableBlockId blockId) override;
 
 
       private:
@@ -190,13 +190,13 @@ namespace voltdb {
 
          void sendPerFragmentStatsBuffer();
 
-         int callJavaUserDefinedFunction();
+         int callJavaUserDefinedFunction() override;
 
          void setViewsEnabled(ipc_command*);
 
          // We do not adjust the UDF buffer size in the IPC mode.
          // The buffer sizes are always MAX_MSG_SZ (10M)
-         void resizeUDFBuffer(int32_t size) {
+         void resizeUDFBuffer(int32_t size) override {
             return;
          }
 

--- a/tests/ee/harness.cpp
+++ b/tests/ee/harness.cpp
@@ -173,7 +173,7 @@ int TestSuite::runAll() {
             }
         }
         catch (voltdb::SerializableEEException& eeExc) {
-            printf("Uncaught SerializableEEException: %s\n", eeExc.message().c_str());
+            printf("Uncaught SerializableEEException: %s\n", eeExc.what());
             test->printErrors();
             printf("\n");
             failed_tests++;


### PR DESCRIPTION
This is some refactory work on EE C++ code, touching mostly Topend, many exception classes, and affected places, that I did over the innovation week. The purpose is to make it more readable and maintainable, and by picking up some good practices from C++11.
The changes are quite extensive, and involves more than style changes:
 - Prefer passing references to pointers and object itself in a method;
 - Prefer constant arguments, local variables and constant member methods over non-constant ones;
 - Reluctance to use macro, unless absolutely necessary;
 - Prefer modern C++11 data types, STLs and new language structure;
 - Simplify logical branches in code;
 - Avoid redundant type casts;
 - Exception classes should really be C++ exception class, i.e. specialize from a standard exception, and support its interface;
 - ...
----
Hopefully these code refactories are healthful for the project, and will benefit other people who read/modify/extend. It barely touches anything below the surface (i.e. the Topend), but the change is already quite large.  Git is already poor at showing a side-by-side diff changes. Sorry for the trouble reviewing my changes!
P.S. I need to make sure Jenkin is happy with this.