### PR TITLE
 ENG-14408: Use a thread to wait for timeout 

### DIFF
--- a/src/frontend/org/voltdb/client/ConnectionUtil.java
+++ b/src/frontend/org/voltdb/client/ConnectionUtil.java
@@ -32,8 +32,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -54,6 +52,7 @@ import org.voltdb.ClientResponseImpl;
 import org.voltdb.common.Constants;
 import org.voltdb.utils.SerializationHelper;
 
+import com.google_voltpatches.common.annotations.VisibleForTesting;
 import com.google_voltpatches.common.base.Function;
 import com.google_voltpatches.common.base.Optional;
 import com.google_voltpatches.common.base.Predicates;
@@ -92,15 +91,119 @@ public class ConnectionUtil {
         }
     }
 
+    /**
+     * Thread instance which delays running a runnable until a delay time is reached or it is canceled.
+     * <p>
+     * A very similar functionality can be achieved using a {@link java.util.concurrent.ScheduledExecutorService} but in
+     * this use case there is no obvious life span for the pool so it is easier to use a fire and forget thread
+     */
+    @VisibleForTesting
+    static final class DelayedExecutionThread extends Thread {
+        // nano time which needs to elapse before runnable is executed
+        private final long m_runAtNanos;
+        // runnable to execute after delay
+        private final Runnable m_runnable;
+        // current state of the thread
+        private volatile State m_state = State.NOT_STARTED;
+
+        public DelayedExecutionThread(long delay, TimeUnit unit, Runnable onTimeout) {
+            super(null, null, "Delayed Execution Thread " + unit.toMillis(delay) + "ms", CoreUtils.SMALL_STACK_SIZE);
+            m_runAtNanos = unit.toNanos(delay) + System.nanoTime();
+            m_runnable = onTimeout;
+            setDaemon(true);
+        }
+
+        @Override
+        public synchronized void run() {
+            if (m_state == State.CANCELED) {
+                // Already canceled before even being started
+                return;
+            }
+
+            if (m_state != State.NOT_STARTED) {
+                throw new IllegalStateException("Not in state " + State.NOT_STARTED + ": " + m_state);
+            }
+
+            setState(State.WAITING);
+
+            long now;
+            while (m_state == State.WAITING && (now = System.nanoTime()) <= m_runAtNanos) {
+                try {
+                    wait(Math.max(1, TimeUnit.NANOSECONDS.toMillis(now - m_runAtNanos)));
+                } catch (InterruptedException e) {
+                    // Ignore interruptions
+                }
+            }
+
+            if (!m_state.m_done) {
+                setState(State.RUNNING);
+                if (m_runnable != null) {
+                    m_runnable.run();
+                }
+                setState(State.COMPLETED);
+            }
+        }
+
+        /**
+         * Cancel the thread if it has not completed yet or is not running. This call will block if the {@code runnable}
+         * is being executed.
+         *
+         * @return {@code true} if the thread was canceled and {@code runnable} has not and will not run
+         */
+        public synchronized boolean cancel() {
+            if (!m_state.m_done) {
+                setState(State.CANCELED);
+            }
+            return m_state == State.CANCELED;
+        }
+
+        /**
+         * Block until a done state is reached. {@link State#COMPLETED} or {@link State#CANCELED}
+         *
+         * @return The done {@link State} of the thread
+         * @throws InterruptedException
+         */
+        public synchronized State waitUntilDone() throws InterruptedException {
+            while (!m_state.m_done) {
+                wait();
+            }
+            return m_state;
+        }
+
+        /**
+         * @return The current {@link State} of this thread
+         */
+        public State state() {
+            return m_state;
+        }
+
+        private void setState(State state) {
+            m_state = state;
+            if (state.m_done) {
+                notifyAll();
+            }
+        }
+
+        public enum State {
+            NOT_STARTED, WAITING, RUNNING, COMPLETED(true), CANCELED(true);
+
+            public final boolean m_done;
+
+            private State() {
+                this(false);
+            }
+
+            private State(boolean done) {
+                this.m_done = done;
+            }
+        }
+    }
+
     private static final HashMap<SocketChannel, ExecutorPair> m_executors =
         new HashMap<SocketChannel, ExecutorPair>();
     private static final AtomicLong m_handle = new AtomicLong(Long.MIN_VALUE);
 
     private static final GSSManager m_gssManager = GSSManager.getInstance();
-
-    // Thread pool for checking authentication timeout
-    private static final ScheduledThreadPoolExecutor m_periodicWorkThread =
-        CoreUtils.getScheduledThreadPoolExecutor("Authentication Timer", 0, CoreUtils.SMALL_STACK_SIZE);
 
     /**
      * Get a hashed password using SHA-1 in a consistent way.
@@ -209,9 +312,9 @@ public class ConnectionUtil {
         }
 
         // Setup a timer that times out the authentication if it is stuck (server dies, connection drops, etc.)
-        final ScheduledFuture<?> timeoutFuture;
+        final DelayedExecutionThread timeoutThread;
         if (timeoutMillis > 0) {
-            timeoutFuture = m_periodicWorkThread.schedule(new Runnable() {
+            timeoutThread = new DelayedExecutionThread(timeoutMillis, TimeUnit.MILLISECONDS, new Runnable() {
                 @Override
                 public void run() {
                     try {
@@ -220,9 +323,10 @@ public class ConnectionUtil {
                         // Ignore
                     }
                 }
-            }, timeoutMillis, TimeUnit.MILLISECONDS);
+            });
+            timeoutThread.start();
         } else {
-            timeoutFuture = null;
+            timeoutThread = null;
         }
 
         MessagingChannel messagingChannel = null;
@@ -356,7 +460,7 @@ public class ConnectionUtil {
                 messagingChannel.cleanUp();
             }
 
-            if (timeoutFuture != null && !timeoutFuture.cancel(false)) {
+            if (timeoutThread != null && !timeoutThread.cancel()) {
                 // Failed to cancel, which means the timeout task must have run
                 throw new IOException("Authentication timed out");
             }

--- a/src/frontend/org/voltdb/client/ConnectionUtil.java
+++ b/src/frontend/org/voltdb/client/ConnectionUtil.java
@@ -118,8 +118,9 @@ public class ConnectionUtil {
      * @return The bytes of the hashed password.
      */
     public static byte[] getHashedPassword(ClientAuthScheme scheme, String password) {
-        if (password == null)
+        if (password == null) {
             return null;
+        }
 
         MessageDigest md = null;
         try {
@@ -179,7 +180,9 @@ public class ConnectionUtil {
     };
 
     public final static Optional<DelegatePrincipal> getDelegate(Subject s) {
-        if (s == null) return Optional.absent();
+        if (s == null) {
+            return Optional.absent();
+        }
         return FluentIterable
                 .from(s.getPrincipals())
                 .filter(Predicates.instanceOf(DelegatePrincipal.class))
@@ -395,7 +398,9 @@ public class ConnectionUtil {
                 bb.clear().limit(4);
 
                 while (bb.hasRemaining()) {
-                    if (channel.read(bb) == -1) throw new EOFException();
+                    if (channel.read(bb) == -1) {
+                        throw new EOFException();
+                    }
                 }
                 bb.flip();
 
@@ -409,7 +414,9 @@ public class ConnectionUtil {
                 bb.clear().limit(msgSize);
 
                 while (bb.hasRemaining()) {
-                    if (channel.read(bb) == -1) throw new EOFException();
+                    if (channel.read(bb) == -1) {
+                        throw new EOFException();
+                    }
                 }
                 bb.flip();
 
@@ -494,7 +501,9 @@ public class ConnectionUtil {
                     } catch (IOException ex) {
                         throw new RuntimeException(ex);
                     } finally {
-                        if (context != null) try { context.dispose(); } catch (Exception ignoreIt) {}
+                        if (context != null) {
+                            try { context.dispose(); } catch (Exception ignoreIt) {}
+                        }
                     }
                     return null;
                 }

--- a/tests/frontend/org/voltdb/client/TestConnectionUtilDelayedExecutionThread.java
+++ b/tests/frontend/org/voltdb/client/TestConnectionUtilDelayedExecutionThread.java
@@ -1,0 +1,159 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.voltdb.client.ConnectionUtil.DelayedExecutionThread;
+import org.voltdb.client.ConnectionUtil.DelayedExecutionThread.State;
+
+import com.google_voltpatches.common.util.concurrent.Uninterruptibles;
+
+/**
+ * Simple unit tests for {@link DelayedExecutionThread}
+ */
+public class TestConnectionUtilDelayedExecutionThread {
+    /*
+     * Test that runnable is only executed after delay time has passed
+     */
+    @Test(timeout = 1000)
+    public void runAfterDelay() throws Exception {
+        CountDownLatch cdl1 = new CountDownLatch(1);
+        CountDownLatch cdl2 = new CountDownLatch(1);
+
+        long delayMs = 30;
+        long before = System.nanoTime();
+
+        DelayedExecutionThread det = new DelayedExecutionThread(delayMs, TimeUnit.MILLISECONDS, () -> {
+            cdl1.countDown();
+            Uninterruptibles.awaitUninterruptibly(cdl2);
+        });
+
+        State state = det.state();
+        assertTrue("State not not started: " + state, state == State.NOT_STARTED);
+
+        det.start();
+
+        // If false delay has already passed so test is not valid
+        assumeTrue(System.nanoTime() - before < TimeUnit.MILLISECONDS.toNanos(delayMs));
+
+        cdl1.await();
+        assertTrue("Executed too early", System.nanoTime() - before >= TimeUnit.MILLISECONDS.toNanos(delayMs));
+
+        state = det.state();
+        assertTrue("State not running: " + state, state == State.RUNNING);
+
+        cdl2.countDown();
+
+        det.waitUntilDone();
+
+        state = det.state();
+        assertTrue("State not completed: " + state, state == State.COMPLETED);
+    }
+
+    /*
+     * Test that a call to cancel causes the DelatedExecutionThread to exit immediately
+     */
+    @Test(timeout = 1000)
+    public void cancelExitsThread() throws Exception {
+        DelayedExecutionThread det = new DelayedExecutionThread(1, TimeUnit.HOURS, null);
+        det.start();
+
+        // Wait until the delay thread is waiting
+        while (det.state() != State.WAITING) {
+            Thread.yield();
+        }
+
+        det.cancel();
+
+        State state = det.state();
+        assertTrue("State not canceled: " + state, state == State.CANCELED);
+
+        det.join();
+    }
+
+    /*
+     * Test that calling cancel before start behaves correctly
+     */
+    @Test(timeout = 1000)
+    public void cancleBeforeStart() throws Exception {
+        boolean[] ran = { false };
+        DelayedExecutionThread det = new DelayedExecutionThread(0, TimeUnit.NANOSECONDS, () -> ran[0] = true);
+        det.cancel();
+
+        State state = det.state();
+        assertTrue("State not canceled: " + state, state == State.CANCELED);
+
+        det.start();
+        det.join();
+
+        state = det.state();
+        assertTrue("State not canceled: " + state, state == State.CANCELED);
+
+        assertFalse("Runnable ran", ran[0]);
+    }
+
+    /*
+     * Test that the cancel method blocks until the runnable completes
+     */
+    @Test(timeout = 1000)
+    public void cancelBlockedByRun() throws Exception {
+        CountDownLatch cdl1 = new CountDownLatch(1);
+        CountDownLatch cdl2 = new CountDownLatch(1);
+
+        long sleepTime = 15;
+        boolean[] failed = { false };
+
+        DelayedExecutionThread det = new DelayedExecutionThread(0, TimeUnit.NANOSECONDS, () -> {
+            cdl1.countDown();
+            try {
+                cdl2.await();
+                Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {
+                failed[0] = true;
+            }
+        });
+        det.start();
+
+        cdl1.await();
+
+        assertEquals(State.RUNNING, det.state());
+
+        long before = System.nanoTime();
+        cdl2.countDown();
+
+        det.cancel();
+
+        assertTrue(System.nanoTime() - before > TimeUnit.MILLISECONDS.toNanos(sleepTime));
+
+        assertFalse(failed[0]);
+    }
+}


### PR DESCRIPTION
The implementation of using a ScheduledThreadPoolExecutor with a core
pool size of 0 and keepAliveTime is 0 any thread in the pool will do
spin loop until the queue is empty. Instead of using a thread pool which
has no real defined start and end to its lifetime use a thread to track
handle tracking the timeout.

Create DelayedExecutionThread which wait for a delay to pass and then
invokes a runnable. The delayed thread can be canceled while waiting for
the delay to pass but not before.