### PR TITLE
ENG-14468 verify buffer length before allocation to handle late arrived responses

### DIFF
--- a/src/frontend/org/voltdb/LightweightNTClientResponseAdapter.java
+++ b/src/frontend/org/voltdb/LightweightNTClientResponseAdapter.java
@@ -118,6 +118,7 @@ public class LightweightNTClientResponseAdapter implements Connection, WriteStre
             ByteBuffer buf = null;
             synchronized (this) {
                 final int serializedSize = ds.getSerializedSize();
+                assert(serializedSize != DeferredSerialization.EMPTY_MESSAGE_LENGTH);
                 if (serializedSize <= 0) {
                     //Bad ignored transacton.
                     return;

--- a/src/frontend/org/voltdb/LightweightNTClientResponseAdapter.java
+++ b/src/frontend/org/voltdb/LightweightNTClientResponseAdapter.java
@@ -118,7 +118,6 @@ public class LightweightNTClientResponseAdapter implements Connection, WriteStre
             ByteBuffer buf = null;
             synchronized (this) {
                 final int serializedSize = ds.getSerializedSize();
-                assert(serializedSize != DeferredSerialization.EMPTY_MESSAGE_LENGTH);
                 if (serializedSize <= 0) {
                     //Bad ignored transacton.
                     return;

--- a/src/frontend/org/voltdb/SimpleClientResponseAdapter.java
+++ b/src/frontend/org/voltdb/SimpleClientResponseAdapter.java
@@ -176,7 +176,11 @@ public class SimpleClientResponseAdapter implements Connection, WriteStream {
             // in NIOWriteStream.enqueue().
             ByteBuffer buf = null;
             synchronized(this) {
-                buf = ByteBuffer.allocate(ds.getSerializedSize());
+                final int serializedSize = ds.getSerializedSize();
+                if (serializedSize <= 0) {
+                    return;
+                }
+                buf = ByteBuffer.allocate(serializedSize);
                 ds.serialize(buf);
             }
             if (buf == null) {


### PR DESCRIPTION
Client Interface may prematurely send response back to client due to leader changes. Responses could then be routed to client interface which could not locate the transaction and does no know how to allocate buffer. 