### PR TITLE
Added a new enumerator to force large temp table queries.

### DIFF
--- a/src/frontend/org/voltdb/BackendTarget.java
+++ b/src/frontend/org/voltdb/BackendTarget.java
@@ -33,15 +33,42 @@ package org.voltdb;
  * tests, where VoltDB results are compared with PostgreSQL results.
  */
 public enum BackendTarget {
-    NATIVE_EE_JNI("jni", false),
-    NATIVE_EE_SPY_JNI("jni_spy", false),
-    NATIVE_EE_IPC("ipc", true),
-    NATIVE_EE_VALGRIND_IPC("valgrind_ipc", true),
-    HSQLDB_BACKEND("hsqldb", false),
-    POSTGRESQL_BACKEND("postgresql", false),
-    POSTGIS_BACKEND("postgis", false),
-    NONE("none", false);
-    private BackendTarget(String display, boolean isIPC) { this.display = display; this.isIPC = isIPC; }
+                   /*      display,        isIPC, isVGABLE, isVG,  isLTT, isDefJNI */
+    NATIVE_EE_JNI(         "jni",          false, true,     false, false, true),
+    NATIVE_EE_LARGE_JNI(   "jni_large",    false, true,     false, true,  true),
+    NATIVE_EE_SPY_JNI(     "jni_spy",      false, false,    false, false, false),
+    NATIVE_EE_IPC(         "ipc",          true,  false,    false, false, false),
+    NATIVE_EE_VALGRIND_IPC("valgrind_ipc", true,  false,    true,  false, false),
+    HSQLDB_BACKEND(        "hsqldb",       false, false,    false, false, false),
+    POSTGRESQL_BACKEND(     "postgresql",  false, false,    false, false, false),
+    POSTGIS_BACKEND(        "postgis",     false, false,    false, false, false),
+    NONE(                   "none",        false, false,    false, false, false);
+
+    private BackendTarget(String display,
+                          boolean isIPC,
+                          boolean isValgrindable,
+                          boolean isValgrindTarget,
+                          boolean isLargeTempTableTarget,
+                          boolean isDefaulJNITarget) {
+        this.display = display;
+        this.isIPC = isIPC;
+        this.isValgrindable = isValgrindable;
+        this.isValgrindTarget = isValgrindTarget;
+        this.isLargeTempTableTarget = isLargeTempTableTarget;
+        this.isDefaultJNITarget = isDefaulJNITarget;
+    }
     public final String display;
     public final boolean isIPC;
+    // True iff this target can be used with Valgrind.
+    // The target need not be a valgrind target, but it's
+    // sensible to convert it to be a valgrind target.
+    public final boolean isValgrindable;
+    // True if this target is actually a valgrind
+    // target.  That is to say, we are going to use
+    // valgrind with this target.
+    public final boolean isValgrindTarget;
+    // True if this target is a large temp table target.
+    public final boolean isLargeTempTableTarget;
+    // True if this is a JNI target with no special engine properties.
+    public final boolean isDefaultJNITarget;
 }

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -79,7 +79,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
         throws KeeperException, InterruptedException, ExecutionException
     {
         // note the mp initiator always uses a non-ipc site, even though it's never used for anything
-        if ((backend == BackendTarget.NATIVE_EE_IPC) || (backend == BackendTarget.NATIVE_EE_VALGRIND_IPC)) {
+        if (backend.isValgrindTarget) {
             backend = BackendTarget.NATIVE_EE_JNI;
         }
 

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -731,7 +731,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         }
 
         try {
-            if (m_backend == BackendTarget.NATIVE_EE_JNI) {
+            // NATIVE_EE_JNI and NATIVE_EE_LARGE_JNI
+            if (m_backend.isDefaultJNITarget) {
                 eeTemp =
                     new ExecutionEngineJNI(
                         m_context.cluster.getRelativeIndex(),
@@ -765,7 +766,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                         exportFlushTimeout);
                 eeTemp = (ExecutionEngine) spyMethod.invoke(null, internalEE);
             }
-            else {
+            else if (m_backend.isIPC) {
                 // set up the EE over IPC
                 eeTemp =
                     new ExecutionEngineIPC(
@@ -783,6 +784,12 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                             hashinatorConfig,
                             m_isLowestSiteId,
                             exportFlushTimeout);
+            }
+            else {
+                /* This seems very bad. */
+                throw new VoltAbortException(
+                        String.format("Unexpected BackendTarget value %s", m_backend)
+                );
             }
             eeTemp.loadCatalog(m_startupConfig.m_timestamp, m_startupConfig.m_serializedCatalog);
             eeTemp.setBatchTimeout(m_context.cluster.getDeployment().get("deployment").

--- a/src/frontend/org/voltdb/sysprocs/AdHoc.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc.java
@@ -72,7 +72,7 @@ public class AdHoc extends AdHocNTBase {
                                   true, // infer partitioning
                                   null, // no partition key
                                   ExplainMode.NONE,
-                                  false, // is not a large query
+                                  m_backendTargetType.isLargeTempTableTarget, // back end dependent.
                                   false, // is not swap tables
                                   userParams);
         }

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -410,7 +410,7 @@ public class LocalCluster extends VoltServerConfig {
 
         // if the user wants valgrind and it makes sense, give it to 'em
         // For now only one host works.
-        if (isMemcheckDefined() && (target == BackendTarget.NATIVE_EE_JNI) && m_hostCount == 1) {
+        if (isMemcheckDefined() && target.isValgrindable && m_hostCount == 1) {
             m_target = BackendTarget.NATIVE_EE_VALGRIND_IPC;
         }
         else {
@@ -504,7 +504,7 @@ public class LocalCluster extends VoltServerConfig {
      * Called after a constructor but before startup.
      */
     public void overrideAnyRequestForValgrind() {
-        if (templateCmdLine.m_backend == BackendTarget.NATIVE_EE_VALGRIND_IPC) {
+        if (templateCmdLine.m_backend.isValgrindTarget) {
             m_target = BackendTarget.NATIVE_EE_JNI;
             templateCmdLine.m_backend = BackendTarget.NATIVE_EE_JNI;
         }

--- a/tests/frontend/org/voltdb/regressionsuites/LocalSingleProcessServer.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalSingleProcessServer.java
@@ -63,7 +63,7 @@ public abstract class LocalSingleProcessServer extends VoltServerConfig {
         assert(siteCount > 0);
         m_jarFileName = Configuration.getPathToCatalogForTest(jarFileName);
         m_siteCount = siteCount;
-        if (LocalCluster.isMemcheckDefined() && target.equals(BackendTarget.NATIVE_EE_JNI)) {
+        if (LocalCluster.isMemcheckDefined() && target.isValgrindable) {
             m_target = BackendTarget.NATIVE_EE_VALGRIND_IPC;
         } else {
             m_target = target;

--- a/tests/frontend/org/voltdb/regressionsuites/TestGroupBySuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGroupBySuite.java
@@ -816,8 +816,6 @@ public class TestGroupBySuite extends RegressionSuite {
         if (TEST_HSQL) {
             configureTests(builder, project, BackendTarget.HSQLDB_BACKEND, 1, 1, 0);
         }
-        builder.addServerConfig(config);
-
         return builder;
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestGroupBySuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGroupBySuite.java
@@ -46,6 +46,9 @@ import org.voltdb.planner.TestPlansGroupBy;
  */
 
 public class TestGroupBySuite extends RegressionSuite {
+    private static final boolean TEST_NORMAL_TABLES = true;
+    private static final boolean TEST_LARGE_TABLES = false;
+    private static final boolean TEST_HSQL = true;
 
     static final Class<?>[] MP_PROCEDURES = {
         org.voltdb_testprocs.regressionsuites.plansgroupbyprocs.CountT1A1.class,
@@ -800,22 +803,35 @@ public class TestGroupBySuite extends RegressionSuite {
         // config.compile(project);
         // builder.addServerConfig(config);
 
-        config = new LocalCluster("plansgroupby-onesite.jar", 1, 1, 0, BackendTarget.NATIVE_EE_JNI);
+        if (TEST_NORMAL_TABLES) {
+            configureTests(builder, project, BackendTarget.NATIVE_EE_JNI, 1, 1, 0);
+            // Cluster.
+            configureTests(builder, project, BackendTarget.NATIVE_EE_JNI, 2, 3, 1);
+        }
+        if (TEST_LARGE_TABLES) {
+            configureTests(builder, project, BackendTarget.NATIVE_EE_LARGE_JNI, 1, 1, 0);
+            // Cluster
+            configureTests(builder, project, BackendTarget.NATIVE_EE_LARGE_JNI, 1, 1, 0);
+        }
+        if (TEST_HSQL) {
+            configureTests(builder, project, BackendTarget.HSQLDB_BACKEND, 1, 1, 0);
+        }
+        builder.addServerConfig(config);
+
+        return builder;
+    }
+
+    private static void configureTests(MultiConfigSuiteBuilder builder,
+                                       VoltProjectBuilder project,
+                                       BackendTarget jniTarget,
+                                       int hostCount,
+                                       int siteCount,
+                                       int kfactor) {
+        VoltServerConfig config;
+        config = new LocalCluster("plansgroupby-onesite.jar", hostCount, siteCount, kfactor, jniTarget);
         boolean success = config.compile(project);
         assertTrue(success);
         builder.addServerConfig(config);
-
-        config = new LocalCluster("plansgroupby-hsql.jar", 1, 1, 0, BackendTarget.HSQLDB_BACKEND);
-        success = config.compile(project);
-        assertTrue(success);
-        builder.addServerConfig(config);
-
-        // Cluster
-        config = new LocalCluster("plansgroupby-cluster.jar", 2, 3, 1, BackendTarget.NATIVE_EE_JNI);
-        success = config.compile(project);
-        assertTrue(success);
-
-        return builder;
     }
 
     public class VRowComparator<T> implements Comparator<VoltTableRow>


### PR DESCRIPTION
There is no test for this really.  The queries in TestOrderBySuite
don't actually work in large temp table mode.  But the test in
TestAdHocLarge runs and passes when we use the new enumerator,
and I can see that the plans are large temp table plans in the
TestGroupBySuite tests, even when we use "@AdHoc".  The tests
fail in the EE, though.

I also added some more properties to BackendTarget.  This makes it
slightly more abstract.
