### PR TITLE
ENG-14347, keep mastership designation runnable when give up mastership.

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1102,12 +1102,10 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                         if (exportLog.isDebugEnabled()) {
                             exportLog.debug("Export table " + getTableName() + " accepting mastership for partition " + getPartitionId());
                         }
-                        if (m_onMastership != null) {
-                            if (m_mastershipAccepted.compareAndSet(false, true)) {
-                                // Either get enough responses or have received TRANSFER_MASTER event, clear the response sender HSids.
-                                m_responseHSIds.clear();
-                                m_onMastership.run();
-                            }
+                        if (m_mastershipAccepted.compareAndSet(false, true)) {
+                            // Either get enough responses or have received TRANSFER_MASTER event, clear the response sender HSids.
+                            m_responseHSIds.clear();
+                            m_onMastership.run();
                         }
                     }
                 } catch (Exception e) {

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1065,7 +1065,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             exportLog.debug("Export table " + getTableName() + " for partition " + getPartitionId() + " mailbox hsid (" +
                     CoreUtils.hsIdToString(m_ackMailboxRefs.get().getFirst().getHSId()) + ") gave up export mastership");
         }
-        m_onMastership = null;
         m_mastershipAccepted.set(false);
         m_isInCatalog = false;
         m_eos = false;


### PR DESCRIPTION
Initialization and catalog update setup new runnable so won't be affected.

The cause of the issue is that when export master give up mastership, it somehow also clears the mastership promotion callback, which is installed only during initialization or catalog update. When the old master was asked to be master again, the promotion will fail because it couldn't find the callback, in turn blocks export buffer to drain. 
