### PR TITLE
ENG-14470: Consistently handle runAnyWhere in ExportDataSource

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -106,9 +106,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             new AtomicReference<>(Pair.of((Mailbox)null, ImmutableList.<Long>builder().build()));
     private final Semaphore m_bufferPushPermits = new Semaphore(16);
 
-    // Set if connector "replicated" property is set to true
-    // Like replicated table, every replicated export stream is its own master.
-    private boolean m_runEveryWhere = false;
     private volatile ListeningExecutorService m_es;
     private final AtomicReference<BBContainer> m_pendingContainer = new AtomicReference<>();
     private volatile boolean m_isInCatalog;
@@ -940,12 +937,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
     }
 
-
-    //Is this a run everywhere source
-    public boolean isRunEveryWhere() {
-        return m_runEveryWhere;
-    }
-
     /**
      * indicate the partition leader has been migrated away
      * prepare to give up the mastership,
@@ -1131,7 +1122,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     public void setOnMastership(Runnable toBeRunOnMastership, boolean runEveryWhere) {
         Preconditions.checkNotNull(toBeRunOnMastership, "mastership runnable is null");
         m_onMastership = toBeRunOnMastership;
-        setRunEveryWhere(runEveryWhere);
+        runEveryWhere(runEveryWhere);
     }
 
     public ExportFormat getExportFormat() {
@@ -1139,14 +1130,11 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     }
 
     /**
-     * Set it from the client
-     *
      * @param runEveryWhere Set if connector "replicated" property is set to true Like replicated table, every
      *                      replicated export stream is its own master.
      */
-    public void setRunEveryWhere(boolean runEveryWhere) {
-        m_runEveryWhere = runEveryWhere;
-        if (m_runEveryWhere) {
+    public void runEveryWhere(boolean runEveryWhere) {
+        if (runEveryWhere) {
             acceptMastership();
         }
     }

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -409,8 +409,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
      */
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ExportDataSource))
+        if (!(o instanceof ExportDataSource)) {
             return false;
+        }
 
         return compareTo((ExportDataSource)o) == 0;
     }
@@ -855,6 +856,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
 
         m_es.submit(new Runnable() {
+            @Override
             public void run() {
                 Pair<Mailbox, ImmutableList<Long>> p = m_ackMailboxRefs.get();
                 Mailbox mbx = p.getFirst();
@@ -954,6 +956,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             return;
         }
         m_es.submit(new Runnable() {
+            @Override
             public void run() {
                 if (exportLog.isDebugEnabled()) {
                     exportLog.debug("Export table " + getTableName() + " mastership prepare to be demoted for partition " + getPartitionId());
@@ -1157,6 +1160,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
         if (!m_mastershipAccepted.get()) {
             m_es.execute(new Runnable() {
+                @Override
                 public void run() {
                     // Query export membership if current stream is not the master
                     queryExportMembership();
@@ -1168,6 +1172,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     public void handleQueryMessage(final long newLeaderHSId) {
         if (m_mastershipAccepted.get()) {
             m_es.execute(new Runnable() {
+                @Override
                 public void run() {
                     m_newLeaderHostId = CoreUtils.getHostIdFromHSId(newLeaderHSId);
                     // memorize end USO of the most recently pushed buffer from EE
@@ -1181,6 +1186,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             });
         } else {
             m_es.execute(new Runnable() {
+                @Override
                 public void run() {
                     sendQueryResponse(newLeaderHSId);
                 }
@@ -1191,6 +1197,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     public void handleQueryResponse(VoltMessage message) {
         if (!m_mastershipAccepted.get()) {
             m_es.execute(new Runnable() {
+                @Override
                 public void run() {
                     m_responseHSIds.add(message.m_sourceHSId);
                     Pair<Mailbox, ImmutableList<Long>> p = m_ackMailboxRefs.get();

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1123,21 +1123,27 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
     /**
      * set the runnable task that is to be executed on mastership designation
+     *
      * @param toBeRunOnMastership a {@link @Runnable} task
+     * @param runEveryWhere       Set if connector "replicated" property is set to true Like replicated table, every
+     *                            replicated export stream is its own master.
      */
-    public void setOnMastership(Runnable toBeRunOnMastership, boolean isRunEveryWhere) {
+    public void setOnMastership(Runnable toBeRunOnMastership, boolean runEveryWhere) {
         Preconditions.checkNotNull(toBeRunOnMastership, "mastership runnable is null");
         m_onMastership = toBeRunOnMastership;
-        if (isRunEveryWhere) {
-            acceptMastership();
-        }
+        setRunEveryWhere(runEveryWhere);
     }
 
     public ExportFormat getExportFormat() {
         return m_format;
     }
 
-    //Set it from client.
+    /**
+     * Set it from the client
+     *
+     * @param runEveryWhere Set if connector "replicated" property is set to true Like replicated table, every
+     *                      replicated export stream is its own master.
+     */
     public void setRunEveryWhere(boolean runEveryWhere) {
         m_runEveryWhere = runEveryWhere;
         if (m_runEveryWhere) {

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -187,7 +187,7 @@ public class GuestProcessor implements ExportDataProcessor {
             }
 
             m_source.setClient(client);
-            m_source.setRunEveryWhere(m_client.isRunEverywhere());
+            m_source.runEveryWhere(m_client.isRunEverywhere());
         }
 
         @Override


### PR DESCRIPTION
* Update setOnMastership to pass the runAnyWhere argument into setRunAnyWhere so that all ways to supply that configuration are handled the same.
* Remove variable m_runAnyWhere and remove _set_ prefix from the method which handles that value since it is no longer a setter.

If we want to keep m_runAnyWhere I will drop the last commit and only update the handling the argument.