### PR TITLE
Bug fix for ENG-14415 core dump when using materialized view to rewrite SELECT query.

### DIFF
--- a/src/frontend/org/voltdb/planner/MVQueryRewriter.java
+++ b/src/frontend/org/voltdb/planner/MVQueryRewriter.java
@@ -53,7 +53,8 @@ final class MVQueryRewriter {
         m_selectStmt = stmt;
         // NOTE: a MV creation stmt can be without group-by, e.g. "SELECT min(c1), max(c2), COUNT(*) FROM FOO"
         if (m_selectStmt.m_tableList.size() == 1 &&                   // For now, support rewrite SELECT from a single table
-                !m_selectStmt.hasOrderByColumns() && m_selectStmt.getHavingPredicate() == null) {   // MVI has GBY, does not have OBY or HAVING clause
+                ! m_selectStmt.m_limitOffset.hasLimitOrOffset() &&    // SELECT with LIMIT xx or OFFSET xx do not match views
+                ! m_selectStmt.hasOrderByColumns() && m_selectStmt.getHavingPredicate() == null) {   // MVI has GBY, does not have OBY or HAVING clause
             final Optional<Pair<MaterializedViewInfo, Map<Pair<String, Integer>, Pair<String, Integer>>>>
                     any = getMviAndViews(m_selectStmt.m_tableList).entrySet().stream()          // Scan all MV associated with SEL source tables,
                     .flatMap(kv -> {


### PR DESCRIPTION
Added check against LIMIT/OFFSET of SELECT stmt. When SELECT contains LIMIT and/or OFFSET, it skips materialized view matching.