### PR TITLE
ENG-14481 - Allow skipping during mp non replicated binary log apply

### DIFF
--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -522,10 +522,11 @@ BinaryLogSink::BinaryLogSink() {}
     partitionHash = taskInfo->readInt();
     bool isLocalMpTxn = UniqueId::isMpUniqueId(localUniqueId);
     bool isLocalRegularSpTxn = !isLocalMpTxn && (hashFlag == TXN_PAR_HASH_SINGLE || hashFlag == TXN_PAR_HASH_MULTI);
-    bool isLocalRegularMpTxn = isLocalMpTxn && (hashFlag == TXN_PAR_HASH_SINGLE || hashFlag == TXN_PAR_HASH_MULTI);
+    bool isLocalRegularMpTxn = isLocalMpTxn && !isCurrentTxnForReplicatedTable;
 
     // Read the whole txn since there is only one version number at the beginning
     type = static_cast<DRRecordType>(taskInfo->readByte());
+    assert(hashFlag != TXN_PAR_HASH_PLACEHOLDER || type == DR_RECORD_END_TXN);
     while (type != DR_RECORD_END_TXN) {
         // fast path for replicated table change, save calls to VoltDBEngine::isLocalSite()
         if (isCurrentTxnForReplicatedTable || isCurrentRecordForReplicatedTable) {


### PR DESCRIPTION
Disabling skip for transactions with TXN_PAR_HASH_SPECIAL caused row
moditications to be applied to partitions which they should not be. Allowing
skip for this transacations allows truncates to be applied to all
partitions but only applies modifications to the correct partition.