### PR TITLE
ENG-14480 stop rejoining node when it sees another node failure

### DIFF
--- a/src/frontend/org/voltcore/agreement/AgreementSite.java
+++ b/src/frontend/org/voltcore/agreement/AgreementSite.java
@@ -825,4 +825,8 @@ public class AgreementSite implements org.apache.zookeeper_voltpatches.server.Zo
         m_mailbox.deliver(lom);
         return cdl;
     }
+
+    public int getFailedSiteCount() {
+        return m_meshArbiter.getFailedSitesCount();
+    }
 }

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1937,4 +1937,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         m_stopNodeNotice.remove(targetHostId);
     }
 
+    public int getFailedSiteCount() {
+        return m_agreementSite.getFailedSiteCount();
+    }
 }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3058,6 +3058,14 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
         try {
             m_messenger.start();
+        } catch (CoreUtils.RetryException e) {
+
+            // do not log as fatal in this case
+            boolean printStackTrace = true;
+            if (e.getMessage() != null  && e.getMessage().indexOf(MeshProber.MESH_ONE_REJOIN_MSG )> -1) {
+                printStackTrace = false;
+            }
+            VoltDB.crashLocalVoltDB(e.getMessage(), printStackTrace, e);
         } catch (Exception e) {
             VoltDB.crashLocalVoltDB(e.getMessage(), true, e);
         }

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -210,7 +210,7 @@ public class SpInitiator extends BaseInitiator implements Promotable
                 // state, it will respond REJOINING to new work which will break
                 // the MPI and/or be unexpected to external clients.
                 if (!migratePartitionLeader && !m_initiatorMailbox.acceptPromotion()) {
-                    tmLog.error(m_whoami
+                    tmLog.info(m_whoami
                             + "rejoining site can not be promoted to leader. Terminating.");
                     VoltDB.crashLocalVoltDB("A rejoining site can not be promoted to leader.", false, null);
                     return;

--- a/src/frontend/org/voltdb/probe/MeshProber.java
+++ b/src/frontend/org/voltdb/probe/MeshProber.java
@@ -94,7 +94,7 @@ public class MeshProber implements JoinAcceptor {
     private static final String MISSING_HOST_COUNT = "missingHostCount";
 
     private static final VoltLogger m_networkLog = new VoltLogger("NETWORK");
-
+    public static final String MESH_ONE_REJOIN_MSG = "Only one host can rejoin at a time. Host";
     /**
      * Helper method that takes a comma delimited list of host specs, validates it,
      * and converts it to a set of valid coordinators
@@ -453,8 +453,7 @@ public class MeshProber implements JoinAcceptor {
             if (rejoiningHost == -1) {
                 return new JoinAcceptor.PleaDecision(null, true, false);
             } else {
-                String msg = "Only one host can rejoin at a time. Host "
-                      + rejoiningHost + " is still rejoining.";
+                String msg = MESH_ONE_REJOIN_MSG + rejoiningHost + " is still rejoining.";
                 return new JoinAcceptor.PleaDecision(msg, false, true);
             }
         }


### PR DESCRIPTION
If the current node hasn't finished rejoin when another node fails, this rejoining node should be shutdown to prevent locking up of the cluster.  If  the host failure notification could come before mesh determination: that is, the current node does not know it is rejoining, and the shutdown is skipped.  The host failure  processing is handed off to a shared executor which could be blocked by other running tasks. To ensure the accurate and timely rejoining node shutdown, use a dedicated executor instead.