### PR TITLE
Eng 14166 sqlcov starts w

### DIFF
--- a/tests/sqlcoverage/SQLGenerator.py
+++ b/tests/sqlcoverage/SQLGenerator.py
@@ -1209,12 +1209,13 @@ class SQLGenerator:
     # The presence of an underbar apparently inside a quoted string after the LIKE keyword
     # is likely enough to be a false positive for an unresolved generator that it is
     # allowed to pass without the usual warning triggered by a leading underbar.
-    LIKELY_FALSE_ALARMS = re.compile(r"LIKE '[^']*_.*'")
+    LIKELY_FALSE_ALARMS = re.compile(r"(LIKE|STARTS WITH) '[^']*_.*'")
 
     def __generate_statement(self, text):
         text = self.__template.apply_macros(text)
         text = unicode(text)
 
+        print_warning = False
         for statement in self.__template.generate_statements_from_text(text):
             ### print ('VERBOSE DEBUG: text and statement post-generate_statements_from_text: "' + text + '", "' + statement + '"')
             statement, generators, field_map = BaseGenerator.prepare_generators(statement,
@@ -1224,6 +1225,7 @@ class SQLGenerator:
             if (SQLGenerator.UNRESOLVED_PUNCTUATION.search(statement) or
                 (SQLGenerator.UNRESOLVED_GENERATOR.search(statement) and
                  not SQLGenerator.LIKELY_FALSE_ALARMS.search(statement))):
+                print_warning = True
                 print ('WARNING: final statement contains suspicious unresolved symbol(s): "' +
                        statement + '"')
                 print ('with schema "' + self.__schema.debug_schema_to_string() + '"')
@@ -1231,7 +1233,13 @@ class SQLGenerator:
             for generated_stmt in BaseGenerator.generate_statements_from_list(statement,
                                                                               generators,
                                                                               field_map):
+                if print_warning:
+                    print ('generators:', str(generators))
+                    print ('field_map :', str(field_map))
+                    print ('statement :\n   ', str(statement))
+                    print ('generated_stmt:\n   ', str(generated_stmt))
                 yield generated_stmt
+            print_warning = False
 
     def generate(self, summarize_successes = False):
         for s in self.__statements:

--- a/tests/sqlcoverage/config/postgis-geo-config.py
+++ b/tests/sqlcoverage/config/postgis-geo-config.py
@@ -23,8 +23,8 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 
-# This file contains the "geo" tests, which are a subset of those run
-# by the "postgis" sqlcoverage Jenkins job.
+# This file (mostly) contains the "geo" tests, which are a subset of those
+# run by the "postgis" sqlcoverage Jenkins job.
 
 # These tests only work when run against PostgreSQL/PostGIS, not HSQL. Hence,
 # to run them on the command line, use something like the following:
@@ -56,4 +56,11 @@
                       "template": "geo-functions.sql",
                       "normalizer": "normalizer.py",
                       "precision": "4"},
+    # This test suite does not contain "geo" tests, but it was added here
+    # anyway, since this config file is the one that runs the fastest,
+    # among the current "postgis" config files.
+    "advanced-starts-with": {"schema": "strings-schema.py",
+                             "ddl": "strings-DDL-null.sql",
+                             "template": "advanced-starts-with.sql",
+                             "normalizer": "nulls-lowest-normalizer.py"},
 }

--- a/tests/sqlcoverage/start_postgresql.sh
+++ b/tests/sqlcoverage/start_postgresql.sh
@@ -38,7 +38,7 @@ echo  "CLASSPATH:" $CLASSPATH
 
 # Start the PostgreSQL server, in the new temp directory
 # Note: '--lc-collate=C' causes VARCHAR sorting to match VoltDB's
-$PG_PATH/initdb -D $PG_TMP_DIR/data --auth=trust --auth-host=trust --auth-local=trust --lc-collate=C
+$PG_PATH/initdb -D $PG_TMP_DIR/data --auth=trust --auth-host=trust --auth-local=trust --encoding='UTF-8' --lc-collate=C
 echo -e "unix_socket_directories='.'\nlisten_addresses='*'\nport=$PG_PORT" >> $PG_TMP_DIR/data/postgresql.conf
 $PG_PATH/pg_ctl start -w -D $PG_TMP_DIR/data -l $PG_TMP_DIR/postgres.log
 

--- a/tests/sqlcoverage/template/string/advanced-starts-with.sql
+++ b/tests/sqlcoverage/template/string/advanced-starts-with.sql
@@ -1,0 +1,27 @@
+-- This file repeats all the same tests in advanced-strings.sql (including LIKE
+-- and STARTS WITH tests), and then adds some tests, mostly of the STARTS WITH
+-- operator, that can only run against PostgreSQL (that is, they do not work in
+-- HSQL), which mostly means tests using UPSERT.
+<advanced-strings.sql>
+
+-- Redo INSERT statements, since advanced-strings.sql ends with DELETE statements
+INSERT INTO @dmltable VALUES (@insertvals)
+-- Insert some extra rows that will have interesting, non-empty STARTS WITH results
+INSERT INTO @dmltable VALUES (_id, 'abc!dez', _value[string null20], _value[string null20], _value[float])
+INSERT INTO @dmltable VALUES (_id, 'abc%',    'abc',                 'a',                   _value[float])
+-- Uncomment these 2 after ENG-14485 is fixed:
+--INSERT INTO @dmltable VALUES (_id, 'abc%%',   'abc',                 'a',                   _value[float])
+--INSERT INTO @dmltable VALUES (_id, 'abc!',    'abc_',                'abc',                 _value[float])
+
+
+-- Redo tests of the SUBSTRING function, since these fail in HSQL,
+-- with the small VARCHAR values above
+SELECT SUBSTRING ( VCHAR FROM _value[int:1,10] FOR _value[int:1,10] ) substrQ1 FROM @fromtables ORDER BY VCHAR
+SELECT VCHAR substrQ3 FROM @fromtables ORDER BY SUBSTRING ( VCHAR FROM _value[int:1,10] ), VCHAR
+
+
+-- Final tests of STARTS WITH in DML: UPSERT (does not work in HSQL)
+UPSERT INTO @dmltable SELECT @upsertselectcols FROM @fromtables WHERE VCHAR _maybe STARTS WITH 'abc'             ORDER BY @idcol
+UPSERT INTO @dmltable SELECT @upsertselectcols FROM @fromtables WHERE VCHAR _maybe STARTS WITH _variable[string] ORDER BY @idcol
+-- Confirm the values that were "upserted"
+SELECT * FROM @fromtables startsW35 ORDER BY @idcol

--- a/tests/sqlcoverage/template/string/advanced-strings.sql
+++ b/tests/sqlcoverage/template/string/advanced-strings.sql
@@ -83,17 +83,17 @@
 {_patterns6 |= "'abc__!_z'"}
 
 
+-- Tests of the SUBSTRING function
+SELECT SUBSTRING ( VCHAR FROM _value[int:1,10] FOR _value[int:1,10] ) substrQ1 FROM @fromtables ORDER BY VCHAR
+SELECT VCHAR substrQ3 FROM @fromtables ORDER BY SUBSTRING ( VCHAR FROM _value[int:1,10] ), VCHAR
+
+
 -- Insert some extra rows that will have interesting, non-empty STARTS WITH results
 INSERT INTO @dmltable VALUES (_id, 'abc!dez', _value[string null20], _value[string null20], _value[float])
 INSERT INTO @dmltable VALUES (_id, 'abc%',    'abc',                 'a',                   _value[float])
 -- Uncomment these 2 after ENG-14485 is fixed:
 --INSERT INTO @dmltable VALUES (_id, 'abc%%',   'abc',                 'a',                   _value[float])
 --INSERT INTO @dmltable VALUES (_id, 'abc!',    'abc_',                'abc',                 _value[float])
-
-
--- Tests of SUBSTRING function
-SELECT SUBSTRING ( VCHAR FROM _value[int:1,10] FOR _value[int:1,10] ) substrQ1 FROM @fromtables ORDER BY VCHAR
-SELECT VCHAR substrQ3 FROM @fromtables ORDER BY SUBSTRING ( VCHAR FROM _value[int:1,10] ), VCHAR
 
 
 -- Tests of LIKE operator
@@ -129,16 +129,12 @@ SELECT VCHAR startsW16 FROM @fromtables WHERE VCHAR _maybe STARTS WITH _patterns
 SELECT _variable[#col1 string], _variable[#col2 string] FROM @fromtables startsW29 WHERE __[#col1] _maybe STARTS WITH __[#col2]
 
 
--- Tests of STARTS WITH in DML: INSERT, UPSERT, UPDATE, DELETE
+-- Tests of STARTS WITH in DML: INSERT, UPDATE, DELETE (but not UPSERT, which only
+-- works testing against PostgreSQL, not HSQL: see advanced-starts-with.sql for that)
 INSERT INTO @dmltable SELECT @insertselectcols FROM @fromtables startsW30 WHERE VCHAR _maybe STARTS WITH 'abc'
 INSERT INTO @dmltable SELECT @insertselectcols FROM @fromtables startsW31 WHERE VCHAR _maybe STARTS WITH _variable[string]
 -- Confirm the values that were inserted
 SELECT * FROM @fromtables startsW32 ORDER BY @idcol
-
-UPSERT INTO @dmltable SELECT @upsertselectcols FROM @fromtables           WHERE VCHAR _maybe STARTS WITH 'abc'             ORDER BY @idcol
-UPSERT INTO @dmltable SELECT @upsertselectcols FROM @fromtables           WHERE VCHAR _maybe STARTS WITH _variable[string] ORDER BY @idcol
--- Confirm the values that were "upserted"
-SELECT * FROM @fromtables startsW35 ORDER BY @idcol
 
 -- Uncomment these 2 after ENG-14478 is fixed (and delete the next 2??):
 --UPDATE @dmltable startsW36 SET VCHAR_INLINE_MAX = VCHAR_INLINE WHERE VCHAR _maybe STARTS WITH 'abc'

--- a/tests/sqlcoverage/template/string/advanced-strings.sql
+++ b/tests/sqlcoverage/template/string/advanced-strings.sql
@@ -1,12 +1,9 @@
 <configure-for-string.sql>
 <advanced-template.sql>
 
-SELECT SUBSTRING ( VCHAR FROM _value[int:1,10] FOR _value[int:1,10] ) substrQ1 FROM @fromtables ORDER BY VCHAR
-SELECT VCHAR substrQ3 FROM @fromtables ORDER BY SUBSTRING ( VCHAR FROM _value[int:1,10] ), VCHAR
-
 -- patterns in set 1 contain '%'
 {_patterns1 |= "'abc%'"}
--- Uncomment after ENG-9449 is fixed (??):
+-- Uncomment after ENG-9449 is fixed:
 --{_patterns1 |= "'%'"}
 {_patterns1 |= "'!%'"}
 {_patterns1 |= "'abc!%'"}
@@ -60,6 +57,7 @@ SELECT VCHAR substrQ3 FROM @fromtables ORDER BY SUBSTRING ( VCHAR FROM _value[in
 
 -- patterns in set 5 contain '%%'
 {_patterns5 |= "'abc%%'"}
+{_patterns5 |= "'abc%%%'"}
 {_patterns5 |= "'%%'"}
 {_patterns5 |= "'!%%'"}
 {_patterns5 |= "'abc!%%'"}
@@ -84,6 +82,21 @@ SELECT VCHAR substrQ3 FROM @fromtables ORDER BY SUBSTRING ( VCHAR FROM _value[in
 {_patterns6 |= "'abc!___z'"}
 {_patterns6 |= "'abc__!_z'"}
 
+
+-- Insert some extra rows that will have interesting, non-empty STARTS WITH results
+INSERT INTO @dmltable VALUES (_id, 'abc!dez', _value[string null20], _value[string null20], _value[float])
+INSERT INTO @dmltable VALUES (_id, 'abc%',    'abc',                 'a',                   _value[float])
+-- Uncomment these 2 after ENG-14485 is fixed:
+--INSERT INTO @dmltable VALUES (_id, 'abc%%',   'abc',                 'a',                   _value[float])
+--INSERT INTO @dmltable VALUES (_id, 'abc!',    'abc_',                'abc',                 _value[float])
+
+
+-- Tests of SUBSTRING function
+SELECT SUBSTRING ( VCHAR FROM _value[int:1,10] FOR _value[int:1,10] ) substrQ1 FROM @fromtables ORDER BY VCHAR
+SELECT VCHAR substrQ3 FROM @fromtables ORDER BY SUBSTRING ( VCHAR FROM _value[int:1,10] ), VCHAR
+
+
+-- Tests of LIKE operator
 SELECT VCHAR likeQ11 FROM @fromtables WHERE VCHAR _maybe LIKE _patterns1
 SELECT VCHAR likeQ12 FROM @fromtables WHERE VCHAR _maybe LIKE _patterns2
 SELECT VCHAR likeQ13 FROM @fromtables WHERE VCHAR _maybe LIKE _patterns3
@@ -96,3 +109,49 @@ SELECT VCHAR likeQ23 FROM @fromtables WHERE VCHAR _maybe LIKE _patterns3 ESCAPE 
 SELECT VCHAR likeQ24 FROM @fromtables WHERE VCHAR _maybe LIKE _patterns4 ESCAPE '!'
 SELECT VCHAR likeQ25 FROM @fromtables WHERE VCHAR _maybe LIKE _patterns5 ESCAPE '!'
 SELECT VCHAR likeQ26 FROM @fromtables WHERE VCHAR _maybe LIKE _patterns6 ESCAPE '!'
+
+-- Tests of one column LIKE another
+SELECT _variable[#col1 string], _variable[#col2 string] FROM @fromtables likeQ28   WHERE __[#col1] _maybe LIKE __[#col2]
+-- Uncomment this after ENG-14485 is fixed:
+--SELECT _variable[#col1 string], _variable[#col2 string] FROM @fromtables likeQ29   WHERE __[#col1] _maybe LIKE __[#col2] || '%'
+
+
+-- Tests of STARTS WITH operator
+SELECT VCHAR startsW11 FROM @fromtables WHERE VCHAR _maybe STARTS WITH _patterns1
+SELECT VCHAR startsW12 FROM @fromtables WHERE VCHAR _maybe STARTS WITH _patterns2
+SELECT VCHAR startsW13 FROM @fromtables WHERE VCHAR _maybe STARTS WITH _patterns3
+SELECT VCHAR startsW14 FROM @fromtables WHERE VCHAR _maybe STARTS WITH _patterns4
+SELECT VCHAR startsW15 FROM @fromtables WHERE VCHAR _maybe STARTS WITH _patterns5
+SELECT VCHAR startsW16 FROM @fromtables WHERE VCHAR _maybe STARTS WITH _patterns6
+-- Note: "STARTS WITH ... ESCAPE" is not valid syntax, so not tested
+
+-- Test of one column STARTS WITH another
+SELECT _variable[#col1 string], _variable[#col2 string] FROM @fromtables startsW29 WHERE __[#col1] _maybe STARTS WITH __[#col2]
+
+
+-- Tests of STARTS WITH in DML: INSERT, UPSERT, UPDATE, DELETE
+INSERT INTO @dmltable SELECT @insertselectcols FROM @fromtables startsW30 WHERE VCHAR _maybe STARTS WITH 'abc'
+INSERT INTO @dmltable SELECT @insertselectcols FROM @fromtables startsW31 WHERE VCHAR _maybe STARTS WITH _variable[string]
+-- Confirm the values that were inserted
+SELECT * FROM @fromtables startsW32 ORDER BY @idcol
+
+UPSERT INTO @dmltable SELECT @upsertselectcols FROM @fromtables           WHERE VCHAR _maybe STARTS WITH 'abc'             ORDER BY @idcol
+UPSERT INTO @dmltable SELECT @upsertselectcols FROM @fromtables           WHERE VCHAR _maybe STARTS WITH _variable[string] ORDER BY @idcol
+-- Confirm the values that were "upserted"
+SELECT * FROM @fromtables startsW35 ORDER BY @idcol
+
+-- Uncomment these 2 after ENG-14478 is fixed (and delete the next 2??):
+--UPDATE @dmltable startsW36 SET VCHAR_INLINE_MAX = VCHAR_INLINE WHERE VCHAR _maybe STARTS WITH 'abc'
+--UPDATE @dmltable startsW37 SET VCHAR_INLINE_MAX = VCHAR_INLINE WHERE VCHAR _maybe STARTS WITH _variable[string]
+UPDATE @dmltable startsW36a SET VCHAR_INLINE_MAX = 'xyz'                  WHERE VCHAR _maybe STARTS WITH 'abc'
+UPDATE @dmltable startsW37a SET VCHAR_INLINE_MAX = 'xyz'                  WHERE VCHAR _maybe STARTS WITH _variable[string]
+-- Confirm the values that were updated
+SELECT * FROM @fromtables startsW38 ORDER BY @idcol
+
+DELETE FROM @dmltable WHERE VCHAR        STARTS WITH 'abc!d'
+DELETE FROM @dmltable WHERE VCHAR    NOT STARTS WITH 'abc'
+-- Confirm which rows were deleted (& which not)
+SELECT * FROM @fromtables startsW40 ORDER BY @idcol
+DELETE FROM @dmltable WHERE VCHAR _maybe STARTS WITH _variable[#col2 string]
+-- Confirm which rows were deleted (& which not, if any)
+SELECT * FROM @fromtables startsW41 ORDER BY @idcol

--- a/tests/sqlcoverage/template/string/configure-for-string.sql
+++ b/tests/sqlcoverage/template/string/configure-for-string.sql
@@ -16,8 +16,10 @@
 {@dmltable = "_table"}
 {@fromtables = "_table"}
 {@idcol = "ID"}
-{@insertcols = "ID, VCHAR, VCHAR_INLINE_MAX, VCHAR_INLINE, RATIO"}
-{@insertselectcols = "ID+16, VCHAR, VCHAR_INLINE_MAX, VCHAR_INLINE, RATIO"}
+{_nonidcols |= "VCHAR, VCHAR_INLINE_MAX, VCHAR_INLINE, RATIO"}
+{@insertcols = "ID, _nonidcols"}
+{@insertselectcols = "_id, _nonidcols"}
+{@upsertselectcols = "ID+16, _nonidcols"}
 {@insertvals = "_id, _value[string null20], _value[string null20], _value[string null20], _value[float]"}
 -- There are no unary string-to-string functions supported yet.
 {@onefun = ""}


### PR DESCRIPTION
ENG-14166: added tests of STARTS WITH to SqlCoverage (in the existing advanced-strings and new advanced-starts-with test suites, the latter running only against PostgreSQL); and a new QueryTransformer that converts VoltDB STARTS WITH clauses into equivalent PostgreSQL LIKE clauses; also improved LIKE tests; improved debugging of QueryTransformers, added a new groupReplaceAll (boolean) parameter, tweaked the handling of special characters like '\' and '$', and the handling of group name substitutions; and tweaked start_postgresql.sh to ensure that PostgreSQL uses UTF-8 encoding (which it already was on Jenkins machines, but not on my Mac).