### PR TITLE
ENG-14488, fix export poll data source twice issue.

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -101,13 +101,19 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     private volatile boolean m_closed = false;
     private final StreamBlockQueue m_committedBuffers;
     private Runnable m_onMastership;
+    // m_pollFuture is used for a common case to improve efficiency, export decoder thread creates
+    // future and passes to EDS executor thread, if EDS executor has no new buffer to poll, the future
+    // is assigned to m_pollFuture. When site thread pushes buffer to EDS executor thread, m_pollFuture
+    // is reused to notify export decoder to stop waiting.
     private SettableFuture<BBContainer> m_pollFuture;
     private final AtomicReference<Pair<Mailbox, ImmutableList<Long>>> m_ackMailboxRefs =
             new AtomicReference<>(Pair.of((Mailbox)null, ImmutableList.<Long>builder().build()));
     private final Semaphore m_bufferPushPermits = new Semaphore(16);
 
     private volatile ListeningExecutorService m_es;
+    // A place to keep unfinished export buffer when processor shuts down.
     private final AtomicReference<BBContainer> m_pendingContainer = new AtomicReference<>();
+    // Is EDS from catalog or from disk pdb?
     private volatile boolean m_isInCatalog;
     private volatile boolean m_eos;
     private final Generation m_generation;
@@ -646,6 +652,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         });
     }
 
+    // Needs to be thread-safe, EDS executor, export decoder and site thread both touch m_pendingContainer.
     public void setPendingContainer(BBContainer container) {
         Preconditions.checkNotNull(m_pendingContainer.get() != null, "Pending container must be null.");
         m_pendingContainer.set(container);
@@ -1062,13 +1069,8 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         m_mastershipAccepted.set(false);
         m_isInCatalog = false;
         m_eos = false;
+        m_pollFuture = null;
 
-        // For case where the previous export processor had only row of the first block to process
-        // and it completed processing it, poll future is not set to null still. Set it to null to
-        // prepare for the new processor polling
-        if ((m_pollFuture != null) && (m_pendingContainer.get() == null)) {
-            m_pollFuture = null;
-        }
     }
 
     /**

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -375,8 +375,12 @@ public class GuestProcessor implements ExportDataProcessor {
                                 if (row != null) {
                                     edb.onBlockCompletion(row);
                                 }
-                                //Make sure to discard after onBlockCompletion so that if completion wants to retry we dont lose block.
-                                if (cont != null) {
+                                // Make sure to discard after onBlockCompletion so that if completion
+                                // wants to retry we don't lose block.
+                                // Please note that if export manager is shutting down it's possible
+                                // that container isn't fully consumed. Discard the buffer prematurely
+                                // would cause missing rows in export stream.
+                                if (!m_shutdown && cont != null) {
                                     cont.discard();
                                     cont = null;
                                 }
@@ -400,7 +404,10 @@ public class GuestProcessor implements ExportDataProcessor {
                                 }
                             }
                         }
-                        //Dont discard the block also set the start position to the begining.
+                        // Don't discard the block also set the start position to the begining.
+                        // TODO: it would be nice to keep the last position in the buffer so that
+                        //       next time connector can pick up from where it left last time and
+                        //       continue. It helps to reduce exporting duplicated rows.
                         if (m_shutdown && cont != null) {
                             if (m_logger.isDebugEnabled()) {
                                 // log message for debugging.


### PR DESCRIPTION
THere are two problems under the hood, first export doesn't set m_pendingContainer properly during export processor shutdown, it may cause data lose in downstream export client. Second, when export master gives up mastership, it no longer needs the m_pollFuture, set to null unconditionally.

Change-Id: Iaf17be7011aba0698da11d756b9c00f5babe8199