### PR TITLE
ENG-14488, fix export poll data source twice issue.

### DIFF
--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -375,8 +375,12 @@ public class GuestProcessor implements ExportDataProcessor {
                                 if (row != null) {
                                     edb.onBlockCompletion(row);
                                 }
-                                //Make sure to discard after onBlockCompletion so that if completion wants to retry we dont lose block.
-                                if (cont != null) {
+                                // Make sure to discard after onBlockCompletion so that if completion
+                                // wants to retry we don't lose block.
+                                // Please note that if export manager is shutting down it's possible
+                                // that container isn't fully consumed. Discard the buffer prematurely
+                                // would cause missing rows in export stream.
+                                if (!m_shutdown && cont != null) {
                                     cont.discard();
                                     cont = null;
                                 }
@@ -400,7 +404,10 @@ public class GuestProcessor implements ExportDataProcessor {
                                 }
                             }
                         }
-                        //Dont discard the block also set the start position to the begining.
+                        // Don't discard the block also set the start position to the begining.
+                        // TODO: it would be nice to keep the last position in the buffer so that
+                        //       next time connector can pick up from where it left last time and
+                        //       continue. It helps to reduce exporting duplicated rows.
                         if (m_shutdown && cont != null) {
                             if (m_logger.isDebugEnabled()) {
                                 // log message for debugging.


### PR DESCRIPTION
THere are two problems under the hood, first export doesn't set m_pendingContainer properly during export processor shutdown, it may cause data lose in downstream export client. Second, when export master gives up mastership, it no longer needs the m_pollFuture, set to null unconditionally.

Change-Id: Iaf17be7011aba0698da11d756b9c00f5babe8199