### PR TITLE
ENG-14491 recreate term if a site regains leadership after leader migration

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -4925,5 +4925,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     public boolean isJoining() {
         return m_joining;
     }
+
+    public Initiator getInitiator(int partition) {
+        return m_iv2Initiators.get(partition);
+    }
 }
 

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -209,6 +209,12 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     {
         super.setLeaderState(isLeader);
         m_snapMonitor.addInterest(this);
+        if (isLeader) {
+            SpInitiator init = (SpInitiator)((RealVoltDB)VoltDB.instance()).getInitiator(m_partitionId);
+            if (init.m_term != null) {
+                ((SpTerm)init.m_term).setPromoting(false);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Old partition leaders could regain leadership upon the failure of  the hosts with new partition leaders acquired via leader migration. The old leaders may miss replica list update.  In this case, the older leaders should  synch their replica list upon re-promotion.