### PR TITLE
ENG-14488, fix export poll more than once issue.

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -661,6 +661,19 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     }
 
     public ListenableFuture<BBContainer> poll() {
+        // ENG-14488, it's possible to have the export master gives up mastership
+        // but still try to poll immediately after that, e.g. from Pico Network
+        // thread the master gives up mastership, from decoder thread it tries to
+        // poll periodically, they won't overlap but poll can happen after giving up
+        // mastership. If it happens m_pollFuture can be mistakingly set, and when
+        // the old master retakes mastership again it refuses to export because
+        // m_pollFuture should be false on a fresh master.
+        //
+        // Add following check to eliminate this window.
+        if (!m_mastershipAccepted.get()) {
+            return null;
+        }
+
         final SettableFuture<BBContainer> fut = SettableFuture.create();
         try {
             m_es.execute(new Runnable() {
@@ -686,6 +699,8 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                         if (m_pollFuture != null) {
                             fut.setException(new RuntimeException("Should not poll more than once: InCat = " + m_isInCatalog +
                                     " ExportDataSource for Table " + getTableName() + " at Partition " + getPartitionId()));
+                            // Since it's not fatal exception, gives it second chance to poll again.
+                            m_pollFuture = null;
                             return;
                         }
                         if (!m_es.isShutdown()) {


### PR DESCRIPTION
It's possible to have the export master gives up mastership but still try to poll immediately after that, e.g. from Pico Network thread the master gives up mastership, from decoder thread it tries to poll periodically, they won't overlap but poll can happen after giving up mastership. If it happens m_pollFuture can be mistakingly set, and when the old master retakes mastership again it refuses to export because m_pollFuture should be false on a fresh master.

Change-Id: I8e02c10044e940eb5976488059eb9163b3bd1539