### PR TITLE
ENG-14504:

### DIFF
--- a/src/frontend/org/voltcore/messaging/ForeignHost.java
+++ b/src/frontend/org/voltcore/messaging/ForeignHost.java
@@ -310,7 +310,7 @@ public class ForeignHost {
     /** Deliver a deserialized message from the network to a local mailbox */
     private void deliverMessage(long destinationHSId, VoltMessage message) {
         if (!m_hostMessenger.validateForeignHostId(m_hostId)) {
-            hostLog.warn(String.format("Message (%s) sent to site id: %s @ (%s) at %d from %s "
+            hostLog.debug(String.format("Message (%s) sent to site id: %s @ (%s) at %d from %s "
                     + "which is a known failed host. The message will be dropped\n",
                     message.getClass().getSimpleName(),
                     CoreUtils.hsIdToString(destinationHSId),

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -879,7 +879,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     }
 
     public synchronized boolean canCompleteRepair(int hostId) {
-        return !m_foreignHosts.containsKey(hostId) && !m_picoZombieForeignHosts.containsKey(hostId) && !m_zkZombieForeignHosts.containsKey(hostId);
+        return !m_foreignHosts.containsKey(hostId) && (m_knownFailedHosts.containsKey(hostId) ||
+                (!m_picoZombieForeignHosts.containsKey(hostId) && !m_zkZombieForeignHosts.containsKey(hostId)));
     }
 
     /**

--- a/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
@@ -555,7 +555,7 @@ public class InitiatorMailbox implements Mailbox
                 deliver(message);
             }
             else {
-                if (req.getRepairRetryCount() > 100 && req.getRepairRetryCount() % 100 == 0) {
+                if (req.getRepairRetryCount() > 1000 && req.getRepairRetryCount() % 1000 == 0) {
                     hostLog.warn("Repair Request for dead host " + deadHostId +
                             " has not been processed yet because connection has not closed");
                 }


### PR DESCRIPTION
We don't need to wait for the pico network to go away before it is safe to start the repair because there is a failedhost check in the message deliver path.