### PR TITLE
ENG-13873-system property for sql execution to use large mode

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1614,6 +1614,10 @@ TEST CASES
     <condition property="regressions" value="${regressions}" else="all">
         <isset property="regressions"/>
     </condition>
+    <!--force execution of SQL queries to use the "large" path (for read-only queries) a certain percentage of the time.-->
+    <condition property="large_mode_ratio" value="${large_mode_ratio}" else="0">
+        <isset property="large_mode_ratio"/>
+    </condition>
 
     <sequential>
 
@@ -1653,6 +1657,7 @@ TEST CASES
             <env key="TEST_DIR" value="${build.testobjects.dir}" />
             <env key="VOLT_REGRESSIONS" value="${regressions}" />
             <env key="VOLT_ENABLEIV2" value="${enableiv2}" />
+            <env key="LARGE_MODE_RATIO" value="${large_mode_ratio}" />
             <!-- Leave breadcrumbs so we can figure out deep in the bowels of VoltDB if
                  this is a test -->
             <env key="VOLT_JUSTATEST" value="true" />

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1620,6 +1620,13 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_configLogger.start();
 
             scheduleDailyLoggingWorkInNextCheckTime();
+
+            // Write a message to the log file if LARGE_MODE_RATIO system property is set to anything other than 0.
+            // This way it will be possible to verify that various frameworks are exercising large mode.
+            final double large_mode_ratio = Double.valueOf(System.getenv("LARGE_MODE_RATIO") == null ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
+            if (large_mode_ratio > 0) {
+                hostLog.info(String.format("The large_mode_ratio property is set as %.2f", large_mode_ratio));
+            }
         }
     }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1623,9 +1623,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
             // Write a message to the log file if LARGE_MODE_RATIO system property is set to anything other than 0.
             // This way it will be possible to verify that various frameworks are exercising large mode.
-            final double large_mode_ratio = Double.valueOf(System.getenv("LARGE_MODE_RATIO") == null ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
-            if (large_mode_ratio > 0) {
-                hostLog.info(String.format("The large_mode_ratio property is set as %.2f", large_mode_ratio));
+            final double largeModeRatio = Double.valueOf(System.getenv("LARGE_MODE_RATIO") == null ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
+            if (largeModeRatio > 0) {
+                hostLog.info(String.format("The large_mode_ratio property is set as %.2f", largeModeRatio));
             }
         }
     }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1623,6 +1623,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
             // Write a message to the log file if LARGE_MODE_RATIO system property is set to anything other than 0.
             // This way it will be possible to verify that various frameworks are exercising large mode.
+
+            // If -Dlarge_mode_ratio=xx is specified via ant, the value will show up in the environment variables and
+            // take higher priority. Otherwise, the value specified via VOLTDB_OPTS will take effect.
             final double largeModeRatio = Double.valueOf(System.getenv("LARGE_MODE_RATIO") == null ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
             if (largeModeRatio > 0) {
                 hostLog.info(String.format("The large_mode_ratio property is set as %.2f", largeModeRatio));

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -56,12 +56,13 @@ public class PlannerTool {
     private byte[] m_catalogHash;
     private AdHocCompilerCache m_cache;
     private long m_adHocLargeFallbackCount = 0;
+    private long m_adHocLargeModeCount = 0;
 
     private final HSQLInterface m_hsql;
 
     private static PlannerStatsCollector m_plannerStats;
 
-    private static final double m_large_mode_ratio = Double.valueOf(System.getenv("LARGE_MODE_RATIO") == null ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
+    private final double m_large_mode_ratio = Double.valueOf(System.getenv("LARGE_MODE_RATIO") == null ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
 
     public PlannerTool(final Database database, byte[] catalogHash)
     {
@@ -120,6 +121,10 @@ public class PlannerTool {
 
     public long getAdHocLargeFallbackCount() {
         return m_adHocLargeFallbackCount;
+    }
+
+    public long getAdHocLargeModeCount() {
+        return m_adHocLargeModeCount;
     }
 
     public AdHocPlannedStatement planSqlForTest(String sqlIn) {
@@ -181,9 +186,9 @@ public class PlannerTool {
         if (m_large_mode_ratio > 0 && !isLargeQuery) {
             if (m_large_mode_ratio >= 1 || m_large_mode_ratio > ThreadLocalRandom.current().nextDouble()) {
                 isLargeQuery = true;
+                m_adHocLargeModeCount++;
             }
         }
-
         CacheUse cacheUse = CacheUse.FAIL;
         if (m_plannerStats != null) {
             m_plannerStats.startStatsCollection();

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -62,7 +62,7 @@ public class PlannerTool {
 
     private static PlannerStatsCollector m_plannerStats;
 
-    private final double m_large_mode_ratio = Double.valueOf(System.getenv("LARGE_MODE_RATIO") == null ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
+    private final double m_largeModeRatio = Double.valueOf(System.getenv("LARGE_MODE_RATIO") == null ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
 
     public PlannerTool(final Database database, byte[] catalogHash)
     {
@@ -183,8 +183,8 @@ public class PlannerTool {
             boolean isExplainMode, final Object[] userParams, boolean isSwapTables, boolean isLargeQuery) {
         // large_mode_ratio will force execution of SQL queries to use the "large" path (for read-only queries)
         // a certain percentage of the time
-        if (m_large_mode_ratio > 0 && !isLargeQuery) {
-            if (m_large_mode_ratio >= 1 || m_large_mode_ratio > ThreadLocalRandom.current().nextDouble()) {
+        if (m_largeModeRatio > 0 && !isLargeQuery) {
+            if (m_largeModeRatio >= 1 || m_largeModeRatio > ThreadLocalRandom.current().nextDouble()) {
                 isLargeQuery = true;
                 m_adHocLargeModeCount++;
             }

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -62,6 +62,8 @@ public class PlannerTool {
 
     private static PlannerStatsCollector m_plannerStats;
 
+    // If -Dlarge_mode_ratio=xx is specified via ant, the value will show up in the environment variables and
+    // take higher priority. Otherwise, the value specified via VOLTDB_OPTS will take effect.
     private final double m_largeModeRatio = Double.valueOf(System.getenv("LARGE_MODE_RATIO") == null ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
 
     public PlannerTool(final Database database, byte[] catalogHash)

--- a/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
@@ -92,11 +92,6 @@ public class TestAdHocPlans extends AdHocQueryTester {
         }
     }
 
-    @Test
-    public void testLargeModeRatio() {
-
-    }
-
     /**
      * For planner-only testing, most of the args are ignored.
      */

--- a/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
@@ -92,6 +92,11 @@ public class TestAdHocPlans extends AdHocQueryTester {
         }
     }
 
+    @Test
+    public void testLargeModeRatio() {
+
+    }
+
     /**
      * For planner-only testing, most of the args are ignored.
      */

--- a/tests/frontend/org/voltdb/planner/TestLargeModeRatio.java
+++ b/tests/frontend/org/voltdb/planner/TestLargeModeRatio.java
@@ -1,0 +1,109 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.planner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.voltcore.messaging.HostMessenger;
+import org.voltdb.AdHocQueryTester;
+import org.voltdb.CatalogContext;
+import org.voltdb.VoltDB;
+import org.voltdb.catalog.Catalog;
+import org.voltdb.compiler.PlannerTool;
+import org.voltdb.settings.DbSettings;
+import org.voltdb.settings.NodeSettings;
+import org.voltdb.utils.CatalogUtil;
+import org.voltdb.utils.MiscUtils;
+
+public class TestLargeModeRatio extends AdHocQueryTester {
+
+    private PlannerTool m_pt;
+    private CatalogContext m_context;
+    private int runQueryTestCount = 0;
+
+    @Before
+    public void setUp() throws Exception {
+        // For planner-only testing, we shouldn't care about IV2
+        VoltDB.Configuration config = setUpSPDB();
+        byte[] bytes = MiscUtils.fileToBytes(new File(config.m_pathToCatalog));
+        String serializedCatalog = CatalogUtil.getSerializedCatalogStringFromJar(CatalogUtil.loadAndUpgradeCatalogFromJar(bytes, false).getFirst());
+        Catalog catalog = new Catalog();
+        catalog.execute(serializedCatalog);
+        DbSettings dbSettings = new DbSettings(
+                config.asClusterSettings().asSupplier(),
+                NodeSettings.create(config.asPathSettingsMap()));
+        m_context = new CatalogContext(catalog, dbSettings, 0, 0, bytes, null, new byte[]{}, mock(HostMessenger.class));
+    }
+
+    @Test
+    public void testLargeModeRatio() throws Exception {
+        String originalLargeModeRatio = System.getProperty("LARGE_MODE_RATIO", "0");
+
+        // LARGE_MODE_RATIO = 0, no large mode flip
+        System.setProperty("LARGE_MODE_RATIO", "0");
+        m_pt = new PlannerTool(m_context.database, m_context.getCatalogHash());
+
+        //DB is empty so the hashable numbers don't really seem to matter
+        runAllAdHocSPtests(0, 1, 2, 3);
+        assertEquals(0, m_pt.getAdHocLargeModeCount());
+
+        // LARGE_MODE_RATIO = 1, always large mode flip
+        System.setProperty("LARGE_MODE_RATIO", "1");
+        m_pt = new PlannerTool(m_context.database, m_context.getCatalogHash());
+
+        runQueryTestCount = 0;
+        //DB is empty so the hashable numbers don't really seem to matter
+        runAllAdHocSPtests(0, 1, 2, 3);
+        assertEquals(runQueryTestCount, m_pt.getAdHocLargeModeCount());
+
+        // LARGE_MODE_RATIO = 0.5, we need some large mode flip
+        System.setProperty("LARGE_MODE_RATIO", "0.5");
+        m_pt = new PlannerTool(m_context.database, m_context.getCatalogHash());
+
+        runQueryTestCount = 0;
+        //DB is empty so the hashable numbers don't really seem to matter
+        runAllAdHocSPtests(0, 1, 2, 3);
+        assertTrue(0 < m_pt.getAdHocLargeModeCount());
+        assertTrue(runQueryTestCount > m_pt.getAdHocLargeModeCount());
+
+        // set back the original system property
+        System.setProperty("LARGE_MODE_RATIO", originalLargeModeRatio);
+    }
+
+    @Override
+    public int runQueryTest(String query, int hash, int spPartialSoFar,
+                            int expected, int validatingSPresult) {
+        // note: always increase the counter before calling planSqlForTest
+        // Otherwise if we got a runtime exception in planSqlForTest, we will miss count that one
+        runQueryTestCount++;
+        m_pt.planSqlForTest(query);
+        return 0;
+    }
+}


### PR DESCRIPTION
- `LARGE_TABLE_RATIO` is a system property that will force execution of SQL queries to use the "large" path (for read-only queries) a certain percentage of the time. It can be used for any tests that are invoked using ant, or for system tests. 
- The default value is 0, means no query will use large mode. If set it to 1, all queries will use large mode.

usage
------
It can be set either from system property:
```bash
export VOLTDB_OPTS="-DLARGE_TABLE_RATIO=0.5"
```
or from ant
```bash
# run in large mode 75% of the time:
ant -Dlarge_mode_ratio=0.75 ...
```
