### PR TITLE
Eng 14444 perform truncate once

### DIFF
--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -506,14 +506,17 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         void updateHashinator(char const* config,
                               int32_t* configPtr, uint32_t numTokens);
 
+        /**
+         * Apply multiple binary logs which can either be one log with multiple transactions to one partition or
+         * multiple logs which are one multi-partition transaction
+         */
         int64_t applyBinaryLog(int64_t txnId,
                             int64_t spHandle,
                             int64_t lastCommittedSpHandle,
                             int64_t uniqueId,
                             int32_t remoteClusterId,
-                            int32_t remotePartitionId,
                             int64_t undoToken,
-                            char const* log);
+                            char const* logs);
 
         /*
          * Execute an arbitrary task represented by the task id and serialized parameters.

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -571,7 +571,7 @@ BinaryLogSink::BinaryLogSink() {}
         }
         ConditionalExecuteWithMpMemory possiblyUseMpMemory(replicatedTableOperation && !skipCurrentRow);
         rowCount += apply(taskInfo, type, tables, pool, engine, remoteClusterId,
-                txnStart, sequenceNumber, uniqueId, skipCurrentRow, replicatedTableOperation);
+                sequenceNumber, uniqueId, skipCurrentRow, replicatedTableOperation);
         int8_t rawType = taskInfo->readByte();
         type = static_cast<DRRecordType>(rawType & ~REPLICATED_TABLE_MASK);
         if (type == DR_RECORD_HASH_DELIMITER) {
@@ -597,7 +597,6 @@ int64_t BinaryLogSink::apply(ReferenceSerializeInputLE *taskInfo,
                              Pool *pool,
                              VoltDBEngine *engine,
                              int32_t remoteClusterId,
-                             const char *txnStart,
                              int64_t sequenceNumber,
                              int64_t uniqueId,
                              bool skipRow,

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -486,13 +486,26 @@ bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, 
     return true;
 }
 
+inline void truncateTable(boost::unordered_map<int64_t, PersistentTable*> &tables,
+        VoltDBEngine *engine, bool replicatedTableOperation, int64_t tableHandle, std::string *tableName) {
+    boost::unordered_map<int64_t, PersistentTable*>::iterator tableIter = tables.find(tableHandle);
+    if (tableIter == tables.end()) {
+        throwSerializableEEException("Unable to find table %s hash %jd while applying binary log for truncate record",
+                                     tableName->c_str(), (intmax_t)tableHandle);
+    }
+
+    PersistentTable *table = tableIter->second;
+
+    table->truncateTable(engine, replicatedTableOperation, true);
+}
+
 } //end of anonymous namespace
 
 /**
- * Utility class to wrap a binary log.
+ * Utility class for managing a binary log
  */
 class BinaryLog {
-    friend BinaryLogSink;
+    friend class BinaryLogSink;
 
 public:
     /**
@@ -512,8 +525,8 @@ public:
      * @param log array containing the binary log. Must not have a log of length 0.
      */
     BinaryLog(const char *log) :
-            BinaryLog(log, readRawInt(log)) {
-        assert(m_txnLen > 0);
+            m_taskInfo(log + sizeof(int32_t), readRawInt(log)) {
+        initialize(readRawInt(log));
     }
 
     /**
@@ -598,8 +611,13 @@ public:
 
 private:
     BinaryLog(const char *log, int32_t logLength) :
-            m_taskInfo(log + sizeof(int32_t), logLength),
-            m_logEnd(m_taskInfo.getRawPointer() + logLength) {
+            m_taskInfo(log + sizeof(int32_t), logLength) {
+        initialize(logLength);
+    }
+
+    void initialize(int32_t logLength) {
+        assert(m_taskInfo.hasRemaining());
+        m_logEnd = m_taskInfo.getRawPointer() + logLength;
 
         bool __attribute__ ((unused)) success = readNextTransaction();
         assert(success);
@@ -621,117 +639,221 @@ private:
 
 BinaryLogSink::BinaryLogSink() {}
 
-    int64_t BinaryLogSink::applyTxn(ReferenceSerializeInputLE *taskInfo,
-                                boost::unordered_map<int64_t, PersistentTable*> &tables,
-                                Pool *pool,
-                                VoltDBEngine *engine,
-                                int32_t remoteClusterId,
-                                const char *txnStart,
-                                int64_t localUniqueId) {
-    int64_t      rowCount = 0;
-    DRRecordType type;
-    int64_t      uniqueId;
-    int64_t      sequenceNumber;
-    int32_t      partitionHash;
-    int32_t      txnLen;
-    bool         isCurrentTxnForReplicatedTable;
-    bool         isCurrentRecordForReplicatedTable;
-    bool         isForLocalPartition;
-    bool         skipCurrentRow;
-    bool         replicatedTableOperation = false;
+// Shared success boolean used when applying binary logs for replicated table
+bool s_replicatedApplySuccess;
 
-    type = static_cast<DRRecordType>(taskInfo->readByte());
-    assert(type == DR_RECORD_BEGIN_TXN);
-    uniqueId = taskInfo->readLong();
-    sequenceNumber = taskInfo->readLong();
+int64_t BinaryLogSink::apply(const char *rawLogs,
+        boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool, VoltDBEngine *engine,
+        int32_t remoteClusterId, int64_t localUniqueId) {
+    int32_t logCount = BinaryLog::readRawInt(rawLogs);
+    rawLogs += sizeof(int32_t);
+    int64_t rowCount;
 
-    int8_t rawHashFlag = taskInfo->readByte();
-    isCurrentRecordForReplicatedTable = rawHashFlag & REPLICATED_TABLE_MASK;
-    DRTxnPartitionHashFlag hashFlag = static_cast<DRTxnPartitionHashFlag>(rawHashFlag & ~REPLICATED_TABLE_MASK);
-    isCurrentTxnForReplicatedTable = hashFlag == TXN_PAR_HASH_REPLICATED;
-    txnLen = taskInfo->readInt();
-    partitionHash = taskInfo->readInt();
-    bool isLocalMpTxn = UniqueId::isMpUniqueId(localUniqueId);
-    bool isLocalRegularSpTxn = !isLocalMpTxn && (hashFlag == TXN_PAR_HASH_SINGLE || hashFlag == TXN_PAR_HASH_MULTI);
-    bool isLocalRegularMpTxn = isLocalMpTxn && !isCurrentTxnForReplicatedTable;
-
-
-    if (isCurrentTxnForReplicatedTable && !engine->isLowestSite()) {
-        // The entire transaction is a replicated table so skip applying on non lowest site
-        taskInfo->getRawPointer(txnLen - (DRTupleStream::BEGIN_RECORD_SIZE + DRTupleStream::END_RECORD_SIZE));
-        type = static_cast<DRRecordType>(taskInfo->readByte());
-        assert(type == DR_RECORD_END_TXN);
+    if (logCount == 1) {
+        // Optimization for single log
+        VOLT_DEBUG("Handling single binary log");
+        BinaryLog log(rawLogs);
+        rowCount = applyLog(&log, tables, pool, engine, remoteClusterId, localUniqueId);
     } else {
-        type = static_cast<DRRecordType>(taskInfo->readByte());
+        VOLT_DEBUG("Handling multiple binary logs %d", logCount);
+        rowCount = applyMpTxn(rawLogs, logCount, tables, pool, engine, remoteClusterId, localUniqueId);
     }
 
-    assert(hashFlag != TXN_PAR_HASH_PLACEHOLDER || type == DR_RECORD_END_TXN);
-    // Read the whole txn since there is only one version number at the beginning
-    while (type != DR_RECORD_END_TXN) {
-        // fast path for replicated table change, save calls to VoltDBEngine::isLocalSite()
-        if (isCurrentTxnForReplicatedTable || isCurrentRecordForReplicatedTable) {
-            // before NO_REPLICATED_STREAM_PROTOCOL_VERSION, decide replicateTable changes with TXN_PAR_HASH_REPLICATED (isCurrentTxnForReplicatedTable)
-            // with NO_REPLICATED_STREAM_PROTOCOL_VERSION, decide replicateTable changes with first bit of rawHashFlag (isCurrentRecordForReplicatedTable)
-            // both cases will only operate replicated Table changes on lowest site
-            // Coordinates with other sites handled in VoltDBEngine->applyBinaryLog()
-            skipCurrentRow = !engine->isLowestSite();
-            replicatedTableOperation = true;
-        } else {
-            isForLocalPartition = engine->isLocalSite(partitionHash);
-            // - Remote MP txns are always executed as local MP txns. Skip hashes that don't match for these.
-            // - Remote single-hash SP txns must throw mispartitioned exception for hashes that don't match.
-            // - Remote SP txns with multihash will be routed as MP txns for mixed size clusters.
-            //   It is OK to skip in this case because they will go
-            //   to all partitions and the records will get applied on the correct partitions.
-            // - Remote SP txns with multihash will be routed as SP txns for same size clusters.
-            //   We should throw mispartitioned for these because for same size, they should
-            //   always map to the same partition on both clusters.
-            // Conclusion: If it is local MP txn, skip. If not, throw mispartitioned.
-            // Replicated (MP txns) and Truncate table txns (could be SP, if runeverywhere) don't have partitionHash value.
-            // So don't throw for those either.
-            if (!isForLocalPartition && isLocalRegularSpTxn) {
-                /** temporary debug stmts **/
-                /*
-                VOLT_ERROR("Throwing mispartitioned from site with partitionId=%d", engine->getPartitionId());
-                VOLT_ERROR("hashFlag=%d, partitionHash=%d, drRecordType=%d", (int) hashFlag, partitionHash, (int) type);
-                */
-                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED,
-                    "Binary log txns were sent to the wrong partition");
-            }
-            skipCurrentRow = (!isForLocalPartition && isLocalRegularMpTxn);
-        }
-        ConditionalExecuteWithMpMemory possiblyUseMpMemory(replicatedTableOperation && !skipCurrentRow);
-        rowCount += apply(taskInfo, type, tables, pool, engine, remoteClusterId,
-                sequenceNumber, uniqueId, skipCurrentRow, replicatedTableOperation);
-        int8_t rawType = taskInfo->readByte();
-        type = static_cast<DRRecordType>(rawType & ~REPLICATED_TABLE_MASK);
-        if (type == DR_RECORD_HASH_DELIMITER) {
-            isCurrentRecordForReplicatedTable = rawType & REPLICATED_TABLE_MASK;
-            partitionHash = taskInfo->readInt();
-            type = static_cast<DRRecordType>(taskInfo->readByte());
-        }
-    }
-
-    int64_t tempSequenceNumber = taskInfo->readLong();
-    if (tempSequenceNumber != sequenceNumber) {
-        throwFatalException("Closing the wrong transaction inside a binary log segment. Expected %jd but found %jd",
-                            (intmax_t)sequenceNumber, (intmax_t)tempSequenceNumber);
-    }
-    uint32_t checksum = taskInfo->readInt();
-    validateChecksum(checksum, txnStart, taskInfo->getRawPointer());
+    VOLT_DEBUG("Completed applying %d log(s) resulting in %jd rows", logCount, rowCount);
     return rowCount;
 }
 
-int64_t BinaryLogSink::apply(ReferenceSerializeInputLE *taskInfo,
+int64_t BinaryLogSink::applyMpTxn(const char *rawLogs, int32_t logCount,
+        boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool, VoltDBEngine *engine,
+        int32_t remoteClusterId, int64_t localUniqueId) {
+    boost::scoped_array<boost::scoped_ptr<BinaryLog>> logs(new boost::scoped_ptr<BinaryLog>[logCount]);
+    int64_t rowCount = 0;
+    const char *position = rawLogs;
+
+    // i is incremented at the end of the loop so logs can be easily skipped
+    for (int i = 0; i < logCount;) {
+        VOLT_DEBUG("Reading start transaction for log: %d", i);
+        logs[i].reset(BinaryLog::create(position));
+        if (logs[i] == NULL) {
+            // Log had no contents so ignore it
+            --logCount;
+            continue;
+        }
+
+        if (i != 0) {
+            if (logs[0]->m_uniqueId != logs[i]->m_uniqueId) {
+                throwFatalException("Unique Id not the same for all sub transactions: unique ID %jd != %jd",
+                        (intmax_t ) logs[0]->m_uniqueId, (intmax_t ) logs[i]->m_uniqueId);
+            }
+        }
+
+        position = logs[i]->m_logEnd;
+
+        // Handle the replicated table transaction up front to reduce the required site coordination
+        if (logs[i]->isReplicatedTableLog()) {
+            rowCount += applyReplicatedTxn(logs[i].get(), tables, pool, engine, remoteClusterId, localUniqueId);
+            --logCount;
+            continue;
+        }
+
+        ++i;
+    }
+
+    switch (logCount) {
+    case 1:
+        rowCount += applyLog(logs[0].get(), tables, pool, engine, remoteClusterId, localUniqueId);
+        /* fallthrough */
+    case 0:
+        return rowCount;
+    }
+
+    assert(UniqueId::isMpUniqueId(localUniqueId));
+
+    VOLT_DEBUG("Applying MP binary log: log count: %d, unique ID: %jd, sequence number: %jd", logCount,
+            logs[0]->m_uniqueId, logs[0]->m_sequenceNumber);
+
+    /*
+     * Iterate over all of the logs until they are depleted. If a TRUNCATE_TABLE is encountered stop processing
+     * operations until the same truncate is encountered in all logs. Once all logs have encountered the truncate apply
+     * the truncate once and continue processing the first log again.
+     */
+    int32_t completedLogs = 0;
+    do {
+        int32_t __attribute__((unused)) truncateCount = 0;
+        int64_t truncateTableHandle = -1;
+        std::string truncateTableName = std::string();
+
+        for (int i = 0; i < logCount; ++i) {
+            assert(!logs[i]->isReplicatedTableLog());
+
+            if (!logs[i]->m_taskInfo.hasRemaining()) {
+                continue;
+            }
+
+            DRRecordType type;
+
+            while ((type = logs[i]->readRecordType()) != DR_RECORD_END_TXN) {
+                if (type == DR_RECORD_TRUNCATE_TABLE) {
+                    ++truncateCount;
+                    if (i == 0) {
+                        assert(truncateTableName.size() == 0);
+                        truncateTableHandle = logs[i]->m_taskInfo.readLong();
+                        truncateTableName = logs[i]->m_taskInfo.readTextString();
+                    } else {
+                        int64_t tempTableHandle = logs[i]->m_taskInfo.readLong();
+                        std::string tempTableName = logs[i]->m_taskInfo.readTextString();
+
+                        if (truncateTableHandle != tempTableHandle || truncateTableName.compare(tempTableName) != 0) {
+                            throwFatalException("Table id or name not the same for all truncate transactions:"
+                                    "table ID %jd != %jd or name '%s' != '%s' log %d", (intmax_t ) truncateTableHandle,
+                                    (intmax_t ) tempTableHandle, truncateTableName.c_str(), tempTableName.c_str(), i);
+                        }
+                    }
+                    break;
+                }
+
+                bool skipRow = !engine->isLocalSite(logs[i]->m_partitionHash);
+                rowCount += applyRecord(logs[i].get(), type, tables, pool, engine, remoteClusterId, skipRow);
+            }
+
+            if (type == DR_RECORD_END_TXN) {
+                assert(truncateCount == 0);
+
+                logs[i]->validateEndTxn();
+                ++completedLogs;
+            }
+        }
+
+        if (truncateTableName.size() > 0) {
+            assert(truncateCount == logCount);
+            truncateCount = 0;
+
+            VOLT_DEBUG("Applying MP binary log truncate to %s", truncateTableName.c_str());
+            truncateTable(tables, engine, false, truncateTableHandle, &truncateTableName);
+            truncateTableName = std::string();
+        }
+    } while (completedLogs < logCount);
+
+#ifndef NDEBUG
+    for (int i = 0; i < logCount; ++i) {
+        assert(!logs[i]->m_taskInfo.hasRemaining());
+    }
+#endif
+
+    return rowCount;
+}
+
+int64_t BinaryLogSink::applyLog(BinaryLog *log, boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool,
+        VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId) {
+
+    int64_t rowCount = 0;
+
+    if (log->isReplicatedTableLog()) {
+        return applyReplicatedTxn(log, tables, pool, engine, remoteClusterId, localUniqueId);
+    }
+
+    do {
+        pool->purge();
+        rowCount += applyTxn(log, tables, pool, engine, remoteClusterId, localUniqueId);
+    } while (log->readNextTransaction());
+
+    return rowCount;
+}
+
+int64_t BinaryLogSink::applyTxn(BinaryLog *log, boost::unordered_map<int64_t, PersistentTable*> &tables,
+                 Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
+                 int64_t localUniqueId) {
+
+    DRRecordType type;
+    int64_t rowCount = 0;
+    bool checkForSkip = log->m_hashFlag != TXN_PAR_HASH_REPLICATED && UniqueId::isMpUniqueId(localUniqueId);
+
+    while ((type = log->readRecordType()) != DR_RECORD_END_TXN) {
+        assert(log->m_hashFlag != TXN_PAR_HASH_PLACEHOLDER);
+        bool skipRow = checkForSkip && !engine->isLocalSite(log->m_partitionHash);
+        rowCount += applyRecord(log, type, tables, pool, engine, remoteClusterId, skipRow);
+    }
+
+    log->validateEndTxn();
+
+    return rowCount;
+}
+
+int64_t BinaryLogSink::applyReplicatedTxn(BinaryLog *log, boost::unordered_map<int64_t, PersistentTable*> &tables,
+        Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId) {
+    ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(true, engine->isLowestSite(),
+            &s_replicatedApplySuccess, false);
+
+    long rowCount = 0;
+    if (possiblySynchronizedUseMpMemory.okToExecute()) {
+        VOLT_TRACE("applyBinaryLogMP for replicated table");
+        rowCount = applyTxn(log, tables, pool, engine, remoteClusterId, localUniqueId);
+        s_replicatedApplySuccess = true;
+    } else if (!s_replicatedApplySuccess) {
+        const char* msg = "Replicated table apply binary log threw an unknown exception on other thread.";
+        VOLT_DEBUG("%s", msg);
+        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
+    } else {
+        VOLT_TRACE("Skipping applyBinaryLogMP for replicated table");
+        log->skipRecordsAndValidateTxn();
+    }
+
+    assert(!log->m_taskInfo.hasRemaining());
+
+    return rowCount;
+}
+
+int64_t BinaryLogSink::applyRecord(BinaryLog *log,
                              const DRRecordType type,
                              boost::unordered_map<int64_t, PersistentTable*> &tables,
                              Pool *pool,
                              VoltDBEngine *engine,
                              int32_t remoteClusterId,
-                             int64_t sequenceNumber,
-                             int64_t uniqueId,
-                             bool skipRow,
-                             bool replicatedTableOperation) {
+                             bool skipRow) {
+    ReferenceSerializeInputLE *taskInfo = &log->m_taskInfo;
+    int64_t uniqueId = log->m_uniqueId;
+    int64_t sequenceNumber = log->m_sequenceNumber;
+
     switch (type) {
     case DR_RECORD_INSERT: {
         int64_t tableHandle = taskInfo->readLong();
@@ -919,20 +1041,8 @@ int64_t BinaryLogSink::apply(ReferenceSerializeInputLE *taskInfo,
     case DR_RECORD_TRUNCATE_TABLE: {
         int64_t tableHandle = taskInfo->readLong();
         std::string tableName = taskInfo->readTextString();
-        // ignore the value of skipRow for truncate table record unless this is a replicated table
-        if (skipRow && replicatedTableOperation) {
-            break;
-        }
 
-        boost::unordered_map<int64_t, PersistentTable*>::iterator tableIter = tables.find(tableHandle);
-        if (tableIter == tables.end()) {
-            throwSerializableEEException("Unable to find table %s hash %jd while applying binary log for truncate record",
-                                         tableName.c_str(), (intmax_t)tableHandle);
-        }
-
-        PersistentTable *table = tableIter->second;
-
-        table->truncateTable(engine, replicatedTableOperation, true);
+        truncateTable(tables, engine, false, tableHandle, &tableName);
 
         break;
     }

--- a/src/ee/storage/BinaryLogSink.h
+++ b/src/ee/storage/BinaryLogSink.h
@@ -29,6 +29,8 @@ class PersistentTable;
 class Pool;
 class VoltDBEngine;
 
+class BinaryLog;
+
 /*
  * Responsible for applying binary logs to table data
  */

--- a/src/ee/storage/BinaryLogSink.h
+++ b/src/ee/storage/BinaryLogSink.h
@@ -37,17 +37,50 @@ class BinaryLog;
 class BinaryLogSink {
 public:
     BinaryLogSink();
-    int64_t applyTxn(ReferenceSerializeInputLE *taskInfo,
-                     boost::unordered_map<int64_t, PersistentTable*> &tables,
-                     Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
-                     const char *txnStart,
-                     int64_t localUniqueId);
+    /**
+     * Apply the binary logs. The logs can either be on log for multiple transactions to the same partition or multiple
+     * logs which correspond to a single multi-partition transaction.
+     *
+     * The format of logs should be:
+     *  number of logs: int32
+     *  for each log:
+     *      size of log: int32
+     *      log contents
+     */
+    int64_t apply(const char *logs, boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool,
+            VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId);
 
 private:
-    int64_t apply(ReferenceSerializeInputLE *taskInfo, const DRRecordType type,
-                  boost::unordered_map<int64_t, PersistentTable*> &tables,
-                  Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
-                  int64_t sequenceNumber, int64_t uniqueId, bool skipRow, bool replicatedTableOperation);
+    /**
+     * Apply all transactions within one log
+     */
+    int64_t applyLog(BinaryLog *log, boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool,
+            VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId);
+
+    /**
+     * Apply all records within a single transaction from the binary log.
+     */
+    int64_t applyTxn(BinaryLog *log, boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool,
+            VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId);
+
+    /**
+     * Apply a single transaction to replicated tables
+     */
+    int64_t applyReplicatedTxn(BinaryLog *log, boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool,
+            VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId);
+
+    /**
+     * Apply multiple logs from a single MP transaction
+     */
+    int64_t applyMpTxn(const char *logs, int32_t logCount, boost::unordered_map<int64_t, PersistentTable*> &tables,
+            Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId);
+
+    /**
+     * Apply a single record from a binary log performing any necessary conflict handling.
+     */
+    int64_t applyRecord(BinaryLog *log, const DRRecordType type,
+            boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool, VoltDBEngine *engine,
+            int32_t remoteClusterId, bool skipRow);
 };
 
 

--- a/src/ee/storage/BinaryLogSink.h
+++ b/src/ee/storage/BinaryLogSink.h
@@ -45,7 +45,7 @@ private:
     int64_t apply(ReferenceSerializeInputLE *taskInfo, const DRRecordType type,
                   boost::unordered_map<int64_t, PersistentTable*> &tables,
                   Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
-                  const char *txnStart, int64_t sequenceNumber, int64_t uniqueId, bool skipRow, bool replicatedTableOperation);
+                  int64_t sequenceNumber, int64_t uniqueId, bool skipRow, bool replicatedTableOperation);
 };
 
 

--- a/src/ee/storage/BinaryLogSinkWrapper.cpp
+++ b/src/ee/storage/BinaryLogSinkWrapper.cpp
@@ -23,25 +23,8 @@
 using namespace std;
 using namespace voltdb;
 
-int64_t BinaryLogSinkWrapper::apply(const char* taskParams, boost::unordered_map<int64_t, PersistentTable*> &tables,
-                                    Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId)
-{
-    ReferenceSerializeInputLE taskInfo(taskParams + 4, ntohl(*reinterpret_cast<const int32_t*>(taskParams)));
-
-    int64_t __attribute__ ((unused)) uniqueId = 0;
-    int64_t __attribute__ ((unused)) sequenceNumber = -1;
-
-    int64_t rowCount = 0;
-    while (taskInfo.hasRemaining()) {
-        pool->purge();
-        const char* recordStart = taskInfo.getRawPointer();
-        const uint8_t drVersion = taskInfo.readByte();
-        if (drVersion >= DRTupleStream::COMPATIBLE_PROTOCOL_VERSION) {
-            rowCount += m_sink.applyTxn(&taskInfo, tables, pool, engine, remoteClusterId,
-                                        recordStart, localUniqueId);
-        } else {
-            throwFatalException("Unsupported DR version %d", drVersion);
-        }
-    }
-    return rowCount;
+int64_t BinaryLogSinkWrapper::apply(const char *logs,
+        boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool, VoltDBEngine *engine,
+        int32_t remoteClusterId, int64_t localUniqueId) {
+    return m_sink.apply(logs, tables, pool, engine, remoteClusterId, localUniqueId);
 }

--- a/src/ee/storage/BinaryLogSinkWrapper.h
+++ b/src/ee/storage/BinaryLogSinkWrapper.h
@@ -35,8 +35,9 @@ class BinaryLogSinkWrapper {
 public:
     BinaryLogSinkWrapper() {}
 
-    int64_t apply(const char* taskParams, boost::unordered_map<int64_t, PersistentTable*> &tables,
-                  Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId);
+    int64_t apply(const char *logs,
+            boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool, VoltDBEngine *engine,
+            int32_t remoteClusterId, int64_t localUniqueId);
 private:
     BinaryLogSink m_sink;
 };

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -1692,7 +1692,6 @@ void VoltDBIPC::applyBinaryLog(struct ipc_command *cmd) {
                                         ntohll(params->lastCommittedSpHandle),
                                         ntohll(params->uniqueId),
                                         ntohl(params->remoteClusterId),
-                                        ntohl(params->remotePartitionId),
                                         ntohll(params->undoToken),
                                         params->log);
         char response[9];

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1380,7 +1380,7 @@ SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_utils_PosixAdvise_fallocate
 SHAREDLIB_JNIEXPORT jlong JNICALL
 Java_org_voltdb_jni_ExecutionEngine_nativeApplyBinaryLog (
     JNIEnv *env, jobject obj, jlong engine_ptr,
-    jlong txnId, jlong spHandle, jlong lastCommittedSpHandle, jlong uniqueId, jint remoteClusterId, jint remotePartitionId, jlong undoToken)
+    jlong txnId, jlong spHandle, jlong lastCommittedSpHandle, jlong uniqueId, jint remoteClusterId, jlong undoToken)
 {
     VoltDBEngine *engine = castToEngine(engine_ptr);
     Topend *topend = static_cast<JNITopend*>(engine->getTopend())->updateJNIEnv(env);
@@ -1392,11 +1392,11 @@ Java_org_voltdb_jni_ExecutionEngine_nativeApplyBinaryLog (
 
     //JNIEnv pointer can change between calls, must be updated
     updateJNILogProxy(engine);
-    VOLT_DEBUG("applying binary log in C++...");
+    VOLT_DEBUG("applying MP binary log in C++...");
 
     try {
-        return engine->applyBinaryLog(txnId, spHandle, lastCommittedSpHandle, uniqueId, remoteClusterId, remotePartitionId, undoToken,
-                               engine->getParameterBuffer() + sizeof(int64_t));
+        return engine->applyBinaryLog(txnId, spHandle, lastCommittedSpHandle, uniqueId, remoteClusterId, undoToken,
+                engine->getParameterBuffer() + sizeof(int64_t));
     } catch (const SerializableEEException &e) {
         engine->resetReusedResultOutputBuffer();
         e.serialize(engine->getExceptionOutputSerializer());

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -237,6 +237,8 @@ public interface SiteProcedureConnection {
     public long[] validatePartitioning(long tableIds[], byte hashinatorConfig[]);
     public void notifyOfSnapshotNonce(String nonce, long snapshotSpHandle);
     public long applyBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, int remotePartitionId, byte logData[]);
+
+    public long applyMpBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, byte logsData[]);
     public void setDRProtocolVersion(int drVersion);
     /*
      * Starting in DR version 7.0, we also generate a special event indicating the beginning of

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -689,6 +689,11 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     }
 
     @Override
+    public long applyMpBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, byte[] logsData) {
+        throw new UnsupportedOperationException("RO MP Site doesn't do this, shouldn't be here");
+    }
+
+    @Override
     public void setBatchTimeout(int batchTimeout) {
         throw new UnsupportedOperationException("RO MP Site doesn't do this, shouldn't be here");
     }

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -830,24 +830,17 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * Apply binary log data. To be able to advance the DR sequence number and
      * regenerate binary log for chaining correctly, proper spHandle and
      * lastCommittedSpHandle from the current transaction need to be passed in.
-     * @param log                      The binary log data
+     * @param logs                     The binary log data
      * @param txnId                    The txnId of the current transaction
      * @param spHandle                 The spHandle of the current transaction
      * @param lastCommittedSpHandle    The spHandle of the last committed transaction
      * @param uniqueId                 The uniqueId of the current transaction
      * @param remoteClusterId          The cluster id of producer cluster
-     * @param remotePartitionId        The partition id of producer cluster
      * @param undoToken                For undo
      * @throws EEException
      */
-    public abstract long applyBinaryLog(ByteBuffer log,
-                                        long txnId,
-                                        long spHandle,
-                                        long lastCommittedSpHandle,
-                                        long uniqueId,
-                                        int remoteClusterId,
-                                        int remotePartitionId,
-                                        long undoToken) throws EEException;
+    public abstract long applyBinaryLog(ByteBuffer logs, long txnId, long spHandle, long lastCommittedSpHandle,
+            long uniqueId, int remoteClusterId, long undoToken) throws EEException;
 
     /**
      * Execute an arbitrary non-transactional task that is described by the task id and
@@ -1128,14 +1121,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      */
     protected native long nativeTableHashCode(long pointer, int tableId);
 
-    protected native long nativeApplyBinaryLog(long pointer,
-                                               long txnId,
-                                               long spHandle,
-                                               long lastCommittedSpHandle,
-                                               long uniqueId,
-                                               int remoteClusterId,
-                                               int remotePartitionId,
-                                               long undoToken);
+    protected native long nativeApplyBinaryLog(long pointer, long txnId, long spHandle, long lastCommittedSpHandle,
+            long uniqueId, int remoteClusterId, long undoToken);
 
     /**
      * Execute an arbitrary task based on the task ID and serialized task parameters.

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -610,11 +610,13 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             dirtyBytes.flip();
             // check if anything was changed
             final boolean dirty  = dirtyBytes.get() > 0;
-            if (dirty)
+            if (dirty) {
                 m_dirty = true;
+            }
 
-            if (resultTablesLength <= 0)
+            if (resultTablesLength <= 0) {
                 return;
+            }
 
             final ByteBuffer resultTablesBuffer = ByteBuffer
                     .allocate(resultTablesLength);
@@ -670,8 +672,9 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             resultTablesLengthBytes.flip();
             final int resultTablesLength = resultTablesLengthBytes.getInt();
 
-            if (resultTablesLength <= 0)
+            if (resultTablesLength <= 0) {
                 return resultTablesLengthBytes;
+            }
 
             final ByteBuffer resultTablesBuffer = ByteBuffer
                     .allocate(resultTablesLength+8);
@@ -1310,7 +1313,9 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             if (result == ExecutionEngine.ERRORCODE_SUCCESS) {
 
                 final ByteBuffer messageBuffer = readMessage();
-                if (messageBuffer == null) return null;
+                if (messageBuffer == null) {
+                    return null;
+                }
 
                 final VoltTable results[] = new VoltTable[1];
                 results[0] = PrivateVoltTableFactory.createVoltTableFromSharedBuffer(messageBuffer);
@@ -1585,8 +1590,9 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             m_connection.write();
 
             ByteBuffer results = ByteBuffer.allocate(8);
-            while (results.remaining() > 0)
+            while (results.remaining() > 0) {
                 m_connection.m_socketChannel.read(results);
+            }
             results.flip();
             long result_offset = results.getLong();
             if (result_offset < 0) {
@@ -1615,8 +1621,9 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             m_connection.write();
 
             ByteBuffer results = ByteBuffer.allocate(16);
-            while (results.remaining() > 0)
+            while (results.remaining() > 0) {
                 m_connection.m_socketChannel.read(results);
+            }
             results.flip();
 
             retval = new long[2];
@@ -1723,10 +1730,8 @@ public class ExecutionEngineIPC extends ExecutionEngine {
     }
 
     @Override
-    public long applyBinaryLog(ByteBuffer log, long txnId, long spHandle, long lastCommittedSpHandle, long uniqueId,
-                               int remoteClusterId, int remotePartitionId, long undoToken)
-    throws EEException
-    {
+    public long applyBinaryLog(ByteBuffer logs, long txnId, long spHandle, long lastCommittedSpHandle,
+            long uniqueId, int remoteClusterId, long undoToken) throws EEException {
         m_data.clear();
         m_data.putInt(Commands.ApplyBinaryLog.m_id);
         m_data.putLong(txnId);
@@ -1734,9 +1739,8 @@ public class ExecutionEngineIPC extends ExecutionEngine {
         m_data.putLong(lastCommittedSpHandle);
         m_data.putLong(uniqueId);
         m_data.putInt(remoteClusterId);
-        m_data.putInt(remotePartitionId);
         m_data.putLong(undoToken);
-        m_data.put(log.array());
+        m_data.put(logs.array());
 
         try {
             m_data.flip();

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -402,7 +402,9 @@ public class ExecutionEngineJNI extends ExecutionEngine {
         // plan frag zero is invalid
         assert((numFragmentIds == 0) || (planFragmentIds[0] != 0));
 
-        if (numFragmentIds == 0) return m_emptyDeserializer;
+        if (numFragmentIds == 0) {
+            return m_emptyDeserializer;
+        }
         final int batchSize = numFragmentIds;
         if (HOST_TRACE_ENABLED) {
             for (int i = 0; i < batchSize; ++i) {
@@ -527,8 +529,12 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
         try {
             int length = m_nextDeserializer.readInt();
-            if (length == 0) return null;
-            if (length < 0) VoltDB.crashLocalVoltDB("Length shouldn't be < 0", true, null);
+            if (length == 0) {
+                return null;
+            }
+            if (length < 0) {
+                VoltDB.crashLocalVoltDB("Length shouldn't be < 0", true, null);
+            }
 
             byte uniqueViolations[] = new byte[length];
             m_nextDeserializer.readFully(uniqueViolations);
@@ -732,12 +738,12 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     }
 
     @Override
-    public long applyBinaryLog(ByteBuffer log, long txnId, long spHandle, long lastCommittedSpHandle, long uniqueId,
-                               int remoteClusterId, int remotePartitionId, long undoToken) throws EEException
-    {
-        long rowCount = nativeApplyBinaryLog(pointer, txnId, spHandle, lastCommittedSpHandle, uniqueId, remoteClusterId,remotePartitionId, undoToken);
+    public long applyBinaryLog(ByteBuffer logs, long txnId, long spHandle, long lastCommittedSpHandle,
+            long uniqueId, int remoteClusterId, long undoToken) throws EEException {
+        long rowCount = nativeApplyBinaryLog(pointer, txnId, spHandle, lastCommittedSpHandle, uniqueId, remoteClusterId,
+                undoToken);
         if (rowCount < 0) {
-            throwExceptionForError((int)rowCount);
+            throwExceptionForError((int) rowCount);
         }
         return rowCount;
     }

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -225,9 +225,8 @@ public class MockExecutionEngine extends ExecutionEngine {
     }
 
     @Override
-    public long applyBinaryLog(ByteBuffer log, long txnId, long spHandle, long lastCommittedSpHandle, long uniqueId,
-                               int remoteClusterId, int remotePartitionId, long undoToken) throws EEException
-    {
+    public long applyBinaryLog(ByteBuffer logs, long txnId, long spHandle, long lastCommittedSpHandle,
+            long uniqueId, int remoteClusterId, long undoToken) throws EEException {
         throw new UnsupportedOperationException();
     }
 

--- a/tests/ee/storage/table_and_indexes_test.cpp
+++ b/tests/ee/storage/table_and_indexes_test.cpp
@@ -301,6 +301,15 @@ class TableAndIndexTest : public Test {
                                                                    customerTable);
         }
 
+        size_t drStartPosition(boost::shared_ptr<StreamBlock> sb) {
+            return sb->headerSize() - 8;
+        }
+
+        void appendDrHeader(boost::shared_array<char> data, size_t startPos, boost::shared_ptr<StreamBlock> sb) {
+            *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(1);
+            *reinterpret_cast<int32_t*>(&data.get()[startPos + 4]) = htonl(static_cast<int32_t>(sb->offset()));
+        }
+
         ~TableAndIndexTest() {
             delete eContext;
             delete mockEngine;
@@ -437,9 +446,9 @@ TEST_F(TableAndIndexTest, DrTest) {
     topend.data.pop_back();
     topend.receivedDRBuffer = false;
 
-    //Add a length prefix for test, then apply it
-    size_t startPos = sb->headerSize() - 4;
-    *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
+    //Add a dr header for test, and apply the update
+    size_t startPos = drStartPosition(sb);
+    appendDrHeader(data, startPos, sb);
     drStream.m_enabled = false;
     districtTable->setDR(false);
     sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(70));
@@ -481,8 +490,8 @@ TEST_F(TableAndIndexTest, DrTest) {
     topend.data.pop_back();
     topend.receivedDRBuffer = false;
 
-    //Add a length prefix for test and apply it
-    *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
+    //Add a dr header for test, and apply the update
+    appendDrHeader(data, startPos, sb);
     drStream.m_enabled = false;
     districtTable->setDR(false);
     sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(72));
@@ -517,8 +526,8 @@ TEST_F(TableAndIndexTest, DrTest) {
     topend.data.pop_back();
     topend.receivedDRBuffer = false;
 
-    //Add a length prefix for test, and apply the update
-    *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
+    //Add a dr header for test, and apply the update
+    appendDrHeader(data, startPos, sb);
     drStream.m_enabled = false;
     districtTable->setDR(false);
     sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(89));
@@ -581,9 +590,9 @@ TEST_F(TableAndIndexTest, DrTestNoPK) {
     topend.data.pop_back();
     topend.receivedDRBuffer = false;
 
-    //Add a length prefix for test, then apply it
-    size_t startPos = sb->headerSize() - 4;
-    *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
+    //Add a dr header for test, and apply the update
+    size_t startPos = drStartPosition(sb);
+    appendDrHeader(data, startPos, sb);
     drStream.m_enabled = false;
     districtTable->setDR(false);
     sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(70));
@@ -621,9 +630,8 @@ TEST_F(TableAndIndexTest, DrTestNoPK) {
     topend.data.pop_back();
     topend.receivedDRBuffer = false;
 
-    //Add a length prefix for test, and apply the update
-    *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
-    drStream.m_enabled = false;
+    //Add a dr header for test, and apply the update
+    appendDrHeader(data, startPos, sb);    drStream.m_enabled = false;
     districtTable->setDR(false);
     sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(72));
     drStream.m_enabled = true;
@@ -700,9 +708,9 @@ TEST_F(TableAndIndexTest, DrTestNoPKUninlinedColumn) {
     topend.data.pop_back();
     topend.receivedDRBuffer = false;
 
-    //Add a length prefix for test, then apply it
-    size_t startPos = sb->headerSize() - 4;
-    *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
+    //Add a dr header for test, and apply the update
+    size_t startPos = drStartPosition(sb);
+    appendDrHeader(data, startPos, sb);
     drStream.m_enabled = false;
     customerTable->setDR(false);
     sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(70));
@@ -740,8 +748,8 @@ TEST_F(TableAndIndexTest, DrTestNoPKUninlinedColumn) {
     topend.data.pop_back();
     topend.receivedDRBuffer = false;
 
-    //Add a length prefix for test, and apply the update
-    *reinterpret_cast<int32_t*>(&data.get()[startPos]) = htonl(static_cast<int32_t>(sb->offset()));
+    //Add a dr header for test, and apply the update
+    appendDrHeader(data, startPos, sb);
     drStream.m_enabled = false;
     customerTable->setDR(false);
     sinkWrapper.apply(&data[startPos], tables, &pool, mockEngine, 1, addPartitionId(72));


### PR DESCRIPTION
Only perform truncate table once when applying an MP transaction with truncate. This is accomplished by applying all operations in all logs before the truncate applying the truncate once and then apply the next set of operations in each log until another truncate if it exists is encountered. This is done until the end of each log is reached.

This method works as long as there is a truncate in every log, which is not guaranteed.