### PR TITLE
ENG-14528 truncate on empty partition

### DIFF
--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -636,6 +636,8 @@ private:
                                     TableTuple const& sourceTupleWithNewValues,
                                     std::vector<TableIndex*> const& indexesToUpdate);
 
+    // Add truncate operation to dr log stream if dr is enabled and running
+    void drLogTruncate(ExecutorContext* ec, bool fallible);
 
     void notifyBlockWasCompactedAway(TBPtr block);
 


### PR DESCRIPTION
Sort logs so that logs with truncates are processed first until all of the truncates are encountered and then process the remainder of all logs.

Update persistent table to always add a truncate to the binary log even if the partition is empty.