### PR TITLE
Eng 14520 ee memory pool for stl container

### DIFF
--- a/src/ee/CMakeLists.txt
+++ b/src/ee/CMakeLists.txt
@@ -129,6 +129,7 @@ SET (VOLTDB_SRC
   catalog/statement.cpp
   catalog/table.cpp
   catalog/tableref.cpp
+  common/Pool.cpp
   common/debuglog.cpp
   common/ExecuteWithMpMemory.cpp
   common/executorcontext.cpp

--- a/src/ee/common/Pool.cpp
+++ b/src/ee/common/Pool.cpp
@@ -119,10 +119,10 @@ void* Pool::allocate(std::size_t size) {
             currentChunk.offset() = size;
             return currentChunk.data();
          } else {                                       // Need to allocate a new chunk
-            std::cout << "Pool had to allocate a new chunk. Not a good thing "
-               "from a performance perspective. If you see this we need to look "
-               "into structuring our pool sizes and allocations so the this doesn't "
-               "happen frequently" << std::endl;
+//            std::cout << "Pool had to allocate a new chunk. Not a good thing "
+//               "from a performance perspective. If you see this we need to look "
+//               "into structuring our pool sizes and allocations so the this doesn't "
+//               "happen frequently" << std::endl;
 #ifdef USE_MMAP
 //            char *storage =
 //               static_cast<char*>(::mmap( 0, m_allocationSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0 ));
@@ -230,11 +230,10 @@ int64_t Pool::getAllocatedMemory() const {
 
 #endif
 
-// Thread-local shared pool for heteregeous STL container with
-// customized allocator: 256 of 160KB chunks, totaling 40MB
-// overhead, per thread.
-
-Pool VoltAllocResourceMng::s_VoltAllocatorPool(163840, 256);
+// Global shared pool for heteregeous STL container with
+// customized allocator: 1024 of 16KB chunks, totaling 4MB
+// of high-watermark overhead.
+Pool VoltAllocResourceMng::s_VoltAllocatorPool(16384, 1024);
 std::mutex VoltAllocResourceMng::s_allocMutex;
 volatile sig_atomic_t VoltAllocResourceMng::s_numInstances = 0;
 

--- a/src/ee/common/Pool.cpp
+++ b/src/ee/common/Pool.cpp
@@ -1,0 +1,254 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Pool.hpp"
+#include <sys/mman.h>
+#include <errno.h>
+#include <climits>
+#include <cstring>
+#include "common/FatalException.hpp"
+
+using namespace voltdb;
+
+#ifndef MEMCHECK
+/*
+ * Find next higher power of two
+ * From http://en.wikipedia.org/wiki/Power_of_two
+ */
+template <class T> inline T nexthigher(T k) {
+   if (k == 0)
+      return 1;
+   k--;
+   for (int i=1; i<sizeof(T)*CHAR_BIT; i<<=1)
+      k = k | k >> i;
+   return k+1;
+}
+
+Pool::Pool() {
+   init();
+}
+
+Pool::Pool(uint64_t allocationSize, uint64_t maxChunkCount) :
+#ifdef USE_MMAP
+   m_allocationSize(nexthigher(allocationSize)),
+#else
+   m_allocationSize(allocationSize),
+#endif
+   m_maxChunkCount(static_cast<std::size_t>(maxChunkCount)),
+   m_currentChunkIndex(0) { init(); }
+
+   void Pool::init() {
+#ifdef USE_MMAP
+      char *storage =
+         static_cast<char*>(::mmap( 0, m_allocationSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0 ));
+      if (storage == MAP_FAILED) {
+         std::cout << strerror( errno ) << std::endl;
+         throwFatalException("Failed mmap");
+      }
+#else
+      char *storage = new char[m_allocationSize];
+#endif
+      m_chunks.push_back(Chunk(m_allocationSize, storage));
+   }
+
+Pool::~Pool() {
+   for (std::size_t ii = 0; ii < m_chunks.size(); ii++) {
+#ifdef USE_MMAP
+      if (::munmap( m_chunks[ii].m_chunkData, m_chunks[ii].m_size) != 0) {
+         std::cout << strerror( errno ) << std::endl;
+         throwFatalException("Failed munmap");
+      }
+#else
+      delete [] m_chunks[ii].m_chunkData;
+#endif
+   }
+   for (std::size_t ii = 0; ii < m_oversizeChunks.size(); ii++) {
+#ifdef USE_MMAP
+      if (::munmap( m_oversizeChunks[ii].m_chunkData, m_oversizeChunks[ii].m_size) != 0) {
+         std::cout << strerror( errno ) << std::endl;
+         throwFatalException("Failed munmap");
+      }
+#else
+      delete [] m_oversizeChunks[ii].m_chunkData;
+#endif
+   }
+}
+
+void* Pool::allocate(std::size_t size) {
+   /*
+    * See if there is space in the current chunk
+    */
+   Chunk *currentChunk = &m_chunks[m_currentChunkIndex];
+   if (size > currentChunk->m_size - currentChunk->m_offset) {
+      /*
+       * Not enough space. Check if it is greater then our allocation size.
+       */
+      if (size > m_allocationSize) {
+         /*
+          * Allocate an oversize chunk that will not be reused.
+          */
+#ifdef USE_MMAP
+         char *storage =
+            static_cast<char*>(::mmap( 0, nexthigher(size), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0 ));
+         if (storage == MAP_FAILED) {
+            std::cout << strerror( errno ) << std::endl;
+            throwFatalException("Failed mmap");
+         }
+#else
+         char *storage = new char[size];
+#endif
+         m_oversizeChunks.push_back(Chunk(nexthigher(size), storage));
+         Chunk &newChunk = m_oversizeChunks.back();
+         newChunk.m_offset = size;
+         return newChunk.m_chunkData;
+      }
+
+      /*
+       * Check if there is an already allocated chunk we can use.
+       */
+      m_currentChunkIndex++;
+      if (m_currentChunkIndex < m_chunks.size()) {
+         currentChunk = &m_chunks[m_currentChunkIndex];
+         currentChunk->m_offset = size;
+         return currentChunk->m_chunkData;
+      } else {
+         /*
+          * Need to allocate a new chunk
+          */
+         //                std::cout << "Pool had to allocate a new chunk. Not a good thing "
+         //                  "from a performance perspective. If you see this we need to look "
+         //                  "into structuring our pool sizes and allocations so the this doesn't "
+         //                  "happen frequently" << std::endl;
+#ifdef USE_MMAP
+         char *storage =
+            static_cast<char*>(::mmap( 0, m_allocationSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0 ));
+         if (storage == MAP_FAILED) {
+            std::cout << strerror( errno ) << std::endl;
+            throwFatalException("Failed mmap");
+         }
+#else
+         char *storage = new char[m_allocationSize];
+#endif
+         m_chunks.push_back(Chunk(m_allocationSize, storage));
+         Chunk &newChunk = m_chunks.back();
+         newChunk.m_offset = size;
+         return newChunk.m_chunkData;
+      }
+   }
+
+   /*
+    * Get the offset into the current chunk. Then increment the
+    * offset counter by the amount being allocated.
+    */
+   void *retval = currentChunk->m_chunkData + currentChunk->m_offset;
+   currentChunk->m_offset += size;
+
+   //Ensure 8 byte alignment of future allocations
+   currentChunk->m_offset += (8 - (currentChunk->m_offset % 8));
+   if (currentChunk->m_offset > currentChunk->m_size) {
+      currentChunk->m_offset = currentChunk->m_size;
+   }
+   return retval;
+}
+
+void* Pool::allocateZeroes(std::size_t size) {
+   return ::memset(allocate(size), 0, size);
+}
+
+void Pool::purge() throw() {
+   /*
+    * Erase any oversize chunks that were allocated
+    */
+   const std::size_t numOversizeChunks = m_oversizeChunks.size();
+   for (std::size_t ii = 0; ii < numOversizeChunks; ii++) {
+#ifdef USE_MMAP
+      if (::munmap( m_oversizeChunks[ii].m_chunkData, m_oversizeChunks[ii].m_size) != 0) {
+         std::cout << strerror( errno ) << std::endl;
+         throwFatalException("Failed munmap");
+      }
+#else
+      delete [] m_oversizeChunks[ii].m_chunkData;
+#endif
+   }
+   m_oversizeChunks.clear();
+
+   /*
+    * Set the current chunk to the first in the list
+    */
+   m_currentChunkIndex = 0;
+   std::size_t numChunks = m_chunks.size();
+
+   /*
+    * If more then maxChunkCount chunks are allocated erase all extra chunks
+    */
+   if (numChunks > m_maxChunkCount) {
+      for (std::size_t ii = m_maxChunkCount; ii < numChunks; ii++) {
+#ifdef USE_MMAP
+         if (::munmap( m_chunks[ii].m_chunkData, m_chunks[ii].m_size) != 0) {
+            std::cout << strerror( errno ) << std::endl;
+            throwFatalException("Failed munmap");
+         }
+#else
+         delete []m_chunks[ii].m_chunkData;
+#endif
+      }
+      m_chunks.resize(m_maxChunkCount);
+   }
+
+   numChunks = m_chunks.size();
+   for (std::size_t ii = 0; ii < numChunks; ii++) {
+      m_chunks[ii].m_offset = 0;
+   }
+}
+
+int64_t Pool::getAllocatedMemory() const {
+   int64_t total = 0;
+   total += m_chunks.size() * m_allocationSize;
+   for (int i = 0; i < m_oversizeChunks.size(); i++)
+   {
+      total += m_oversizeChunks[i].getSize();
+   }
+   return total;
+}
+
+#else // for MEMCHECK builds
+
+void* Pool::allocate(std::size_t size) {
+   char *retval = new char[size];
+   m_allocations.push_back(retval);
+   m_memTotal += size;
+   return retval;
+}
+void* Pool::allocateZeroes(std::size_t size) {
+   return ::memset(allocate(size), 0, size);
+}
+void Pool::purge() throw() {
+   for (std::size_t ii = 0; ii < m_allocations.size(); ii++) {
+      delete [] m_allocations[ii];
+   }
+   m_allocations.clear();
+   m_memTotal = 0;
+}
+int64_t Pool::getAllocatedMemory() const {
+   return m_memTotal;
+}
+
+#endif
+
+Pool VoltAllocResourceMng::s_VoltAllocatorPool(8192, 2048);
+std::atomic_int VoltAllocResourceMng::s_AllocInUse(0);
+

--- a/src/ee/common/Pool.cpp
+++ b/src/ee/common/Pool.cpp
@@ -66,6 +66,7 @@ void Pool::init() {
 //         throwFatalException("Failed mmap");
 //      }
 #endif
+   m_chunks.reserve(m_maxChunkCount);
    m_chunks.emplace_back(m_allocationSize, 0);
 }
 

--- a/src/ee/common/Pool.cpp
+++ b/src/ee/common/Pool.cpp
@@ -231,15 +231,10 @@ int64_t Pool::getAllocatedMemory() const {
 #endif
 
 // Thread-local shared pool for heteregeous STL container with
-// customized allocator: 1024 of 16KB chunks, totaling 16MB
+// customized allocator: 256 of 160KB chunks, totaling 40MB
 // overhead, per thread.
 
-#ifdef MODERN_CXX
-thread_local Pool VoltAllocResourceMng::s_VoltAllocatorPool(16384, 1024);
-thread_local std::atomic_ulong VoltAllocResourceMng::s_numInstances;
-#else
-Pool VoltAllocResourceMng::s_VoltAllocatorPool(16384, 1024);
+Pool VoltAllocResourceMng::s_VoltAllocatorPool(163840, 256);
 std::mutex VoltAllocResourceMng::s_allocMutex;
 volatile sig_atomic_t VoltAllocResourceMng::s_numInstances = 0;
-#endif
 

--- a/src/ee/common/Pool.hpp
+++ b/src/ee/common/Pool.hpp
@@ -15,336 +15,148 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef POOL_HPP_
-#define POOL_HPP_
+#pragma once
+#include <cstdio>
+#include <cstring>
+#include <cstdint>
 #include <vector>
-#include <iostream>
-#include <stdint.h>
-#include <sys/mman.h>
-#include <errno.h>
-#include <climits>
-#include <string.h>
-#include "common/FatalException.hpp"
+#include <deque>
+#include <atomic>
 
 namespace voltdb {
-static const size_t TEMP_POOL_CHUNK_SIZE = 262144;
 
+   static const size_t TEMP_POOL_CHUNK_SIZE = 262144;
 #ifndef MEMCHECK
-/**
- * Description of a chunk of memory allocated on the heap
- */
-class Chunk {
-public:
-    Chunk()
-        : m_offset(0), m_size(0), m_chunkData(NULL)
-    {
-    }
-
-    inline Chunk(uint64_t size, void *chunkData)
-        : m_offset(0), m_size(size), m_chunkData(static_cast<char*>(chunkData))
-    {
-    }
-
-    int64_t getSize() const
-    {
-        return static_cast<int64_t>(m_size);
-    }
-
-    uint64_t m_offset;
-    uint64_t m_size;
-    char *m_chunkData;
-};
-
-/*
- * Find next higher power of two
- * From http://en.wikipedia.org/wiki/Power_of_two
- */
-template <class T>
-inline T nexthigher(T k) {
-        if (k == 0)
-                return 1;
-        k--;
-        for (int i=1; i<sizeof(T)*CHAR_BIT; i<<=1)
-                k = k | k >> i;
-        return k+1;
-}
-
-/**
- * A memory pool that provides fast allocation and deallocation. The
- * only way to release memory is to free all memory in the pool by
- * calling purge.
- */
-class Pool {
-public:
-
-    Pool() :
-        m_allocationSize(TEMP_POOL_CHUNK_SIZE), m_maxChunkCount(1), m_currentChunkIndex(0)
-    {
-        init();
-    }
-
-    Pool(uint64_t allocationSize, uint64_t maxChunkCount) :
-#ifdef USE_MMAP
-        m_allocationSize(nexthigher(allocationSize)),
-#else
-        m_allocationSize(allocationSize),
-#endif
-        m_maxChunkCount(static_cast<std::size_t>(maxChunkCount)),
-        m_currentChunkIndex(0)
-    {
-        init();
-    }
-
-    void init() {
-#ifdef USE_MMAP
-        char *storage =
-                static_cast<char*>(::mmap( 0, m_allocationSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0 ));
-        if (storage == MAP_FAILED) {
-            std::cout << strerror( errno ) << std::endl;
-            throwFatalException("Failed mmap");
-        }
-#else
-        char *storage = new char[m_allocationSize];
-#endif
-        m_chunks.push_back(Chunk(m_allocationSize, storage));
-    }
-
-    ~Pool() {
-        for (std::size_t ii = 0; ii < m_chunks.size(); ii++) {
-#ifdef USE_MMAP
-            if (::munmap( m_chunks[ii].m_chunkData, m_chunks[ii].m_size) != 0) {
-                std::cout << strerror( errno ) << std::endl;
-                throwFatalException("Failed munmap");
-            }
-#else
-            delete [] m_chunks[ii].m_chunkData;
-#endif
-        }
-        for (std::size_t ii = 0; ii < m_oversizeChunks.size(); ii++) {
-#ifdef USE_MMAP
-            if (::munmap( m_oversizeChunks[ii].m_chunkData, m_oversizeChunks[ii].m_size) != 0) {
-                std::cout << strerror( errno ) << std::endl;
-                throwFatalException("Failed munmap");
-            }
-#else
-            delete [] m_oversizeChunks[ii].m_chunkData;
-#endif
-        }
-    }
-
-    /*
-     * Allocate a continous block of memory of the specified size.
-     */
-    inline void* allocate(std::size_t size) {
-        /*
-         * See if there is space in the current chunk
-         */
-        Chunk *currentChunk = &m_chunks[m_currentChunkIndex];
-        if (size > currentChunk->m_size - currentChunk->m_offset) {
-            /*
-             * Not enough space. Check if it is greater then our allocation size.
-             */
-            if (size > m_allocationSize) {
-                /*
-                 * Allocate an oversize chunk that will not be reused.
-                 */
-#ifdef USE_MMAP
-                char *storage =
-                        static_cast<char*>(::mmap( 0, nexthigher(size), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0 ));
-                if (storage == MAP_FAILED) {
-                    std::cout << strerror( errno ) << std::endl;
-                    throwFatalException("Failed mmap");
-                }
-#else
-                char *storage = new char[size];
-#endif
-                m_oversizeChunks.push_back(Chunk(nexthigher(size), storage));
-                Chunk &newChunk = m_oversizeChunks.back();
-                newChunk.m_offset = size;
-                return newChunk.m_chunkData;
-            }
-
-            /*
-             * Check if there is an already allocated chunk we can use.
-             */
-            m_currentChunkIndex++;
-            if (m_currentChunkIndex < m_chunks.size()) {
-                currentChunk = &m_chunks[m_currentChunkIndex];
-                currentChunk->m_offset = size;
-                return currentChunk->m_chunkData;
-            } else {
-                /*
-                 * Need to allocate a new chunk
-                 */
-//                std::cout << "Pool had to allocate a new chunk. Not a good thing "
-//                  "from a performance perspective. If you see this we need to look "
-//                  "into structuring our pool sizes and allocations so the this doesn't "
-//                  "happen frequently" << std::endl;
-#ifdef USE_MMAP
-                char *storage =
-                        static_cast<char*>(::mmap( 0, m_allocationSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0 ));
-                if (storage == MAP_FAILED) {
-                    std::cout << strerror( errno ) << std::endl;
-                    throwFatalException("Failed mmap");
-                }
-#else
-                char *storage = new char[m_allocationSize];
-#endif
-                m_chunks.push_back(Chunk(m_allocationSize, storage));
-                Chunk &newChunk = m_chunks.back();
-                newChunk.m_offset = size;
-                return newChunk.m_chunkData;
-            }
-        }
-
-        /*
-         * Get the offset into the current chunk. Then increment the
-         * offset counter by the amount being allocated.
-         */
-        void *retval = currentChunk->m_chunkData + currentChunk->m_offset;
-        currentChunk->m_offset += size;
-
-        //Ensure 8 byte alignment of future allocations
-        currentChunk->m_offset += (8 - (currentChunk->m_offset % 8));
-        if (currentChunk->m_offset > currentChunk->m_size) {
-            currentChunk->m_offset = currentChunk->m_size;
-        }
-
-        return retval;
-    }
-
-    /*
-     * Allocate a continous block of memory of the specified size conveniently initialized to 0s
-     */
-    inline void* allocateZeroes(std::size_t size) { return ::memset(allocate(size), 0, size); }
-
-    inline void purge() {
-        /*
-         * Erase any oversize chunks that were allocated
-         */
-        const std::size_t numOversizeChunks = m_oversizeChunks.size();
-        for (std::size_t ii = 0; ii < numOversizeChunks; ii++) {
-#ifdef USE_MMAP
-            if (::munmap( m_oversizeChunks[ii].m_chunkData, m_oversizeChunks[ii].m_size) != 0) {
-                std::cout << strerror( errno ) << std::endl;
-                throwFatalException("Failed munmap");
-            }
-#else
-            delete [] m_oversizeChunks[ii].m_chunkData;
-#endif
-        }
-        m_oversizeChunks.clear();
-
-        /*
-         * Set the current chunk to the first in the list
-         */
-        m_currentChunkIndex = 0;
-        std::size_t numChunks = m_chunks.size();
-
-        /*
-         * If more then maxChunkCount chunks are allocated erase all extra chunks
-         */
-        if (numChunks > m_maxChunkCount) {
-            for (std::size_t ii = m_maxChunkCount; ii < numChunks; ii++) {
-#ifdef USE_MMAP
-                if (::munmap( m_chunks[ii].m_chunkData, m_chunks[ii].m_size) != 0) {
-                    std::cout << strerror( errno ) << std::endl;
-                    throwFatalException("Failed munmap");
-                }
-#else
-                delete []m_chunks[ii].m_chunkData;
-#endif
-            }
-            m_chunks.resize(m_maxChunkCount);
-        }
-
-        numChunks = m_chunks.size();
-        for (std::size_t ii = 0; ii < numChunks; ii++) {
-            m_chunks[ii].m_offset = 0;
-        }
-    }
-
-    int64_t getAllocatedMemory()
-    {
-        int64_t total = 0;
-        total += m_chunks.size() * m_allocationSize;
-        for (int i = 0; i < m_oversizeChunks.size(); i++)
-        {
-            total += m_oversizeChunks[i].getSize();
-        }
-        return total;
-    }
-
-private:
-    const uint64_t m_allocationSize;
-    std::size_t m_maxChunkCount;
-    std::size_t m_currentChunkIndex;
-    std::vector<Chunk> m_chunks;
-    /*
-     * Oversize chunks that will be freed and not reused.
-     */
-    std::vector<Chunk> m_oversizeChunks;
-    // No implicit copies
-    Pool(const Pool&);
-    Pool& operator=(const Pool&);
-};
+   /**
+    * A memory pool that provides fast allocation and deallocation. The
+    * only way to release memory is to free all memory in the pool by
+    * calling purge.
+    */
+   class Pool {
+      /**
+       * Description of a chunk of memory allocated on the heap
+       */
+      struct Chunk {
+         uint64_t m_offset = 0;
+         uint64_t m_size = 0;
+         char *m_chunkData = nullptr;
+         Chunk() {}
+         Chunk(uint64_t size, void *chunkData)
+            : m_size(size), m_chunkData(static_cast<char*>(chunkData)) { }
+         int64_t getSize() const {
+            return m_size;
+         }
+      };
+      const uint64_t m_allocationSize = TEMP_POOL_CHUNK_SIZE;
+      std::size_t m_maxChunkCount = 1;
+      std::size_t m_currentChunkIndex = 0;
+      std::vector<Chunk> m_chunks;
+      /*
+       * Oversize chunks that will be freed and not reused.
+       */
+      std::vector<Chunk> m_oversizeChunks;
+      // No implicit copies
+      Pool(const Pool&);
+      Pool& operator=(const Pool&);
+   public:
+      Pool();
+      Pool(uint64_t allocationSize, uint64_t maxChunkCount);
+      void init();
+      virtual ~Pool();
+      /*
+       * Allocate a continous block of memory of the specified size.
+       */
+      void* allocate(std::size_t size);
+      /*
+       * Allocate a continous block of memory of the specified size conveniently initialized to 0s
+       */
+      void* allocateZeroes(std::size_t size);
+      void purge() throw();
+      int64_t getAllocatedMemory() const;
+   };
 #else // for MEMCHECK builds
-/**
- * A debug version of the memory pool that does each allocation on the heap keeps a list for when purge is called
- */
-class Pool {
-public:
-    Pool()
-        : m_allocations()
-        , m_memTotal(0)
-    {
-    }
-
-    Pool(uint64_t allocationSize, uint64_t maxChunkCount)
-        : m_allocations()
-        , m_memTotal(0)
-    {
-    }
-
-    ~Pool() {
-        purge();
-    }
-
-    /*
-     * Allocate a continous block of memory of the specified size.
-     */
-    inline void* allocate(std::size_t size) {
-        char *retval = new char[size];
-        m_allocations.push_back(retval);
-        m_memTotal += size;
-        return retval;
-    }
-
-    /*
-     * Allocate a continous block of memory of the specified size conveniently initialized to 0s
-     */
-    inline void* allocateZeroes(std::size_t size) { return ::memset(allocate(size), 0, size); }
-
-    inline void purge() {
-        for (std::size_t ii = 0; ii < m_allocations.size(); ii++) {
-            delete [] m_allocations[ii];
-        }
-        m_allocations.clear();
-        m_memTotal = 0;
-    }
-
-    int64_t getAllocatedMemory()
-    {
-        return m_memTotal;
-    }
-
-private:
-    std::vector<char*> m_allocations;
-    int64_t m_memTotal;
-    // No implicit copies
-    Pool(const Pool&);
-    Pool& operator=(const Pool&);
-};
+   /**
+    * A debug version of the memory pool that does each allocation on the heap keeps a list for when purge is called
+    */
+   class Pool {
+      std::vector<char*> m_allocations();
+      int64_t m_memTotal = 0;
+      // No implicit copies
+      Pool(const Pool&);
+      Pool& operator=(const Pool&);
+   public:
+      Pool() {}
+      Pool(uint64_t allocationSize, uint64_t maxChunkCount) {}
+      virtual ~Pool() {purge();}
+      /*
+       * Allocate a continous block of memory of the specified size.
+       */
+      void* allocate(std::size_t size);
+      /*
+       * Allocate a continous block of memory of the specified size conveniently initialized to 0s
+       */
+      void* allocateZeroes(std::size_t size);
+      void purge() throw();
+      int64_t getAllocatedMemory() const;
+   };
 #endif
+   /**
+    * Resource pool for all heteregeous VoltAllocs.
+    */
+   class VoltAllocResourceMng {
+   protected:
+      static Pool s_VoltAllocatorPool;
+      static std::atomic_int s_AllocInUse;
+      static void* operator new(std::size_t sz) {
+//         fprintf(stderr, "Ask for %lu bytes\n", sz);
+         void* p = s_VoltAllocatorPool.allocate(sz);
+//         fputs("granted\n", stderr);
+         return p;
+      }
+      static void* operator new(std::size_t sz, void* p) {
+         return p;
+      }
+      static void operator delete(void*) { /* every-day deallocator does nothing -- lets the pool cope */ }
+   };
+   /**
+    * An allocator to be used in lieu with STL containers, but
+    * allocate from a global memory pool.
+    * e.g. std::vector<TxnMem, VoltAlloc<TxnMem>> s;
+    */
+   template<typename T> class allocator: public VoltAllocResourceMng {
+      public:
+         typedef size_t     size_type;
+         typedef ptrdiff_t  difference_type;
+         typedef T*       pointer;
+         typedef const T* const_pointer;
+         typedef T&       reference;
+         typedef const T& const_reference;
+         typedef T        value_type;
+         template<typename Tp1> struct rebind { typedef allocator<Tp1> other; };
+
+         allocator() throw() { }
+         allocator(const allocator&) throw() { }
+         template<typename Tp1> allocator(const allocator<Tp1>&) throw() { }
+         ~allocator() throw() { }
+         pointer address(reference x) const throw() { return std::addressof(x); }
+         const_pointer address(const_reference x) const throw() { return std::addressof(x); }
+         pointer allocate(size_type n, const void* = static_cast<const void*>(nullptr)) {
+            if (n > this->max_size())
+               throw std::bad_alloc();
+            return static_cast<T*>(VoltAllocResourceMng::operator new(n * sizeof(T)));
+         }
+         void deallocate(pointer p, size_type) {
+            VoltAllocResourceMng::operator delete(p);
+         }
+         size_type max_size() const throw() { return size_t(-1) / sizeof(T); }
+//         void construct(pointer p, const T& val) { new((void *)p) T(val); }
+         template<typename U> void destroy(U* p) { p->~U(); }
+   };
+
+   template<typename T1, typename T2> inline bool operator==(const allocator<T1>&, const allocator<T2>&) throw() { return true; }
+   template<typename T> inline bool operator==(const allocator<T>&, const allocator<T>&) throw() { return true; }
+
+   template<typename T1, typename T2> inline bool operator!=(const allocator<T1>&, const allocator<T2>&) throw() { return false; }
+   template<typename T> inline bool operator!=(const allocator<T>&, const allocator<T>&) throw() { return false; }
+
 }
-#endif /* POOL_HPP_ */

--- a/src/ee/common/Pool.hpp
+++ b/src/ee/common/Pool.hpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cstdint>
+#include <list>
 #include <vector>
 #include <memory>
 #include <signal.h>     // for sig_atomic_t typedef
@@ -103,7 +104,7 @@ namespace voltdb {
       /*
        * Oversize chunks that will be freed and not reused.
        */
-      std::vector<Chunk> m_oversizeChunks;
+      std::list<Chunk> m_oversizeChunks;
       // No implicit copies
       Pool(const Pool&);
       Pool& operator=(const Pool&);

--- a/src/ee/common/Pool.hpp
+++ b/src/ee/common/Pool.hpp
@@ -166,6 +166,11 @@ namespace voltdb {
     * which needs full C++11 support. Therefore, I leave it till
     * we migrate off from any C++11-partial-supported
     * compilers/platforms.
+    *
+    * Warning: Be cautious when using this global pool. The pool
+    * itself does not compact, and therefore will never release memory.
+    * This means it is leaking memory as soon as you start using it
+    * on anything but ephemeral storages!!!
     */
    class VoltAllocResourceMng {
       static Pool s_VoltAllocatorPool;
@@ -282,6 +287,18 @@ namespace voltdb {
    template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5>
    T* createInstanceFromPool(Pool& pool, Arg1 arg1, Arg2 arg2, Arg3 arg3, Arg4 arg4, Arg5 arg5) {
       return ::new (pool.allocate(sizeof(T))) T(arg1, arg2, arg3, arg4, arg5);
+   }
+   template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6>
+   T* createInstanceFromPool(Pool& pool, Arg1 arg1, Arg2 arg2, Arg3 arg3, Arg4 arg4, Arg5 arg5, Arg6 arg6) {
+      return ::new (pool.allocate(sizeof(T))) T(arg1, arg2, arg3, arg4, arg5, arg6);
+   }
+   template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6, typename Arg7>
+   T* createInstanceFromPool(Pool& pool, Arg1 arg1, Arg2 arg2, Arg3 arg3, Arg4 arg4, Arg5 arg5, Arg6 arg6, Arg7 arg7) {
+      return ::new (pool.allocate(sizeof(T))) T(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+   }
+   template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6, typename Arg7, typename Arg8>
+   T* createInstanceFromPool(Pool& pool, Arg1 arg1, Arg2 arg2, Arg3 arg3, Arg4 arg4, Arg5 arg5, Arg6 arg6, Arg7 arg7, Arg8 arg8) {
+      return ::new (pool.allocate(sizeof(T))) T(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
    }
 #endif
 

--- a/src/ee/common/Pool.hpp
+++ b/src/ee/common/Pool.hpp
@@ -189,14 +189,18 @@ namespace voltdb {
     * allocate from a global memory pool.
     * e.g. std::vector<TxnMem, VoltAlloc<TxnMem>> s;
     *
-    * The voltdb::allocator (conceptually) uses a common thread-local Pool,
-    * which means that:
+    * The voltdb::allocator (conceptually) uses a common global
+    * Pool with small chunk size, and locks when allocating.
+    * This means:
     *
     * 1. The allocator is thread-safe, i.e. multiple threads
     * using allocator should be free to use it in any manner;
     *
     * 2. One thread's memory is invisible to the other, meaning
     * that they cannot access the same object in any manner.
+    *
+    * 3. Small chunk size helps avoid memory fragmentation, and
+    * increases memory utility.
     */
    template<typename T> class allocator {
    public:

--- a/src/ee/common/UndoLog.cpp
+++ b/src/ee/common/UndoLog.cpp
@@ -29,7 +29,7 @@ void UndoLog::clear()
     if (m_undoQuantums.size() > 0) {
         release(m_lastUndoToken);
     }
-    for (std::vector<Pool*>::iterator i = m_undoDataPools.begin();
+    for (auto i = m_undoDataPools.begin();
          i != m_undoDataPools.end();
          i++) {
         delete *i;

--- a/src/ee/common/UndoLog.cpp
+++ b/src/ee/common/UndoLog.cpp
@@ -20,7 +20,7 @@
 namespace voltdb {
 
 UndoLog::UndoLog()
-  : m_lastUndoToken(INT64_MIN), m_lastReleaseToken(INT64_MIN), m_undoLogForLowestSite(false)
+  : m_lastUndoToken(INT64_MIN), m_lastReleaseToken(INT64_MIN)
 {
 }
 
@@ -29,9 +29,7 @@ void UndoLog::clear()
     if (! m_undoQuantums.empty()) {
         release(m_lastUndoToken);
     }
-    for (auto i = m_undoDataPools.begin();
-         i != m_undoDataPools.end();
-         i++) {
+    for (auto i = m_undoDataPools.begin(); i != m_undoDataPools.end(); i++) {
         delete *i;
     }
     m_undoDataPools.clear();

--- a/src/ee/common/UndoLog.cpp
+++ b/src/ee/common/UndoLog.cpp
@@ -26,7 +26,7 @@ UndoLog::UndoLog()
 
 void UndoLog::clear()
 {
-    if (m_undoQuantums.size() > 0) {
+    if (! m_undoQuantums.empty()) {
         release(m_lastUndoToken);
     }
     for (auto i = m_undoDataPools.begin();

--- a/src/ee/common/UndoLog.h
+++ b/src/ee/common/UndoLog.h
@@ -18,13 +18,11 @@
 #ifndef UNDOLOG_H_
 #define UNDOLOG_H_
 
-#include <vector>
-#include <deque>
 #include <stdint.h>
 #include <iostream>
 #include <cassert>
 
-#include "common/Pool.hpp"
+#include "common/VoltContainer.hpp"
 #include "common/UndoQuantum.h"
 
 namespace voltdb
@@ -199,8 +197,8 @@ namespace voltdb
         // any larger value might exist (gaps are possible)
         int64_t m_lastReleaseToken;
 
-        std::vector<Pool*> m_undoDataPools;
-        std::deque<UndoQuantum*> m_undoQuantums;
+        volt_vector<Pool*> m_undoDataPools;
+        volt_deque<UndoQuantum*> m_undoQuantums;
         bool m_undoLogForLowestSite;
     };
 }

--- a/src/ee/common/UndoLog.h
+++ b/src/ee/common/UndoLog.h
@@ -56,7 +56,7 @@ namespace voltdb
             assert(nextUndoToken > m_lastReleaseToken);
             m_lastUndoToken = nextUndoToken;
             Pool *pool = NULL;
-            if (m_undoDataPools.size() == 0) {
+            if (m_undoDataPools.empty()) {
                 pool = new Pool(TEMP_POOL_CHUNK_SIZE, 1);
             } else {
                 pool = m_undoDataPools.back();

--- a/src/ee/common/UndoLog.h
+++ b/src/ee/common/UndoLog.h
@@ -193,8 +193,8 @@ namespace voltdb
         // any larger value might exist (gaps are possible)
         int64_t m_lastReleaseToken;
 
-        std::vector<Pool*, voltdb::allocator<Pool*>> m_undoDataPools;
-        std::deque<UndoQuantum*, voltdb::allocator<UndoQuantum*>> m_undoQuantums;
+        std::vector<Pool*> m_undoDataPools;
+        std::deque<UndoQuantum*> m_undoQuantums;
     };
 }
 #endif /* UNDOLOG_H_ */

--- a/src/ee/common/UndoLog.h
+++ b/src/ee/common/UndoLog.h
@@ -197,8 +197,8 @@ namespace voltdb
         // any larger value might exist (gaps are possible)
         int64_t m_lastReleaseToken;
 
-        volt_vector<Pool*> m_undoDataPools;
-        volt_deque<UndoQuantum*> m_undoQuantums;
+        std::vector<Pool*, voltdb::allocator<Pool*>> m_undoDataPools;
+        std::deque<UndoQuantum*, voltdb::allocator<UndoQuantum*>> m_undoQuantums;
         bool m_undoLogForLowestSite;
     };
 }

--- a/src/ee/common/UndoQuantum.h
+++ b/src/ee/common/UndoQuantum.h
@@ -18,12 +18,12 @@
 #ifndef UNDOQUANTUM_H_
 #define UNDOQUANTUM_H_
 
-#include <vector>
 #include <stdint.h>
 #include <cassert>
 #include <string.h>
 
 #include "common/Pool.hpp"
+#include "common/VoltContainer.hpp"
 #include "common/UndoReleaseAction.h"
 #include "common/UndoQuantumReleaseInterest.h"
 #include "boost/unordered_set.hpp"
@@ -91,7 +91,7 @@ protected:
      * but their no-op delete operator leaves them to be purged in one go with the data pool.
      */
     inline Pool* undo() {
-        for (std::vector<UndoReleaseAction*>::reverse_iterator i = m_undoActions.rbegin();
+        for (auto i = m_undoActions.rbegin();
              i != m_undoActions.rend(); ++i) {
             UndoReleaseAction* goner = *i;
             goner->undo();
@@ -116,7 +116,7 @@ protected:
      * table before all the inserts and deletes are released.
      */
     inline Pool* release() {
-        for (std::vector<UndoReleaseAction*>::iterator i = m_undoActions.begin();
+        for (auto i = m_undoActions.begin();
              i != m_undoActions.end(); ++i) {
             UndoReleaseAction* goner = *i;
             goner->release();
@@ -154,7 +154,7 @@ public:
 
 private:
     const int64_t m_undoToken;
-    std::vector<UndoReleaseAction*> m_undoActions;
+    volt_vector<UndoReleaseAction*> m_undoActions;
     uint32_t m_numInterests;
     uint32_t m_interestsCapacity;
     UndoQuantumReleaseInterest **m_interests;

--- a/src/ee/common/UndoQuantum.h
+++ b/src/ee/common/UndoQuantum.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <cassert>
 #include <string.h>
+#include <list>
 
 #include "common/Pool.hpp"
 #include "common/VoltContainer.hpp"
@@ -136,8 +137,8 @@ private:
        UndoReleaseActionRevIter_t;
     uint32_t m_numInterests;
     uint32_t m_interestsCapacity;
-    std::deque<UndoQuantumReleaseInterest*, voltdb::allocator<UndoQuantumReleaseInterest*>> m_interests;
-    typedef std::deque<UndoQuantumReleaseInterest*, voltdb::allocator<UndoQuantumReleaseInterest*>>::iterator
+    std::list<UndoQuantumReleaseInterest*, voltdb::allocator<UndoQuantumReleaseInterest*>> m_interests;
+    typedef std::list<UndoQuantumReleaseInterest*, voltdb::allocator<UndoQuantumReleaseInterest*>>::iterator
        UndoQuantumReleaseInterestIter_t;
     const bool m_forLowestSite;
 protected:

--- a/src/ee/common/UndoQuantum.h
+++ b/src/ee/common/UndoQuantum.h
@@ -121,8 +121,8 @@ public:
     void* allocateAction(size_t sz) { return m_dataPool->allocate(sz); }
 private:
     const int64_t m_undoToken;
-    std::deque<UndoReleaseAction*, voltdb::allocator<UndoReleaseAction*>> m_undoActions;
-    std::list<UndoQuantumReleaseInterest*, voltdb::allocator<UndoQuantumReleaseInterest*>> m_interests;
+    std::deque<UndoReleaseAction*> m_undoActions;
+    std::list<UndoQuantumReleaseInterest*> m_interests;
 protected:
     Pool *m_dataPool;
 };

--- a/src/ee/common/UndoQuantum.h
+++ b/src/ee/common/UndoQuantum.h
@@ -71,7 +71,7 @@ protected:
      * but their no-op delete operator leaves them to be purged in one go with the data pool.
      */
     inline Pool* undo() {
-        for (UndoReleaseActionRevIter_t i = m_undoActions.rbegin();
+        for (auto i = m_undoActions.rbegin();
              i != m_undoActions.rend(); ++i) {
             (*i)->undo();
             delete *i;
@@ -95,12 +95,12 @@ protected:
      * table before all the inserts and deletes are released.
      */
     inline Pool* release() {
-        for (UndoReleaseActionIter_t i = m_undoActions.begin();
+        for (auto i = m_undoActions.begin();
              i != m_undoActions.end(); ++i) {
             (*i)->release();
             delete *i;
         }
-        for(UndoQuantumReleaseInterestIter_t cur = m_interests.begin(); cur != m_interests.end(); ++cur) {
+        for(auto cur = m_interests.begin(); cur != m_interests.end(); ++cur) {
            (*cur)->notifyQuantumRelease();
         }
         Pool* result = m_dataPool;
@@ -131,15 +131,9 @@ public:
 private:
     const int64_t m_undoToken;
     std::deque<UndoReleaseAction*, voltdb::allocator<UndoReleaseAction*>> m_undoActions;
-    typedef std::deque<UndoReleaseAction*, voltdb::allocator<UndoReleaseAction*>>::iterator
-       UndoReleaseActionIter_t;
-    typedef std::deque<UndoReleaseAction*, voltdb::allocator<UndoReleaseAction*>>::reverse_iterator
-       UndoReleaseActionRevIter_t;
     uint32_t m_numInterests;
     uint32_t m_interestsCapacity;
     std::list<UndoQuantumReleaseInterest*, voltdb::allocator<UndoQuantumReleaseInterest*>> m_interests;
-    typedef std::list<UndoQuantumReleaseInterest*, voltdb::allocator<UndoQuantumReleaseInterest*>>::iterator
-       UndoQuantumReleaseInterestIter_t;
     const bool m_forLowestSite;
 protected:
     Pool *m_dataPool;

--- a/src/ee/common/VoltContainer.hpp
+++ b/src/ee/common/VoltContainer.hpp
@@ -1,0 +1,7 @@
+
+#pragma once
+#include <memory>
+#include "Pool.hpp"
+template<typename T> using volt_vector = std::vector<T, voltdb::allocator<T>>;
+template<typename T> using volt_deque = std::deque<T, std::allocator<T>>;    // NOTE: do not use voltdb::allocator: will crash indeterministically
+

--- a/src/ee/common/VoltContainer.hpp
+++ b/src/ee/common/VoltContainer.hpp
@@ -1,7 +1,26 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
-#include <memory>
+#include <deque>
 #include "Pool.hpp"
-template<typename T> using volt_vector = std::vector<T, voltdb::allocator<T>>;
-template<typename T> using volt_deque = std::deque<T, std::allocator<T>>;    // NOTE: do not use voltdb::allocator: will crash indeterministically
+
+// This is the preferred way, but CentOS6 does not support this
+// yet...
+//template<typename T> using volt_vector = std::vector<T, voltdb::allocator<T>>;
+//template<typename T> using volt_deque = std::deque<T, voltdb::allocator<T>>;
 

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -72,6 +72,10 @@ namespace voltdb {
 
 #define TABLE_BLOCKSIZE 2097152
 
+   template<typename T> inline static T* partialCopyToPool(Pool* pool, const T* src, size_t partialSize) {
+      return reinterpret_cast<T*>(memcpy(pool->allocate(partialSize), src, partialSize));
+   }
+
 class SetAndRestorePendingDeleteFlag
 {
 public:
@@ -885,11 +889,11 @@ void PersistentTable::doInsertTupleCommon(TableTuple& source, TableTuple& target
          */
         UndoQuantum *uq = ExecutorContext::currentUndoQuantum();
         if (uq) {
-            char* tupleData = uq->allocatePooledCopy(target.address(), target.tupleLength());
+           char* tupleData = partialCopyToPool(uq->getPool(), target.address(), target.tupleLength());
             //* enable for debug */ std::cout << "DEBUG: inserting " << (void*)target.address()
             //* enable for debug */           << " { " << target.debugNoHeader() << " } "
             //* enable for debug */           << " copied to " << (void*)tupleData << std::endl;
-            UndoReleaseAction* undoAction = new (*uq) PersistentTableUndoInsertAction(tupleData, &m_surgeon);
+            UndoReleaseAction* undoAction = createInstanceFromPool<PersistentTableUndoInsertAction>(*uq->getPool(), tupleData, &m_surgeon);
             SynchronizedThreadLock::addUndoAction(isCatalogTableReplicated(), uq, undoAction);
         }
     }
@@ -988,7 +992,7 @@ void PersistentTable::updateTupleWithSpecificIndexes(TableTuple& targetTupleToUp
              * For undo purposes, before making any changes, save a copy of the state of the tuple
              * into the undo pool temp storage and hold onto it with oldTupleData.
              */
-            oldTupleData = uq->allocatePooledCopy(targetTupleToUpdate.address(), targetTupleToUpdate.tupleLength());
+           oldTupleData = partialCopyToPool(uq->getPool(), targetTupleToUpdate.address(), targetTupleToUpdate.tupleLength());
         }
     }
 
@@ -1010,7 +1014,8 @@ void PersistentTable::updateTupleWithSpecificIndexes(TableTuple& targetTupleToUp
 
         UndoQuantum* uq = ExecutorContext::currentUndoQuantum();
         if (uq && fallible) {
-            uq->registerUndoAction(new (*uq) DRTupleStreamUndoAction(drStream, drMark, rowCostForDRRecord(DR_RECORD_UPDATE)));
+            uq->registerUndoAction(createInstanceFromPool<DRTupleStreamUndoAction>(
+                     *uq->getPool(), drStream, drMark, rowCostForDRRecord(DR_RECORD_UPDATE)));
         }
     }
 
@@ -1095,10 +1100,9 @@ void PersistentTable::updateTupleWithSpecificIndexes(TableTuple& targetTupleToUp
          * Create and register an undo action with copies of the "before" and "after" tuple storage
          * and the "before" and "after" object pointers for non-inlined columns that changed.
          */
-        char* newTupleData = uq->allocatePooledCopy(targetTupleToUpdate.address(), tupleLength);
-        UndoReleaseAction* undoAction = new (*uq) PersistentTableUndoUpdateAction(oldTupleData, newTupleData,
-                                                                           oldObjects, newObjects,
-                                                                           &m_surgeon, someIndexGotUpdated);
+       char* newTupleData = partialCopyToPool(uq->getPool(), targetTupleToUpdate.address(), tupleLength);
+        UndoReleaseAction* undoAction = createInstanceFromPool<PersistentTableUndoUpdateAction>(
+              *uq->getPool(), oldTupleData, newTupleData, oldObjects, newObjects, &m_surgeon, someIndexGotUpdated);
         SynchronizedThreadLock::addUndoAction(isCatalogTableReplicated(), uq, undoAction);
     }
     else {
@@ -1222,7 +1226,8 @@ void PersistentTable::deleteTuple(TableTuple& target, bool fallible) {
                                               currentUniqueId, target, DR_RECORD_DELETE);
 
         if (createUndoAction) {
-            uq->registerUndoAction(new (*uq) DRTupleStreamUndoAction(drStream, drMark, rowCostForDRRecord(DR_RECORD_DELETE)));
+            uq->registerUndoAction(createInstanceFromPool<DRTupleStreamUndoAction>(
+                     *uq->getPool(), drStream, drMark, rowCostForDRRecord(DR_RECORD_DELETE)));
         }
     }
 
@@ -1233,7 +1238,8 @@ void PersistentTable::deleteTuple(TableTuple& target, bool fallible) {
         target.setPendingDeleteOnUndoReleaseTrue();
         ++m_tuplesPinnedByUndo;
         ++m_invisibleTuplesPendingDeleteCount;
-        UndoReleaseAction* undoAction = new (*uq) PersistentTableUndoDeleteAction(target.address(), &m_surgeon);
+        UndoReleaseAction* undoAction = createInstanceFromPool<PersistentTableUndoDeleteAction>(
+              *uq->getPool(), target.address(), &m_surgeon);
         SynchronizedThreadLock::addUndoAction(isCatalogTableReplicated(), uq, undoAction, this);
     }
 

--- a/tests/ee/common/pool_test.cpp
+++ b/tests/ee/common/pool_test.cpp
@@ -110,6 +110,138 @@ TEST_F(PoolTest, OversizeTest) {
     EXPECT_NE(space, NULL);
 }
 
+// Tests voltdb::allocator with multiple threads. Run this test
+// only for the moderately new compilers.
+#if defined __GNUC__ && __GNUC__ >= 5
+#include <algorithm>
+#include <cassert>
+#include <deque>
+#include <list>
+#include <random>
+#include <thread>
+
+struct S1 {
+   static std::mt19937 s_gen;
+   static std::uniform_int_distribution<> s_dist;     // hole allowed in string
+   static void genRandString(char* dst, size_t len) {
+      for(size_t i = 0; i < len; ++i) {
+         dst[i] = S1::s_dist(S1::s_gen);
+      }
+      dst[len - 1] = 0;     // last byte set to sentinel
+   }
+   static std::string genRandString(size_t len) {
+      std::string s(len, 0);
+      genRandString(&s[0], len);
+      return s;
+   }
+public:
+   const size_t m_stringLen;
+   char m_char;
+   std::string m_str;
+   S1(const std::string& s): m_stringLen(s.size()), m_char(s[0]), m_str(s) {}
+   S1() : S1(genRandString(255)) {}
+   virtual ~S1() { }
+};
+std::random_device rd;
+std::mt19937 S1::s_gen(rd());
+std::uniform_int_distribution<> S1::s_dist(0, 255);     // hole allowed in string
+
+struct S2 {
+   S1 m_s1;
+   std::string m_str;
+   double m_doubleVal = -1.243;
+   char m_stringOnStack[512];
+   S2() : m_s1(), m_str(S1::genRandString(S1::s_dist(S1::s_gen))) { }
+   virtual ~S2() {}
+};
+
+struct S3 : public S2 {
+   char m_char;
+   S1 m_S1Array[32];
+   S3() : S2(), m_char(S1::s_dist(S1::s_gen)) {
+   }
+};
+
+struct S4 {
+   std::vector<S1> m_s1;
+   std::deque<S2> m_s2;
+   std::list<S3> m_s3;
+   std::string m_str;
+   S4() {
+      for(int i = 0; i < 6; ++i) {
+         m_s1.emplace_back();
+         m_s2.emplace_back();
+         m_s3.emplace_back();
+      }
+   }
+};
+
+template<typename T, typename Alloc, template<typename, typename> class Cont>
+void updateContainer(Cont<T, Alloc>& cont) {
+   // flip a coin to determine using emplace_back() with 80% of likelihood, or pop_back() with 20% of likelihood.
+   static std::bernoulli_distribution dist(.8);
+   if (cont.empty() || dist(S1::s_gen)) {
+      cont.emplace_back();
+   } else {
+      cont.pop_back();
+   }
+   // and with 20% likelihood mutating 1st and last elem's std::string field
+   if (!cont.empty() && !dist(S1::s_gen)) {
+      cont.front().m_str.append("- foo");
+      cont.back().m_str.append("- bar");
+   }
+}
+
+template<typename T> using Alloc = voltdb::allocator<T>;
+/**
+ * Test logic for using multiple containers from an allocator at
+ * the same time. Note that each container shall have at most 1
+ * thread on it, as operations on STL container is not
+ * thread-safe.
+ */
+TEST_F(PoolTest, AllocatorTest) {
+   using Cont1 = std::vector<S1, Alloc<S1>>;
+   using Cont2 = std::deque<S2, Alloc<S2>>;
+#if defined __GNUC__ && __GNUC__ > 5
+   using Cont3 = std::list<S3, Alloc<S3>>;              // GCC-5 std::list's allocator requires a different allocator's construct() method
+   using Cont4 = std::list<S4, Alloc<S4>>;
+#else
+   using Cont3 = std::deque<S3, Alloc<S3>>;
+   using Cont4 = std::vector<S4, Alloc<S4>>;
+#endif
+   Cont1 cont1;
+   Cont2 cont2;
+   Cont3 cont3;
+   Cont4 cont4;
+   // Creating thread pool to freely contend with each other for
+   // allocator resources
+   std::vector<std::thread> threads;
+   for(int i = 0; i < 4; ++i) {                         // shall have only 3 threads, each working on one container
+      threads.emplace_back([&cont1, &cont2, &cont3, &cont4, i]() {
+            for(size_t iter = 0; iter < 10000lu; ++iter) {
+               switch(i) {
+                  case 0:
+                     updateContainer(cont1);
+                     break;
+                  case 1:
+                     updateContainer(cont2);
+                     break;
+                  case 2:
+                     updateContainer(cont3);
+                     break;
+                  case 3:
+                     updateContainer(cont4);
+                     break;
+                  default:
+                     assert(!"Each container can only have 1 thread associated");
+                  }
+               }
+            });
+   }
+   std::for_each(threads.begin(), threads.end(), [](std::thread& thrd) { thrd.join(); });
+}
+#endif
+
 int main() {
     return TestSuite::globalInstance()->runAll();
 }

--- a/tests/ee/storage/StreamedTable_test.cpp
+++ b/tests/ee/storage/StreamedTable_test.cpp
@@ -55,7 +55,7 @@ public:
         srand(0);
         m_topend = new DummyTopend();
         m_pool = new Pool();
-        m_quantum = new (*m_pool) UndoQuantum(0, m_pool, false);
+        m_quantum = createInstanceFromPool<UndoQuantum>(*m_pool, 0, m_pool);
         VoltDBEngine* noEngine = NULL;
         m_context = new ExecutorContext(0, 0, m_quantum, m_topend, m_pool,
                                         noEngine, "", 0, NULL, NULL, 0);
@@ -99,8 +99,8 @@ public:
     void nextQuantum(int i, int64_t tokenOffset)
     {
         // Takes advantage of "grey box test" friend privileges on UndoQuantum.
-        m_quantum->release();
-        m_quantum = new (*m_pool) UndoQuantum(i + tokenOffset, m_pool, false);
+       UndoQuantum::release(std::move(*m_quantum));
+        m_quantum = createInstanceFromPool<UndoQuantum>(*m_pool, i + tokenOffset, m_pool);
         // quant, currTxnId, committedTxnId
         m_context->setupForPlanFragments(m_quantum, i, i, i - 1, 0, false);
     }
@@ -111,7 +111,7 @@ public:
             TupleSchema::freeTupleSchema(m_schema);
         delete m_table;
         delete m_context;
-        m_quantum->release();
+        UndoQuantum::release(std::move(*m_quantum));
         delete m_pool;
         delete m_topend;
         voltdb::globalDestroyOncePerProcess();


### PR DESCRIPTION
1. Clean up of Pool.hpp:
 - Put bulk implementation into .cpp file. I don't understand why so many of function/method definitions are in the .h/.hpp file instead of .cpp file. Maybe we were more comfortable writing Java code? Or maybe we want compiler to `inline` those methods? But we lose so much more clarity by doing that, and for C++ code, class layout as API is much more important than Java. (Welcome to compare changes to Pool class before/after)
 - Commented out unused build condition (`USE_MMAP`), to make it easier to follow.
 - Fixed a small bug that we almost always waste 8 bytes between different allocations.
 - Use `std::unique_ptr<char[]>` in place of manual `new`/`delete` invocations to the OS.
 - Changed container type from `std::vector` to `std::list` and `std::deque` for the `Pool` implementation, to reduce unnecessary `memcpy` overhead when reallocating.
 - Other details of making `Pool::allocate()` logic easier to follow
2. Added `class VoltAllocResourceMng` that owns a global, shared `Pool` instance, with thread-safe `new()` function that allocates from the global pool. Thread-safety is achieved by using `std::mutex`, because 1. the new C++11 `thread_local` keyword is unsupported in many old compilers, and using `pthread` solution is much more clumsy; 2. `thread_local` memory pool doesn't really work: it doesn't always pass my cpp test. The global pool uses a lot of small chunks (16 KB) instead of "standard" larger ones (default chunk size is ~260KB), and should help avoid memory fragmentation.
3. Added `voltdb::allocator` template that uses the global memory pool from `VoltAllocResourceMng` class, and used it in a few places related to `UndoLog` to prove the concept. Seems to work towards the goal of simplifying need for double-pointer and manual memory management using Pool.
4. Added cpp unit test for `voltdb::allocator` only for the relatively late compiler/platforms (GCC>5). The test creates threads that share the same `voltdb::allocator` template but run write/updates on different containers on different objects, and the class types of these artificial types are inter-related. Easy to modify the test to use `std::allocator` with single line of change. Using `std::mutex` to lock critical section of `Pool::allocate()` does not introduce any performance hit compared with using `std::allocator` template. It is a hassle to make the test work on older compiler/platforms, so I did not bother.

Other thoughts:
1. It was a hassle to write code that builds on all platforms, but I don't want to make the code too backward-compatible. I used macro to have **basically** same code that gets compiled on all platforms.
2. @wweiss-voltdb suggested that I read `ThreadLocalPool.h` and `ThreadLocalPool.cpp`, which uses `pthread` solution to create thread-local pool for certain uses, and asks that the allocator I write be able to use whatever Pool instance given to it. Doing this requires a stateful allocator, which is even a big hassle without full support of C++11. Furthermore, `ThreadLocalPool.cpp` `#include "SynchronizedThreadLock"`, which is further related to `UndoQuantumReleaseInterest` class hierarchy; at this point the design decision to get `UndoQuantumReleaseInterest` involved in `ThreadLocalPool` is even more confusing.
I will leave fully understanding/cleaning up of related stuff of `ThreadLocalPool` later, possibly after cleaning up of undo quantum related logic. So far Jenkins is not giving me a hard time on any DR tests.
3. I'm already doing conditional code for different compilers, and I hope that the day we ditch old compiler will come sooner. Maintaining different versions of code is hard; but it is easier than to write fully backward-compatible code, discarding all the good things of newer C++ standard, and rewrite it with new C++ standard later.