### PR TITLE
ENG-14541:

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -391,6 +391,7 @@ public class MpPromoteAlgo implements RepairAlgo
                             true,
                             false);
                     rollback.setTimestamp(m_restartSeqGenerator.getNextSeqNum());
+                    rollback.setTruncationHandle(Long.MIN_VALUE);
                 }
             }
 

--- a/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
+++ b/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
@@ -27,11 +27,7 @@ import org.voltdb.iv2.TxnEgo;
 
 public class CompleteTransactionMessage extends TransactionInfoBaseMessage
 {
-    boolean m_isRollback;
-    boolean m_requiresAck;
-    boolean m_rollbackForFault;
     long m_timestamp = INITIAL_TIMESTAMP;
-    boolean m_isAbortDuringRepair;
     int m_hash;
     int m_flags = 0;
     static final int ISROLLBACK = 0;

--- a/src/frontend/org/voltdb/messaging/CompleteTransactionResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/CompleteTransactionResponseMessage.java
@@ -45,7 +45,7 @@ public class CompleteTransactionResponseMessage extends VoltMessage
         m_isRestart = msg.isRestart();
         m_spiHSId = msg.getCoordinatorHSId();
         m_ackRequired = msg.requiresAck();
-        m_isAborted = msg.isRestart() || msg.m_isAbortDuringRepair;
+        m_isAborted = msg.isRestart() || msg.isAbortDuringRepair();
     }
 
     public long getTxnId()

--- a/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
+++ b/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
@@ -386,6 +386,7 @@ public class TestVoltMessageSerialization extends TestCase {
         assertTrue(ctm2.isForReplay());
         assertFalse(ctm2.isNPartTxn());
         assertFalse(ctm2.isAbortDuringRepair());
+        assertEquals(ctm.m_hash, ctm2.m_hash);
     }
 
     public void testCompleteTransactionResponseMessage() throws IOException

--- a/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
+++ b/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
@@ -378,10 +378,14 @@ public class TestVoltMessageSerialization extends TestCase {
                                            true, false, true, false, false, false);
 
         CompleteTransactionMessage ctm2 = (CompleteTransactionMessage) checkVoltMessage(ctm);
-        assertEquals(ctm.m_isRollback, ctm2.m_isRollback);
-        assertEquals(ctm.m_requiresAck, ctm2.m_requiresAck);
-        assertEquals(ctm.m_rollbackForFault, ctm2.m_rollbackForFault);
-        assertEquals(ctm.m_hash, ctm2.m_hash);
+        assertEquals(ctm.m_flags, ctm2.m_flags);
+        assertFalse(ctm2.isReadOnly());
+        assertFalse(ctm2.isRollback());
+        assertTrue(ctm2.requiresAck());
+        assertFalse(ctm2.isRestart());
+        assertTrue(ctm2.isForReplay());
+        assertFalse(ctm2.isNPartTxn());
+        assertFalse(ctm2.isAbortDuringRepair());
     }
 
     public void testCompleteTransactionResponseMessage() throws IOException


### PR DESCRIPTION
After MpPromoteAlgo collects repair logs, it identifies the incomplete, non-restartable sysprocs and generates a rollback message to all partitions to clear out the transaction. However, it does not assign the truncation handle to the completion which can cause a random value to be in the truncation handle (in some cases). If the random value happens to be large enough, the partitions can truncation in progress transactions from the repair log ultimately causing mp deadlocks. To ensure that these rollback completions never alter the repair log, the truncation handle must be explicitly assigned to Long.MIN_VALUE.