### PR TITLE
ENG-14541:

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -389,6 +389,7 @@ public class MpPromoteAlgo implements RepairAlgo
                             ftm.isNPartTxn(),
                             true);
                     rollback.setTimestamp(m_restartSeqGenerator.getNextSeqNum());
+                    rollback.setTruncationHandle(Long.MIN_VALUE);
                 }
             }
 


### PR DESCRIPTION
After MpPromoteAlgo collects repair logs, it identifies the incomplete, non-restartable sysprocs and generates a rollback message to all partitions to clear out the transaction. However, it does not assign the truncation handle to the completion which can cause a random value to be in the truncation handle (in some cases). If the random value happens to be large enough, the partitions can truncation in progress transactions from the repair log ultimately causing mp deadlocks. To ensure that these rollback completions never alter the repair log, the truncation handle must be explicitly assigned to Long.MIN_VALUE.