### PR TITLE
ENG-14550, put nibble delete procedure into default procedure list.

### DIFF
--- a/src/frontend/org/voltdb/LoadedProcedureSet.java
+++ b/src/frontend/org/voltdb/LoadedProcedureSet.java
@@ -298,6 +298,8 @@ public class LoadedProcedureSet {
             // for this plan-on-the-fly procedure
             pr.setProcNameToLoadForFragmentTasks(newCatProc.getTypeName());
             m_defaultProcCache.put(procName, pr);
+            // also list nibble delete into default procedures
+            m_defaultProcManager.m_defaultProcMap.put(procName, pr.getCatalogProcedure());
         }
         return pr;
     }


### PR DESCRIPTION
When system detects hash mismatch exception, it prints all user procedures and default procedures, nibble delete procedures are in neither of them.