### PR TITLE
ENG-14547 remove mp repair blocker in the last round of repair

### DIFF
--- a/src/frontend/org/voltcore/utils/CoreUtils.java
+++ b/src/frontend/org/voltcore/utils/CoreUtils.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -68,6 +69,7 @@ import com.google_voltpatches.common.base.Supplier;
 import com.google_voltpatches.common.base.Suppliers;
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import com.google_voltpatches.common.util.concurrent.ListenableFutureTask;
 import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
@@ -846,6 +848,14 @@ public class CoreUtils {
 
     public static int getHostIdFromHSId(long HSId) {
         return (int) (HSId & 0xffffffff);
+    }
+
+    public static Set<Integer> getHostIdsFromHSIDs(Collection<Long> hsids) {
+        Set<Integer> hosts = Sets.newHashSet();
+        for (Long id : hsids) {
+            hosts.add(getHostIdFromHSId(id));
+        }
+        return hosts;
     }
 
     public static String hsIdToString(long hsId) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1670,7 +1670,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             {
                 //create a blocker for repair if this is a MP leader and partition leaders change
                 if (m_leaderAppointer.isLeader() && m_cartographer.hasPartitionMastersOnHosts(failedHosts)) {
-                    VoltZK.createPartitionPromotionIndicator(m_messenger.getZK(), MpInitiator.MP_INIT_PID, hostLog);
+                    VoltZK.createActionBlocker(m_messenger.getZK(), VoltZK.mpRepairInProgress,
+                            CreateMode.EPHEMERAL, hostLog, "MP Repair");
                 }
 
                 // First check to make sure that the cluster still is viable before

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -42,7 +42,6 @@ import org.voltcore.zk.ZooKeeperLock;
 import org.voltdb.iv2.LeaderCache;
 import org.voltdb.iv2.LeaderCache.LeaderCallBackInfo;
 import org.voltdb.iv2.MigratePartitionLeaderInfo;
-import org.voltdb.iv2.MpInitiator;
 
 /**
  * VoltZK provides constants for all voltdb-registered
@@ -458,7 +457,7 @@ public class VoltZK {
                 } else if (blockers.contains(migrate_partition_leader)){
                     errorMsg = "while leader migration is active. Please retry node rejoin later.";
                 } else if (isRepairProgress(zk)){
-                    errorMsg = "while leader promotion or transaction repair are in progress. Please retry node rejoin later.";
+                    errorMsg = "while leader promotions or transaction repairs are in progress. Please retry node rejoin later.";
                 }
                 break;
             case elasticJoinInProgress:
@@ -554,21 +553,7 @@ public class VoltZK {
 
     public static void removePartitionPromotionIndicator(ZooKeeper zk, int partitionId, VoltLogger log) {
         String path = ZKUtil.joinZKPath(mpRepairBlocker, Integer.toString(partitionId));
-        if (partitionId == MpInitiator.MP_INIT_PID) {
-            try {
-                // do not remove MP partition yet. MP partition should be the last one to be removed.
-                List<String> partitions = zk.getChildren(VoltZK.mpRepairBlocker, false);
-                if (partitions.size() > 1) {
-                    return;
-                }
-            } catch (KeeperException | InterruptedException e) {
-            }
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("Remove partition leader promotin indicator:" + path);
-        }
-
-        removeActionBlocker(zk, path, log);
+         removeActionBlocker(zk, path, log);
     }
 
     private static boolean isRepairProgress(ZooKeeper zk) {

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -185,7 +185,8 @@ public class VoltZK {
     public static final String catalogUpdateInProgress = actionBlockers + "/" + leafNodeCatalogUpdateInProgress;
 
     //register partition while the partition elects a new leader upon node failure
-    public static final String mpRepairBlocker = "/db/mp_repair_blocker";
+    public static final String mpRepairBlocker = "mp_repair_blocker";
+    public static final String mpRepairInProgress = actionBlockers + "/" + mpRepairBlocker;
 
     public static final String request_truncation_snapshot_node = ZKUtil.joinZKPath(request_truncation_snapshot, "request_");
 
@@ -226,8 +227,7 @@ public class VoltZK {
             actionBlockers,
             request_truncation_snapshot,
             host_ids_be_stopped,
-            actionLock,
-            mpRepairBlocker
+            actionLock
     };
 
     /**
@@ -444,7 +444,10 @@ public class VoltZK {
             case catalogUpdateInProgress:
                 if (blockers.contains(leafNodeRejoinInProgress)) {
                     errorMsg = "while a node rejoin is active. Please retry catalog update later.";
-                } else if (isRepairProgress(zk)) {
+                } else if (blockers.contains(mpRepairBlocker)){
+                    // Upon node failures, a MP repair blocker may be registered right before they
+                    // unregistered after repair is done. Let rejoining nodes wait to avoid any
+                    // interference with the transaction repair process.
                     errorMsg = "while leader promotion or transaction repair are in progress. Please retry catalog update later.";
                 }
                 break;
@@ -456,8 +459,11 @@ public class VoltZK {
                     errorMsg = "while an elastic join is active. Please retry node rejoin later.";
                 } else if (blockers.contains(migrate_partition_leader)){
                     errorMsg = "while leader migration is active. Please retry node rejoin later.";
-                } else if (isRepairProgress(zk)){
-                    errorMsg = "while leader promotions or transaction repairs are in progress. Please retry node rejoin later.";
+                } else if (blockers.contains(mpRepairBlocker)){
+                    // Upon node failures, a MP repair blocker may be registered right before they
+                    // unregistered after repair is done. Let rejoining nodes wait to avoid any
+                    // interference with the transaction repair process.
+                    errorMsg = "while leader promotion or transaction repair are in progress. Please retry node rejoin later.";
                 }
                 break;
             case elasticJoinInProgress:
@@ -485,6 +491,8 @@ public class VoltZK {
                 if (blockers.contains(leafNodeElasticJoinInProgress)) {
                     errorMsg = "while an elastic join is active";
                 }
+                break;
+            case mpRepairInProgress:
                 break;
             default:
                 // not possible
@@ -534,35 +542,6 @@ public class VoltZK {
             }
             return;
         } catch (InterruptedException ignore) {}
-    }
-
-    public static void createPartitionPromotionIndicator(ZooKeeper zk, int partitionId, VoltLogger log) {
-        String path = ZKUtil.joinZKPath(mpRepairBlocker, Integer.toString(partitionId));
-        try {
-            zk.create(path, null, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
-            if (log.isDebugEnabled()) {
-                log.debug("Create partition leader promotin indicator:" + path);
-            }
-        } catch (KeeperException e) {
-            if (e.code() != KeeperException.Code.NODEEXISTS) {
-                VoltDB.crashLocalVoltDB("Unable to create action blocker " + path, true, e);
-            }
-        } catch (InterruptedException e) {
-        }
-    }
-
-    public static void removePartitionPromotionIndicator(ZooKeeper zk, int partitionId, VoltLogger log) {
-        String path = ZKUtil.joinZKPath(mpRepairBlocker, Integer.toString(partitionId));
-         removeActionBlocker(zk, path, log);
-    }
-
-    private static boolean isRepairProgress(ZooKeeper zk) {
-        try {
-            List<String> partitions = zk.getChildren(VoltZK.mpRepairBlocker, false);
-            return (!partitions.isEmpty());
-        } catch (KeeperException | InterruptedException e) {
-        }
-        return false;
     }
 
     /**

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -170,7 +170,6 @@ public class MpInitiator extends BaseInitiator implements Promotable
                             m_zkMailboxNode);
                     iv2masters.put(m_partitionId, m_initiatorMailbox.getHSId());
                     TTLManager.instance().scheduleTTLTasks();
-                    VoltZK.removePartitionPromotionIndicator(m_messenger.getZK(), MP_INIT_PID, tmLog);
                 }
                 else {
                     // The only known reason to fail is a failed replica during

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -129,7 +129,6 @@ public class MpInitiator extends BaseInitiator implements Promotable
             while (!success) {
                 final RepairAlgo repair = m_initiatorMailbox.constructRepairAlgo(m_term.getInterestingHSIds(),
                                 deadMPIHost, m_whoami, false);
-                ((MpPromoteAlgo)repair).setMpiPromotionRepair();
                 // term syslogs the start of leader promotion.
                 long txnid = Long.MIN_VALUE;
                 try {

--- a/src/frontend/org/voltdb/iv2/MpRepairTask.java
+++ b/src/frontend/org/voltdb/iv2/MpRepairTask.java
@@ -26,6 +26,7 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.VoltDB;
+import org.voltdb.VoltZK;
 import org.voltdb.rejoin.TaskLog;
 
 import com.google_voltpatches.common.base.Suppliers;
@@ -55,13 +56,20 @@ public class MpRepairTask extends SiteTasker
     private final String whoami;
     private final RepairAlgo algo;
 
-    public MpRepairTask(InitiatorMailbox mailbox, List<Long> spMasters, boolean balanceSPI)
+    // Indicate if this repair is triggered via partition leader migration
+    private final boolean m_leaderMigration;
+
+    // Indicate if the round of leader promotion has been completed
+    private final boolean m_partitionLeaderPromotionComplete;
+    public MpRepairTask(InitiatorMailbox mailbox, List<Long> spMasters, boolean leaderMigration, boolean partitionLeaderPromotionComplete)
     {
         m_mailbox = mailbox;
         m_spMasters = new ArrayList<Long>(spMasters);
         whoami = "MP leader repair " +
                 CoreUtils.hsIdToString(m_mailbox.getHSId()) + " ";
-        algo = mailbox.constructRepairAlgo(Suppliers.ofInstance(m_spMasters), Integer.MAX_VALUE, whoami, balanceSPI);
+        m_leaderMigration = leaderMigration;
+        m_partitionLeaderPromotionComplete = partitionLeaderPromotionComplete;
+        algo = mailbox.constructRepairAlgo(Suppliers.ofInstance(m_spMasters), Integer.MAX_VALUE, whoami, leaderMigration);
     }
 
     @Override
@@ -69,24 +77,23 @@ public class MpRepairTask extends SiteTasker
         synchronized (m_lock) {
             if (!m_repairRan) {
                 try {
-                    boolean success = false;
                     try {
                         algo.start().get();
-                        success = true;
-                    } catch (CancellationException e) {}
-                    if (success) {
                         repairLogger.info(whoami + "finished repair.");
-                    }
-                    else {
+                    } catch (CancellationException e) {
                         repairLogger.info(whoami + "interrupted during repair.  Retrying.");
                     }
-                }
-                catch (InterruptedException ie) {}
-                catch (Exception e) {
+                } catch (InterruptedException ie) {
+                } catch (Exception e) {
                     VoltDB.crashLocalVoltDB("Terminally failed MPI repair.", true, e);
-                }
-                finally {
+                } finally {
                     m_repairRan = true;
+
+                    // At this point, all the repairs are completed. This should be the final repair task
+                    // in the repair process. Remove the mp repair blocker
+                    if (!m_leaderMigration && m_partitionLeaderPromotionComplete) {
+                        VoltZK.removePartitionPromotionIndicator(m_mailbox.m_messenger.getZK(), MpInitiator.MP_INIT_PID, repairLogger);
+                    }
                 }
             }
         }

--- a/src/frontend/org/voltdb/iv2/MpRepairTask.java
+++ b/src/frontend/org/voltdb/iv2/MpRepairTask.java
@@ -91,8 +91,8 @@ public class MpRepairTask extends SiteTasker
 
                     // At this point, all the repairs are completed. This should be the final repair task
                     // in the repair process. Remove the mp repair blocker
-                    if (!m_leaderMigration && m_partitionLeaderPromotionComplete) {
-                        VoltZK.removePartitionPromotionIndicator(m_mailbox.m_messenger.getZK(), MpInitiator.MP_INIT_PID, repairLogger);
+                    if (!m_leaderMigration && m_partitionLeaderPromotionComplete && m_mailbox.m_messenger != null) {
+                        VoltZK.removeActionBlocker(m_mailbox.m_messenger.getZK(), VoltZK.mpRepairInProgress, repairLogger);
                     }
                 }
             }

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -174,8 +174,13 @@ public class MpScheduler extends Scheduler
             }
         }
 
+        // Determine if all the partition leaders are on live hosts, that is, all partitions have promoted
+        // their leaders.
+        Set<Integer> partitionLeaderHosts = CoreUtils.getHostIdsFromHSIDs(m_iv2Masters);
+        partitionLeaderHosts.removeAll(((MpInitiatorMailbox)m_mailbox).m_messenger.getLiveHostIds());
+
         // This is a non MPI Promotion (but SPI Promotion) path for repairing outstanding MP Txns
-        MpRepairTask repairTask = new MpRepairTask((InitiatorMailbox)m_mailbox, replicas, balanceSPI);
+        MpRepairTask repairTask = new MpRepairTask((InitiatorMailbox)m_mailbox, replicas, balanceSPI, partitionLeaderHosts.isEmpty());
         m_pendingTasks.repair(repairTask, replicas, partitionMasters, balanceSPI);
         return new long[0];
     }

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -260,7 +260,6 @@ public class SpInitiator extends BaseInitiator implements Promotable
                         iv2masters.put(m_partitionId, m_initiatorMailbox.getHSId());
                     }
                     m_initiatorMailbox.setMigratePartitionLeaderStatus(migratePartitionLeader);
-                    VoltZK.removePartitionPromotionIndicator(m_messenger.getZK(), m_partitionId, tmLog);
                 } else {
                     // The only known reason to fail is a failed replica during
                     // recovery; that's a bounded event (by k-safety).

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -20,7 +20,6 @@ package org.voltdb.rejoin;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -175,11 +175,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
 
             if (elapsed % 10 == 5) {
                 // log the info message every 10 seconds, log the initial message under 5 seconds
-                REJOINLOG.info(String.format("Rejoin node is waiting for catalog update or elastic join to finish, "
-                        + "time elapsed " + elapsed + " seconds"));
-                if (REJOINLOG.isDebugEnabled()) {
-                    REJOINLOG.debug("Rejoin fails to acquire lock:" + blockerError);
-                }
+                REJOINLOG.info("Rejoin node is waiting " + blockerError + "time elapsed " + elapsed + " seconds");
             }
 
             try {


### PR DESCRIPTION
Provide MpRepairTask with partition leader promotion status. If all the partitions have been promoted, then the MpRepairTask is the last repair task in this round of repair process. Then after this MpRepairTask is completed, remove mp repair blocker.