### PR TITLE
ENG-14547 block rejoin or uac during tx repair

### DIFF
--- a/src/frontend/org/voltcore/utils/CoreUtils.java
+++ b/src/frontend/org/voltcore/utils/CoreUtils.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -68,6 +69,7 @@ import com.google_voltpatches.common.base.Supplier;
 import com.google_voltpatches.common.base.Suppliers;
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import com.google_voltpatches.common.util.concurrent.ListenableFutureTask;
 import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
@@ -846,6 +848,14 @@ public class CoreUtils {
 
     public static int getHostIdFromHSId(long HSId) {
         return (int) (HSId & 0xffffffff);
+    }
+
+    public static Set<Integer> getHostIdsFromHSIDs(Collection<Long> hsids) {
+        Set<Integer> hosts = Sets.newHashSet();
+        for (Long id : hsids) {
+            hosts.add(getHostIdFromHSId(id));
+        }
+        return hosts;
     }
 
     public static String hsIdToString(long hsId) {

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -445,9 +445,8 @@ public class VoltZK {
                 if (blockers.contains(leafNodeRejoinInProgress)) {
                     errorMsg = "while a node rejoin is active. Please retry catalog update later.";
                 } else if (blockers.contains(mpRepairBlocker)){
-                    // Upon node failures, a MP repair blocker may be registered right before they
-                    // unregistered after repair is done. Let rejoining nodes wait to avoid any
-                    // interference with the transaction repair process.
+                    // Avoid UAC during MP repair or promotion since UAC will invoke GlobalServiceElector to
+                    // register other promotable services while MPI is accepting promotion
                     errorMsg = "while leader promotion or transaction repair are in progress. Please retry catalog update later.";
                 }
                 break;

--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -25,14 +25,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeSet;
 import java.util.concurrent.Future;
-
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
 import org.voltdb.ElasticHashinator;
 import org.voltdb.SystemProcedureCatalog;
 import org.voltdb.TheHashinator;
-import org.voltdb.VoltZK;
 import org.voltdb.messaging.CompleteTransactionMessage;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
@@ -116,12 +114,7 @@ public class MpPromoteAlgo implements RepairAlgo
     public MpPromoteAlgo(List<Long> survivors, int deadHost, InitiatorMailbox mailbox,
             MpRestartSequenceGenerator seqGen, String whoami)
     {
-        m_survivors = new ArrayList<Long>(survivors);
-        m_deadHost = deadHost;
-        m_mailbox = mailbox;
-        m_isMigratePartitionLeader = false;
-        m_whoami = whoami;
-        m_restartSeqGenerator = seqGen;
+        this(survivors, deadHost, mailbox,seqGen, whoami, false);
     }
 
     /**
@@ -146,13 +139,6 @@ public class MpPromoteAlgo implements RepairAlgo
         } catch (Exception e) {
             repairLogger.error(m_whoami + "failed leader promotion:", e);
             m_promotionResult.setException(e);
-        } finally {
-            //remove the flag for the partition if the repair process is not cancelled.
-            //The flag is registered upon host failure or MPI promotion. The repair may be interrupted but will
-            //be eventually completed.
-            if (!m_promotionResult.isCancelled() && m_mailbox.m_messenger != null) {
-                VoltZK.removeActionBlocker(m_mailbox.m_messenger.getZK(), VoltZK.mpRepairInProgress, repairLogger);
-            }
         }
         return m_promotionResult;
     }

--- a/src/frontend/org/voltdb/iv2/MpRepairTask.java
+++ b/src/frontend/org/voltdb/iv2/MpRepairTask.java
@@ -26,6 +26,7 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.VoltDB;
+import org.voltdb.VoltZK;
 import org.voltdb.rejoin.TaskLog;
 
 import com.google_voltpatches.common.base.Suppliers;
@@ -55,38 +56,46 @@ public class MpRepairTask extends SiteTasker
     private final String whoami;
     private final RepairAlgo algo;
 
-    public MpRepairTask(InitiatorMailbox mailbox, List<Long> spMasters, boolean balanceSPI)
+    // Indicate if this repair is triggered via partition leader migration
+    private final boolean m_leaderMigration;
+
+    // Indicate if the round of leader promotion has been completed
+    private final boolean m_partitionLeaderPromotionComplete;
+    public MpRepairTask(InitiatorMailbox mailbox, List<Long> spMasters, boolean leaderMigration, boolean partitionLeaderPromotionComplete)
     {
         m_mailbox = mailbox;
         m_spMasters = new ArrayList<Long>(spMasters);
         whoami = "MP leader repair " +
                 CoreUtils.hsIdToString(m_mailbox.getHSId()) + " ";
-        algo = mailbox.constructRepairAlgo(Suppliers.ofInstance(m_spMasters), Integer.MAX_VALUE, whoami, balanceSPI);
+        m_leaderMigration = leaderMigration;
+        m_partitionLeaderPromotionComplete = partitionLeaderPromotionComplete;
+        algo = mailbox.constructRepairAlgo(Suppliers.ofInstance(m_spMasters), Integer.MAX_VALUE, whoami, leaderMigration);
     }
 
     @Override
     public void run(SiteProcedureConnection connection) {
+
+        // When MP is processing reads, the task will be queued to all MpRoSite but the task is processed only on one of MpRoSite.
         synchronized (m_lock) {
             if (!m_repairRan) {
                 try {
-                    boolean success = false;
                     try {
                         algo.start().get();
-                        success = true;
-                    } catch (CancellationException e) {}
-                    if (success) {
                         repairLogger.info(whoami + "finished repair.");
-                    }
-                    else {
+                    } catch (CancellationException e) {
                         repairLogger.info(whoami + "interrupted during repair.  Retrying.");
                     }
-                }
-                catch (InterruptedException ie) {}
-                catch (Exception e) {
+                } catch (InterruptedException ie) {
+                } catch (Exception e) {
                     VoltDB.crashLocalVoltDB("Terminally failed MPI repair.", true, e);
-                }
-                finally {
+                } finally {
                     m_repairRan = true;
+
+                    // At this point, all the repairs are completed. This should be the final repair task
+                    // in the repair process. Remove the mp repair blocker
+                    if (!m_leaderMigration && m_partitionLeaderPromotionComplete && m_mailbox.m_messenger != null) {
+                        VoltZK.removeActionBlocker(m_mailbox.m_messenger.getZK(), VoltZK.mpRepairInProgress, repairLogger);
+                    }
                 }
             }
         }

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -175,8 +175,13 @@ public class MpScheduler extends Scheduler
             }
         }
 
+        // Determine if all the partition leaders are on live hosts, that is, all partitions have promoted
+        // their leaders.
+        Set<Integer> partitionLeaderHosts = CoreUtils.getHostIdsFromHSIDs(m_iv2Masters);
+        partitionLeaderHosts.removeAll(((MpInitiatorMailbox)m_mailbox).m_messenger.getLiveHostIds());
+
         // This is a non MPI Promotion (but SPI Promotion) path for repairing outstanding MP Txns
-        MpRepairTask repairTask = new MpRepairTask((InitiatorMailbox)m_mailbox, replicas, balanceSPI);
+        MpRepairTask repairTask = new MpRepairTask((InitiatorMailbox)m_mailbox, replicas, balanceSPI, partitionLeaderHosts.isEmpty());
         m_pendingTasks.repair(repairTask, replicas, partitionMasters, balanceSPI);
         return new long[0];
     }

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -20,7 +20,6 @@ package org.voltdb.rejoin;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -175,8 +174,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
 
             if (elapsed % 10 == 5) {
                 // log the info message every 10 seconds, log the initial message under 5 seconds
-                REJOINLOG.info(String.format("Rejoin node is waiting for catalog update or elastic join to finish, "
-                        + "time elapsed " + elapsed + " seconds"));
+                REJOINLOG.info("Rejoin node is waiting " + blockerError + " time elapsed " + elapsed + " seconds");
             }
 
             try {


### PR DESCRIPTION
Provide MpRepairTask with partition leader promotion status. If all the partitions have been promoted, then the MpRepairTask is the last repair task in this round of repair process. Then after this MpRepairTask is completed, remove mp repair blocker.
