### PR TITLE
ENG-14563:

### DIFF
--- a/src/frontend/org/voltcore/messaging/TransactionInfoBaseMessage.java
+++ b/src/frontend/org/voltcore/messaging/TransactionInfoBaseMessage.java
@@ -49,6 +49,7 @@ public abstract class TransactionInfoBaseMessage extends VoltMessage {
     protected boolean m_isForReplica = false;
 
     public static final long INITIAL_TIMESTAMP = Long.MIN_VALUE;
+    public static final long UNUSED_TRUNC_HANDLE = Long.MIN_VALUE;
 
     /** Empty constructor for de-serialization */
     protected TransactionInfoBaseMessage() {

--- a/src/frontend/org/voltdb/ProcedureRunnerNT.java
+++ b/src/frontend/org/voltdb/ProcedureRunnerNT.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.messaging.Mailbox;
+import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.network.Connection;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.AuthSystem.AuthUser;
@@ -269,7 +270,7 @@ public class ProcedureRunnerNT {
         final Iv2InitiateTaskMessage workRequest =
                 new Iv2InitiateTaskMessage(m_mailbox.getHSId(),
                                            m_mailbox.getHSId(),
-                                           Iv2InitiateTaskMessage.UNUSED_TRUNC_HANDLE,
+                                           TransactionInfoBaseMessage.UNUSED_TRUNC_HANDLE,
                                            m_id,
                                            m_id,
                                            true,

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.voltcore.messaging.HostMessenger;
+import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.zk.LeaderElector;
 import org.voltdb.BackendTarget;
@@ -158,7 +159,9 @@ public class MpInitiator extends BaseInitiator implements Promotable
                             throw new RuntimeException("Failing promoted MPI node with unresolvable repair condition.");
                         }
                         tmLog.debug(m_whoami + " restarting MP transaction: " + restartTxns.get(0));
-                        m_initiatorMailbox.repairReplicasWith(null, restartTxns.get(0));
+                        Iv2InitiateTaskMessage firstMsg = restartTxns.get(0);
+                        assert(firstMsg.getTruncationHandle() == TransactionInfoBaseMessage.UNUSED_TRUNC_HANDLE);
+                        m_initiatorMailbox.repairReplicasWith(null, firstMsg);
                     }
                     tmLog.info(m_whoami
                              + "finished leader promotion. Took "

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -161,7 +161,7 @@ public class MpScheduler extends Scheduler
             VoltMessage resp = counter.getLastResponse();
             if (resp != null && resp instanceof InitiateResponseMessage) {
                 InitiateResponseMessage msg = (InitiateResponseMessage)resp;
-                if (msg.shouldCommit()) {
+                if (msg.shouldCommit() && msg.haveSentMpFragment()) {
                     m_repairLogTruncationHandle = m_repairLogAwaitingCommit;
                     m_repairLogAwaitingCommit = msg.getTxnId();
                 }

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -458,8 +458,9 @@ public class MpScheduler extends Scheduler
             int result = counter.offer(message);
             if (result == DuplicateCounter.DONE) {
                 m_duplicateCounters.remove(message.getTxnId());
-                // Only advance the truncation point on committed transactions.  See ENG-4211
-                if (message.shouldCommit()) {
+                // Only advance the truncation point on committed transactions that sent fragments to SPIs.
+                // See ENG-4211 & ENG-14563
+                if (message.shouldCommit() && message.haveSentMpFragment()) {
                     m_repairLogTruncationHandle = m_repairLogAwaitingCommit;
                     m_repairLogAwaitingCommit = message.getTxnId();
                 }
@@ -475,8 +476,8 @@ public class MpScheduler extends Scheduler
             // doing duplicate suppresion: all done.
         }
         else {
-            // Only advance the truncation point on committed transactions.
-            if (message.shouldCommit()) {
+            // Only advance the truncation point on committed transactions that sent fragments to SPIs.
+            if (message.shouldCommit() && message.haveSentMpFragment()) {
                 m_repairLogTruncationHandle = m_repairLogAwaitingCommit;
                 m_repairLogAwaitingCommit = message.getTxnId();
             }

--- a/src/frontend/org/voltdb/iv2/MpTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionState.java
@@ -459,10 +459,10 @@ public class MpTransactionState extends TransactionState
                     StringBuilder deadlockMsg = new StringBuilder();
                     deadlockMsg.append("Possible multipartition transaction deadlock detected for: ").append(m_initiationMsg);
                     if (m_remoteWork == null) {
-                        deadlockMsg.append("Waiting on local BorrowTask response from site: ").append(CoreUtils.hsIdToString(m_buddyHSId));
+                        deadlockMsg.append("\nWaiting on local BorrowTask response from site: ").append(CoreUtils.hsIdToString(m_buddyHSId));
                     }
                     else {
-                        deadlockMsg.append("Waiting on remote dependencies for message:\n").append(m_remoteWork).append("\n");
+                        deadlockMsg.append("\nWaiting on remote dependencies for message:\n").append(m_remoteWork).append("\n");
                         for (Entry<Integer, Set<Long>> e : m_remoteDeps.entrySet()) {
                             deadlockMsg.append("Dep ID: " + e.getKey() + " waiting on: ").append(CoreUtils.hsIdCollectionToString(e.getValue()));
                         }

--- a/src/frontend/org/voltdb/messaging/Iv2InitiateTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/Iv2InitiateTaskMessage.java
@@ -39,7 +39,6 @@ public class Iv2InitiateTaskMessage extends TransactionInfoBaseMessage {
     // The default MP transaction id set by client interface when
     // initiating a single-partition transaction.
     public static final long UNUSED_MP_TXNID = Long.MIN_VALUE;
-    public static final long UNUSED_TRUNC_HANDLE = Long.MIN_VALUE;
 
     public static int SINGLE_PARTITION_MASK = 1;
     public static int N_PARTITION_MASK = 2;


### PR DESCRIPTION
Don't disable the truncation handle in all messages generated by the mp repair / mp promote algorithms. Inadvertently advancing the handles can remove repair messages that are needed by partitions that have not completed repair yet.

Also don't all MP transactions that have no fragments for MP transactions from advancing the MP repair truncation point. Otherwise we may remove completions from some parititons that have not been seen at all by other partitions.