### PR TITLE
ENG-14573, fix hash mismatch check.

### DIFF
--- a/src/frontend/org/voltdb/iv2/DuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/DuplicateCounter.java
@@ -157,19 +157,19 @@ public class DuplicateCounter
                 m_responseHashes = hashes;
                 m_txnSucceed = txnSucceed;
             }
+            else if (m_txnSucceed != txnSucceed) {
+                tmLog.fatal("Stored procedure " + getStoredProcedureName()
+                + " succeeded on one partition but failed on another partition."
+                + " Shutting down to preserve data integrity.");
+                logRelevantMismatchInformation("PARTIAL ROLLBACK/ABORT", hashes, message, pos);
+                return ABORT;
+            }
             else if ((pos = DeterminismHash.compareHashes(m_responseHashes, hashes)) >= 0) {
                 tmLog.fatal("Stored procedure " + getStoredProcedureName()
                         + " generated different SQL queries at different partitions."
                         + " Shutting down to preserve data integrity.");
                 logRelevantMismatchInformation("HASH MISMATCH", hashes, message, pos);
                 return MISMATCH;
-            }
-            else if (m_txnSucceed != txnSucceed) {
-                tmLog.fatal("Stored procedure " + getStoredProcedureName()
-                        + " succeeded on one partition but failed on another partition."
-                        + " Shutting down to preserve data integrity.");
-                logRelevantMismatchInformation("PARTIAL ROLLBACK/ABORT", hashes, message, pos);
-                return ABORT;
             }
             m_lastResponse = message;
             m_lastResultTables = resultTables;


### PR DESCRIPTION
It causes hash mismatch check is bypassed if the indeterministic statement is not in the first 32 statements.

Pro change: https://github.com/VoltDB/pro/pull/2331