### PR TITLE
ENG-14566 handle misrouted message for EveryPartitionTask

### DIFF
--- a/src/frontend/org/voltdb/iv2/DuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/DuplicateCounter.java
@@ -91,6 +91,11 @@ public class DuplicateCounter
         }
     }
 
+    public void updateReplica (Long previousMaster, Long newMaster){
+        m_expectedHSIds.remove(previousMaster);
+        m_expectedHSIds.add(newMaster);
+    }
+
     void logRelevantMismatchInformation(String reason, int[] hashes, VoltMessage recentMessage, int misMatchPos) {
         if (misMatchPos >= 0) {
             ((InitiateResponseMessage) recentMessage).setMismatchPos(misMatchPos);

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -196,8 +196,9 @@ public class MpScheduler extends Scheduler
     }
 
     private void applyLeaderMigration(final List<Long> updatedReplicas, boolean balanceSPI) {
-        m_leaderMigrationMap.clear();
+
         if (!balanceSPI || !m_isLeader) {
+            m_leaderMigrationMap.clear();
             return;
         }
          // Find the old leader
@@ -491,11 +492,12 @@ public class MpScheduler extends Scheduler
             tmLog.info("The message on the partition is misrouted. TxnID: " + TxnEgo.txnIdToString(message.getTxnId()));
             Long newLeader = m_leaderMigrationMap.get(message.m_sourceHSId);
             if (newLeader != null) {
-                // Leader migration has updated the leader, send the request to the new leader
-                m_mailbox.send(newLeader, (Iv2InitiateTaskMessage)counter.getOpenMessage());
                 // Update the DuplicateCounter with new replica
                 counter.updateReplica(message.m_sourceHSId, newLeader);
-                m_leaderMigrationMap.clear();
+                m_leaderMigrationMap.remove(message.m_sourceHSId);
+
+                // Leader migration has updated the leader, send the request to the new leader
+                m_mailbox.send(newLeader, (Iv2InitiateTaskMessage)counter.getOpenMessage());
             } else {
                 // Leader migration not done yet.
                 m_mailbox.send(message.m_sourceHSId, (Iv2InitiateTaskMessage)counter.getOpenMessage());

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -73,6 +73,9 @@ public class MpScheduler extends Scheduler
     private final List<Long> m_iv2Masters;
     private final Map<Integer, Long> m_partitionMasters;
     private final List<Long> m_buddyHSIds;
+    // Leader migrated from one site to another
+    private final Map<Long, Long> m_leaderMigrationMap;
+
     private int m_nextBuddy = 0;
     //Generator of pre-IV2ish timestamp based unique IDs
     private final UniqueIdGenerator m_uniqueIdGenerator;
@@ -95,6 +98,7 @@ public class MpScheduler extends Scheduler
         m_partitionMasters = Maps.newHashMap();
         m_uniqueIdGenerator = new UniqueIdGenerator(partitionId, 0);
         m_leaderNodeId = leaderNodeId;
+        m_leaderMigrationMap = Maps.newHashMap();
     }
 
     void setMpRoSitePool(MpRoSitePool sitePool)
@@ -133,6 +137,8 @@ public class MpScheduler extends Scheduler
     public long[] updateReplicas(final List<Long> replicas, final Map<Integer, Long> partitionMasters,
             boolean balanceSPI)
     {
+        applyLeaderMigration(replicas, balanceSPI);
+
         // Handle startup and promotion semi-gracefully
         m_iv2Masters.clear();
         m_iv2Masters.addAll(replicas);
@@ -146,35 +152,38 @@ public class MpScheduler extends Scheduler
         // Stolen from SpScheduler.  Need to update the duplicate counters associated with any EveryPartitionTasks
         // Cleanup duplicate counters and collect DONE counters
         // in this list for further processing.
-        List<Long> doneCounters = new LinkedList<Long>();
-        for (Entry<Long, DuplicateCounter> entry : m_duplicateCounters.entrySet()) {
-            DuplicateCounter counter = entry.getValue();
-            int result = counter.updateReplicas(m_iv2Masters);
-            if (result == DuplicateCounter.DONE) {
-                doneCounters.add(entry.getKey());
-            }
-        }
 
-        // Maintain the CI invariant that responses arrive in txnid order.
-        Collections.sort(doneCounters);
-        for (Long key : doneCounters) {
-            DuplicateCounter counter = m_duplicateCounters.remove(key);
-            VoltMessage resp = counter.getLastResponse();
-            if (resp != null && resp instanceof InitiateResponseMessage) {
-                InitiateResponseMessage msg = (InitiateResponseMessage)resp;
-                if (msg.shouldCommit() && msg.haveSentMpFragment()) {
-                    m_repairLogTruncationHandle = m_repairLogAwaitingCommit;
-                    m_repairLogAwaitingCommit = msg.getTxnId();
+        // Do not update DuplicateCounter upon leader migration
+        if (!balanceSPI) {
+            List<Long> doneCounters = new LinkedList<Long>();
+            for (Entry<Long, DuplicateCounter> entry : m_duplicateCounters.entrySet()) {
+                DuplicateCounter counter = entry.getValue();
+                int result = counter.updateReplicas(m_iv2Masters);
+                if (result == DuplicateCounter.DONE) {
+                    doneCounters.add(entry.getKey());
                 }
-                m_outstandingTxns.remove(msg.getTxnId());
-                m_mailbox.send(counter.m_destinationId, resp);
             }
-            else {
-                hostLog.warn("TXN " + counter.getTxnId() + " lost all replicas and " +
-                        "had no responses.  This should be impossible?");
+
+            // Maintain the CI invariant that responses arrive in txnid order.
+            Collections.sort(doneCounters);
+            for (Long key : doneCounters) {
+                DuplicateCounter counter = m_duplicateCounters.remove(key);
+                VoltMessage resp = counter.getLastResponse();
+                if (resp != null && resp instanceof InitiateResponseMessage) {
+                    InitiateResponseMessage msg = (InitiateResponseMessage)resp;
+                    if (msg.shouldCommit() && msg.haveSentMpFragment()) {
+                        m_repairLogTruncationHandle = m_repairLogAwaitingCommit;
+                        m_repairLogAwaitingCommit = msg.getTxnId();
+                    }
+                    m_outstandingTxns.remove(msg.getTxnId());
+                    m_mailbox.send(counter.m_destinationId, resp);
+                }
+                else {
+                    hostLog.warn("TXN " + counter.getTxnId() + " lost all replicas and " +
+                            "had no responses.  This should be impossible?");
+                }
             }
         }
-
         // Determine if all the partition leaders are on live hosts, that is, all partitions have promoted
         // their leaders.
         Set<Integer> partitionLeaderHosts = CoreUtils.getHostIdsFromHSIDs(m_iv2Masters);
@@ -184,6 +193,24 @@ public class MpScheduler extends Scheduler
         MpRepairTask repairTask = new MpRepairTask((InitiatorMailbox)m_mailbox, replicas, balanceSPI, partitionLeaderHosts.isEmpty());
         m_pendingTasks.repair(repairTask, replicas, partitionMasters, balanceSPI);
         return new long[0];
+    }
+
+    private void applyLeaderMigration(final List<Long> updatedReplicas, boolean balanceSPI) {
+        m_leaderMigrationMap.clear();
+        if (!balanceSPI || !m_isLeader) {
+            return;
+        }
+         // Find the old leader
+        Set<Long> previousLeaders = Sets.newHashSet();
+        previousLeaders.addAll(m_iv2Masters);
+        previousLeaders.removeAll(updatedReplicas);
+         // Find the new leader
+        Set<Long> currentLeaders = Sets.newHashSet();
+        currentLeaders.addAll(updatedReplicas);
+        currentLeaders.removeAll(m_iv2Masters);
+         // Leader migration moves partition leader from a host to another, one at a time
+        assert(previousLeaders.size() == 1 && currentLeaders.size() == 1);
+        m_leaderMigrationMap.put(previousLeaders.iterator().next(), currentLeaders.iterator().next());
     }
 
     /**
@@ -458,6 +485,23 @@ public class MpScheduler extends Scheduler
         }
 
         DuplicateCounter counter = m_duplicateCounters.get(message.getTxnId());
+
+        // A transaction may be routed back here for EveryPartitionTask via leader migration
+        if (counter != null && message.isMisrouted()) {
+            tmLog.info("The message on the partition is misrouted. TxnID: " + TxnEgo.txnIdToString(message.getTxnId()));
+            Long newLeader = m_leaderMigrationMap.get(message.m_sourceHSId);
+            if (newLeader != null) {
+                // Leader migration has updated the leader, send the request to the new leader
+                m_mailbox.send(newLeader, (Iv2InitiateTaskMessage)counter.getOpenMessage());
+                // Update the DuplicateCounter with new replica
+                counter.updateReplica(message.m_sourceHSId, newLeader);
+                m_leaderMigrationMap.clear();
+            } else {
+                // Leader migration not done yet.
+                m_mailbox.send(message.m_sourceHSId, (Iv2InitiateTaskMessage)counter.getOpenMessage());
+            }
+        }
+
         if (counter != null) {
             int result = counter.offer(message);
             if (result == DuplicateCounter.DONE) {


### PR DESCRIPTION
For EveryPartition stored procedures, Initial task message could be misrouted back to MpScheduler upon leader migration, resulting in no hash exception. Upon leader migration, Now the misrouted message will be routed to the new partition leader for transactional processing.