### PR TITLE
ENG-14614:

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -302,6 +302,22 @@ public class MpProcedureTask extends ProcedureTask
         m_queue.restart();
     }
 
+    // Use this version when it is possible for multiple threads to make a string from the invocation
+    // at the same time (seems to only be an issue if the parameter to the procedure is a VoltTable)
+    public String toShortString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("MpProcedureTask:");
+        sb.append("  TXN ID: ").append(TxnEgo.txnIdToString(getTxnId()));
+        sb.append("  SP HANDLE ID: ").append(TxnEgo.txnIdToString(getSpHandle()));
+        sb.append("  ON HSID: ").append(CoreUtils.hsIdToString(m_initiator.getHSId()));
+        if (m_msg != null) {
+            sb.append("\n");
+            m_msg.toShortString(sb);
+        }
+        return sb.toString();
+    }
+
     @Override
     public String toString()
     {

--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -302,15 +302,20 @@ public class MpProcedureTask extends ProcedureTask
         m_queue.restart();
     }
 
+    private void taskToString(StringBuilder sb)
+    {
+        sb.append("MpProcedureTask:");
+        sb.append("  TXN ID: ").append(TxnEgo.txnIdToString(getTxnId()));
+        sb.append("  SP HANDLE ID: ").append(TxnEgo.txnIdToString(getSpHandle()));
+        sb.append("  ON HSID: ").append(CoreUtils.hsIdToString(m_initiator.getHSId()));
+    }
+
     // Use this version when it is possible for multiple threads to make a string from the invocation
     // at the same time (seems to only be an issue if the parameter to the procedure is a VoltTable)
     public String toShortString()
     {
         StringBuilder sb = new StringBuilder();
-        sb.append("MpProcedureTask:");
-        sb.append("  TXN ID: ").append(TxnEgo.txnIdToString(getTxnId()));
-        sb.append("  SP HANDLE ID: ").append(TxnEgo.txnIdToString(getSpHandle()));
-        sb.append("  ON HSID: ").append(CoreUtils.hsIdToString(m_initiator.getHSId()));
+        taskToString(sb);
         if (m_msg != null) {
             sb.append("\n");
             m_msg.toShortString(sb);
@@ -322,10 +327,7 @@ public class MpProcedureTask extends ProcedureTask
     public String toString()
     {
         StringBuilder sb = new StringBuilder();
-        sb.append("MpProcedureTask:");
-        sb.append("  TXN ID: ").append(TxnEgo.txnIdToString(getTxnId()));
-        sb.append("  SP HANDLE ID: ").append(TxnEgo.txnIdToString(getSpHandle()));
-        sb.append("  ON HSID: ").append(CoreUtils.hsIdToString(m_initiator.getHSId()));
+        taskToString(sb);
         if (m_msg != null) {
             sb.append("\n" + m_msg);
         }

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -199,26 +199,34 @@ public class MpScheduler extends Scheduler
     @Override
     public void deliver(VoltMessage message)
     {
-        if (tmLog.isDebugEnabled()) {
-            tmLog.debug("DELIVER: " + message.toString());
-        }
         if (message instanceof Iv2InitiateTaskMessage) {
+            if (tmLog.isDebugEnabled()) {
+                // Protect against race in string conversion of VoltTable parameter on deliver and site threads
+                StringBuilder sb = new StringBuilder("DELIVER: ");
+                ((Iv2InitiateTaskMessage)message).toShortString(sb);
+                tmLog.debug(sb.toString());
+            }
             handleIv2InitiateTaskMessage((Iv2InitiateTaskMessage)message);
         }
-        else if (message instanceof InitiateResponseMessage) {
-            handleInitiateResponseMessage((InitiateResponseMessage)message);
-        }
-        else if (message instanceof FragmentResponseMessage) {
-            handleFragmentResponseMessage((FragmentResponseMessage)message);
-        }
-        else if (message instanceof Iv2EndOfLogMessage) {
-            handleEOLMessage();
-        }
-        else if (message instanceof DummyTransactionTaskMessage) {
-            // leave empty to ignore it on purpose
-        }
         else {
-            throw new RuntimeException("UNKNOWN MESSAGE TYPE, BOOM!");
+            if (tmLog.isDebugEnabled()) {
+                tmLog.debug("DELIVER: " + message.toString());
+            }
+            if (message instanceof InitiateResponseMessage) {
+                handleInitiateResponseMessage((InitiateResponseMessage)message);
+            }
+            else if (message instanceof FragmentResponseMessage) {
+                handleFragmentResponseMessage((FragmentResponseMessage)message);
+            }
+            else if (message instanceof Iv2EndOfLogMessage) {
+                handleEOLMessage();
+            }
+            else if (message instanceof DummyTransactionTaskMessage) {
+                // leave empty to ignore it on purpose
+            }
+            else {
+                throw new RuntimeException("UNKNOWN MESSAGE TYPE, BOOM!");
+            }
         }
     }
 

--- a/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
@@ -125,7 +125,7 @@ public class MpTransactionTaskQueue extends TransactionTaskQueue
             if (e.getValue() instanceof MpProcedureTask) {
                 MpProcedureTask next = (MpProcedureTask)e.getValue();
                 if (tmLog.isDebugEnabled()) {
-                    tmLog.debug("MpTTQ: poisoning task: " + next);
+                    tmLog.debug("MpTTQ: poisoning task: " + next.toShortString());
                 }
                 next.doRestart(masters, partitionMasters);
 
@@ -145,7 +145,7 @@ public class MpTransactionTaskQueue extends TransactionTaskQueue
                     poison.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, restart);
                     txn.offerReceivedFragmentResponse(poison);
                     if (tmLog.isDebugEnabled()) {
-                        tmLog.debug("MpTTQ: restarting:" + next);
+                        tmLog.debug("MpTTQ: restarting:" + next.toShortString());
                     }
                 }
             }
@@ -159,7 +159,7 @@ public class MpTransactionTaskQueue extends TransactionTaskQueue
                 MpProcedureTask next = (MpProcedureTask)tt;
 
                 if (tmLog.isDebugEnabled()) {
-                    tmLog.debug("Repair updating task: " + next + " with masters: " + CoreUtils.hsIdCollectionToString(masters));
+                    tmLog.debug("Repair updating task: " + next.toShortString() + " with masters: " + CoreUtils.hsIdCollectionToString(masters));
                 }
                 next.updateMasters(masters, partitionMasters);
             }

--- a/src/frontend/org/voltdb/messaging/Iv2InitiateTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/Iv2InitiateTaskMessage.java
@@ -287,10 +287,9 @@ public class Iv2InitiateTaskMessage extends TransactionInfoBaseMessage {
         m_invocation.initFromBuffer(buf);
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-
+    // Use this version when it is possible for multiple threads to make a string from the invocation
+    // at the same time (seems to only be an issue if the parameter to the procedure is a VoltTable)
+    public void toShortString(StringBuilder sb) {
         sb.append("IV2 INITITATE_TASK (FROM ");
         sb.append(CoreUtils.hsIdToString(getInitiatorHSId()));
         sb.append(" TO ");
@@ -321,6 +320,13 @@ public class Iv2InitiateTaskMessage extends TransactionInfoBaseMessage {
             sb.append("NOT REPLAY, ");
         sb.append("COORD ");
         sb.append(CoreUtils.hsIdToString(getCoordinatorHSId()));
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        toShortString(sb);
 
         if (m_invocation != null) {
             sb.append("\n  PROCEDURE: ");


### PR DESCRIPTION
It is possible for the MP Deliver and the MP Site threads to debug print the Invocation for the same transaction at the same time. When this happens the parameters can be printed as well. It appears that some parameters (specifically VoltTable) are not thread safe at least for ToString(). To avoid this, only the TxnSummary will be printed out on non site threads and the invocation will only be printed out in detail on the site thread.