### PR TITLE
ENG-14577 - 14613: correctly pass replicated table into truncate table

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.h
+++ b/src/ee/common/SynchronizedThreadLock.h
@@ -86,8 +86,13 @@ public:
     static bool countDownGlobalTxnStartCount(bool lowestSite);
     static void signalLowestSiteFinished();
 
+    /**
+     * Add a new undo action possibly in a synchronized manner.
+     *
+     * Wrapper around calling UndoQuantum::registerUndoAction
+     */
     static void addUndoAction(bool synchronized, UndoQuantum *uq, UndoReleaseAction* action,
-            PersistentTable *interest = NULL);
+            PersistentTable *interest = NULL, PersistentTable *removeInterest = NULL);
 
     static bool isInSingleThreadMode();
     static void setIsInSingleThreadMode(bool value);

--- a/src/ee/common/UndoQuantum.h
+++ b/src/ee/common/UndoQuantum.h
@@ -51,12 +51,25 @@ public:
     inline UndoQuantum(int64_t undoToken, Pool *dataPool)
         : m_undoToken(undoToken), m_dataPool(dataPool) {}
     inline virtual ~UndoQuantum() {}
-    virtual inline void registerUndoAction(UndoReleaseAction *undoAction, UndoQuantumReleaseInterest *interest = NULL) {
+
+    /**
+     * Add a new UndoReleaseAction to the list of undo actions. interest is an optional UndoQuantumReleaseInterest which
+     * will be added to the list of interested parties and invoked upon release of the undo quantum after all
+     * undoActions have been performed. removeInterest is an optional UndoQuantumReleaseInterest which will be removed
+     * from the list of interested parties if it had been previously added.
+     */
+    virtual inline void registerUndoAction(UndoReleaseAction *undoAction, UndoQuantumReleaseInterest *interest = NULL,
+            UndoQuantumReleaseInterest *removeInterest = NULL) {
         assert(undoAction);
         m_undoActions.push_back(undoAction);
 
         if (interest != NULL) {
            m_interests.push_back(interest);
+        }
+
+        if (removeInterest != NULL) {
+            assert(removeInterest != interest);
+            m_interests.remove(removeInterest);
         }
     }
 

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -766,7 +766,7 @@ int64_t BinaryLogSink::applyMpTxn(const char *rawLogs, int32_t logCount,
                 }
 
                 bool skipRow = !engine->isLocalSite(logs[i]->m_partitionHash);
-                rowCount += applyRecord(logs[i].get(), type, tables, pool, engine, remoteClusterId, skipRow);
+                rowCount += applyRecord(logs[i].get(), type, tables, pool, engine, remoteClusterId, false, skipRow);
             }
 
             if (type == DR_RECORD_END_TXN) {
@@ -807,7 +807,7 @@ int64_t BinaryLogSink::applyLog(BinaryLog *log, boost::unordered_map<int64_t, Pe
 
     do {
         pool->purge();
-        rowCount += applyTxn(log, tables, pool, engine, remoteClusterId, localUniqueId);
+        rowCount += applyTxn(log, tables, pool, engine, remoteClusterId, localUniqueId, false);
     } while (log->readNextTransaction());
 
     return rowCount;
@@ -815,7 +815,7 @@ int64_t BinaryLogSink::applyLog(BinaryLog *log, boost::unordered_map<int64_t, Pe
 
 int64_t BinaryLogSink::applyTxn(BinaryLog *log, boost::unordered_map<int64_t, PersistentTable*> &tables,
                  Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
-                 int64_t localUniqueId) {
+                 int64_t localUniqueId, bool replicatedTable) {
 
     DRRecordType type;
     int64_t rowCount = 0;
@@ -824,7 +824,7 @@ int64_t BinaryLogSink::applyTxn(BinaryLog *log, boost::unordered_map<int64_t, Pe
     while ((type = log->readRecordType()) != DR_RECORD_END_TXN) {
         assert(log->m_hashFlag != TXN_PAR_HASH_PLACEHOLDER);
         bool skipRow = checkForSkip && !engine->isLocalSite(log->m_partitionHash);
-        rowCount += applyRecord(log, type, tables, pool, engine, remoteClusterId, skipRow);
+        rowCount += applyRecord(log, type, tables, pool, engine, remoteClusterId, replicatedTable, skipRow);
     }
 
     log->validateEndTxn();
@@ -840,7 +840,7 @@ int64_t BinaryLogSink::applyReplicatedTxn(BinaryLog *log, boost::unordered_map<i
     long rowCount = 0;
     if (possiblySynchronizedUseMpMemory.okToExecute()) {
         VOLT_TRACE("applyBinaryLogMP for replicated table");
-        rowCount = applyTxn(log, tables, pool, engine, remoteClusterId, localUniqueId);
+        rowCount = applyTxn(log, tables, pool, engine, remoteClusterId, localUniqueId, true);
         s_replicatedApplySuccess = true;
     } else if (!s_replicatedApplySuccess) {
         const char* msg = "Replicated table apply binary log threw an unknown exception on other thread.";
@@ -862,6 +862,7 @@ int64_t BinaryLogSink::applyRecord(BinaryLog *log,
                              Pool *pool,
                              VoltDBEngine *engine,
                              int32_t remoteClusterId,
+                             bool replicatedTable,
                              bool skipRow) {
     ReferenceSerializeInputLE *taskInfo = &log->m_taskInfo;
     int64_t uniqueId = log->m_uniqueId;
@@ -1055,7 +1056,7 @@ int64_t BinaryLogSink::applyRecord(BinaryLog *log,
         int64_t tableHandle = taskInfo->readLong();
         std::string tableName = taskInfo->readTextString();
 
-        truncateTable(tables, engine, false, tableHandle, &tableName);
+        truncateTable(tables, engine, replicatedTable, tableHandle, &tableName);
 
         break;
     }

--- a/src/ee/storage/BinaryLogSink.h
+++ b/src/ee/storage/BinaryLogSink.h
@@ -61,7 +61,7 @@ private:
      * Apply all records within a single transaction from the binary log.
      */
     int64_t applyTxn(BinaryLog *log, boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool,
-            VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId);
+            VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId, bool replicatedTable);
 
     /**
      * Apply a single transaction to replicated tables
@@ -80,7 +80,7 @@ private:
      */
     int64_t applyRecord(BinaryLog *log, const DRRecordType type,
             boost::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool, VoltDBEngine *engine,
-            int32_t remoteClusterId, bool skipRow);
+            int32_t remoteClusterId, bool replicatedTable, bool skipRow);
 };
 
 

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -554,7 +554,7 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool replicatedTable, 
         emptyTable->m_invisibleTuplesPendingDeleteCount = emptyTable->m_tupleCount;
         // Create and register an undo action.
         UndoReleaseAction* undoAction = new (*uq) PersistentTableUndoTruncateTableAction(tcd, this, emptyTable, replicatedTable);
-        SynchronizedThreadLock::addUndoAction(isCatalogTableReplicated(), uq, undoAction);
+        SynchronizedThreadLock::addUndoAction(isCatalogTableReplicated(), uq, undoAction, NULL, this);
     }
     else {
         if (fallible) {

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -236,7 +236,8 @@ public interface SiteProcedureConnection {
     public void setViewsEnabled(String viewNames, boolean enabled);
     public long[] validatePartitioning(long tableIds[], byte hashinatorConfig[]);
     public void notifyOfSnapshotNonce(String nonce, long snapshotSpHandle);
-    public long applyBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, int remotePartitionId, byte logData[]);
+
+    public long applyBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, byte logData[]);
 
     public long applyMpBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, byte logsData[]);
     public void setDRProtocolVersion(int drVersion);

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -684,7 +684,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     }
 
     @Override
-    public long applyBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, int remotePartitionId, byte log[]) {
+    public long applyBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, byte log[]) {
         throw new UnsupportedOperationException("RO MP Site doesn't do this, shouldn't be here");
     }
 

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1755,9 +1755,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
-    public long applyBinaryLog(long txnId, long spHandle,
-                               long uniqueId, int remoteClusterId, int remotePartitionId,
-                               byte log[]) throws EEException {
+    public long applyBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, byte log[])
+            throws EEException {
         ByteBuffer paramBuffer = m_ee.getParamBufferForExecuteTask(Integer.BYTES * 2 + log.length);
         paramBuffer.putInt(1);
         paramBuffer.putInt(log.length);


### PR DESCRIPTION
truncateTable was always being called with replicatedTable false by applyRecord. This was causing memory corruption when a replicated table was being truncated.

Also, remove unused argument from applyBinaryLog.