### PR TITLE
ENG-14355 Timeout waiting for file to roll over

### DIFF
--- a/tests/frontend/org/voltdb/exportclient/TestExportToFileClient.java
+++ b/tests/frontend/org/voltdb/exportclient/TestExportToFileClient.java
@@ -204,19 +204,32 @@ public class TestExportToFileClient extends ExportClientTestBase {
         decoder.onBlockCompletion(row);
 
         // The file should rollover after 1s
-        boolean rolledOver = false;
         while (System.currentTimeMillis() - startTs < 60 * 1000) { // timeout after 1 minute
             final File dir = new File(m_dir);
             final File[] files = dir.listFiles();
-            if (files != null && files.length > 0 && !files[0].getName().startsWith("active")) {
+            int index;
+            if (files != null && files.length > 0 && (index = findFileNotStartWithActive(files)) >= 0) {
                 assertTrue(System.currentTimeMillis() - startTs > 1000);
-                verifyContent(files[0], l);
-                rolledOver = true;
-                break;
+                verifyContent(files[index], l);
+                return;
             }
             Thread.sleep(100);
         }
-        assertTrue("Timed out waiting for file to roll over", rolledOver);
+        fail("Timed out waiting for file to roll over");
+    }
+
+    // Find the index of file array whose name does not start with "active"; -1 when not found.
+    private static int findFileNotStartWithActive(File[] files) {
+        if (files == null || files.length == 0) {
+            return -1;
+        } else {
+            for (int indx = 0; indx < files.length; ++indx) {
+                if (!files[indx].getName().startsWith("active")) {
+                    return indx;
+                }
+            }
+            return -1;
+        }
     }
 
     @Test


### PR DESCRIPTION
I don't see reason to only check the first file for match.
On rare cases (say running this test for 40 times, the expected file might
come in the middle and the 1 minute limit is passed, therefore fails the
testcase.
With this fix, I have run the test for 100 times (with `-Dbuild=memcheck`) and did
not see failures. (But the original code wasn't failing quite frequent either).

@luyangco Please confirm that the test logic for the `testFileRollingUnbatched()`
method is not compromised.