### PR TITLE
ENG-14622: Add setupProcedure method to the EE

### DIFF
--- a/src/ee/common/executorcontext.hpp
+++ b/src/ee/common/executorcontext.hpp
@@ -133,6 +133,8 @@ class ExecutorContext {
         m_currentTxnTimestamp = (m_uniqueId >> 23) + VOLT_EPOCH_IN_MILLIS;
         m_currentDRTimestamp = createDRTimestampHiddenValue(static_cast<int64_t>(m_drClusterId), m_uniqueId);
         m_traceOn = traceOn;
+        // reset stats for each plan
+        m_progressStats.resetForNewBatch();
     }
 
     // data available via tick()

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -430,8 +430,6 @@ int VoltDBEngine::executePlanFragments(int32_t numFragments,
 
     bool hasDRBinaryLog = m_executorContext->checkTransactionForDR();
 
-    // reset these at the start of each batch
-    m_executorContext->m_progressStats.resetForNewBatch();
     NValueArray &params = m_executorContext->getParameterContainer();
 
     // Reserve the space to track the number of succeeded fragments.

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -328,7 +328,7 @@ public class ProcedureRunner {
         m_spBigBatchBeginToken = -1;
 
         // set procedure name in the site/ee
-        m_site.setProcedureName(m_procedureName);
+        m_site.setupProcedure(m_procedureName);
 
         // use local var to avoid warnings about reassigning method argument
         Object[] paramList = paramListIn;
@@ -504,7 +504,7 @@ public class ProcedureRunner {
             m_cachedSingleStmt.expectation = null;
             m_seenFinalBatch = false;
 
-            m_site.setProcedureName(null);
+            m_site.completeProcedure();
         }
 
         return retval;

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 
+import javax.annotation_voltpatches.Nullable;
+
 import org.voltcore.utils.Pair;
 import org.voltdb.DRConsumerDrIdTracker.DRSiteDrIdTracker;
 import org.voltdb.VoltProcedure.VoltAbortException;
@@ -141,10 +143,18 @@ public interface SiteProcedureConnection {
     public void setBatch(int batchIndex);
 
     /**
-     * Let the EE know what the name of the currently executing procedure is
-     * so it can include this information in any slow query progress log messages.
+     * Let the EE know what the name of the currently executing procedure is so it can include this information in any
+     * slow query progress log messages.
+     *
+     * @param procedureName Name of the procedure which is about to be run.
      */
-    public void setProcedureName(String procedureName);
+    public void setupProcedure(@Nullable String procedureName);
+
+    /**
+     * Let the EE know that the currently executing procedure has completed. Should be called by all callers of
+     * {@link #setupProcedure(String)}
+     */
+    public void completeProcedure();
 
     public void setBatchTimeout(int batchTimeout);
     public int getBatchTimeout();

--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -124,12 +124,8 @@ public class FragmentTask extends FragmentTaskBase
                                                        "partition", Integer.toString(siteConnection.getCorrespondingPartitionId())));
         }
 
-        // if this has a procedure name from the initiation bundled,
-        // inform the site connection here
-        String procName = m_fragmentMsg.getProcedureName();
-        if (procName != null) {
-            siteConnection.setProcedureName(procName);
-        }
+        // Setup this procedure with the site connection
+        siteConnection.setupProcedure(m_fragmentMsg.getProcedureName());
 
         // Set the begin undo token if we haven't already
         // In the future we could record a token per batch
@@ -158,6 +154,7 @@ public class FragmentTask extends FragmentTaskBase
             if (BatchTimeoutOverrideType.isUserSetTimeout(individualTimeout)) {
                 siteConnection.setBatchTimeout(originalTimeout);
             }
+            siteConnection.completeProcedure();
         }
 
         completeFragment();
@@ -234,7 +231,6 @@ public class FragmentTask extends FragmentTaskBase
     {
         // Check and see if we can flush early
         // right now, this is just read-only and final task
-        // This
         if (m_fragmentMsg.isFinalTask() && m_txnState.isReadOnly())
         {
             doCommonSPICompleteActions();
@@ -456,6 +452,7 @@ public class FragmentTask extends FragmentTaskBase
         return sb.toString();
     }
 
+    @Override
     public boolean needCoordination() {
         return !(m_txnState.isReadOnly() || isBorrowedTask() || m_isNPartition);
     }

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -679,8 +679,13 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     }
 
     @Override
-    public void setProcedureName(String procedureName) {
+    public void setupProcedure(String procedureName) {
         // don't need to do anything here I think?
+    }
+
+    @Override
+    public void completeProcedure() {
+        // don't need to do anything here
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1745,8 +1745,13 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
-    public void setProcedureName(String procedureName) {
-        m_ee.setProcedureName(procedureName);
+    public void setupProcedure(String procedureName) {
+        m_ee.setupProcedure(procedureName);
+    }
+
+    @Override
+    public void completeProcedure() {
+        m_ee.completeProcedure();
     }
 
     @Override

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -608,8 +608,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
     /** Pass the catalog to the engine */
     public void loadCatalog(long timestamp, String serializedCatalog) {
         try {
-            m_startTime = 0;
-            m_logDuration = INITIAL_LOG_DURATION;
+            setupProcedure(null);
             m_fragmentContext = FragmentContext.CATALOG_LOAD;
             coreLoadCatalog(timestamp, getStringBytes(serializedCatalog));
         }
@@ -623,8 +622,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
     /** Pass diffs to apply to the EE's catalog to update it */
     public final void updateCatalog(final long timestamp, final boolean isStreamUpdate, final String diffCommands) throws EEException {
         try {
-            m_startTime = 0;
-            m_logDuration = INITIAL_LOG_DURATION;
+            setupProcedure(null);
             m_fragmentContext = FragmentContext.CATALOG_UPDATE;
             coreUpdateCatalog(timestamp, isStreamUpdate, diffCommands);
         }
@@ -639,8 +637,14 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
         m_currentBatchIndex = batchIndex;
     }
 
-    public void setProcedureName(String procedureName) {
+    public void setupProcedure(String procedureName) {
         m_currentProcedureName = procedureName;
+        m_startTime = 0;
+        m_logDuration = INITIAL_LOG_DURATION;
+    }
+
+    public void completeProcedure() {
+        m_currentProcedureName = null;
     }
 
     /** Run multiple plan fragments */
@@ -665,8 +669,6 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             m_fragmentContext = (undoQuantumToken == Long.MAX_VALUE) ? FragmentContext.RO_BATCH : FragmentContext.RW_BATCH;
 
             // reset context for progress updates
-            m_startTime = 0;
-            m_logDuration = INITIAL_LOG_DURATION;
             m_sqlTexts = sqlTexts;
 
             if (traceOn) {

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -115,7 +115,9 @@ public class TestFragmentProgressUpdate extends TestCase {
         int i = 0;
         // this kinda assumes the right order
         for (PlanFragment f : selectStmt.getFragments()) {
-            if (i != 0) selectBottomFrag = f;
+            if (i != 0) {
+                selectBottomFrag = f;
+            }
             i++;
         }
         // populate plan cache
@@ -171,7 +173,9 @@ public class TestFragmentProgressUpdate extends TestCase {
         int i = 0;
         // this kinda assumes the right order
         for (PlanFragment f : selectStmt.getFragments()) {
-            if (i != 0) selectBottomFrag = f;
+            if (i != 0) {
+                selectBottomFrag = f;
+            }
             i++;
         }
         // populate plan cache
@@ -211,7 +215,9 @@ public class TestFragmentProgressUpdate extends TestCase {
         int j = 0;
         // this kinda assumes the right order
         for (PlanFragment f : deleteStmt.getFragments()) {
-            if (j != 0) deleteBottomFrag = f;
+            if (j != 0) {
+                deleteBottomFrag = f;
+            }
             j++;
         }
         // populate plan cache
@@ -286,7 +292,9 @@ public class TestFragmentProgressUpdate extends TestCase {
         int i = 0;
         // this kinda assumes the right order
         for (PlanFragment f : selectStmt.getFragments()) {
-            if (i != 0) selectBottomFrag = f;
+            if (i != 0) {
+                selectBottomFrag = f;
+            }
             i++;
         }
         // populate plan cache
@@ -479,6 +487,8 @@ public class TestFragmentProgressUpdate extends TestCase {
                 fail("Invalid value for sqlTextExpectation");
             }
 
+            m_ee.setupProcedure(null);
+
             m_ee.executePlanFragments(
                     numFragsToExecute,
                     fragIds,
@@ -539,30 +549,24 @@ public class TestFragmentProgressUpdate extends TestCase {
         verifyLongRunningQueries(numRowsToInsert, timeout, stmtName, 1, readOnly, SqlTextExpectation.SQL_STATEMENT);
     }
 
-    public void testTimingoutQueries() throws Exception {
-        //
-        // ReadOnly query
-        //
-        String procName = "item_crazy_join";
+    public void testTimingQueriyReadOnly200() throws Exception {
+        verifyLongRunningQueries(200, 0, "item_crazy_join", true);
+    }
 
-        verifyLongRunningQueries(200, 0, procName, true);
-        tearDown(); setUp();
+    public void testTimingQueryReadOnly200_2() throws Exception {
+        verifyLongRunningQueries(200, 0, "item_crazy_join", true);
+    }
 
-        verifyLongRunningQueries(200, 0, procName, true);
-        tearDown(); setUp();
+    public void testTimingQueryReadOnly300() throws Exception {
+        verifyLongRunningQueries(300, 0, "item_crazy_join", true);
+    }
 
-        verifyLongRunningQueries(300, 0, procName, true);
-        tearDown(); setUp();
+    public void testTimingQueryWrite() throws Exception {
+        verifyLongRunningQueries(50000, 0, "item_big_del", false);
+    }
 
-        //
-        // Write query (negative)
-        //
-        procName = "item_big_del";
-        verifyLongRunningQueries(50000, 0, procName, false);
-        tearDown(); setUp();
-
-        verifyLongRunningQueries(50000, 100, procName, false);
-        tearDown(); setUp();
+    public void testTimingoutQueryWrite() throws Exception {
+        verifyLongRunningQueries(50000, 100, "item_big_del", false);
     }
 
     private ExecutionEngine m_ee;


### PR DESCRIPTION
Currently startTime is only cleared when executePlanFragment,
loadCatalog or updateCatalog is called. That means that if a procedure
runs in the EE and does not go through one of those paths it will have a
bogus start time. Rename setProcedureName to setupProcedure and update
it so that it reset startTime and logDuration for the procedure to be
executed. Also, add a completeProcedure to clear the procedure name.