### PR TITLE
ENG-14485: LIKE operator handles two or more consecutive '%' 

### DIFF
--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -3944,7 +3944,19 @@ inline NValue NValue::like(const NValue& rhs) const {
                     }
 
                     const char *postPercentPatternIterator = m_pattern.getCursor();
-                    const uint32_t nextPatternCodePointAfterPercent = m_pattern.extractCodePoint();
+                    uint32_t nextPatternCodePointAfterPercent = m_pattern.extractCodePoint();
+
+                    // ENG-14485 handle two or more consecutive '%' characters at the end of the pattern
+                    if (m_value.atEnd()) {
+                        while (nextPatternCodePointAfterPercent == '%') {
+                            if (m_pattern.atEnd()) {
+                                return true;
+                            }
+                            nextPatternCodePointAfterPercent = m_pattern.extractCodePoint();
+                        }
+                        return false;
+                    }
+
                     const bool nextPatternCodePointAfterPercentIsSpecial =
                             (nextPatternCodePointAfterPercent == '_') ||
                             (nextPatternCodePointAfterPercent == '%');

--- a/tests/frontend/org/voltdb/TestLikeQueries.java
+++ b/tests/frontend/org/voltdb/TestLikeQueries.java
@@ -114,6 +114,7 @@ public class TestLikeQueries extends TestCase {
             new LikeTestData("âxxxéyy", "âxxx%"),
             new LikeTestData("â🀲x一xxéyyԱ", "â🀲x一%"),
             new LikeTestData("â🀲x", "â🀲%"),
+            new LikeTestData("ENG-14485", "ENG-14485%%"),
         };
 
     static final LikeTest[] tests = new LikeTest[] {
@@ -137,6 +138,13 @@ public class TestLikeQueries extends TestCase {
             new LikeTest("â🀲x_xxéyyԱ", 1),
             new LikeTest("â🀲x一xxéyy_", 1),
             new LikeTest("â🀲x一xéyyԱ", 0),
+            // ENG-14485 handle two or more consecutive '%' characters
+            new LikeTest("ENG-14485%%%", 1),
+            new LikeTest("%%ENG-14485", 1),
+            new LikeTest("EN%%G-14485", 1),
+            new LikeTest("ENG-144__%%", 1),
+            new LikeTest("%%%", rowData.length),
+
             new NotLikeTest("aaa%", rowData.length - 1),
             new EscapeLikeTest("ââ🀲x一xxéyyԱ", 1, "â"),
             new EscapeLikeTest("abccccâ%", 1, "â"),


### PR DESCRIPTION
Fix a bug that LIKE operator does not handle two or more consecutive '%' characters correctly.

The patterns `abc%%`, `%%abc`, `a%%bc`, `%%` should all match the string `abc`.