### PR TITLE
ENG-14690: detect mispartitioned transaction

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
@@ -127,7 +127,7 @@ public class ExecuteTask extends VoltSystemProcedure {
                     result.addRow(STATUS_OK);
                 } catch (Exception e) {
                     e.printStackTrace();
-                    result.addRow("FAILURE");
+                    result.addRow(STATUS_FAILURE);
                 }
                 break;
             }
@@ -145,7 +145,7 @@ public class ExecuteTask extends VoltSystemProcedure {
                     result.addRow(STATUS_OK);
                 } catch (Exception e) {
                     e.printStackTrace();
-                    result.addRow("FAILURE");
+                    result.addRow(STATUS_FAILURE);
                 }
                 break;
             }

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -135,8 +135,8 @@ public:
 
 class MockHashinator : public TheHashinator {
 public:
-    static MockHashinator* newInstance() {
-        return new MockHashinator();
+    static MockHashinator* newInstance(int32_t partition = 0) {
+        return new MockHashinator(partition);
     }
 
     std::string debug() const {
@@ -156,8 +156,13 @@ protected:
 
     int32_t partitionForToken(int32_t hashCode) const {
         // partition of VoltDBEngine super of MockVoltDBEngine is 0
-        return 0;
+        return m_partition;
     }
+
+private:
+    MockHashinator(int32_t partition) : m_partition(partition) {}
+
+    int32_t m_partition;
 };
 
 class MockVoltDBEngine : public VoltDBEngine {
@@ -220,6 +225,10 @@ public:
     ExportTupleStream* getExportTupleStream() { return m_exportStream; }
     ExecutorContext* getExecutorContext() { return m_context.get(); }
     void prepareContext() { m_context.get()->bindToThread(); }
+
+    void setHashinator(TheHashinator *hashinator) {
+        VoltDBEngine::setHashinator(hashinator);
+    }
 
 private:
     boost::scoped_ptr<StreamedTable> m_conflictStreamedTable;
@@ -2388,6 +2397,38 @@ TEST_F(DRBinaryLogTest, MultiPartNoDataChange) {
     m_undoToken = prevUndoToken;
 
     s_multiPartitionFlag = false;
+}
+
+TEST_F(DRBinaryLogTest, MissPartitionedExceptionIsThrown) {
+    // replica hashinator puts everything in partition 1
+    m_engineReplica->setHashinator(MockHashinator::newInstance(1));
+
+    // Replicated table updates do not throw TXN_MISPARTITIONED
+    beginTxn(m_engine, 99, 99, 98, 70);
+    TableTuple source_tuple = insertTuple(m_replicatedTable, prepareTempTuple(m_replicatedTable, 99, 29058, "92384598.2342", "what", "really, why am I writing anything in these?", 3455));
+    endTxn(m_engine, true);
+
+    {
+        ReplicaProcessContextSwitcher switcher;
+        flushAndApply(99, true, true);
+    }
+
+    EXPECT_EQ(1, m_replicatedTableReplica->activeTupleCount());
+    TableTuple tuple = m_replicatedTableReplica->lookupTupleForDR(source_tuple);
+    ASSERT_FALSE(tuple.isNullTuple());
+
+    // Partitioned table updates do throw TXN_MISPARTITIONED
+    beginTxn(m_engine, 100, 100, 99, 71);
+    insertTuple(m_table, prepareTempTuple(m_table, 42, 55555, "349508345.34583", "a thing", "this is a rather long string of text that is used to cause nvalue to use outline storage for the underlying data. It should be longer than 64 bytes.", 5433));
+    insertTuple(m_table, prepareTempTuple(m_table, 24, 2321, "23455.5554", "and another", "this is starting to get even sillier", 2222));
+    endTxn(m_engine, true);
+
+    try {
+        flushAndApply(100);
+        FAIL("Should have thrown SerializableEEException");
+    } catch (SerializableEEException &e) {
+        ASSERT_EQ(VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED, e.getType());
+    }
 }
 
 int main() {


### PR DESCRIPTION
ExecuteTask: Only put integers in result table
When a binary log contains a transaction for another partition throw SerializableEEException with a type of VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED.