### PR TITLE
ENG-14745: grammar-gen hangs on CREATE PROCEDURE / TRUNCATE

### DIFF
--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -1152,7 +1152,8 @@ if __name__ == "__main__":
                             ["Explain doesn't support DDL"],
                             ['PartitionInfo specifies invalid parameter index for procedure'],
                             ['Failed to plan for statement'],
-                            ['Invalid parameter index value']
+                            ['Invalid parameter index value'],
+                            ['Single partitioned procedure', 'has TRUNCATE statement:']
                            ]
 
     # A list of headers found in responses to valid 'show' commands: one of

--- a/tools/killstragglers.sh
+++ b/tools/killstragglers.sh
@@ -37,10 +37,10 @@ if [ $USER = "test" ]; then
 fi
 
 # Uncomment these to get debug print:
-#echo "Debug: STANDARD_VOLTDB_PORTS: $STANDARD_VOLTDB_PORTS"
-#echo "Debug: SUDO: $SUDO"
-#echo "Debug: USER: $USER"
-#echo "Debug: BUILD_TAG: $BUILD_TAG"
+echo "Debug: STANDARD_VOLTDB_PORTS: $STANDARD_VOLTDB_PORTS"
+echo "Debug: SUDO: $SUDO"
+echo "Debug: USER: $USER"
+echo "Debug: BUILD_TAG: $BUILD_TAG"
 
 # Make an attempt to kill any VoltDB server processes; however,
 # this might not work when the process command is extremely long
@@ -82,16 +82,16 @@ else
 fi
 
 # Uncomment these to get debug print:
-#echo "Debug: GET_PORT_PROCESS_COMMAND : $GET_PORT_PROCESS_COMMAND"
-#echo "Debug: KILL_PORT_PROCESS_COMMAND: $KILL_PORT_PROCESS_COMMAND"
+echo "Debug: GET_PORT_PROCESS_COMMAND : $GET_PORT_PROCESS_COMMAND"
+echo "Debug: KILL_PORT_PROCESS_COMMAND: $KILL_PORT_PROCESS_COMMAND"
 
 PROC=
 for PORT in $STANDARD_VOLTDB_PORTS
 do
     $GET_PORT_PROCESS_COMMAND
     # Uncomment these to get debug print:
-    #echo "Debug: PORT: $PORT"
-    #echo "Debug: PROC: $PROC"
+    echo "Debug: PORT: $PORT"
+    echo "Debug: PROC: $PROC"
     if [ -n "$PROC" ]; then
         logger -sp user.notice -t TESTKILL "User $USER Port $PORT $BUILD_TAG Killing ($KILL_PORT_PROCESS_COMMAND): `$SUDO ps -p $PROC -o pid= -o user= -o command=`"
         $KILL_PORT_PROCESS_COMMAND

--- a/tools/killstragglers.sh
+++ b/tools/killstragglers.sh
@@ -37,10 +37,10 @@ if [ $USER = "test" ]; then
 fi
 
 # Uncomment these to get debug print:
-echo "Debug: STANDARD_VOLTDB_PORTS: $STANDARD_VOLTDB_PORTS"
-echo "Debug: SUDO: $SUDO"
-echo "Debug: USER: $USER"
-echo "Debug: BUILD_TAG: $BUILD_TAG"
+#echo "Debug: STANDARD_VOLTDB_PORTS: $STANDARD_VOLTDB_PORTS"
+#echo "Debug: SUDO: $SUDO"
+#echo "Debug: USER: $USER"
+#echo "Debug: BUILD_TAG: $BUILD_TAG"
 
 # Make an attempt to kill any VoltDB server processes; however,
 # this might not work when the process command is extremely long
@@ -82,16 +82,16 @@ else
 fi
 
 # Uncomment these to get debug print:
-echo "Debug: GET_PORT_PROCESS_COMMAND : $GET_PORT_PROCESS_COMMAND"
-echo "Debug: KILL_PORT_PROCESS_COMMAND: $KILL_PORT_PROCESS_COMMAND"
+#echo "Debug: GET_PORT_PROCESS_COMMAND : $GET_PORT_PROCESS_COMMAND"
+#echo "Debug: KILL_PORT_PROCESS_COMMAND: $KILL_PORT_PROCESS_COMMAND"
 
 PROC=
 for PORT in $STANDARD_VOLTDB_PORTS
 do
     $GET_PORT_PROCESS_COMMAND
     # Uncomment these to get debug print:
-    echo "Debug: PORT: $PORT"
-    echo "Debug: PROC: $PROC"
+    #echo "Debug: PORT: $PORT"
+    #echo "Debug: PROC: $PROC"
     if [ -n "$PROC" ]; then
         logger -sp user.notice -t TESTKILL "User $USER Port $PORT $BUILD_TAG Killing ($KILL_PORT_PROCESS_COMMAND): `$SUDO ps -p $PROC -o pid= -o user= -o command=`"
         $KILL_PORT_PROCESS_COMMAND


### PR DESCRIPTION
Added "Single partitioned procedure: FOO has TRUNCATE statement" to the
list of known error messages.