### PR TITLE
Eng 14347 exclude schema from usos 84

### DIFF
--- a/src/ee/common/StreamBlock.h
+++ b/src/ee/common/StreamBlock.h
@@ -187,6 +187,10 @@ namespace voltdb
             return m_data + m_offset;
         }
 
+        char* headerDataPtr() {
+            return m_data - (m_headerSize - MAGIC_HEADER_SPACE_FOR_JAVA);
+        }
+
         void consumed(size_t consumed) {
             assert ((m_offset + consumed) <= m_capacity);
             m_offset += consumed;

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1112,7 +1112,8 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
                     ExportTupleStream *wrapper = m_exportingStreams[catalogTable->signature()];
                     if (wrapper == NULL) {
                         wrapper = new ExportTupleStream(m_executorContext->m_partitionId,
-                                m_executorContext->m_siteId, timestamp, catalogTable->signature());
+                                m_executorContext->m_siteId, timestamp, catalogTable->signature(),
+                                streamedtable->name(), streamedtable->getColumnNames());
                         m_exportingStreams[catalogTable->signature()] = wrapper;
                     } else {
                         // If stream was dropped in UAC and the added back we should not purge the wrapper.
@@ -1191,7 +1192,8 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
                             ExportTupleStream *wrapper = m_exportingStreams[catalogTable->signature()];
                             if (wrapper == NULL) {
                                 wrapper = new ExportTupleStream(m_executorContext->m_partitionId,
-                                        m_executorContext->m_siteId, timestamp, catalogTable->signature());
+                                        m_executorContext->m_siteId, timestamp, catalogTable->signature(),
+                                        streamedTable->name(), streamedTable->getColumnNames());
                                 m_exportingStreams[catalogTable->signature()] = wrapper;
                             } else {
                                 //If stream was altered in UAC and the added back we should not purge the wrapper.

--- a/src/ee/storage/ExportTupleStream.cpp
+++ b/src/ee/storage/ExportTupleStream.cpp
@@ -130,7 +130,7 @@ size_t ExportTupleStream::appendTuple(int64_t lastCommittedSpHandle,
     ::memset(m_currBlock->mutableDataPtr(), 0, streamHeaderSz);
 
     // the nullarray lives in rowheader after the 4 byte header length prefix + 4 bytes for column count +
-    // 4 partition index + a byte of hasSchema
+    // 4 partition index
     uint8_t *nullArray =
       reinterpret_cast<uint8_t*>(m_currBlock->mutableDataPtr()
               + sizeof(int32_t)         // row length

--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -97,6 +97,12 @@ public:
     virtual int partitionId() { return m_partitionId; }
     void setNew() { m_new = true; }
 
+public:
+    // Computed size for metadata columns
+    static const size_t s_mdSchemaSize;
+    // Size of Fixed header (not including schema)
+    static const size_t s_FIXED_BUFFER_HEADER_SIZE;
+
 private:
     // cached catalog values
     const CatalogId m_partitionId;
@@ -110,10 +116,6 @@ private:
     const std::vector<std::string> &m_columnNames;
     const int32_t m_ddlSchemaSize;
 
-    // Computed size for metadata columns
-    static const size_t s_mdSchemaSize;
-    // Size of Fixed header (not including schema)
-    static const size_t s_FIXED_BUFFER_HEADER_SIZE;
     // Buffer version (used for proper decoding of buffers by standalone processors)
     static const uint8_t s_EXPORT_BUFFER_VERSION;
     // meta-data column count

--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -27,11 +27,20 @@ namespace voltdb {
 
 class StreamBlock;
 
+//If you change this constant here change it in Java in the StreamBlockQueue where
+//it is used to calculate the number of bytes queued
+//I am not sure if the statements on the previous 2 lines are correct. I didn't see anything in SBQ that would care
+//It just reports the size of used bytes and not the size of the allocation
+//Add a 4k page at the end for bytes beyond the 2 meg row limit due to null mask and length prefix and so on
+//Necessary for very large rows
+const int EL_BUFFER_SIZE = /* 1024; */ (2 * 1024 * 1024) + MAGIC_HEADER_SPACE_FOR_JAVA + (4096 - MAGIC_HEADER_SPACE_FOR_JAVA);
+
 class ExportTupleStream : public voltdb::TupleStreamBase {
 public:
     enum Type { INSERT, DELETE };
 
-    ExportTupleStream(CatalogId partitionId, int64_t siteId, int64_t generation, std::string signature);
+    ExportTupleStream(CatalogId partitionId, int64_t siteId, int64_t generation, std::string signature,
+                      const std::string &tableName, const std::vector<std::string> &columnNames);
 
     virtual ~ExportTupleStream() {
     }
@@ -61,7 +70,7 @@ public:
     }
 
     // compute # of bytes needed to serialize the meta data column names
-    inline size_t getMDColumnNamesSerializedSize() const { return m_mdSchemaSize; }
+    inline size_t getMDColumnNamesSerializedSize() const { return s_mdSchemaSize; }
 
     int64_t allocatedByteCount() const {
         return (m_pendingBlocks.size() * (m_defaultCapacity - m_headerSpace)) +
@@ -77,32 +86,36 @@ public:
             int64_t seqNo,
             int64_t uniqueId,
             int64_t timestamp,
-            const std::string &tableName,
             const TableTuple &tuple,
-            const std::vector<std::string> &columnNames,
             int partitionColumn,
             ExportTupleStream::Type type);
 
     size_t computeOffsets(const TableTuple &tuple, size_t *rowHeaderSz) const;
     size_t computeSchemaSize(const std::string &tableName, const std::vector<std::string> &columnNames);
-    void writeSchema(ExportSerializeOutput &io, const TableTuple &tuple, const std::string &tableName, const std::vector<std::string> &columnNames);
+    void writeSchema(ExportSerializeOutput &hdr, const TableTuple &tuple);
 
     virtual int partitionId() { return m_partitionId; }
-    void setNew() { m_new = true; m_schemaSize = 0; }
+    void setNew() { m_new = true; }
 
 private:
     // cached catalog values
     const CatalogId m_partitionId;
     const int64_t m_siteId;
 
-    //This indicates that stream is new or has been marked as new after UAC so that we include schema in next export stream write.
+    // This indicates that stream is new or has been marked as new after UAC so that we include schema in next export stream write.
     bool m_new;
     std::string m_signature;
     int64_t m_generation;
-    size_t m_schemaSize;
+    const std::string &m_tableName;
+    const std::vector<std::string> &m_columnNames;
+    const int32_t m_ddlSchemaSize;
 
-    //Computed size for metadata columns
-    static const size_t m_mdSchemaSize;
+    // Computed size for metadata columns
+    static const size_t s_mdSchemaSize;
+    // Size of Fixed header (not including schema)
+    static const size_t s_FIXED_BUFFER_HEADER_SIZE;
+    // Buffer version (used for proper decoding of buffers by standalone processors)
+    static const uint8_t s_EXPORT_BUFFER_VERSION;
     // meta-data column count
     static const int METADATA_COL_CNT = 6;
 

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -30,14 +30,6 @@ namespace voltdb {
 
 class Topend;
 
-//If you change this constant here change it in Java in the StreamBlockQueue where
-//it is used to calculate the number of bytes queued
-//I am not sure if the statements on the previous 2 lines are correct. I didn't see anything in SBQ that would care
-//It just reports the size of used bytes and not the size of the allocation
-//Add a 4k page at the end for bytes beyond the 2 meg row limit due to null mask and length prefix and so on
-//Necessary for very large rows
-const int EL_BUFFER_SIZE = /* 1024; */ (2 * 1024 * 1024) + MAGIC_HEADER_SPACE_FOR_JAVA + (4096 - MAGIC_HEADER_SPACE_FOR_JAVA);
-
 class TupleStreamBase {
 public:
 

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -61,8 +61,9 @@ StreamedTable *
 StreamedTable::createForTest(size_t wrapperBufSize, ExecutorContext *ctx,
     TupleSchema *schema, std::string tableName, std::vector<std::string> & columnNames) {
     StreamedTable * st = new StreamedTable();
+    st->m_name = tableName;
     st->m_wrapper = new ExportTupleStream(ctx->m_partitionId,
-                                           ctx->m_siteId, 0, "sign", tableName, columnNames);
+                                           ctx->m_siteId, 0, "sign", st->m_name, columnNames);
     st->initializeWithColumns(schema, columnNames, false, wrapperBufSize);
     st->m_wrapper->setDefaultCapacityForTest(wrapperBufSize);
     return st;

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -59,10 +59,10 @@ StreamedTable::StreamedTable(ExportTupleStream *wrapper, int partitionColumn)
 
 StreamedTable *
 StreamedTable::createForTest(size_t wrapperBufSize, ExecutorContext *ctx,
-    TupleSchema *schema, std::vector<std::string> & columnNames) {
+    TupleSchema *schema, std::string tableName, std::vector<std::string> & columnNames) {
     StreamedTable * st = new StreamedTable();
     st->m_wrapper = new ExportTupleStream(ctx->m_partitionId,
-                                           ctx->m_siteId, 0, "sign");
+                                           ctx->m_siteId, 0, "sign", tableName, columnNames);
     st->initializeWithColumns(schema, columnNames, false, wrapperBufSize);
     st->m_wrapper->setDefaultCapacityForTest(wrapperBufSize);
     return st;
@@ -148,9 +148,7 @@ bool StreamedTable::insertTuple(TableTuple &source)
                                       m_sequenceNo++,
                                       m_executorContext->currentUniqueId(),
                                       m_executorContext->currentTxnTimestamp(),
-                                      name(),
                                       source,
-                                      getColumnNames(),
                                       partitionColumn(),
                                       ExportTupleStream::INSERT);
         m_tupleCount++;

--- a/src/ee/storage/streamedtable.h
+++ b/src/ee/storage/streamedtable.h
@@ -50,7 +50,8 @@ public:
     StreamedTable(int partitionColumn = -1);
     //Used for test
     StreamedTable(ExportTupleStream *wrapper, int partitionColumn = -1);
-    static StreamedTable* createForTest(size_t, ExecutorContext*, TupleSchema *schema, std::vector<std::string> & columnNames);
+    static StreamedTable* createForTest(size_t, ExecutorContext*, TupleSchema *schema,
+            std::string tableName, std::vector<std::string> & columnNames);
 
     virtual ~StreamedTable();
 

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -23,6 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -459,6 +460,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             exportLog.trace("pushExportBufferImpl with uso=" + uso + ", sync=" + sync + ", poll=" + poll);
         }
         if (buffer != null) {
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
             //There will be 8 bytes of no data that we can ignore, it is header space for storing
             //the USO in stream block
             if (buffer.capacity() > 8) {

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -20,6 +20,7 @@ package org.voltdb.export;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -595,6 +596,7 @@ public class ExportManager
                 }
                 return;
             }
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
             generation.pushExportBuffer(partitionId, signature, uso, buffer, sync);
         } catch (Exception e) {
             //Don't let anything take down the execution site thread

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -596,7 +596,6 @@ public class ExportManager
                 }
                 return;
             }
-            buffer.order(ByteOrder.LITTLE_ENDIAN);
             generation.pushExportBuffer(partitionId, signature, uso, buffer, sync);
         } catch (Exception e) {
             //Don't let anything take down the execution site thread

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -337,6 +337,7 @@ public class GuestProcessor implements ExportDataProcessor {
                             try {
                                 final ByteBuffer buf = cont.b();
                                 buf.position(startPosition);
+                                buf.order(ByteOrder.LITTLE_ENDIAN);
                                 byte version = buf.get();
                                 assert(version == 1);
                                 long generation = buf.getLong();

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -337,7 +337,6 @@ public class GuestProcessor implements ExportDataProcessor {
                             try {
                                 final ByteBuffer buf = cont.b();
                                 buf.position(startPosition);
-                                buf.order(ByteOrder.LITTLE_ENDIAN);
                                 byte version = buf.get();
                                 assert(version == 1);
                                 long generation = buf.getLong();

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -348,19 +348,7 @@ public class GuestProcessor implements ExportDataProcessor {
                                     buf.get(schemadata, 0, schemaSize);
                                     ByteBuffer sbuf = ByteBuffer.wrap(schemadata);
                                     sbuf.order(ByteOrder.LITTLE_ENDIAN);
-
-                                    String tableName = ExportRow.decodeString(sbuf);
-                                    List<String> colNames = new ArrayList<>();
-                                    List<Integer> colLengths = new ArrayList<>();
-                                    List<VoltType> colTypes = new ArrayList<>();
-                                    while (sbuf.position() < schemaSize) {
-                                        colNames.add(ExportRow.decodeString(sbuf));
-                                        colTypes.add(VoltType.get(sbuf.get()));
-                                        colLengths.add(sbuf.getInt());
-                                    }
-
-                                    edb.setPreviousRow(new ExportRow(tableName, colNames, colTypes, colLengths,
-                                            new Object[] {}, null, -1, source.getPartitionId(), generation));
+                                    edb.setPreviousRow(ExportRow.decodeBufferSchema(sbuf, schemaSize, source.getPartitionId(), generation));
                                 }
                                 else {
                                     // Skip past the schema header because it has not changed.

--- a/src/frontend/org/voltdb/exportclient/ExportEncoder.java
+++ b/src/frontend/org/voltdb/exportclient/ExportEncoder.java
@@ -37,17 +37,63 @@ import org.voltdb.types.VoltDecimalHelper;
  */
 public class ExportEncoder {
 
+    static class SizeWriter {
+        final FastSerializer m_fs;
+        final int m_writePos;
+
+        SizeWriter(FastSerializer fs) throws IOException {
+            m_fs = fs;
+            m_writePos = fs.getPosition();
+            m_fs.writeInt(0);
+        }
+
+        void finishWrite() throws IOException {
+            int bookmark = m_fs.getPosition();
+            m_fs.setPosition(m_writePos);
+            m_fs.writeInt(bookmark - m_writePos - 4);
+            m_fs.setPosition(bookmark);
+        }
+    }
+
+    static void writeSchema(FastSerializer fs, VoltTable table, String tableName) throws IOException {
+        SizeWriter schemaSize = new SizeWriter(fs);
+
+        fs.writeString(tableName);
+        VoltType type;
+        for (int i = 0; i < table.getColumnCount(); i++) {
+            fs.writeString(table.getColumnName(i));         // name
+
+            type = table.getColumnType(i);
+            fs.writeByte(type.getValue());                  // type
+
+            int columnLength = 0;
+            if (type.isVariableLength()) {
+                if (type.equals(VoltType.STRING)) {
+                    columnLength = VoltType.MAX_VALUE_LENGTH_IN_CHARACTERS;
+                } else {
+                    columnLength = VoltType.MAX_VALUE_LENGTH;
+                }
+            } else {
+                columnLength = type.getLengthInBytesForFixedTypes();
+            }
+            fs.writeInt(columnLength);                      // length
+        }
+        schemaSize.finishWrite();
+    }
+
     static byte[] encodeRow(VoltTable table, String tableName, int partitionColumnIndex, long generation)
     throws IOException {
 
         FastSerializer fs = new FastSerializer(false, true);
         try {
-            fs.writeLong(generation);
-            fs.writeInt(partitionColumnIndex);
+            writeSchema(fs, table, tableName);
+
             int colCount = table.getColumnCount();
+
+            SizeWriter rowSize = new SizeWriter(fs);
+            fs.writeInt(partitionColumnIndex);
             // column count
             fs.writeInt(colCount);
-            fs.writeByte(1);                  // has schema
             // pack the null flags
             int nullArrayLen = ((colCount + 7) & -8) >> 3;
             boolean[] nullArray = new boolean[colCount];
@@ -63,33 +109,13 @@ public class ExportEncoder {
             }
             fs.write(nullBits);
 
-            fs.writeString(tableName);
-            VoltType type;
-            for (int i = 0; i < table.getColumnCount(); i++) {
-                fs.writeString(table.getColumnName(i));         // name
-
-                type = table.getColumnType(i);
-                fs.writeByte(type.getValue());                  // type
-
-                int columnLength = 0;
-                if (type.isVariableLength()) {
-                    if (type.equals(VoltType.STRING)) {
-                        columnLength = VoltType.MAX_VALUE_LENGTH_IN_CHARACTERS;
-                    } else {
-                        columnLength = VoltType.MAX_VALUE_LENGTH;
-                    }
-                } else {
-                    columnLength = type.getLengthInBytesForFixedTypes();
-                }
-                fs.writeInt(columnLength);                      // length
-            }
-
             // write the non-null columns
             for (int i = 0; i < colCount; i++) {
                 if (!nullArray[i]) {
                     encodeColumn(fs, i, table);
                 }
             }
+            rowSize.finishWrite();
 
             final byte[] bytes = fs.getBytes();
             return bytes;
@@ -103,18 +129,13 @@ public class ExportEncoder {
 
         FastSerializer fs = new FastSerializer(false, true);
         try {
-            boolean hasSchema = true;
+            writeSchema(fs, table, tableName);
             while (table.advanceRow()) {
-                fs.writeLong(generation);
+                SizeWriter rowSize = new SizeWriter(fs);
                 fs.writeInt(partitionColumnIndex);
                 int colCount = table.getColumnCount();
                 // column count
                 fs.writeInt(colCount);
-                if (hasSchema) {
-                    fs.writeByte(1);                  // has schema
-                } else {
-                    fs.writeByte(0);                  // No schema
-                }
                 // pack the null flags
                 int nullArrayLen = ((colCount + 7) & -8) >> 3;
                 boolean[] nullArray = new boolean[colCount];
@@ -129,29 +150,6 @@ public class ExportEncoder {
                     }
                 }
                 fs.write(nullBits);
-                if (hasSchema) {
-                    fs.writeString(tableName);
-                    VoltType type;
-                    for (int i = 0; i < table.getColumnCount(); i++) {
-                        fs.writeString(table.getColumnName(i));         // name
-
-                        type = table.getColumnType(i);
-                        fs.writeByte(type.getValue());                  // type
-
-                        int columnLength = 0;
-                        if (type.isVariableLength()) {
-                            if (type.equals(VoltType.STRING)) {
-                                columnLength = VoltType.MAX_VALUE_LENGTH_IN_CHARACTERS;
-                            } else {
-                                columnLength = VoltType.MAX_VALUE_LENGTH;
-                            }
-                        } else {
-                            columnLength = type.getLengthInBytesForFixedTypes();
-                        }
-                        fs.writeInt(columnLength);                      // length
-                    }
-                    hasSchema = false;
-                }
 
                 // write the non-null columns
                 for (int i = 0; i < colCount; i++) {
@@ -159,6 +157,7 @@ public class ExportEncoder {
                         encodeColumn(fs, i, table);
                     }
                 }
+                rowSize.finishWrite();
                 System.out.println("Row done.");
             }
             final byte[] bytes = fs.getBytes();

--- a/src/frontend/org/voltdb/exportclient/ExportRow.java
+++ b/src/frontend/org/voltdb/exportclient/ExportRow.java
@@ -78,6 +78,21 @@ public class ExportRow {
         return "";
     }
 
+    public static ExportRow decodeBufferSchema(ByteBuffer bb, int schemaSize,
+            int partitionCol, long generation) throws IOException {
+        String tableName = ExportRow.decodeString(bb);
+        List<String> colNames = new ArrayList<>();
+        List<Integer> colLengths = new ArrayList<>();
+        List<VoltType> colTypes = new ArrayList<>();
+        while (bb.position() < schemaSize) {
+            colNames.add(ExportRow.decodeString(bb));
+            colTypes.add(VoltType.get(bb.get()));
+            colLengths.add(bb.getInt());
+        }
+        return new ExportRow(tableName, colNames, colTypes, colLengths,
+                new Object[] {}, null, -1, partitionCol, generation);
+    }
+
     /**
      * Decode a byte array of row data into ExportRow
      *

--- a/src/frontend/org/voltdb/exportclient/ExportRow.java
+++ b/src/frontend/org/voltdb/exportclient/ExportRow.java
@@ -57,7 +57,8 @@ public class ExportRow {
     public final long generation;
     public static final int INTERNAL_FIELD_COUNT = 6;
 
-    public ExportRow(String tableName, List<String> columnNames, List<VoltType> t, List<Integer> l, Object[] vals, Object pval, int partitionColIndex, int pid, long generation) {
+    public ExportRow(String tableName, List<String> columnNames, List<VoltType> t, List<Integer> l,
+            Object[] vals, Object pval, int partitionColIndex, int pid, long generation) {
         this.tableName = tableName;
         values = vals;
         partitionValue = pval;
@@ -87,38 +88,21 @@ public class ExportRow {
      * @return ExportRow row data with metadata
      * @throws IOException
      */
-    public static ExportRow decodeRow(ExportRow previous, int partition, long startTS, byte[] rowData) throws IOException {
-        ByteBuffer bb = ByteBuffer.wrap(rowData);
-        bb.order(ByteOrder.LITTLE_ENDIAN);
-
-        final long generation = bb.getLong();
+    public static ExportRow decodeRow(ExportRow previous, int partition, long startTS, ByteBuffer bb) throws IOException {
         final int partitionColIndex = bb.getInt();
         final int columnCount = bb.getInt();
-        final byte hasSchema = bb.get();
         assert(columnCount <= DDLCompiler.MAX_COLUMNS);
         boolean[] is_null = extractNullFlags(bb, columnCount);
 
-        List<String> colNames = new ArrayList<>();
-        List<Integer> colLengths = new ArrayList<>();
-        List<VoltType> colTypes = new ArrayList<>();
-        String tableName = null;
-        if (hasSchema == 1) {
-            tableName = decodeString(bb);
-            for (int i = 0; i < columnCount; i++) {
-                colNames.add(decodeString(bb));
-                colTypes.add(VoltType.get(bb.get()));
-                colLengths.add(bb.getInt());
-            }
-        } else {
-            assert(previous != null);
-            if (previous == null) {
-                throw new IOException("Export block with no schema found without prior block with schema.");
-            }
-            tableName = previous.tableName;
-            colNames = previous.names;
-            colTypes = previous.types;
-            colLengths = previous.lengths;
+        assert(previous != null);
+        if (previous == null) {
+            throw new IOException("Export block with no schema found without prior block with schema.");
         }
+        final long generation = previous.generation;
+        final String tableName = previous.tableName;
+        final List<String> colNames = previous.names;
+        final List<VoltType> colTypes = previous.types;
+        final List<Integer> colLengths = previous.lengths;
 
         Object[] retval = new Object[colNames.size()];
         Object pval = null;
@@ -143,51 +127,10 @@ public class ExportRow {
      * @return ExportRow
      * @throws IOException
      */
-    public static ExportRow decodeRow(ExportRow previous, int partition, long startTS, ByteBuffer bb) throws IOException {
-
-        final long generation = bb.getLong();
-        final int partitionColIndex = bb.getInt();
-        final int columnCount = bb.getInt();
-        final byte hasSchema = bb.get();
-        assert(columnCount <= DDLCompiler.MAX_COLUMNS);
-        boolean[] is_null = extractNullFlags(bb, columnCount);
-
-        List<String> colNames = new ArrayList<>();
-        List<Integer> colLengths = new ArrayList<>();
-        List<VoltType> colTypes = new ArrayList<>();
-        String tableName = null;
-        if (hasSchema == 1) {
-            tableName = decodeString(bb);
-
-            for (int i = 0; i < columnCount; i++) {
-                colNames.add(decodeString(bb));
-                colTypes.add(VoltType.get(bb.get()));
-                colLengths.add(bb.getInt());
-            }
-        } else {
-            assert(previous != null);
-            if (previous == null) {
-                throw new IOException("Export block with no schema found without prior block with schema.");
-            }
-            tableName = previous.tableName;
-            colNames = previous.names;
-            colTypes = previous.types;
-        }
-
-        Object[] retval = new Object[colNames.size()];
-        Object pval = null;
-        for (int i = 0; i < colNames.size(); ++i) {
-            if (is_null[i]) {
-                retval[i] = null;
-            } else {
-                retval[i] = decodeNextColumn(bb, colTypes.get(i));
-            }
-            if (i == partitionColIndex) {
-                pval = retval[i];
-            }
-        }
-
-        return new ExportRow(tableName, colNames, colTypes, colLengths, retval, pval, partitionColIndex, partition, generation);
+    public static ExportRow decodeRow(ExportRow previous, int partition, long startTS, byte[] rowData) throws IOException {
+        ByteBuffer bb = ByteBuffer.wrap(rowData);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        return decodeRow(previous, partition, startTS, bb);
     }
 
     //Based on your skipinternal value return index of first field.

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -112,8 +112,9 @@ static std::map<int, ClusterCtx> s_clusterMap;
 
 class MockExportTupleStream : public ExportTupleStream {
 public:
-    MockExportTupleStream(CatalogId partitionId, int64_t siteId, int64_t generation, std::string signature)
-        : ExportTupleStream(partitionId, siteId, generation, signature)
+    MockExportTupleStream(CatalogId partitionId, int64_t siteId, int64_t generation, std::string signature,
+                          const std::string &tableName, const std::vector<std::string> &columnNames)
+        : ExportTupleStream(partitionId, siteId, generation, signature, tableName, columnNames)
     { }
 
     virtual size_t appendTuple(int64_t lastCommittedSpHandle,
@@ -121,9 +122,7 @@ public:
                                            int64_t seqNo,
                                            int64_t uniqueId,
                                            int64_t timestamp,
-                                           const std::string &tableName,
                                            const TableTuple &tuple,
-                                           const std::vector<std::string> &columnNames,
                                            int partitionColumn,
                                            ExportTupleStream::Type type) {
         receivedTuples.push_back(tuple);
@@ -200,10 +199,11 @@ public:
                                            "ROW_DECISION", "CLUSTER_ID", "TIMESTAMP", "DIVERGENCE", "TABLE_NAME",
                                            "CURRENT_CLUSTER_ID", "CURRENT_TIMESTAMP", "TUPLE"};
         const vector<string> exportColumnName(exportColumnNamesArray, exportColumnNamesArray + 12);
+        const std::string tableName = "VOLTDB_AUTOGEN_DR_CONFLICTS_PARTITIONED";
 
-        m_exportStream = new MockExportTupleStream(1, 1, 0, "sign");
+        m_exportStream = new MockExportTupleStream(1, 1, 0, "sign", tableName, exportColumnName);
         m_conflictStreamedTable.reset(TableFactory::getStreamedTableForTest(0,
-                "VOLTDB_AUTOGEN_DR_CONFLICTS_PARTITIONED",
+                tableName,
                 m_exportSchema,
                 exportColumnName,
                 m_exportStream,

--- a/tests/ee/storage/StreamedTable_test.cpp
+++ b/tests/ee/storage/StreamedTable_test.cpp
@@ -64,13 +64,13 @@ public:
         std::vector<ValueType> columnTypes;
         std::vector<int32_t> columnLengths;
         std::vector<bool> columnAllowNull;
-        std::vector<std::string> columnNames;
         //Five columns
-        columnNames.push_back("one");
-        columnNames.push_back("two");
-        columnNames.push_back("three");
-        columnNames.push_back("four");
-        columnNames.push_back("five");
+        m_columnNames = new std::vector<std::string>();
+        m_columnNames->push_back("one");
+        m_columnNames->push_back("two");
+        m_columnNames->push_back("three");
+        m_columnNames->push_back("four");
+        m_columnNames->push_back("five");
         for (int i = 0; i < COLUMN_COUNT; i++) {
             columnTypes.push_back(VALUE_TYPE_INTEGER);
             columnLengths.push_back(NValue::getTupleStorageSize(VALUE_TYPE_INTEGER));
@@ -93,7 +93,7 @@ public:
 
         // a simple helper around the constructor that sets the
         // wrapper buffer size to the specified value
-        m_table = StreamedTable::createForTest(1024, m_context, m_schema, columnNames);
+        m_table = StreamedTable::createForTest(1024, m_context, m_schema, "test", *m_columnNames);
     }
 
     void nextQuantum(int i, int64_t tokenOffset)
@@ -114,6 +114,7 @@ public:
         UndoQuantum::release(std::move(*m_quantum));
         delete m_pool;
         delete m_topend;
+        delete m_columnNames;
         voltdb::globalDestroyOncePerProcess();
     }
 
@@ -127,7 +128,7 @@ protected:
     TupleSchema* m_schema;
     char m_tupleMemory[(COLUMN_COUNT + 1) * 8];
     TableTuple* m_tuple;
-
+    std::vector<std::string>* m_columnNames;
 };
 
 /**

--- a/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
+++ b/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
@@ -57,6 +57,7 @@ public class TestStreamBlockQueue {
     private static ByteBuffer getFilledBuffer(byte fillValue) {
         //8 bytes is magic prefix space
         ByteBuffer buf = ByteBuffer.allocateDirect(1024 * 1024 * 2 + 8);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
         while (buf.hasRemaining()) {
             buf.put(fillValue);
         }

--- a/tests/frontend/org/voltdb/exportclient/TestExportToFileClient.java
+++ b/tests/frontend/org/voltdb/exportclient/TestExportToFileClient.java
@@ -34,6 +34,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -198,7 +200,12 @@ public class TestExportToFileClient extends ExportClientTestBase {
                 GEOG_POINT, GEOG);
         vtable.advanceRow();
         byte[] rowBytes = ExportEncoder.encodeRow(vtable, "mytable", 0, 1L);
-        ExportRow row = ExportRow.decodeRow(null, 0, 0L, rowBytes);
+        ByteBuffer bb = ByteBuffer.wrap(rowBytes);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        int schemaSize = bb.getInt();
+        ExportRow schemaRow = ExportRow.decodeBufferSchema(bb, schemaSize, 1, 0);
+        bb.getInt(); // row size
+        ExportRow row = ExportRow.decodeRow(schemaRow, 0, 0L, bb);
         decoder.onBlockStart(row);
         decoder.processRow(row);
         decoder.onBlockCompletion(row);
@@ -255,7 +262,12 @@ public class TestExportToFileClient extends ExportClientTestBase {
                 GEOG_POINT, GEOG);
         vtable.advanceRow();
         byte[] rowBytes = ExportEncoder.encodeRow(vtable, "mytable", 0, 1L);
-        ExportRow row = ExportRow.decodeRow(null, 0, 0L, rowBytes);
+        ByteBuffer bb = ByteBuffer.wrap(rowBytes);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        int schemaSize = bb.getInt();
+        ExportRow schemaRow = ExportRow.decodeBufferSchema(bb, schemaSize, 1, 0);
+        bb.getInt(); // row size
+        ExportRow row = ExportRow.decodeRow(schemaRow, 0, 0L, bb);
         decoder.onBlockStart(row);
         decoder.processRow(row);
         decoder.onBlockCompletion(row);
@@ -325,7 +337,12 @@ public class TestExportToFileClient extends ExportClientTestBase {
                 GEOG_POINT, GEOG);
                 vtable.advanceRow();
                 byte[] rowBytes = ExportEncoder.encodeRow(vtable, "mytable", 0, 1L);
-                ExportRow row = ExportRow.decodeRow(null, 0, 0L, rowBytes);
+                ByteBuffer bb = ByteBuffer.wrap(rowBytes);
+                bb.order(ByteOrder.LITTLE_ENDIAN);
+                int schemaSize = bb.getInt();
+                ExportRow schemaRow = ExportRow.decodeBufferSchema(bb, schemaSize, 1, 0);
+                bb.getInt(); // row size
+                ExportRow row = ExportRow.decodeRow(schemaRow, 0, 0L, bb);
                 decoder.onBlockStart(row);
                 decoder.processRow(row);
                 decoder.onBlockCompletion(row);
@@ -373,7 +390,12 @@ public class TestExportToFileClient extends ExportClientTestBase {
                         GEOG_POINT, GEOG);
                 vtable.advanceRow();
                 byte[] rowBytes = ExportEncoder.encodeRow(vtable, "mytable", 0, 1L);
-                ExportRow row = ExportRow.decodeRow(null, 0, 0L, rowBytes);
+                ByteBuffer bb = ByteBuffer.wrap(rowBytes);
+                bb.order(ByteOrder.LITTLE_ENDIAN);
+                int schemaSize = bb.getInt();
+                ExportRow schemaRow = ExportRow.decodeBufferSchema(bb, schemaSize, 1, 0);
+                bb.getInt(); // row size
+                ExportRow row = ExportRow.decodeRow(schemaRow, 0, 0L, bb);
                 decoder.onBlockStart(row);
                 decoder.processRow(row);
                 decoder.onBlockCompletion(row);
@@ -422,7 +444,12 @@ public class TestExportToFileClient extends ExportClientTestBase {
                         GEOG_POINT, GEOG);
                 vtable.advanceRow();
                 byte[] rowBytes = ExportEncoder.encodeRow(vtable, "mytable", 0, 1L);
-                ExportRow row = ExportRow.decodeRow(null, 0, 0L, rowBytes);
+                ByteBuffer bb = ByteBuffer.wrap(rowBytes);
+                bb.order(ByteOrder.LITTLE_ENDIAN);
+                int schemaSize = bb.getInt();
+                ExportRow schemaRow = ExportRow.decodeBufferSchema(bb, schemaSize, 1, 0);
+                bb.getInt(); // row size
+                ExportRow row = ExportRow.decodeRow(schemaRow, 0, 0L, bb);
                 decoder.onBlockStart(row);
                 decoder.processRow(row);
                 decoder.onBlockCompletion(row);
@@ -459,7 +486,12 @@ public class TestExportToFileClient extends ExportClientTestBase {
                 GEOG_POINT, GEOG);
         vtable.advanceRow();
         byte[] rowBytes = ExportEncoder.encodeRow(vtable, "mytable", 0, 1L);
-        ExportRow row = ExportRow.decodeRow(null, 0, 0L, rowBytes);
+        ByteBuffer bb = ByteBuffer.wrap(rowBytes);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        int schemaSize = bb.getInt();
+        ExportRow schemaRow = ExportRow.decodeBufferSchema(bb, schemaSize, 1, 0);
+        bb.getInt(); // row size
+        ExportRow row = ExportRow.decodeRow(schemaRow, 0, 0L, bb);
         decoder.onBlockStart(row);
         decoder.processRow(row);
         decoder.onBlockCompletion(row);
@@ -512,7 +544,12 @@ public class TestExportToFileClient extends ExportClientTestBase {
                 GEOG_POINT, GEOG);
         vtable.advanceRow();
         byte[] rowBytes = ExportEncoder.encodeRow(vtable, "mytable", 0, 1L);
-        ExportRow row = ExportRow.decodeRow(null, 0, 0L, rowBytes);
+        ByteBuffer bb = ByteBuffer.wrap(rowBytes);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        int schemaSize = bb.getInt();
+        ExportRow schemaRow = ExportRow.decodeBufferSchema(bb, schemaSize, 1, 0);
+        bb.getInt(); // row size
+        ExportRow row = ExportRow.decodeRow(schemaRow, 0, 0L, bb);
         decoder.onBlockStart(row);
         decoder.processRow(row);
         decoder.onBlockCompletion(row);
@@ -564,7 +601,12 @@ public class TestExportToFileClient extends ExportClientTestBase {
                 GEOG_POINT, GEOG);
         vtable.advanceRow();
         byte[] rowBytes = ExportEncoder.encodeRow(vtable, "mytable", 0, 1L);
-        ExportRow row = ExportRow.decodeRow(null, 0, 0L, rowBytes);
+        ByteBuffer bb = ByteBuffer.wrap(rowBytes);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        int schemaSize = bb.getInt();
+        ExportRow schemaRow = ExportRow.decodeBufferSchema(bb, schemaSize, 1, 0);
+        bb.getInt(); // row size
+        ExportRow row = ExportRow.decodeRow(schemaRow, 0, 0L, bb);
         decoder.onBlockStart(row);
         decoder.processRow(row);
         decoder.onBlockCompletion(row);
@@ -608,7 +650,12 @@ public class TestExportToFileClient extends ExportClientTestBase {
                 GEOG_POINT, GEOG);
         vtable.advanceRow();
         byte[] rowBytes = ExportEncoder.encodeRow(vtable, "mytable", 0, 1L);
-        ExportRow row = ExportRow.decodeRow(null, 0, 0L, rowBytes);
+        ByteBuffer bb = ByteBuffer.wrap(rowBytes);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        int schemaSize = bb.getInt();
+        ExportRow schemaRow = ExportRow.decodeBufferSchema(bb, schemaSize, 1, 0);
+        bb.getInt(); // row size
+        ExportRow row = ExportRow.decodeRow(schemaRow, 0, 0L, bb);
         decoder.onBlockStart(row);
         decoder.processRow(row);
         decoder.onBlockCompletion(row);

--- a/tests/frontend/org/voltdb/exportclient/TestHttpExportClient.java
+++ b/tests/frontend/org/voltdb/exportclient/TestHttpExportClient.java
@@ -34,6 +34,8 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Properties;
@@ -1258,12 +1260,18 @@ public class TestHttpExportClient extends ExportClientTestBase {
 
         final ExportDecoderBase decoder = dut.constructExportDecoder(constructTestSource(false, 0));
         populateTable(headerValue, useNullValues);
-        byte[] rowBytes = ExportEncoder.encodeRow(m_table, "yankeelover", 7, 32L);
+        byte[] bufBytes = ExportEncoder.encodeRow(m_table, "yankeelover", 7, 32L);
 
-        ExportRow row = null;
+        ByteBuffer bb = ByteBuffer.wrap(bufBytes);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        int schemaSize = bb.getInt();
+        ExportRow schemaRow = ExportRow.decodeBufferSchema(bb, schemaSize, 1, 0);
+        int size = bb.getInt(); // row size
+        byte [] rowBytes = new byte[size];
+        bb.get(rowBytes);
         while (true) {
             try {
-                row = ExportRow.decodeRow(row, 0, 0L, rowBytes);
+                ExportRow row = ExportRow.decodeRow(schemaRow, 0, 0L, rowBytes);
                 decoder.onBlockStart(row);
                 decoder.processRow(row);
                 decoder.onBlockCompletion(row);


### PR DESCRIPTION
As export streams build buffers, the number of records in buffers can diverge on different hosts due to the timing of the Tick() calls on the individual sites of each host. This in turn can result in different buffer counts for the same stream and partition on different hosts although the total number of records (sequence number) are the same. The first row of each buffer contains the streams schema, but this schema data is included in the USO calculation. Because we use stream offset (USO) to coordinate acknowledgements between hosts, the different number of buffers can result in the same record on different hosts starting at different USOs resulting in acking the wrong record. At promotion or SPI migration time, we can either skip past a record or send the same record twice with different USOs. Further, the different USO values can cause us to report that there are non-empty Export Streams when in fact all the Export data has been processed.

This fix removes the Schema out of the first record of the buffer allowing for consistent USO assignments for all records generated for the same stream on different hosts. The movement of the schema out of the record and into the buffer header is transparent to the connector interface.

A version field has also been added to the buffer header to disambiguate the format of the buffer for offline processing. The generation field has also been moved to the header so that buffers from identical generations can skip past the schema parsing step when decoding the buffer.