### PR TITLE
ENG-14787: Extract StackTrace to its own file

### DIFF
--- a/src/ee/CMakeLists.txt
+++ b/src/ee/CMakeLists.txt
@@ -131,7 +131,7 @@ SET (VOLTDB_SRC
   catalog/table.cpp
   catalog/tableref.cpp
   common/Pool.cpp
-  common/debuglog.cpp
+  common/StackTrace.cpp
   common/ExecuteWithMpMemory.cpp
   common/executorcontext.cpp
   common/FatalException.cpp

--- a/src/ee/common/StackTrace.cpp
+++ b/src/ee/common/StackTrace.cpp
@@ -17,18 +17,19 @@
 
 // For backtrace and backtrace_symbols
 // These do not appear to work on the Mac in a JNI library
-#include <cxxabi.h>
 #include <execinfo.h>
 #include <cstring>
 #include <cxxabi.h>   // for abi
 #include <cstdlib>    // for malloc/free
 #include <sstream>    // for std::ostringstream
 
-#include "common/debuglog.h"
+#include "common/StackTrace.h"
+
+#ifdef MACOSX
 #include "common/executorcontext.hpp"
 #include "common/Topend.h"
-
 #include "execution/JNITopend.h"
+#endif
 
 namespace voltdb {
 

--- a/src/ee/common/StackTrace.h
+++ b/src/ee/common/StackTrace.h
@@ -1,0 +1,53 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <vector>
+#include <cstdio>
+#include <string>
+
+namespace voltdb {
+
+class StackTrace {
+public:
+    StackTrace();
+    ~StackTrace();
+
+    static void printMangledAndUnmangledToFile(FILE *targetFile);
+
+    static void printStackTrace() {
+        StackTrace st;
+        for (int ii=1; ii < st.m_traces.size(); ii++) {
+            printf("   %s\n", st.m_traces[ii].c_str());
+        }
+    }
+
+    static std::string stringStackTrace();
+
+    void printLocalTrace() {
+        for (int ii=1; ii < m_traces.size(); ii++) {
+            printf("   %s\n", m_traces[ii].c_str());
+        }
+    }
+
+private:
+    char** m_traceSymbols;
+    std::vector<std::string> m_traces;
+};
+
+}

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -19,6 +19,9 @@
 #define THREADLOCALPOOL_H_
 
 #include "structures/CompactingPool.h"
+#ifdef VOLT_POOL_CHECKING
+#include "common/StackTrace.h"
+#endif
 
 #include "boost/pool/pool.hpp"
 #include "boost/shared_ptr.hpp"

--- a/src/ee/common/debuglog.h
+++ b/src/ee/common/debuglog.h
@@ -43,8 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef HSTOREDEBUGLOG_H
-#define HSTOREDEBUGLOG_H
+#pragma once
 
 /**
  * Debug logging functions for EE. Unlike the performance counters,
@@ -55,15 +54,13 @@
 */
 
 #include "common/ThreadLocalPool.h"
+#include "common/StackTrace.h"
 
 #include <string>
 #include <ctime>
 #include <cstdio>
-#include <vector>
 #include <chrono>
 #include <sys/time.h>
-
-namespace voltdb {
 
 // Log levels.
 #define VOLT_LEVEL_OFF    1000
@@ -220,35 +217,4 @@ struct _TimerLevels {
 #define STOP_TIMER(...) ((void)0)
 #endif
 
-class StackTrace {
-public:
-    StackTrace();
-    ~StackTrace();
-
-    static void printMangledAndUnmangledToFile(FILE *targetFile);
-
-    static void printStackTrace() {
-        StackTrace st;
-        for (int ii=1; ii < st.m_traces.size(); ii++) {
-            printf("   %s\n", st.m_traces[ii].c_str());
-        }
-    }
-
-    static std::string stringStackTrace();
-
-    void printLocalTrace() {
-        for (int ii=1; ii < m_traces.size(); ii++) {
-            printf("   %s\n", m_traces[ii].c_str());
-        }
-    }
-
-private:
-    char** m_traceSymbols;
-    std::vector<std::string> m_traces;
-};
-
 #define PRINT_STACK_TRACE() VOLT_LOG_STACK("UNKWN")
-
-} // namespace voltdb
-
-#endif // HSTOREDEBUGLOG_H


### PR DESCRIPTION
When the logger was implemented as a pure macro a cycle was created
between debuglog.h and ThreadLocalPool.h. This was resolved by removing
the include of debuglog.h from ThreadLocalPool.h. However, the
StackTrace class is used by ThreadLocalPool.h when pool checking is
enabled.

In order to keep the logging as a macro and still use the StackTrace in
ThreadLocalPool.h, StackTrace is being extracted to its own header and
source file. This allows both debuglog.h and ThreadLocalPool.h to
include StackTrace.h and not have a cycle.