### PR TITLE
ENG-14162:

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -406,10 +406,9 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
     protected String verifyAndWriteCatalogJar(CatalogChangeResult ccr)
     {
         String procedureName = "@VerifyCatalogAndWriteJar";
-        String diffCommands = CompressionService.decodeBase64AndDecompress(ccr.encodedDiffCommands);
 
         CompletableFuture<Map<Integer,ClientResponse>> cf =
-                callNTProcedureOnAllHosts(procedureName, ccr.catalogBytes, diffCommands,
+                callNTProcedureOnAllHosts(procedureName, ccr.catalogBytes, ccr.encodedDiffCommands,
                         ccr.catalogHash, ccr.deploymentBytes);
 
         Map<Integer, ClientResponse> resultMapByHost = null;

--- a/src/frontend/org/voltdb/sysprocs/VerifyCatalogAndWriteJar.java
+++ b/src/frontend/org/voltdb/sysprocs/VerifyCatalogAndWriteJar.java
@@ -25,6 +25,7 @@ import org.voltdb.ClientResponseImpl;
 import org.voltdb.NTProcedureService;
 import org.voltdb.VoltDB;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.utils.CompressionService;
 
 /**
  *
@@ -81,12 +82,14 @@ public class VerifyCatalogAndWriteJar extends UpdateApplicationBase {
     public final static long TIMEOUT = getTimeoutValue();
 
 
-    public CompletableFuture<ClientResponse> run(byte[] catalogBytes, String diffCommands,
+    public CompletableFuture<ClientResponse> run(byte[] catalogBytes, String encodedDiffCommands,
             byte[] catalogHash, byte[] deploymentBytes)
     {
-        log.info("Verify user procedure classes and write catalog jar");
-
         // This should only be called once on each host
+        String diffCommands = CompressionService.decodeBase64AndDecompress(encodedDiffCommands);
+        log.info("Verify user procedure classes and write catalog jar (compressed size = " + encodedDiffCommands.length() +
+                ", uncompressed size = " + diffCommands.length() +")");
+
         String err = VoltDB.instance().verifyJarAndPrepareProcRunners(
                 catalogBytes, diffCommands, catalogHash, deploymentBytes);
         if (err != null) {


### PR DESCRIPTION
A customer has a catalog that exceeds the 50MB message size. In most of the paths, catalogs and catalog diffs are passed around compressed but UAC passes the catalog diffs uncompressed to each host. This branch passes the catalog diffs compressed and asks each host to decompress locally before building the local jar file. This reduces the size of the message by half.