### PR TITLE
ENG-14739:

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionState.java
@@ -184,6 +184,7 @@ public class MpTransactionState extends TransactionState
         m_haveDistributedInitTask = false;
         m_isRestart = true;
         m_haveSentfragment = false;
+        m_drBufferChangedAgg = 0;
     }
 
     @Override
@@ -207,7 +208,6 @@ public class MpTransactionState extends TransactionState
         m_remoteWork = null;
         m_remoteDeps = null;
         m_remoteDepTables.clear();
-        m_drBufferChangedAgg = 0;
     }
 
     // I met this List at bandcamp...


### PR DESCRIPTION
- DR buffer change variables need to be reset and updated only on a write fragment, which happens in recursableRun. Do not reset drBufferChangedAgg in setupResume because this resets it for reads and the value will not be updated to correct value in recursableRun for reads.

- Reset the DR buffer change variable on a restart.