### PR TITLE
MInor miscenalious cleanup and fixes

### DIFF
--- a/src/frontend/org/voltcore/logging/VoltLogger.java
+++ b/src/frontend/org/voltcore/logging/VoltLogger.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -173,7 +174,12 @@ public class VoltLogger {
         }
 
         final Runnable runnableLoggingTask = createRunnableLoggingTask(level, message, t);
-        m_asynchLoggerPool.execute(runnableLoggingTask);
+        try {
+            m_asynchLoggerPool.execute(runnableLoggingTask);
+        } catch (RejectedExecutionException e) {
+            m_logger.log(Level.DEBUG, "Failed to execute logging task. Running in-line", e);
+            runnableLoggingTask.run();
+        }
     }
 
     /**

--- a/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
+++ b/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
@@ -17,6 +17,8 @@
 
 package org.voltdb;
 
+import static org.voltdb.DRLogSegmentId.isEmptyDRId;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -37,8 +39,6 @@ import com.google_voltpatches.common.collect.DiscreteDomain;
 import com.google_voltpatches.common.collect.Range;
 import com.google_voltpatches.common.collect.RangeSet;
 import com.google_voltpatches.common.collect.TreeRangeSet;
-
-import static org.voltdb.DRLogSegmentId.isEmptyDRId;
 
 /*
  * WARNING:
@@ -89,6 +89,7 @@ public class DRConsumerDrIdTracker implements Serializable {
             return obj;
         }
 
+        @Override
         public String toShortString() {
             if (m_map.isEmpty()) {
                 return "Empty Map";
@@ -332,7 +333,9 @@ public class DRConsumerDrIdTracker implements Serializable {
      * @param newTruncationPoint    New safe point
      */
     public void truncate(long newTruncationPoint) {
-        if (newTruncationPoint < getFirstDrId()) return;
+        if (newTruncationPoint < getFirstDrId()) {
+            return;
+        }
         final Iterator<Range<Long>> iter = m_map.asRanges().iterator();
         while (iter.hasNext()) {
             final Range<Long> next = iter.next();
@@ -445,7 +448,7 @@ public class DRConsumerDrIdTracker implements Serializable {
     }
 
     protected void toShortString(StringBuilder sb) {
-        sb.append("lastMpUniqueId ").append(UniqueIdGenerator.toShortString(m_lastMpUniqueId)).append(" ");
+        sb.append("lastSpUniqueId ").append(UniqueIdGenerator.toShortString(m_lastSpUniqueId)).append(" ");
         sb.append("lastMpUniqueId ").append(UniqueIdGenerator.toShortString(m_lastMpUniqueId)).append(" ");
         sb.append("producerPartitionId ").append(m_producerPartitionId).append(" ");
         sb.append("span [").append(DRLogSegmentId.getSequenceNumberFromDRId(getFirstDrId())).append("-");

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -565,7 +565,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                                     Long.MIN_VALUE, Long.MIN_VALUE, MpInitiator.MP_INIT_PID);
                     clusterSources.put(MpInitiator.MP_INIT_PID, tracker);
                 }
-                int oldProducerPartitionCount = clusterSources.size() - (clusterSources.containsKey(MpInitiator.MP_INIT_PID) ? 1 : 0);
+                int oldProducerPartitionCount = clusterSources.size() - 1;
                 int newProducerPartitionCount = entry.getValue();
                 assert(oldProducerPartitionCount >= 0);
                 assert(newProducerPartitionCount != -1);
@@ -1809,19 +1809,13 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
-    public void generateElasticChangeEvents(int oldPartitionCnt, int newPartitionCnt, long txnId, long spHandle, long uniqueId) {
-//        Enable this code and fix up generateDREvent in DRTuplestream once the DR ReplicatedTable Stream has been removed
-//        if (m_partitionId >= oldPartitionCnt) {
-//            generateDREvent(
-//                    EventType.DR_STREAM_START, uniqueId, m_lastCommittedSpHandle, spHandle, new byte[0]);
-//        }
-//        else {
-            ByteBuffer paramBuffer = ByteBuffer.allocate(8);
-            paramBuffer.putInt(oldPartitionCnt);
-            paramBuffer.putInt(newPartitionCnt);
-            generateDREvent(
-                    EventType.DR_ELASTIC_CHANGE, txnId, uniqueId, m_lastCommittedSpHandle, spHandle, paramBuffer.array());
-//        }
+    public void generateElasticChangeEvents(int oldPartitionCnt, int newPartitionCnt, long txnId, long spHandle,
+            long uniqueId) {
+        ByteBuffer paramBuffer = ByteBuffer.allocate(8);
+        paramBuffer.putInt(oldPartitionCnt);
+        paramBuffer.putInt(newPartitionCnt);
+        generateDREvent(EventType.DR_ELASTIC_CHANGE, txnId, uniqueId, m_lastCommittedSpHandle, spHandle,
+                paramBuffer.array());
     }
 
     @Override


### PR DESCRIPTION
* Avoid throwing RejectedExecutionException out of logger after executor shutsdown
* Correct DRConsumerDrIdTracker.toShortString to include both sp and mp unique ID
* Remove some dangling code for removal of replicated stream