### PR TITLE
ENG-14537: Do not return success when there is no logId

### DIFF
--- a/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
+++ b/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
@@ -50,6 +50,11 @@ import com.google_voltpatches.common.collect.TreeRangeSet;
 public class DRConsumerDrIdTracker implements Serializable {
     private static final long serialVersionUID = -4057397384030151271L;
 
+    /** The offset at which {@link #m_lastSpUniqueId} can be found in the result of {@link #serialize(ByteBuffer)} */
+    public static final int LAST_SP_UNIQUE_ID_OFFSET = 0;
+    /** The offset at which {@link #m_lastMpUniqueId} can be found in the result of {@link #serialize(ByteBuffer)} */
+    public static final int LAST_MP_UNIQUE_ID_OFFSET = LAST_SP_UNIQUE_ID_OFFSET + Long.BYTES;
+
     protected RangeSet<Long> m_map;
     private long m_lastSpUniqueId;
     private long m_lastMpUniqueId;

--- a/src/frontend/org/voltdb/DRIdempotencyResult.java
+++ b/src/frontend/org/voltdb/DRIdempotencyResult.java
@@ -18,17 +18,25 @@
 package org.voltdb;
 
 public enum DRIdempotencyResult {
-    SUCCESS((byte) 0),    // Is the expect next DR ID
-    DUPLICATE((byte) -1), // Is a duplicate DR ID seen before
-    GAP((byte) 1);        // Is way in the future
+    SUCCESS((byte) 0, false),    // Is the expected next DR ID
+    DUPLICATE((byte) -1, true),  // Is a duplicate DR ID seen before
+    GAP((byte) 1, true),         // Is way in the future
+    AMBIGUOUS((byte) -2, false); // DR was applied to a new partition that did not have a tracker
 
     private final byte m_id;
-    DRIdempotencyResult(byte id) {
+    private final boolean m_failure;
+
+    DRIdempotencyResult(byte id, boolean failure) {
         m_id = id;
+        m_failure = failure;
     }
 
     public byte id() {
         return m_id;
+    }
+
+    public boolean isFailure() {
+        return m_failure;
     }
 
     public static DRIdempotencyResult fromID(byte id) {
@@ -38,6 +46,8 @@ public enum DRIdempotencyResult {
             return DUPLICATE;
         } else if (GAP.id() == id) {
             return GAP;
+        } else if (AMBIGUOUS.id() == id) {
+            return AMBIGUOUS;
         } else {
             throw new IllegalArgumentException("Invalid DRIdempotencyResult ID " + id);
         }


### PR DESCRIPTION
When a partition is first created it might not have logIds for some partitions. Previously that was considered a success which means some sites can return success because of this and others can return GAP or DUPLICATE. With the additional enforcement that all results must be the same this is an issue. Add a new result AMBIGUOUS to specify when a site didn't have a logId for a transaction.