### PR TITLE
Correct and simplify NodeStateTracker

### DIFF
--- a/src/frontend/org/voltdb/Inits.java
+++ b/src/frontend/org/voltdb/Inits.java
@@ -111,8 +111,9 @@ public class Inits {
                 catch (InterruptedException e) {
                     VoltDB.crashLocalVoltDB(e.getMessage(), true, e);
                 }
-                if (iw instanceof COMPLETION_WORK)
+                if (iw instanceof COMPLETION_WORK) {
                     return;
+                }
                 //hostLog.info("Running InitWorker: " + iw.getClass().getName());
                 iw.run();
                 completeInitWork(iw);
@@ -135,8 +136,12 @@ public class Inits {
         Class<?>[] declaredClasses = Inits.class.getDeclaredClasses();
         for (Class<?> cls : declaredClasses) {
             // skip base classes and fake classes
-            if (cls == InitWork.class) continue;
-            if (cls == COMPLETION_WORK.class) continue;
+            if (cls == InitWork.class) {
+                continue;
+            }
+            if (cls == COMPLETION_WORK.class) {
+                continue;
+            }
 
             if (InitWork.class.isAssignableFrom(cls)) {
                 InitWork instance = null;
@@ -395,8 +400,9 @@ public class Inits {
                 VoltDB.crashLocalVoltDB("Unable to load catalog", false, e);
             }
 
-            if ((serializedCatalog == null) || (serializedCatalog.length() == 0))
+            if ((serializedCatalog == null) || (serializedCatalog.length() == 0)) {
                 VoltDB.crashLocalVoltDB("Catalog loading failure", false, null);
+            }
 
             /* N.B. node recovery requires discovering the current catalog version. */
             Catalog catalog = new Catalog();
@@ -600,8 +606,9 @@ public class Inits {
             int adminPort = VoltDB.DEFAULT_ADMIN_PORT;
 
             // allow command line override
-            if (m_config.m_adminPort > 0)
+            if (m_config.m_adminPort > 0) {
                 adminPort = m_config.m_adminPort;
+            }
             // other places might use config to figure out the port
             m_config.m_adminPort = adminPort;
             //Allow cli to set admin mode otherwise use whats in deployment for backward compatibility
@@ -777,7 +784,7 @@ public class Inits {
                 // Generate plans and get (hostID, catalogPath) pair
                 Pair<Integer,String> catalog = m_rvdb.m_restoreAgent.findRestoreCatalog();
                 if (catalog != null) {
-                    m_statusTracker.setNodeState(NodeState.RECOVERING);
+                    m_statusTracker.set(NodeState.RECOVERING);
                 }
                 // if the restore agent found a catalog, set the following info
                 // so the right node can send it out to the others.

--- a/src/frontend/org/voltdb/NodeStateTracker.java
+++ b/src/frontend/org/voltdb/NodeStateTracker.java
@@ -25,37 +25,12 @@ import com.google_voltpatches.common.base.Supplier;
 /**
  * Class that aides in the tracking of a VoltDB node state.
  */
-public class NodeStateTracker {
-
-    private final AtomicReference<NodeState> nodeState = new AtomicReference<>(NodeState.INITIALIZING);
-
+public class NodeStateTracker extends AtomicReference<NodeState> {
     public NodeStateTracker() {
+        super(NodeState.INITIALIZING);
     }
 
-    static class NodeStateSupplier implements Supplier<NodeState> {
-        private final AtomicReference<NodeState> ref;
-        private NodeStateSupplier(AtomicReference<NodeState> ref) {
-            this.ref = ref;
-        }
-        @Override
-        public NodeState get() {
-            return ref.get();
-        }
-    }
-
-    public Supplier<NodeState> getNodeStateSupplier() {
-        return new NodeStateSupplier(nodeState);
-    }
-
-    public boolean setNodeState(NodeState update) {
-        return compareAndSetNodeState(nodeState.get(), update);
-    }
-
-    public boolean compareAndSetNodeState(NodeState expect, NodeState update) {
-        return nodeState.compareAndSet(expect, update);
-    }
-
-    public NodeState getNodeState() {
-        return nodeState.get();
+    public Supplier<NodeState> getSupplier() {
+        return this::get;
     }
 }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1067,7 +1067,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_joining = m_config.m_startAction == StartAction.JOIN;
 
             if (m_rejoining || m_joining) {
-                m_statusTracker.setNodeState(NodeState.REJOINING);
+                m_statusTracker.set(NodeState.REJOINING);
             }
             //Register dummy agents immediately
             m_opsRegistrar.registerMailboxes(m_messenger);
@@ -3044,7 +3044,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 .hostCountSupplier(hostCountSupplier)
                 .kfactor(clusterType.getKfactor())
                 .paused(m_config.m_isPaused)
-                .nodeStateSupplier(m_statusTracker.getNodeStateSupplier())
+                .nodeStateSupplier(m_statusTracker.getSupplier())
                 .addAllowed(m_config.m_enableAdd)
                 .safeMode(m_config.m_safeMode)
                 .terminusNonce(getTerminusNonce())
@@ -3365,7 +3365,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         // Start the rejoin coordinator
         if (m_joinCoordinator != null) {
             try {
-                m_statusTracker.setNodeState(NodeState.REJOINING);
+                m_statusTracker.set(NodeState.REJOINING);
                 if (!m_joinCoordinator.startJoin(m_catalogContext.database)) {
                     VoltDB.crashLocalVoltDB("Failed to join the cluster", true, null);
                 }
@@ -3682,7 +3682,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             synchronized(m_catalogUpdateLock) {
                 final ReplicationRole oldRole = getReplicationRole();
 
-                m_statusTracker.setNodeState(NodeState.UPDATING);
+                m_statusTracker.set(NodeState.UPDATING);
                 if (m_catalogContext.catalogVersion != expectedCatalogVersion) {
                     if (m_catalogContext.catalogVersion < expectedCatalogVersion) {
                         throw new RuntimeException("Trying to update main catalog context with diff " +
@@ -3852,7 +3852,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
         } finally {
             //Set state back to UP
-            m_statusTracker.setNodeState(NodeState.UP);
+            m_statusTracker.set(NodeState.UP);
         }
     }
 
@@ -4160,7 +4160,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             VoltDB.crashLocalVoltDB("Unable to log host rejoin completion to ZK", true, e);
         }
         hostLog.info("Logging host rejoin completion to ZK");
-        m_statusTracker.setNodeState(NodeState.UP);
+        m_statusTracker.set(NodeState.UP);
         Object args[] = { (VoltDB.instance().getMode() == OperationMode.PAUSED) ? "PAUSED" : "NORMAL"};
         consoleLog.l7dlog( Level.INFO, LogKeys.host_VoltDB_ServerOpMode.name(), args, null);
         consoleLog.l7dlog( Level.INFO, LogKeys.host_VoltDB_ServerCompletedInitialization.name(), null, null);
@@ -4185,13 +4185,13 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             if (mode == OperationMode.PAUSED)
             {
                 m_config.m_isPaused = true;
-                m_statusTracker.setNodeState(NodeState.PAUSED);
+                m_statusTracker.set(NodeState.PAUSED);
                 hostLog.info("Server is entering admin mode and pausing.");
             }
             else if (m_mode == OperationMode.PAUSED)
             {
                 m_config.m_isPaused = false;
-                m_statusTracker.setNodeState(NodeState.UP);
+                m_statusTracker.set(NodeState.UP);
                 hostLog.info("Server is exiting admin mode and resuming operation.");
             }
         }
@@ -4362,7 +4362,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             Object args[] = { (m_mode == OperationMode.PAUSED) ? "PAUSED" : "NORMAL"};
             consoleLog.l7dlog( Level.INFO, LogKeys.host_VoltDB_ServerOpMode.name(), args, null);
             consoleLog.l7dlog( Level.INFO, LogKeys.host_VoltDB_ServerCompletedInitialization.name(), null, null);
-            m_statusTracker.setNodeState(NodeState.UP);
+            m_statusTracker.set(NodeState.UP);
         } else {
             // Set m_mode to RUNNING
             databaseIsRunning();


### PR DESCRIPTION
NodeStateTracker.setNodeStatus could fail but no callers were checking
for failure. Simplify NodeStateTracker to be a type safe AtomicReference
with a utility method to get a Supplier.