### PR TITLE
remove old features legacy-compile and create from run.sh,

### DIFF
--- a/tests/test_apps/genqa/build.xml
+++ b/tests/test_apps/genqa/build.xml
@@ -2,6 +2,7 @@
 <project name="genqa" basedir="." default="all">
 
     <property name="procedures.dir"     value="${basedir}/src/genqa/procedures"/>
+    <property name="procedures2.dir"     value="${basedir}/src/genqa2/procedures"/>
     <property name="clientsrc.dir"     value="${basedir}/src/genqa"/>
 
     <property name="build.dir"   value="build"/>
@@ -54,6 +55,9 @@
     <target name="procedures-compile">
         <mkdir dir="${proceduresclasses.dir}"/>
         <javac debug="on" srcdir="${procedures.dir}" destdir="${proceduresclasses.dir}">
+            <classpath refid="build-classpath"/>
+        </javac>
+        <javac debug="on" srcdir="${procedures2.dir}" destdir="${proceduresclasses.dir}">
             <classpath refid="build-classpath"/>
         </javac>
     </target>

--- a/tests/test_apps/genqa/ddl-all-nocat-stream.sql
+++ b/tests/test_apps/genqa/ddl-all-nocat-stream.sql
@@ -1,0 +1,417 @@
+load classes sp.jar;
+
+file -inlinebatch END_OF_BATCH
+
+-- Partitioned Data Table
+CREATE TABLE partitioned_table
+(
+  rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+, PRIMARY KEY (rowid)
+);
+PARTITION TABLE partitioned_table ON COLUMN rowid;
+
+-- Index over rowid_group on Partitioned Data Table
+CREATE INDEX IX_partitioned_table_rowid_group
+    ON partitioned_table ( rowid_group );
+
+-- Grouping view over Partitioned Data Table
+CREATE VIEW partitioned_table_group
+(
+  rowid_group
+, record_count
+)
+AS
+   SELECT rowid_group
+        , COUNT(*)
+     FROM partitioned_table
+ GROUP BY rowid_group;
+
+-- Export Table for Partitioned Data Table deletions
+CREATE STREAM export_partitioned_stream PARTITION ON COLUMN rowid EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+
+CREATE STREAM export_partitioned_stream_foo PARTITION ON COLUMN rowid EXPORT TO TARGET foo
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+
+CREATE STREAM export_partitioned_stream2 PARTITION ON COLUMN rowid export to target default
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+
+CREATE TABLE export_mirror_partitioned_table
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+PARTITION TABLE export_mirror_partitioned_table ON COLUMN rowid;
+
+CREATE TABLE export_mirror_partitioned_table2
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+PARTITION TABLE export_mirror_partitioned_table2 ON COLUMN rowid;
+
+CREATE STREAM export_done_stream PARTITION ON COLUMN txnid EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+);
+
+CREATE STREAM export_done_stream_foo PARTITION ON COLUMN txnid EXPORT TO TARGET foo
+(
+  txnid                     BIGINT        NOT NULL
+);
+
+-- Replicated Table
+CREATE TABLE replicated_table
+(
+  rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+, PRIMARY KEY (rowid)
+);
+
+-- Index over rowid_group on Replicated Data Table
+CREATE INDEX IX_replicated_table_rowid_group
+    ON replicated_table ( rowid_group );
+
+-- Grouping view over Replicated Data Table
+CREATE VIEW replicated_table_group
+(
+  rowid_group
+, record_count
+)
+AS
+   SELECT rowid_group
+        , COUNT(*)
+     FROM replicated_table
+ GROUP BY rowid_group;
+
+-- Export Table for Replicated Data Table deletions
+CREATE STREAM  export_replicated_stream EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+
+CREATE STREAM export_replicated_stream_foo EXPORT TO TARGET foo
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+
+
+CREATE STREAM export_skinny_partitioned_stream  PARTITION ON COLUMN rowid EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+);
+
+CREATE STREAM export_skinny_partitioned_stream_foo PARTITION ON COLUMN rowid EXPORT TO TARGET foo
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+);
+
+CREATE STREAM export_skinny_partitioned_stream2 PARTITION ON COLUMN rowid export to target default
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+);
+
+
+CREATE PROCEDURE FROM CLASS genqa.procedures.JiggleSkinnyExportSinglePartition;
+CREATE PROCEDURE PARTITION ON TABLE partitioned_table COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.JiggleSinglePartition;
+CREATE PROCEDURE FROM CLASS genqa.procedures.JiggleMultiPartition;
+CREATE PROCEDURE PARTITION ON TABLE partitioned_table COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.JiggleSinglePartitionWithDeletionExport;
+CREATE PROCEDURE FROM CLASS genqa.procedures.JiggleMultiPartitionWithDeletionExport;
+CREATE PROCEDURE PARTITION ON TABLE export_partitioned_stream COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.JiggleExportSinglePartition;
+CREATE PROCEDURE PARTITION ON TABLE export_partitioned_stream COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.JiggleExportGroupSinglePartition;
+CREATE PROCEDURE FROM CLASS genqa.procedures.JiggleExportMultiPartition;
+CREATE PROCEDURE PARTITION ON TABLE partitioned_table COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.WaitSinglePartition;
+CREATE PROCEDURE FROM CLASS genqa.procedures.WaitMultiPartition;
+CREATE PROCEDURE PARTITION ON TABLE export_done_stream COLUMN txnid PARAMETER 0 FROM CLASS genqa.procedures.JiggleExportDoneTable;
+CREATE PROCEDURE PARTITION ON TABLE export_done_stream COLUMN txnid PARAMETER 0 FROM CLASS genqa.procedures.JiggleExportGroupDoneTable;
+
+CREATE PROCEDURE SelectwithLimit as select * from export_mirror_partitioned_table where rowid between ? and ? order by rowid limit ?;
+
+-- CREATE PROCEDURE FROM CLASS genqa2.procedures.JiggleSkinnyExportSinglePartition;
+-- CREATE PROCEDURE PARTITION ON TABLE export_partitioned_table2 COLUMN rowid PARAMETER 0 FROM CLASS genqa2.procedures.JiggleExportSinglePartition;
+-- CREATE PROCEDURE PARTITION ON TABLE export_done_table COLUMN txnid PARAMETER 0 FROM CLASS genqa2.procedures.JiggleExportDoneTable;
+
+-- Export Stream with extra Geo columns
+CREATE STREAM export_geo_partitioned_stream PARTITION ON COLUMN rowid EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+, type_null_geography       GEOGRAPHY(1024)
+, type_not_null_geography   GEOGRAPHY(1024)   NOT NULL
+, type_null_geography_point GEOGRAPHY_POINT
+, type_not_null_geography_point GEOGRAPHY_POINT NOT NULL
+
+);
+
+-- should be an exact copy of the stream. Used for verifiing
+-- export stream contents.
+CREATE TABLE export_geo_mirror_partitioned_table
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+, type_null_geography       GEOGRAPHY(1024)
+, type_not_null_geography   GEOGRAPHY(1024)   NOT NULL
+, type_null_geography_point GEOGRAPHY_POINT
+, type_not_null_geography_point GEOGRAPHY_POINT NOT NULL
+);
+PARTITION TABLE export_geo_mirror_partitioned_table ON COLUMN rowid;
+
+CREATE STREAM export_geo_done_table PARTITION ON COLUMN txnid EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+);
+
+
+-- this is analogous to JiggleExportSinglePartition to insert tuples, but has the extra 4 geo columns
+CREATE PROCEDURE PARTITION ON TABLE export_geo_partitioned_stream COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.JiggleExportGeoSinglePartition;
+
+-- this is used by the verifier inside JDBCGetData, re-point to the geo tables
+-- DROP PROCEDURE SelectwithLimit IF EXISTS;
+-- CREATE PROCEDURE SelectwithLimit as select * from export_geo_mirror_partitioned_table where rowid between ? and ? order by rowid limit ?;
+
+
+END_OF_BATCH

--- a/tests/test_apps/genqa/ddl-all-nocat.sql
+++ b/tests/test_apps/genqa/ddl-all-nocat.sql
@@ -1,0 +1,417 @@
+load classes sp.jar;
+
+file -inlinebatch END_OF_BATCH
+
+-- Partitioned Data Table
+CREATE TABLE partitioned_table
+(
+  rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+, PRIMARY KEY (rowid)
+);
+PARTITION TABLE partitioned_table ON COLUMN rowid;
+
+-- Index over rowid_group on Partitioned Data Table
+CREATE INDEX IX_partitioned_table_rowid_group
+    ON partitioned_table ( rowid_group );
+
+-- Grouping view over Partitioned Data Table
+CREATE VIEW partitioned_table_group
+(
+  rowid_group
+, record_count
+)
+AS
+   SELECT rowid_group
+        , COUNT(*)
+     FROM partitioned_table
+ GROUP BY rowid_group;
+
+-- Export Table for Partitioned Data Table deletions
+CREATE STREAM export_partitioned_table PARTITION ON COLUMN rowid EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+
+CREATE STREAM export_partitioned_table_foo PARTITION ON COLUMN rowid EXPORT TO TARGET foo
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+
+CREATE STREAM export_partitioned_table2 PARTITION ON COLUMN rowid export to target default
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+
+CREATE TABLE export_mirror_partitioned_table
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+PARTITION TABLE export_mirror_partitioned_table ON COLUMN rowid;
+
+CREATE TABLE export_mirror_partitioned_table2
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+PARTITION TABLE export_mirror_partitioned_table2 ON COLUMN rowid;
+
+CREATE STREAM export_done_table PARTITION ON COLUMN txnid EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+);
+
+CREATE STREAM export_done_table_foo PARTITION ON COLUMN txnid EXPORT TO TARGET foo
+(
+  txnid                     BIGINT        NOT NULL
+);
+
+-- Replicated Table
+CREATE TABLE replicated_table
+(
+  rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+, PRIMARY KEY (rowid)
+);
+
+-- Index over rowid_group on Replicated Data Table
+CREATE INDEX IX_replicated_table_rowid_group
+    ON replicated_table ( rowid_group );
+
+-- Grouping view over Replicated Data Table
+CREATE VIEW replicated_table_group
+(
+  rowid_group
+, record_count
+)
+AS
+   SELECT rowid_group
+        , COUNT(*)
+     FROM replicated_table
+ GROUP BY rowid_group;
+
+-- Export Table for Replicated Data Table deletions
+CREATE STREAM  export_replicated_table EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+
+CREATE STREAM export_replicated_table_foo EXPORT TO TARGET foo
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+);
+
+
+CREATE STREAM export_skinny_partitioned_table  PARTITION ON COLUMN rowid EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+);
+
+CREATE STREAM export_skinny_partitioned_table_foo PARTITION ON COLUMN rowid EXPORT TO TARGET foo
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+);
+
+CREATE STREAM export_skinny_partitioned_table2 PARTITION ON COLUMN rowid export to target default
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+);
+
+
+CREATE PROCEDURE FROM CLASS genqa.procedures.JiggleSkinnyExportSinglePartition;
+CREATE PROCEDURE PARTITION ON TABLE partitioned_table COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.JiggleSinglePartition;
+CREATE PROCEDURE FROM CLASS genqa.procedures.JiggleMultiPartition;
+CREATE PROCEDURE PARTITION ON TABLE partitioned_table COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.JiggleSinglePartitionWithDeletionExport;
+CREATE PROCEDURE FROM CLASS genqa.procedures.JiggleMultiPartitionWithDeletionExport;
+CREATE PROCEDURE PARTITION ON TABLE export_partitioned_table COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.JiggleExportSinglePartition;
+CREATE PROCEDURE PARTITION ON TABLE export_partitioned_table COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.JiggleExportGroupSinglePartition;
+CREATE PROCEDURE FROM CLASS genqa.procedures.JiggleExportMultiPartition;
+CREATE PROCEDURE PARTITION ON TABLE partitioned_table COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.WaitSinglePartition;
+CREATE PROCEDURE FROM CLASS genqa.procedures.WaitMultiPartition;
+CREATE PROCEDURE PARTITION ON TABLE export_done_table COLUMN txnid PARAMETER 0 FROM CLASS genqa.procedures.JiggleExportDoneTable;
+CREATE PROCEDURE PARTITION ON TABLE export_done_table COLUMN txnid PARAMETER 0 FROM CLASS genqa.procedures.JiggleExportGroupDoneTable;
+
+CREATE PROCEDURE SelectwithLimit as select * from export_mirror_partitioned_table where rowid between ? and ? order by rowid limit ?;
+
+-- CREATE PROCEDURE FROM CLASS genqa2.procedures.JiggleSkinnyExportSinglePartition;
+-- CREATE PROCEDURE PARTITION ON TABLE export_partitioned_table2 COLUMN rowid PARAMETER 0 FROM CLASS genqa2.procedures.JiggleExportSinglePartition;
+-- CREATE PROCEDURE PARTITION ON TABLE export_done_table COLUMN txnid PARAMETER 0 FROM CLASS genqa2.procedures.JiggleExportDoneTable;
+
+-- Export Stream with extra Geo columns
+CREATE STREAM export_geo_partitioned_table PARTITION ON COLUMN rowid EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+, type_null_geography       GEOGRAPHY(1024)
+, type_not_null_geography   GEOGRAPHY(1024)   NOT NULL
+, type_null_geography_point GEOGRAPHY_POINT
+, type_not_null_geography_point GEOGRAPHY_POINT NOT NULL
+
+);
+
+-- should be an exact copy of the stream. Used for verifiing
+-- export stream contents.
+CREATE TABLE export_geo_mirror_partitioned_table
+(
+  txnid                     BIGINT        NOT NULL
+, rowid                     BIGINT        NOT NULL
+, rowid_group               TINYINT       NOT NULL
+, type_null_tinyint         TINYINT
+, type_not_null_tinyint     TINYINT       NOT NULL
+, type_null_smallint        SMALLINT
+, type_not_null_smallint    SMALLINT      NOT NULL
+, type_null_integer         INTEGER
+, type_not_null_integer     INTEGER       NOT NULL
+, type_null_bigint          BIGINT
+, type_not_null_bigint      BIGINT        NOT NULL
+, type_null_timestamp       TIMESTAMP
+, type_not_null_timestamp   TIMESTAMP     NOT NULL
+, type_null_decimal         DECIMAL
+, type_not_null_decimal     DECIMAL       NOT NULL
+, type_null_float           FLOAT
+, type_not_null_float       FLOAT         NOT NULL
+, type_null_varchar25       VARCHAR(32)
+, type_not_null_varchar25   VARCHAR(32)   NOT NULL
+, type_null_varchar128      VARCHAR(128)
+, type_not_null_varchar128  VARCHAR(128)  NOT NULL
+, type_null_varchar1024     VARCHAR(1024)
+, type_not_null_varchar1024 VARCHAR(1024) NOT NULL
+, type_null_geography       GEOGRAPHY(1024)
+, type_not_null_geography   GEOGRAPHY(1024)   NOT NULL
+, type_null_geography_point GEOGRAPHY_POINT
+, type_not_null_geography_point GEOGRAPHY_POINT NOT NULL
+);
+PARTITION TABLE export_geo_mirror_partitioned_table ON COLUMN rowid;
+
+CREATE STREAM export_geo_done_table PARTITION ON COLUMN txnid EXPORT TO TARGET abc
+(
+  txnid                     BIGINT        NOT NULL
+);
+
+
+-- this is analogous to JiggleExportSinglePartition to insert tuples, but has the extra 4 geo columns
+CREATE PROCEDURE PARTITION ON TABLE export_geo_partitioned_table COLUMN rowid PARAMETER 0 FROM CLASS genqa.procedures.JiggleExportGeoSinglePartition;
+
+-- this is used by the verifier inside JDBCGetData, re-point to the geo tables
+-- DROP PROCEDURE SelectwithLimit IF EXISTS;
+-- CREATE PROCEDURE SelectwithLimit as select * from export_geo_mirror_partitioned_table where rowid between ? and ? order by rowid limit ?;
+
+
+END_OF_BATCH

--- a/tests/test_apps/genqa/deployment-kafka.xml
+++ b/tests/test_apps/genqa/deployment-kafka.xml
@@ -6,8 +6,8 @@
     <httpd port="8080">
         <jsonapi enabled="true"/>
     </httpd>
-    <export enabled="true" target="kafka">
-        <configuration>
+    <export>
+        <configuration enabled="true" target="abc" type="kafka">
             <property name="metadata.broker.list">kafka1:9092</property>
             <property name="producer.type">async</property>
             <property name="request.required.acks">1</property>

--- a/tests/test_apps/genqa/deployment-rabbitmq.xml
+++ b/tests/test_apps/genqa/deployment-rabbitmq.xml
@@ -6,8 +6,8 @@
     <httpd port="8080">
         <jsonapi enabled="true"/>
     </httpd>
-    <export enabled="true" target="rabbitmq">
-        <configuration>
+    <export>
+        <configuration enabled="true" target="abc" type="rabbitmq">
             <property name="broker.host">kafka1</property>
             <property name="username">test</property>
             <property name="password">test</property>

--- a/tests/test_apps/genqa/deployment.xml
+++ b/tests/test_apps/genqa/deployment.xml
@@ -4,8 +4,8 @@
     <httpd enabled="true">
         <jsonapi enabled="true" />
     </httpd>
-    <export enabled="true" target="file">
-        <configuration>
+    <export>
+        <configuration enabled="true" target="file">
             <property name="type">csv</property>
             <property name="with-schema">false</property>
             <property name="batched">false</property>

--- a/tests/test_apps/genqa/deployment_custom.xml
+++ b/tests/test_apps/genqa/deployment_custom.xml
@@ -4,8 +4,8 @@
     <httpd enabled="true">
         <jsonapi enabled="true" />
     </httpd>
-    <export enabled="true" target="custom" exportconnectorclass="customexport.OverflowingServerExportClient" >
-        <configuration>
+    <export>
+        <configuration enabled="true" target="abc" type="custom" exportconnectorclass="customexport.OverflowingServerExportClient">
             <property name="drain">true</property>
         </configuration>
     </export>

--- a/tests/test_apps/genqa/deployment_mysql.xml
+++ b/tests/test_apps/genqa/deployment_mysql.xml
@@ -4,8 +4,8 @@
     <httpd enabled="true">
         <jsonapi enabled="true" />
     </httpd>
-    <export enabled="true" target="jdbc">
-        <configuration>
+    <export>
+        <configuration enabled="true" target="abc" type="jdbc">
             <property name="jdbcurl">jdbc:mysql://localhost:3306/mysql?zeroDateTimeBehavior=convertToNull</property>
             <property name="jdbcuser">root</property>
             <property name="schema">vexport</property>

--- a/tests/test_apps/genqa/deployment_pg.xml
+++ b/tests/test_apps/genqa/deployment_pg.xml
@@ -5,7 +5,7 @@
         <jsonapi enabled="true" />
     </httpd>
     <export enabled="true" target="jdbc">
-        <configuration>
+        <configuration enabled="true" target="abc" type="jdbc">
             <property name="jdbcurl">jdbc:postgresql://localhost/vexport</property>
             <property name="jdbcuser">vexport</property>
         </configuration>

--- a/tests/test_apps/genqa/deployment_pg_nocat.xml
+++ b/tests/test_apps/genqa/deployment_pg_nocat.xml
@@ -7,7 +7,7 @@
     </httpd>
     -->
     <export>
-        <configuration enabled="true" stream="abc" type="jdbc">
+        <configuration enabled="true" target="abc" type="jdbc">
             <property name="jdbcurl">jdbc:postgresql://localhost/vexport</property>
             <property name="jdbcuser">vexport</property>
             <property name="ignoregenerations">true</property>

--- a/tests/test_apps/genqa/deployment_vertica.xml
+++ b/tests/test_apps/genqa/deployment_vertica.xml
@@ -5,7 +5,7 @@
         <jsonapi enabled="true" />
     </httpd>
     <export>
-        <configuration enabled="true" stream="abc" type="jdbc">
+        <configuration enabled="true" target="abc" type="jdbc">
             <property name="jdbcurl">jdbc:vertica://volt15d:5433/Test1</property>
             <property name="jdbcuser">dbadmin</property>
             <property name="skipinternals">true</property>

--- a/tests/test_apps/genqa/run.sh
+++ b/tests/test_apps/genqa/run.sh
@@ -2,9 +2,6 @@
 
 APPNAME="genqa"
 APPNAME2="genqa2"
-APPNAME3="eggenqa"
-APPNAME4="eggenqa2"
-APPNAME_EXPORT="genqa_nocat"
 
 # find voltdb binaries in either installation or distribution directory.
 if [ -n "$(which voltdb 2> /dev/null)" ]; then
@@ -37,7 +34,10 @@ CLASSPATH=$({ \
 # ZK Jars needed to compile kafka verifier. Apprunner uses a nfs shared path.
 ZKCP=${ZKLIB:-"/home/opt/kafka/libs"}
 RBMQ=${RBMQLIB:-"/home/opt/rabbitmq"}
-CLASSPATH="$CLASSPATH:$ZKCP/zkclient-0.3.jar:$ZKCP/zookeeper-3.3.4.jar:$RBMQ/rabbitmq.jar:vertica-jdbc.jar"
+MYSQLLIB=${MYSQLLIB:-"/home/opt/mysql.jar"}
+VERTICALIB=${VERTICALIB:-"/home/opt/vertica-jdbc.jar"}
+POSTGRESLIB=${POSTGRESLIB:="/home/opt/postgresql.jar"}
+CLASSPATH="$CLASSPATH:$ZKCP/zkclient-0.3.jar:$ZKCP/zookeeper-3.3.4.jar:$RBMQ/rabbitmq.jar:vertica-jdbc.jar:$MYSQLLIB"
 VOLTDB="$VOLTDB_BIN/voltdb"
 LOG4J="$VOLTDB_VOLTDB/log4j.xml"
 LICENSE="$VOLTDB_VOLTDB/license.xml"
@@ -48,14 +48,25 @@ CLIENTLOG="clientlog"
 
 # remove build artifacts
 function clean() {
-    rm -rf obj debugoutput $APPNAME.jar $APPNAME2.jar $APPNAME3.jar $APPNAME4.jar $APPNAME_EXPORT.jar voltdbroot voltdbroot
+    rm -rf obj debugoutput $APPNAME.jar $APPNAME2.jar sp.jar voltdbroot voltdbroot genqa.jar genqq2.jar eggenqa.jar eggenqa2.jar genqa_nocat.jar
     rm -f $VOLTDB_LIB/extension/customexport.jar
 }
 
 # compile the source code for procedures and the client
 function srccompile() {
+    # this will create a sp.jar file
     ant -f build.xml
+
+    # these are deprecated and necessary for legacy test coverage in older apps.
+    cp sp.jar genqa.jar
+    cp sp.jar genqa2.jar
+    cp sp.jar eggenqa.jar
+    cp sp.jar eggenqa2.jar
+    cp sp.jar genqa_nocat.jar
+
+    # this is needed for the customexporter
     mkdir -p obj
+
     javac -classpath $CLASSPATH -d obj \
         src/$APPNAME/*.java \
         src/$APPNAME/procedures/*.java
@@ -69,26 +80,15 @@ function srccompile() {
 }
 
 # build an application catalog
-function catalog() {
+function jars() {
     srccompile
-    #cmd="$VOLTDB compile --classpath obj -o $APPNAME_EXPORT.jar ddl-nocat.sql"
-    #echo $cmd; $cmd
-    cmd="$VOLTDB legacycompile --classpath obj -o $APPNAME.jar ddl.sql"
-    echo $cmd; $cmd
-    cmd="$VOLTDB legacycompile --classpath obj -o $APPNAME2.jar ddl2.sql"
-    echo $cmd; $cmd
-    cmd="$VOLTDB legacycompile --classpath obj -o $APPNAME3.jar ddl3.sql"
-    echo $cmd; $cmd
-    cmd="$VOLTDB legacycompile --classpath obj -o $APPNAME4.jar ddl4.sql"
-    echo $cmd; $cmd
-    #jar cvf sp.jar obj/*
 
     # stop if compilation fails
     rm -rf $EXPORTDATA
     mkdir $EXPORTDATA
     rm -fR $CLIENTLOG
     mkdir $CLIENTLOG
-    if [ $? != 0 ]; then exit; fi
+    if [ $? != 0 ]; then exit -1; fi
 }
 
 function wait-for-create() {
@@ -101,43 +101,39 @@ function wait-for-create() {
 }
 
 # run the voltdb server locally
+function startvolt() {
+    $VOLTDB init -C $1 -s $2 -j $3 --force
+    $VOLTDB start  -l $LICENSE &
+    wait-for-create
+}
+
 function server() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
-    $VOLTDB create -d deployment.xml -l $LICENSE -H $HOST $APPNAME.jar
+    startvolt deployment.xml ddl-all-nocat.sql sp.jar
+
 }
 
 # run the voltdb server locally with kafka connector
 function server-kafka() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
-    $VOLTDB create -d deployment-kafka.xml -l $LICENSE -H $HOST $APPNAME.jar
+    startvolt deployment-kafka.xml ddl-all-nocat.sql sp.jar
 }
 
 function server-rabbitmq() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
-    $VOLTDB create -d deployment-rabbitmq.xml -l $LICENSE -H $HOST $APPNAME.jar
+    cp $RBMQ/rabbitmq.jar $VOLTDB_LIB/extension/
+    cp ../../../../export-rabbitmq/voltdb-rabbitmq.jar $VOLTDB_LIB/extension/
+    startvolt deployment-rabbitmq.xml ddl-all-nocat.sql sp.jar
 }
 
 # run the voltdb server locally with mysql connector
 function server-mysql() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
-    $VOLTDB create -d deployment_mysql.xml -l $LICENSE -H $HOST $APPNAME.jar
+    cp $MYSQLLIB $VOLTDB_LIB/extension/
+    startvolt deployment_mysql.xml ddl-all-nocat.sql sp.jar
 }
 
 
 # run the voltdb server locally with vertica connector
 function server-vertica() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
-    $VOLTDB create -d deployment_vertica.xml -l $LICENSE -H $HOST $APPNAME.jar
+    cp $VERTICALIB $VOLTDB_LIB/extension/
+    startvolt deployment_vertica.xml ddl-all-nocat.sql sp.jar
 }
 
 # run the voltdb server locally with postgresql connector
@@ -151,16 +147,8 @@ function server-vertica() {
 # ./run.sh stop-postgres;
 
 function server-pg() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
-
-    #$VOLTDB create --force -d deployment_pg.xml -l $LICENSE -H $HOST $APPNAME.jar
-
-    $VOLTDB create --force -d deployment_pg_nocat.xml -l $LICENSE -H $HOST &
-    sleep 5
-    wait-for-create
-    $VOLTDB_BIN/sqlcmd < ddl-nocat.sql
+    cp $POSTGRESLIB $VOLTDB_LIB/extension/
+    startvolt deployment_pg_nocat.xml ddl-all-nocat.sql sp.jar
 }
 
 # to run the postgres jdbc geo export test manually:
@@ -173,61 +161,22 @@ function server-pg() {
 # ./run.sh stop-postgres;
 
 function server-pg-geo() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
+    cp $POSTGRESLIB $VOLTDB_LIB/extension/
+    startvolt deployment_pg_nocat.xml ddl-all-nocat-geo.sql sp.jar
 
-    #$VOLTDB create --force -d deployment_pg.xml -l $LICENSE -H $HOST $APPNAME.jar
-
-    $VOLTDB create --force -d deployment_pg_nocat.xml -l $LICENSE -H $HOST &
-    sleep 5
-    wait-for-create
-    $VOLTDB_BIN/sqlcmd < ddl-nocat-geo.sql
-
-}
-
-# run the voltdb server locally
-function server-legacy() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
-    $VOLTDB create -d deployment_legacy.xml -l $LICENSE -H $HOST $APPNAME.jar
 }
 
 function server-custom() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
+    if [ ! -f $APPNAME.jar ]; then jars; fi
     # Get custom class in jar
     cd obj
     jar cvf ../customexport.jar customexport/*
     cd ..
     cp customexport.jar $VOLTDB_LIB/extension/customexport.jar
     # run the server
-    $VOLTDB create -d deployment_custom.xml -l $LICENSE -H $HOST $APPNAME.jar
+    #$VOLTDB create -d deployment_custom.xml -l $LICENSE -H $HOST $APPNAME.jar
+    startvolt deployment_custom.xml ddl-all-nocat.sql sp.jar
 }
-
-# run the voltdb server locally
-function server1() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
-    $VOLTDB create -d deployment_multinode.xml -l $LICENSE -H $HOST:3021 --internalport=3024 $APPNAME.jar
-}
-
-function server2() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
-    $VOLTDB create -d deployment_multinode.xml -l $LICENSE -H $HOST:21216 --adminport=21215 --internalport=3022 --zkport=2182 $APPNAME.jar
-}
-
-function server3() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
-    # run the server
-    $VOLTDB create -d deployment_multinode.xml -l $LICENSE -H $HOST:3021 --internalport==3023 --adminport=21213 --port=21214 --zkport=2183 $APPNAME.jar
-}
-
 
 # run the client that drives the example
 function client() {
@@ -243,7 +192,7 @@ function async-benchmark-help() {
 
 function async-benchmark() {
     # srccompile
-    echo java -classpath obj:$CLASSPATH:obj genqa.AsyncBenchmark \
+    java -classpath obj:$CLASSPATH:obj genqa.AsyncBenchmark \
         --displayinterval=5 \
         --duration=120 \
         --servers=localhost \
@@ -257,7 +206,7 @@ function async-benchmark() {
 }
 
 function clean-vertica() {
-    echo "drop table export_partitioned_table" | ssh volt15d /opt/vertica/bin/vsql -U dbadmin test1
+    echo "drop stream export_partitioned_stream" | ssh volt15d /opt/vertica/bin/vsql -U dbadmin test1
 }
 
 function async-export() {
@@ -273,7 +222,6 @@ function async-export() {
         --procedure=JiggleExportSinglePartition \
         --poolsize=100000 \
         --autotune=false \
-        --catalogswap=false \
         --latencytarget=10 \
         --ratelimit=500 \
         --timeout=300
@@ -292,7 +240,6 @@ function async-export-geo() {
         --procedure=JiggleExportGeoSinglePartition \
         --poolsize=100000 \
         --autotune=false \
-        --catalogswap=false \
         --latencytarget=10 \
         --ratelimit=500 \
         --timeout=300
@@ -327,7 +274,7 @@ function jdbc-benchmark-help() {
 
 function jdbc-benchmark() {
     # srccompile
-    echo jdbc-benchmark: java -classpath obj:$CLASSPATH:obj genqa.JDBCBenchmark \
+    java -classpath obj:$CLASSPATH:obj genqa.JDBCBenchmark \
         --threads=40 \
         --displayinterval=5 \
         --duration=120 \
@@ -447,13 +394,8 @@ function stop-postgres() {
     fi
 }
 
-# compile the source code for procedures and the client into jarfiles
-function jars() {
-    ant all
-}
-
 function help() {
-    echo "Usage: ./run.sh {clean|catalog|server|async-benchmark|async-benchmark-help|...}"
+    echo "Usage: ./run.sh {clean|jars|server|async-benchmark|async-benchmark-help|...}"
     echo "       {...|sync-benchmark|sync-benchmark-help|jdbc-benchmark|jdbc-benchmark-help}"
 }
 

--- a/tests/test_apps/genqa/src/genqa/AsyncExportClient.java
+++ b/tests/test_apps/genqa/src/genqa/AsyncExportClient.java
@@ -282,7 +282,7 @@ public class AsyncExportClient
                 .add("ratelimit", "rate_limit", "Rate limit to start from (number of transactions per second).", 100000)
                 .add("autotune", "auto_tune", "Flag indicating whether the benchmark should self-tune the transaction rate for a target execution latency (true|false).", "true")
                 .add("latencytarget", "latency_target", "Execution latency to target to tune transaction rate (in milliseconds).", 10)
-                .add("catalogswap", "catlog_swap", "Swap catalogs from the client", "true")
+                .add("catalogswap", "catlog_swap", "Swap catalogs from the client", "false")
                 .add("exportgroups", "export_groups", "Multiple export connections", "false")
                 .add("timeout","export_timeout","max seconds to wait for export to complete",300)
                 .setArguments(args)


### PR DESCRIPTION
This will remove the catalog creation from the run.sh and use voltdb init/start instead of create.  It also creates a single ddl with the combination of all the old ddls ddl.sql ddl2.sql ddl3.sql etc.