### PR TITLE
Send an error response to avoid sqlcmd hanging, and support concurrent default procedures updates

### DIFF
--- a/src/frontend/org/voltdb/DefaultProcedureManager.java
+++ b/src/frontend/org/voltdb/DefaultProcedureManager.java
@@ -20,9 +20,9 @@ package org.voltdb;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.voltdb.CatalogContext.ProcedurePartitionInfo;
 import org.voltdb.catalog.Catalog;
@@ -49,7 +49,7 @@ import org.voltdb.utils.CatalogUtil;
  */
 public class DefaultProcedureManager {
 
-    Map<String, Procedure> m_defaultProcMap = new HashMap<>();
+    Map<String, Procedure> m_defaultProcMap = new ConcurrentHashMap<>();
 
     private final Database m_db;
     // fake db makes it easy to create procedures that aren't

--- a/src/frontend/org/voltdb/DefaultProcedureManager.java
+++ b/src/frontend/org/voltdb/DefaultProcedureManager.java
@@ -49,6 +49,7 @@ import org.voltdb.utils.CatalogUtil;
  */
 public class DefaultProcedureManager {
 
+    // ENG-14639, made concurrent to support LoadedProcedureSet.getNibbleDeleteProc
     Map<String, Procedure> m_defaultProcMap = new ConcurrentHashMap<>();
 
     private final Database m_db;

--- a/src/frontend/org/voltdb/OpsAgent.java
+++ b/src/frontend/org/voltdb/OpsAgent.java
@@ -18,6 +18,7 @@ package org.voltdb;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -270,6 +271,16 @@ public abstract class OpsAgent
                     collectStatsImpl(c, clientHandle, selector, params);
                 } catch (Exception e) {
                     hostLog.warn("Exception while attempting to collect stats", e);
+                    if (e instanceof ConcurrentModificationException) {
+                        sendErrorResponse(c, ClientResponse.GRACEFUL_FAILURE,
+                                "Statistics are unavailable, try again (" + e.getMessage() + ").",
+                                clientHandle);
+                    }
+                    else {
+                        sendErrorResponse(c, ClientResponse.OPERATIONAL_FAILURE,
+                                "Failed to get statistics (" + e.getMessage() + ").",
+                                clientHandle);
+                    }
                 }
             }
         });

--- a/src/frontend/org/voltdb/OpsAgent.java
+++ b/src/frontend/org/voltdb/OpsAgent.java
@@ -18,7 +18,6 @@ package org.voltdb;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -271,16 +270,10 @@ public abstract class OpsAgent
                     collectStatsImpl(c, clientHandle, selector, params);
                 } catch (Exception e) {
                     hostLog.warn("Exception while attempting to collect stats", e);
-                    if (e instanceof ConcurrentModificationException) {
-                        sendErrorResponse(c, ClientResponse.GRACEFUL_FAILURE,
-                                "Statistics are unavailable, try again (" + e.getMessage() + ").",
-                                clientHandle);
-                    }
-                    else {
-                        sendErrorResponse(c, ClientResponse.OPERATIONAL_FAILURE,
-                                "Failed to get statistics (" + e.getMessage() + ").",
-                                clientHandle);
-                    }
+                    // ENG-14639, prevent clients like sqlcmd from hanging on exception
+                    sendErrorResponse(c, ClientResponse.OPERATIONAL_FAILURE,
+                            "Failed to get statistics (" + e.getMessage() + ").",
+                            clientHandle);
                 }
             }
         });


### PR DESCRIPTION
Send an error response when hitting exception in runnable executed in OpsAgent. This should prevent sqlcmd from hanging forever and system tests to report failures faster.

Use ConcurrentHashMap to support updates from LoadedProcedure.getNibbleDeleteProc