### PR TITLE
Log a stacktrace as a single printf

### DIFF
--- a/src/ee/common/StackTrace.cpp
+++ b/src/ee/common/StackTrace.cpp
@@ -67,7 +67,7 @@ bool backtraceIsSupported() {
 
 }
 
-StackTrace::StackTrace() {
+StackTrace::StackTrace(uint32_t skipFrames) {
 
     if (backtraceIsSupported()) {
         /**
@@ -79,7 +79,7 @@ StackTrace::StackTrace() {
         const int numTraces = backtrace( traces, 128);
         m_traceSymbols = backtrace_symbols( traces, numTraces);
 
-        for (int ii = 0; ii < numTraces; ii++) {
+        for (int ii = skipFrames; ii < numTraces; ii++) {
             std::size_t sz = 200;
             // Note: must use malloc vs. new so __cxa_demangle can use realloc.
             char *function = static_cast<char*>(::malloc(sz));
@@ -141,16 +141,6 @@ void StackTrace::printMangledAndUnmangledToFile(FILE *targetFile) {
         const char *str = st.m_traces[ii].c_str();
         fprintf(targetFile, "demangled[%d]: %s\n", ii, str);
     }
-}
-
-std::string StackTrace::stringStackTrace()
-{
-    StackTrace st;
-    std::ostringstream stacked;
-    for (int ii=2; ii < st.m_traces.size(); ii++) {
-        stacked << st.m_traces[ii] << "\n";
-    }
-    return stacked.str();
 }
 
 } // namespace voltdb

--- a/src/ee/common/StackTrace.h
+++ b/src/ee/common/StackTrace.h
@@ -20,29 +20,42 @@
 #include <vector>
 #include <cstdio>
 #include <string>
+#include <iostream>
+#include <sstream>
 
 namespace voltdb {
 
 class StackTrace {
 public:
-    StackTrace();
+    // By default do not include the frame with the constructor
+    StackTrace(uint32_t skipFrames = 1);
     ~StackTrace();
 
     static void printMangledAndUnmangledToFile(FILE *targetFile);
 
     static void printStackTrace() {
-        StackTrace st;
-        for (int ii=1; ii < st.m_traces.size(); ii++) {
-            printf("   %s\n", st.m_traces[ii].c_str());
-        }
+        StackTrace(2).printLocalTrace();
     }
 
-    static std::string stringStackTrace();
+    static std::string stringStackTrace(std::string prefix) {
+        std::ostringstream stacked;
+        StackTrace(2).streamLocalTrace(stacked, prefix);
+        return stacked.str();
+    }
+
+    static void streamStackTrace(std::ostream& stream, std::string prefix) {
+        StackTrace(2).streamLocalTrace(stream, prefix);
+    }
 
     void printLocalTrace() {
-        for (int ii=1; ii < m_traces.size(); ii++) {
-            printf("   %s\n", m_traces[ii].c_str());
+        streamLocalTrace(std::cout, "    ");
+    }
+
+    void streamLocalTrace(std::ostream& stream, std::string prefix) {
+        for (int ii=0; ii < m_traces.size(); ii++) {
+            stream << prefix << m_traces[ii] << '\n';
         }
+        stream.flush();
     }
 
 private:

--- a/src/ee/common/debuglog.h
+++ b/src/ee/common/debuglog.h
@@ -88,26 +88,23 @@
     #define __FUNCTION__ ""
 #endif
 
-#define VOLT_LOG_START(lvl, msg, ...) do {                                      \
+#define _VOLT_LOG(lvl, msg, ...) do {                                           \
         struct timeval __now__;                                                 \
         ::gettimeofday(&__now__, NULL);                                         \
         tm *__curTime__ = localtime(&__now__.tv_sec);                           \
         char __time_str__[32];                                                  \
         ::strftime(__time_str__, 32, VOLT_LOG_TIME_FORMAT, __curTime__);        \
-        ::printf("[%s] [T%d:E%d] [%s:%d:%s()] %s,%03jd - " msg "\n", lvl,       \
+        ::printf("[%s] [T%d:E%d] [%s:%d:%s()] %s,%03jd - " msg, lvl,            \
                 voltdb::ThreadLocalPool::getThreadPartitionIdWithNullCheck(),   \
                 voltdb::ThreadLocalPool::getEnginePartitionIdWithNullCheck(),   \
                 __FILE__, __LINE__, __FUNCTION__,                               \
                 __time_str__, (intmax_t) __now__.tv_usec / 1000, ##__VA_ARGS__);\
+        ::fflush(stdout);                                                       \
     } while (0)
 
-#define VOLT_LOG_END ::fflush(stdout)
+#define VOLT_LOG(lvl, msg, ...) _VOLT_LOG(lvl, msg  "\n", ##__VA_ARGS__)
 
-#define VOLT_LOG(...) VOLT_LOG_START(__VA_ARGS__); VOLT_LOG_END
-
-#define VOLT_LOG_STACK(lvl) VOLT_LOG_START(lvl, "STACK TRACE");             \
-    voltdb::StackTrace::printStackTrace();                                  \
-    VOLT_LOG_END
+#define VOLT_LOG_STACK(lvl) _VOLT_LOG(lvl, "STACK TRACE\n%s", voltdb::StackTrace::stringStackTrace("    ").c_str())
 
 // Two convenient macros for debugging
 // 1. Logging macros.
@@ -170,7 +167,7 @@
 #if VOLT_LOG_LEVEL<=VOLT_LEVEL_TRACE
     #define VOLT_TRACE_ENABLED
     //#pragma message("VOLT_TRACE was enabled.")
-    #define VOLT_TRACE(...) VOLT_LOG("TRACE", __VA_ARGS__); VOLT_LOG_END
+    #define VOLT_TRACE(...) VOLT_LOG("TRACE", __VA_ARGS__)
     #define VOLT_TRACE_STACK() VOLT_LOG_STACK("TRACE")
 #else
     #define VOLT_TRACE(...) ((void)0)

--- a/src/ee/expressions/expressionutil.cpp
+++ b/src/ee/expressions/expressionutil.cpp
@@ -484,8 +484,8 @@ tupleValueFactory(PlannerDomValue obj, ExpressionType et,
     if (columnIndex < 0) {
         std::ostringstream message;
         message << "tupleValueFactory: invalid column_idx " << columnIndex <<
-                " for " << ((tableIdx == 0) ? "" : "inner ") << "table\nStack trace:\n" <<
-                StackTrace::stringStackTrace();
+                " for " << ((tableIdx == 0) ? "" : "inner ") << "table\nStack trace:\n";
+        StackTrace::streamStackTrace(message, "");
         throw UnexpectedEEException(message.str());
     }
 


### PR DESCRIPTION
Since stack traces are written as multiple printf statements their
printing could be interrupted by other log statements. To prevent this
from happening build a single string stack trace and log that in one
printf.

Reduce the implementations of rendering a stack trace down to one method
which operates on an ostream.