### PR TITLE
ENG-10775: removed use of FULL JOIN from 3 problematic query templates

### DIFF
--- a/tests/sqlcoverage/sql_coverage_test.py
+++ b/tests/sqlcoverage/sql_coverage_test.py
@@ -233,18 +233,9 @@ def get_max_mismatches(comparison_database, suite_name):
     # Kludge to not fail for known issues, when running against PostgreSQL
     # (or the PostGIS extension of PostgreSQL)
     if comparison_database.startswith('Post'):
-        # Known failures in the basic-joins test suite, and in the basic-index-joins,
-        # and basic-compoundex-joins "extended" test suites (see ENG-10775)
-        if (config_name == 'basic-joins' or config_name == 'basic-index-joins' or
-              config_name == 'basic-compoundex-joins'):
-            max_mismatches = 5280
-        # Known failures, related to the ones above, in the basic-int-joins test
-        # suite (see ENG-10775, ENG-11401)
-        elif config_name == 'basic-int-joins':
-            max_mismatches = 600
         # Known failures in the joined-matview-* test suites ...
         # Failures in joined-matview-default-full due to ENG-11086
-        elif config_name == 'joined-matview-default-full':
+        if config_name == 'joined-matview-default-full':
             max_mismatches = 3390
         # Failures in joined-matview-int due to ENG-11086
         elif config_name == 'joined-matview-int':

--- a/tests/sqlcoverage/template/include/join-template.sql
+++ b/tests/sqlcoverage/template/include/join-template.sql
@@ -48,6 +48,7 @@ SELECT LHS41.@idcol, LHS41.@numcol FROM @fromtables LHS41 @jointype JOIN @fromta
 -- Uncomment after ENG-9367 is fixed (??):
 --SELECT       @idcol,       @numcol FROM @fromtables LHS42 @jointype JOIN @fromtables MHS ON  LHS42.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON LHS42.@numcol = RHS.@numcol
 
-SELECT *                           FROM @fromtables LHS43 @jointype JOIN @fromtables MHS ON  LHS43.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON LHS43.@numcol _cmp 45;
-SELECT *                           FROM @fromtables LHS44 @jointype JOIN @fromtables MHS ON  LHS44.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON MHS.@numcol _cmp 45;
-SELECT *                           FROM @fromtables LHS45 @jointype JOIN @fromtables MHS ON  LHS45.@idcol = MHS.@idcol  @jointype JOIN @fromtables RHS ON RHS.@numcol _cmp 45;
+-- Use non-full joins only, because these queries do not work in PostgreSQL, with FULL JOIN (see ENG-10775)
+SELECT *                    FROM @fromtables LHS43 _nonfulljointype JOIN @fromtables MHS ON  LHS43.@idcol = MHS.@idcol _nonfulljointype JOIN @fromtables RHS ON LHS43.@numcol _cmp 45;
+SELECT *                    FROM @fromtables LHS44 _nonfulljointype JOIN @fromtables MHS ON  LHS44.@idcol = MHS.@idcol _nonfulljointype JOIN @fromtables RHS ON MHS.@numcol _cmp 45;
+SELECT *                    FROM @fromtables LHS45 _nonfulljointype JOIN @fromtables MHS ON  LHS45.@idcol = MHS.@idcol _nonfulljointype JOIN @fromtables RHS ON RHS.@numcol _cmp 45;


### PR DESCRIPTION
in join-template.sql, because they fail in PostgreSQL when using FULL
JOIN; and removed associated kludges in sql_coverage_test.py's
get_max_mismatches function, which are no longer needed.