### PR TITLE
Eng 14937

### DIFF
--- a/src/frontend/org/voltcore/network/CipherExecutor.java
+++ b/src/frontend/org/voltcore/network/CipherExecutor.java
@@ -101,12 +101,14 @@ public enum CipherExecutor {
     }
 
     public void startup() {
+        /*
         if (m_active.compareAndSet(false, true)) synchronized(this) {
             ThreadFactory thrdfct = CoreUtils.getThreadFactory(
                     name () + " SSL cipher service", CoreUtils.MEDIUM_STACK_SIZE);
             m_es = MoreExecutors.listeningDecorator(
                     Executors.newFixedThreadPool(m_threadCount, thrdfct));
         }
+        */
     }
 
     public void shutdown() {

--- a/src/frontend/org/voltcore/network/CipherExecutor.java
+++ b/src/frontend/org/voltcore/network/CipherExecutor.java
@@ -101,14 +101,12 @@ public enum CipherExecutor {
     }
 
     public void startup() {
-        /*
         if (m_active.compareAndSet(false, true)) synchronized(this) {
             ThreadFactory thrdfct = CoreUtils.getThreadFactory(
                     name () + " SSL cipher service", CoreUtils.MEDIUM_STACK_SIZE);
             m_es = MoreExecutors.listeningDecorator(
                     Executors.newFixedThreadPool(m_threadCount, thrdfct));
         }
-        */
     }
 
     public void shutdown() {

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -123,6 +123,8 @@ public class MockVoltDB implements VoltDBInterface
             obj.put("httpPort", httpPort);
             obj.put("drPort", drPort);
             obj.put("drInterface", "127.0.0.1");
+            obj.put(VoltZK.drPublicHostProp, "");
+            obj.put(VoltZK.drPublicPortProp, Integer.toString(VoltDB.DISABLED_PORT));
 
             m_localMetadata = obj.toString(4);
 


### PR DESCRIPTION
Fix testMeshQuery failure. MockVoltDB must also include drPublic host and port into local metadata.