### PR TITLE
ENG-11349: Make PostgreSQL, not HSQL, the default sqlcov comparison DB

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2151,6 +2151,9 @@ TEST CASES
     <condition property="config_config" value="-c ${sql_coverage_config}" else="">
         <isset property="sql_coverage_config"/>
     </condition>
+    <condition property="config_hsql" value="-H" else="">
+        <isset property="hsql"/>
+    </condition>
     <condition property="config_postgresql" value="-P" else="">
         <isset property="postgresql"/>
     </condition>
@@ -2223,6 +2226,7 @@ TEST CASES
         <arg line='sql_coverage_test.py' />
         <arg line="${config_seed}" />
         <arg line="${config_config}" />
+        <arg line="${config_hsql}" />
         <arg line="${config_postgresql}" />
         <arg line="${config_postgis}" />
         <arg line="${config_ascii_only}" />

--- a/tests/sqlcoverage/sql_coverage_test.py
+++ b/tests/sqlcoverage/sql_coverage_test.py
@@ -254,8 +254,7 @@ def ignore_known_mismatches(comparison_database, suite_name, reproducer):
     to avoid producing lots of meaningless reproducer*.html files.
     """
     if (comparison_database.startswith('Post') and reproducer == Reproduce.DML and
-            suite_name in ['basic-joins', 'basic-index-joins', 'basic-compoundex-joins',
-            'basic-int-joins', 'joined-matview-default-full', 'joined-matview-int']):
+            suite_name in ['joined-matview-default-full', 'joined-matview-int']):
         reproducer = Reproduce.NONE
     return reproducer
 
@@ -760,6 +759,9 @@ if __name__ == "__main__":
     parser.add_option("-g", "--generate-only", action="store_true",
                       dest="generate_only", default=False,
                       help="only generate and report SQL statements, do not start any database servers")
+    parser.add_option("-H", "--hsql", action="store_true",
+                      dest="hsql", default=False,
+                      help="compare VoltDB results to HSqlDB, rather than PostgreSQL")
     parser.add_option("-P", "--postgresql", action="store_true",
                       dest="postgresql", default=False,
                       help="compare VoltDB results to PostgreSQL, rather than HSqlDB")
@@ -803,8 +805,11 @@ if __name__ == "__main__":
     else:
         configs_to_run = config_list.get_configs()
 
-    comparison_database = "HSqlDB"  # default value
-    debug_transform_sql = False
+    comparison_database = "PostgreSQL"  # default value (new 11/2018)
+    debug_transform_sql = True
+    if options.hsql:
+        comparison_database = 'HSqlDB'
+        debug_transform_sql = False
     if options.postgresql:
         comparison_database = 'PostgreSQL'
         debug_transform_sql = True

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -553,7 +553,7 @@ function tt-help() {
     echo -e "    tt-echo-build-args) may have '-if-needed' appended, e.g.,"
     echo -e "    'test-tools-server-if-needed' will start a VoltDB server only if"
     echo -e "    one is not already running."
-    echo -e "Some options (tt-set-build-args, tt-set-build-args) may be passed argument(s)"
+    echo -e "Some options (tt-set-build-args, tt-set-setseed) may be passed argument(s)"
     echo -e "    that determine what the relevant environment variable will be set to."
     echo -e "Multiple options may be specified; but options usually call other options that are prerequisites.\n"
     PRINT_ERROR_CODE=0

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -16,6 +16,9 @@ function test-tools-find-directories() {
     if [[ -e $TT_HOME_DIR/tests/test-tools.sh ]]; then
         # It looks like we're running from a <voltdb> directory
         VOLTDB_COM_DIR=$TT_HOME_DIR
+    elif [[ -e $TT_HOME_DIR/voltdb/tests/test-tools.sh ]]; then
+        # It looks like we're running from just 'above' a <voltdb> directory
+        VOLTDB_COM_DIR=$TT_HOME_DIR/voltdb
     elif [[ $TT_HOME_DIR == */tests ]] && [[ -e $TT_HOME_DIR/test-tools.sh ]]; then
         # It looks like we're running from a <voltdb>/tests/ directory
         VOLTDB_COM_DIR=$(cd $TT_HOME_DIR/..; pwd)
@@ -63,6 +66,168 @@ function test-tools-find-directories-if-needed() {
     if [[ -z "$TT_HOME_DIR" || -z "$VOLTDB_COM_DIR" || -z "$VOLTDB_COM_BIN" || -z "$VOLTDB_TESTS" ]]; then
         test-tools-find-directories
     fi
+}
+
+# Echo environment variables that are commonly used in Jenkins jobs
+function tt-echo-build-args() {
+    echo -e "\n${BASH_SOURCE[0]} performing: $FUNCNAME"
+    echo "VOLTDB_REV: $VOLTDB_REV"
+    echo "PRO_REV   : $PRO_REV"
+    echo "BUILD_OPTS: $BUILD_OPTS"
+    echo "BUILD_ARGS: $BUILD_ARGS"
+    echo "SEED      : $SEED"
+    echo "SETSEED   : $SETSEED"
+    BUILD_ARGS_WERE_ECHOED="true"
+}
+
+# Echo environment variables that are commonly used in Jenkins jobs,
+# only if not echoed already
+function tt-echo-build-args-if-needed() {
+    if [[ -z "$BUILD_ARGS_WERE_ECHOED" ]]; then
+        tt-echo-build-args
+    fi
+}
+
+# Set build arguments to be passed to a build of VoltDB (community or pro),
+# based on simpler arguments passed to this function, such as 'debug', 'pool',
+# 'memcheck', etc.
+function tt-set-build-args() {
+    tt-echo-build-args-if-needed
+    echo -e "\n${BASH_SOURCE[0]} performing: $FUNCNAME $@"
+
+    if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then
+        echo -e "\nWARNING: ${BASH_SOURCE[0]} function $FUNCNAME called without 'source' or '.':"
+        echo -e "    will have no external effect!\n"
+    fi
+
+    if [[ -z "$1" || "$1" == tt-* || "$1" == test-tools* ]]; then
+        echo -e "\nWARNING: ${BASH_SOURCE[0]} function $FUNCNAME called without an argument:"
+        echo -e "    will have no effect!\n"
+    fi
+
+    while [[ -n "$1" ]]; do
+        # Stop if we encounter other "test-tools" functions as args
+        if [[ "$1" == tt-* || "$1" == test-tools* ]]; then
+            break
+        fi
+
+        IFS=',' read -r -a build_options <<< "$1"
+        for option in "${build_options[@]}"; do
+            # Check for standard BUILD_ARGS abbreviations
+            if [[ "$option" == "reset" || "$option" == "release" ]]; then
+                BUILD_ARGS=
+            elif [[ "$option" == "debug" ]]; then
+                BUILD_ARGS="$BUILD_ARGS -Dbuild=debug"
+            elif [[ "$option" == "pool" ]]; then
+                BUILD_ARGS="$BUILD_ARGS -Dbuild=debug -DVOLT_POOL_CHECKING=true"
+            elif [[ "$option" == "memcheck" ]]; then
+                BUILD_ARGS="$BUILD_ARGS -Dbuild=memcheck"
+            elif [[ "$option" == "memcheckrelease" || "$option" == "memcheck-release" || \
+                    "$option" == "memcheck_release" ]]; then
+                BUILD_ARGS="$BUILD_ARGS -Dbuild=memcheck_release"
+            elif [[ "$option" == "jmemcheck" ]]; then
+                BUILD_ARGS="$BUILD_ARGS -Djmemcheck=MEMCHECK_FULL"
+            elif [[ "$option" == "nojmemcheck" ]]; then
+                BUILD_ARGS="$BUILD_ARGS -Djmemcheck=NO_MEMCHECK"
+            # User is allowed to specify their own -D... option(s)
+            elif [[ "$option" == -D* ]]; then
+                BUILD_ARGS="$BUILD_ARGS $option"
+            else
+                echo -e "\nERROR: Unrecognized arg / build option in ${BASH_SOURCE[0]} function $FUNCNAME:"
+                echo -e "    $1 / $option"
+                exit -4
+            fi
+        done
+        shift
+        SHIFT_BY=$((SHIFT_BY+1))
+    done
+    echo -e "\nBUILD_ARGS: $BUILD_ARGS"
+}
+
+# Sets the SETSEED variable, typically to be used by SqlCoverage, based on
+# an argument passed to this function, or on the current value (if any) of
+# the SEED variable
+function tt-set-setseed() {
+    tt-echo-build-args-if-needed
+    echo -e "\n${BASH_SOURCE[0]} performing: $FUNCNAME $1"
+
+    if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then
+        echo -e "\nWARNING: ${BASH_SOURCE[0]} function $FUNCNAME called without 'source' or '.':"
+        echo -e "    will have no external effect!\n"
+    fi
+
+    SETSEED=
+    if [[ -n "$1" && "$1" != tt-* && "$1" != test-tools* ]]; then
+        SETSEED="-Dsql_coverage_seed=$1"
+        SHIFT_BY=$((SHIFT_BY+1))
+    elif [[ -n "$SEED" ]]; then
+        SETSEED="-Dsql_coverage_seed=$SEED"
+    fi
+    echo -e "SETSEED: $SETSEED"
+}
+
+# Call the 'killstragglers' script, passing it the standard PostgreSQL port number
+function tt-killstragglers() {
+    test-tools-find-directories-if-needed
+    echo -e "\n${BASH_SOURCE[0]} performing: $FUNCNAME"
+
+    cd $VOLTDB_COM_DIR
+    ant killstragglers -Dport=5432
+    cd -
+}
+
+# Call the start_postgresql.sh script
+function tt-start-postgresql() {
+    test-tools-find-directories-if-needed
+    echo -e "\n${BASH_SOURCE[0]} performing: $FUNCNAME"
+
+    # SqlCoverage will only work well with PostgreSQL, if PostgreSQL is
+    # started by user 'test'
+    if [[ `whoami` != "test" ]]; then
+        echo -e "\nWARNING: ${BASH_SOURCE[0]} function $FUNCNAME called as user '`whoami`', not 'test':"
+        echo -e "    SqlCoverage will not work well!!!\n"
+    fi
+
+    if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then
+        echo -e "\nWARNING: ${BASH_SOURCE[0]} function $FUNCNAME called without 'source' or '.':"
+        echo -e "    stop-postgresql will be unable to access the environment variables set here!\n"
+    fi
+
+    # Start the PostgreSQL server, in a new temp directory ('source' is used so that
+    # the environment variables defined here can be used by stop_postgresql.sh later)
+    source $VOLTDB_TESTS/sqlcoverage/start_postgresql.sh
+
+    # TODO: does this have any effect, inside this script, or only in Jenkins??
+    # Prevent exit before stopping the PostgreSQL server & deleting the temp directory,
+    # if the sqlCoverage tests fail
+    set +e
+}
+
+# Equivalent, shorter function name
+function tt-start-postgres() {
+    tt-start-postgresql $@
+}
+
+# Call the stop_postgresql.sh script
+function tt-stop-postgresql() {
+    test-tools-find-directories-if-needed
+    echo -e "\n${BASH_SOURCE[0]} performing: $FUNCNAME"
+
+    # Stop the PostgreSQL server & delete the temp directory
+    $VOLTDB_TESTS/sqlcoverage/stop_postgresql.sh
+}
+
+# Equivalent, shorter function name
+function tt-stop-postgres() {
+    tt-stop-postgresql $@
+}
+
+# TODO: this could be implemented in the future, to run the SqlCoverage test
+# program, with various arguments
+function tt-sqlcoverage() {
+    echo -e "\n${BASH_SOURCE[0]} performing: [test-tools.]run-sqlcoverage $@"
+
+    echo -e "\nWARNING: ${BASH_SOURCE[0]} function $FUNCNAME not implemented yet!!!\n"
 }
 
 # Build VoltDB: 'community', open-source version
@@ -358,11 +523,13 @@ function test-tools-all-pro() {
 }
 
 # Print a simple help message, describing the options for this script
-function test-tools-help() {
-    echo -e "\nUsage: ./test-tools.sh test-tools-{build|build-pro|init|debug|server|all|shutdown|all|help}\n"
-    echo -e "This script is mainly intended to provide useful functions that may be called"
-    echo -e "  by a variety of other test scripts, e.g., <voltdb>/tests/sqlgrammar/run.sh,"
-    echo -e "  but it may also be called directly on the command line."
+function tt-help() {
+    echo -e "\nUsage: ./test-tools.sh test-tools-{build[-pro]|init|debug|server[-pro]|all[-pro]|shutdown}"
+    echo -e "Or   : ./test-tools.sh tt-{echo-build-args|set-build-args|set-setseed|killstragglers|"
+    echo -e "                           start-postgres[ql]|stop-postgres[ql]|help}"
+    echo -e "This script is largely intended to provide useful functions that may be called"
+    echo -e "    by a variety of other test scripts, e.g., <voltdb>/tests/sqlgrammar/run.sh,"
+    echo -e "    but it may also be called directly on the command line."
     echo -e "Options:"
     echo -e "    test-tools-build      : builds VoltDB ('community', open-source version)"
     echo -e "    test-tools-build-pro  : builds VoltDB ('pro' version)"
@@ -373,22 +540,38 @@ function test-tools-help() {
     echo -e "    test-tools-all        : runs (almost) all of the above, except the '-pro' options"
     echo -e "    test-tools-all-pro    : runs (almost) all of the above, using the '-pro' options"
     echo -e "    test-tools-shutdown   : stops a VoltDB server that is currently running"
-    echo -e "    test-tools-help       : prints this message"
-    echo -e "Some options (test-tools-build[-pro], test-tools-init, test-tools-server[-pro])"
-    echo -e "  may have '-if-needed' appended, e.g., 'test-tools-server-if-needed'"
-    echo -e "  will start a VoltDB server only if one is not already running."
+    echo -e "    tt-echo-build-args    : echoes build args commonly used in Jenkins"
+    echo -e "    tt-set-build-args     : sets the BUILD_ARGS environment variable"
+    echo -e "    tt-set-setseed        : sets the SETSEED environment variable"
+    echo -e "    tt-killstragglers     : calls the 'killstragglers' script, passing"
+    echo -e "                                it the standard PostgreSQL port number"
+    echo -e "    tt-start-postgres[ql] : calls the start_postgresql.sh script"
+    echo -e "    tt-stop-postgres[ql]  : calls the stop_postgresql.sh script"
+    #echo -e "    tt-sqlcoverage        : NOT YET IMPLEMENTED!"
+    echo -e "    tt-help               : prints this message"
+    echo -e "Some options (test-tools-build[-pro], test-tools-init, test-tools-server[-pro],"
+    echo -e "    tt-echo-build-args) may have '-if-needed' appended, e.g.,"
+    echo -e "    'test-tools-server-if-needed' will start a VoltDB server only if"
+    echo -e "    one is not already running."
+    echo -e "Some options (tt-set-build-args, tt-set-build-args) may be passed argument(s)"
+    echo -e "    that determine what the relevant environment variable will be set to."
     echo -e "Multiple options may be specified; but options usually call other options that are prerequisites.\n"
     PRINT_ERROR_CODE=0
 }
 
-# If run on the command line with no options specified, run test-tools-help
-if [[ $# -eq 0 && $0 == */test-tools.sh ]]; then
-    test-tools-help
+# Old name for tt-help
+function test-tools-help() {
+    tt-help
+}
+
+# If run on the command line with no options specified, run tt-help
+if [[ $# -eq 0 && $0 == *test-tools.sh ]]; then
+    tt-help
 fi
 
-# Run options passed on the command line, if any
+# Run options passed on the command line, if any; with arguments, if any
 while [[ -n "$1" ]]; do
-    CMD="$1"
-    $CMD
-    shift
+    SHIFT_BY=1  # Can be increased, by a function that handles multiple args
+    $@
+    shift $SHIFT_BY
 done


### PR DESCRIPTION
Added, to SqlCoverage, a new 'hsql' option (in both sql_coverage_test.py
and build.xml), so you can still use HSQL as your comparison database if
you wish; but made 'postgresql' the default option (though not
'postgis', FYI).