### PR TITLE
ENG-14925 backport scoreboard refactoring

### DIFF
--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -17,11 +17,11 @@
 
 package org.voltdb.iv2;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.TreeMap;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.Pair;
+import org.voltdb.iv2.TransactionTaskQueue.CompletionCounter;
 import org.voltdb.messaging.CompleteTransactionMessage;
 
 /*
@@ -35,7 +35,7 @@ import org.voltdb.messaging.CompleteTransactionMessage;
  * a transaction that has been processed as well as an abort for the actual transaction in progress.
  */
 public class Scoreboard {
-    private Deque<Pair<CompleteTransactionTask, Boolean>> m_compTasks = new ArrayDeque<>(2);
+    private TreeMap<Long, Pair<CompleteTransactionTask, Boolean>> m_compTasks = new TreeMap<>();
     private FragmentTaskBase m_fragTask;
     protected static final VoltLogger tmLog = new VoltLogger("TM");
 
@@ -53,57 +53,58 @@ public class Scoreboard {
             m_fragTask = null;
         }
 
-        // special case, scoreboard is empty
-        if (m_compTasks.peekFirst() == null) {
-            m_compTasks.addFirst(Pair.of(task, missingTxn));
-            return;
-        }
-
-        // scoreboard has one completion
-        if (m_compTasks.size() == 1) {
-            Pair<CompleteTransactionTask, Boolean> head = m_compTasks.peekFirst();
-            if (head.getFirst().getMsgTxnId() < task.getMsgTxnId()) {
-                // Completion with higher txnId adds to tail
-                m_compTasks.addLast(Pair.of(task, missingTxn));
-            } else if (head.getFirst().getMsgTxnId() > task.getMsgTxnId()) {
-                // Completion with lower txnId goes to head
-                m_compTasks.removeFirst();
-                m_compTasks.addFirst(Pair.of(task, missingTxn));
-                m_compTasks.addLast(head);
-            } else {
-                // Only keep the completion with latest timestamp if txnId is same
-                if (head.getFirst().getTimestamp() < task.getTimestamp() && isComparable(head.getFirst(), task)) {
-                    m_compTasks.removeFirst();
-                    m_compTasks.addFirst(Pair.of(task, missingTxn));
-                }
-                // Ignore stale completion
-            }
+        Pair<CompleteTransactionTask, Boolean> pair = m_compTasks.get(task.getMsgTxnId());
+        if ( pair == null) {
+            m_compTasks.put(task.getMsgTxnId(), Pair.of(task, missingTxn));
         } else {
-            // scoreboard has two completions
-            Pair<CompleteTransactionTask, Boolean> head = m_compTasks.peekFirst();
-            Pair<CompleteTransactionTask, Boolean> tail = m_compTasks.peekLast();
-            // scoreboard can take completions from two transactions at most
-            assert (task.getMsgTxnId() == head.getFirst().getMsgTxnId() || task.getMsgTxnId() == tail.getFirst().getMsgTxnId());
-
-            // Keep newer completion, discard the older one
-            if ( task.getTimestamp() > head.getFirst().getTimestamp() && isComparable(head.getFirst(), task)) {
-                m_compTasks.removeFirst();
-                m_compTasks.addFirst(Pair.of(task, missingTxn));
-            } else if ( task.getTimestamp() > tail.getFirst().getTimestamp() && isComparable(tail.getFirst(), task)) {
-                m_compTasks.removeLast();
-                m_compTasks.addLast(Pair.of(task, missingTxn));
+            if ( task.getTimestamp() > pair.getFirst().getTimestamp() && isComparable(pair.getFirst(), task)) {
+                m_compTasks.put(task.getMsgTxnId(), Pair.of(task, missingTxn));
             }
-            // Ignore stale completion
         }
-
     }
 
     public void addFragmentTask(FragmentTaskBase task) {
         m_fragTask = task;
     }
 
-    public Deque<Pair<CompleteTransactionTask, Boolean>> getCompletionTasks() {
-        return m_compTasks;
+    /**
+     * Remove the CompleteTransactionTask from the head and count the next CompleteTransactionTask
+     * @param nextTaskCounter CompletionCounter
+     * @return the removed CompleteTransactionTask
+     */
+    public Pair<CompleteTransactionTask, Boolean> pollFirstCompletionTask(CompletionCounter nextTaskCounter) {
+
+        // remove from the head
+        Pair<CompleteTransactionTask, Boolean> pair = m_compTasks.pollFirstEntry().getValue();
+        if (m_compTasks.isEmpty()) {
+            return pair;
+        }
+        // check next task for completion to ensure that the heads on all the site
+        // have the same transaction and timestamp
+        Pair<CompleteTransactionTask, Boolean> next = peekFirst();
+        if (nextTaskCounter.txnId == 0L) {
+            nextTaskCounter.txnId = next.getFirst().getMsgTxnId();
+            nextTaskCounter.completionCount++;
+            nextTaskCounter.timestamp = next.getFirst().getTimestamp();
+        } else if (nextTaskCounter.txnId == next.getFirst().getMsgTxnId() &&
+                nextTaskCounter.timestamp == next.getFirst().getTimestamp()) {
+            nextTaskCounter.completionCount++;
+        }
+        return pair;
+    }
+
+    public Pair<CompleteTransactionTask, Boolean> peekFirst() {
+        if (!m_compTasks.isEmpty()) {
+            return m_compTasks.firstEntry().getValue();
+        }
+        return null;
+    }
+
+    public Pair<CompleteTransactionTask, Boolean> peekLast() {
+        if (!m_compTasks.isEmpty()) {
+            return m_compTasks.lastEntry().getValue();
+        }
+        return null;
     }
 
     public FragmentTaskBase getFragmentTask() {
@@ -126,15 +127,12 @@ public class Scoreboard {
     }
 
     private boolean hasRestartCompletion(CompleteTransactionTask task) {
-        if (m_compTasks.peekFirst() != null &&
-                MpRestartSequenceGenerator.isForRestart(m_compTasks.peekFirst().getFirst().getTimestamp()) &&
-                task.getMsgTxnId() < m_compTasks.peekFirst().getFirst().getMsgTxnId()) {
-            return true;
-        } else if (m_compTasks.size() == 2 &&
-                MpRestartSequenceGenerator.isForRestart(m_compTasks.peekLast().getFirst().getTimestamp()) &&
-                task.getMsgTxnId() < m_compTasks.peekLast().getFirst().getMsgTxnId()) {
-            return true;
+        Pair<CompleteTransactionTask, Boolean> pair = peekFirst();
+        if (pair != null) {
+            return (MpRestartSequenceGenerator.isForRestart(pair.getFirst().getTimestamp()) &&
+                    task.getMsgTxnId() < pair.getFirst().getMsgTxnId());
         }
+
         return false;
     }
 
@@ -144,29 +142,26 @@ public class Scoreboard {
 
     // Only match CompleteTransactionTask at head of the queue
     public boolean matchCompleteTransactionTask(long txnId, long timestamp) {
-        return !m_compTasks.isEmpty() &&
-                m_compTasks.peekFirst().getFirst().getMsgTxnId() == txnId &&
-                m_compTasks.peekFirst().getFirst().getTimestamp() == timestamp;
-    }
-
-    public boolean isTransactionMissing(long txnId) {
-        if (m_compTasks.peekFirst().getSecond() && txnId == m_compTasks.peekFirst().getFirst().getMsgTxnId()) {
-            return true;
+        if (!m_compTasks.isEmpty()) {
+            long lowestTxnId = m_compTasks.firstKey();
+            if (txnId == lowestTxnId) {
+                Pair<CompleteTransactionTask, Boolean> pair = m_compTasks.get(lowestTxnId);
+                return timestamp == pair.getFirst().getTimestamp();
+            }
         }
-
-        return (m_compTasks.size() == 2 && m_compTasks.peekLast().getSecond() &&
-                txnId == m_compTasks.peekLast().getFirst().getMsgTxnId());
+        return false;
     }
 
     public String toString() {
         StringBuilder builder = new StringBuilder();
         if (!m_compTasks.isEmpty()){
-            builder.append("CompleteTransactionTasks: " + m_compTasks.peekFirst() +
-                    (m_compTasks.size() == 2 ? "\n" + m_compTasks.peekLast() : ""));
-            builder.append("\n");
+            builder.append("CompleteTransactionTasks: ");
+            for (Pair<CompleteTransactionTask, Boolean> pair : m_compTasks.values()) {
+                builder.append("\n" + pair);
+            }
         }
         if (m_fragTask != null) {
-            builder.append("FragmentTask: " + m_fragTask);
+            builder.append("\nFragmentTask: " + m_fragTask);
         }
         return builder.toString();
     }

--- a/tests/frontend/org/voltdb/iv2/TestScoreboard.java
+++ b/tests/frontend/org/voltdb/iv2/TestScoreboard.java
@@ -74,17 +74,17 @@ public class TestScoreboard {
         CompleteTransactionTask comp2 = createComp(1000L, expectedTimestamp);
         scoreboard.addCompletedTransactionTask(comp2, false);
 
-        assertEquals(1000L, scoreboard.getCompletionTasks().peekFirst().getFirst().getMsgTxnId());
-        assertEquals(expectedTimestamp, scoreboard.getCompletionTasks().peekFirst().getFirst().getTimestamp());
+        assertEquals(1000L, scoreboard.peekFirst().getFirst().getMsgTxnId());
+        assertEquals(expectedTimestamp, scoreboard.peekFirst().getFirst().getTimestamp());
 
         // Message from different transaction can't step on each other
         CompleteTransactionTask comp3 = createComp(2000L, CompleteTransactionMessage.INITIAL_TIMESTAMP);
         scoreboard.addCompletedTransactionTask(comp3, false);
 
-        assertEquals(1000L, scoreboard.getCompletionTasks().peekFirst().getFirst().getMsgTxnId());
-        assertEquals(expectedTimestamp, scoreboard.getCompletionTasks().peekFirst().getFirst().getTimestamp());
-        assertEquals(2000L, scoreboard.getCompletionTasks().peekLast().getFirst().getMsgTxnId());
-        assertEquals(CompleteTransactionMessage.INITIAL_TIMESTAMP, scoreboard.getCompletionTasks().peekLast().getFirst().getTimestamp());
+        assertEquals(1000L, scoreboard.peekFirst().getFirst().getMsgTxnId());
+        assertEquals(expectedTimestamp, scoreboard.peekFirst().getFirst().getTimestamp());
+        assertEquals(2000L, scoreboard.peekLast().getFirst().getMsgTxnId());
+        assertEquals(CompleteTransactionMessage.INITIAL_TIMESTAMP, scoreboard.peekLast().getFirst().getTimestamp());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class TestScoreboard {
         long expectedTimestamp = repairGen.getNextSeqNum();
         CompleteTransactionTask comp1 = createComp(1000L, expectedTimestamp);
         scoreboard.addCompletedTransactionTask(comp1, false);
-        assertEquals(1000L, scoreboard.getCompletionTasks().peekFirst().getFirst().getMsgTxnId());
+        assertEquals(1000L, scoreboard.peekFirst().getFirst().getMsgTxnId());
         assertNull(scoreboard.getFragmentTask());
     }
 
@@ -114,10 +114,10 @@ public class TestScoreboard {
         CompleteTransactionTask comp2 = createComp(2000L, restartTimestamp);
         scoreboard.addCompletedTransactionTask(comp2, false);
 
-        assertEquals(1000L, scoreboard.getCompletionTasks().peekFirst().getFirst().getMsgTxnId());
-        assertEquals(expectedTimestamp, scoreboard.getCompletionTasks().peekFirst().getFirst().getTimestamp());
-        assertEquals(2000L, scoreboard.getCompletionTasks().peekLast().getFirst().getMsgTxnId());
-        assertEquals(restartTimestamp, scoreboard.getCompletionTasks().peekLast().getFirst().getTimestamp());
+        assertEquals(1000L, scoreboard.peekFirst().getFirst().getMsgTxnId());
+        assertEquals(expectedTimestamp, scoreboard.peekFirst().getFirst().getTimestamp());
+        assertEquals(2000L, scoreboard.peekLast().getFirst().getMsgTxnId());
+        assertEquals(restartTimestamp, scoreboard.peekLast().getFirst().getTimestamp());
     }
 
     @Test
@@ -134,9 +134,8 @@ public class TestScoreboard {
         CompleteTransactionTask comp2 = createComp(1000L, CompleteTransactionMessage.INITIAL_TIMESTAMP);
         scoreboard.addCompletedTransactionTask(comp2, false);
 
-        assertEquals(1000L, scoreboard.getCompletionTasks().peekFirst().getFirst().getMsgTxnId());
-        assertEquals(expectedTimestamp, scoreboard.getCompletionTasks().peekFirst().getFirst().getTimestamp());
-        assertEquals(1, scoreboard.getCompletionTasks().size());
+        assertEquals(1000L, scoreboard.peekFirst().getFirst().getMsgTxnId());
+        assertEquals(expectedTimestamp, scoreboard.peekFirst().getFirst().getTimestamp());
 
         long restartTimestamp = restartGen.getNextSeqNum();
         CompleteTransactionTask comp3 = createComp(2000L, restartTimestamp);
@@ -145,10 +144,10 @@ public class TestScoreboard {
         // stale initial completion doesn't overwrite restart completion
         scoreboard.addCompletedTransactionTask(comp2, false);
 
-        assertEquals(1000L, scoreboard.getCompletionTasks().peekFirst().getFirst().getMsgTxnId());
-        assertEquals(expectedTimestamp, scoreboard.getCompletionTasks().peekFirst().getFirst().getTimestamp());
-        assertEquals(2000L, scoreboard.getCompletionTasks().peekLast().getFirst().getMsgTxnId());
-        assertEquals(restartTimestamp, scoreboard.getCompletionTasks().peekLast().getFirst().getTimestamp());
+        assertEquals(1000L, scoreboard.peekFirst().getFirst().getMsgTxnId());
+        assertEquals(expectedTimestamp, scoreboard.peekFirst().getFirst().getTimestamp());
+        assertEquals(2000L, scoreboard.peekLast().getFirst().getMsgTxnId());
+        assertEquals(restartTimestamp, scoreboard.peekLast().getFirst().getTimestamp());
     }
 
     @Test
@@ -165,10 +164,10 @@ public class TestScoreboard {
         CompleteTransactionTask comp2 = createComp(1000L, expectedTimestamp);
         scoreboard.addCompletedTransactionTask(comp2, false);
 
-        assertEquals(1000L, scoreboard.getCompletionTasks().peekFirst().getFirst().getMsgTxnId());
-        assertEquals(expectedTimestamp, scoreboard.getCompletionTasks().peekFirst().getFirst().getTimestamp());
-        assertEquals(2000L, scoreboard.getCompletionTasks().peekLast().getFirst().getMsgTxnId());
-        assertEquals(restartTimestamp, scoreboard.getCompletionTasks().peekLast().getFirst().getTimestamp());
+        assertEquals(1000L, scoreboard.peekFirst().getFirst().getMsgTxnId());
+        assertEquals(expectedTimestamp, scoreboard.peekFirst().getFirst().getTimestamp());
+        assertEquals(2000L, scoreboard.peekLast().getFirst().getMsgTxnId());
+        assertEquals(restartTimestamp, scoreboard.peekLast().getFirst().getTimestamp());
     }
 
     @Test
@@ -183,8 +182,26 @@ public class TestScoreboard {
         CompleteTransactionTask comp2 = createComp(1000L, expectedTimestamp);
         scoreboard.addCompletedTransactionTask(comp2, true);
 
-        assertEquals(1000L, scoreboard.getCompletionTasks().peekFirst().getFirst().getMsgTxnId());
-        assertEquals(expectedTimestamp, scoreboard.getCompletionTasks().peekFirst().getFirst().getTimestamp());
-        assertEquals(1, scoreboard.getCompletionTasks().size());
+        assertEquals(1000L, scoreboard.peekFirst().getFirst().getMsgTxnId());
+        assertEquals(expectedTimestamp, scoreboard.peekFirst().getFirst().getTimestamp());
+    }
+
+    @Test
+    public void testTwoRepairsFollowedByRestart() {
+        Scoreboard scoreboard = new Scoreboard();
+        MpRestartSequenceGenerator repairGen = new MpRestartSequenceGenerator(1, false);
+        MpRestartSequenceGenerator restartGen = new MpRestartSequenceGenerator(1, true);
+
+        long expectedTimestamp = repairGen.getNextSeqNum();
+        scoreboard.addCompletedTransactionTask(createComp(1000L, expectedTimestamp), false);
+        scoreboard.addCompletedTransactionTask(createComp(1100L, repairGen.getNextSeqNum()), false);
+
+        long restartTimestamp = restartGen.getNextSeqNum();
+        scoreboard.addCompletedTransactionTask(createComp(2000L, restartTimestamp), false);
+
+        assertEquals(1000L, scoreboard.peekFirst().getFirst().getMsgTxnId());
+        assertEquals(expectedTimestamp, scoreboard.peekFirst().getFirst().getTimestamp());
+        assertEquals(2000L, scoreboard.peekLast().getFirst().getMsgTxnId());
+        assertEquals(restartTimestamp, scoreboard.peekLast().getFirst().getTimestamp());
     }
 }


### PR DESCRIPTION
The scoreboard for SRT can hold complete transaction messages from 2 transactions. However the complete transaction messages could come from more than 2 transactions. For example, node failure occurs when t1 is processing CompleteTransactionMessage, t2 is processing FragmentTaskMessage. t2 is a non-restartable system store procedure. When repair process kicks in, CompleteTransactionMessages for both t1 and t2 will be broadcasted. Since t2 is the ongoing transaction, t2 will be restarted, and then immediately aborted since it is non-restartable. Then t3 will kick in and will send out CompleteTransactionMessage if restarted. Thus 3 CompleteTransactionMessages will reach the scoreboard but one of them will be ignored since the scoreboard can only take 2. Under this circumstance, t3 will hit deadlock.
This issue is addressed in this pull request.