### PR TITLE
ENG-12409: Shutdown client interface after dr

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3563,11 +3563,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     m_adminListener.stop();
                 }
 
-                // shut down the client interface
-                if (m_clientInterface != null) {
-                    m_clientInterface.shutdown();
-                    m_clientInterface = null;
-                }
                 // send hostDown trap as client interface is
                 // no longer available
                 m_snmp.hostDown(FaultLevel.INFO, m_messenger.getHostId(), "Host is shutting down");
@@ -3606,6 +3601,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 }
 
                 shutdownReplicationConsumerRole();
+
+                // shut down the client interface
+                if (m_clientInterface != null) {
+                    m_clientInterface.shutdown();
+                    m_clientInterface = null;
+                }
 
                 if (m_snapshotIOAgent != null) {
                     m_snapshotIOAgent.shutdown();


### PR DESCRIPTION
When the ClientInterface is shutdown before dr the responses to the requests which the consumer has sent out will never be delivered which can block a graceful shutdown which waits for outstanding requests.