### PR TITLE
Calcite DQL

### DIFF
--- a/src/frontend/org/voltdb/ProcedureRunnerNT.java
+++ b/src/frontend/org/voltdb/ProcedureRunnerNT.java
@@ -511,7 +511,6 @@ public class ProcedureRunnerNT {
                                                     null,
                                                     ex);
         }
-
         return responseFromTableArray(results);
     }
 

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -905,7 +905,7 @@ public class VoltDB {
             }
 
             if (!inzFH.exists() || !inzFH.isFile() || !inzFH.canRead()) {
-                hostLog.fatal("Specified directory is not a VoltDB initialized root");
+                hostLog.fatal("Specified directory " + inzFH.toString() + " is not a VoltDB initialized root");
                 referToDocAndExit();
             }
 
@@ -918,7 +918,9 @@ public class VoltDB {
             }
 
             if (m_clusterName != null && !m_clusterName.equals(stagedName)) {
-                hostLog.fatal("The database root directory has changed. Either initialization did not complete properly or the directory has been corrupted. You must reinitialize the database directory before using it.");
+                hostLog.fatal("The database root directory has changed. Either initialization did not complete properly, "
+                        + "or the directory has been corrupted. You must reinitialize the database directory before using it: "
+                 + m_clusterName);
                 referToDocAndExit();
             } else {
                 m_clusterName = stagedName;

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -208,7 +208,8 @@ public class PlannerTool {
      * Plan a query with the Calcite planner.
      * @param task the query to plan.
      * @param batch the query batch which this query belongs to.
-     * @return a planned statement.
+     * @return a planned statement. Untill DQL is fully supported, it returns null, and the caller
+     * will use fall-back behavior.
      */
     public synchronized AdHocPlannedStatement planSqlCalcite(SqlTask task, NonDdlBatch batch) {
         // create VoltSqlValidator from SchemaPlus.
@@ -224,6 +225,7 @@ public class PlannerTool {
         RelNode nodeAfterLogical = CalcitePlanner.transform(CalcitePlannerType.VOLCANO, PlannerPhase.LOGICAL,
                 root.rel, logicalTraits);
 
+        // TODO: finish Calcite planning and convert into AdHocPlannedStatement.
         return null;
     }
 

--- a/src/frontend/org/voltdb/newplanner/AbstractSqlTaskDecorator.java
+++ b/src/frontend/org/voltdb/newplanner/AbstractSqlTaskDecorator.java
@@ -38,6 +38,16 @@ public abstract class AbstractSqlTaskDecorator implements SqlTask {
     }
 
     @Override
+    public boolean isDML() {
+        return m_taskToDecorate.isDML();
+    }
+
+    @Override
+    public boolean isDQL() {
+        return m_taskToDecorate.isDQL();
+    }
+
+    @Override
     public String getSQL() {
         return m_taskToDecorate.getSQL();
     }

--- a/src/frontend/org/voltdb/newplanner/NonDdlBatchCompiler.java
+++ b/src/frontend/org/voltdb/newplanner/NonDdlBatchCompiler.java
@@ -61,17 +61,18 @@ public class NonDdlBatchCompiler {
 
         for (final SqlTask task : m_batch) {
             try {
-                AdHocPlannedStatement result = compileTask(task);
-                // The planning tool may have optimized for the single partition case
-                // and generated a partition parameter.
-                if (m_batch.inferPartitioning()) {
+                final AdHocPlannedStatement result = compileTask(task);
+                if (result == null) {   // if any SQL of the batch is unsupported, signal caller to use fall back behavior.
+                    return null;
+                } else if (m_batch.inferPartitioning()) {
+                    // The planning tool may have optimized for the single partition case
+                    // and generated a partition parameter.
                     partitionParamIndex = result.getPartitioningParameterIndex();
                     partitionParamType = result.getPartitioningParameterType();
                     partitionParamValue = result.getPartitioningParameterValue();
                 }
                 plannedStmts.add(result);
-            }
-            catch (AdHocPlanningException e) {
+            } catch (AdHocPlanningException e) {
                 errorMsgs.add(e.getMessage());
             }
         }
@@ -93,6 +94,8 @@ public class NonDdlBatchCompiler {
     /**
      * Compile a batch of one or more SQL statements into a set of plans.
      * Parameters are valid iff there is exactly one DML/DQL statement.
+     * @param task SqlTask for one SQL statement
+     * @return planned statement, or null if the SqlTask is not fully planned/supported.
      */
     private AdHocPlannedStatement compileTask(SqlTask task) throws AdHocPlanningException {
         // TRAIL [Calcite:3] NonDdlBatchCompiler.compileTask()

--- a/src/frontend/org/voltdb/newplanner/SqlBatch.java
+++ b/src/frontend/org/voltdb/newplanner/SqlBatch.java
@@ -35,20 +35,20 @@ public interface SqlBatch extends Iterable<SqlTask>  {
      * Check if the batch is purely comprised of DDL statements.
      * @return true if the batch is comprised of DDL statements only.
      */
-    public boolean isDDLBatch();
+    boolean isDDLBatch();
 
 
     /**
      * Get the user parameters.
      * @return the user parameter array.
      */
-    public Object[] getUserParameters();
+    Object[] getUserParameters();
 
     /**
      * Get the number of tasks in this batch.
      * @return the count of tasks in this batch.
      */
-    public int getTaskCount();
+    int getTaskCount();
 
     /**
      * Build a {@link SqlBatch} from a {@link ParameterSet} passed through the {@code @AdHoc}
@@ -61,15 +61,11 @@ public interface SqlBatch extends Iterable<SqlTask>  {
      * @throws UnsupportedOperationException when the batch is a mixture of
      * DDL and non-DDL statements or has parameters and more than one query at the same time.
      */
-    public static SqlBatch fromParameterSet(ParameterSet params) throws SqlParseException, PlannerFallbackException {
+    static SqlBatch fromParameterSet(ParameterSet params) throws SqlParseException, PlannerFallbackException {
         Object[] paramArray = params.toArray();
         // The first parameter is always the query string.
         String sqlBlock = (String) paramArray[0];
-        Object[] userParams = null;
-        // AdHoc query can have parameters, see TestAdHocQueries.testAdHocWithParams.
-        if (params.size() > 1) {
-            userParams = Arrays.copyOfRange(paramArray, 1, paramArray.length);
-        }
+        Object[] userParams = Arrays.copyOfRange(paramArray, 0, paramArray.length);
         return new SqlBatchImpl(sqlBlock, userParams);
     }
 }

--- a/src/frontend/org/voltdb/newplanner/SqlBatchImpl.java
+++ b/src/frontend/org/voltdb/newplanner/SqlBatchImpl.java
@@ -107,7 +107,7 @@ public class SqlBatchImpl implements SqlBatch {
             m_tasks.add(sqlTask);
         }
         m_isDDLBatch = isDDLBatch;
-        m_userParams = userParams;
+        m_userParams = userParams == null ? new Object[0] : userParams;
     }
 
     @Override

--- a/src/frontend/org/voltdb/newplanner/SqlTask.java
+++ b/src/frontend/org/voltdb/newplanner/SqlTask.java
@@ -28,10 +28,22 @@ import org.apache.calcite.sql.parser.SqlParseException;
 public interface SqlTask {
 
     /**
-     * Tell if this {@link SqlTaskImpl} is a DDL task.
+     * Tell if this {@code SqlTask} is a DDL task.
      * @return true if this {@code SqlTask} is a DDL task.
      */
     boolean isDDL();
+
+    /**
+     * Tell if this {@code SqlTask} is a DQL task.
+     * @return true if this {@code SqlTask} is a DQL task.
+     */
+    boolean isDQL();
+
+    /**
+     * Tell if this {@code SqlTask} is a DML task.
+     * @return true if this {@code SqlTask} is a DML task.
+     */
+    boolean isDML();
 
     /**
      * Get the original SQL query text.

--- a/src/frontend/org/voltdb/newplanner/SqlTaskImpl.java
+++ b/src/frontend/org/voltdb/newplanner/SqlTaskImpl.java
@@ -56,6 +56,16 @@ public class SqlTaskImpl implements SqlTask {
         return m_parsedQuery.isA(SqlKind.DDL);
     }
 
+    @Override
+    public boolean isDQL() {
+        return m_parsedQuery.getKind() == SqlKind.SELECT;
+    }
+
+    @Override
+    public boolean isDML() {
+        return m_parsedQuery.isA(SqlKind.DML);
+    }
+
     /**
      * Get the original SQL query text.
      * @return the original SQL query text.

--- a/src/frontend/org/voltdb/newplanner/guards/RealCalciteCheck.java
+++ b/src/frontend/org/voltdb/newplanner/guards/RealCalciteCheck.java
@@ -18,6 +18,7 @@
 package org.voltdb.newplanner.guards;
 
 import org.apache.calcite.sql.parser.SqlParseException;
+import org.voltdb.newplanner.SqlTask;
 import org.voltdb.newplanner.SqlTaskImpl;
 import org.voltdb.planner.PlanningErrorException;
 
@@ -39,7 +40,8 @@ public class RealCalciteCheck extends CalciteCheck {
     @Override
     protected boolean doCheck(String sql) {
         try {
-            return new SqlTaskImpl(sql).isDDL();
+            final SqlTask task = new SqlTaskImpl(sql);
+            return task.isDDL() || task.isDQL();
         } catch (SqlParseException e) {
             if (e.getCause() instanceof StackOverflowError) {
                 throw new PlanningErrorException("Encountered stack overflow error. " +

--- a/src/frontend/org/voltdb/sysprocs/AdHoc.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc.java
@@ -93,7 +93,6 @@ public class AdHoc extends AdHocNTBase {
 
         List<String> sqlStatements = new ArrayList<>();
         AdHocSQLMix mix = processAdHocSQLStmtTypes(sql, sqlStatements);
-
         if (mix == AdHocSQLMix.EMPTY) {
             // we saw neither DDL or DQL/DML.  Make sure that we get a
             // response back to the client

--- a/template.classpath
+++ b/template.classpath
@@ -44,55 +44,57 @@
 	-->
     <classpathentry kind="lib" path="third_party/java/jars/kafka-clients-0.10.2.1.jar"/>
     <classpathentry kind="lib" path="lib/kafka-clients-0.8.2.2.jar"/>
-	<classpathentry kind="lib" path="lib/kafka_2.11-0.8.2.2.jar"/>
+    <classpathentry kind="lib" path="lib/kafka_2.11-0.8.2.2.jar"/>
 
-	<classpathentry kind="lib" path="lib/lz4-1.2.0.jar"/>
-	<classpathentry kind="lib" path="lib/metrics-core-2.2.0.jar"/>
-	<classpathentry kind="lib" path="lib/scala-library-2.11.5.jar"/>
-	<classpathentry kind="lib" path="lib/jackson-core-asl-1.9.13.jar"/>
-	<classpathentry kind="lib" path="lib/jackson-mapper-asl-1.9.13.jar"/>
-	<classpathentry kind="lib" path="lib/felix.jar"/>
-	<classpathentry kind="lib" path="lib/httpclient-4.3.6.jar"/>
-	<classpathentry kind="lib" path="lib/httpcore-4.3.3.jar"/>
-	<classpathentry kind="lib" path="lib/commons-logging-1.1.3.jar"/>
-	<classpathentry kind="lib" path="lib/tomcat-jdbc.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/amazon-kinesis-client-1.6.2.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/aws-java-sdk-1.10.72.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/jackson-dataformat-cbor-2.5.3.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/jackson-databind-2.5.3.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/jackson-core-2.5.3.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/jackson-annotations-2.5.0.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/joda-time-2.9.3.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/commons-lang-2.6.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/guava-18.0.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-		<attributes>
-			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="voltdb/voltdb"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="lib/tomcat-juli.jar"/>
-	<classpathentry kind="lib" path="lib/scala-parser-combinators_2.11-1.0.2.jar"/>
-	<classpathentry kind="lib" path="lib/scala-xml_2.11-1.0.2.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/javassist-3.20.0-GA.jar"/>
-	<classpathentry kind="lib" path="lib/calcite-core-1.17.0.jar" sourcepath="lib/calcite-core-1.17.0-sources.jar"/>
-	<classpathentry kind="lib" path="lib/calcite-server-1.17.0.jar" sourcepath="lib/calcite-server-1.17.0-sources.jar"/>
-	<classpathentry kind="lib" path="lib/calcite-linq4j-1.17.0.jar" sourcepath="lib/calcite-linq4j-1.17.0-sources.jar"/>
-	<classpathentry kind="lib" path="lib/avatica-core-1.12.0.jar" sourcepath="lib/avatica-core-1.12.0-sources.jar"/>
-	<!-- zkclient is used for tests only -->
-	<classpathentry kind="lib" path="third_party/java/jars/zkclient-0.10.jar"/>
-	<!-- regular zookeeaper server 3.4.10 is used for tests only -->
-	<classpathentry kind="lib" path="third_party/java/jars/zookeeper-3.4.10.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/commons-io-1.4.jar"/>
-	<classpathentry kind="lib" path="third_party/java/jars/httpclient-4.3.4-tests.jar"/>
-	<classpathentry kind="lib" path="lib/avro-1.7.7.jar"/>
-	<classpathentry kind="lib" path="lib/httpasyncclient-4.0.2.jar"/>
-	<classpathentry kind="lib" path="lib/httpcore-nio-4.3.2.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-continuation-9.3.21.v20170918.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-http-9.3.21.v20170918.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-io-9.3.21.v20170918.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-server-9.3.21.v20170918.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-util-9.3.21.v20170918.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-servlet-9.3.21.v20170918.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-security-9.3.21.v20170918.jar"/>
-	<classpathentry kind="output" path="obj/eclipse"/>
+    <classpathentry kind="lib" path="lib/lz4-1.2.0.jar"/>
+    <classpathentry kind="lib" path="lib/metrics-core-2.2.0.jar"/>
+    <classpathentry kind="lib" path="lib/scala-library-2.11.5.jar"/>
+    <classpathentry kind="lib" path="lib/jackson-core-asl-1.9.13.jar"/>
+    <classpathentry kind="lib" path="lib/jackson-mapper-asl-1.9.13.jar"/>
+    <classpathentry kind="lib" path="lib/felix.jar"/>
+    <classpathentry kind="lib" path="lib/httpclient-4.3.6.jar"/>
+    <classpathentry kind="lib" path="lib/httpcore-4.3.3.jar"/>
+    <classpathentry kind="lib" path="lib/commons-logging-1.1.3.jar"/>
+    <classpathentry kind="lib" path="lib/tomcat-jdbc.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/amazon-kinesis-client-1.6.2.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/aws-java-sdk-1.10.72.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/jackson-dataformat-cbor-2.5.3.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/jackson-databind-2.5.3.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/jackson-core-2.5.3.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/jackson-annotations-2.5.0.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/joda-time-2.9.3.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/commons-lang-2.6.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/guava-18.0.jar"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+       <attributes>
+          <attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="voltdb/voltdb"/>
+       </attributes>
+    </classpathentry>
+    <classpathentry kind="lib" path="lib/tomcat-juli.jar"/>
+    <classpathentry kind="lib" path="lib/scala-parser-combinators_2.11-1.0.2.jar"/>
+    <classpathentry kind="lib" path="lib/scala-xml_2.11-1.0.2.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/javassist-3.20.0-GA.jar"/>
+    <classpathentry kind="lib" path="lib/calcite-core-1.17.0.jar" sourcepath="lib/calcite-core-1.17.0-sources.jar"/>
+    <classpathentry kind="lib" path="lib/calcite-server-1.17.0.jar" sourcepath="lib/calcite-server-1.17.0-sources.jar"/>
+    <classpathentry kind="lib" path="lib/calcite-linq4j-1.17.0.jar" sourcepath="lib/calcite-linq4j-1.17.0-sources.jar"/>
+    <classpathentry kind="lib" path="lib/avatica-core-1.12.0.jar" sourcepath="lib/avatica-core-1.12.0-sources.jar"/>
+    <classpathentry kind="lib" path="lib/commons-compiler-2.7.6.jar" />
+    <classpathentry kind="lib" path="lib/janino-2.7.6.jar" />
+    <!-- zkclient is used for tests only -->
+    <classpathentry kind="lib" path="third_party/java/jars/zkclient-0.10.jar"/>
+    <!-- regular zookeeaper server 3.4.10 is used for tests only -->
+    <classpathentry kind="lib" path="third_party/java/jars/zookeeper-3.4.10.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/commons-io-1.4.jar"/>
+    <classpathentry kind="lib" path="third_party/java/jars/httpclient-4.3.4-tests.jar"/>
+    <classpathentry kind="lib" path="lib/avro-1.7.7.jar"/>
+    <classpathentry kind="lib" path="lib/httpasyncclient-4.0.2.jar"/>
+    <classpathentry kind="lib" path="lib/httpcore-nio-4.3.2.jar"/>
+    <classpathentry kind="lib" path="lib/jetty-continuation-9.3.21.v20170918.jar"/>
+    <classpathentry kind="lib" path="lib/jetty-http-9.3.21.v20170918.jar"/>
+    <classpathentry kind="lib" path="lib/jetty-io-9.3.21.v20170918.jar"/>
+    <classpathentry kind="lib" path="lib/jetty-server-9.3.21.v20170918.jar"/>
+    <classpathentry kind="lib" path="lib/jetty-util-9.3.21.v20170918.jar"/>
+    <classpathentry kind="lib" path="lib/jetty-servlet-9.3.21.v20170918.jar"/>
+    <classpathentry kind="lib" path="lib/jetty-security-9.3.21.v20170918.jar"/>
+    <classpathentry kind="output" path="obj/eclipse"/>
 </classpath>


### PR DESCRIPTION
Excercise Calcite parsing/planning for all ad-hoc DQL queries. Since
planning is not supported, the PlannerTool.planSqlCalcite() method will
just exercise to the point that Calcite planning is built, then return
null, and its caller chain will use fall back behavior to plan the
query.

Based off my latest, un-merged dev branch. Changes/fixes of indenting 
in file `template.classpath`.