### PR TITLE
Eng 14941 export blocked

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1436,7 +1436,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     return;
                 }
                 if (exportLog.isDebugEnabled()) {
-                    exportLog.debug(ExportDataSource.this.toString() + " decides to claw mastership back from other node.");
+                    exportLog.debug(ExportDataSource.this.toString() + " is going to export data because partition leader is on current node.");
                 }
                 // Query export membership if current stream is not the master
                 sendTakeMastershipMessage();

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1004,15 +1004,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
     }
 
-    private void releaseBlock() {
-        if (m_status == StreamStatus.BLOCKED) {
-            RealVoltDB voltdb = (RealVoltDB)VoltDB.instance();
-            if (voltdb.isClusterComplete()) {
-                processStreamControl(OperationMode.RELEASE);
-            }
-        }
-    }
-
     public class AckingContainer extends BBContainer {
         final long m_seqNo;
         final int m_tuplesCount;
@@ -1501,7 +1492,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                                             ExportDataSource.this.toString() + ". Please rejoin a node with the missing export queue data or " +
                                             "use 'voltadmin release' command to skip the missing data.");
                                 } else {
-                                    releaseBlock();
+                                    processStreamControl(OperationMode.RELEASE);
                                 }
                             }
                         } else {

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1282,7 +1282,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     private void sendQueryResponse(long senderHSId, long requestId, long lastSeq) {
         Pair<Mailbox, ImmutableList<Long>> p = m_ackMailboxRefs.get();
         Mailbox mbx = p.getFirst();
-        if (mbx != null && p.getSecond().size() > 0 && p.getSecond().contains(senderHSId)) {
+        if (mbx != null) {
             // msg type(1) + partition:int(4) + length:int(4) + signaturesBytes.length
             // requestId(8) + lastSeq(8)
             int msgLen = 1 + 4 + 4 + m_signatureBytes.length + 8 + 8;
@@ -1591,7 +1591,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     @Override
     public String toString() {
         return "ExportDataSource for table " + getTableName() + " partition " + getPartitionId()
-           + " (" + m_status + ", " + m_mastershipAccepted.get() + ")";
+           + " (" + m_status + ", " + (m_mastershipAccepted.get() ? "Master":"Replica") + ")";
     }
 
     private void mastershipCheckpoint(long seq) {


### PR DESCRIPTION
So far I identified two problems: 1) auto release feature checks cluster completeness meanwhile gap detection/resolution checks export mailboxes list, so it’s possible that before gap resolution gets a chance to query other nodes, cluster completeness check is passed. This causes premature gap release which lead to missing rows.
2) There is a race window between updating export mailboxes list and receiving query message, if query message is received before export mailboxes update, it causes blocked stream failed to find missing data on other nodes.