### PR TITLE
Eng 15004 investigation notest (NOT FOR MERGING)

### DIFF
--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -375,7 +375,7 @@ public class GuestProcessor implements ExportDataProcessor {
                                             row = ExportRow.decodeRow(edb.getPreviousRow(), source.getPartitionId(), m_startTS, rowdata);
                                             edb.setPreviousRow(row);
                                         } catch (IOException ioe) {
-                                            m_logger.warn("Failed decoding row for partition" + source.getPartitionId() + ". " + ioe.getMessage());
+                                            m_logger.warn("YYY Failed decoding row for partition" + source.getPartitionId() + ". " + ioe.getMessage());
                                             cont.discard();
                                             cont = null;
                                             break;
@@ -404,7 +404,7 @@ public class GuestProcessor implements ExportDataProcessor {
                                 }
                                 break;
                             } catch (RestartBlockException e) {
-                                m_logger.warn("YYY restart exception, seq: " + cont.m_seqNo + ", cnt: " + cont.m_tuplesCount);
+                                m_logger.warn("YYY restart exception, seq: " + cont.m_seqNo + ", cnt: " + cont.m_tuplesCount + ", e: " + e.getMessage());
                                 if (m_shutdown) {
                                     if (m_logger.isDebugEnabled()) {
                                         // log message for debugging.

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -404,6 +404,7 @@ public class GuestProcessor implements ExportDataProcessor {
                                 }
                                 break;
                             } catch (RestartBlockException e) {
+                                m_logger.warn("YYY restart exception, seq: " + cont.m_seqNo + ", cnt: " + cont.m_tuplesCount);
                                 if (m_shutdown) {
                                     if (m_logger.isDebugEnabled()) {
                                         // log message for debugging.

--- a/src/frontend/org/voltdb/exportclient/kafka/KafkaExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/kafka/KafkaExportClient.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -84,6 +85,8 @@ public class KafkaExportClient extends ExportClientBase {
     Map<String, String> m_tablePartitionColumns;
     boolean m_pollFutures = false;
     int m_acksTimeout = 5_000;
+
+    static public AtomicLong rowCount = new AtomicLong(0);
 
     @Override
     public void configure(Properties config) throws Exception {
@@ -353,6 +356,7 @@ public class KafkaExportClient extends ExportClientBase {
             } finally {
                 m_futures.clear();
                 m_failure.set(false);
+                LOG.warn("XXX Rows processed: " + rowCount.get());
             }
         }
 
@@ -379,6 +383,9 @@ public class KafkaExportClient extends ExportClientBase {
                             LOG.warn("Failed to send data. Verify if the kafka server matches bootstrap.servers %s", e,
                                     m_producerConfig.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
                             m_failure.compareAndSet(false, true);
+                        }
+                        else {
+                            rowCount.incrementAndGet();
                         }
                     }
                 }));

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaConsumerRunner.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaConsumerRunner.java
@@ -48,8 +48,8 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.EstTime;
 import org.voltdb.client.ProcedureCallback;
 import org.voltdb.importclient.kafka.util.DurableTracker;
-import org.voltdb.importclient.kafka.util.KafkaConstants;
 import org.voltdb.importclient.kafka.util.KafkaCommitPolicy;
+import org.voltdb.importclient.kafka.util.KafkaConstants;
 import org.voltdb.importclient.kafka.util.KafkaUtils;
 import org.voltdb.importclient.kafka.util.PendingWorkTracker;
 import org.voltdb.importclient.kafka.util.ProcedureInvocationCallback;
@@ -459,13 +459,12 @@ public abstract class KafkaConsumerRunner implements Runnable {
             return;
         }
 
-        if (LOGGER.isDebugEnabled()) {
-            StringBuilder builder = new StringBuilder("Consumer group " + m_config.getGroupId() + " committs offsets:");
+            StringBuilder builder = new StringBuilder("ZZZ Consumer group " + m_config.getGroupId() + " committs offsets: ");
             for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : partitionToMetadataMap.entrySet()) {
                 builder.append(entry.getKey() + ":" + entry.getValue().offset());
+                builder.append(", ");
             }
-            LOGGER.debug(builder.toString());
-        }
+            LOGGER.warn(builder.toString());
 
         try {
             m_consumer.commitSync(partitionToMetadataMap);
@@ -476,10 +475,10 @@ public abstract class KafkaConsumerRunner implements Runnable {
                 m_consumer.commitSync(partitionToMetadataMap);
                 m_lastCommitTime = EstTime.currentTimeMillis();
             } catch(KafkaException ke) {
-                LOGGER.warn("Consumer group " + m_config.getGroupId() + " commit offsets:" + ke.getMessage());
+                LOGGER.warn("Consumer group " + m_config.getGroupId() + " commit offsets: " + ke.getMessage());
             }
         } catch (CommitFailedException ce) {
-            LOGGER.warn("Consumer group " + m_config.getGroupId() + " commit offsets:" + ce.getMessage());
+            LOGGER.warn("Consumer group " + m_config.getGroupId() + " commit offsets: " + ce.getMessage());
         }
     }
 

--- a/tests/test_apps/kafkaimporter/client/kafkaimporter/KafkaImportBenchmark.java
+++ b/tests/test_apps/kafkaimporter/client/kafkaimporter/KafkaImportBenchmark.java
@@ -594,6 +594,7 @@ public class KafkaImportBenchmark {
                 } else {
                     log.error(mirrorStreamCounts + " Rows not imported by all streams, failing test");
                 }
+                MatchChecks.findMirrorTableMissingRows(config.streams, client);
             }
         }
 

--- a/tests/test_apps/kafkaimporter/client/kafkaimporter/MatchChecks.java
+++ b/tests/test_apps/kafkaimporter/client/kafkaimporter/MatchChecks.java
@@ -333,6 +333,7 @@ public class MatchChecks {
     */
     protected static long getExportBacklog(Client client) {
         long backlog = 0;
+        long tcount = 0;
         try {
             VoltTable tableStats = client.callProcedure("@Statistics", "export", 0).getResults()[0];
             while (tableStats.advanceRow()) {
@@ -340,11 +341,18 @@ public class MatchChecks {
                 if ( allocatedMemory > 0 ) {
                         backlog = backlog + allocatedMemory;
                 }
+                Long tuple_count = tableStats.getLong("TUPLE_COUNT");
+                if ( tuple_count > 0 ) {
+                        tcount += tuple_count;
+                }
             }
         } catch (Exception e) {
             log.error("Table Stats query failed: " + e.getMessage());
         }
 
+        if ( backlog == 0 ) {
+            log.info("No exports pending, total rows exported: " + tcount);
+        }
         return backlog;
 
     }
@@ -404,4 +412,3 @@ public class MatchChecks {
         return false;
     }
 }
-


### PR DESCRIPTION
NOT FOR MERGING

Can you review the instrumentation in ExportDataSource.java only and verify if I made a gross mistake. If not, then ENG-15004 may be caused by what is reported in method checkContinuity(), or it's a red herring and the root cause is something else.

What is disturbing is that the 'rowCount' variable consistently reports the exact number of rows that the CLIENT test progam claims to have inserted in the export stream.
