### PR TITLE
ENG-13811: added randomized Indexes to grammar-gen

### DIFF
--- a/tests/sqlgrammar/sql-ddl-grammar.txt
+++ b/tests/sqlgrammar/sql-ddl-grammar.txt
@@ -14,14 +14,6 @@
 #   CREATE STREAM, DROP STREAM; CREATE PROCEDURE FROM CLASS
 
 ################################################################################
-# Grammar rules for any (SQL) DDL statement:
-ddl-statement           ::= {create-statement} | {alter-table-statement} | \
-                            {drop-statement}   | {partition-statement}
-
-create-statement        ::= {create-table-statement} | {create-view-statement} | \
-                            {create-index-statement} | {create-proc-as-statement}
-
-################################################################################
 # Define names & types needed in the DDL definitions below:
 small-digit             ::= 1 | 2 | 3 | 4 | 5 | 6
 
@@ -66,15 +58,6 @@ create-view-statement   ::= CREATE VIEW {view-name} ({column-name-list}) AS \
                             [GROUP BY {column-expression}]
 
 column-name-list        ::= {column-name} [, {column-name-list}] [, {column-name-list}]
-
-################################################################################
-# Grammar rules for CREATE INDEX statements:
-################################################################################
-create-index-statement  ::= CREATE [{unique-or-assume-unique}] INDEX {index-name} \
-                            ON {table-or-view-name} ({column-name-list}) \
-                            [{where-clause}]
-
-unique-or-assume-unique ::= UNIQUE | ASSUMEUNIQUE
 
 ################################################################################
 # Grammar rules for ALTER TABLE statements:

--- a/tests/sqlgrammar/sql-grammar.txt
+++ b/tests/sqlgrammar/sql-grammar.txt
@@ -109,11 +109,15 @@ swappable-tables        ::= R11[,] R12 | P11[,] P12 | R21[,] R22 | P21[,] P22 | 
                             'R12'[,] R11 | P12[,] 'P11' | R22[,] 'R21' | 'P22'[,] P21 | \
                             {table-name}[,] {table-name} | '{table-name}'[,] '{table-name}'
 
-legit-table-name        ::= {table-name-w-no-pk} | {table-name-w-pk-int} 4| {table-name-w-pk-str} | \
+# TODO: include {ddl-table-name} (with non-zero weight), once implemented:
+legit-table-name        ::= {ddl-table-name} 0| {table-name-w-no-pk} | \
+                            {table-name-w-pk-int} 4| {table-name-w-pk-str} | \
                             {table-name-w-pk-int-str} | {table-name-w-pk-str-int} | \
                             {table-name-w-pk-varbin}  | {table-name-w-pk-i-s-v}
 
-legit-view-name         ::= VR1 | VP1 | VR2 | VP2 | VR3 | VP3 | VR4 | VP4 | \
+# TODO: include {ddl-view-name} (with non-zero weight), once implemented:
+legit-view-name         ::= {ddl-view-name} 0| \
+                            VR1 | VP1 | VR2 | VP2 | VR3 | VP3 | VR4 | VP4 | \
                             VR5 | VP5 | VR6 | VP6 | VR7 | VP7
 
 table-name              ::= {legit-table-name} 199| NONEXISTENT_TABLE
@@ -199,6 +203,7 @@ view-column-name        ::= {table-column-name}
 legit-column-name       ::= {table-column-name} 9| {view-column-name}
 column-name             ::= {legit-column-name} 399| NONEXISTENT_COLUMN
 column-list             ::= {column-name} [, {column-list}]
+column-expression-list  ::= {column-expression} [, {column-expression-list}]
 
 # These versions include the JSON and 'internet' columns (used with the INET... functions),
 # which we don't normally want to set to invalid values (but selecting them is fine)
@@ -214,7 +219,7 @@ any-varbin-column-name  ::= {varbin-ipv-column-name} 2| {varbinary-column-name}
 any-table-column-name   ::= {table-column-name} 15| {varbin-ipv-column-name} 2| {string-ipv-column-name} 2| {json-column-name}
 any-view-column-name    ::= {any-table-column-name}
 any-legit-column-name   ::= {any-table-column-name} 9| {any-view-column-name}
-any-column-name         ::= {any-legit-column-name} 399| NONEXISTENT_COLUMN
+any-column-name         ::= {any-legit-column-name} 999| NONEXISTENT_COLUMN
 
 # Note: if you add a new column to the DDL file, add it here
 # (and in other places with this comment)
@@ -273,6 +278,7 @@ t0                      ::= {t0-set:t5} 6| \
                             {t0-set:t1}
 
 table-name-or-alias-set ::= {table-name-set} 3| {table-alias-set}
+table-or-view-name-set  ::= {table-name-set} 3| {view-name-set}
 view-name-or-alias-set  ::= {view-name-set}  3| {view-alias-set}
 
 table-ref-set           ::= {table-name-or-alias-set} 5| \
@@ -296,15 +302,19 @@ column-alias-set        ::= {column-alias:ca1} 6| \
 column-alias-ref        ::= {column-alias;ca1,ca2,ca3,ca4,ca5,c1,c2,c3,c4}
 
 ################################################################################
-# Any (non-DDL) SQL statement:
+# Any SQL statement (this now includes some DDL statements):
 # The "50" before the first "|" makes the "select-statement" option 50 times as
 # likely as the least likely (last) option; so half of these SQL statements will
-# be SELECT statements; but only 1% will be "delete-statement", since we don't
-# want to delete all the rows in a table too often.
+# be SELECT statements; but only 1% will be "ddl-statement", since we don't want
+# to change the schema too often. Similarly, only 1% will be "delete-statement",
+# since we don't want to delete all the rows in a table too often.
 #
-sql-statement           ::= {select-statement} 50| {cte-statement} 5| \
-                            {insert-statement} 14| {upsert-statement} 13| {update-statement} 12| \
-                            {special-sql-statement} 5| {delete-statement}
+sql-statement           ::= {select-statement} 50| {cte-statement}     5| \
+                            {dml-statement}    40| {sqlcmd-statement}  4| \
+                            {ddl-statement}
+
+dml-statement           ::= {insert-statement} 13| {upsert-statement} 13| \
+                            {update-statement} 13| {delete-statement}
 
 ################################################################################
 # Grammar rules for an INSERT statement:
@@ -1178,17 +1188,16 @@ recursive-clause-point1 ::= add2GeographyPoint({cte-col1:ctec1}, {point-rarely-n
 recursive-clause-poly1  ::= addGeographyPointToGeography({cte-col1:ctec1}, {point-rarely-null-value})
 
 ################################################################################
-# Grammar rules for special non-standard SQL statements that can be used in
-# sqlcmd (and therefore should be tested), even though they are not part of
-# standard SQL. The most important such statements are the ones that 'exec'
-# a (System, Default, or User-defined) Stored Procedure; but you can also
-# CREATE or DROP a Stored Procedure (which are DDL statements); or 'explain'
-# a SQL statement, procedure, or view; or 'show' a list of tables, classes,
+# Grammar rules for special non-standard statements that can be used in sqlcmd
+# (and therefore should be tested), even though they are not part of standard
+# SQL. The most important such statements are the ones that 'exec' a (System,
+# Default, or User-defined) Stored Procedure; but you can also 'explain' a SQL
+# statement, procedure, or view; or 'show' a list of tables, classes,
 # procedures, or functions.
 ################################################################################
 #
-special-sql-statement   ::= {exec-stored-proc} 80| {explain-statement} 10| \
-                            {random-proc-statement} 9| {show-statement}
+sqlcmd-statement        ::= {exec-stored-proc} 89| {explain-statement} 10| \
+                            {show-statement}
 
 # Note: both 'exec' and 'show' have two spaces after them; this is a kludge
 # so that all 'exec' statements, and similarly all 'show' statements, will be
@@ -1207,10 +1216,6 @@ explainproc-statement   ::= explainproc {stored-proc-name}
 explainview-statement   ::= explainview {view-name}
 
 stored-proc-name        ::= {user-proc-name} 5| {default-proc-name} 4| {system-proc-name}
-
-# Note that these are DDL statements
-# TODO: enable {drop-create-proc-stmnt}, once hanging issues resolved
-random-proc-statement   ::= {drop-create-proc-stmnt} 0| {create-proc-as-statement} 2| {drop-proc-statement}
 
 ################################################################################
 # System Stored Procedures
@@ -2213,9 +2218,64 @@ ng-polygon-value           ::= NULL
 
 
 ################################################################################
+################################################################################
+################################################################################
+#
+# DDL statements
+#
 # TODO: we probably should eventually combine the sql-ddl-grammar.txt file with
 # this one (i.e., copy it to here), but what follows are the only sections that
-# we need so far (formerly in that file but moved here).
+# we need so far (formerly in that file but moved here, with modifications).
+
+################################################################################
+# Grammar rules for all DDL statements:
+#
+# TODO: include all DDL statements (with non-zero weights), once implemented,
+# especially CREATE TABLE, CREATE VIEW, ALTER TABLE, and PARTITION statements
+#
+ddl-statement           ::= {create-statement}     | {alter-table-statement} 0| \
+                            {partition-statement} 0| {drop-statement}
+
+create-statement        ::= {create-table-statement} 0| {create-index-statement} | \
+                            {create-view-statement}  0| {create-proc-statement}
+
+################################################################################
+# Names for tables, views, indexes, and stored procedures, to be used in DDL
+# statements: some, listed elsewhere, use a fixed schema; others, listed here,
+# may be changed via DDL:
+#
+ddl-table-name          ::= DT{digit-0-to-5}
+ddl-view-name           ::= DV{digit-0-to-5}
+ddl-index-name          ::= DIDX{digit-0-to-5}
+ddl-proc-name           ::= {random-proc-0params}
+
+################################################################################
+# Grammar rules for a CREATE INDEX statement:
+# indexes may be created on any table or view, not only on the 'ddl-...' ones
+# defined above.
+################################################################################
+#
+create-index-statement  ::= CREATE[ {unique-or-assume-unique}] INDEX {ddl-index-name} \
+                            ON {table-or-view-name-set} ({column-expression-list}) \
+                            [[{where-clause}]]
+
+unique-or-assume-unique ::= UNIQUE | ASSUMEUNIQUE
+
+################################################################################
+# Grammar rules for CREATE / DROP PROCEDURE statements:
+# stored procedures may be created on any table or view, not only on the
+# 'ddl-...' ones defined above.
+################################################################################
+#
+# TODO: enable {drop-create-proc-stmnt} (with non-zero weight), once hanging
+# issues are resolved
+create-proc-statement   ::= {create-proc-as-statement} 2| {drop-create-proc-stmnt} 0|  \
+                            {drop-proc-statement}
+
+# This version drops a procedure first (if it exists), before creating a new
+# one using the same procedure name, so this is more likely to be valid
+drop-create-proc-stmnt  ::= DROP PROCEDURE {ddl-proc-name:p0} IF EXISTS; \
+                            {create-proc-as-statement}
 
 ################################################################################
 # Grammar rules for a CREATE PROCEDURE AS statement:
@@ -2223,24 +2283,21 @@ ng-polygon-value           ::= NULL
 #
 # TODO: eventually uncomment the ALLOW {role-name-list} clause (after defining
 # role-name-list, and dealing with roles generally)
-create-proc-as-statement::= CREATE PROCEDURE {random-proc-0params:p0} \
-                            [PARTITION ON TABLE {table-name} COLUMN {column-name}[ PARAMETER {digit}]] \
+create-proc-as-statement::= CREATE PROCEDURE {ddl-proc-name:p0} \
+                            [PARTITION ON TABLE {table-name-ref} \
+                              COLUMN {column-name}[ PARAMETER {digit}]] \
 #                           [[[ALLOW {role-name-list}]]] \
                             AS {sql-statement}
-
-# This version drops a procedure first (if it exists), before creating a new
-# one using the same procedure name, so this is more likely to be valid
-drop-create-proc-stmnt  ::= DROP PROCEDURE {random-proc-0params:p0} IF EXISTS; \
-                            {create-proc-as-statement}
 
 ################################################################################
 # Grammar rules for all DROP statements, i.e., DROP TABLE, DROP VIEW,
 # DROP INDEX, and DROP PROCEDURE statements:
 ################################################################################
 #
-drop-statement          ::= {drop-table-statement} | {drop-view-statement} | \
-                            {drop-index-statement} | {drop-proc-statement}
-drop-table-statement    ::= DROP TABLE {table-name}[[ IF EXISTS]][[ CASCADE]]
-drop-view-statement     ::= DROP VIEW  {view-name}[   IF EXISTS]
-drop-index-statement    ::= DROP INDEX {index-name}[  IF EXISTS]
-drop-proc-statement     ::= DROP PROCEDURE {random-proc-0params}[ IF EXISTS]
+# TODO: include all DROP statements (with non-zero weights), once implemented:
+drop-statement          ::= {drop-table-statement} 0| {drop-index-statement} | \
+                            {drop-view-statement}  0| {drop-proc-statement}
+drop-table-statement    ::= DROP TABLE     {ddl-table-name}[[ IF EXISTS]][[ CASCADE]]
+drop-view-statement     ::= DROP VIEW      {ddl-view-name}[   IF EXISTS]
+drop-index-statement    ::= DROP INDEX     {ddl-index-name}[  IF EXISTS]
+drop-proc-statement     ::= DROP PROCEDURE {ddl-proc-name}[   IF EXISTS]

--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -554,7 +554,10 @@ def print_summary(error_message=''):
                 count_sql_statements[sql_type]['invalid'] = 0
             elif count_sql_statements[sql_type].get('invalid') and not count_sql_statements[sql_type].get('valid'):
                 count_sql_statements[sql_type]['valid'] = 0
-            summary_message += '\n    {0:6s}:'.format(sql_type)
+            if len(sql_type) > 6:
+                summary_message += '\n    {0:6s}:'.format(sql_type[6:])
+            else:
+                summary_message += '\n    {0:6s}:'.format(sql_type)
             for validity in sorted(count_sql_statements[sql_type], reverse=True):
                 if validity != 'total':  # save total for last
                     count = count_sql_statements[sql_type][validity]
@@ -615,7 +618,9 @@ def increment_sql_statement_indexes(index1, index2):
         count_sql_statements[index1][index2] = 1
 
 
-def increment_sql_statement_type(type=None, validity=None, incrementTotal=True):
+def increment_sql_statement_type(type=None, num_chars_in_sql_type=6, validity=None,
+                                 incrementTotal=True, num_chars_in_sub_type=None,
+                                 sql_types_to_use_sub_type='CREATE'):
     """Increment the value of 'count_sql_statements' (a 2D dictionary, i.e.,
     a dict of dict), both for the 'total', 'total' element and for the 'type',
     if specified (i.e., for the type, 'total' element); also, if the 'validity'
@@ -623,14 +628,24 @@ def increment_sql_statement_type(type=None, validity=None, incrementTotal=True):
     values as well (i.e., the 'total', validity and type, validity elements).
     """
 
+    if num_chars_in_sub_type is None:
+        num_chars_in_sub_type = num_chars_in_sql_type
+    total_chars_in_sub_type = num_chars_in_sql_type + num_chars_in_sub_type
+
     if incrementTotal:
         increment_sql_statement_indexes('total', 'total')
         if validity:
             increment_sql_statement_indexes('total', validity)
     if type:
-        increment_sql_statement_indexes(type, 'total')
+        increment_sql_statement_indexes(type[0:num_chars_in_sql_type], 'total')
         if validity:
-            increment_sql_statement_indexes(type, validity)
+            increment_sql_statement_indexes(type[0:num_chars_in_sql_type], validity)
+        if sql_types_to_use_sub_type:
+            for sub_type in sql_types_to_use_sub_type.split(','):
+                if type[0:num_chars_in_sql_type] in sub_type or sub_type in type[0:num_chars_in_sql_type]:
+                    increment_sql_statement_indexes(type[0:total_chars_in_sub_type], 'total')
+                    if validity:
+                        increment_sql_statement_indexes(type[0:total_chars_in_sub_type], validity)
 
 
 class TimeoutException(Exception):
@@ -752,9 +767,9 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                         # which can return multiple '(Returned N rows in X.XXs)' messages
                         continue
                     elif sql_was_echoed_as_output:
-                        increment_sql_statement_type(sql[0:num_chars_in_sql_type], 'valid')
+                        increment_sql_statement_type(sql, num_chars_in_sql_type, 'valid')
                         if sql_contains_echo_substring:
-                            increment_sql_statement_type(' [echo', 'valid', False)
+                            increment_sql_statement_type(' [echo', num_chars_in_sql_type, 'valid', False)
                         break
                     elif debug > 3:
                         # this can happen, though it's uncommon, when two SQL statements
@@ -768,9 +783,9 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                 # indicated by the word 'ERROR' (case insensitive)
                 elif 'ERROR' in output.upper():
                     if sql_was_echoed_as_output:
-                        increment_sql_statement_type(sql[0:num_chars_in_sql_type], 'invalid')
+                        increment_sql_statement_type(sql, num_chars_in_sql_type, 'invalid')
                         if sql_contains_echo_substring:
-                            increment_sql_statement_type(' [echo', 'invalid', False)
+                            increment_sql_statement_type(' [echo', num_chars_in_sql_type, 'invalid', False)
                         break
                     elif debug > 3:
                         # this can happen, though it's uncommon, when there is a multi-line
@@ -782,9 +797,9 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                 # respond with various messages that do not include 'ERROR'
                 elif any( all(err_msg in output for err_msg in kem) for kem in known_error_messages):
                     if sql_was_echoed_as_output:
-                        increment_sql_statement_type(sql[0:num_chars_in_sql_type], 'invalid')
+                        increment_sql_statement_type(sql, num_chars_in_sql_type, 'invalid')
                         if sql_contains_echo_substring:
-                            increment_sql_statement_type(' [echo', 'invalid', False)
+                            increment_sql_statement_type(' [echo', num_chars_in_sql_type, 'invalid', False)
                         break
                     elif debug > 2:
                         # this can happen, though it's uncommon, when there is a multi-line
@@ -809,17 +824,17 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
                             continue
 
                     # Normal 'show' command case
-                    increment_sql_statement_type(sql[0:num_chars_in_sql_type], 'valid')
+                    increment_sql_statement_type(sql, num_chars_in_sql_type, 'valid')
                     if sql_contains_echo_substring:
-                        increment_sql_statement_type(' [echo', 'valid', False)
+                        increment_sql_statement_type(' [echo', num_chars_in_sql_type, 'valid', False)
                     break
 
                 # Invalid 'show' commands return a simple error message; also, once again, these commands
                 # don't get echoed back by sqlcmd, so we don't check sql_was_echoed_as_output here
                 elif 'The valid SHOW command completions are' in output:
-                    increment_sql_statement_type(sql[0:num_chars_in_sql_type], 'invalid')
+                    increment_sql_statement_type(sql, num_chars_in_sql_type, 'invalid')
                     if sql_contains_echo_substring:
-                        increment_sql_statement_type(' [echo', 'invalid', False)
+                        increment_sql_statement_type(' [echo', num_chars_in_sql_type, 'invalid', False)
                     break
 
                 # Check if sqlcmd command not found, or if sqlcmd cannot, or
@@ -864,7 +879,7 @@ def print_sql_statement(sql, num_chars_in_sql_type=6):
             find['previous_tail'] = tail_of_log_file[len(tail_of_log_file)/2:]
 
     else:
-        increment_sql_statement_type(sql[0:num_chars_in_sql_type])
+        increment_sql_statement_type(sql, num_chars_in_sql_type)
 
     if sql_contains_echo_substring and options.echo_grammar:
         print >> echo_output_file, '\nGrammar symbols used (in order), and how many times, and resulting SQL:'
@@ -930,10 +945,11 @@ if __name__ == "__main__":
                       help="seed for random number generator; a blank string, or None, means that the seed "
                           + "should itself be randomly generated [default: None]")
     parser.add_option("-i", "--initial_type", dest="initial_type", default="insert-statement",
-                      help="a type, or comma-separated list of types, of SQL statements to generate initially; typically "
-                          + "used to initialize the database using INSERT statements [default: insert-statement]")
+                      help="a type, or comma-separated list of types, of SQL statements to generate initially; "
+                          + "typically used to initialize the database using DDL and INSERT statements "
+                          + "[default: ddl-statement,insert-statement]")
     parser.add_option("-I", "--initial_number", dest="initial_number", default=5,
-                      help="the number of each INITIAL_TYPE of SQL statement to generate [default: 5]")
+                      help="the number of each INITIAL_TYPE of SQL statement to generate [default: 200]")
     parser.add_option("-t", "--type", dest="type", default="sql-statement",
                       help="a type, or comma-separated list of types, of SQL statements to generate "
                          + "(after the initial ones, if any) [default: sql-statement]")
@@ -1153,7 +1169,17 @@ if __name__ == "__main__":
                             ['PartitionInfo specifies invalid parameter index for procedure'],
                             ['Failed to plan for statement'],
                             ['Invalid parameter index value'],
-                            ['Single partitioned procedure', 'has TRUNCATE statement:']
+                            ['Single partitioned procedure', 'has TRUNCATE statement:'],
+                            ['Unexpected condition occurred applying DDL statements'],
+                            ['A UNIQUE or ASSUMEUNIQUE index is not allowed on a materialized view'],
+                            ['involving other tables is not supported'],
+                            ['Invalid use of UNIQUE'],
+                            ['Cannot create', 'index'],
+                            ['ASSUMEUNIQUE is not valid for an index that includes the partitioning column'],
+                            ['cannot contain aggregate expressions'],
+                            ['cannot contain calls to user defined functions'],
+                            ['cannot contain subqueries'],
+                            ['cannot include the function NOW or CURRENT_TIMESTAMP'],
                            ]
 
     # A list of headers found in responses to valid 'show' commands: one of


### PR DESCRIPTION
Modified sql-grammar.txt to include CREATE (and DROP) INDEX statements,
and organized them into a new "DDL" section, along with the existing
CREATE (and DROP) PROCEDURE AS statements, with a few other minor tweaks
(and deleted a few things from sql-ddl-grammar.txt, which were moved
into sql-grammar.txt, with modifications). Modified
sql_grammar_generator.py to include multiple new error messages that we
see in response to CREATE INDEX statements; and to keep track of, and
for the summary to list, certain statement sub-types separately, e.g.
CREATE PROCEDURE vs. CREATE INDEX vs. CREATE UNIQUE/ASSUMEUNIQUE INDEX,
which are all quite different.