### PR TITLE
Eng 15019 incorrect stat

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -588,6 +588,12 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     }
                     maxLatency = m_overallMaxLatency;
                 }
+                if (exportLog.isDebugEnabled()) {
+                    exportLog.debug("Export stats: " + m_partitionId + " " + m_siteId + " " + m_tableName +
+                            " " + m_exportTargetName + " " + m_mastershipAccepted.get() + " " + m_tupleCount +
+                             " " + m_tuplesPending.get() + " " + m_lastQueuedTimestamp + " " + m_lastAckedTimestamp +
+                             " " + avgLatency + " " + maxLatency + " " + m_queueGap + " " + m_status.toString());
+                }
                 return new ExportStatsRow(m_partitionId, m_siteId, m_tableName, m_exportTargetName,
                         m_mastershipAccepted.get(), m_tupleCount, m_tuplesPending.get(),
                         m_lastQueuedTimestamp, m_lastAckedTimestamp,

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -426,7 +426,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             setStatus(StreamStatus.ACTIVE);
             m_queueGap = 0;
         }
-        m_lastReleasedSeqNo = releaseSeqNo;
         // If persistent log contains gap, mostly due to node failures and rejoins, ACK from leader might
         // cover the gap gradually.
         m_gapTracker.truncate(releaseSeqNo);
@@ -442,6 +441,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("tuplesPending " + original + " minus " + (m_lastReleasedSeqNo - releaseSeqNo) + ": " + m_tuplesPending.get());
         }
+        m_lastReleasedSeqNo = releaseSeqNo;
         return;
     }
 

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -376,8 +376,12 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
     public synchronized void updateAckMailboxes(final Pair<Mailbox, ImmutableList<Long>> ackMailboxes) {
         if (exportLog.isDebugEnabled()) {
-            exportLog.debug("Mailbox " + CoreUtils.hsIdToString(ackMailboxes.getFirst().getHSId()) + " is registered for " + this.toString() +
-                    " : replicas " + CoreUtils.hsIdCollectionToString(ackMailboxes.getSecond()) );
+            if (ackMailboxes.getSecond() != null) {
+                exportLog.debug("Mailbox " + CoreUtils.hsIdToString(ackMailboxes.getFirst().getHSId()) + " is registered for " + this.toString() +
+                        " : replicas " + CoreUtils.hsIdCollectionToString(ackMailboxes.getSecond()) );
+            } else {
+                exportLog.debug("Mailbox " + CoreUtils.hsIdToString(ackMailboxes.getFirst().getHSId()) + " is registered for " + this.toString());
+            }
         }
         m_ackMailboxRefs.set( ackMailboxes);
     }

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -423,13 +423,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             setStatus(StreamStatus.ACTIVE);
             m_queueGap = 0;
         }
-        int original = m_tuplesPending.get();
         m_lastReleasedSeqNo = releaseSeqNo;
         int tuplesDeleted = m_gapTracker.truncate(releaseSeqNo);
         m_tuplesPending.addAndGet(-tuplesDeleted);
-        if (exportLog.isDebugEnabled()) {
-            exportLog.debug("tuplesPending " + original + " minus " + tuplesDeleted + ": " + m_tuplesPending.get());
-        }
         // If persistent log contains gap, mostly due to node failures and rejoins, ACK from leader might
         // cover the gap gradually.
         // Next poll starts from this number, if it sit in between buffers and stream is active, next poll will
@@ -591,12 +587,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     }
                     maxLatency = m_overallMaxLatency;
                 }
-                if (exportLog.isDebugEnabled()) {
-                    exportLog.debug("Export stats: " + m_partitionId + " " + m_siteId + " " + m_tableName +
-                            " " + m_exportTargetName + " " + m_mastershipAccepted.get() + " " + m_tupleCount +
-                             " " + m_tuplesPending.get() + " " + m_lastQueuedTimestamp + " " + m_lastAckedTimestamp +
-                             " " + avgLatency + " " + maxLatency + " " + m_queueGap + " " + m_status.toString());
-                }
                 return new ExportStatsRow(m_partitionId, m_siteId, m_tableName, m_exportTargetName,
                         m_mastershipAccepted.get(), m_tupleCount, m_tuplesPending.get(),
                         m_lastQueuedTimestamp, m_lastAckedTimestamp,
@@ -672,11 +662,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 m_lastQueuedTimestamp = sb.getTimestamp();
                 m_lastPushedSeqNo = lastSequenceNumber;
                 m_tupleCount += tupleCount;
-                int original = m_tuplesPending.get();
                 m_tuplesPending.addAndGet((int)sb.unreleasedRowCount());
-                if (exportLog.isDebugEnabled()) {
-                    exportLog.debug("tuplesPending " + original + " add " + sb.unreleasedRowCount() + ": " + m_tuplesPending.get());
-                }
                 m_committedBuffers.offer(sb);
             } catch (IOException e) {
                 VoltDB.crashLocalVoltDB("Unable to write to export overflow.", true, e);

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -621,7 +621,6 @@ public class ExportGeneration implements Generation {
                                 " signature " + key + " partition " + partition + " site " + siteId);
                     }
 
-
                     dataSourcesForPartition.put(key, exportDataSource);
                 } else {
                     //Since we are loading from catalog any found EDS mark it to be in catalog.

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -272,17 +272,15 @@ public class ExportGeneration implements Generation {
                             if (exportLog.isDebugEnabled()) {
                                 exportLog.debug("Received RELEASE_BUFFER message for " + eds.toString() +
                                         " with sequence number: " + seqNo +
-                                        " tuples sent " + tuplesSent +
                                         " from " + CoreUtils.hsIdToString(message.m_sourceHSId) +
                                         " to " + CoreUtils.hsIdToString(m_mbox.getHSId()));
                             }
-                            eds.ack(seqNo, tuplesSent);
+                            eds.ack(seqNo);
                         } catch (RejectedExecutionException ignoreIt) {
                             // ignore it: as it is already shutdown
                         }
                     } else if (msgType == ExportManager.GIVE_MASTERSHIP) {
                         final long ackSeqNo = buf.getLong();
-                        int tuplesSent = 0;
                         try {
                             if (exportLog.isDebugEnabled()) {
                                 exportLog.debug("Received GIVE_MASTERSHIP message for " + eds.toString() +
@@ -290,7 +288,7 @@ public class ExportGeneration implements Generation {
                                         " from " + CoreUtils.hsIdToString(message.m_sourceHSId) +
                                         " to " + CoreUtils.hsIdToString(m_mbox.getHSId()));
                             }
-                            eds.ack(ackSeqNo, tuplesSent);
+                            eds.ack(ackSeqNo);
                         } catch (RejectedExecutionException ignoreIt) {
                             // ignore it: as it is already shutdown
                         }

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -48,7 +48,6 @@ import org.voltcore.zk.ZKUtil;
 import org.voltdb.CatalogContext;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
 import org.voltdb.VoltDB;
-import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltZK;
 import org.voltdb.RealVoltDB;
@@ -856,7 +855,7 @@ public class ExportGeneration implements Generation {
                     }
 
                     if (eds.processStreamControl(operation)) {
-                        results.addRow(eds.getTableName(), eds.getTarget(), partition, VoltSystemProcedure.STATUS_OK, "");
+                        results.addRow(eds.getTableName(), eds.getTarget(), partition, "SUCCESS", "");
                     }
                 }
             }

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -260,14 +260,6 @@ public class ExportGeneration implements Generation {
 
                     if (msgType == ExportManager.RELEASE_BUFFER) {
                         final long seqNo = buf.getLong();
-                        int tuplesSent = buf.getInt();
-                        if (tuplesSent < 0 ) {
-                            exportLog.warn("Received an export ack for partition "+eds.getTableName()+" Partition:"+eds.getPartitionId());
-                            tuplesSent = 0;
-                        }
-                        if (m_mbox.getHSId() == message.m_sourceHSId) {
-                            tuplesSent = 0;
-                        }
                         try {
                             if (exportLog.isDebugEnabled()) {
                                 exportLog.debug("Received RELEASE_BUFFER message for " + eds.toString() +

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1485,7 +1485,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                     m_partitionId,
                     catalogTable.getSignature());
             // assign the stats to the other partition's value
-            ExportManager.instance().updateInitialExportStateToSeqNo(m_partitionId, tableEntry.getKey(),
+            ExportManager.instance().updateInitialExportStateToSeqNo(m_partitionId, catalogTable.getSignature(),
                     false, sequenceNumbers.getSecond());
         }
 

--- a/src/frontend/org/voltdb/sysprocs/ExportControl.java
+++ b/src/frontend/org/voltdb/sysprocs/ExportControl.java
@@ -70,7 +70,7 @@ public class ExportControl extends VoltSystemProcedure {
                     new ColumnInfo("SOURCE", VoltType.STRING),
                     new ColumnInfo("TARGET", VoltType.STRING),
                     new ColumnInfo("PARTITIONID", VoltType.BIGINT),
-                    new ColumnInfo("STATUS", VoltType.BIGINT),
+                    new ColumnInfo("STATUS", VoltType.STRING),
                     new ColumnInfo("MESSAGE", VoltType.STRING));
 
             if (context.isLowestSiteId()) {
@@ -99,12 +99,12 @@ public class ExportControl extends VoltSystemProcedure {
                 new ColumnInfo("SOURCE", VoltType.STRING),
                 new ColumnInfo("TARGET", VoltType.STRING),
                 new ColumnInfo("PARTITIONID", VoltType.BIGINT),
-                new ColumnInfo("STATUS", VoltType.BIGINT),
+                new ColumnInfo("STATUS", VoltType.STRING),
                 new ColumnInfo("MESSAGE", VoltType.STRING));
         try {
             OperationMode.valueOf(operationMode.toUpperCase());
         } catch (IllegalArgumentException e){
-            results.addRow("", "", -1, VoltSystemProcedure.STATUS_FAILURE, e.getMessage());
+            results.addRow("", "", -1, "FAILURE", e.getMessage());
             return new VoltTable[] {results};
         }
 
@@ -115,7 +115,7 @@ public class ExportControl extends VoltSystemProcedure {
             Set<String> exportStreams = CatalogUtil.getExportTableNames( volt.getCatalogContext().database);
             boolean isThere = exportStreams.stream().anyMatch(exportSource::equalsIgnoreCase);
             if (!isThere) {
-                results.addRow(exportSource, "", -1,VoltSystemProcedure.STATUS_FAILURE, "Export stream " + exportSource + " does not exist.");
+                results.addRow(exportSource, "", -1,"FAILURE", "Export stream " + exportSource + " does not exist.");
                 return new VoltTable[] {results};
             }
         }

--- a/tests/frontend/org/voltdb/export/ExportMatchers.java
+++ b/tests/frontend/org/voltdb/export/ExportMatchers.java
@@ -113,7 +113,6 @@ public class ExportMatchers {
         int partitionId;
         String signature;
         long seqNo;
-        int tuplesSent;
 
         AckPayloadMessage(BinaryPayloadMessage p) {
             ByteBuffer buf = ByteBuffer.wrap(p.m_payload);
@@ -127,17 +126,15 @@ public class ExportMatchers {
             signature = new String( pSignatureBytes, Constants.UTF8ENCODING);
 
             seqNo = buf.getLong();
-            tuplesSent = buf.getInt();
         }
 
-        AckPayloadMessage(int partitionId, String signature, long seqNo, int tuplesSent) {
+        AckPayloadMessage(int partitionId, String signature, long seqNo) {
             Preconditions.checkArgument(signature != null && ! signature.trim().isEmpty());
             Preconditions.checkArgument(seqNo >= 0);
 
             this.partitionId = partitionId;
             this.signature = signature;
             this.seqNo = seqNo;
-            this.tuplesSent = tuplesSent;
         }
 
         int getPartitionId() {
@@ -152,19 +149,14 @@ public class ExportMatchers {
             return seqNo;
         }
 
-        int getTuplesSent() {
-            return tuplesSent;
-        }
-
         VoltMessage asVoltMessage() {
             byte [] signatureBytes = signature.getBytes(Constants.UTF8ENCODING);
-            ByteBuffer buf = ByteBuffer.allocate(25 + signatureBytes.length);
+            ByteBuffer buf = ByteBuffer.allocate(17 + signatureBytes.length);
             buf.put((byte)ExportManager.RELEASE_BUFFER);
             buf.putInt(partitionId);
             buf.putInt(signatureBytes.length);
             buf.put(signatureBytes);
             buf.putLong(seqNo);
-            buf.putLong(tuplesSent);
 
             return new BinaryPayloadMessage(new byte[0], buf.array());
         }

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -483,7 +483,7 @@ public class TestExportDataSource extends TestCase {
                 TEST_DIR.getAbsolutePath());
         try {
             //Ack before push
-            s.ack(100, 0);
+            s.ack(100);
             TreeSet<String> listing = getSortedDirectoryListingSegments();
             assertEquals(listing.size(), 1);
 
@@ -497,7 +497,7 @@ public class TestExportDataSource extends TestCase {
             assertEquals(listing.size(), 1);
 
             //Ack after push beyond size...last segment kept.
-            s.ack(110, 0);
+            s.ack(110);
             sz = s.sizeInBytes();
             assertEquals(0, sz);
             listing = getSortedDirectoryListingSegments();
@@ -513,7 +513,7 @@ public class TestExportDataSource extends TestCase {
             assertEquals(listing.size(), 1);
 
             //Low ack should have no effect.
-            s.ack(100, 0);
+            s.ack(100);
             sz = s.sizeInBytes();
             assertEquals(900, sz);
             listing = getSortedDirectoryListingSegments();
@@ -542,7 +542,7 @@ public class TestExportDataSource extends TestCase {
             s.unacceptMastership();
 
             //Last segment is always kept.
-            s.ack(2000, 0);
+            s.ack(2000);
             sz = s.sizeInBytes();
             assertEquals(sz, 0);
             listing = getSortedDirectoryListingSegments();

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -239,7 +239,7 @@ public class TestExportDataSource extends TestCase {
             //No change in size because the buffers are flattened to disk, until the whole
             //file is polled/acked it won't shrink
             assertEquals( 60, s.sizeInBytes());
-            assertEquals( 1, cont.m_seqNo);
+            assertEquals( 1, cont.m_lastSeqNo);
 
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
@@ -257,7 +257,7 @@ public class TestExportDataSource extends TestCase {
             //Should lose 20 bytes for the stuff in memory
             assertEquals( 40, s.sizeInBytes());
 
-            assertEquals( 2, cont.m_seqNo);
+            assertEquals( 2, cont.m_lastSeqNo);
             assertTrue( foo.equals(cont.b()));
 
             cont.discard();
@@ -268,7 +268,7 @@ public class TestExportDataSource extends TestCase {
 
             //No more buffers on disk, so the + 8 is gone, just the last one pulled in memory
             assertEquals( 20, s.sizeInBytes());
-            assertEquals( 3, cont.m_seqNo);
+            assertEquals( 3, cont.m_lastSeqNo);
             assertEquals( foo, cont.b());
 
             cont.discard();
@@ -428,7 +428,7 @@ public class TestExportDataSource extends TestCase {
         //No change in size because the buffers are flattened to disk, until the whole
         //file is polled/acked it won't shrink
         assertEquals( 60, s.sizeInBytes());
-        assertEquals( 1, cont.m_seqNo);
+        assertEquals( 1, cont.m_lastSeqNo);
 
         foo = ByteBuffer.allocateDirect(20 + StreamBlock.HEADER_SIZE);
         foo.duplicate().put(new byte[20]);
@@ -461,7 +461,7 @@ public class TestExportDataSource extends TestCase {
         cont = s.poll().get();
         cont.updateStartTime(System.currentTimeMillis());
         assertEquals(s.sizeInBytes(), 20);
-        assertEquals(3, cont.m_seqNo);
+        assertEquals(3, cont.m_lastSeqNo);
         cont.discard();
 
         } finally {

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -254,7 +254,7 @@ public class TestExportGeneration {
 
         m_mbox.send(
                 hsid,
-                new AckPayloadMessage(m_part, m_tableSignature, 1L, 1).asVoltMessage()
+                new AckPayloadMessage(m_part, m_tableSignature, 1L).asVoltMessage()
                 );
 
         while( --retries >= 0 && size == m_expDs.sizeInBytes()) {

--- a/tests/frontend/org/voltdb/export/TestExportSequenceNumberTracker.java
+++ b/tests/frontend/org/voltdb/export/TestExportSequenceNumberTracker.java
@@ -46,18 +46,19 @@ public class TestExportSequenceNumberTracker {
     }
 
     @Test
-    public void testAppend() throws Exception {
+    public void testBasic() throws Exception {
         // Append single to range
         tracker.append(1L, 1L);
         assertEquals(1L, tracker.getFirstSeqNo());
         assertEquals(1L, tracker.getLastSeqNo());
         assertEquals(1L, tracker.getSafePoint());
 
-        tracker.truncate(1L);
+        int truncated = tracker.truncate(1L);
         assertEquals(1L, tracker.getFirstSeqNo());
         assertEquals(1L, tracker.getLastSeqNo());
         assertEquals(1L, tracker.getSafePoint());
         assertEquals(null, tracker.getFirstGap());
+        assertEquals(1, truncated);
 
         // Append adjacent single to range
         tracker.append(2L, 9L);
@@ -96,30 +97,35 @@ public class TestExportSequenceNumberTracker {
 
         assertEquals(4, tracker.size());
 
-        tracker.truncate(7L);
+        truncated = tracker.truncate(7L);
         assertEquals(7L, tracker.getFirstSeqNo());
         assertEquals(40L, tracker.getLastSeqNo());
         assertEquals(9L, tracker.getSafePoint());
         assertEquals(10L, tracker.getFirstGap().getFirst().longValue());
         assertEquals(14L, tracker.getFirstGap().getSecond().longValue());
         assertEquals(4, tracker.size());
+        assertEquals(7, truncated);
+        assertEquals(21, tracker.sizeInSequence());
 
         tracker.truncateAfter(22L);
         assertEquals(7L, tracker.getFirstSeqNo());
-        assertEquals(22L, tracker.getLastSeqNo());
+        assertEquals(20L, tracker.getLastSeqNo());
         assertEquals(9L, tracker.getSafePoint());
         assertEquals(10L, tracker.getFirstGap().getFirst().longValue());
         assertEquals(14L, tracker.getFirstGap().getSecond().longValue());
-        assertEquals(3, tracker.size());
+        assertEquals(2, tracker.size());
+        assertEquals(9, tracker.sizeInSequence());
 
         // Truncate inside a gap
-        tracker.truncate(11L);
+        truncated = tracker.truncate(11L);
         assertEquals(11L, tracker.getFirstSeqNo());
-        assertEquals(22L, tracker.getLastSeqNo());
+        assertEquals(20L, tracker.getLastSeqNo());
         assertEquals(11L, tracker.getSafePoint());
         assertEquals(12L, tracker.getFirstGap().getFirst().longValue());
         assertEquals(14L, tracker.getFirstGap().getSecond().longValue());
-        assertEquals(3, tracker.size());
+        assertEquals(2, tracker.size());
+        assertEquals(3, truncated);
+        assertEquals(6, tracker.sizeInSequence());
 
 
     }

--- a/tests/frontend/org/voltdb/export/TestExportSequenceNumberTracker.java
+++ b/tests/frontend/org/voltdb/export/TestExportSequenceNumberTracker.java
@@ -105,7 +105,7 @@ public class TestExportSequenceNumberTracker {
         assertEquals(14L, tracker.getFirstGap().getSecond().longValue());
         assertEquals(4, tracker.size());
         assertEquals(6, truncated);
-        assertEquals(21, tracker.sizeInSequence());
+        assertEquals(20, tracker.sizeInSequence());
 
         tracker.truncateAfter(22L);
         assertEquals(7L, tracker.getFirstSeqNo());
@@ -114,7 +114,7 @@ public class TestExportSequenceNumberTracker {
         assertEquals(10L, tracker.getFirstGap().getFirst().longValue());
         assertEquals(14L, tracker.getFirstGap().getSecond().longValue());
         assertEquals(2, tracker.size());
-        assertEquals(9, tracker.sizeInSequence());
+        assertEquals(8, tracker.sizeInSequence());
 
         // Truncate inside a gap
         truncated = tracker.truncate(11L);
@@ -124,7 +124,7 @@ public class TestExportSequenceNumberTracker {
         assertEquals(12L, tracker.getFirstGap().getFirst().longValue());
         assertEquals(14L, tracker.getFirstGap().getSecond().longValue());
         assertEquals(2, tracker.size());
-        assertEquals(3, truncated);
+        assertEquals(2, truncated);
         assertEquals(6, tracker.sizeInSequence());
 
 

--- a/tests/frontend/org/voltdb/export/TestExportSequenceNumberTracker.java
+++ b/tests/frontend/org/voltdb/export/TestExportSequenceNumberTracker.java
@@ -104,7 +104,7 @@ public class TestExportSequenceNumberTracker {
         assertEquals(10L, tracker.getFirstGap().getFirst().longValue());
         assertEquals(14L, tracker.getFirstGap().getSecond().longValue());
         assertEquals(4, tracker.size());
-        assertEquals(7, truncated);
+        assertEquals(6, truncated);
         assertEquals(21, tracker.sizeInSequence());
 
         tracker.truncateAfter(22L);


### PR DESCRIPTION
This patch includes five changes:
1) completely reply on export sequence tracker to compute pending data,
2) fix a race condition that sometimes replica stream fails to retrieve local mailbox to send back gap query response,
3) fix the accounting problem in export sequence tracker itself,
4) fix the wrong ‘blocked’ status in some cases for active non-blocking stream.
5) fix a pre-8.0 bug that in `m_dataSourcesByPartition` it uses table signature as key but in snapshot digest the key of exportSequence map is table name, causing truncateToSeqNo never find the right stream.
Pro PR: https://github.com/VoltDB/pro/pull/2416