### PR TITLE
ENG-14559:

### DIFF
--- a/src/frontend/org/voltdb/StoredProcedureInvocation.java
+++ b/src/frontend/org/voltdb/StoredProcedureInvocation.java
@@ -277,6 +277,8 @@ public class StoredProcedureInvocation implements JSONString {
                 return ParameterSet.fromByteBuffer(duplicate);
             }
         });
+        params.run(); // do this because in some cases the buffer may be a pooled buffer,
+                      // which may be returned back to the pool before we deserialize.
     }
 
     @Override


### PR DESCRIPTION
Deserialize params immediately in initFromBuffer because
sometimes the buffers are returned back to the pool before the bytes are used for deserialization.