### PR TITLE
Eng 12963 start speedup

### DIFF
--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -241,8 +241,10 @@ public class Cartographer extends StatsSource
         super(false);
         m_hostMessenger = hostMessenger;
         m_zk = hostMessenger.getZK();
-        m_iv2Masters = new LeaderCache(m_zk, VoltZK.iv2masters, m_SPIMasterCallback);
-        m_iv2Mpi = new LeaderCache(m_zk, VoltZK.iv2mpi, m_MPICallback);
+        m_iv2Masters = new LeaderCache(m_zk, "Cartographer-iv2Masters-" + hostMessenger.getHostId(),
+                VoltZK.iv2masters, m_SPIMasterCallback);
+        m_iv2Mpi = new LeaderCache(m_zk, "Cartographer-iv2Mpi-" + hostMessenger.getHostId(),
+                VoltZK.iv2mpi, m_MPICallback);
         m_configuredReplicationFactor = configuredReplicationFactor;
         try {
             m_iv2Masters.start(true);

--- a/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
@@ -177,7 +177,8 @@ public class InitiatorMailbox implements Mailbox
         m_repairLog = repairLog;
         m_joinProducer = joinProducer;
 
-        m_masterLeaderCache = new LeaderCache(m_messenger.getZK(), VoltZK.iv2masters);
+        m_masterLeaderCache = new LeaderCache(m_messenger.getZK(),
+                "InitiatorMailbox-masterLeaderCache-" + m_partitionId, VoltZK.iv2masters);
         try {
             m_masterLeaderCache.start(false);
         } catch (InterruptedException ignored) {
@@ -399,7 +400,8 @@ public class InitiatorMailbox implements Mailbox
         m_newLeaderHSID = newLeaderHSId;
         m_migratePartitionLeaderStatus = MigratePartitionLeaderStatus.STARTED;
 
-        LeaderCache leaderAppointee = new LeaderCache(m_messenger.getZK(), VoltZK.iv2appointees);
+        LeaderCache leaderAppointee = new LeaderCache(m_messenger.getZK(),
+                "initiateSPIMigrationIfRequested-" + m_partitionId, VoltZK.iv2appointees);
         try {
             leaderAppointee.start(true);
             leaderAppointee.put(pid, LeaderCache.suffixHSIdsWithMigratePartitionLeaderRequest(newLeaderHSId));

--- a/src/frontend/org/voltdb/iv2/LeaderAppointer.java
+++ b/src/frontend/org/voltdb/iv2/LeaderAppointer.java
@@ -421,8 +421,10 @@ public class LeaderAppointer implements Promotable
         m_initialPartitionCount = numberOfPartitions;
         m_callbacks = new HashMap<Integer, PartitionCallback>();
         m_partitionWatchers = new HashMap<Integer, BabySitter>();
-        m_iv2appointees = new LeaderCache(m_zk, VoltZK.iv2appointees);
-        m_iv2masters = new LeaderCache(m_zk, VoltZK.iv2masters, m_masterCallback);
+        m_iv2appointees = new LeaderCache(m_zk, "LeaderAppointer-iv2Appointees-host" + hm.getHostId(),
+                VoltZK.iv2appointees);
+        m_iv2masters = new LeaderCache(m_zk, "LeaderAppointer-iv2Masters-host" + hm.getHostId(),
+                VoltZK.iv2masters, m_masterCallback);
         m_stats = stats;
         m_expectingDrSnapshot = expectingDrSnapshot;
     }

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -170,8 +170,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
 
                     // THIS IS where map cache should be updated, not
                     // in the promotion algorithm.
-                    LeaderCacheWriter iv2masters = new LeaderCache(m_messenger.getZK(),
-                            m_zkMailboxNode);
+                    LeaderCacheWriter iv2masters = new LeaderCache(m_messenger.getZK(), "MpInitiator", m_zkMailboxNode);
                     iv2masters.put(m_partitionId, m_initiatorMailbox.getHSId());
                     TTLManager.instance().scheduleTTLTasks();
                 }

--- a/src/frontend/org/voltdb/iv2/MpTerm.java
+++ b/src/frontend/org/voltdb/iv2/MpTerm.java
@@ -102,7 +102,7 @@ public class MpTerm implements Term
     public void start()
     {
         try {
-            m_leaderCache = new LeaderCache(m_zk, VoltZK.iv2masters, m_leadersChangeHandler);
+            m_leaderCache = new LeaderCache(m_zk, "MpTerm-iv2masters", VoltZK.iv2masters, m_leadersChangeHandler);
             m_leaderCache.start(true);
         }
         catch (ExecutionException ee) {

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -29,6 +29,7 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.zk.LeaderElector;
+import org.voltcore.zk.ZKUtil;
 import org.voltdb.BackendTarget;
 import org.voltdb.CatalogContext;
 import org.voltdb.CommandLog;
@@ -115,8 +116,8 @@ public class SpInitiator extends BaseInitiator implements Promotable
                 "SP", agent, startAction);
         ((SpScheduler)m_scheduler).initializeScoreboard(CoreUtils.getSiteIdFromHSId(getInitiatorHSId()),
                 m_initiatorMailbox);
-        m_leaderCache = new LeaderCache(messenger.getZK(), "SpInitiator-appointees-" + partition,
-                VoltZK.iv2appointees, m_leadersChangeHandler);
+        m_leaderCache = new LeaderCache(messenger.getZK(), "SpInitiator-iv2appointees-" + partition,
+                ZKUtil.joinZKPath(VoltZK.iv2appointees, Integer.toString(partition)), m_leadersChangeHandler);
         m_tickProducer = new TickProducer(m_scheduler.m_tasks);
         ((SpScheduler)m_scheduler).m_repairLog = m_repairLog;
     }
@@ -135,7 +136,8 @@ public class SpInitiator extends BaseInitiator implements Promotable
         throws KeeperException, InterruptedException, ExecutionException
     {
         try {
-            m_leaderCache.start(true);
+            // Put child watch on /db/iv2appointees/<partition> node
+            m_leaderCache.startPartitionWatch();
         } catch (Exception e) {
             VoltDB.crashLocalVoltDB("Unable to configure SpInitiator.", true, e);
         }

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -115,7 +115,8 @@ public class SpInitiator extends BaseInitiator implements Promotable
                 "SP", agent, startAction);
         ((SpScheduler)m_scheduler).initializeScoreboard(CoreUtils.getSiteIdFromHSId(getInitiatorHSId()),
                 m_initiatorMailbox);
-        m_leaderCache = new LeaderCache(messenger.getZK(), VoltZK.iv2appointees, m_leadersChangeHandler);
+        m_leaderCache = new LeaderCache(messenger.getZK(), "SpInitiator-appointees-" + partition,
+                VoltZK.iv2appointees, m_leadersChangeHandler);
         m_tickProducer = new TickProducer(m_scheduler.m_tasks);
         ((SpScheduler)m_scheduler).m_repairLog = m_repairLog;
     }
@@ -245,6 +246,7 @@ public class SpInitiator extends BaseInitiator implements Promotable
                     // THIS IS where map cache should be updated, not
                     // in the promotion algorithm.
                     LeaderCacheWriter iv2masters = new LeaderCache(m_messenger.getZK(),
+                            "SpInitiator-iv2masters-" + m_partitionId,
                             m_zkMailboxNode);
 
                     if (migratePartitionLeader) {

--- a/tests/frontend/org/voltdb/iv2/TestCartographer.java
+++ b/tests/frontend/org/voltdb/iv2/TestCartographer.java
@@ -152,7 +152,7 @@ public class TestCartographer extends ZKTestBase {
     {
         ZooKeeper zk = getClient(0);
         VoltZK.createPersistentZKNodes(zk);
-        LeaderCache spwriter = new LeaderCache(zk, VoltZK.iv2masters);
+        LeaderCache spwriter = new LeaderCache(zk, "", VoltZK.iv2masters);
         HostMessenger hm = mock(HostMessenger.class);
         when(hm.getZK()).thenReturn(m_messengers.get(0).getZK());
         Cartographer dut = new Cartographer(hm, 0, false);
@@ -187,7 +187,7 @@ public class TestCartographer extends ZKTestBase {
     {
         ZooKeeper zk = getClient(0);
         VoltZK.createPersistentZKNodes(zk);
-        LeaderCache mpwriter = new LeaderCache(zk, VoltZK.iv2mpi);
+        LeaderCache mpwriter = new LeaderCache(zk, "", VoltZK.iv2mpi);
         HostMessenger hm = mock(HostMessenger.class);
         when(hm.getZK()).thenReturn(m_messengers.get(0).getZK());
         Cartographer dut = new Cartographer(hm, 0, false);

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -135,7 +135,7 @@ public class TestLeaderAppointer extends ZKTestBase {
         m_mpi = mock(MpInitiator.class);
         createAppointer(enablePPD);
 
-        m_cache = new LeaderCache(m_zk, VoltZK.iv2appointees, m_changeCallback);
+        m_cache = new LeaderCache(m_zk, "", VoltZK.iv2appointees, m_changeCallback);
         m_cache.start(true);
     }
 
@@ -169,7 +169,7 @@ public class TestLeaderAppointer extends ZKTestBase {
 
     void registerLeader(int partitionId, long HSId) throws KeeperException, InterruptedException
     {
-        LeaderCacheWriter iv2masters = new LeaderCache(m_zk, VoltZK.iv2masters);
+        LeaderCacheWriter iv2masters = new LeaderCache(m_zk, "", VoltZK.iv2masters);
         iv2masters.put(partitionId, HSId);
     }
 

--- a/tests/frontend/org/voltdb/iv2/TestLeaderCache.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderCache.java
@@ -88,7 +88,7 @@ public class TestLeaderCache extends ZKTestBase {
         ZooKeeper zk = getClient(0);
         configure("/cache01", zk);
 
-        LeaderCache dut = new  LeaderCache(zk, "/cache01");
+        LeaderCache dut = new  LeaderCache(zk, "", "/cache01");
         dut.start(true);
         Map<Integer, Long> cache = dut.pointInTimeCache();
 
@@ -108,7 +108,7 @@ public class TestLeaderCache extends ZKTestBase {
         configure("/cache01", zk);
 
         TestCallback cb = new TestCallback();
-        LeaderCache dut = new  LeaderCache(zk, "/cache01", cb);
+        LeaderCache dut = new  LeaderCache(zk, "", "/cache01", cb);
         dut.start(true);
 
         assertEquals("3 items cached.", 3, cb.m_cache.size());
@@ -126,7 +126,7 @@ public class TestLeaderCache extends ZKTestBase {
         ZooKeeper zk = getClient(0);
         configure("/cache03", zk);
 
-        LeaderCache dut = new  LeaderCache(zk, "/cache03");
+        LeaderCache dut = new  LeaderCache(zk, "", "/cache03");
         dut.start(true);
         Map<Integer, Long> cache = dut.pointInTimeCache();
 
@@ -155,7 +155,7 @@ public class TestLeaderCache extends ZKTestBase {
         configure("/cache03", zk);
 
         TestCallback cb = new TestCallback();
-        LeaderCache dut = new  LeaderCache(zk, "/cache03", cb);
+        LeaderCache dut = new  LeaderCache(zk, "", "/cache03", cb);
         dut.start(true);
         Map<Integer, LeaderCallBackInfo> cache = cb.m_cache;
 
@@ -185,7 +185,7 @@ public class TestLeaderCache extends ZKTestBase {
         ZooKeeper zk = getClient(0);
         configure("/cache02", zk);
 
-        LeaderCache dut = new LeaderCache(zk, "/cache02");
+        LeaderCache dut = new LeaderCache(zk, "", "/cache02");
         dut.start(true);
         Map<Integer, Long> cache = dut.pointInTimeCache();
         assertEquals("3 items cached.", 3, cache.size());
@@ -216,7 +216,7 @@ public class TestLeaderCache extends ZKTestBase {
         configure("/cache02", zk);
 
         TestCallback cb = new TestCallback();
-        LeaderCache dut = new LeaderCache(zk, "/cache02", cb);
+        LeaderCache dut = new LeaderCache(zk, "", "/cache02", cb);
         dut.start(true);
         Map<Integer, LeaderCallBackInfo> cache = cb.m_cache;
         assertEquals("3 items cached.", 3, cache.size());
@@ -246,7 +246,7 @@ public class TestLeaderCache extends ZKTestBase {
         ZooKeeper zk = getClient(0);
         configure("/cache04", zk);
 
-        LeaderCache dut = new LeaderCache(zk, "/cache04");
+        LeaderCache dut = new LeaderCache(zk, "", "/cache04");
         dut.start(true);
         Map<Integer, Long> cache = dut.pointInTimeCache();
 
@@ -289,7 +289,7 @@ public class TestLeaderCache extends ZKTestBase {
         configure("/cache04", zk);
 
         TestCallback cb = new TestCallback();
-        LeaderCache dut = new LeaderCache(zk, "/cache04", cb);
+        LeaderCache dut = new LeaderCache(zk, "", "/cache04", cb);
         dut.start(true);
         Map<Integer, LeaderCallBackInfo> cache = cb.m_cache;
 

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -80,9 +80,9 @@
         <level value="TRACE"/>
     </logger -->
 
-    <logger name="TM">
-        <level value="DEBUG"/>
-    </logger>
+    <!-- logger name="TM">
+        <level value="INFO"/>
+    </logger -->
 
     <!-- logger name="REJOIN">
         <level value="INFO"/>

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -80,9 +80,9 @@
         <level value="TRACE"/>
     </logger -->
 
-    <!-- logger name="TM">
-        <level value="INFO"/>
-    </logger -->
+    <logger name="TM">
+        <level value="DEBUG"/>
+    </logger>
 
     <!-- logger name="REJOIN">
         <level value="INFO"/>


### PR DESCRIPTION
Change is to ask SPI monitors zk node that belongs to its own partition, instead of monitoring whole /db/iv2appointees directory which brings a lots unnecessary overhead. On test machines start time ofa  5-node 100sph cluster improves from 12 minutes to 5 minutes.  