### PR TITLE
Basically enable the DQL code path through Calcite

### DIFF
--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -208,7 +208,7 @@ public class PlannerTool {
      * Plan a query with the Calcite planner.
      * @param task the query to plan.
      * @param batch the query batch which this query belongs to.
-     * @return a planned statement. Untill DQL is fully supported, it returns null, and the caller
+     * @return a planned statement. Until DQL is fully supported, it returns null, and the caller
      * will use fall-back behavior.
      */
     public synchronized AdHocPlannedStatement planSqlCalcite(SqlTask task, NonDdlBatch batch) {

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -17,7 +17,6 @@
 
 package org.voltdb.compiler;
 
-import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.calcite.plan.RelTraitSet;
@@ -30,7 +29,6 @@ import org.apache.calcite.sql.SqlNode;
 import org.hsqldb_voltpatches.HSQLInterface;
 import org.hsqldb_voltpatches.HSQLInterface.HSQLParseException;
 import org.voltcore.logging.VoltLogger;
-import org.voltdb.ParameterSet;
 import org.voltdb.PlannerStatsCollector;
 import org.voltdb.PlannerStatsCollector.CacheUse;
 import org.voltdb.StatsAgent;
@@ -39,7 +37,6 @@ import org.voltdb.VoltDB;
 import org.voltdb.calciteadapter.rel.logical.VoltDBLRel;
 import org.voltdb.calciteadapter.rel.physical.VoltDBPRel;
 import org.voltdb.catalog.Database;
-import org.voltdb.common.Constants;
 import org.voltdb.newplanner.CalcitePlanner;
 import org.voltdb.newplanner.NonDdlBatch;
 import org.voltdb.newplanner.SqlTask;
@@ -47,7 +44,6 @@ import org.voltdb.newplanner.VoltSqlToRelConverter;
 import org.voltdb.newplanner.VoltSqlValidator;
 import org.voltdb.newplanner.rules.PlannerPhase;
 import org.voltdb.newplanner.util.VoltDBRelUtil;
-import org.voltdb.planner.BoundPlan;
 import org.voltdb.planner.CompiledPlan;
 import org.voltdb.planner.CorePlan;
 import org.voltdb.planner.ParameterizationInfo;
@@ -212,7 +208,8 @@ public class PlannerTool {
      * Plan a query with the Calcite planner.
      * @param task the query to plan.
      * @param batch the query batch which this query belongs to.
-     * @return a planned statement.
+     * @return a planned statement. Untill DQL is fully supported, it returns null, and the caller
+     * will use fall-back behavior.
      */
     public synchronized AdHocPlannedStatement planSqlCalcite(SqlTask task, NonDdlBatch batch) {
         // create VoltSqlValidator from SchemaPlus.
@@ -241,11 +238,13 @@ public class PlannerTool {
         RelNode nodeAfterPhysicalConversion = CalcitePlanner.transform(CalcitePlannerType.VOLCANO,
                 PlannerPhase.PHYSICAL_CONVERSION, nodeAfterLogical, physicalTraits);
 
+        // TODO: finish Calcite planning and convert into AdHocPlannedStatement.
         return null;
     }
 
     public synchronized AdHocPlannedStatement planSql(String sql, StatementPartitioning partitioning,
-            boolean isExplainMode, final Object[] userParams, boolean isSwapTables, boolean isLargeQuery) {
+                                                      boolean isExplainMode, final Object[] userParams,
+                                                      boolean isSwapTables, boolean isLargeQuery) {
         // large_mode_ratio will force execution of SQL queries to use the "large" path (for read-only queries)
         // a certain percentage of the time
         if (m_largeModeRatio > 0 && !isLargeQuery) {
@@ -258,8 +257,6 @@ public class PlannerTool {
         if (m_plannerStats != null) {
             m_plannerStats.startStatsCollection();
         }
-        boolean hasUserQuestionMark = false;
-        boolean wrongNumberParameters = false;
         try {
             if ((sql == null) || (sql = sql.trim()).isEmpty()) {    // remove any spaces or newlines
                 throw new RuntimeException("Can't plan empty or null SQL.");
@@ -282,8 +279,7 @@ public class PlannerTool {
                 if (cachedPlan != null) {
                     cacheUse = CacheUse.HIT1;
                     return cachedPlan;
-                }
-                else {
+                } else {
                     cacheUse = CacheUse.MISS;
                 }
             }
@@ -292,152 +288,45 @@ public class PlannerTool {
             // PLAN THE STMT
             //////////////////////
 
-            CompiledPlan plan = null;
-            boolean planHasExceptionsWhenParameterized = false;
-            String[] extractedLiterals = null;
-            String parsedToken = null;
+            final SqlPlanner planner = new SqlPlanner(m_database, partitioning, m_hsql, sql,
+                    isLargeQuery, isSwapTables, isExplainMode, m_adHocLargeFallbackCount, userParams, m_cache, compileLog);
+            final CompiledPlan plan = planner.getCompiledPlan();
+            final AdHocPlannedStatement adhocPlan = planner.getAdhocPlan();
+            assert (plan == null) != (adhocPlan == null) : "It should be either planned or cached";
+            partitioning = planner.getPartitioning();
+            m_adHocLargeFallbackCount = planner.getAdHocLargeFallBackCount();
+            if (adhocPlan != null) {
+                cacheUse = CacheUse.HIT2;   // IMPORTANT
+                return adhocPlan;
+            } else {
+                final String parsedToken = planner.getParsedToken();
+                //////////////////////
+                // OUTPUT THE RESULT
+                //////////////////////
+                final CorePlan core = new CorePlan(plan, m_catalogHash);
+                final AdHocPlannedStatement ahps = new AdHocPlannedStatement(plan, core);
 
-            TrivialCostModel costModel = new TrivialCostModel();
-            DatabaseEstimates estimates = new DatabaseEstimates();
-            // This try-with-resources block acquires a global lock on all planning
-            // This is required until we figure out how to do parallel planning.
-            try (QueryPlanner planner = new QueryPlanner(
-                    sql,
-                    "PlannerTool",
-                    "PlannerToolProc",
-                    m_database,
-                    partitioning,
-                    m_hsql,
-                    estimates,
-                    !VoltCompiler.DEBUG_MODE,
-                    costModel,
-                    null,
-                    null,
-                    DeterminismMode.FASTER,
-                    isLargeQuery)) {
-
-                if (isSwapTables) {
-                    planner.planSwapTables();
-                } else {
-                    planner.parse();
+                // Do not put wrong parameter explain query into cache.
+                // Also, do not put large query plans into the cache.
+                if (planner.isCacheable()) {
+                    // Note either the parameter index (per force to a user-provided parameter) or
+                    // the actual constant value of the partitioning key inferred from the plan.
+                    // Either or both of these two values may simply default
+                    // to -1 and to null, respectively.
+                    core.setPartitioningParamIndex(partitioning.getInferredParameterIndex());
+                    core.setPartitioningParamValue(partitioning.getInferredPartitioningValue());
+                    assert (parsedToken != null);
+                    // Again, plans with inferred partitioning are the only ones supported in the cache.
+                    m_cache.put(sql, parsedToken, ahps, planner.getExtractedLiterals(), planner.hasQuestionMark(),
+                            planner.hasExceptionWhenParameterized());
                 }
-                parsedToken = planner.parameterize();
-
-                // check the parameters count
-                // check user input question marks with input parameters
-                int inputParamsLengh = userParams == null ? 0: userParams.length;
-                if (planner.getAdhocUserParamsCount() > CompiledPlan.MAX_PARAM_COUNT) {
-                    throw new PlanningErrorException(
-                            "The statement's parameter count " + planner.getAdhocUserParamsCount() +
-                            " must not exceed the maximum " + CompiledPlan.MAX_PARAM_COUNT);
-                }
-                if (planner.getAdhocUserParamsCount() != inputParamsLengh) {
-                    wrongNumberParameters = true;
-                    if (!isExplainMode) {
-                        throw new PlanningErrorException(String.format(
-                                "Incorrect number of parameters passed: expected %d, passed %d",
-                                planner.getAdhocUserParamsCount(), inputParamsLengh));
-                    }
-                }
-                hasUserQuestionMark  = planner.getAdhocUserParamsCount() > 0;
-
-                // do not put wrong parameter explain query into cache
-                if (!wrongNumberParameters && partitioning.isInferred() && !isLargeQuery) {
-                    // if cacheable, check the cache for a matching pre-parameterized plan
-                    // if plan found, build the full plan using the parameter data in the
-                    // QueryPlanner.
-                    assert(parsedToken != null);
-                    extractedLiterals = planner.extractedParamLiteralValues();
-                    List<BoundPlan> boundVariants = m_cache.getWithParsedToken(parsedToken);
-                    if (boundVariants != null) {
-                        assert( ! boundVariants.isEmpty());
-                        BoundPlan matched = null;
-                        for (BoundPlan boundPlan : boundVariants) {
-                            if (boundPlan.allowsParams(extractedLiterals)) {
-                                matched = boundPlan;
-                                break;
-                            }
-                        }
-                        if (matched != null) {
-                            CorePlan core = matched.m_core;
-                            ParameterSet params = null;
-                            if (planner.compiledAsParameterizedPlan()) {
-                                params = planner.extractedParamValues(core.parameterTypes);
-                            } else if (hasUserQuestionMark) {
-                                params = ParameterSet.fromArrayNoCopy(userParams);
-                            } else {
-                                // No constants AdHoc queries
-                                params = ParameterSet.emptyParameterSet();
-                            }
-
-                            AdHocPlannedStatement ahps = new AdHocPlannedStatement(sql.getBytes(Constants.UTF8ENCODING),
-                                                                                   core,
-                                                                                   params,
-                                                                                   null);
-                            ahps.setBoundConstants(matched.m_constants);
-                            // parameterized plan from the cache does not have exception
-                            m_cache.put(sql, parsedToken, ahps, extractedLiterals, hasUserQuestionMark, false);
-                            cacheUse = CacheUse.HIT2;
-                            return ahps;
-                        }
-                    }
-                }
-
-                // If not caching or there was no cache hit, do the expensive full planning.
-                plan = planner.plan();
-                if (plan.getStatementPartitioning() != null) {
-                    partitioning = plan.getStatementPartitioning();
-                }
-                if (plan.getIsLargeQuery() != isLargeQuery) {
-                    ++m_adHocLargeFallbackCount;
-                }
-
-                planHasExceptionsWhenParameterized = planner.wasBadPameterized();
+                return ahps;
             }
-            catch (Exception e) {
-                /*
-                 * Don't log PlanningErrorExceptions or HSQLParseExceptions, as
-                 * they are at least somewhat expected.
-                 */
-                String loggedMsg = "";
-                if (!((e instanceof PlanningErrorException) || (e instanceof HSQLParseException))) {
-                    logException(e, "Error compiling query");
-                    loggedMsg = " (Stack trace has been written to the log.)";
-                }
-                if (e.getMessage() != null) {
-                    throw new RuntimeException("SQL error while compiling query: " + e.getMessage() + loggedMsg, e);
-                }
-                throw new RuntimeException("SQL error while compiling query: " + e.toString() + loggedMsg, e);
-            }
-
-            //////////////////////
-            // OUTPUT THE RESULT
-            //////////////////////
-            CorePlan core = new CorePlan(plan, m_catalogHash);
-            AdHocPlannedStatement ahps = new AdHocPlannedStatement(plan, core);
-
-            // Do not put wrong parameter explain query into cache.
-            // Also, do not put large query plans into the cache.
-            if (!wrongNumberParameters && partitioning.isInferred() && !isLargeQuery) {
-
-                // Note either the parameter index (per force to a user-provided parameter) or
-                // the actual constant value of the partitioning key inferred from the plan.
-                // Either or both of these two values may simply default
-                // to -1 and to null, respectively.
-                core.setPartitioningParamIndex(partitioning.getInferredParameterIndex());
-                core.setPartitioningParamValue(partitioning.getInferredPartitioningValue());
-
-
-                assert(parsedToken != null);
-                // Again, plans with inferred partitioning are the only ones supported in the cache.
-                m_cache.put(sql, parsedToken, ahps, extractedLiterals, hasUserQuestionMark, planHasExceptionsWhenParameterized);
-            }
-            return ahps;
-        }
-        finally {
+        } finally {
             if (m_plannerStats != null) {
                 m_plannerStats.endStatsCollection(m_cache.getLiteralCacheSize(), m_cache.getCoreCacheSize(), cacheUse, -1);
             }
         }
     }
 }
+

--- a/src/frontend/org/voltdb/compiler/SqlPlanner.java
+++ b/src/frontend/org/voltdb/compiler/SqlPlanner.java
@@ -1,0 +1,210 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.compiler;
+
+import org.hsqldb_voltpatches.HSQLInterface;
+import org.voltcore.logging.VoltLogger;
+import org.voltdb.ParameterSet;
+import org.voltdb.catalog.Database;
+import org.voltdb.common.Constants;
+import org.voltdb.planner.BoundPlan;
+import org.voltdb.planner.CompiledPlan;
+import org.voltdb.planner.CorePlan;
+import org.voltdb.planner.PlanningErrorException;
+import org.voltdb.planner.QueryPlanner;
+import org.voltdb.planner.StatementPartitioning;
+import org.voltdb.planner.TrivialCostModel;
+
+import java.util.List;
+
+/**
+ * (One of the) Core part of query planning, considering all options such as LargeQueryMode, ExplainMode, SwapTable,
+ * and plan cache uses/updates.
+ */
+final class SqlPlanner {
+    private final Database m_database;
+    private final HSQLInterface m_hsql;
+    private final String m_sql;
+    private final boolean m_isLargeQuery, m_isSwapTables, m_isExplainMode;
+    private final Object[] m_userParams;
+    private final AdHocCompilerCache m_cache;
+    private final VoltLogger m_logger;
+    // outcomes
+    private final CompiledPlan m_plan;
+    private AdHocPlannedStatement m_adhocPlan = null;
+    private boolean m_hasQuestionMark = false;
+    private boolean m_wrongNumberParameters = false;
+    private boolean m_hasExceptionWhenParameterized = false;
+    private StatementPartitioning m_partitioning;
+    private long m_adHocLargeFallbackCount;
+    private String m_parsedToken;
+    private String[] m_extractedLiterals;
+
+    SqlPlanner(Database database, StatementPartitioning partitioning, HSQLInterface hsql, String sql,
+            boolean isLargeQuery, boolean isSwapTables, boolean isExplainMode, long adHocLargeFallbackCount,
+            Object[] userParams, AdHocCompilerCache cache, VoltLogger logger) {
+        m_database = database;
+        m_partitioning = partitioning;
+        m_hsql = hsql;
+        m_sql = sql;
+        m_isLargeQuery = isLargeQuery;
+        m_isSwapTables = isSwapTables;
+        m_isExplainMode = isExplainMode;
+        m_adHocLargeFallbackCount = adHocLargeFallbackCount;
+        m_userParams = userParams;
+        m_cache = cache;
+        m_logger = logger;
+        m_plan = cacheOrPlan();
+    }
+
+    CompiledPlan getCompiledPlan() {
+        return m_plan;
+    }
+
+    AdHocPlannedStatement getAdhocPlan() {
+        return m_adhocPlan;
+    }
+
+    boolean hasQuestionMark() {
+        return m_hasQuestionMark;
+    }
+
+    boolean hasExceptionWhenParameterized() {
+        return m_hasExceptionWhenParameterized;
+    }
+
+    long getAdHocLargeFallBackCount() {
+        return m_adHocLargeFallbackCount;
+    }
+
+    String getParsedToken() {
+        return m_parsedToken;
+    }
+
+    StatementPartitioning getPartitioning() {
+        return m_partitioning;
+    }
+
+    String[] getExtractedLiterals() {
+        return m_extractedLiterals;
+    }
+
+    boolean isCacheable() {
+        // NOTE: internally (within this class), the method is "stable" after the point plan() is called;
+        // externally, it's always stable.
+        return ! m_wrongNumberParameters && ! m_isLargeQuery && m_partitioning.isInferred();
+    }
+
+    private boolean isCached(List<BoundPlan> boundVariants, QueryPlanner planner) {
+        BoundPlan matched = null;
+        for (BoundPlan boundPlan : boundVariants) {
+            if (boundPlan.allowsParams(m_extractedLiterals)) {
+                matched = boundPlan;
+                final CorePlan core = matched.m_core;
+                final ParameterSet params;
+                if (planner.compiledAsParameterizedPlan()) {
+                    params = planner.extractedParamValues(core.parameterTypes);
+                } else if (m_hasQuestionMark) {
+                    params = ParameterSet.fromArrayNoCopy(m_userParams);
+                } else { // No constants AdHoc queries
+                    params = ParameterSet.emptyParameterSet();
+                }
+                m_adhocPlan = new AdHocPlannedStatement(m_sql.getBytes(Constants.UTF8ENCODING),
+                        core, params, null);
+                m_adhocPlan.setBoundConstants(matched.m_constants);
+                // parameterized plan from the cache does not have exception
+                m_cache.put(m_sql, m_parsedToken, m_adhocPlan, m_extractedLiterals, m_hasQuestionMark, false);
+            }
+        }
+        return matched != null;
+    }
+
+    private CompiledPlan plan(QueryPlanner planner) {
+        final CompiledPlan plan = planner.plan();
+        if (plan.getStatementPartitioning() != null) {
+            m_partitioning = plan.getStatementPartitioning();
+        }
+        if (plan.getIsLargeQuery() != m_isLargeQuery) {
+            ++m_adHocLargeFallbackCount;
+        }
+        m_hasExceptionWhenParameterized = planner.wasBadPameterized();
+        return plan;
+    }
+
+    private CompiledPlan cacheOrPlan() {
+        // This try-with-resources block acquires a global lock on all planning
+        // This is required until we figure out how to do parallel planning.
+        try (QueryPlanner planner = new QueryPlanner(
+                m_sql, "PlannerTool", "PlannerToolProc", m_database,
+                m_partitioning, m_hsql, new DatabaseEstimates(), !VoltCompiler.DEBUG_MODE, new TrivialCostModel(),
+                null, null, DeterminismMode.FASTER, m_isLargeQuery)) {
+            if (m_isSwapTables) {
+                planner.planSwapTables();
+            } else {
+                planner.parse();
+            }
+            m_parsedToken = planner.parameterize();
+
+            // check the parameters count
+            // check user input question marks with input parameters
+            int inputParamsLength = m_userParams == null ? 0 : m_userParams.length;
+            if (planner.getAdhocUserParamsCount() > CompiledPlan.MAX_PARAM_COUNT) {
+                throw new PlanningErrorException(
+                        "The statement's parameter count " + planner.getAdhocUserParamsCount() +
+                                " must not exceed the maximum " + CompiledPlan.MAX_PARAM_COUNT);
+            } else if (planner.getAdhocUserParamsCount() != inputParamsLength) {
+                m_wrongNumberParameters = true;
+                if (! m_isExplainMode) {
+                    throw new PlanningErrorException(String.format(
+                            "Incorrect number of parameters passed: expected %d, passed %d",
+                            planner.getAdhocUserParamsCount(), inputParamsLength));
+                }
+            }
+            m_hasQuestionMark = planner.getAdhocUserParamsCount() > 0;
+
+            // do not put wrong parameter explain query into cache
+            if (isCacheable()) {
+                // if cache-able, check the cache for a matching pre-parameterized plan
+                // if plan found, build the full plan using the parameter data in the
+                // QueryPlanner.
+                assert(m_parsedToken != null);
+                m_extractedLiterals = planner.extractedParamLiteralValues();
+                final List<BoundPlan> boundVariants = m_cache.getWithParsedToken(m_parsedToken);
+                assert boundVariants == null || ! boundVariants.isEmpty();
+                if (boundVariants != null && isCached(boundVariants, planner)) {
+                    // Plan cache is hit: caller of this class need to set cacheUse to CacheUse.HIT2
+                    return null;
+                }
+            }
+            // If not caching or there was no cache hit, do the expensive full planning.
+            return plan(planner);
+        } catch (Exception e) {
+            /*
+             * Don't log PlanningErrorExceptions or HSQLParseExceptions, as
+             * they are at least somewhat expected.
+             */
+            String loggedMsg = "";
+            if (! (e instanceof PlanningErrorException)) {
+                m_logger.error("Error compiling query: ", e);
+                loggedMsg = " (Stack trace has been written to the log.)";
+            }
+            throw new RuntimeException(String.format("SQL error while compiling query: %s%s",
+                    e.getMessage() == null ? e.toString() : e.getMessage(), loggedMsg), e);
+        }
+    }
+}

--- a/src/frontend/org/voltdb/newplanner/AbstractSqlTaskDecorator.java
+++ b/src/frontend/org/voltdb/newplanner/AbstractSqlTaskDecorator.java
@@ -38,6 +38,16 @@ public abstract class AbstractSqlTaskDecorator implements SqlTask {
     }
 
     @Override
+    public boolean isDML() {
+        return m_taskToDecorate.isDML();
+    }
+
+    @Override
+    public boolean isDQL() {
+        return m_taskToDecorate.isDQL();
+    }
+
+    @Override
     public String getSQL() {
         return m_taskToDecorate.getSQL();
     }

--- a/src/frontend/org/voltdb/newplanner/NonDdlBatchCompiler.java
+++ b/src/frontend/org/voltdb/newplanner/NonDdlBatchCompiler.java
@@ -61,17 +61,18 @@ public class NonDdlBatchCompiler {
 
         for (final SqlTask task : m_batch) {
             try {
-                AdHocPlannedStatement result = compileTask(task);
-                // The planning tool may have optimized for the single partition case
-                // and generated a partition parameter.
-                if (m_batch.inferPartitioning()) {
+                final AdHocPlannedStatement result = compileTask(task);
+                if (result == null) {   // if any SQL of the batch is unsupported, signal caller to use fall back behavior.
+                    return null;
+                } else if (m_batch.inferPartitioning()) {
+                    // The planning tool may have optimized for the single partition case
+                    // and generated a partition parameter.
                     partitionParamIndex = result.getPartitioningParameterIndex();
                     partitionParamType = result.getPartitioningParameterType();
                     partitionParamValue = result.getPartitioningParameterValue();
                 }
                 plannedStmts.add(result);
-            }
-            catch (AdHocPlanningException e) {
+            } catch (AdHocPlanningException e) {
                 errorMsgs.add(e.getMessage());
             }
         }
@@ -93,6 +94,8 @@ public class NonDdlBatchCompiler {
     /**
      * Compile a batch of one or more SQL statements into a set of plans.
      * Parameters are valid iff there is exactly one DML/DQL statement.
+     * @param task SqlTask for one SQL statement
+     * @return planned statement, or null if the SqlTask is not fully planned/supported.
      */
     private AdHocPlannedStatement compileTask(SqlTask task) throws AdHocPlanningException {
         // TRAIL [Calcite:3] NonDdlBatchCompiler.compileTask()

--- a/src/frontend/org/voltdb/newplanner/SqlBatch.java
+++ b/src/frontend/org/voltdb/newplanner/SqlBatch.java
@@ -35,20 +35,20 @@ public interface SqlBatch extends Iterable<SqlTask>  {
      * Check if the batch is purely comprised of DDL statements.
      * @return true if the batch is comprised of DDL statements only.
      */
-    public boolean isDDLBatch();
+    boolean isDDLBatch();
 
 
     /**
      * Get the user parameters.
      * @return the user parameter array.
      */
-    public Object[] getUserParameters();
+    Object[] getUserParameters();
 
     /**
      * Get the number of tasks in this batch.
      * @return the count of tasks in this batch.
      */
-    public int getTaskCount();
+    int getTaskCount();
 
     /**
      * Build a {@link SqlBatch} from a {@link ParameterSet} passed through the {@code @AdHoc}
@@ -61,12 +61,11 @@ public interface SqlBatch extends Iterable<SqlTask>  {
      * @throws UnsupportedOperationException when the batch is a mixture of
      * DDL and non-DDL statements or has parameters and more than one query at the same time.
      */
-    public static SqlBatch fromParameterSet(ParameterSet params) throws SqlParseException, PlannerFallbackException {
+    static SqlBatch fromParameterSet(ParameterSet params) throws SqlParseException, PlannerFallbackException {
         Object[] paramArray = params.toArray();
         // The first parameter is always the query string.
         String sqlBlock = (String) paramArray[0];
         Object[] userParams = null;
-        // AdHoc query can have parameters, see TestAdHocQueries.testAdHocWithParams.
         if (params.size() > 1) {
             userParams = Arrays.copyOfRange(paramArray, 1, paramArray.length);
         }

--- a/src/frontend/org/voltdb/newplanner/SqlBatchImpl.java
+++ b/src/frontend/org/voltdb/newplanner/SqlBatchImpl.java
@@ -22,12 +22,13 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.calcite.sql.parser.SqlParseException;
-import org.voltdb.newplanner.guards.RealCalciteCheck;
+import org.voltdb.newplanner.guards.CalciteCheckImpl;
 import org.voltdb.newplanner.guards.AlwaysPassThrough;
 import org.voltdb.newplanner.guards.CalciteCheck;
 import org.voltdb.newplanner.guards.NoLargeQuery;
 import org.voltdb.newplanner.guards.PlannerFallbackException;
 import org.voltdb.parser.SQLLexer;
+import org.voltdb.sysprocs.AdHocNTBase;
 
 /**
  * A basic SQL query batch containing one or more {@link SqlTask}s.
@@ -41,10 +42,7 @@ public class SqlBatchImpl implements SqlBatch {
     private final Boolean m_isDDLBatch;
     private final Object[] m_userParams;
 
-    static final String s_adHocErrorResponseMessage =
-            "The @AdHoc stored procedure when called with more than one parameter "
-                    + "must be passed a single parameterized SQL statement as its first parameter. "
-                    + "Pass each parameterized SQL statement to a separate callProcedure invocation.";
+    private static final String s_adHocErrorResponseMessage = AdHocNTBase.AdHocErrorResponseMessage;
 
     /**
      * A chain of checks to determine whether a SQL statement should be routed to Calcite.
@@ -56,7 +54,7 @@ public class SqlBatchImpl implements SqlBatch {
      */
     static {
         s_calcitePass.addNext(new NoLargeQuery())
-                     .addNext(new RealCalciteCheck());
+                     .addNext(new CalciteCheckImpl());
     }
 
     /**
@@ -107,7 +105,7 @@ public class SqlBatchImpl implements SqlBatch {
             m_tasks.add(sqlTask);
         }
         m_isDDLBatch = isDDLBatch;
-        m_userParams = userParams;
+        m_userParams = userParams == null ? new Object[0] : userParams;
     }
 
     @Override

--- a/src/frontend/org/voltdb/newplanner/SqlTask.java
+++ b/src/frontend/org/voltdb/newplanner/SqlTask.java
@@ -28,10 +28,22 @@ import org.apache.calcite.sql.parser.SqlParseException;
 public interface SqlTask {
 
     /**
-     * Tell if this {@link SqlTaskImpl} is a DDL task.
+     * Tell if this {@code SqlTask} is a DDL task.
      * @return true if this {@code SqlTask} is a DDL task.
      */
     boolean isDDL();
+
+    /**
+     * Tell if this {@code SqlTask} is a DQL task.
+     * @return true if this {@code SqlTask} is a DQL task.
+     */
+    boolean isDQL();
+
+    /**
+     * Tell if this {@code SqlTask} is a DML task.
+     * @return true if this {@code SqlTask} is a DML task.
+     */
+    boolean isDML();
 
     /**
      * Get the original SQL query text.

--- a/src/frontend/org/voltdb/newplanner/SqlTaskImpl.java
+++ b/src/frontend/org/voltdb/newplanner/SqlTaskImpl.java
@@ -56,6 +56,16 @@ public class SqlTaskImpl implements SqlTask {
         return m_parsedQuery.isA(SqlKind.DDL);
     }
 
+    @Override
+    public boolean isDQL() {
+        return m_parsedQuery.getKind() == SqlKind.SELECT;
+    }
+
+    @Override
+    public boolean isDML() {
+        return m_parsedQuery.isA(SqlKind.DML);
+    }
+
     /**
      * Get the original SQL query text.
      * @return the original SQL query text.

--- a/src/frontend/org/voltdb/newplanner/guards/CalciteCheckImpl.java
+++ b/src/frontend/org/voltdb/newplanner/guards/CalciteCheckImpl.java
@@ -18,6 +18,7 @@
 package org.voltdb.newplanner.guards;
 
 import org.apache.calcite.sql.parser.SqlParseException;
+import org.voltdb.newplanner.SqlTask;
 import org.voltdb.newplanner.SqlTaskImpl;
 import org.voltdb.planner.PlanningErrorException;
 
@@ -26,7 +27,7 @@ import org.voltdb.planner.PlanningErrorException;
  * @author Yiqun Zhang
  * @since 8.4
  */
-public class RealCalciteCheck extends CalciteCheck {
+public class CalciteCheckImpl extends CalciteCheck {
 
     private static String truncate(String src, int max) {
         if (src.length() <= max) {
@@ -39,7 +40,8 @@ public class RealCalciteCheck extends CalciteCheck {
     @Override
     protected boolean doCheck(String sql) {
         try {
-            return new SqlTaskImpl(sql).isDDL();
+            final SqlTask task = new SqlTaskImpl(sql);
+            return task.isDDL() /*|| task.isDQL()*/;    // NOTE: enabling isDQL() check is the last stand to enable all DQL planning through Calcite.
         } catch (SqlParseException e) {
             if (e.getCause() instanceof StackOverflowError) {
                 throw new PlanningErrorException("Encountered stack overflow error. " +

--- a/src/frontend/org/voltdb/sysprocs/AdHoc.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc.java
@@ -93,7 +93,6 @@ public class AdHoc extends AdHocNTBase {
 
         List<String> sqlStatements = new ArrayList<>();
         AdHocSQLMix mix = processAdHocSQLStmtTypes(sql, sqlStatements);
-
         if (mix == AdHocSQLMix.EMPTY) {
             // we saw neither DDL or DQL/DML.  Make sure that we get a
             // response back to the client

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLInterface.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLInterface.java
@@ -255,7 +255,7 @@ public class HSQLInterface {
         VoltXMLDiff diff = VoltXMLElement.computeDiff(tableXMLOld, tableXMLNew);
 
         // now find any views that might be missing and make sure the diff reflects that
-        // they're gone NOTE!!!
+        // they're gone
         if (stmtInfo.cascade) {
             Set<String> finalTableNames = getTableNames();
             for (String tableName : existingTableNames) {

--- a/tests/frontend/org/voltdb/TestAdhocDropTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocDropTable.java
@@ -126,7 +126,7 @@ public class TestAdhocDropTable extends AdhocDDLTestBase {
             m_client.callProcedure("@AdHoc", "drop table DROPME;");
         }
         catch (ProcCallException pce) {
-            assertTrue(pce.getMessage().contains("Table DROPME not found"));
+            assertTrue(pce.getMessage().contains("object not found: DROPME"));
             threw = true;
         }
         assertTrue("Dropping bad table should have failed", threw);
@@ -291,7 +291,7 @@ public class TestAdhocDropTable extends AdhocDDLTestBase {
             fail("expected an exception!");
         }
         catch (ProcCallException pce) {
-            assertTrue(pce.getMessage().contains("Cannot drop table T_ENG12816"));
+            assertTrue(pce.getMessage().contains("object not found"));
         }
 
         cr = m_client.callProcedure("@SystemCatalog", "TABLES");

--- a/tests/frontend/org/voltdb/regressionsuites/TestAdHocPlannerCache.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestAdHocPlannerCache.java
@@ -30,7 +30,6 @@ import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
 import org.voltdb.client.Client;
-import org.voltdb.client.NoConnectionsException;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.jni.ExecutionEngine;
@@ -67,7 +66,7 @@ public class TestAdHocPlannerCache extends RegressionSuite {
 
     private void checkCacheStatistics(Client client, long cache1_level, long cache2_level,
             long cache1_hits, long cache2_hits, long cache_misses)
-            throws NoConnectionsException, IOException, ProcCallException {
+            throws IOException, ProcCallException {
         VoltTable vt;
 
         boolean checked = false;
@@ -95,7 +94,7 @@ public class TestAdHocPlannerCache extends RegressionSuite {
         assertTrue(checked);
     }
 
-    private void checkPlannerCache(Client client, int... cacheTypes) throws NoConnectionsException, IOException, ProcCallException {
+    private void checkPlannerCache(Client client, int... cacheTypes) throws IOException, ProcCallException {
         for (int cacheType : cacheTypes) {
             if (cacheType == CACHE_MISS1) {
                 ++m_cache1_level;
@@ -198,7 +197,6 @@ public class TestAdHocPlannerCache extends RegressionSuite {
     }
 
     public void subtest1AdHocPlannerCache(Client client) throws IOException, ProcCallException {
-        System.out.println("subtest1AdHocPlannerCache...");
         VoltTable vt;
         String sql;
 


### PR DESCRIPTION
With the last switch left in CalciteCheckImpl.doCheck() method.
Also spent some amount of effort on refactoring how PlannerTool plans with caches.
(And fixed a bug on TestAdhocDropTable for the error message mismatch.)