### PR TITLE
 Add a utility class to handle pro classes

### DIFF
--- a/src/frontend/org/voltdb/Inits.java
+++ b/src/frontend/org/voltdb/Inits.java
@@ -56,13 +56,13 @@ import org.voltdb.largequery.LargeBlockManager;
 import org.voltdb.modular.ModuleManager;
 import org.voltdb.settings.DbSettings;
 import org.voltdb.settings.NodeSettings;
-import org.voltdb.snmp.SnmpTrapSender;
 import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.CatalogUtil.CatalogAndDeployment;
 import org.voltdb.utils.HTTPAdminListener;
 import org.voltdb.utils.InMemoryJarfile;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.PlatformProperties;
+import org.voltdb.utils.ProClass;
 
 /**
  * This breaks up VoltDB initialization tasks into discrete units.
@@ -473,24 +473,10 @@ public class Inits {
 
             if (logConfig.getEnabled()) {
                 if (m_config.m_isEnterprise) {
-                    try {
-                        Class<?> loggerClass = MiscUtils.loadProClass("org.voltdb.CommandLogImpl",
-                                                                   "Command logging", false);
-                        if (loggerClass != null) {
-                            final Constructor<?> constructor = loggerClass.getConstructor(boolean.class,
-                                                                                          int.class,
-                                                                                          int.class,
-                                                                                          String.class,
-                                                                                          String.class);
-                            m_rvdb.m_commandLog = (CommandLog) constructor.newInstance(logConfig.getSynchronous(),
-                                                                                       logConfig.getFsyncinterval(),
-                                                                                       logConfig.getMaxtxns(),
-                                                                                       VoltDB.instance().getCommandLogPath(),
-                                                                                       VoltDB.instance().getCommandLogSnapshotPath());
-                        }
-                    } catch (Exception e) {
-                        VoltDB.crashLocalVoltDB("Unable to instantiate command log", true, e);
-                    }
+                    m_rvdb.m_commandLog = ProClass.newInstanceOf("org.voltdb.CommandLogImpl", "Command logging",
+                            ProClass.HANDLER_LOG, logConfig.getSynchronous(), logConfig.getFsyncinterval(),
+                            logConfig.getMaxtxns(), VoltDB.instance().getCommandLogPath(),
+                            VoltDB.instance().getCommandLogSnapshotPath());
                 }
             }
         }
@@ -503,19 +489,13 @@ public class Inits {
         @Override
         public void run() {
             if (m_config.m_isEnterprise && m_deployment.getSnmp() != null && m_deployment.getSnmp().isEnabled()) {
-                try {
-                    Class<?> loggerClass = MiscUtils.loadProClass("org.voltdb.snmp.SnmpTrapSenderImpl",
-                                                               "SNMP Adapter", false);
-                    if (loggerClass != null) {
-                        final Constructor<?> constructor = loggerClass.getConstructor();
-                        m_rvdb.m_snmp = (SnmpTrapSender) constructor.newInstance();
+                m_rvdb.m_snmp = ProClass.newInstanceOf("org.voltdb.snmp.SnmpTrapSenderImpl", "SNMP Adapter",
+                        ProClass.HANDLER_LOG);
+                if (m_rvdb.m_snmp != null) {
                         m_rvdb.m_snmp.initialize(
                                 m_deployment.getSnmp(),
                                 m_rvdb.getHostMessenger(),
                                 m_rvdb.getCatalogContext().cluster.getDrclusterid());
-                    }
-                } catch (Exception e) {
-                    VoltDB.crashLocalVoltDB("Unable to instantiate SNMP", true, e);
                 }
             }
         }

--- a/src/frontend/org/voltdb/RestoreAgent.java
+++ b/src/frontend/org/voltdb/RestoreAgent.java
@@ -793,7 +793,9 @@ SnapshotCompletionInterest, Promotable
         try
         {
             JSONObject digest_detail = SnapshotUtil.CRCCheck(digest, LOG);
-            if (digest_detail == null) throw new IOException();
+            if (digest_detail == null) {
+                throw new IOException();
+            }
             catalog_crc = digest_detail.getLong("catalogCRC");
 
             if (digest_detail.has("partitionTransactionIds")) {
@@ -1191,7 +1193,9 @@ SnapshotCompletionInterest, Promotable
             Long clStartTxnId = null;
             for (String node : children) {
                 //This might be created before we are done fetching the restore info
-                if (node.equals("snapshot_id")) continue;
+                if (node.equals("snapshot_id")) {
+                    continue;
+                }
 
                 byte[] data = null;
                 data = m_zk.getData(VoltZK.restore + "/" + node, false, null);

--- a/src/frontend/org/voltdb/iv2/JoinProducerBase.java
+++ b/src/frontend/org/voltdb/iv2/JoinProducerBase.java
@@ -18,8 +18,6 @@
 package org.voltdb.iv2;
 
 import java.io.File;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -34,7 +32,7 @@ import org.voltdb.messaging.RejoinMessage;
 import org.voltdb.rejoin.StreamSnapshotSink.RestoreWork;
 import org.voltdb.rejoin.TaskLog;
 import org.voltdb.utils.CachedByteBufferAllocator;
-import org.voltdb.utils.MiscUtils;
+import org.voltdb.utils.ProClass;
 
 import com.google_voltpatches.common.util.concurrent.SettableFuture;
 
@@ -147,20 +145,8 @@ public abstract class JoinProducerBase extends SiteTasker {
     {
         // Construct task log and start logging task messages
         File overflowDir = new File(voltroot, "join_overflow");
-        Class<?> taskLogKlass =
-                MiscUtils.loadProClass("org.voltdb.rejoin.TaskLogImpl", "Join", false);
-        if (taskLogKlass != null) {
-            Constructor<?> taskLogConstructor;
-            try {
-                taskLogConstructor = taskLogKlass.getConstructor(int.class, File.class);
-                return (TaskLog) taskLogConstructor.newInstance(pid, overflowDir);
-            } catch (InvocationTargetException e) {
-                VoltDB.crashLocalVoltDB("Unable to construct join task log", true, e.getCause());
-            } catch (Exception e) {
-                VoltDB.crashLocalVoltDB("Unable to construct join task log", true, e);
-            }
-        }
-        return null;
+        return ProClass.newInstanceOf("org.voltdb.rejoin.TaskLogImpl", "Join", ProClass.HANDLER_LOG, pid,
+                overflowDir);
     }
 
     // Received a datablock. Reset the watchdog timer and hand the block to the Site.

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -505,10 +505,10 @@ public class MpScheduler extends Scheduler
                 m_leaderMigrationMap.remove(message.m_sourceHSId);
 
                 // Leader migration has updated the leader, send the request to the new leader
-                m_mailbox.send(newLeader, (Iv2InitiateTaskMessage)counter.getOpenMessage());
+                m_mailbox.send(newLeader, counter.getOpenMessage());
             } else {
                 // Leader migration not done yet.
-                m_mailbox.send(message.m_sourceHSId, (Iv2InitiateTaskMessage)counter.getOpenMessage());
+                m_mailbox.send(message.m_sourceHSId, counter.getOpenMessage());
             }
             return;
         }

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -108,28 +108,6 @@ public class MiscUtils {
     }
 
     /**
-     * Try to load a PRO class. If it's running the community edition, an error
-     * message will be logged and null will be returned.
-     *
-     * @param classname The class name of the PRO class
-     * @param feature The name of the feature
-     * @param suppress true to suppress the log message
-     * @return null if running the community edition
-     */
-    public static Class<?> loadProClass(String classname, String feature, boolean suppress) {
-        try {
-            Class<?> klass = Class.forName(classname);
-            return klass;
-        } catch (ClassNotFoundException e) {
-            if (!suppress) {
-                hostLog.warn("Cannot load " + classname + " in VoltDB community edition. " +
-                             feature + " will be disabled.");
-            }
-            return null;
-        }
-    }
-
-    /**
      * Instantiate the license api impl based on enterprise/community editions
      * @return a valid API for community and pro editions, or null on error.
      */
@@ -232,24 +210,10 @@ public class MiscUtils {
             };
         }
 
-        // boilerplate to create a license api interface
-        LicenseApi licenseApi = null;
-        Class<?> licApiKlass = MiscUtils.loadProClass("org.voltdb.licensetool.LicenseApiImpl",
-                                                      "License API", false);
-        if (licApiKlass != null) {
-            try {
-                licenseApi = (LicenseApi)licApiKlass.newInstance();
-            } catch (InstantiationException e) {
-                hostLog.fatal("Unable to process license file: could not create license API.");
-                return null;
-            } catch (IllegalAccessException e) {
-                hostLog.fatal("Unable to process license file: could not create license API.");
-                return null;
-            }
-        }
-
+        LicenseApi licenseApi = ProClass
+                .<LicenseApi>load("org.voltdb.licensetool.LicenseApiImpl", "License API", hostLog::fatal)
+                .errorHandler(hostLog::fatal).newInstance();
         if (licenseApi == null) {
-            hostLog.fatal("Unable to load license file: could not create License API.");
             return null;
         }
 
@@ -606,7 +570,8 @@ public class MiscUtils {
         if (m_isPro == null) {
             //Allow running pro kit as community.
             if (!Boolean.parseBoolean(System.getProperty("community", "false"))) {
-                m_isPro = null != MiscUtils.loadProClass("org.voltdb.CommandLogImpl", "Command logging", true);
+                m_isPro = ProClass.load("org.voltdb.CommandLogImpl", "Command logging", ProClass.HANDLER_IGNORE)
+                        .hasProClass();
             } else {
                 m_isPro = false;
             }

--- a/src/frontend/org/voltdb/utils/ProClass.java
+++ b/src/frontend/org/voltdb/utils/ProClass.java
@@ -1,0 +1,261 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2018 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.utils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.voltcore.logging.VoltLogger;
+import org.voltdb.VoltDB;
+
+import com.google_voltpatches.common.primitives.Primitives;
+
+/**
+ * Utility class for loading and constructing pro classes which might not exist in community edition
+ *
+ * @param <T> Type of pro class
+ */
+public class ProClass<T> {
+    private static final VoltLogger hostLog = new VoltLogger("HOST");
+
+    private static final ProClass<?> NO_CLASS = new ProClass<Object>(null) {
+        @Override
+        public ProClass<Object> useConstructorFor(Class<?>... parameterTypes) {
+            return this;
+        }
+
+        @Override
+        public Object newInstance(Object... parameters) {
+            return null;
+        }
+    };;
+
+    /**
+     * {@link ErrorHandler} which just ignores and drops the error on the floor
+     */
+    public static final ErrorHandler HANDLER_IGNORE = (m, t) -> {};
+
+    /**
+     * {@link ErrorHandler} which logs only the error message in the host log at warning
+     */
+    public static final ErrorHandler HANDLER_LOG = (m, t) -> hostLog.warn(m);
+
+    /**
+     * {@link ErrorHandler} which calls {@link VoltDB#crashLocalVoltDB(String, boolean, Throwable)}
+     */
+    public static final ErrorHandler HANDLER_CRASH = (m, t) -> VoltDB.crashLocalVoltDB(m, true, t);
+
+    private final Class<T> m_proClass;
+    private ErrorHandler m_errorHandler = HANDLER_CRASH;
+    private boolean m_loadConstructor = true;
+    private Constructor<T> m_constructor;
+
+    /**
+     * Try to load a PRO class. If the load fails {@code loadFailure} will be invoked to handle the error.
+     *
+     * @param className   The class name of the PRO class
+     * @param feature     The name of the feature
+     * @param loadFailure {@link ErrorHandler} for handling when class loading fails
+     * @return an instance of {@link ProClass}. Never {@code null}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> ProClass<T> load(String className, String feature, ErrorHandler loadFailure) {
+        try {
+            return new ProClass<T>((Class<T>) ProClass.class.getClassLoader().loadClass(className));
+        } catch (ClassNotFoundException e) {
+            loadFailure.handle("Cannot load pro" + className + " in VoltDB community edition to support the feature "
+                    + feature + '.', e);
+        }
+
+        return (ProClass<T>) NO_CLASS;
+    }
+
+    /**
+     * Construct a new instance of {@code className} using {@code parameters}. If the class cannot be loaded
+     * {@code loadFailure} will be invoked and {@code null} is returned. If the class cannot be constructed
+     * {@link VoltDB#crashLocalVoltDB(String, boolean, Throwable)} will be invoked with the instantiation exception.
+     *
+     * @param className   The class name of the PRO class
+     * @param feature     The name of the feature
+     * @param loadFailure {@link ErrorHandler} for handling when class loading fails
+     * @param parameters  to pass to the constructor of {@code className}
+     * @return an instance of {@code T}
+     */
+    public static <T> T newInstanceOf(String className, String feature, ErrorHandler loadFailure,
+            Object... parameters) {
+        return ProClass.<T>load(className, feature, loadFailure).newInstance(parameters);
+    }
+
+    private ProClass(Class<T> proClass) {
+        super();
+        m_proClass = proClass;
+    }
+
+    /**
+     * @param errorHandler {@link ErrorHandler} to invoke when an exception occurs. Defaults to {@link #HANDLER_CRASH}
+     * @return {@code this}
+     */
+    public ProClass<T> errorHandler(ErrorHandler errorHandler) {
+        m_errorHandler = Objects.requireNonNull(errorHandler);
+        return this;
+    }
+
+    /**
+     * Specify which constructor is to be called when {@link #newInstance(Object...)} is invoked. If the constructor
+     * cannot be found the configured {@link ErrorHandler} will be invoked.
+     *
+     * @param parameterTypes array of parameterTypes which the constructor uses.
+     * @return {@code this}
+     * @see Class#getConstructor(Class...)
+     */
+    public ProClass<T> useConstructorFor(Class<?>... parameterTypes) {
+        try {
+            m_constructor = m_proClass.getConstructor(parameterTypes);
+        } catch (NoSuchMethodException e) {
+            m_errorHandler.handle("Unable to find constructor for  " + m_proClass.getName() + " with parameterTypes: "
+                    + Arrays.toString(parameterTypes), e);
+        }
+        m_loadConstructor = false;
+        return this;
+    }
+
+    /**
+     * Construct a new instance of the pro class using {@code parameters}. If the constructor fails the configured
+     * {@link ErrorHandler} will be invoked. If a constructor was not selected by {@link #useConstructorFor(Class...)}
+     * then the constructor will be selected using the {@link Class} of each {@code parameter}. If there isn't an exact
+     * type match the first constructor found where all parameter types can be assigned to the constructors parameter
+     * types will be used. This makes passing {@code null} in as a parameter dangerous since that can be passed in for
+     * any object
+     *
+     * @param parameters array of parameters to pass to the constructor
+     * @return new instance of {@code T} or {@code null} if the class or constructor could not be found
+     * @see Constructor#newInstance(Object...)
+     */
+    public T newInstance(Object... parameters) {
+        Constructor<T> constructor = m_constructor;
+        if (m_loadConstructor) {
+            Class<?>[] parameterTypes = new Class[parameters.length];
+            for (int i = 0; i < parameters.length; ++i) {
+                parameterTypes[i] = parameters[i] == null ? null : parameters[i].getClass();
+            }
+            constructor = findConstructor(parameterTypes);
+        }
+        if (constructor != null) {
+            try {
+                return constructor.newInstance(parameters);
+            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+                    | InvocationTargetException e) {
+                m_errorHandler.handle(
+                        "Unable to construct " + m_proClass.getName() + " with parameters: "
+                                + Arrays.toString(parameters),
+                        e instanceof InvocationTargetException ? e.getCause() : e);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Reset the constructor which was set by {@link #useConstructorFor(Class...)}
+     *
+     * @return {@code this}
+     */
+    public ProClass<T> resetConstructor() {
+        m_constructor = null;
+        m_loadConstructor = true;
+        return this;
+    }
+
+    /**
+     * @return {@code true} if the pro class was loaded
+     */
+    public boolean hasProClass() {
+        return m_proClass != null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Constructor<T> findConstructor(Class<?>... parameterTypes) {
+        try {
+            return m_proClass.getConstructor(parameterTypes);
+        } catch (NoSuchMethodException e) {
+        }
+
+        Constructor<?> result = null;
+        for (Constructor<?> constructor : m_proClass.getConstructors()) {
+            int compatibility = checkCompatibility(parameterTypes, constructor);
+            if (compatibility == 0) {
+                result = constructor;
+                break;
+            } else if (result == null && compatibility == 1) {
+                result = constructor;
+            }
+        }
+
+        if (result == null) {
+           m_errorHandler.handle("Unable to find constructor for  " + m_proClass.getName() + " with parameterTypes: "
+                   + Arrays.toString(parameterTypes), null);
+        }
+        return (Constructor<T>) result;
+    }
+
+    /**
+     * Check if {@code parameterTypes} are compatible with the {@code executable}
+     *
+     * @param parameterTypes which are going to be passed into the executable
+     * @param executable     which is being tested for compatibility
+     * @return {@code -1} if the types are not compatible, {@code 0} if they are an exact match ignoring primitive
+     *         wrapping or {@code 1} if they are compatible
+     */
+    private int checkCompatibility(Class<?>[] parameterTypes, Executable executable) {
+        if (executable.getParameterCount() != parameterTypes.length) {
+            return -1;
+        }
+        Class<?>[] executableParameterTypes = executable.getParameterTypes();
+        int result = 0;
+        for (int i = 0; i < parameterTypes.length; ++i) {
+            if (parameterTypes[i] == null) {
+                if (executableParameterTypes[i].isPrimitive()) {
+                    return -1;
+                }
+                result = 1;
+            } else {
+                Class<?> wrapped = Primitives.wrap(executableParameterTypes[i]);
+                if (wrapped != parameterTypes[i]) {
+                    if (!wrapped.isAssignableFrom(parameterTypes[i])) {
+                        return -1;
+                    }
+                    result = 1;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Interface for handling errors which occur while loading or constructing pro classes
+     */
+    public interface ErrorHandler {
+        /**
+         * @param message   detailed error message describing when the error occurred
+         * @param throwable which was thrown
+         */
+        void handle(String message, Throwable throwable);
+    };
+}


### PR DESCRIPTION
Currently there is a single method which assits in loading a pro class but that
still requires the caller to retrieve the constructor and do the construction.
The ProClass utility class wraps that and simplifies the error handling for
the common use cases.