### PR TITLE
There is a race between UAC notifcations to export and EOS notificati…

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -164,9 +164,19 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     private static final boolean DISABLE_AUTO_GAP_RELEASE = Boolean.getBoolean("DISABLE_AUTO_GAP_RELEASE");
 
     static enum StreamStatus {
-        ACTIVE,
-        DROPPED,
-        BLOCKED
+        ACTIVE("ACTIVE"),
+        BLOCKED("BLOCKED"),
+        DROPPED_PENDING_EOS("DROPPED"),
+        EOS_PROCESSED("DROPPED"),
+        DROPPED("DROPPED");
+
+        private final String m_displayName;
+        private StreamStatus(String displayName) {
+            m_displayName = displayName;
+        }
+        public String toString() {
+            return m_displayName;
+        }
     }
 
     static class QueryResponse {
@@ -702,6 +712,12 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         exportLog.info("End of stream for table: " + getTableName() +
                 " partition: " + getPartitionId() + " signature: " + getSignature());
         m_eos = true;
+        if (m_status == StreamStatus.DROPPED_PENDING_EOS) {
+            setStatus(StreamStatus.DROPPED);
+        }
+        else {
+            setStatus(StreamStatus.EOS_PROCESSED);
+        }
     }
 
     public void pushExportBuffer(

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -214,8 +214,15 @@ public class ExportGeneration implements Generation {
                 for (String signature : sources.keySet()) {
                     ExportDataSource src = sources.get(signature);
                     if (!exportSignatures.contains(signature)) {
-                        src.setStatus(ExportDataSource.StreamStatus.DROPPED);
-                    } else if (src.getStatus() == ExportDataSource.StreamStatus.DROPPED) {
+                        synchronized (src) {
+                            if (src.getStatus() == ExportDataSource.StreamStatus.EOS_PROCESSED) {
+                                src.setStatus(ExportDataSource.StreamStatus.DROPPED);
+                            }
+                            else {
+                                src.setStatus(ExportDataSource.StreamStatus.DROPPED_PENDING_EOS);
+                            }
+                        }
+                    } else if (src.getStatus().ordinal() >= ExportDataSource.StreamStatus.DROPPED_PENDING_EOS.ordinal()) {
                         src.setStatus(ExportDataSource.StreamStatus.ACTIVE);
                     }
                 }


### PR DESCRIPTION
…ons from Sites. This means that if either is used to trigger the removal of the ExportDataSource, the other fails an assertion. This is exposed with the TestExportStatsSuite which is currently failing.

This branch adds 2 intermediate states that an EOS can fall into before transitioning into the DROPPED state. Stats will report DROPPED for all 3 states.

Further testing will need to verify that races between DROPPED and ADDED streams are correctly handled for all 3 states.