### PR TITLE
ENG-15083:

### DIFF
--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -68,6 +68,8 @@ class Topend {
             std::string signature,
             StreamBlock *block,
             bool sync) = 0;
+    // Not used right now and will be removed or altered after a decision has been made on how Schema changes
+    // are managed (they really don't belong in row buffers).
     virtual void pushEndOfStream(
             int32_t partitionId,
             std::string signature) = 0;

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -143,7 +143,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     private final AtomicReference<AckingContainer> m_pendingContainer = new AtomicReference<>();
     // Is EDS from catalog or from disk pdb?
     private volatile boolean m_isInCatalog;
-    private volatile boolean m_eos;
     private final Generation m_generation;
     private final File m_adFile;
     private ExportClientBase m_client;
@@ -290,7 +289,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             fos.getFD().sync();
         }
         m_isInCatalog = true;
-        m_eos = false;
         m_client = null;
         m_es = CoreUtils.getListeningExecutorService("ExportDataSource for table " +
                     m_tableName + " partition " + m_partitionId, 1);
@@ -360,7 +358,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
         //EDS created from adfile is always from disk.
         m_isInCatalog = false;
-        m_eos = false;
         m_client = null;
         m_es = CoreUtils.getListeningExecutorService("ExportDataSource for table " +
                 m_tableName + " partition " + m_partitionId, 1);
@@ -695,13 +692,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 //Its ok.
             }
         }
-    }
-
-
-    public void pushEndOfStream() {
-        exportLog.info("End of stream for table: " + getTableName() +
-                " partition: " + getPartitionId() + " signature: " + getSignature());
-        m_eos = true;
     }
 
     public void pushExportBuffer(

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -684,28 +684,6 @@ public class ExportGeneration implements Generation {
         source.pushExportBuffer(startSequenceNumber, tupleCount, uniqueId, buffer, sync);
     }
 
-    @Override
-    public void pushEndOfStream(int partitionId, String signature) {
-        assert(m_dataSourcesByPartition.containsKey(partitionId));
-        assert(m_dataSourcesByPartition.get(partitionId).containsKey(signature));
-        Map<String, ExportDataSource> sources = m_dataSourcesByPartition.get(partitionId);
-
-        if (sources == null) {
-            exportLog.error("EOS Could not find export data sources for partition "
-                    + partitionId + ". The export end of stream is being discarded.");
-            return;
-        }
-
-        ExportDataSource source = sources.get(signature);
-        if (source == null) {
-            exportLog.error("EOS Could not find export data source for partition " + partitionId +
-                    " signature " + signature + ". The export end of stream is being discarded.");
-            return;
-        }
-
-        source.pushEndOfStream();
-    }
-
     private void cleanup(final HostMessenger messenger) {
         shutdown = true;
         //We need messenger NULL guard for tests.

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -673,16 +673,6 @@ public class ExportManager
     public static void pushEndOfStream(
             int partitionId,
             String signature) {
-        ExportManager instance = instance();
-        try {
-            ExportGeneration generation = instance.m_generation.get();
-            if (generation != null) {
-                generation.pushEndOfStream(partitionId, signature);
-            }
-        } catch (Exception e) {
-            //Don't let anything take down the execution site thread
-            exportLog.error("Error pushing export end of stream", e);
-        }
     }
     /*
      * This method pulls double duty as a means of pushing export buffers

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -37,7 +37,6 @@ public interface Generation {
 
     public void pushExportBuffer(int partitionId, String signature, long seqNo, int tupleCount,
                                  long uniqueId, ByteBuffer buffer, boolean sync);
-    public void pushEndOfStream(int partitionId, String signature);
     public void updateInitialExportStateToSeqNo(int partitionId, String signature,
                                                 boolean isRecover, long sequenceNumber);
 

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -119,10 +119,6 @@ public class TestExportDataSource extends TestCase {
         }
 
         @Override
-        public void pushEndOfStream(int partitionId, String signature) {
-        }
-
-        @Override
         public void updateInitialExportStateToSeqNo(int partitionId, String signature,
                                                     boolean isRecover, long sequenceNumber) {
         }


### PR DESCRIPTION
There is a race between UAC notifcations to export and EOS notifications from Sites. This means that if either is used to trigger the removal of the ExportDataSource, the other fails an assertion. This is exposed with the TestExportStatsSuite which is currently failing.

However, the m_eos flag is no longer used so the notification of the EndOfStream is no longer necessary. There is a small chance that the Export streams may start injecting events into the PBD. If this ends up being the case, we will still need the CPP api so the Topend callback will be kept until the need for this is decided.