### PR TITLE
ENG-15096 race between rejoining node shutdown and partition leader p…

### DIFF
--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -1227,6 +1227,12 @@ public class VoltDB {
      * Exit the process with an error message, optionally with a stack trace.
      */
     public static void crashLocalVoltDB(String errMsg, boolean stackTrace, Throwable thrown) {
+        crashLocalVoltDB(errMsg, stackTrace, thrown, true);
+    }
+    /**
+     * Exit the process with an error message, optionally with a stack trace.
+     */
+    public static void crashLocalVoltDB(String errMsg, boolean stackTrace, Throwable thrown, boolean logFatal) {
 
         if (exitAfterMessage) {
             System.err.println(errMsg);
@@ -1323,7 +1329,9 @@ public class VoltDB {
 
                 if (log != null)
                 {
-                    log.fatal(errMsg);
+                    if (logFatal) {
+                        log.fatal(errMsg);
+                    }
                     if (thrown != null) {
                         if (stackTrace) {
                             log.fatal("Fatal exception", thrown);

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -221,7 +221,9 @@ public class SpInitiator extends BaseInitiator implements Promotable
                 if (!migratePartitionLeader && !m_initiatorMailbox.acceptPromotion()) {
                     tmLog.info(m_whoami
                             + "rejoining site can not be promoted to leader. Terminating.");
-                    VoltDB.crashLocalVoltDB("A rejoining site can not be promoted to leader.", false, null);
+                    // rejoining not completed. The node will be shutdown @RealVoltDB.hostFailed() anyway.
+                    // do not log extra fatal message.
+                    VoltDB.crashLocalVoltDB("A rejoining site can not be promoted to leader.", false, null, false);
                     return;
                 }
 


### PR DESCRIPTION
…romotion. A rejoining will be shutdown when it sees other node failures to prevent a cluster from being locked up.  However, there is a race between the rejoining node shutdown process and the partition leader election process.  Before the shutdown is invoked, the partitions on the rejoining node could be picked up as new leaders and go through promotion process, which is not allowed and will also trigger node shutdown.  There is no need to log additional fatal message.