### PR TITLE
ENG-15080:

### DIFF
--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -88,4 +88,9 @@ public interface ConsumerDRGateway extends Promotable {
     boolean isSafeForDropLocal();
 
     void handleProducerClusterElasticChange(byte producerClusterId, int newProducerPartitionCount);
+
+    /**
+     * Log the current set of clusters that this consumer is receiving data from.
+     */
+    public void logActiveConversations();
 }

--- a/src/frontend/org/voltdb/ProducerDRGateway.java
+++ b/src/frontend/org/voltdb/ProducerDRGateway.java
@@ -205,4 +205,9 @@ public interface ProducerDRGateway {
     public void dropLocal();
 
     public void elasticChangeUpdatesPartitionCount(int newPartitionCnt);
+
+    /**
+     * If DR producer is enabled and listening, this will log the current conversations.
+     */
+    public void logActiveConversations();
 }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3373,6 +3373,14 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
         }
 
+        final String drRole = m_catalogContext.getCluster().getDrrole();
+        if (m_producerDRGateway != null && (DrRoleType.MASTER.value().equals(drRole) || DrRoleType.XDCR.value().equals(drRole))) {
+            m_producerDRGateway.logActiveConversations();
+        }
+        if (m_consumerDRGateway != null) {
+            m_consumerDRGateway.logActiveConversations();
+        }
+
         try {
             if (operationModeFuture.getData() != null) {
                 String operationModeStr = new String(operationModeFuture.getData(), "UTF-8");


### PR DESCRIPTION
Log the clusters that DR producer and consumer are talking with, at startup time and for daily logging task.
- At server initialization time, producer and consumer will not be ready. So the initial log message happens when the producer and consumer are initialized.
- Added log conversation calls to daily logging task