### PR TITLE
ENG-15166: Always consume partition data and replicas

### DIFF
--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -18,7 +18,6 @@
 package org.voltdb.iv2;
 
 import java.util.AbstractMap;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,11 +28,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.function.BiConsumer;
 
 import org.apache.zookeeper_voltpatches.CreateMode;
 import org.apache.zookeeper_voltpatches.KeeperException;
@@ -97,6 +96,46 @@ public class Cartographer extends StatsSource
 
     private final ExecutorService m_es
             = CoreUtils.getCachedSingleThreadExecutor("Cartographer", 15000);
+
+    /**
+     * Retrieve the list of partitions in the system. Since each partition information is being populated individually
+     * asynchronously some partitions may throw exceptions or block when accessing data and other may not.
+     * <p>
+     * The arguments passed to {@code errorHandler} will be the zookeeper path which was being accessed at the time of
+     * the exception and the exception which was thrown.
+     *
+     * @param zk           {@link ZooKeeper} instance to use to retrieve partition information
+     * @param skipMp       If {@code true} the MP partition will not be included in the result
+     * @param errorHandler {@link BiConsumer} that will be invoked when exception is encountered
+     * @return {@link List} of {@link AsyncPartition}s
+     */
+    public static List<AsyncPartition> getPartitionsAsync(ZooKeeper zk, boolean skipMp,
+            BiConsumer<String, Exception> errorHandler) {
+        List<String> partitionDirs = null;
+        try {
+            partitionDirs = zk.getChildren(VoltZK.leaders_initiators, null);
+        } catch (Exception e) {
+            errorHandler.accept(VoltZK.leaders_initiators, e);
+            return null;
+        }
+
+        // Don't fetch the values serially do it asynchronously
+        List<AsyncPartition> partitions = new ArrayList<>(partitionDirs.size());
+        for (String partitionDir : partitionDirs) {
+            try {
+                int pid = LeaderElector.getPartitionFromElectionDir(partitionDir);
+                if (skipMp && pid == MpInitiator.MP_INIT_PID) {
+                    continue;
+                }
+                partitions.add(new AsyncPartition(pid, partitionDir, zk));
+            } catch (Exception e) {
+                errorHandler.accept(ZKUtil.joinZKPath(VoltZK.leaders_initiators, partitionDir), e);
+                return null;
+            }
+        }
+
+        return partitions;
+    }
 
     // This message used to be sent by the SP or MP initiator when they accepted a promotion.
     // For dev speed, we'll detect mastership changes here and construct and send this message to the
@@ -756,51 +795,31 @@ public class Cartographer extends StatsSource
     private String doPartitionsHaveReplicas(int hid, Set<Integer> nodesBeingStopped) {
         hostLog.debug("Cartographer: Reloading partition information.");
         assert (!nodesBeingStopped.contains(hid));
-        List<String> partitionDirs = null;
-        try {
-            partitionDirs = m_zk.getChildren(VoltZK.leaders_initiators, null);
-        } catch (KeeperException | InterruptedException e) {
-            return "Failed to read ZooKeeper node " + VoltZK.leaders_initiators +": " + e.getMessage();
+
+        String[] error = { null };
+        List<AsyncPartition> partitions = getPartitionsAsync(m_zk, false,
+                (d, e) -> error[0] = "Failed to read ZooKeeper node " + d + ": " + e.getMessage());
+
+        if (error[0] != null) {
+            return error[0];
         }
 
-        //Don't fetch the values serially do it asynchronously
-        Queue<ZKUtil.ByteArrayCallback> dataCallbacks = new ArrayDeque<>();
-        Queue<ZKUtil.ChildrenCallback> childrenCallbacks = new ArrayDeque<>();
-        for (String partitionDir : partitionDirs) {
-            String dir = ZKUtil.joinZKPath(VoltZK.leaders_initiators, partitionDir);
-            try {
-                ZKUtil.ByteArrayCallback callback = new ZKUtil.ByteArrayCallback();
-                m_zk.getData(dir, false, callback, null);
-                dataCallbacks.offer(callback);
-                ZKUtil.ChildrenCallback childrenCallback = new ZKUtil.ChildrenCallback();
-                m_zk.getChildren(dir, false, childrenCallback, null);
-                childrenCallbacks.offer(childrenCallback);
-            } catch (Exception e) {
-                return "Failed to read ZooKeeper node " + dir + ": " + e.getMessage();
-            }
-        }
         //Assume that we are ksafe
-        for (String partitionDir : partitionDirs) {
-            int pid = LeaderElector.getPartitionFromElectionDir(partitionDir);
+        for (AsyncPartition partition : partitions) {
             try {
                 //Dont let anyone die if someone is in INITIALIZING state
-                byte[] partitionState = dataCallbacks.poll().getData();
-                if (partitionState != null && partitionState.length == 1) {
-                    if (partitionState[0] == LeaderElector.INITIALIZING) {
-                        return "StopNode is disallowed in initialization phase";
-                    }
+                if (partition.isInitializing()) {
+                    return "StopNode is disallowed in initialization phase";
                 }
 
-                List<String> replicas = childrenCallbacks.poll().getChildren();
-                //This is here just so callback is polled.
-                if (pid == MpInitiator.MP_INIT_PID) {
+                if (partition.getPid() == MpInitiator.MP_INIT_PID) {
                     continue;
                 }
                 //Get Hosts for replicas
                 final List<Integer> replicaHost = new ArrayList<>();
                 final List<Integer> replicaOnStoppingHost = new ArrayList<>();
                 boolean hostHasReplicas = false;
-                for (String replica : replicas) {
+                for (String replica : partition.getReplicas()) {
                     final String split[] = replica.split("/");
                     final long hsId = Long.valueOf(split[split.length - 1].split("_")[0]);
                     final int hostId = CoreUtils.getHostIdFromHSId(hsId);
@@ -812,7 +831,9 @@ public class Cartographer extends StatsSource
                     }
                     replicaHost.add(hostId);
                 }
-                hostLog.debug("Replica Host for Partition " + pid + " " + replicaHost);
+                if (hostLog.isDebugEnabled()) {
+                    hostLog.debug("Replica Host for Partition " + partition.getPid() + " " + replicaHost);
+                }
                 if (hostHasReplicas && replicaHost.size() <= 1) {
                     return "Cluster doesn't have enough replicas";
                 }
@@ -1073,5 +1094,76 @@ public class Cartographer extends StatsSource
             }
         }
         return false;
+    }
+
+    /**
+     * Simple class to retrieve a partition data and replicas through async zookeeper callbacks
+     */
+    public static final class AsyncPartition {
+        private final int m_pid;
+        private final String m_path;
+        private final ZKUtil.ByteArrayCallback m_stateCallback = new ZKUtil.ByteArrayCallback();
+        private final ZKUtil.ChildrenCallback m_childrenCallback = new ZKUtil.ChildrenCallback();
+
+        public AsyncPartition(String partitionDir, ZooKeeper zooKeeper) {
+            this(LeaderElector.getPartitionFromElectionDir(partitionDir), partitionDir, zooKeeper);
+        }
+
+        AsyncPartition(int pid, String partitionDir, ZooKeeper zooKeeper) {
+            m_pid = pid;
+            m_path = ZKUtil.joinZKPath(VoltZK.leaders_initiators, partitionDir);
+            zooKeeper.getData(m_path, false, m_stateCallback, null);
+            zooKeeper.getChildren(m_path, false, m_childrenCallback, null);
+        }
+
+        /**
+         * @return the pid of the partition
+         */
+        public int getPid() {
+            return m_pid;
+        }
+
+        /**
+         * @return The absolute zookeeper path to the partition
+         */
+        public String getPath() {
+            return m_path;
+        }
+
+        /**
+         * This call blocks until the data is populated by zookeeper or an exception occurs
+         *
+         * @return {@code true} if the state is exactly {@link LeaderElector#INITIALIZING}
+         * @throws InterruptedException If this thread is interrupted while waiting for data
+         * @throws KeeperException      If there was an error retrieving the state from zookeeper
+         */
+        public boolean isInitializing() throws InterruptedException, KeeperException {
+            byte[] state = m_stateCallback.getData();
+            return state != null && state.length == 1 && state[0] == LeaderElector.INITIALIZING;
+        }
+
+        /**
+         * This call blocks until the data is populated by zookeeper or an exception occurs
+         *
+         * @return {@code true} if the state is exactly {@link LeaderElector#INITIALIZED}
+         * @throws InterruptedException If this thread is interrupted while waiting for data
+         * @throws KeeperException      If there was an error retrieving the state from zookeeper
+         */
+        public boolean isInitialized() throws InterruptedException, KeeperException {
+            byte[] state = m_stateCallback.getData();
+            assert state != null && state.length == 1;
+            return state != null && state.length == 1 && state[0] == LeaderElector.INITIALIZED;
+        }
+
+        /**
+         * This call blocks until the data is populated by zookeeper or an exception occurs
+         *
+         * @return list of replicas for partition
+         * @throws InterruptedException If this thread is interrupted while waiting for data
+         * @throws KeeperException      If there was an error retrieving the state from zookeeper
+         */
+        public List<String> getReplicas() throws InterruptedException, KeeperException {
+            return m_childrenCallback.getChildren();
+        }
     }
 }


### PR DESCRIPTION
The root cause of the issue was that there were two queues one for the partition
data and one for the children data. If an ignored exception was thrown
retrieving the partition data then the item in the children queue was not
removed which caused the two queues to become out of sync.

This change simplifies the async retrieval of partition information by making a
single utility method which returns a list AsynPartitions. This ties the async
request for the partition data to the child request so that the processing of
both will not get out of sync. Also, this condenses two different implementation
of this algorithm down to one common implementation.