### PR TITLE
ENG-15100, truncate dangling pbd after cluster receovery.

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -385,6 +385,10 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         m_isInCatalog = true;
     }
 
+    public boolean inCatalog() {
+        return m_isInCatalog;
+    }
+
     public synchronized void updateAckMailboxes(final Pair<Mailbox, ImmutableList<Long>> ackMailboxes) {
         //export stream for run-everywhere clients doesn't need ack mailboxes
         if (m_runEveryWhere) {

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -710,13 +710,15 @@ public class ExportManager
     }
 
     public void updateInitialExportStateToSeqNo(int partitionId, String signature,
-                                                boolean isRecover, long sequenceNumber) {
+                                                boolean isRecover,
+                                                Map<Integer, Pair<Long, Long>> sequenceNumberPerPartition,
+                                                boolean isLowestSite) {
         //If the generation was completely drained, wait for the task to finish running
         //by waiting for the permit that will be generated
         ExportGeneration generation = m_generation.get();
         if (generation != null) {
             generation.updateInitialExportStateToSeqNo(partitionId, signature,
-                                                       isRecover, sequenceNumber);
+                                                       isRecover, sequenceNumberPerPartition, isLowestSite);
         }
     }
 

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.voltcore.messaging.HostMessenger;
+import org.voltcore.utils.Pair;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
 
 /**
@@ -38,7 +39,9 @@ public interface Generation {
     public void pushExportBuffer(int partitionId, String signature, long seqNo, int tupleCount,
                                  long uniqueId, ByteBuffer buffer, boolean sync);
     public void updateInitialExportStateToSeqNo(int partitionId, String signature,
-                                                boolean isRecover, long sequenceNumber);
+                                                boolean isRecover,
+                                                Map<Integer, Pair<Long, Long>> sequenceNumberPerPartition,
+                                                boolean isLowestSite);
 
     public Map<Integer, Map<String, ExportDataSource>> getDataSourceByPartition();
 }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1486,7 +1486,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                     catalogTable.getSignature());
             // assign the stats to the other partition's value
             ExportManager.instance().updateInitialExportStateToSeqNo(m_partitionId, catalogTable.getSignature(),
-                    false, sequenceNumbers.getSecond());
+                    false, tableEntry.getValue(), m_sysprocContext.isLowestSiteId());
         }
 
         if (drSequenceNumbers != null) {

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -1593,7 +1593,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                     signature);
             // Truncate the PBD buffers (if recovering) and assign the stats to the restored value
             ExportManager.instance().updateInitialExportStateToSeqNo(myPartitionId, signature,
-                    isRecover, sequenceNumber);
+                    isRecover, sequenceNumberPerPartition, context.isLowestSiteId());
         }
     }
 

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -125,8 +125,10 @@ public class TestExportDataSource extends TestCase {
         }
 
         @Override
-        public void updateInitialExportStateToSeqNo(int partitionId, String signature,
-                                                    boolean isRecover, long sequenceNumber) {
+        public void updateInitialExportStateToSeqNo(int partitionId,
+                String signature, boolean isRecover,
+                Map<Integer, Pair<Long, Long>> sequenceNumberPerPartition,
+                boolean isLowestSite) {
         }
 
         @Override


### PR DESCRIPTION
Export manager truncates export buffer after truncation point during recovery, however PBD files which its partition is not on the machine doesn't get truncated because truncation is done by each site thread. So this patch asks the lowest site on each node to do some extra work, that is, not just truncating it own partition's export buffer, but also looking for any dangling PBD files to see if the buffer can be truncated.