### PR TITLE
ENG-15167: MpInitiator and elastic coordinator colocation with p0

### DIFF
--- a/src/frontend/org/voltcore/zk/LeaderElector.java
+++ b/src/frontend/org/voltcore/zk/LeaderElector.java
@@ -198,10 +198,6 @@ public class LeaderElector {
         return isLeader;
     }
 
-    public String getNode() {
-        return node;
-    }
-
     /**
      * Deletes the ephemeral node. Make sure that no future watches will fire.
      *

--- a/src/frontend/org/voltcore/zk/LeaderNoticeHandler.java
+++ b/src/frontend/org/voltcore/zk/LeaderNoticeHandler.java
@@ -18,5 +18,4 @@ package org.voltcore.zk;
 
 public interface LeaderNoticeHandler {
     public abstract void becomeLeader();
-    public void noticedTopologyChange(boolean added, boolean removed);
 }

--- a/src/frontend/org/voltdb/GlobalServiceElector.java
+++ b/src/frontend/org/voltdb/GlobalServiceElector.java
@@ -97,8 +97,4 @@ class GlobalServiceElector implements LeaderNoticeHandler
             VoltDB.crashLocalVoltDB("Error shutting down GlobalServiceElector's LeaderElector", true, e);
         }
     }
-
-    @Override
-    public void noticedTopologyChange(boolean added, boolean removed) {
-    }
 }

--- a/src/frontend/org/voltdb/GlobalServiceElector.java
+++ b/src/frontend/org/voltdb/GlobalServiceElector.java
@@ -101,10 +101,4 @@ class GlobalServiceElector implements LeaderNoticeHandler
     @Override
     public void noticedTopologyChange(boolean added, boolean removed) {
     }
-
-    int getLeaderElectorNode() {
-        String path = m_leaderElector.getNode();
-        // last ten characters are numeric
-        return Integer.valueOf(path.substring(path.length() - 10));
-    }
 }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1762,6 +1762,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 // let the client interface know host(s) have failed to clean up any outstanding work
                 // especially non-transactional work
                 m_clientInterface.handleFailedHosts(failedHosts);
+
+                if (m_elasticService != null) {
+                    m_elasticService.hostsFailed(failedHosts);
+                }
             }
         });
     }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1260,7 +1260,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 for (Initiator ii : m_iv2Initiators.values()) {
                     localHSIds.add(ii.getInitiatorHSId());
                 }
-                m_MPI = new MpInitiator(m_messenger, localHSIds, getStatsAgent(), m_globalServiceElector.getLeaderElectorNode());
+                m_MPI = new MpInitiator(m_messenger, localHSIds, getStatsAgent());
                 m_iv2Initiators.put(MpInitiator.MP_INIT_PID, m_MPI);
 
                 // Make a list of HDIds to join

--- a/src/frontend/org/voltdb/VoltType.java
+++ b/src/frontend/org/voltdb/VoltType.java
@@ -852,7 +852,7 @@ public enum VoltType {
     public boolean isUniqueIndexable() { return isNumber(); }
 
     /** Most VoltTypes are not compatible with an array-typed value.
-     * @see VARBINARY
+     * @see #VARBINARY
      * @param arrayArgClass a java array class like byte[] or String[]
      * @return false, unless overridden to enable a specific VoltType
      * (like VARBINARY) to support certain specific array types (like byte[]). */

--- a/src/frontend/org/voltdb/elastic/ElasticService.java
+++ b/src/frontend/org/voltdb/elastic/ElasticService.java
@@ -17,6 +17,8 @@
 
 package org.voltdb.elastic;
 
+import java.util.Collection;
+
 import org.json_voltpatches.JSONObject;
 import org.voltdb.CatalogContext;
 
@@ -31,4 +33,11 @@ public interface ElasticService {
      *         {@code null}
      */
     JSONObject getResumeMetadata();
+
+    /**
+     * Notify the ElasticService that one or more host failed
+     *
+     * @param failedHostIds {@link Collection} of host IDs which failed
+     */
+    void hostsFailed(Collection<Integer> failedHostIds);
 }

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -51,7 +51,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
 {
     public static final int MP_INIT_PID = TxnEgo.PARTITIONID_MAX_VALUE;
 
-    public MpInitiator(HostMessenger messenger, List<Long> buddyHSIds, StatsAgent agent, int leaderNodeId)
+    public MpInitiator(HostMessenger messenger, List<Long> buddyHSIds, StatsAgent agent)
     {
         super(VoltZK.iv2mpi,
                 messenger,
@@ -60,7 +60,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
                     MP_INIT_PID,
                     buddyHSIds,
                     new SiteTaskerQueue(MP_INIT_PID),
-                    leaderNodeId),
+                    messenger.getHostId()),
                 "MP",
                 agent,
                 StartAction.CREATE /* never for rejoin */);

--- a/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
@@ -198,7 +198,7 @@ public class MpInitiatorMailbox extends InitiatorMailbox
     {
         super(partitionId, scheduler, messenger, repairLog, rejoinProducer);
         m_restartSeqGenerator = new MpRestartSequenceGenerator(
-                ((MpScheduler)m_scheduler).getLeaderNodeId(), false);
+                ((MpScheduler)m_scheduler).getHostId(), false);
         m_taskThread.start();
         m_sendThread.start();
     }

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -80,7 +80,7 @@ public class MpScheduler extends Scheduler
     //Generator of pre-IV2ish timestamp based unique IDs
     private final UniqueIdGenerator m_uniqueIdGenerator;
     final private MpTransactionTaskQueue m_pendingTasks;
-    private final int m_leaderNodeId;
+    private final int m_hostId;
 
     // the current not-needed-any-more point of the repair log.
     long m_repairLogTruncationHandle = Long.MIN_VALUE;
@@ -89,7 +89,7 @@ public class MpScheduler extends Scheduler
     // Let the one we can't be sure about linger here.  See ENG-4211 for more.
     long m_repairLogAwaitingCommit = Long.MIN_VALUE;
 
-    MpScheduler(int partitionId, List<Long> buddyHSIds, SiteTaskerQueue taskQueue, int leaderNodeId)
+    MpScheduler(int partitionId, List<Long> buddyHSIds, SiteTaskerQueue taskQueue, int hostId)
     {
         super(partitionId, taskQueue);
         m_pendingTasks = new MpTransactionTaskQueue(m_tasks);
@@ -97,7 +97,7 @@ public class MpScheduler extends Scheduler
         m_iv2Masters = new ArrayList<Long>();
         m_partitionMasters = Maps.newHashMap();
         m_uniqueIdGenerator = new UniqueIdGenerator(partitionId, 0);
-        m_leaderNodeId = leaderNodeId;
+        m_hostId = hostId;
         m_leaderMigrationMap = Maps.newHashMap();
     }
 
@@ -360,7 +360,7 @@ public class MpScheduler extends Scheduler
 
                 task = instantiateNpProcedureTask(m_mailbox, procedureName,
                         m_pendingTasks, mp, involvedPartitionMasters,
-                        m_buddyHSIds.get(m_nextBuddy), false, m_leaderNodeId);
+                        m_buddyHSIds.get(m_nextBuddy), false, m_hostId);
             }
 
             // if cannot figure out the involved partitions, run it as an MP txn
@@ -375,14 +375,14 @@ public class MpScheduler extends Scheduler
 
             task = instantiateNpProcedureTask(m_mailbox, procedureName,
                     m_pendingTasks, mp, involvedPartitionMasters,
-                    m_buddyHSIds.get(m_nextBuddy), false, m_leaderNodeId);
+                    m_buddyHSIds.get(m_nextBuddy), false, m_hostId);
         }
 
 
         if (task == null) {
             task = new MpProcedureTask(m_mailbox, procedureName,
                     m_pendingTasks, mp, m_iv2Masters, m_partitionMasters,
-                    m_buddyHSIds.get(m_nextBuddy), false, m_leaderNodeId, false);
+                    m_buddyHSIds.get(m_nextBuddy), false, m_hostId, false);
         }
 
         m_nextBuddy = (m_nextBuddy + 1) % m_buddyHSIds.size();
@@ -461,7 +461,7 @@ public class MpScheduler extends Scheduler
 
                 task = instantiateNpProcedureTask(m_mailbox, procedureName,
                         m_pendingTasks, mp, involvedPartitionMasters,
-                        m_buddyHSIds.get(m_nextBuddy), true, m_leaderNodeId);
+                        m_buddyHSIds.get(m_nextBuddy), true, m_hostId);
             }
 
             // if cannot figure out the involved partitions, run it as an MP txn
@@ -470,7 +470,7 @@ public class MpScheduler extends Scheduler
         if (task == null) {
             task = new MpProcedureTask(m_mailbox, procedureName,
                     m_pendingTasks, mp, m_iv2Masters, m_partitionMasters,
-                    m_buddyHSIds.get(m_nextBuddy), true, m_leaderNodeId, false);
+                    m_buddyHSIds.get(m_nextBuddy), true, m_hostId, false);
         }
 
         m_nextBuddy = (m_nextBuddy + 1) % m_buddyHSIds.size();
@@ -654,8 +654,8 @@ public class MpScheduler extends Scheduler
         return NP_PROCEDURE_CLASS.newInstance(params);
     }
 
-    public int getLeaderNodeId() {
-        return m_leaderNodeId;
+    public int getHostId() {
+        return m_hostId;
     }
 
     @Override

--- a/tests/frontend/org/voltcore/zk/TestZK.java
+++ b/tests/frontend/org/voltcore/zk/TestZK.java
@@ -376,9 +376,6 @@ public class TestZK extends ZKTestBase {
             public void becomeLeader() {
                 sem2.release();
             }
-
-            @Override
-            public void noticedTopologyChange(boolean added, boolean removed) {}
         };
         final Semaphore sem3 = new Semaphore(0);
         LeaderNoticeHandler r3 = new LeaderNoticeHandler() {
@@ -386,9 +383,6 @@ public class TestZK extends ZKTestBase {
             public void becomeLeader() {
                 sem3.release();
             }
-
-            @Override
-            public void noticedTopologyChange(boolean added, boolean removed) {}
         };
 
         LeaderElector elector1 = new LeaderElector(zk, "/election", "node", new byte[0], null);
@@ -432,9 +426,6 @@ public class TestZK extends ZKTestBase {
             public void becomeLeader() {
                 sem2.release();
             }
-
-            @Override
-            public void noticedTopologyChange(boolean added, boolean removed) {}
         };
         final Semaphore sem3 = new Semaphore(0);
         LeaderNoticeHandler r3 = new LeaderNoticeHandler() {
@@ -442,9 +433,6 @@ public class TestZK extends ZKTestBase {
             public void becomeLeader() {
                 sem3.release();
             }
-
-            @Override
-            public void noticedTopologyChange(boolean added, boolean removed) {}
         };
         final Semaphore sem4 = new Semaphore(0);
         LeaderNoticeHandler r4 = new LeaderNoticeHandler() {
@@ -452,9 +440,6 @@ public class TestZK extends ZKTestBase {
             public void becomeLeader() {
                 sem4.release();
             }
-
-            @Override
-            public void noticedTopologyChange(boolean added, boolean removed) {}
         };
 
         LeaderElector elector1 = new LeaderElector(zk, "/election", "node", new byte[0], null);
@@ -504,20 +489,12 @@ public class TestZK extends ZKTestBase {
             public void becomeLeader() {
                 sem1.release();
             }
-
-            @Override
-            public void noticedTopologyChange(boolean added, boolean removed) {
-            }
         };
         final Semaphore sem7 = new Semaphore(0);
         LeaderNoticeHandler r7 = new LeaderNoticeHandler() {
             @Override
             public void becomeLeader() {
                 sem7.release();
-            }
-
-            @Override
-            public void noticedTopologyChange(boolean added, boolean removed) {
             }
         };
 
@@ -585,9 +562,6 @@ public class TestZK extends ZKTestBase {
             public void becomeLeader() {
                 sem3.release();
             }
-
-            @Override
-            public void noticedTopologyChange(boolean added, boolean removed) {}
         };
 
         LeaderElector elector1 = new LeaderElector(zk, "/election", "node", new byte[0], null);

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -106,8 +106,7 @@ public class TestLeaderAppointer extends ZKTestBase {
         tearDownZK();
     }
 
-    void configure(int hostCount, int sitesPerHost, int replicationFactor,
-            boolean enablePPD) throws JSONException, Exception
+    void configure(int hostCount, int sitesPerHost, int replicationFactor) throws JSONException, Exception
     {
         m_hm = mock(HostMessenger.class);
         m_zk = getClient(0);
@@ -124,13 +123,13 @@ public class TestLeaderAppointer extends ZKTestBase {
         TheHashinator.initialize(TheHashinator.getConfiguredHashinatorClass(), TheHashinator.getConfigureBytes(partitionCount));
         when(m_hm.getLiveHostIds()).thenReturn(hostInfos.keySet());
         m_mpi = mock(MpInitiator.class);
-        createAppointer(enablePPD);
+        createAppointer();
 
         m_cache = new LeaderCache(m_zk, VoltZK.iv2appointees, m_changeCallback);
         m_cache.start(true);
     }
 
-    void createAppointer(boolean enablePPD) throws JSONException
+    void createAppointer() throws JSONException
     {
         KSafetyStats stats = new KSafetyStats();
         m_dut = new LeaderAppointer(m_hm, m_topo.getPartitionCount(),
@@ -174,7 +173,7 @@ public class TestLeaderAppointer extends ZKTestBase {
     @Test
     public void testBasicStartup() throws Exception
     {
-        configure(2, 2, 0, false);
+        configure(2, 2, 0);
 
         Thread dutthread = new Thread() {
             @Override
@@ -212,7 +211,7 @@ public class TestLeaderAppointer extends ZKTestBase {
     @Test
     public void testStartupFailure() throws Exception
     {
-        configure(2, 2, 1, false);
+        configure(2, 2, 1);
         // Write an appointee before we start to simulate a failure during startup
         m_cache.put(0, 0L);
         VoltDB.ignoreCrash = true;
@@ -232,7 +231,7 @@ public class TestLeaderAppointer extends ZKTestBase {
     @Test
     public void testStartupFailure2() throws Exception
     {
-        configure(2, 2, 1, false);
+        configure(2, 2, 1);
         // Write the appointees and one master before we start to simulate a failure during startup
         m_cache.put(0, 0L);
         m_cache.put(1, 1L);
@@ -255,7 +254,7 @@ public class TestLeaderAppointer extends ZKTestBase {
     @Test
     public void testFailureDuringReplay() throws Exception
     {
-        configure(2, 2, 1, false);
+        configure(2, 2, 1);
         Thread dutthread = new Thread() {
             @Override
             public void run() {
@@ -302,7 +301,7 @@ public class TestLeaderAppointer extends ZKTestBase {
     @Test
     public void testWaitsForAllReplicasAndLeaders() throws Exception
     {
-        configure(2, 2, 1, false);
+        configure(2, 2, 1);
         Thread dutthread = new Thread() {
             @Override
             public void run() {
@@ -343,7 +342,7 @@ public class TestLeaderAppointer extends ZKTestBase {
     public void testPromotesOnReplicaDeathAndDiesOnKSafety() throws Exception
     {
         // run once to get to a startup state
-        configure(2, 2, 1, false);
+        configure(2, 2, 1);
         VoltDB.ignoreCrash = true;
         Thread dutthread = new Thread() {
             @Override
@@ -384,7 +383,7 @@ public class TestLeaderAppointer extends ZKTestBase {
     public void testAppointerPromotion() throws Exception
     {
         // run once to get to a startup state
-        configure(2, 2, 1, false);
+        configure(2, 2, 1);
         VoltDB.ignoreCrash = true;
         Thread dutthread = new Thread() {
             @Override
@@ -411,7 +410,7 @@ public class TestLeaderAppointer extends ZKTestBase {
         long expectedNewLeader = m_cache.pointInTimeCache().get(0).equals(0L) ? 1L : 0L;
         deleteReplica(0, m_cache.pointInTimeCache().get(0));
         // create a new appointer and start it up
-        createAppointer(false);
+        createAppointer();
         m_newAppointee.set(false);
         m_dut.acceptPromotion();
         while (!m_newAppointee.get()) {
@@ -430,7 +429,7 @@ public class TestLeaderAppointer extends ZKTestBase {
     public void testAddPartition() throws Exception
     {
         // run once to get to a startup state
-        configure(2, 2, 1, false);
+        configure(2, 2, 1);
         VoltDB.ignoreCrash = true;
         Thread dutthread = new Thread() {
             @Override
@@ -500,7 +499,7 @@ public class TestLeaderAppointer extends ZKTestBase {
         doReturn(ReplicationRole.REPLICA).when(mVolt).getReplicationRole();
         VoltDB.replaceVoltDBInstanceForTest(mVolt);
 
-        configure(2, 2, 1, false);
+        configure(2, 2, 1);
         Thread dutthread = new Thread() {
             @Override
             public void run() {


### PR DESCRIPTION
Only allow hosts that are in the partition group with partition 0 be eligible to be leaders of services. This is being done so that a service leader is not killed during elastic removal.