### PR TITLE
Fix unit tests broken by MpInitiator only existing on the first partition group

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1250,13 +1250,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                         partitions,
                         m_config.m_startAction,
                         m_partitionsToSitesAtStartupForExportInit);
-
-                // Pass the local HSIds to the MPI so it can farm out buddy sites
-                // to the RO MP site pool
-                List<Long> localHSIds = new ArrayList<>();
-                for (Initiator ii : m_iv2Initiators.values()) {
-                    localHSIds.add(ii.getInitiatorHSId());
-                }
+                m_iv2InitiatorStartingTxnIds.put(MpInitiator.MP_INIT_PID,
+                        TxnEgo.makeZero(MpInitiator.MP_INIT_PID).getTxnId());
 
                 if (m_eligibleAsLeader) {
                     // Start the GlobalServiceElector. Not sure where this will actually belong.
@@ -1265,8 +1260,14 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     } catch (Exception e) {
                         VoltDB.crashLocalVoltDB("Unable to start GlobalServiceElector", true, e);
                     }
-                    m_iv2InitiatorStartingTxnIds.put(MpInitiator.MP_INIT_PID,
-                            TxnEgo.makeZero(MpInitiator.MP_INIT_PID).getTxnId());
+
+                    // Pass the local HSIds to the MPI so it can farm out buddy sites
+                    // to the RO MP site pool
+                    List<Long> localHSIds = new ArrayList<>();
+                    for (Initiator ii : m_iv2Initiators.values()) {
+                        localHSIds.add(ii.getInitiatorHSId());
+                    }
+
                     m_MPI = new MpInitiator(m_messenger, localHSIds, getStatsAgent());
                     m_iv2Initiators.put(MpInitiator.MP_INIT_PID, m_MPI);
                 }

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -49,8 +49,8 @@ public class StatsAgent extends OpsAgent
     {
         super("StatsAgent");
         StatsSelector selectors[] = StatsSelector.values();
-        for (int ii = 0; ii < selectors.length; ii++) {
-            m_registeredStatsSources.put(selectors[ii], new NonBlockingHashMap<Long,NonBlockingHashSet<StatsSource>>());
+        for (StatsSelector selector : selectors) {
+            m_registeredStatsSources.put(selector, new NonBlockingHashMap<Long,NonBlockingHashSet<StatsSource>>());
         }
     }
 
@@ -688,13 +688,7 @@ public class StatsAgent extends OpsAgent
                 m_registeredStatsSources.get(selector);
         assert siteIdToStatsSources != null;
 
-        //putIfAbsent idiom, may return existing map value from another thread
-        NonBlockingHashSet<StatsSource> statsSources = siteIdToStatsSources.get(siteId);
-        if (statsSources == null) {
-            statsSources = new NonBlockingHashSet<StatsSource>();
-            siteIdToStatsSources.putIfAbsent(siteId, statsSources);
-        }
-        statsSources.add(source);
+        siteIdToStatsSources.computeIfAbsent(siteId, s -> new NonBlockingHashSet<>()).add(source);
     }
 
     public void deregisterStatsSource(StatsSelector selector, long siteId, StatsSource source) {

--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -70,6 +70,7 @@ import org.voltdb.client.ClientStatusListenerExt.AutoConnectionStatus;
 import org.voltdb.client.ClientStatusListenerExt.DisconnectCause;
 import org.voltdb.common.Constants;
 
+import com.google_voltpatches.common.base.Strings;
 import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableSet;
@@ -1456,7 +1457,7 @@ class Distributer {
 
             String leader = vt.getString("Leader");
             String sites = vt.getString("Sites");
-            if (sites == null || leader == null) {
+            if (Strings.isNullOrEmpty(sites) || Strings.isNullOrEmpty(leader)) {
                 continue;
             }
 

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -43,7 +43,7 @@ import org.voltdb.rejoin.TaskLog;
  * This class is primarily used for object construction and configuration plumbing;
  * Try to avoid filling it with lots of other functionality.
  */
-public abstract class BaseInitiator implements Initiator
+public abstract class BaseInitiator<S extends Scheduler> implements Initiator
 {
     VoltLogger tmLog = new VoltLogger("TM");
 
@@ -54,7 +54,7 @@ public abstract class BaseInitiator implements Initiator
     protected final String m_whoami;
 
     // Encapsulated objects
-    protected final Scheduler m_scheduler;
+    protected final S m_scheduler;
     protected final InitiatorMailbox m_initiatorMailbox;
     protected Term m_term = null;
     protected Site m_executionSite = null;
@@ -63,8 +63,7 @@ public abstract class BaseInitiator implements Initiator
 
 
     public BaseInitiator(String zkMailboxNode, HostMessenger messenger, Integer partition,
-            Scheduler scheduler, String whoamiPrefix, StatsAgent agent,
-            StartAction startAction)
+            S scheduler, String whoamiPrefix, StatsAgent agent, StartAction startAction)
     {
         m_zkMailboxNode = zkMailboxNode;
         m_messenger = messenger;

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -47,7 +47,7 @@ import org.voltdb.messaging.Iv2InitiateTaskMessage;
  * This class is primarily used for object construction and configuration plumbing;
  * Try to avoid filling it with lots of other functionality.
  */
-public class MpInitiator extends BaseInitiator implements Promotable
+public class MpInitiator extends BaseInitiator<MpScheduler> implements Promotable
 {
     public static final int MP_INIT_PID = TxnEgo.PARTITIONID_MAX_VALUE;
 
@@ -87,7 +87,7 @@ public class MpInitiator extends BaseInitiator implements Promotable
         super.configureCommon(backend, catalogContext, serializedCatalog,
                 numberOfPartitions, startAction, null, null, cl, coreBindIds, false);
         // Hacky
-        MpScheduler sched = (MpScheduler)m_scheduler;
+        MpScheduler sched = m_scheduler;
         MpRoSitePool sitePool = new MpRoSitePool(m_initiatorMailbox.getHSId(),
                 backend,
                 catalogContext,
@@ -220,15 +220,13 @@ public class MpInitiator extends BaseInitiator implements Promotable
         // note this will never require snapshot isolation because the MPI has no snapshot funtionality
         m_executionSite.updateCatalog(diffCmds, context, false, true, Long.MIN_VALUE, Long.MIN_VALUE, Long.MIN_VALUE,
                 isReplay, requireCatalogDiffCmdsApplyToEE, requiresNewExportGeneration);
-        MpScheduler sched = (MpScheduler)m_scheduler;
-        sched.updateCatalog(diffCmds, context);
+        m_scheduler.updateCatalog(diffCmds, context);
     }
 
     public void updateSettings(CatalogContext context)
     {
         m_executionSite.updateSettings(context);
-        MpScheduler sched = (MpScheduler)m_scheduler;
-        sched.updateSettings(context);
+        m_scheduler.updateSettings(context);
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -55,7 +55,7 @@ import com.google_voltpatches.common.collect.Sets;
  * This class is primarily used for object construction and configuration plumbing;
  * Try to avoid filling it with lots of other functionality.
  */
-public class SpInitiator extends BaseInitiator implements Promotable
+public class SpInitiator extends BaseInitiator<SpScheduler> implements Promotable
 {
     final private LeaderCache m_leaderCache;
     private final TickProducer m_tickProducer;
@@ -113,11 +113,10 @@ public class SpInitiator extends BaseInitiator implements Promotable
                 new SpScheduler(partition, new SiteTaskerQueue(partition), snapMonitor,
                         startAction != StartAction.JOIN),
                 "SP", agent, startAction);
-        ((SpScheduler)m_scheduler).initializeScoreboard(CoreUtils.getSiteIdFromHSId(getInitiatorHSId()),
-                m_initiatorMailbox);
+        m_scheduler.initializeScoreboard(CoreUtils.getSiteIdFromHSId(getInitiatorHSId()), m_initiatorMailbox);
         m_leaderCache = new LeaderCache(messenger.getZK(), VoltZK.iv2appointees, m_leadersChangeHandler);
         m_tickProducer = new TickProducer(m_scheduler.m_tasks);
-        ((SpScheduler)m_scheduler).m_repairLog = m_repairLog;
+        m_scheduler.m_repairLog = m_repairLog;
     }
 
     @Override
@@ -333,7 +332,7 @@ public class SpInitiator extends BaseInitiator implements Promotable
 
     public void resetMigratePartitionLeaderStatus(int failedHostId) {
         m_initiatorMailbox.resetMigratePartitionLeaderStatus();
-        ((SpScheduler)m_scheduler).updateReplicasFromMigrationLeaderFailedHost(failedHostId);
+        m_scheduler.updateReplicasFromMigrationLeaderFailedHost(failedHostId);
     }
 
     public Scheduler getScheduler() {
@@ -346,6 +345,6 @@ public class SpInitiator extends BaseInitiator implements Promotable
         if (m_term != null) {
             replicasAdded = ((SpTerm)m_term).updateReplicas(snapshotSaveTxnId);
         }
-        ((SpScheduler)m_scheduler).forwardPendingTaskToRejoinNode(replicasAdded, snapshotSaveTxnId);
+        m_scheduler.forwardPendingTaskToRejoinNode(replicasAdded, snapshotSaveTxnId);
     }
 }

--- a/tests/frontend/org/voltdb/TestMixedPauseModeCluster.java
+++ b/tests/frontend/org/voltdb/TestMixedPauseModeCluster.java
@@ -73,36 +73,11 @@ public class TestMixedPauseModeCluster extends JUnit4LocalClusterTest {
             return true;
         }
 
-        boolean killAndRejoin(String mode) {
-            try {
-                m_cluster.killSingleHost(2);
-                // just set the override for the last host
-                m_cluster.setOverridesForModes(new String[]{"", "", mode});
-                return m_cluster.recoverOne(2, 0, "");
-            } catch (Exception e) {
-                e.printStackTrace();
-                return false;
-            }
-        }
-
-        boolean killAndRejoin() {
-            try {
-                m_cluster.killSingleHost(2);
-                return m_cluster.recoverOne(2, 0, "");
-            } catch (Exception e) {
-                e.printStackTrace();
-                return false;
-            }
-        }
-
-        boolean killAndRejoin(int node) {
-            try {
-                m_cluster.killSingleHost(node);
-                return m_cluster.recoverOne(node, 0, "");
-            } catch (Exception e) {
-                e.printStackTrace();
-                return false;
-            }
+        boolean killAndRejoin(int node) throws Exception {
+            // Rejoin does not support paused so clear it
+            m_cluster.clearOverridesForModes();
+            m_cluster.killSingleHost(node);
+            return m_cluster.recoverOne(node, 0, "");
         }
 
         void shutdown() throws InterruptedException {
@@ -199,7 +174,7 @@ public class TestMixedPauseModeCluster extends JUnit4LocalClusterTest {
     }
 
     @Test
-    public void testJoins() throws InterruptedException {
+    public void testRejoins() throws InterruptedException {
         try {
             MixedPauseCluster cluster = null;
 

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -2078,6 +2078,15 @@ public class LocalCluster extends VoltServerConfig {
         m_modeOverrides = modes;
     }
 
+    public void clearOverridesForModes() {
+        m_modeOverrides = null;
+        if (m_cmdLines != null) {
+            for (CommandLine commandLine : m_cmdLines) {
+                commandLine.m_modeOverrideForTest = null;
+            }
+        }
+    }
+
     public void setPlacementGroups(String[] placementGroups) {
         this.m_placementGroups = placementGroups;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -646,7 +646,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         // One row per site, we don't use HSID though, so hard to do straightforward
         // per-site unique check.  Finesse it.
         // We also get starvation stats for the MPI, so we need to add a site per host.
-        assertEquals(HOSTS * (SITES + 1), results[0].getRowCount());
+        assertEquals(HOSTS * SITES + (KFACTOR == 0 ? 1 : HOSTS), results[0].getRowCount());
         results[0].advanceRow();
         Map<String, String> columnTargets = new HashMap<String, String>();
         columnTargets.put("HOSTNAME", results[0].getString("HOSTNAME"));
@@ -680,7 +680,7 @@ public class TestStatisticsSuite extends StatisticsTestSuiteBase {
         // One row per site, we don't use HSID though, so hard to do straightforward
         // per-site unique check.  Finesse it.
         // We also get starvation stats for the MPI, so we need to add a site per host.
-        assertEquals(HOSTS * (SITES + 1), results[0].getRowCount());
+        assertEquals(HOSTS * SITES + (KFACTOR == 0 ? 1 : HOSTS), results[0].getRowCount());
         results[0].advanceRow();
         Map<String, String> columnTargets = new HashMap<String, String>();
         columnTargets.put("HOSTNAME", results[0].getString("HOSTNAME"));


### PR DESCRIPTION
Do not assume that MpI is on host 0
Change expected partition count based on kfactor with respect to MpI
Always initialize MpI starting transaction