### PR TITLE
TestMixedPauseModeCluster: Do not append paused on rejoin commandline

### DIFF
--- a/tests/frontend/org/voltdb/TestMixedPauseModeCluster.java
+++ b/tests/frontend/org/voltdb/TestMixedPauseModeCluster.java
@@ -73,36 +73,11 @@ public class TestMixedPauseModeCluster extends JUnit4LocalClusterTest {
             return true;
         }
 
-        boolean killAndRejoin(String mode) {
-            try {
-                m_cluster.killSingleHost(2);
-                // just set the override for the last host
-                m_cluster.setOverridesForModes(new String[]{"", "", mode});
-                return m_cluster.recoverOne(2, 0, "");
-            } catch (Exception e) {
-                e.printStackTrace();
-                return false;
-            }
-        }
-
-        boolean killAndRejoin() {
-            try {
-                m_cluster.killSingleHost(2);
-                return m_cluster.recoverOne(2, 0, "");
-            } catch (Exception e) {
-                e.printStackTrace();
-                return false;
-            }
-        }
-
-        boolean killAndRejoin(int node) {
-            try {
-                m_cluster.killSingleHost(node);
-                return m_cluster.recoverOne(node, 0, "");
-            } catch (Exception e) {
-                e.printStackTrace();
-                return false;
-            }
+        boolean killAndRejoin(int node) throws Exception {
+            // Rejoin does not support paused so clear it
+            m_cluster.clearOverridesForModes();
+            m_cluster.killSingleHost(node);
+            return m_cluster.recoverOne(node, 0, "");
         }
 
         void shutdown() throws InterruptedException {
@@ -199,7 +174,7 @@ public class TestMixedPauseModeCluster extends JUnit4LocalClusterTest {
     }
 
     @Test
-    public void testJoins() throws InterruptedException {
+    public void testRejoins() throws InterruptedException {
         try {
             MixedPauseCluster cluster = null;
 

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -2077,6 +2077,15 @@ public class LocalCluster extends VoltServerConfig {
         m_modeOverrides = modes;
     }
 
+    public void clearOverridesForModes() {
+        m_modeOverrides = null;
+        if (m_cmdLines != null) {
+            for (CommandLine commandLine : m_cmdLines) {
+                commandLine.m_modeOverrideForTest = null;
+            }
+        }
+    }
+
     public void setOverridesForSitesperhost(Map<Integer, Integer> sphMap) {
         assert(sphMap != null);
         assert(!sphMap.isEmpty());


### PR DESCRIPTION
The paused flag cannot be used on the commandline with the rejoin start action.
Before perforing the rejoin test clear the overrides so it is not appended to
the end of the command line.

Also, rename the test to testRejoins because that is what it is testing.