### PR TITLE
ENG-15213.partial.index.creation.with.unsafe.function.crashes.database

### DIFF
--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -1652,6 +1652,7 @@ public class DDLCompiler {
         // can't be indexed like boolean, geo ... We gather rest of expression into
         // checkExpressions list.  We will check on them all at once.
         List<AbstractExpression> checkExpressions = new ArrayList<>();
+        final UnsafeOperatorsForDDL unsafeOps = new UnsafeOperatorsForDDL();
         for (VoltXMLElement subNode : node.children) {
             if (subNode.name.equals("exprs")) {
                 exprs = new ArrayList<>();
@@ -1672,7 +1673,6 @@ public class DDLCompiler {
                         throw compiler.new VoltCompilerException("Cannot create unique index \""+ name +
                                 "\" because it contains " + exprMsg + ", which is not supported.");
                     }
-
                     // rest of the validity guards will be evaluated after collecting all the expressions.
                     checkExpressions.add(expr);
                     exprs.add(expr);
@@ -1684,6 +1684,7 @@ public class DDLCompiler {
                 assert(predicateXML != null);
                 predicate = buildPartialIndexPredicate(dummy, name,
                         predicateXML, table, compiler);
+                predicate.findUnsafeOperatorsForDDL(unsafeOps);
             }
         }
 
@@ -1706,7 +1707,6 @@ public class DDLCompiler {
             }
         }
 
-        UnsafeOperatorsForDDL unsafeOps = new UnsafeOperatorsForDDL();
         if (exprs == null) {
             for (int i = 0; i < colNames.length; i++) {
                 VoltType colType = VoltType.get((byte)columns[i].getType());

--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -1302,12 +1302,10 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         if (containsFunctionById(FunctionSQL.voltGetCurrentTimestampId())) {
             msg.append("cannot include the function NOW or CURRENT_TIMESTAMP.");
             return false;
-        }
-        if (hasAnySubexpressionOfClass(AggregateExpression.class)) {
+        } else if (hasAnySubexpressionOfClass(AggregateExpression.class)) {
             msg.append("cannot contain aggregate expressions.");
             return false;
-        }
-        if (hasAnySubexpressionOfClass(AbstractSubqueryExpression.class)) {
+        } else if (hasAnySubexpressionOfClass(AbstractSubqueryExpression.class)) {
             // There may not be any of these in HSQL1.9.3b.  However, in
             // HSQL2.3.2 subqueries are stored as expressions.  So, we may
             // find some here.  We will keep it here for the moment.
@@ -1317,12 +1315,12 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
                 msg.append("cannot contain subqueries.");
             }
             return false;
-        }
-        if (hasUserDefinedFunctionExpression()) {
+        } else if (hasUserDefinedFunctionExpression()) {
             msg.append("cannot contain calls to user defined functions.");
             return false;
+        } else {
+            return true;
         }
-        return true;
     }
 
     public List<AbstractExpression> findAllUserDefinedFunctionCalls() {


### PR DESCRIPTION
The cause for the crash is at partial index creation time, DDLCompiler failed to check predicate for unsafe operations.