### PR TITLE
OP-362:

### DIFF
--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -213,9 +213,10 @@ public class PBDRegularSegment extends PBDSegment {
     public void closeAndTruncate() throws IOException {
         try
         {
-            if (m_ras != null) {
-                m_ras.setLength(0);
+            if (m_ras == null) {
+                m_ras = new RandomAccessFile( m_file, "rw");
             }
+            m_ras.setLength(0);
         }
         finally
         {

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -91,7 +91,9 @@ public class TestPersistentBinaryDeque {
     public static TreeSet<String> getSortedDirectoryListing() {
         TreeSet<String> names = new TreeSet<String>();
         for (File f : TEST_DIR.listFiles()) {
-            names.add(f.getName());
+            if (f.length() > 0) {
+                names.add(f.getName());
+            }
         }
         return names;
     }


### PR DESCRIPTION
Sometimes PBD files that would normally be deleted need to truncated. However, the truncation does not occur if the file is already closed so this branch opens the file to truncate the file before closing it again. Unit test was also updated to ignore truncated PBD files in counting the number of files with data.