### PR TITLE
ENG-15155, fix ExportBenchmark to avoid rejecting samples < 1 ms elap…

### DIFF
--- a/tests/test_apps/exportbenchmark/client/exportbenchmark/ExportBenchmark.java
+++ b/tests/test_apps/exportbenchmark/client/exportbenchmark/ExportBenchmark.java
@@ -413,6 +413,8 @@ public class ExportBenchmark {
 
         System.out.println("Benchmark complete: wrote " + successfulInserts.get() + " objects");
         System.out.println("Failed to insert " + failedInserts.get() + " objects");
+        // Use this to correlate the total rows exported
+        System.out.println("Total inserts: " + totalInserts);
 
         testFinished.set(true);
         if (config.target.equals("socket")) {
@@ -654,53 +656,6 @@ public class ExportBenchmark {
                 stats.kPercentileLatencyAsDouble(0.99999));
     }
 
-    public synchronized Double calcRatio(StatClass index, StatClass indexPrime) {
-        Double ratio = new Double(0);
-        // Check for overlap format:
-        //      |-----index window-----|
-        //   |-----indexPrime window-----|
-        if (indexPrime.m_endTime >= index.m_endTime && indexPrime.m_startTime <= index.m_startTime) {
-            ratio = new Double(index.m_endTime - index.m_startTime) / (indexPrime.m_endTime - indexPrime.m_startTime);
-            if (ratio <= 0 || ratio > 1) {
-                System.out.println("Bad Ratio 1 - ratio: " + ratio + " || index.endTime: " + index.m_endTime +
-                        " || index.startTime: " + index.m_startTime + " || indexPrime.endTime: " + indexPrime.m_endTime +
-                        " || indexPrime.startTime: " + indexPrime.m_startTime);
-                System.exit(-1);
-            }
-        }
-        // Check for overlap format:
-        //      |-----index window-----|
-        //        |-indexPrime window-|
-        else if (indexPrime.m_endTime <= index.m_endTime && indexPrime.m_startTime >= index.m_startTime) {
-            ratio = new Double(1);
-        }
-        // Check for overlap format:
-        //      |-----index window-----|
-        //            |--indexPrime window--|
-        else if (indexPrime.m_startTime >= index.m_startTime && indexPrime.m_startTime < index.m_endTime) {
-            ratio = new Double(index.m_endTime - indexPrime.m_startTime) / (indexPrime.m_endTime - indexPrime.m_startTime);
-            if (ratio <= 0 || ratio > 1) {
-                System.out.println("Bad Ratio 2 - ratio: " + ratio + " || index.endTime: " + index.m_endTime +
-                        " || index.startTime: " + index.m_startTime + " || indexPrime.endTime: " + indexPrime.m_endTime +
-                        " || indexPrime.startTime: " + indexPrime.m_startTime);
-                System.exit(-1);
-            }
-        }
-        // Check for overlap format:
-        //      |-----index window-----|
-        // |--indexPrime window--|
-        else if (indexPrime.m_endTime <= index.m_endTime && indexPrime.m_endTime > index.m_startTime) {
-            ratio = new Double(indexPrime.m_endTime - index.m_startTime) / (indexPrime.m_endTime - indexPrime.m_startTime);
-            if (ratio <= 0 || ratio > 1) {
-                System.out.println("Bad Ratio 3 - ratio: " + ratio + " || index.endTime: " + index.m_endTime +
-                        " || index.startTime: " + index.m_startTime + " || indexPrime.endTime: " + indexPrime.m_endTime +
-                        " || indexPrime.startTime: " + indexPrime.m_startTime);
-                System.exit(-1);
-            }
-        }
-        return ratio;
-    }
-
     /**
      * Prints the results of the voting simulation and statistics
      * about performance.
@@ -711,30 +666,17 @@ public class ExportBenchmark {
     public synchronized void printResults(long duration) {
         ClientStats stats = fullStatsContext.fetch().getStats();
 
-        // Accumulate transaction counts of all partitions to the partition 0 entries,
-        // based on detecting time overlaps and calculating transaction number ratio 
-        // based on the time overlap.
-        ArrayList<StatClass> indexStats = new ArrayList<StatClass>();
+        // Calculate "server tps" i.e. export performance.
+        // Note that some stats messages may have been missed, so the number of 
+        // exported rows collected may be lower than the total inserts; however,
+        // we can verify that the sum of TUPLE_COUNT values in the export stats 
+        // do match the total inserts when no error occurred.
+        
+        long serverTxn= 0L;
         for (StatClass index : serverStats) {
-            if (index.m_partition == 0) {
-                Double transactions = new Double(index.m_transactions);
-                for (StatClass indexPrime : serverStats) {
-                    // If indexPrime is not partition 0 check for window overlap.
-                    // If an overlap exists, accumulate transaction ratio
-                    if (indexPrime.m_partition != 0) {
-                        Double ratio = calcRatio(index, indexPrime);
-                        transactions +=  ratio * indexPrime.m_transactions;
-                    }
-                }
-                indexStats.add(new StatClass(index.m_partition, transactions.longValue(), index.m_startTime, index.m_endTime));
-            }
+            serverTxn += index.m_transactions;
         }
-
-        Double tpsSum = new Double(0);
-        for (StatClass index : indexStats) {
-            tpsSum += (new Double(index.m_transactions * 1000) / (index.m_endTime - index.m_startTime));
-        }
-        tpsSum = (tpsSum / indexStats.size());
+        long serverTps = serverTxn * 1000 / (serverEndTS - serverStartTS);
 
         // Performance statistics
         System.out.print(HORIZONTAL_RULE);
@@ -755,8 +697,9 @@ public class ExportBenchmark {
         System.out.printf("99.999th percentile latency:   %,9.2f ms\n", stats.kPercentileLatencyAsDouble(.99999));
 
         System.out.print("\n" + HORIZONTAL_RULE);
-        System.out.println(" System Server Statistics");
-        System.out.printf("Average throughput:            %,9d txns/sec\n", tpsSum.longValue());
+        System.out.println(" System Server Statistics (note that some stats messages may be missed)");
+        System.out.printf("Exported rows collected:       %,9d \n", serverTxn);
+        System.out.printf("Average throughput:            %,9d txns/sec\n", serverTps);
 
         System.out.println(HORIZONTAL_RULE);
 
@@ -776,7 +719,7 @@ public class ExportBenchmark {
                                     duration,
                                     successfulInserts.get(),
                                     serverEndTS - serverStartTS,
-                                    tpsSum.longValue()));
+                                    serverTps));
                 fw.close();
             }
         } catch (IOException e) {

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport.java
@@ -34,7 +34,7 @@ public class InsertExport extends VoltProcedure {
             + "type_null_decimal, type_not_null_decimal, type_null_varchar25, type_not_null_varchar25, type_null_varchar128, type_not_null_varchar128, type_null_varchar1024, "
             + "type_not_null_varchar1024) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
-    public long run(long rowid, int reversed)
+    public long run(long rowid, int multiply)
     {
         @SuppressWarnings("deprecation")
         long txid = DeprecatedProcedureAPIAccess.getVoltPrivateRealTransactionId(this);
@@ -42,35 +42,42 @@ public class InsertExport extends VoltProcedure {
         // Critical for proper determinism: get a cluster-wide consistent Random instance
         Random rand = new Random(txid);
 
-        // Insert a new record
+        // Check multiply factor and adjust to reasonable value
+        if (multiply <= 0) {
+            multiply = 1;
+        }
+
+        // Insert a new record with olptional multiply factor
         SampleRecord record = new SampleRecord(rowid, rand);
 
-        voltQueueSQL(
-                export
-                , txid
-                , rowid
-                , record.rowid_group
-                , record.type_null_tinyint
-                , record.type_not_null_tinyint
-                , record.type_null_smallint
-                , record.type_not_null_smallint
-                , record.type_null_integer
-                , record.type_not_null_integer
-                , record.type_null_bigint
-                , record.type_not_null_bigint
-                , record.type_null_timestamp
-                , record.type_not_null_timestamp
-                , record.type_null_float
-                , record.type_not_null_float
-                , record.type_null_decimal
-                , record.type_not_null_decimal
-                , record.type_null_varchar25
-                , record.type_not_null_varchar25
-                , record.type_null_varchar128
-                , record.type_not_null_varchar128
-                , record.type_null_varchar1024
-                , record.type_not_null_varchar1024
-        );
+        for (int i = 0; i < multiply; i++) {
+            voltQueueSQL(
+                    export
+                    , txid
+                    , rowid
+                    , record.rowid_group
+                    , record.type_null_tinyint
+                    , record.type_not_null_tinyint
+                    , record.type_null_smallint
+                    , record.type_not_null_smallint
+                    , record.type_null_integer
+                    , record.type_not_null_integer
+                    , record.type_null_bigint
+                    , record.type_not_null_bigint
+                    , record.type_null_timestamp
+                    , record.type_not_null_timestamp
+                    , record.type_null_float
+                    , record.type_not_null_float
+                    , record.type_null_decimal
+                    , record.type_not_null_decimal
+                    , record.type_null_varchar25
+                    , record.type_not_null_varchar25
+                    , record.type_null_varchar128
+                    , record.type_not_null_varchar128
+                    , record.type_null_varchar1024
+                    , record.type_not_null_varchar1024
+                    );
+        }
 
         // Execute last statement batch
         voltExecuteSQL(true);

--- a/tests/test_apps/exportbenchmark/run.sh
+++ b/tests/test_apps/exportbenchmark/run.sh
@@ -133,6 +133,26 @@ function run_benchmark() {
         --statsfile=exportbench.csv
 }
 
+function run_benchmark_10x() {
+    srccompile-ifneeded
+    java -classpath exportbenchmark-client.jar:$CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
+        exportbenchmark.ExportBenchmark \
+        --duration=30 \
+	--multiply=10 \
+        --servers=localhost \
+        --statsfile=exportbench.csv
+}
+
+function run_benchmark_100x() {
+    srccompile-ifneeded
+    java -classpath exportbenchmark-client.jar:$CLIENTCLASSPATH -Dlog4j.configuration=file://$LOG4J \
+        exportbenchmark.ExportBenchmark \
+        --duration=60 \
+	--multiply=100 \
+        --servers=localhost \
+        --statsfile=exportbench.csv
+}
+
 function shutdown() {
     voltadmin shutdown
 }

--- a/tests/test_apps/exportbenchmark/server/exportbenchmark/SocketExporter.java
+++ b/tests/test_apps/exportbenchmark/server/exportbenchmark/SocketExporter.java
@@ -42,6 +42,7 @@ import org.voltdb.export.AdvertisedDataSource;
 import org.voltdb.exportclient.ExportClientBase;
 import org.voltdb.exportclient.ExportDecoderBase;
 import org.voltdb.exportclient.ExportRow;
+import org.voltdb.exportclient.ExportDecoderBase.RestartBlockException;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -53,6 +54,11 @@ import java.util.Properties;
  * Export class for performance measuring.
  * Export statistics are checked for timestamps, and performance metrics are
  * periodically pushed to a UDP socket for collection.
+ * 
+ * Note: due to the way timerStart is managed, the statistics are only 
+ * valid for the first execution of the test client. If the system is not
+ * restarted between executions of the test client, then the first interval
+ * reported will be much longer and will skew the test results.
  */
 public class SocketExporter extends ExportClientBase {
 
@@ -96,39 +102,38 @@ public class SocketExporter extends ExportClientBase {
          *   -Partition ID
          */
         public void sendStatistics() {
-            if (timerStart > 0) {
-                ByteBuffer buffer = ByteBuffer.allocate(1024);
-                Long endTime = System.currentTimeMillis();
+            // Do not count the time spent sending the stats
+            Long endTime = System.currentTimeMillis();
+            ByteBuffer buffer = ByteBuffer.allocate(1024);
 
-                // Create message
-                JSONObject message = new JSONObject();
-                try {
-                    message.put("transactions", transactions);
-                    message.put("startTime", timerStart);
-                    message.put("endTime", endTime);
-                    message.put("partitionId", getPartition());
-                } catch (JSONException e) {
-                    m_logger.error("Couldn't create JSON object: " + e.getLocalizedMessage());
-                }
-
-                String messageString = message.toString();
-                buffer.clear();
-                buffer.put((byte)messageString.length());
-                buffer.put(messageString.getBytes());
-                buffer.flip();
-
-                // Send message over socket
-                try {
-                    int sent = channel.send(buffer, address);
-                    if (sent != messageString.getBytes().length+1) {
-                        // Should always send the whole packet.
-                        m_logger.error("Error sending entire stats message");
-                    }
-                } catch (IOException e) {
-                    m_logger.error("Couldn't send stats to socket");
-                }
-                transactions = 0;
+            // Create message
+            JSONObject message = new JSONObject();
+            try {
+                message.put("transactions", transactions);
+                message.put("startTime", timerStart);
+                message.put("endTime", endTime);
+                message.put("partitionId", getPartition());
+            } catch (JSONException e) {
+                m_logger.error("Couldn't create JSON object: " + e.getLocalizedMessage());
             }
+
+            String messageString = message.toString();
+            buffer.clear();
+            buffer.put((byte)messageString.length());
+            buffer.put(messageString.getBytes());
+            buffer.flip();
+
+            // Send message over socket
+            try {
+                int sent = channel.send(buffer, address);
+                if (sent != messageString.getBytes().length+1) {
+                    // Should always send the whole packet.
+                    m_logger.error("Error sending entire stats message");
+                }
+            } catch (IOException e) {
+                m_logger.error("Couldn't send stats to socket");
+            }
+            transactions = 0;
             timerStart = System.currentTimeMillis();
         }
 
@@ -139,12 +144,16 @@ public class SocketExporter extends ExportClientBase {
             } catch (IOException ignore) {}
         }
 
-        @Override
         /**
          * Logs the transactions, and determines how long it take to decode
          * the row.
          */
+        @Override
         public boolean processRow(ExportRow r) throws RestartBlockException {
+            // Start reporting stats from first row of first block
+            if (timerStart == 0) {
+                timerStart = System.currentTimeMillis();
+            }
             // Transaction count
             transactions++;
 


### PR DESCRIPTION
Fixed a number of issues in ExportBenchmark's calculation of "server statistics". In particular we make sure we don't miss any stats at the leading and trailing edges of the test. Also simplified TPS calculation wich was giving wildlly unrealistic results.