### PR TITLE
ENG-Add netty deps to maven POM

### DIFF
--- a/tools/kit_tools/upload.gradle
+++ b/tools/kit_tools/upload.gradle
@@ -108,6 +108,17 @@ uploadClientArchives {
                        organizationUrl 'http://www.voltdb.com'
                    }
                }
+
+               dependencies {
+                   runtime 'io.netty:netty-all:4.1.32.Final'
+                   runtime 'io.netty:netty-tcnative-boringssl-static:2.0.20.Final'
+               }
+            }
+            // Set all dependencies as optional
+            pom.withXml {
+                asNode().dependencies.dependency.findAll {
+                    it.appendNode('optional').value = 'true'
+                }
             }
         }
     }

--- a/tools/kit_tools/upload.gradle
+++ b/tools/kit_tools/upload.gradle
@@ -151,7 +151,7 @@ uploadServerArchives {
             pom.project {
                name 'voltdb'
                packaging 'jar'
-               description 'VoltDB client interface libraries'
+               description 'VoltDB server libraries'
                url 'http://www.voltdb.com/'
 
                scm {


### PR DESCRIPTION
The client needs to use the netty library for SSL but the library was not added
to the POM as a dependency. Add both netty-all and
netty-tcnative-boringssl-static as optional dependencies for the client
library.