### PR TITLE
ENG-15246 include site thread dump in the site dump with deadlock warning

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionState.java
@@ -465,8 +465,8 @@ public class MpTransactionState extends TransactionState
                         }
                     }
                     tmLog.warn(deadlockMsg.toString());
-                    m_mbox.send(com.google_voltpatches.common.primitives.Longs.toArray(m_useHSIds), new DumpMessage());
-                    m_mbox.send(m_mbox.getHSId(), new DumpMessage());
+                    m_mbox.send(com.google_voltpatches.common.primitives.Longs.toArray(m_useHSIds), new DumpMessage(txnId));
+                    m_mbox.send(m_mbox.getHSId(), new DumpMessage(txnId));
                 }
 
                 if (msg != null) {

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -88,7 +88,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     static final VoltLogger tmLog = new VoltLogger("TM");
     static final VoltLogger hostLog = new VoltLogger("HOST");
     private static final Object threadDumpLock = new Object();
-    static long JSTACK_DUMP_TXNID = 0;
+    static long txnIdForSiteThreadDump = 0;
     static class DuplicateCounterKey implements Comparable<DuplicateCounterKey> {
         private final long m_txnId;
         private final long m_spHandle;
@@ -1442,11 +1442,11 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         }
         builder.append("END of STATE DUMP FOR SITE: ").append(who);
         synchronized(threadDumpLock) {
-            if (message.getTxnId() > JSTACK_DUMP_TXNID) {
-                JSTACK_DUMP_TXNID = message.getTxnId();
-                builder.append("\nTHREAD DUMP FROM TXNID:" + TxnEgo.txnIdToString(message.getTxnId()) +"\n");
+            if (message.getTxnId() > txnIdForSiteThreadDump) {
+                txnIdForSiteThreadDump = message.getTxnId();
+                builder.append("\nSITE THREAD DUMP FROM TXNID:" + TxnEgo.txnIdToString(message.getTxnId()) +"\n");
                 builder.append(generateSiteThreadDump());
-                builder.append("\nEND OF THREAD DUMP FROM TXNID:" + TxnEgo.txnIdToString(message.getTxnId()));
+                builder.append("\nEND OF SITE THREAD DUMP FROM TXNID:" + TxnEgo.txnIdToString(message.getTxnId()));
             }
         }
         hostLog.warn(builder.toString());

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -17,6 +17,9 @@
 
 package org.voltdb.iv2;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -84,7 +87,8 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 {
     static final VoltLogger tmLog = new VoltLogger("TM");
     static final VoltLogger hostLog = new VoltLogger("HOST");
-
+    private static final Object threadDumpLock = new Object();
+    static long JSTACK_DUMP_TXNID = 0;
     static class DuplicateCounterKey implements Comparable<DuplicateCounterKey> {
         private final long m_txnId;
         private final long m_spHandle;
@@ -462,7 +466,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             handleIv2LogFaultMessage((Iv2LogFaultMessage)message);
         }
         else if (message instanceof DumpMessage) {
-            handleDumpMessage();
+            handleDumpMessage((DumpMessage)message);
         } else if (message instanceof DumpPlanThenExitMessage) {
             handleDumpPlanMessage((DumpPlanThenExitMessage)message);
         }
@@ -1411,11 +1415,14 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         }
     }
 
-    private void handleDumpMessage()
+    private void handleDumpMessage(DumpMessage message)
     {
         String who = CoreUtils.hsIdToString(m_mailbox.getHSId());
         StringBuilder builder = new StringBuilder();
         builder.append("START OF STATE DUMP FOR SITE: ").append(who);
+        if (message.getTxnId() > 0) {
+            builder.append(" FROM TXNID:" + TxnEgo.txnIdToString(message.getTxnId()));
+        }
         builder.append("\n  partition: ").append(m_partitionId).append(", isLeader: ").append(m_isLeader);
         if (m_isLeader) {
             builder.append("  replicas: ").append(CoreUtils.hsIdCollectionToString(m_replicaHSIds));
@@ -1434,6 +1441,14 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             }
         }
         builder.append("END of STATE DUMP FOR SITE: ").append(who);
+        synchronized(threadDumpLock) {
+            if (message.getTxnId() > JSTACK_DUMP_TXNID) {
+                JSTACK_DUMP_TXNID = message.getTxnId();
+                builder.append("\nTHREAD DUMP FROM TXNID:" + TxnEgo.txnIdToString(message.getTxnId()) +"\n");
+                builder.append(generateSiteThreadDump());
+                builder.append("\nEND OF THREAD DUMP FROM TXNID:" + TxnEgo.txnIdToString(message.getTxnId()));
+            }
+        }
         hostLog.warn(builder.toString());
     }
 
@@ -1823,5 +1838,16 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
 
         // flush all RO transactions out of backlog
         m_pendingTasks.removeMPReadTransactions();
+    }
+
+    private static String generateSiteThreadDump() {
+        StringBuilder threadDumps = new StringBuilder();
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        ThreadInfo[] threadInfos = threadMXBean.dumpAllThreads(true, true);
+        for (ThreadInfo t : threadInfos) {
+            if (t.getThreadName().startsWith("SP") || t.getThreadName().startsWith("MP Site") || t.getThreadName().startsWith("RO MP Site"))
+            threadDumps.append(t);
+        }
+        return threadDumps.toString();
     }
 }

--- a/src/frontend/org/voltdb/messaging/DumpMessage.java
+++ b/src/frontend/org/voltdb/messaging/DumpMessage.java
@@ -31,15 +31,19 @@ import org.voltcore.utils.CoreUtils;
  */
 public class DumpMessage extends VoltMessage
 {
-    public DumpMessage()
-    {
-        super();
+    private long m_txnId;
+    public DumpMessage(){
+        this(0);
     }
 
+    public DumpMessage(long txnId){
+        super();
+        m_txnId = txnId;
+    }
     @Override
     public int getSerializedSize()
     {
-        int msgsize = super.getSerializedSize();
+        int msgsize = super.getSerializedSize() + 8;
         return msgsize;
     }
 
@@ -47,13 +51,14 @@ public class DumpMessage extends VoltMessage
     public void flattenToBuffer(ByteBuffer buf) throws IOException
     {
         buf.put(VoltDbMessageFactory.DUMP);
-
+        buf.putLong(m_txnId);
         assert(buf.capacity() == buf.position());
         buf.limit(buf.position());
     }
 
     @Override
     public void initFromBuffer(ByteBuffer buf) throws IOException {
+        m_txnId = buf.getLong();
     }
 
     @Override
@@ -63,5 +68,9 @@ public class DumpMessage extends VoltMessage
         sb.append("DUMP (FROM ");
         sb.append(CoreUtils.hsIdToString(m_sourceHSId));
         return sb.toString();
+    }
+
+    public long getTxnId() {
+        return m_txnId;
     }
 }


### PR DESCRIPTION
Threads for MP, RO MP and SP sites will be dumped per transaction when MP deadlock shows up so that no additional jstack is needed.