### PR TITLE
ENG-15070: Rename JOIN log facility to ELASTIC

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1167,7 +1167,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             // when we construct it below
             m_globalServiceElector = new GlobalServiceElector(m_messenger.getZK(), m_messenger.getHostId());
 
-            // Always create a mailbox for elastic join data transfer
+            // Always create a mailbox for elastic service data transfer
             if (m_config.m_isEnterprise) {
                 long elasticHSId = m_messenger.getHSIdForLocalSite(HostMessenger.REBALANCE_SITE_ID);
                 m_messenger.createMailbox(elasticHSId, new SiteMailbox(m_messenger, elasticHSId));
@@ -1613,7 +1613,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_clientInterface.initializeSnapshotDaemon(m_messenger, m_globalServiceElector);
             TTLManager.initialze();
             getStatsAgent().registerStatsSource(StatsSelector.TTL, 0, TTLManager.instance());
-            // Start elastic join service
+            // Start elastic services
             try {
                 if (m_config.m_isEnterprise) {
                     m_elasticService = ProClass.newInstanceOf("org.voltdb.elastic.ElasticCoordinator",
@@ -1624,7 +1624,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     m_elasticService.updateConfig(m_catalogContext);
                 }
             } catch (Exception e) {
-                VoltDB.crashLocalVoltDB("Failed to instantiate elastic join service", false, e);
+                VoltDB.crashLocalVoltDB("Failed to instantiate elastic services", false, e);
             }
 
             // set additional restore agent stuff
@@ -3889,7 +3889,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 ExportManager.instance().updateCatalog(m_catalogContext, requireCatalogDiffCmdsApplyToEE,
                         requiresNewExportGeneration, partitions);
 
-                // 1.1 Update the elastic join throughput settings
+                // 1.1 Update the elastic service throughput settings
                 if (m_elasticService != null) {
                     m_elasticService.updateConfig(m_catalogContext);
                 }

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -54,7 +54,7 @@ public class VoltZK {
     public static final String catalogbytes = "/db/catalogbytes";
     public static final String catalogbytesPrevious = "/db/catalogbytes_previous";
     //This node doesn't mean as much as it used to, it is accurate at startup
-    //but isn't updated after elastic join. We use the cartographer for most things
+    //but isn't updated after elastic operation. We use the cartographer for most things
     //now
     public static final String topology = "/db/topology";
     public static final String replicationconfig = "/db/replicationconfig";
@@ -173,16 +173,16 @@ public class VoltZK {
     public static final String migrate_partition_leader = "migrate_partition_leader_blocker";
     public static final String migratePartitionLeaderBlocker = actionBlockers + "/" + migrate_partition_leader;
 
-    // three elastic join blockers
-    // elasticJoinInProgress blocks the rejoin (create in init state, release before data migration start)
-    // banElasticJoin blocks elastic join (currently created by DRProducer if the agreed protocol version
-    //                                     for the mesh does not support elastic join during DR (i.e. version <= 7).
+    // three elastic blockers
+    // elasticOperationInProgress blocks the rejoin (create in init state, release before data migration start)
+    // banElasticOperation blocks elastic operation (currently created by DRProducer if the agreed protocol version
+    //                                     for the mesh does not support elastic operation during DR (i.e. version <= 7).
     //                                     It is now only released after a DR global reset.)
-    // elasticJoinMigration only blocks SPI Migration
+    // elasticMigration only blocks SPI Migration
     public static final String leafNodeElasticOperationInProgress = "elastic_blocker";
     public static final String elasticOperationInProgress = actionBlockers + "/" + leafNodeElasticOperationInProgress;
     public static final String leafNodeBanElasticOperation = "no_elastic_blocker";
-    public static final String banElasticJoin = actionBlockers + "/" + leafNodeBanElasticOperation;
+    public static final String banElasticOperation = actionBlockers + "/" + leafNodeBanElasticOperation;
     public static final String leafNodeElasticMigration = "elastic_migration_blocker";
     public static final String elasticMigration = actionBlockers + "/" + leafNodeElasticMigration;
 
@@ -396,14 +396,14 @@ public class VoltZK {
     }
 
     /**
-     * Create a ZK node under action blocker directory.
-     * Exclusive execution of elastic join, rejoin or catalog update is checked.
+     * Create a ZK node under action blocker directory. Exclusive execution of elastic operation, rejoin or catalog
+     * update is checked.
      * </p>
      * Catalog update can not happen during node rejoin.
      * </p>
-     * Node rejoin can not happen during catalog update or elastic join.
+     * Node rejoin can not happen during catalog update or elastic operation.
      * </p>
-     * Elastic join can not happen during node rejoin or catalog update.
+     * Elastic operation can not happen during node rejoin or catalog update.
      *
      * @param zk
      * @param node
@@ -448,11 +448,11 @@ public class VoltZK {
         }
 
         /*
-         * Validate exclusive access of elastic join, rejoin, MigratePartitionLeader and catalog update.
+         * Validate exclusive access of elastic operation, rejoin, MigratePartitionLeader and catalog update.
          */
 
         // UAC can not happen during node rejoin
-        // some UAC can happen with elastic join
+        // some UAC can happen with elastic operation
         // UAC NT and TXN are exclusive
         String errorMsg = null;
         try {
@@ -468,11 +468,11 @@ public class VoltZK {
                 }
                 break;
             case rejoinInProgress:
-                // node rejoin can not happen during UAC or elastic join
+                // node rejoin can not happen during UAC or elastic operation
                 if (blockers.contains(leafNodeCatalogUpdateInProgress)) {
                     errorMsg = "while a catalog update is active. Please retry node rejoin later.";
                 } else if (blockers.contains(leafNodeElasticOperationInProgress)) {
-                    errorMsg = "while an elastic join is active. Please retry node rejoin later.";
+                    errorMsg = "while an elastic operation is active. Please retry node rejoin later.";
                 } else if (blockers.contains(migrate_partition_leader)){
                     errorMsg = "while leader migration is active. Please retry node rejoin later.";
                 } else if (blockers.contains(mpRepairBlocker)){
@@ -483,35 +483,35 @@ public class VoltZK {
                 }
                 break;
             case elasticOperationInProgress:
-                // elastic join can not happen during node rejoin
+                // elastic operation can not happen during node rejoin
                 if (blockers.contains(leafNodeRejoinInProgress)) {
-                    errorMsg = "while a node rejoin is active. Please retry elastic join later.";
+                    errorMsg = "while a node rejoin is active. Please retry elastic operation later.";
                 } else if (blockers.contains(leafNodeCatalogUpdateInProgress)) {
-                    errorMsg = "while a catalog update is active. Please retyr elastic join later.";
+                    errorMsg = "while a catalog update is active. Please retyr elastic operation later.";
                 } else if (blockers.contains(leafNodeBanElasticOperation)) {
-                    errorMsg = "while elastic join is blocked by DR established with a cluster that " +
-                            "does not support remote elastic join during DR. " +
-                            "DR needs to be reset before elastic join is allowed again.";
+                    errorMsg = "while elastic operation is blocked by DR established with a cluster that "
+                            + "does not support remote elastic operation during DR. "
+                            + "DR needs to be reset before elastic operation is allowed again.";
                 } else if ( blockers.contains(migrate_partition_leader)) {
-                    errorMsg = "while leader migration is active. Please retry elastic join later.";
+                    errorMsg = "while leader migration is active. Please retry elastic operation later.";
                 }
                 break;
             case migratePartitionLeaderBlocker:
                 //MigratePartitionLeader can not happen when join (before data fully migrated), rejoin, catalog update, or repair is in progress.
                 blockers.remove(leafNodeBanElasticOperation);
                 if (blockers.size() > 1) {
-                    errorMsg = "while elastic join, rejoin or catalog update is active";
+                    errorMsg = "while elastic operation, rejoin or catalog update is active";
                 }
                 break;
             case elasticMigration:
-                // elastic join balancePartition currently cannot coexist with partition leader migration
+                // elastic operation balancePartition currently cannot coexist with partition leader migration
                if (blockers.contains(migrate_partition_leader)) {
                    errorMsg = "while leader migration is active.";
                }
                break;
-            case banElasticJoin:
+            case banElasticOperation:
                 if (blockers.contains(leafNodeElasticOperationInProgress)) {
-                    errorMsg = "while an elastic join is active";
+                    errorMsg = "while an elastic operation is active";
                 }
                 break;
             case mpRepairInProgress:

--- a/src/frontend/org/voltdb/elastic/BalancePartitionsStatistics.java
+++ b/src/frontend/org/voltdb/elastic/BalancePartitionsStatistics.java
@@ -40,7 +40,7 @@ import org.voltdb.utils.MiscUtils;
 import com.google_voltpatches.common.collect.Maps;
 
 public class BalancePartitionsStatistics extends StatsSource {
-    private static final VoltLogger log = new VoltLogger("JOIN");
+    private static final VoltLogger log = new VoltLogger("ELASTIC");
 
     private static long logIntervalNanos = TimeUnit.SECONDS.toNanos(120);
 

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -39,7 +39,7 @@ import org.voltdb.rejoin.StreamSnapshotSink.RestoreWork;
 import org.voltdb.rejoin.TaskLog;
 
 public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
-    private static final VoltLogger JOINLOG = new VoltLogger("JOIN");
+    private static final VoltLogger ELASTICLOG = new VoltLogger("ELASTIC");
 
     // true if the site has received the first fragment task message
     private boolean m_receivedFirstFragment = false;
@@ -65,8 +65,8 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
     {
         super(partitionId, "Elastic join producer:" + partitionId + " ", taskQueue);
         m_completionAction = new CompletionAction();
-        if (JOINLOG.isDebugEnabled()) {
-            JOINLOG.debug(m_whoami + "created");
+        if (ELASTICLOG.isDebugEnabled()) {
+            ELASTICLOG.debug(m_whoami + "created");
         }
     }
 
@@ -137,7 +137,7 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
         RejoinMessage msg = new RejoinMessage(m_mailbox.getHSId(), -1, sinkHSId);
         m_mailbox.send(m_coordinatorHsId, msg);
         m_taskQueue.offer(this);
-        JOINLOG.info("P" + m_partitionId + " received initiation" +
+        ELASTICLOG.info("P" + m_partitionId + " received initiation" +
                 " sinkHSID:" + sinkHSId + " haveTwoSources:" + haveTwoSources);
     }
 
@@ -146,8 +146,8 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
      */
     private void sendFirstFragResponse()
     {
-        if (JOINLOG.isDebugEnabled()) {
-            JOINLOG.debug("P" + m_partitionId + " sending first fragment response to coordinator " +
+        if (ELASTICLOG.isDebugEnabled()) {
+            ELASTICLOG.debug("P" + m_partitionId + " sending first fragment response to coordinator " +
                     CoreUtils.hsIdToString(m_coordinatorHsId));
         }
         RejoinMessage msg = new RejoinMessage(m_mailbox.getHSId(),
@@ -178,7 +178,7 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
             if (m_streamSnapshotMb != null) {
                 VoltDB.instance().getHostMessenger().removeMailbox(m_streamSnapshotMb.getHSId());
                 m_streamSnapshotMb = null;
-                JOINLOG.debug(m_whoami + " data transfer is finished");
+                ELASTICLOG.debug(m_whoami + " data transfer is finished");
             }
 
             if (m_snapshotCompletionMonitor.isDone()) {
@@ -186,7 +186,7 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
                     SnapshotCompletionEvent event = m_snapshotCompletionMonitor.get();
                     siteConnection.setDRProtocolVersion(event.drVersion);
                     assert(event != null);
-                    JOINLOG.debug("P" + m_partitionId + " noticed data transfer completion");
+                    ELASTICLOG.debug("P" + m_partitionId + " noticed data transfer completion");
                     m_completionAction.setSnapshotTxnId(event.multipartTxnId);
 
                     setJoinComplete(siteConnection,
@@ -240,7 +240,7 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
 
     @Override
     protected VoltLogger getLogger() {
-        return JOINLOG;
+        return ELASTICLOG;
     }
 
     @Override
@@ -272,8 +272,8 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
     {
         assert(!(message instanceof Iv2InitiateTaskMessage));
         if (message instanceof FragmentTaskMessage) {
-            if (JOINLOG.isTraceEnabled()) {
-                JOINLOG.trace("P" + m_partitionId + " received first fragment");
+            if (ELASTICLOG.isTraceEnabled()) {
+                ELASTICLOG.trace("P" + m_partitionId + " received first fragment");
             }
             m_receivedFirstFragment = true;
         }

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -88,9 +88,9 @@
         <level value="INFO"/>
     </logger -->
 
-	<!-- logger name="JOIN">
-		<level value="INFO"/>
-	</logger -->
+    <!-- logger name="ELASTIC">
+        <level value="INFO"/>
+    </logger -->
 
     <!-- logger name="SNAPSHOT">
         <level value="INFO"/>


### PR DESCRIPTION
Use the log component ELASTIC instead of JOIN for all elastic operatins.
Also change references to elastic join to elastic operation when it is
not specifically about joins.