### PR TITLE
ENG-15220

### DIFF
--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -1833,7 +1833,7 @@ public class DDLCompiler {
         }
 
         index.setUnique(unique);
-        if (! index.getTypeName().startsWith("VOLTDB_AUTOGEN_IDX_") && table.getIsreplicated() && assumeUnique) {
+        if (! index.getTypeName().startsWith(HSQLInterface.AUTO_GEN_PREFIX) && table.getIsreplicated() && assumeUnique) {
             // Warn and convert AssumeUnique -> Unique index only on
             // non-auto-generated index (i.e. from "CREATE ASSUMEUNIQUE INDEX ..." statement rather than "CREATE TABLE(...)" statement),
             // because "PARTITION TABLE ..." statement cannot be specified together with "CREATE TABLE" statement!

--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -734,6 +734,9 @@ public class DDLCompiler {
         final CatalogMap<Table> tables = db.getTables();
         for (Table table : tables) {
             String tableName = table.getTypeName();
+            // Here, we restore that the table is always replicated, and set it to be partitioned if
+            // the partition makes sense.
+            table.setIsreplicated(true);
 
             if (m_tracker.m_partitionMap.containsKey(tableName.toLowerCase())) {
                 String colName = m_tracker.m_partitionMap.get(tableName.toLowerCase());
@@ -1270,8 +1273,11 @@ public class DDLCompiler {
         final String streamPartitionColumn = node.attributes.get("partitioncolumn");
         // all tables start replicated
         // if a partition is found in the project file later,
-        //  then this is reversed
-        table.setIsreplicated(true);
+        //  then this is reversed;
+        // But the index creation needs to know if the table is replicated, and coerce
+        // any ASSUMEUNIQUE index to be UNIQUE index on replicated table. Therefore, we
+        // set it according to current DDL state, then recheck table.m_isreplicated in handlePartitions().
+        table.setIsreplicated(! node.attributes.containsKey("partitioncolumn"));
 
         // map of index replacements for later constraint fixup
         final Map<String, String> indexReplacementMap = new TreeMap<>();
@@ -1827,7 +1833,11 @@ public class DDLCompiler {
         }
 
         index.setUnique(unique);
-        if (assumeUnique) {
+        if (table.getIsreplicated() && assumeUnique) {
+            compiler.addWarn(String.format("On replicated table %s, ASSUMEUNIQUE index %s is converted to UNIQUE index.",
+                    table.getTypeName(), index.getTypeName()));
+            assumeUnique = false;
+        } else if (assumeUnique) {
             index.setUnique(true);
         }
         index.setAssumeunique(assumeUnique);

--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -1837,8 +1837,9 @@ public class DDLCompiler {
             // Warn and convert AssumeUnique -> Unique index only on
             // non-auto-generated index (i.e. from "CREATE ASSUMEUNIQUE INDEX ..." statement rather than "CREATE TABLE(...)" statement),
             // because "PARTITION TABLE ..." statement cannot be specified together with "CREATE TABLE" statement!
-            final String warn = String.format("On replicated table %s, ASSUMEUNIQUE index %s is converted to UNIQUE index.",
-                    table.getTypeName(), index.getTypeName());
+            final String warn = String.format(
+                    "Converting ASSUMEUNIQUE index %s to UNIQUE because table %s is a replicated table.",
+                    index.getTypeName(), table.getTypeName());
             compiler.addWarn(warn);
             System.err.println(warn);
             assumeUnique = false;

--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -1833,9 +1833,14 @@ public class DDLCompiler {
         }
 
         index.setUnique(unique);
-        if (table.getIsreplicated() && assumeUnique) {
-            compiler.addWarn(String.format("On replicated table %s, ASSUMEUNIQUE index %s is converted to UNIQUE index.",
-                    table.getTypeName(), index.getTypeName()));
+        if (! index.getTypeName().startsWith("VOLTDB_AUTOGEN_IDX_") && table.getIsreplicated() && assumeUnique) {
+            // Warn and convert AssumeUnique -> Unique index only on
+            // non-auto-generated index (i.e. from "CREATE ASSUMEUNIQUE INDEX ..." statement rather than "CREATE TABLE(...)" statement),
+            // because "PARTITION TABLE ..." statement cannot be specified together with "CREATE TABLE" statement!
+            final String warn = String.format("On replicated table %s, ASSUMEUNIQUE index %s is converted to UNIQUE index.",
+                    table.getTypeName(), index.getTypeName());
+            compiler.addWarn(warn);
+            System.err.println(warn);
             assumeUnique = false;
         } else if (assumeUnique) {
             index.setUnique(true);

--- a/src/frontend/org/voltdb/compilereport/ReportMaker.java
+++ b/src/frontend/org/voltdb/compilereport/ReportMaker.java
@@ -1040,7 +1040,7 @@ public class ReportMaker {
                 }
                 sb.append("<tr><td>").append(nameLink).append("</td><td>").append(escapeHtml4(warning.getMessage())).append("</td></tr>\n");
             }
-            sb.append("").append("</table>\n").append("</td></tr>\n");
+            sb.append("</table>\n").append("</td></tr>\n");
         }
 
         return sb.toString();


### PR DESCRIPTION
Warn and convert AssumeUnique index on replicated table into Unique index on `CREATE ASSUMEUNIQUE INDEX ...` statement,
since EE treats the two indexes identically for replicated table.