### PR TITLE
ENG-15141: createTransaction use return code

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -1076,7 +1076,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     }
 
     // Wrap API to SimpleDtxnInitiator - mostly for the future
-    public boolean createTransaction(
+    public CreateTransactionResult createTransaction(
             final long connectionId,
             final StoredProcedureInvocation invocation,
             final boolean isReadOnly,
@@ -1101,7 +1101,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     }
 
     // Wrap API to SimpleDtxnInitiator - mostly for the future
-    public boolean createTransaction(
+    public CreateTransactionResult createTransaction(
             final long connectionId,
             final long txnId,
             final long uniqueId,

--- a/src/frontend/org/voltdb/CreateTransactionResult.java
+++ b/src/frontend/org/voltdb/CreateTransactionResult.java
@@ -1,0 +1,30 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb;
+
+/**
+ * Results returned by {@link InvocationDispatcher#createTransaction}
+ */
+public enum CreateTransactionResult {
+    /** The transaction was created successfully */
+    SUCCESS,
+    /** There is no client handler registered with that connection ID */
+    NO_CLIENT_HANDLER,
+    /** The partition which this transaction was sent was removed */
+    PARTITION_REMOVED;
+}

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -541,7 +541,9 @@ public final class InvocationDispatcher {
 
     private final boolean shouldLoadSchemaFromSnapshot() {
         CatalogMap<Table> tables = m_catalogContext.get().database.getTables();
-        if(tables.size() == 0) return true;
+        if(tables.size() == 0) {
+            return true;
+        }
         for(Table t : tables) {
             if(!t.getSignature().startsWith("VOLTDB_AUTOGEN_XDCR")) {
                 return false;
@@ -581,7 +583,9 @@ public final class InvocationDispatcher {
         }
 
         if (voltdb.isPreparingShuttingdown()) {
-            if (procedure.getAllowedinshutdown()) return null;
+            if (procedure.getAllowedinshutdown()) {
+                return null;
+            }
 
             return serverUnavailableResponse(
                     SHUTDOWN_MSG,

--- a/src/frontend/org/voltdb/Iv2TransactionCreator.java
+++ b/src/frontend/org/voltdb/Iv2TransactionCreator.java
@@ -36,7 +36,7 @@ public class Iv2TransactionCreator implements TransactionCreator
     }
 
     @Override
-    public final boolean createTransaction(long connectionId,
+    public final CreateTransactionResult createTransaction(long connectionId,
             StoredProcedureInvocation invocation, boolean isReadOnly,
             boolean isSinglePartition, boolean isEverySite, int partition, int messageSize, long nowNanos)
     {
@@ -51,7 +51,7 @@ public class Iv2TransactionCreator implements TransactionCreator
     }
 
     @Override
-    public final boolean createTransaction(long connectionId,
+    public final CreateTransactionResult createTransaction(long connectionId,
             long txnId,
             long uniqueId,
             StoredProcedureInvocation invocation, boolean isReadOnly,

--- a/src/frontend/org/voltdb/dtxn/TransactionCreator.java
+++ b/src/frontend/org/voltdb/dtxn/TransactionCreator.java
@@ -19,6 +19,7 @@ package org.voltdb.dtxn;
 
 import org.voltcore.network.Connection;
 import org.voltdb.ClientResponseImpl;
+import org.voltdb.CreateTransactionResult;
 import org.voltdb.InvocationDispatcher.OverrideCheck;
 import org.voltdb.StoredProcedureInvocation;
 
@@ -28,7 +29,7 @@ import org.voltdb.StoredProcedureInvocation;
 public interface TransactionCreator
 {
     // create a new transaction.
-    public boolean createTransaction(
+    public CreateTransactionResult createTransaction(
             long connectionId,
             StoredProcedureInvocation invocation,
             boolean isReadOnly,
@@ -39,7 +40,7 @@ public interface TransactionCreator
             long nowNanos);
 
     // Create a transaction using the provided txnId.
-    public boolean createTransaction(
+    public CreateTransactionResult createTransaction(
             long connectionId,
             long txnId,
             long uniqueId,

--- a/src/frontend/org/voltdb/dtxn/TransactionInitiator.java
+++ b/src/frontend/org/voltdb/dtxn/TransactionInitiator.java
@@ -20,6 +20,7 @@ package org.voltdb.dtxn;
 import java.util.ArrayList;
 import java.util.Map;
 
+import org.voltdb.CreateTransactionResult;
 import org.voltdb.StoredProcedureInvocation;
 
 /**
@@ -49,7 +50,7 @@ public abstract class TransactionInitiator implements TransactionCreator {
      * @param messageSize Size in bytes of the message that created this invocation
      */
     @Override
-    public abstract boolean createTransaction(
+    public abstract CreateTransactionResult createTransaction(
             long connectionId,
             StoredProcedureInvocation invocation,
             boolean isReadOnly,
@@ -84,7 +85,7 @@ public abstract class TransactionInitiator implements TransactionCreator {
      *            Size in bytes of the message that created this invocation
      */
     @Override
-    public abstract boolean createTransaction(
+    public abstract CreateTransactionResult createTransaction(
             long connectionId,
             long txnId,
             long timestamp,


### PR DESCRIPTION
With the ability to remove partitions from the system a boolean is not
descriptive enough of a return code for InvocationDispatcher.createTransaction().
Instead return an enum which allows the caller to determine the cause of the
error better.