### PR TITLE
ENG-15078, fix issue that during rollback EE generates invalid sequen…

### DIFF
--- a/src/ee/common/StreamBlock.h
+++ b/src/ee/common/StreamBlock.h
@@ -230,7 +230,7 @@ namespace voltdb
         }
 
         void truncateTo(size_t mark, int64_t exportSeqNo) {
-            // just move offset and row count (only export block cares). pretty easy.
+            // just move offset and update export row count. pretty easy.
             if (((m_uso + offset()) >= mark ) && (m_uso <= mark)) {
                 m_offset = mark - m_uso;
                 if (lastExportSequenceNumber() >= exportSeqNo && startExportSequenceNumber() <= exportSeqNo) {

--- a/src/ee/common/StreamBlock.h
+++ b/src/ee/common/StreamBlock.h
@@ -229,10 +229,13 @@ namespace voltdb
             m_offset += consumed;
         }
 
-        void truncateTo(size_t mark) {
-            // just move offset. pretty easy.
+        void truncateTo(size_t mark, int64_t exportSeqNo) {
+            // just move offset and row count (only export block cares). pretty easy.
             if (((m_uso + offset()) >= mark ) && (m_uso <= mark)) {
                 m_offset = mark - m_uso;
+                if (lastExportSequenceNumber() >= exportSeqNo && startExportSequenceNumber() <= exportSeqNo) {
+                    m_rowCountForExport = exportSeqNo - startExportSequenceNumber() + 1;
+                }
             }
             else {
                 throwFatalException("Attempted Export block truncation past start of block."

--- a/src/ee/storage/AbstractDRTupleStream.cpp
+++ b/src/ee/storage/AbstractDRTupleStream.cpp
@@ -133,7 +133,7 @@ void AbstractDRTupleStream::handleOpenTransaction(StreamBlock *oldBlock)
     m_currBlock->recordLastBeginTxnOffset();
     m_currBlock->consumed(partialTxnLength);
     ::memset(oldBlock->mutableLastBeginTxnDataPtr(), 0, partialTxnLength);
-    oldBlock->truncateTo(uso);
+    oldBlock->truncateTo(uso, SIZE_MAX);
     oldBlock->clearLastBeginTxnOffset();
     // If the whole previous block has been moved to new block, discards the empty one.
     if (oldBlock->offset() == 0) {

--- a/src/ee/storage/ExportTupleStream.cpp
+++ b/src/ee/storage/ExportTupleStream.cpp
@@ -156,6 +156,10 @@ size_t ExportTupleStream::appendTuple(int64_t lastCommittedSpHandle,
     tuple.serializeToExport(io, METADATA_COL_CNT, nullArray);
 
     m_uncommittedTupleCount++;
+    std::cout << "Append tuple m_uncommittedTupleCount=" << m_uncommittedTupleCount
+              << " start exportSequenceNumber=" << m_currBlock->startExportSequenceNumber()
+              << " row count=" << m_currBlock->getRowCountforExport()
+              << std::endl;
 
     // row size, generation, partition-index, column count and hasSchema flag (byte)
     ExportSerializeOutput hdr(m_currBlock->mutableDataPtr(), streamHeaderSz);

--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -61,7 +61,7 @@ public:
         assert(m_uso == 0);
         m_uso = count;
         // this is for start sequence number of stream block
-        m_exportSequenceNumber = seqNo + 1;
+        m_exportSequenceNumber = seqNo;
         //Extend the buffer chain to replace any existing stream blocks with a new one
         //with the correct sequence number
         extendBufferChain(0);

--- a/src/ee/storage/TupleStreamBase.cpp
+++ b/src/ee/storage/TupleStreamBase.cpp
@@ -288,6 +288,8 @@ void TupleStreamBase::extendBufferChain(size_t minLength)
 
     if (m_currBlock) {
         if (m_currBlock->offset() > 0) {
+            // Update tuple count in current block with the number of tuples
+            // inserted so far by the current transaction
             m_currBlock->updateRowCountForExport(m_stashedTupleCount);
             m_stashedTupleCount = 0;
             m_pendingBlocks.push_back(m_currBlock);

--- a/src/ee/storage/TupleStreamBase.cpp
+++ b/src/ee/storage/TupleStreamBase.cpp
@@ -229,7 +229,7 @@ void TupleStreamBase::rollbackTo(size_t mark, size_t, int64_t rollbackTo)
     // in a transaction and it is rolled back, uncommitted tuple count may be negative.
     // The real fix would be stream table commits at end of transaction or flush.
     m_uncommittedTupleCount -= m_exportSequenceNumber - rollbackTo;
-    if (m_uncommittedTupleCount < 0 && rollbackTo != SIZE_MAX) {
+    if (m_uncommittedTupleCount < 0) {
         m_uncommittedTupleCount = 0;
     }
     m_exportSequenceNumber = rollbackTo;

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -118,12 +118,12 @@ public:
     size_t m_headerSpace;
 
     /**
-    * The number of Export tuples hasn't added to row count header of Export Stream Block in the current txn;
-    * Note that before the stashed tuple count is reset (and row count of stream block is updated) when
-    * 1) transaction is committed by the *next* txn,
-    * 2) remaining space of current stream block is not enough, new stream block is created,
-    * 3) transaction rolls back which affects one or more stream blocks.
-    */
+     * Count of exported tuples not yet counted in the row count header of the Export Stream Block for the current transaction;
+     * this count will be added to the row count header (and this count reset to 0) on the following conditions:
+     * 1) current transaction appears "committed" when we start handling the _next_ transaction
+     * 2) when the current transaction needs a new Stream Block
+     * 3) current transaction is rolled back (with the rollback affecting one or more Stream blocks)
+     */
     int64_t m_stashedTupleCount;
 
     int64_t m_exportSequenceNumber;

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -118,8 +118,11 @@ public:
     size_t m_headerSpace;
 
     /**
-    * The number of Export Tuples applied to the Export Stream Block in the current txn;
-    * Note that before the Export Tuples are only committed by the *next* Txn that updates the StreamBLock
+    * The number of Export tuples hasn't added to row count header of Export Stream Block in the current txn;
+    * Note that before the stashed tuple count is reset (and row count of stream block is updated) when
+    * 1) transaction is committed by the *next* txn,
+    * 2) remaining space of current stream block is not enough, new stream block is created,
+    * 3) transaction rolls back which affects one or more stream blocks.
     */
     int64_t m_stashedTupleCount;
 

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -118,10 +118,10 @@ public:
     size_t m_headerSpace;
 
     /**
-     * The number of Export Tuples applied to the Export Stream Block in the current txn;
-     * Note that before the Export Tuples are only committed by the *next* Txn that updates the StreamBLock
-     */
-    int64_t m_uncommittedTupleCount;
+    * The number of Export Tuples applied to the Export Stream Block in the current txn;
+    * Note that before the Export Tuples are only committed by the *next* Txn that updates the StreamBLock
+    */
+    int64_t m_stashedTupleCount;
 
     int64_t m_exportSequenceNumber;
 };

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -416,7 +416,6 @@ TEST_F(ExportTupleStreamTest, FillWithOneTxn) {
     // the transaction is still open.
     ASSERT_FALSE(m_topend.receivedExportBuffer);
     int64_t seqNo = m_wrapper->getSequenceNumber();
-    std::cout << " seqNo = " << seqNo << std::endl;
 }
 
 /**

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -489,9 +489,11 @@ TEST_F(ExportTupleStreamTest, RollbackWholeBuffer)
         appendTuple(10, 11);
     }
     m_wrapper->rollbackTo(mark, 0, seqNo);
+    EXPECT_GE(m_wrapper->m_stashedTupleCount, 0);
     m_wrapper->periodicFlush(-1, 3);
 
     ASSERT_TRUE(m_topend.receivedExportBuffer);
+    EXPECT_EQ(m_wrapper->m_stashedTupleCount, 0);
     boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
     m_topend.blocks.pop_front();
     EXPECT_EQ(results->uso(), 0);
@@ -527,6 +529,7 @@ TEST_F(ExportTupleStreamTest, PartialRollback)
         }
     }
     m_wrapper->rollbackTo(mark, 0, seqNo);
+    EXPECT_GE(m_wrapper->m_stashedTupleCount, 0);
     m_wrapper->periodicFlush(-1, 11);
     ASSERT_TRUE(m_topend.receivedExportBuffer);
     boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -60,6 +60,8 @@ static const int BUFFER_HEADER_SIZE = ExportTupleStream::s_FIXED_BUFFER_HEADER_S
 // 1k buffer
 static const int BUFFER_SIZE = 1024;
 
+static int64_t s_seqNo = 1;
+
 class ExportTupleStreamTest : public Test {
 public:
     ExportTupleStreamTest()
@@ -117,8 +119,9 @@ public:
             m_tuple->setNValue(col, ValueFactory::getIntegerValue(value));
         }
         // append into the buffer
+        int64_t seqNo = s_seqNo;
         m_wrapper->appendTuple(lastCommittedTxnId,
-                               currentTxnId, 1, 1, 1, *m_tuple,
+                               currentTxnId, s_seqNo++, 1, 1, *m_tuple,
                                 1,
                                ExportTupleStream::INSERT);
     }

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -415,7 +415,6 @@ TEST_F(ExportTupleStreamTest, FillWithOneTxn) {
     // We shouldn't yet get a buffer even though we've filled a bunch because
     // the transaction is still open.
     ASSERT_FALSE(m_topend.receivedExportBuffer);
-    int64_t seqNo = m_wrapper->getSequenceNumber();
 }
 
 /**

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -119,7 +119,6 @@ public:
             m_tuple->setNValue(col, ValueFactory::getIntegerValue(value));
         }
         // append into the buffer
-        int64_t seqNo = s_seqNo;
         m_wrapper->appendTuple(lastCommittedTxnId,
                                currentTxnId, s_seqNo++, 1, 1, *m_tuple,
                                 1,
@@ -205,167 +204,167 @@ protected:
 /**
  * Get one tuple
  */
-//TEST_F(ExportTupleStreamTest, DoOneTuple) {
-//
-//    // write a new tuple and then flush the buffer
-//    appendTuple(1, 2);
-//    m_wrapper->periodicFlush(-1, 2);
-//
-//    // we should only have one tuple in the buffer
-//    ASSERT_TRUE(m_topend.receivedExportBuffer);
-//    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
-//    EXPECT_EQ(results->uso(), 0);
-//    std::ostringstream os;
-//    os << "Offset mismatch. Expected: " << m_tupleSize << ", actual: " << results->offset();
-//    ASSERT_TRUE_WITH_MESSAGE(results->offset() == m_tupleSize, os.str().c_str());
-//}
-//
-///**
-// * Test the really basic operation order
-// */
-//TEST_F(ExportTupleStreamTest, BasicOps) {
-//
-//    // verify the block count statistic.
-//    size_t allocatedByteCount = m_wrapper->debugAllocatedBytesInEE();
-//
-//    EXPECT_TRUE(allocatedByteCount == 0);
-//    std::ostringstream os;
-//    int cnt = 0;
-//    // Push 2 rows to fill the block less thn half
-//    for (cnt = 1; cnt < 3; cnt++) {
-//        appendTuple(cnt-1, cnt);
-//    }
-//
-//    m_wrapper->periodicFlush(-1, 2);
-//    allocatedByteCount = (m_tupleSize * 2) + BUFFER_HEADER_SIZE;
-//    os << "Allocated byte count - expected: " << allocatedByteCount << ", actual: " << m_wrapper->debugAllocatedBytesInEE();
-//    ASSERT_TRUE_WITH_MESSAGE( allocatedByteCount == m_wrapper->debugAllocatedBytesInEE(), os.str().c_str());
-//    os.str(""); os << "Blocks on top-end expected: " << 1 << ", actual: " << m_topend.blocks.size();
-//    ASSERT_TRUE_WITH_MESSAGE(m_topend.blocks.size() == 1, os.str().c_str());
-//    boost::shared_ptr<StreamBlock> results2 = m_topend.blocks.front();
-//    EXPECT_EQ(results2->uso(), 0);
-//
-//    // Push 3 rows
-//    for (cnt = 3; cnt < 6; cnt++) {
-//        appendTuple(cnt-1, cnt);
-//    }
-//    m_wrapper->periodicFlush(-1, 5);
-//
-//    // 3 rows - 2 blocks (2, 3)
-//    allocatedByteCount = (m_tupleSize * 5) + (BUFFER_HEADER_SIZE * 2);
-//    os.str(""); os << "Allocated byte count - expected: " << allocatedByteCount << ", actual: " << m_wrapper->debugAllocatedBytesInEE();
-//    ASSERT_TRUE_WITH_MESSAGE( allocatedByteCount == m_wrapper->debugAllocatedBytesInEE(), os.str().c_str());
-//    os.str(""); os << "Blocks on top-end expected: " << 2 << ", actual: " << m_topend.blocks.size();
-//    ASSERT_TRUE_WITH_MESSAGE(m_topend.blocks.size() == 2, os.str().c_str());
-//
-//    // get the first buffer flushed
-//    ASSERT_TRUE(m_topend.receivedExportBuffer);
-//    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
-//    m_topend.blocks.pop_front();
-//    EXPECT_EQ(results->uso(), 0);
-//    EXPECT_EQ(results->offset(), (m_tupleSize * 2));
-//
-//    // now get the second
-//    ASSERT_FALSE(m_topend.blocks.empty());
-//    results = m_topend.blocks.front();
-//    m_topend.blocks.pop_front();
-//    os.str(""); os << "Second block uso - expected: " << (m_tupleSize * 2) << ", actual: " << results->uso();
-//    ASSERT_TRUE_WITH_MESSAGE(results->uso() == (m_tupleSize * 2), os.str().c_str());
-//    os.str(""); os << "Second block offset - expected: " << (m_tupleSize * 2) << ", actual: " << results->offset();
-//    ASSERT_TRUE_WITH_MESSAGE(results->offset() == (m_tupleSize * 3), os.str().c_str());
-//
-//    // ack all of the data and re-verify block count
-//    os.str(""); os << "Allocated byte count - expected: " << 0 << ", actual: " << m_wrapper->debugAllocatedBytesInEE();
-//    EXPECT_TRUE(m_wrapper->debugAllocatedBytesInEE()== 0);
-//}
-//
-///**
-// * Verify that a periodicFlush with distant TXN IDs works properly
-// */
-//TEST_F(ExportTupleStreamTest, FarFutureFlush) {
-//    std::ostringstream os;
-//    for (int i = 1; i < 3; i++) {
-//        appendTuple(i-1, i);
-//    }
-//    m_wrapper->periodicFlush(-1, 99);
-//
-//    for (int i = 100; i < 103; i++) {
-//        appendTuple(i-1, i);
-//    }
-//    m_wrapper->periodicFlush(-1, 130);
-//
-//    // get the first buffer flushed
-//    ASSERT_TRUE(m_topend.receivedExportBuffer);
-//    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
-//    m_topend.blocks.pop_front();
-//    os << "USO in first block - expected: " << 0 << ", actual " << results->uso();
-//    ASSERT_TRUE_WITH_MESSAGE(results->uso() == 0, os.str().c_str());
-//    os.str(""); os << "Offset expected: " << (m_tupleSize * 2) << ", actual " << results->offset();
-//    ASSERT_TRUE_WITH_MESSAGE((results->offset() == m_tupleSize * 2), os.str().c_str());
-//
-//    // now get the second
-//    ASSERT_FALSE(m_topend.blocks.empty());
-//    results = m_topend.blocks.front();
-//    m_topend.blocks.pop_front();
-//    os << "uso in second block - expected: " << (m_tupleSize * 2) << ", actual " << results->uso();
-//    ASSERT_TRUE_WITH_MESSAGE(results->uso() == (m_tupleSize * 2), os.str().c_str());
-//    os << "Offset expected: " << (m_tupleSize * 3) << ", actual " << results->offset();
-//    ASSERT_TRUE_WITH_MESSAGE((results->offset() == m_tupleSize * 3), os.str().c_str());
-//}
-//
-///**
-// * Fill a buffer by appending tuples that advance the last committed TXN
-// */
-//TEST_F(ExportTupleStreamTest, Fill) {
-//
-//    // fill with just enough tuples to avoid exceeding buffer
-//    for (int i = 1; i <= m_tuplesToFill; i++) {
-//        appendTuple(i-1, i);
-//    }
-//    // We shouldn't yet get a buffer because we haven't forced the
-//    // generation of a new one by exceeding the current one.
-//    ASSERT_FALSE(m_topend.receivedExportBuffer);
-//
-//    // now, drop in one more
-//    appendTuple(m_tuplesToFill, m_tuplesToFill + 1);
-//
-//    ASSERT_TRUE(m_topend.receivedExportBuffer);
-//    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
-//    m_topend.blocks.pop_front();
-//    EXPECT_EQ(results->uso(), 0);
-//    EXPECT_EQ(results->offset(), (m_tupleSize * m_tuplesToFill));
-//}
-//
-///**
-// * Fill a buffer with a single TXN, and then finally close it in the next
-// * buffer.
-// */
-//TEST_F(ExportTupleStreamTest, FillSingleTxnAndAppend) {
-//
-//    // fill with just enough tuples to avoid exceeding buffer
-//    for (int i = 1; i <= m_tuplesToFill; i++) {
-//        appendTuple(0, 1);
-//    }
-//    // We shouldn't yet get a buffer because we haven't forced the
-//    // generation of a new one by exceeding the current one.
-//    ASSERT_FALSE(m_topend.receivedExportBuffer);
-//
-//    // now, drop in one more on the same TXN ID
-//    appendTuple(0, 1);
-//
-//    // We shouldn't yet get a buffer because we haven't closed the current
-//    // transaction
-//    ASSERT_FALSE(m_topend.receivedExportBuffer);
-//
-//    // now, finally drop in a tuple that closes the first TXN
-//    appendTuple(1, 2);
-//
-//    ASSERT_TRUE(m_topend.receivedExportBuffer);
-//    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
-//    m_topend.blocks.pop_front();
-//    EXPECT_EQ(results->uso(), 0);
-//    EXPECT_EQ(results->offset(), (m_tupleSize * m_tuplesToFill));
-//}
+TEST_F(ExportTupleStreamTest, DoOneTuple) {
+
+    // write a new tuple and then flush the buffer
+    appendTuple(1, 2);
+    m_wrapper->periodicFlush(-1, 2);
+
+    // we should only have one tuple in the buffer
+    ASSERT_TRUE(m_topend.receivedExportBuffer);
+    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
+    EXPECT_EQ(results->uso(), 0);
+    std::ostringstream os;
+    os << "Offset mismatch. Expected: " << m_tupleSize << ", actual: " << results->offset();
+    ASSERT_TRUE_WITH_MESSAGE(results->offset() == m_tupleSize, os.str().c_str());
+}
+
+/**
+ * Test the really basic operation order
+ */
+TEST_F(ExportTupleStreamTest, BasicOps) {
+
+    // verify the block count statistic.
+    size_t allocatedByteCount = m_wrapper->debugAllocatedBytesInEE();
+
+    EXPECT_TRUE(allocatedByteCount == 0);
+    std::ostringstream os;
+    int cnt = 0;
+    // Push 2 rows to fill the block less thn half
+    for (cnt = 1; cnt < 3; cnt++) {
+        appendTuple(cnt-1, cnt);
+    }
+
+    m_wrapper->periodicFlush(-1, 2);
+    allocatedByteCount = (m_tupleSize * 2) + BUFFER_HEADER_SIZE;
+    os << "Allocated byte count - expected: " << allocatedByteCount << ", actual: " << m_wrapper->debugAllocatedBytesInEE();
+    ASSERT_TRUE_WITH_MESSAGE( allocatedByteCount == m_wrapper->debugAllocatedBytesInEE(), os.str().c_str());
+    os.str(""); os << "Blocks on top-end expected: " << 1 << ", actual: " << m_topend.blocks.size();
+    ASSERT_TRUE_WITH_MESSAGE(m_topend.blocks.size() == 1, os.str().c_str());
+    boost::shared_ptr<StreamBlock> results2 = m_topend.blocks.front();
+    EXPECT_EQ(results2->uso(), 0);
+
+    // Push 3 rows
+    for (cnt = 3; cnt < 6; cnt++) {
+        appendTuple(cnt-1, cnt);
+    }
+    m_wrapper->periodicFlush(-1, 5);
+
+    // 3 rows - 2 blocks (2, 3)
+    allocatedByteCount = (m_tupleSize * 5) + (BUFFER_HEADER_SIZE * 2);
+    os.str(""); os << "Allocated byte count - expected: " << allocatedByteCount << ", actual: " << m_wrapper->debugAllocatedBytesInEE();
+    ASSERT_TRUE_WITH_MESSAGE( allocatedByteCount == m_wrapper->debugAllocatedBytesInEE(), os.str().c_str());
+    os.str(""); os << "Blocks on top-end expected: " << 2 << ", actual: " << m_topend.blocks.size();
+    ASSERT_TRUE_WITH_MESSAGE(m_topend.blocks.size() == 2, os.str().c_str());
+
+    // get the first buffer flushed
+    ASSERT_TRUE(m_topend.receivedExportBuffer);
+    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
+    m_topend.blocks.pop_front();
+    EXPECT_EQ(results->uso(), 0);
+    EXPECT_EQ(results->offset(), (m_tupleSize * 2));
+
+    // now get the second
+    ASSERT_FALSE(m_topend.blocks.empty());
+    results = m_topend.blocks.front();
+    m_topend.blocks.pop_front();
+    os.str(""); os << "Second block uso - expected: " << (m_tupleSize * 2) << ", actual: " << results->uso();
+    ASSERT_TRUE_WITH_MESSAGE(results->uso() == (m_tupleSize * 2), os.str().c_str());
+    os.str(""); os << "Second block offset - expected: " << (m_tupleSize * 2) << ", actual: " << results->offset();
+    ASSERT_TRUE_WITH_MESSAGE(results->offset() == (m_tupleSize * 3), os.str().c_str());
+
+    // ack all of the data and re-verify block count
+    os.str(""); os << "Allocated byte count - expected: " << 0 << ", actual: " << m_wrapper->debugAllocatedBytesInEE();
+    EXPECT_TRUE(m_wrapper->debugAllocatedBytesInEE()== 0);
+}
+
+/**
+ * Verify that a periodicFlush with distant TXN IDs works properly
+ */
+TEST_F(ExportTupleStreamTest, FarFutureFlush) {
+    std::ostringstream os;
+    for (int i = 1; i < 3; i++) {
+        appendTuple(i-1, i);
+    }
+    m_wrapper->periodicFlush(-1, 99);
+
+    for (int i = 100; i < 103; i++) {
+        appendTuple(i-1, i);
+    }
+    m_wrapper->periodicFlush(-1, 130);
+
+    // get the first buffer flushed
+    ASSERT_TRUE(m_topend.receivedExportBuffer);
+    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
+    m_topend.blocks.pop_front();
+    os << "USO in first block - expected: " << 0 << ", actual " << results->uso();
+    ASSERT_TRUE_WITH_MESSAGE(results->uso() == 0, os.str().c_str());
+    os.str(""); os << "Offset expected: " << (m_tupleSize * 2) << ", actual " << results->offset();
+    ASSERT_TRUE_WITH_MESSAGE((results->offset() == m_tupleSize * 2), os.str().c_str());
+
+    // now get the second
+    ASSERT_FALSE(m_topend.blocks.empty());
+    results = m_topend.blocks.front();
+    m_topend.blocks.pop_front();
+    os << "uso in second block - expected: " << (m_tupleSize * 2) << ", actual " << results->uso();
+    ASSERT_TRUE_WITH_MESSAGE(results->uso() == (m_tupleSize * 2), os.str().c_str());
+    os << "Offset expected: " << (m_tupleSize * 3) << ", actual " << results->offset();
+    ASSERT_TRUE_WITH_MESSAGE((results->offset() == m_tupleSize * 3), os.str().c_str());
+}
+
+/**
+ * Fill a buffer by appending tuples that advance the last committed TXN
+ */
+TEST_F(ExportTupleStreamTest, Fill) {
+
+    // fill with just enough tuples to avoid exceeding buffer
+    for (int i = 1; i <= m_tuplesToFill; i++) {
+        appendTuple(i-1, i);
+    }
+    // We shouldn't yet get a buffer because we haven't forced the
+    // generation of a new one by exceeding the current one.
+    ASSERT_FALSE(m_topend.receivedExportBuffer);
+
+    // now, drop in one more
+    appendTuple(m_tuplesToFill, m_tuplesToFill + 1);
+
+    ASSERT_TRUE(m_topend.receivedExportBuffer);
+    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
+    m_topend.blocks.pop_front();
+    EXPECT_EQ(results->uso(), 0);
+    EXPECT_EQ(results->offset(), (m_tupleSize * m_tuplesToFill));
+}
+
+/**
+ * Fill a buffer with a single TXN, and then finally close it in the next
+ * buffer.
+ */
+TEST_F(ExportTupleStreamTest, FillSingleTxnAndAppend) {
+
+    // fill with just enough tuples to avoid exceeding buffer
+    for (int i = 1; i <= m_tuplesToFill; i++) {
+        appendTuple(0, 1);
+    }
+    // We shouldn't yet get a buffer because we haven't forced the
+    // generation of a new one by exceeding the current one.
+    ASSERT_FALSE(m_topend.receivedExportBuffer);
+
+    // now, drop in one more on the same TXN ID
+    appendTuple(0, 1);
+
+    // We shouldn't yet get a buffer because we haven't closed the current
+    // transaction
+    ASSERT_FALSE(m_topend.receivedExportBuffer);
+
+    // now, finally drop in a tuple that closes the first TXN
+    appendTuple(1, 2);
+
+    ASSERT_TRUE(m_topend.receivedExportBuffer);
+    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
+    m_topend.blocks.pop_front();
+    EXPECT_EQ(results->uso(), 0);
+    EXPECT_EQ(results->offset(), (m_tupleSize * m_tuplesToFill));
+}
 
 
 /**
@@ -398,101 +397,151 @@ TEST_F(ExportTupleStreamTest, FillSingleTxnAndCommitWithRollback) {
     boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
     m_topend.blocks.pop_front();
     EXPECT_EQ(results->uso(), 0);
+    EXPECT_EQ(results->getRowCountforExport(), m_tuplesToFill);
     EXPECT_EQ(results->offset(), (m_tupleSize * m_tuplesToFill));
 }
-//
-///**
-// * Verify that several filled buffers all with one open transaction returns
-// * nada.
-// */
-//TEST_F(ExportTupleStreamTest, FillWithOneTxn) {
-//
-//    // fill several buffers
-//    for (int i = 0; i <= (m_tuplesToFill + 10) * 3; i++)
-//    {
-//        appendTuple(1, 2);
-//    }
-//    // We shouldn't yet get a buffer even though we've filled a bunch because
-//    // the transaction is still open.
-//    ASSERT_FALSE(m_topend.receivedExportBuffer);
-//}
-//
-///**
-// * Simple rollback test, verify that we can rollback the first tuple,
-// * append another tuple, and only get one tuple in the output buffer.
-// */
-//TEST_F(ExportTupleStreamTest, RollbackFirstTuple) {
-//
-//    appendTuple(1, 2);
-//    // rollback the first tuple
-//    m_wrapper->rollbackTo(0, 0, 1);
-//
-//    // write a new tuple and then flush the buffer
-//    appendTuple(1, 2);
-//    m_wrapper->periodicFlush(-1, 2);
-//
-//    // we should only have one tuple in the buffer
-//    ASSERT_TRUE(m_topend.receivedExportBuffer);
-//    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
-//    m_topend.blocks.pop_front();
-//    EXPECT_EQ(results->uso(), 0);
-//    EXPECT_EQ(results->offset(), m_tupleSize);
-//}
-//
-//
-///**
-// * Another simple rollback test, verify that a tuple in the middle of
-// * a buffer can get rolled back and leave the committed transaction
-// * untouched.
-// */
-//TEST_F(ExportTupleStreamTest, RollbackMiddleTuple) {
-//
-//    // append a bunch of tuples
-//    for (int i = 1; i <= m_tuplesToFill - 1; i++) {
-//        appendTuple(i-1, i);
-//    }
-//
-//    // add another and roll it back and flush
-//    size_t mark = m_wrapper->bytesUsed();
-//    int64_t seqNo = m_wrapper->getSequenceNumber();
-//    appendTuple(m_tuplesToFill - 1, m_tuplesToFill);
-//    m_wrapper->rollbackTo(mark, 0, seqNo);
-//    m_wrapper->periodicFlush(-1, m_tuplesToFill - 1);
-//
-//    ASSERT_TRUE(m_topend.receivedExportBuffer);
-//    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
-//    m_topend.blocks.pop_front();
-//    EXPECT_EQ(results->uso(), 0);
-//    EXPECT_EQ(results->offset(), ((m_tuplesToFill - 1) * m_tupleSize));
-//}
-//
-///**
-// * Verify that a transaction can generate entire buffers, they can all
-// * be rolled back, and the original committed bytes are untouched.
-// */
-//TEST_F(ExportTupleStreamTest, RollbackWholeBuffer)
-//{
-//    // append a bunch of tuples
-//    for (int i = 1; i <= 3; i++) {
-//        appendTuple(i-1, i);
-//    }
-//
-//    // now, fill a couple of buffers with tuples from a single transaction
-//    size_t mark = m_wrapper->bytesUsed();
-//    int64_t seqNo = m_wrapper->getSequenceNumber();
-//    for (int i = 0; i < (m_tuplesToFill + 10) * 2; i++)
-//    {
-//        appendTuple(10, 11);
-//    }
-//    m_wrapper->rollbackTo(mark, 0, seqNo);
-//    m_wrapper->periodicFlush(-1, 3);
-//
-//    ASSERT_TRUE(m_topend.receivedExportBuffer);
-//    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
-//    m_topend.blocks.pop_front();
-//    EXPECT_EQ(results->uso(), 0);
-//    EXPECT_EQ(results->offset(), (m_tupleSize * 3));
-//}
+
+/**
+ * Verify that several filled buffers all with one open transaction returns
+ * nada.
+ */
+TEST_F(ExportTupleStreamTest, FillWithOneTxn) {
+
+    // fill several buffers
+    for (int i = 0; i <= (m_tuplesToFill + 10) * 3; i++)
+    {
+        appendTuple(1, 2);
+    }
+    // We shouldn't yet get a buffer even though we've filled a bunch because
+    // the transaction is still open.
+    ASSERT_FALSE(m_topend.receivedExportBuffer);
+    int64_t seqNo = m_wrapper->getSequenceNumber();
+    std::cout << " seqNo = " << seqNo << std::endl;
+}
+
+/**
+ * Simple rollback test, verify that we can rollback the first tuple,
+ * append another tuple, and only get one tuple in the output buffer.
+ */
+TEST_F(ExportTupleStreamTest, RollbackFirstTuple) {
+
+    size_t mark = m_wrapper->bytesUsed();
+    size_t seqNo = s_seqNo;
+    appendTuple(1, 2);
+    // rollback the first tuple
+    m_wrapper->rollbackTo(mark, 0, seqNo);
+
+    // write a new tuple and then flush the buffer
+    appendTuple(1, 2);
+    m_wrapper->periodicFlush(-1, 2);
+
+    // we should only have one tuple in the buffer
+    ASSERT_TRUE(m_topend.receivedExportBuffer);
+    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
+    m_topend.blocks.pop_front();
+    EXPECT_EQ(results->uso(), 0);
+    EXPECT_EQ(results->getRowCountforExport(), 1);
+    EXPECT_EQ(results->offset(), m_tupleSize);
+}
+
+
+/**
+ * Another simple rollback test, verify that a tuple in the middle of
+ * a buffer can get rolled back and leave the committed transaction
+ * untouched.
+ */
+TEST_F(ExportTupleStreamTest, RollbackMiddleTuple) {
+
+    // append a bunch of tuples
+    for (int i = 1; i <= m_tuplesToFill - 1; i++) {
+        appendTuple(i-1, i);
+    }
+
+    // add another and roll it back and flush
+    size_t mark = m_wrapper->bytesUsed();
+    int64_t seqNo = m_wrapper->getSequenceNumber();
+    appendTuple(m_tuplesToFill - 1, m_tuplesToFill);
+    m_wrapper->rollbackTo(mark, 0, seqNo);
+    m_wrapper->periodicFlush(-1, m_tuplesToFill - 1);
+
+    ASSERT_TRUE(m_topend.receivedExportBuffer);
+    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
+    m_topend.blocks.pop_front();
+    EXPECT_EQ(results->uso(), 0);
+    EXPECT_EQ(results->offset(), ((m_tuplesToFill - 1) * m_tupleSize));
+    EXPECT_EQ(results->getRowCountforExport(), m_tuplesToFill - 1);
+}
+
+/**
+ * Verify that a transaction can generate entire buffers, they can all
+ * be rolled back, and the original committed bytes are untouched.
+ */
+TEST_F(ExportTupleStreamTest, RollbackWholeBuffer)
+{
+    // append a bunch of tuples
+    for (int i = 1; i <= 3; i++) {
+        appendTuple(i-1, i);
+    }
+
+    // now, fill a couple of buffers with tuples from a single transaction
+    size_t mark = m_wrapper->bytesUsed();
+    int64_t seqNo = m_wrapper->getSequenceNumber();
+    for (int i = 0; i < (m_tuplesToFill + 10) * 2; i++)
+    {
+        appendTuple(10, 11);
+    }
+    m_wrapper->rollbackTo(mark, 0, seqNo);
+    m_wrapper->periodicFlush(-1, 3);
+
+    ASSERT_TRUE(m_topend.receivedExportBuffer);
+    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
+    m_topend.blocks.pop_front();
+    EXPECT_EQ(results->uso(), 0);
+    EXPECT_EQ(results->offset(), (m_tupleSize * 3));
+    EXPECT_EQ(results->getRowCountforExport(), 3);
+}
+
+TEST_F(ExportTupleStreamTest, PartialRollback)
+{
+    // append a bunch of tuples
+    for (int i = 1; i <= 3; i++) {
+        appendTuple(i-1, i);
+    }
+    // now, fill a couple of buffers with tuples from a single transaction
+    /*------------------------------
+     * Txn1 | Txn2 | Txn3 | Txn11  |
+     *------------------------------
+     * Txn11 | <- rollback         |
+     *------------------------------
+     * Txn11                       |
+     *------------------------------
+     * Txn11 |
+     *--------
+     */
+    size_t mark;
+    int64_t seqNo;
+    for (int i = 4; i < (m_tuplesToFill + 1) * 2; i++)
+    {
+        appendTuple(10, 11);
+        if (i == m_tuplesToFill + 1) {
+            mark = m_wrapper->bytesUsed();
+            seqNo = m_wrapper->getSequenceNumber();
+        }
+    }
+    m_wrapper->rollbackTo(mark, 0, seqNo);
+    m_wrapper->periodicFlush(-1, 11);
+    ASSERT_TRUE(m_topend.receivedExportBuffer);
+    boost::shared_ptr<StreamBlock> results = m_topend.blocks.front();
+    m_topend.blocks.pop_front();
+    EXPECT_EQ(m_wrapper->m_stashedTupleCount, 0);
+    EXPECT_EQ(results->uso(), 0);
+    EXPECT_EQ(results->offset(), (m_tupleSize * m_tuplesToFill));
+    EXPECT_EQ(results->getRowCountforExport(), m_tuplesToFill);
+    results = m_topend.blocks.front();
+    EXPECT_EQ(results->uso(), m_tupleSize * m_tuplesToFill);
+    EXPECT_EQ(results->offset(), (m_tupleSize * 1));
+    EXPECT_EQ(results->getRowCountforExport(), 1);
+}
 
 
 int main() {


### PR DESCRIPTION
…ce number range for export buffers.

In general row count of the block needs to be updated when
1) new transaction starts,
2) new block is created after the old one is full,
3) rollback one or more blocks,