### PR TITLE
Misc cleanup and enhancements

### DIFF
--- a/src/frontend/org/voltdb/ParameterSet.java
+++ b/src/frontend/org/voltdb/ParameterSet.java
@@ -42,6 +42,7 @@ import org.voltdb.utils.SerializationHelper;
  *
  */
 public class ParameterSet implements JSONString {
+    private static final ParameterSet EMPTY = fromArray(ArrayUtils.EMPTY_OBJECT_ARRAY);
 
     static final byte ARRAY = -99;
 
@@ -67,14 +68,24 @@ public class ParameterSet implements JSONString {
     private final int m_serializedSize;
 
     public static ParameterSet emptyParameterSet() {
-        return fromArrayNoCopy();
+        return EMPTY;
     }
 
     public static ParameterSet fromArrayWithCopy(Object... params) {
-        return fromArrayNoCopy(params.clone());
+        if (params.length == 0) {
+            return EMPTY;
+        }
+        return fromArray(params.clone());
     }
 
     public static ParameterSet fromArrayNoCopy(Object... params) {
+        if (params.length == 0) {
+            return EMPTY;
+        }
+        return fromArray(params);
+    }
+
+    private static ParameterSet fromArray(Object[] params) {
         byte[][][] encodedStringArrays = new byte[params.length][][];
         byte[][] encodedStrings = new byte[params.length][];
 

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -1551,7 +1551,7 @@ public class ProcedureRunner {
             if (state.m_depsForLocalTask[i] < 0) {
                 continue;
             }
-            state.m_localTask.addInputDepId(i, state.m_depsForLocalTask[i]);
+            state.m_localTask.setInputDepId(i, state.m_depsForLocalTask[i]);
         }
 
         // note: non-transactional work only helps us if it's final work

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -55,8 +55,6 @@ public class SystemProcedureCatalog {
         public final boolean commercial;
         // whether this procedure will terminate replication
         public final boolean terminatesReplication;
-        // whether this procedure should be skipped in replication
-        public final boolean skipReplication;
         // whether normal clients can call this sysproc in secondary
         public final boolean allowedInReplica;
         //Durable?
@@ -76,7 +74,6 @@ public class SystemProcedureCatalog {
                       VoltType partitionParamType,
                       boolean commercial,
                       boolean terminatesReplication,
-                      boolean skipReplication,
                       boolean allowedInReplica,
                       boolean durable,
                       boolean allowedInShutdown,
@@ -91,7 +88,6 @@ public class SystemProcedureCatalog {
             this.partitionParamType = partitionParamType;
             this.commercial = commercial;
             this.terminatesReplication = terminatesReplication;
-            this.skipReplication = skipReplication;
             this.allowedInReplica = allowedInReplica;
             this.durable = durable;
             this.allowedInShutdown = allowedInShutdown;
@@ -148,81 +144,81 @@ public class SystemProcedureCatalog {
 
     public static final ImmutableMap<String, Config> listing;
 
-    static {                                                                                                                    // SP     RO     Every  Param ParamType           PRO    killDR skipDR replica-ok durable allowedInShutdown transactional restartable
+    static {                                                                                            // SP     RO     Every  Param ParamType           PRO    killDR replica-ok durable allowedInShutdown transactional restartable
         // special-case replica acceptability by DR version
         ImmutableMap.Builder<String, Config> builder = ImmutableMap.builder();
-        builder.put("@AdHoc_RW_MP",             new Config("org.voltdb.sysprocs.AdHoc_RW_MP",              false, false, false, 0,    VoltType.INVALID,   false, false, false, false,     true,   false,            true,         true  ));
-        builder.put("@AdHoc_RW_SP",             new Config("org.voltdb.sysprocs.AdHoc_RW_SP",              true,  false, false, 0,    VoltType.VARBINARY, false, false, false, false,     true,   false,            true,         true  ));
-        builder.put("@AdHoc_RO_MP",             new Config("org.voltdb.sysprocs.AdHoc_RO_MP",              false, true,  false, 0,    VoltType.INVALID,   false, false, false, true,      false,  false,            true,         true  ));
-        builder.put("@MigratePartitionLeader",  new Config("org.voltdb.sysprocs.MigratePartitionLeader",   true,  true,  false, 0,    VoltType.BIGINT,    false, true,  true,  false,     false,  false,            true,         false  ));
-        builder.put("@AdHoc_RO_SP",             new Config("org.voltdb.sysprocs.AdHoc_RO_SP",              true,  true,  false, 0,    VoltType.VARBINARY, false, false, false, true,      false,  false,            true,         true  ));
-        builder.put("@JStack",                  new Config(null,                                           false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  true,             true,         false ));
-        builder.put("@Pause",                   new Config("org.voltdb.sysprocs.Pause",                    false, false, true,  0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@Resume",                  new Config("org.voltdb.sysprocs.Resume",                   false, false, true,  0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@Quiesce",                 new Config("org.voltdb.sysprocs.Quiesce",                  false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  true ,            true,         false ));
-        builder.put("@SnapshotSave",            new Config("org.voltdb.sysprocs.SnapshotSave",             false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  true ,            true,         false ));
-        builder.put("@SnapshotRestore",         new Config("org.voltdb.sysprocs.SnapshotRestore",          false, false, false, 0,    VoltType.INVALID,   false, true,  true,  false,     false,  false,            true,         false ));
-        builder.put("@SnapshotStatus",          new Config("org.voltdb.sysprocs.SnapshotStatus",           false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@SnapshotScan",            new Config("org.voltdb.sysprocs.SnapshotScan",             false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@SnapshotDelete",          new Config("org.voltdb.sysprocs.SnapshotDelete",           false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@Shutdown",                new Config("org.voltdb.sysprocs.Shutdown",                 false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  true ,            true,         false ));
-        builder.put("@ProfCtl",                 new Config("org.voltdb.sysprocs.ProfCtl",                  false, false, true,  0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@Statistics",              new Config("org.voltdb.sysprocs.Statistics",               false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  true ,            true,         false ));
-        builder.put("@SystemCatalog",           new Config("org.voltdb.sysprocs.SystemCatalog",            true,  true,  false, 0,    VoltType.STRING,    false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@SystemInformation",       new Config("org.voltdb.sysprocs.SystemInformation",        false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@UpdateLogging",           new Config("org.voltdb.sysprocs.UpdateLogging",            false, false, true,  0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@BalancePartitions",       new Config("org.voltdb.sysprocs.BalancePartitions",        false, false, false, 0,    VoltType.INVALID,   true,  false, true,  false,     true,   false,            true,         false ));
-        builder.put("@UpdateCore",              new Config("org.voltdb.sysprocs.UpdateCore",               false, false, false, 0,    VoltType.INVALID,   false, false, false, true,      true,   false,            true,         true  ));
-        builder.put("@VerifyCatalogAndWriteJar",new Config("org.voltdb.sysprocs.VerifyCatalogAndWriteJar", false, false, false, 0,    VoltType.INVALID,   false, false, false, true,      true,   false,            false,        false ));
-        builder.put("@UpdateApplicationCatalog",new Config("org.voltdb.sysprocs.UpdateApplicationCatalog", false, false, false, 0,    VoltType.INVALID,   false, false, false, true,      true,   false,            false,        false ));
-        builder.put("@UpdateClasses",           new Config("org.voltdb.sysprocs.UpdateClasses",            false, false, false, 0,    VoltType.INVALID,   false, false, false, true,      true,   false,            false,        false ));
-        builder.put("@LoadMultipartitionTable", new Config("org.voltdb.sysprocs.LoadMultipartitionTable",  false, false, false, 0,    VoltType.INVALID,   false, false, false, false,     true,   false,            true,         true  ));
-        builder.put("@LoadSinglepartitionTable",new Config("org.voltdb.sysprocs.LoadSinglepartitionTable", true,  false, false, 0,    VoltType.VARBINARY, false, false, false, false,     true,   false,            true,         false ));
-        builder.put("@Promote",                 new Config("org.voltdb.sysprocs.Promote",                  false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            false,        false ));
-        builder.put("@ValidatePartitioning",    new Config("org.voltdb.sysprocs.ValidatePartitioning",     false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@GetHashinatorConfig",     new Config("org.voltdb.sysprocs.GetHashinatorConfig",      false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@ApplyBinaryLogSP",        new Config("org.voltdb.sysprocs.ApplyBinaryLogSP",         true,  false, false, 0,    VoltType.VARBINARY, true,  false, false, true,      true,   false,            true,         false ));
-        builder.put("@ApplyBinaryLogMP",        new Config("org.voltdb.sysprocs.ApplyBinaryLogMP",         false, false, false, 0,    VoltType.INVALID,   true,  false, false, true,      true,   false,            true,         true  ));
-        builder.put("@LoadVoltTableSP",         new Config("org.voltdb.sysprocs.LoadVoltTableSP",          true,  false, false, 0,    VoltType.VARBINARY, true,  false, false, true,      true,   false,            true,         false ));
-        builder.put("@LoadVoltTableMP",         new Config("org.voltdb.sysprocs.LoadVoltTableMP",          false, false, false, 0,    VoltType.INVALID,   true,  false, false, true,      true,   false,            true,         false ));
-        builder.put("@ResetDR",                 new Config("org.voltdb.sysprocs.ResetDR",                  false, false, false, 0,    VoltType.INVALID,   true,  false, true,  true,      false,  false,            true,         false ));
-        //------------------------------------------------------------------------------------------------ SP     RO     Every  Param ParamType           PRO    killDR skipDR replica-ok durable allowedInShutdown transactional restartable
+        builder.put("@AdHoc_RW_MP",             new Config("org.voltdb.sysprocs.AdHoc_RW_MP",              false, false, false, 0,    VoltType.INVALID,   false, false, false,     true,   false,            true,         true  ));
+        builder.put("@AdHoc_RW_SP",             new Config("org.voltdb.sysprocs.AdHoc_RW_SP",              true,  false, false, 0,    VoltType.VARBINARY, false, false, false,     true,   false,            true,         true  ));
+        builder.put("@AdHoc_RO_MP",             new Config("org.voltdb.sysprocs.AdHoc_RO_MP",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         true  ));
+        builder.put("@MigratePartitionLeader",  new Config("org.voltdb.sysprocs.MigratePartitionLeader",   true,  true,  false, 0,    VoltType.BIGINT,    false, true,  false,     false,  false,            true,         false  ));
+        builder.put("@AdHoc_RO_SP",             new Config("org.voltdb.sysprocs.AdHoc_RO_SP",              true,  true,  false, 0,    VoltType.VARBINARY, false, false, true,      false,  false,            true,         true  ));
+        builder.put("@JStack",                  new Config(null,                                           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true,             true,         false ));
+        builder.put("@Pause",                   new Config("org.voltdb.sysprocs.Pause",                    false, false, true,  0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@Resume",                  new Config("org.voltdb.sysprocs.Resume",                   false, false, true,  0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@Quiesce",                 new Config("org.voltdb.sysprocs.Quiesce",                  false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
+        builder.put("@SnapshotSave",            new Config("org.voltdb.sysprocs.SnapshotSave",             false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
+        builder.put("@SnapshotRestore",         new Config("org.voltdb.sysprocs.SnapshotRestore",          false, false, false, 0,    VoltType.INVALID,   false, true,  false,     false,  false,            true,         false ));
+        builder.put("@SnapshotStatus",          new Config("org.voltdb.sysprocs.SnapshotStatus",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@SnapshotScan",            new Config("org.voltdb.sysprocs.SnapshotScan",             false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@SnapshotDelete",          new Config("org.voltdb.sysprocs.SnapshotDelete",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@Shutdown",                new Config("org.voltdb.sysprocs.Shutdown",                 false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
+        builder.put("@ProfCtl",                 new Config("org.voltdb.sysprocs.ProfCtl",                  false, false, true,  0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@Statistics",              new Config("org.voltdb.sysprocs.Statistics",               false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
+        builder.put("@SystemCatalog",           new Config("org.voltdb.sysprocs.SystemCatalog",            true,  true,  false, 0,    VoltType.STRING,    false, false, true,      false,  false,            true,         false ));
+        builder.put("@SystemInformation",       new Config("org.voltdb.sysprocs.SystemInformation",        false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@UpdateLogging",           new Config("org.voltdb.sysprocs.UpdateLogging",            false, false, true,  0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@BalancePartitions",       new Config("org.voltdb.sysprocs.BalancePartitions",        false, false, false, 0,    VoltType.INVALID,   true,  false, false,     true,   false,            true,         false ));
+        builder.put("@UpdateCore",              new Config("org.voltdb.sysprocs.UpdateCore",               false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         true  ));
+        builder.put("@VerifyCatalogAndWriteJar",new Config("org.voltdb.sysprocs.VerifyCatalogAndWriteJar", false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            false,        false ));
+        builder.put("@UpdateApplicationCatalog",new Config("org.voltdb.sysprocs.UpdateApplicationCatalog", false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            false,        false ));
+        builder.put("@UpdateClasses",           new Config("org.voltdb.sysprocs.UpdateClasses",            false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            false,        false ));
+        builder.put("@LoadMultipartitionTable", new Config("org.voltdb.sysprocs.LoadMultipartitionTable",  false, false, false, 0,    VoltType.INVALID,   false, false, false,     true,   false,            true,         true  ));
+        builder.put("@LoadSinglepartitionTable",new Config("org.voltdb.sysprocs.LoadSinglepartitionTable", true,  false, false, 0,    VoltType.VARBINARY, false, false, false,     true,   false,            true,         false ));
+        builder.put("@Promote",                 new Config("org.voltdb.sysprocs.Promote",                  false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
+        builder.put("@ValidatePartitioning",    new Config("org.voltdb.sysprocs.ValidatePartitioning",     false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@GetHashinatorConfig",     new Config("org.voltdb.sysprocs.GetHashinatorConfig",      false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@ApplyBinaryLogSP",        new Config("org.voltdb.sysprocs.ApplyBinaryLogSP",         true,  false, false, 0,    VoltType.VARBINARY, true,  false, true,      true,   false,            true,         false ));
+        builder.put("@ApplyBinaryLogMP",        new Config("org.voltdb.sysprocs.ApplyBinaryLogMP",         false, false, false, 0,    VoltType.INVALID,   true,  false, true,      true,   false,            true,         true  ));
+        builder.put("@LoadVoltTableSP",         new Config("org.voltdb.sysprocs.LoadVoltTableSP",          true,  false, false, 0,    VoltType.VARBINARY, true,  false, true,      true,   false,            true,         false ));
+        builder.put("@LoadVoltTableMP",         new Config("org.voltdb.sysprocs.LoadVoltTableMP",          false, false, false, 0,    VoltType.INVALID,   true,  false, true,      true,   false,            true,         false ));
+        builder.put("@ResetDR",                 new Config("org.voltdb.sysprocs.ResetDR",                  false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            true,         false ));
+        //------------------------------------------------------------------------------------------------ SP     RO     Every  Param ParamType           PRO    killDR replica-ok durable allowedInShutdown transactional restartable
         /* @ExecuteTask is a all-in-one system store procedure and should be ONLY used for internal purpose */
-        builder.put("@ExecuteTask",             new Config("org.voltdb.sysprocs.ExecuteTask",              false, false, false, 0,    VoltType.INVALID,   false, false, false, true,      true,   false,            true,         true  ));
-        builder.put("@ExecuteTask_SP",          new Config("org.voltdb.sysprocs.ExecuteTask_SP",           true,  false, false, 0,    VoltType.VARBINARY, false, false, true,  true,      true,   false,            true,         false ));
-        builder.put("@UpdateSettings",          new Config("org.voltdb.sysprocs.UpdateSettings",           false, false, false, 0,    VoltType.INVALID,   false, false, false, true,      true,   false,            true,         false ));
-        builder.put("@Ping",                    new Config(null,                                           false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  true,             true,         false ));
-        builder.put("@PingPartitions",          new Config("org.voltdb.sysprocs.PingPartitions",           false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         true  ));
-        builder.put("@GetPartitionKeys",        new Config(null,                                           false, true,  true,  0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@Subscribe",               new Config(null,                                           false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@GC",                      new Config("org.voltdb.sysprocs.GC",                       false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            false,        false ));
-        builder.put("@AdHoc",                   new Config("org.voltdb.sysprocs.AdHoc",                    false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            false,        true  ));
-        builder.put("@AdHocSpForTest",          new Config("org.voltdb.sysprocs.AdHocSpForTest",           false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            false,        true  ));
-        builder.put("@AdHocLarge",              new Config("org.voltdb.sysprocs.AdHocLarge",               false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            false,        true  ));
-        builder.put("@StopNode",                new Config(null,                                           true,  false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@PrepareStopNode",         new Config(null,                                           true,  false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@Explain",                 new Config("org.voltdb.sysprocs.Explain",                  false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            false,        false ));
-        builder.put("@ExplainProc",             new Config("org.voltdb.sysprocs.ExplainProc",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            false,        false ));
-        builder.put("@ExplainView",             new Config("org.voltdb.sysprocs.ExplainView",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            false,        false ));
-        builder.put("@ExplainJSON",             new Config("org.voltdb.sysprocs.ExplainJSON",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            false,        false ));
-        builder.put("@ExplainCatalog",          new Config("org.voltdb.sysprocs.ExplainCatalog",           false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            false,        false ));
-        builder.put("@SendSentinel",            new Config(null,                                           true,  false, false, 0,    VoltType.INVALID,   true,  false, false, true,      false,  false,            true,         false ));
-        builder.put("@PrepareShutdown",         new Config("org.voltdb.sysprocs.PrepareShutdown",          false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  true ,            true,         false ));
-        builder.put("@SwapTables",              new Config("org.voltdb.sysprocs.SwapTables",               false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      true,   false,            false,        false ));
-        builder.put("@SwapTablesCore",          new Config("org.voltdb.sysprocs.SwapTablesCore",           false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      true,   false,            true,         false ));
-        builder.put("@Trace",                   new Config(null,                                           false, true,  false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
-        builder.put("@CheckUpgradePlanNT",      new Config("org.voltdb.sysprocs.CheckUpgradePlanNT",       true,  false, false, 0,    VoltType.INVALID,   true,  false, true,  true,      false,  false,            false,        false ));
+        builder.put("@ExecuteTask",             new Config("org.voltdb.sysprocs.ExecuteTask",              false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         true  ));
+        builder.put("@ExecuteTask_SP",          new Config("org.voltdb.sysprocs.ExecuteTask_SP",           true,  false, false, 0,    VoltType.VARBINARY, false, false, true,      true,   false,            true,         false ));
+        builder.put("@UpdateSettings",          new Config("org.voltdb.sysprocs.UpdateSettings",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         false ));
+        builder.put("@Ping",                    new Config(null,                                           false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  true,             true,         false ));
+        builder.put("@PingPartitions",          new Config("org.voltdb.sysprocs.PingPartitions",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         true  ));
+        builder.put("@GetPartitionKeys",        new Config(null,                                           false, true,  true,  0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@Subscribe",               new Config(null,                                           false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@GC",                      new Config("org.voltdb.sysprocs.GC",                       false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
+        builder.put("@AdHoc",                   new Config("org.voltdb.sysprocs.AdHoc",                    false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        true  ));
+        builder.put("@AdHocSpForTest",          new Config("org.voltdb.sysprocs.AdHocSpForTest",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        true  ));
+        builder.put("@AdHocLarge",              new Config("org.voltdb.sysprocs.AdHocLarge",               false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        true  ));
+        builder.put("@StopNode",                new Config(null,                                           true,  false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@PrepareStopNode",         new Config(null,                                           true,  false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@Explain",                 new Config("org.voltdb.sysprocs.Explain",                  false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
+        builder.put("@ExplainProc",             new Config("org.voltdb.sysprocs.ExplainProc",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
+        builder.put("@ExplainView",             new Config("org.voltdb.sysprocs.ExplainView",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
+        builder.put("@ExplainJSON",             new Config("org.voltdb.sysprocs.ExplainJSON",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
+        builder.put("@ExplainCatalog",          new Config("org.voltdb.sysprocs.ExplainCatalog",           false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
+        builder.put("@SendSentinel",            new Config(null,                                           true,  false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            true,         false ));
+        builder.put("@PrepareShutdown",         new Config("org.voltdb.sysprocs.PrepareShutdown",          false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
+        builder.put("@SwapTables",              new Config("org.voltdb.sysprocs.SwapTables",               false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            false,        false ));
+        builder.put("@SwapTablesCore",          new Config("org.voltdb.sysprocs.SwapTablesCore",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         false ));
+        builder.put("@Trace",                   new Config(null,                                           false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
+        builder.put("@CheckUpgradePlanNT",      new Config("org.voltdb.sysprocs.CheckUpgradePlanNT",       true,  false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
         builder.put("@PrerequisitesCheckNT",    new Config("org.voltdb.sysprocs.CheckUpgradePlanNT$PrerequisitesCheckNT",
-                                                                                                           false, false, false, 0,    VoltType.INVALID,   true,  false, true,  true,      false,  false,            false,        false ));
-        builder.put("@RestartDRConsumerNT",     new Config("org.voltdb.sysprocs.RestartDRConsumerNT",      false, false, false, 0,    VoltType.INVALID,   true,  false, true,  true,      false,  false,            false,        false ));
+                                                                                                           false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
+        builder.put("@RestartDRConsumerNT",     new Config("org.voltdb.sysprocs.RestartDRConsumerNT",      false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
         builder.put("@ShutdownNodeDRConsumerNT", new Config("org.voltdb.sysprocs.RestartDRConsumerNT$ShutdownNodeDRConsumerNT",
-                                                                                                           false, false, false, 0,    VoltType.INVALID,   true,  false, true,  true,      false,  false,            false,        false ));
+                                                                                                           false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
         builder.put("@StartNodeDRConsumerNT",   new Config("org.voltdb.sysprocs.RestartDRConsumerNT$StartNodeDRConsumerNT",
-                                                                                                           false, false, false, 0,    VoltType.INVALID,   true,  false, true,  true,      false,  false,            false,        false ));
-        builder.put("@NibbleDeleteSP",          new Config("org.voltdb.sysprocs.NibbleDeleteSP",           true,  false, false, 0,    VoltType.INVALID,   false, false, true,  true,      true,   false,            true,         true ));
-        builder.put("@NibbleDeleteMP",          new Config("org.voltdb.sysprocs.NibbleDeleteMP",           false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      true,   false,            true,         true ));
-        builder.put("@LowImpactDeleteNT",       new Config("org.voltdb.sysprocs.LowImpactDeleteNT",        true,  false, false, 0,    VoltType.INVALID,   false, false, false, true,      false,  false,            false,        false ));
-        builder.put("@ExportControl",           new Config("org.voltdb.sysprocs.ExportControl",            false, false, false, 0,    VoltType.INVALID,   false, false, true,  true,      false,  false,            true,         false ));
+                                                                                                           false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
+        builder.put("@NibbleDeleteSP",          new Config("org.voltdb.sysprocs.NibbleDeleteSP",           true,  false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         true ));
+        builder.put("@NibbleDeleteMP",          new Config("org.voltdb.sysprocs.NibbleDeleteMP",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         true ));
+        builder.put("@LowImpactDeleteNT",       new Config("org.voltdb.sysprocs.LowImpactDeleteNT",        true,  false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
+        builder.put("@ExportControl",           new Config("org.voltdb.sysprocs.ExportControl",            false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
 
         listing = builder.build();
     }

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -120,21 +120,30 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
     /** Bundles the data needed to describe a plan fragment. */
     public static class SynthesizedPlanFragment {
         public long siteId = -1;
-        public long fragmentId = -1;
-        public int outputDepId = -1;
-        public ParameterSet parameters = null;
+        public final long fragmentId;
+        public final int outputDepId;
+        public final ParameterSet parameters;
         /** true if distributes to all executable partitions */
-        public boolean multipartition = false;
-
-        public SynthesizedPlanFragment() {}
+        public final boolean multipartition;
 
         public SynthesizedPlanFragment(int fragmentId, boolean multipartition) {
             this(fragmentId, multipartition, ParameterSet.emptyParameterSet());
         }
 
         public SynthesizedPlanFragment(int fragmentId, boolean multipartition, ParameterSet parameters) {
+            this(fragmentId, fragmentId, multipartition, parameters);
+        }
+
+        public SynthesizedPlanFragment(int fragmentId, int outputDepId, boolean multipartition,
+                ParameterSet parameters) {
+            this(-1, fragmentId, outputDepId, multipartition, parameters);
+        }
+
+        public SynthesizedPlanFragment(long siteId, int fragmentId, int outputDepId, boolean multipartition,
+                ParameterSet parameters) {
+            this.siteId = siteId;
             this.fragmentId = fragmentId;
-            this.outputDepId = fragmentId;
+            this.outputDepId = outputDepId;
             this.parameters = parameters;
             this.multipartition = multipartition;
         }

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -140,20 +140,6 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
         }
 
         /**
-         * Most MP sysprocs use this pattern of MP fragment and a non-MP aggregator fragment.
-         * Utility method to create that.
-         * @param fragmentId Id of the MP fragment distributed to sites. This will be the fragment id of the first
-         *        SynthesizedPlanFragment, its output dependency id and input dependency id of the aggregator fragment.
-         * @param aggFragmentId Id of the aggregator fragment. This will be the fragment id of the second SynthesizedPlanFragment
-         *        and its output dependency id.
-         * @param params Parameters for the first fragment.
-         * @return Array of fragments in the correct order
-         */
-        public static SynthesizedPlanFragment[] createFragmentAndAggregator(int fragmentId, int aggFragmentId, Object... params) {
-            return createFragmentAndAggregatorFromParameterSet(fragmentId, aggFragmentId, ParameterSet.fromArrayNoCopy(params));
-        }
-
-        /**
          * Most MP sysprocs use this pattern of MP fragment and a non-MP aggregator fragment. Utility method to create
          * that.
          *

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -122,7 +122,6 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
         public long siteId = -1;
         public long fragmentId = -1;
         public int outputDepId = -1;
-        public int inputDepIds[] = null;
         public ParameterSet parameters = null;
         /** true if distributes to all executable partitions */
         public boolean multipartition = false;
@@ -149,14 +148,12 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
 
             pfs[0] = new SynthesizedPlanFragment();
             pfs[0].fragmentId = fragmentId;
-            pfs[0].inputDepIds = ArrayUtils.EMPTY_INT_ARRAY;
             pfs[0].outputDepId = (int) fragmentId;
             pfs[0].multipartition = true;
             pfs[0].parameters = params;
 
             pfs[1] = new SynthesizedPlanFragment();
             pfs[1].fragmentId = aggFragmentId;
-            pfs[1].inputDepIds = new int[]{ (int) fragmentId };
             pfs[1].outputDepId = (int) aggFragmentId;
             pfs[1].multipartition = false;
             pfs[1].parameters = ParameterSet.emptyParameterSet();
@@ -253,11 +250,6 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
             //During @MigratePartitionLeader, a fragment may be mis-routed. fragmentIndex is used to check which fragment is mis-routed and
             //to determine how the follow-up fragments are processed.
             task.setBatch(fragmentIndex++);
-            if (pf.inputDepIds != null) {
-                for (int depId : pf.inputDepIds) {
-                    task.setInputDepId(0, depId);
-                }
-            }
             task.setFragmentTaskType(FragmentTaskMessage.SYS_PROC_PER_SITE);
 
             if (pf.multipartition) {

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -124,15 +124,8 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
         public int outputDepId = -1;
         public int inputDepIds[] = null;
         public ParameterSet parameters = null;
-        public boolean multipartition = false;
         /** true if distributes to all executable partitions */
-        /**
-         * Used to tell the DTXN to suppress duplicate results from sites that
-         * replicate a partition. Most system procedures don't want this, but,
-         * for example, adhoc queries actually do want duplicate suppression
-         * like user sysprocs.
-         */
-        public boolean suppressDuplicates = false;
+        public boolean multipartition = false;
 
         /**
          * Most MP sysprocs use this pattern of MP fragment and a non-MP aggregator fragment.
@@ -266,20 +259,18 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
                 }
             }
             task.setFragmentTaskType(FragmentTaskMessage.SYS_PROC_PER_SITE);
-            if (pf.suppressDuplicates) {
-                task.setFragmentTaskType(FragmentTaskMessage.SYS_PROC_PER_PARTITION);
-            }
 
             if (pf.multipartition) {
                 // create a workunit for every execution site
                 txnState.createAllParticipatingFragmentWork(task);
             } else {
                 // create one workunit for the current site
-                if (pf.siteId == -1)
+                if (pf.siteId == -1) {
                     txnState.createLocalFragmentWork(task, false);
-                else
+                } else {
                     txnState.createFragmentWork(new long[] { pf.siteId },
                                                          task);
+                }
             }
         }
     }

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -136,25 +136,25 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
          * @param params Parameters for the first fragment.
          * @return Array of fragments in the correct order
          */
-        public static SynthesizedPlanFragment[] createFragmentAndAggregator(long fragmentId, long aggFragmentId, Object... params) {
+        public static SynthesizedPlanFragment[] createFragmentAndAggregator(int fragmentId, int aggFragmentId, Object... params) {
             return createFragmentAndAggregatorFromParameterSet(fragmentId, aggFragmentId, ParameterSet.fromArrayNoCopy(params));
         }
 
         /**
          * Similar to {@link #createFragmentAndAggregator(long, long, Object...)}, but takes in ParameterSet as input for first fragment.
          */
-        public static SynthesizedPlanFragment[] createFragmentAndAggregatorFromParameterSet(long fragmentId, long aggFragmentId, ParameterSet params) {
+        public static SynthesizedPlanFragment[] createFragmentAndAggregatorFromParameterSet(int fragmentId, int aggFragmentId, ParameterSet params) {
             SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
 
             pfs[0] = new SynthesizedPlanFragment();
             pfs[0].fragmentId = fragmentId;
-            pfs[0].outputDepId = (int) fragmentId;
+            pfs[0].outputDepId = fragmentId;
             pfs[0].multipartition = true;
             pfs[0].parameters = params;
 
             pfs[1] = new SynthesizedPlanFragment();
             pfs[1].fragmentId = aggFragmentId;
-            pfs[1].outputDepId = (int) aggFragmentId;
+            pfs[1].outputDepId = aggFragmentId;
             pfs[1].multipartition = false;
             pfs[1].parameters = ParameterSet.emptyParameterSet();
 

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -262,7 +262,7 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
             task.setBatch(fragmentIndex++);
             if (pf.inputDepIds != null) {
                 for (int depId : pf.inputDepIds) {
-                    task.addInputDepId(0, depId);
+                    task.setInputDepId(0, depId);
                 }
             }
             task.setFragmentTaskType(FragmentTaskMessage.SYS_PROC_PER_SITE);

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
@@ -191,10 +191,8 @@ public class ExecuteTask extends VoltSystemProcedure
             return new VoltTable[] { result };
         }
 
-        SynthesizedPlanFragment pfs[] = SynthesizedPlanFragment.createFragmentAndAggregator(
-                SysProcFragmentId.PF_executeTask, SysProcFragmentId.PF_executeTaskAggregate, params);
-        VoltTable[] results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_executeTaskAggregate);
-        return results;
+        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_executeTask, SysProcFragmentId.PF_executeTaskAggregate,
+                params);
     }
 
 }

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
@@ -171,10 +171,10 @@ public class ExecuteTask extends VoltSystemProcedure
             default:
                 throw new VoltAbortException("Unable to find the task associated with the given task id");
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_executeTask, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_executeTask, result);
         } else if (fragmentId == SysProcFragmentId.PF_executeTaskAggregate) {
-            VoltTable unionTable = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_executeTask));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_executeTaskAggregate, unionTable);
+            VoltTable unionTable = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_executeTask));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_executeTaskAggregate, unionTable);
         }
         assert false;
         return null;
@@ -193,7 +193,7 @@ public class ExecuteTask extends VoltSystemProcedure
 
         SynthesizedPlanFragment pfs[] = SynthesizedPlanFragment.createFragmentAndAggregator(
                 SysProcFragmentId.PF_executeTask, SysProcFragmentId.PF_executeTaskAggregate, params);
-        VoltTable[] results = executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_executeTaskAggregate);
+        VoltTable[] results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_executeTaskAggregate);
         return results;
     }
 

--- a/src/frontend/org/voltdb/sysprocs/ExportControl.java
+++ b/src/frontend/org/voltdb/sysprocs/ExportControl.java
@@ -117,21 +117,7 @@ public class ExportControl extends VoltSystemProcedure {
 
     private final VoltTable[] performExportControl(String exportSource,
             String[] exportTargets, String operationMode) {
-        SynthesizedPlanFragment[] pfs = new SynthesizedPlanFragment[2];
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = SysProcFragmentId.PF_exportControl;
-        pfs[0].outputDepId = SysProcFragmentId.PF_exportControl;
-        pfs[0].multipartition = true;
-        pfs[0].parameters = ParameterSet.fromArrayNoCopy(
-                exportSource, exportTargets, operationMode);
-
-        // This fragment aggregates the results of creating those files
-        pfs[1] = new SynthesizedPlanFragment();
-        pfs[1].fragmentId = SysProcFragmentId.PF_exportControlAggregate;
-        pfs[1].outputDepId = SysProcFragmentId.PF_exportControlAggregate;
-        pfs[1].multipartition = false;
-        pfs[1].parameters = ParameterSet.emptyParameterSet();
-
-        return executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_exportControlAggregate);
+        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_exportControl,
+                SysProcFragmentId.PF_exportControlAggregate, exportSource, exportTargets, operationMode);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/ExportControl.java
+++ b/src/frontend/org/voltdb/sysprocs/ExportControl.java
@@ -32,8 +32,8 @@ import org.voltdb.SystemProcedureExecutionContext;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
-import org.voltdb.VoltType;
 import org.voltdb.VoltTable.ColumnInfo;
+import org.voltdb.VoltType;
 import org.voltdb.export.ExportManager;
 import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.VoltTableUtil;
@@ -121,7 +121,6 @@ public class ExportControl extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_exportControl;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_exportControl;
-        pfs[0].inputDepIds = new int[] {};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(
                 exportSource, exportTargets, operationMode);
@@ -130,7 +129,6 @@ public class ExportControl extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_exportControlAggregate;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_exportControlAggregate;
-        pfs[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_exportControl };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 

--- a/src/frontend/org/voltdb/sysprocs/ExportControl.java
+++ b/src/frontend/org/voltdb/sysprocs/ExportControl.java
@@ -79,10 +79,10 @@ public class ExportControl extends VoltSystemProcedure {
                         OperationMode.valueOf(operationMode.toUpperCase()), results);
             }
 
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_exportControl, results);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_exportControl, results);
         } else if (fragmentId == SysProcFragmentId.PF_exportControlAggregate) {
-            VoltTable result = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_exportControl));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_exportControlAggregate, result);
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_exportControl));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_exportControlAggregate, result);
         }
         return null;
     }
@@ -120,7 +120,7 @@ public class ExportControl extends VoltSystemProcedure {
         SynthesizedPlanFragment[] pfs = new SynthesizedPlanFragment[2];
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_exportControl;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_exportControl;
+        pfs[0].outputDepId = SysProcFragmentId.PF_exportControl;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(
                 exportSource, exportTargets, operationMode);
@@ -128,10 +128,10 @@ public class ExportControl extends VoltSystemProcedure {
         // This fragment aggregates the results of creating those files
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_exportControlAggregate;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_exportControlAggregate;
+        pfs[1].outputDepId = SysProcFragmentId.PF_exportControlAggregate;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
-        return executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_exportControlAggregate);
+        return executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_exportControlAggregate);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
+++ b/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
@@ -20,7 +20,6 @@ package org.voltdb.sysprocs;
 import java.util.List;
 import java.util.Map;
 
-import org.voltcore.logging.VoltLogger;
 import org.voltdb.DependencyPair;
 import org.voltdb.DeprecatedProcedureAPIAccess;
 import org.voltdb.ParameterSet;
@@ -109,9 +108,10 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
                     modifiedTuples[partitionId] = rowsModified;
                 }
                 else {
-                    if (modifiedTuples[partitionId] != rowsModified)
+                    if (modifiedTuples[partitionId] != rowsModified) {
                         throw new RuntimeException(
                                 "@LoadMultipartitionTable received different tuple mod counts from two replicas.");
+                    }
                 }
             }
 
@@ -172,7 +172,6 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
             pfs[0] = new SynthesizedPlanFragment();
             pfs[0].fragmentId = SysProcFragmentId.PF_distribute;
             pfs[0].outputDepId = (int) SysProcFragmentId.PF_distribute;
-            pfs[0].inputDepIds = new int[] {};
             pfs[0].multipartition = true;
             pfs[0].parameters = ParameterSet.fromArrayNoCopy(tableName, table);
 
@@ -181,7 +180,6 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
             pfs[1] = new SynthesizedPlanFragment();
             pfs[1].fragmentId = SysProcFragmentId.PF_aggregate;
             pfs[1].outputDepId = (int) SysProcFragmentId.PF_aggregate;
-            pfs[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_distribute };
             pfs[1].multipartition = false;
             pfs[1].parameters = ParameterSet.emptyParameterSet();
 

--- a/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
+++ b/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
@@ -90,11 +90,11 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
                 // result.addRow(-1);
                 throw e;
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_distribute, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_distribute, result);
 
         } else if (fragmentId == SysProcFragmentId.PF_aggregate) {
             long[] modifiedTuples = new long[context.getNumberOfPartitions()];
-            List<VoltTable> deps = dependencies.get((int) SysProcFragmentId.PF_distribute);
+            List<VoltTable> deps = dependencies.get(SysProcFragmentId.PF_distribute);
             assert(deps.size() > 0);
 
             // go through all the deps and find one mod tuple count per partition
@@ -119,7 +119,7 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
             long rowsModified =  modifiedTuples[0];
 
             result.addRow(rowsModified);
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_aggregate, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_aggregate, result);
         }
 
         // must handle every dependency id.
@@ -171,7 +171,7 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
             // create a work unit to invoke super.loadTable() on each site.
             pfs[0] = new SynthesizedPlanFragment();
             pfs[0].fragmentId = SysProcFragmentId.PF_distribute;
-            pfs[0].outputDepId = (int) SysProcFragmentId.PF_distribute;
+            pfs[0].outputDepId = SysProcFragmentId.PF_distribute;
             pfs[0].multipartition = true;
             pfs[0].parameters = ParameterSet.fromArrayNoCopy(tableName, table);
 
@@ -179,13 +179,13 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
             // MULTIPARTION_DEPENDENCY bit set, requiring result from each site
             pfs[1] = new SynthesizedPlanFragment();
             pfs[1].fragmentId = SysProcFragmentId.PF_aggregate;
-            pfs[1].outputDepId = (int) SysProcFragmentId.PF_aggregate;
+            pfs[1].outputDepId = SysProcFragmentId.PF_aggregate;
             pfs[1].multipartition = false;
             pfs[1].parameters = ParameterSet.emptyParameterSet();
 
             // distribute and execute the fragments providing pfs and id
             // of the aggregator's output dependency table.
-            VoltTable[] results = executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_aggregate);
+            VoltTable[] results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_aggregate);
             return results[0].asScalarLong();
         }
 

--- a/src/frontend/org/voltdb/sysprocs/PingPartitions.java
+++ b/src/frontend/org/voltdb/sysprocs/PingPartitions.java
@@ -79,14 +79,12 @@ public class PingPartitions extends VoltSystemProcedure {
         spf[0] = new SynthesizedPlanFragment();
         spf[0].fragmentId = SysProcFragmentId.PF_pingPartitions;
         spf[0].outputDepId = (int) SysProcFragmentId.PF_pingPartitions;
-        spf[0].inputDepIds = new int[] {};
         spf[0].multipartition = true;
         spf[0].parameters = ParameterSet.emptyParameterSet();
 
         spf[1] = new SynthesizedPlanFragment();
         spf[1].fragmentId = SysProcFragmentId.PF_pingPartitionsAggregate;
         spf[1].outputDepId = (int) SysProcFragmentId.PF_pingPartitionsAggregate;
-        spf[1].inputDepIds = new int[] {(int) SysProcFragmentId.PF_pingPartitions};
         spf[1].multipartition = false;
         spf[1].parameters = ParameterSet.emptyParameterSet();
         return executeSysProcPlanFragments(spf, (int) SysProcFragmentId.PF_pingPartitionsAggregate);
@@ -97,14 +95,12 @@ public class PingPartitions extends VoltSystemProcedure {
         spf[0] = new SynthesizedPlanFragment();
         spf[0].fragmentId = SysProcFragmentId.PF_enableScoreboard;
         spf[0].outputDepId = (int) SysProcFragmentId.PF_enableScoreboard;
-        spf[0].inputDepIds = new int[] {};
         spf[0].multipartition = true;
         spf[0].parameters = ParameterSet.emptyParameterSet();
 
         spf[1] = new SynthesizedPlanFragment();
         spf[1].fragmentId = SysProcFragmentId.PF_enableScoreboardAggregate;
         spf[1].outputDepId = (int) SysProcFragmentId.PF_enableScoreboardAggregate;
-        spf[1].inputDepIds = new int[] {(int) SysProcFragmentId.PF_enableScoreboard};
         spf[1].multipartition = false;
         spf[1].parameters = ParameterSet.emptyParameterSet();
         return executeSysProcPlanFragments(spf, (int) SysProcFragmentId.PF_enableScoreboardAggregate);

--- a/src/frontend/org/voltdb/sysprocs/PingPartitions.java
+++ b/src/frontend/org/voltdb/sysprocs/PingPartitions.java
@@ -17,21 +17,18 @@
 
 package org.voltdb.sysprocs;
 
-import org.voltcore.logging.VoltLogger;
+import java.util.List;
+import java.util.Map;
+
 import org.voltdb.DependencyPair;
 import org.voltdb.ParameterSet;
 import org.voltdb.SystemProcedureExecutionContext;
 import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
 
-import java.util.List;
-import java.util.Map;
-
 
 /**
  * Dummy MP Write System Procedure for generate fragments to all sites in cluster
- *
- * @throws VoltAbortException
  */
 public class PingPartitions extends VoltSystemProcedure {
 
@@ -54,20 +51,20 @@ public class PingPartitions extends VoltSystemProcedure {
         dummy.addRow(STATUS_OK);
 
         if (fragmentId == SysProcFragmentId.PF_pingPartitions) {
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_pingPartitions, dummy);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_pingPartitions, dummy);
         } else if (fragmentId == SysProcFragmentId.PF_pingPartitionsAggregate) {
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_pingPartitionsAggregate, dummy);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_pingPartitionsAggregate, dummy);
         } else if (fragmentId == SysProcFragmentId.PF_enableScoreboard) {
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_enableScoreboard, dummy);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_enableScoreboard, dummy);
         } else if (fragmentId == SysProcFragmentId.PF_enableScoreboardAggregate) {
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_enableScoreboardAggregate, dummy);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_enableScoreboardAggregate, dummy);
         }
 
         assert (false);
         return null;
     }
 
-    public VoltTable[] run(SystemProcedureExecutionContext ctx, byte enableScoreboard) throws VoltAbortException {
+    public VoltTable[] run(SystemProcedureExecutionContext ctx, byte enableScoreboard) {
         if (enableScoreboard == (byte) 1) {
             return runPingAndEnableScoreboard();
         }
@@ -78,32 +75,32 @@ public class PingPartitions extends VoltSystemProcedure {
         SynthesizedPlanFragment spf[] = new SynthesizedPlanFragment[2];
         spf[0] = new SynthesizedPlanFragment();
         spf[0].fragmentId = SysProcFragmentId.PF_pingPartitions;
-        spf[0].outputDepId = (int) SysProcFragmentId.PF_pingPartitions;
+        spf[0].outputDepId = SysProcFragmentId.PF_pingPartitions;
         spf[0].multipartition = true;
         spf[0].parameters = ParameterSet.emptyParameterSet();
 
         spf[1] = new SynthesizedPlanFragment();
         spf[1].fragmentId = SysProcFragmentId.PF_pingPartitionsAggregate;
-        spf[1].outputDepId = (int) SysProcFragmentId.PF_pingPartitionsAggregate;
+        spf[1].outputDepId = SysProcFragmentId.PF_pingPartitionsAggregate;
         spf[1].multipartition = false;
         spf[1].parameters = ParameterSet.emptyParameterSet();
-        return executeSysProcPlanFragments(spf, (int) SysProcFragmentId.PF_pingPartitionsAggregate);
+        return executeSysProcPlanFragments(spf, SysProcFragmentId.PF_pingPartitionsAggregate);
     }
 
     private VoltTable[] runPingAndEnableScoreboard() {
         SynthesizedPlanFragment spf[] = new SynthesizedPlanFragment[2];
         spf[0] = new SynthesizedPlanFragment();
         spf[0].fragmentId = SysProcFragmentId.PF_enableScoreboard;
-        spf[0].outputDepId = (int) SysProcFragmentId.PF_enableScoreboard;
+        spf[0].outputDepId = SysProcFragmentId.PF_enableScoreboard;
         spf[0].multipartition = true;
         spf[0].parameters = ParameterSet.emptyParameterSet();
 
         spf[1] = new SynthesizedPlanFragment();
         spf[1].fragmentId = SysProcFragmentId.PF_enableScoreboardAggregate;
-        spf[1].outputDepId = (int) SysProcFragmentId.PF_enableScoreboardAggregate;
+        spf[1].outputDepId = SysProcFragmentId.PF_enableScoreboardAggregate;
         spf[1].multipartition = false;
         spf[1].parameters = ParameterSet.emptyParameterSet();
-        return executeSysProcPlanFragments(spf, (int) SysProcFragmentId.PF_enableScoreboardAggregate);
+        return executeSysProcPlanFragments(spf, SysProcFragmentId.PF_enableScoreboardAggregate);
     }
 
 }

--- a/src/frontend/org/voltdb/sysprocs/PingPartitions.java
+++ b/src/frontend/org/voltdb/sysprocs/PingPartitions.java
@@ -72,35 +72,13 @@ public class PingPartitions extends VoltSystemProcedure {
     }
 
     private VoltTable[] runDummyPings() {
-        SynthesizedPlanFragment spf[] = new SynthesizedPlanFragment[2];
-        spf[0] = new SynthesizedPlanFragment();
-        spf[0].fragmentId = SysProcFragmentId.PF_pingPartitions;
-        spf[0].outputDepId = SysProcFragmentId.PF_pingPartitions;
-        spf[0].multipartition = true;
-        spf[0].parameters = ParameterSet.emptyParameterSet();
-
-        spf[1] = new SynthesizedPlanFragment();
-        spf[1].fragmentId = SysProcFragmentId.PF_pingPartitionsAggregate;
-        spf[1].outputDepId = SysProcFragmentId.PF_pingPartitionsAggregate;
-        spf[1].multipartition = false;
-        spf[1].parameters = ParameterSet.emptyParameterSet();
-        return executeSysProcPlanFragments(spf, SysProcFragmentId.PF_pingPartitionsAggregate);
+        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_pingPartitions,
+                SysProcFragmentId.PF_pingPartitionsAggregate);
     }
 
     private VoltTable[] runPingAndEnableScoreboard() {
-        SynthesizedPlanFragment spf[] = new SynthesizedPlanFragment[2];
-        spf[0] = new SynthesizedPlanFragment();
-        spf[0].fragmentId = SysProcFragmentId.PF_enableScoreboard;
-        spf[0].outputDepId = SysProcFragmentId.PF_enableScoreboard;
-        spf[0].multipartition = true;
-        spf[0].parameters = ParameterSet.emptyParameterSet();
-
-        spf[1] = new SynthesizedPlanFragment();
-        spf[1].fragmentId = SysProcFragmentId.PF_enableScoreboardAggregate;
-        spf[1].outputDepId = SysProcFragmentId.PF_enableScoreboardAggregate;
-        spf[1].multipartition = false;
-        spf[1].parameters = ParameterSet.emptyParameterSet();
-        return executeSysProcPlanFragments(spf, SysProcFragmentId.PF_enableScoreboardAggregate);
+        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_enableScoreboard,
+                SysProcFragmentId.PF_enableScoreboardAggregate);
     }
 
 }

--- a/src/frontend/org/voltdb/sysprocs/PrepareShutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/PrepareShutdown.java
@@ -93,27 +93,8 @@ public class PrepareShutdown extends Pause {
         throw new RuntimeException("Should not reach this code");
     }
 
-    private SynthesizedPlanFragment[] createPrepareFragments() {
-        SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
-
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = PF_prepareShutdown;
-        pfs[0].outputDepId = SysProcFragmentId.PF_prepareShutdown;
-        pfs[0].multipartition = true;
-        pfs[0].parameters = ParameterSet.emptyParameterSet();
-
-        pfs[1] = new SynthesizedPlanFragment();
-        pfs[1].fragmentId = PF_prepareShutdownAggregate;
-        pfs[1].outputDepId = SysProcFragmentId.PF_prepareShutdownAggregate;
-        pfs[1].multipartition = false;
-        pfs[1].parameters = ParameterSet.emptyParameterSet();
-
-        return pfs;
-
-    }
-
     @Override
     public VoltTable[] run(SystemProcedureExecutionContext ctx) {
-        return executeSysProcPlanFragments(createPrepareFragments(), SysProcFragmentId.PF_prepareShutdownAggregate);
+        return createAndExecuteSysProcPlan(PF_prepareShutdown, PF_prepareShutdownAggregate);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/PrepareShutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/PrepareShutdown.java
@@ -99,14 +99,12 @@ public class PrepareShutdown extends Pause {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = PF_prepareShutdown;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_prepareShutdown;
-        pfs[0].inputDepIds = new int[]{};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = PF_prepareShutdownAggregate;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_prepareShutdownAggregate;
-        pfs[1].inputDepIds = new int[] {(int) SysProcFragmentId.PF_prepareShutdown};
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 

--- a/src/frontend/org/voltdb/sysprocs/PrepareShutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/PrepareShutdown.java
@@ -65,12 +65,12 @@ public class PrepareShutdown extends Pause {
                     LOG.debug("@PrepareShutdown returning sigil " + ll(m_stat.getMzxid()));
                 }
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_prepareShutdown, t);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_prepareShutdown, t);
 
         } else if (fragmentId == PF_prepareShutdownAggregate) {
 
             NavigableSet<Long> uniqueTxnIds = new TreeSet<>();
-            for (VoltTable t: dependencies.get((int) SysProcFragmentId.PF_prepareShutdown)) {
+            for (VoltTable t: dependencies.get(SysProcFragmentId.PF_prepareShutdown)) {
                 while (t.advanceRow()) {
                     uniqueTxnIds.add(t.getLong(0));
                 }
@@ -81,7 +81,7 @@ public class PrepareShutdown extends Pause {
                 t.addRow(zktxnid);
             }
 
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_prepareShutdownAggregate, t);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_prepareShutdownAggregate, t);
 
         } else {
 
@@ -98,13 +98,13 @@ public class PrepareShutdown extends Pause {
 
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = PF_prepareShutdown;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_prepareShutdown;
+        pfs[0].outputDepId = SysProcFragmentId.PF_prepareShutdown;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = PF_prepareShutdownAggregate;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_prepareShutdownAggregate;
+        pfs[1].outputDepId = SysProcFragmentId.PF_prepareShutdownAggregate;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -114,6 +114,6 @@ public class PrepareShutdown extends Pause {
 
     @Override
     public VoltTable[] run(SystemProcedureExecutionContext ctx) {
-        return executeSysProcPlanFragments(createPrepareFragments(), (int) SysProcFragmentId.PF_prepareShutdownAggregate);
+        return executeSysProcPlanFragments(createPrepareFragments(), SysProcFragmentId.PF_prepareShutdownAggregate);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/Quiesce.java
+++ b/src/frontend/org/voltdb/sysprocs/Quiesce.java
@@ -73,28 +73,15 @@ public class Quiesce extends VoltSystemProcedure {
      * @return {@link org.voltdb.VoltSystemProcedure#STATUS_SCHEMA}
      */
     public VoltTable[] run(SystemProcedureExecutionContext ctx) {
-            VoltTable[] result = null;
+        VoltTable[] result = null;
 
-            SynthesizedPlanFragment pfs1[] = new SynthesizedPlanFragment[2];
-            pfs1[0] = new SynthesizedPlanFragment();
-            pfs1[0].fragmentId = SysProcFragmentId.PF_quiesce_sites;
-            pfs1[0].outputDepId = SysProcFragmentId.PF_quiesce_sites;
-            pfs1[0].multipartition = true;
-            pfs1[0].parameters = ParameterSet.emptyParameterSet();
-
-            pfs1[1] = new SynthesizedPlanFragment();
-            pfs1[1].fragmentId = SysProcFragmentId.PF_quiesce_processed_sites;
-            pfs1[1].outputDepId = SysProcFragmentId.PF_quiesce_processed_sites;
-            pfs1[1].multipartition = false;
-            pfs1[1].parameters = ParameterSet.emptyParameterSet();
-
-            try {
-                result = executeSysProcPlanFragments(pfs1, SysProcFragmentId.PF_quiesce_processed_sites);
-            }
-            catch (Exception ex) {
-                ex.printStackTrace();
-            }
-            return result;
+        try {
+            result = createAndExecuteSysProcPlan(SysProcFragmentId.PF_quiesce_sites,
+                    SysProcFragmentId.PF_quiesce_processed_sites);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return result;
     }
 
 }

--- a/src/frontend/org/voltdb/sysprocs/Quiesce.java
+++ b/src/frontend/org/voltdb/sysprocs/Quiesce.java
@@ -53,12 +53,12 @@ public class Quiesce extends VoltSystemProcedure {
                 context.getSiteProcedureConnection().quiesce();
                 VoltTable results = new VoltTable(new ColumnInfo("id", VoltType.BIGINT));
                 results.addRow(context.getSiteId());
-                return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_quiesce_sites, results);
+                return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_quiesce_sites, results);
             }
             else if (fragmentId == SysProcFragmentId.PF_quiesce_processed_sites) {
                 VoltTable dummy = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
                 dummy.addRow(VoltSystemProcedure.STATUS_OK);
-                return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_quiesce_processed_sites, dummy);
+                return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_quiesce_processed_sites, dummy);
             }
         }
         catch (Exception ex) {
@@ -78,18 +78,18 @@ public class Quiesce extends VoltSystemProcedure {
             SynthesizedPlanFragment pfs1[] = new SynthesizedPlanFragment[2];
             pfs1[0] = new SynthesizedPlanFragment();
             pfs1[0].fragmentId = SysProcFragmentId.PF_quiesce_sites;
-            pfs1[0].outputDepId = (int) SysProcFragmentId.PF_quiesce_sites;
+            pfs1[0].outputDepId = SysProcFragmentId.PF_quiesce_sites;
             pfs1[0].multipartition = true;
             pfs1[0].parameters = ParameterSet.emptyParameterSet();
 
             pfs1[1] = new SynthesizedPlanFragment();
             pfs1[1].fragmentId = SysProcFragmentId.PF_quiesce_processed_sites;
-            pfs1[1].outputDepId = (int) SysProcFragmentId.PF_quiesce_processed_sites;
+            pfs1[1].outputDepId = SysProcFragmentId.PF_quiesce_processed_sites;
             pfs1[1].multipartition = false;
             pfs1[1].parameters = ParameterSet.emptyParameterSet();
 
             try {
-                result = executeSysProcPlanFragments(pfs1, (int) SysProcFragmentId.PF_quiesce_processed_sites);
+                result = executeSysProcPlanFragments(pfs1, SysProcFragmentId.PF_quiesce_processed_sites);
             }
             catch (Exception ex) {
                 ex.printStackTrace();

--- a/src/frontend/org/voltdb/sysprocs/Quiesce.java
+++ b/src/frontend/org/voltdb/sysprocs/Quiesce.java
@@ -79,14 +79,12 @@ public class Quiesce extends VoltSystemProcedure {
             pfs1[0] = new SynthesizedPlanFragment();
             pfs1[0].fragmentId = SysProcFragmentId.PF_quiesce_sites;
             pfs1[0].outputDepId = (int) SysProcFragmentId.PF_quiesce_sites;
-            pfs1[0].inputDepIds = new int[]{};
             pfs1[0].multipartition = true;
             pfs1[0].parameters = ParameterSet.emptyParameterSet();
 
             pfs1[1] = new SynthesizedPlanFragment();
             pfs1[1].fragmentId = SysProcFragmentId.PF_quiesce_processed_sites;
             pfs1[1].outputDepId = (int) SysProcFragmentId.PF_quiesce_processed_sites;
-            pfs1[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_quiesce_sites };
             pfs1[1].multipartition = false;
             pfs1[1].parameters = ParameterSet.emptyParameterSet();
 

--- a/src/frontend/org/voltdb/sysprocs/Shutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/Shutdown.java
@@ -128,14 +128,12 @@ public class Shutdown extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_shutdownSync;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_shutdownSync;
-        pfs[0].inputDepIds = new int[]{};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_shutdownSyncDone;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_shutdownSyncDone;
-        pfs[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_shutdownSync };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -145,7 +143,6 @@ public class Shutdown extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_shutdownCommand;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_procedureDone;
-        pfs[0].inputDepIds = new int[]{};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 

--- a/src/frontend/org/voltdb/sysprocs/Shutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/Shutdown.java
@@ -81,11 +81,11 @@ public class Shutdown extends VoltSystemProcedure {
                 CoreUtils.printAsciiArtLog(voltLogger, msg, Level.INFO);
             }
             VoltTable rslt = new VoltTable(new ColumnInfo[] { new ColumnInfo("HA", VoltType.STRING) });
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_shutdownSync, rslt);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_shutdownSync, rslt);
         }
         else if (fragmentId == SysProcFragmentId.PF_shutdownSyncDone) {
             VoltTable rslt = new VoltTable(new ColumnInfo[] { new ColumnInfo("HA", VoltType.STRING) });
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_shutdownSyncDone, rslt);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_shutdownSyncDone, rslt);
         }
         else if (fragmentId == SysProcFragmentId.PF_shutdownCommand) {
             Thread shutdownThread = new Thread() {
@@ -127,26 +127,26 @@ public class Shutdown extends VoltSystemProcedure {
         SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_shutdownSync;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_shutdownSync;
+        pfs[0].outputDepId = SysProcFragmentId.PF_shutdownSync;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_shutdownSyncDone;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_shutdownSyncDone;
+        pfs[1].outputDepId = SysProcFragmentId.PF_shutdownSyncDone;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
-        executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_shutdownSyncDone);
+        executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_shutdownSyncDone);
 
         pfs = new SynthesizedPlanFragment[1];
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_shutdownCommand;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_procedureDone;
+        pfs[0].outputDepId = SysProcFragmentId.PF_procedureDone;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
-        executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_procedureDone);
+        executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_procedureDone);
         return new VoltTable[0];
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/Shutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/Shutdown.java
@@ -124,27 +124,10 @@ public class Shutdown extends VoltSystemProcedure {
      * @return Never returned, no he never returned...
      */
     public VoltTable[] run(SystemProcedureExecutionContext ctx) {
-        SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = SysProcFragmentId.PF_shutdownSync;
-        pfs[0].outputDepId = SysProcFragmentId.PF_shutdownSync;
-        pfs[0].multipartition = true;
-        pfs[0].parameters = ParameterSet.emptyParameterSet();
+        createAndExecuteSysProcPlan(SysProcFragmentId.PF_shutdownSync, SysProcFragmentId.PF_shutdownSyncDone);
 
-        pfs[1] = new SynthesizedPlanFragment();
-        pfs[1].fragmentId = SysProcFragmentId.PF_shutdownSyncDone;
-        pfs[1].outputDepId = SysProcFragmentId.PF_shutdownSyncDone;
-        pfs[1].multipartition = false;
-        pfs[1].parameters = ParameterSet.emptyParameterSet();
-
-        executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_shutdownSyncDone);
-
-        pfs = new SynthesizedPlanFragment[1];
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = SysProcFragmentId.PF_shutdownCommand;
-        pfs[0].outputDepId = SysProcFragmentId.PF_procedureDone;
-        pfs[0].multipartition = true;
-        pfs[0].parameters = ParameterSet.emptyParameterSet();
+        SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[] {
+                new SynthesizedPlanFragment(SysProcFragmentId.PF_shutdownCommand, true) };
 
         executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_procedureDone);
         return new VoltTable[0];

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -318,7 +318,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 SNAP_LOG.error(e);
                 result.addRow("FAILURE");
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbersResults)
         {
@@ -326,8 +326,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 TRACE_LOG.trace("Aggregating digest scan state");
             }
             assert(dependencies.size() > 0);
-            VoltTable result = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbersResults, result);
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbersResults, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_restoreDigestScan)
         {
@@ -369,10 +369,10 @@ public class SnapshotRestore extends VoltSystemProcedure {
                     e.printStackTrace();//l4j doesn't print stack traces
                     SNAP_LOG.error(e);
                     result.addRow(null, "FAILURE", sw.toString());
-                    return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreDigestScan, result);
+                    return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreDigestScan, result);
                 }
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreDigestScan, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreDigestScan, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_restoreDigestScanResults)
         {
@@ -380,11 +380,11 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 TRACE_LOG.trace("Aggregating digest scan state");
             }
             assert(dependencies.size() > 0);
-            VoltTable result = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_restoreDigestScan));
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_restoreDigestScan));
             if (TRACE_LOG.isTraceEnabled()){
                 TRACE_LOG.trace(result.toFormattedString());
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreDigestScanResults, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreDigestScanResults, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_restoreHashinatorScan)
         {
@@ -416,7 +416,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                     result.addRow(null, "FAILURE", errMsg);
                 }
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreHashinatorScan, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreHashinatorScan, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_restoreHashinatorScanResults)
         {
@@ -424,8 +424,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 TRACE_LOG.trace("Aggregating hashinator state");
             }
             assert(dependencies.size() > 0);
-            VoltTable result = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_restoreHashinatorScan));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreHashinatorScanResults, result);
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_restoreHashinatorScan));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreHashinatorScanResults, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_restoreDistributeHashinator)
         {
@@ -453,7 +453,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 SNAP_LOG.error("Error updating hashinator in snapshot restore", e);
                 result.addRow("FAILURE", CoreUtils.throwableToString(e));
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreDistributeHashinator, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreDistributeHashinator, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_restoreDistributeHashinatorResults)
         {
@@ -461,8 +461,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 TRACE_LOG.trace("Aggregating hashinator distribution state");
             }
             assert(dependencies.size() > 0);
-            VoltTable result = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_restoreDistributeHashinator));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreDistributeHashinatorResults, result);
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_restoreDistributeHashinator));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreDistributeHashinatorResults, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_restoreScan)
         {
@@ -510,7 +510,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                     if (errorMsg != null) {
                         result.addRow(m_hostId, hostname, ClusterSaveFileState.ERROR_CODE, errorMsg,
                                 null, null, null, null, null, null, null);
-                        return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreScan, result);
+                        return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreScan, result);
                     }
 
                     m_duplicateRowHandler = new DuplicateRowHandler(dupPath, getTransactionTime());
@@ -522,7 +522,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 }
                 File[] savefiles = SnapshotUtil.retrieveRelevantFiles(m_filePath, m_fileNonce);
                 if (savefiles == null) {
-                    return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreScan, result);
+                    return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreScan, result);
                 }
                 for (File file : savefiles)
                 {
@@ -580,7 +580,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 }
             }
 
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreScan, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreScan, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_restoreScanResults)
         {
@@ -588,11 +588,11 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 TRACE_LOG.trace("Aggregating saved table state");
             }
             assert(dependencies.size() > 0);
-            VoltTable result = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_restoreScan));
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_restoreScan));
             if (TRACE_LOG.isTraceEnabled()) {
                 TRACE_LOG.trace(result.toFormattedString());
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreScanResults, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreScanResults, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_restoreAsyncRunLoop)
         {
@@ -687,12 +687,12 @@ public class SnapshotRestore extends VoltSystemProcedure {
                     //Null result table is intentional
                     //The results of the process are propagated through a future in performTableRestoreWork
                     VoltTable emptyResult = constructResultsTable();
-                    return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreAsyncRunLoop, emptyResult);
+                    return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreAsyncRunLoop, emptyResult);
                 }
             }
         } else if (fragmentId == SysProcFragmentId.PF_restoreAsyncRunLoopResults) {
             VoltTable emptyResult = constructResultsTable();
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_restoreAsyncRunLoopResults, emptyResult);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_restoreAsyncRunLoopResults, emptyResult);
         }
 
         // called by: performDistributeReplicatedTable() and performDistributePartitionedTable
@@ -1462,19 +1462,19 @@ public class SnapshotRestore extends VoltSystemProcedure {
         // success of writing tables to disk
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers;
+        pfs[0].outputDepId = SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(exportSequenceNumberBytes, txnId, perPartitionTxnIds, clusterCreateTime, drVersion, isRecover? 1 : 0);
 
         // This fragment aggregates the save-to-disk sanity check results
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbersResults;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbersResults;
+        pfs[1].outputDepId = SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbersResults;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
         VoltTable[] results;
-        results = executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbersResults);
+        results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbersResults);
         return results;
     }
 
@@ -1643,18 +1643,18 @@ public class SnapshotRestore extends VoltSystemProcedure {
         //enter an async run loop to do restore work out of that mailbox
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreAsyncRunLoop;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreAsyncRunLoop;
+        pfs[0].outputDepId = SysProcFragmentId.PF_restoreAsyncRunLoop;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(coordinatorHSId);
 
         // This fragment aggregates the save-to-disk sanity check results
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreAsyncRunLoopResults;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreAsyncRunLoopResults;
+        pfs[1].outputDepId = SysProcFragmentId.PF_restoreAsyncRunLoopResults;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
-        return executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_restoreAsyncRunLoopResults);
+        return executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_restoreAsyncRunLoopResults);
     }
 
     private final VoltTable[] performRestoreScanWork(String filePath, String pathType,
@@ -1667,19 +1667,19 @@ public class SnapshotRestore extends VoltSystemProcedure {
         // success of writing tables to disk
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreScan;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreScan;
+        pfs[0].outputDepId = SysProcFragmentId.PF_restoreScan;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(filePath, pathType, fileNonce, dupsPath);
 
         // This fragment aggregates the save-to-disk sanity check results
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreScanResults;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreScanResults;
+        pfs[1].outputDepId = SysProcFragmentId.PF_restoreScanResults;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
         VoltTable[] results;
-        results = executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_restoreScanResults);
+        results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_restoreScanResults);
         return results;
     }
 
@@ -1736,19 +1736,19 @@ public class SnapshotRestore extends VoltSystemProcedure {
         // success of writing tables to disk
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreDigestScan;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreDigestScan;
+        pfs[0].outputDepId = SysProcFragmentId.PF_restoreDigestScan;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
         // This fragment aggregates the save-to-disk sanity check results
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreDigestScanResults;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreDigestScanResults;
+        pfs[1].outputDepId = SysProcFragmentId.PF_restoreDigestScanResults;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
         VoltTable[] results;
-        results = executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_restoreDigestScanResults);
+        results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_restoreDigestScanResults);
 
         HashMap<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers =
                 new HashMap<String, Map<Integer, Pair<Long, Long>>>();
@@ -1924,14 +1924,14 @@ public class SnapshotRestore extends VoltSystemProcedure {
         // success of writing tables to disk
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreHashinatorScan;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreHashinatorScan;
+        pfs[0].outputDepId = SysProcFragmentId.PF_restoreHashinatorScan;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
         // This fragment aggregates the save-to-disk sanity check results
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreHashinatorScanResults;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreHashinatorScanResults;
+        pfs[1].outputDepId = SysProcFragmentId.PF_restoreHashinatorScanResults;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -1942,7 +1942,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
          *      - All versions are identical.
          *      - The instance IDs match the digest.
          */
-        VoltTable[] results = executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_restoreHashinatorScanResults);
+        VoltTable[] results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_restoreHashinatorScanResults);
         byte[] result = null;
         int ioErrors = 0;
         int iidErrors = 0;
@@ -2003,7 +2003,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
         // success of writing tables to disk
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreDistributeHashinator;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreDistributeHashinator;
+        pfs[0].outputDepId = SysProcFragmentId.PF_restoreDistributeHashinator;
         pfs[0].multipartition = true;
 
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(new Object[]{hashConfig});
@@ -2011,11 +2011,11 @@ public class SnapshotRestore extends VoltSystemProcedure {
         // This fragment aggregates the save-to-disk sanity check results
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreDistributeHashinatorResults;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreDistributeHashinatorResults;
+        pfs[1].outputDepId = SysProcFragmentId.PF_restoreDistributeHashinatorResults;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
-        return executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_restoreDistributeHashinatorResults);
+        return executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_restoreDistributeHashinatorResults);
     }
 
     private Set<Table> getTablesToRestore(Set<String> savedTableNames,
@@ -2084,7 +2084,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         0,            // uniqueId
                         false,        // isReadOnly
                         fragIdToHash(SysProcFragmentId.PF_setViewEnabled), //planHash
-                        (int) SysProcFragmentId.PF_setViewEnabled,
+                        SysProcFragmentId.PF_setViewEnabled,
                         ParameterSet.fromArrayNoCopy(enabledAsInt, commaSeparatedViewNames),
                         false,        // isFinal
                         m_runner.getTxnState().isForReplay(),

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -1463,7 +1463,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers;
-        pfs[0].inputDepIds = new int[] {};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(exportSequenceNumberBytes, txnId, perPartitionTxnIds, clusterCreateTime, drVersion, isRecover? 1 : 0);
 
@@ -1471,7 +1470,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbersResults;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbersResults;
-        pfs[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -1646,7 +1644,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreAsyncRunLoop;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreAsyncRunLoop;
-        pfs[0].inputDepIds = new int[] {};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(coordinatorHSId);
 
@@ -1654,7 +1651,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreAsyncRunLoopResults;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreAsyncRunLoopResults;
-        pfs[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_restoreAsyncRunLoop };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -1672,7 +1668,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreScan;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreScan;
-        pfs[0].inputDepIds = new int[] {};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(filePath, pathType, fileNonce, dupsPath);
 
@@ -1680,7 +1675,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreScanResults;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreScanResults;
-        pfs[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_restoreScan };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -1743,7 +1737,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreDigestScan;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreDigestScan;
-        pfs[0].inputDepIds = new int[] {};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
@@ -1751,7 +1744,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreDigestScanResults;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreDigestScanResults;
-        pfs[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_restoreDigestScan };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -1933,7 +1925,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreHashinatorScan;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreHashinatorScan;
-        pfs[0].inputDepIds = new int[] {};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
@@ -1941,7 +1932,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreHashinatorScanResults;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreHashinatorScanResults;
-        pfs[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_restoreHashinatorScan };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -2014,7 +2004,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_restoreDistributeHashinator;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_restoreDistributeHashinator;
-        pfs[0].inputDepIds = new int[] {};
         pfs[0].multipartition = true;
 
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(new Object[]{hashConfig});
@@ -2023,7 +2012,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_restoreDistributeHashinatorResults;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_restoreDistributeHashinatorResults;
-        pfs[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_restoreDistributeHashinator };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -2390,7 +2378,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
                                 loadFragment.siteId = m_actualToGenerated.get(site_id);
                                 loadFragment.multipartition = false;
                                 loadFragment.outputDepId = dependencyIds[pfs_index];
-                                loadFragment.inputDepIds = new int[] {};
                                 loadFragment.parameters = ParameterSet.fromArrayNoCopy(
                                         tableName,
                                         dependencyIds[pfs_index],
@@ -2408,7 +2395,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         aggregatorFragment.fragmentId = SysProcFragmentId.PF_restoreReceiveResultTables;
                         aggregatorFragment.multipartition = false;
                         aggregatorFragment.outputDepId = result_dependency_id;
-                        aggregatorFragment.inputDepIds = dependencyIds;
                         aggregatorFragment.parameters = ParameterSet.fromArrayNoCopy(
                                 result_dependency_id,
                                 "Received confirmation of successful partitioned-to-replicated table load");
@@ -2423,7 +2409,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         pfs[0].fragmentId = SysProcFragmentId.PF_restoreLoadTable;
                         pfs[0].siteId = m_actualToGenerated.get(siteId);
                         pfs[0].outputDepId = result_dependency_id;
-                        pfs[0].inputDepIds = new int[] {};
                         pfs[0].multipartition = false;
                         pfs[0].parameters = ParameterSet.fromArrayNoCopy(
                                 tableName, result_dependency_id, compressedTable,
@@ -2434,7 +2419,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         pfs[1].fragmentId =
                                 SysProcFragmentId.PF_restoreReceiveResultTables;
                         pfs[1].outputDepId = final_dependency_id;
-                        pfs[1].inputDepIds = new int[] { result_dependency_id };
                         pfs[1].multipartition = false;
                         pfs[1].parameters = ParameterSet.fromArrayNoCopy(
                                 final_dependency_id,
@@ -2596,7 +2580,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         loadFragment.siteId = m_actualToGenerated.get(site_id);
                         loadFragment.multipartition = false;
                         loadFragment.outputDepId = dependencyIds[pfs_index];
-                        loadFragment.inputDepIds = new int [] {};
                         loadFragment.parameters = ParameterSet.fromArrayNoCopy(
                                 tableName,
                                 dependencyIds[pfs_index],
@@ -2615,7 +2598,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
                             loadFragment.siteId = m_actualToGenerated.get(site_id);
                             loadFragment.multipartition = false;
                             loadFragment.outputDepId = dependencyIds[pfs_index];
-                            loadFragment.inputDepIds = new int [] {};
                             loadFragment.parameters = ParameterSet.fromArrayNoCopy(
                                     tableName,
                                     dependencyIds[pfs_index],
@@ -2633,7 +2615,6 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         SysProcFragmentId.PF_restoreReceiveResultTables;
                 aggregatorFragment.multipartition = false;
                 aggregatorFragment.outputDepId = result_dependency_id;
-                aggregatorFragment.inputDepIds = dependencyIds;
                 if(asReplicated) {
                     aggregatorFragment.parameters = ParameterSet.fromArrayNoCopy(
                             result_dependency_id,

--- a/src/frontend/org/voltdb/sysprocs/SnapshotSave.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotSave.java
@@ -320,30 +320,13 @@ public class SnapshotSave extends VoltSystemProcedure
             String data,
             HashinatorSnapshotData hashinatorData)
     {
-        SynthesizedPlanFragment[] pfs = new SynthesizedPlanFragment[2];
         // TRAIL [SnapSave:2] 2 [MPI] Build & send create snapshot targets requests to all SP sites.
         // This fragment causes each execution node to create the files
         // that will be written to during the snapshot
         byte[] hashinatorBytes = (hashinatorData != null ? hashinatorData.m_serData : null);
         long hashinatorVersion = (hashinatorData != null ? hashinatorData.m_version : 0);
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = SysProcFragmentId.PF_createSnapshotTargets;
-        pfs[0].outputDepId = SysProcFragmentId.PF_createSnapshotTargets;
-        pfs[0].multipartition = true;
-        pfs[0].parameters = ParameterSet.fromArrayNoCopy(
+        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_createSnapshotTargets,  SysProcFragmentId.PF_createSnapshotTargetsResults,
                 filePath, fileNonce, txnId, perPartitionTxnIds, block, format.name(), data,
-                hashinatorBytes, hashinatorVersion,
-                System.currentTimeMillis(), pathType);
-
-        // This fragment aggregates the results of creating those files
-        pfs[1] = new SynthesizedPlanFragment();
-        pfs[1].fragmentId = SysProcFragmentId.PF_createSnapshotTargetsResults;
-        pfs[1].outputDepId = SysProcFragmentId.PF_createSnapshotTargetsResults;
-        pfs[1].multipartition = false;
-        pfs[1].parameters = ParameterSet.emptyParameterSet();
-
-        VoltTable[] results;
-        results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_createSnapshotTargetsResults);
-        return results;
+                hashinatorBytes, hashinatorVersion, System.currentTimeMillis(), pathType);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/SnapshotSave.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotSave.java
@@ -87,7 +87,7 @@ public class SnapshotSave extends VoltSystemProcedure
                 // progress.
                 SNAP_LOG.error("@SnapshotSave is called while another snapshot is still in progress");
                 result.addRow(context.getHostId(), hostname, null, "FAILURE", "SNAPSHOT IN PROGRESS");
-                return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_createSnapshotTargets, result);
+                return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_createSnapshotTargets, result);
             }
 
             // Tell each site to quiesce - bring the Export and DR system to a steady state with
@@ -151,12 +151,12 @@ public class SnapshotSave extends VoltSystemProcedure
                     ((RealVoltDB)VoltDB.instance()).updateReplicaForJoin(context.getSiteId(), txnId);
                 }
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_createSnapshotTargets, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_createSnapshotTargets, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_createSnapshotTargetsResults)
         {
-            VoltTable result = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_createSnapshotTargets));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_createSnapshotTargetsResults, result);
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_createSnapshotTargets));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_createSnapshotTargetsResults, result);
         }
         assert (false);
         return null;
@@ -328,7 +328,7 @@ public class SnapshotSave extends VoltSystemProcedure
         long hashinatorVersion = (hashinatorData != null ? hashinatorData.m_version : 0);
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_createSnapshotTargets;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_createSnapshotTargets;
+        pfs[0].outputDepId = SysProcFragmentId.PF_createSnapshotTargets;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(
                 filePath, fileNonce, txnId, perPartitionTxnIds, block, format.name(), data,
@@ -338,12 +338,12 @@ public class SnapshotSave extends VoltSystemProcedure
         // This fragment aggregates the results of creating those files
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_createSnapshotTargetsResults;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_createSnapshotTargetsResults;
+        pfs[1].outputDepId = SysProcFragmentId.PF_createSnapshotTargetsResults;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
         VoltTable[] results;
-        results = executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_createSnapshotTargetsResults);
+        results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_createSnapshotTargetsResults);
         return results;
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/SnapshotSave.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotSave.java
@@ -329,7 +329,6 @@ public class SnapshotSave extends VoltSystemProcedure
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_createSnapshotTargets;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_createSnapshotTargets;
-        pfs[0].inputDepIds = new int[] {};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(
                 filePath, fileNonce, txnId, perPartitionTxnIds, block, format.name(), data,
@@ -340,7 +339,6 @@ public class SnapshotSave extends VoltSystemProcedure
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_createSnapshotTargetsResults;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_createSnapshotTargetsResults;
-        pfs[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_createSnapshotTargets };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 

--- a/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
@@ -91,14 +91,12 @@ public class SwapTablesCore extends AdHocBase {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_swapTables;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_swapTables;
-        pfs[0].inputDepIds = new int[]{};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(oneTable, otherTable);
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_swapTablesAggregate;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_swapTablesAggregate;
-        pfs[1].inputDepIds = new int[]{(int) SysProcFragmentId.PF_swapTables};
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 

--- a/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
@@ -86,20 +86,7 @@ public class SwapTablesCore extends AdHocBase {
 
     private VoltTable[] performSwapTablesCallback(String oneTable, String otherTable)
     {
-        SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
-
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = SysProcFragmentId.PF_swapTables;
-        pfs[0].outputDepId = SysProcFragmentId.PF_swapTables;
-        pfs[0].multipartition = true;
-        pfs[0].parameters = ParameterSet.fromArrayNoCopy(oneTable, otherTable);
-
-        pfs[1] = new SynthesizedPlanFragment();
-        pfs[1].fragmentId = SysProcFragmentId.PF_swapTablesAggregate;
-        pfs[1].outputDepId = SysProcFragmentId.PF_swapTablesAggregate;
-        pfs[1].multipartition = false;
-        pfs[1].parameters = ParameterSet.emptyParameterSet();
-
-        return executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_swapTablesAggregate);
+        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_swapTables, SysProcFragmentId.PF_swapTablesAggregate,
+                oneTable, otherTable);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
@@ -51,11 +51,11 @@ public class SwapTablesCore extends AdHocBase {
             if (context.isLowestSiteId()) {
                 VoltDB.instance().swapTables((String) params.getParam(0), (String) params.getParam(1));
             }
-            return new TableDependencyPair((int) SysProcFragmentId.PF_swapTables, dummy);
+            return new TableDependencyPair(SysProcFragmentId.PF_swapTables, dummy);
         }
         else if (fragmentId == SysProcFragmentId.PF_swapTablesAggregate) {
-            return new TableDependencyPair((int) SysProcFragmentId.PF_swapTablesAggregate,
-                    VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_swapTables)));
+            return new TableDependencyPair(SysProcFragmentId.PF_swapTablesAggregate,
+                    VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_swapTables)));
         }
 
         assert false;
@@ -90,16 +90,16 @@ public class SwapTablesCore extends AdHocBase {
 
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_swapTables;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_swapTables;
+        pfs[0].outputDepId = SysProcFragmentId.PF_swapTables;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(oneTable, otherTable);
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_swapTablesAggregate;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_swapTablesAggregate;
+        pfs[1].outputDepId = SysProcFragmentId.PF_swapTablesAggregate;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
-        return executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_swapTablesAggregate);
+        return executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_swapTablesAggregate);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
+++ b/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
@@ -22,51 +22,51 @@ import org.voltdb.VoltSystemProcedure;
 public class SysProcFragmentId
 {
     // @LastCommittedTransaction -- UNUSED
-    public static final long PF_lastCommittedScan = 1;
-    public static final long PF_lastCommittedResults = 2;
+    public static final int PF_lastCommittedScan = 1;
+    public static final int PF_lastCommittedResults = 2;
 
     // @UpdateLogging -- UNUSED
-    public static final long PF_updateLoggers = 3;
+    public static final int PF_updateLoggers = 3;
 
     // @Statistics -- UNUSED
-    public static final long PF_starvationData = 4;
-    public static final long PF_starvationDataAggregator = 5;
-    public static final long PF_tableData = 6;
-    public static final long PF_tableAggregator = 7;
-    public static final long PF_indexData = 8;
-    public static final long PF_indexAggregator = 9;
-    public static final long PF_nodeMemory = 10;
-    public static final long PF_nodeMemoryAggregator = 11;
-    public static final long PF_procedureData = 13;
-    public static final long PF_procedureAggregator = 14;
-    public static final long PF_initiatorData = 15;
-    public static final long PF_initiatorAggregator = 16;
-    public static final long PF_partitionCount = 17;
-    public static final long PF_ioData = 18;
-    public static final long PF_ioDataAggregator = 19;
-    public static final long PF_liveClientData = 20;
-    public static final long PF_liveClientDataAggregator = 21;
-    public static final long PF_plannerData = 22;
-    public static final long PF_plannerAggregator = 23;
+    public static final int PF_starvationData = 4;
+    public static final int PF_starvationDataAggregator = 5;
+    public static final int PF_tableData = 6;
+    public static final int PF_tableAggregator = 7;
+    public static final int PF_indexData = 8;
+    public static final int PF_indexAggregator = 9;
+    public static final int PF_nodeMemory = 10;
+    public static final int PF_nodeMemoryAggregator = 11;
+    public static final int PF_procedureData = 13;
+    public static final int PF_procedureAggregator = 14;
+    public static final int PF_initiatorData = 15;
+    public static final int PF_initiatorAggregator = 16;
+    public static final int PF_partitionCount = 17;
+    public static final int PF_ioData = 18;
+    public static final int PF_ioDataAggregator = 19;
+    public static final int PF_liveClientData = 20;
+    public static final int PF_liveClientDataAggregator = 21;
+    public static final int PF_plannerData = 22;
+    public static final int PF_plannerAggregator = 23;
 
     // @Shutdown
-    public static final long PF_shutdownSync = 26;
-    public static final long PF_shutdownSyncDone = 27;
-    public static final long PF_shutdownCommand = 28;
-    public static final long PF_procedureDone = 29;
+    public static final int PF_shutdownSync = 26;
+    public static final int PF_shutdownSyncDone = 27;
+    public static final int PF_shutdownCommand = 28;
+    public static final int PF_procedureDone = 29;
 
     // @AdHoc -- UNUSED
-    public static final long PF_runAdHocFragment = 31;
+    public static final int PF_runAdHocFragment = 31;
 
     // @SnapshotSave
     /*
      * Create and distribute tasks and targets to each EE
      */
-    public static final long PF_createSnapshotTargets = 42;
+    public static final int PF_createSnapshotTargets = 42;
     /*
      * Confirm the targets were successfully created
      */
-    public static final long PF_createSnapshotTargetsResults = 43;
+    public static final int PF_createSnapshotTargetsResults = 43;
 
     public static boolean isSnapshotSaveFragment(byte[] planHash) {
         long fragId = VoltSystemProcedure.hashToFragId(planHash);
@@ -90,28 +90,28 @@ public class SysProcFragmentId
     }
 
     // @LoadMultipartitionTable
-    public static final long PF_distribute = 50;
-    public static final long PF_aggregate = 51;
+    public static final int PF_distribute = 50;
+    public static final int PF_aggregate = 51;
 
     // @SnapshotRestore
-    public static final long PF_restoreScan = 60;
-    public static final long PF_restoreScanResults = 61;
+    public static final int PF_restoreScan = 60;
+    public static final int PF_restoreScanResults = 61;
     /*
      * Plan fragments for retrieving the digests
      * for the snapshot visible at every node. Can't be combined
      * with the other scan because only one result table can be returned
      * by a plan fragment.
      */
-    public static final long PF_restoreDigestScan = 62;
-    public static final long PF_restoreDigestScanResults = 63;
+    public static final int PF_restoreDigestScan = 62;
+    public static final int PF_restoreDigestScanResults = 63;
     /*
      * Plan fragments for distributing the full set of export sequence numbers
      * to every partition where the relevant ones can be selected
      * and forwarded to the EE. Also distributes the txnId of the snapshot
      * which is used to truncate export data on disk from after the snapshot
      */
-    public static final long PF_restoreDistributeExportAndPartitionSequenceNumbers = 64;
-    public static final long PF_restoreDistributeExportAndPartitionSequenceNumbersResults = 65;
+    public static final int PF_restoreDistributeExportAndPartitionSequenceNumbers = 64;
+    public static final int PF_restoreDistributeExportAndPartitionSequenceNumbersResults = 65;
     /*
      * Plan fragment for entering an asynchronous run loop that generates a mailbox
      * and sends the generated mailbox id to the MP coordinator which then propagates the info.
@@ -119,75 +119,75 @@ public class SysProcFragmentId
      * bypassing the master/slave replication system that doesn't understand plan fragments
      * directed at individual executions sites.
      */
-    public static final long PF_restoreAsyncRunLoop = 66;
-    public static final long PF_restoreAsyncRunLoopResults = 67;
-    public static final long PF_restoreLoadTable = 70;                                  // called by 4 distribute cases, to load received table
-    public static final long PF_restoreReceiveResultTables = 71;                        // union received result tables
-    public static final long PF_restoreLoadReplicatedTable = 72;                        // special case for replicated-to-replicated
-    public static final long PF_restoreDistributeReplicatedTableAsReplicated = 73;      // replicated to replicated
-    public static final long PF_restoreDistributePartitionedTableAsPartitioned = 74;    // partitioned to partitioned
-    public static final long PF_restoreDistributePartitionedTableAsReplicated = 75;     // partitioned to replicated
-    public static final long PF_restoreDistributeReplicatedTableAsPartitioned = 76;     // replicated to replicated
+    public static final int PF_restoreAsyncRunLoop = 66;
+    public static final int PF_restoreAsyncRunLoopResults = 67;
+    public static final int PF_restoreLoadTable = 70; // called by 4 distribute cases, to load received table
+    public static final int PF_restoreReceiveResultTables = 71; // union received result tables
+    public static final int PF_restoreLoadReplicatedTable = 72; // special case for replicated-to-replicated
+    public static final int PF_restoreDistributeReplicatedTableAsReplicated = 73; // replicated to replicated
+    public static final int PF_restoreDistributePartitionedTableAsPartitioned = 74; // partitioned to partitioned
+    public static final int PF_restoreDistributePartitionedTableAsReplicated = 75; // partitioned to replicated
+    public static final int PF_restoreDistributeReplicatedTableAsPartitioned = 76; // replicated to replicated
     /*
      * Plan fragments for retrieving the hashinator data
      * for the snapshot visible at every node. Can't be combined
      * with the other scan because only one result table can be returned
      * by a plan fragment.
      */
-    public static final long PF_restoreHashinatorScan = 77;
-    public static final long PF_restoreHashinatorScanResults = 78;
+    public static final int PF_restoreHashinatorScan = 77;
+    public static final int PF_restoreHashinatorScanResults = 78;
     /*
      * Plan fragments for retrieving the hashinator data
      * for the snapshot visible at every node. Can't be combined
      * with the other scan because only one result table can be returned
      * by a plan fragment.
      */
-    public static final long PF_restoreDistributeHashinator = 79;
-    public static final long PF_restoreDistributeHashinatorResults = 80;
+    public static final int PF_restoreDistributeHashinator = 79;
+    public static final int PF_restoreDistributeHashinatorResults = 80;
 
     // @StartSampler -- UNUSED
-    public static final long PF_startSampler = 90;
+    public static final int PF_startSampler = 90;
 
     // @Quiesce
-    public static final long PF_quiesce_sites = 100;
-    public static final long PF_quiesce_processed_sites = 101;
+    public static final int PF_quiesce_sites = 100;
+    public static final int PF_quiesce_processed_sites = 101;
 
     // @SnapshotScan -- UNUSED
-    public static final long PF_snapshotDigestScan = 124;
-    public static final long PF_snapshotDigestScanResults = 125;
-    public static final long PF_snapshotScan = 120;
-    public static final long PF_snapshotScanResults = 121;
-    public static final long PF_hostDiskFreeScan = 122;
-    public static final long PF_hostDiskFreeScanResults = 123;
+    public static final int PF_snapshotDigestScan = 124;
+    public static final int PF_snapshotDigestScanResults = 125;
+    public static final int PF_snapshotScan = 120;
+    public static final int PF_snapshotScanResults = 121;
+    public static final int PF_hostDiskFreeScan = 122;
+    public static final int PF_hostDiskFreeScanResults = 123;
 
     // @SnapshotScan
-    public static final long PF_snapshotDelete = 130;
-    public static final long PF_snapshotDeleteResults = 131;
+    public static final int PF_snapshotDelete = 130;
+    public static final int PF_snapshotDeleteResults = 131;
 
     // @InstanceId -- UNUSED
-    public static final long PF_retrieveInstanceId = 160;
-    public static final long PF_retrieveInstanceIdAggregator = 161;
-    public static final long PF_setInstanceId = 162;
-    public static final long PF_setInstanceIdAggregator = 163;
+    public static final int PF_retrieveInstanceId = 160;
+    public static final int PF_retrieveInstanceIdAggregator = 161;
+    public static final int PF_setInstanceId = 162;
+    public static final int PF_setInstanceIdAggregator = 163;
 
     // @Rejoin -- UNUSED
-    public static final long PF_rejoinBlock = 170;
-    public static final long PF_rejoinPrepare = 171;
-    public static final long PF_rejoinCommit = 172;
-    public static final long PF_rejoinRollback = 173;
-    public static final long PF_rejoinAggregate = 174;
+    public static final int PF_rejoinBlock = 170;
+    public static final int PF_rejoinPrepare = 171;
+    public static final int PF_rejoinCommit = 172;
+    public static final int PF_rejoinRollback = 173;
+    public static final int PF_rejoinAggregate = 174;
 
     // @SystemInformation
-    public static final long PF_systemInformationDeployment = 190;
-    public static final long PF_systemInformationAggregate = 191;
-    public static final long PF_systemInformationOverview = 192;
-    public static final long PF_systemInformationOverviewAggregate = 193;
+    public static final int PF_systemInformationDeployment = 190;
+    public static final int PF_systemInformationAggregate = 191;
+    public static final int PF_systemInformationOverview = 192;
+    public static final int PF_systemInformationOverviewAggregate = 193;
 
     // @Update application catalog
-    public static final long PF_updateCatalogPrecheckAndSync = 210;
-    public static final long PF_updateCatalogPrecheckAndSyncAggregate = 211;
-    public static final long PF_updateCatalog = 212;
-    public static final long PF_updateCatalogAggregate = 213;
+    public static final int PF_updateCatalogPrecheckAndSync = 210;
+    public static final int PF_updateCatalogPrecheckAndSyncAggregate = 211;
+    public static final int PF_updateCatalog = 212;
+    public static final int PF_updateCatalogAggregate = 213;
 
     public static boolean isCatalogUpdateFragment(byte[] planHash) {
         long fragId = VoltSystemProcedure.hashToFragId(planHash);
@@ -197,74 +197,74 @@ public class SysProcFragmentId
     }
 
     // @BalancePartitions
-    public static final long PF_prepBalancePartitions = 228;
-    public static final long PF_prepBalancePartitionsAggregate = 229;
-    public static final long PF_balancePartitions = 230;
-    public static final long PF_balancePartitionsAggregate = 231;
-    public static final long PF_balancePartitionsData = 232;
-    public static final long PF_balancePartitionsClearIndex = 233;
-    public static final long PF_balancePartitionsClearIndexAggregate = 234;
+    public static final int PF_prepBalancePartitions = 228;
+    public static final int PF_prepBalancePartitionsAggregate = 229;
+    public static final int PF_balancePartitions = 230;
+    public static final int PF_balancePartitionsAggregate = 231;
+    public static final int PF_balancePartitionsData = 232;
+    public static final int PF_balancePartitionsClearIndex = 233;
+    public static final int PF_balancePartitionsClearIndexAggregate = 234;
 
     // @ValidatePartitioning
-    public static final long PF_validatePartitioning = 240;
-    public static final long PF_validatePartitioningResults = 241;
+    public static final int PF_validatePartitioning = 240;
+    public static final int PF_validatePartitioningResults = 241;
 
     // @MatchesHashinator
-    public static final long PF_matchesHashinator = 250;
-    public static final long PF_matchesHashinatorResults = 251;
+    public static final int PF_matchesHashinator = 250;
+    public static final int PF_matchesHashinatorResults = 251;
 
     // @ApplyBinaryLog
-    public static final long PF_applyBinaryLog = 260;
-    public static final long PF_applyBinaryLogAggregate = 261;
+    public static final int PF_applyBinaryLog = 260;
+    public static final int PF_applyBinaryLogAggregate = 261;
 
     // @LoadVoltTable
-    public static final long PF_loadVoltTable = 270;
-    public static final long PF_loadVoltTableAggregate = 271;
+    public static final int PF_loadVoltTable = 270;
+    public static final int PF_loadVoltTableAggregate = 271;
 
     // @ResetDR
-    public static final long PF_resetDR = 280;
-    public static final long PF_resetDRAggregate = 281;
+    public static final int PF_resetDR = 280;
+    public static final int PF_resetDRAggregate = 281;
 
     // @ResetDRSingle
-    public static final long PF_preResetDRSingle = 282;
-    public static final long PF_preResetDRSingleAggregate = 283;
-    public static final long PF_postResetDRSingle = 284;
-    public static final long PF_postResetDRSingleAggregate = 285;
+    public static final int PF_preResetDRSingle = 282;
+    public static final int PF_preResetDRSingleAggregate = 283;
+    public static final int PF_postResetDRSingle = 284;
+    public static final int PF_postResetDRSingleAggregate = 285;
 
     // @DropDRSelf
-    public static final long PF_DropDRSelf = 286;
-    public static final long PF_DropDRSelfAggregate = 287;
+    public static final int PF_DropDRSelf = 286;
+    public static final int PF_DropDRSelfAggregate = 287;
 
     // @ExecuteTask
-    public static final long PF_executeTask = 290;
-    public static final long PF_executeTaskAggregate = 291;
+    public static final int PF_executeTask = 290;
+    public static final int PF_executeTaskAggregate = 291;
 
     // @UpdatedSettings
-    public static final long PF_updateSettingsBarrier = 300;
-    public static final long PF_updateSettingsBarrierAggregate = 301;
-    public static final long PF_updateSettings = 302;
-    public static final long PF_updateSettingsAggregate = 303;
+    public static final int PF_updateSettingsBarrier = 300;
+    public static final int PF_updateSettingsBarrierAggregate = 301;
+    public static final int PF_updateSettings = 302;
+    public static final int PF_updateSettingsAggregate = 303;
 
     // @PrepareShutdown
-    public static final long PF_prepareShutdown = 310;
-    public static final long PF_prepareShutdownAggregate = 311;
+    public static final int PF_prepareShutdown = 310;
+    public static final int PF_prepareShutdownAggregate = 311;
 
     // @SwapTables
-    public static final long PF_swapTables = 320;
-    public static final long PF_swapTablesAggregate = 321;
+    public static final int PF_swapTables = 320;
+    public static final int PF_swapTablesAggregate = 321;
 
     // @PingPartitions
-    public static final long PF_pingPartitions = 330;
-    public static final long PF_pingPartitionsAggregate = 331;
-    public static final long PF_enableScoreboard = 332;
-    public static final long PF_enableScoreboardAggregate = 333;
+    public static final int PF_pingPartitions = 330;
+    public static final int PF_pingPartitionsAggregate = 331;
+    public static final int PF_enableScoreboard = 332;
+    public static final int PF_enableScoreboardAggregate = 333;
 
     // Pause/resume materialized views
-    public static final long PF_setViewEnabled = 340;
+    public static final int PF_setViewEnabled = 340;
 
     // @ExportControl
-    public static final long PF_exportControl = 350;
-    public static final long PF_exportControlAggregate = 351;
+    public static final int PF_exportControl = 350;
+    public static final int PF_exportControlAggregate = 351;
 
     public static boolean isEnableScoreboardFragment(byte[] planHash) {
         long fragId = VoltSystemProcedure.hashToFragId(planHash);

--- a/src/frontend/org/voltdb/sysprocs/SystemInformation.java
+++ b/src/frontend/org/voltdb/sysprocs/SystemInformation.java
@@ -111,12 +111,12 @@ public class SystemInformation extends VoltSystemProcedure
                                        new ColumnInfo("KEY", VoltType.STRING),
                                        new ColumnInfo("VALUE", VoltType.STRING));
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_systemInformationOverview, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_systemInformationOverview, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_systemInformationOverviewAggregate)
         {
-            VoltTable result = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_systemInformationOverview));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_systemInformationOverviewAggregate, result);
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_systemInformationOverview));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_systemInformationOverviewAggregate, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_systemInformationDeployment)
         {
@@ -132,14 +132,14 @@ public class SystemInformation extends VoltSystemProcedure
             {
                 result = new VoltTable(clusterInfoSchema);
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_systemInformationDeployment, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_systemInformationDeployment, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_systemInformationAggregate)
         {
             VoltTable result = null;
             // Check for KEY/VALUE consistency
             List<VoltTable> answers =
-                dependencies.get((int) SysProcFragmentId.PF_systemInformationDeployment);
+                dependencies.get(SysProcFragmentId.PF_systemInformationDeployment);
             for (VoltTable answer : answers)
             {
                 // if we got an empty table from a non-lowest execution site ID,
@@ -171,7 +171,7 @@ public class SystemInformation extends VoltSystemProcedure
                     }
                 }
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_systemInformationAggregate, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_systemInformationAggregate, result);
         }
         assert(false);
         return null;
@@ -273,18 +273,18 @@ public class SystemInformation extends VoltSystemProcedure
         SynthesizedPlanFragment spf[] = new SynthesizedPlanFragment[2];
         spf[0] = new SynthesizedPlanFragment();
         spf[0].fragmentId = SysProcFragmentId.PF_systemInformationOverview;
-        spf[0].outputDepId = (int) SysProcFragmentId.PF_systemInformationOverview;
+        spf[0].outputDepId = SysProcFragmentId.PF_systemInformationOverview;
         spf[0].multipartition = true;
         spf[0].parameters = ParameterSet.emptyParameterSet();
 
         spf[1] = new SynthesizedPlanFragment();
         spf[1] = new SynthesizedPlanFragment();
         spf[1].fragmentId = SysProcFragmentId.PF_systemInformationOverviewAggregate;
-        spf[1].outputDepId = (int) SysProcFragmentId.PF_systemInformationOverviewAggregate;
+        spf[1].outputDepId = SysProcFragmentId.PF_systemInformationOverviewAggregate;
         spf[1].multipartition = false;
         spf[1].parameters = ParameterSet.emptyParameterSet();
 
-        return executeSysProcPlanFragments(spf, (int) SysProcFragmentId.PF_systemInformationOverviewAggregate);
+        return executeSysProcPlanFragments(spf, SysProcFragmentId.PF_systemInformationOverviewAggregate);
     }
 
     private VoltTable[] getDeploymentInfo() {
@@ -293,20 +293,20 @@ public class SystemInformation extends VoltSystemProcedure
         // create a work fragment to gather deployment data from each of the sites.
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_systemInformationDeployment;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_systemInformationDeployment;
+        pfs[1].outputDepId = SysProcFragmentId.PF_systemInformationDeployment;
         pfs[1].multipartition = true;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
         // create a work fragment to aggregate the results.
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_systemInformationAggregate;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_systemInformationAggregate;
+        pfs[0].outputDepId = SysProcFragmentId.PF_systemInformationAggregate;
         pfs[0].multipartition = false;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
         // distribute and execute these fragments providing pfs and id of the
         // aggregator's output dependency table.
-        results = executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_systemInformationAggregate);
+        results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_systemInformationAggregate);
         return results;
     }
 

--- a/src/frontend/org/voltdb/sysprocs/SystemInformation.java
+++ b/src/frontend/org/voltdb/sysprocs/SystemInformation.java
@@ -270,44 +270,14 @@ public class SystemInformation extends VoltSystemProcedure
      */
     private VoltTable[] getOverviewInfo()
     {
-        SynthesizedPlanFragment spf[] = new SynthesizedPlanFragment[2];
-        spf[0] = new SynthesizedPlanFragment();
-        spf[0].fragmentId = SysProcFragmentId.PF_systemInformationOverview;
-        spf[0].outputDepId = SysProcFragmentId.PF_systemInformationOverview;
-        spf[0].multipartition = true;
-        spf[0].parameters = ParameterSet.emptyParameterSet();
-
-        spf[1] = new SynthesizedPlanFragment();
-        spf[1] = new SynthesizedPlanFragment();
-        spf[1].fragmentId = SysProcFragmentId.PF_systemInformationOverviewAggregate;
-        spf[1].outputDepId = SysProcFragmentId.PF_systemInformationOverviewAggregate;
-        spf[1].multipartition = false;
-        spf[1].parameters = ParameterSet.emptyParameterSet();
-
-        return executeSysProcPlanFragments(spf, SysProcFragmentId.PF_systemInformationOverviewAggregate);
+        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_systemInformationOverview,
+                SysProcFragmentId.PF_systemInformationOverviewAggregate);
     }
 
     private VoltTable[] getDeploymentInfo() {
-        VoltTable[] results;
-        SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
         // create a work fragment to gather deployment data from each of the sites.
-        pfs[1] = new SynthesizedPlanFragment();
-        pfs[1].fragmentId = SysProcFragmentId.PF_systemInformationDeployment;
-        pfs[1].outputDepId = SysProcFragmentId.PF_systemInformationDeployment;
-        pfs[1].multipartition = true;
-        pfs[1].parameters = ParameterSet.emptyParameterSet();
-
-        // create a work fragment to aggregate the results.
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = SysProcFragmentId.PF_systemInformationAggregate;
-        pfs[0].outputDepId = SysProcFragmentId.PF_systemInformationAggregate;
-        pfs[0].multipartition = false;
-        pfs[0].parameters = ParameterSet.emptyParameterSet();
-
-        // distribute and execute these fragments providing pfs and id of the
-        // aggregator's output dependency table.
-        results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_systemInformationAggregate);
-        return results;
+        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_systemInformationDeployment,
+                SysProcFragmentId.PF_systemInformationAggregate);
     }
 
     public static VoltTable constructOverviewTable() {

--- a/src/frontend/org/voltdb/sysprocs/SystemInformation.java
+++ b/src/frontend/org/voltdb/sysprocs/SystemInformation.java
@@ -274,7 +274,6 @@ public class SystemInformation extends VoltSystemProcedure
         spf[0] = new SynthesizedPlanFragment();
         spf[0].fragmentId = SysProcFragmentId.PF_systemInformationOverview;
         spf[0].outputDepId = (int) SysProcFragmentId.PF_systemInformationOverview;
-        spf[0].inputDepIds = new int[] {};
         spf[0].multipartition = true;
         spf[0].parameters = ParameterSet.emptyParameterSet();
 
@@ -282,7 +281,6 @@ public class SystemInformation extends VoltSystemProcedure
         spf[1] = new SynthesizedPlanFragment();
         spf[1].fragmentId = SysProcFragmentId.PF_systemInformationOverviewAggregate;
         spf[1].outputDepId = (int) SysProcFragmentId.PF_systemInformationOverviewAggregate;
-        spf[1].inputDepIds = new int[] { (int) SysProcFragmentId.PF_systemInformationOverview };
         spf[1].multipartition = false;
         spf[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -296,7 +294,6 @@ public class SystemInformation extends VoltSystemProcedure
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_systemInformationDeployment;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_systemInformationDeployment;
-        pfs[1].inputDepIds = new int[]{};
         pfs[1].multipartition = true;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -304,7 +301,6 @@ public class SystemInformation extends VoltSystemProcedure
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_systemInformationAggregate;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_systemInformationAggregate;
-        pfs[0].inputDepIds = new int[]{(int) SysProcFragmentId.PF_systemInformationDeployment};
         pfs[0].multipartition = false;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
@@ -405,14 +401,16 @@ public class SystemInformation extends VoltSystemProcedure
         vt.addRow(hostId, "VERSION", VoltDB.instance().getVersionString());
         // catalog path
         String path = VoltDB.instance().getConfig().m_pathToCatalog;
-        if (path != null && !path.startsWith("http"))
+        if (path != null && !path.startsWith("http")) {
             path = (new File(path)).getAbsolutePath();
+        }
         vt.addRow(hostId, "CATALOG", path);
 
         // deployment path
         path = VoltDB.instance().getConfig().m_pathToDeployment;
-        if (path != null && !path.startsWith("http"))
+        if (path != null && !path.startsWith("http")) {
             path = (new File(path)).getAbsolutePath();
+        }
         vt.addRow(hostId, "DEPLOYMENT", path);
 
         String cluster_state = VoltDB.instance().getMode().toString();
@@ -441,8 +439,9 @@ public class SystemInformation extends VoltSystemProcedure
         SocketHubAppender hubAppender =
             (SocketHubAppender) Logger.getRootLogger().getAppender("hub");
         int port = 0;
-        if (hubAppender != null)
+        if (hubAppender != null) {
             port = hubAppender.getPort();
+        }
         vt.addRow(hostId, "LOG4JPORT", Integer.toString(port));
         //Add license information
         if (MiscUtils.isPro()) {

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -339,8 +339,7 @@ public class UpdateCore extends VoltSystemProcedure {
 
     private final void performCatalogVerifyWork(
             String[] tablesThatMustBeEmpty,
-            String[] reasonsForEmptyTables,
-            byte requiresSnapshotIsolation)
+            String[] reasonsForEmptyTables)
     {
         SynthesizedPlanFragment[] pfs = new SynthesizedPlanFragment[2];
 
@@ -357,7 +356,6 @@ public class UpdateCore extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate;
-        pfs[1].inputDepIds  = new int[] { (int) SysProcFragmentId.PF_updateCatalogPrecheckAndSync };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -394,7 +392,6 @@ public class UpdateCore extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_updateCatalogAggregate;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_updateCatalogAggregate;
-        pfs[1].inputDepIds  = new int[] { (int) SysProcFragmentId.PF_updateCatalog };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -475,8 +472,7 @@ public class UpdateCore extends VoltSystemProcedure {
         try {
             performCatalogVerifyWork(
                     tablesThatMustBeEmpty,
-                    reasonsForEmptyTables,
-                    requiresSnapshotIsolation);
+                    reasonsForEmptyTables);
         }
         catch (VoltAbortException vae) {
             log.info("Catalog verification failed: " + vae.getMessage());

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -249,7 +249,7 @@ public class UpdateCore extends VoltSystemProcedure {
             // the actual work on the second round-trip below
 
             // Don't actually care about the returned table, just need to send something back to the MPI
-            DependencyPair success = new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_updateCatalogPrecheckAndSync,
+            DependencyPair success = new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateCatalogPrecheckAndSync,
                     new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
 
             if (log.isDebugEnabled()) {
@@ -263,7 +263,7 @@ public class UpdateCore extends VoltSystemProcedure {
             // back to the MPI scoreboard
             log.info("Site " + CoreUtils.hsIdToString(m_site.getCorrespondingSiteId()) +
                     " acknowledged data and catalog prechecks.");
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate,
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate,
                     new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
         }
         else if (fragmentId == SysProcFragmentId.PF_updateCatalog) {
@@ -322,11 +322,11 @@ public class UpdateCore extends VoltSystemProcedure {
 
             VoltTable result = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
             result.addRow(VoltSystemProcedure.STATUS_OK);
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_updateCatalog, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateCatalog, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_updateCatalogAggregate) {
-            VoltTable result = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_updateCatalog));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_updateCatalogAggregate, result);
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_updateCatalog));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateCatalogAggregate, result);
         }
         else {
             VoltDB.crashLocalVoltDB(
@@ -349,17 +349,17 @@ public class UpdateCore extends VoltSystemProcedure {
 
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_updateCatalogPrecheckAndSync;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_updateCatalogPrecheckAndSync;
+        pfs[0].outputDepId = SysProcFragmentId.PF_updateCatalogPrecheckAndSync;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(tablesThatMustBeEmpty, reasonsForEmptyTables);
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate;
+        pfs[1].outputDepId = SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
-        executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate);
+        executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate);
     }
 
     private final VoltTable[] performCatalogUpdateWork(
@@ -377,7 +377,7 @@ public class UpdateCore extends VoltSystemProcedure {
         // Now do the real work
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_updateCatalog;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_updateCatalog;
+        pfs[0].outputDepId = SysProcFragmentId.PF_updateCatalog;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(
                 catalogDiffCommands,
@@ -391,13 +391,13 @@ public class UpdateCore extends VoltSystemProcedure {
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_updateCatalogAggregate;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_updateCatalogAggregate;
+        pfs[1].outputDepId = SysProcFragmentId.PF_updateCatalogAggregate;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
 
         VoltTable[] results;
-        results = executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_updateCatalogAggregate);
+        results = executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_updateCatalogAggregate);
         return results;
     }
 

--- a/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
@@ -140,36 +140,11 @@ public class UpdateSettings extends VoltSystemProcedure {
 
         SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
 
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = SysProcFragmentId.PF_updateSettingsBarrier;
-        pfs[0].outputDepId = SysProcFragmentId.PF_updateSettingsBarrier;
-        pfs[0].multipartition = true;
-        pfs[0].parameters = ParameterSet.emptyParameterSet();
+        pfs[0] = new SynthesizedPlanFragment(SysProcFragmentId.PF_updateSettingsBarrier, true,
+                ParameterSet.emptyParameterSet());
 
-        pfs[1] = new SynthesizedPlanFragment();
-        pfs[1].fragmentId = SysProcFragmentId.PF_updateSettingsBarrierAggregate;
-        pfs[1].outputDepId = SysProcFragmentId.PF_updateSettingsBarrierAggregate;
-        pfs[1].multipartition = false;
-        pfs[1].parameters = ParameterSet.fromArrayNoCopy(new Object[] { settingsBytes, version });
-
-        return pfs;
-    }
-
-    private SynthesizedPlanFragment[] createUpdateFragment(byte[] settingsBytes, int version) {
-
-        SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
-
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = SysProcFragmentId.PF_updateSettings;
-        pfs[0].outputDepId = SysProcFragmentId.PF_updateSettings;
-        pfs[0].multipartition = true;
-        pfs[0].parameters = ParameterSet.fromArrayNoCopy(new Object[] { settingsBytes, version });
-
-        pfs[1] = new SynthesizedPlanFragment();
-        pfs[1].fragmentId = SysProcFragmentId.PF_updateSettingsAggregate;
-        pfs[1].outputDepId = SysProcFragmentId.PF_updateSettingsAggregate;
-        pfs[1].multipartition = false;
-        pfs[1].parameters = ParameterSet.emptyParameterSet();
+        pfs[1] = new SynthesizedPlanFragment(SysProcFragmentId.PF_updateSettingsBarrierAggregate, false,
+                ParameterSet.fromArrayNoCopy(settingsBytes, version));
 
         return pfs;
     }
@@ -188,7 +163,6 @@ public class UpdateSettings extends VoltSystemProcedure {
 
         executeSysProcPlanFragments(
                 createBarrierFragment(settingsBytes, version), SysProcFragmentId.PF_updateSettingsBarrierAggregate);
-        return executeSysProcPlanFragments(
-                createUpdateFragment(settingsBytes, version), SysProcFragmentId.PF_updateSettingsAggregate);
+        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_updateSettings,  SysProcFragmentId.PF_updateSettingsAggregate, settingsBytes, version);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
@@ -143,14 +143,12 @@ public class UpdateSettings extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_updateSettingsBarrier;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_updateSettingsBarrier;
-        pfs[0].inputDepIds = new int[]{};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_updateSettingsBarrierAggregate;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_updateSettingsBarrierAggregate;
-        pfs[1].inputDepIds = new int[] {(int) SysProcFragmentId.PF_updateSettingsBarrier};
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.fromArrayNoCopy(new Object[] { settingsBytes, version });
 
@@ -164,14 +162,12 @@ public class UpdateSettings extends VoltSystemProcedure {
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_updateSettings;
         pfs[0].outputDepId = (int) SysProcFragmentId.PF_updateSettings;
-        pfs[0].inputDepIds = new int[]{};
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(new Object[] { settingsBytes, version });
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_updateSettingsAggregate;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_updateSettingsAggregate;
-        pfs[1].inputDepIds = new int[] {(int) SysProcFragmentId.PF_updateSettings};
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 

--- a/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
@@ -79,7 +79,7 @@ public class UpdateSettings extends VoltSystemProcedure {
 
         if (fragmentId == SysProcFragmentId.PF_updateSettingsBarrier) {
 
-            DependencyPair success = new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_updateSettingsBarrier,
+            DependencyPair success = new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateSettingsBarrier,
                     new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
             if (log.isInfoEnabled()) {
                 log.info("Site " + CoreUtils.hsIdToString(m_site.getCorrespondingSiteId()) +
@@ -103,7 +103,7 @@ public class UpdateSettings extends VoltSystemProcedure {
                 throw new SettingsException(msg, e);
             }
             log.info("Saved new cluster settings state");
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_updateSettingsBarrierAggregate,
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateSettingsBarrierAggregate,
                     getVersionResponse(stat.getVersion()));
 
         } else if (fragmentId == SysProcFragmentId.PF_updateSettings) {
@@ -120,12 +120,12 @@ public class UpdateSettings extends VoltSystemProcedure {
 
             VoltTable result = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
             result.addRow(VoltSystemProcedure.STATUS_OK);
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_updateSettings, result);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateSettings, result);
 
         } else if (fragmentId == SysProcFragmentId.PF_updateSettingsAggregate) {
 
-            VoltTable result = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_updateSettings));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_updateSettingsAggregate, result);
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_updateSettings));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateSettingsAggregate, result);
 
         } else {
             VoltDB.crashLocalVoltDB(
@@ -142,13 +142,13 @@ public class UpdateSettings extends VoltSystemProcedure {
 
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_updateSettingsBarrier;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_updateSettingsBarrier;
+        pfs[0].outputDepId = SysProcFragmentId.PF_updateSettingsBarrier;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.emptyParameterSet();
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_updateSettingsBarrierAggregate;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_updateSettingsBarrierAggregate;
+        pfs[1].outputDepId = SysProcFragmentId.PF_updateSettingsBarrierAggregate;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.fromArrayNoCopy(new Object[] { settingsBytes, version });
 
@@ -161,13 +161,13 @@ public class UpdateSettings extends VoltSystemProcedure {
 
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_updateSettings;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_updateSettings;
+        pfs[0].outputDepId = SysProcFragmentId.PF_updateSettings;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(new Object[] { settingsBytes, version });
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_updateSettingsAggregate;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_updateSettingsAggregate;
+        pfs[1].outputDepId = SysProcFragmentId.PF_updateSettingsAggregate;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -187,8 +187,8 @@ public class UpdateSettings extends VoltSystemProcedure {
         final int version = stat.getVersion();
 
         executeSysProcPlanFragments(
-                createBarrierFragment(settingsBytes, version), (int) SysProcFragmentId.PF_updateSettingsBarrierAggregate);
+                createBarrierFragment(settingsBytes, version), SysProcFragmentId.PF_updateSettingsBarrierAggregate);
         return executeSysProcPlanFragments(
-                createUpdateFragment(settingsBytes, version), (int) SysProcFragmentId.PF_updateSettingsAggregate);
+                createUpdateFragment(settingsBytes, version), SysProcFragmentId.PF_updateSettingsAggregate);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
+++ b/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
@@ -151,38 +151,14 @@ public class ValidatePartitioning extends VoltSystemProcedure {
 
     private final VoltTable[] performValidatePartitioningWork(byte[] config)
     {
-        SynthesizedPlanFragment[] pfs = new SynthesizedPlanFragment[2];
-
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = SysProcFragmentId.PF_validatePartitioning;
-        pfs[0].outputDepId = SysProcFragmentId.PF_validatePartitioning;
-        pfs[0].multipartition = true;
-        pfs[0].parameters = ParameterSet.fromArrayNoCopy(config);
-
-        pfs[1] = new SynthesizedPlanFragment();
-        pfs[1].fragmentId = SysProcFragmentId.PF_validatePartitioningResults;
-        pfs[1].outputDepId = SysProcFragmentId.PF_validatePartitioningResults;
-        pfs[1].multipartition = false;
-        pfs[1].parameters = ParameterSet.emptyParameterSet();
-
         ArrayList<VoltTable> results = new ArrayList<VoltTable>();
-        for (VoltTable t: executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_validatePartitioningResults)) {
+        for (VoltTable t : createAndExecuteSysProcPlan(SysProcFragmentId.PF_validatePartitioning,
+                SysProcFragmentId.PF_validatePartitioningResults, config)) {
             results.add(t);
         }
 
-        pfs[0] = new SynthesizedPlanFragment();
-        pfs[0].fragmentId = SysProcFragmentId.PF_matchesHashinator;
-        pfs[0].outputDepId = SysProcFragmentId.PF_matchesHashinator;
-        pfs[0].multipartition = true;
-        pfs[0].parameters = ParameterSet.fromArrayNoCopy(config);
-
-        pfs[1] = new SynthesizedPlanFragment();
-        pfs[1].fragmentId = SysProcFragmentId.PF_matchesHashinatorResults;
-        pfs[1].outputDepId = SysProcFragmentId.PF_matchesHashinatorResults;
-        pfs[1].multipartition = false;
-        pfs[1].parameters = ParameterSet.emptyParameterSet();
-
-        for (VoltTable t: executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_matchesHashinatorResults)) {
+        for (VoltTable t : createAndExecuteSysProcPlan(SysProcFragmentId.PF_matchesHashinator,
+                SysProcFragmentId.PF_matchesHashinatorResults, config)) {
             results.add(t);
         }
 

--- a/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
+++ b/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
@@ -77,13 +77,13 @@ public class ValidatePartitioning extends VoltSystemProcedure {
             for (int ii = 0; ii < tableNames.size(); ii++) {
                 results.addRow(context.getHostId(), CoreUtils.getSiteIdFromHSId(context.getSiteId()), context.getPartitionId(), tableNames.get(ii), mispartitionedCounts[ii]);
             }
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_validatePartitioning, results);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_validatePartitioning, results);
 
         } else if (fragmentId == SysProcFragmentId.PF_validatePartitioningResults) {
 
             assert (dependencies.size() > 0);
-            final VoltTable results = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_validatePartitioning));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_validatePartitioningResults, results);
+            final VoltTable results = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_validatePartitioning));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_validatePartitioningResults, results);
 
         } else if (fragmentId == SysProcFragmentId.PF_matchesHashinator) {
 
@@ -99,13 +99,13 @@ public class ValidatePartitioning extends VoltSystemProcedure {
                     context.getPartitionId(),
                     givenConfigurationSignature == TheHashinator.getConfigurationSignature() ? (byte)1 : (byte)0);
 
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_matchesHashinator, matchesHashinator);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_matchesHashinator, matchesHashinator);
 
         } else if (fragmentId == SysProcFragmentId.PF_matchesHashinatorResults) {
 
             assert (dependencies.size() > 0);
-            final VoltTable results = VoltTableUtil.unionTables(dependencies.get((int) SysProcFragmentId.PF_matchesHashinator));
-            return new DependencyPair.TableDependencyPair((int) SysProcFragmentId.PF_matchesHashinatorResults, results);
+            final VoltTable results = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_matchesHashinator));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_matchesHashinatorResults, results);
 
         }
         assert (false);
@@ -155,34 +155,34 @@ public class ValidatePartitioning extends VoltSystemProcedure {
 
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_validatePartitioning;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_validatePartitioning;
+        pfs[0].outputDepId = SysProcFragmentId.PF_validatePartitioning;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(config);
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_validatePartitioningResults;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_validatePartitioningResults;
+        pfs[1].outputDepId = SysProcFragmentId.PF_validatePartitioningResults;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
         ArrayList<VoltTable> results = new ArrayList<VoltTable>();
-        for (VoltTable t: executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_validatePartitioningResults)) {
+        for (VoltTable t: executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_validatePartitioningResults)) {
             results.add(t);
         }
 
         pfs[0] = new SynthesizedPlanFragment();
         pfs[0].fragmentId = SysProcFragmentId.PF_matchesHashinator;
-        pfs[0].outputDepId = (int) SysProcFragmentId.PF_matchesHashinator;
+        pfs[0].outputDepId = SysProcFragmentId.PF_matchesHashinator;
         pfs[0].multipartition = true;
         pfs[0].parameters = ParameterSet.fromArrayNoCopy(config);
 
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_matchesHashinatorResults;
-        pfs[1].outputDepId = (int) SysProcFragmentId.PF_matchesHashinatorResults;
+        pfs[1].outputDepId = SysProcFragmentId.PF_matchesHashinatorResults;
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
-        for (VoltTable t: executeSysProcPlanFragments(pfs, (int) SysProcFragmentId.PF_matchesHashinatorResults)) {
+        for (VoltTable t: executeSysProcPlanFragments(pfs, SysProcFragmentId.PF_matchesHashinatorResults)) {
             results.add(t);
         }
 

--- a/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
+++ b/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
@@ -162,7 +162,6 @@ public class ValidatePartitioning extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_validatePartitioningResults;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_validatePartitioningResults;
-        pfs[1].inputDepIds  = new int[] { (int) SysProcFragmentId.PF_validatePartitioning };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 
@@ -180,7 +179,6 @@ public class ValidatePartitioning extends VoltSystemProcedure {
         pfs[1] = new SynthesizedPlanFragment();
         pfs[1].fragmentId = SysProcFragmentId.PF_matchesHashinatorResults;
         pfs[1].outputDepId = (int) SysProcFragmentId.PF_matchesHashinatorResults;
-        pfs[1].inputDepIds  = new int[] { (int) SysProcFragmentId.PF_matchesHashinator };
         pfs[1].multipartition = false;
         pfs[1].parameters = ParameterSet.emptyParameterSet();
 

--- a/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
@@ -332,7 +332,6 @@ public class PartitionedTableSaveFileState extends TableSaveFileState
         plan_fragment.multipartition = false;
         plan_fragment.siteId = distributorSiteId;
         plan_fragment.outputDepId = result_dependency_id;
-        addPlanDependencyId(result_dependency_id);
         plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
                 originalHostsArray,

--- a/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
@@ -324,40 +324,28 @@ public class PartitionedTableSaveFileState extends TableSaveFileState
             int originalHostsArray[],           // used to locate .vpt files
             boolean asReplicated)
     {
-        int result_dependency_id = getNextDependencyId();
-        SynthesizedPlanFragment plan_fragment = new SynthesizedPlanFragment();
-        plan_fragment.fragmentId =
-                (asReplicated ? SysProcFragmentId.PF_restoreDistributePartitionedTableAsReplicated
-                              : SysProcFragmentId.PF_restoreDistributePartitionedTableAsPartitioned);
-        plan_fragment.multipartition = false;
-        plan_fragment.siteId = distributorSiteId;
-        plan_fragment.outputDepId = result_dependency_id;
-        plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
-                getTableName(),
-                originalHostsArray,
-                uncoveredPartitionsAtHost,
-                result_dependency_id,
-                getIsRecoverParam());
-        return plan_fragment;
+        int fragmentId = (asReplicated ? SysProcFragmentId.PF_restoreDistributePartitionedTableAsReplicated
+                : SysProcFragmentId.PF_restoreDistributePartitionedTableAsPartitioned);
+        int resultDependencyId = getNextDependencyId();
+        ParameterSet params = ParameterSet.fromArrayNoCopy(getTableName(), originalHostsArray,
+                uncoveredPartitionsAtHost, resultDependencyId, getIsRecoverParam());
+
+        return new SynthesizedPlanFragment(distributorSiteId, fragmentId, resultDependencyId, false, params);
     }
 
     private SynthesizedPlanFragment
     constructDistributePartitionedTableAggregatorFragment(boolean asReplicated)
     {
-        int result_dependency_id = getNextDependencyId();
-        SynthesizedPlanFragment plan_fragment = new SynthesizedPlanFragment();
-        plan_fragment.fragmentId =
-            SysProcFragmentId.PF_restoreReceiveResultTables;
-        plan_fragment.multipartition = false;
-        plan_fragment.outputDepId = result_dependency_id;
-        setRootDependencyId(result_dependency_id);
-        plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
-                result_dependency_id,
+        int resultDependencyId = getNextDependencyId();
+        setRootDependencyId(resultDependencyId);
+        ParameterSet parameters = ParameterSet.fromArrayNoCopy(
+                resultDependencyId,
                 (asReplicated ?
                         "Aggregating partitioned-to-replicated table restore results"
                         : "Aggregating partitioned table restore results"),
                 getIsRecoverParam());
-        return plan_fragment;
+        return new SynthesizedPlanFragment(SysProcFragmentId.PF_restoreReceiveResultTables, resultDependencyId,
+                false, parameters);
     }
 
     // XXX-BLAH should this move to SiteTracker?

--- a/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
@@ -204,7 +204,7 @@ public class PartitionedTableSaveFileState extends TableSaveFileState
         }
         restorePlan.add(constructDistributePartitionedTableAggregatorFragment(true));
         assert(coveredPartitions.size() == m_partitionsSeen.size());
-        return restorePlan.toArray(new SynthesizedPlanFragment[0]);
+        return restorePlan.toArray(new SynthesizedPlanFragment[restorePlan.size()]);
     }
 
     private SynthesizedPlanFragment[] generatePartitionedToPartitionedPlan(SiteTracker st) {
@@ -314,7 +314,7 @@ public class PartitionedTableSaveFileState extends TableSaveFileState
         }
         restorePlan
                 .add(constructDistributePartitionedTableAggregatorFragment(false));
-        return restorePlan.toArray(new SynthesizedPlanFragment[0]);
+        return restorePlan.toArray(new SynthesizedPlanFragment[restorePlan.size()]);
     }
 
     private SynthesizedPlanFragment

--- a/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
@@ -332,7 +332,6 @@ public class PartitionedTableSaveFileState extends TableSaveFileState
         plan_fragment.multipartition = false;
         plan_fragment.siteId = distributorSiteId;
         plan_fragment.outputDepId = result_dependency_id;
-        plan_fragment.inputDepIds = new int[] {};
         addPlanDependencyId(result_dependency_id);
         plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
@@ -352,7 +351,6 @@ public class PartitionedTableSaveFileState extends TableSaveFileState
             SysProcFragmentId.PF_restoreReceiveResultTables;
         plan_fragment.multipartition = false;
         plan_fragment.outputDepId = result_dependency_id;
-        plan_fragment.inputDepIds = getPlanDependencyIds();
         setRootDependencyId(result_dependency_id);
         plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
                 result_dependency_id,

--- a/src/frontend/org/voltdb/sysprocs/saverestore/ReplicatedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/ReplicatedTableSaveFileState.java
@@ -132,7 +132,6 @@ public class ReplicatedTableSaveFileState extends TableSaveFileState
         plan_fragment.multipartition = false;
         plan_fragment.siteId = siteId;
         plan_fragment.outputDepId = result_dependency_id;
-        plan_fragment.inputDepIds = new int[] {};
         addPlanDependencyId(result_dependency_id);
         plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
@@ -199,7 +198,6 @@ public class ReplicatedTableSaveFileState extends TableSaveFileState
             SysProcFragmentId.PF_restoreLoadReplicatedTable;
         plan_fragment.multipartition = false;
         plan_fragment.outputDepId = result_dependency_id;
-        plan_fragment.inputDepIds = new int[] {};
         addPlanDependencyId(result_dependency_id);
         plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
@@ -219,7 +217,6 @@ public class ReplicatedTableSaveFileState extends TableSaveFileState
         plan_fragment.multipartition = false;
         plan_fragment.siteId = sourceSiteId;
         plan_fragment.outputDepId = result_dependency_id;
-        plan_fragment.inputDepIds = new int[] {};
         addPlanDependencyId(result_dependency_id);
         plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
@@ -238,7 +235,6 @@ public class ReplicatedTableSaveFileState extends TableSaveFileState
             SysProcFragmentId.PF_restoreReceiveResultTables;
         plan_fragment.multipartition = false;
         plan_fragment.outputDepId = result_dependency_id;
-        plan_fragment.inputDepIds = getPlanDependencyIds();
         setRootDependencyId(result_dependency_id);
         plan_fragment.parameters = ParameterSet.fromArrayNoCopy(result_dependency_id,
                 (asPartitioned ? "Aggregating replicated-to-partitioned table restore results"

--- a/src/frontend/org/voltdb/sysprocs/saverestore/ReplicatedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/ReplicatedTableSaveFileState.java
@@ -125,18 +125,13 @@ public class ReplicatedTableSaveFileState extends TableSaveFileState
     private SynthesizedPlanFragment
     constructDistributeReplicatedTableAsPartitionedFragment(long siteId)
     {
-        int result_dependency_id = getNextDependencyId();
-        SynthesizedPlanFragment plan_fragment = new SynthesizedPlanFragment();
-        plan_fragment.fragmentId =
-            SysProcFragmentId.PF_restoreDistributeReplicatedTableAsPartitioned;
-        plan_fragment.multipartition = false;
-        plan_fragment.siteId = siteId;
-        plan_fragment.outputDepId = result_dependency_id;
-        plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
+        int resultDependencyId = getNextDependencyId();
+        ParameterSet parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
-                result_dependency_id,
+                resultDependencyId,
                 getIsRecoverParam());
-        return plan_fragment;
+        return new SynthesizedPlanFragment(siteId, SysProcFragmentId.PF_restoreDistributeReplicatedTableAsPartitioned,
+                resultDependencyId, false, parameters);
     }
 
     private SynthesizedPlanFragment[]
@@ -191,53 +186,41 @@ public class ReplicatedTableSaveFileState extends TableSaveFileState
     private SynthesizedPlanFragment
     constructLoadReplicatedTableFragment()
     {
-        int result_dependency_id = getNextDependencyId();
-        SynthesizedPlanFragment plan_fragment = new SynthesizedPlanFragment();
-        plan_fragment.fragmentId =
-            SysProcFragmentId.PF_restoreLoadReplicatedTable;
-        plan_fragment.multipartition = false;
-        plan_fragment.outputDepId = result_dependency_id;
-        plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
+        int resultDependencyId = getNextDependencyId();
+        ParameterSet parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
-                result_dependency_id,
+                resultDependencyId,
                 getIsRecoverParam());
-        return plan_fragment;
+        return new SynthesizedPlanFragment(SysProcFragmentId.PF_restoreLoadReplicatedTable, resultDependencyId,
+                false, parameters);
     }
 
     private SynthesizedPlanFragment
     constructDistributeReplicatedTableAsReplicatedFragment(long sourceSiteId,
                                                            long destinationSiteId)
     {
-        int result_dependency_id = getNextDependencyId();
-        SynthesizedPlanFragment plan_fragment = new SynthesizedPlanFragment();
-        plan_fragment.fragmentId =
-            SysProcFragmentId.PF_restoreDistributeReplicatedTableAsReplicated;
-        plan_fragment.multipartition = false;
-        plan_fragment.siteId = sourceSiteId;
-        plan_fragment.outputDepId = result_dependency_id;
-        plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
+        int resultDependencyId = getNextDependencyId();
+        ParameterSet parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
                 destinationSiteId,
-                result_dependency_id,
+                resultDependencyId,
                 getIsRecoverParam());
-        return plan_fragment;
+        return new SynthesizedPlanFragment(sourceSiteId,
+                SysProcFragmentId.PF_restoreDistributeReplicatedTableAsReplicated, resultDependencyId, false,
+                parameters);
     }
 
     private SynthesizedPlanFragment
     constructLoadReplicatedTableAggregatorFragment(boolean asPartitioned)
     {
-        int result_dependency_id = getNextDependencyId();
-        SynthesizedPlanFragment plan_fragment = new SynthesizedPlanFragment();
-        plan_fragment.fragmentId =
-            SysProcFragmentId.PF_restoreReceiveResultTables;
-        plan_fragment.multipartition = false;
-        plan_fragment.outputDepId = result_dependency_id;
-        setRootDependencyId(result_dependency_id);
-        plan_fragment.parameters = ParameterSet.fromArrayNoCopy(result_dependency_id,
+        int resultDependencyId = getNextDependencyId();
+        setRootDependencyId(resultDependencyId);
+        ParameterSet parameters = ParameterSet.fromArrayNoCopy(resultDependencyId,
                 (asPartitioned ? "Aggregating replicated-to-partitioned table restore results"
                                : "Aggregating replicated table restore results"),
                 getIsRecoverParam());
-        return plan_fragment;
+        return new SynthesizedPlanFragment(SysProcFragmentId.PF_restoreReceiveResultTables, resultDependencyId, false,
+                parameters);
     }
 
     private final Set<Integer> m_hostsWithThisTable = new HashSet<Integer>();

--- a/src/frontend/org/voltdb/sysprocs/saverestore/ReplicatedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/ReplicatedTableSaveFileState.java
@@ -132,7 +132,6 @@ public class ReplicatedTableSaveFileState extends TableSaveFileState
         plan_fragment.multipartition = false;
         plan_fragment.siteId = siteId;
         plan_fragment.outputDepId = result_dependency_id;
-        addPlanDependencyId(result_dependency_id);
         plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
                 result_dependency_id,
@@ -198,7 +197,6 @@ public class ReplicatedTableSaveFileState extends TableSaveFileState
             SysProcFragmentId.PF_restoreLoadReplicatedTable;
         plan_fragment.multipartition = false;
         plan_fragment.outputDepId = result_dependency_id;
-        addPlanDependencyId(result_dependency_id);
         plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
                 result_dependency_id,
@@ -217,7 +215,6 @@ public class ReplicatedTableSaveFileState extends TableSaveFileState
         plan_fragment.multipartition = false;
         plan_fragment.siteId = sourceSiteId;
         plan_fragment.outputDepId = result_dependency_id;
-        addPlanDependencyId(result_dependency_id);
         plan_fragment.parameters = ParameterSet.fromArrayNoCopy(
                 getTableName(),
                 destinationSiteId,

--- a/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFileState.java
@@ -18,8 +18,6 @@
 package org.voltdb.sysprocs.saverestore;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.voltdb.VoltSystemProcedure.SynthesizedPlanFragment;
 import org.voltdb.VoltTableRow;
@@ -42,7 +40,6 @@ public abstract class TableSaveFileState
         m_tableName = tableName;
         m_txnId = txnId;
         m_consistencyResult = "Table: " + m_tableName + " not yet processed";
-        m_planDependencyIds = new HashSet<Integer>();
     }
 
     abstract public SynthesizedPlanFragment[]
@@ -66,23 +63,6 @@ public abstract class TableSaveFileState
     abstract void addHostData(VoltTableRow row) throws IOException;
 
     public abstract boolean isConsistent();
-
-    void addPlanDependencyId(int dependencyId)
-    {
-        m_planDependencyIds.add(dependencyId);
-    }
-
-    int[] getPlanDependencyIds()
-    {
-        int[] unboxed_ids = new int[m_planDependencyIds.size()];
-        int id_index = 0;
-        for (int id : m_planDependencyIds)
-        {
-            unboxed_ids[id_index] = id;
-            id_index++;
-        }
-        return unboxed_ids;
-    }
 
     void setRootDependencyId(int dependencyId)
     {
@@ -108,6 +88,5 @@ public abstract class TableSaveFileState
     protected String m_consistencyResult;
     private final String m_tableName;
     private final long m_txnId;
-    private final Set<Integer> m_planDependencyIds;
     private boolean m_isRecover;
 }

--- a/tests/frontend/org/voltdb/iv2/TestMpTransactionState.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpTransactionState.java
@@ -170,7 +170,7 @@ public class TestMpTransactionState extends TestCase
 
         for (int i = 0; i < depsForLocalTask.size(); i++) {
             if (depsForLocalTask.get(i) < 0) continue;
-            plan.localWork.addInputDepId(i, depsForLocalTask.get(i));
+            plan.localWork.setInputDepId(i, depsForLocalTask.get(i));
         }
         // create the FragmentResponse for the BorrowTask
         FragmentResponseMessage resp =

--- a/tests/frontend/org/voltdb/regressionsuites/MultiConfigSuiteBuilder.java
+++ b/tests/frontend/org/voltdb/regressionsuites/MultiConfigSuiteBuilder.java
@@ -26,9 +26,10 @@ package org.voltdb.regressionsuites;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+
+import com.google_voltpatches.common.base.Predicate;
+import com.google_voltpatches.common.base.Predicates;
 
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -48,7 +49,7 @@ public class MultiConfigSuiteBuilder extends TestSuite {
     /** The class that contains the JUnit test methods to run */
     final Class<? extends TestCase> m_testClass;
     // Collection of test method names to be ignored and not executed
-    final Collection<String> m_ignoredTests;
+    final Predicate<String> m_testPredicate;
 
     /**
      * Get the JUnit test methods for a given class. These methods have no
@@ -67,7 +68,7 @@ public class MultiConfigSuiteBuilder extends TestSuite {
                 continue;
             }
             String name = m.getName();
-            if (!name.startsWith("test") || m_ignoredTests.contains(name)) {
+            if (!name.startsWith("test") || !m_testPredicate.apply(name)) {
                 continue;
             }
             retval.add(name);
@@ -82,19 +83,19 @@ public class MultiConfigSuiteBuilder extends TestSuite {
      * @param testClass The class that contains the JUnit test methods to run.
      */
     public MultiConfigSuiteBuilder(Class<? extends TestCase> testClass) {
-        this(testClass, Collections.emptySet());
+        this(testClass, Predicates.alwaysTrue());
     }
 
     /**
      * Initialize by passing in a class that contains JUnit test methods to run.
      *
-     * @param testClass The class that contains the JUnit test methods to run.
-     * @param ignoredTests {@link Collection} of test names to be skipped. A test will be skipped if
-     *                  {@code skipTest.contains(methodName)} returns {@code true}
+     * @param testClass     The class that contains the JUnit test methods to run.
+     * @param testPredicate {@link Predicate} which will test the test names. If {@code testPredicate} returns
+     *                      {@code false} the test will not be executed.
      */
-    public MultiConfigSuiteBuilder(Class<? extends TestCase> testClass, Collection<String> ignoredTests) {
+    public MultiConfigSuiteBuilder(Class<? extends TestCase> testClass, Predicate<String> testPredicate) {
         m_testClass = testClass;
-        m_ignoredTests = ignoredTests;
+        m_testPredicate = testPredicate;
     }
 
     /**

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestPartitionedTableSaveFileState.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestPartitionedTableSaveFileState.java
@@ -417,24 +417,8 @@ public class TestPartitionedTableSaveFileState extends TestCase
                      PF_restoreReceiveResultTables,
                      plan[plan.length - 1].fragmentId);
         assertFalse(plan[plan.length - 1].multipartition);
-        checkPlanDependencies(plan);
         assertEquals(m_state.getRootDependencyId(),
                      plan[plan.length - 1].parameters.toArray()[0]);
-    }
-
-    private void checkPlanDependencies(SynthesizedPlanFragment[] plan)
-    {
-        Set<Integer> aggregate_deps = new HashSet<Integer>();
-        for (int dependency_id : plan[plan.length - 1].inputDepIds)
-        {
-            aggregate_deps.add(dependency_id);
-        }
-        Set<Integer> plan_deps = new HashSet<Integer>();
-        for (int i = 0; i < plan.length - 1; ++i)
-        {
-            plan_deps.add((Integer) plan[i].parameters.toArray()[3]);
-        }
-        assertTrue(aggregate_deps.equals(plan_deps));
     }
 
     private PartitionedTableSaveFileState m_state;

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestReplicatedTableSaveFileState.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestReplicatedTableSaveFileState.java
@@ -24,7 +24,6 @@
 package org.voltdb.sysprocs.saverestore;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.voltcore.utils.CoreUtils;
@@ -160,7 +159,6 @@ public class TestReplicatedTableSaveFileState extends TestCase
         assertEquals(test_plan[number_of_sites].fragmentId,
                      SysProcFragmentId.PF_restoreReceiveResultTables);
         assertFalse(test_plan[number_of_sites].multipartition);
-        checkPlanDependencies(test_plan);
         assertEquals(test_plan[number_of_sites].parameters.toArray()[0],
                      m_state.getRootDependencyId());
         catalog_creator.shutdown(null);
@@ -228,7 +226,6 @@ public class TestReplicatedTableSaveFileState extends TestCase
         assertEquals(test_plan[number_of_sites].fragmentId,
                      SysProcFragmentId.PF_restoreReceiveResultTables);
         assertFalse(test_plan[number_of_sites].multipartition);
-        checkPlanDependencies(test_plan);
         assertEquals(test_plan[number_of_sites].parameters.toArray()[0],
                      m_state.getRootDependencyId());
         catalog_creator.shutdown(null);
@@ -244,32 +241,6 @@ public class TestReplicatedTableSaveFileState extends TestCase
     {
         m_siteInput.addRow(hostId, "host", hostId, "ohost", "cluster", DATABASE_NAME,
                            TABLE_NAME, 0, "FALSE", 0, 2);
-    }
-
-    private void checkPlanDependencies(SynthesizedPlanFragment[] plan)
-    {
-        Set<Integer> aggregate_deps = new HashSet<Integer>();
-        for (int dependency_id : plan[plan.length - 1].inputDepIds)
-        {
-            aggregate_deps.add(dependency_id);
-        }
-        Set<Integer> plan_deps = new HashSet<Integer>();
-        for (int i = 0; i < plan.length - 1; ++i)
-        {
-            int fragment_dep = -1;
-            if (plan[i].fragmentId ==
-                SysProcFragmentId.PF_restoreLoadReplicatedTable)
-            {
-                fragment_dep = (Integer) plan[i].parameters.toArray()[1];
-            }
-            else if (plan[i].fragmentId ==
-                SysProcFragmentId.PF_restoreDistributeReplicatedTableAsReplicated)
-            {
-                fragment_dep = (Integer) plan[i].parameters.toArray()[2];
-            }
-            plan_deps.add(fragment_dep);
-        }
-        assertTrue(aggregate_deps.equals(plan_deps));
     }
 
     private ReplicatedTableSaveFileState m_state;


### PR DESCRIPTION
ParameterSet: Add static empty instance
FragmentTaskMessage: Only supports one inputDepId
VoltSystemProcedure.SynthesizedPlanFragment: remove suppressDuplicates
VoltSystemProcedure.SynthesizedPlanFragment: remove inputDepIds
TableSaveFileState: remove m_planDependencyIds
TestSaveRestoreSysprocSuite: move test from TestIV2BlacklistSaveRestore
MultiConfigSuiteBuilder: Use a more generic predicate
SystemProcedureCatalog.Config: remove skipReplication
SysProcFragmentId: Change all IDs to int
Remove unnecessary int casting on SysProcFragmentIds
VoltSystemProcedure: Add more utility methods
VoltSystemProcedure: Subclasses use utility method 