### PR TITLE
ENG-15291:

### DIFF
--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -403,7 +403,7 @@ void ExecutorContext::setDrReplicatedStream(AbstractDRTupleStream *drReplicatedS
 bool ExecutorContext::checkTransactionForDR() {
     bool result = false;
     if (UniqueId::isMpUniqueId(m_uniqueId) && m_undoQuantum != NULL) {
-        if (m_drStream && m_drStream->drStreamStarted()) {
+        if (m_externalStreamsEnabled && m_drStream && m_drStream->drStreamStarted()) {
             if (m_drStream->transactionChecks(m_lastCommittedSpHandle,
                     m_spHandle, m_uniqueId)) {
                 m_undoQuantum->registerUndoAction(

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2826,6 +2826,10 @@ void VoltDBEngine::disableExternalStreams() {
     m_executorContext->disableExternalStreams();
 }
 
+bool VoltDBEngine::externalStreamsEnabled() {
+    return m_executorContext->externalStreamsEnabled();
+}
+
 void VoltDBEngine::loadBuiltInJavaFunctions() {
     // Hard code the info of format_timestamp function
     UserDefinedFunctionInfo *info = new UserDefinedFunctionInfo();

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -542,6 +542,8 @@ class __attribute__((visibility("default"))) VoltDBEngine {
 
         void disableExternalStreams();
 
+        bool externalStreamsEnabled();
+
     protected:
         void setHashinator(TheHashinator* hashinator);
 

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -332,11 +332,7 @@ void PersistentTable::deleteAllTuples(bool, bool fallible) {
 }
 
 bool PersistentTable::doDRActions(AbstractDRTupleStream* drStream) {
-    //TODO: See if we can set drStream to NULL when streams are disabled
-    // to avoid adding another if check here.
-    ExecutorContext* ec = ExecutorContext::getExecutorContext();
-    return m_drEnabled && drStream && drStream->drStreamStarted() &&
-          (isReplicatedTable() || ec->externalStreamsEnabled());
+    return m_drEnabled && drStream && drStream->drStreamStarted();
 }
 
 void PersistentTable::truncateTableUndo(TableCatalogDelegate* tcd,

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1489,13 +1489,23 @@ SHAREDLIB_JNIEXPORT void JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeSetVi
 }
 
 /*
- * Implemention of ExecutionEngineJNI.nativeSetExternalStreamsEnabled
+ * Implemention of ExecutionEngineJNI.nativeDisableExternalStreams
  */
 SHAREDLIB_JNIEXPORT void JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeDisableExternalStreams
   (JNIEnv *env, jobject object, jlong engine_ptr) {
     VoltDBEngine *engine = castToEngine(engine_ptr);
     assert(engine);
     engine->disableExternalStreams();
+}
+
+/*
+ * Implemention of ExecutionEngineJNI.nativeExternalStreamsEnabled
+ */
+SHAREDLIB_JNIEXPORT jboolean JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExternalStreamsEnabled
+  (JNIEnv *env, jobject object, jlong engine_ptr) {
+    VoltDBEngine *engine = castToEngine(engine_ptr);
+    assert(engine);
+    return engine->externalStreamsEnabled();
 }
 
 /** @} */ // end of JNI doxygen group

--- a/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
+++ b/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
@@ -92,7 +92,7 @@ public class ExtensibleSnapshotDigestData {
         m_elasticOperationMetadata = elasticOperationMetadata;
     }
 
-    void setDisabledExternalStreams(Set<Integer> disabledStreams) {
+    public void setDisabledExternalStreams(Set<Integer> disabledStreams) {
         m_disabledExternalStreams = disabledStreams;
     }
 

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -272,4 +272,11 @@ public interface SiteProcedureConnection {
      * <p> By default this is enabled in all sites.
      */
     public void disableExternalStreams();
+
+    /**
+     * Returns value showing whether external streams (DR and export) are enabled for this Site.
+     *
+     * @return true if external streams are enabled for this site, false otherwise.
+     */
+    public boolean externalStreamsEnabled();
 }

--- a/src/frontend/org/voltdb/SnapshotSaveAPI.java
+++ b/src/frontend/org/voltdb/SnapshotSaveAPI.java
@@ -182,6 +182,8 @@ public class SnapshotSaveAPI
                             SnapshotSiteProcessor.getDRTupleStreamStateInfo(),
                             remoteDataCenterLastIds, es == null ? null : es.getResumeMetadata(),
                             finalJsData);
+                    m_allLocalSiteSnapshotDigestData.setDisabledExternalStreams(
+                            SnapshotSiteProcessor.getDisabledExternalStreams());
                     createSetupIv2(
                             file_path,
                             pathType,
@@ -206,7 +208,7 @@ public class SnapshotSaveAPI
 
             //From within this EE, record the sequence numbers as of the start of the snapshot (now)
             //so that the info can be put in the digest.
-            SnapshotSiteProcessor.populateSequenceNumbersForExecutionSite(context);
+            SnapshotSiteProcessor.populateExternalStreamsStatesFromSites(context);
             Integer partitionId = TxnEgo.getPartitionId(partitionTxnId);
             if (SNAP_LOG.isDebugEnabled()) {
                 SNAP_LOG.debug("Registering transaction id " + partitionTxnId + " for " + TxnEgo.getPartitionId(partitionTxnId) + " SP Txn:" +

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -60,6 +60,7 @@ import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.MiscUtils;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.ImmutableSet;
 import com.google_voltpatches.common.collect.ListMultimap;
 import com.google_voltpatches.common.collect.Lists;
 import com.google_voltpatches.common.collect.Maps;
@@ -121,10 +122,13 @@ public class SnapshotSiteProcessor {
      * Sequence numbers for export tables. This is repopulated before each snapshot by each execution site
      * that reaches the snapshot.
      */
-    private static final Map<String, Map<Integer, Pair<Long, Long>>> m_exportSequenceNumbers =
+    private static final Map<String, Map<Integer, Pair<Long, Long>>> s_exportSequenceNumbers =
         new HashMap<String, Map<Integer, Pair<Long, Long>>>();
 
-    private static final Map<Integer, TupleStreamStateInfo> m_drTupleStreamInfo = new HashMap<>();
+    private static final Map<Integer, TupleStreamStateInfo> s_drTupleStreamInfo = new HashMap<>();
+    // Stores whether external streams (DR and export) are enabled from this site.
+    // This will be set to false when we remove a partition for Elastic Shrink, for example.
+    private static final Set<Integer> s_disabledStreams = new HashSet<>();
 
     private ExtensibleSnapshotDigestData m_extraSnapshotData;
 
@@ -209,16 +213,16 @@ public class SnapshotSiteProcessor {
      * site that gets the setup permit will  use getExportSequenceNumbers to retrieve the full
      * set and reset the contents.
      */
-    public static void populateSequenceNumbersForExecutionSite(SystemProcedureExecutionContext context) {
+    public static void populateExternalStreamsStatesFromSites(SystemProcedureExecutionContext context) {
         Database database = context.getDatabase();
         for (Table t : database.getTables()) {
             if (!CatalogUtil.isTableExportOnly(database, t))
                 continue;
 
-            Map<Integer, Pair<Long,Long>> sequenceNumbers = m_exportSequenceNumbers.get(t.getTypeName());
+            Map<Integer, Pair<Long,Long>> sequenceNumbers = s_exportSequenceNumbers.get(t.getTypeName());
             if (sequenceNumbers == null) {
                 sequenceNumbers = new HashMap<Integer, Pair<Long, Long>>();
-                m_exportSequenceNumbers.put(t.getTypeName(), sequenceNumbers);
+                s_exportSequenceNumbers.put(t.getTypeName(), sequenceNumbers);
             }
 
             long[] usoAndSequenceNumber =
@@ -230,23 +234,32 @@ public class SnapshotSiteProcessor {
                                 usoAndSequenceNumber[1]));
         }
         TupleStreamStateInfo drStateInfo = context.getSiteProcedureConnection().getDRTupleStreamStateInfo();
-        m_drTupleStreamInfo.put(context.getPartitionId(), drStateInfo);
+        s_drTupleStreamInfo.put(context.getPartitionId(), drStateInfo);
         if (drStateInfo.containsReplicatedStreamInfo) {
-            m_drTupleStreamInfo.put(MpInitiator.MP_INIT_PID, drStateInfo);
+            s_drTupleStreamInfo.put(MpInitiator.MP_INIT_PID, drStateInfo);
+        }
+
+        if (!context.getSiteProcedureConnection().externalStreamsEnabled()) {
+            s_disabledStreams.add(context.getPartitionId());
         }
     }
 
     public static Map<String, Map<Integer, Pair<Long, Long>>> getExportSequenceNumbers() {
-        HashMap<String, Map<Integer, Pair<Long, Long>>> sequenceNumbers =
-                new HashMap<String, Map<Integer, Pair<Long, Long>>>(m_exportSequenceNumbers);
-        m_exportSequenceNumbers.clear();
+        HashMap<String, Map<Integer, Pair<Long, Long>>> sequenceNumbers = new HashMap<>(s_exportSequenceNumbers);
+        s_exportSequenceNumbers.clear();
         return sequenceNumbers;
     }
 
     public static Map<Integer, TupleStreamStateInfo> getDRTupleStreamStateInfo() {
-        Map<Integer, TupleStreamStateInfo> stateInfo = ImmutableMap.copyOf(m_drTupleStreamInfo);
-        m_drTupleStreamInfo.clear();
+        Map<Integer, TupleStreamStateInfo> stateInfo = ImmutableMap.copyOf(s_drTupleStreamInfo);
+        s_drTupleStreamInfo.clear();
         return stateInfo;
+    }
+
+    public static Set<Integer> getDisabledExternalStreams() {
+        Set<Integer> disabledStreams = ImmutableSet.copyOf(s_disabledStreams);
+        s_disabledStreams.clear();
+        return disabledStreams;
     }
 
     private long m_quietUntil = 0;

--- a/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
+++ b/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
@@ -306,7 +306,7 @@ public class VoltProjectBuilder {
     private List<String> m_diagnostics;
 
     private List<HashMap<String, Object>> m_ilImportConnectors = new ArrayList<>();
-    private List<HashMap<String, Object>> m_elExportConnectors = new ArrayList<>();
+    private List<ExportConfigurationType> m_exportConfigs = new ArrayList<>();
 
     private Integer m_deadHostTimeout = null;
 
@@ -739,14 +739,30 @@ public class VoltProjectBuilder {
         m_ilImportConnectors.add(importConnector);
     }
 
-    public void addExport(boolean enabled, String exportTarget, Properties config) {
-        addExport(enabled, exportTarget, config, Constants.DEFAULT_EXPORT_CONNECTOR_NAME);
+    public void addExport(boolean enabled) {
+        addExport(enabled, null, null);
     }
 
-    public void addExport(boolean enabled, String exportTarget, Properties config, String target) {
-        HashMap<String, Object> exportConnector = new HashMap<>();
-        exportConnector.put("elLoader", "org.voltdb.export.processors.GuestProcessor");
-        exportConnector.put("elEnabled", enabled);
+    public void addExport(boolean enabled, ServerExportEnum exportType, Properties config) {
+        addExport(enabled, exportType, config, Constants.DEFAULT_EXPORT_CONNECTOR_NAME);
+    }
+
+    public void addExport(boolean enabled, ServerExportEnum exportType, Properties config, String target) {
+        addExport(enabled, exportType, null, config, target);
+    }
+    public void addExport(boolean enabled, ServerExportEnum exportType, String connectorClass, Properties config, String target) {
+        org.voltdb.compiler.deploymentfile.ObjectFactory factory = new org.voltdb.compiler.deploymentfile.ObjectFactory();
+
+        ExportConfigurationType exportConfig = factory.createExportConfigurationType();
+        exportConfig.setEnabled(enabled);
+
+        exportConfig.setType(exportType);
+        if (exportType == ServerExportEnum.CUSTOM) {
+            exportConfig.setExportconnectorclass(
+                    connectorClass == null ? System.getProperty(ExportDataProcessor.EXPORT_TO_TYPE) : connectorClass);
+        }
+
+        exportConfig.setTarget(target);
 
         if (config == null) {
             config = new Properties();
@@ -756,20 +772,19 @@ public class VoltProjectBuilder {
                     "type","tsv", "batched","true", "with-schema","true", "nonce","zorag"
                     ));
         }
-        exportConnector.put("elConfig", config);
+        List<PropertyType> configProperties = exportConfig.getProperty();
 
-        if ((exportTarget != null) && !exportTarget.trim().isEmpty()) {
-            exportConnector.put("elExportTarget", exportTarget);
-        }
-        else {
-            exportConnector.put("elExportTarget", "file");
-        }
-        exportConnector.put("elGroup", target);
-        m_elExportConnectors.add(exportConnector);
-    }
+        for(Object nameObj: config.keySet()) {
+            String name = (String) nameObj;
 
-    public void addExport(boolean enabled) {
-        addExport(enabled, null, null);
+            PropertyType prop = factory.createPropertyType();
+            prop.setName(name);
+            prop.setValue(config.getProperty(name));
+
+            configProperties.add(prop);
+        }
+
+        m_exportConfigs.add(exportConfig);
     }
 
     public void setCompilerDebugPrintStream(final PrintStream out) {
@@ -1236,33 +1251,7 @@ public class VoltProjectBuilder {
         ExportType export = factory.createExportType();
         deployment.setExport(export);
 
-        for (HashMap<String,Object> exportConnector : m_elExportConnectors) {
-            ExportConfigurationType exportConfig = factory.createExportConfigurationType();
-            exportConfig.setEnabled((boolean)exportConnector.get("elEnabled") && exportConnector.get("elLoader") != null &&
-                    !((String)exportConnector.get("elLoader")).trim().isEmpty());
-
-            ServerExportEnum exportTarget = ServerExportEnum.fromValue(((String)exportConnector.get("elExportTarget")).toLowerCase());
-            exportConfig.setType(exportTarget);
-            if (exportTarget.equals(ServerExportEnum.CUSTOM)) {
-                exportConfig.setExportconnectorclass(System.getProperty(ExportDataProcessor.EXPORT_TO_TYPE));
-            }
-
-            exportConfig.setTarget((String)exportConnector.get("elGroup"));
-
-            Properties config = (Properties)exportConnector.get("elConfig");
-            if((config != null) && (config.size() > 0)) {
-                List<PropertyType> configProperties = exportConfig.getProperty();
-
-                for( Object nameObj: config.keySet()) {
-                    String name = String.class.cast(nameObj);
-
-                    PropertyType prop = factory.createPropertyType();
-                    prop.setName(name);
-                    prop.setValue(config.getProperty(name));
-
-                    configProperties.add(prop);
-                }
-            }
+        for (ExportConfigurationType exportConfig : m_exportConfigs) {
             export.getConfiguration().add(exportConfig);
         }
 

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -746,6 +746,11 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
 
     @Override
     public void disableExternalStreams() {
-        throw new RuntimeException("setExternalStreamsEnabled should not be called on MpRoSite");
+        throw new RuntimeException("disableExternalStreams should not be called on MpRoSite");
+    }
+
+    @Override
+    public boolean externalStreamsEnabled() {
+        throw new RuntimeException("externalStreamsEnabled should not be called on MpRoSite");
     }
 }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1869,6 +1869,11 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
+    public boolean externalStreamsEnabled() {
+        return m_ee.externalStreamsEnabled();
+    }
+
+    @Override
     public SystemProcedureExecutionContext getSystemProcedureExecutionContext() {
         return m_sysprocContext;
     }

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -873,13 +873,17 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      */
     public abstract void disableExternalStreams();
 
+    /**
+     * Return the EE state that indicates if external streams are enabled for this Site or not.
+     */
+    public abstract boolean externalStreamsEnabled();
+
     /*
      * Declare the native interface. Structurally, in Java, it would be cleaner to
      * declare this in ExecutionEngineJNI.java. However, that would necessitate multiple
      * jni_class instances in the execution engine. From the EE perspective, a single
      * JNI class is better.  So put this here with the backend->frontend api definition.
      */
-
     protected native byte[] nextDependencyTest(int dependencyId);
 
     /**
@@ -1162,9 +1166,14 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
     protected native void nativeSetViewsEnabled(long pointer, byte[] viewNamesAsBytes, boolean enabled);
 
     /**
-     * @see ExecutionEngine#setExternalStreamsEnabled(boolean)
+     * @see ExecutionEngine#disableExternalStreams()
      */
     protected native void nativeDisableExternalStreams(long pointer);
+
+    /**
+     * @see ExecutionEngine#externalStreamsEnabled()
+     */
+    protected native boolean nativeExternalStreamsEnabled(long pointer);
 
     /**
      * Get the USO for an export table. This is primarily used for recovery.

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -45,8 +45,6 @@ import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 import org.voltdb.types.GeographyValue;
 import org.voltdb.utils.SerializationHelper;
 
-import com.google_voltpatches.common.base.Throwables;
-
 /**
  * Wrapper for native Execution Engine library.
  * All native methods are private to make it simple
@@ -901,9 +899,8 @@ public class ExecutionEngineJNI extends ExecutionEngine {
             checkErrorCode(errorCode);
             return (byte[])m_nextDeserializer.readArray(byte.class);
         } catch (IOException e) {
-            Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     @Override
@@ -930,5 +927,10 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     @Override
     public void disableExternalStreams() {
         nativeDisableExternalStreams(pointer);
+    }
+
+    @Override
+    public boolean externalStreamsEnabled() {
+        return nativeExternalStreamsEnabled(pointer);
     }
 }

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -262,4 +262,9 @@ public class MockExecutionEngine extends ExecutionEngine {
     @Override
     public void disableExternalStreams() {
     }
+
+    @Override
+    public boolean externalStreamsEnabled() {
+        return true;
+    }
 }

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -267,9 +267,9 @@ public class SnapshotRestore extends VoltSystemProcedure {
         if (fragmentId == SysProcFragmentId.PF_restoreDistributeExportAndPartitionSequenceNumbers)
         {
             Object[] paramsArr = params.toArray();
-            assert(paramsArr[0] != null);
             assert(paramsArr.length == 6);
             assert(paramsArr[0] instanceof byte[]);
+            assert(paramsArr[1] instanceof Long);
             assert(paramsArr[2] instanceof long[]);
             assert(paramsArr[3] instanceof Long);
             assert(paramsArr[4] instanceof Long);

--- a/tests/frontend/org/voltdb/TestDeleteInExportRecoverWithView.java
+++ b/tests/frontend/org/voltdb/TestDeleteInExportRecoverWithView.java
@@ -36,6 +36,7 @@ import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.regressionsuites.JUnit4LocalClusterTest;
 import org.voltdb.regressionsuites.LocalCluster;
@@ -63,7 +64,7 @@ public class TestDeleteInExportRecoverWithView extends JUnit4LocalClusterTest {
         }
         project.setUseDDLSchema(true);
         Properties props = new Properties();
-        project.addExport(true /* enabled */, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
         LocalCluster db = new LocalCluster("exportview.jar", 2, 1, 0, 2, BackendTarget.NATIVE_EE_JNI,
                 LocalCluster.FailureState.ALL_RUNNING, true, additionalEnv);
         boolean compile = db.compile(project);

--- a/tests/frontend/org/voltdb/TestExportGroups.java
+++ b/tests/frontend/org/voltdb/TestExportGroups.java
@@ -33,6 +33,7 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ClientImpl;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.export.ExportTestClient;
 import org.voltdb.export.ExportTestVerifier;
@@ -72,7 +73,6 @@ public class TestExportGroups extends TestExportBase {
         File f = new File("/tmp/" + System.getProperty("user.name"));
         f.mkdirs();
         super.setUp();
-
     }
 
     @Override
@@ -206,7 +206,7 @@ public class TestExportGroups extends TestExportBase {
                 "with-schema", "true",
                 "nonce", "zorag1",
                 "outdir", "/tmp/" + System.getProperty("user.name")));
-        project.addExport(true /* enabled */, "custom", props, "NO_NULLS");
+        project.addExport(true, ServerExportEnum.CUSTOM, props, "NO_NULLS");
 
         // Foo tables for testing export groups
         Properties propsGrp = new Properties();
@@ -216,7 +216,7 @@ public class TestExportGroups extends TestExportBase {
                 "with-schema", "true",
                 "nonce", "grpnonce",
                 "outdir", "/tmp/" + System.getProperty("user.name")));
-        project.addExport(true /* enabled */, "file", propsGrp, "grp");
+        project.addExport(true, ServerExportEnum.FILE, propsGrp, "grp");
         project.addProcedures(PROCEDURES);
 
         // JNI, single server
@@ -237,6 +237,7 @@ public class TestExportGroups extends TestExportBase {
         config.setMaxHeap(1024);
         //ExportToFile needs diff paths which VoltFile magic provides so need to run in old mode.
         ((LocalCluster )config).setNewCli(false);
+        ((LocalCluster )config).setHasLocalServer(false);
         boolean compile = config.compile(project);
         MiscUtils.copyFile(project.getPathToDeployment(),
                 Configuration.getPathToCatalogForTest("export-ddl.xml"));
@@ -251,14 +252,15 @@ public class TestExportGroups extends TestExportBase {
                 BackendTarget.NATIVE_EE_JNI, LocalCluster.FailureState.ALL_RUNNING, true, additionalEnv);
         //ExportToFile needs diff paths which VoltFile magic provides so need to run in old mode.
         ((LocalCluster )config).setNewCli(false);
+        ((LocalCluster )config).setHasLocalServer(false);
         config.setMaxHeap(1024);
         project = new VoltProjectBuilder();
         project.addRoles(GROUPS);
         project.addUsers(USERS);
         project.addSchema(TestSQLTypesSuite.class.getResource("sqltypessuite-export-ddl-with-target.sql"));
         project.addSchema(TestSQLTypesSuite.class.getResource("sqltypessuite-nonulls-export-ddl-with-target.sql"));
-        project.addExport(true /* enabled */, "custom", props, "NO_NULLS");
-        project.addExport(true /* enabled */, "file", propsGrp, "grp");
+        project.addExport(true, ServerExportEnum.CUSTOM, props, "NO_NULLS");
+        project.addExport(true, ServerExportEnum.FILE, propsGrp, "grp");
         project.addProcedures(PROCEDURES);
         compile = config.compile(project);
         MiscUtils.copyFile(project.getPathToDeployment(),
@@ -272,14 +274,15 @@ public class TestExportGroups extends TestExportBase {
                 BackendTarget.NATIVE_EE_JNI, LocalCluster.FailureState.ALL_RUNNING, true, additionalEnv);
         //ExportToFile needs diff paths which VoltFile magic provides so need to run in old mode.
         ((LocalCluster )config).setNewCli(false);
+        ((LocalCluster )config).setHasLocalServer(false);
         config.setMaxHeap(1024);
         project = new VoltProjectBuilder();
         project.addRoles(GROUPS);
         project.addUsers(USERS);
         project.addSchema(TestSQLTypesSuite.class.getResource("sqltypessuite-export-ddl-with-target.sql"));
         project.addSchema(TestSQLTypesSuite.class.getResource("sqltypessuite-nonulls-export-ddl-with-target.sql"));
-        project.addExport(true /* enabled */, "custom", props, "NO_NULLS");
-        project.addExport(true /* enabled */, "file", propsGrp, "grp");
+        project.addExport(true, ServerExportEnum.CUSTOM, props, "NO_NULLS");
+        project.addExport(true, ServerExportEnum.FILE, propsGrp, "grp");
         project.addProcedures(PROCEDURES);
         compile = config.compile(project);
         MiscUtils.copyFile(project.getPathToDeployment(),

--- a/tests/frontend/org/voltdb/TestExportOverflow.java
+++ b/tests/frontend/org/voltdb/TestExportOverflow.java
@@ -38,6 +38,7 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ClientImpl;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
@@ -154,15 +155,14 @@ public class TestExportOverflow extends RegressionSuite {
             new MultiConfigSuiteBuilder(TestExportOverflow.class);
         VoltProjectBuilder project = new VoltProjectBuilder();
 
-        // configure export
-        project.addLiteralSchema(
-                "CREATE STREAM stream1 EXPORT TO TARGET rejecting1 (id integer NOT NULL, value varchar(25) NOT NULL);");
-        project.addExport(true, "custom", null, "rejecting1");
-
         // set up default export connector
         System.setProperty(ExportDataProcessor.EXPORT_TO_TYPE, "org.voltdb.exportclient.RejectingExportClient");
         Map<String, String> additionalEnv = new HashMap<String, String>();
         additionalEnv.put(ExportDataProcessor.EXPORT_TO_TYPE, "org.voltdb.exportclient.RejectingExportClient");
+
+        project.addLiteralSchema(
+                "CREATE STREAM stream1 EXPORT TO TARGET rejecting1 (id integer NOT NULL, value varchar(25) NOT NULL);");
+        project.addExport(true, ServerExportEnum.CUSTOM, null, "rejecting1");
 
         LocalCluster config = new LocalCluster("export-overflow-test.jar", 1, 1, 0,
                 BackendTarget.NATIVE_EE_JNI, LocalCluster.FailureState.ALL_RUNNING, true, additionalEnv);

--- a/tests/frontend/org/voltdb/TestExportRecoverWithView.java
+++ b/tests/frontend/org/voltdb/TestExportRecoverWithView.java
@@ -36,6 +36,7 @@ import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.regressionsuites.JUnit4LocalClusterTest;
 import org.voltdb.regressionsuites.LocalCluster;
@@ -63,7 +64,7 @@ public class TestExportRecoverWithView extends JUnit4LocalClusterTest {
         }
         project.setUseDDLSchema(true);
         Properties props = new Properties();
-        project.addExport(true /* enabled */, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
         LocalCluster db = new LocalCluster("exportview.jar", 2, 1, 0, 2, BackendTarget.NATIVE_EE_JNI,
                 LocalCluster.FailureState.ALL_RUNNING, true, additionalEnv);
         boolean compile = db.compile(project);

--- a/tests/frontend/org/voltdb/TestExportRejoinWithView.java
+++ b/tests/frontend/org/voltdb/TestExportRejoinWithView.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.export.ExportTestClient;
 import org.voltdb.export.ExportTestVerifier;
@@ -193,7 +194,7 @@ public class TestExportRejoinWithView extends TestExportBase {
         VoltProjectBuilder project = new VoltProjectBuilder();
         project.setUseDDLSchema(true);
         Properties props = new Properties();
-        project.addExport(true /* enabled */, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
 
         /*
          * compile the catalog all tests start with

--- a/tests/frontend/org/voltdb/TestExportSPIMigration.java
+++ b/tests/frontend/org/voltdb/TestExportSPIMigration.java
@@ -49,6 +49,7 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.regressionsuites.JUnit4LocalClusterTest;
 import org.voltdb.regressionsuites.LocalCluster;
@@ -97,7 +98,7 @@ public class TestExportSPIMigration extends JUnit4LocalClusterTest
             Properties props = new Properties();
             //props.put("replicated", "true");
             props.put("skipinternals", "true");
-            builder.addExport(true, "custom", props);
+            builder.addExport(true, ServerExportEnum.CUSTOM, props);
 
             cluster = new LocalCluster("testFlushExportBuffer.jar", 2, 2, 1, BackendTarget.NATIVE_EE_JNI);
             cluster.setJavaProperty("MAX_EXPORT_BUFFER_FLUSH_INTERVAL", "50000");

--- a/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExport.java
+++ b/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExport.java
@@ -33,8 +33,10 @@ import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientConfigForTest;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.export.TestExportBase;
+import org.voltdb.export.SocketExportTestServer;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
 import org.voltdb.utils.VoltFile;
@@ -45,7 +47,7 @@ import org.voltdb.utils.VoltFile;
  */
 public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
 
-    private static ServerListener m_serverSocket;
+    private static SocketExportTestServer m_serverSocket;
     private static LocalCluster config;
     @Override
     public void setUp() throws Exception {
@@ -55,7 +57,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         File f = new File("/tmp/" + System.getProperty("user.name"));
         f.mkdirs();
         super.setUp();
-        m_serverSocket = new ServerListener(5001);
+        m_serverSocket = new SocketExportTestServer(5001);
         m_serverSocket.start();
     }
 
@@ -63,7 +65,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
     public void tearDown() throws Exception {
         super.tearDown();
         try {
-            m_serverSocket.close();
+            m_serverSocket.shutdown();
             m_serverSocket = null;
         } catch (Exception e) {}
     }
@@ -81,7 +83,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         }
         client.drain();
         waitForExportAllocatedMemoryZero(client);
-        verifyExportedTuples(5000);
+        m_serverSocket.verifyExportedTuples(5000);
 
         for (int i=5000;i<10000;i++) {
             insertSql = new StringBuilder();
@@ -90,7 +92,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         }
         client.drain();
         waitForExportAllocatedMemoryZero(client);
-        verifyExportedTuples(10000);
+        m_serverSocket.verifyExportedTuples(10000);
 
         for (int i=10000;i<15000;i++) {
             insertSql = new StringBuilder();
@@ -99,7 +101,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         }
         client.drain();
         waitForExportAllocatedMemoryZero(client);
-        verifyExportedTuples(15000);
+        m_serverSocket.verifyExportedTuples(15000);
 
         for (int i=15000;i<30000;i++) {
             insertSql = new StringBuilder();
@@ -108,7 +110,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         }
         client.drain();
         waitForExportAllocatedMemoryZero(client);
-        verifyExportedTuples(30000);
+        m_serverSocket.verifyExportedTuples(30000);
 
         for (int i=30000;i<45000;i++) {
             insertSql = new StringBuilder();
@@ -117,7 +119,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         }
         client.drain();
         waitForExportAllocatedMemoryZero(client);
-        verifyExportedTuples(45000);
+        m_serverSocket.verifyExportedTuples(45000);
     }
 
     public void testExportReplicatedExportToSocketRejoin() throws Exception {
@@ -134,7 +136,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         client.callProcedure("@AdHoc", insertSql.toString());
         client.drain();
         waitForExportAllocatedMemoryZero(client);
-        verifyExportedTuples(50);
+        m_serverSocket.verifyExportedTuples(50);
 
         config.killSingleHost(1);
         config.recoverOne(1, 0, "");
@@ -147,7 +149,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         client.drain();
         waitForExportAllocatedMemoryZero(client);
         //After recovery make sure we get exact 2 of each.
-        verifyExportedTuples(100);
+        m_serverSocket.verifyExportedTuples(100);
 
         config.killSingleHost(2);
         config.recoverOne(2, 0, "");
@@ -160,7 +162,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         client.drain();
         waitForExportAllocatedMemoryZero(client);
         //After recovery make sure we get exact 2 of each.
-        verifyExportedTuples(150);
+        m_serverSocket.verifyExportedTuples(150);
 
         //Kill host with all masters now.
         config.killSingleHost(0);
@@ -175,7 +177,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         client.callProcedure("@AdHoc", insertSql.toString());
         client.drain();
         waitForExportAllocatedMemoryZero(client);
-        verifyExportedTuples(2000);
+        m_serverSocket.verifyExportedTuples(2000);
     }
 
     public TestExportSuiteReplicatedSocketExport(final String name) {
@@ -198,7 +200,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         props.put("replicated", "true");
         props.put("skipinternals", "true");
 
-        project.addExport(true /* enabled */, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
         /*
          * compile the catalog all tests start with
          */

--- a/tests/frontend/org/voltdb/TestExportView.java
+++ b/tests/frontend/org/voltdb/TestExportView.java
@@ -32,6 +32,7 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.export.TestExportBase;
 import org.voltdb.regressionsuites.LocalCluster;
@@ -168,7 +169,7 @@ public class TestExportView extends TestExportBase {
 
         Properties props = new Properties();
 
-        project.addExport(true /* enabled */, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
         /*
          * compile the catalog all tests start with
          */

--- a/tests/frontend/org/voltdb/TestPrepareShutdownWithExport.java
+++ b/tests/frontend/org/voltdb/TestPrepareShutdownWithExport.java
@@ -32,15 +32,17 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.export.TestExportBase;
+import org.voltdb.export.SocketExportTestServer;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
 import org.voltdb.utils.VoltFile;
 
 public class TestPrepareShutdownWithExport extends TestExportBase
 {
-    private ServerListener m_serverSocket;
+    private SocketExportTestServer m_serverSocket;
     public TestPrepareShutdownWithExport(String name) {
         super(name);
     }
@@ -53,7 +55,7 @@ public class TestPrepareShutdownWithExport extends TestExportBase
         File f = new File("/tmp/" + System.getProperty("user.name"));
         f.mkdirs();
         super.setUp();
-        m_serverSocket = new ServerListener(5001);
+        m_serverSocket = new SocketExportTestServer(5001);
         m_serverSocket.start();
     }
 
@@ -61,7 +63,7 @@ public class TestPrepareShutdownWithExport extends TestExportBase
     public void tearDown() throws Exception {
         super.tearDown();
         try {
-            m_serverSocket.close();
+            m_serverSocket.shutdown();
             m_serverSocket = null;
         } catch (Exception e) {}
     }
@@ -81,7 +83,7 @@ public class TestPrepareShutdownWithExport extends TestExportBase
 
         //push out export buffer and verify if there are any export queue.
         waitForExportAllocatedMemoryZero(client2);
-        verifyExportedTuples(10000);
+        m_serverSocket.verifyExportedTuples(10000);
 
         long sum = Long.MAX_VALUE;
         while (sum > 0) {
@@ -127,7 +129,7 @@ public class TestPrepareShutdownWithExport extends TestExportBase
         Properties props = new Properties();
         props.put("replicated", "true");
         props.put("skipinternals", "true");
-        project.addExport(true, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
 
         LocalCluster config = new LocalCluster("client-all-partitions.jar", 4, 2, 0, BackendTarget.NATIVE_EE_JNI,
                 LocalCluster.FailureState.ALL_RUNNING, true, additionalEnv);

--- a/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
+++ b/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
@@ -40,6 +40,7 @@ import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.client.ProcedureCallback;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.RegressionSuite;
@@ -903,7 +904,7 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         //builder.setTableAsExportOnly("blah_replicated", false);
         //builder.setTableAsExportOnly("PARTITIONED", false);
         //builder.setTableAsExportOnly("PARTITIONED_LARGE", false);
-        builder.addExport(true, "file", null);  // authGroups (off)
+        builder.addExport(true, ServerExportEnum.FILE, null);  // authGroups (off)
 
         System.setProperty(ExportDataProcessor.EXPORT_TO_TYPE, "org.voltdb.export.ExportTestClient");
         String dexportClientClassName = System.getProperty("exportclass", "");
@@ -996,7 +997,7 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
     public void testRejoinWithExportWithActuallyExportedTables() throws Exception {
         VoltProjectBuilder builder = getBuilderForTest();
 
-        builder.addExport(true, "file", null);  // authGroups (off)
+        builder.addExport(true, ServerExportEnum.FILE, null);  // authGroups (off)
 
         System.setProperty(ExportDataProcessor.EXPORT_TO_TYPE, "org.voltdb.export.ExportTestClient");
         String dexportClientClassName = System.getProperty("exportclass", "");

--- a/tests/frontend/org/voltdb/TestSnapshotWithViews.java
+++ b/tests/frontend/org/voltdb/TestSnapshotWithViews.java
@@ -32,6 +32,7 @@ import org.voltdb.VoltDB.Configuration;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.export.ExportTestClient;
 import org.voltdb.export.ExportTestVerifier;
@@ -317,7 +318,7 @@ public class TestSnapshotWithViews extends TestExportBase {
         VoltProjectBuilder project = new VoltProjectBuilder();
         project.setUseDDLSchema(true);
         Properties props = new Properties();
-        project.addExport(true /* enabled */, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
 
         /*
          * compile the catalog all tests start with

--- a/tests/frontend/org/voltdb/TestStreamView.java
+++ b/tests/frontend/org/voltdb/TestStreamView.java
@@ -37,6 +37,7 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.regressionsuites.RegressionSuite;
 import org.voltdb.utils.MiscUtils;
@@ -344,7 +345,7 @@ public class TestStreamView
            "CREATE INDEX bidask_minmax_idx on bidask_minmax ( ABS(min_ask) );");
 
         Properties props = new Properties();
-        project.addExport(true, "custom", props, "noop");
+        project.addExport(true, ServerExportEnum.CUSTOM, props, "noop");
 
         boolean compiled = project.compile(Configuration.getPathToCatalogForTest("test-stream-view.jar"), 1, 1, 0);
         assertTrue(compiled);

--- a/tests/frontend/org/voltdb/TestUpdateInExportRecoverWithView.java
+++ b/tests/frontend/org/voltdb/TestUpdateInExportRecoverWithView.java
@@ -36,6 +36,7 @@ import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.regressionsuites.JUnit4LocalClusterTest;
 import org.voltdb.regressionsuites.LocalCluster;
@@ -63,7 +64,7 @@ public class TestUpdateInExportRecoverWithView extends JUnit4LocalClusterTest {
         }
         project.setUseDDLSchema(true);
         Properties props = new Properties();
-        project.addExport(true /* enabled */, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
         LocalCluster db = new LocalCluster("exportview.jar", 2, 1, 0, 2, BackendTarget.NATIVE_EE_JNI,
                 LocalCluster.FailureState.ALL_RUNNING, true, additionalEnv);
         boolean compile = db.compile(project);

--- a/tests/frontend/org/voltdb/export/SocketExportTestServer.java
+++ b/tests/frontend/org/voltdb/export/SocketExportTestServer.java
@@ -1,0 +1,197 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.export;
+
+import static junit.framework.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import au.com.bytecode.opencsv_voltpatches.CSVParser;
+
+public class SocketExportTestServer extends Thread {
+
+    private final ConcurrentMap<Long, AtomicLong> m_seenIds = new ConcurrentHashMap<Long, AtomicLong>();
+    private final List<ClientConnectionHandler> m_clients = Collections.synchronizedList(new ArrayList<ClientConnectionHandler>());
+    private ServerSocket ssocket;
+    private final int m_port;
+    private volatile boolean shuttingDown;
+    private volatile boolean m_paused;
+
+    public SocketExportTestServer(int port) {
+        m_port = port;
+        try {
+            ssocket = new ServerSocket(port);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private void close() throws IOException {
+        if (ssocket == null) {
+            return;
+        }
+
+        try {
+            ssocket.close();
+        } catch (Exception e) {}
+        ssocket = null;
+    }
+
+    public void shutdown() throws IOException {
+        shuttingDown = true;
+        stopClients();
+        close();
+        m_seenIds.clear();
+    }
+
+    public void stopCurrentConnsAndPause() throws IOException {
+        m_paused = true;
+        stopClients();
+        // close the socket and reopen to avoid new connections
+        close();
+        try {
+            ssocket = new ServerSocket(m_port);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    public void unpause() {
+        m_paused = false;
+    }
+
+    private void stopClients() {
+        synchronized(m_clients) {
+            for (ClientConnectionHandler s : m_clients) {
+                s.stopClient();
+            }
+            m_clients.clear();
+        }
+    }
+
+    @Override
+    public void run() {
+        while (!shuttingDown) {
+            if (m_paused) {
+                try { Thread.sleep(250); } catch(InterruptedException e) { }
+                continue;
+            }
+            try {
+                Socket clientSocket = ssocket.accept();
+                synchronized(m_clients) {
+                    if (!m_paused && !shuttingDown) {
+                        ClientConnectionHandler ch = new ClientConnectionHandler(clientSocket);
+                        m_clients.add(ch);
+                        ch.start();
+                    }
+                }
+            } catch (IOException ex) {
+                System.out.println("Exception in socket server accept loop: " + ex.getMessage());
+            }
+        }
+    }
+
+    public void verifyExportedTuples(int expsize) {
+        verifyExportedTuples(expsize, TimeUnit.MINUTES.toMillis(5));
+    }
+
+    public void verifyExportedTuples(int expsize, long waitTimeMs) {
+        long end = System.currentTimeMillis() + waitTimeMs;
+        boolean passed = false;
+        while (true) {
+            if (m_seenIds.size() == expsize) {
+                passed = true;
+                break;
+            }
+            long ctime = System.currentTimeMillis();
+            if (ctime > end) {
+                System.out.println("Waited too long...");
+                break;
+            }
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException ex) {
+            }
+        }
+        System.out.println("Seen Id size is: " + m_seenIds.size() + " expected:" + expsize + " Passed: " + passed);
+        assertTrue(passed);
+    }
+
+
+    public class ClientConnectionHandler extends Thread {
+        private final Socket m_clientSocket;
+        private boolean m_closed = false;
+        final CSVParser m_parser = new CSVParser();
+        public ClientConnectionHandler(Socket clientSocket) {
+            m_clientSocket = clientSocket;
+        }
+
+        @Override
+        public void run() {
+            try {
+                BufferedReader in = new BufferedReader(
+                        new InputStreamReader(m_clientSocket.getInputStream()));
+                while (!m_closed) {
+                    String line = in.readLine();
+                    //You should convert your data to params here.
+                    if (line == null && m_closed) {
+                        break;
+                    }
+                    if (line == null) {
+                        try { Thread.sleep(100); } catch(InterruptedException e) { }
+                        continue;
+                    }
+                    String parts[] = m_parser.parseLine(line);
+                    if (parts == null) {
+                        continue;
+                    }
+                    Long i = Long.parseLong(parts[0]);
+                    if (m_seenIds.putIfAbsent(i, new AtomicLong(1)) != null) {
+                        synchronized(m_seenIds) {
+                            m_seenIds.get(i).incrementAndGet();
+                        }
+                    }
+                }
+                m_clientSocket.close();
+            } catch (IOException ioe) {
+                System.out.println("ClientConnection handler exited with IOException: " + ioe.getMessage());
+            }
+        }
+
+        public void stopClient() {
+            m_closed = true;
+        }
+    }
+}

--- a/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
+++ b/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
@@ -49,6 +49,7 @@ import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.compiler.VoltProjectBuilder.ProcedureInfo;
 import org.voltdb.compiler.VoltProjectBuilder.RoleInfo;
 import org.voltdb.compiler.VoltProjectBuilder.UserInfo;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.exportclient.ExportDecoderBase;
 import org.voltdb.regressionsuites.RegressionSuite;
 import org.voltdb_testprocs.regressionsuites.sqltypesprocs.Insert;
@@ -448,7 +449,7 @@ public class TestExportBaseSocketExport extends RegressionSuite {
         Properties props = new Properties();
         props.put("procedure", procedure);
         props.put("timezone", "GMT");
-        project.addExport(true /* enabled */, "custom", props, streamName);
+        project.addExport(true, ServerExportEnum.CUSTOM, props, streamName);
     }
 
     public static void wireupExportTableToSocketExport(String streamName) {
@@ -464,7 +465,7 @@ public class TestExportBaseSocketExport extends RegressionSuite {
         props.put("skipinternals", "false");
         props.put("socket.dest", "localhost:" + m_portForTable.get(streamName));
         props.put("timezone", "GMT");
-        project.addExport(true /* enabled */, "custom", props, streamName);
+        project.addExport(true, ServerExportEnum.CUSTOM, props, streamName);
     }
 
     private static Integer getNextPort() {

--- a/tests/frontend/org/voltdb/np/Test2PTransactionExport.java
+++ b/tests/frontend/org/voltdb/np/Test2PTransactionExport.java
@@ -53,6 +53,7 @@ import org.voltdb.VoltTableRow;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.regressionsuites.LocalCluster;
 
@@ -128,7 +129,7 @@ public class Test2PTransactionExport {
         Properties props = new Properties();
         props.put("replicated", "true");
         props.put("skipinternals", "true");
-        builder.addExport(true, "custom", props);
+        builder.addExport(true, ServerExportEnum.CUSTOM, props);
 
         cluster = new LocalCluster("test2pexport.jar", 4, 2, KFACTOR,
                                    BackendTarget.NATIVE_EE_JNI, LocalCluster.FailureState.ALL_RUNNING,

--- a/tests/frontend/org/voltdb/regressionsuites/TestExportRowLengthLimit.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestExportRowLengthLimit.java
@@ -34,6 +34,7 @@ import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.client.SyncCallback;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.utils.CatalogUtil;
 
@@ -69,7 +70,7 @@ public class TestExportRowLengthLimit extends RegressionSuite {
         Properties props = new Properties();
         props.put("skipinternals", "true");
         props.put(CatalogUtil.ROW_LENGTH_LIMIT, "16");
-        project.addExport(true, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
 
         config = new LocalCluster("export-ddl-cluster-rep.jar", 2, 3, 1,
                 BackendTarget.NATIVE_EE_JNI, LocalCluster.FailureState.ALL_RUNNING, true, additionalEnv);
@@ -104,7 +105,7 @@ public class TestExportRowLengthLimit extends RegressionSuite {
         Properties props = new Properties();
         props.put("skipinternals", "true");
         props.put(CatalogUtil.ROW_LENGTH_LIMIT, "8");
-        project.addExport(true, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
 
         config = new LocalCluster("export-ddl-cluster-rep.jar", 2, 3, 1,
                 BackendTarget.NATIVE_EE_JNI, LocalCluster.FailureState.ALL_RUNNING, true, additionalEnv);

--- a/tests/frontend/org/voltdb/regressionsuites/TestExportWithMisconfiguredExportClient.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestExportWithMisconfiguredExportClient.java
@@ -36,6 +36,7 @@ import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.compiler.VoltProjectBuilder.ProcedureInfo;
 import org.voltdb.compiler.VoltProjectBuilder.RoleInfo;
 import org.voltdb.compiler.VoltProjectBuilder.UserInfo;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.export.ExportTestClient;
 import org.voltdb.export.ExportTestVerifier;
@@ -151,7 +152,7 @@ public class TestExportWithMisconfiguredExportClient extends RegressionSuite {
                 "with-schema", "true",
                 "complain", "true",
                 "outdir", "/tmp/" + System.getProperty("user.name")));
-        project.addExport(true /* enabled */, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
         project.addPartitionInfo("NO_NULLS", "PKEY");
         project.addPartitionInfo("NO_NULLS_GRP", "PKEY");
         project.addPartitionInfo("ALLOW_NULLS", "PKEY");

--- a/tests/frontend/org/voltdb/regressionsuites/TestUpdateDeployment.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUpdateDeployment.java
@@ -45,6 +45,7 @@ import org.voltdb.common.Constants;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.compiler.VoltProjectBuilder.RoleInfo;
 import org.voltdb.compiler.VoltProjectBuilder.UserInfo;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.utils.MiscUtils;
 
@@ -368,7 +369,7 @@ public class TestUpdateDeployment extends RegressionSuite {
                 "with-schema", "true",
                 "complain", "true",
                 "outdir", "/tmp/" + System.getProperty("user.name"));
-        project.addExport(true /* enabled */, "custom", props);
+        project.addExport(true, ServerExportEnum.CUSTOM, props);
         // build the jarfile
         boolean compile = config.compile(project);
         assertTrue(compile);


### PR DESCRIPTION
Store external streams states of sites in snapshot and use it at recover time.
Check for stream disabled was in the wrong place. Moved it out of persistent table
because it will never get there for partitioned table because there is nothing in the
hash ring for that partition. Added the check where we insert empty txn for MP txns for
partitions where it produced no actual data change.