### PR TITLE
ParameterSet: Do not use commons-lang during class initialization

### DIFF
--- a/src/frontend/org/voltdb/ParameterSet.java
+++ b/src/frontend/org/voltdb/ParameterSet.java
@@ -42,7 +42,7 @@ import org.voltdb.utils.SerializationHelper;
  *
  */
 public class ParameterSet implements JSONString {
-    private static final ParameterSet EMPTY = fromArray(ArrayUtils.EMPTY_OBJECT_ARRAY);
+    private static final ParameterSet EMPTY = fromArray(new Object[0]);
 
     static final byte ARRAY = -99;
 


### PR DESCRIPTION
ParameterSet is used by the client but the client is not suppose to depend upon
commons-lang3. The client now will throw ClassNotFoundError when ParameterSet
is loaded but commons-lang3 is not on the classpath. To avoid referencing
commons-lang3 during class initialization use a new empty Object array instead
of the static instance in ArrayUtils.