### PR TITLE
ENG-12876: Remove rejoin node from zk on failure

### DIFF
--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -48,6 +48,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.net.ssl.SSLEngine;
 
 import org.apache.commons.lang3.StringUtils;
@@ -992,7 +993,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                 synchronized(HostMessenger.this) {
                     removeForeignHost(hostId);
                 }
-                m_acceptor.detract(hostId);
+                m_acceptor.detract(m_zk, hostId);
                 socket.close();
                 return;
             }

--- a/src/frontend/org/voltcore/messaging/JoinAcceptor.java
+++ b/src/frontend/org/voltcore/messaging/JoinAcceptor.java
@@ -71,9 +71,11 @@ public interface JoinAcceptor extends JSONString {
 
     /**
      * notifies the acceptor when a host is removed from the mesh
-     * @param hostId
+     *
+     * @param zooKeeper {@link ZooKeeper} instance to use for zookeeper operations
+     * @param hostId    ID of host which was removed
      */
-    public void detract(int hostId);
+    public void detract(ZooKeeper zooKeeper, int hostId);
 
     /**
      * notifies the acceptor when a {@link Set&lt;Integer&gt;} hostIds

--- a/src/frontend/org/voltdb/probe/MeshProber.java
+++ b/src/frontend/org/voltdb/probe/MeshProber.java
@@ -349,7 +349,7 @@ public class MeshProber implements JoinAcceptor {
     }
 
     @Override
-    public void detract(int hostId) {
+    public void detract(ZooKeeper zooKeeper, int hostId) {
         checkArgument(hostId >= 0, "host id %s is not greater or equal to 0", hostId);
         Map<Integer,HostCriteria> expect;
         Map<Integer,HostCriteria> update;
@@ -360,6 +360,7 @@ public class MeshProber implements JoinAcceptor {
                 .putAll(Maps.filterKeys(expect, not(equalTo(hostId))))
                 .build();
         } while (!m_hostCriteria.compareAndSet(expect, update));
+        CoreZK.removeRejoinNodeIndicatorForHost(zooKeeper, hostId);
     }
 
     @Override

--- a/src/frontend/org/voltdb/probe/MeshProber.java
+++ b/src/frontend/org/voltdb/probe/MeshProber.java
@@ -717,24 +717,32 @@ public class MeshProber implements JoinAcceptor {
 
         @Override @Generated("by eclipse's equals and hashCode source generators")
         public boolean equals(Object obj) {
-            if (this == obj)
+            if (this == obj) {
                 return true;
-            if (obj == null)
+            }
+            if (obj == null) {
                 return false;
-            if (getClass() != obj.getClass())
+            }
+            if (getClass() != obj.getClass()) {
                 return false;
+            }
             Determination other = (Determination) obj;
-            if (hostCount != other.hostCount)
+            if (hostCount != other.hostCount) {
                 return false;
-            if (paused != other.paused)
+            }
+            if (paused != other.paused) {
                 return false;
-            if (startAction != other.startAction)
+            }
+            if (startAction != other.startAction) {
                 return false;
+            }
             if (terminusNonce == null) {
-                if (other.terminusNonce != null)
+                if (other.terminusNonce != null) {
                     return false;
-            } else if (!terminusNonce.equals(other.terminusNonce))
+                }
+            } else if (!terminusNonce.equals(other.terminusNonce)) {
                 return false;
+            }
             return true;
         }
 

--- a/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
+++ b/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
+import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -1296,7 +1297,7 @@ public class TestHostMessenger {
             }
 
             @Override
-            public void detract(int hostId) {
+            public void detract(ZooKeeper zooKeeper, int hostId) {
             }
 
             @Override


### PR DESCRIPTION
There is a time when a the zk rejoin node exists for a rejoining host but the
host is not in zookeeper. If the host failed in this window the rejoin node
would be left in zookeeper not allowing any other hosts to rejoin.
    
Update MeshProber.detract(int) to also take in a zookepeer instance and call
CoreZK.removeRejoinNodeIndicatorForHost to remove the rejoin node from
zookeeper.
