### PR TITLE
Eng 15035 junit flaky2

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1730,6 +1730,8 @@ TEST CASES
 
             <jvmarg value="-Dtestindex=${testindex}" />
             <jvmarg value="-Dtestcount=${testcount}" />
+            <jvmarg value="-Drun.flaky.tests=${run.flaky.tests}" />
+            <jvmarg value="-Drun.flaky.tests.debug=${run.flaky.tests.debug}" />
 
             <!-- write per-testcase output to console if verbose mode -->
             <formatter type="plain" usefile="false" if="verbosereport"/>

--- a/tests/frontend/org/voltcore/agreement/TestFuzzMeshArbiter.java
+++ b/tests/frontend/org/voltcore/agreement/TestFuzzMeshArbiter.java
@@ -25,6 +25,8 @@ package org.voltcore.agreement;
 
 import static com.google_voltpatches.common.base.Predicates.equalTo;
 import static com.google_voltpatches.common.base.Predicates.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,10 +39,16 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.voltcore.agreement.MiniNode.NodeState;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.CoreUtils;
+import org.voltdb.FlakyTestRule;
+import org.voltdb.FlakyTestRule.Flaky;
 
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.collect.ImmutableSortedMap;
@@ -48,11 +56,12 @@ import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.primitives.Ints;
 
-import junit.framework.TestCase;
 
-
-public class TestFuzzMeshArbiter extends TestCase
+public class TestFuzzMeshArbiter
 {
+    @Rule
+    public FlakyTestRule ftRule = new FlakyTestRule();
+
     public static VoltLogger m_fuzzLog = new VoltLogger("FUZZ");
     public static VoltLogger m_rejoinLog = new VoltLogger("REJOIN");
 
@@ -93,7 +102,7 @@ public class TestFuzzMeshArbiter extends TestCase
         }
     }
 
-    @Override
+    @After
     public void tearDown() throws InterruptedException
     {
         for (MiniNode node : m_nodes.values()) {
@@ -139,6 +148,7 @@ public class TestFuzzMeshArbiter extends TestCase
         return result;
     }
 
+    @Test
     public void testNodeFail() throws InterruptedException
     {
         m_rejoinLog.info("testNodeFail");
@@ -158,6 +168,7 @@ public class TestFuzzMeshArbiter extends TestCase
         state.expect();
     }
 
+    @Test
     public void testLinkFail() throws InterruptedException
     {
         m_rejoinLog.info("testLinkFail");
@@ -177,6 +188,7 @@ public class TestFuzzMeshArbiter extends TestCase
         state.expect();
     }
 
+    @Test
     public void testUnidirectionalLinkFailure() throws InterruptedException {
         m_rejoinLog.info("testUnidirectionalLinkFailure");
         // Fill the array if you want to use specific per-site random seed to reproduce an issue.
@@ -548,6 +560,8 @@ public class TestFuzzMeshArbiter extends TestCase
         }
     }
 
+    @Test
+    @Flaky(isFlaky=false, description="TestFuzzMeshArbiter.testSimpleJoin: slightly flaky, fails rarely")
     public void testSimpleJoin() throws InterruptedException {
         m_rejoinLog.info("testSimpleJoin");
         // Fill the array if you want to use specific per-site random seed to reproduce an issue.
@@ -585,6 +599,8 @@ public class TestFuzzMeshArbiter extends TestCase
         }
     }
 
+    @Test
+    @Flaky(isFlaky=true, description="TestFuzzMeshArbiter.testFuzz: still flaky, fails intermittently")
     public void testFuzz() throws InterruptedException
     {
         m_rejoinLog.info("testFuzz");

--- a/tests/frontend/org/voltdb/FlakyTestRule.java
+++ b/tests/frontend/org/voltdb/FlakyTestRule.java
@@ -1,0 +1,238 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb;
+
+import static org.junit.Assume.assumeTrue;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class FlakyTestRule implements TestRule {
+    // Print debug statements only if -Drun.flaky.tests.debug=TRUE
+    private final boolean DEBUG = FlakyTestStandardRunner.debug();
+
+    /**
+     * The @Flaky annotation is intended to be used for JUnit tests that do not
+     * pass reliably, failing either intermittently or consistently; such tests
+     * may or may not be skipped, depending on several factors:<br>
+     *     o The value of the system property run.flaky.tests (set on the command
+     *       line via '-Drun.flaky.tests=...'), when running the tests.<br>
+     *     o The value of the <i>isFlaky</i> parameter, e.g. @Flaky(isFlaky=true), which
+     *       is the default value.<br>
+     *     o If you choose, rather than using <i>FlakyTestStandardRunner</i>,
+     *       which is the the default runCondition parameter, to write your own
+     *       implementation of FlakyTestRunner, then it could depend on whatever
+     *       other factors you choose.<br>
+     * Once a test passes reliably again, the @Flaky annotation may be removed,
+     * or changed to use @Flaky(isFlaky=false). There is also an optional
+     * <i>description</i> parameter, which may be used to describe the test or
+     * the ways and circumstances in which it is flaky.
+     */
+    @Documented
+    @Target(ElementType.METHOD)
+    @Inherited
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Flaky {
+        boolean isFlaky() default true;
+        String description() default "";
+        Class<? extends FlakyTestRunner> runCondition() default FlakyTestStandardRunner.class;
+    }
+
+    /**
+     * Interface to determine, via either of its runFlakyTest methods, whether or not a
+     * particular @Flaky test (that is, a JUnit test with an @Flaky annotation)
+     * should be run.
+     * @param testIsFlaky boolean: the value of a test's @Flaky annotation's
+     * 'isFlaky' parameter
+     * @param description String: the value of a test's @Flaky annotation's
+     * 'description' parameter
+     */
+    public interface FlakyTestRunner {
+        /**
+         * Used to determine whether or not a particular @Flaky test (that is,
+         * a JUnit test with an @Flaky annotation) should be run.
+         * @param testIsFlaky boolean: the value of a test's @Flaky annotation's
+         * 'isFlaky' parameter
+         */
+        boolean runFlakyTest(boolean testIsFlaky);
+        /**
+         * Used to determine whether or not a particular @Flaky test (that is,
+         * a JUnit test with an @Flaky annotation) should be run.
+         * @param testIsFlaky boolean: the value of a test's @Flaky annotation's
+         * 'isFlaky' parameter
+         * @param description String: the value of a test's @Flaky annotation's
+         * 'description' parameter
+         */
+        boolean runFlakyTest(boolean testIsFlaky, String description);
+    }
+
+    /**
+     * Implements TestRule.apply: modifies the method-running Statement per this
+     * test-running rule, which determines whether or not this particular JUnit
+     * test with an @Flaky annotation should be Ignored (i.e., not run).
+     * @param base The Statement to (perhaps) be modified
+     * @param desc A Description of the test implemented in <i>base</i>
+     */
+    @Override
+    public Statement apply(Statement base, Description desc) {
+        if (DEBUG) {
+            System.out.println("DEBUG: In FlakyTestRule.apply:");
+            System.out.println("DEBUG:   base: "+base);
+            System.out.println("DEBUG:   desc: "+desc);
+        }
+
+        Statement result = base;
+        Flaky flakyAnnotation = desc.getAnnotation(Flaky.class);
+        if (flakyAnnotation != null) {
+            FlakyTestRunner runCondition = (new FlakyTestRunnerCreator(desc, flakyAnnotation)).create();
+            if (!runCondition.runFlakyTest(flakyAnnotation.isFlaky(), flakyAnnotation.description())) {
+                result = new IgnoreThisTest();
+            }
+        }
+        return result;
+    }
+
+    private static class FlakyTestRunnerCreator {
+        private final Description description;
+        private final Class<? extends FlakyTestRunner> runCondition;
+        // Print debug statements only if -Drun.flaky.tests.debug=TRUE
+        private final boolean DEBUG = FlakyTestStandardRunner.debug();
+
+        FlakyTestRunnerCreator(Description description, Flaky flakyAnnotation) {
+            if (DEBUG) {
+                System.out.println("DEBUG: In FlakyTestRule.FTRCreator constructor");
+            }
+            this.description = description;
+            this.runCondition = flakyAnnotation.runCondition();
+        }
+
+        FlakyTestRunner create() {
+            if (DEBUG) {
+                System.out.println("DEBUG: In FlakyTestRule.FTRCreator.create");
+            }
+            checkConditionType();
+            try {
+                return createRunCondition();
+            } catch (RuntimeException re) {
+                throw re;
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private FlakyTestRunner createRunCondition() throws Exception {
+            if (DEBUG) {
+                System.out.println("DEBUG: In FlakyTestRule.FTRCreator.createRunCondition");
+            }
+            FlakyTestRunner result;
+            if (isConditionTypeStandalone()) {
+                if (DEBUG) {
+                    System.out.println("DEBUG:   isConditionTypeStandalone true");
+                }
+                result = runCondition.newInstance();
+            } else {
+                Constructor<? extends FlakyTestRunner> declaredConstructor = runCondition.getDeclaredConstructor(description.getTestClass());
+                if (DEBUG) {
+                    System.out.println("DEBUG:   isConditionTypeStandalone false");
+                    System.out.println("DEBUG:     runCondition : "+runCondition);
+                    System.out.println("DEBUG:     getAnnotation: "+runCondition.getAnnotation(Flaky.class));
+                    System.out.println("DEBUG:     description  : "+description);
+                    System.out.println("DEBUG:     getAnnotation: "+description.getAnnotation(Flaky.class));
+                    System.out.println("DEBUG:     getTestClass : "+description.getTestClass());
+                    System.out.println("DEBUG:     declaredConstructor: "+declaredConstructor);
+                    System.out.println("DEBUG:     runCondition : "+runCondition);
+                    System.out.println("DEBUG:     runCondition : "+runCondition);
+                }
+                result = declaredConstructor.newInstance(description);
+            }
+            if (DEBUG) {
+                System.out.println("DEBUG:   result: "+result);
+            }
+            return result;
+        }
+
+        private void checkConditionType() {
+            if (DEBUG) {
+                System.out.println("DEBUG:   In FlakyTestRule.FTRCreator.checkConditionType");
+            }
+            if( !isConditionTypeStandalone() && !isConditionTypeDeclaredInTarget() ) {
+                System.out.println("DEBUG:     condidition type not good!");
+                String msg
+                  = "Conditional class '%s' is a member class "
+                  + "but was not declared inside the test case using it.\n"
+                  + "Either make this class a static class, "
+                  + "standalone class (by declaring it in it's own file) "
+                  + "or move it inside the test case using it";
+                throw new IllegalArgumentException( String.format ( msg, runCondition.getName() ) );
+            }
+        }
+
+      private boolean isConditionTypeStandalone() {
+          if (DEBUG) {
+              System.out.println("DEBUG:   In FlakyTestRule.FTRCreator.isConditionTypeStandalone");
+              System.out.println("DEBUG:     runCondition : "+runCondition);
+              System.out.println("DEBUG:     isMemberClass: "+runCondition.isMemberClass());
+              System.out.println("DEBUG:     getModifiers : "+runCondition.getModifiers());
+              System.out.println("DEBUG:     isStatic     : "+Modifier.isStatic(runCondition.getModifiers()));
+              System.out.println("DEBUG:     returns      : "+(!runCondition.isMemberClass() || Modifier.isStatic(runCondition.getModifiers())));
+          }
+          return !runCondition.isMemberClass() || Modifier.isStatic(runCondition.getModifiers());
+      }
+
+      private boolean isConditionTypeDeclaredInTarget() {
+          if (DEBUG) {
+              System.out.println("DEBUG:   In FlakyTestRule.FTRCreator.isConditionTypeDeclaredInTarget");
+              System.out.println("DEBUG:     description  : "+description);
+              System.out.println("DEBUG:     getTestClass : "+description.getTestClass());
+              System.out.println("DEBUG:     runCondition : "+runCondition);
+              System.out.println("DEBUG:     getDeclaringClass: "+runCondition.getDeclaringClass());
+              System.out.println("DEBUG:     returns      : "+(description.getTestClass().isAssignableFrom(runCondition.getDeclaringClass())));
+          }
+          return description.getTestClass().isAssignableFrom(runCondition.getDeclaringClass());
+      }
+    }
+
+    /** A (JUnit) Statement that always indicates that the test should be
+        ignored, i.e., not run. */
+    private static class IgnoreThisTest extends Statement {
+        @Override
+        public void evaluate() {
+            if (FlakyTestStandardRunner.debug()) {
+                System.out.println("DEBUG: In FlakyTestRule.IgnoreThisTest.evaluate");
+            }
+            assumeTrue(false);
+        }
+    }
+
+}

--- a/tests/frontend/org/voltdb/FlakyTestStandardRunner.java
+++ b/tests/frontend/org/voltdb/FlakyTestStandardRunner.java
@@ -68,10 +68,11 @@ public class FlakyTestStandardRunner implements FlakyTestRunner {
 
         // Optional debug print
         if (DEBUG) {
-            System.out.println("DEBUG: run.flaky.tests.debug: "+debug());
-            System.out.println("DEBUG: run.flaky.tests: "+RUN_FLAKY_TESTS);
-            System.out.println("DEBUG: testIsFlaky    : "+testIsFlaky);
-            System.out.println("DEBUG: description    : "+description);
+            System.out.println("DEBUG: In FlakyTestStandardRunner.runFlakyTest: "+debug());
+            System.out.println("DEBUG:   run.flaky.tests.debug: "+debug());
+            System.out.println("DEBUG:   run.flaky.tests: "+RUN_FLAKY_TESTS);
+            System.out.println("DEBUG:   testIsFlaky    : "+testIsFlaky);
+            System.out.println("DEBUG:   description    : "+description);
         }
 
         // When '-Drun.flaky.tests=FALSE' (or ='false', case insensitive),
@@ -79,7 +80,7 @@ public class FlakyTestStandardRunner implements FlakyTestRunner {
         // @Flaky, e.g., '@Flaky(isFlaky = false)'
         if ("FALSE".equalsIgnoreCase(RUN_FLAKY_TESTS)) {
             if (DEBUG) {
-                System.out.println("DEBUG: test will run : "+!testIsFlaky);
+                System.out.println("DEBUG:   test will run  : "+!testIsFlaky);
             }
             return !testIsFlaky;
 
@@ -88,7 +89,7 @@ public class FlakyTestStandardRunner implements FlakyTestRunner {
         // longer) @Flaky, e.g., '@Flaky(isFlaky = false)'
         } else if ("NONE".equalsIgnoreCase(RUN_FLAKY_TESTS)) {
             if (DEBUG) {
-                System.out.println("DEBUG: test will NOT be run!");
+                System.out.println("DEBUG:   test will NOT be run!");
             }
             return false;
 
@@ -96,7 +97,7 @@ public class FlakyTestStandardRunner implements FlakyTestRunner {
         // or 'ALL', or 'DEFAULT', or anything else), run all @Flaky tests
         } else {
             if (DEBUG) {
-                System.out.println("DEBUG: test WILL be run!");
+                System.out.println("DEBUG:   test WILL be run!");
             }
             return true;
         }

--- a/tests/frontend/org/voltdb/FlakyTestStandardRunner.java
+++ b/tests/frontend/org/voltdb/FlakyTestStandardRunner.java
@@ -1,0 +1,104 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb;
+
+import org.voltdb.FlakyTestRule.FlakyTestRunner;
+
+/**
+ * Class used (by default and, for now at least, always) to determine whether
+ * or not a particular @Flaky test (that is, a JUnit test with an @Flaky
+ * annotation) should be run, based on the value of the '-Drun.flaky.tests=...'
+ * system variable, as well as the value of its 'isFlaky' parameter.
+ */
+public class FlakyTestStandardRunner implements FlakyTestRunner {
+
+    private static final String RUN_FLAKY_TESTS = System.getProperty("run.flaky.tests", "DEFAULT");
+    private static final Boolean DEBUG = Boolean.getBoolean("run.flaky.tests.debug");
+
+    public static boolean debug() {
+        return DEBUG;
+    }
+
+    /**
+     * Determine whether or not this particular @Flaky test (that is, a JUnit
+     * test with an @Flaky annotation) should be run, based on the value of
+     * the '-Drun.flaky.tests=...' system variable, as well as the value of
+     * its 'isFlaky' parameter.
+     * @param testIsFlaky boolean: the value of the current test's @Flaky
+     * annotation's 'isFlaky' parameter
+     */
+    @Override
+    public boolean runFlakyTest(boolean testIsFlaky) {
+        return runFlakyTest(testIsFlaky, null);
+    }
+
+    /**
+     * Determine whether or not this particular @Flaky test (that is, a JUnit
+     * test with an @Flaky annotation) should be run, based on the value of
+     * the '-Drun.flaky.tests=...' system variable, as well as the value of
+     * its 'isFlaky' parameter.
+     * @param testIsFlaky boolean: the value of the current test's @Flaky
+     * annotation's 'isFlaky' parameter
+     * @param description String: the value of the current test's @Flaky
+     * annotation's 'description' parameter
+     */
+    @Override
+    public boolean runFlakyTest(boolean testIsFlaky, String description) {
+
+        // Optional debug print
+        if (DEBUG) {
+            System.out.println("DEBUG: run.flaky.tests.debug: "+debug());
+            System.out.println("DEBUG: run.flaky.tests: "+RUN_FLAKY_TESTS);
+            System.out.println("DEBUG: testIsFlaky    : "+testIsFlaky);
+            System.out.println("DEBUG: description    : "+description);
+        }
+
+        // When '-Drun.flaky.tests=FALSE' (or ='false', case insensitive),
+        // run only those @Flaky tests that have been marked not (or no longer)
+        // @Flaky, e.g., '@Flaky(isFlaky = false)'
+        if ("FALSE".equalsIgnoreCase(RUN_FLAKY_TESTS)) {
+            if (DEBUG) {
+                System.out.println("DEBUG: test will run : "+!testIsFlaky);
+            }
+            return !testIsFlaky;
+
+        // When '-Drun.flaky.tests=NONE' (or 'none', case insensitive), don't
+        // run any @Flaky test, not even if it has been marked as not (or no
+        // longer) @Flaky, e.g., '@Flaky(isFlaky = false)'
+        } else if ("NONE".equalsIgnoreCase(RUN_FLAKY_TESTS)) {
+            if (DEBUG) {
+                System.out.println("DEBUG: test will NOT be run!");
+            }
+            return false;
+
+        // By default, including when '-Drun.flaky.tests=TRUE' (or 'true',
+        // or 'ALL', or 'DEFAULT', or anything else), run all @Flaky tests
+        } else {
+            if (DEBUG) {
+                System.out.println("DEBUG: test WILL be run!");
+            }
+            return true;
+        }
+    }
+}

--- a/tests/frontend/org/voltdb/regressionsuites/MultiConfigSuiteBuilder.java
+++ b/tests/frontend/org/voltdb/regressionsuites/MultiConfigSuiteBuilder.java
@@ -31,7 +31,11 @@ import java.util.List;
 import com.google_voltpatches.common.base.Predicate;
 import com.google_voltpatches.common.base.Predicates;
 
-import junit.framework.Test;
+import org.junit.Test;
+import org.voltdb.FlakyTestStandardRunner;
+import org.voltdb.FlakyTestRule.Flaky;
+import org.voltdb.FlakyTestRule.FlakyTestRunner;
+
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
@@ -47,9 +51,11 @@ import junit.framework.TestSuite;
 public class MultiConfigSuiteBuilder extends TestSuite {
 
     /** The class that contains the JUnit test methods to run */
-    final Class<? extends TestCase> m_testClass;
+    private final Class<? extends TestCase> m_testClass;
     // Collection of test method names to be ignored and not executed
     final Predicate<String> m_testPredicate;
+    // Print debug statements only if -Drun.flaky.tests.debug=TRUE
+    private final boolean DEBUG = FlakyTestStandardRunner.debug();
 
     /**
      * Get the JUnit test methods for a given class. These methods have no
@@ -58,6 +64,10 @@ public class MultiConfigSuiteBuilder extends TestSuite {
      * @return A list of the names of each JUnit test method.
      */
     List<String> getTestMethodNames() {
+        if (DEBUG) {
+            System.out.println("DEBUG: Entering MultiConfigSuiteBuilder.getTestMethodNames");
+        }
+
         ArrayList<String> retval = new ArrayList<>();
 
         for (Method m : m_testClass.getMethods()) {
@@ -68,12 +78,45 @@ public class MultiConfigSuiteBuilder extends TestSuite {
                 continue;
             }
             String name = m.getName();
-            if (!name.startsWith("test") || !m_testPredicate.apply(name)) {
+
+            // TODO: once all tests are converted to JUnit4, we can remove the
+            // '!name.startsWith("test") &&' part (and could also remove checking
+            // getReturnType and getParameterCount, above)
+            if ((!name.startsWith("test") && m.getAnnotation(Test.class) == null)
+                    || !m_testPredicate.apply(name)) {
                 continue;
+            }
+            Flaky flakyAnnotation = m.getAnnotation(Flaky.class);
+            if (flakyAnnotation != null) {
+                Method runFlakyTestMethod = null;
+                boolean runFlakyTest = true;
+                Class<? extends FlakyTestRunner> flakyTestRunner = flakyAnnotation.runCondition();
+                try {
+                    runFlakyTestMethod = flakyTestRunner.getMethod( "runFlakyTest",
+                                          Boolean.TYPE, String.class );
+                    runFlakyTest = (boolean) runFlakyTestMethod.invoke(
+                                          flakyTestRunner.getDeclaredConstructor().newInstance(),
+                                          flakyAnnotation.isFlaky(), flakyAnnotation.description() );
+                } catch (Exception e) {
+                    System.out.println("WARNING: in MultiConfigSuiteBuilder.getTestMethodNames, caught exception:");
+                    e.printStackTrace(System.out);
+                }
+                if (DEBUG) {
+                    System.out.println("DEBUG:   flakyAnnotation   : "+flakyAnnotation);
+                    System.out.println("DEBUG:   flakyTestRunner   : "+flakyTestRunner);
+                    System.out.println("DEBUG:   runFlakyTestMethod: "+runFlakyTestMethod);
+                    System.out.println("DEBUG:   runFlakyTest      : "+runFlakyTest);
+                }
+                if (!runFlakyTest) {
+                    continue;
+                }
             }
             retval.add(name);
         }
 
+        if (DEBUG) {
+            System.out.println("DEBUG: Leaving  MultiConfigSuiteBuilder.getTestMethodNames");
+        }
         return retval;
     }
 
@@ -84,6 +127,9 @@ public class MultiConfigSuiteBuilder extends TestSuite {
      */
     public MultiConfigSuiteBuilder(Class<? extends TestCase> testClass) {
         this(testClass, Predicates.alwaysTrue());
+        if (DEBUG) {
+            System.out.println("DEBUG: Leaving  MultiConfigSuiteBuilder constructor(1): "+testClass);
+        }
     }
 
     /**
@@ -94,8 +140,14 @@ public class MultiConfigSuiteBuilder extends TestSuite {
      *                      {@code false} the test will not be executed.
      */
     public MultiConfigSuiteBuilder(Class<? extends TestCase> testClass, Predicate<String> testPredicate) {
+        if (DEBUG) {
+            System.out.println("DEBUG: Entering MultiConfigSuiteBuilder constructor(2): "+testClass+", "+testPredicate);
+        }
         m_testClass = testClass;
         m_testPredicate = testPredicate;
+        if (DEBUG) {
+            System.out.println("DEBUG: Leaving  MultiConfigSuiteBuilder constructor(2)");
+        }
     }
 
     /**
@@ -105,10 +157,16 @@ public class MultiConfigSuiteBuilder extends TestSuite {
      * @param config A Server Configuration to run this set of tests on.
      */
     public boolean addServerConfig(VoltServerConfig config) {
+        if (DEBUG) {
+            System.out.println("DEBUG: Entering MultiConfigSuiteBuilder.addServerConfig (1): "+config);
+        }
         return addServerConfig(config, true);
     }
 
     public boolean addServerConfig(VoltServerConfig config, boolean reuseServer) {
+        if (DEBUG) {
+            System.out.println("DEBUG: Entering MultiConfigSuiteBuilder.addServerConfig (2): "+config+", "+reuseServer);
+        }
 
         if (config.isValgrind()) {
             reuseServer = false;
@@ -157,6 +215,15 @@ public class MultiConfigSuiteBuilder extends TestSuite {
         // get the set of test methods
         List<String> methods = getTestMethodNames();
 
+        if (DEBUG) {
+            if (methods.size() < 10) {
+                System.out.println("DEBUG:    methods: "+methods);
+            } else {
+                System.out.println("DEBUG:    methods: ["+methods.get(0)
+                        +", ..., "+methods.get(methods.size()-1)+"]");
+            }
+        }
+
         // add a test case instance for each method for the specified
         // server config
         for (int i = 0; i < methods.size(); i++) {
@@ -172,14 +239,25 @@ public class MultiConfigSuiteBuilder extends TestSuite {
             // The last test method for the current cluster configuration will need to
             // shutdown the cluster completely after finishing the test.
             rs.m_completeShutdown = ! reuseServer || (i == methods.size() - 1);
+
+            if (DEBUG) {
+                if (i < 3 || i > 145) {
+                    System.out.println("DEBUG:    i, mname, rs: "+i+", "+mname+", "+rs);
+                } else if (i == 3) {
+                    System.out.println("DEBUG:      ...");
+                }
+            }
             super.addTest(rs);
         }
 
+        if (DEBUG) {
+            System.out.println("DEBUG: Leaving  MultiConfigSuiteBuilder.addServerConfig (2), true");
+        }
         return true;
     }
 
     @Override
-    public void addTest(Test test) {
+    public void addTest(junit.framework.Test test) {
         // don't let users do this
         throw new RuntimeException("Unsupported Usage");
     }

--- a/tests/sqlgrammar/run.sh
+++ b/tests/sqlgrammar/run.sh
@@ -392,8 +392,12 @@ function exit-with-code() {
         fi
         echo -e "\ncodes 0-6: ${code[*]} (build, init, jars, server, ddl, tests, shutdown)"
     fi
-    if [[ $PRINT_ERROR_CODE -ne 0 ]]; then
-        echo "error code:" $errcode
+    if [[ -n "$TT_EXIT_CODE" && "$TT_EXIT_CODE" -ne "0" ]]; then
+        echo "TT_EXIT_CODE: $TT_EXIT_CODE"
+        errcode=$(($errcode|$TT_EXIT_CODE))
+    fi
+    if [[ "$errcode" -ne "0" || (-n "$PRINT_ERROR_CODE" && "$PRINT_ERROR_CODE" -ne "0") ]]; then
+        echo "\nError code:" $errcode
     fi
     exit $errcode
 }

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -109,10 +109,16 @@ function tt-set-build-args() {
 
     if [[ -z "$1" || "$1" == tt-* || "$1" == test-tools* ]]; then
         echo -e "\nWARNING: ${BASH_SOURCE[0]} function $FUNCNAME called without an argument:"
-        echo -e "    will have no effect!\n"
+        echo -e "    will have little or no effect!\n"
     else
-        VOLTBUILD_ARG=
+        # If at least one arg was passed, reset BUILD_ARGS to start over from
+        # scratch, since it is set cumulatively, possibly containing many values
         BUILD_ARGS=
+    fi
+
+    # If VOLTBUILD_ARG is unset, give it a default value
+    if [[ -z "$VOLTBUILD_ARG" ]]; then
+        VOLTBUILD_ARG="release"
     fi
 
     while [[ -n "$1" ]]; do

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -46,9 +46,9 @@ function test-tools-find-directories() {
             VOLTDB_COM_DIR=$(cd $VOLTDB_BIN_DIR/..; pwd)
         fi
     else
-        echo "Unable to find VoltDB installation."
-        echo "Please add VoltDB's bin directory to your PATH."
-        exit -1
+        tt-exit-script 11 $FUNCNAME "Unable to find VoltDB installation" \
+                       "Please add VoltDB's bin directory to your PATH."
+        return
     fi
     VOLTDB_COM_BIN=$VOLTDB_COM_DIR/bin
     VOLTDB_TESTS=$VOLTDB_COM_DIR/tests
@@ -75,8 +75,11 @@ function tt-echo-build-args() {
     echo -e "\n${BASH_SOURCE[0]} performing: $FUNCNAME"
     echo "VOLTDB_REV: $VOLTDB_REV"
     echo "PRO_REV   : $PRO_REV"
+    echo "GIT_BRANCH: $GIT_BRANCH"
+    echo "VERIFY_ARG: $VERIFY_ARG"
     echo "BUILD_OPTS: $BUILD_OPTS"
     echo "BUILD_ARGS: $BUILD_ARGS"
+    echo "VOLTBUILD_ARG: $VOLTBUILD_ARG"
     echo "TEST_OPTS : $TEST_OPTS"
     echo "TEST_ARGS : $TEST_ARGS"
     echo "SEED      : $SEED"
@@ -107,6 +110,9 @@ function tt-set-build-args() {
     if [[ -z "$1" || "$1" == tt-* || "$1" == test-tools* ]]; then
         echo -e "\nWARNING: ${BASH_SOURCE[0]} function $FUNCNAME called without an argument:"
         echo -e "    will have no effect!\n"
+    else
+        VOLTBUILD_ARG=
+        BUILD_ARGS=
     fi
 
     while [[ -n "$1" ]]; do
@@ -118,34 +124,41 @@ function tt-set-build-args() {
         IFS=',' read -r -a build_options <<< "$1"
         for option in "${build_options[@]}"; do
             # Check for standard build options
-            if [[ "$option" == "reset" || "$option" == "release" ]]; then
+            if [[ "$option" == "release" || "$option" == "reset" ]]; then
+                VOLTBUILD_ARG="release"
                 BUILD_ARGS=
             elif [[ "$option" == "debug" ]]; then
+                VOLTBUILD_ARG="debug"
                 BUILD_ARGS="$BUILD_ARGS -Dbuild=debug"
             elif [[ "$option" == "pool" ]]; then
+                VOLTBUILD_ARG="debug"
                 BUILD_ARGS="$BUILD_ARGS -Dbuild=debug -DVOLT_POOL_CHECKING=true"
             elif [[ "$option" == "memcheck" ]]; then
+                VOLTBUILD_ARG="memcheck"
                 BUILD_ARGS="$BUILD_ARGS -Dbuild=memcheck"
             elif [[ "$option" == "memcheckrelease" || "$option" == "memcheck-release" || \
                     "$option" == "memcheck_release" ]]; then
+                VOLTBUILD_ARG="memcheck_release"
                 BUILD_ARGS="$BUILD_ARGS -Dbuild=memcheck_release"
             elif [[ "$option" == "jmemcheck" ]]; then
+                VOLTBUILD_ARG="jmemcheck"
                 BUILD_ARGS="$BUILD_ARGS -Djmemcheck=MEMCHECK_FULL"
             elif [[ "$option" == "nojmemcheck" ]]; then
+                VOLTBUILD_ARG="nojmemcheck"
                 BUILD_ARGS="$BUILD_ARGS -Djmemcheck=NO_MEMCHECK"
             # User is allowed to specify their own -D... option(s)
             elif [[ "$option" == -D* ]]; then
                 BUILD_ARGS="$BUILD_ARGS $option"
             else
-                echo -e "\nERROR: Unrecognized arg / build option in ${BASH_SOURCE[0]} function $FUNCNAME:"
-                echo -e "    $1 / $option"
-                exit -4
+                tt-exit-script 14 $FUNCNAME "Unrecognized arg / build option" "$1 / $option"
+                return
             fi
         done
         shift
         SHIFT_BY=$((SHIFT_BY+1))
     done
-    echo -e "\nBUILD_ARGS: $BUILD_ARGS"
+    echo -e "VOLTBUILD_ARG: $VOLTBUILD_ARG"
+    echo -e "BUILD_ARGS: $BUILD_ARGS"
 }
 
 # Set test arguments to be passed to tests of VoltDB (community or pro), e.g.,
@@ -165,6 +178,7 @@ function tt-set-test-args() {
         echo -e "    will have no effect!\n"
     fi
 
+    TEST_ARGS=
     while [[ -n "$1" ]]; do
         # Stop if we encounter other "test-tools" functions as args
         if [[ "$1" == tt-* || "$1" == test-tools* ]]; then
@@ -188,15 +202,47 @@ function tt-set-test-args() {
             elif [[ "$option" == -D* ]]; then
                 TEST_ARGS="$TEST_ARGS $option"
             else
-                echo -e "\nERROR: Unrecognized arg / test option in ${BASH_SOURCE[0]} function $FUNCNAME:"
-                echo -e "    $1 / $option"
-                exit -5
+                tt-exit-script 15 $FUNCNAME "Unrecognized arg / test option" "$1 / $option"
+                return
             fi
         done
         shift
         SHIFT_BY=$((SHIFT_BY+1))
     done
-    echo -e "\nTEST_ARGS: $TEST_ARGS"
+    echo -e "TEST_ARGS: $TEST_ARGS"
+}
+
+# Set the VERIFY_ARG environment variable, to be used for one of the arguments
+# to be passed to JUnit tests of VoltDB (community or pro); typically, the
+# GIT_BRANCH environment variable is passed as the (one and only) argument to
+# this function, which will then set VERIFY_ARG to 'false' only if the GIT_BRANCH
+# is 'master'; but if you wish to explicitly pass 'false' to set VERIFY_ARG to
+# 'false' and avoid verifying DDL regardless of the current branch, you may do
+# so. Any argument value other than 'master' or 'false' will leave VERIFY_ARG
+# unset, so the default behavior of verifying DDL will occur.
+function tt-set-verify-arg() {
+    tt-echo-build-args-if-needed
+    echo -e "\n${BASH_SOURCE[0]} performing: $FUNCNAME $1"
+
+    if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then
+        echo -e "\nWARNING: ${BASH_SOURCE[0]} function $FUNCNAME called without 'source' or '.':"
+        echo -e "    will have no external effect!\n"
+    fi
+
+    # On master, don't verify DDL; on all other branches always verify
+    # (which is the default), unless explicitly passed 'false'
+    if [[ "$1" = "master" || "$1" == "false" ]]; then
+        VERIFY_ARG="false";
+    fi
+
+    if [[ -z "$1" || "$1" == tt-* || "$1" == test-tools* ]]; then
+        echo -e "\nWARNING: ${BASH_SOURCE[0]} function $FUNCNAME called without an argument."
+        echo -e "    will have no external effect!\n"
+    else
+        SHIFT_BY=$((SHIFT_BY+1))
+    fi
+
+    echo -e "VERIFY_ARG: $VERIFY_ARG"
 }
 
 # Sets the SETSEED variable, typically to be used by SqlCoverage, based on
@@ -445,18 +491,20 @@ function test-tools-wait-for-server-to-start() {
 
         # Otherwise, print an error message and exit
         else
-            echo -e "\nVoltDB server unable to start: sqlcmd response had error(s):\n$SQLCMD_RESPONSE\n"
-            exit -2
+            tt-exit-script 12 $FUNCNAME "VoltDB server unable to start" \
+                           "sqlcmd response had error(s):\n    $SQLCMD_RESPONSE"
+            return
         fi
     done
 
     if [[ "$i" -gt "$MAX_SECONDS" ]]; then
-        echo -e "\n\nERROR: VoltDB server unable to start after waiting $MAX_SECONDS seconds"
-        echo -e "Here is the end of the VoltDB console output (./volt_console.out):"
-        tail -10 volt_console.out
-        echo -e "\nHere is the end of the VoltDB log (./voltdbroot/log/volt.log):"
-        tail -10 voltdbroot/log/volt.log
-        exit -3
+        EXTENDED_ERROR_MSG="Here is the end of the VoltDB console output (./volt_console.out):" \
+                           `tail -10 volt_console.out` \
+                           "\nHere is the end of the VoltDB log (./voltdbroot/log/volt.log):" \
+                           `tail -10 voltdbroot/log/volt.log`
+        tt-exit-script 13 $FUNCNAME "VoltDB server unable to start after waiting $MAX_SECONDS seconds" \
+                       $EXTENDED_ERROR_MSG
+        return
     fi
 }
 
@@ -596,8 +644,9 @@ function tt-help() {
     echo -e "    test-tools-all-pro    : runs (almost) all of the above, using the '-pro' options"
     echo -e "    test-tools-shutdown   : stops a VoltDB server that is currently running"
     echo -e "    tt-echo-build-args    : echoes build (& test) args commonly used in Jenkins"
-    echo -e "    tt-set-build-args     : sets the BUILD_ARGS environment variable"
+    echo -e "    tt-set-build-args     : sets the BUILD_ARGS, VOLTBUILD_ARG environment variables"
     echo -e "    tt-set-test-args      : sets the TEST_ARGS environment variable"
+    echo -e "    tt-set-verify-arg     : sets the VERIFY_ARG environment variable"
     echo -e "    tt-set-setseed        : sets the SETSEED environment variable"
     echo -e "    tt-killstragglers     : calls the 'killstragglers' script, passing"
     echo -e "                                it the standard PostgreSQL port number"
@@ -609,8 +658,8 @@ function tt-help() {
     echo -e "    tt-echo-build-args) may have '-if-needed' appended, e.g.,"
     echo -e "    'test-tools-server-if-needed' will start a VoltDB server only if"
     echo -e "    one is not already running."
-    echo -e "Some options (tt-set-build-args, tt-set-setseed) may be passed argument(s)"
-    echo -e "    that determine what the relevant environment variable will be set to."
+    echo -e "Some options (tt-set-build-args, tt-set-test-args, tt-set-verify-arg, tt-set-setseed) may be"
+    echo -e "    passed argument(s) that determine what the relevant environment variable will be set to."
     echo -e "Multiple options may be specified; but options usually call other options that are prerequisites.\n"
     PRINT_ERROR_CODE=0
 }
@@ -620,14 +669,62 @@ function test-tools-help() {
     tt-help
 }
 
+# After detecting a fatal error, call this function, which will exit with the
+# specified exit code ($1), after printing the specified function name ($2)
+# and error messages ($3 and $4); note that all parameters are optional, and
+# will assume default values if unspecified
+function tt-exit-script() {
+    if [[ "$TT_DEBUG" -ge "1" ]]; then
+        echo -e "\n${BASH_SOURCE[0]} performing: $FUNCNAME $@"
+    fi
+
+    # Set variables equal to the first 4 args or, if not specified, default values
+    TT_EXIT_CODE="${1:-1}"
+    FUNC_NAME="${2:-$FUNCNAME}"
+    ERROR_MSG="${3:-Unknown error}"
+    EXTRA_MSG="$4"
+
+    if [[ "$TT_DEBUG" -ge "2" ]]; then
+        echo -e "\nTT_EXIT_CODE: $TT_EXIT_CODE"
+        echo -e "FUNC_NAME: $FUNC_NAME"
+        echo -e "ERROR_MSG: $ERROR_MSG"
+        echo -e "EXTRA_MSG: $EXTRA_MSG"
+    fi
+
+    if [[ "$TT_EXIT_CODE" -ne "0" ]]; then
+        echo -e "\nFATAL: $ERROR_MSG in ${BASH_SOURCE[0]}, function $FUNC_NAME"
+        if [[ -n "$EXTRA_MSG" ]]; then
+            echo -e "    $EXTRA_MSG"
+        fi
+        echo -e "exiting with code: $TT_EXIT_CODE\n"
+    fi
+
+    # If this script was called "normally", then 'exit' with the appropriate
+    # error code; but if it was called using 'source' or '.', then simply
+    # 'return' with that code, in order to avoid also exiting the shell
+    if [[ "$0" == "${BASH_SOURCE[0]}" ]]; then
+        exit $TT_EXIT_CODE
+    else
+        return $TT_EXIT_CODE
+    fi
+}
+
 # If run on the command line with no options specified, run tt-help
 if [[ $# -eq 0 && $0 == *test-tools.sh ]]; then
     tt-help
 fi
+
+# Set (or reset) environment variables used only in this script, not externally
+BUILD_ARGS_WERE_ECHOED=
+TT_EXIT_CODE=0
 
 # Run options passed on the command line, if any; with arguments, if any
 while [[ -n "$1" ]]; do
     SHIFT_BY=1  # Can be increased, by a function that handles multiple args
     $@
     shift $SHIFT_BY
+
+    if [[ "$TT_EXIT_CODE" -ne "0" ]]; then
+        return $TT_EXIT_CODE
+    fi
 done


### PR DESCRIPTION
ENG-15035-junit-flaky2, v2 after review commments:
Added FlakyTestRule (including @Flaky annotation) and
FlakyTestStandardRunner, to allow marking of Flaky tests as such;
included modifications of TestFuzzMeshArbiter to show how to use @flaky;
and minor changes to MultiConfigSuiteBuilder (including debug print) and
build.xml. Also modified test-tools.sh: added a tt-set-test-args function,
to set a TEST_ARGS environment variable, based on a value passed to it
(which will probably be called TEST_OPTS), for passing @Flaky-related
command-line args to the JUnit tests (very similar to the way the
tt-set-build-args function works for VoltDB builds args).