### PR TITLE
Eng 13435 v6 rackware (#5134)

### DIFF
--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -32,6 +32,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import com.google_voltpatches.common.collect.HashMultimap;
+import com.google_voltpatches.common.collect.Multimap;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.apache.zookeeper_voltpatches.data.Stat;
@@ -233,6 +235,14 @@ public class Cartographer extends StatsSource
     }
 
     /**
+     * Get the HSID of all the partition masters
+     */
+    public Map<Integer, Long> getHSIdsForSinglePartitionMasters()
+    {
+        return new HashMap<>(m_iv2Masters.pointInTimeCache());
+    }
+
+    /**
      * Get the HSID of the single partition master for the specified partition ID
      */
     public long getHSIdForSinglePartitionMaster(int partitionId)
@@ -319,8 +329,8 @@ public class Cartographer extends StatsSource
     /**
      * Given a set of partition IDs, return a map of partition to a list of HSIDs of all the sites with copies of each partition
      */
-    public Map<Integer, List<Long>> getReplicasForPartitions(Collection<Integer> partitions) {
-        Map<Integer, List<Long>> retval = new HashMap<Integer, List<Long>>();
+    public Multimap<Integer, Long> getReplicasForPartitions(Collection<Integer> partitions) {
+        Multimap<Integer, Long> retval = HashMultimap.create();
         List<Pair<Integer,ZKUtil.ChildrenCallback>> callbacks = new ArrayList<Pair<Integer, ZKUtil.ChildrenCallback>>();
 
         for (Integer partition : partitions) {
@@ -334,11 +344,9 @@ public class Cartographer extends StatsSource
             final Integer partition = p.getFirst();
             try {
                 List<String> children = p.getSecond().getChildren();
-                List<Long> sites = new ArrayList<Long>();
                 for (String child : children) {
-                    sites.add(Long.valueOf(child.split("_")[0]));
+                    retval.put(partition, Long.valueOf(child.split("_")[0]));
                 }
-                retval.put(partition, sites);
             } catch (KeeperException.NoNodeException e) {
                 //This can happen when a partition is being removed from the system
             } catch (KeeperException ke) {
@@ -371,41 +379,6 @@ public class Cartographer extends StatsSource
             keys.add(entry.getKey());
         }
         return keys;
-    }
-
-    /**
-     * Given the current state of the cluster, compute the partitions which should be replicated on a single new host.
-     * Break this method out to be static and testable independent of ZK, JSON, other ugh.
-     */
-    static public List<Integer> computeReplacementPartitions(Map<Integer, Integer> repsPerPart, int kfactor,
-                                                             int sitesPerHost)
-    {
-        List<Integer> partitions = new ArrayList<Integer>();
-        List<Integer> partSortedByRep = sortKeysByValue(repsPerPart);
-        for (int i = 0; i < partSortedByRep.size(); i++) {
-            int leastReplicatedPart = partSortedByRep.get(i);
-            if (repsPerPart.get(leastReplicatedPart) < kfactor + 1) {
-                partitions.add(leastReplicatedPart);
-                if (partitions.size() == sitesPerHost) {
-                    break;
-                }
-            }
-        }
-        return partitions;
-    }
-
-    public List<Integer> getIv2PartitionsToReplace(int kfactor, int sitesPerHost)
-        throws JSONException
-    {
-        List<Integer> partitions = getPartitions();
-        hostLog.info("Computing partitions to replace.  Total partitions: " + partitions);
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        for (int pid : partitions) {
-            repsPerPart.put(pid, getReplicaCountForPartition(pid));
-        }
-        List<Integer> partitionsToReplace = computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        hostLog.info("IV2 Sites will replicate the following partitions: " + partitionsToReplace);
-        return partitionsToReplace;
     }
 
     /**
@@ -442,14 +415,10 @@ public class Cartographer extends StatsSource
     {
         List<MailboxNodeContent> sitesList = new ArrayList<MailboxNodeContent>();
         final Set<Integer> iv2MastersKeySet = m_iv2Masters.pointInTimeCache().keySet();
-        Map<Integer, List<Long>> hsidsForPartMap = getReplicasForPartitions(iv2MastersKeySet);
-        for (Map.Entry<Integer, List<Long>> entry : hsidsForPartMap.entrySet()) {
-            Integer partId = entry.getKey();
-            List<Long> hsidsForPart = entry.getValue();
-            for (long hsid : hsidsForPart) {
-                MailboxNodeContent mnc = new MailboxNodeContent(hsid, partId);
-                sitesList.add(mnc);
-            }
+        Multimap<Integer, Long> hsidsForPartMap = getReplicasForPartitions(iv2MastersKeySet);
+        for (Map.Entry<Integer, Long> entry : hsidsForPartMap.entries()) {
+            MailboxNodeContent mnc = new MailboxNodeContent(entry.getValue(), entry.getKey());
+            sitesList.add(mnc);
         }
         return sitesList;
     }

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -716,7 +716,7 @@ public class MiscUtils {
      * Zip the two lists up into a multimap
      * @return null if one of the lists is empty
      */
-    public static <K, V> Multimap<K, V> zipToMap(List<K> keys, List<V> values)
+    public static <K, V> Multimap<K, V> zipToMap(Collection<K> keys, Collection<V> values)
     {
         if (keys.isEmpty() || values.isEmpty()) {
             return null;
@@ -732,7 +732,7 @@ public class MiscUtils {
 
         // In case there are more values than keys, assign the rest of the
         // values to the first key
-        K firstKey = keys.get(0);
+        K firstKey = keys.iterator().next();
         while (valueIter.hasNext()) {
             result.put(firstKey, valueIter.next());
         }

--- a/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestClusterCompiler.java
@@ -23,20 +23,27 @@
 package org.voltdb.compiler;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
-import com.google_voltpatches.common.collect.HashMultimap;
-import com.google_voltpatches.common.collect.Maps;
-import com.google_voltpatches.common.collect.Multimap;
-import com.google_voltpatches.common.collect.Sets;
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
+import org.voltcore.utils.CoreUtils;
+import org.voltdb.VoltDB;
+
+import com.google_voltpatches.common.collect.HashMultimap;
+import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.Maps;
+import com.google_voltpatches.common.collect.Multimap;
+import com.google_voltpatches.common.collect.Multimaps;
+import com.google_voltpatches.common.collect.Sets;
 
 import junit.framework.TestCase;
-import org.voltdb.VoltDB;
 
 public class TestClusterCompiler extends TestCase
 {
@@ -47,7 +54,7 @@ public class TestClusterCompiler extends TestCase
         topology.put(0, "0");
         topology.put(1, "0");
         topology.put(2, "0");
-        JSONObject obj = config.getTopology(topology);
+        JSONObject obj = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         config.validate();
         System.out.println(obj.toString(4));
         JSONArray partitions = obj.getJSONArray("partitions");
@@ -99,7 +106,7 @@ public class TestClusterCompiler extends TestCase
         ClusterConfig config = new ClusterConfig(1, 6, 0);
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(1, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(0, topo.getInt("kfactor"));
@@ -116,7 +123,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(0, topo.getInt("kfactor"));
@@ -135,7 +142,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(1, topo.getInt("kfactor"));
@@ -152,7 +159,7 @@ public class TestClusterCompiler extends TestCase
         Map<Integer, String> topology = Maps.newHashMap();
         topology.put(0, "0");
         topology.put(1, "0");
-        JSONObject topo = config.getTopology(topology);
+        JSONObject topo = config.getTopology(topology, HashMultimap.create(), new HashMap<>());
         assertEquals(2, topo.getInt("hostcount"));
         assertEquals(6, topo.getInt("sites_per_host"));
         assertEquals(1, topo.getInt("kfactor"));
@@ -163,68 +170,6 @@ public class TestClusterCompiler extends TestCase
             ClusterConfig.addHosts(3, topo);
             fail("Shouldn't allow adding more than ksafe + 1 node");
         } catch (AssertionError e) {}
-    }
-
-    public void testFourNodesOneGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "0");
-        hostGroups.put(3, "0");
-        runConfigAndVerifyTopology(hostGroups, 1);
-    }
-
-    public void testFourNodesTwoGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "1");
-        hostGroups.put(3, "1");
-        runConfigAndVerifyTopology(hostGroups, 1);
-    }
-
-    public void testFourNodesTwoGroupsNonoptimal() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "0");
-        hostGroups.put(3, "1");
-        runConfigAndVerifyTopology(hostGroups, 1);
-    }
-
-    public void testThreeNodesThreeGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "1");
-        hostGroups.put(2, "2");
-        runConfigAndVerifyTopology(hostGroups, 2);
-    }
-
-    public void testSixNodesThreeGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "1");
-        hostGroups.put(3, "1");
-        hostGroups.put(4, "2");
-        hostGroups.put(5, "2");
-        runConfigAndVerifyTopology(hostGroups, 2);
-    }
-
-    public void testFiveNodesTwoGroups() throws JSONException
-    {
-        Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "1");
-        hostGroups.put(3, "1");
-        hostGroups.put(4, "1");
-        runConfigAndVerifyTopology(hostGroups, 2);
     }
 
     public void testEightNodesTwoLevelsOfGroups() throws JSONException
@@ -238,55 +183,348 @@ public class TestClusterCompiler extends TestCase
         hostGroups.put(5, "1.0");
         hostGroups.put(6, "1.1");
         hostGroups.put(7, "1.1");
-        runConfigAndVerifyTopology(hostGroups, 3);
+        int kfactor = 3;
+        for (int sph = 1; sph <= 20; sph++) {
+            runConfiguration(true, hostGroups, sph, kfactor, true);
+        }
     }
 
-    public void testFifteenNodesTwoGroups() throws JSONException
+    public void testTenNodes_ENG13435() throws JSONException
     {
         Map<Integer, String> hostGroups = Maps.newHashMap();
-        hostGroups.put(0, "0");
-        hostGroups.put(1, "0");
-        hostGroups.put(2, "0");
-        hostGroups.put(3, "0");
-        hostGroups.put(4, "0");
-        hostGroups.put(5, "0");
-        hostGroups.put(6, "0");
-        hostGroups.put(7, "0");
-        hostGroups.put(8, "1");
-        hostGroups.put(9, "1");
-        hostGroups.put(10, "1");
-        hostGroups.put(11, "1");
-        hostGroups.put(12, "1");
-        hostGroups.put(13, "1");
-        hostGroups.put(14, "1");
-        runConfigAndVerifyTopology(hostGroups, 2);
+        hostGroups.put(0, "FC1");
+        hostGroups.put(1, "FC2");
+        hostGroups.put(2, "FC2");
+        hostGroups.put(3, "FC2");
+        hostGroups.put(4, "FC2");
+        hostGroups.put(5, "FC1");
+        hostGroups.put(6, "FC2");
+        hostGroups.put(7, "FC1");
+        hostGroups.put(8, "FC1");
+        hostGroups.put(9, "FC1");
+        int kfactor = 3;
+        for (int sph = 1; sph <= 20; sph++) {
+            runConfiguration(true, hostGroups, sph, kfactor, false);
+        }
     }
 
-    private static void runConfigAndVerifyTopology(Map<Integer, String> hostGroups, int kfactor) throws JSONException
+    public void testSixNodes_ENG13435() throws JSONException
     {
-        final int maxSites = 20;
-        int invalidConfigCount = 0;
-        int expectedInvalidConfigs = 0;
-        if (hostGroups.size() % (kfactor + 1) != 0) {
-            expectedInvalidConfigs = maxSites - (maxSites / (kfactor + 1));
+        Map<Integer, String> hostGroups = Maps.newHashMap();
+        hostGroups.put(0, "FC1");
+        hostGroups.put(1, "FC2");
+        hostGroups.put(2, "FC2");
+        hostGroups.put(3, "FC2");
+        hostGroups.put(4, "FC1");
+        hostGroups.put(5, "FC1");
+        int kfactor = 3;
+        for (int sph = 1; sph <= 20; sph++) {
+            runConfiguration(true, hostGroups, sph, kfactor, false);
         }
-
-        for (int sites = 1; sites <= maxSites; sites++) {
-            final ClusterConfig config = new ClusterConfig(hostGroups.size(), sites, kfactor);
-            System.out.println("Running config " + sites + " sitesperhost, k=" + kfactor);
-            if (config.validate()) {
-                final JSONObject topo = config.getTopology(hostGroups);
-                verifyTopology(hostGroups, topo);
-            } else {
-                System.out.println(config.getErrorMsg());
-                invalidConfigCount++;
-            }
-        }
-
-        assertEquals(expectedInvalidConfigs, invalidConfigCount);
     }
 
-    private static void verifyTopology(Map<Integer, String> hostGroups, JSONObject topo) throws JSONException
+    // For non-optimal but legitimate configuration, only verify that
+    // all the nodes have right number of partitions and k-safety constrain
+    // is satisfied.
+    public void testRandomNonOptimalConfig() throws JSONException
+    {
+        for (int i = 0; i < 200; i++) {
+            runRandomHAGroupTest(false);
+        }
+        System.out.println("Hooooray!!!!!!!!!!!");
+    }
+
+    public void testRandomOptimalConfig() throws JSONException
+    {
+        for (int i = 0; i < 200; i++) {
+            runRandomHAGroupTest(true);
+        }
+    }
+
+    public void testRejoinOneNode() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology =
+        ImmutableMap.of(0, "0",
+                        1, "0");
+        killAndRejoinNodes(topology, 1, 1);
+    }
+
+    public void testRejoinTwoNodes() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology =
+        ImmutableMap.of(0, "0",
+                        1, "1",
+                        2, "2");
+        killAndRejoinNodes(topology, 2, 2);
+    }
+
+    public void testRejoinTwoNodesToTwo() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
+                                                 .put(0, "0")
+                                                 .put(1, "0")
+                                                 .put(2, "1")
+                                                 .put(3, "1")
+                                                 .put(4, "2")
+                                                 .put(5, "2")
+                                                 .build();
+        killAndRejoinNodes(topology, 2, 2);
+    }
+
+    public void testRejoinThreeNodesToFour() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
+                                                 .put(0, "0")
+                                                 .put(1, "0")
+                                                 .put(2, "0")
+                                                 .put(3, "0")
+                                                 .put(4, "1")
+                                                 .put(5, "1")
+                                                 .put(6, "1")
+                                                 .put(7, "1")
+                                                 .build();
+        killAndRejoinNodes(topology, 3, 3);
+    }
+
+    // Kill entire rack plus one more node on the other rack, then rejoin them back
+    public void testRejoinSixNodes() throws JSONException
+    {
+        ImmutableMap<Integer, String> topology = new ImmutableMap.Builder<Integer, String>()
+                                                 .put(0, "0")
+                                                 .put(1, "1")
+                                                 .put(2, "1")
+                                                 .put(3, "1")
+                                                 .put(4, "1")
+                                                 .put(5, "0")
+                                                 .put(6, "0")
+                                                 .put(7, "1")
+                                                 .put(8, "0")
+                                                 .put(9, "0")
+                                                 .build();
+        killAndRejoinNodes(topology, 3, 6);
+    }
+
+    private static void killAndRejoinNodes(ImmutableMap<Integer, String> fullHostGroup, int kfactor, int nodesToKill)
+    throws JSONException
+    {
+        final int maxSph = 20;
+        for (int sph = 1; sph < maxSph; sph++) {
+            final Map<Integer, String> rejoinHostGroup = new HashMap<>(fullHostGroup);
+            final ClusterConfig initialConfig = new ClusterConfig(rejoinHostGroup.size(), sph, kfactor);
+            if (!initialConfig.validate()) {
+                // Invalid config, skip
+                continue;
+            }
+            final JSONObject initialTopo = initialConfig.getTopology(rejoinHostGroup, HashMultimap.create(), new HashMap<>());
+
+            final Multimap<Integer, Integer> partitionToHosts = HashMultimap.create();
+            final Multimap<Integer, Integer> hostPartitions = HashMultimap.create();
+            final Multimap<Integer, Integer> hostMasters = HashMultimap.create();
+            for (int hostId : rejoinHostGroup.keySet()) {
+                for (int pid : ClusterConfig.partitionsForHost(initialTopo, hostId)) {
+                    partitionToHosts.put(pid, hostId);
+                }
+                hostPartitions.putAll(hostId, ClusterConfig.partitionsForHost(initialTopo, hostId));
+                hostMasters.putAll(hostId, ClusterConfig.partitionsForHost(initialTopo, hostId, true));
+            }
+
+            // Pick nodes to kill from different groups. if this is
+            // not a valid topology for multiple rejoins in different
+            // groups, the returned set will be empty.
+            Multimap<String, Integer> groupToHosts = Multimaps.invertFrom(Multimaps.forMap(rejoinHostGroup), HashMultimap.create());
+            final Set<Integer> hostIdsToKill = pickNodesInDiffGroupsToKill(fullHostGroup, groupToHosts, hostPartitions, kfactor, nodesToKill);
+            if (hostIdsToKill.isEmpty()) {
+                System.out.println("Not a valid topology for multi node rejoin, skipping. Sites per host " + sph);
+                continue;
+            }
+            System.out.println("Running config: sites " + sph + ", k-factor " + kfactor
+                    + ", host partitions: " + hostPartitions +
+                               ", nodes to kill: " + hostIdsToKill);
+
+            // Remove all partitions and masters from the failed nodes, migrate masters to remaining nodes
+            final Multimap<Integer, Integer> expectedRejoinHostPartitions = HashMultimap.create();
+            final HashSet<Integer> liveHosts = new HashSet<>(hostPartitions.keySet());
+            final Map<Integer, String> rejoinHostGroups = new HashMap<>();
+            for (int toKill : hostIdsToKill) {
+                liveHosts.remove(toKill);
+                for (int masterToRedistribute : hostMasters.get(toKill)) {
+                    for (int hostCandidate : partitionToHosts.get(masterToRedistribute)) {
+                        if (hostCandidate != toKill && liveHosts.contains(hostCandidate)) {
+                            hostMasters.put(hostCandidate, masterToRedistribute);
+                            break;
+                        }
+                    }
+                }
+                expectedRejoinHostPartitions.putAll(toKill, hostPartitions.removeAll(toKill));
+                hostMasters.removeAll(toKill);
+                rejoinHostGroups.put(toKill, rejoinHostGroup.remove(toKill));
+            }
+
+            // Fake partition to HSID mappings
+            Multimap<Integer, Long> replicas = HashMultimap.create();
+            for (Map.Entry<Integer, Integer> e : hostPartitions.entries()) {
+                replicas.put(e.getValue(), CoreUtils.getHSIdFromHostAndSite(e.getKey(), e.getValue()));
+            }
+            Map<Integer, Long> masters = new HashMap<>();
+            for (Map.Entry<Integer, Integer> e : hostMasters.entries()) {
+                masters.put(e.getValue(), CoreUtils.getHSIdFromHostAndSite(e.getKey(), e.getValue()));
+            }
+
+            // Rejoin one node at a time and verify that they have the correct partitions
+            JSONObject rejoinTopo = null;
+            for (Map.Entry<Integer, String> rejoin : rejoinHostGroups.entrySet()) {
+                final int rejoinHostId = rejoin.getKey() + fullHostGroup.size();
+                System.out.println("Rejoining " + rejoin.getKey() + " as " + rejoinHostId + " in group " + rejoin.getValue());
+                rejoinHostGroup.put(rejoinHostId, rejoin.getValue());
+                rejoinTopo = initialConfig.getTopology(rejoinHostGroup, replicas, masters);
+                final List<Integer> partitionsOnRejoinHost = ClusterConfig.partitionsForHost(rejoinTopo, rejoinHostId);
+
+                // No master on rejoined host
+                assertTrue(ClusterConfig.partitionsForHost(rejoinTopo, rejoinHostId, true).isEmpty());
+
+                // Verify existing hosts remain the same
+                for (Map.Entry<Integer, Collection<Integer>> e : hostPartitions.asMap().entrySet()) {
+                    int hostId = e.getKey();
+                    if (rejoinHostGroups.containsKey(e.getKey())) {
+                        hostId = e.getKey() + fullHostGroup.size();
+                    }
+                    assertEquals("host " + hostId + " key " + e.getKey(), e.getValue(), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, hostId)));
+                    assertEquals(hostMasters.get(e.getKey()), new HashSet<>(ClusterConfig.partitionsForHost(rejoinTopo, hostId, true)));
+                }
+
+                // Now add the rejoined host to the live host maps
+                hostPartitions.putAll(rejoin.getKey(), partitionsOnRejoinHost);
+                for (int pid : partitionsOnRejoinHost) {
+                    replicas.put(pid, CoreUtils.getHSIdFromHostAndSite(rejoinHostId, pid));
+                }
+            }
+            assert (rejoinTopo != null);
+            // Verify partitions are well balanced across groups
+            verifyTopology(true, true, rejoinHostGroup, rejoinTopo, kfactor);
+        }
+    }
+
+    private static Set<Integer> pickNodesInDiffGroupsToKill(ImmutableMap<Integer, String> topo,
+                                                            Multimap<String, Integer> groupToHosts,
+                                                            Multimap<Integer, Integer> hostPartitions,
+                                                            int kfactor,
+                                                            int nodesToKill)
+    {
+        // Find minimum number of nodes in placement groups
+        int minNode = groupToHosts.asMap().values().stream()
+                .mapToInt(c -> c.size())
+                .min()
+                .orElse(Integer.MAX_VALUE);
+        for (Set<Integer> perm : Sets.powerSet(topo.keySet())) {
+            // Skip permutation size not equal to the node count to kill
+            if (perm.size() != nodesToKill) {
+                continue;
+            }
+
+            if (nodesToKill > minNode) {
+                boolean killRack = false;
+                for (Map.Entry<String, Collection<Integer>> group : groupToHosts.asMap().entrySet()) {
+                    // Then kill entire rack
+                    if (perm.containsAll(group.getValue())) {
+                        killRack = true;
+                        break;
+                    }
+                }
+                if (!killRack) {
+                    continue;
+                }
+            }
+
+            // Count the occurrences of each partition in the candidate nodes
+            Map<Integer, Integer> partitionOccurrances = new HashMap<>();
+            perm.stream().map(hostPartitions::get).forEach(s -> s.forEach(a -> {
+                if (partitionOccurrances.containsKey(a)) {
+                    partitionOccurrances.put(a, partitionOccurrances.get(a) + 1);
+                } else {
+                    partitionOccurrances.put(a, 1);
+                }
+            }));
+
+            // If a partition appears k+1 times in the candidate nodes, killing
+            // them will take the cluster down, so skip this set of candidate nodes
+            boolean skip = false;
+            for (int count : partitionOccurrances.values()) {
+                if (count > kfactor) {
+                    skip = true;
+                }
+            }
+            if (skip) {
+                continue;
+            }
+
+            return new HashSet<>(perm);
+        }
+        return new HashSet<>();
+    }
+
+    // optimal means only generate configurations that
+    // 1) each placement group has same number of nodes
+    // 2) number of placement groups is divisible to (kfactor + 1)
+    private static void runRandomHAGroupTest(boolean optimal) throws JSONException
+    {
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        final int MAX_RACKS = 5;
+        final int MAX_RACK_NODES = 10;
+        final int MAX_K = 10;
+        final int MAX_PARTITIONS = 20;
+        int rackCount = optimal ? (r.nextInt(MAX_RACKS) + 1 ): r.nextInt(2, MAX_RACKS + 1); // [1-5] or [2-5]
+        int rackNodeCount = r.nextInt(MAX_RACK_NODES) + 1; // [1-10]
+        int totalNodeCount = rackNodeCount * rackCount;
+        int k, sph;
+        do {
+            int lowerBound = optimal ? (rackCount - 1) : 0;
+            k = r.nextInt(lowerBound, Math.min(totalNodeCount, MAX_K));  // [rackCount - 1, 10]
+        } while (optimal ?
+                (k + 1) % rackCount != 0 : (k + 1) % rackCount == 0);
+        do {
+            sph = r.nextInt(MAX_PARTITIONS) + 1; // [1-20]
+        } while ((totalNodeCount * sph) % (k + 1) != 0 );
+        //////////////////////////////////////////////////////////////////////////
+        System.out.println(
+                String.format("Optimal=%s Node count: %d, kfactor: %d, SPH: %d, # of racks: %d",
+                              optimal ? "true" : "false", totalNodeCount, k, sph, rackCount));
+        //////////////////////////////////////////////////////////////////////////
+        Map<Integer, String> hostGroups = Maps.newHashMap();
+        for (int i = 0; i < totalNodeCount; i++) {
+            hostGroups.put(i, String.valueOf(i % rackCount));
+        }
+
+        runConfiguration(optimal, hostGroups, sph, k, true);
+    }
+
+    private static void runConfiguration(
+            boolean optimal,
+            Map<Integer, String> hostGroups,
+            int sph,
+            int kfactor,
+            boolean print) throws JSONException
+    {
+        final ClusterConfig config = new ClusterConfig(hostGroups.size(), sph, kfactor);
+        System.out.println("Running config " + hostGroups.size() + " hosts, " + sph + " sitesperhost, k=" + kfactor);
+        if (config.validate()) {
+            long start = System.currentTimeMillis();
+            final JSONObject topo = config.getTopology(hostGroups, HashMultimap.create(), new HashMap<>());
+            if (print) {
+                System.out.println("It takes " + (System.currentTimeMillis() - start) + " ms to compute the topo.");
+                System.out.println(topo);
+            }
+            verifyTopology(optimal, false, hostGroups, topo, kfactor);
+        } else {
+            System.out.println(config.getErrorMsg());
+        }
+    }
+
+    private static void verifyTopology(
+            boolean optimal,
+            boolean isRejoin,
+            Map<Integer, String> hostGroups,
+            JSONObject topo,
+            int kfactor) throws JSONException
     {
         final int hostCount = new ClusterConfig(topo).getHostCount();
         final int sitesPerHost = new ClusterConfig(topo).getSitesPerHost();
@@ -297,40 +535,55 @@ public class TestClusterCompiler extends TestCase
 
         Multimap<Integer, Integer> masterCountToHost = HashMultimap.create();
         Multimap<String, Integer> groupHosts = HashMultimap.create();
-        Multimap<String, Integer> groupPartitions = HashMultimap.create();
+        Map<String, Map<Integer, Integer>> groupPartitions = new HashMap<>();   // <groupId, <pId, count>>
         for (Map.Entry<Integer, String> entry : hostGroups.entrySet()) {
             final List<Integer> hostPartitions = ClusterConfig.partitionsForHost(topo, entry.getKey());
             final List<Integer> hostMasters = ClusterConfig.partitionsForHost(topo, entry.getKey(), true);
+            // Make sure a host has exactly sitesPerHost number of partitions
             assertEquals(sitesPerHost, hostPartitions.size());
             // Make sure a host only has unique partitions
             assertEquals(hostPartitions.size(), Sets.newHashSet(hostPartitions).size());
 
             masterCountToHost.put(hostMasters.size(), entry.getKey());
             groupHosts.put(entry.getValue(), entry.getKey());
-            groupPartitions.putAll(entry.getValue(), hostPartitions);
-        }
-
-        // Make sure master partitions are spread out
-        if (nodesWithMaxMasterCount == 0) {
-            assertEquals(1, masterCountToHost.keySet().size());
-            assertTrue(masterCountToHost.containsKey(minMasterCount));
-        } else {
-            assertEquals(2, masterCountToHost.keySet().size());
-            assertTrue(masterCountToHost.containsKey(minMasterCount));
-            assertEquals(nodesWithMaxMasterCount, masterCountToHost.get(maxMasterCount).size());
-        }
-
-        for (Map.Entry<String, Collection<Integer>> ghEntry : groupHosts.asMap().entrySet()) {
-            if (ghEntry.getValue().size() * sitesPerHost < partitionCount) {
-                // Non-optimal topology, no need to verify the rest
-                System.out.println("Group " + ghEntry.getKey() + " only has " + ghEntry.getValue().size() + " hosts");
-                return;
+            Map<Integer, Integer> pidCountMap = groupPartitions.get(entry.getValue());
+            if (pidCountMap != null) {
+                for (Integer pid : hostPartitions) {
+                    if (pidCountMap.containsKey(pid)) {
+                        int count = pidCountMap.get(pid);
+                        pidCountMap.put(pid, count + 1);
+                    } else {
+                        pidCountMap.put(pid, 1);
+                    }
+                }
+            } else {
+                pidCountMap = new HashMap<Integer, Integer>();
+                groupPartitions.put(entry.getValue(), pidCountMap);
+                for (Integer pid : hostPartitions) {
+                    pidCountMap.put(pid, 1);
+                }
             }
         }
 
-        // Each group should have at least one copy of all the partitions
-        for (Collection<Integer> partitions : groupPartitions.asMap().values()) {
-            assertEquals(partitionCount, Sets.newHashSet(partitions).size());
+        if (optimal) {
+            if (!isRejoin) {
+                // Make sure master partitions are spread out
+                if (nodesWithMaxMasterCount == 0) {
+                    assertEquals(1, masterCountToHost.keySet().size());
+                    assertTrue(masterCountToHost.containsKey(minMasterCount));
+                } else {
+                    assertEquals(2, masterCountToHost.keySet().size());
+                    assertTrue(masterCountToHost.containsKey(minMasterCount));
+                    assertEquals(nodesWithMaxMasterCount, masterCountToHost.get(maxMasterCount).size());
+                }
+            }
+            int expectedReplicasPerGroup = (kfactor + 1) / groupPartitions.size();
+
+            // Each group should have equal number of copies of all the partitions
+            for (Map.Entry<String, Map<Integer, Integer>> groupAndPids : groupPartitions.entrySet()) {
+                assertTrue( groupPartitions.toString(),
+                        groupAndPids.getValue().values().stream().allMatch(c -> c == expectedReplicasPerGroup));
+            }
         }
     }
 }

--- a/tests/frontend/org/voltdb/iv2/TestCartographer.java
+++ b/tests/frontend/org/voltdb/iv2/TestCartographer.java
@@ -80,65 +80,6 @@ public class TestCartographer extends ZKTestBase {
     }
 
     @Test
-    public void testReplicateLeastReplicated()
-    {
-        // Gin up our fake replication counts to leave the last partition needing two replicas
-        // 5 hosts, 3 sites/host, k=2 is 15 sites, 5 partitions.
-        // Need 2 hosts dead, so 6 missing replicas, last one needs to miss 2
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        repsPerPart.put(0, 2);
-        repsPerPart.put(1, 2);
-        repsPerPart.put(2, 2);
-        repsPerPart.put(3, 2);
-        repsPerPart.put(4, 1);
-        int kfactor = 2;
-        int numberOfPartitions = 5;
-        int sitesPerHost = 3;
-
-        List<Integer> firstRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(3, firstRejoin.size());
-        assertEquals((Integer)4, firstRejoin.get(0));
-        assertEquals((Integer)0, firstRejoin.get(1));
-        assertEquals((Integer)1, firstRejoin.get(2));
-        // add to each of the repsPerPart from the firstRejoin results
-        for (int partition : firstRejoin) {
-            repsPerPart.put(partition, repsPerPart.get(partition) + 1);
-        }
-
-        // now do it again and make sure we fully replicate
-        List<Integer> secondRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(3, secondRejoin.size());
-        assertEquals((Integer)2, secondRejoin.get(0));
-        assertEquals((Integer)3, secondRejoin.get(1));
-        assertEquals((Integer)4, secondRejoin.get(2));
-    }
-
-    @Test
-    public void testNoOverReplication()
-    {
-        // We'll set things up to only require one more replica and then offer up a host with more sites
-        // than we need.  This particular case could never happen but should test the logic correctly.
-        // Also, test that we don't replicate the same partition twice on the same host again.
-        int kfactor = 2;
-        int numberOfPartitions = 5;
-        int sitesPerHost = 3;
-
-        Map<Integer, Integer> repsPerPart = new HashMap<Integer, Integer>();
-        repsPerPart.put(0, 3);
-        repsPerPart.put(1, 3);
-        repsPerPart.put(2, 3);
-        repsPerPart.put(3, 3);
-        repsPerPart.put(4, 1);
-
-        List<Integer> firstRejoin =
-            Cartographer.computeReplacementPartitions(repsPerPart, kfactor, sitesPerHost);
-        assertEquals(1, firstRejoin.size());
-        assertEquals((Integer)4, firstRejoin.get(0));
-    }
-
-    @Test
     public void testSPMasterChange() throws Exception
     {
         ZooKeeper zk = getClient(0);

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +52,7 @@ import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
 import org.voltdb.compiler.ClusterConfig;
 
+import com.google_voltpatches.common.collect.HashMultimap;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.collect.Sets;
@@ -128,8 +130,10 @@ public class TestLeaderAppointer extends ZKTestBase {
     {
         KSafetyStats stats = new KSafetyStats();
         m_dut = new LeaderAppointer(m_hm, m_config.getPartitionCount(),
-                m_config.getReplicationFactor(),
-                null, m_config.getTopology(m_hostGroups), m_mpi, stats, false);
+                                    m_config.getReplicationFactor(),
+                                    null,
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
+                                    m_mpi, stats, false);
         m_dut.onReplayCompletion();
     }
 
@@ -278,7 +282,7 @@ public class TestLeaderAppointer extends ZKTestBase {
                                     m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(),
                                     null,
-                                    m_config.getTopology(m_hostGroups),
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
                                     m_mpi,
                                     new KSafetyStats(),
                                     false);
@@ -525,7 +529,7 @@ public class TestLeaderAppointer extends ZKTestBase {
                                     m_config.getPartitionCount(),
                                     m_config.getReplicationFactor(),
                                     null,
-                                    m_config.getTopology(m_hostGroups),
+                                    m_config.getTopology(m_hostGroups, HashMultimap.create(), new HashMap<>()),
                                     m_mpi,
                                     new KSafetyStats(),
                                     true);


### PR DESCRIPTION
* ENG-13435, improve rack-aware alogrithm to generate well-balanced partitions assignment.

The original algorithm was using greedy rack-aware algorithm to always assign partitions
to *furthest* node. The problem is that it may not always come up with a feasible partition
assignment even though one exists. And also it doesn't guarantte partition replicas are
well balanced across multiple placement groups, e.g. in 2-rack K=3 configuration one group
may have 3 or 4 replicas for some partitions.

Rejoin may also break the rack-awareness by bring too many replicas to one of the placement
groups.

This patch improves the original algorithm by adding extra step after it couldn't find the
viable solution. First it spreads partition replicas out across placement groups,
until no more partitions can be assigned due to k-safety constraint (each host must have
unique partitions), then it tries to move a partition from other nodes with the same placement
group to a emptier host. Repeat above steps until all the nodes get enough partition replicas.

This algorithm works best when following rules are met in the configuration:

1. each placement group must have same number of nodes, and
2. number of partition replicas (kfactor + 1) must be multiple of number of placement groups.

When those rules aren't met, this algorithm still tries best to generate feasible solution but
there is no further guarantee on the rack-awareness.

Change-Id: I27d962cc5e292cfc8241bccbff2d0015d8d08f7f