### PR TITLE
ENG-15258: add VoltLogicalValues

### DIFF
--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalValues.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalValues.java
@@ -21,13 +21,21 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 
-public class VoltLogicalValues extends LogicalValues implements VoltLogicalRel {
+import java.util.List;
+
+public class VoltLogicalValues extends Values implements VoltLogicalRel {
     public VoltLogicalValues(RelOptCluster cluster, RelTraitSet traitSet, RelDataType rowType, ImmutableList<ImmutableList<RexLiteral>> tuples) {
-        super(cluster, traitSet, rowType, tuples);
+        super(cluster, rowType, tuples, traitSet);
         Preconditions.checkArgument(getConvention() == VoltLogicalRel.CONVENTION);
+    }
+
+    @Override
+    public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+        return new VoltLogicalValues(getCluster(), traitSet, rowType, tuples);
     }
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalValues.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalValues.java
@@ -28,6 +28,13 @@ import org.apache.calcite.rex.RexLiteral;
 
 import java.util.List;
 
+/**
+ * Sub-class of {@link org.apache.calcite.rel.core.Values}
+ * targeted at the VoltDB logical calling {@link #CONVENTION}.
+ *
+ * @author Chao Zhou
+ * @since 9.0
+ */
 public class VoltLogicalValues extends Values implements VoltLogicalRel {
     public VoltLogicalValues(RelOptCluster cluster, RelTraitSet traitSet, RelDataType rowType, ImmutableList<ImmutableList<RexLiteral>> tuples) {
         super(cluster, rowType, tuples, traitSet);

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalValues.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalValues.java
@@ -15,17 +15,19 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.voltdb.plannerv2.rules.physical;
+package org.voltdb.plannerv2.rel.logical;
 
-public final class Constants {
-    private Constants() {
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+
+public class VoltLogicalValues extends LogicalValues implements VoltLogicalRel {
+    public VoltLogicalValues(RelOptCluster cluster, RelTraitSet traitSet, RelDataType rowType, ImmutableList<ImmutableList<RexLiteral>> tuples) {
+        super(cluster, traitSet, rowType, tuples);
+        Preconditions.checkArgument(getConvention() == VoltLogicalRel.CONVENTION);
     }
-
-    static final int JOIN_SPLIT_COUNT = 1;
-    static final int VALUES_SPLIT_COUNT = 1;
-    // TODO: why 30?
-    static public final int DISTRIBUTED_SPLIT_COUNT = 30;
-
-    // TODO: verify this
-    static public final int MAX_TABLE_ROW_COUNT = 1000000;
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/AbstractVoltPhysicalAggregate.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/AbstractVoltPhysicalAggregate.java
@@ -90,7 +90,7 @@ public abstract class AbstractVoltPhysicalAggregate extends Aggregate implements
     public RelWriter explainTerms(RelWriter pw) {
         super.explainTerms(pw);
         pw.item("split", m_splitCount);
-        pw.item("coorinator", m_isCoordinatorAggr);
+        pw.item("coordinator", m_isCoordinatorAggr);
         pw.itemIf("having", m_postPredicate, m_postPredicate != null);
         return pw;
     }

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalValues.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalValues.java
@@ -23,13 +23,13 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
-import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 
 import java.util.List;
 
-public class VoltPhysicalValues extends LogicalValues implements VoltPhysicalRel {
+public class VoltPhysicalValues extends Values implements VoltPhysicalRel {
     private final int m_splitCount;
 
     public VoltPhysicalValues(RelOptCluster cluster,
@@ -37,7 +37,7 @@ public class VoltPhysicalValues extends LogicalValues implements VoltPhysicalRel
                               RelDataType rowType,
                               ImmutableList<ImmutableList<RexLiteral>> tuples,
                               int splitCount) {
-        super(cluster, traitSet, rowType, tuples);
+        super(cluster, rowType, tuples, traitSet);
         Preconditions.checkArgument(getConvention() == VoltPhysicalRel.CONVENTION);
         m_splitCount = splitCount;
     }
@@ -50,8 +50,6 @@ public class VoltPhysicalValues extends LogicalValues implements VoltPhysicalRel
 
     @Override
     public RelWriter explainTerms(RelWriter pw) {
-        // Don't ever print semiJoinDone=false. This way, we
-        // don't clutter things up in optimizers that don't use semi-joins.
         return super.explainTerms(pw)
                 .item("split", m_splitCount);
     }

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalValues.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalValues.java
@@ -1,0 +1,63 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.plannerv2.rel.physical;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+
+import java.util.List;
+
+public class VoltPhysicalValues extends LogicalValues implements VoltPhysicalRel {
+    private final int m_splitCount;
+
+    public VoltPhysicalValues(RelOptCluster cluster,
+                              RelTraitSet traitSet,
+                              RelDataType rowType,
+                              ImmutableList<ImmutableList<RexLiteral>> tuples,
+                              int splitCount) {
+        super(cluster, traitSet, rowType, tuples);
+        Preconditions.checkArgument(getConvention() == VoltPhysicalRel.CONVENTION);
+        m_splitCount = splitCount;
+    }
+
+    @Override
+    public VoltPhysicalValues copy(RelTraitSet traitSet, List<RelNode> inputs) {
+        return new VoltPhysicalValues(getCluster(),
+                traitSet, rowType, tuples, m_splitCount);
+    }
+
+    @Override
+    public RelWriter explainTerms(RelWriter pw) {
+        // Don't ever print semiJoinDone=false. This way, we
+        // don't clutter things up in optimizers that don't use semi-joins.
+        return super.explainTerms(pw)
+                .item("split", m_splitCount);
+    }
+
+    @Override
+    public int getSplitCount() {
+        return m_splitCount;
+    }
+}

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalValues.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalValues.java
@@ -29,6 +29,13 @@ import org.apache.calcite.rex.RexLiteral;
 
 import java.util.List;
 
+/**
+ * Sub-class of {@link org.apache.calcite.rel.core.Values}
+ * targeted at the VoltDB Physical calling {@link #CONVENTION}.
+ *
+ * @author Chao Zhou
+ * @since 9.0
+ */
 public class VoltPhysicalValues extends Values implements VoltPhysicalRel {
     private final int m_splitCount;
 

--- a/src/frontend/org/voltdb/plannerv2/rules/PlannerRules.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/PlannerRules.java
@@ -45,12 +45,14 @@ import org.voltdb.plannerv2.rules.logical.VoltLCalcRule;
 import org.voltdb.plannerv2.rules.logical.VoltLJoinRule;
 import org.voltdb.plannerv2.rules.logical.VoltLSortRule;
 import org.voltdb.plannerv2.rules.logical.VoltLTableScanRule;
+import org.voltdb.plannerv2.rules.logical.VoltLValuesRule;
 import org.voltdb.plannerv2.rules.physical.VoltPAggregateRule;
 import org.voltdb.plannerv2.rules.physical.VoltPCalcRule;
 import org.voltdb.plannerv2.rules.physical.VoltPJoinRule;
 import org.voltdb.plannerv2.rules.physical.VoltPLimitRule;
 import org.voltdb.plannerv2.rules.physical.VoltPSeqScanRule;
 import org.voltdb.plannerv2.rules.physical.VoltPSortConvertRule;
+import org.voltdb.plannerv2.rules.physical.VoltPValuesRule;
 
 /**
  * Rules used by the VoltDB query planner in various planning stages.
@@ -121,7 +123,8 @@ public class PlannerRules {
             VoltLTableScanRule.INSTANCE,
             VoltLCalcRule.INSTANCE,
             VoltLAggregateRule.INSTANCE,
-            VoltLJoinRule.INSTANCE
+            VoltLJoinRule.INSTANCE,
+            VoltLValuesRule.INSTANCE
 
 //            // Filter   ->  Project
 //            // Project      Filter
@@ -162,7 +165,8 @@ public class PlannerRules {
             VoltPSortConvertRule.INSTANCE_VOLTDB,
             VoltPLimitRule.INSTANCE,
             VoltPAggregateRule.INSTANCE,
-            VoltPJoinRule.INSTANCE
+            VoltPJoinRule.INSTANCE,
+            VoltPValuesRule.INSTANCE
     );
 
     private static final RuleSet INLINE = RuleSets.ofList(

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLValuesRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLValuesRule.java
@@ -1,0 +1,42 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.plannerv2.rules.logical;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.voltdb.plannerv2.rel.logical.VoltLogicalRel;
+import org.voltdb.plannerv2.rel.logical.VoltLogicalValues;
+
+public class VoltLValuesRule extends RelOptRule {
+    public static final VoltLValuesRule INSTANCE = new VoltLValuesRule();
+
+    VoltLValuesRule() {
+        super(operand(LogicalValues.class, Convention.NONE, any()));
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        LogicalValues values = call.rel(0);
+        RelTraitSet convertedTraits = values.getTraitSet().replace(VoltLogicalRel.CONVENTION).simplify();
+
+        call.transformTo(new VoltLogicalValues(values.getCluster(), convertedTraits, values.getRowType(), values.getTuples()));
+    }
+}

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLValuesRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLValuesRule.java
@@ -25,6 +25,12 @@ import org.apache.calcite.rel.logical.LogicalValues;
 import org.voltdb.plannerv2.rel.logical.VoltLogicalRel;
 import org.voltdb.plannerv2.rel.logical.VoltLogicalValues;
 
+/**
+ * VoltDB logical rule that transform {@link LogicalValues} to {@link VoltLogicalValues}.
+ *
+ * @author Chao Zhou
+ * @since 9.0
+ */
 public class VoltLValuesRule extends RelOptRule {
     public static final VoltLValuesRule INSTANCE = new VoltLValuesRule();
 

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLValuesRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLValuesRule.java
@@ -28,7 +28,7 @@ import org.voltdb.plannerv2.rel.logical.VoltLogicalValues;
 public class VoltLValuesRule extends RelOptRule {
     public static final VoltLValuesRule INSTANCE = new VoltLValuesRule();
 
-    VoltLValuesRule() {
+    private VoltLValuesRule() {
         super(operand(LogicalValues.class, Convention.NONE, any()));
     }
 

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPValuesRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPValuesRule.java
@@ -29,7 +29,7 @@ public class VoltPValuesRule extends RelOptRule {
 
     public static final VoltPValuesRule INSTANCE = new VoltPValuesRule();
 
-    VoltPValuesRule() {
+    private VoltPValuesRule() {
         super(operand(VoltLogicalValues.class, VoltLogicalRel.CONVENTION, any()));
     }
 

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPValuesRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPValuesRule.java
@@ -26,6 +26,12 @@ import org.voltdb.plannerv2.rel.logical.VoltLogicalValues;
 import org.voltdb.plannerv2.rel.physical.VoltPhysicalRel;
 import org.voltdb.plannerv2.rel.physical.VoltPhysicalValues;
 
+/**
+ * VoltDB physical rule that transform {@link VoltLogicalValues} to {@link VoltPhysicalValues}.
+ *
+ * @author Chao Zhou
+ * @since 9.0
+ */
 public class VoltPValuesRule extends RelOptRule {
 
     public static final VoltPValuesRule INSTANCE = new VoltPValuesRule();

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPValuesRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPValuesRule.java
@@ -1,0 +1,45 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.plannerv2.rules.physical;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.voltdb.plannerv2.rel.logical.VoltLogicalRel;
+import org.voltdb.plannerv2.rel.logical.VoltLogicalValues;
+import org.voltdb.plannerv2.rel.physical.VoltPhysicalRel;
+import org.voltdb.plannerv2.rel.physical.VoltPhysicalValues;
+
+public class VoltPValuesRule extends RelOptRule {
+
+    public static final VoltPValuesRule INSTANCE = new VoltPValuesRule();
+
+    VoltPValuesRule() {
+        super(operand(VoltLogicalValues.class, VoltLogicalRel.CONVENTION, any()));
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        VoltLogicalValues values = call.rel(0);
+        RelTraitSet convertedTraits = values.getTraitSet().replace(VoltPhysicalRel.CONVENTION).simplify();
+
+        call.transformTo(new VoltPhysicalValues(values.getCluster(),
+                convertedTraits, values.getRowType(), values.getTuples(),
+                Constants.VALUES_SPLIT_COUNT));
+    }
+}

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPValuesRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPValuesRule.java
@@ -20,6 +20,7 @@ package org.voltdb.plannerv2.rules.physical;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelDistributions;
 import org.voltdb.plannerv2.rel.logical.VoltLogicalRel;
 import org.voltdb.plannerv2.rel.logical.VoltLogicalValues;
 import org.voltdb.plannerv2.rel.physical.VoltPhysicalRel;
@@ -36,7 +37,10 @@ public class VoltPValuesRule extends RelOptRule {
     @Override
     public void onMatch(RelOptRuleCall call) {
         VoltLogicalValues values = call.rel(0);
-        RelTraitSet convertedTraits = values.getTraitSet().replace(VoltPhysicalRel.CONVENTION).simplify();
+        RelTraitSet convertedTraits = values.getTraitSet()
+                .replace(VoltPhysicalRel.CONVENTION)
+                .replace(RelDistributions.SINGLETON)    // VoltPhysicalValues must be a SINGLETON Distribution.
+                .simplify();
 
         call.transformTo(new VoltPhysicalValues(values.getCluster(),
                 convertedTraits, values.getRowType(), values.getTuples(),

--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -446,42 +446,41 @@ public class TestAdHocQueries extends AdHocQueryTester {
         }
     }
 
-    // ENG-15258
-//    @Test
-//    public void testAdHocLengthLimit() throws Exception {
-//        System.out.println("Starting testAdHocLengthLimit");
-//        TestEnv env = new TestEnv(m_catalogJar, m_pathToDeployment, 2, 2, 1);
-//
-//        env.setUp();
-//        // by pass valgrind due to ENG-7843
-//        if (env.isValgrind() || env.isMemcheckDefined()) {
-//            env.tearDown();
-//            System.out.println("Skipped testAdHocLengthLimit");
-//            return;
-//        }
-//        try {
-//            StringBuffer adHocQueryTemp = new StringBuffer("SELECT * FROM VOTES WHERE PHONE_NUMBER IN (");
-//            int i = 0;
-//            while (adHocQueryTemp.length() <= Short.MAX_VALUE * 2) {
-//                String randPhone = RandomStringUtils.randomNumeric(10);
-//                VoltTable result = env.m_client.callProcedure("@AdHoc", "INSERT INTO VOTES VALUES(?, ?, ?);", randPhone, "MA", i).getResults()[0];
-//                assertEquals(1, result.getRowCount());
-//                adHocQueryTemp.append(randPhone);
-//                adHocQueryTemp.append(", ");
-//                i++;
-//            }
-//            adHocQueryTemp.replace(adHocQueryTemp.length()-2, adHocQueryTemp.length(), ");");
-//            // assure that adhoc query text can exceed 2^15 length, but the literals still cannot exceed 2^15
-//            assert(adHocQueryTemp.length() > Short.MAX_VALUE);
-//            assert(i < Short.MAX_VALUE);
-//            VoltTable result = env.m_client.callProcedure("@AdHoc", adHocQueryTemp.toString()).getResults()[0];
-//            assertEquals(i, result.getRowCount());
-//        }
-//         finally {
-//            env.tearDown();
-//            System.out.println("Ending testAdHocLengthLimit");
-//        }
-//    }
+    @Test
+    public void testAdHocLengthLimit() throws Exception {
+        System.out.println("Starting testAdHocLengthLimit");
+        TestEnv env = new TestEnv(m_catalogJar, m_pathToDeployment, 2, 2, 1);
+
+        env.setUp();
+        // by pass valgrind due to ENG-7843
+        if (env.isValgrind() || env.isMemcheckDefined()) {
+            env.tearDown();
+            System.out.println("Skipped testAdHocLengthLimit");
+            return;
+        }
+        try {
+            StringBuffer adHocQueryTemp = new StringBuffer("SELECT * FROM VOTES WHERE PHONE_NUMBER IN (");
+            int i = 0;
+            while (adHocQueryTemp.length() <= Short.MAX_VALUE * 2) {
+                String randPhone = RandomStringUtils.randomNumeric(10);
+                VoltTable result = env.m_client.callProcedure("@AdHoc", "INSERT INTO VOTES VALUES(?, ?, ?);", randPhone, "MA", i).getResults()[0];
+                assertEquals(1, result.getRowCount());
+                adHocQueryTemp.append(randPhone);
+                adHocQueryTemp.append(", ");
+                i++;
+            }
+            adHocQueryTemp.replace(adHocQueryTemp.length()-2, adHocQueryTemp.length(), ");");
+            // assure that adhoc query text can exceed 2^15 length, but the literals still cannot exceed 2^15
+            assert(adHocQueryTemp.length() > Short.MAX_VALUE);
+            assert(i < Short.MAX_VALUE);
+            VoltTable result = env.m_client.callProcedure("@AdHoc", adHocQueryTemp.toString()).getResults()[0];
+            assertEquals(i, result.getRowCount());
+        }
+         finally {
+            env.tearDown();
+            System.out.println("Ending testAdHocLengthLimit");
+        }
+    }
 
     // ENG-15263
 //    @Test

--- a/tests/frontend/org/voltdb/plannerv2/TestInlineRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestInlineRules.java
@@ -247,58 +247,58 @@ public class TestInlineRules extends Plannerv2TestCase {
 
     public void testAggr() {
         m_tester.sql("select avg(ti) from R1")
-                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#49,group={},EXPR$0=AVG($0),split=1,coorinator=false,type=serial)_split_1_coordinator_false])\n")
+                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#49,group={},EXPR$0=AVG($0),split=1,coordinator=false,type=serial)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select avg(ti) from R1 group by i")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#128,group={0},EXPR$0=AVG($1),split=1,coorinator=false,type=hash)_split_1_coordinator_false])\n")
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#128,group={0},EXPR$0=AVG($1),split=1,coordinator=false,type=hash)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select count(i) from R1 where ti > 3")
-                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#196,group={},EXPR$0=COUNT($0),split=1,coorinator=false,type=serial)_split_1_coordinator_false])\n")
+                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#196,group={},EXPR$0=COUNT($0),split=1,coordinator=false,type=serial)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select count(*) from R1")
-                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#252,group={},EXPR$0=COUNT(),split=1,coorinator=false,type=serial)_split_1_coordinator_false])\n")
+                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#252,group={},EXPR$0=COUNT(),split=1,coordinator=false,type=serial)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select max(TI) from R1 group by SI having SI > 0")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#341,group={0},EXPR$0=MAX($1),split=1,coorinator=false,having=>($0, 0),type=hash)_split_1_coordinator_false>($0, 0)])\n")
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#341,group={0},EXPR$0=MAX($1),split=1,coordinator=false,having=>($0, 0),type=hash)_split_1_coordinator_false>($0, 0)])\n")
                 .test();
 
         m_tester.sql("select max(TI), SI, min(TI), I from R1 group by SI, I having avg(BI) > max(BI)")
                 .transform("VoltPhysicalCalc(expr#0..5=[{inputs}], EXPR$0=[$t2], SI=[$t0], EXPR$2=[$t3], I=[$t1], split=[1])\n" +
-                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#437,group={0, 1},EXPR$0=MAX($2),EXPR$2=MIN($2),agg#2=AVG($3),agg#3=MAX($3),split=1,coorinator=false,having=>($4, $5),type=hash)_split_1_coordinator_false>($4, $5)])\n")
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#437,group={0, 1},EXPR$0=MAX($2),EXPR$2=MIN($2),agg#2=AVG($3),agg#3=MAX($3),split=1,coordinator=false,having=>($4, $5),type=hash)_split_1_coordinator_false>($4, $5)])\n")
                 .test();
 
         m_tester.sql("select max(TI), SI, I, min(TI) from R1 group by I, SI having avg(BI) > 0 and si > 0")
                 .transform("VoltPhysicalCalc(expr#0..4=[{inputs}], EXPR$0=[$t2], SI=[$t1], I=[$t0], EXPR$3=[$t3], split=[1])\n" +
-                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..4=[{inputs}], proj#0..4=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#533,group={0, 1},EXPR$0=MAX($2),EXPR$3=MIN($2),agg#2=AVG($3),split=1,coorinator=false,having=AND(>($4, 0), >($1, 0)),type=hash)_split_1_coordinator_falseAND(>($4, 0), >($1, 0))])\n")
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..4=[{inputs}], proj#0..4=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#533,group={0, 1},EXPR$0=MAX($2),EXPR$3=MIN($2),agg#2=AVG($3),split=1,coordinator=false,having=AND(>($4, 0), >($1, 0)),type=hash)_split_1_coordinator_falseAND(>($4, 0), >($1, 0))])\n")
                 .test();
 
         m_tester.sql("select max(TI), SI from R1 where I > 0 group by SI, I order by SI limit 3")
                 .transform("VoltPhysicalSort(sort0=[$1], dir0=[ASC], fetch=[3], split=[1])\n" +
                         "  VoltPhysicalCalc(expr#0..2=[{inputs}], EXPR$0=[$t2], SI=[$t0], split=[1])\n" +
-                        "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..2=[{inputs}], proj#0..2=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#661,group={0, 1},EXPR$0=MAX($2),split=1,coorinator=false,type=hash)_split_1_coordinator_false])\n")
+                        "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..2=[{inputs}], proj#0..2=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#661,group={0, 1},EXPR$0=MAX($2),split=1,coordinator=false,type=hash)_split_1_coordinator_false])\n")
                 .test();
     }
 
     public void testDistinct() {
         m_tester.sql("select distinct TI, I from R1")
-                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#54,group={0, 1},split=1,coorinator=false,type=hash)_split_1_coordinator_false])\n")
+                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#54,group={0, 1},split=1,coordinator=false,type=hash)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select distinct max(TI) from R1 group by I")
-                .transform("VoltPhysicalHashAggregate(group=[{0}], split=[1], coorinator=[false], type=[hash])\n" +
+                .transform("VoltPhysicalHashAggregate(group=[{0}], split=[1], coordinator=[false], type=[hash])\n" +
                         "  VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#155,group={0},EXPR$0=MAX($1),split=1,coorinator=false,type=hash)_split_1_coordinator_false])\n")
+                        "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#155,group={0},EXPR$0=MAX($1),split=1,coordinator=false,type=hash)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select max (distinct (TI)) from R1 group by I")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#238,group={0},EXPR$0=MAX(DISTINCT $1),split=1,coorinator=false,type=hash)_split_1_coordinator_false])\n")
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#238,group={0},EXPR$0=MAX(DISTINCT $1),split=1,coordinator=false,type=hash)_split_1_coordinator_false])\n")
                 .test();
     }
 

--- a/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
@@ -479,6 +479,11 @@ public class TestLogicalRules extends Plannerv2TestCase {
                         "  VoltLogicalTableScan(table=[[public, R1]])\n")
                 .test();
 
+        m_tester.sql("select * from r1 where i in(si, 1, 2, 3, 4)")
+                .transform("VoltLogicalCalc(expr#0..5=[{inputs}], expr#6=[CAST($t1):INTEGER], expr#7=[=($t0, $t6)], expr#8=[1], expr#9=[=($t0, $t8)], expr#10=[2], expr#11=[=($t0, $t10)], expr#12=[3], expr#13=[=($t0, $t12)], expr#14=[4], expr#15=[=($t0, $t14)], expr#16=[OR($t7, $t9, $t11, $t13, $t15)], proj#0..5=[{exprs}], $condition=[$t16])\n" +
+                        "  VoltLogicalTableScan(table=[[public, R1]])\n")
+                .test();
+
         // If we have many items in the IN clause, Calcite will use
         // VoltLogicalJoin
         //      VoltLogicalTableScan
@@ -491,5 +496,8 @@ public class TestLogicalRules extends Plannerv2TestCase {
                         "    VoltLogicalAggregate(group=[{0}])\n" +
                         "      VoltLogicalValues(tuples=[[{ 0 }, { 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }, { 10 }, { 11 }, { 12 }, { 13 }, { 14 }, { 15 }, { 16 }, { 17 }, { 18 }, { 19 }, { 20 }, { 21 }]])\n")
                 .test();
+
+        // ENG-15397
+        // m_tester.sql("select * from r1 where i in (si, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)").transform("foo").test();
     }
 }

--- a/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
@@ -474,7 +474,7 @@ public class TestLogicalRules extends Plannerv2TestCase {
 
     public void testLogicalValues() {
         // ENG-15258
-//        m_tester.sql("select * from r1 where i in(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)")
-//                .transform("foo").test();
+        m_tester.sql("select * from r1 where i in(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)")
+                .transform("foo").test();
     }
 }

--- a/tests/frontend/org/voltdb/plannerv2/TestMPQueryFallbackRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestMPQueryFallbackRules.java
@@ -298,6 +298,13 @@ public class TestMPQueryFallbackRules extends Plannerv2TestCase {
         m_tester.sql("select si from P1 where si in (select i from R1)").testFail();
 
         m_tester.sql("select i from R1 where i in (select si from P1)").testFail();
+
+        // calcite will use Values to represent long list of IN items.
+        m_tester.sql("select * from r1 where i in(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)")
+                .test();
+
+        m_tester.sql("select * from P1 where i in(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)")
+                .testFail();
     }
 
     public void testPartitionKeyEqualToTableColumn() {

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalConversion.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalConversion.java
@@ -290,47 +290,47 @@ public class TestPhysicalConversion extends Plannerv2TestCase {
 
     public void testAggr() {
         m_tester.sql("select avg(ti) from R1")
-                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[AVG($0)], split=[1], coorinator=[false], type=[serial])\n" +
+                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[AVG($0)], split=[1], coordinator=[false], type=[serial])\n" +
                         "  VoltPhysicalCalc(expr#0..5=[{inputs}], TI=[$t2], split=[1])\n" +
                         "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select avg(ti) from R1 group by i")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[AVG($1)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[AVG($1)], split=[1], coordinator=[false], type=[hash])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], I=[$t0], TI=[$t2], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select count(i) from R1 where ti > 3")
-                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT($0)], split=[1], coorinator=[false], type=[serial])\n" +
+                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT($0)], split=[1], coordinator=[false], type=[serial])\n" +
                         "  VoltPhysicalCalc(expr#0..5=[{inputs}], expr#6=[3], expr#7=[>($t2, $t6)], I=[$t0], $condition=[$t7], split=[1])\n" +
                         "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select count(*) from R1")
-                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT()], split=[1], coorinator=[false], type=[serial])\n" +
+                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT()], split=[1], coordinator=[false], type=[serial])\n" +
                         "  VoltPhysicalCalc(expr#0..5=[{inputs}], expr#6=[0], $f0=[$t6], split=[1])\n" +
                         "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select max(TI) from R1 group by SI having SI > 0")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], expr#2=[0], expr#3=[>($t0, $t2)], EXPR$0=[$t1], $condition=[$t3], split=[1])\n" +
-                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX($1)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX($1)], split=[1], coordinator=[false], type=[hash])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], SI=[$t1], TI=[$t2], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select max(TI), SI, min(TI), I from R1 group by SI, I having avg(BI) > max(BI)")
                 .transform("VoltPhysicalCalc(expr#0..5=[{inputs}], expr#6=[>($t4, $t5)], EXPR$0=[$t2], SI=[$t0], EXPR$2=[$t3], I=[$t1], $condition=[$t6], split=[1])\n" +
-                        "  VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], EXPR$2=[MIN($2)], agg#2=[AVG($3)], agg#3=[MAX($3)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], EXPR$2=[MIN($2)], agg#2=[AVG($3)], agg#3=[MAX($3)], split=[1], coordinator=[false], type=[hash])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], SI=[$t1], I=[$t0], TI=[$t2], BI=[$t3], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select max(TI), SI, I, min(TI) from R1 group by I, SI having avg(BI) > 0 and si > 0")
                 .transform("VoltPhysicalCalc(expr#0..4=[{inputs}], expr#5=[0], expr#6=[>($t4, $t5)], expr#7=[>($t1, $t5)], expr#8=[AND($t6, $t7)], EXPR$0=[$t2], SI=[$t1], I=[$t0], EXPR$3=[$t3], $condition=[$t8], split=[1])\n" +
-                        "  VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], EXPR$3=[MIN($2)], agg#2=[AVG($3)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], EXPR$3=[MIN($2)], agg#2=[AVG($3)], split=[1], coordinator=[false], type=[hash])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], proj#0..3=[{exprs}], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
@@ -339,7 +339,7 @@ public class TestPhysicalConversion extends Plannerv2TestCase {
                 .transform("VoltPhysicalLimit(split=[1], limit=[3])\n" +
                         "  VoltPhysicalSort(sort0=[$1], dir0=[ASC], split=[1])\n" +
                         "    VoltPhysicalCalc(expr#0..2=[{inputs}], EXPR$0=[$t2], SI=[$t0], split=[1])\n" +
-                        "      VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "      VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], split=[1], coordinator=[false], type=[hash])\n" +
                         "        VoltPhysicalCalc(expr#0..5=[{inputs}], expr#6=[0], expr#7=[>($t0, $t6)], SI=[$t1], I=[$t0], TI=[$t2], $condition=[$t7], split=[1])\n" +
                         "          VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
@@ -347,22 +347,22 @@ public class TestPhysicalConversion extends Plannerv2TestCase {
 
     public void testDistinct() {
         m_tester.sql("select distinct TI, I from R1")
-                .transform("VoltPhysicalHashAggregate(group=[{0, 1}], split=[1], coorinator=[false], type=[hash])\n" +
+                .transform("VoltPhysicalHashAggregate(group=[{0, 1}], split=[1], coordinator=[false], type=[hash])\n" +
                         "  VoltPhysicalCalc(expr#0..5=[{inputs}], TI=[$t2], I=[$t0], split=[1])\n" +
                         "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select distinct max(TI) from R1 group by I")
-                .transform("VoltPhysicalHashAggregate(group=[{0}], split=[1], coorinator=[false], type=[hash])\n" +
+                .transform("VoltPhysicalHashAggregate(group=[{0}], split=[1], coordinator=[false], type=[hash])\n" +
                         "  VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "    VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX($1)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "    VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX($1)], split=[1], coordinator=[false], type=[hash])\n" +
                         "      VoltPhysicalCalc(expr#0..5=[{inputs}], I=[$t0], TI=[$t2], split=[1])\n" +
                         "        VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select max (distinct (TI)) from R1 group by I")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX(DISTINCT $1)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX(DISTINCT $1)], split=[1], coordinator=[false], type=[hash])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], I=[$t0], TI=[$t2], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
@@ -436,6 +436,21 @@ public class TestPhysicalConversion extends Plannerv2TestCase {
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], expr#6=[CAST($t4):DOUBLE NOT NULL], expr#7=[30.3], expr#8=[=($t6, $t7)], proj#0..5=[{exprs}], $condition=[$t8], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R2]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
+                .test();
+    }
+
+    public void testIn() {
+        m_tester.sql("select * from r1 where i in(0, 1, 2, 3, 4)")
+                .transform("VoltPhysicalCalc(expr#0..5=[{inputs}], expr#6=[0], expr#7=[=($t0, $t6)], expr#8=[1], expr#9=[=($t0, $t8)], expr#10=[2], expr#11=[=($t0, $t10)], expr#12=[3], expr#13=[=($t0, $t12)], expr#14=[4], expr#15=[=($t0, $t14)], expr#16=[OR($t7, $t9, $t11, $t13, $t15)], proj#0..5=[{exprs}], $condition=[$t16], split=[1])\n" +
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
+                .test();
+
+        m_tester.sql("select * from r1 where i in(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)")
+                .transform("VoltPhysicalCalc(expr#0..6=[{inputs}], proj#0..5=[{exprs}], split=[1])\n" +
+                        "  VoltPhysicalJoin(condition=[=($0, $6)], joinType=[inner], split=[1])\n" +
+                        "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n" +
+                        "    VoltPhysicalSerialAggregate(group=[{0}], split=[1], coordinator=[false], type=[serial])\n" +
+                        "      VoltPhysicalValues(tuples=[[{ 0 }, { 1 }, { 2 }, { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }, { 10 }, { 11 }, { 12 }, { 13 }, { 14 }, { 15 }, { 16 }, { 17 }, { 18 }, { 19 }, { 20 }, { 21 }]], split=[1])\n")
                 .test();
     }
 }

--- a/tests/frontend/org/voltdb/plannerv2/TestPlanConversion.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPlanConversion.java
@@ -383,6 +383,17 @@ public class TestPlanConversion extends CalcitePlannerTestCase {
 //        comparePlans(sql, ignores);
     }
 
+    public void testCompareVeryLongInExpr() {
+        String sql = "select 1 from RTYPES where i IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)"; // Calcite Regular OR
+        // TODO: If we have many items in the IN clause, Calcite will use
+        // VoltLogicalJoin
+        //      VoltLogicalTableScan
+        //      VoltLogicalAggregate
+        //          VoltLogicalValues
+        // We have not implemented the plan conversion for join yet
+//        comparePlans(sql);
+    }
+
     public void testCompareLikeExpr1() {
         String sql = "select 1 from RTYPES where vc LIKE 'ab%c'";
         Map<String, String> ignores = new HashMap<>();

--- a/tests/frontend/org/voltdb/plannerv2/TestRelConversion.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestRelConversion.java
@@ -42,4 +42,11 @@ public class TestRelConversion extends Plannerv2TestCase {
                 .plan("Root {kind: SELECT, rel: LogicalProject#1, rowType: RecordType(INTEGER I), fields: [<0, I>], collation: []}")
                 .test();
     }
+
+    public void testVeryLongInExpr() {
+        m_tester.sql("select * from r1 where i in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)").test();
+
+        // ENG-15397
+//        m_tester.sql("select * from r1 where i in (si, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)").test();
+    }
 }

--- a/tests/frontend/org/voltdb/plannerv2/TestValidation.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestValidation.java
@@ -118,4 +118,10 @@ public class TestValidation extends Plannerv2TestCase {
         // TODO: fix this
 //        m_tester.sql("select i from R1 FUll JOIN R2 using(i)").test();
     }
+
+    public void testVeryLongInExpr() {
+        m_tester.sql("select * from r1 where i in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)").test();
+
+        m_tester.sql("select * from r1 where i in (si, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)").test();
+    }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/TestMaxSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMaxSuite.java
@@ -80,13 +80,12 @@ public class TestMaxSuite extends RegressionSuite {
         stringBuilder.append(") order by column0;");
         assert(stringBuilder.length() > Short.MAX_VALUE);        // previous limit
         assert(stringBuilder.length() < SQL_LITERAL_MAX_LENGTH); // new limit due to ENG-10059
-        // ENG-15258
-//        try {
-//            VoltTable result = client.callProcedure("@AdHoc", stringBuilder.toString()).getResults()[0];
-//            assertEquals(0, result.getRowCount());
-//        } catch(Exception ex) {
-//            fail();
-//        }
+        try {
+            VoltTable result = client.callProcedure("@AdHoc", stringBuilder.toString()).getResults()[0];
+            assertEquals(0, result.getRowCount());
+        } catch(Exception ex) {
+            fail();
+        }
     }
 
     public void testMaxIn() throws Exception {
@@ -107,18 +106,17 @@ public class TestMaxSuite extends RegressionSuite {
             }
         }
         stringBuilder.append(") order by column0;");
-        // ENG-15258
-//        resp = client.callProcedure("@AdHoc", stringBuilder.toString());
-//        assertEquals(ClientResponse.SUCCESS, resp.getStatus());
-//
-//        assertEquals(1, resp.getResults().length);
-//        VoltTable results = resp.getResults()[0];
-//        int rowCount = results.getRowCount();
-//        assertEquals(10, rowCount);
-//        assertEquals(2, results.getColumnCount());
-//        for (int i = 0; i < rowCount; i++) {
-//            assertEquals(i, results.fetchRow(i).getLong(0));
-//        }
+        resp = client.callProcedure("@AdHoc", stringBuilder.toString());
+        assertEquals(ClientResponse.SUCCESS, resp.getStatus());
+
+        assertEquals(1, resp.getResults().length);
+        VoltTable results = resp.getResults()[0];
+        int rowCount = results.getRowCount();
+        assertEquals(10, rowCount);
+        assertEquals(2, results.getColumnCount());
+        for (int i = 0; i < rowCount; i++) {
+            assertEquals(i, results.fetchRow(i).getLong(0));
+        }
     }
 
     public void testMaxColumn() throws Exception {


### PR DESCRIPTION
Add the corresponding `VoltLogicalValues` & `VoltPhysicalvalues` to handle the **long** IN expression, like `select * from r1 where i in(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)`.

That the calcite conveter have some problem when we try to put a Column reference in a very long IN expression, like `select * from r1 where i in (col1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)`. I create **ENG-15397** for that.

