### PR TITLE
ENG-15258: support IN expression through calcite

### DIFF
--- a/src/frontend/org/voltdb/plannerv2/VoltSqlToRelConverterConfig.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltSqlToRelConverterConfig.java
@@ -59,7 +59,8 @@ public class VoltSqlToRelConverterConfig implements SqlToRelConverter.Config {
 
     @Override
     public int getInSubQueryThreshold() {
-        return this.DEFAULT.getInSubQueryThreshold();
+        // forces usage of OR rather than join against an inline table in all cases.
+        return Integer.MAX_VALUE;
     }
 
     @Override

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/AbstractVoltPhysicalAggregate.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/AbstractVoltPhysicalAggregate.java
@@ -90,7 +90,7 @@ public abstract class AbstractVoltPhysicalAggregate extends Aggregate implements
     public RelWriter explainTerms(RelWriter pw) {
         super.explainTerms(pw);
         pw.item("split", m_splitCount);
-        pw.item("coorinator", m_isCoordinatorAggr);
+        pw.item("coordinator", m_isCoordinatorAggr);
         pw.itemIf("having", m_postPredicate, m_postPredicate != null);
         return pw;
     }

--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -446,42 +446,41 @@ public class TestAdHocQueries extends AdHocQueryTester {
         }
     }
 
-    // ENG-15258
-//    @Test
-//    public void testAdHocLengthLimit() throws Exception {
-//        System.out.println("Starting testAdHocLengthLimit");
-//        TestEnv env = new TestEnv(m_catalogJar, m_pathToDeployment, 2, 2, 1);
-//
-//        env.setUp();
-//        // by pass valgrind due to ENG-7843
-//        if (env.isValgrind() || env.isMemcheckDefined()) {
-//            env.tearDown();
-//            System.out.println("Skipped testAdHocLengthLimit");
-//            return;
-//        }
-//        try {
-//            StringBuffer adHocQueryTemp = new StringBuffer("SELECT * FROM VOTES WHERE PHONE_NUMBER IN (");
-//            int i = 0;
-//            while (adHocQueryTemp.length() <= Short.MAX_VALUE * 2) {
-//                String randPhone = RandomStringUtils.randomNumeric(10);
-//                VoltTable result = env.m_client.callProcedure("@AdHoc", "INSERT INTO VOTES VALUES(?, ?, ?);", randPhone, "MA", i).getResults()[0];
-//                assertEquals(1, result.getRowCount());
-//                adHocQueryTemp.append(randPhone);
-//                adHocQueryTemp.append(", ");
-//                i++;
-//            }
-//            adHocQueryTemp.replace(adHocQueryTemp.length()-2, adHocQueryTemp.length(), ");");
-//            // assure that adhoc query text can exceed 2^15 length, but the literals still cannot exceed 2^15
-//            assert(adHocQueryTemp.length() > Short.MAX_VALUE);
-//            assert(i < Short.MAX_VALUE);
-//            VoltTable result = env.m_client.callProcedure("@AdHoc", adHocQueryTemp.toString()).getResults()[0];
-//            assertEquals(i, result.getRowCount());
-//        }
-//         finally {
-//            env.tearDown();
-//            System.out.println("Ending testAdHocLengthLimit");
-//        }
-//    }
+    @Test
+    public void testAdHocLengthLimit() throws Exception {
+        System.out.println("Starting testAdHocLengthLimit");
+        TestEnv env = new TestEnv(m_catalogJar, m_pathToDeployment, 2, 2, 1);
+
+        env.setUp();
+        // by pass valgrind due to ENG-7843
+        if (env.isValgrind() || env.isMemcheckDefined()) {
+            env.tearDown();
+            System.out.println("Skipped testAdHocLengthLimit");
+            return;
+        }
+        try {
+            StringBuffer adHocQueryTemp = new StringBuffer("SELECT * FROM VOTES WHERE PHONE_NUMBER IN (");
+            int i = 0;
+            while (adHocQueryTemp.length() <= Short.MAX_VALUE * 2) {
+                String randPhone = RandomStringUtils.randomNumeric(10);
+                VoltTable result = env.m_client.callProcedure("@AdHoc", "INSERT INTO VOTES VALUES(?, ?, ?);", randPhone, "MA", i).getResults()[0];
+                assertEquals(1, result.getRowCount());
+                adHocQueryTemp.append(randPhone);
+                adHocQueryTemp.append(", ");
+                i++;
+            }
+            adHocQueryTemp.replace(adHocQueryTemp.length()-2, adHocQueryTemp.length(), ");");
+            // assure that adhoc query text can exceed 2^15 length, but the literals still cannot exceed 2^15
+            assert(adHocQueryTemp.length() > Short.MAX_VALUE);
+            assert(i < Short.MAX_VALUE);
+            VoltTable result = env.m_client.callProcedure("@AdHoc", adHocQueryTemp.toString()).getResults()[0];
+            assertEquals(i, result.getRowCount());
+        }
+         finally {
+            env.tearDown();
+            System.out.println("Ending testAdHocLengthLimit");
+        }
+    }
 
     // ENG-15263
 //    @Test

--- a/tests/frontend/org/voltdb/plannerv2/TestInlineRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestInlineRules.java
@@ -247,58 +247,58 @@ public class TestInlineRules extends Plannerv2TestCase {
 
     public void testAggr() {
         m_tester.sql("select avg(ti) from R1")
-                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#49,group={},EXPR$0=AVG($0),split=1,coorinator=false,type=serial)_split_1_coordinator_false])\n")
+                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#49,group={},EXPR$0=AVG($0),split=1,coordinator=false,type=serial)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select avg(ti) from R1 group by i")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#128,group={0},EXPR$0=AVG($1),split=1,coorinator=false,type=hash)_split_1_coordinator_false])\n")
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#128,group={0},EXPR$0=AVG($1),split=1,coordinator=false,type=hash)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select count(i) from R1 where ti > 3")
-                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#196,group={},EXPR$0=COUNT($0),split=1,coorinator=false,type=serial)_split_1_coordinator_false])\n")
+                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#196,group={},EXPR$0=COUNT($0),split=1,coordinator=false,type=serial)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select count(*) from R1")
-                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#252,group={},EXPR$0=COUNT(),split=1,coorinator=false,type=serial)_split_1_coordinator_false])\n")
+                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0=[{inputs}], EXPR$0=[$t0], aggregate=[VoltPhysicalSerialAggregate.CONVENTION.[].single(input=HepRelVertex#252,group={},EXPR$0=COUNT(),split=1,coordinator=false,type=serial)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select max(TI) from R1 group by SI having SI > 0")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#341,group={0},EXPR$0=MAX($1),split=1,coorinator=false,having=>($0, 0),type=hash)_split_1_coordinator_false>($0, 0)])\n")
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#341,group={0},EXPR$0=MAX($1),split=1,coordinator=false,having=>($0, 0),type=hash)_split_1_coordinator_false>($0, 0)])\n")
                 .test();
 
         m_tester.sql("select max(TI), SI, min(TI), I from R1 group by SI, I having avg(BI) > max(BI)")
                 .transform("VoltPhysicalCalc(expr#0..5=[{inputs}], EXPR$0=[$t2], SI=[$t0], EXPR$2=[$t3], I=[$t1], split=[1])\n" +
-                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#437,group={0, 1},EXPR$0=MAX($2),EXPR$2=MIN($2),agg#2=AVG($3),agg#3=MAX($3),split=1,coorinator=false,having=>($4, $5),type=hash)_split_1_coordinator_false>($4, $5)])\n")
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#437,group={0, 1},EXPR$0=MAX($2),EXPR$2=MIN($2),agg#2=AVG($3),agg#3=MAX($3),split=1,coordinator=false,having=>($4, $5),type=hash)_split_1_coordinator_false>($4, $5)])\n")
                 .test();
 
         m_tester.sql("select max(TI), SI, I, min(TI) from R1 group by I, SI having avg(BI) > 0 and si > 0")
                 .transform("VoltPhysicalCalc(expr#0..4=[{inputs}], EXPR$0=[$t2], SI=[$t1], I=[$t0], EXPR$3=[$t3], split=[1])\n" +
-                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..4=[{inputs}], proj#0..4=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#533,group={0, 1},EXPR$0=MAX($2),EXPR$3=MIN($2),agg#2=AVG($3),split=1,coorinator=false,having=AND(>($4, 0), >($1, 0)),type=hash)_split_1_coordinator_falseAND(>($4, 0), >($1, 0))])\n")
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..4=[{inputs}], proj#0..4=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#533,group={0, 1},EXPR$0=MAX($2),EXPR$3=MIN($2),agg#2=AVG($3),split=1,coordinator=false,having=AND(>($4, 0), >($1, 0)),type=hash)_split_1_coordinator_falseAND(>($4, 0), >($1, 0))])\n")
                 .test();
 
         m_tester.sql("select max(TI), SI from R1 where I > 0 group by SI, I order by SI limit 3")
                 .transform("VoltPhysicalSort(sort0=[$1], dir0=[ASC], fetch=[3], split=[1])\n" +
                         "  VoltPhysicalCalc(expr#0..2=[{inputs}], EXPR$0=[$t2], SI=[$t0], split=[1])\n" +
-                        "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..2=[{inputs}], proj#0..2=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#661,group={0, 1},EXPR$0=MAX($2),split=1,coorinator=false,type=hash)_split_1_coordinator_false])\n")
+                        "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..2=[{inputs}], proj#0..2=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#661,group={0, 1},EXPR$0=MAX($2),split=1,coordinator=false,type=hash)_split_1_coordinator_false])\n")
                 .test();
     }
 
     public void testDistinct() {
         m_tester.sql("select distinct TI, I from R1")
-                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#54,group={0, 1},split=1,coorinator=false,type=hash)_split_1_coordinator_false])\n")
+                .transform("VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#54,group={0, 1},split=1,coordinator=false,type=hash)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select distinct max(TI) from R1 group by I")
-                .transform("VoltPhysicalHashAggregate(group=[{0}], split=[1], coorinator=[false], type=[hash])\n" +
+                .transform("VoltPhysicalHashAggregate(group=[{0}], split=[1], coordinator=[false], type=[hash])\n" +
                         "  VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#155,group={0},EXPR$0=MAX($1),split=1,coorinator=false,type=hash)_split_1_coordinator_false])\n")
+                        "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#155,group={0},EXPR$0=MAX($1),split=1,coordinator=false,type=hash)_split_1_coordinator_false])\n")
                 .test();
 
         m_tester.sql("select max (distinct (TI)) from R1 group by I")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#238,group={0},EXPR$0=MAX(DISTINCT $1),split=1,coorinator=false,type=hash)_split_1_coordinator_false])\n")
+                        "  VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..1=[{inputs}], proj#0..1=[{exprs}], aggregate=[VoltPhysicalHashAggregate.CONVENTION.[].single(input=HepRelVertex#238,group={0},EXPR$0=MAX(DISTINCT $1),split=1,coordinator=false,type=hash)_split_1_coordinator_false])\n")
                 .test();
     }
 

--- a/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
@@ -472,9 +472,13 @@ public class TestLogicalRules extends Plannerv2TestCase {
 //                transform("foo").test();
     }
 
-    public void testLogicalValues() {
-        // ENG-15258
-//        m_tester.sql("select * from r1 where i in(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)")
-//                .transform("foo").test();
+    public void testInExpr() {
+        m_tester.sql("select * from r1 where i in(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)")
+                .transform("VoltLogicalCalc(expr#0..5=[{inputs}], expr#6=[0], expr#7=[=($t0, $t6)], expr#8=[1], expr#9=[=($t0, $t8)], expr#10=[2], expr#11=[=($t0, $t10)], expr#12=[3], expr#13=[=($t0, $t12)], expr#14=[4], expr#15=[=($t0, $t14)], expr#16=[5], expr#17=[=($t0, $t16)], expr#18=[6], expr#19=[=($t0, $t18)], expr#20=[7], expr#21=[=($t0, $t20)], expr#22=[8], expr#23=[=($t0, $t22)], expr#24=[9], expr#25=[=($t0, $t24)], expr#26=[10], expr#27=[=($t0, $t26)], expr#28=[11], expr#29=[=($t0, $t28)], expr#30=[12], expr#31=[=($t0, $t30)], expr#32=[13], expr#33=[=($t0, $t32)], expr#34=[14], expr#35=[=($t0, $t34)], expr#36=[15], expr#37=[=($t0, $t36)], expr#38=[16], expr#39=[=($t0, $t38)], expr#40=[17], expr#41=[=($t0, $t40)], expr#42=[18], expr#43=[=($t0, $t42)], expr#44=[19], expr#45=[=($t0, $t44)], expr#46=[20], expr#47=[=($t0, $t46)], expr#48=[21], expr#49=[=($t0, $t48)], expr#50=[OR($t7, $t9, $t11, $t13, $t15, $t17, $t19, $t21, $t23, $t25, $t27, $t29, $t31, $t33, $t35, $t37, $t39, $t41, $t43, $t45, $t47, $t49)], proj#0..5=[{exprs}], $condition=[$t50])\n" +
+                        "  VoltLogicalTableScan(table=[[public, R1]])\n").test();
+
+        m_tester.sql("select * from r3 where ii in(pk, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)")
+                .transform("VoltLogicalCalc(expr#0..2=[{inputs}], expr#3=[=($t2, $t0)], expr#4=[1], expr#5=[=($t2, $t4)], expr#6=[2], expr#7=[=($t2, $t6)], expr#8=[3], expr#9=[=($t2, $t8)], expr#10=[4], expr#11=[=($t2, $t10)], expr#12=[5], expr#13=[=($t2, $t12)], expr#14=[6], expr#15=[=($t2, $t14)], expr#16=[7], expr#17=[=($t2, $t16)], expr#18=[8], expr#19=[=($t2, $t18)], expr#20=[9], expr#21=[=($t2, $t20)], expr#22=[10], expr#23=[=($t2, $t22)], expr#24=[11], expr#25=[=($t2, $t24)], expr#26=[12], expr#27=[=($t2, $t26)], expr#28=[13], expr#29=[=($t2, $t28)], expr#30=[14], expr#31=[=($t2, $t30)], expr#32=[15], expr#33=[=($t2, $t32)], expr#34=[16], expr#35=[=($t2, $t34)], expr#36=[17], expr#37=[=($t2, $t36)], expr#38=[18], expr#39=[=($t2, $t38)], expr#40=[19], expr#41=[=($t2, $t40)], expr#42=[20], expr#43=[=($t2, $t42)], expr#44=[21], expr#45=[=($t2, $t44)], expr#46=[OR($t3, $t5, $t7, $t9, $t11, $t13, $t15, $t17, $t19, $t21, $t23, $t25, $t27, $t29, $t31, $t33, $t35, $t37, $t39, $t41, $t43, $t45)], proj#0..2=[{exprs}], $condition=[$t46])\n" +
+                        "  VoltLogicalTableScan(table=[[public, R3]])\n").test();
     }
 }

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalConversion.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalConversion.java
@@ -290,47 +290,47 @@ public class TestPhysicalConversion extends Plannerv2TestCase {
 
     public void testAggr() {
         m_tester.sql("select avg(ti) from R1")
-                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[AVG($0)], split=[1], coorinator=[false], type=[serial])\n" +
+                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[AVG($0)], split=[1], coordinator=[false], type=[serial])\n" +
                         "  VoltPhysicalCalc(expr#0..5=[{inputs}], TI=[$t2], split=[1])\n" +
                         "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select avg(ti) from R1 group by i")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[AVG($1)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[AVG($1)], split=[1], coordinator=[false], type=[hash])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], I=[$t0], TI=[$t2], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select count(i) from R1 where ti > 3")
-                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT($0)], split=[1], coorinator=[false], type=[serial])\n" +
+                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT($0)], split=[1], coordinator=[false], type=[serial])\n" +
                         "  VoltPhysicalCalc(expr#0..5=[{inputs}], expr#6=[3], expr#7=[>($t2, $t6)], I=[$t0], $condition=[$t7], split=[1])\n" +
                         "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select count(*) from R1")
-                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT()], split=[1], coorinator=[false], type=[serial])\n" +
+                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT()], split=[1], coordinator=[false], type=[serial])\n" +
                         "  VoltPhysicalCalc(expr#0..5=[{inputs}], expr#6=[0], $f0=[$t6], split=[1])\n" +
                         "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select max(TI) from R1 group by SI having SI > 0")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], expr#2=[0], expr#3=[>($t0, $t2)], EXPR$0=[$t1], $condition=[$t3], split=[1])\n" +
-                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX($1)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX($1)], split=[1], coordinator=[false], type=[hash])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], SI=[$t1], TI=[$t2], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select max(TI), SI, min(TI), I from R1 group by SI, I having avg(BI) > max(BI)")
                 .transform("VoltPhysicalCalc(expr#0..5=[{inputs}], expr#6=[>($t4, $t5)], EXPR$0=[$t2], SI=[$t0], EXPR$2=[$t3], I=[$t1], $condition=[$t6], split=[1])\n" +
-                        "  VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], EXPR$2=[MIN($2)], agg#2=[AVG($3)], agg#3=[MAX($3)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], EXPR$2=[MIN($2)], agg#2=[AVG($3)], agg#3=[MAX($3)], split=[1], coordinator=[false], type=[hash])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], SI=[$t1], I=[$t0], TI=[$t2], BI=[$t3], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select max(TI), SI, I, min(TI) from R1 group by I, SI having avg(BI) > 0 and si > 0")
                 .transform("VoltPhysicalCalc(expr#0..4=[{inputs}], expr#5=[0], expr#6=[>($t4, $t5)], expr#7=[>($t1, $t5)], expr#8=[AND($t6, $t7)], EXPR$0=[$t2], SI=[$t1], I=[$t0], EXPR$3=[$t3], $condition=[$t8], split=[1])\n" +
-                        "  VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], EXPR$3=[MIN($2)], agg#2=[AVG($3)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], EXPR$3=[MIN($2)], agg#2=[AVG($3)], split=[1], coordinator=[false], type=[hash])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], proj#0..3=[{exprs}], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
@@ -339,7 +339,7 @@ public class TestPhysicalConversion extends Plannerv2TestCase {
                 .transform("VoltPhysicalLimit(split=[1], limit=[3])\n" +
                         "  VoltPhysicalSort(sort0=[$1], dir0=[ASC], split=[1])\n" +
                         "    VoltPhysicalCalc(expr#0..2=[{inputs}], EXPR$0=[$t2], SI=[$t0], split=[1])\n" +
-                        "      VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "      VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($2)], split=[1], coordinator=[false], type=[hash])\n" +
                         "        VoltPhysicalCalc(expr#0..5=[{inputs}], expr#6=[0], expr#7=[>($t0, $t6)], SI=[$t1], I=[$t0], TI=[$t2], $condition=[$t7], split=[1])\n" +
                         "          VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
@@ -347,22 +347,22 @@ public class TestPhysicalConversion extends Plannerv2TestCase {
 
     public void testDistinct() {
         m_tester.sql("select distinct TI, I from R1")
-                .transform("VoltPhysicalHashAggregate(group=[{0, 1}], split=[1], coorinator=[false], type=[hash])\n" +
+                .transform("VoltPhysicalHashAggregate(group=[{0, 1}], split=[1], coordinator=[false], type=[hash])\n" +
                         "  VoltPhysicalCalc(expr#0..5=[{inputs}], TI=[$t2], I=[$t0], split=[1])\n" +
                         "    VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select distinct max(TI) from R1 group by I")
-                .transform("VoltPhysicalHashAggregate(group=[{0}], split=[1], coorinator=[false], type=[hash])\n" +
+                .transform("VoltPhysicalHashAggregate(group=[{0}], split=[1], coordinator=[false], type=[hash])\n" +
                         "  VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "    VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX($1)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "    VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX($1)], split=[1], coordinator=[false], type=[hash])\n" +
                         "      VoltPhysicalCalc(expr#0..5=[{inputs}], I=[$t0], TI=[$t2], split=[1])\n" +
                         "        VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();
 
         m_tester.sql("select max (distinct (TI)) from R1 group by I")
                 .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], split=[1])\n" +
-                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX(DISTINCT $1)], split=[1], coorinator=[false], type=[hash])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX(DISTINCT $1)], split=[1], coordinator=[false], type=[hash])\n" +
                         "    VoltPhysicalCalc(expr#0..5=[{inputs}], I=[$t0], TI=[$t2], split=[1])\n" +
                         "      VoltSeqTableScan(table=[[public, R1]], split=[1], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n")
                 .test();

--- a/tests/frontend/org/voltdb/plannerv2/TestPlanConversion.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPlanConversion.java
@@ -383,6 +383,16 @@ public class TestPlanConversion extends CalcitePlannerTestCase {
 //        comparePlans(sql, ignores);
     }
 
+    public void testCompareVeryLongInExpr1() {
+        String sql = "select * from r1 where i in(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)";
+        comparePlans(sql);
+    }
+
+    public void testCompareVeryLongInExpr2() {
+        String sql = "select * from r3 where ii in(pk, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)";
+        comparePlans(sql);
+    }
+
     public void testCompareLikeExpr1() {
         String sql = "select 1 from RTYPES where vc LIKE 'ab%c'";
         Map<String, String> ignores = new HashMap<>();

--- a/tests/frontend/org/voltdb/regressionsuites/TestMaxSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMaxSuite.java
@@ -80,13 +80,12 @@ public class TestMaxSuite extends RegressionSuite {
         stringBuilder.append(") order by column0;");
         assert(stringBuilder.length() > Short.MAX_VALUE);        // previous limit
         assert(stringBuilder.length() < SQL_LITERAL_MAX_LENGTH); // new limit due to ENG-10059
-        // ENG-15258
-//        try {
-//            VoltTable result = client.callProcedure("@AdHoc", stringBuilder.toString()).getResults()[0];
-//            assertEquals(0, result.getRowCount());
-//        } catch(Exception ex) {
-//            fail();
-//        }
+        try {
+            VoltTable result = client.callProcedure("@AdHoc", stringBuilder.toString()).getResults()[0];
+            assertEquals(0, result.getRowCount());
+        } catch(Exception ex) {
+            fail();
+        }
     }
 
     public void testMaxIn() throws Exception {
@@ -107,18 +106,17 @@ public class TestMaxSuite extends RegressionSuite {
             }
         }
         stringBuilder.append(") order by column0;");
-        // ENG-15258
-//        resp = client.callProcedure("@AdHoc", stringBuilder.toString());
-//        assertEquals(ClientResponse.SUCCESS, resp.getStatus());
-//
-//        assertEquals(1, resp.getResults().length);
-//        VoltTable results = resp.getResults()[0];
-//        int rowCount = results.getRowCount();
-//        assertEquals(10, rowCount);
-//        assertEquals(2, results.getColumnCount());
-//        for (int i = 0; i < rowCount; i++) {
-//            assertEquals(i, results.fetchRow(i).getLong(0));
-//        }
+        resp = client.callProcedure("@AdHoc", stringBuilder.toString());
+        assertEquals(ClientResponse.SUCCESS, resp.getStatus());
+
+        assertEquals(1, resp.getResults().length);
+        VoltTable results = resp.getResults()[0];
+        int rowCount = results.getRowCount();
+        assertEquals(10, rowCount);
+        assertEquals(2, results.getColumnCount());
+        for (int i = 0; i < rowCount; i++) {
+            assertEquals(i, results.fetchRow(i).getLong(0));
+        }
     }
 
     public void testMaxColumn() throws Exception {


### PR DESCRIPTION
By default, calcite will convert the IN expression with size > 20 to a join against a `LogicalValues`.
But 
First, we won't get any benefit from this transform.
Second, calcite has some bugs when we put a column reference in that `LogicalValues` tuple.

Therefore, I simply disable that transform and force usage of OR in all cases (` a IN (1, 2, 3)` will become `a=1 OR a=2 OR a=3`). And we can get rid of the `LogicalValues`.