### PR TITLE
ENG-15396:

### DIFF
--- a/src/frontend/org/voltdb/exportclient/SocketExporter.java
+++ b/src/frontend/org/voltdb/exportclient/SocketExporter.java
@@ -227,7 +227,6 @@ public class SocketExporter extends ExportClientBase {
                         connect();
                     }
                     if (haplist.isEmpty()) {
-                        m_atomicWorkLock.unlock();
                         m_logger.rateLimitedLog(120, Level.ERROR, null, "Failed to connect to export socket endpoint %s, some servers may be down.", host);
                         throw new RestartBlockException(true);
                     }

--- a/src/frontend/org/voltdb/exportclient/SocketExporter.java
+++ b/src/frontend/org/voltdb/exportclient/SocketExporter.java
@@ -157,7 +157,8 @@ public class SocketExporter extends ExportClientBase {
         try {
             Socket pushSocket = new Socket(server, port);
             OutputStream out = pushSocket.getOutputStream();
-            m_logger.info("Connected to export endpoint node at: " + server + ":" + port);
+            m_logger.info("Connected to export endpoint node at: " + server +
+                    ":" + port + " using port " + pushSocket.getLocalPort());
             return out;
         } catch (UnknownHostException e) {
             m_logger.rateLimitedLog(120, Level.ERROR, e, "Don't know about host: " + server);
@@ -215,21 +216,28 @@ public class SocketExporter extends ExportClientBase {
         @Override
         public boolean processRow(ExportRow rd) throws ExportDecoderBase.RestartBlockException {
             try {
-                if (haplist.isEmpty()) {
-                    connect();
-                }
-                if (haplist.isEmpty()) {
-                    m_logger.rateLimitedLog(120, Level.ERROR, null, "Failed to connect to export socket endpoint %s, some servers may be down.", host);
-                    throw new RestartBlockException(true);
-                }
                 String decoded = m_decoder.decode(rd.generation, rd.tableName, rd.types, rd.names,null, rd.values).concat("\n");
                 byte b[] = decoded.getBytes();
                 ByteBuffer buf = ByteBuffer.allocate(b.length);
                 buf.put(b);
                 buf.flip();
-                for (OutputStream hap : haplist.values()) {
-                    hap.write(buf.array());
-                    hap.flush();
+                m_atomicWorkLock.lock();
+                try {
+                    if (haplist.isEmpty()) {
+                        connect();
+                    }
+                    if (haplist.isEmpty()) {
+                        m_atomicWorkLock.unlock();
+                        m_logger.rateLimitedLog(120, Level.ERROR, null, "Failed to connect to export socket endpoint %s, some servers may be down.", host);
+                        throw new RestartBlockException(true);
+                    }
+                    for (OutputStream hap : haplist.values()) {
+                        hap.write(buf.array());
+                        hap.flush();
+                    }
+                }
+                finally {
+                    m_atomicWorkLock.unlock();
                 }
             } catch (Exception e) {
                 m_logger.error(e.getLocalizedMessage());

--- a/tests/frontend/org/voltdb/export/ExportToSocketTestVerifier.java
+++ b/tests/frontend/org/voltdb/export/ExportToSocketTestVerifier.java
@@ -90,7 +90,7 @@ public class ExportToSocketTestVerifier {
         return isExpectedRow(true);
     }
 
-    public Matcher<String[]> isExpectedRow(final boolean m_verifySequenceNumber) {
+    public Matcher<String[]> isExpectedRow(final boolean verifySequenceNumber) {
         return new TypeSafeDiagnosingMatcher<String[]>() {
             String [] expected = ( m_data.peek() == null ? null : m_data.poll() );
             int matchSequenceNumber = m_sequenceNumber;
@@ -116,7 +116,7 @@ public class ExportToSocketTestVerifier {
                 if( ! match) {
                     d.appendText("{ EOD exhausted expected rows }");
                 }
-                if (match && m_verifySequenceNumber) {
+                if (match && verifySequenceNumber) {
                     int rowSeq = Integer.valueOf(gotten[2]);
                     if (! (match = seqMatcher.matches(rowSeq))) {
                         d.appendText("{ expected sequence " ).appendDescriptionOf(seqMatcher);
@@ -129,7 +129,7 @@ public class ExportToSocketTestVerifier {
                 if (match) {
                     String [] toBeMatched;
                     Matcher<String[]> rowMatcher;
-                    if (m_verifySequenceNumber) {
+                    if (verifySequenceNumber) {
                         toBeMatched = Arrays.copyOfRange(
                            gotten, ExportDecoderBase.INTERNAL_FIELD_COUNT - 1,
                            gotten.length

--- a/tests/frontend/org/voltdb/export/ExportToSocketTestVerifier.java
+++ b/tests/frontend/org/voltdb/export/ExportToSocketTestVerifier.java
@@ -93,7 +93,8 @@ public class ExportToSocketTestVerifier {
     public Matcher<String[]> isExpectedRow(final boolean m_verifySequenceNumber) {
         return new TypeSafeDiagnosingMatcher<String[]>() {
             String [] expected = ( m_data.peek() == null ? null : m_data.poll() );
-            Matcher<Integer> seqMatcher = equalTo(m_sequenceNumber);
+            int matchSequenceNumber = m_sequenceNumber;
+            Matcher<Integer> seqMatcher = equalTo(matchSequenceNumber);
 
             @Override
             public void describeTo(Description d) {
@@ -150,7 +151,7 @@ public class ExportToSocketTestVerifier {
                     }
                 }
                 d.appendText("]");
-                System.out.println("Validated table " + m_tableName + " partition id " + m_partitionId + " sequence " + m_sequenceNumber);
+                System.out.println("Validated table " + m_tableName + " partition id " + m_partitionId + " sequence " + matchSequenceNumber);
                 return match;
             }
         };


### PR DESCRIPTION
A JUnit test failure for Export identified an issue with the Quiesce command, which did not ensure that flushed export buffers had been delivered to the Export persistence layer.

This did not fix the JUnit test, which found additional issues with the synchronization of socket connection initialization as well as synchronization of the writes but this issue was only in the socket exporter used for testing.