### PR TITLE
Eng 14565 integration

### DIFF
--- a/src/ee/common/StreamBlock.h
+++ b/src/ee/common/StreamBlock.h
@@ -167,22 +167,17 @@ namespace voltdb
         ExportStreamBlock(char* data, size_t headerSize, size_t capacity, size_t uso) :
             StreamBlock(data, headerSize, capacity, uso),
             m_rowCount(0),
-            m_needsSchema(true),
             m_startSequenceNumber(0)
         {}
 
         ExportStreamBlock(ExportStreamBlock* other) :
             StreamBlock(other),
             m_rowCount(other->m_rowCount),
-            m_needsSchema(other->m_needsSchema),
             m_startSequenceNumber(other->m_startSequenceNumber)
         {}
 
         ~ExportStreamBlock()
         {}
-
-        inline bool needsSchema() { return m_needsSchema; }
-        inline void noSchema() { m_needsSchema = false; }
 
         inline void recordStartSequenceNumber(int64_t startSequenceNumber) {
             m_startSequenceNumber = startSequenceNumber;
@@ -216,7 +211,6 @@ namespace voltdb
 
     private:
         size_t m_rowCount;
-        bool m_needsSchema;
         int64_t m_startSequenceNumber;
     };
 

--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -69,12 +69,14 @@ namespace voltdb {
         return bytes;
     }
 
-    void DummyTopend::pushExportBuffer(int32_t partitionId, std::string signature, ExportStreamBlock *block, bool sync) {
+    void DummyTopend::pushExportBuffer(int32_t partitionId, std::string signature,
+            ExportStreamBlock *block, bool sync, int64_t generationId) {
         if (sync && !block) {
             return;
         }
         partitionIds.push(partitionId);
         signatures.push(signature);
+        generationIds.push(generationId);
         exportBlocks.push_back(boost::shared_ptr<ExportStreamBlock>(new ExportStreamBlock(block)));
         data.push_back(boost::shared_array<char>(block->rawPtr()));
         receivedExportBuffer = true;

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -68,7 +68,8 @@ class Topend {
             int32_t partitionId,
             std::string signature,
             ExportStreamBlock *block,
-            bool sync) = 0;
+            bool sync,
+            int64_t generationId) = 0;
     // Not used right now and will be removed or altered after a decision has been made on how Schema changes
     // are managed (they really don't belong in row buffers).
     virtual void pushEndOfStream(
@@ -136,7 +137,7 @@ public:
     void crashVoltDB(voltdb::FatalException e);
 
     int64_t getFlushedExportBytes(int32_t partitionId, std::string signature);
-    virtual void pushExportBuffer(int32_t partitionId, std::string signature, ExportStreamBlock *block, bool sync);
+    virtual void pushExportBuffer(int32_t partitionId, std::string signature, ExportStreamBlock *block, bool sync, int64_t generationId);
     virtual void pushEndOfStream(int32_t partitionId, std::string signature);
 
     int64_t pushDRBuffer(int32_t partitionId, DrStreamBlock *block);
@@ -164,6 +165,7 @@ public:
 
     std::queue<int32_t> partitionIds;
     std::queue<std::string> signatures;
+    std::queue<int64_t> generationIds;
     std::deque<boost::shared_ptr<DrStreamBlock> > drBlocks;
     std::deque<boost::shared_ptr<ExportStreamBlock> > exportBlocks;
     std::deque<boost::shared_array<char> > data;

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -160,7 +160,7 @@ JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecuti
     m_pushExportBufferMID = m_jniEnv->GetStaticMethodID(
             m_exportManagerClass,
             "pushExportBuffer",
-            "(ILjava/lang/String;JJJJLjava/nio/ByteBuffer;Z)V");
+            "(ILjava/lang/String;JJJJJLjava/nio/ByteBuffer;Z)V");
     if (m_pushExportBufferMID == NULL) {
         m_jniEnv->ExceptionDescribe();
         assert(m_pushExportBufferMID != NULL);
@@ -537,7 +537,8 @@ void JNITopend::pushExportBuffer(
         int32_t partitionId,
         string signature,
         ExportStreamBlock *block,
-        bool sync) {
+        bool sync,
+        int64_t generationId) {
     jstring signatureString = m_jniEnv->NewStringUTF(signature.c_str());
 
     if (block != NULL) {
@@ -554,6 +555,7 @@ void JNITopend::pushExportBuffer(
                 block->startSequenceNumber(),
                 block->getRowCount(),
                 block->lastSpUniqueId(),
+                generationId,
                 reinterpret_cast<jlong>(block->rawPtr()),
                 buffer,
                 sync ? JNI_TRUE : JNI_FALSE);
@@ -567,6 +569,7 @@ void JNITopend::pushExportBuffer(
                 static_cast<int64_t>(0),
                 static_cast<int64_t>(0),
                 static_cast<int64_t>(0),
+                generationId,
                 NULL,
                 NULL,
                 sync ? JNI_TRUE : JNI_FALSE);

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -49,7 +49,8 @@ public:
             int32_t partitionId,
             std::string signature,
             ExportStreamBlock *block,
-            bool sync);
+            bool sync,
+            int64_t generationId);
     void pushEndOfStream(
             int32_t partitionId,
             std::string signature);

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1496,8 +1496,6 @@ bool VoltDBEngine::updateCatalog(int64_t timestamp, bool isStreamUpdate, std::st
         return false;
     }
 
-    markAllExportingStreamsNew();
-
     std::map<std::string, ExportTupleStream*> purgedStreams;
     processCatalogDeletes(timestamp, false, purgedStreams);
     if (SynchronizedThreadLock::countDownGlobalTxnStartCount(m_isLowestSite)) {
@@ -1553,16 +1551,6 @@ VoltDBEngine::purgeMissingStreams(std::map<std::string, ExportTupleStream*> & pu
             m_exportingStreams[entry.first] = NULL;
             m_exportingDeletedStreams[entry.first] = entry.second;
             entry.second->removeFromFlushList(this, false);
-        }
-    }
-}
-
-void
-VoltDBEngine::markAllExportingStreamsNew() {
-    //Mark all streams new so that schema is sent on next tuple.
-    BOOST_FOREACH (LabeledStreamWrapper entry, m_exportingStreams) {
-        if (entry.second != NULL) {
-            entry.second->setNew();
         }
     }
 }

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -262,7 +262,6 @@ class __attribute__((visibility("default"))) VoltDBEngine {
             return processCatalogAdditions(timestamp, true, isStreamUpdate, purgedStreams);
         }
         void purgeMissingStreams(std::map<std::string, ExportTupleStream*> & purgedStreams);
-        void markAllExportingStreamsNew();
 
         /**
         * Load table data into a persistent table specified by the tableId parameter.

--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -76,9 +76,6 @@ public:
         return value.length() + sizeof(int32_t);
     }
 
-    // compute # of bytes needed to serialize the meta data column names
-    inline size_t getMDColumnNamesSerializedSize() const { return s_mdSchemaSize; }
-
     int64_t testAllocatedBytesInEE() const {
         DummyTopend* te = static_cast<DummyTopend*>(ExecutorContext::getPhysicalTopend());
         int64_t flushedBytes = te->getFlushedExportBytes(m_partitionId, m_signature);
@@ -129,8 +126,6 @@ public:
     virtual void extendBufferChain(size_t minLength);
 
     virtual int partitionId() { return m_partitionId; }
-    void setNew() { m_new = true; }
-    bool isNew() { return m_new; }
 
     inline ExportTupleStream* getNextFlushStream() const {
         return m_nextFlushStream;
@@ -146,10 +141,6 @@ public:
 
 
 public:
-    // Computed size for metadata columns
-    static const size_t s_mdSchemaSize;
-    // Size of Fixed header (not including schema)
-    static const size_t s_FIXED_BUFFER_HEADER_SIZE;
     // Size of Fixed buffer header (rowCount + uniqueId)
     static const size_t s_EXPORT_BUFFER_HEADER_SIZE;
 
@@ -158,13 +149,10 @@ private:
     const CatalogId m_partitionId;
     const int64_t m_siteId;
 
-    // This indicates that stream is new or has been marked as new after UAC so that we include schema in next export stream write.
-    bool m_new;
     std::string m_signature;
     int64_t m_generation;
     const std::string &m_tableName;
     const std::vector<std::string> &m_columnNames;
-    const int32_t m_ddlSchemaSize;
 
     int64_t m_nextSequenceNumber;
     int64_t m_committedSequenceNumber;

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -106,7 +106,6 @@ StreamedTable::~StreamedTable() {
 // Stream writes were done so commit all the writes
 void StreamedTable::notifyQuantumRelease() {
     if (m_wrapper) {
-        assert(!m_wrapper->isNew());
         m_wrapper->commit(m_executorContext->getContextEngine(),
                 m_executorContext->currentSpHandle(), m_executorContext->currentUniqueId());
     }

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -138,7 +138,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     // future and passes to EDS executor thread, if EDS executor has no new buffer to poll, the future
     // is assigned to m_pollFuture. When site thread pushes buffer to EDS executor thread, m_pollFuture
     // is reused to notify export decoder to stop waiting.
-    private SettableFuture<AckingContainer> m_pollFuture;
+    private PollTask m_pollTask;
     private final AtomicReference<Pair<Mailbox, ImmutableList<Long>>> m_ackMailboxRefs =
             new AtomicReference<>(Pair.of((Mailbox)null, ImmutableList.<Long>builder().build()));
     private final Semaphore m_bufferPushPermits = new Semaphore(16);
@@ -193,13 +193,44 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         public boolean canCoverGap() {
             return lastSeq != Long.MIN_VALUE;
         }
-
     }
 
     public static class ReentrantPollException extends ExecutionException {
         private static final long serialVersionUID = 1L;
         ReentrantPollException() { super(); }
         ReentrantPollException(String s) { super(s); }
+    }
+
+    public static class PollTask {
+        private SettableFuture<AckingContainer> m_pollFuture;
+        private boolean m_forcePollSchema;
+
+        public PollTask(SettableFuture<AckingContainer> fut, Boolean forcePollSchema) {
+            m_pollFuture = fut;
+            m_forcePollSchema = forcePollSchema;
+        }
+
+        public SettableFuture<AckingContainer> getPollFuture() {
+            return m_pollFuture;
+        }
+
+        public boolean forcePollSchema() {
+            return m_forcePollSchema;
+        }
+
+        public void setFuture(AckingContainer cont) {
+            m_pollFuture.set(cont);
+        }
+
+        public void setException(Throwable t) {
+            m_pollFuture.setException(t);
+        }
+
+        public void clear() {
+            m_pollFuture.set(null);
+            m_pollFuture = null;
+            m_forcePollSchema = false;
+        }
     }
 
     /**
@@ -724,7 +755,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
         if (poll) {
             try {
-                pollImpl(m_pollFuture);
+                pollImpl(m_pollTask);
             } catch (RejectedExecutionException ex) {
                 //Its ok.
             }
@@ -884,26 +915,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         m_pendingContainer.set(container);
     }
 
-    public ListenableFuture<BBContainer> pollSchema() {
-        final SettableFuture<BBContainer> fut = SettableFuture.create();
-        try {
-            m_es.execute(new Runnable() {
-                public void run() {
-                    //  Auto-generated method stub
-                    if (!m_es.isShutdown()) {
-                        pollSchemaImpl(fut);
-                    }
-                }
-            });
-        } catch (RejectedExecutionException rej) {
-            //Don't expect this to happen outside of test, but in test it's harmless
-            exportLog.info("Polling schema from export data source rejected, this should be harmless");
-        }
-        return fut;
-    }
-
-    public ListenableFuture<AckingContainer> poll() {
+    public ListenableFuture<AckingContainer> poll(boolean forcePollSchema) {
         final SettableFuture<AckingContainer> fut = SettableFuture.create();
+        PollTask pollTask = new PollTask(fut, forcePollSchema);
         try {
             m_es.execute(new Runnable() {
                 @Override
@@ -918,20 +932,20 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     //
                     // Add following check to eliminate this window.
                     if (!m_mastershipAccepted.get()) {
-                        fut.set(null);
-                        m_pollFuture = null;
+                        pollTask.clear();
+                        m_pollTask = null;
                         return;
                     }
 
                     try {
                         //If we have anything pending set that before moving to next block.
                         if (m_pendingContainer.get() != null) {
-                            fut.set(m_pendingContainer.getAndSet(null));
-                            if (m_pollFuture != null) {
+                            pollTask.setFuture(m_pendingContainer.getAndSet(null));
+                            if (m_pollTask != null) {
                                 if (exportLog.isDebugEnabled()) {
                                     exportLog.debug("Pick up work from pending container, set poll future to null");
                                 }
-                                m_pollFuture = null;
+                                m_pollTask = null;
                             }
                             return;
                         }
@@ -940,13 +954,13 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                          * call poll a second time until a response has been given
                          * which satisfies the cached future.
                          */
-                        if (m_pollFuture != null) {
+                        if (m_pollTask != null) {
                             fut.setException(new ReentrantPollException("Reentrant poll detected: InCat = " + m_isInCatalog +
                                     " In ExportDataSource for Table " + getTableName() + ", Partition " + getPartitionId()));
                             return;
                         }
                         if (!m_es.isShutdown()) {
-                            pollImpl(fut);
+                            pollImpl(pollTask);
                         }
                     } catch (Exception e) {
                         exportLog.error("Exception polling export buffer", e);
@@ -962,13 +976,8 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         return fut;
     }
 
-    private synchronized void pollSchemaImpl(SettableFuture<BBContainer> fut) {
-        BBContainer schemaC = m_committedBuffers.pollSchema();
-        fut.set(schemaC);
-    }
-
-    private synchronized void pollImpl(SettableFuture<AckingContainer> fut) {
-        if (fut == null) {
+    private synchronized void pollImpl(PollTask pollTask) {
+        if (pollTask == null) {
             return;
         }
 
@@ -1040,7 +1049,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
             //If there are no unpolled blocks return the firstUnpolledUSO with no data
             if (first_unpolled_block == null) {
-                m_pollFuture = fut;
+                m_pollTask = pollTask;
             } else {
                 // If stream was previously blocked by a gap, now it skips/fulfills the gap
                 // change the status back to normal.
@@ -1049,19 +1058,25 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     setStatus(StreamStatus.ACTIVE);
                     m_queueGap = 0;
                 }
+                BBContainer schemaContainer = null;
+                if (pollTask.forcePollSchema()) {
+                    schemaContainer = m_committedBuffers.pollSchema();
+                } else {
+                    schemaContainer = first_unpolled_block.getSchemaContainer();
+                }
                 final AckingContainer ackingContainer =
                         new AckingContainer(first_unpolled_block.unreleasedContainer(),
-                                first_unpolled_block.getSchemaContainer(),
+                                schemaContainer,
                                 first_unpolled_block.startSequenceNumber() + first_unpolled_block.rowCount() - 1);
                 try {
-                    fut.set(ackingContainer);
+                    pollTask.setFuture(ackingContainer);
                 } catch (RejectedExecutionException reex) {
                     //We are closing source dont discard next processor will pick it up.
                 }
-                m_pollFuture = null;
+                m_pollTask = null;
             }
         } catch (Throwable t) {
-            fut.setException(t);
+            pollTask.setException(t);
         }
     }
 
@@ -1264,13 +1279,13 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         if ((!this.m_isInCatalog || m_status == StreamStatus.DROPPED) && m_committedBuffers.isEmpty()) {
             //Returning null indicates end of stream
             try {
-                if (m_pollFuture != null) {
-                    m_pollFuture.set(null);
+                if (m_pollTask != null) {
+                    m_pollTask.setFuture(null);
                 }
             } catch (RejectedExecutionException reex) {
                 //We are closing source.
             }
-            m_pollFuture = null;
+            m_pollTask = null;
             m_generation.onSourceDone(m_partitionId, m_signature);
             return;
         }
@@ -1393,7 +1408,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             exportLog.debug(toString() + " is no longer the export stream master.");
         }
         m_mastershipAccepted.set(false);
-        m_pollFuture = null;
+        m_pollTask = null;
         m_readyForPolling = false;
         m_seqNoToDrain = Long.MAX_VALUE;
         m_newLeaderHostId = null;

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -53,18 +53,23 @@ import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
+import org.voltcore.utils.DeferredSerialization;
 import org.voltcore.utils.Pair;
+import org.voltdb.CatalogContext;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
 import org.voltdb.RealVoltDB;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Column;
+import org.voltdb.catalog.Table;
+import org.voltdb.common.Constants;
 import org.voltdb.export.AdvertisedDataSource.ExportFormat;
 import org.voltdb.exportclient.ExportClientBase;
 import org.voltdb.iv2.MpInitiator;
 import org.voltdb.sysprocs.ExportControl.OperationMode;
 import org.voltdb.utils.CatalogUtil;
+import org.voltdb.utils.PBDSegment;
 import org.voltdb.utils.VoltFile;
 
 import com.google_voltpatches.common.base.Preconditions;
@@ -152,6 +157,11 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     private boolean m_runEveryWhere = false;
     // It is used to filter stale message responses
     private long m_currentRequestId = 0L;
+    // *Generation Id* is actually a timestamp generated during catalog update(UpdateApplicationBase.java)
+    // genId in this class represents the genId of the most recent pushed buffer. If a new buffer contains
+    // different genId than the previous value, the new buffer needs to be written to new PBD segment.
+    //
+    private long m_previousGenId;
 
     private ExportSequenceNumberTracker m_gapTracker = new ExportSequenceNumberTracker();
 
@@ -161,6 +171,13 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     private String m_partitionColumnName = "";
 
     private static final boolean DISABLE_AUTO_GAP_RELEASE = Boolean.getBoolean("DISABLE_AUTO_GAP_RELEASE");
+
+    private static final String VOLT_TRANSACTION_ID = "VOLT_TRANSACTION_ID";
+    private static final String VOLT_EXPORT_TIMESTAMP = "VOLT_EXPORT_TIMESTAMP";
+    private static final String VOLT_EXPORT_SEQUENCE_NUMBER = "VOLT_EXPORT_SEQUENCE_NUMBER";
+    private static final String VOLT_PARTITION_ID = "VOLT_PARTITION_ID";
+    private static final String VOLT_SITE_ID = "VOLT_SITE_ID";
+    private static final String VOLT_EXPORT_OPERATION = "VOLT_EXPORT_OPERATION";
 
     static enum StreamStatus {
         ACTIVE,
@@ -198,12 +215,14 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             String tableName,
             int partitionId,
             int siteId,
+            long genId,
             String signature,
             CatalogMap<Column> catalogMap,
             Column partitionColumn,
             String overflowPath
             ) throws IOException
     {
+        m_previousGenId = genId;
         m_generation = generation;
         m_format = ExportFormat.SEVENDOTX;
         m_database = db;
@@ -215,7 +234,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         crc.update(m_signatureBytes);
         String nonce = m_tableName + "_" + crc.getValue() + "_" + partitionId;
 
-        m_committedBuffers = new StreamBlockQueue(overflowPath, nonce);
+        m_committedBuffers = new StreamBlockQueue(overflowPath, nonce, m_tableName);
         m_gapTracker = m_committedBuffers.scanForGap();
         // Pretend it's rejoin so we set first unpolled to a safe place
         resetStateInRejoinOrRecover(0L, true);
@@ -304,7 +323,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
     public ExportDataSource(Generation generation, File adFile,
             List<Pair<Integer, Integer>> localPartitionsToSites,
-            final ExportDataProcessor processor) throws IOException {
+            final ExportDataProcessor processor,
+            final long genId) throws IOException {
+        m_previousGenId = genId;
         m_generation = generation;
         m_adFile = adFile;
         String overflowPath = adFile.getParent();
@@ -359,7 +380,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         PureJavaCrc32 crc = new PureJavaCrc32();
         crc.update(m_signatureBytes);
         final String nonce = m_tableName + "_" + crc.getValue() + "_" + m_partitionId;
-        m_committedBuffers = new StreamBlockQueue(overflowPath, nonce);
+        m_committedBuffers = new StreamBlockQueue(overflowPath, nonce, m_tableName);
         m_gapTracker = m_committedBuffers.scanForGap();
          // Pretend it's rejoin so we set first unpolled to a safe place
         resetStateInRejoinOrRecover(0L, true);
@@ -635,6 +656,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             long startSequenceNumber,
             int tupleCount,
             long uniqueId,
+            long genId,
             ByteBuffer buffer,
             boolean poll) throws Exception {
         final java.util.concurrent.atomic.AtomicBoolean deleted = new java.util.concurrent.atomic.AtomicBoolean(false);
@@ -669,7 +691,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                                 cont.discard();
                                 deleted.set(true);
                             }
-                        }, startSequenceNumber, tupleCount, uniqueId, false);
+                        }, null, startSequenceNumber, tupleCount, uniqueId, false);
 
                 // Mark release sequence number to partially acked buffer.
                 if (isAcked(sb.startSequenceNumber())) {
@@ -689,7 +711,13 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 m_lastPushedSeqNo = lastSequenceNumber;
                 m_tupleCount += newTuples;
                 m_tuplesPending.addAndGet((int)newTuples);
-                m_committedBuffers.offer(sb);
+                assert (genId >= m_previousGenId);
+                // This serializer is used to write stream schema to pbd
+                StreamTableSchemaSerializer ds = new StreamTableSchemaSerializer(
+                        VoltDB.instance().getCatalogContext(), m_tableName);
+                // check generation id change at every push to tell when to create new segment
+                m_committedBuffers.offer(sb, ds, genId != m_previousGenId);
+                m_previousGenId = genId;
             } catch (IOException e) {
                 VoltDB.crashLocalVoltDB("Unable to write to export overflow.", true, e);
             }
@@ -707,6 +735,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             final long startSequenceNumber,
             final int tupleCount,
             final long uniqueId,
+            final long genId,
             final ByteBuffer buffer,
             final boolean sync) {
         try {
@@ -718,7 +747,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         if (m_es.isShutdown()) {
             //If we are shutting down push it to PBD
             try {
-                pushExportBufferImpl(startSequenceNumber, tupleCount, uniqueId, buffer, false);
+                pushExportBufferImpl(startSequenceNumber, tupleCount, uniqueId, genId, buffer, false);
             } catch (Throwable t) {
                 VoltDB.crashLocalVoltDB("Error pushing export  buffer", true, t);
             } finally {
@@ -732,7 +761,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 public void run() {
                     try {
                         if (!m_es.isShutdown()) {
-                            pushExportBufferImpl(startSequenceNumber, tupleCount, uniqueId, buffer, m_readyForPolling);
+                            pushExportBufferImpl(startSequenceNumber, tupleCount, uniqueId, genId, buffer, m_readyForPolling);
                         }
                     } catch (Throwable t) {
                         VoltDB.crashLocalVoltDB("Error pushing export  buffer", true, t);
@@ -999,6 +1028,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 }
                 final AckingContainer ackingContainer =
                         new AckingContainer(first_unpolled_block.unreleasedContainer(),
+                                first_unpolled_block.getSchemaContainer(),
                                 first_unpolled_block.startSequenceNumber() + first_unpolled_block.rowCount() - 1);
                 try {
                     fut.set(ackingContainer);
@@ -1015,16 +1045,25 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     public class AckingContainer extends BBContainer {
         final long m_lastSeqNo;
         final BBContainer m_backingCont;
+        final BBContainer m_schemaCont;
         long m_startTime = 0;
 
-        public AckingContainer(BBContainer cont, long seq) {
+        public AckingContainer(BBContainer cont, BBContainer schemaCont, long seq) {
             super(cont.b());
             m_lastSeqNo = seq;
             m_backingCont = cont;
+            m_schemaCont = schemaCont;
         }
 
         public void updateStartTime(long startTime) {
             m_startTime = startTime;
+        }
+
+        public ByteBuffer schema() {
+            if (m_schemaCont == null) {
+                return null;
+            }
+            return m_schemaCont.b();
         }
 
         @Override
@@ -1048,6 +1087,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
                         try {
                              m_backingCont.discard();
+                             if (m_schemaCont != null) {
+                                 m_schemaCont.discard();
+                             }
                             try {
                                 if (!m_es.isShutdown()) {
                                     ackImpl(m_lastSeqNo);
@@ -1066,6 +1108,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                   //Don't expect this to happen outside of test, but in test it's harmless
                   exportLog.info("Acking export data task rejected, this should be harmless");
                   m_backingCont.discard();
+                  m_schemaCont.discard();
             }
         }
     }
@@ -1690,5 +1733,133 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             // should not happen since the operation is verified prior to this call
         }
         return false;
+    }
+
+    public static class StreamTableSchemaSerializer implements DeferredSerialization {
+        private final CatalogContext m_catalogContext;
+        private final String m_streamName;
+        public StreamTableSchemaSerializer(CatalogContext catalogContext, String streamName) {
+            m_catalogContext = catalogContext;
+            m_streamName = streamName;
+        }
+
+        public static void writeMetaColumns(ByteBuffer buf) {
+            // VOLT_TRANSACTION_ID, VoltType.BIGINT
+            buf.putInt(VOLT_TRANSACTION_ID.length());
+            buf.put(VOLT_TRANSACTION_ID.getBytes(Constants.UTF8ENCODING));
+            buf.put(VoltType.BIGINT.getValue());
+            buf.putInt(Long.BYTES);
+
+            // VOLT_EXPORT_TIMESTAMP, VoltType.BIGINT
+            buf.putInt(VOLT_EXPORT_TIMESTAMP.length());
+            buf.put(VOLT_EXPORT_TIMESTAMP.getBytes(Constants.UTF8ENCODING));
+            buf.put(VoltType.BIGINT.getValue());
+            buf.putInt(Long.BYTES);
+
+            // VOLT_EXPORT_SEQUENCE_NUMBER, VoltType.BIGINT
+            buf.putInt(VOLT_EXPORT_SEQUENCE_NUMBER.length());
+            buf.put(VOLT_EXPORT_SEQUENCE_NUMBER.getBytes(Constants.UTF8ENCODING));
+            buf.put(VoltType.BIGINT.getValue());
+            buf.putInt(Long.BYTES);
+
+            // VOLT_PARTITION_ID, VoltType.BIGINT
+            buf.putInt(VOLT_PARTITION_ID.length());
+            buf.put(VOLT_PARTITION_ID.getBytes(Constants.UTF8ENCODING));
+            buf.put(VoltType.BIGINT.getValue());
+            buf.putInt(Long.BYTES);
+
+            // VOLT_SITE_ID, VoltType.BIGINT
+            buf.putInt(VOLT_SITE_ID.length());
+            buf.put(VOLT_SITE_ID.getBytes(Constants.UTF8ENCODING));
+            buf.put(VoltType.BIGINT.getValue());
+            buf.putInt(Long.BYTES);
+
+            // VOLT_EXPORT_OPERATION, VoltType.TINYINT
+            buf.putInt(VOLT_EXPORT_OPERATION.length());
+            buf.put(VOLT_EXPORT_OPERATION.getBytes(Constants.UTF8ENCODING));
+            buf.put(VoltType.TINYINT.getValue());
+            buf.putInt(Byte.BYTES);
+        }
+        /*
+         * Export PBD segment schema layout:
+         *
+         * export buffer version(1)
+         * generation ID(8)
+         * schema length(4)
+         * stream name length(4)
+         * stream name
+         * (meta columns)
+         * column name length(4)
+         * column name(VOLT_TRANSACTION_ID)
+         * column type(1, VoltType.BIGINT)
+         * column length(4)
+         * column name length(4)
+         * column name(VOLT_EXPORT_TIMESTAMP)
+         * column type(1, VoltType.BIGINT)
+         * column length(4)
+         * column name length(4)
+         * column name(VOLT_EXPORT_SEQUENCE_NUMBER)
+         * column type(1, VoltType.BIGINT)
+         * column length(4)
+         * column name length(4)
+         * column name(VOLT_PARTITION_ID)
+         * column type(1, VoltType.BIGINT)
+         * column length(4)
+         * column name length(4)
+         * column name(VOLT_SITE_ID)
+         * column type(1, VoltType.BIGINT)
+         * column length(4)
+         * column name length(4)
+         * column name(VOLT_EXPORT_OPERATION)
+         * column type(1, VoltType.TINYINT)
+         * column length(4)
+         * (every column)
+         * column name length(4)
+         * column name
+         * column type(1)
+         * column length(4)
+         *
+         */
+        public void serialize(ByteBuffer buf) throws IOException {
+            buf.put((byte)StreamBlockQueue.EXPORT_BUFFER_VERSION);
+            buf.putLong(m_catalogContext.m_genId);
+            buf.putInt(buf.limit() - PBDSegment.EXPORT_SCHEMA_HEADER_BYTES); // size of schema
+            buf.putInt(m_streamName.length());
+            buf.put(m_streamName.getBytes(Constants.UTF8ENCODING));
+
+            // write export meta columns
+            writeMetaColumns(buf);
+            // column name length, name, type, length
+            Table streamTable = m_catalogContext.database.getTables().get(m_streamName);
+            assert (streamTable != null);
+            for (Column c : CatalogUtil.getSortedCatalogItems(streamTable.getColumns(), "index")) {
+                buf.putInt(c.getName().length());
+                buf.put(c.getName().getBytes(Constants.UTF8ENCODING));
+                buf.put((byte)c.getType());
+                buf.putInt(c.getSize());
+            }
+        }
+
+        public void cancel() {}
+
+        public int getSerializedSize() throws IOException {
+            int size = 0;
+            // column name length, name, type, length
+            Table streamTable = m_catalogContext.database.getTables().get(m_streamName);
+            assert (streamTable != null);
+            for (Column c : CatalogUtil.getSortedCatalogItems(streamTable.getColumns(), "index")) {
+                size += 4 + c.getName().length() + 1 + 4;
+            }
+            return  PBDSegment.EXPORT_SCHEMA_HEADER_BYTES + /*schema size*/
+                    4 /*name length*/ + m_streamName.length() +
+                    4 /*name length*/ + VOLT_TRANSACTION_ID.length() + 1 /*column type*/ + 4 /*column length*/ +
+                    4 + VOLT_EXPORT_TIMESTAMP.length() + 1 + 4 +
+                    4 + VOLT_EXPORT_SEQUENCE_NUMBER.length() + 1 + 4 +
+                    4 + VOLT_PARTITION_ID.length() + 1 + 4 +
+                    4 + VOLT_SITE_ID.length() + 1 + 4 +
+                    4 + VOLT_EXPORT_OPERATION.length() + 1 + 4 +
+                    size;
+        }
+
     }
 }

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -687,6 +687,7 @@ public class ExportManager
             long startSequenceNumber,
             long tupleCount,
             long uniqueId,
+            long genId,
             long bufferPtr,
             ByteBuffer buffer,
             boolean sync) {
@@ -702,7 +703,7 @@ public class ExportManager
                 return;
             }
             generation.pushExportBuffer(partitionId, signature, startSequenceNumber,
-                    (int)tupleCount, uniqueId, buffer, sync);
+                    (int)tupleCount, uniqueId, genId, buffer, sync);
         } catch (Exception e) {
             //Don't let anything take down the execution site thread
             exportLog.error("Error pushing export buffer", e);

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -37,7 +37,7 @@ public interface Generation {
     public void onSourceDone(int partitionId, String signature);
 
     public void pushExportBuffer(int partitionId, String signature, long seqNo, int tupleCount,
-                                 long uniqueId, ByteBuffer buffer, boolean sync);
+                                 long uniqueId, long genId, ByteBuffer buffer, boolean sync);
     public void updateInitialExportStateToSeqNo(int partitionId, String signature,
                                                 boolean isRecover, boolean isRejoin,
                                                 Map<Integer, Pair<Long, Long>> sequenceNumberPerPartition,

--- a/src/frontend/org/voltdb/export/StreamBlock.java
+++ b/src/frontend/org/voltdb/export/StreamBlock.java
@@ -52,7 +52,7 @@ public class StreamBlock {
     public static final int UNIQUE_ID_OFFSET = 12;
 
     StreamBlock(BBContainer fcont, BBContainer schemaCont, long startSequenceNumber, int rowCount,
-            long uniqueId, boolean isPersisted) {
+            long uniqueId, long segmentIndex, boolean isPersisted) {
         m_buffer = fcont;
         m_schema = schemaCont;
         m_startSequenceNumber = startSequenceNumber;
@@ -62,6 +62,7 @@ public class StreamBlock {
         // if we end up persisting
         m_buffer.b().position(HEADER_SIZE);
         m_totalSize = m_buffer.b().remaining();
+        m_segmentIndex = segmentIndex;
         //The first 8 bytes are space for us to store the sequence number if we end up persisting
         m_isPersisted = isPersisted;
     }
@@ -150,6 +151,8 @@ public class StreamBlock {
     private BBContainer m_schema;
     // index of the last row that has been released.
     private int m_releaseOffset = -1;
+    // reverse lookup to find pbd segment
+    private long m_segmentIndex = -1;
 
     /*
      * True if this block is still backed by a file and false
@@ -192,5 +195,9 @@ public class StreamBlock {
         m_buffer.b().position(SEQUENCE_NUMBER_OFFSET);
         m_buffer.b().order(ByteOrder.BIG_ENDIAN);
         return getRefCountingContainer(m_buffer.b().asReadOnlyBuffer());
+    }
+
+    public long getSegmentIndex() {
+        return m_segmentIndex;
     }
 }

--- a/src/frontend/org/voltdb/export/StreamBlock.java
+++ b/src/frontend/org/voltdb/export/StreamBlock.java
@@ -46,14 +46,20 @@ import org.voltdb.iv2.UniqueIdGenerator;
  */
 public class StreamBlock {
 
-    public static final int HEADER_SIZE = 20; //sequence number + row count + uniqueId
+    public static final int HEADER_SIZE = 20; //sequence number(8) + row count(4) + uniqueId(8)
+    public static final int SEQUENCE_NUMBER_OFFSET = 0;
+    public static final int ROW_NUMBER_OFFSET = 8;
+    public static final int UNIQUE_ID_OFFSET = 12;
 
-    StreamBlock(BBContainer cont, long startSequenceNumber, int rowCount, long uniqueId, boolean isPersisted) {
-        m_buffer = cont;
+    StreamBlock(BBContainer fcont, BBContainer schemaCont, long startSequenceNumber, int rowCount,
+            long uniqueId, boolean isPersisted) {
+        m_buffer = fcont;
+        m_schema = schemaCont;
         m_startSequenceNumber = startSequenceNumber;
         m_rowCount = rowCount;
         m_uniqueId = uniqueId;
-        // The first 12 bytes are space for us to store the sequence number and row count if we end up persisting
+        // The first 20 bytes are space for us to store the sequence number, row count and uniqueId
+        // if we end up persisting
         m_buffer.b().position(HEADER_SIZE);
         m_totalSize = m_buffer.b().remaining();
         //The first 8 bytes are space for us to store the sequence number if we end up persisting
@@ -70,6 +76,10 @@ public class StreamBlock {
         if (count == 0) {
             m_buffer.discard();
             m_buffer = null;
+            if (m_schema != null) {
+                m_schema.discard();
+                m_schema = null;
+            }
         } else if (count < 0) {
             VoltDB.crashLocalVoltDB("Broken refcounting in export", true, null);
         }
@@ -137,6 +147,7 @@ public class StreamBlock {
     private final long m_uniqueId;
     private final long m_totalSize;
     private BBContainer m_buffer;
+    private BBContainer m_schema;
     // index of the last row that has been released.
     private int m_releaseOffset = -1;
 
@@ -149,6 +160,14 @@ public class StreamBlock {
     BBContainer unreleasedContainer() {
         m_refCount.incrementAndGet();
         return getRefCountingContainer(m_buffer.b().slice().asReadOnlyBuffer());
+    }
+
+    BBContainer getSchemaContainer() {
+        if (m_schema == null) {
+            return null;
+        }
+        m_refCount.incrementAndGet();
+        return getRefCountingContainer(m_schema.b().slice().asReadOnlyBuffer());
     }
 
     private BBContainer getRefCountingContainer(ByteBuffer buf) {
@@ -167,10 +186,10 @@ public class StreamBlock {
      */
     BBContainer asBBContainer() {
         m_buffer.b().order(ByteOrder.LITTLE_ENDIAN);
-        m_buffer.b().putLong(0, startSequenceNumber());
-        m_buffer.b().putInt(8, rowCount());
-        m_buffer.b().putLong(12, uniqueId());
-        m_buffer.b().position(0);
+        m_buffer.b().putLong(SEQUENCE_NUMBER_OFFSET, startSequenceNumber());
+        m_buffer.b().putInt(ROW_NUMBER_OFFSET, rowCount());
+        m_buffer.b().putLong(UNIQUE_ID_OFFSET, uniqueId());
+        m_buffer.b().position(SEQUENCE_NUMBER_OFFSET);
         m_buffer.b().order(ByteOrder.BIG_ENDIAN);
         return getRefCountingContainer(m_buffer.b().asReadOnlyBuffer());
     }

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -127,7 +127,7 @@ public class StreamBlockQueue {
             }
             cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         } catch (IOException e) {
-            exportLog.error(e);
+            exportLog.error("Failed to poll from persistent binary deque:" + e);
         }
 
         if (cont == null) {

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -176,7 +176,7 @@ public class StreamBlockQueue {
         try {
             schemaCont = m_reader.getSchema(segmentIndex, true, false);
         } catch (IOException e) {
-            exportLog.error(e);
+            exportLog.error("Failed to poll schema: " + e);
         }
         return schemaCont;
 

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -123,10 +123,9 @@ public class StreamBlockQueue {
         try {
             // Start to read a new segment
             if (m_reader.isStartOfSegment()) {
-                schemaCont = m_reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                schemaCont = m_reader.getSchema(-1, false, false);
             }
             cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
-
         } catch (IOException e) {
             exportLog.error(e);
         }
@@ -134,6 +133,7 @@ public class StreamBlockQueue {
         if (cont == null) {
             return null;
         } else {
+            long segmentIndex = m_reader.getSegmentIndex();
             cont.b().order(ByteOrder.LITTLE_ENDIAN);
             //If the container is not null, unpack it.
             final BBContainer fcont = cont;
@@ -147,6 +147,7 @@ public class StreamBlockQueue {
                 seqNo,
                 tupleCount,
                 uniqueId,
+                segmentIndex,
                 true);
 
             //Optionally store a reference to the block in the in memory deque
@@ -155,6 +156,30 @@ public class StreamBlockQueue {
             }
             return block;
         }
+    }
+
+    /*
+     * Poll stream table schema that either represents the first object in the memory dequeue, or
+     * from the segment that the cursor is currently reading on.
+     */
+    public BBContainer pollSchema() {
+        BBContainer schemaCont = null;
+        long segmentIndex = -1;
+        if (m_memoryDeque.peek() != null) {
+            StreamBlock sb = m_memoryDeque.peek();
+            BBContainer cont = sb.getSchemaContainer();
+            if (cont != null) {
+                return cont;
+            }
+            segmentIndex = sb.getSegmentIndex();
+        }
+        try {
+            schemaCont = m_reader.getSchema(segmentIndex, true, false);
+        } catch (IOException e) {
+            exportLog.error(e);
+        }
+        return schemaCont;
+
     }
     /*
      * Present an iterator that is backed by the blocks
@@ -300,45 +325,50 @@ public class StreamBlockQueue {
             @Override
             public TruncatorResponse parse(BBContainer bbc) {
                 ByteBuffer b = bbc.b();
+                ByteOrder endianness = b.order();
                 b.order(ByteOrder.LITTLE_ENDIAN);
-                final long startSequenceNumber = b.getLong();
-                // If after the truncation point is the first row in the block, the entire block is to be discarded
-                if (startSequenceNumber > truncationSeqNo) {
-                    return PersistentBinaryDeque.fullTruncateResponse();
-                }
-                final int tupleCountPos = b.position();
-                final int tupleCount = b.getInt();
-                // There is nothing to do with this buffer
-                final long lastSequenceNumber = startSequenceNumber + tupleCount - 1;
-                if (lastSequenceNumber <= truncationSeqNo) {
-                    return null;
-                }
-                b.getLong(); // uniqueId
+                try {
+                    final long startSequenceNumber = b.getLong();
+                    // If after the truncation point is the first row in the block, the entire block is to be discarded
+                    if (startSequenceNumber > truncationSeqNo) {
+                        return PersistentBinaryDeque.fullTruncateResponse();
+                    }
+                    final int tupleCountPos = b.position();
+                    final int tupleCount = b.getInt();
+                    // There is nothing to do with this buffer
+                    final long lastSequenceNumber = startSequenceNumber + tupleCount - 1;
+                    if (lastSequenceNumber <= truncationSeqNo) {
+                        return null;
+                    }
+                    b.getLong(); // uniqueId
 
-                // Partial truncation
-                int offset = 0;
-                while (b.hasRemaining()) {
-                    if (startSequenceNumber + offset > truncationSeqNo) {
-                        // The sequence number of this row is the greater than the truncation sequence number.
-                        // Don't want this row, but want to preserve all rows before it.
-                        // Move back before the row length prefix, txnId and header
-                        // Return everything in the block before the truncation point.
-                        // Indicate this is the end of the interesting data.
-                        b.limit(b.position());
-                        // update tuple count in the header
-                        b.putInt(tupleCountPos, offset - 1);
-                        b.position(0);
-                        return new ByteBufferTruncatorResponse(b);
+                    // Partial truncation
+                    int offset = 0;
+                    while (b.hasRemaining()) {
+                        if (startSequenceNumber + offset > truncationSeqNo) {
+                            // The sequence number of this row is the greater than the truncation sequence number.
+                            // Don't want this row, but want to preserve all rows before it.
+                            // Move back before the row length prefix, txnId and header
+                            // Return everything in the block before the truncation point.
+                            // Indicate this is the end of the interesting data.
+                            b.limit(b.position());
+                            // update tuple count in the header
+                            b.putInt(tupleCountPos, offset - 1);
+                            b.position(0);
+                            return new ByteBufferTruncatorResponse(b);
+                        }
+                        offset++;
+                        // Not the row we are looking to truncate at. Skip past it (row length + row length field).
+                        final int rowLength = b.getInt();
+                        if (b.position() + rowLength > b.limit()) {
+                            System.out.println(rowLength);
+                        }
+                        b.position(b.position() + rowLength);
                     }
-                    offset++;
-                    // Not the row we are looking to truncate at. Skip past it (row length + row length field).
-                    final int rowLength = b.getInt();
-                    if (b.position() + rowLength > b.limit()) {
-                        System.out.println(rowLength);
-                    }
-                    b.position(b.position() + rowLength);
+                    return null;
+                } finally {
+                    b.order(endianness);
                 }
-                return null;
             }
         });
 
@@ -358,9 +388,11 @@ public class StreamBlockQueue {
 
             public ExportSequenceNumberTracker scan(BBContainer bbc) {
                 ByteBuffer b = bbc.b();
+                ByteOrder endianness = b.order();
                 b.order(ByteOrder.LITTLE_ENDIAN);
                 final long startSequenceNumber = b.getLong();
                 final int tupleCount = b.getInt();
+                b.order(endianness);
                 ExportSequenceNumberTracker gapTracker = new ExportSequenceNumberTracker();
                 gapTracker.append(startSequenceNumber, startSequenceNumber + tupleCount - 1);
                 return gapTracker;

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -477,6 +477,10 @@ public class GuestProcessor implements ExportDataProcessor {
                         if (cont != null) {
                             cont.discard();
                         }
+                        if (schemaCont != null) {
+                            schemaCont.discard();
+                            schemaCont = null;
+                        }
                     }
                 } catch (Exception e) {
                     if (e.getCause() instanceof ReentrantPollException) {

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -32,7 +32,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.voltcore.logging.VoltLogger;
-import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltType;
@@ -226,9 +225,8 @@ public class GuestProcessor implements ExportDataProcessor {
             detectDecoder(m_client, edb);
             Pair<ExportDecoderBase, AdvertisedDataSource> pair = Pair.of(edb, ads);
             m_decoders.add(pair);
-            final ListenableFuture<AckingContainer> fut = m_source.poll();
-            final ListenableFuture<BBContainer> schemaFut = m_source.pollSchema();
-            addBlockListener(m_source, fut, schemaFut, edb);
+            final ListenableFuture<AckingContainer> fut = m_source.poll(true);
+            addBlockListener(m_source, fut, edb);
             m_source.forwardAckToOtherReplicas();
         }
 
@@ -313,7 +311,6 @@ public class GuestProcessor implements ExportDataProcessor {
     private void addBlockListener(
             final ExportDataSource source,
             final ListenableFuture<AckingContainer> fut,
-            final ListenableFuture<BBContainer> schemaFut,
             final ExportDecoderBase edb) {
         /*
          * The listener runs in the thread specified by the EDB.
@@ -335,10 +332,6 @@ public class GuestProcessor implements ExportDataProcessor {
                     }
                     // If export master accepts promotion in case of mastership migration or leader re-election,
                     // we need an extra poll to get the schema of current buffer to setup the decoder
-                    BBContainer schemaCont = null;
-                    if (schemaFut != null) {
-                        schemaCont = schemaFut.get();
-                    }
                     try {
                         //Position to restart at on error
                         final int startPosition = cont.b().position();
@@ -361,9 +354,6 @@ public class GuestProcessor implements ExportDataProcessor {
                                 ByteBuffer schemaBuf = null;
                                 if (cont.schema() != null) {
                                     schemaBuf = cont.schema();
-                                } else if (schemaCont != null) {
-                                    // This happens when export master migration or leader re-election
-                                    schemaBuf = schemaCont.b();
                                 }
                                 if (schemaBuf != null) {
                                     schemaBuf.position(0);
@@ -438,10 +428,6 @@ public class GuestProcessor implements ExportDataProcessor {
                                 if (!m_shutdown && cont != null) {
                                     cont.discard();
                                     cont = null;
-                                    if (schemaCont != null) {
-                                        schemaCont.discard();
-                                        schemaCont = null;
-                                    }
                                 }
                                 break;
                             } catch (RestartBlockException e) {
@@ -477,10 +463,6 @@ public class GuestProcessor implements ExportDataProcessor {
                         if (cont != null) {
                             cont.discard();
                         }
-                        if (schemaCont != null) {
-                            schemaCont.discard();
-                            schemaCont = null;
-                        }
                     }
                 } catch (Exception e) {
                     if (e.getCause() instanceof ReentrantPollException) {
@@ -492,7 +474,7 @@ public class GuestProcessor implements ExportDataProcessor {
                     }
                 }
                 if (!m_shutdown) {
-                    addBlockListener(source, source.poll(), null, edb);
+                    addBlockListener(source, source.poll(false), edb);
                 }
             }
         }, edb.getExecutor());

--- a/src/frontend/org/voltdb/exportclient/ExportDecoderBase.java
+++ b/src/frontend/org/voltdb/exportclient/ExportDecoderBase.java
@@ -18,23 +18,26 @@
 package org.voltdb.exportclient;
 
 
-import au.com.bytecode.opencsv_voltpatches.CSVWriter;
-import com.google_voltpatches.common.base.Preconditions;
-import org.voltcore.logging.VoltLogger;
-import org.voltcore.utils.CoreUtils;
-import org.voltdb.export.AdvertisedDataSource;
+import static org.voltdb.exportclient.ExportRow.getFirstField;
 
-import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+
+import org.voltcore.logging.VoltLogger;
+import org.voltcore.utils.CoreUtils;
 import org.voltdb.VoltType;
-import static org.voltdb.exportclient.ExportRow.getFirstField;
+import org.voltdb.export.AdvertisedDataSource;
 import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.types.TimestampType;
 import org.voltdb.utils.Encoder;
+
+import com.google_voltpatches.common.base.Preconditions;
+import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
+
+import au.com.bytecode.opencsv_voltpatches.CSVWriter;
 
 
 /**
@@ -82,7 +85,7 @@ public abstract class ExportDecoderBase {
     final ExportRow m_legacyRow;
 
     //Used by new style connector to pickup schema information from previous record.
-    ExportRow m_previousRow;
+    ExportRow m_rowSchema;
     public ExportDecoderBase(AdvertisedDataSource ads) {
         m_source = ads;
         m_startTS = System.currentTimeMillis();
@@ -275,13 +278,13 @@ public abstract class ExportDecoderBase {
         return m_legacy;
     }
 
-    public void setPreviousRow(ExportRow row) {
-        //We do keep the values of previous row but they are not used.
-        m_previousRow = row;
+    public void setExportRowSchema(ExportRow row) {
+        //We do keep the values in the schema row but they are not used.
+        m_rowSchema = row;
     }
 
-    public ExportRow getPreviousRow() {
+    public ExportRow getExportRowSchema() {
         //We do keep the values of previous row but they should not be relied upon only schema information is used.
-        return m_previousRow;
+        return m_rowSchema;
     }
 }

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -441,6 +441,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                     long tupleCount = getBytes(8).getLong();
                     long uniqueId = getBytes(8).getLong();
                     boolean sync = getBytes(1).get() == 1 ? true : false;
+                    long genId = getBytes(8).getLong();
                     int length = getBytes(4).getInt();
                     ExportManager.pushExportBuffer(
                             partitionId,
@@ -448,6 +449,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                             startSequenceNumber,
                             tupleCount,
                             uniqueId,
+                            genId,
                             0,
                             length == 0 ? null : getBytes(length),
                             sync);

--- a/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
@@ -31,7 +31,7 @@ import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.VoltDB;
 import org.voltdb.utils.BinaryDeque;
-import org.voltdb.utils.BinaryDeque.BinaryDequeReader;
+import org.voltdb.utils.BinaryDequeReader;
 import org.voltdb.utils.PersistentBinaryDeque;
 
 /**
@@ -78,7 +78,8 @@ public class TaskLogImpl implements TaskLog {
 
         m_partitionId = partitionId;
         m_cursorId = "TaskLog-" + partitionId;
-        m_buffers = new PersistentBinaryDeque(Integer.toString(partitionId), overflowDir, new VoltLogger("REJOIN"));
+        m_buffers = new PersistentBinaryDeque(
+                Integer.toString(partitionId), null, overflowDir, new VoltLogger("REJOIN"));
         m_reader = m_buffers.openForRead(m_cursorId);
         m_es = CoreUtils.getSingleThreadExecutor("TaskLog partition " + partitionId);
     }
@@ -172,7 +173,7 @@ public class TaskLogImpl implements TaskLog {
                 @Override
                 public void run() {
                     try {
-                        BBContainer cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+                        BBContainer cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
                         if (cont != null) {
                            m_headBuffers.offer(new RejoinTaskBuffer(cont));
                         }

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -282,6 +282,9 @@ public class UpdateCore extends VoltSystemProcedure {
             // if this is a new catalog, do the work to update
             if (context.getCatalogVersion() == expectedCatalogVersion) {
 
+                // Bring the DR and Export buffer update to date.
+                context.getSiteProcedureConnection().quiesce();
+
                 // update the global catalog if we get there first
                 CatalogContext catalogContext =
                         VoltDB.instance().catalogUpdate(

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -53,10 +53,11 @@ public interface BinaryDeque {
      * is larger then the implementation defined max. 64 megabytes in the case of PersistentBinaryDeque.
      * If there is an exception attempting to write the buffers then all the buffers will be discarded
      * @param object
+     * @param ds
      * @param allowCompression
      * @throws IOException
      */
-    void offer(BBContainer object, boolean allowCompression) throws IOException;
+    void offer(BBContainer object, DeferredSerialization ds, boolean allowCompression, boolean createNewFile) throws IOException;
 
     int offer(DeferredSerialization ds) throws IOException;
 
@@ -67,9 +68,10 @@ public interface BinaryDeque {
      * is larger then the implementation defined max. 64 megabytes in the case of PersistentBinaryDeque.
      * If there is an exception attempting to write the buffers then all the buffers will be discarded
      * @param objects Array of buffers representing the objects to be pushed to the head of the queue
+     * @param DeferredSerialization serializer method to write subsystem-specific meta data.
      * @throws java.io.IOException
      */
-    public void push(BBContainer objects[]) throws IOException;
+    public void push(BBContainer objects[], DeferredSerialization ds) throws IOException;
 
     /**
      * Start a BinaryDequeReader for reading, positioned at the start of the deque.
@@ -108,42 +110,6 @@ public interface BinaryDeque {
     public Pair<Integer, Long> getBufferCountAndSize() throws IOException;
 
     public void closeAndDelete() throws IOException;
-
-    /**
-     * Reader class used to read entries from the deque. Multiple readers may be active at the same time,
-     * each of them maintaining their own read location within the deque.
-     */
-    public interface BinaryDequeReader {
-        /**
-         * Read and return the object at the current read position of this reader.
-         * The entry will be removed once all active readers have read the entry.
-         * @param ocf
-         * @return BBContainer with the bytes read. Null if there is nothing left to read.
-         * @throws IOException
-         */
-        public BBContainer poll(OutputContainerFactory ocf) throws IOException;
-
-        /**
-         * Number of bytes left to read for this reader.
-         * @return number of bytes left to read for this reader.
-         * @throws IOException
-         */
-        public long sizeInBytes() throws IOException;
-
-        /**
-         *  Number of objects left to read for this reader.
-         * @return number of objects left to read for this reader
-         * @throws IOException
-         */
-        public int getNumObjects() throws IOException;
-
-        /**
-         * Returns true if this reader still has entries to read. False otherwise
-         * @return true if this reader still has entries to read. False otherwise
-         * @throws IOException
-         */
-        public boolean isEmpty() throws IOException;
-    }
 
     public static class TruncatorResponse {
         public enum Status {

--- a/src/frontend/org/voltdb/utils/BinaryDequeReader.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeReader.java
@@ -1,0 +1,75 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb.utils;
+
+import java.io.IOException;
+
+import org.voltcore.utils.DBBPool.BBContainer;
+import org.voltdb.utils.BinaryDeque.OutputContainerFactory;
+
+/**
+ * Reader interface used to read entries from the deque. Multiple readers may be active at the same time,
+ * each of them maintaining their own read location within the deque.
+ */
+public interface BinaryDequeReader {
+    /**
+     * Read and return the object at the current read position of this reader.
+     * The entry will be removed once all active readers have read the entry.
+     * @param ocf
+     * @param checkCRC
+     * @return BBContainer with the bytes read. Null if there is nothing left to read.
+     * @throws IOException
+     */
+    public BBContainer poll(OutputContainerFactory ocf, boolean checkCRC) throws IOException;
+
+    /**
+     * Read and return the schema of table located in the segment header
+     * @param ocf
+     * @param checkCRC
+     * @return
+     * @throws IOException
+     */
+    public BBContainer getSchema(OutputContainerFactory ocf, boolean checkCRC) throws IOException;
+
+    /**
+     * Number of bytes left to read for this reader.
+     * @return number of bytes left to read for this reader.
+     * @throws IOException
+     */
+    public long sizeInBytes() throws IOException;
+
+    /**
+     *  Number of objects left to read for this reader.
+     * @return number of objects left to read for this reader
+     * @throws IOException
+     */
+    public int getNumObjects() throws IOException;
+
+    /**
+     * Returns true if this reader still has entries to read. False otherwise
+     * @return true if this reader still has entries to read. False otherwise
+     * @throws IOException
+     */
+    public boolean isEmpty() throws IOException;
+
+    /**
+     * Is the object this reader going to read the first object of segment?
+     * @return true if the object this reader going to read is the first object of segment
+     * throws IOException
+     */
+    public boolean isStartOfSegment() throws IOException;
+}

--- a/src/frontend/org/voltdb/utils/BinaryDequeReader.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeReader.java
@@ -38,12 +38,13 @@ public interface BinaryDequeReader {
 
     /**
      * Read and return the schema of table located in the segment header
-     * @param ocf
-     * @param checkCRC
+     * @param segmentIndex index of the segment to get schema from, -1 means get schema from current segment
+     * @param updateReaderOffset whether to restore reader's original read offset after polling schema
+     * @param checkCRC check PBD header CRC while getting schema
      * @return
      * @throws IOException
      */
-    public BBContainer getSchema(OutputContainerFactory ocf, boolean checkCRC) throws IOException;
+    public BBContainer getSchema(long segmentIndex, boolean restoreReaderOffset, boolean checkCRC) throws IOException;
 
     /**
      * Number of bytes left to read for this reader.
@@ -72,4 +73,10 @@ public interface BinaryDequeReader {
      * throws IOException
      */
     public boolean isStartOfSegment() throws IOException;
+
+    /**
+     * Returns the index of the segment that reader currently reads on
+     * @return
+     */
+    public long getSegmentIndex();
 }

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -45,6 +45,7 @@ import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONObject;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
+import org.voltcore.utils.DeferredSerialization;
 import org.voltdb.PrivateVoltTableFactory;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.TheHashinator;
@@ -1084,5 +1085,25 @@ public class MiscUtils {
             }
         }
         return props;
+    }
+
+    /**
+     * Serialize the deferred serializer data into byte buffer
+     * @param mbuf ByteBuffer the buffer is written to
+     * @param ds DeferredSerialization data writes to the byte buffer
+     * @return size of data
+     * @throws IOException
+     */
+    public static int writeDeferredSerialization(ByteBuffer mbuf, DeferredSerialization ds) throws IOException
+    {
+        int written = 0;
+        try {
+            final int objStartPosition = mbuf.position();
+            ds.serialize(mbuf);
+            written = mbuf.position() - objStartPosition;
+        } finally {
+            ds.cancel();
+        }
+        return written;
     }
 }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -369,7 +369,7 @@ public class PBDRegularSegment extends PBDSegment {
             m_entryCRC.reset();
             m_entryHeaderBuf.b().clear();
             final int written = MiscUtils.writeDeferredSerialization(destBuf.b(), ds);
-
+            destBuf.b().flip();
             // Write entry header
             PBDUtils.writeEntryHeader(m_entryCRC, m_entryHeaderBuf.b(), destBuf.b(),
                     written, PBDSegment.NO_FLAGS);

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -22,13 +22,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.DBBPool;
-import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.DeferredSerialization;
+import org.voltdb.HybridCrc32;
 import org.voltdb.utils.BinaryDeque.OutputContainerFactory;
 
 import com.google_voltpatches.common.base.Preconditions;
@@ -41,6 +42,7 @@ import com.google_voltpatches.common.base.Preconditions;
  */
 public class PBDRegularSegment extends PBDSegment {
     private static final VoltLogger LOG = new VoltLogger("HOST");
+    private static final VoltLogger exportLog = new VoltLogger("EXPORT");
 
     private final Map<String, SegmentReader> m_readCursors = new HashMap<>();
     private final Map<String, SegmentReader> m_closedCursors = new HashMap<>();
@@ -54,9 +56,11 @@ public class PBDRegularSegment extends PBDSegment {
     private int m_numOfEntries = -1;
     private int m_size = -1;
 
-    private DBBPool.BBContainer m_tmpHeaderBuf = null;
+    private DBBPool.BBContainer m_segmentHeaderBuf = null;
+    private DBBPool.BBContainer m_entryHeaderBuf = null;
+    Boolean INJECT_PBD_CHECKSUM_ERROR = Boolean.getBoolean("INJECT_PBD_CHECKSUM_ERROR");
 
-    public PBDRegularSegment(Long index, Long  id, File file) {
+    public PBDRegularSegment(Long index, long id, File file) {
         super(file);
         m_index = index;
         m_id = id;
@@ -84,28 +88,49 @@ public class PBDRegularSegment extends PBDSegment {
     public void reset()
     {
         m_syncedSinceLastEdit = false;
-        if (m_tmpHeaderBuf != null) {
-            m_tmpHeaderBuf.discard();
-            m_tmpHeaderBuf = null;
+        if (m_segmentHeaderBuf != null) {
+            m_segmentHeaderBuf.discard();
+            m_segmentHeaderBuf = null;
         }
+        if (m_entryHeaderBuf != null) {
+            m_entryHeaderBuf.discard();
+            m_entryHeaderBuf = null;
+        }
+        m_segmentHeaderCRC.reset();
+        m_entryCRC.reset();
     }
 
     @Override
-    public int getNumEntries() throws IOException
+    public int getNumEntries(boolean crcCheck) throws IOException
     {
         boolean wasClosed = false;
         if (m_closed) {
             wasClosed = true;
             open(false, false);
         }
+        m_numOfEntries = 0;
+        m_size = 0;
         if (m_fc.size() >= SEGMENT_HEADER_BYTES) {
-            m_tmpHeaderBuf.b().clear();
-            PBDUtils.readBufferFully(m_fc, m_tmpHeaderBuf.b(), 0);
-            m_numOfEntries = m_tmpHeaderBuf.b().getInt();
-            m_size = m_tmpHeaderBuf.b().getInt();
-        } else {
-            m_numOfEntries = 0;
-            m_size = 0;
+            m_segmentHeaderBuf.b().clear();
+            PBDUtils.readBufferFully(m_fc, m_segmentHeaderBuf.b(), 0);
+            if (crcCheck) {
+                long crc = m_segmentHeaderBuf.b().getLong();
+                int numOfEntries = m_segmentHeaderBuf.b().getInt();
+                int size = m_segmentHeaderBuf.b().getInt();
+                m_segmentHeaderCRC.reset();
+                m_segmentHeaderCRC.update(numOfEntries);
+                m_segmentHeaderCRC.update(size);
+                if (crc != m_segmentHeaderCRC.getValue()) {
+                    LOG.warn("File corruption detected in" + m_file.getName() + ": invalid file header. ");
+                    throw new IOException("File corruption detected in" + m_file.getName() + ": invalid file header.");
+                }
+                m_numOfEntries = numOfEntries;
+                m_size = size;
+            } else {
+                // skip the checksum if don't check crc
+                m_numOfEntries = m_segmentHeaderBuf.b().getInt(HEADER_NUM_OF_ENTRY_OFFSET);
+                m_size = m_segmentHeaderBuf.b().getInt(HEADER_TOTAL_BYTES_OFFSET);
+            }
         }
         if (wasClosed) closeReadersAndFile();
         return m_numOfEntries;
@@ -163,41 +188,50 @@ public class PBDRegularSegment extends PBDSegment {
         assert(m_ras == null);
         m_ras = new RandomAccessFile( m_file, forWrite ? "rw" : "r");
         m_fc = m_ras.getChannel();
-        m_tmpHeaderBuf = DBBPool.allocateDirect(SEGMENT_HEADER_BYTES);
+        m_segmentHeaderBuf = DBBPool.allocateDirect(SEGMENT_HEADER_BYTES);
+        m_entryHeaderBuf = DBBPool.allocateDirect(ENTRY_HEADER_BYTES);
 
+        // Those asserts ensure the file is opened with correct flag
         if (emptyFile) {
             initNumEntries(0, 0);
+
         }
-        m_fc.position(SEGMENT_HEADER_BYTES);
+        if (forWrite) {
+            m_fc.position(m_fc.size());
+        } else {
+            m_fc.position(SEGMENT_HEADER_BYTES);
+        }
 
         m_closed = false;
     }
 
+    private void updateNumEntries() throws IOException {
+        // Update segment header CRC
+        m_segmentHeaderCRC.reset();
+        m_segmentHeaderCRC.update(m_numOfEntries);
+        m_segmentHeaderCRC.update(m_size);
+
+        m_segmentHeaderBuf.b().clear();
+        m_segmentHeaderBuf.b().putLong(m_segmentHeaderCRC.getValue()); // crc of segment header
+        m_segmentHeaderBuf.b().putInt(m_numOfEntries);
+        m_segmentHeaderBuf.b().putInt(m_size);
+        m_segmentHeaderBuf.b().flip();
+        PBDUtils.writeBuffer(m_fc, m_segmentHeaderBuf.bDR(), PBDSegment.HEADER_CRC_OFFSET);
+        m_syncedSinceLastEdit = false;
+    }
 
     @Override
     protected void initNumEntries(int count, int size) throws IOException {
         m_numOfEntries = count;
         m_size = size;
-
-        m_tmpHeaderBuf.b().clear();
-        m_tmpHeaderBuf.b().putInt(m_numOfEntries);
-        m_tmpHeaderBuf.b().putInt(m_size);
-        m_tmpHeaderBuf.b().flip();
-        PBDUtils.writeBuffer(m_fc, m_tmpHeaderBuf.bDR(), COUNT_OFFSET);
-        m_syncedSinceLastEdit = false;
+        updateNumEntries();
     }
 
     private void incrementNumEntries(int size) throws IOException
     {
         m_numOfEntries++;
         m_size += size;
-
-        m_tmpHeaderBuf.b().clear();
-        m_tmpHeaderBuf.b().putInt(m_numOfEntries);
-        m_tmpHeaderBuf.b().putInt(m_size);
-        m_tmpHeaderBuf.b().flip();
-        PBDUtils.writeBuffer(m_fc, m_tmpHeaderBuf.bDR(), COUNT_OFFSET);
-        m_syncedSinceLastEdit = false;
+        updateNumEntries();
     }
 
     /**
@@ -205,7 +239,7 @@ public class PBDRegularSegment extends PBDSegment {
      * @return
      */
     private int remaining() throws IOException {
-        //Subtract 8 for the length and size prefix
+        //Subtract 12 for the crc, number of entries and size prefix
         return (int)(PBDSegment.CHUNK_SIZE - m_fc.position()) - SEGMENT_HEADER_BYTES;
     }
 
@@ -218,20 +252,6 @@ public class PBDRegularSegment extends PBDSegment {
         m_size = -1;
     }
 
-    @Override
-    public void closeAndTruncate() throws IOException {
-        try
-        {
-            if (m_ras == null) {
-                m_ras = new RandomAccessFile( m_file, "rw");
-            }
-            m_ras.setLength(0);
-        }
-        finally
-        {
-            close();
-        }
-    }
     @Override
     public boolean isClosed()
     {
@@ -282,6 +302,7 @@ public class PBDRegularSegment extends PBDSegment {
         return true;
     }
 
+    // Used by Export path
     @Override
     public boolean offer(DBBPool.BBContainer cont, boolean compress) throws IOException
     {
@@ -289,37 +310,38 @@ public class PBDRegularSegment extends PBDSegment {
         final ByteBuffer buf = cont.b();
         final int remaining = buf.remaining();
         if (remaining < 32 || !buf.isDirect()) compress = false;
-        final int maxCompressedSize = (compress ? CompressionService.maxCompressedLength(remaining) : remaining) + OBJECT_HEADER_BYTES;
+        final int maxCompressedSize = (compress ? CompressionService.maxCompressedLength(remaining) : remaining) + ENTRY_HEADER_BYTES;
         if (remaining() < maxCompressedSize) return false;
 
         m_syncedSinceLastEdit = false;
         DBBPool.BBContainer destBuf = cont;
-
+        m_entryCRC.reset();
         try {
-            m_tmpHeaderBuf.b().clear();
+            m_entryHeaderBuf.b().clear();
 
             if (compress) {
                 destBuf = DBBPool.allocateDirectAndPool(maxCompressedSize);
                 final int compressedSize = CompressionService.compressBuffer(buf, destBuf.b());
                 destBuf.b().limit(compressedSize);
-
-                m_tmpHeaderBuf.b().putInt(compressedSize);
-                m_tmpHeaderBuf.b().putInt(FLAG_COMPRESSED);
+                PBDUtils.writeEntryHeader(m_entryCRC, m_entryHeaderBuf.b(), destBuf.b(),
+                        compressedSize, FLAG_COMPRESSED);
             } else {
                 destBuf = cont;
-                m_tmpHeaderBuf.b().putInt(remaining);
-                m_tmpHeaderBuf.b().putInt(NO_FLAGS);
+                PBDUtils.writeEntryHeader(m_entryCRC, m_entryHeaderBuf.b(), destBuf.b(),
+                        remaining, NO_FLAGS);
+            }
+            // Write entry header
+            m_entryHeaderBuf.b().flip();
+            while (m_entryHeaderBuf.b().hasRemaining()) {
+                m_fc.write(m_entryHeaderBuf.b());
             }
 
-            m_tmpHeaderBuf.b().flip();
-            while (m_tmpHeaderBuf.b().hasRemaining()) {
-                m_fc.write(m_tmpHeaderBuf.b());
-            }
-
+            // Write entry
+            destBuf.b().flip();
             while (destBuf.b().hasRemaining()) {
                 m_fc.write(destBuf.b());
             }
-
+            // Update segment header
             incrementNumEntries(remaining);
         } finally {
             destBuf.discard();
@@ -331,24 +353,34 @@ public class PBDRegularSegment extends PBDSegment {
         return true;
     }
 
+    // Used by DR path
     @Override
     public int offer(DeferredSerialization ds) throws IOException
     {
         if (m_closed) throw new IOException("closed");
-        final int fullSize = ds.getSerializedSize() + OBJECT_HEADER_BYTES;
+        final int fullSize = ds.getSerializedSize();
         if (remaining() < fullSize) return -1;
 
         m_syncedSinceLastEdit = false;
         DBBPool.BBContainer destBuf = DBBPool.allocateDirectAndPool(fullSize);
 
         try {
+            m_entryCRC.reset();
             final int written = PBDUtils.writeDeferredSerialization(destBuf.b(), ds);
-            destBuf.b().flip();
 
+            // Write entry header
+            PBDUtils.writeEntryHeader(m_entryCRC, m_entryHeaderBuf.b(), destBuf.b(),
+                    written, PBDSegment.NO_FLAGS);
+            m_entryHeaderBuf.b().flip();
+            while (m_entryHeaderBuf.b().hasRemaining()) {
+                m_fc.write(m_entryHeaderBuf.b());
+            }
+            // Write entry
+            destBuf.b().flip();
             while (destBuf.b().hasRemaining()) {
                 m_fc.write(destBuf.b());
             }
-
+            // Update segment header
             incrementNumEntries(written);
             return written;
         } finally {
@@ -365,7 +397,8 @@ public class PBDRegularSegment extends PBDSegment {
     protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry) throws IOException
     {
         int written = 0;
-        final DBBPool.BBContainer partialCont = DBBPool.allocateDirect(OBJECT_HEADER_BYTES + entry.getTruncatedBuffSize());
+        final DBBPool.BBContainer partialCont =
+                DBBPool.allocateDirect(ENTRY_HEADER_BYTES + entry.getTruncatedBuffSize());
         try {
             written += entry.writeTruncatedObject(partialCont.b());
             partialCont.b().flip();
@@ -379,6 +412,18 @@ public class PBDRegularSegment extends PBDSegment {
         return written;
     }
 
+    @Override
+    public void writeExtraHeader(DeferredSerialization ds) throws IOException {
+        DBBPool.BBContainer destBuf = DBBPool.allocateDirect(ds.getSerializedSize());
+        destBuf.b().order(ByteOrder.LITTLE_ENDIAN);
+        ds.serialize(destBuf.b());
+        destBuf.b().flip();
+        while (destBuf.b().hasRemaining()) {
+            m_fc.write(destBuf.b());
+        }
+        destBuf.discard();
+    }
+
     private class SegmentReader implements PBDSegmentReader {
         private final String m_cursorId;
         private long m_readOffset = SEGMENT_HEADER_BYTES;
@@ -387,6 +432,7 @@ public class PBDRegularSegment extends PBDSegment {
         private int m_bytesRead = 0;
         private int m_discardCount = 0;
         private boolean m_closed = false;
+        private HybridCrc32 m_crc = new HybridCrc32();
 
         public SegmentReader(String cursorId) {
             assert(cursorId != null);
@@ -398,6 +444,7 @@ public class PBDRegularSegment extends PBDSegment {
             m_bytesRead = 0;
             m_readOffset = SEGMENT_HEADER_BYTES;
             m_discardCount = 0;
+            m_crc.reset();
         }
 
         @Override
@@ -411,7 +458,8 @@ public class PBDRegularSegment extends PBDSegment {
         }
 
         @Override
-        public BBContainer poll(OutputContainerFactory factory) throws IOException {
+        public DBBPool.BBContainer poll(OutputContainerFactory factory, boolean checkCRC) throws IOException {
+
             if (m_closed) throw new IOException("Reader closed");
 
             if (!hasMoreEntries()) {
@@ -423,21 +471,30 @@ public class PBDRegularSegment extends PBDSegment {
 
             try {
                 //Get the length and size prefix and then read the object
-                m_tmpHeaderBuf.b().clear();
-                while (m_tmpHeaderBuf.b().hasRemaining()) {
-                    int read = m_fc.read(m_tmpHeaderBuf.b());
+                m_entryHeaderBuf.b().clear();
+                while (m_entryHeaderBuf.b().hasRemaining()) {
+                    int read = m_fc.read(m_entryHeaderBuf.b());
                     if (read == -1) {
                         throw new EOFException();
                     }
                 }
-                m_tmpHeaderBuf.b().flip();
-                final int length = m_tmpHeaderBuf.b().getInt();
-                final int flags = m_tmpHeaderBuf.b().getInt();
+                m_entryHeaderBuf.b().flip();
+                m_entryHeaderBuf.b().order(ByteOrder.LITTLE_ENDIAN);
+                final long entryCRC = m_entryHeaderBuf.b().getLong();
+                final int length = m_entryHeaderBuf.b().getInt();
+                final int flags = m_entryHeaderBuf.b().getInt();
+                m_entryHeaderBuf.b().order(ByteOrder.BIG_ENDIAN);
                 final boolean compressed = (flags & FLAG_COMPRESSED) != 0;
                 final int uncompressedLen;
 
-                if (length < 1) {
-                    throw new IOException("Read an invalid length");
+                if (length < 1 || length > PBDSegment.CHUNK_SIZE - PBDSegment.SEGMENT_HEADER_BYTES) {
+                    LOG.warn("File corruption detected in " + m_file.getName() + ": invalid entry length. "
+                            + "Truncate the file to last safe point.");
+                    PBDRegularSegment.this.close();
+                    openForWrite(false);
+                    initNumEntries(m_objectReadIndex, m_bytesRead);
+                    m_fc.truncate(m_readOffset);
+                    return null;
                 }
 
                 final DBBPool.BBContainer retcont;
@@ -451,6 +508,22 @@ public class PBDRegularSegment extends PBDSegment {
                             }
                         }
                         compressedBuf.b().flip();
+                        if (checkCRC) {
+                            m_crc.reset();
+                            m_crc.update(length);
+                            m_crc.update(flags);
+                            m_crc.update(compressedBuf.b());
+                            compressedBuf.b().flip();
+                            if (entryCRC != m_crc.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
+                                LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
+                                        + "Truncate the file to last safe point.");
+                                PBDRegularSegment.this.close();
+                                openForWrite(false);
+                                initNumEntries(m_objectReadIndex, m_bytesRead);
+                                m_fc.truncate(m_readOffset);
+                                return null;
+                            }
+                        }
 
                         uncompressedLen = CompressionService.uncompressedLength(compressedBuf.bDR());
                         retcont = factory.getContainer(uncompressedLen);
@@ -470,6 +543,21 @@ public class PBDRegularSegment extends PBDSegment {
                         }
                     }
                     retcont.b().flip();
+                    if (checkCRC) {
+                        m_crc.update(length);
+                        m_crc.update(flags);
+                        m_crc.update(retcont.b());
+                        retcont.b().flip();
+                        if (entryCRC != m_crc.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
+                            LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
+                                    + "Truncate the file to last safe point.");
+                            PBDRegularSegment.this.close();
+                            openForWrite(false);
+                            initNumEntries(m_objectReadIndex, m_bytesRead);
+                            m_fc.truncate(m_readOffset);
+                            return null;
+                        }
+                    }
                 }
 
                 m_bytesRead += uncompressedLen;
@@ -492,6 +580,52 @@ public class PBDRegularSegment extends PBDSegment {
                     }
                 };
             } finally {
+                m_readOffset = m_fc.position();
+                m_fc.position(writePos);
+            }
+        }
+
+        @Override
+        public DBBPool.BBContainer getSchema(OutputContainerFactory factory, boolean checkCRC) throws IOException {
+            if (m_closed) throw new IOException("Reader closed");
+
+            final long writePos = m_fc.position();
+            m_fc.position(SEGMENT_HEADER_BYTES);
+
+            DBBPool.BBContainer schemaHeader = null;
+            try {
+                schemaHeader = DBBPool.allocateDirect(EXPORT_SCHEMA_HEADER_BYTES);
+                schemaHeader.b().order(ByteOrder.LITTLE_ENDIAN);
+                while (schemaHeader.b().hasRemaining()) {
+                    int read = m_fc.read(schemaHeader.b());
+                    if (read == -1) {
+                        throw new EOFException();
+                    }
+                }
+                schemaHeader.b().flip();
+                byte exportVersion = schemaHeader.b().get();
+                long genId = schemaHeader.b().getLong();
+                int schemaSize = schemaHeader.b().getInt();
+                DBBPool.BBContainer schemaBuf = DBBPool.allocateDirect(EXPORT_SCHEMA_HEADER_BYTES + schemaSize);
+                schemaBuf.b().order(ByteOrder.LITTLE_ENDIAN);
+                schemaBuf.b().put(exportVersion);
+                schemaBuf.b().putLong(genId);
+                schemaBuf.b().putInt(schemaSize);
+                while (schemaBuf.b().hasRemaining()) {
+                    int read = m_fc.read(schemaBuf.b());
+                    if (read == -1) {
+                        throw new EOFException();
+                    }
+                }
+                schemaBuf.b().flip();
+                return schemaBuf;
+            } catch (Exception e) {
+                LOG.error(e);
+                return null;
+            } finally {
+                if (schemaHeader != null) {
+                    schemaHeader.discard();
+                }
                 m_readOffset = m_fc.position();
                 m_fc.position(writePos);
             }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -672,5 +672,15 @@ public class PBDRegularSegment extends PBDSegment {
         public void setReadOffset(long readOffset) {
             m_readOffset = readOffset;
         }
+
+        public void reopen(boolean forWrite, boolean emptyFile) throws IOException {
+            if (m_closed) {
+                open(forWrite, emptyFile);
+            }
+            if (m_cursorId != null) {
+                m_closedCursors.remove(m_cursorId);
+                m_readCursors.put(m_cursorId, this);
+            }
+        }
     }
 }

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -29,78 +29,10 @@ import java.util.List;
 
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DeferredSerialization;
+import org.voltdb.HybridCrc32;
 import org.voltdb.export.ExportSequenceNumberTracker;
 
 public abstract class PBDSegment {
-
-    /**
-     * Represents a reader for a segment. Multiple readers may be active
-     * at any point in time, reading from different locations in the segment.
-     */
-    public interface PBDSegmentReader {
-        /**
-         * Are there any more entries to read from this segment for this reader
-         *
-         * @return true if there are still more entries to be read. False otherwise.
-         * @throws IOException if the reader was closed or on any error trying to read from the segment file.
-         */
-        public boolean hasMoreEntries() throws IOException;
-
-        /**
-         * Have all the entries in this segment been read by this reader and
-         * acknowledged as ready for discarding.
-         *
-         * @return true if all entries have been read and discarded by this reader. False otherwise.
-         * @throws IOException if the reader was closed
-         */
-        public boolean allReadAndDiscarded() throws IOException;
-
-        /**
-         * Read the next entry from the segment for this reader.
-         * Returns null if all entries in this segment were already read by this reader.
-         *
-         * @param factory
-         * @return BBContainer with the bytes read
-         * @throws IOException
-         */
-        public DBBPool.BBContainer poll(BinaryDeque.OutputContainerFactory factory) throws IOException;
-
-        //Don't use size in bytes to determine empty, could potentially
-        //diverge from object count on crash or power failure
-        //although incredibly unlikely
-        /**
-         * Returns the number of bytes that are left to read in this segment
-         * for this reader.
-         */
-        public int uncompressedBytesToRead();
-
-        /**
-         * Returns the current read offset for this reader in this segment.
-         */
-        public long readOffset();
-
-        /**
-         * Entry that this reader will read next.
-         * @return
-         */
-        public int readIndex();
-
-        /**
-         * Rewinds the read offset for this reader by the specified number of bytes.
-         */
-        public void rewindReadOffset(int byBytes);
-
-        /**
-         * Close this reader and release any resources.
-         * <code>getReader</code> will still return this reader until the segment is closed.
-         */
-        public void close() throws IOException;
-
-        /**
-         * Has this reader been closed.
-         */
-        public boolean isClosed();
-    }
 
     private static final String TRUNCATOR_CURSOR = "__truncator__";
     private static final String SCANNER_CURSOR = "__scanner__";
@@ -109,13 +41,25 @@ public abstract class PBDSegment {
     static final int NO_FLAGS = 0;
     static final int FLAG_COMPRESSED = 1;
 
-    static final int COUNT_OFFSET = 0;
-    static final int SIZE_OFFSET = 4;
-
     // Has to be able to hold at least one object (compressed or not)
     public static final int CHUNK_SIZE = Integer.getInteger("PBDSEGMENT_CHUNK_SIZE", 1024 * 1024 * 64);
-    static final int OBJECT_HEADER_BYTES = 8;
-    static final int SEGMENT_HEADER_BYTES = 8; // number of entries (4 bytes), total bytes of data (4 bytes)
+    // Segment Header layout:
+    //  - crc of segment header (8 bytes),
+    //  - total number of entries (4 bytes),
+    //  - total bytes of data (4 bytes),
+    static final int SEGMENT_HEADER_BYTES = 16;
+    public static final int HEADER_CRC_OFFSET = 0;
+    public static final int HEADER_NUM_OF_ENTRY_OFFSET = 8;
+    public static final int HEADER_TOTAL_BYTES_OFFSET = 12;
+
+    public static final int EXPORT_SCHEMA_HEADER_BYTES = 1 /*export buffer version*/ + 8 /*generation id*/ + 4 /*schema size*/;
+    // Export Segment Entry Header layout (each segment has multiple entries):
+    //  - crc of segment entry (8 bytes),
+    //  - total bytes of the entry (4 bytes),
+    //  - entry flag (4 bytes)
+    // TODO: Does DR Segment Entry needs a header? PartitionDRGatewayImpl defines
+    //       DR_BLOCK_HEADER_SIZE but also says this header is unused.
+    public static final int ENTRY_HEADER_BYTES = 16;
     protected final File m_file;
 
     protected boolean m_closed = true;
@@ -123,10 +67,14 @@ public abstract class PBDSegment {
     protected FileChannel m_fc;
     //Avoid unnecessary sync with this flag
     protected boolean m_syncedSinceLastEdit = true;
+    protected HybridCrc32 m_segmentHeaderCRC;
+    protected HybridCrc32 m_entryCRC;
 
     public PBDSegment(File file)
     {
         m_file = file;
+        m_segmentHeaderCRC = new HybridCrc32();
+        m_entryCRC = new HybridCrc32();
     }
 
     abstract long segmentIndex();
@@ -135,7 +83,7 @@ public abstract class PBDSegment {
 
     abstract void reset();
 
-    abstract int getNumEntries() throws IOException;
+    abstract int getNumEntries(boolean crcCheck) throws IOException;
 
     abstract boolean isBeingPolled();
 
@@ -160,8 +108,6 @@ public abstract class PBDSegment {
 
     abstract void closeAndDelete() throws IOException;
 
-    abstract void closeAndTruncate() throws IOException;
-
     abstract boolean isClosed();
 
     abstract void close() throws IOException;
@@ -179,6 +125,8 @@ public abstract class PBDSegment {
 
     abstract protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry) throws IOException;
 
+    abstract void writeExtraHeader(DeferredSerialization ds) throws IOException;
+
     /**
      * Parse the segment and truncate the file if necessary.
      * @param truncator    A caller-supplied truncator that decides where in the segment to truncate
@@ -194,20 +142,33 @@ public abstract class PBDSegment {
         PBDSegmentReader reader = openForRead(TRUNCATOR_CURSOR);
 
         // Do stuff
-        final int initialEntryCount = getNumEntries();
+        final int initialEntryCount = getNumEntries(true);
         int entriesTruncated = 0;
+        // Zero entry count means the segment is empty or corrupted, in both cases
+        // the segment can be deleted.
+        if (initialEntryCount == 0) {
+            reader.close();
+            close();
+            return -1;
+        }
         int sizeInBytes = 0;
 
         DBBPool.BBContainer cont;
+        DBBPool.BBContainer schemaCont = null;
+        boolean isFinal = isFinal();
         while (true) {
             final long beforePos = reader.readOffset();
 
-            cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            if (reader.readIndex() == 0) {
+                schemaCont = reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, !isFinal);
+            }
+
+            cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, !isFinal());
             if (cont == null) {
                 break;
             }
 
-            final int compressedLength = (int) (reader.readOffset() - beforePos - OBJECT_HEADER_BYTES);
+            final int compressedLength = (int) (reader.readOffset() - beforePos - ENTRY_HEADER_BYTES);
             final int uncompressedLength = cont.b().limit();
 
             try {
@@ -227,33 +188,42 @@ public abstract class PBDSegment {
                             entriesTruncated = -1;
                         } else {
                             entriesTruncated = initialEntryCount - (reader.readIndex() - 1);
+
                             //Don't forget to update the number of entries in the file
                             initNumEntries(reader.readIndex() - 1, sizeInBytes);
-                            m_fc.truncate(reader.readOffset() - (compressedLength + OBJECT_HEADER_BYTES));
+                            m_fc.truncate(reader.readOffset() - (compressedLength + ENTRY_HEADER_BYTES));
                         }
                     } else {
                         assert retval.status == BinaryDeque.TruncatorResponse.Status.PARTIAL_TRUNCATE;
                         entriesTruncated = initialEntryCount - reader.readIndex();
                         //Partial object truncation
-                        reader.rewindReadOffset(compressedLength + OBJECT_HEADER_BYTES);
+                        reader.rewindReadOffset(compressedLength + ENTRY_HEADER_BYTES);
                         final long partialEntryBeginOffset = reader.readOffset();
                         m_fc.position(partialEntryBeginOffset);
 
                         final int written = writeTruncatedEntry(retval);
                         sizeInBytes += written;
-
                         initNumEntries(reader.readIndex(), sizeInBytes);
-                        m_fc.truncate(partialEntryBeginOffset + written + OBJECT_HEADER_BYTES);
+                        m_fc.truncate(partialEntryBeginOffset + written + ENTRY_HEADER_BYTES);
                     }
 
                     break;
                 }
             } finally {
                 cont.discard();
+                if (schemaCont != null) {
+                    schemaCont.discard();
+                    schemaCont = null;
+                }
             }
         }
-
+        int entriesScanned = reader.readIndex();
+        reader.close();
         close();
+        // If we checksum the file and it looks good, mark as final
+        if (!isFinal() && entriesScanned == initialEntryCount) {
+            setFinal(true);
+        }
 
         return entriesTruncated;
     }
@@ -268,13 +238,22 @@ public abstract class PBDSegment {
     ExportSequenceNumberTracker scan(BinaryDeque.BinaryDequeScanner scanner) throws IOException {
         if (!m_closed) throw new IOException(("Segment should not be open before truncation"));
 
-        openForWrite(false);
         PBDSegmentReader reader = openForRead(SCANNER_CURSOR);
         ExportSequenceNumberTracker tracker = new ExportSequenceNumberTracker();
 
-        DBBPool.BBContainer cont;
+        DBBPool.BBContainer cont = null;
+        DBBPool.BBContainer schemaCont = null;
+        int initialEntryCount = getNumEntries(true);
+        if (initialEntryCount == 0) {
+            reader.close();
+            return tracker;
+        }
         while (true) {
-            cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            // Start to read a new segment
+            if (reader.readIndex() == 0) {
+                schemaCont = reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            }
+            cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, true);
             if (cont == null) {
                 break;
             }
@@ -285,10 +264,20 @@ public abstract class PBDSegment {
 
             } finally {
                 cont.discard();
+                if (schemaCont != null) {
+                    schemaCont.discard();
+                    schemaCont = null;
+                }
             }
         }
-
+        int entriesScanned = reader.readIndex();
+        reader.close();
+        // Forcefully close the file
         close();
+        // Scan through entire file, everything looks good
+        if (!isFinal() && entriesScanned == initialEntryCount) {
+            setFinal(true);
+        }
 
         return tracker;
     }
@@ -313,9 +302,7 @@ public abstract class PBDSegment {
      *
      * @param isFinal   true if segment is set to final, false otherwise
      */
-
     public void setFinal(boolean isFinal) {
-
         setFinal(m_file, isFinal);
     }
 
@@ -338,7 +325,6 @@ public abstract class PBDSegment {
      * @return true if file is final, false otherwise
      */
     public boolean isFinal() {
-
         return isFinal(m_file);
     }
 

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -1,0 +1,96 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.utils;
+
+import java.io.IOException;
+
+import org.voltcore.utils.DBBPool;
+
+/**
+ * Represents a reader for a segment. Multiple readers may be active
+ * at any point in time, reading from different locations in the segment.
+ */
+public interface PBDSegmentReader {
+    /**
+     * Are there any more entries to read from this segment for this reader
+     *
+     * @return true if there are still more entries to be read. False otherwise.
+     * @throws IOException if the reader was closed or on any error trying to read from the segment file.
+     */
+    public boolean hasMoreEntries() throws IOException;
+
+    /**
+     * Have all the entries in this segment been read by this reader and
+     * acknowledged as ready for discarding.
+     *
+     * @return true if all entries have been read and discarded by this reader. False otherwise.
+     * @throws IOException if the reader was closed
+     */
+    public boolean allReadAndDiscarded() throws IOException;
+
+    /**
+     * Read the next entry from the segment for this reader.
+     * Returns null if all entries in this segment were already read by this reader.
+     *
+     * @param factory
+     * @param checkCRC
+     * @return BBContainer with the bytes read
+     * @throws IOException
+     */
+    public DBBPool.BBContainer poll(BinaryDeque.OutputContainerFactory factory,
+            boolean checkCRC) throws IOException;
+
+    public DBBPool.BBContainer getSchema(BinaryDeque.OutputContainerFactory factory,
+            boolean checkCRC) throws IOException;
+
+    //Don't use size in bytes to determine empty, could potentially
+    //diverge from object count on crash or power failure
+    //although incredibly unlikely
+    /**
+     * Returns the number of bytes that are left to read in this segment
+     * for this reader.
+     */
+    public int uncompressedBytesToRead();
+
+    /**
+     * Returns the current read offset for this reader in this segment.
+     */
+    public long readOffset();
+
+    /**
+     * Entry that this reader will read next.
+     * @return
+     */
+    public int readIndex();
+
+    /**
+     * Rewinds the read offset for this reader by the specified number of bytes.
+     */
+    public void rewindReadOffset(int byBytes);
+
+    /**
+     * Close this reader and release any resources.
+     * <code>getReader</code> will still return this reader until the segment is closed.
+     */
+    public void close() throws IOException;
+
+    /**
+     * Has this reader been closed.
+     */
+    public boolean isClosed();
+}

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -88,6 +88,11 @@ public interface PBDSegmentReader {
     public void setReadOffset(long readOffset);
 
     /**
+     * Reopen a previously closed reader. Re-opened reader still keeps the original read offset.
+     */
+    public void reopen(boolean forWrite, boolean emptyFile) throws IOException;
+
+    /**
      * Close this reader and release any resources.
      * <code>getReader</code> will still return this reader until the segment is closed.
      */

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -55,8 +55,7 @@ public interface PBDSegmentReader {
     public DBBPool.BBContainer poll(BinaryDeque.OutputContainerFactory factory,
             boolean checkCRC) throws IOException;
 
-    public DBBPool.BBContainer getSchema(BinaryDeque.OutputContainerFactory factory,
-            boolean checkCRC) throws IOException;
+    public DBBPool.BBContainer getSchema(boolean checkCRC) throws IOException;
 
     //Don't use size in bytes to determine empty, could potentially
     //diverge from object count on crash or power failure
@@ -82,6 +81,11 @@ public interface PBDSegmentReader {
      * Rewinds the read offset for this reader by the specified number of bytes.
      */
     public void rewindReadOffset(int byBytes);
+
+    /**
+     * Set the current read offset for this reader in this segment to given value
+     */
+    public void setReadOffset(long readOffset);
 
     /**
      * Close this reader and release any resources.

--- a/src/frontend/org/voltdb/utils/PBDUtils.java
+++ b/src/frontend/org/voltdb/utils/PBDUtils.java
@@ -20,26 +20,10 @@ package org.voltdb.utils;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
-
-import org.voltcore.utils.DeferredSerialization;
-import org.voltdb.HybridCrc32;
+import java.util.zip.CRC32;
 
 public class PBDUtils {
-    public static int writeDeferredSerialization(ByteBuffer mbuf, DeferredSerialization ds) throws IOException
-    {
-        int written = 0;
-        try {
-            mbuf.position(mbuf.position() + PBDSegment.ENTRY_HEADER_BYTES);
-            final int objStartPosition = mbuf.position();
-            ds.serialize(mbuf);
-            written = mbuf.position() - objStartPosition;
-        } finally {
-            ds.cancel();
-        }
-        return written;
-    }
 
     public static void writeBuffer(FileChannel fc, ByteBuffer buf, int startPos) throws IOException
     {
@@ -62,16 +46,14 @@ public class PBDUtils {
         buf.flip();
     }
 
-    public static void writeEntryHeader(HybridCrc32 crc, ByteBuffer headerBuf,
+    public static void writeEntryHeader(CRC32 crc, ByteBuffer headerBuf,
             ByteBuffer destBuf, int size, int flag) {
         crc.update(size);
         crc.update(flag);
         crc.update(destBuf);
-        headerBuf.order(ByteOrder.LITTLE_ENDIAN);
-        headerBuf.clear();
-        headerBuf.putLong(crc.getValue());
+        // the checksum here is really an unsigned int, store integer to save 4 bytes
+        headerBuf.putInt((int)crc.getValue());
         headerBuf.putInt(size);
         headerBuf.putInt(flag);
-        headerBuf.order(ByteOrder.BIG_ENDIAN);
     }
 }

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -295,7 +295,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         public boolean isStartOfSegment() throws IOException {
             synchronized(PersistentBinaryDeque.this) {
                 if (m_closed) {
-                    throw new IOException("Cannot call isReadFirstObjectOfSegment: PBD has been closed");
+                    throw new IOException("Cannot call isStartOfSegment: PBD has been closed");
                 }
                 assertions();
                 moveToValidSegment();

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -157,6 +157,8 @@ public class PersistentBinaryDeque implements BinaryDeque {
                     segmentReader = segment.getReader(m_cursorId);
                     if (segmentReader == null) {
                         segmentReader = segment.openForRead(m_cursorId);
+                    } else if (segmentReader.isClosed()) {
+                        segmentReader.reopen(false, false);
                     }
                     // need to restore the read offset
                     originalOffset = segmentReader.readOffset();

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -275,7 +275,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                                 // If the segment that cursor currently points to is going to be deleted,
                                 // looks for next segment.
                                 long lastSegmentId = peekLastSegment().segmentIndex();
-                                if (m_segment == segment) {
+                                if (m_segment.segmentIndex() == segment.segmentIndex()) {
                                     // Tail segment should always exists
                                     if (m_segment.segmentIndex() == lastSegmentId) {
                                         throw new IOException("Tail segment file " + m_segment.file().getName() + " shouldn't be deleted! ");
@@ -849,6 +849,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
     }
 
     private PBDSegment addSegment(PBDSegment tail, DeferredSerialization schemaDS) throws IOException {
+        boolean previousTailIsDeleted = false;
         //Check to see if the tail is completely consumed so we can close and delete it
         if (tail.hasAllFinishedReading() && canDeleteSegment(tail)) {
             pollLastSegment();
@@ -856,24 +857,28 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 m_usageSpecificLog.debug("Segment " + tail.file() + " has been closed and deleted because of empty queue");
             }
             closeAndDeleteSegment(tail);
+            previousTailIsDeleted = true;
         }
         Long nextIndex = tail.segmentIndex() + 1;
         long lastId = tail.segmentId();
 
         long curId = getNextSegmentId();
         String fname = getSegmentFileName(curId, lastId);
-        tail = newSegment(nextIndex, curId, new VoltFile(m_path, fname));
-        tail.openForWrite(true);
-        tail.setFinal(false);
+        PBDSegment newSegment = newSegment(nextIndex, curId, new VoltFile(m_path, fname));
+        newSegment.openForWrite(true);
+        newSegment.setFinal(false);
         if (schemaDS != null) {
-            tail.writeExtraHeader(schemaDS);
+            newSegment.writeExtraHeader(schemaDS);
         }
         if (m_usageSpecificLog.isDebugEnabled()) {
-            m_usageSpecificLog.debug("Segment " + tail.file()
-                + " (final: " + tail.isFinal() + "), has been created because of an offer");
+            m_usageSpecificLog.debug("Segment " + newSegment.file()
+                + " (final: " + newSegment.isFinal() + "), has been created because of an offer");
         }
-        closeTailAndOffer(tail);
-        return tail;
+        closeTailAndOffer(newSegment);
+        if (previousTailIsDeleted) {
+            advanceCursorTo(tail, newSegment);
+        }
+        return newSegment;
     }
 
     private void closeAndDeleteSegment(PBDSegment segment) throws IOException {
@@ -1058,6 +1063,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         return true;
+    }
+
+    private void advanceCursorTo(PBDSegment deletedSegment, PBDSegment newSegment) {
+        for (ReadCursor cursor : m_readCursors.values()) {
+            if (cursor.m_segment != null && cursor.m_segment.segmentIndex() == deletedSegment.segmentIndex()) {
+                cursor.m_segment = newSegment;
+            }
+        }
     }
 
     @Override

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -259,7 +259,7 @@ public class TestExportDataSource extends TestCase {
 
             assertEquals( 60, s.sizeInBytes());
 
-            AckingContainer cont = s.poll().get();
+            AckingContainer cont = s.poll(false).get();
             cont.updateStartTime(System.currentTimeMillis());
             //No change in size because the buffers are flattened to disk, until the whole
             //file is polled/acked it won't shrink
@@ -276,7 +276,7 @@ public class TestExportDataSource extends TestCase {
             cont.discard();
             cont = null;
             System.gc(); System.runFinalization(); Thread.sleep(200);
-            cont = s.poll().get();
+            cont = s.poll(false).get();
             cont.updateStartTime(System.currentTimeMillis());
 
             //Should lose 20 bytes for the stuff in memory
@@ -288,7 +288,7 @@ public class TestExportDataSource extends TestCase {
             cont.discard();
             cont = null;
             System.gc(); System.runFinalization(); Thread.sleep(200);
-            cont = s.poll().get();
+            cont = s.poll(false).get();
             cont.updateStartTime(System.currentTimeMillis());
 
             //No more buffers on disk, so the + 8 is gone, just the last one pulled in memory
@@ -299,7 +299,7 @@ public class TestExportDataSource extends TestCase {
             cont.discard();
             cont = null;
             System.gc(); System.runFinalization(); Thread.sleep(200);
-            ListenableFuture<AckingContainer> fut = s.poll();
+            ListenableFuture<AckingContainer> fut = s.poll(false);
             try {
                 cont = fut.get(100,TimeUnit.MILLISECONDS);
                 fail("did not get expected timeout");
@@ -344,7 +344,7 @@ public class TestExportDataSource extends TestCase {
             foo0.duplicate().put(new byte[buffSize]);
             s.pushExportBuffer(1, 1, 0, 0, foo0, false);
 
-            AckingContainer cont0 = s.poll().get();
+            AckingContainer cont0 = s.poll(false).get();
             cont0.updateStartTime(System.currentTimeMillis());
 
             cont0.discard();
@@ -352,11 +352,11 @@ public class TestExportDataSource extends TestCase {
             System.gc(); System.runFinalization(); Thread.sleep(200);
 
             // Poll once with no data left - EDS sould set m_pollFuture
-            ListenableFuture<AckingContainer> fut1 = s.poll();
+            ListenableFuture<AckingContainer> fut1 = s.poll(false);
             assertFalse(fut1.isDone());
 
             // Do a reentrant poll - the returned fut should have the expected exception
-            ListenableFuture<AckingContainer> fut2 = s.poll();
+            ListenableFuture<AckingContainer> fut2 = s.poll(false);
             try {
                 AckingContainer c = fut2.get();
                 fail("Did not get expected exception");
@@ -448,7 +448,7 @@ public class TestExportDataSource extends TestCase {
         //flattened size
         assertEquals( 60, s.sizeInBytes());
 
-        AckingContainer cont = s.poll().get();
+        AckingContainer cont = s.poll(false).get();
         cont.updateStartTime(System.currentTimeMillis());
         //No change in size because the buffers are flattened to disk, until the whole
         //file is polled/acked it won't shrink
@@ -472,7 +472,7 @@ public class TestExportDataSource extends TestCase {
                 );
 
         // Poll and discard buffer 2, too
-        cont = s.poll().get();
+        cont = s.poll(false).get();
         cont.updateStartTime(System.currentTimeMillis());
         cont.discard();
 
@@ -483,7 +483,7 @@ public class TestExportDataSource extends TestCase {
         // 20, no overhead because it was pulled back in
         assertEquals( 20, s.sizeInBytes());
 
-        cont = s.poll().get();
+        cont = s.poll(false).get();
         cont.updateStartTime(System.currentTimeMillis());
         assertEquals(s.sizeInBytes(), 20);
         assertEquals(3, cont.m_lastSeqNo);
@@ -556,7 +556,7 @@ public class TestExportDataSource extends TestCase {
             cdl.await();
 
             //Poll and check before and after discard segment files.
-            AckingContainer cont = s.poll().get();
+            AckingContainer cont = s.poll(false).get();
             cont.updateStartTime(System.currentTimeMillis());
             listing = getSortedDirectoryListingSegments();
             assertEquals(listing.size(), 1);

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -121,7 +121,7 @@ public class TestExportDataSource extends TestCase {
 
         @Override
         public void pushExportBuffer(int partitionId, String signature, long seqNo,
-                int tupleCount, long uniqueId, ByteBuffer buffer, boolean sync) {
+                int tupleCount, long uniqueId, long genId, ByteBuffer buffer, boolean sync) {
         }
 
         @Override
@@ -147,6 +147,7 @@ public class TestExportDataSource extends TestCase {
         m_mockVoltDB.addTable("RepTableName", false);
         m_mockVoltDB.addColumnToTable("RepTableName", "COL1", VoltType.INTEGER, false, null, VoltType.INTEGER);
         m_mockVoltDB.addColumnToTable("RepTableName", "COL2", VoltType.STRING, false, null, VoltType.STRING);
+        VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
         if (TEST_DIR.exists()) {
             for (File f : TEST_DIR.listFiles()) {
                 VoltFile.recursivelyDelete(f);
@@ -194,6 +195,7 @@ public class TestExportDataSource extends TestCase {
                     table.getTypeName(),
                     m_part,
                     CoreUtils.getSiteIdFromHSId(m_site),
+                    0,
                     table.getSignature(),
                     table.getColumns(),
                     table.getPartitioncolumn(),
@@ -211,12 +213,12 @@ public class TestExportDataSource extends TestCase {
 
     public void testPollV2() throws Exception{
         System.out.println("Running testPollV2");
-        VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
         Table table = m_mockVoltDB.getCatalogContext().database.getTables().get("TableName");
         ExportDataSource s = new ExportDataSource(null, m_processor, "database",
                 table.getTypeName(),
                 m_part,
                 CoreUtils.getSiteIdFromHSId(m_site),
+                0,
                 table.getSignature(),
                 table.getColumns(),
                 table.getPartitioncolumn(),
@@ -237,23 +239,23 @@ public class TestExportDataSource extends TestCase {
             int buffSize = 20 + StreamBlock.HEADER_SIZE;
             ByteBuffer foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(1, 1, 0L, foo, false);
+            s.pushExportBuffer(1, 1, 0, 0, foo, false);
             assertEquals(s.sizeInBytes(), 20 );
 
             //Push it twice more to check stats calc
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(2, 1, 0, foo, false);
+            s.pushExportBuffer(2, 1, 0, 0, foo, false);
             assertEquals(s.sizeInBytes(), 40);
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(3, 1, 0, foo, false);
+            s.pushExportBuffer(3, 1, 0, 0, foo, false);
 
             assertEquals(s.sizeInBytes(), 60);
 
             //Sync which flattens them all, but then pulls the first two back in memory
             //resulting in no change
-            s.pushExportBuffer(3, 1, 0, null, true);
+            s.pushExportBuffer(3, 1, 0, 0, null, true);
 
             assertEquals( 60, s.sizeInBytes());
 
@@ -310,12 +312,12 @@ public class TestExportDataSource extends TestCase {
 
     public void testDoublePoll() throws Exception{
         System.out.println("Running testDoublePoll");
-        VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
         Table table = m_mockVoltDB.getCatalogContext().database.getTables().get("TableName");
         ExportDataSource s = new ExportDataSource(null, m_processor, "database",
                 table.getTypeName(),
                 m_part,
                 CoreUtils.getSiteIdFromHSId(m_site),
+                0,
                 table.getSignature(),
                 table.getColumns(),
                 table.getPartitioncolumn(),
@@ -340,7 +342,7 @@ public class TestExportDataSource extends TestCase {
             // Push a first buffer - and read it back
             ByteBuffer foo0 = ByteBuffer.allocateDirect(buffSize);
             foo0.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(1, 1, 0L, foo0, false);
+            s.pushExportBuffer(1, 1, 0, 0, foo0, false);
 
             AckingContainer cont0 = s.poll().get();
             cont0.updateStartTime(System.currentTimeMillis());
@@ -371,7 +373,7 @@ public class TestExportDataSource extends TestCase {
             // Push a buffer - should satisfy fut1
             ByteBuffer foo1 = ByteBuffer.allocateDirect(buffSize);
             foo1.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(2, 1, 0L, foo1, false);
+            s.pushExportBuffer(2, 1, 0, 0, foo1, false);
 
             // Verify the pushed buffer can be got
             AckingContainer cont1 = fut1.get();
@@ -388,12 +390,12 @@ public class TestExportDataSource extends TestCase {
 
     public void testReplicatedPoll() throws Exception {
         System.out.println("Running testReplicatedPoll");
-        VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
         Table table = m_mockVoltDB.getCatalogContext().database.getTables().get("TableName");
         ExportDataSource s = new ExportDataSource(null, m_processor, "database",
                 table.getTypeName(),
                 m_part,
                 CoreUtils.getSiteIdFromHSId(m_site),
+                0,
                 table.getSignature(),
                 table.getColumns(),
                 table.getPartitioncolumn(),
@@ -426,22 +428,22 @@ public class TestExportDataSource extends TestCase {
         foo.duplicate().put(new byte[20]);
         // we are not purposely starting at 0, because on rejoin
         // we may start at non zero offsets
-        s.pushExportBuffer(1, 1, 0L, foo, false);
+        s.pushExportBuffer(1, 1, 0, 0, foo, false);
         assertEquals(s.sizeInBytes(), 20 );
 
         //Push it twice more to check stats calc
         foo = ByteBuffer.allocateDirect(20 + StreamBlock.HEADER_SIZE);
         foo.duplicate().put(new byte[20]);
-        s.pushExportBuffer(2, 1, 0, foo, false);
+        s.pushExportBuffer(2, 1, 0, 0, foo, false);
         assertEquals(s.sizeInBytes(), 40 );
         foo = ByteBuffer.allocateDirect(20 + StreamBlock.HEADER_SIZE);
         foo.duplicate().put(new byte[20]);
-        s.pushExportBuffer(3, 1, 0, foo, false);
+        s.pushExportBuffer(3, 1, 0, 0, foo, false);
 
         assertEquals(s.sizeInBytes(), 60);
 
         //Sync which flattens them all
-        s.pushExportBuffer(3, 1, 0, null, true);
+        s.pushExportBuffer(3, 1, 0, 0, null, true);
 
         //flattened size
         assertEquals( 60, s.sizeInBytes());
@@ -494,12 +496,12 @@ public class TestExportDataSource extends TestCase {
 
     public void testReleaseExportBytes() throws Exception {
         System.out.println("Running testReleaseExportBytes");
-        VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
         Table table = m_mockVoltDB.getCatalogContext().database.getTables().get("TableName");
         ExportDataSource s = new ExportDataSource(null, m_processor, "database",
                 table.getTypeName(),
                 m_part,
                 CoreUtils.getSiteIdFromHSId(m_site),
+                0,
                 table.getSignature(),
                 table.getColumns(),
                 table.getPartitioncolumn(),
@@ -513,7 +515,7 @@ public class TestExportDataSource extends TestCase {
             //Push and sync
             ByteBuffer foo = ByteBuffer.allocateDirect(200 + StreamBlock.HEADER_SIZE);
             foo.duplicate().put(new byte[200]);
-            s.pushExportBuffer(101, 1, 0L, foo, true);
+            s.pushExportBuffer(101, 1, 0, 0, foo, true);
             long sz = s.sizeInBytes();
             assertEquals(200, sz);
             listing = getSortedDirectoryListingSegments();
@@ -529,7 +531,7 @@ public class TestExportDataSource extends TestCase {
             //Push again and sync to test files.
             ByteBuffer foo2 = ByteBuffer.allocateDirect(900 + StreamBlock.HEADER_SIZE);
             foo2.duplicate().put(new byte[900]);
-            s.pushExportBuffer(111, 1, 0, foo2, true);
+            s.pushExportBuffer(111, 1, 0, 0, foo2, true);
             sz = s.sizeInBytes();
             assertEquals(900, sz);
             listing = getSortedDirectoryListingSegments();

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -54,6 +54,7 @@ import org.voltcore.utils.Pair;
 import org.voltcore.zk.ZKUtil;
 import org.voltdb.MockVoltDB;
 import org.voltdb.VoltDB;
+import org.voltdb.VoltType;
 import org.voltdb.VoltZK;
 import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Connector;
@@ -157,6 +158,9 @@ public class TestExportGeneration {
 
         m_mockVoltDB = new MockVoltDB();
         m_mockVoltDB.addSite(CoreUtils.getHSIdFromHostAndSite(m_host, m_site), m_part);
+        m_mockVoltDB.addTable("e1", false);
+        m_mockVoltDB.addColumnToTable("e1", "id", VoltType.INTEGER, true, "AA", VoltType.INTEGER);
+        m_mockVoltDB.addColumnToTable("e1", "f1", VoltType.STRING, true, "AA", VoltType.STRING);
 
         VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
 
@@ -224,6 +228,7 @@ public class TestExportGeneration {
                     seqNo,
                     1,
                     0L,
+                    System.currentTimeMillis(),
                     foo.duplicate(),
                     false
                     );
@@ -254,6 +259,7 @@ public class TestExportGeneration {
                 /*seqNo*/1L,
                 1,
                 0L,
+                System.currentTimeMillis(),
                 foo.duplicate(),
                 false
                 );

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -48,6 +48,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.voltcore.messaging.BinaryPayloadMessage;
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
@@ -173,6 +174,15 @@ public class TestExportGeneration {
         m_mbox = new LocalMailbox(m_mockVoltDB.getHostMessenger()) {
             @Override
             public void deliver(VoltMessage message) {
+                if (message instanceof BinaryPayloadMessage) {
+                    BinaryPayloadMessage bpm = (BinaryPayloadMessage)message;
+                    ByteBuffer buf = ByteBuffer.wrap(bpm.m_payload);
+                    final byte msgType = buf.get();
+                    // Skip non-related messages
+                    if (msgType != ExportManager.RELEASE_BUFFER) {
+                        return;
+                    }
+                }
                 assertThat( message, m_ackMatcherRef.get());
                 m_mbxNotifyCdlRef.get().countDown();
             }

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -242,7 +242,7 @@ public class TestExportGeneration {
                     foo.duplicate(),
                     false
                     );
-            AckingContainer cont = (AckingContainer)m_expDs.poll().get();
+            AckingContainer cont = (AckingContainer)m_expDs.poll(false).get();
             cont.updateStartTime(System.currentTimeMillis());
 
             m_ackMatcherRef.set(ackMbxMessageIs(m_part, m_tableSignature, seqNo));

--- a/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
+++ b/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
@@ -68,7 +68,8 @@ public class TestStreamBlockQueue extends TestCase {
 
     private static StreamBlock getStreamBlockWithFill(byte fillValue) {
         g_seqNo += 100;
-        return new StreamBlock(DBBPool.wrapBB(getFilledBuffer(fillValue)), null, g_seqNo, 1, 0L, false);
+        return new StreamBlock(DBBPool.wrapBB(getFilledBuffer(fillValue)),
+                null, g_seqNo, 1, 0L, -1, false);
     }
 
     @Before

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -1175,7 +1175,7 @@ public class TestPersistentBinaryDeque {
         BBContainer schema = null;
         try {
             if (reader.isStartOfSegment()) {
-                schema = reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                schema = reader.getSchema(-1, false, false);
                 assertNotNull(schema);
                 assertFalse(reader.isEmpty());
             }
@@ -1192,7 +1192,7 @@ public class TestPersistentBinaryDeque {
         BBContainer retval = null;
         try {
             if (reader.isStartOfSegment()) {
-                schema = reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                schema = reader.getSchema(-1, false, false);
                 assertNotNull(schema);
                 assertFalse(reader.isEmpty());
             }
@@ -1212,7 +1212,7 @@ public class TestPersistentBinaryDeque {
         BBContainer retval = null;
         try {
             if (reader.isStartOfSegment()) {
-                schema = reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                schema = reader.getSchema(-1, false, false);
                 assertNotNull(schema);
                 assertFalse(reader.isEmpty());
             }

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -46,7 +46,10 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
-import org.voltdb.utils.BinaryDeque.BinaryDequeReader;
+import org.voltdb.MockVoltDB;
+import org.voltdb.VoltDB;
+import org.voltdb.VoltType;
+import org.voltdb.export.ExportDataSource.StreamTableSchemaSerializer;
 import org.voltdb.utils.BinaryDeque.BinaryDequeTruncator;
 import org.voltdb.utils.BinaryDeque.TruncatorResponse;
 
@@ -68,6 +71,56 @@ public class TestPersistentBinaryDeque {
     }
 
     private PersistentBinaryDeque m_pbd;
+    private MockVoltDB m_mockVoltDB;
+    StreamTableSchemaSerializer m_ds;
+
+    @Before
+    public void setUp() throws Exception {
+        setupTestDir();
+        m_mockVoltDB = new MockVoltDB();
+        m_mockVoltDB.addTable("TableName", false);
+        m_mockVoltDB.addColumnToTable("TableName", "COL1", VoltType.INTEGER, false, null, VoltType.INTEGER);
+        m_mockVoltDB.addColumnToTable("TableName", "COL2", VoltType.STRING, false, null, VoltType.STRING);
+        VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
+        m_ds = new StreamTableSchemaSerializer(
+                VoltDB.instance().getCatalogContext(), "TableName");
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, m_ds, TEST_DIR, logger );
+    }
+
+    public static void setupTestDir() throws IOException {
+        if (TEST_DIR.exists()) {
+            for (File f : TEST_DIR.listFiles()) {
+                VoltFile.recursivelyDelete(f);
+            }
+            TEST_DIR.delete();
+        }
+        TEST_DIR.mkdir();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            m_mockVoltDB.shutdown(null);
+            m_pbd.close();
+        } catch (Exception e) {}
+        try {
+            tearDownTestDir();
+        } finally {
+            m_pbd = null;
+            m_ds = null;
+        }
+        System.gc();
+        System.runFinalization();
+    }
+
+    public static void tearDownTestDir() {
+        if (TEST_DIR.exists()) {
+            for (File f : TEST_DIR.listFiles()) {
+                f.delete();
+            }
+            TEST_DIR.delete();
+        }
+    }
 
     public static ByteBuffer getFilledBuffer(long fillValue) {
         ByteBuffer buf = ByteBuffer.allocateDirect(1024 * 1024 * 2);
@@ -212,7 +265,7 @@ public class TestPersistentBinaryDeque {
         listing = getSortedDirectoryListing(true);
         assertEquals(listing.size(), 4);
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, m_ds, TEST_DIR, logger );
 
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 5);
@@ -228,7 +281,7 @@ public class TestPersistentBinaryDeque {
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 1);
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
     }
 
     @Test
@@ -242,7 +295,7 @@ public class TestPersistentBinaryDeque {
         listing = getSortedDirectoryListing(true);
         assertEquals(listing.size(), 1);
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, m_ds, TEST_DIR, logger );
 
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 1);
@@ -262,7 +315,7 @@ public class TestPersistentBinaryDeque {
 
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         for (long ii = 0; ii < 96; ii++) {
-            BBContainer cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             try {
                 assertNotNull(cont);
                 assertEquals(cont.b().remaining(), 1024 * 1024 * 2);
@@ -284,15 +337,15 @@ public class TestPersistentBinaryDeque {
     public void testTruncatorWithFullTruncateReturn() throws Exception {
         System.out.println("Running testTruncatorWithFullTruncateReturn");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         for (int ii = 0; ii < 150; ii++) {
-            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)) );
+            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
         }
 
         m_pbd.close();
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, m_ds, TEST_DIR, logger );
 
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 5);
@@ -325,7 +378,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(listing.size(), 2);
 
         for (int ii = 46; ii < 96; ii++) {
-            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)) );
+            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
         }
 
         reader = m_pbd.openForRead(CURSOR_ID);
@@ -333,7 +386,8 @@ public class TestPersistentBinaryDeque {
         long reportedSizeInBytes = reader.sizeInBytes();
         long blocksFound = 0;
         BBContainer cont = null;
-        while ((cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY)) != null) {
+
+        while ((cont = pollOnceWithoutDiscard(reader)) != null) {
             try {
                 ByteBuffer buffer = cont.b();
                 if (blocksFound == 45) {
@@ -358,15 +412,15 @@ public class TestPersistentBinaryDeque {
     public void testTruncator() throws Exception {
         System.out.println("Running testTruncator");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         for (int ii = 0; ii < 160; ii++) {
-            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)) );
+            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
         }
 
         m_pbd.close();
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, m_ds, TEST_DIR, logger );
 
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 5);
@@ -398,14 +452,14 @@ public class TestPersistentBinaryDeque {
         assertEquals(listing.size(), 2);
 
         for (int ii = 46; ii < 96; ii++) {
-            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)) );
+            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
         }
 
         long actualSizeInBytes = 0;
         long reportedSizeInBytes = reader.sizeInBytes();
         long blocksFound = 0;
         BBContainer cont = null;
-        while ((cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY)) != null) {
+        while ((cont = pollOnceWithoutDiscard(reader)) != null) {
             try {
                 ByteBuffer buffer = cont.b();
                 if (blocksFound == 45) {
@@ -432,24 +486,21 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testReaderIsEmpty");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         assertTrue(reader.isEmpty());
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
         assertTrue(reader.isEmpty());
 
-        m_pbd.offer(defaultContainer());
+        m_pbd.offer(defaultContainer(), m_ds, true, false);
         assertFalse(reader.isEmpty());
-
-        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-        retval.discard();
+        pollOnce(reader);
         assertTrue(reader.isEmpty());
 
         // more than one segment
         for (int i = 0; i < 50; i++) {
-            m_pbd.offer(defaultContainer());
+            m_pbd.offer(defaultContainer(), m_ds, true, false);
         }
         assertFalse(reader.isEmpty());
         for (int i = 0; i < 50; i++) {
-            retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            retval.discard();
+            pollOnce(reader);
             if (i<49) {
                 assertFalse(reader.isEmpty());
             } else {
@@ -466,11 +517,11 @@ public class TestPersistentBinaryDeque {
         int count = 0;
         int totalAdded = 0;
         assertEquals(count, reader1.getNumObjects());
-        assertNull(reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
         assertEquals(count, reader1.getNumObjects());
 
         count++;
-        m_pbd.offer(defaultContainer());
+        m_pbd.offer(defaultContainer(), m_ds, true, false);
         totalAdded++;
         assertEquals(count, reader1.getNumObjects());
 
@@ -478,17 +529,17 @@ public class TestPersistentBinaryDeque {
         String cursor2 = "testPBD2";
         BinaryDequeReader reader2 = m_pbd.openForRead(cursor2);
 
-        pollDiscard(reader1);
+        pollOnce(reader1);
         assertEquals(count-1, reader1.getNumObjects());
         assertEquals(count, reader2.getNumObjects());
-        pollDiscard(reader2);
+        pollOnce(reader2);
         count--;
         assertEquals(count, reader1.getNumObjects());
         assertEquals(count, reader2.getNumObjects());
 
         // offer segments
         for (int i = 0; i < 50; i++) {
-            m_pbd.offer(defaultContainer());
+            m_pbd.offer(defaultContainer(), m_ds, true, false);
             totalAdded++;
             count++;
             assertEquals(count, reader1.getNumObjects());
@@ -496,10 +547,10 @@ public class TestPersistentBinaryDeque {
         }
 
         for (int i = 0; i < 50; i++) {
-            pollDiscard(reader1);
+            pollOnce(reader1);
             assertEquals(count-1, reader1.getNumObjects());
             assertEquals(count, reader2.getNumObjects());
-            pollDiscard(reader2);
+            pollOnce(reader2);
             count--;
             assertEquals(count, reader1.getNumObjects());
             assertEquals(count, reader2.getNumObjects());
@@ -514,7 +565,7 @@ public class TestPersistentBinaryDeque {
 
         // offer segments with all 3 readers
         for (int i = 0; i < 50; i++) {
-            m_pbd.offer(defaultContainer());
+            m_pbd.offer(defaultContainer(), m_ds, true, false);
             count++;
             assertEquals(count, reader1.getNumObjects());
             assertEquals(count, reader2.getNumObjects());
@@ -522,15 +573,15 @@ public class TestPersistentBinaryDeque {
         }
 
         for (int i = 0; i < 50; i++) {
-            pollDiscard(reader1);
+            pollOnce(reader1);
             assertEquals(count-1, reader1.getNumObjects());
             assertEquals(count, reader2.getNumObjects());
             assertEquals(count+toAddForLate, lateReader.getNumObjects());
-            pollDiscard(reader2);
+            pollOnce(reader2);
             assertEquals(count-1, reader1.getNumObjects());
             assertEquals(count-1, reader2.getNumObjects());
             assertEquals(count+toAddForLate, lateReader.getNumObjects());
-            pollDiscard(lateReader);
+            pollOnce(lateReader);
             count--;
             assertEquals(count, reader1.getNumObjects());
             assertEquals(count, reader2.getNumObjects());
@@ -539,7 +590,7 @@ public class TestPersistentBinaryDeque {
 
         assert(count==0);
         for (int i=0; i < toAddForLate; i++) {
-            pollDiscard(lateReader);
+            pollOnce(lateReader);
             assertEquals(toAddForLate-i-1, lateReader.getNumObjects());
         }
 
@@ -548,16 +599,11 @@ public class TestPersistentBinaryDeque {
         assertEquals(0, lateReader.getNumObjects());
     }
 
-    private void pollDiscard(BinaryDequeReader reader) throws IOException {
-        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-        retval.discard();
-    }
-
     @Test
     public void testOfferThenPoll() throws Exception {
         System.out.println("Running testOfferThenPoll");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         //Make sure a single file with the appropriate data is created
         m_pbd.offer(defaultContainer());
@@ -566,7 +612,7 @@ public class TestPersistentBinaryDeque {
         assertTrue("pbd_nonce_0000000001_0000000002.pbd".equals(files[0].getName()));
 
         //Now make sure the current write file is stolen and a new write file created
-        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         retval.discard();
     }
 
@@ -574,13 +620,13 @@ public class TestPersistentBinaryDeque {
     public void testCloseOldSegments() throws Exception {
         System.out.println("Running testCloseOldSegments");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         final int total = 100;
 
         //Make sure several files with the appropriate data is created
         for (int i = 0; i < total; i++) {
-            m_pbd.offer(defaultContainer());
+            m_pbd.offer(defaultContainer(), m_ds, true, false);
         }
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 3);
@@ -597,8 +643,7 @@ public class TestPersistentBinaryDeque {
 
         //Now make sure the current write file is stolen and a new write file created
         for (int i = 0; i < total; i++) {
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            retval.discard();
+            pollOnce(reader);
         }
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 1);
@@ -608,21 +653,21 @@ public class TestPersistentBinaryDeque {
     public void testDontCloseReadSegment() throws Exception {
         System.out.println("Running testDontCloseReadSegment");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         final int total = 100;
 
         //Make sure a single file with the appropriate data is created
         for (int i = 0; i < 5; i++) {
-            m_pbd.offer(defaultContainer());
+            m_pbd.offer(defaultContainer(), m_ds, true, false);
         }
         assertEquals(1, TEST_DIR.listFiles().length);
 
         // Read one buffer from the segment so that it's considered being polled from.
-        reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY).discard();
+        pollOnce(reader);
 
         for (int i = 5; i < total; i++) {
-            m_pbd.offer(defaultContainer());
+            m_pbd.offer(defaultContainer(), m_ds, true, false);
         }
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 3);
@@ -639,8 +684,7 @@ public class TestPersistentBinaryDeque {
 
         //Now make sure the current write file is stolen and a new write file created
         for (int i = 1; i < total; i++) {
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            retval.discard();
+            pollOnce(reader);
         }
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 1);
@@ -653,7 +697,7 @@ public class TestPersistentBinaryDeque {
         assertTrue(reader.isEmpty());
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(defaultContainer());
+            m_pbd.offer(defaultContainer(), m_ds, true, false);
             assertFalse(reader.isEmpty());
         }
         File files[] = TEST_DIR.listFiles();
@@ -666,7 +710,7 @@ public class TestPersistentBinaryDeque {
         pushContainers[0] = DBBPool.dummyWrapBB(buffer1);
         pushContainers[1] = DBBPool.dummyWrapBB(buffer2);
 
-        m_pbd.push(pushContainers);
+        m_pbd.push(pushContainers, m_ds);
 
         //Expect this to create a single new file
         List<File> listing = getSortedDirectoryListing();
@@ -683,28 +727,10 @@ public class TestPersistentBinaryDeque {
         assertEquals("pbd_nonce_0000000004_0000000003.pbd", f0.getName());
 
         //Poll the two at the front and check that the contents are what is expected
-        BBContainer retval1 = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-        try {
-            buffer1.clear();
-            System.err.println(Long.toHexString(buffer1.getLong(0)) + " " + Long.toHexString(retval1.b().getLong(0)));
-            assertEquals(retval1.b(), buffer1);
-
-            BBContainer retval2 = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            try {
-                buffer2.clear();
-                assertEquals(retval2.b(), buffer2);
-
-                //Expect the file for the two polled objects to still be there
-                //until the discard
-                listing = getSortedDirectoryListing();
-                assertEquals( 4, listing.size());
-            } finally {
-                retval2.discard();
-            }
-
-        } finally {
-            retval1.discard();
-        }
+        buffer1.clear();
+        pollOnceAndVerify(reader, buffer1);
+        buffer2.clear();
+        pollOnceAndVerify(reader, buffer2);
 
         listing = getSortedDirectoryListing();
         assertEquals( 3, listing.size());
@@ -720,9 +746,7 @@ public class TestPersistentBinaryDeque {
         //Now poll the rest and make sure the data is correct
         for (int ii = 0; ii < 96; ii++) {
             defaultBuffer.clear();
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            assertTrue(defaultBuffer.equals(retval.b()));
-            retval.discard();
+            pollOnceAndVerify(reader, defaultBuffer);
         }
 
         assertTrue(reader.isEmpty());
@@ -739,7 +763,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseThenReopen");
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(defaultContainer());
+            m_pbd.offer(defaultContainer(), m_ds, true, false);
         }
         File files[] = TEST_DIR.listFiles();
         assertEquals( 3, files.length);
@@ -747,16 +771,14 @@ public class TestPersistentBinaryDeque {
         m_pbd.sync();
         m_pbd.close();
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, m_ds, TEST_DIR, logger );
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
 
         ByteBuffer defaultBuffer = defaultBuffer();
         //Now poll all of it and make sure the data is correct
         for (int ii = 0; ii < 96; ii++) {
             defaultBuffer.clear();
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            assertTrue(defaultBuffer.equals(retval.b()));
-            retval.discard();
+            pollOnceAndVerify(reader, defaultBuffer);
         }
 
         //Expect just the current write segment
@@ -769,7 +791,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testInvalidDirectory");
         m_pbd.close();
         try {
-            m_pbd = new PersistentBinaryDeque( "foo", new File("/usr/bin"), logger);
+            m_pbd = new PersistentBinaryDeque( "foo", m_ds, new File("/usr/bin"), logger);
         } catch (IOException e) {
             return;
         }
@@ -795,7 +817,7 @@ public class TestPersistentBinaryDeque {
         assertTrue(toDelete.exists());
         assertTrue(toDelete.delete());
         try {
-            m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+            m_pbd = new PersistentBinaryDeque( TEST_NONCE, m_ds, TEST_DIR, logger );
         } catch (IOException e) {
             return;
         }
@@ -823,7 +845,7 @@ public class TestPersistentBinaryDeque {
         m_pbd.close();
         BBContainer objs[] = new BBContainer[] { DBBPool.wrapBB(ByteBuffer.allocate(20)) };
         try {
-            m_pbd.push(objs);
+            m_pbd.push(objs, m_ds);
         } catch (IOException e) {
             return;
         } finally {
@@ -838,7 +860,8 @@ public class TestPersistentBinaryDeque {
         m_pbd.push(new BBContainer[] {
                 DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)) ,
                 DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)) ,
-                DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)) });
+                DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)) },
+                m_ds);
     }
 
     @Test
@@ -847,7 +870,7 @@ public class TestPersistentBinaryDeque {
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         m_pbd.close();
         try {
-            reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         } catch (IOException e) {
             return;
         }
@@ -885,7 +908,7 @@ public class TestPersistentBinaryDeque {
         BBContainer objs[] = new BBContainer[] {
                 DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 64)) };
         try {
-            m_pbd.push(objs);
+            m_pbd.push(objs, m_ds);
         } catch (IOException e) {
             return;
         } finally {
@@ -912,33 +935,29 @@ public class TestPersistentBinaryDeque {
     public void testOverlappingNonces() throws Exception {
         System.out.println("Running testOverlappingNonces");
         for (int i = 0; i < 20; i++) {
-            PersistentBinaryDeque pbd = new PersistentBinaryDeque(Integer.toString(i), TEST_DIR, logger);
+            PersistentBinaryDeque pbd = new PersistentBinaryDeque(
+                    Integer.toString(i), m_ds, TEST_DIR, logger);
             pbd.offer(defaultContainer());
             pbd.close();
         }
 
-        PersistentBinaryDeque pbd = new PersistentBinaryDeque("1", TEST_DIR, logger);
+        PersistentBinaryDeque pbd = new PersistentBinaryDeque("1", m_ds, TEST_DIR, logger);
         pbd.close();
     }
 
     @Test
     public void testNonceWithDots() throws Exception {
         System.out.println("Running testNonceWithDots");
-        PersistentBinaryDeque pbd = new PersistentBinaryDeque("ha.ha", TEST_DIR, logger);
-        pbd.offer(defaultContainer());
+        PersistentBinaryDeque pbd = new PersistentBinaryDeque("ha.ha", m_ds, TEST_DIR, logger);
+        pbd.offer(defaultContainer(), m_ds, true, false);
         pbd.close();
 
-        pbd = new PersistentBinaryDeque("ha.ha", TEST_DIR, logger);
+        pbd = new PersistentBinaryDeque("ha.ha", null, TEST_DIR, logger);
         BinaryDequeReader reader = pbd.openForRead(CURSOR_ID);
-        BBContainer bb = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-        try {
-            ByteBuffer defaultBuffer = defaultBuffer();
-            defaultBuffer.clear();
-            assertEquals(defaultBuffer, bb.b());
-            pbd.close();
-        } finally {
-            bb.discard();
-        }
+        ByteBuffer defaultBuffer = defaultBuffer();
+        defaultBuffer.clear();
+        pollOnceAndVerify(reader, defaultBuffer);
+        pbd.close();
     }
 
     @Test
@@ -946,7 +965,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseThenReopen");
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
         }
         File files[] = TEST_DIR.listFiles();
         assertEquals(3, files.length);
@@ -954,13 +973,13 @@ public class TestPersistentBinaryDeque {
         m_pbd.sync();
         m_pbd.close();
 
-        m_pbd = new PersistentBinaryDeque(TEST_NONCE, TEST_DIR, logger);
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
 
         for (int ii = 96; ii < 192; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
         }
         m_pbd.sync();
         cnt = reader.getNumObjects();
@@ -969,12 +988,7 @@ public class TestPersistentBinaryDeque {
         //Now poll all of it and make sure the data is correct
         for (int ii = 0; ii < 192; ii++) {
             ByteBuffer defaultBuffer = getFilledBuffer(ii);
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            try {
-                assertTrue(defaultBuffer.equals(retval.b()));
-            } finally {
-                retval.discard();
-            }
+            pollOnceAndVerify(reader, defaultBuffer);
             defaultBuffer.clear();
         }
 
@@ -988,10 +1002,10 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseReopenOfferSmall");
         final String SMALL_TEST_NONCE = "asmall_pbd_nonce";
 
-        PersistentBinaryDeque small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, TEST_DIR, logger);
+        PersistentBinaryDeque small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, m_ds, TEST_DIR, logger);
         //Keep in 1 segment.
         for (int ii = 0; ii < 10; ii++) {
-            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)));
+            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)), m_ds, true, false);
         }
         File files[] = TEST_DIR.listFiles();
         //We have the default pbd and new one.
@@ -1002,13 +1016,13 @@ public class TestPersistentBinaryDeque {
         System.gc();
         System.runFinalization();
 
-        small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, TEST_DIR, logger);
+        small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, m_ds, TEST_DIR, logger);
         BinaryDequeReader reader = small_pbd.openForRead(CURSOR_ID);
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 10);
 
         for (int ii = 10; ii < 20; ii++) {
-            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)));
+            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)), m_ds, true, false);
         }
         small_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1022,17 +1036,12 @@ public class TestPersistentBinaryDeque {
         files = TEST_DIR.listFiles();
         assertEquals(3, files.length);
 
-        small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, TEST_DIR, logger);
+        small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, m_ds, TEST_DIR, logger);
         reader = small_pbd.openForRead(CURSOR_ID);
         //Now poll all of it and make sure the data is correct dont poll everything out.
         for (int ii = 0; ii < 10; ii++) {
             ByteBuffer defaultBuffer = getFilledSmallBuffer(ii);
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            try {
-                assertTrue(defaultBuffer.equals(retval.b()));
-            } finally {
-                retval.discard();
-            }
+            pollOnceAndVerify(reader, defaultBuffer);
             defaultBuffer.clear();
         }
         small_pbd.sync();
@@ -1047,7 +1056,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseHoleReopenOffer");
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
         }
         File files[] = TEST_DIR.listFiles();
         assertEquals(3, files.length);
@@ -1056,12 +1065,12 @@ public class TestPersistentBinaryDeque {
         m_pbd = null;
         System.gc();
         System.runFinalization();
-        m_pbd = new PersistentBinaryDeque(TEST_NONCE, TEST_DIR, logger);
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
         for (int ii = 96; ii < 192; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
         }
         m_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1070,9 +1079,7 @@ public class TestPersistentBinaryDeque {
         //Now poll half of it and make sure the data is correct
         for (int ii = 0; ii < 96; ii++) {
             ByteBuffer defaultBuffer = getFilledBuffer(ii);
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            assertTrue(defaultBuffer.equals(retval.b()));
-            retval.discard();
+            pollOnceAndVerify(reader, defaultBuffer);
             defaultBuffer.clear();
         }
         m_pbd.sync();
@@ -1084,9 +1091,8 @@ public class TestPersistentBinaryDeque {
         //Expect just the current write segment
         List<File> listing = getSortedDirectoryListing(true);
         assertEquals(3, listing.size());
-
         //Reload
-        m_pbd = new PersistentBinaryDeque(TEST_NONCE, TEST_DIR, logger);
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
         reader = m_pbd.openForRead(CURSOR_ID);
         cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
@@ -1095,7 +1101,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(4, listing.size());
 
         for (int ii = 96; ii < 192; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
         }
         m_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1103,9 +1109,7 @@ public class TestPersistentBinaryDeque {
         //Now poll half of it and make sure the data is correct
         for (int ii = 96; ii < 192; ii++) {
             ByteBuffer defaultBuffer = getFilledBuffer(ii);
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            assertTrue(defaultBuffer.equals(retval.b()));
-            retval.discard();
+            pollOnceAndVerify(reader, defaultBuffer);
             defaultBuffer.clear();
         }
         //Expect just the current write segment
@@ -1115,9 +1119,7 @@ public class TestPersistentBinaryDeque {
         //Poll and leave one behind.
         for (int ii = 96; ii < 191; ii++) {
             ByteBuffer defaultBuffer = getFilledBuffer(ii);
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-            assertTrue(defaultBuffer.equals(retval.b()));
-            retval.discard();
+            pollOnceAndVerify(reader, defaultBuffer);
             defaultBuffer.clear();
         }
         //Expect just the current write segment
@@ -1129,12 +1131,11 @@ public class TestPersistentBinaryDeque {
             DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)),
             DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)),
             DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32))};
-        m_pbd.push(objs);
+        m_pbd.push(objs, m_ds);
         listing = getSortedDirectoryListing();
         assertEquals(4, listing.size());
 
-        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-        retval.discard();
+        pollOnce(reader);
         listing = getSortedDirectoryListing();
         assertEquals(3, listing.size());
     }
@@ -1143,26 +1144,26 @@ public class TestPersistentBinaryDeque {
     public void testDeleteOnNonEmptyNextSegment() throws Exception {
         System.out.println("Running testDeleteOnNonEmptyNextSegment");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         final int total = 47;      // Number of buffers it takes to fill a segment
 
         //Make sure a single file with the appropriate data is created
         for (int i = 0; i < total; i++) {
-            m_pbd.offer(defaultContainer());
+            m_pbd.offer(defaultContainer(), m_ds, true, false);
         }
         assertEquals(1, TEST_DIR.listFiles().length);
 
         // Read all the buffers from the segment (isEmpty() returns true)
         for (int i = 0; i < total; i++) {
-            reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY).discard();
+            pollOnce(reader);
         }
 
         assert(reader.isEmpty());
         File files[] = TEST_DIR.listFiles();
         assertEquals(1, files.length);
         assertEquals("pbd_nonce_0000000001_0000000002.pbd", files[0].getName());
-        m_pbd.offer(defaultContainer());
+        m_pbd.offer(defaultContainer(), m_ds, true, false);
 
         files = TEST_DIR.listFiles();
         // Make sure a new segment was created and the old segment was deleted
@@ -1170,43 +1171,60 @@ public class TestPersistentBinaryDeque {
         assertEquals("pbd_nonce_0000000003_0000000001.pbd", files[0].getName());
     }
 
-    @Before
-    public void setUp() throws Exception {
-        setupTestDir();
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
-    }
-
-    public static void setupTestDir() throws IOException {
-        if (TEST_DIR.exists()) {
-            for (File f : TEST_DIR.listFiles()) {
-                VoltFile.recursivelyDelete(f);
+    private BBContainer pollOnceWithoutDiscard(BinaryDequeReader reader) throws IOException {
+        BBContainer schema = null;
+        try {
+            if (reader.isStartOfSegment()) {
+                schema = reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                assertNotNull(schema);
+                assertFalse(reader.isEmpty());
             }
-            TEST_DIR.delete();
-        }
-        TEST_DIR.mkdir();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        try {
-            m_pbd.close();
-        } catch (Exception e) {}
-        try {
-            tearDownTestDir();
+            return reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         } finally {
-            m_pbd = null;
-        }
-        System.gc();
-        System.runFinalization();
-    }
-
-    public static void tearDownTestDir() {
-        if (TEST_DIR.exists()) {
-            for (File f : TEST_DIR.listFiles()) {
-                f.delete();
+            if (schema != null) {
+                schema.discard();
             }
-            TEST_DIR.delete();
         }
     }
 
+    private void pollOnce(BinaryDequeReader reader) throws IOException {
+        BBContainer schema = null;
+        BBContainer retval = null;
+        try {
+            if (reader.isStartOfSegment()) {
+                schema = reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                assertNotNull(schema);
+                assertFalse(reader.isEmpty());
+            }
+            retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+        } finally {
+            if (retval != null) {
+                retval.discard();
+            }
+            if (schema != null) {
+                schema.discard();
+            }
+        }
+    }
+
+    private void pollOnceAndVerify(BinaryDequeReader reader, ByteBuffer destBuf) throws IOException {
+        BBContainer schema = null;
+        BBContainer retval = null;
+        try {
+            if (reader.isStartOfSegment()) {
+                schema = reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                assertNotNull(schema);
+                assertFalse(reader.isEmpty());
+            }
+            retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            assertEquals(destBuf, retval.b());
+        } finally {
+            if (retval != null) {
+                retval.discard();
+            }
+            if (schema != null) {
+                schema.discard();
+            }
+        }
+    }
 }

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -606,14 +606,13 @@ public class TestPersistentBinaryDeque {
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         //Make sure a single file with the appropriate data is created
-        m_pbd.offer(defaultContainer());
+        m_pbd.offer(defaultContainer(), m_ds, true, false);
         File files[] = TEST_DIR.listFiles();
         assertEquals( 1, files.length);
         assertTrue("pbd_nonce_0000000001_0000000002.pbd".equals(files[0].getName()));
 
         //Now make sure the current write file is stolen and a new write file created
-        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
-        retval.discard();
+        pollOnce(reader);
     }
 
     @Test

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -64,9 +64,9 @@
         <level value="INFO"/>
     </logger -->
 
-    <!-- logger name="EXPORT">
-        <level value="INFO"/>
-    </logger -->
+    <logger name="EXPORT">
+        <level value="DEBUG"/>
+    </logger>
 
     <!-- logger name="IMPORT">
         <level value="INFO"/>

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -64,9 +64,9 @@
         <level value="INFO"/>
     </logger -->
 
-    <logger name="EXPORT">
-        <level value="DEBUG"/>
-    </logger>
+    <!-- logger name="EXPORT">
+        <level value="INFO"/>
+    </logger -->
 
     <!-- logger name="IMPORT">
         <level value="INFO"/>


### PR DESCRIPTION
This pull request contains two main changes.
1) move the export schema from per-entry to per-segment, the first entry of segment contains schema. Catalog update involves export streams will cause export to close current segment and start a new segment with new schema. Export client will update the decoder when new schema is detected.
2) add CRC field to segment header and entry header, check the CRC of PBD files when cluster is recovered or restored, truncate the file to last safe point if file corruption is detected.

New PBD segment layout:

> Segment Header (Each PBD file is a segment)
> --
> segment header CRC (4 bytes)
> total number of entries (4 bytes)
> total size in bytes (4 bytes)
>
> Export Segment Header
> --
>  export version (1 byte)
>  generation ID (8 bytes)
>  length of schema ( 4 bytes)
>  schema (variable length)
>
> Entry Header (Each segment contains one or more entries)
> --
> entry CRC (4 bytes)
> length of entry (4 bytes)
> flags ( COMPRESSED or NONE, 4 bytes)
>
> Export Entry Header
> --
> export sequence number (8 bytes)
> row count (4 bytes)
> unique ID (8 bytes)
>
> Per Row Data (for EXPORT)
> --
> // each row repeats
> { 
>     row length (4 bytes)
>     partition column index (4 bytes)
>     column count (4 bytes)
>     null array length (4 bytes)
>     null array (variable length)
>     export meta column (txnId + timestamp + seqNo + partitionId + siteId + exportOperation)
>     row data (variable length)
> }