### PR TITLE
ENG-15084:

### DIFF
--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -112,6 +112,10 @@ public:
     size_t computeSchemaSize(const std::string &tableName, const std::vector<std::string> &columnNames);
     void writeSchema(ExportSerializeOutput &hdr, const TableTuple &tuple);
 
+    inline void resetFlushLinkages() {
+        m_nextFlushStream = NULL;
+        m_prevFlushStream = NULL;
+    }
     void appendToList(ExportTupleStream** oldest, ExportTupleStream** newest);
     void stitchToNextNode(ExportTupleStream* next);
     void removeFromFlushList(VoltDBEngine* engine, bool moveToTail);

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -184,7 +184,7 @@ public:
     bool checkTargetFlushTime(int64_t target) {
         if (!m_engine->streamsToFlush() || !m_wrapper->testFlushPending()) return -1;
         int64_t expectedUniqueId = UniqueId::makeIdFromComponents(target + VOLT_EPOCH_IN_MILLIS, 0, 0);
-        return m_wrapper->testFlushBuffCreateTime() == UniqueId::ts(expectedUniqueId);
+        return m_wrapper->testFlushBuffCreateTime() == UniqueId::tsInMillis(expectedUniqueId);
     }
 
     bool testNoStreamsToFlush() {


### PR DESCRIPTION
Fix corner case of list processing where tick went through the whole flush list but some streams were not flushable because they were in the middle of an MP Txn.