### PR TITLE
 ENG-15435: Provide a clear error message when role is changed to xdcr

### DIFF
--- a/src/frontend/org/voltdb/Inits.java
+++ b/src/frontend/org/voltdb/Inits.java
@@ -783,12 +783,12 @@ public class Inits {
                 m_rvdb.m_globalServiceElector.registerService(m_rvdb.m_restoreAgent);
                 // Generate plans and get (hostID, catalogPath) pair
                 Pair<Integer,String> catalog = m_rvdb.m_restoreAgent.findRestoreCatalog();
-                if (catalog != null) {
-                    m_statusTracker.set(NodeState.RECOVERING);
-                }
+
                 // if the restore agent found a catalog, set the following info
                 // so the right node can send it out to the others.
                 if (catalog != null) {
+                    m_statusTracker.set(NodeState.RECOVERING);
+
                     // Make sure the catalog corresponds to the current server version.
                     // Prevent automatic upgrades by rejecting mismatched versions.
                     int hostId = catalog.getFirst().intValue();

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -1179,8 +1179,9 @@ public abstract class CatalogUtil {
 
             boolean foundAdminUser = false;
             for (UsersType.User user : deployment.getUsers().getUser()) {
-                if (user.getRoles() == null)
+                if (user.getRoles() == null) {
                     continue;
+                }
 
                 for (String role : extractUserRoles(user)) {
                     if (role.equalsIgnoreCase(ADMIN)) {
@@ -1792,7 +1793,9 @@ public abstract class CatalogUtil {
         for (ImportConfigurationType importConfiguration : importType.getConfiguration()) {
 
             boolean connectorEnabled = importConfiguration.isEnabled();
-            if (!connectorEnabled) continue;
+            if (!connectorEnabled) {
+                continue;
+            }
 
             if (importConfiguration.getType().equals(ServerImportEnum.KAFKA)) {
                 kafkaConfigs.add(importConfiguration);
@@ -1877,7 +1880,9 @@ public abstract class CatalogUtil {
         for (ImportConfigurationType importConfiguration : importType.getConfiguration()) {
 
             boolean connectorEnabled = importConfiguration.isEnabled();
-            if (!connectorEnabled) continue;
+            if (!connectorEnabled) {
+                continue;
+            }
 
             ImportConfiguration processorProperties = buildImportProcessorConfiguration(importConfiguration, false);
 
@@ -2288,12 +2293,16 @@ public abstract class CatalogUtil {
      */
     private static Set<String> extractUserRoles(final UsersType.User user) {
         Set<String> roles = new TreeSet<>();
-        if (user == null) return roles;
+        if (user == null) {
+            return roles;
+        }
 
         if (user.getRoles() != null && !user.getRoles().trim().isEmpty()) {
             String [] rolelist = user.getRoles().trim().split(",");
             for (String role: rolelist) {
-                if( role == null || role.trim().isEmpty()) continue;
+                if( role == null || role.trim().isEmpty()) {
+                    continue;
+                }
                 roles.add(role.trim().toLowerCase());
             }
         }
@@ -2336,13 +2345,11 @@ public abstract class CatalogUtil {
                 clusterId = clusterType.getId();
             } else if (clusterType.getId() == null && dr.getId() == null) {
                 clusterId = 0;
+            } else if (clusterType.getId().equals(dr.getId())) {
+                clusterId = clusterType.getId();
             } else {
-                if (clusterType.getId().equals(dr.getId())) {
-                    clusterId = clusterType.getId();
-                } else {
-                    throw new RuntimeException("Detected two conflicting cluster ids in deployment file, setting cluster id in DR tag is "
-                            + "deprecated, please remove");
-                }
+                throw new RuntimeException("Detected two conflicting cluster ids in deployment file, "
+                        + "setting cluster id in DR tag is deprecated, please remove");
             }
             cluster.setDrflushinterval(dr.getFlushInterval());
             if (drConnection != null) {
@@ -2366,12 +2373,10 @@ public abstract class CatalogUtil {
                     }
                 }
                 hostLog.info("Configured connection for DR replica role to host " + drSource + drConsumerSSLInfo);
-            } else {
-                if (dr.getRole() == DrRoleType.XDCR) {
-                    // consumer should be enabled even without connection source for XDCR
-                    cluster.setDrconsumerenabled(true);
-                    cluster.setPreferredsource(-1); // reset to -1, if this is an update catalog
-                }
+            } else if (dr.getRole() == DrRoleType.XDCR) {
+                // consumer should be enabled even without connection source for XDCR
+                cluster.setDrconsumerenabled(true);
+                cluster.setPreferredsource(-1); // reset to -1, if this is an update catalog
             }
         } else {
             cluster.setDrrole(DrRoleType.NONE.value());
@@ -2876,8 +2881,9 @@ public abstract class CatalogUtil {
      * by a LIMIT PARTITION ROWS constraint, or NULL if there isn't one. */
     public static String getLimitPartitionRowsDeleteStmt(Table table) {
         CatalogMap<Statement> map = table.getTuplelimitdeletestmt();
-        if (map.isEmpty())
+        if (map.isEmpty()) {
             return null;
+        }
 
         assert (map.size() == 1);
         return map.iterator().next().getSqltext();


### PR DESCRIPTION
If the DR role of a cluster was ever updated to xdcr the error message which
was printed reported errors because export was misconfigured for DR. This error
message is confusing especially because export is reporting invalid dr changes.
Create a check in the dr validation method that checks if the role is xdcr the
cluster was correctly initialized for xdcr. Remove DR specific checks from
export configuration validation.