### PR TITLE
ENG-15193:

### DIFF
--- a/src/catgen/spec.txt
+++ b/src/catgen/spec.txt
@@ -18,7 +18,6 @@ begin Cluster                      "A set of connected hosts running one or more
   string drConsumerSslPropertyFile "Path to DR consumer property file containing path to trust store and the trust store password"
   int drFlushInterval              "Time interval in milliseconds between flushing partially filled DR buffers"
   int preferredSource              "The cluster id from which this joining cluster should request snapshot"
-  string schemaCheckMode           "Whether remote db schema compatibility check should be strict or flexible"
 end
 
 begin Deployment javaonly         "Run-time deployment settings"

--- a/src/ee/storage/DRTableNotFoundException.cpp
+++ b/src/ee/storage/DRTableNotFoundException.cpp
@@ -26,8 +26,9 @@ DRTableNotFoundException::DRTableNotFoundException(int64_t hash, std::string mes
 { }
 
 void DRTableNotFoundException::p_serialize(ReferenceSerializeOutput *output) const {
-    SerializableEEException::p_serialize(output);
     output->writeLong(m_hash);
+    // This is a placeholder for remote cluster's txn unique id that gets added in the java layer.
+    output->writeLong(-1);
 }
 
 const std::string

--- a/src/frontend/org/voltdb/ClientResponseImpl.java
+++ b/src/frontend/org/voltdb/ClientResponseImpl.java
@@ -120,17 +120,21 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
     }
 
     private void setResults(byte status, VoltTable[] results, String statusString) {
+        setResultTables(results);
+
+        this.status = status;
+        this.statusString = statusString;
+        this.setProperly = true;
+    }
+
+    public void setResultTables(VoltTable[] results) {
         assert results != null;
         for (VoltTable result : results) {
             // null values are not permitted in results. If there is one, it will cause an
             // exception in writeExternal. This throws the exception sooner.
             assert result != null;
         }
-
-        this.status = status;
         this.results = results;
-        this.statusString = statusString;
-        this.setProperly = true;
     }
 
     public void setHashes(int[] hashes) {

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -391,7 +391,6 @@ public class ProcedureRunner {
                     log.trace("invoked");
                 }
                 catch (InvocationTargetException itex) {
-                    //itex.printStackTrace();
                     Throwable ex = itex.getCause();
                     if (CoreUtils.isStoredProcThrowableFatalToServer(ex)) {
                         // If the stored procedure attempted to do something other than linklibraray or instantiate
@@ -1330,6 +1329,8 @@ public class ProcedureRunner {
                 "VOLTDB ERROR: " + msg);
        if (status == ClientResponse.TXN_MISPARTITIONED) {
            response.setMispartitionedResult(TheHashinator.getCurrentVersionedConfig());
+       } else if (status == ClientResponse.DR_TABLE_HASH_NOT_FOUND) {
+           ((DRTableNotFoundException) e).setClientResponseResults(response);
        }
 
        return response;

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -249,7 +249,7 @@ public interface SiteProcedureConnection {
 
     public long applyBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, byte logData[]);
 
-    public long applyMpBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, byte logsData[]);
+    public long applyMpBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, long remoteTxnUniqueId, byte logsData[]);
     public void setDRProtocolVersion(int drVersion);
     /*
      * Starting in DR version 7.0, we also generate a special event indicating the beginning of

--- a/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
+++ b/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
@@ -460,15 +460,7 @@
         </xs:simpleType>
     </xs:attribute>
     <xs:attribute name="role" type="drRoleType" default="master" />
-    <xs:attribute name="schema" type="drSchemaCheckType" default="strict" />
   </xs:complexType>
-
-  <xs:simpleType name="drSchemaCheckType">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="strict"/>
-      <xs:enumeration value="flexible"/>
-    </xs:restriction>
-  </xs:simpleType>
 
   <!-- DR cluster role -->
   <xs:simpleType name="drRoleType">

--- a/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
+++ b/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
@@ -49,7 +49,6 @@ import org.voltdb.compiler.deploymentfile.ConnectionType;
 import org.voltdb.compiler.deploymentfile.DeploymentType;
 import org.voltdb.compiler.deploymentfile.DiskLimitType;
 import org.voltdb.compiler.deploymentfile.DrRoleType;
-import org.voltdb.compiler.deploymentfile.DrSchemaCheckType;
 import org.voltdb.compiler.deploymentfile.DrType;
 import org.voltdb.compiler.deploymentfile.ExportConfigurationType;
 import org.voltdb.compiler.deploymentfile.ExportType;
@@ -329,7 +328,6 @@ public class VoltProjectBuilder {
     private String m_drConsumerSslPropertyFile = null;
     private Boolean m_drProducerEnabled = null;
     private DrRoleType m_drRole = DrRoleType.MASTER;
-    private DrSchemaCheckType m_drSchemaCheckMode = DrSchemaCheckType.STRICT;
 
     public VoltProjectBuilder setQueryTimeout(int target) {
         m_queryTimeout = target;
@@ -823,10 +821,6 @@ public class VoltProjectBuilder {
 
     public void setXDCR() {
         m_drRole = DrRoleType.XDCR;
-    }
-
-    public void setDrSchemaCheckMode(DrSchemaCheckType mode) {
-        m_drSchemaCheckMode = mode;
     }
 
     public boolean compile(final String jarPath) {
@@ -1328,7 +1322,6 @@ public class VoltProjectBuilder {
         deployment.setDr(dr);
         dr.setListen(m_drProducerEnabled);
         dr.setRole(m_drRole);
-        dr.setSchema(m_drSchemaCheckMode);
         if (m_drMasterHost != null && !m_drMasterHost.isEmpty()) {
             ConnectionType conn = factory.createConnectionType();
             dr.setConnection(conn);

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -694,7 +694,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     }
 
     @Override
-    public long applyMpBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, byte[] logsData) {
+    public long applyMpBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, long remoteTxnUniqueId, byte[] logsData) {
         throw new UnsupportedOperationException("RO MP Site doesn't do this, shouldn't be here");
     }
 

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1772,16 +1772,16 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         paramBuffer.putInt(log.length);
         paramBuffer.put(log);
         return m_ee.applyBinaryLog(paramBuffer, txnId, spHandle, m_lastCommittedSpHandle, uniqueId,
-                remoteClusterId, getNextUndoToken(m_currentTxnId));
+                remoteClusterId, -1, getNextUndoToken(m_currentTxnId));
     }
 
     @Override
-    public long applyMpBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, byte logs[])
+    public long applyMpBinaryLog(long txnId, long spHandle, long uniqueId, int remoteClusterId, long remoteTxnUniqueId, byte logs[])
             throws EEException {
         ByteBuffer paramBuffer = m_ee.getParamBufferForExecuteTask(logs.length);
         paramBuffer.put(logs);
         return m_ee.applyBinaryLog(paramBuffer, txnId, spHandle, m_lastCommittedSpHandle, uniqueId,
-                remoteClusterId, getNextUndoToken(m_currentTxnId));
+                remoteClusterId, remoteTxnUniqueId, getNextUndoToken(m_currentTxnId));
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -247,67 +247,26 @@ public class SysprocFragmentTask extends FragmentTaskBase
                 if (dep != null) {
                     currentFragResponse.addDependency(dep);
                 }
-            } catch (final EEException e) {
+            } catch (final EEException | SQLException | ReplicatedTableException e) {
                 hostLog.l7dlog(Level.TRACE, LogKeys.host_ExecutionSite_ExceptionExecutingPF.name(),
                         new Object[] { Encoder.hexEncode(m_fragmentMsg.getFragmentPlan(frag)) }, e);
                 currentFragResponse.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, e);
-                if (currentFragResponse.getTableCount() == 0) {
-                    // Make sure the response has at least 1 result with a valid DependencyId
-                    currentFragResponse.addDependency(new
-                            DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                                    m_rawDummyResult, 0, m_rawDummyResult.length));
-                }
-                break;
-            } catch (final SQLException e) {
-                hostLog.l7dlog(Level.TRACE, LogKeys.host_ExecutionSite_ExceptionExecutingPF.name(),
-                        new Object[] { Encoder.hexEncode(m_fragmentMsg.getFragmentPlan(frag)) }, e);
-                currentFragResponse.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, e);
-                if (currentFragResponse.getTableCount() == 0) {
-                    // Make sure the response has at least 1 result with a valid DependencyId
-                    currentFragResponse.addDependency(new
-                            DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                                    m_rawDummyResult, 0, m_rawDummyResult.length));
-                }
-                break;
-            } catch (final ReplicatedTableException e) {
-                hostLog.l7dlog(Level.TRACE, LogKeys.host_ExecutionSite_ExceptionExecutingPF.name(),
-                        new Object[] { Encoder.hexEncode(m_fragmentMsg.getFragmentPlan(frag)) }, e);
-                currentFragResponse.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, e);
-                if (currentFragResponse.getTableCount() == 0) {
-                    // Make sure the response has at least 1 result with a valid DependencyId
-                    currentFragResponse.addDependency(new
-                            DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                                    m_rawDummyResult, 0, m_rawDummyResult.length));
-                }
+                addDependencyToFragment(currentFragResponse);
                 break;
             }
-            catch (final SpecifiedException e) {
-                // Note that with SpecifiedException, the error code here might get changed before
+            catch (final SerializableException e) {
+                // Note that with SerializableException, the error code here might get changed before
                 // the client/user sees it. It really just needs to indicate failure.
                 //
                 // Key point here vs the next catch block for VAE is to not wrap the subclass of
                 // SerializableException here to preserve it during the serialization.
                 //
-                currentFragResponse.setStatus(
-                        FragmentResponseMessage.USER_ERROR,
-                        e);
-                if (currentFragResponse.getTableCount() == 0) {
-                    // Make sure the response has at least 1 result with a valid DependencyId
-                    currentFragResponse.addDependency(new
-                            DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                                    m_rawDummyResult, 0, m_rawDummyResult.length));
-                }
-            }
-            catch (final VoltAbortException e) {
-                currentFragResponse.setStatus(
-                        FragmentResponseMessage.USER_ERROR,
-                        new SerializableException(CoreUtils.throwableToString(e)));
-                if (currentFragResponse.getTableCount() == 0) {
-                    // Make sure the response has at least 1 result with a valid DependencyId
-                    currentFragResponse.addDependency(new
-                            DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                                    m_rawDummyResult, 0, m_rawDummyResult.length));
-                }
+                currentFragResponse.setStatus( FragmentResponseMessage.USER_ERROR, e);
+                addDependencyToFragment(currentFragResponse);
+                break;
+            } catch (final VoltAbortException e) {
+                currentFragResponse.setStatus( FragmentResponseMessage.USER_ERROR, new SerializableException(CoreUtils.throwableToString(e)));
+                addDependencyToFragment(currentFragResponse);
                 break;
             }
 
@@ -319,6 +278,15 @@ public class SysprocFragmentTask extends FragmentTaskBase
         // we should never rollback DR buffer for MP sysprocs because we don't report the DR buffer size and therefore don't know if it is empty or not.
         currentFragResponse.setDrBufferSize(1);
         return currentFragResponse;
+    }
+
+    private void addDependencyToFragment(FragmentResponseMessage response) {
+        if (response.getTableCount() == 0) {
+            // Make sure the response has at least 1 result with a valid DependencyId
+            response.addDependency(new
+                    DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
+                            m_rawDummyResult, 0, m_rawDummyResult.length));
+        }
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -253,8 +253,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
                 currentFragResponse.setStatus(FragmentResponseMessage.UNEXPECTED_ERROR, e);
                 addDependencyToFragment(currentFragResponse);
                 break;
-            }
-            catch (final SerializableException e) {
+            } catch (final SerializableException e) {
                 // Note that with SerializableException, the error code here might get changed before
                 // the client/user sees it. It really just needs to indicate failure.
                 //

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -839,11 +839,13 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * @param lastCommittedSpHandle    The spHandle of the last committed transaction
      * @param uniqueId                 The uniqueId of the current transaction
      * @param remoteClusterId          The cluster id of producer cluster
+     * @param remoteTxnUniqueId        The unique id from the source cluster. This is currently passed
+     *                                 in only for MPs
      * @param undoToken                For undo
      * @throws EEException
      */
     public abstract long applyBinaryLog(ByteBuffer logs, long txnId, long spHandle, long lastCommittedSpHandle,
-            long uniqueId, int remoteClusterId, long undoToken) throws EEException;
+            long uniqueId, int remoteClusterId, long remoteTxnUniqueId, long undoToken) throws EEException;
 
     /**
      * Execute an arbitrary non-transactional task that is described by the task id and

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -1705,7 +1705,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
 
     @Override
     public long applyBinaryLog(ByteBuffer logs, long txnId, long spHandle, long lastCommittedSpHandle,
-            long uniqueId, int remoteClusterId, long undoToken) throws EEException {
+            long uniqueId, int remoteClusterId, long remoteTxnUniqueId, long undoToken) throws EEException {
         m_data.clear();
         m_data.putInt(Commands.ApplyBinaryLog.m_id);
         m_data.putLong(txnId);
@@ -1713,6 +1713,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
         m_data.putLong(lastCommittedSpHandle);
         m_data.putLong(uniqueId);
         m_data.putInt(remoteClusterId);
+        m_data.putLong(remoteTxnUniqueId);
         m_data.putLong(undoToken);
         m_data.put(logs.array());
 

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -35,6 +35,7 @@ import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
 import org.voltdb.common.Constants;
+import org.voltdb.exceptions.DRTableNotFoundException;
 import org.voltdb.exceptions.EEException;
 import org.voltdb.exceptions.SerializableException;
 import org.voltdb.iv2.DeterminismHash;
@@ -44,8 +45,6 @@ import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 import org.voltdb.types.GeographyValue;
 import org.voltdb.utils.SerializationHelper;
-
-import com.google_voltpatches.common.base.Throwables;
 
 /**
  * Wrapper for native Execution Engine library.
@@ -282,15 +281,19 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     /** Utility method to throw a Runtime exception based on the error code and serialized exception **/
     @Override
     final protected void throwExceptionForError(final int errorCode) throws RuntimeException {
+        throw getExceptionFromError(errorCode);
+    }
+
+    private SerializableException getExceptionFromError(final int errorCode) {
         m_exceptionBuffer.clear();
         final int exceptionLength = m_exceptionBuffer.getInt();
 
         if (exceptionLength == 0) {
-            throw new EEException(errorCode);
+            return new EEException(errorCode);
         } else {
             m_exceptionBuffer.position(0);
             m_exceptionBuffer.limit(4 + exceptionLength);
-            throw SerializableException.deserializeFromBuffer(m_exceptionBuffer);
+            return SerializableException.deserializeFromBuffer(m_exceptionBuffer);
         }
     }
 
@@ -745,11 +748,15 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
     @Override
     public long applyBinaryLog(ByteBuffer logs, long txnId, long spHandle, long lastCommittedSpHandle,
-            long uniqueId, int remoteClusterId, long undoToken) throws EEException {
+            long uniqueId, int remoteClusterId, long remoteTxnUniqueId, long undoToken) throws EEException {
         long rowCount = nativeApplyBinaryLog(pointer, txnId, spHandle, lastCommittedSpHandle, uniqueId, remoteClusterId,
                 undoToken);
         if (rowCount < 0) {
-            throwExceptionForError((int) rowCount);
+            SerializableException exc = getExceptionFromError((int) rowCount);
+            if (exc instanceof DRTableNotFoundException) {
+                ((DRTableNotFoundException) exc).setRemoteTxnUniqueId(remoteTxnUniqueId);
+            }
+            throw exc;
         }
         return rowCount;
     }
@@ -901,9 +908,8 @@ public class ExecutionEngineJNI extends ExecutionEngine {
             checkErrorCode(errorCode);
             return (byte[])m_nextDeserializer.readArray(byte.class);
         } catch (IOException e) {
-            Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     @Override

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -226,7 +226,7 @@ public class MockExecutionEngine extends ExecutionEngine {
 
     @Override
     public long applyBinaryLog(ByteBuffer logs, long txnId, long spHandle, long lastCommittedSpHandle,
-            long uniqueId, int remoteClusterId, long undoToken) throws EEException {
+            long uniqueId, int remoteClusterId, long remoteTxnUniqueId, long undoToken) throws EEException {
         throw new UnsupportedOperationException();
     }
 

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2326,7 +2326,6 @@ public abstract class CatalogUtil {
                 // Setting this for compatibility mode only, don't use in new code
                 db.setIsactiveactivedred(true);
             }
-            cluster.setSchemacheckmode(dr.getSchema().value());
 
             // Backward compatibility to support cluster id in DR tag
             if (clusterType.getId() == null && dr.getId() != null) {

--- a/tests/sqlcmd/baselines/sysproc/explaincatalog.outbaseline
+++ b/tests/sqlcmd/baselines/sysproc/explaincatalog.outbaseline
@@ -26,7 +26,6 @@ set $PREV drMasterHost ""
 set $PREV drConsumerSslPropertyFile ""
 set $PREV drFlushInterval 0
 set $PREV preferredSource 0
-set $PREV schemaCheckMode ""
 add /clusters#cluster databases database
 set /clusters#cluster/databases#database schema "+QFUNDM1MjQ1NDE1NDQ1MjA1NDQxNDI0QwEMXDQ1NEQ1MDRDNEY1OTQ1NDU1MzIwMjgyMBECPDRDNDE1MzU0NUY0RTQxNEQBNCQ1NjQxNTI0MzQ4AQg8MjgzMjMwMjkyMDRFNEY1NAEIHDU1NEM0QzJDEUYEMjAJaBA1RjQ5NAEiMDk0RTU0NDU0NzQ1NTIBMgg0RjUBGE46AAhENDEFfAUsokIAFDAyOTNCCg=="
 set $PREV isActiveActiveDRed false


### PR DESCRIPTION
- Removed configuration for flexible vs. strict schema mode and always use flexible mode.
- Pause DR streams when we receive a binary log record for which schema does not match and
  unpause on local catalog update.