### PR TITLE
ENG-15408 restrict nibble export for replicated tables

### DIFF
--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -1390,7 +1390,7 @@ public class DDLCompiler {
             final String migrationTarget = ttlNode.attributes.get("migrationTarget");
             if (!StringUtil.isEmpty(migrationTarget)) {
                 if (table.getIsreplicated()) {
-                    throw m_compiler.new VoltCompilerException("Nibble export is not supported for replicated table:" + table.getTypeName());
+                    throw m_compiler.new VoltCompilerException("'MIGRATE TO TARGET' is not supported for replicated table:" + table.getTypeName());
                 }
                 ttl.setMigrationtarget(migrationTarget);
                 table.setTabletype(TableType.PERSISTENT_MIGRATE.get());

--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -96,7 +96,6 @@ import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.Encoder;
 import org.voltdb.utils.LineReaderAdapter;
 import org.voltdb.utils.SQLCommand;
-import org.voltdb.utils.VoltTypeUtil;
 
 
 
@@ -1389,7 +1388,10 @@ public class DDLCompiler {
             ttlValue = Integer.parseInt(ttlNode.attributes.get("maxFrequency"));
             ttl.setMaxfrequency(ttlValue);
             final String migrationTarget = ttlNode.attributes.get("migrationTarget");
-            if (migrationTarget != null) {
+            if (!StringUtil.isEmpty(migrationTarget)) {
+                if (table.getIsreplicated()) {
+                    throw m_compiler.new VoltCompilerException("Nibble export is not supported for replicated table:" + table.getTypeName());
+                }
                 ttl.setMigrationtarget(migrationTarget);
                 table.setTabletype(TableType.PERSISTENT_MIGRATE.get());
             }

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -3630,7 +3630,8 @@ public class TestVoltCompiler extends TestCase {
 
     public void testDDLCompilerStreamType() throws Exception {
         String ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-                " USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 3 BATCH_SIZE 10 MIGRATE TO TARGET TEST;\n";
+                " USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 3 BATCH_SIZE 10 MIGRATE TO TARGET TEST;\n" +
+                "partition table ttl on column a;";
         Database db = checkDDLAgainstGivenSchema(null,
                 "CREATE STREAM e PARTITION ON COLUMN D1 (D1 INTEGER NOT NULL, D2 INTEGER);\n",
                 "CREATE STREAM e1 PARTITION ON COLUMN D1 EXPORT TO TARGET T(D1 INTEGER NOT NULL, D2 INTEGER);\n" +
@@ -3900,7 +3901,7 @@ public class TestVoltCompiler extends TestCase {
                 " USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 3 BATCH_SIZE 10 MIGRATE TO TARGET TEST;\n";
         VoltProjectBuilder pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);
-        assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
+        assertFalse(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
 
         ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
               "USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 3 BATCH_SIZE 10 MIGRATE TO TARGET TEST;\n" +
@@ -3910,6 +3911,7 @@ public class TestVoltCompiler extends TestCase {
         assertFalse(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
 
         ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a));\n" +
+              "partition table ttl on column a;\n" +
               "alter table ttl USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 3 BATCH_SIZE 10 MIGRATE TO TARGET TEST;\n";
         pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);
@@ -3918,6 +3920,7 @@ public class TestVoltCompiler extends TestCase {
 
         ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a));\n" +
               "USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 3 BATCH_SIZE 10 MIGRATE TO TARGET TEST;\n" +
+              "partition table ttl on column a;\n" +
               "alter table ttl drop TTL;\n";
         pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);


### PR DESCRIPTION
Compiler throws errors if nibble export is configured on replicated table.