### PR TITLE
ENG-14890: Table defined with no columns causes crash when preparing to take command log truncation snapshot

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ErrorCode.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ErrorCode.java
@@ -611,6 +611,7 @@ public interface ErrorCode {
     // A VoltDB extension to implement subquery syntax limitations
     int X_47000 = 7000;                                   // invalid WHERE expression
     int X_47001 = 7001;                                   // subquery WHERE expression with parent aggregates
+    int X_47002 = 7002;                                   // zero-column table is not allowed
 
     // End of VoltDB extension
     // Unknown Error: Catch-All - xxxx

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -1331,6 +1331,11 @@ public class ParserDDL extends ParserRoutine {
             }
         }
 
+        // zero-column table is not allowed
+        if (table.getColumnCount() == 0) {
+            throw Error.error(ErrorCode.X_47002);
+        }
+
         if (token.tokenType == Tokens.ON) {
             if (!table.isTemp()) {
                 throw unexpectedToken();

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/resources/sql-state-messages.properties
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/resources/sql-state-messages.properties
@@ -626,5 +626,6 @@
 #            /************************* Volt DB Extensions *************************/
 7000=47000 invalid WHERE expression
 7001=47001 subquery with WHERE expression with aggregates on parent columns are not supported
+7002=47002 zero-column table is not allowed
 #            /**********************************************************************/
 


### PR DESCRIPTION
Disable creation of zero-column tables, because we do not support zero-column table.

Actually, we have the assertion in EE and will crash the server when trying to create a zero-column table in debug build. Now we are checking it in the parsing stage before getting to the EE.

We already have a guard when we try to drop the last column in the table. So guard the zero-column table creation is enough. 