### PR TITLE
ENG-14565, harden the integrity check of PBD segment, reorganize the …

### DIFF
--- a/src/ee/common/StreamBlock.h
+++ b/src/ee/common/StreamBlock.h
@@ -167,22 +167,17 @@ namespace voltdb
         ExportStreamBlock(char* data, size_t headerSize, size_t capacity, size_t uso) :
             StreamBlock(data, headerSize, capacity, uso),
             m_rowCount(0),
-            m_needsSchema(true),
             m_startSequenceNumber(0)
         {}
 
         ExportStreamBlock(ExportStreamBlock* other) :
             StreamBlock(other),
             m_rowCount(other->m_rowCount),
-            m_needsSchema(other->m_needsSchema),
             m_startSequenceNumber(other->m_startSequenceNumber)
         {}
 
         ~ExportStreamBlock()
         {}
-
-        inline bool needsSchema() { return m_needsSchema; }
-        inline void noSchema() { m_needsSchema = false; }
 
         inline void recordStartSequenceNumber(int64_t startSequenceNumber) {
             m_startSequenceNumber = startSequenceNumber;
@@ -216,7 +211,6 @@ namespace voltdb
 
     private:
         size_t m_rowCount;
-        bool m_needsSchema;
         int64_t m_startSequenceNumber;
     };
 

--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -69,12 +69,14 @@ namespace voltdb {
         return bytes;
     }
 
-    void DummyTopend::pushExportBuffer(int32_t partitionId, std::string signature, ExportStreamBlock *block, bool sync) {
+    void DummyTopend::pushExportBuffer(int32_t partitionId, std::string signature,
+            ExportStreamBlock *block, bool sync, int64_t generationId) {
         if (sync && !block) {
             return;
         }
         partitionIds.push(partitionId);
         signatures.push(signature);
+        generationIds.push(generationId);
         exportBlocks.push_back(boost::shared_ptr<ExportStreamBlock>(new ExportStreamBlock(block)));
         data.push_back(boost::shared_array<char>(block->rawPtr()));
         receivedExportBuffer = true;

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -68,7 +68,8 @@ class Topend {
             int32_t partitionId,
             std::string signature,
             ExportStreamBlock *block,
-            bool sync) = 0;
+            bool sync,
+            int64_t generationId) = 0;
     // Not used right now and will be removed or altered after a decision has been made on how Schema changes
     // are managed (they really don't belong in row buffers).
     virtual void pushEndOfStream(
@@ -136,7 +137,7 @@ public:
     void crashVoltDB(voltdb::FatalException e);
 
     int64_t getFlushedExportBytes(int32_t partitionId, std::string signature);
-    virtual void pushExportBuffer(int32_t partitionId, std::string signature, ExportStreamBlock *block, bool sync);
+    virtual void pushExportBuffer(int32_t partitionId, std::string signature, ExportStreamBlock *block, bool sync, int64_t generationId);
     virtual void pushEndOfStream(int32_t partitionId, std::string signature);
 
     int64_t pushDRBuffer(int32_t partitionId, DrStreamBlock *block);
@@ -164,6 +165,7 @@ public:
 
     std::queue<int32_t> partitionIds;
     std::queue<std::string> signatures;
+    std::queue<int64_t> generationIds;
     std::deque<boost::shared_ptr<DrStreamBlock> > drBlocks;
     std::deque<boost::shared_ptr<ExportStreamBlock> > exportBlocks;
     std::deque<boost::shared_array<char> > data;

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -160,7 +160,7 @@ JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecuti
     m_pushExportBufferMID = m_jniEnv->GetStaticMethodID(
             m_exportManagerClass,
             "pushExportBuffer",
-            "(ILjava/lang/String;JJJJLjava/nio/ByteBuffer;Z)V");
+            "(ILjava/lang/String;JJJJJLjava/nio/ByteBuffer;Z)V");
     if (m_pushExportBufferMID == NULL) {
         m_jniEnv->ExceptionDescribe();
         assert(m_pushExportBufferMID != NULL);
@@ -537,7 +537,8 @@ void JNITopend::pushExportBuffer(
         int32_t partitionId,
         string signature,
         ExportStreamBlock *block,
-        bool sync) {
+        bool sync,
+        int64_t generationId) {
     jstring signatureString = m_jniEnv->NewStringUTF(signature.c_str());
 
     if (block != NULL) {
@@ -554,6 +555,7 @@ void JNITopend::pushExportBuffer(
                 block->startSequenceNumber(),
                 block->getRowCount(),
                 block->lastSpUniqueId(),
+                generationId,
                 reinterpret_cast<jlong>(block->rawPtr()),
                 buffer,
                 sync ? JNI_TRUE : JNI_FALSE);
@@ -567,6 +569,7 @@ void JNITopend::pushExportBuffer(
                 static_cast<int64_t>(0),
                 static_cast<int64_t>(0),
                 static_cast<int64_t>(0),
+                generationId,
                 NULL,
                 NULL,
                 sync ? JNI_TRUE : JNI_FALSE);

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -49,7 +49,8 @@ public:
             int32_t partitionId,
             std::string signature,
             ExportStreamBlock *block,
-            bool sync);
+            bool sync,
+            int64_t generationId);
     void pushEndOfStream(
             int32_t partitionId,
             std::string signature);

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1530,8 +1530,6 @@ bool VoltDBEngine::updateCatalog(int64_t timestamp, bool isStreamUpdate, std::st
         return false;
     }
 
-    markAllExportingStreamsNew();
-
     std::map<std::string, ExportTupleStream*> purgedStreams;
     processCatalogDeletes(timestamp, false, purgedStreams);
     if (SynchronizedThreadLock::countDownGlobalTxnStartCount(m_isLowestSite)) {
@@ -1587,16 +1585,6 @@ VoltDBEngine::purgeMissingStreams(std::map<std::string, ExportTupleStream*> & pu
             m_exportingStreams[entry.first] = NULL;
             m_exportingDeletedStreams[entry.first] = entry.second;
             entry.second->removeFromFlushList(this, false);
-        }
-    }
-}
-
-void
-VoltDBEngine::markAllExportingStreamsNew() {
-    //Mark all streams new so that schema is sent on next tuple.
-    BOOST_FOREACH (LabeledStreamWrapper entry, m_exportingStreams) {
-        if (entry.second != NULL) {
-            entry.second->setNew();
         }
     }
 }

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -262,7 +262,6 @@ class __attribute__((visibility("default"))) VoltDBEngine {
             return processCatalogAdditions(timestamp, true, isStreamUpdate, purgedStreams);
         }
         void purgeMissingStreams(std::map<std::string, ExportTupleStream*> & purgedStreams);
-        void markAllExportingStreamsNew();
 
         /**
         * Load table data into a persistent table specified by the tableId parameter.

--- a/src/ee/storage/ExportTupleStream.cpp
+++ b/src/ee/storage/ExportTupleStream.cpp
@@ -29,32 +29,18 @@
 using namespace std;
 using namespace voltdb;
 
-const std::string ExportTupleStream::VOLT_TRANSACTION_ID = "VOLT_TRANSACTION_ID"; // 19 + sizeof(int32_t)
-const std::string ExportTupleStream::VOLT_EXPORT_TIMESTAMP = "VOLT_EXPORT_TIMESTAMP"; // 21 + sizeof(int32_t)
-const std::string ExportTupleStream::VOLT_EXPORT_SEQUENCE_NUMBER = "VOLT_EXPORT_SEQUENCE_NUMBER"; // 27 + sizeof(int32_t)
-const std::string ExportTupleStream::VOLT_PARTITION_ID = "VOLT_PARTITION_ID"; // 17 + sizeof(int32_t)
-const std::string ExportTupleStream::VOLT_SITE_ID = "VOLT_SITE_ID"; // 12 + sizeof(int32_t);
-const std::string ExportTupleStream::VOLT_EXPORT_OPERATION = "VOLT_EXPORT_OPERATION"; // 21 + sizeof(int32_t)
-//Change this constant if anything changes with metadata column names number etc. (171)
-const size_t ExportTupleStream::s_mdSchemaSize = (19 + 21 + 27 + 17 + 12 + 21 //Size of string column names
-                                                                + ExportTupleStream::METADATA_COL_CNT // Volt Type byte
-                                                                + (ExportTupleStream::METADATA_COL_CNT * sizeof(int32_t)) // Int for column names string size
-                                                                + (ExportTupleStream::METADATA_COL_CNT * sizeof(int32_t))); // column length colInfo->length
 const size_t ExportTupleStream::s_EXPORT_BUFFER_HEADER_SIZE = 12; // row count(4) + uniqueId(8)
-const size_t ExportTupleStream::s_FIXED_BUFFER_HEADER_SIZE = 13; // Size of header before schema: Version(1) + GenerationId(8) + SchemaLen(4)
-const uint8_t ExportTupleStream::s_EXPORT_BUFFER_VERSION = 1;
 
 ExportTupleStream::ExportTupleStream(CatalogId partitionId, int64_t siteId, int64_t generation,
                                      std::string signature, const std::string &tableName,
                                      const std::vector<std::string> &columnNames)
-    : TupleStreamBase(EL_BUFFER_SIZE, computeSchemaSize(tableName, columnNames) + s_FIXED_BUFFER_HEADER_SIZE + s_EXPORT_BUFFER_HEADER_SIZE),
+    : TupleStreamBase(EL_BUFFER_SIZE, s_EXPORT_BUFFER_HEADER_SIZE),
       m_partitionId(partitionId),
       m_siteId(siteId),
       m_signature(signature),
       m_generation(generation),
       m_tableName(tableName),
       m_columnNames(columnNames),
-      m_ddlSchemaSize(m_headerSpace - MAGIC_HEADER_SPACE_FOR_JAVA - s_FIXED_BUFFER_HEADER_SIZE - s_EXPORT_BUFFER_HEADER_SIZE),
       m_nextSequenceNumber(1),
       m_committedSequenceNumber(0),
       m_flushPending(false),
@@ -63,7 +49,6 @@ ExportTupleStream::ExportTupleStream(CatalogId partitionId, int64_t siteId, int6
 
 {
     extendBufferChain(m_defaultCapacity);
-    m_new = true;
 }
 
 void ExportTupleStream::setSignatureAndGeneration(std::string signature, int64_t generation) {
@@ -117,20 +102,6 @@ size_t ExportTupleStream::appendTuple(
         //If we can not fit the data get a new block with size that includes schemaSize as well.
         extendBufferChain(tupleMaxLength);
     }
-    bool includeSchema = m_currBlock->needsSchema();
-    if (includeSchema) {
-        ExportSerializeOutput blkhdr(m_currBlock->headerDataPtr()+s_EXPORT_BUFFER_HEADER_SIZE,
-                          m_currBlock->headerSize() - (MAGIC_HEADER_SPACE_FOR_JAVA+s_EXPORT_BUFFER_HEADER_SIZE));
-        // FIXED_BUFFER_HEADER
-        // version and generation Id for the buffer
-        blkhdr.writeByte(s_EXPORT_BUFFER_VERSION);
-        blkhdr.writeLong(m_generation);
-        // length of schema header
-        blkhdr.writeInt(m_ddlSchemaSize);
-        // Schema
-        writeSchema(blkhdr, tuple);
-        m_currBlock->noSchema();
-    }
 
     // initialize the full row header to 0. This also
     // has the effect of setting each column non-null.
@@ -176,11 +147,9 @@ size_t ExportTupleStream::appendTuple(
     assert(seqNo > 0 && m_nextSequenceNumber == seqNo);
     m_nextSequenceNumber++;
     m_currBlock->recordCompletedSpTxn(uniqueId);
-    //cout << "Appending row " << streamHeaderSz + io.position() << " to uso " << m_currBlock->uso()
-    //        << " sequence number " << seqNo
-    //        << " offset " << m_currBlock->offset() << std::endl;
-    //Not new anymore as we have new transaction after UAC
-    m_new = false;
+//    cout << "Appending row " << streamHeaderSz + io.position() << " to uso " << m_currBlock->uso()
+//            << " sequence number " << seqNo
+//            << " offset " << m_currBlock->offset() << std::endl;
     return startingUso;
 }
 
@@ -287,64 +256,6 @@ void ExportTupleStream::commit(VoltDBEngine* engine, int64_t currentSpHandle, in
     }
 }
 
-//Computes full schema size includes metadata columns.
-size_t
-ExportTupleStream::computeSchemaSize(const std::string &tableName, const std::vector<std::string> &columnNames) {
-    // column names size for metadata columns
-    size_t schemaSz = s_mdSchemaSize;
-    // table name size
-    schemaSz += getTextStringSerializedSize(tableName);
-    // Column name sizes for table columns + Column length field.
-    for (int i = 0; i < columnNames.size(); i++) {
-        schemaSz += getTextStringSerializedSize(columnNames[i]);
-        schemaSz += sizeof(int32_t);
-    }
-    // Add type byte for every column
-    schemaSz += columnNames.size();
-    return schemaSz;
-}
-
-void
-ExportTupleStream::writeSchema(ExportSerializeOutput &hdr, const TableTuple &tuple) {
-    // table name
-    hdr.writeTextString(m_tableName);
-
-    // encode name, type, column length
-    hdr.writeTextString(VOLT_TRANSACTION_ID);
-    hdr.writeEnumInSingleByte(VALUE_TYPE_BIGINT);
-    hdr.writeInt(sizeof(int64_t));
-
-    hdr.writeTextString(VOLT_EXPORT_TIMESTAMP);
-    hdr.writeEnumInSingleByte(VALUE_TYPE_BIGINT);
-    hdr.writeInt(sizeof(int64_t));
-
-    hdr.writeTextString(VOLT_EXPORT_SEQUENCE_NUMBER);
-    hdr.writeEnumInSingleByte(VALUE_TYPE_BIGINT);
-    hdr.writeInt(sizeof(int64_t));
-
-    hdr.writeTextString(VOLT_PARTITION_ID);
-    hdr.writeEnumInSingleByte(VALUE_TYPE_BIGINT);
-    hdr.writeInt(sizeof(int64_t));
-
-    hdr.writeTextString(VOLT_SITE_ID);
-    hdr.writeEnumInSingleByte(VALUE_TYPE_BIGINT);
-    hdr.writeInt(sizeof(int64_t));
-
-    hdr.writeTextString(VOLT_EXPORT_OPERATION);
-    hdr.writeEnumInSingleByte(VALUE_TYPE_TINYINT);
-    hdr.writeInt(sizeof(int8_t));
-
-    const TupleSchema::ColumnInfo *columnInfo;
-    // encode table columns name, type, length
-    for (int i = 0; i < m_columnNames.size(); i++) {
-        hdr.writeTextString(m_columnNames[i]);
-        columnInfo = tuple.getSchema()->getColumnInfo(i);
-        assert (columnInfo != NULL);
-        hdr.writeEnumInSingleByte(columnInfo->getVoltType());
-        hdr.writeInt(columnInfo->length);
-    }
-}
-
 size_t
 ExportTupleStream::computeOffsets(const TableTuple &tuple, size_t *streamHeaderSz) const {
     // round-up columncount to next multiple of 8 and divide by 8
@@ -374,7 +285,8 @@ void ExportTupleStream::pushStreamBuffer(ExportStreamBlock *block, bool sync) {
                     m_partitionId,
                     m_signature,
                     block,
-                    sync);
+                    sync,
+                    m_generation);
 }
 
 void ExportTupleStream::pushEndOfStream() {

--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -76,9 +76,6 @@ public:
         return value.length() + sizeof(int32_t);
     }
 
-    // compute # of bytes needed to serialize the meta data column names
-    inline size_t getMDColumnNamesSerializedSize() const { return s_mdSchemaSize; }
-
     int64_t testAllocatedBytesInEE() const {
         DummyTopend* te = static_cast<DummyTopend*>(ExecutorContext::getPhysicalTopend());
         int64_t flushedBytes = te->getFlushedExportBytes(m_partitionId, m_signature);
@@ -129,8 +126,6 @@ public:
     virtual void extendBufferChain(size_t minLength);
 
     virtual int partitionId() { return m_partitionId; }
-    void setNew() { m_new = true; }
-    bool isNew() { return m_new; }
 
     inline ExportTupleStream* getNextFlushStream() const {
         return m_nextFlushStream;
@@ -146,10 +141,6 @@ public:
 
 
 public:
-    // Computed size for metadata columns
-    static const size_t s_mdSchemaSize;
-    // Size of Fixed header (not including schema)
-    static const size_t s_FIXED_BUFFER_HEADER_SIZE;
     // Size of Fixed buffer header (rowCount + uniqueId)
     static const size_t s_EXPORT_BUFFER_HEADER_SIZE;
 
@@ -158,13 +149,10 @@ private:
     const CatalogId m_partitionId;
     const int64_t m_siteId;
 
-    // This indicates that stream is new or has been marked as new after UAC so that we include schema in next export stream write.
-    bool m_new;
     std::string m_signature;
     int64_t m_generation;
     const std::string &m_tableName;
     const std::vector<std::string> &m_columnNames;
-    const int32_t m_ddlSchemaSize;
 
     int64_t m_nextSequenceNumber;
     int64_t m_committedSequenceNumber;

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -106,7 +106,6 @@ StreamedTable::~StreamedTable() {
 // Stream writes were done so commit all the writes
 void StreamedTable::notifyQuantumRelease() {
     if (m_wrapper) {
-        assert(!m_wrapper->isNew());
         m_wrapper->commit(m_executorContext->getContextEngine(),
                 m_executorContext->currentSpHandle(), m_executorContext->currentUniqueId());
     }

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -128,7 +128,7 @@ public class ExportGeneration implements Generation {
     {
         File files[] = exportOverflowDirectory.listFiles();
         if (files != null) {
-            initializeGenerationFromDisk(messenger, processor, files, localPartitionsToSites);
+            initializeGenerationFromDisk(messenger, processor, files, localPartitionsToSites, catalogContext.m_genId);
         }
         initializeGenerationFromCatalog(catalogContext, connectors, processor, hostId, messenger, localPartitionsToSites);
 
@@ -136,7 +136,8 @@ public class ExportGeneration implements Generation {
 
     private void initializeGenerationFromDisk(HostMessenger messenger,
             final ExportDataProcessor processor,
-            File[] files, List<Pair<Integer, Integer>> localPartitionsToSites) {
+            File[] files, List<Pair<Integer, Integer>> localPartitionsToSites,
+            long genId) {
         List<Integer> onDiskPartitions = new ArrayList<Integer>();
 
         /*
@@ -159,7 +160,7 @@ public class ExportGeneration implements Generation {
                 File dataFile = dataFiles.get(nonce);
                 if (dataFile != null) {
                     try {
-                        addDataSource(ad, localPartitionsToSites, onDiskPartitions, processor);
+                        addDataSource(ad, localPartitionsToSites, onDiskPartitions, processor, genId);
                     } catch (IOException e) {
                         VoltDB.crashLocalVoltDB("Error intializing export datasource " + ad, true, e);
                     }
@@ -196,7 +197,7 @@ public class ExportGeneration implements Generation {
             if (conn.getEnabled()) {
                 for (ConnectorTableInfo ti : conn.getTableinfo()) {
                     Table table = ti.getTable();
-                    addDataSources(table, hostId, localPartitionsToSites, processor);
+                    addDataSources(table, hostId, localPartitionsToSites, processor, catalogContext.m_genId);
                     exportSignatures.add(table.getSignature());
                     createdSources = true;
                 }
@@ -598,8 +599,9 @@ public class ExportGeneration implements Generation {
     private void addDataSource(File adFile,
             List<Pair<Integer, Integer>> localPartitionsToSites,
             List<Integer> adFilePartitions,
-            final ExportDataProcessor processor) throws IOException {
-        ExportDataSource source = new ExportDataSource(this, adFile, localPartitionsToSites, processor);
+            final ExportDataProcessor processor,
+            final long genId) throws IOException {
+        ExportDataSource source = new ExportDataSource(this, adFile, localPartitionsToSites, processor, genId);
         adFilePartitions.add(source.getPartitionId());
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("Creating " + source.toString() + " for " + adFile + " bytes " + source.sizeInBytes());
@@ -622,7 +624,8 @@ public class ExportGeneration implements Generation {
     // silly helper to add datasources for a table catalog object
     private void addDataSources(Table table, int hostId,
             List<Pair<Integer, Integer>> localPartitionsToSites,
-            final ExportDataProcessor processor)
+            final ExportDataProcessor processor,
+            final long genId)
     {
         for (Pair<Integer, Integer> partitionAndSiteId : localPartitionsToSites) {
 
@@ -647,6 +650,7 @@ public class ExportGeneration implements Generation {
                                 table.getTypeName(),
                                 partition,
                                 siteId,
+                                genId,
                                 key,
                                 table.getColumns(),
                                 table.getPartitioncolumn(),
@@ -676,7 +680,8 @@ public class ExportGeneration implements Generation {
 
     @Override
     public void pushExportBuffer(int partitionId, String signature,
-            long startSequenceNumber, int tupleCount, long uniqueId, ByteBuffer buffer, boolean sync) {
+            long startSequenceNumber, int tupleCount, long uniqueId,
+            long genId, ByteBuffer buffer, boolean sync) {
         Map<String, ExportDataSource> sources = m_dataSourcesByPartition.get(partitionId);
 
         if (sources == null) {
@@ -696,7 +701,7 @@ public class ExportGeneration implements Generation {
                     " Signature " + signature + ". Using export data source Signature:" + defaultSig);
         }
 
-        source.pushExportBuffer(startSequenceNumber, tupleCount, uniqueId, buffer, sync);
+        source.pushExportBuffer(startSequenceNumber, tupleCount, uniqueId, genId, buffer, sync);
     }
 
     private void cleanup(final HostMessenger messenger) {

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -687,6 +687,7 @@ public class ExportManager
             long startSequenceNumber,
             long tupleCount,
             long uniqueId,
+            long genId,
             long bufferPtr,
             ByteBuffer buffer,
             boolean sync) {
@@ -702,7 +703,7 @@ public class ExportManager
                 return;
             }
             generation.pushExportBuffer(partitionId, signature, startSequenceNumber,
-                    (int)tupleCount, uniqueId, buffer, sync);
+                    (int)tupleCount, uniqueId, genId, buffer, sync);
         } catch (Exception e) {
             //Don't let anything take down the execution site thread
             exportLog.error("Error pushing export buffer", e);

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -37,7 +37,7 @@ public interface Generation {
     public void onSourceDone(int partitionId, String signature);
 
     public void pushExportBuffer(int partitionId, String signature, long seqNo, int tupleCount,
-                                 long uniqueId, ByteBuffer buffer, boolean sync);
+                                 long uniqueId, long genId, ByteBuffer buffer, boolean sync);
     public void updateInitialExportStateToSeqNo(int partitionId, String signature,
                                                 boolean isRecover, boolean isRejoin,
                                                 Map<Integer, Pair<Long, Long>> sequenceNumberPerPartition,

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -24,6 +24,9 @@ import java.util.Iterator;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.DBBPool.BBContainer;
+import org.voltcore.utils.DeferredSerialization;
+import org.voltdb.VoltDB;
+import org.voltdb.export.ExportDataSource.StreamTableSchemaSerializer;
 import org.voltdb.utils.BinaryDeque;
 import org.voltdb.utils.BinaryDeque.BinaryDequeReader;
 import org.voltdb.utils.BinaryDeque.BinaryDequeScanner;
@@ -41,12 +44,15 @@ import org.voltdb.utils.VoltFile;
  * portion of the queue.
  *
  * Export PBD buffer layout:
- *    --- Buffer Header   ---
- *    seqNo(8) + tupleCount(4) + uniqueId(8) + exportVersion(1) + generationId(8) + schemaLen(4) + tupleSchema(var length)
- *    {
- *          ---Inside schema---
- *          tableNameLength(4) + tableName(var length) + colNameLength(4) + colName(var length) + colType(1) + colLength(4) + ...
- *    }
+ *    -- Segment Header ---
+ *    crc(8) + numberOfEntries(4) + totalBytes(4)
+ *    -- Export Segment Header ---
+ *    exportVersion(1) + generationId(8) + schemaLen(4) + tupleSchema(var length) +
+ *    tableNameLength(4) + tableName(var length) + colNameLength(4) + colName(var length) + colType(1) + colLength(4) + ...
+ *    --- Common Entry Header   ---
+ *    crc(8) + length(4) + flags(4)
+ *    --- Export Entry Header   ---
+ *    seqNo(8) + tupleCount(4) + uniqueId(8)
  *    --- Row Header      ---
  *    rowLength(4) + partitionColumnIndex(4) + columnCount(4, includes metadata columns) +
  *    nullArrayLength(4) + nullArray(var length)
@@ -78,10 +84,28 @@ public class StreamBlockQueue {
 
     private final String m_nonce;
     private final String m_path;
+    private final String m_streamName;
     private BinaryDequeReader m_reader;
 
-    public StreamBlockQueue(String path, String nonce) throws java.io.IOException {
-        m_persistentDeque = new PersistentBinaryDeque( nonce, new VoltFile(path), exportLog);
+    // For test
+    public StreamBlockQueue(String path, String nonce)
+            throws java.io.IOException {
+        m_streamName = null;
+        m_persistentDeque = new PersistentBinaryDeque( nonce, null, new VoltFile(path), exportLog);
+        m_path = path;
+        m_nonce = nonce;
+        m_reader = m_persistentDeque.openForRead(m_nonce);
+        if (exportLog.isDebugEnabled()) {
+            exportLog.debug(m_nonce + " At SBQ creation, PBD size is " + (m_reader.sizeInBytes() - (8 * m_reader.getNumObjects())));
+        }
+    }
+
+    public StreamBlockQueue(String path, String nonce, String streamName)
+            throws java.io.IOException {
+        m_streamName = streamName;
+        StreamTableSchemaSerializer ds = new StreamTableSchemaSerializer(
+                VoltDB.instance().getCatalogContext(), m_streamName);
+        m_persistentDeque = new PersistentBinaryDeque( nonce, ds, new VoltFile(path), exportLog);
         m_path = path;
         m_nonce = nonce;
         m_reader = m_persistentDeque.openForRead(m_nonce);
@@ -108,8 +132,14 @@ public class StreamBlockQueue {
      */
     private StreamBlock pollPersistentDeque(boolean actuallyPoll) {
         BBContainer cont = null;
+        BBContainer schemaCont = null;
         try {
-            cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            // Start to read a new segment
+            if (m_reader.isStartOfSegment()) {
+                schemaCont = m_reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            }
+            cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+
         } catch (IOException e) {
             exportLog.error(e);
         }
@@ -120,12 +150,13 @@ public class StreamBlockQueue {
             cont.b().order(ByteOrder.LITTLE_ENDIAN);
             //If the container is not null, unpack it.
             final BBContainer fcont = cont;
-            long seqNo = cont.b().getLong(0);
-            int tupleCount = cont.b().getInt(8);
-            long uniqueId = cont.b().getLong(12);
+            long seqNo = cont.b().getLong(StreamBlock.SEQUENCE_NUMBER_OFFSET);
+            int tupleCount = cont.b().getInt(StreamBlock.ROW_NUMBER_OFFSET);
+            long uniqueId = cont.b().getLong(StreamBlock.UNIQUE_ID_OFFSET);
             //Pass the stream block a subset of the bytes, provide
             //a container that discards the original returned by the persistent deque
             StreamBlock block = new StreamBlock( fcont,
+                schemaCont,
                 seqNo,
                 tupleCount,
                 uniqueId,
@@ -224,8 +255,8 @@ public class StreamBlockQueue {
     /*
      * Only allow two blocks in memory, put the rest in the persistent deque
      */
-    public void offer(StreamBlock streamBlock) throws IOException {
-        m_persistentDeque.offer(streamBlock.asBBContainer(), !DISABLE_COMPRESSION);
+    public void offer(StreamBlock streamBlock, DeferredSerialization ds, boolean createNewFile) throws IOException {
+        m_persistentDeque.offer(streamBlock.asBBContainer(), ds, !DISABLE_COMPRESSION, createNewFile);
         long unreleasedSeqNo = streamBlock.unreleasedSequenceNumber();
         if (m_memoryDeque.size() < 2) {
             StreamBlock fromPBD = pollPersistentDeque(false);
@@ -296,11 +327,6 @@ public class StreamBlockQueue {
                     return null;
                 }
                 b.getLong(); // uniqueId
-                byte version = b.get(); // export version
-                assert(version == EXPORT_BUFFER_VERSION);
-                b.getLong(); // generation id
-                int firstRowStart = b.getInt() + b.position();
-                b.position(firstRowStart);
 
                 // Partial truncation
                 int offset = 0;
@@ -331,7 +357,9 @@ public class StreamBlockQueue {
 
         // close reopen reader
         m_persistentDeque.close();
-        m_persistentDeque = new PersistentBinaryDeque(m_nonce, new VoltFile(m_path), exportLog);
+        StreamTableSchemaSerializer ds = new StreamTableSchemaSerializer(
+                VoltDB.instance().getCatalogContext(), m_streamName);
+        m_persistentDeque = new PersistentBinaryDeque(m_nonce, ds, new VoltFile(m_path), exportLog);
         m_reader = m_persistentDeque.openForRead(m_nonce);
         // temporary debug stmt
         exportLog.info("After truncate, PBD size is " + (m_reader.sizeInBytes() - (8 * m_reader.getNumObjects())));
@@ -354,7 +382,6 @@ public class StreamBlockQueue {
         });
     }
 
-
     @Override
     public void finalize() {
         try {
@@ -371,5 +398,4 @@ public class StreamBlockQueue {
             }
         }
     }
-
 }

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -66,6 +66,7 @@ public class GuestProcessor implements ExportDataProcessor {
 
     private final long m_startTS = System.currentTimeMillis();
     private volatile boolean m_startPolling = false;
+    private long m_genId;
 
     // Instantiated at ExportManager
     public GuestProcessor() {
@@ -343,24 +344,36 @@ public class GuestProcessor implements ExportDataProcessor {
                          */
                         while (!m_shutdown) {
                             try {
+                                ByteBuffer sbuf = null;
+                                int schemaSize = 0;
                                 final ByteBuffer buf = cont.b();
                                 buf.position(startPosition);
                                 buf.order(ByteOrder.LITTLE_ENDIAN);
-                                byte version = buf.get();
-                                assert(version == StreamBlockQueue.EXPORT_BUFFER_VERSION);
-                                long generation = buf.getLong();
-                                int schemaSize = buf.getInt();
-                                ExportRow previousRow = edb.getPreviousRow();
-                                if (previousRow == null || previousRow.generation != generation) {
-                                    byte[] schemadata = new byte[schemaSize];
-                                    buf.get(schemadata, 0, schemaSize);
-                                    ByteBuffer sbuf = ByteBuffer.wrap(schemadata);
-                                    sbuf.order(ByteOrder.LITTLE_ENDIAN);
-                                    edb.setPreviousRow(ExportRow.decodeBufferSchema(sbuf, schemaSize, source.getPartitionId(), generation));
-                                }
-                                else {
-                                    // Skip past the schema header because it has not changed.
-                                    buf.position(buf.position() + schemaSize);
+                                final ByteBuffer schemaBuf = cont.schema();
+                                if (schemaBuf != null) {
+                                    schemaBuf.position(0);
+                                    schemaBuf.order(ByteOrder.LITTLE_ENDIAN);
+                                    byte version = schemaBuf.get();
+                                    assert(version == StreamBlockQueue.EXPORT_BUFFER_VERSION);
+                                    // update the global generation id of guest processor
+                                    m_genId = schemaBuf.getLong();
+                                    schemaSize = schemaBuf.getInt();
+                                    ExportRow previousRow = edb.getPreviousRow();
+                                    // update the decoder if current generation is different than previous row
+                                    if (previousRow == null || previousRow.generation != m_genId) {
+                                        byte[] schemadata = new byte[schemaSize];
+                                        schemaBuf.get(schemadata, 0, schemaSize);
+                                        sbuf = ByteBuffer.wrap(schemadata);
+                                        sbuf.order(ByteOrder.LITTLE_ENDIAN);
+                                        edb.setPreviousRow(
+                                                ExportRow.decodeBufferSchema(
+                                                        sbuf, schemaSize,
+                                                        source.getPartitionId(), m_genId));
+                                    } else {
+                                        // If generation is same, skip past the schema header
+                                        // because it has not changed.
+                                        buf.position(buf.position() + schemaSize);
+                                    }
                                 }
                                 ExportRow row = null;
                                 boolean firstRowOfBlock = true;
@@ -379,10 +392,16 @@ public class GuestProcessor implements ExportDataProcessor {
                                         //New style connector.
                                         try {
                                             cont.updateStartTime(System.currentTimeMillis());
+                                            if (edb.getPreviousRow() == null && sbuf != null) {
+                                                edb.setPreviousRow(
+                                                        ExportRow.decodeBufferSchema(
+                                                                sbuf, schemaSize,
+                                                                source.getPartitionId(), m_genId));
+                                            }
                                             row = ExportRow.decodeRow(edb.getPreviousRow(), source.getPartitionId(), m_startTS, rowdata);
                                             edb.setPreviousRow(row);
                                         } catch (IOException ioe) {
-                                            m_logger.warn("Failed decoding row for partition" + source.getPartitionId() + ". " + ioe.getMessage());
+                                            m_logger.warn("Failed decoding row for partition " + source.getPartitionId() + ". " + ioe.getMessage());
                                             cont.discard();
                                             cont = null;
                                             break;

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -441,6 +441,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                     long tupleCount = getBytes(8).getLong();
                     long uniqueId = getBytes(8).getLong();
                     boolean sync = getBytes(1).get() == 1 ? true : false;
+                    long genId = getBytes(8).getLong();
                     int length = getBytes(4).getInt();
                     ExportManager.pushExportBuffer(
                             partitionId,
@@ -448,6 +449,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                             startSequenceNumber,
                             tupleCount,
                             uniqueId,
+                            genId,
                             0,
                             length == 0 ? null : getBytes(length),
                             sync);

--- a/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
@@ -78,7 +78,8 @@ public class TaskLogImpl implements TaskLog {
 
         m_partitionId = partitionId;
         m_cursorId = "TaskLog-" + partitionId;
-        m_buffers = new PersistentBinaryDeque(Integer.toString(partitionId), overflowDir, new VoltLogger("REJOIN"));
+        m_buffers = new PersistentBinaryDeque(
+                Integer.toString(partitionId), null, overflowDir, new VoltLogger("REJOIN"));
         m_reader = m_buffers.openForRead(m_cursorId);
         m_es = CoreUtils.getSingleThreadExecutor("TaskLog partition " + partitionId);
     }
@@ -172,7 +173,7 @@ public class TaskLogImpl implements TaskLog {
                 @Override
                 public void run() {
                     try {
-                        BBContainer cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+                        BBContainer cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
                         if (cont != null) {
                            m_headBuffers.offer(new RejoinTaskBuffer(cont));
                         }

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -282,6 +282,9 @@ public class UpdateCore extends VoltSystemProcedure {
             // if this is a new catalog, do the work to update
             if (context.getCatalogVersion() == expectedCatalogVersion) {
 
+                // Bring the DR and Export buffer update to date.
+                context.getSiteProcedureConnection().quiesce();
+
                 // update the global catalog if we get there first
                 CatalogContext catalogContext =
                         VoltDB.instance().catalogUpdate(

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -53,10 +53,11 @@ public interface BinaryDeque {
      * is larger then the implementation defined max. 64 megabytes in the case of PersistentBinaryDeque.
      * If there is an exception attempting to write the buffers then all the buffers will be discarded
      * @param object
+     * @param ds
      * @param allowCompression
      * @throws IOException
      */
-    void offer(BBContainer object, boolean allowCompression) throws IOException;
+    void offer(BBContainer object, DeferredSerialization ds, boolean allowCompression, boolean createNewFile) throws IOException;
 
     int offer(DeferredSerialization ds) throws IOException;
 
@@ -118,10 +119,20 @@ public interface BinaryDeque {
          * Read and return the object at the current read position of this reader.
          * The entry will be removed once all active readers have read the entry.
          * @param ocf
+         * @param checkCRC
          * @return BBContainer with the bytes read. Null if there is nothing left to read.
          * @throws IOException
          */
-        public BBContainer poll(OutputContainerFactory ocf) throws IOException;
+        public BBContainer poll(OutputContainerFactory ocf, boolean checkCRC) throws IOException;
+
+        /**
+         * Read and return the schema of table located in the segment header
+         * @param ocf
+         * @param checkCRC
+         * @return
+         * @throws IOException
+         */
+        public BBContainer getSchema(OutputContainerFactory ocf, boolean checkCRC) throws IOException;
 
         /**
          * Number of bytes left to read for this reader.
@@ -143,6 +154,13 @@ public interface BinaryDeque {
          * @throws IOException
          */
         public boolean isEmpty() throws IOException;
+
+        /**
+         * Is the object this reader going to read the first object of segment?
+         * @return true if the object this reader going to read is the first object of segment
+         * throws IOException
+         */
+        public boolean isStartOfSegment() throws IOException;
     }
 
     public static class TruncatorResponse {

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -22,13 +22,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.DBBPool;
-import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.DeferredSerialization;
+import org.voltdb.HybridCrc32;
 import org.voltdb.utils.BinaryDeque.OutputContainerFactory;
 
 import com.google_voltpatches.common.base.Preconditions;
@@ -53,10 +54,13 @@ public class PBDRegularSegment extends PBDSegment {
 
     private int m_numOfEntries = -1;
     private int m_size = -1;
+    private long m_writeOffset = SEGMENT_HEADER_BYTES;
 
-    private DBBPool.BBContainer m_tmpHeaderBuf = null;
+    private DBBPool.BBContainer m_segmentHeaderBuf = null;
+    private DBBPool.BBContainer m_entryHeaderBuf = null;
+    Boolean INJECT_PBD_CHECKSUM_ERROR = Boolean.getBoolean("INJECT_PBD_CHECKSUM_ERROR");
 
-    public PBDRegularSegment(Long index, Long  id, File file) {
+    public PBDRegularSegment(Long index, long id, File file) {
         super(file);
         m_index = index;
         m_id = id;
@@ -84,28 +88,49 @@ public class PBDRegularSegment extends PBDSegment {
     public void reset()
     {
         m_syncedSinceLastEdit = false;
-        if (m_tmpHeaderBuf != null) {
-            m_tmpHeaderBuf.discard();
-            m_tmpHeaderBuf = null;
+        if (m_segmentHeaderBuf != null) {
+            m_segmentHeaderBuf.discard();
+            m_segmentHeaderBuf = null;
         }
+        if (m_entryHeaderBuf != null) {
+            m_entryHeaderBuf.discard();
+            m_entryHeaderBuf = null;
+        }
+        m_segmentHeaderCRC.reset();
+        m_entryCRC.reset();
     }
 
     @Override
-    public int getNumEntries() throws IOException
+    public int getNumEntries(boolean crcCheck) throws IOException
     {
         boolean wasClosed = false;
         if (m_closed) {
             wasClosed = true;
             open(false, false);
         }
+        m_numOfEntries = 0;
+        m_size = 0;
         if (m_fc.size() >= SEGMENT_HEADER_BYTES) {
-            m_tmpHeaderBuf.b().clear();
-            PBDUtils.readBufferFully(m_fc, m_tmpHeaderBuf.b(), 0);
-            m_numOfEntries = m_tmpHeaderBuf.b().getInt();
-            m_size = m_tmpHeaderBuf.b().getInt();
-        } else {
-            m_numOfEntries = 0;
-            m_size = 0;
+            m_segmentHeaderBuf.b().clear();
+            PBDUtils.readBufferFully(m_fc, m_segmentHeaderBuf.b(), 0);
+            if (crcCheck) {
+                long crc = m_segmentHeaderBuf.b().getLong();
+                int numOfEntries = m_segmentHeaderBuf.b().getInt();
+                int size = m_segmentHeaderBuf.b().getInt();
+                m_segmentHeaderCRC.reset();
+                m_segmentHeaderCRC.update(numOfEntries);
+                m_segmentHeaderCRC.update(size);
+                if (crc != m_segmentHeaderCRC.getValue()) {
+                    LOG.warn("File corruption detected in" + m_file.getName() + ": invalid file header. ");
+                    throw new IOException("File corruption detected in" + m_file.getName() + ": invalid file header.");
+                }
+                m_numOfEntries = numOfEntries;
+                m_size = size;
+            } else {
+                // skip the checksum if don't check crc
+                m_numOfEntries = m_segmentHeaderBuf.b().getInt(HEADER_NUM_OF_ENTRY_OFFSET);
+                m_size = m_segmentHeaderBuf.b().getInt(HEADER_TOTAL_BYTES_OFFSET);
+            }
         }
         if (wasClosed) closeReadersAndFile();
         return m_numOfEntries;
@@ -163,41 +188,48 @@ public class PBDRegularSegment extends PBDSegment {
         assert(m_ras == null);
         m_ras = new RandomAccessFile( m_file, forWrite ? "rw" : "r");
         m_fc = m_ras.getChannel();
-        m_tmpHeaderBuf = DBBPool.allocateDirect(SEGMENT_HEADER_BYTES);
+        m_segmentHeaderBuf = DBBPool.allocateDirect(SEGMENT_HEADER_BYTES);
+        m_entryHeaderBuf = DBBPool.allocateDirect(ENTRY_HEADER_BYTES);
 
+        // Those asserts ensure the file is opened with correct flag
         if (emptyFile) {
             initNumEntries(0, 0);
+            m_fc.position(SEGMENT_HEADER_BYTES);
+            m_writeOffset = SEGMENT_HEADER_BYTES;
+        } else if (forWrite) {
+            m_fc.position(m_writeOffset);
         }
-        m_fc.position(SEGMENT_HEADER_BYTES);
 
         m_closed = false;
     }
 
+    private void updateNumEntries() throws IOException {
+        // Update segment header CRC
+        m_segmentHeaderCRC.reset();
+        m_segmentHeaderCRC.update(m_numOfEntries);
+        m_segmentHeaderCRC.update(m_size);
+
+        m_segmentHeaderBuf.b().clear();
+        m_segmentHeaderBuf.b().putLong(m_segmentHeaderCRC.getValue()); // crc of segment header
+        m_segmentHeaderBuf.b().putInt(m_numOfEntries);
+        m_segmentHeaderBuf.b().putInt(m_size);
+        m_segmentHeaderBuf.b().flip();
+        PBDUtils.writeBuffer(m_fc, m_segmentHeaderBuf.bDR(), PBDSegment.HEADER_CRC_OFFSET);
+        m_syncedSinceLastEdit = false;
+    }
 
     @Override
     protected void initNumEntries(int count, int size) throws IOException {
         m_numOfEntries = count;
         m_size = size;
-
-        m_tmpHeaderBuf.b().clear();
-        m_tmpHeaderBuf.b().putInt(m_numOfEntries);
-        m_tmpHeaderBuf.b().putInt(m_size);
-        m_tmpHeaderBuf.b().flip();
-        PBDUtils.writeBuffer(m_fc, m_tmpHeaderBuf.bDR(), COUNT_OFFSET);
-        m_syncedSinceLastEdit = false;
+        updateNumEntries();
     }
 
     private void incrementNumEntries(int size) throws IOException
     {
         m_numOfEntries++;
         m_size += size;
-
-        m_tmpHeaderBuf.b().clear();
-        m_tmpHeaderBuf.b().putInt(m_numOfEntries);
-        m_tmpHeaderBuf.b().putInt(m_size);
-        m_tmpHeaderBuf.b().flip();
-        PBDUtils.writeBuffer(m_fc, m_tmpHeaderBuf.bDR(), COUNT_OFFSET);
-        m_syncedSinceLastEdit = false;
+        updateNumEntries();
     }
 
     /**
@@ -205,7 +237,7 @@ public class PBDRegularSegment extends PBDSegment {
      * @return
      */
     private int remaining() throws IOException {
-        //Subtract 8 for the length and size prefix
+        //Subtract 12 for the crc, number of entries and size prefix
         return (int)(PBDSegment.CHUNK_SIZE - m_fc.position()) - SEGMENT_HEADER_BYTES;
     }
 
@@ -219,20 +251,6 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public void closeAndTruncate() throws IOException {
-        try
-        {
-            if (m_ras == null) {
-                m_ras = new RandomAccessFile( m_file, "rw");
-            }
-            m_ras.setLength(0);
-        }
-        finally
-        {
-            close();
-        }
-    }
-    @Override
     public boolean isClosed()
     {
         return m_closed;
@@ -240,6 +258,9 @@ public class PBDRegularSegment extends PBDSegment {
 
     @Override
     public void close() throws IOException {
+        if (m_fc != null) {
+            m_writeOffset = m_fc.position();
+        }
         m_closedCursors.clear();
         closeReadersAndFile();
     }
@@ -282,6 +303,7 @@ public class PBDRegularSegment extends PBDSegment {
         return true;
     }
 
+    // Used by Export path
     @Override
     public boolean offer(DBBPool.BBContainer cont, boolean compress) throws IOException
     {
@@ -289,37 +311,38 @@ public class PBDRegularSegment extends PBDSegment {
         final ByteBuffer buf = cont.b();
         final int remaining = buf.remaining();
         if (remaining < 32 || !buf.isDirect()) compress = false;
-        final int maxCompressedSize = (compress ? CompressionService.maxCompressedLength(remaining) : remaining) + OBJECT_HEADER_BYTES;
+        final int maxCompressedSize = (compress ? CompressionService.maxCompressedLength(remaining) : remaining) + ENTRY_HEADER_BYTES;
         if (remaining() < maxCompressedSize) return false;
 
         m_syncedSinceLastEdit = false;
         DBBPool.BBContainer destBuf = cont;
-
+        m_entryCRC.reset();
         try {
-            m_tmpHeaderBuf.b().clear();
+            m_entryHeaderBuf.b().clear();
 
             if (compress) {
                 destBuf = DBBPool.allocateDirectAndPool(maxCompressedSize);
                 final int compressedSize = CompressionService.compressBuffer(buf, destBuf.b());
                 destBuf.b().limit(compressedSize);
-
-                m_tmpHeaderBuf.b().putInt(compressedSize);
-                m_tmpHeaderBuf.b().putInt(FLAG_COMPRESSED);
+                PBDUtils.writeEntryHeader(m_entryCRC, m_entryHeaderBuf.b(), destBuf.b(),
+                        compressedSize, FLAG_COMPRESSED);
             } else {
                 destBuf = cont;
-                m_tmpHeaderBuf.b().putInt(remaining);
-                m_tmpHeaderBuf.b().putInt(NO_FLAGS);
+                PBDUtils.writeEntryHeader(m_entryCRC, m_entryHeaderBuf.b(), destBuf.b(),
+                        remaining, NO_FLAGS);
+            }
+            // Write entry header
+            m_entryHeaderBuf.b().flip();
+            while (m_entryHeaderBuf.b().hasRemaining()) {
+                m_fc.write(m_entryHeaderBuf.b());
             }
 
-            m_tmpHeaderBuf.b().flip();
-            while (m_tmpHeaderBuf.b().hasRemaining()) {
-                m_fc.write(m_tmpHeaderBuf.b());
-            }
-
+            // Write entry
+            destBuf.b().flip();
             while (destBuf.b().hasRemaining()) {
                 m_fc.write(destBuf.b());
             }
-
+            // Update segment header
             incrementNumEntries(remaining);
         } finally {
             destBuf.discard();
@@ -331,24 +354,34 @@ public class PBDRegularSegment extends PBDSegment {
         return true;
     }
 
+    // Used by DR path
     @Override
     public int offer(DeferredSerialization ds) throws IOException
     {
         if (m_closed) throw new IOException("closed");
-        final int fullSize = ds.getSerializedSize() + OBJECT_HEADER_BYTES;
+        final int fullSize = ds.getSerializedSize();
         if (remaining() < fullSize) return -1;
 
         m_syncedSinceLastEdit = false;
         DBBPool.BBContainer destBuf = DBBPool.allocateDirectAndPool(fullSize);
 
         try {
+            m_entryCRC.reset();
             final int written = PBDUtils.writeDeferredSerialization(destBuf.b(), ds);
-            destBuf.b().flip();
 
+            // Write entry header
+            PBDUtils.writeEntryHeader(m_entryCRC, m_entryHeaderBuf.b(), destBuf.b(),
+                    written, PBDSegment.NO_FLAGS);
+            m_entryHeaderBuf.b().flip();
+            while (m_entryHeaderBuf.b().hasRemaining()) {
+                m_fc.write(m_entryHeaderBuf.b());
+            }
+            // Write entry
+            destBuf.b().flip();
             while (destBuf.b().hasRemaining()) {
                 m_fc.write(destBuf.b());
             }
-
+            // Update segment header
             incrementNumEntries(written);
             return written;
         } finally {
@@ -365,7 +398,8 @@ public class PBDRegularSegment extends PBDSegment {
     protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry) throws IOException
     {
         int written = 0;
-        final DBBPool.BBContainer partialCont = DBBPool.allocateDirect(OBJECT_HEADER_BYTES + entry.getTruncatedBuffSize());
+        final DBBPool.BBContainer partialCont =
+                DBBPool.allocateDirect(ENTRY_HEADER_BYTES + entry.getTruncatedBuffSize());
         try {
             written += entry.writeTruncatedObject(partialCont.b());
             partialCont.b().flip();
@@ -379,6 +413,18 @@ public class PBDRegularSegment extends PBDSegment {
         return written;
     }
 
+    @Override
+    public void writeExtraHeader(DeferredSerialization ds) throws IOException {
+        DBBPool.BBContainer destBuf = DBBPool.allocateDirect(ds.getSerializedSize());
+        destBuf.b().order(ByteOrder.LITTLE_ENDIAN);
+        ds.serialize(destBuf.b());
+        destBuf.b().flip();
+        while (destBuf.b().hasRemaining()) {
+            m_fc.write(destBuf.b());
+        }
+        destBuf.discard();
+    }
+
     private class SegmentReader implements PBDSegmentReader {
         private final String m_cursorId;
         private long m_readOffset = SEGMENT_HEADER_BYTES;
@@ -387,6 +433,7 @@ public class PBDRegularSegment extends PBDSegment {
         private int m_bytesRead = 0;
         private int m_discardCount = 0;
         private boolean m_closed = false;
+        private HybridCrc32 m_crc = new HybridCrc32();
 
         public SegmentReader(String cursorId) {
             assert(cursorId != null);
@@ -398,6 +445,7 @@ public class PBDRegularSegment extends PBDSegment {
             m_bytesRead = 0;
             m_readOffset = SEGMENT_HEADER_BYTES;
             m_discardCount = 0;
+            m_crc.reset();
         }
 
         @Override
@@ -411,7 +459,8 @@ public class PBDRegularSegment extends PBDSegment {
         }
 
         @Override
-        public BBContainer poll(OutputContainerFactory factory) throws IOException {
+        public DBBPool.BBContainer poll(OutputContainerFactory factory, boolean checkCRC) throws IOException {
+
             if (m_closed) throw new IOException("Reader closed");
 
             if (!hasMoreEntries()) {
@@ -423,21 +472,28 @@ public class PBDRegularSegment extends PBDSegment {
 
             try {
                 //Get the length and size prefix and then read the object
-                m_tmpHeaderBuf.b().clear();
-                while (m_tmpHeaderBuf.b().hasRemaining()) {
-                    int read = m_fc.read(m_tmpHeaderBuf.b());
+                m_entryHeaderBuf.b().clear();
+                while (m_entryHeaderBuf.b().hasRemaining()) {
+                    int read = m_fc.read(m_entryHeaderBuf.b());
                     if (read == -1) {
                         throw new EOFException();
                     }
                 }
-                m_tmpHeaderBuf.b().flip();
-                final int length = m_tmpHeaderBuf.b().getInt();
-                final int flags = m_tmpHeaderBuf.b().getInt();
+                m_entryHeaderBuf.b().flip();
+                final long entryCRC = m_entryHeaderBuf.b().getLong();
+                final int length = m_entryHeaderBuf.b().getInt();
+                final int flags = m_entryHeaderBuf.b().getInt();
                 final boolean compressed = (flags & FLAG_COMPRESSED) != 0;
                 final int uncompressedLen;
 
-                if (length < 1) {
-                    throw new IOException("Read an invalid length");
+                if (length < 1 || length > PBDSegment.CHUNK_SIZE - PBDSegment.SEGMENT_HEADER_BYTES) {
+                    LOG.warn("File corruption detected in " + m_file.getName() + ": invalid entry length. "
+                            + "Truncate the file to last safe point.");
+                    PBDRegularSegment.this.close();
+                    openForWrite(false);
+                    initNumEntries(m_objectReadIndex, m_bytesRead);
+                    m_fc.truncate(m_readOffset);
+                    return null;
                 }
 
                 final DBBPool.BBContainer retcont;
@@ -451,6 +507,22 @@ public class PBDRegularSegment extends PBDSegment {
                             }
                         }
                         compressedBuf.b().flip();
+                        if (checkCRC) {
+                            m_crc.reset();
+                            m_crc.update(length);
+                            m_crc.update(flags);
+                            m_crc.update(compressedBuf.b());
+                            compressedBuf.b().flip();
+                            if (entryCRC != m_crc.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
+                                LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
+                                        + "Truncate the file to last safe point.");
+                                PBDRegularSegment.this.close();
+                                openForWrite(false);
+                                initNumEntries(m_objectReadIndex, m_bytesRead);
+                                m_fc.truncate(m_readOffset);
+                                return null;
+                            }
+                        }
 
                         uncompressedLen = CompressionService.uncompressedLength(compressedBuf.bDR());
                         retcont = factory.getContainer(uncompressedLen);
@@ -470,6 +542,21 @@ public class PBDRegularSegment extends PBDSegment {
                         }
                     }
                     retcont.b().flip();
+                    if (checkCRC) {
+                        m_crc.update(length);
+                        m_crc.update(flags);
+                        m_crc.update(retcont.b());
+                        retcont.b().flip();
+                        if (entryCRC != m_crc.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
+                            LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
+                                    + "Truncate the file to last safe point.");
+                            PBDRegularSegment.this.close();
+                            openForWrite(false);
+                            initNumEntries(m_objectReadIndex, m_bytesRead);
+                            m_fc.truncate(m_readOffset);
+                            return null;
+                        }
+                    }
                 }
 
                 m_bytesRead += uncompressedLen;
@@ -492,6 +579,52 @@ public class PBDRegularSegment extends PBDSegment {
                     }
                 };
             } finally {
+                m_readOffset = m_fc.position();
+                m_fc.position(writePos);
+            }
+        }
+
+        @Override
+        public DBBPool.BBContainer getSchema(OutputContainerFactory factory, boolean checkCRC) throws IOException {
+            if (m_closed) throw new IOException("Reader closed");
+
+            final long writePos = m_fc.position();
+            m_fc.position(SEGMENT_HEADER_BYTES);
+
+            DBBPool.BBContainer schemaHeader = null;
+            try {
+                schemaHeader = DBBPool.allocateDirect(EXPORT_SCHEMA_HEADER_BYTES);
+                schemaHeader.b().order(ByteOrder.LITTLE_ENDIAN);
+                while (schemaHeader.b().hasRemaining()) {
+                    int read = m_fc.read(schemaHeader.b());
+                    if (read == -1) {
+                        throw new EOFException();
+                    }
+                }
+                schemaHeader.b().flip();
+                byte exportVersion = schemaHeader.b().get();
+                long genId = schemaHeader.b().getLong();
+                int schemaSize = schemaHeader.b().getInt();
+                DBBPool.BBContainer schemaBuf = DBBPool.allocateDirect(EXPORT_SCHEMA_HEADER_BYTES + schemaSize);
+                schemaBuf.b().order(ByteOrder.LITTLE_ENDIAN);
+                schemaBuf.b().put(exportVersion);
+                schemaBuf.b().putLong(genId);
+                schemaBuf.b().putInt(schemaSize);
+                while (schemaBuf.b().hasRemaining()) {
+                    int read = m_fc.read(schemaBuf.b());
+                    if (read == -1) {
+                        throw new EOFException();
+                    }
+                }
+                schemaBuf.b().flip();
+                return schemaBuf;
+            } catch (Exception e) {
+                LOG.error(e);
+                return null;
+            } finally {
+                if (schemaHeader != null) {
+                    schemaHeader.discard();
+                }
                 m_readOffset = m_fc.position();
                 m_fc.position(writePos);
             }

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DeferredSerialization;
+import org.voltdb.HybridCrc32;
 import org.voltdb.export.ExportSequenceNumberTracker;
 
 public abstract class PBDSegment {
@@ -60,10 +61,15 @@ public abstract class PBDSegment {
          * Returns null if all entries in this segment were already read by this reader.
          *
          * @param factory
+         * @param checkCRC
          * @return BBContainer with the bytes read
          * @throws IOException
          */
-        public DBBPool.BBContainer poll(BinaryDeque.OutputContainerFactory factory) throws IOException;
+        public DBBPool.BBContainer poll(BinaryDeque.OutputContainerFactory factory,
+                boolean checkCRC) throws IOException;
+
+        public DBBPool.BBContainer getSchema(BinaryDeque.OutputContainerFactory factory,
+                boolean checkCRC) throws IOException;
 
         //Don't use size in bytes to determine empty, could potentially
         //diverge from object count on crash or power failure
@@ -109,13 +115,25 @@ public abstract class PBDSegment {
     static final int NO_FLAGS = 0;
     static final int FLAG_COMPRESSED = 1;
 
-    static final int COUNT_OFFSET = 0;
-    static final int SIZE_OFFSET = 4;
-
     // Has to be able to hold at least one object (compressed or not)
     public static final int CHUNK_SIZE = Integer.getInteger("PBDSEGMENT_CHUNK_SIZE", 1024 * 1024 * 64);
-    static final int OBJECT_HEADER_BYTES = 8;
-    static final int SEGMENT_HEADER_BYTES = 8; // number of entries (4 bytes), total bytes of data (4 bytes)
+    // Segment Header layout:
+    //  - crc of segment header (8 bytes),
+    //  - total number of entries (4 bytes),
+    //  - total bytes of data (4 bytes),
+    static final int SEGMENT_HEADER_BYTES = 16;
+    public static final int HEADER_CRC_OFFSET = 0;
+    public static final int HEADER_NUM_OF_ENTRY_OFFSET = 8;
+    public static final int HEADER_TOTAL_BYTES_OFFSET = 12;
+
+    public static final int EXPORT_SCHEMA_HEADER_BYTES = 1 /*export buffer version*/ + 8 /*generation id*/ + 4 /*schema size*/;
+    // Export Segment Entry Header layout (each segment has multiple entries):
+    //  - crc of segment entry (8 bytes),
+    //  - total bytes of the entry (4 bytes),
+    //  - entry flag (4 bytes)
+    // TODO: Does DR Segment Entry needs a header? PartitionDRGatewayImpl defines
+    //       DR_BLOCK_HEADER_SIZE but also says this header is unused.
+    public static final int ENTRY_HEADER_BYTES = 16;
     protected final File m_file;
 
     protected boolean m_closed = true;
@@ -123,10 +141,14 @@ public abstract class PBDSegment {
     protected FileChannel m_fc;
     //Avoid unnecessary sync with this flag
     protected boolean m_syncedSinceLastEdit = true;
+    protected HybridCrc32 m_segmentHeaderCRC;
+    protected HybridCrc32 m_entryCRC;
 
     public PBDSegment(File file)
     {
         m_file = file;
+        m_segmentHeaderCRC = new HybridCrc32();
+        m_entryCRC = new HybridCrc32();
     }
 
     abstract long segmentIndex();
@@ -135,7 +157,7 @@ public abstract class PBDSegment {
 
     abstract void reset();
 
-    abstract int getNumEntries() throws IOException;
+    abstract int getNumEntries(boolean crcCheck) throws IOException;
 
     abstract boolean isBeingPolled();
 
@@ -160,8 +182,6 @@ public abstract class PBDSegment {
 
     abstract void closeAndDelete() throws IOException;
 
-    abstract void closeAndTruncate() throws IOException;
-
     abstract boolean isClosed();
 
     abstract void close() throws IOException;
@@ -179,6 +199,8 @@ public abstract class PBDSegment {
 
     abstract protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry) throws IOException;
 
+    abstract void writeExtraHeader(DeferredSerialization ds) throws IOException;
+
     /**
      * Parse the segment and truncate the file if necessary.
      * @param truncator    A caller-supplied truncator that decides where in the segment to truncate
@@ -194,20 +216,33 @@ public abstract class PBDSegment {
         PBDSegmentReader reader = openForRead(TRUNCATOR_CURSOR);
 
         // Do stuff
-        final int initialEntryCount = getNumEntries();
+        final int initialEntryCount = getNumEntries(true);
         int entriesTruncated = 0;
+        // Zero entry count means the segment is empty or corrupted, in both cases
+        // the segment can be deleted.
+        if (initialEntryCount == 0) {
+            reader.close();
+            close();
+            return -1;
+        }
         int sizeInBytes = 0;
 
         DBBPool.BBContainer cont;
+        DBBPool.BBContainer schemaCont = null;
+        boolean isFinal = isFinal();
         while (true) {
             final long beforePos = reader.readOffset();
 
-            cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            if (reader.readIndex() == 0) {
+                schemaCont = reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, !isFinal);
+            }
+
+            cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, !isFinal());
             if (cont == null) {
                 break;
             }
 
-            final int compressedLength = (int) (reader.readOffset() - beforePos - OBJECT_HEADER_BYTES);
+            final int compressedLength = (int) (reader.readOffset() - beforePos - ENTRY_HEADER_BYTES);
             final int uncompressedLength = cont.b().limit();
 
             try {
@@ -227,33 +262,42 @@ public abstract class PBDSegment {
                             entriesTruncated = -1;
                         } else {
                             entriesTruncated = initialEntryCount - (reader.readIndex() - 1);
+
                             //Don't forget to update the number of entries in the file
                             initNumEntries(reader.readIndex() - 1, sizeInBytes);
-                            m_fc.truncate(reader.readOffset() - (compressedLength + OBJECT_HEADER_BYTES));
+                            m_fc.truncate(reader.readOffset() - (compressedLength + ENTRY_HEADER_BYTES));
                         }
                     } else {
                         assert retval.status == BinaryDeque.TruncatorResponse.Status.PARTIAL_TRUNCATE;
                         entriesTruncated = initialEntryCount - reader.readIndex();
                         //Partial object truncation
-                        reader.rewindReadOffset(compressedLength + OBJECT_HEADER_BYTES);
+                        reader.rewindReadOffset(compressedLength + ENTRY_HEADER_BYTES);
                         final long partialEntryBeginOffset = reader.readOffset();
                         m_fc.position(partialEntryBeginOffset);
 
                         final int written = writeTruncatedEntry(retval);
                         sizeInBytes += written;
-
                         initNumEntries(reader.readIndex(), sizeInBytes);
-                        m_fc.truncate(partialEntryBeginOffset + written + OBJECT_HEADER_BYTES);
+                        m_fc.truncate(partialEntryBeginOffset + written + ENTRY_HEADER_BYTES);
                     }
 
                     break;
                 }
             } finally {
                 cont.discard();
+                if (schemaCont != null) {
+                    schemaCont.discard();
+                    schemaCont = null;
+                }
             }
         }
-
+        int entriesScanned = reader.readIndex();
+        reader.close();
         close();
+        // If we checksum the file and it looks good, mark as final
+        if (!isFinal() && entriesScanned == initialEntryCount) {
+            setFinal(true);
+        }
 
         return entriesTruncated;
     }
@@ -268,13 +312,25 @@ public abstract class PBDSegment {
     ExportSequenceNumberTracker scan(BinaryDeque.BinaryDequeScanner scanner) throws IOException {
         if (!m_closed) throw new IOException(("Segment should not be open before truncation"));
 
+        // Open for write because corrupted file may be truncated
         openForWrite(false);
         PBDSegmentReader reader = openForRead(SCANNER_CURSOR);
         ExportSequenceNumberTracker tracker = new ExportSequenceNumberTracker();
 
-        DBBPool.BBContainer cont;
+        DBBPool.BBContainer cont = null;
+        DBBPool.BBContainer schemaCont = null;
+        int initialEntryCount = getNumEntries(true);
+        if (initialEntryCount == 0) {
+            reader.close();
+            close();
+            return tracker;
+        }
         while (true) {
-            cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            // Start to read a new segment
+            if (reader.readIndex() == 0) {
+                schemaCont = reader.getSchema(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            }
+            cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, true);
             if (cont == null) {
                 break;
             }
@@ -285,10 +341,20 @@ public abstract class PBDSegment {
 
             } finally {
                 cont.discard();
+                if (schemaCont != null) {
+                    schemaCont.discard();
+                    schemaCont = null;
+                }
             }
         }
-
+        int entriesScanned = reader.readIndex();
+        reader.close();
+        // Forcefully close the file
         close();
+        // Scan through entire file, everything looks good
+        if (!isFinal() && entriesScanned == initialEntryCount) {
+            setFinal(true);
+        }
 
         return tracker;
     }
@@ -313,9 +379,7 @@ public abstract class PBDSegment {
      *
      * @param isFinal   true if segment is set to final, false otherwise
      */
-
     public void setFinal(boolean isFinal) {
-
         setFinal(m_file, isFinal);
     }
 
@@ -338,7 +402,6 @@ public abstract class PBDSegment {
      * @return true if file is final, false otherwise
      */
     public boolean isFinal() {
-
         return isFinal(m_file);
     }
 

--- a/src/frontend/org/voltdb/utils/PBDUtils.java
+++ b/src/frontend/org/voltdb/utils/PBDUtils.java
@@ -17,25 +17,23 @@
 
 package org.voltdb.utils;
 
-import org.voltcore.utils.DeferredSerialization;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+
+import org.voltcore.utils.DeferredSerialization;
+import org.voltdb.HybridCrc32;
 
 public class PBDUtils {
     public static int writeDeferredSerialization(ByteBuffer mbuf, DeferredSerialization ds) throws IOException
     {
         int written = 0;
         try {
-            final int objSizePosition = mbuf.position();
-            mbuf.position(mbuf.position() + PBDSegment.OBJECT_HEADER_BYTES);
+            mbuf.position(mbuf.position() + PBDSegment.ENTRY_HEADER_BYTES);
             final int objStartPosition = mbuf.position();
             ds.serialize(mbuf);
             written = mbuf.position() - objStartPosition;
-            mbuf.putInt(objSizePosition, written);
-            mbuf.putInt(objSizePosition + 4, PBDSegment.NO_FLAGS);
         } finally {
             ds.cancel();
         }
@@ -61,5 +59,16 @@ public class PBDUtils {
             pos += read;
         }
         buf.flip();
+    }
+
+    public static void writeEntryHeader(HybridCrc32 crc, ByteBuffer headerBuf,
+            ByteBuffer destBuf, int size, int flag) {
+        crc.update(size);
+        crc.update(flag);
+        crc.update(destBuf);
+        headerBuf.clear();
+        headerBuf.putLong(crc.getValue());
+        headerBuf.putInt(size);
+        headerBuf.putInt(flag);
     }
 }

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -33,7 +33,7 @@ import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.DeferredSerialization;
 import org.voltcore.utils.Pair;
 import org.voltdb.EELibraryLoader;
-import org.voltdb.VoltDB;
+import org.voltdb.HybridCrc32;
 import org.voltdb.export.ExportSequenceNumberTracker;
 import org.voltdb.utils.BinaryDeque.TruncatorResponse.Status;
 import org.voltdb.utils.PBDSegment.PBDSegmentReader;
@@ -94,7 +94,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         @Override
-        public BBContainer poll(OutputContainerFactory ocf) throws IOException {
+        public BBContainer poll(OutputContainerFactory ocf, boolean checkCRC) throws IOException {
             synchronized (PersistentBinaryDeque.this) {
                 if (m_closed) {
                     throw new IOException("PBD.ReadCursor.poll(): " + m_cursorId + " - Reader has been closed");
@@ -118,10 +118,44 @@ public class PersistentBinaryDeque implements BinaryDeque {
                     segmentReader = m_segment.getReader(m_cursorId);
                     if (segmentReader == null) segmentReader = m_segment.openForRead(m_cursorId);
                 }
-                BBContainer retcont = segmentReader.poll(ocf);
+                BBContainer retcont = segmentReader.poll(ocf, checkCRC);
+                if (retcont == null) {
+                    return null;
+                }
 
                 m_numRead++;
                 assertions();
+                assert (retcont.b() != null);
+                return wrapRetCont(m_segment, retcont);
+            }
+        }
+
+        @Override
+        public BBContainer getSchema(OutputContainerFactory ocf, boolean checkCRC) throws IOException {
+            synchronized (PersistentBinaryDeque.this) {
+                if (m_closed) {
+                    throw new IOException("PBD.ReadCursor.poll(): " + m_cursorId + " - Reader has been closed");
+                }
+                assertions();
+
+                moveToValidSegment();
+                PBDSegmentReader segmentReader = m_segment.getReader(m_cursorId);
+                if (segmentReader == null) {
+                    segmentReader = m_segment.openForRead(m_cursorId);
+                }
+                long lastSegmentId = peekLastSegment().segmentIndex();
+                while (!segmentReader.hasMoreEntries()) {
+                    if (m_segment.segmentIndex() == lastSegmentId) { // nothing more to read
+                        return null;
+                    }
+
+                    segmentReader.close();
+                    m_segment = m_segments.higherEntry(m_segment.segmentIndex()).getValue();
+                    // push to PBD will rewind cursors. So, this cursor may have already opened this segment
+                    segmentReader = m_segment.getReader(m_cursorId);
+                    if (segmentReader == null) segmentReader = m_segment.openForRead(m_cursorId);
+                }
+                BBContainer retcont = segmentReader.getSchema(ocf, checkCRC);
                 assert (retcont.b() != null);
                 return wrapRetCont(m_segment, retcont);
             }
@@ -191,7 +225,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 }
 
                 for (PBDSegment currSegment : m_segments.tailMap(m_segment.segmentIndex(), inclusive).values()) {
-                    if (currSegment.getNumEntries() > 0)  return false;
+                    if (currSegment.getNumEntries(false) > 0)  return false;
                 }
 
                 return true;
@@ -217,7 +251,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                             PBDSegmentReader segmentReader = segment.getReader(m_cursorId);
                             // Don't delete if this is the last segment.
                             // Cannot be deleted if this reader hasn't finished discarding this.
-                            if (segment == peekLastSegment() || !segmentReader.allReadAndDiscarded()) {
+                            if (segment == peekLastSegment() || (segmentReader != null && !segmentReader.allReadAndDiscarded())) {
                                 return;
                             }
                             if (canDeleteSegment(segment)) {
@@ -233,6 +267,24 @@ public class PersistentBinaryDeque implements BinaryDeque {
                     }
                 }
             };
+        }
+
+        public boolean isStartOfSegment() throws IOException {
+            synchronized(PersistentBinaryDeque.this) {
+                if (m_closed) {
+                    throw new IOException("Cannot call isReadFirstObjectOfSegment: PBD has been closed");
+                }
+                assertions();
+                moveToValidSegment();
+                PBDSegmentReader segmentReader = m_segment.getReader(m_cursorId);
+                if (segmentReader == null) {
+                    segmentReader = m_segment.openForRead(m_cursorId);
+                }
+                if (m_segment.getReader(m_cursorId).readIndex() == 0) {
+                    return true;
+                }
+                return false;
+            }
         }
     }
 
@@ -265,12 +317,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
      * back at the specified path.
      *
      * @param nonce
+     * @param schemaDS
      * @param path
      * @param logger
      * @throws IOException
      */
-    public PersistentBinaryDeque(final String nonce, final File path, VoltLogger logger) throws IOException {
-        this(nonce, path, logger, true);
+    public PersistentBinaryDeque(final String nonce, DeferredSerialization schemaDS,
+            final File path, VoltLogger logger) throws IOException {
+        this(nonce, schemaDS, path, logger, true);
     }
 
     /**
@@ -278,11 +332,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
      * This is a convenience method for testing so that poll with delete can be tested.
      *
      * @param nonce
+     * @param schemaDS
      * @param path
      * @param deleteEmpty
      * @throws IOException
      */
-    public PersistentBinaryDeque(final String nonce, final File path, VoltLogger logger, final boolean deleteEmpty) throws IOException {
+    public PersistentBinaryDeque(final String nonce, DeferredSerialization schemaDS,
+            final File path, VoltLogger logger,
+            final boolean deleteEmpty) throws IOException {
         EELibraryLoader.loadExecutionEngineLibrary(true);
         m_path = path;
         m_nonce = nonce;
@@ -306,11 +363,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         Long writeSegmentIndex = lastEntry == null ? 1L : lastEntry.getKey() + 1;
 
         String fname = getSegmentFileName(curId, prevId);
-        PBDSegment writeSegment =
-            newSegment(
-                    writeSegmentIndex,
-                    curId,
-                    new VoltFile(m_path, fname));
+        PBDSegment writeSegment = newSegment(writeSegmentIndex, curId, new VoltFile(m_path, fname));
 
         PBDSegment check = m_segments.put(writeSegmentIndex, writeSegment);
         if (check != null) {
@@ -319,6 +372,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
         writeSegment.openForWrite(true);
         writeSegment.setFinal(false);
+        if (schemaDS != null) {
+            writeSegment.writeExtraHeader(schemaDS);
+        }
 
         if (m_usageSpecificLog.isDebugEnabled()) {
             m_usageSpecificLog.debug("Segment " + writeSegment.file()
@@ -333,11 +389,11 @@ public class PersistentBinaryDeque implements BinaryDeque {
      * @return the next segment id
      */
     private synchronized long getNextSegmentId() {
-        long newId = ++m_segmentCounter;
-        if (newId == Long.MAX_VALUE) {
-            // Extremely unlikely
-            VoltDB.crashLocalVoltDB("Unable to allocate segment id for " + m_nonce);
+        // reset to 0 when overflow
+        if (m_segmentCounter == Long.MAX_VALUE) {
+            m_segmentCounter = 0L;
         }
+        long newId = ++m_segmentCounter;
         return newId;
     }
 
@@ -548,10 +604,10 @@ public class PersistentBinaryDeque implements BinaryDeque {
      */
     private void recoverSegment(PBDSegment qs, boolean deleteEmpty) throws IOException {
 
-        if (deleteEmpty && qs.getNumEntries() == 0) {
+        if (deleteEmpty && qs.getNumEntries(false) == 0) {
             qs.setFinal(false);
             if (m_usageSpecificLog.isDebugEnabled()) {
-                m_usageSpecificLog.debug("Found Empty Segment with entries: " + qs.getNumEntries() + " For: " + qs.file().getName());
+                m_usageSpecificLog.debug("Found Empty Segment with entries: " + qs.getNumEntries(false) + " For: " + qs.file().getName());
                 m_usageSpecificLog.debug("Segment " + qs.file()
                 + " (final: " + qs.isFinal() + "), will be closed and deleted during init");
             }
@@ -575,7 +631,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
     private int countNumObjects() throws IOException {
         int numObjects = 0;
         for (PBDSegment segment : m_segments.values()) {
-            numObjects += segment.getNumEntries();
+            numObjects += segment.getNumEntries(false);
         }
 
         return numObjects;
@@ -646,7 +702,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 break;
             }
             PBDSegment segment = m_segments.get(segmentId);
-            m_numObjects -= segment.getNumEntries();
+            m_numObjects -= segment.getNumEntries(false);
             iterator.remove();
 
             // Ensure the file is not final before closing and truncating
@@ -744,11 +800,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
     @Override
     public synchronized void offer(BBContainer object) throws IOException {
-        offer(object, true);
+        offer(object, null, true, false);
     }
 
     @Override
-    public synchronized void offer(BBContainer object, boolean allowCompression) throws IOException {
+    public synchronized void offer( BBContainer object,
+                                    DeferredSerialization schemaDS,
+                                    boolean allowCompression,
+                                    boolean createNewFile) throws IOException {
         assertions();
         if (m_closed) {
             throw new IOException("Closed");
@@ -756,8 +815,11 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         PBDSegment tail = peekLastSegment();
         final boolean compress = object.b().isDirect() && allowCompression;
+        if (createNewFile) {
+            tail = addSegment(tail, schemaDS);
+        }
         if (!tail.offer(object, compress)) {
-            tail = addSegment(tail);
+            tail = addSegment(tail, schemaDS);
             final boolean success = tail.offer(object, compress);
             if (!success) {
                 throw new IOException("Failed to offer object in PBD");
@@ -777,7 +839,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         PBDSegment tail = peekLastSegment();
         int written = tail.offer(ds);
         if (written < 0) {
-            tail = addSegment(tail);
+            tail = addSegment(tail, null);
             written = tail.offer(ds);
             if (written < 0) {
                 throw new IOException("Failed to offer object in PBD");
@@ -788,7 +850,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         return written;
     }
 
-    private PBDSegment addSegment(PBDSegment tail) throws IOException {
+    private PBDSegment addSegment(PBDSegment tail, DeferredSerialization schemaDS) throws IOException {
         //Check to see if the tail is completely consumed so we can close and delete it
         if (tail.hasAllFinishedReading() && canDeleteSegment(tail)) {
             pollLastSegment();
@@ -805,6 +867,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
         tail = newSegment(nextIndex, curId, new VoltFile(m_path, fname));
         tail.openForWrite(true);
         tail.setFinal(false);
+        if (schemaDS != null) {
+            tail.writeExtraHeader(schemaDS);
+        }
         if (m_usageSpecificLog.isDebugEnabled()) {
             m_usageSpecificLog.debug("Segment " + tail.file()
                 + " (final: " + tail.isFinal() + "), has been created because of an offer");
@@ -814,7 +879,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
     }
 
     private void closeAndDeleteSegment(PBDSegment segment) throws IOException {
-        int toDelete = segment.getNumEntries();
+        int toDelete = segment.getNumEntries(false);
         segment.setFinal(false);
         if (m_usageSpecificLog.isDebugEnabled()) {
             m_usageSpecificLog.debug("Closing and deleting segment " + segment.file()
@@ -836,17 +901,18 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         //Take the objects that were provided and separate them into deques of objects
         //that will fit in a single write segment
-        int available = PBDSegment.CHUNK_SIZE - 4;
+        int maxObjectSize = PBDSegment.CHUNK_SIZE - PBDSegment.SEGMENT_HEADER_BYTES;
+        int available = maxObjectSize;
         for (BBContainer object : objects) {
-            int needed = PBDSegment.OBJECT_HEADER_BYTES + object.b().remaining();
+            int needed = PBDSegment.ENTRY_HEADER_BYTES + object.b().remaining();
 
-            if (available - needed < 0) {
-                if (needed > PBDSegment.CHUNK_SIZE - 4) {
-                    throw new IOException("Maximum object size is " + (PBDSegment.CHUNK_SIZE - 4));
+            if (available < needed) {
+                if (needed > maxObjectSize) {
+                    throw new IOException("Maximum object size is " + maxObjectSize);
                 }
-                segments.offer( currentSegment );
                 currentSegment = new ArrayDeque<BBContainer>();
-                available = PBDSegment.CHUNK_SIZE - 4;
+                segments.offer(currentSegment);
+                available = maxObjectSize;
             }
             available -= needed;
             currentSegment.add(object);
@@ -860,7 +926,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         Long nextIndex = first == null ? 1L : first.segmentIndex() - 1;
 
         // The first segment id is either the "previous" of the current head
-        // (this avoids having to rename the file of the current head), or  new id.
+        // (this avoids having to rename the file of the current head), or new id.
         long curId = first == null ? getNextSegmentId() : getPreviousSegmentId(first.file());
 
         while (segments.peek() != null) {
@@ -1027,7 +1093,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         int count = 0;
         long size = 0;
         for (PBDSegment segment : m_segments.values()) {
-            count += segment.getNumEntries();
+            count += segment.getNumEntries(false);
             size += segment.size();
         }
         return Pair.of(count, size);
@@ -1050,11 +1116,13 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
     public static class ByteBufferTruncatorResponse extends TruncatorResponse {
         private final ByteBuffer m_retval;
+        private final HybridCrc32 m_crc;
 
         public ByteBufferTruncatorResponse(ByteBuffer retval) {
             super(Status.PARTIAL_TRUNCATE);
             assert retval.remaining() > 0;
             m_retval = retval;
+            m_crc = new HybridCrc32();
         }
 
         @Override
@@ -1065,8 +1133,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
         @Override
         public int writeTruncatedObject(ByteBuffer output) {
             int objectSize = m_retval.remaining();
-            output.putInt(objectSize);
-            output.putInt(PBDSegment.NO_FLAGS);
+            // write entry header
+            PBDUtils.writeEntryHeader(m_crc, output, m_retval, objectSize, PBDSegment.NO_FLAGS);
+            // write entry
             output.put(m_retval);
             return objectSize;
         }
@@ -1079,6 +1148,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         private final DeferredSerialization m_ds;
         private final Callback m_truncationCallback;
+        private final HybridCrc32 m_crc = new HybridCrc32();
 
         public DeferredSerializationTruncatorResponse(DeferredSerialization ds, Callback truncationCallback) {
             super(Status.PARTIAL_TRUNCATE);
@@ -1094,6 +1164,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
         @Override
         public int writeTruncatedObject(ByteBuffer output) throws IOException {
             int bytesWritten = PBDUtils.writeDeferredSerialization(output, m_ds);
+            m_crc.update(bytesWritten);
+            m_crc.update(PBDSegment.NO_FLAGS);
+            m_crc.updateFromPosition(PBDSegment.ENTRY_HEADER_BYTES, output);
+            // write entry header
+            output.flip();
+            output.putLong(m_crc.getValue());
+            output.putInt(bytesWritten);
+            output.putInt(PBDSegment.NO_FLAGS);
             if (m_truncationCallback != null) {
                 m_truncationCallback.bytesWritten(bytesWritten);
             }
@@ -1125,9 +1203,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 for (PBDSegment segment : m_segments.values()) {
                     PBDSegmentReader reader = segment.getReader(cursor.m_cursorId);
                     if (reader == null) {
-                        numObjects += segment.getNumEntries();
+                        numObjects += segment.getNumEntries(false);
                     } else {
-                        numObjects += segment.getNumEntries() - reader.readIndex();
+                        numObjects += segment.getNumEntries(false) - reader.readIndex();
                     }
                 }
                 assert numObjects == cursor.getNumObjects() : numObjects + " != " + cursor.getNumObjects();
@@ -1161,7 +1239,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
     public ExportSequenceNumberTracker scanForGap(BinaryDequeScanner scaner) throws IOException
     {
         if (m_closed) {
-            throw new IOException("Cannot parseAndTruncate(): PBD has been closed");
+            throw new IOException("Cannot scanForGap(): PBD has been closed");
         }
 
         assertions();
@@ -1183,7 +1261,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             gapTracker.mergeTracker(tracker);
         }
         // Reopen the last segment for write
-        peekLastSegment().openForWrite(true);
+        peekLastSegment().openForWrite(false);
         return gapTracker;
     }
 }

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -46,16 +46,11 @@ static const int COLUMN_COUNT = 5;
 static const int TUPLE_SIZE = 20;
 //RowSize(int32_t)+PartitionIndex(int32_t)+ColumnCount(int32_t)+nullMaskLength(2)
 static const int TUPLE_HEADER_SZ = 14;
-//ColumnNamesLength(5*int32_t)+ColumnNames(5)+TypeBytes(5*1)+ColumnLength(5*int32_t)+TableName(int32_t + 3)+metadataColumnInfo(ExportTupleStream::s_mdSchemaSize)
-static const int SCHEMA_SIZE = 20 + 5 + 5 + 20 + 7 + ExportTupleStream::s_mdSchemaSize; // 228
-//MetadataDataSize 5*int64_t+1byte (DB supplied columns)
-static const int METADATA_DATA_SIZE = 41;
 //Data size without schema information. = 75
-static const int MAGIC_TUPLE_SIZE = TUPLE_HEADER_SZ + METADATA_DATA_SIZE + TUPLE_SIZE;
+static const int MAGIC_TUPLE_SIZE = TUPLE_HEADER_SZ + TUPLE_SIZE;
 //Buffer row count size
-// Size of Buffer header including schema and uso(ExportTupleStream::s_FIXED_BUFFER_HEADER_SIZE + MAGIC_HEADER_SPACE_FOR_JAVA + EXPORT_BUFFER_HEADER_SIZE)
-static const int BUFFER_HEADER_SIZE = ExportTupleStream::s_FIXED_BUFFER_HEADER_SIZE +
-        MAGIC_HEADER_SPACE_FOR_JAVA + SCHEMA_SIZE + ExportTupleStream::s_EXPORT_BUFFER_HEADER_SIZE;
+// Size of Buffer header including schema and uso
+static const int BUFFER_HEADER_SIZE = MAGIC_HEADER_SPACE_FOR_JAVA + ExportTupleStream::s_EXPORT_BUFFER_HEADER_SIZE;
 
 // 1k buffer
 static const int BUFFER_SIZE = 1024;
@@ -131,8 +126,6 @@ public:
         *(reinterpret_cast<bool*>(m_tupleMemory)) = true;
         m_tuple = new TableTuple(m_schema);
         m_tuple->move(m_tupleMemory);
-        m_schemaSize = SCHEMA_SIZE;
-        assert(m_wrapper->computeSchemaSize(m_tableName, m_columnNames) == SCHEMA_SIZE);
         m_tupleSize = MAGIC_TUPLE_SIZE;
         m_tuplesToFill = (BUFFER_SIZE - BUFFER_HEADER_SIZE) / (m_tupleSize);
 //        cout << "tuple size: " << m_tupleSize << " column name size: metadata - " << m_wrapper->getMDColumnNamesSerializedSize()
@@ -211,7 +204,6 @@ protected:
     MockVoltDBEngine* m_engine;
     boost::scoped_ptr<ExecutorContext> m_context;
     size_t m_tupleSize;
-    size_t m_schemaSize;
     int m_tuplesToFill;
     std::string m_tableName;
 };

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -121,7 +121,7 @@ public class TestExportDataSource extends TestCase {
 
         @Override
         public void pushExportBuffer(int partitionId, String signature, long seqNo,
-                int tupleCount, long uniqueId, ByteBuffer buffer, boolean sync) {
+                int tupleCount, long uniqueId, long genId, ByteBuffer buffer, boolean sync) {
         }
 
         @Override
@@ -194,6 +194,7 @@ public class TestExportDataSource extends TestCase {
                     table.getTypeName(),
                     m_part,
                     CoreUtils.getSiteIdFromHSId(m_site),
+                    0,
                     table.getSignature(),
                     table.getColumns(),
                     table.getPartitioncolumn(),
@@ -217,6 +218,7 @@ public class TestExportDataSource extends TestCase {
                 table.getTypeName(),
                 m_part,
                 CoreUtils.getSiteIdFromHSId(m_site),
+                0,
                 table.getSignature(),
                 table.getColumns(),
                 table.getPartitioncolumn(),
@@ -237,23 +239,23 @@ public class TestExportDataSource extends TestCase {
             int buffSize = 20 + StreamBlock.HEADER_SIZE;
             ByteBuffer foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(1, 1, 0L, foo, false);
+            s.pushExportBuffer(1, 1, 0, 0, foo, false);
             assertEquals(s.sizeInBytes(), 20 );
 
             //Push it twice more to check stats calc
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(2, 1, 0, foo, false);
+            s.pushExportBuffer(2, 1, 0, 0, foo, false);
             assertEquals(s.sizeInBytes(), 40);
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(3, 1, 0, foo, false);
+            s.pushExportBuffer(3, 1, 0, 0, foo, false);
 
             assertEquals(s.sizeInBytes(), 60);
 
             //Sync which flattens them all, but then pulls the first two back in memory
             //resulting in no change
-            s.pushExportBuffer(3, 1, 0, null, true);
+            s.pushExportBuffer(3, 1, 0, 0, null, true);
 
             assertEquals( 60, s.sizeInBytes());
 
@@ -316,6 +318,7 @@ public class TestExportDataSource extends TestCase {
                 table.getTypeName(),
                 m_part,
                 CoreUtils.getSiteIdFromHSId(m_site),
+                0,
                 table.getSignature(),
                 table.getColumns(),
                 table.getPartitioncolumn(),
@@ -340,7 +343,7 @@ public class TestExportDataSource extends TestCase {
             // Push a first buffer - and read it back
             ByteBuffer foo0 = ByteBuffer.allocateDirect(buffSize);
             foo0.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(1, 1, 0L, foo0, false);
+            s.pushExportBuffer(1, 1, 0, 0, foo0, false);
 
             AckingContainer cont0 = s.poll().get();
             cont0.updateStartTime(System.currentTimeMillis());
@@ -371,7 +374,7 @@ public class TestExportDataSource extends TestCase {
             // Push a buffer - should satisfy fut1
             ByteBuffer foo1 = ByteBuffer.allocateDirect(buffSize);
             foo1.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(2, 1, 0L, foo1, false);
+            s.pushExportBuffer(2, 1, 0, 0, foo1, false);
 
             // Verify the pushed buffer can be got
             AckingContainer cont1 = fut1.get();
@@ -394,6 +397,7 @@ public class TestExportDataSource extends TestCase {
                 table.getTypeName(),
                 m_part,
                 CoreUtils.getSiteIdFromHSId(m_site),
+                0,
                 table.getSignature(),
                 table.getColumns(),
                 table.getPartitioncolumn(),
@@ -426,22 +430,22 @@ public class TestExportDataSource extends TestCase {
         foo.duplicate().put(new byte[20]);
         // we are not purposely starting at 0, because on rejoin
         // we may start at non zero offsets
-        s.pushExportBuffer(1, 1, 0L, foo, false);
+        s.pushExportBuffer(1, 1, 0, 0, foo, false);
         assertEquals(s.sizeInBytes(), 20 );
 
         //Push it twice more to check stats calc
         foo = ByteBuffer.allocateDirect(20 + StreamBlock.HEADER_SIZE);
         foo.duplicate().put(new byte[20]);
-        s.pushExportBuffer(2, 1, 0, foo, false);
+        s.pushExportBuffer(2, 1, 0, 0, foo, false);
         assertEquals(s.sizeInBytes(), 40 );
         foo = ByteBuffer.allocateDirect(20 + StreamBlock.HEADER_SIZE);
         foo.duplicate().put(new byte[20]);
-        s.pushExportBuffer(3, 1, 0, foo, false);
+        s.pushExportBuffer(3, 1, 0, 0, foo, false);
 
         assertEquals(s.sizeInBytes(), 60);
 
         //Sync which flattens them all
-        s.pushExportBuffer(3, 1, 0, null, true);
+        s.pushExportBuffer(3, 1, 0, 0, null, true);
 
         //flattened size
         assertEquals( 60, s.sizeInBytes());
@@ -500,6 +504,7 @@ public class TestExportDataSource extends TestCase {
                 table.getTypeName(),
                 m_part,
                 CoreUtils.getSiteIdFromHSId(m_site),
+                0,
                 table.getSignature(),
                 table.getColumns(),
                 table.getPartitioncolumn(),
@@ -513,7 +518,7 @@ public class TestExportDataSource extends TestCase {
             //Push and sync
             ByteBuffer foo = ByteBuffer.allocateDirect(200 + StreamBlock.HEADER_SIZE);
             foo.duplicate().put(new byte[200]);
-            s.pushExportBuffer(101, 1, 0L, foo, true);
+            s.pushExportBuffer(101, 1, 0, 0, foo, true);
             long sz = s.sizeInBytes();
             assertEquals(200, sz);
             listing = getSortedDirectoryListingSegments();
@@ -529,7 +534,7 @@ public class TestExportDataSource extends TestCase {
             //Push again and sync to test files.
             ByteBuffer foo2 = ByteBuffer.allocateDirect(900 + StreamBlock.HEADER_SIZE);
             foo2.duplicate().put(new byte[900]);
-            s.pushExportBuffer(111, 1, 0, foo2, true);
+            s.pushExportBuffer(111, 1, 0, 0, foo2, true);
             sz = s.sizeInBytes();
             assertEquals(900, sz);
             listing = getSortedDirectoryListingSegments();

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -54,6 +54,7 @@ import org.voltcore.utils.Pair;
 import org.voltcore.zk.ZKUtil;
 import org.voltdb.MockVoltDB;
 import org.voltdb.VoltDB;
+import org.voltdb.VoltType;
 import org.voltdb.VoltZK;
 import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Connector;
@@ -157,6 +158,9 @@ public class TestExportGeneration {
 
         m_mockVoltDB = new MockVoltDB();
         m_mockVoltDB.addSite(CoreUtils.getHSIdFromHostAndSite(m_host, m_site), m_part);
+        m_mockVoltDB.addTable("e1", false);
+        m_mockVoltDB.addColumnToTable("e1", "id", VoltType.INTEGER, true, "AA", VoltType.INTEGER);
+        m_mockVoltDB.addColumnToTable("e1", "f1", VoltType.STRING, true, "AA", VoltType.STRING);
 
         VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
 
@@ -224,6 +228,7 @@ public class TestExportGeneration {
                     seqNo,
                     1,
                     0L,
+                    System.currentTimeMillis(),
                     foo.duplicate(),
                     false
                     );
@@ -254,6 +259,7 @@ public class TestExportGeneration {
                 /*seqNo*/1L,
                 1,
                 0L,
+                System.currentTimeMillis(),
                 foo.duplicate(),
                 false
                 );

--- a/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
+++ b/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
@@ -67,14 +67,14 @@ public class TestStreamBlockQueue {
 
     private static StreamBlock getStreamBlockWithFill(byte fillValue) {
         g_seqNo += 100;
-        return new StreamBlock(DBBPool.wrapBB(getFilledBuffer(fillValue)), g_seqNo, 1, 0L, false);
+        return new StreamBlock(DBBPool.wrapBB(getFilledBuffer(fillValue)), null, g_seqNo, 1, 0L, false);
     }
 
     @Test
     public void testOfferCloseReopen() throws Exception {
         assertTrue(m_sbq.isEmpty());
         StreamBlock sb = getStreamBlockWithFill((byte)1);
-        m_sbq.offer(sb);
+        m_sbq.offer(sb, null, false);
         StreamBlock fromPeek = m_sbq.peek();
         assertEquals(sb.startSequenceNumber(), fromPeek.startSequenceNumber());
         assertEquals(sb.totalSize(), fromPeek.totalSize());
@@ -85,7 +85,7 @@ public class TestStreamBlockQueue {
         System.gc();
         System.gc();
         System.runFinalization();
-        m_sbq = new StreamBlockQueue(  TEST_DIR, TEST_NONCE);
+        m_sbq = new StreamBlockQueue(TEST_DIR, TEST_NONCE);
         sb = m_sbq.peek();
         assertFalse(m_sbq.isEmpty());
         assertEquals(m_sbq.sizeInBytes(), 1024 * 1024 * 2);//USO and length prefix on disk
@@ -128,7 +128,7 @@ public class TestStreamBlockQueue {
                 case 5:
                 case 0:
                     System.out.println("Iteration " + iteration + " Action offer");
-                    m_sbq.offer(getStreamBlockWithFill(zero));
+                    m_sbq.offer(getStreamBlockWithFill(zero), null, false);
                     break;
                 case 1:
                     System.out.println("Iteration " + iteration + " Action sync");
@@ -168,7 +168,7 @@ public class TestStreamBlockQueue {
     public void testIterator() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb);
+            m_sbq.offer(sb, null, false);
             if (ii == 2) {
                 m_sbq.poll().discard();
             }
@@ -228,7 +228,7 @@ public class TestStreamBlockQueue {
     public void testIterator2() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb);
+            m_sbq.offer(sb, null, false);
             if (ii == 2) {
                 m_sbq.poll().discard();
                 m_sbq.poll().discard();
@@ -290,7 +290,7 @@ public class TestStreamBlockQueue {
     public void testIterator2WithSync() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb);
+            m_sbq.offer(sb, null, false);
             if (ii == 2) {
                 m_sbq.poll().discard();
                 m_sbq.poll().discard();
@@ -355,7 +355,7 @@ public class TestStreamBlockQueue {
     public void testSyncReopenThenPop() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb);
+            m_sbq.offer(sb, null, false);
             if (ii == 2) {
                 m_sbq.poll().discard();
                 m_sbq.poll().discard();
@@ -421,7 +421,7 @@ public class TestStreamBlockQueue {
     public void testIterator3() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb);
+            m_sbq.offer(sb, null, false);
             if (ii == 3) {
                 m_sbq.poll().discard();
                 m_sbq.poll().discard();
@@ -485,7 +485,7 @@ public class TestStreamBlockQueue {
     public void testIterator4() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb);
+            m_sbq.offer(sb, null, false);
         }
         //Strange scenario where one block in the memory deque is persisted and the others isn't
         long weirdSizeValue = 1024 * 1024 * 2 * 32;

--- a/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
+++ b/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
@@ -58,7 +58,7 @@ public class TestPBDMultipleReaders {
             boolean done = false;
             int numRead = 0;
             for (int i=m_totalRead; i<end && !done; i++) {
-                BBContainer bbC = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+                BBContainer bbC = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
                 if (bbC==null) {
                     done = true;
                     continue;
@@ -115,7 +115,7 @@ public class TestPBDMultipleReaders {
         }
 
         for (int j=0; j<numBuffers; j++) {
-            BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false );
             bbC.discard();
         }
         assertTrue(reader1.isEmpty());
@@ -144,7 +144,7 @@ public class TestPBDMultipleReaders {
         for (int i=0; i<3; i++) {
             for (int j=0; j<s_segmentFillCount; j++) {
                 m_pbd.offer( DBBPool.wrapBB(TestPersistentBinaryDeque.getFilledBuffer(j)) );
-                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
                 bbC.discard();
             }
             assertEquals(1, m_pbd.numOpenSegments());
@@ -166,13 +166,13 @@ public class TestPBDMultipleReaders {
         BinaryDequeReader reader = m_pbd.openForRead("reader0");
         for (int i=0; i<numSegments; i++) {
             for (int j=0; j<46; j++) {
-                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
                 bbC.discard();
             }
             int expected = (i == numSegments-1) ? 1 : 2;
             assertEquals(expected, m_pbd.numOpenSegments());
 
-            BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             bbC.discard();
             // there should only be 1 open because last discard closes and deletes
             assertEquals(1, m_pbd.numOpenSegments());
@@ -196,15 +196,15 @@ public class TestPBDMultipleReaders {
         // Position first reader0 on penultimate segment and reader1 on first segment
         for (int i=0; i<numSegments-1; i++) {
             for (int j=0; j<46; j++) {
-                BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+                BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
                 bbC.discard();
                 if (i==0) {
-                    bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+                    bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
                     bbC.discard();
                 }
             }
 
-            BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             bbC.discard();
             if (i==0) {
                 assertEquals(2, m_pbd.numOpenSegments());
@@ -213,7 +213,7 @@ public class TestPBDMultipleReaders {
             }
         }
 
-        BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         bbC.discard();
         // Both readers finished reading first segment, so that is closed and deleted,
         // which reduces the # of open segments by 1
@@ -222,13 +222,13 @@ public class TestPBDMultipleReaders {
         // reader0 at penultimate. Move reader1 through segments and check open segments
         for (int i=1; i<numSegments-1; i++) {
             for (int j=0; j<46; j++) {
-                bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+                bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
                 bbC.discard();
             }
             int expected = (i == numSegments-2) ? 2 : 3;
             assertEquals(expected, m_pbd.numOpenSegments());
 
-            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             bbC.discard();
             expected = (i == numSegments-2) ? 1 : 2;
             assertEquals(expected, m_pbd.numOpenSegments());
@@ -236,9 +236,9 @@ public class TestPBDMultipleReaders {
 
         // read the last segment
         for (int j=0; j<s_segmentFillCount; j++) {
-            bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             bbC.discard();
-            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             bbC.discard();
         }
         assertEquals(1, m_pbd.numOpenSegments());
@@ -247,7 +247,7 @@ public class TestPBDMultipleReaders {
     @Before
     public void setUp() throws Exception {
         TestPersistentBinaryDeque.setupTestDir();
-        m_pbd = new PersistentBinaryDeque(TestPersistentBinaryDeque.TEST_NONCE, TestPersistentBinaryDeque.TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque(TestPersistentBinaryDeque.TEST_NONCE, null, TestPersistentBinaryDeque.TEST_DIR, logger );
     }
 
     @After

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -212,7 +212,7 @@ public class TestPersistentBinaryDeque {
         listing = getSortedDirectoryListing(true);
         assertEquals(listing.size(), 4);
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, null, TEST_DIR, logger );
 
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 5);
@@ -228,7 +228,7 @@ public class TestPersistentBinaryDeque {
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 1);
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
     }
 
     @Test
@@ -242,7 +242,7 @@ public class TestPersistentBinaryDeque {
         listing = getSortedDirectoryListing(true);
         assertEquals(listing.size(), 1);
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, null, TEST_DIR, logger );
 
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 1);
@@ -262,7 +262,7 @@ public class TestPersistentBinaryDeque {
 
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         for (long ii = 0; ii < 96; ii++) {
-            BBContainer cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             try {
                 assertNotNull(cont);
                 assertEquals(cont.b().remaining(), 1024 * 1024 * 2);
@@ -284,7 +284,7 @@ public class TestPersistentBinaryDeque {
     public void testTruncatorWithFullTruncateReturn() throws Exception {
         System.out.println("Running testTruncatorWithFullTruncateReturn");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         for (int ii = 0; ii < 150; ii++) {
             m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)) );
@@ -292,7 +292,7 @@ public class TestPersistentBinaryDeque {
 
         m_pbd.close();
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, null, TEST_DIR, logger );
 
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 5);
@@ -333,7 +333,7 @@ public class TestPersistentBinaryDeque {
         long reportedSizeInBytes = reader.sizeInBytes();
         long blocksFound = 0;
         BBContainer cont = null;
-        while ((cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY)) != null) {
+        while ((cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false)) != null) {
             try {
                 ByteBuffer buffer = cont.b();
                 if (blocksFound == 45) {
@@ -358,7 +358,7 @@ public class TestPersistentBinaryDeque {
     public void testTruncator() throws Exception {
         System.out.println("Running testTruncator");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         for (int ii = 0; ii < 160; ii++) {
             m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)) );
@@ -366,7 +366,7 @@ public class TestPersistentBinaryDeque {
 
         m_pbd.close();
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, null, TEST_DIR, logger );
 
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 5);
@@ -405,7 +405,7 @@ public class TestPersistentBinaryDeque {
         long reportedSizeInBytes = reader.sizeInBytes();
         long blocksFound = 0;
         BBContainer cont = null;
-        while ((cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY)) != null) {
+        while ((cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false)) != null) {
             try {
                 ByteBuffer buffer = cont.b();
                 if (blocksFound == 45) {
@@ -432,13 +432,13 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testReaderIsEmpty");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         assertTrue(reader.isEmpty());
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
         assertTrue(reader.isEmpty());
 
         m_pbd.offer(defaultContainer());
         assertFalse(reader.isEmpty());
 
-        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         retval.discard();
         assertTrue(reader.isEmpty());
 
@@ -448,7 +448,7 @@ public class TestPersistentBinaryDeque {
         }
         assertFalse(reader.isEmpty());
         for (int i = 0; i < 50; i++) {
-            retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             retval.discard();
             if (i<49) {
                 assertFalse(reader.isEmpty());
@@ -466,7 +466,7 @@ public class TestPersistentBinaryDeque {
         int count = 0;
         int totalAdded = 0;
         assertEquals(count, reader1.getNumObjects());
-        assertNull(reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
         assertEquals(count, reader1.getNumObjects());
 
         count++;
@@ -549,7 +549,7 @@ public class TestPersistentBinaryDeque {
     }
 
     private void pollDiscard(BinaryDequeReader reader) throws IOException {
-        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         retval.discard();
     }
 
@@ -557,7 +557,7 @@ public class TestPersistentBinaryDeque {
     public void testOfferThenPoll() throws Exception {
         System.out.println("Running testOfferThenPoll");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         //Make sure a single file with the appropriate data is created
         m_pbd.offer(defaultContainer());
@@ -566,7 +566,7 @@ public class TestPersistentBinaryDeque {
         assertTrue("pbd_nonce_0000000001_0000000002.pbd".equals(files[0].getName()));
 
         //Now make sure the current write file is stolen and a new write file created
-        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         retval.discard();
     }
 
@@ -574,7 +574,7 @@ public class TestPersistentBinaryDeque {
     public void testCloseOldSegments() throws Exception {
         System.out.println("Running testCloseOldSegments");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         final int total = 100;
 
@@ -597,7 +597,7 @@ public class TestPersistentBinaryDeque {
 
         //Now make sure the current write file is stolen and a new write file created
         for (int i = 0; i < total; i++) {
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             retval.discard();
         }
         listing = getSortedDirectoryListing();
@@ -608,7 +608,7 @@ public class TestPersistentBinaryDeque {
     public void testDontCloseReadSegment() throws Exception {
         System.out.println("Running testDontCloseReadSegment");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         final int total = 100;
 
@@ -619,7 +619,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(1, TEST_DIR.listFiles().length);
 
         // Read one buffer from the segment so that it's considered being polled from.
-        reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY).discard();
+        reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false).discard();
 
         for (int i = 5; i < total; i++) {
             m_pbd.offer(defaultContainer());
@@ -639,7 +639,7 @@ public class TestPersistentBinaryDeque {
 
         //Now make sure the current write file is stolen and a new write file created
         for (int i = 1; i < total; i++) {
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             retval.discard();
         }
         listing = getSortedDirectoryListing();
@@ -683,13 +683,13 @@ public class TestPersistentBinaryDeque {
         assertEquals("pbd_nonce_0000000004_0000000003.pbd", f0.getName());
 
         //Poll the two at the front and check that the contents are what is expected
-        BBContainer retval1 = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        BBContainer retval1 = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         try {
             buffer1.clear();
             System.err.println(Long.toHexString(buffer1.getLong(0)) + " " + Long.toHexString(retval1.b().getLong(0)));
             assertEquals(retval1.b(), buffer1);
 
-            BBContainer retval2 = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer retval2 = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             try {
                 buffer2.clear();
                 assertEquals(retval2.b(), buffer2);
@@ -720,7 +720,7 @@ public class TestPersistentBinaryDeque {
         //Now poll the rest and make sure the data is correct
         for (int ii = 0; ii < 96; ii++) {
             defaultBuffer.clear();
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             assertTrue(defaultBuffer.equals(retval.b()));
             retval.discard();
         }
@@ -747,14 +747,14 @@ public class TestPersistentBinaryDeque {
         m_pbd.sync();
         m_pbd.close();
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, null, TEST_DIR, logger );
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
 
         ByteBuffer defaultBuffer = defaultBuffer();
         //Now poll all of it and make sure the data is correct
         for (int ii = 0; ii < 96; ii++) {
             defaultBuffer.clear();
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             assertTrue(defaultBuffer.equals(retval.b()));
             retval.discard();
         }
@@ -769,7 +769,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testInvalidDirectory");
         m_pbd.close();
         try {
-            m_pbd = new PersistentBinaryDeque( "foo", new File("/usr/bin"), logger);
+            m_pbd = new PersistentBinaryDeque( "foo", null, new File("/usr/bin"), logger);
         } catch (IOException e) {
             return;
         }
@@ -795,7 +795,7 @@ public class TestPersistentBinaryDeque {
         assertTrue(toDelete.exists());
         assertTrue(toDelete.delete());
         try {
-            m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+            m_pbd = new PersistentBinaryDeque( TEST_NONCE, null, TEST_DIR, logger );
         } catch (IOException e) {
             return;
         }
@@ -847,7 +847,7 @@ public class TestPersistentBinaryDeque {
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         m_pbd.close();
         try {
-            reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         } catch (IOException e) {
             return;
         }
@@ -912,25 +912,26 @@ public class TestPersistentBinaryDeque {
     public void testOverlappingNonces() throws Exception {
         System.out.println("Running testOverlappingNonces");
         for (int i = 0; i < 20; i++) {
-            PersistentBinaryDeque pbd = new PersistentBinaryDeque(Integer.toString(i), TEST_DIR, logger);
+            PersistentBinaryDeque pbd = new PersistentBinaryDeque(
+                    Integer.toString(i), null, TEST_DIR, logger);
             pbd.offer(defaultContainer());
             pbd.close();
         }
 
-        PersistentBinaryDeque pbd = new PersistentBinaryDeque("1", TEST_DIR, logger);
+        PersistentBinaryDeque pbd = new PersistentBinaryDeque("1", null, TEST_DIR, logger);
         pbd.close();
     }
 
     @Test
     public void testNonceWithDots() throws Exception {
         System.out.println("Running testNonceWithDots");
-        PersistentBinaryDeque pbd = new PersistentBinaryDeque("ha.ha", TEST_DIR, logger);
+        PersistentBinaryDeque pbd = new PersistentBinaryDeque("ha.ha", null, TEST_DIR, logger);
         pbd.offer(defaultContainer());
         pbd.close();
 
-        pbd = new PersistentBinaryDeque("ha.ha", TEST_DIR, logger);
+        pbd = new PersistentBinaryDeque("ha.ha", null, TEST_DIR, logger);
         BinaryDequeReader reader = pbd.openForRead(CURSOR_ID);
-        BBContainer bb = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        BBContainer bb = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         try {
             ByteBuffer defaultBuffer = defaultBuffer();
             defaultBuffer.clear();
@@ -954,7 +955,7 @@ public class TestPersistentBinaryDeque {
         m_pbd.sync();
         m_pbd.close();
 
-        m_pbd = new PersistentBinaryDeque(TEST_NONCE, TEST_DIR, logger);
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, null, TEST_DIR, logger);
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
@@ -969,7 +970,7 @@ public class TestPersistentBinaryDeque {
         //Now poll all of it and make sure the data is correct
         for (int ii = 0; ii < 192; ii++) {
             ByteBuffer defaultBuffer = getFilledBuffer(ii);
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             try {
                 assertTrue(defaultBuffer.equals(retval.b()));
             } finally {
@@ -988,7 +989,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseReopenOfferSmall");
         final String SMALL_TEST_NONCE = "asmall_pbd_nonce";
 
-        PersistentBinaryDeque small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, TEST_DIR, logger);
+        PersistentBinaryDeque small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, null, TEST_DIR, logger);
         //Keep in 1 segment.
         for (int ii = 0; ii < 10; ii++) {
             small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)));
@@ -1002,7 +1003,7 @@ public class TestPersistentBinaryDeque {
         System.gc();
         System.runFinalization();
 
-        small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, TEST_DIR, logger);
+        small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, null, TEST_DIR, logger);
         BinaryDequeReader reader = small_pbd.openForRead(CURSOR_ID);
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 10);
@@ -1022,12 +1023,12 @@ public class TestPersistentBinaryDeque {
         files = TEST_DIR.listFiles();
         assertEquals(3, files.length);
 
-        small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, TEST_DIR, logger);
+        small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, null, TEST_DIR, logger);
         reader = small_pbd.openForRead(CURSOR_ID);
         //Now poll all of it and make sure the data is correct dont poll everything out.
         for (int ii = 0; ii < 10; ii++) {
             ByteBuffer defaultBuffer = getFilledSmallBuffer(ii);
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             try {
                 assertTrue(defaultBuffer.equals(retval.b()));
             } finally {
@@ -1056,7 +1057,7 @@ public class TestPersistentBinaryDeque {
         m_pbd = null;
         System.gc();
         System.runFinalization();
-        m_pbd = new PersistentBinaryDeque(TEST_NONCE, TEST_DIR, logger);
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, null, TEST_DIR, logger);
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
@@ -1070,7 +1071,7 @@ public class TestPersistentBinaryDeque {
         //Now poll half of it and make sure the data is correct
         for (int ii = 0; ii < 96; ii++) {
             ByteBuffer defaultBuffer = getFilledBuffer(ii);
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             assertTrue(defaultBuffer.equals(retval.b()));
             retval.discard();
             defaultBuffer.clear();
@@ -1084,9 +1085,8 @@ public class TestPersistentBinaryDeque {
         //Expect just the current write segment
         List<File> listing = getSortedDirectoryListing(true);
         assertEquals(3, listing.size());
-
         //Reload
-        m_pbd = new PersistentBinaryDeque(TEST_NONCE, TEST_DIR, logger);
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, null, TEST_DIR, logger);
         reader = m_pbd.openForRead(CURSOR_ID);
         cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
@@ -1103,7 +1103,7 @@ public class TestPersistentBinaryDeque {
         //Now poll half of it and make sure the data is correct
         for (int ii = 96; ii < 192; ii++) {
             ByteBuffer defaultBuffer = getFilledBuffer(ii);
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             assertTrue(defaultBuffer.equals(retval.b()));
             retval.discard();
             defaultBuffer.clear();
@@ -1115,7 +1115,7 @@ public class TestPersistentBinaryDeque {
         //Poll and leave one behind.
         for (int ii = 96; ii < 191; ii++) {
             ByteBuffer defaultBuffer = getFilledBuffer(ii);
-            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+            BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
             assertTrue(defaultBuffer.equals(retval.b()));
             retval.discard();
             defaultBuffer.clear();
@@ -1133,7 +1133,7 @@ public class TestPersistentBinaryDeque {
         listing = getSortedDirectoryListing();
         assertEquals(4, listing.size());
 
-        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        BBContainer retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         retval.discard();
         listing = getSortedDirectoryListing();
         assertEquals(3, listing.size());
@@ -1143,7 +1143,7 @@ public class TestPersistentBinaryDeque {
     public void testDeleteOnNonEmptyNextSegment() throws Exception {
         System.out.println("Running testDeleteOnNonEmptyNextSegment");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         final int total = 47;      // Number of buffers it takes to fill a segment
 
@@ -1155,7 +1155,7 @@ public class TestPersistentBinaryDeque {
 
         // Read all the buffers from the segment (isEmpty() returns true)
         for (int i = 0; i < total; i++) {
-            reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY).discard();
+            reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false).discard();
         }
 
         assert(reader.isEmpty());
@@ -1173,7 +1173,7 @@ public class TestPersistentBinaryDeque {
     @Before
     public void setUp() throws Exception {
         setupTestDir();
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque( TEST_NONCE, null, TEST_DIR, logger );
     }
 
     public static void setupTestDir() throws IOException {


### PR DESCRIPTION
…export buffer layout from one schema per-stream-block to per-pbd-generation, but eventually we want to implement per-schema-per-segment, this will be included in next commit of this pull request.

Change-Id: I1f6654c6aade4da6ed70f811e53fad31e090770d

ENG-14565, move export table schema to pbd segment header.

Change-Id: I56aa10fe7b385a01fc03c2484bb411ae0f7d1ee4

ENG-14565, wip

Change-Id: I23aac13163f9350a243ed3b754dec6465be31dbe

ENG-14565, fix NPEs.

Change-Id: I6c7b1789155fd63799896f973549732145b4fef0

ENG-14565, fix junit tests.

Change-Id: I2d2cf6fab34793063e20170c278e87b8e84b32f8

ENG-14565, remove warning.

Change-Id: I72a9da58f121ff174f7197d10585575ed6b74848

ENG-14565, address review comments.

Change-Id: I61ee2ce05de0f204ffed3ff76217122b73f6bf3b

ENG-14565, fix junit tests.

Change-Id: I49e58cd82e82a80da567d325f6612a77f0b6293f