### PR TITLE
ENG-14942: Disable JVM stats if tmp is not a tmpfs

### DIFF
--- a/lib/python/voltcli/environment.py
+++ b/lib/python/voltcli/environment.py
@@ -91,6 +91,11 @@ if not [opt for opt in java_opts if opt.startswith('-Xmx')]:
         java_opts.append('-Xms2048m')
         java_opts.append('-XX:+AlwaysPreTouch')
 
+# Find the temp directory which is going to be used by java
+tmpDir = '/tmp'
+for opt in filter(lambda o: o.startswith('-Djava.io.tmpdir='), java_opts):
+    tmpDir = opt.split('=', 1)[1]
+
 # Set common options now.
 java_opts.append('-server')
 java_opts.append('-Djava.awt.headless=true')
@@ -117,6 +122,27 @@ java_opts.append('-XX:+CMSClassUnloadingEnabled')
 # skip PermSize in Java 8
 if "1.8" not in java_version:
     java_opts.append('-XX:PermSize=64m')
+
+def _is_tmpfs(path):
+    '''
+    Test if path is on a tmpfs filesystem
+    '''
+    if not os.access('/proc/mounts', os.R_OK):
+        return False
+    while path and not os.path.ismount(path):
+        path = os.path.dirname(path)
+    if not path:
+        return False
+    is_tmpfs = False
+    with open('/proc/mounts') as f:
+        for line in f:
+            line = line.split()
+            if line[1] == path:
+                is_tmpfs = line[2] == 'tmpfs'
+    return is_tmpfs
+
+if not _is_tmpfs(tmpDir):
+    java_opts.append('-XX:+PerfDisableSharedMem')
 
 def initialize(standalone_arg, command_name_arg, command_dir_arg, version_arg):
     """


### PR DESCRIPTION
Determine the temp directory to be used by java and if it is not on a tmpfs
filesystem set the option -XX:+PerfDisableSharedMem to disable JVM stats.