### PR TITLE
ENG-15532: sqlcmdtest broken by explaincatalog addition: set $PREV tableType 0

### DIFF
--- a/tests/sqlcmd/baselines/sysproc/explaincatalog.outbaseline
+++ b/tests/sqlcmd/baselines/sysproc/explaincatalog.outbaseline
@@ -53,6 +53,7 @@ set $PREV materializer null
 set $PREV signature "EMPLOYEES|vii"
 set $PREV tuplelimit 2147483647
 set $PREV isDRed false
+set $PREV tableType 0
 add /clusters#cluster/databases#database/tables#EMPLOYEES columns EMP_ID
 set /clusters#cluster/databases#database/tables#EMPLOYEES/columns#EMP_ID index 1
 set $PREV type 5


### PR DESCRIPTION
One-line fix to explaincatalog.outbaseline, which was broken by Zeeman's check-in for ENG-15408.