### PR TITLE
ENG-15348 fix but in m_previousGenId management that resulted in PBD …

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -732,6 +732,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                         VoltDB.instance().getCatalogContext(), m_tableName);
                 // check generation id change at every push to tell when to create new segment
                 m_buffers.offer(sb, ds, genId != m_previousGenId);
+                m_previousGenId = genId;
             } catch (IOException e) {
                 VoltDB.crashLocalVoltDB("Unable to write to export overflow.", true, e);
             }


### PR DESCRIPTION
After a catalog update, every push buffer would request a new segment, which resulted in an NPE after PBD detected an inconsistency and truncated the segment. We need to reset m_previousGenId on each buffer after the genId change has been detected.
