### PR TITLE
ENG-15348, fix missing parameter in call to pushExportBuffer in JNITo…

### DIFF
--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -570,6 +570,7 @@ void JNITopend::pushExportBuffer(
                 static_cast<int64_t>(0),
                 static_cast<int64_t>(0),
                 static_cast<int64_t>(0),
+                static_cast<int64_t>(0),
                 generationId,
                 NULL,
                 NULL,

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -747,8 +747,8 @@ TEST_F(ExportTupleStreamTest, PartialRollback)
     EXPECT_EQ(results->offset(), (m_tupleSize * 1));
     EXPECT_EQ(results->getRowCount(), 1);
 
-    os.str(""); os << "committedSequenceNumber expected: " << 11 << ", actual: " << results->getCommittedSequenceNumber();
-    ASSERT_TRUE_WITH_MESSAGE(results->getCommittedSequenceNumber() == 11, os.str().c_str());
+    os.str(""); os << "committedSequenceNumber expected: " << 14 << ", actual: " << results->getCommittedSequenceNumber();
+    ASSERT_TRUE_WITH_MESSAGE(results->getCommittedSequenceNumber() == 14, os.str().c_str());
 }
 
 int main() {


### PR DESCRIPTION
…pend. This fixes a SIGSEGV in JNITopend when calling pushExportBuffer with the wrong number of parameters. The SIGSEGV occurred when dropping a stream.