### PR TITLE
PersistentTable: Simplify isReplicatedTable vs isCatalogTableReplicated

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -294,7 +294,7 @@ VoltDBEngine::~VoltDBEngine() {
             if (!table) {
                 VOLT_DEBUG("Partition %d Deallocating %s table", m_partitionId, eraseThis->second->getTable()->name().c_str());
             }
-            else if(!table->isCatalogTableReplicated()) {
+            else if(!table->isReplicatedTable()) {
                 VOLT_DEBUG("Partition %d Deallocating partitioned table %s", m_partitionId, eraseThis->second->getTable()->name().c_str());
             }
             else {
@@ -882,7 +882,7 @@ VoltDBEngine::processCatalogDeletes(int64_t timestamp, bool updateReplicated,
             Table* table = tcd->getTable();
             PersistentTable * persistenttable = dynamic_cast<PersistentTable*>(table);
             if (persistenttable) {
-                if (updateReplicated != persistenttable->isCatalogTableReplicated()) {
+                if (updateReplicated != persistenttable->isReplicatedTable()) {
                     deletions.erase(path);
                 }
             }
@@ -903,7 +903,7 @@ VoltDBEngine::processCatalogDeletes(int64_t timestamp, bool updateReplicated,
         if (table->activeTupleCount() == 0) {
             PersistentTable *persistenttable = dynamic_cast<PersistentTable*>(table);
             if (persistenttable) {
-                if (persistenttable->isCatalogTableReplicated()) {
+                if (persistenttable->isReplicatedTable()) {
                     if (updateReplicated) {
                         // identify empty tables and mark for deletion
                         deletions.insert(delegatePair.first);
@@ -957,7 +957,7 @@ VoltDBEngine::processCatalogDeletes(int64_t timestamp, bool updateReplicated,
         if (tcd) {
             Table* table = tcd->getTable();
             PersistentTable * persistenttable = dynamic_cast<PersistentTable*>(table);
-            if (persistenttable && persistenttable->isCatalogTableReplicated()) {
+            if (persistenttable && persistenttable->isReplicatedTable()) {
                 isReplicatedTable = true;
                 ExecuteWithAllSitesMemory execAllSites;
                 for (auto engineIt = execAllSites.begin(); engineIt != execAllSites.end(); ++engineIt) {
@@ -1295,7 +1295,7 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
             PersistentTable *deltaTable = persistentTable->deltaTable();
 
             {
-                ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(persistentTable->isCatalogTableReplicated());
+                ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(persistentTable->isReplicatedTable());
                 // iterate over indexes for this table in the catalog
                 BOOST_FOREACH (LabeledIndex labeledIndex, catalogTable->indexes()) {
                     auto foundIndex = labeledIndex.second;
@@ -1423,7 +1423,7 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
                     }
                 }
 
-                ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(persistentTable->isCatalogTableReplicated());
+                ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(persistentTable->isReplicatedTable());
                 // This guards its destTable from accidental deletion with a refcount bump.
                 MaterializedViewTriggerForWrite::build(persistentTable, destTable, currInfo);
                 obsoleteViews.push_back(currView);
@@ -1431,7 +1431,7 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
 
 
             {
-                ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(persistentTable->isCatalogTableReplicated());
+                ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(persistentTable->isReplicatedTable());
                 BOOST_FOREACH (auto toDrop, obsoleteViews) {
                     persistentTable->dropMaterializedView(toDrop);
                 }
@@ -1628,7 +1628,7 @@ VoltDBEngine::loadTable(int32_t tableId,
     //   Perhaps we cannot be ensured of data integrity for other kinds of exceptions?
 
     ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory
-            (table->isCatalogTableReplicated(), isLowestSite(), &s_loadTableException, VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
+            (table->isReplicatedTable(), isLowestSite(), &s_loadTableException, VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
     if (possiblySynchronizedUseMpMemory.okToExecute()) {
         try {
             table->loadTuplesForLoadTable(serializeIn,
@@ -1663,7 +1663,7 @@ VoltDBEngine::loadTable(int32_t tableId,
             throwFatalException("%s", serializableExc.message().c_str());
         }
 
-        if (table->isCatalogTableReplicated() && returnConflictRows) {
+        if (table->isReplicatedTable() && returnConflictRows) {
             // There may or may not have been conflicts but the call always succeeds. We need to copy the
             // lowest site result into the results of other sites so there are no hash mismatches.
             ExecuteWithAllSitesMemory execAllSites;
@@ -2853,7 +2853,7 @@ void VoltDBEngine::setViewsEnabled(const std::string& viewNames, bool value) {
                     // We should have prevented this in the Java layer.
                     continue;
                 }
-                if (persistentTable->isCatalogTableReplicated() != updateReplicated) {
+                if (persistentTable->isReplicatedTable() != updateReplicated) {
                     VOLT_TRACE("[Partition %d] skip %s\n", m_partitionId, persistentTable->name().c_str());
                     continue;
                 }

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -65,7 +65,7 @@ bool DeleteExecutor::p_init(AbstractPlanNode *abstract_node,
 
     PersistentTable* targetTable = dynamic_cast<PersistentTable*>(m_node->getTargetTable());
     assert(targetTable);
-    m_replicatedTableOperation = targetTable->isCatalogTableReplicated();
+    m_replicatedTableOperation = targetTable->isReplicatedTable();
 
     m_truncate = m_node->getTruncate();
     if (m_truncate) {
@@ -93,7 +93,7 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
     int64_t modified_tuples = 0;
 
     {
-        assert(targetTable->isCatalogTableReplicated() ==
+        assert(targetTable->isReplicatedTable() ==
                 (m_replicatedTableOperation || SynchronizedThreadLock::isInSingleThreadMode()));
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
                 m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -109,7 +109,7 @@ bool InsertExecutor::p_init(AbstractPlanNode* abstractNode,
 
     if (persistentTarget) {
         m_partitionColumn = persistentTarget->partitionColumn();
-        m_replicatedTableOperation = persistentTarget->isCatalogTableReplicated();
+        m_replicatedTableOperation = persistentTarget->isReplicatedTable();
     }
 
     m_multiPartition = m_node->isMultiPartition();
@@ -180,7 +180,7 @@ bool InsertExecutor::p_execute_init_internal(const TupleSchema *inputSchema,
     m_persistentTable = m_isStreamed ?
             NULL : static_cast<PersistentTable*>(m_targetTable);
     assert((!m_persistentTable && !m_replicatedTableOperation) ||
-            m_replicatedTableOperation == m_persistentTable->isCatalogTableReplicated());
+            m_replicatedTableOperation == m_persistentTable->isReplicatedTable());
 
     m_upsertTuple = TableTuple(m_targetTable->schema());
 
@@ -217,7 +217,7 @@ bool InsertExecutor::p_execute_init_internal(const TupleSchema *inputSchema,
     }
 
     VOLT_DEBUG("Initializing insert executor to insert into %s table %s",
-               static_cast<PersistentTable*>(m_targetTable)->isCatalogTableReplicated() ? "replicated" : "partitioned",
+               static_cast<PersistentTable*>(m_targetTable)->isReplicatedTable() ? "replicated" : "partitioned",
                m_targetTable->name().c_str());
     VOLT_DEBUG("This is a %s insert on partition with id %d",
                m_node->isInline() ? "inline"

--- a/src/ee/executors/swaptablesexecutor.cpp
+++ b/src/ee/executors/swaptablesexecutor.cpp
@@ -64,7 +64,7 @@ bool SwapTablesExecutor::p_init(AbstractPlanNode* abstract_node,
     assert(node->getInputTableCount() == 0);
 #endif
 
-    m_replicatedTableOperation = static_cast<PersistentTable*>(node->getTargetTable())->isCatalogTableReplicated();
+    m_replicatedTableOperation = static_cast<PersistentTable*>(node->getTargetTable())->isReplicatedTable();
     setDMLCountOutputTable(executorVector.limits());
     return true;
 }
@@ -86,7 +86,7 @@ bool SwapTablesExecutor::p_execute(NValueArray const& params) {
                theTargetTable->name().c_str(),
                otherTargetTable->name().c_str());
     {
-        assert(m_replicatedTableOperation == theTargetTable->isCatalogTableReplicated());
+        assert(m_replicatedTableOperation == theTargetTable->isReplicatedTable());
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
                 m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
         if (possiblySynchronizedUseMpMemory.okToExecute()) {

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -119,7 +119,7 @@ bool UpdateExecutor::p_init(AbstractPlanNode* abstract_node,
     m_partitionColumn = targetTable->partitionColumn();
 
     // for shared replicated table special handling
-    m_replicatedTableOperation = targetTable->isCatalogTableReplicated();
+    m_replicatedTableOperation = targetTable->isReplicatedTable();
     return true;
 }
 
@@ -139,7 +139,7 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
     int64_t modified_tuples = 0;
 
     {
-        assert(m_replicatedTableOperation == targetTable->isCatalogTableReplicated());
+        assert(m_replicatedTableOperation == targetTable->isReplicatedTable());
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
                 m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
         if (possiblySynchronizedUseMpMemory.okToExecute()) {

--- a/src/ee/storage/CopyOnWriteContext.cpp
+++ b/src/ee/storage/CopyOnWriteContext.cpp
@@ -52,7 +52,7 @@ CopyOnWriteContext::CopyOnWriteContext(
              m_updates(0),
              m_skippedDirtyRows(0),
              m_skippedInactiveRows(0),
-             m_replicated(table.isCatalogTableReplicated())
+             m_replicated(table.isReplicatedTable())
 {
     if (m_replicated) {
         // There is a corner case where a replicated table is streamed from a thread other than the lowest

--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -755,9 +755,9 @@ TableCatalogDelegate::processSchemaChanges(catalog::Database const& catalogDatab
     // Drop the old table
     ///////////////////////////////////////////////
     if (existingPersistentTable && newPersistentTable &&
-            newPersistentTable->isCatalogTableReplicated() != existingPersistentTable->isCatalogTableReplicated()) {
+            newPersistentTable->isReplicatedTable() != existingPersistentTable->isReplicatedTable()) {
         // A table can only be modified from replicated to partitioned
-        assert(newPersistentTable->isCatalogTableReplicated());
+        assert(newPersistentTable->isReplicatedTable());
         // Assume the MP memory context before starting the deallocate
         ExecuteWithMpMemory useMpMemory;
         existingTable->decrementRefcount();

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -553,7 +553,7 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool replicatedTable, 
         emptyTable->m_invisibleTuplesPendingDeleteCount = emptyTable->m_tupleCount;
         // Create and register an undo action.
         UndoReleaseAction* undoAction = new (*uq) PersistentTableUndoTruncateTableAction(tcd, this, emptyTable, replicatedTable);
-        SynchronizedThreadLock::addTruncateUndoAction(isCatalogTableReplicated(), uq, undoAction, this);
+        SynchronizedThreadLock::addTruncateUndoAction(isReplicatedTable(), uq, undoAction, this);
     }
     else {
         if (fallible) {
@@ -885,7 +885,7 @@ void PersistentTable::doInsertTupleCommon(TableTuple& source, TableTuple& target
             //* enable for debug */           << " { " << target.debugNoHeader() << " } "
             //* enable for debug */           << " copied to " << (void*)tupleData << std::endl;
             UndoReleaseAction* undoAction = createInstanceFromPool<PersistentTableUndoInsertAction>(*uq->getPool(), tupleData, &m_surgeon);
-            SynchronizedThreadLock::addUndoAction(isCatalogTableReplicated(), uq, undoAction);
+            SynchronizedThreadLock::addUndoAction(isReplicatedTable(), uq, undoAction);
         }
     }
 
@@ -1094,7 +1094,7 @@ void PersistentTable::updateTupleWithSpecificIndexes(TableTuple& targetTupleToUp
        char* newTupleData = partialCopyToPool(uq->getPool(), targetTupleToUpdate.address(), tupleLength);
         UndoReleaseAction* undoAction = createInstanceFromPool<PersistentTableUndoUpdateAction>(
               *uq->getPool(), oldTupleData, newTupleData, oldObjects, newObjects, &m_surgeon, someIndexGotUpdated);
-        SynchronizedThreadLock::addUndoAction(isCatalogTableReplicated(), uq, undoAction);
+        SynchronizedThreadLock::addUndoAction(isReplicatedTable(), uq, undoAction);
     }
     else {
         // This is normally handled by the Undo Action's release (i.e. when there IS an Undo Action)
@@ -1230,7 +1230,7 @@ void PersistentTable::deleteTuple(TableTuple& target, bool fallible) {
         ++m_invisibleTuplesPendingDeleteCount;
         UndoReleaseAction* undoAction = createInstanceFromPool<PersistentTableUndoDeleteAction>(
               *uq->getPool(), target.address(), &m_surgeon);
-        SynchronizedThreadLock::addUndoAction(isCatalogTableReplicated(), uq, undoAction, this);
+        SynchronizedThreadLock::addUndoAction(isReplicatedTable(), uq, undoAction, this);
     }
 
     // handle any materialized views, insert the tuple into delta table,

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -445,9 +445,7 @@ public:
 
     int tupleLimit() const { return m_tupleLimit; }
 
-    bool isReplicatedTable() const { return (m_partitionColumn == -1); }
-
-    bool isCatalogTableReplicated() const {
+    bool isReplicatedTable() const {
         if (!m_isMaterialized && m_isReplicated != (m_partitionColumn == -1)) {
             VOLT_ERROR("CAUTION: detected inconsistent isReplicate flag. Table name:%s\n", m_name.c_str());
         }

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -513,7 +513,7 @@ public:
     }
 
     TableTuple insertTuple(PersistentTable* table, TableTuple temp_tuple) {
-        if (table->isCatalogTableReplicated()) {
+        if (table->isReplicatedTable()) {
             return insertTupleForReplicated(table, temp_tuple);
         }
         table->insertTuple(temp_tuple);
@@ -547,7 +547,7 @@ public:
     }
 
     TableTuple updateTuple(PersistentTable* table, TableTuple oldTuple, TableTuple newTuple) {
-        assert(!table->isCatalogTableReplicated());
+        assert(!table->isReplicatedTable());
         table->updateTuple(oldTuple, newTuple);
         TableTuple tuple = table->lookupTupleByValues(newTuple);
         assert(!tuple.isNullTuple());
@@ -555,14 +555,14 @@ public:
     }
 
     void deleteTuple(PersistentTable* table, TableTuple tuple) {
-        assert(!table->isCatalogTableReplicated());
+        assert(!table->isReplicatedTable());
         TableTuple tuple_to_delete = table->lookupTupleForDR(tuple);
         ASSERT_FALSE(tuple_to_delete.isNullTuple());
         table->deleteTuple(tuple_to_delete, true);
     }
 
     TableTuple updateTuple(PersistentTable* table, TableTuple tuple, int8_t new_index_value, const std::string& new_nonindex_value) {
-        assert(!table->isCatalogTableReplicated());
+        assert(!table->isReplicatedTable());
         TableTuple tuple_to_update = table->lookupTupleForDR(tuple);
         assert(!tuple_to_update.isNullTuple());
         TableTuple new_tuple = table->tempTuple();
@@ -574,7 +574,7 @@ public:
     }
 
     TableTuple updateTupleFirstAndSecondColumn(PersistentTable* table, TableTuple tuple, int8_t new_tinyint_value, int64_t new_bigint_value) {
-        assert(!table->isCatalogTableReplicated());
+        assert(!table->isReplicatedTable());
         TableTuple tuple_to_update = table->lookupTupleByValues(tuple);
         assert(!tuple_to_update.isNullTuple());
         TableTuple new_tuple = table->tempTuple();

--- a/tests/ee/test_utils/plan_testing_baseclass.h
+++ b/tests/ee/test_utils/plan_testing_baseclass.h
@@ -255,7 +255,7 @@ public:
         assert(pTable != NULL);
         int dummyExceptionTracker;
         voltdb::ConditionalSynchronizedExecuteWithMpMemory setMpMemoryIfNeeded
-                (pTable->isCatalogTableReplicated(), true, &dummyExceptionTracker, -1);
+                (pTable->isReplicatedTable(), true, &dummyExceptionTracker, -1);
         for (int row = 0; row < nRows; row += 1) {
             if (row > 0 && (row % 100 == 0)) {
                 std::cout << '.';


### PR DESCRIPTION
There were two methods which implied they were testing if a table was
replicated isReplicatedTable and isCatalogTableReplicated. The first one tested
if there wasn't a partition column while the second actually returned if the
table was replicated. The results of these methods can disagree for views.

Having the two methods was confusing and resulted in asserts checking the wrong
value. All callers of isReplicatedTable didn't actually care about the
partition column state and really wanted to know if the table was marked
replicated. To simplify the methods the original implementation of
isReplicatedTable was reaplaced with the implementation of
isCatalogTableReplicated and isCatalogTableReplicated was removed.