### PR TITLE
 TestSaveRestoreSysprocSuite: Fix up tests and fix one bug in restore

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -1909,6 +1909,16 @@ public class SnapshotRestore extends VoltSystemProcedure {
                     // If the table is a snapshotted persistent table view, we will try to
                     // temporarily disable its maintenance job to boost restore performance.
                     commaSeparatedViewNamesToDisable.append(table.getTypeName()).append(",");
+                } else if (table.getMaterializer() != null
+                        && !CatalogUtil.isSnapshotableStreamedTableView(m_database, table)) {
+                    SNAP_LOG.info("Skipping restore of " + table.getTypeName()
+                            + " which normally would not be in a snapshot for the current schema");
+                    /*
+                     * This is a table which would have been excluded by SnapshotUtil.getTablesToSave(). This can happen
+                     * if the schema of the current cluster is different from the snapshot so that a previously
+                     * replicated view is now a randomly partitioned view
+                     */
+                    continue;
                 }
                 tables_to_restore.add(table);
             }


### PR DESCRIPTION
Add a tearDown which always reverts the catalog at the end of a test so that
catalog changes from one test do not bleed into another.

Remove catch blocks which surround the test and swallows the exception, making
the test always pass.

Remove unnecessary try/catch blocks which just print the exception and fail the
test. Just let junit do its job and fail when it encounters an exception.

 SnapshotRestore: Should not restore randomly partitioned views