### PR TITLE
ENG-15557 retain TTL while table is altered. 

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -4212,7 +4212,7 @@ public class ParserDDL extends ParserRoutine {
         if (table.timeToLive != null) {
             final String ttlColumn = table.timeToLive.ttlColumn.getNameString();
             if (colName.equalsIgnoreCase(ttlColumn)) {
-                throw Error.error("This column used by TTL cannot be dropped.");
+                throw Error.error("Columns used by TTL cannot be dropped.");
             }
         }
         Object[] args = new Object[] {

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -4209,6 +4209,12 @@ public class ParserDDL extends ParserRoutine {
             throw Error.error(ErrorCode.X_42591);
         }
 
+        if (table.timeToLive != null) {
+            final String ttlColumn = table.timeToLive.ttlColumn.getNameString();
+            if (colName.equalsIgnoreCase(ttlColumn)) {
+                throw Error.error("This column used by TTL cannot be dropped.");
+            }
+        }
         Object[] args = new Object[] {
             table.getColumn(colindex).getName(),
             Integer.valueOf(SchemaObject.CONSTRAINT), Boolean.valueOf(cascade),

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Table.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Table.java
@@ -2220,6 +2220,7 @@ public class Table extends TableBase implements SchemaObject {
 
                 store.indexRow(null, newrow);
             }
+            this.timeToLive = from.timeToLive;
         } catch (Throwable t) {
             store.release();
 

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -104,6 +104,12 @@ public class TestVoltCompiler extends TestCase {
         VoltProjectBuilder pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);
         assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
+
+        ddl = "create table ttl (a integer NOT NULL, b integer, PRIMARY KEY(a)) USING TTL 10 SECONDS ON COLUMN a;\n" +
+              "alter table ttl drop column a;\n";
+        pb = new VoltProjectBuilder();
+        pb.addLiteralSchema(ddl);
+        assertFalse(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
     }
 
     public void testDDLFiltering() throws Exception {
@@ -3639,7 +3645,8 @@ public class TestVoltCompiler extends TestCase {
     public void testDDLCompilerStreamType() throws Exception {
         String ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
                 " USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATE TO TARGET TEST;\n" +
-                "partition table ttl on column a;";
+                "partition table ttl on column a;" +
+                "ALTER TABLE TTL DROP COLUMN B;";
         Database db = checkDDLAgainstGivenSchema(null,
                 "CREATE STREAM e PARTITION ON COLUMN D1 (D1 INTEGER NOT NULL, D2 INTEGER);\n",
                 "CREATE STREAM e1 PARTITION ON COLUMN D1 EXPORT TO TARGET T(D1 INTEGER NOT NULL, D2 INTEGER);\n" +


### PR DESCRIPTION
The pull request addressed the issue that TTL definition is accidentally dropped  while a table is altered. And enforce a restriction that a column used by TTL is not allowed to be dropped. 