### PR TITLE
ENG-15347 reset migrate hidden column value for elastic join

### DIFF
--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -1111,8 +1111,9 @@ inline void TableTuple::deserializeFrom(voltdb::SerializeInputBE &tupleIn, Pool 
         if (hiddenColumnMigrateElastic && j == hiddenColumnCount -1) {
             NValue value = NValue::getNullValue(columnInfo->getVoltType());
             setHiddenNValue(j, value);
+            VOLT_DEBUG("Deserializing migrate hidden column for elastic operation");
         } else {
-        char *dataPtr = getWritableDataPtr(columnInfo);
+            char *dataPtr = getWritableDataPtr(columnInfo);
             NValue::deserializeFrom(tupleIn, dataPool, dataPtr, columnInfo->getVoltType(),
                 columnInfo->inlined, static_cast<int32_t>(columnInfo->length), columnInfo->inBytes);
         }

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1574,7 +1574,8 @@ VoltDBEngine::loadTable(int32_t tableId,
                         int64_t uniqueId,
                         bool returnConflictRows,
                         bool shouldDRStream,
-                        int64_t undoToken) {
+                        int64_t undoToken,
+                        bool elastic) {
     //Not going to thread the unique id through.
     //The spHandle and lastCommittedSpHandle aren't really used in load table
     //since their only purpose as of writing this (1/2013) they are only used
@@ -1635,7 +1636,8 @@ VoltDBEngine::loadTable(int32_t tableId,
                                           NULL,
                                           returnConflictRows ? &m_resultOutput : NULL,
                                           shouldDRStream,
-                                          ExecutorContext::currentUndoQuantum() == NULL);
+                                          ExecutorContext::currentUndoQuantum() == NULL,
+                                          elastic);
         }
         catch (const ConstraintFailureException &cfe) {
             s_loadTableException = VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION;

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -276,7 +276,8 @@ class __attribute__((visibility("default"))) VoltDBEngine {
                        int64_t uniqueId,
                        bool returnConflictRows,
                        bool shouldDRStream,
-                       int64_t undoToken);
+                       int64_t undoToken,
+                       bool elastic);
 
         /**
          * Reset the result buffer (use the nextResultBuffer by default)

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1571,7 +1571,8 @@ void PersistentTable::loadTuplesForLoadTable(SerializeInputBE &serialInput,
                                              Pool *stringPool,
                                              ReferenceSerializeOutput *uniqueViolationOutput,
                                              bool shouldDRStreamRows,
-                                             bool ignoreTupleLimit) {
+                                             bool ignoreTupleLimit,
+                                             bool elastic) {
     serialInput.readInt(); // rowstart
 
     serialInput.readByte();
@@ -1613,8 +1614,6 @@ void PersistentTable::loadTuplesForLoadTable(SerializeInputBE &serialInput,
                                       message.str().c_str());
     }
 
-
-
     int tupleCount = serialInput.readInt();
     assert(tupleCount >= 0);
 
@@ -1636,7 +1635,7 @@ void PersistentTable::loadTuplesForLoadTable(SerializeInputBE &serialInput,
         target.setPendingDeleteOnUndoReleaseFalse();
 
         try {
-            target.deserializeFrom(serialInput, stringPool);
+            target.deserializeFrom(serialInput, stringPool, elastic);
         } catch (SQLException &e) {
             deleteTupleStorage(target);
             throw;

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -569,7 +569,8 @@ public:
                                 Pool* stringPool = NULL,
                                 ReferenceSerializeOutput* uniqueViolationOutput = NULL,
                                 bool shouldDRStreamRows = false,
-                                bool ignoreTupleLimit = true);
+                                bool ignoreTupleLimit = true,
+                                bool elastic = false);
 
 private:
     // Zero allocation size uses defaults.

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -283,6 +283,7 @@ typedef struct {
     int64_t undoToken;
     int32_t returnUniqueViolations;
     int32_t shouldDRStream;
+    int32_t elastic;
     char data[0];
 }__attribute__((packed)) load_table_cmd;
 
@@ -984,6 +985,7 @@ int8_t VoltDBIPC::loadTable(struct ipc_command *cmd) {
     const int64_t undoToken = ntohll(loadTableCommand->undoToken);
     const bool returnUniqueViolations = loadTableCommand->returnUniqueViolations != 0;
     const bool shouldDRStream = loadTableCommand->shouldDRStream != 0;
+    const bool elastic = loadTableCommand->elastic != 0;
     // ...and fast serialized table last.
     void* offset = loadTableCommand->data;
     int sz = static_cast<int> (ntohl(cmd->msgsize) - sizeof(load_table_cmd));
@@ -992,7 +994,7 @@ int8_t VoltDBIPC::loadTable(struct ipc_command *cmd) {
 
         bool success = m_engine->loadTable(tableId, serialize_in,
                                            txnId, spHandle, lastCommittedSpHandle, uniqueId,
-                                           returnUniqueViolations, shouldDRStream, undoToken);
+                                           returnUniqueViolations, shouldDRStream, undoToken, elastic);
         if (success) {
             return kErrorCode_Success;
         } else {

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -413,7 +413,7 @@ SHAREDLIB_JNIEXPORT jint JNICALL
 Java_org_voltdb_jni_ExecutionEngine_nativeLoadTable (
     JNIEnv *env, jobject obj, jlong engine_ptr, jint table_id,
     jbyteArray serialized_table, jlong txnId, jlong spHandle, jlong lastCommittedSpHandle,
-    jlong uniqueId, jboolean returnUniqueViolations, jboolean shouldDRStream, jlong undoToken)
+    jlong uniqueId, jboolean returnUniqueViolations, jboolean shouldDRStream, jlong undoToken, jboolean elastic)
 {
     VoltDBEngine *engine = castToEngine(engine_ptr);
     Topend *topend = static_cast<JNITopend*>(engine->getTopend())->updateJNIEnv(env);
@@ -436,7 +436,7 @@ Java_org_voltdb_jni_ExecutionEngine_nativeLoadTable (
         try {
             bool success = engine->loadTable(table_id, serialize_in, txnId,
                                              spHandle, lastCommittedSpHandle, uniqueId,
-                                             returnUniqueViolations, shouldDRStream, undoToken);
+                                             returnUniqueViolations, shouldDRStream, undoToken, elastic);
             env->ReleaseByteArrayElements(serialized_table, bytes, JNI_ABORT);
             VOLT_DEBUG("deserialized table");
 

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -108,7 +108,8 @@ public interface SiteProcedureConnection {
             VoltTable data,
             boolean returnUniqueViolations,
             boolean shouldDRStream,
-            boolean undo);
+            boolean undo,
+            boolean elastic);
 
     /**
      * Execute a set of plan fragments.

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -469,7 +469,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     @Override
     public byte[] loadTable(long txnId, long spHandle, long uniqueId, int tableId, VoltTable data, boolean returnUniqueViolations,
             boolean shouldDRStream,
-            boolean undo)
+            boolean undo, boolean elastic)
     {
         throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
     }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1105,13 +1105,13 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             throw new VoltAbortException("table '" + tableName + "' does not exist in database " + clusterName + "." + databaseName);
         }
 
-        return loadTable(txnId, spHandle, uniqueId, table.getRelativeIndex(), data, returnUniqueViolations, shouldDRStream, undo);
+        return loadTable(txnId, spHandle, uniqueId, table.getRelativeIndex(), data, returnUniqueViolations, shouldDRStream, undo, false);
     }
 
     @Override
     public byte[] loadTable(long txnId, long spHandle, long uniqueId, int tableId,
             VoltTable data, boolean returnUniqueViolations, boolean shouldDRStream,
-            boolean undo)
+            boolean undo, boolean elastic)
     {
         // Long.MAX_VALUE is a no-op don't track undo token
         return m_ee.loadTable(tableId, data, txnId,
@@ -1120,7 +1120,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                 uniqueId,
                 returnUniqueViolations,
                 shouldDRStream,
-                undo ? getNextUndoToken(m_currentTxnId) : Long.MAX_VALUE);
+                undo ? getNextUndoToken(m_currentTxnId) : Long.MAX_VALUE,
+                elastic);
     }
 
     @Override

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -736,8 +736,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
 
     public abstract byte[] loadTable(
         int tableId, VoltTable table, long txnId, long spHandle,
-        long lastCommittedSpHandle, long uniqueId, boolean returnUniqueViolations, boolean shouldDRStream,
-        long undoToken) throws EEException;
+        long lastCommittedSpHandle, long uniqueId, boolean returnUniqueViolations,
+        boolean shouldDRStream, long undoToken, boolean elsaticJoin) throws EEException;
 
     /**
      * Set the log levels to be used when logging in this engine
@@ -973,8 +973,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * @param undoToken The undo token to release
      */
     protected native int nativeLoadTable(long pointer, int table_id, byte[] serialized_table, long txnId,
-            long spHandle, long lastCommittedSpHandle, long uniqueId, boolean returnUniqueViolations, boolean shouldDRStream,
-            long undoToken);
+            long spHandle, long lastCommittedSpHandle, long uniqueId, boolean returnUniqueViolations,
+            boolean shouldDRStream, long undoToken, boolean elastic);
 
     /**
      * Executes multiple plan fragments with the given parameter sets and gets the results.

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -1189,7 +1189,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
     @Override
     public byte[] loadTable(final int tableId, final VoltTable table, final long txnId,
             final long spHandle, final long lastCommittedSpHandle, final long uniqueId,
-            boolean returnUniqueViolations, boolean shouldDRStream, long undoToken)
+            boolean returnUniqueViolations, boolean shouldDRStream, long undoToken, boolean elastic)
     throws EEException
     {
         if (returnUniqueViolations) {
@@ -1207,6 +1207,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             m_data.putLong(undoToken);
             m_data.putInt(returnUniqueViolations ? 1 : 0);
             m_data.putInt(shouldDRStream ? 1 : 0);
+            m_data.putInt(elastic ? 1 : 0);
             verifyDataCapacity(m_data.position() + tableBytes.remaining());
         } while (m_data.position() == 0);
 

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -513,7 +513,8 @@ public class ExecutionEngineJNI extends ExecutionEngine {
         final long uniqueId,
         boolean returnUniqueViolations,
         boolean shouldDRStream,
-        long undoToken) throws EEException
+        long undoToken,
+        boolean elastic) throws EEException
     {
         if (HOST_TRACE_ENABLED) {
             LOG.trace("loading table id=" + tableId + "...");
@@ -527,7 +528,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
         m_nextDeserializer.clear();
         final int errorCode = nativeLoadTable(pointer, tableId, serialized_table,
                                               txnId, spHandle, lastCommittedSpHandle, uniqueId,
-                                              returnUniqueViolations, shouldDRStream, undoToken);
+                                              returnUniqueViolations, shouldDRStream, undoToken, elastic);
         checkErrorCode(errorCode);
 
         try {

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -143,7 +143,7 @@ public class MockExecutionEngine extends ExecutionEngine {
     @Override
     public byte[] loadTable(final int tableId, final VoltTable table, final long txnId,
         final long spHandle, final long lastCommittedTxnId, long uniqueId,
-        boolean returnUniqueViolations, boolean shouldDRStream, long undoToken)
+        boolean returnUniqueViolations, boolean shouldDRStream, long undoToken, boolean elastic)
     throws EEException
     {
         return null;

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotSink.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotSink.java
@@ -141,7 +141,7 @@ public class StreamSnapshotSink {
             // Currently, only export cares about this TXN ID.  Since we don't have one handy,
             // just use Long.MIN_VALUE to match how m_openSpHandle is initialized in ee/storage/TupleStreamWrapper
 
-            connection.loadTable(Long.MIN_VALUE, Long.MIN_VALUE, Long.MIN_VALUE, tableId, table, false, false, false);
+            connection.loadTable(Long.MIN_VALUE, Long.MIN_VALUE, Long.MIN_VALUE, tableId, table, false, false, false, false);
         }
     }
 

--- a/tests/frontend/org/voltdb/jni/TestExecutionEngine.java
+++ b/tests/frontend/org/voltdb/jni/TestExecutionEngine.java
@@ -115,10 +115,10 @@ public class TestExecutionEngine extends TestCase {
 
         System.out.println(warehousedata.toString());
         // Long.MAX_VALUE is a no-op don't track undo token
-        sourceEngine.loadTable(WAREHOUSE_TABLEID, warehousedata, 0, 0, 0, 0, false, false, Long.MAX_VALUE);
+        sourceEngine.loadTable(WAREHOUSE_TABLEID, warehousedata, 0, 0, 0, 0, false, false, Long.MAX_VALUE, false);
 
         //Check that we can detect and handle the dups when loading the data twice
-        byte results[] = sourceEngine.loadTable(WAREHOUSE_TABLEID, warehousedata, 0, 0, 0, 0, true, false, Long.MAX_VALUE);
+        byte results[] = sourceEngine.loadTable(WAREHOUSE_TABLEID, warehousedata, 0, 0, 0, 0, true, false, Long.MAX_VALUE, false);
         System.out.println("Printing dups");
         System.out.println(PrivateVoltTableFactory.createVoltTableFromBuffer(ByteBuffer.wrap(results), true));
 
@@ -147,7 +147,7 @@ public class TestExecutionEngine extends TestCase {
                              "sdist9", "sdist10", 0, 0, 0, "sdata");
         }
         // Long.MAX_VALUE is a no-op don't track undo token
-        sourceEngine.loadTable(STOCK_TABLEID, stockdata, 0, 0, 0, 0, false, false, Long.MAX_VALUE);
+        sourceEngine.loadTable(STOCK_TABLEID, stockdata, 0, 0, 0, 0, false, false, Long.MAX_VALUE, false);
     }
 
     public void testLoadTable() throws Exception {
@@ -179,7 +179,7 @@ public class TestExecutionEngine extends TestCase {
         // Assemble a very long string.
         testTable.addRow(String.join("", Collections.nCopies(15, "我能吞下玻璃而不伤身体。")));
         try {
-            sourceEngine.loadTable(TEST_TABLEID, testTable, 0, 0, 0, 0, false, false, Long.MAX_VALUE);
+            sourceEngine.loadTable(TEST_TABLEID, testTable, 0, 0, 0, 0, false, false, Long.MAX_VALUE, false);
             fail("The loadTable() call is expected to fail, but did not.");
         }
         catch (SQLException ex) {
@@ -243,7 +243,7 @@ public class TestExecutionEngine extends TestCase {
             public byte[] call() throws Exception {
                 try {
                     byte[] rslt = source2Engine.get().loadTable(ITEM_TABLEID, itemdata, 0, 0, 0, 0,
-                            returnUniqueViolations, false, Long.MAX_VALUE);
+                            returnUniqueViolations, false, Long.MAX_VALUE, false);
                     return rslt;
                 }
                 catch (ReplicatedTableException e) {
@@ -258,7 +258,7 @@ public class TestExecutionEngine extends TestCase {
         byte[] srcRslt = null;
         try {
             srcRslt = sourceEngine.loadTable(ITEM_TABLEID, itemdata, 0, 0, 0, 0,
-                    returnUniqueViolations, false, Long.MAX_VALUE);
+                    returnUniqueViolations, false, Long.MAX_VALUE, false);
         }
         catch (ConstraintFailureException e) {
             // srcRslt already null

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -105,7 +105,7 @@ public class TestFragmentProgressUpdate extends TestCase {
             m_warehousedata.addRow(i, "name" + i, "st1", "st2", "city", "ST", "zip", 0, 0);
         }
 
-        m_ee.loadTable(WAREHOUSE_TABLEID, m_warehousedata, 0, 0, 0, 0, false, false, WRITE_TOKEN);
+        m_ee.loadTable(WAREHOUSE_TABLEID, m_warehousedata, 0, 0, 0, 0, false, false, WRITE_TOKEN, false);
         assertEquals(tableSize, m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
         System.out.println("Rows loaded to table "+m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
 
@@ -161,7 +161,7 @@ public class TestFragmentProgressUpdate extends TestCase {
             m_warehousedata.addRow(i, "name" + i, "st1", "st2", "city", "ST", "zip", 0, 0);
         }
 
-        m_ee.loadTable(WAREHOUSE_TABLEID, m_warehousedata, 0, 0, 0, 0, false, false, Long.MAX_VALUE);
+        m_ee.loadTable(WAREHOUSE_TABLEID, m_warehousedata, 0, 0, 0, 0, false, false, Long.MAX_VALUE, false);
         assertEquals(tableSize, m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
         System.out.println("Rows loaded to table "+m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
 
@@ -280,7 +280,7 @@ public class TestFragmentProgressUpdate extends TestCase {
             m_warehousedata.addRow(i, "name" + i, "st1", "st2", "city", "ST", "zip", 0, 0);
         }
 
-        m_ee.loadTable(WAREHOUSE_TABLEID, m_warehousedata, 0, 0, 0, 0, false, false, WRITE_TOKEN);
+        m_ee.loadTable(WAREHOUSE_TABLEID, m_warehousedata, 0, 0, 0, 0, false, false, WRITE_TOKEN, false);
         assertEquals(tableSize, m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
         System.out.println("Rows loaded to table "+m_ee.serializeTable(WAREHOUSE_TABLEID).getRowCount());
 
@@ -444,7 +444,7 @@ public class TestFragmentProgressUpdate extends TestCase {
             m_itemData.addRow(i, i + 50, "item" + i, (double)i / 2, "data" + i);
         }
 
-        m_ee.loadTable(ITEM_TABLEID, m_itemData, 0, 0, 0, 0, false, false, WRITE_TOKEN);
+        m_ee.loadTable(ITEM_TABLEID, m_itemData, 0, 0, 0, 0, false, false, WRITE_TOKEN, false);
         assertEquals(numRowsToInsert, m_ee.serializeTable(ITEM_TABLEID).getRowCount());
         System.out.println("Rows loaded to table " + m_ee.serializeTable(ITEM_TABLEID).getRowCount());
 


### PR DESCRIPTION
The migrate hidden column holds transaction ids. While tuples are streamed over to a new elastically joined node, the transaction ids are not relevant on the new node since the new node hosts new partitions and partition ids are part of transaction ids. The values of migrate hidden column will be reset to null while tuples are streamed over to newly joined hosts.