### PR TITLE
ENG-15583: Assert that seqNo matches before decrement

### DIFF
--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -201,12 +201,12 @@ void StreamedTable::setSignatureAndGeneration(std::string signature, int64_t gen
 
 void StreamedTable::undo(size_t mark, int64_t seqNo) {
     if (m_wrapper) {
+        assert(seqNo == m_sequenceNo);
         m_wrapper->rollbackExportTo(mark, seqNo);
         //Decrementing the sequence number should make the stream of tuples
         //contiguous outside of actual system failures. Should be more useful
         //than having gaps.
         m_sequenceNo--;
-        assert(seqNo == m_sequenceNo);
     }
 }
 


### PR DESCRIPTION
m_sequenceNo is the current sequence number and not the next number. The
provided seqNo should match m_sequenceNo prior to being decremented not after.