### PR TITLE
ENG-15347 fix auto partition issue

### DIFF
--- a/src/frontend/org/voltdb/TableType.java
+++ b/src/frontend/org/voltdb/TableType.java
@@ -41,6 +41,10 @@ public enum TableType {
         return (e ==STREAM.get() || e == STREAM_VIEW_ONLY.get());
     }
 
+    public static boolean isPersistentMigrate(int e) {
+        return (e == PERSISTENT_MIGRATE.get());
+    }
+
     public static boolean needsMigrateHiddenColumn(int e) {
         return (e == PERSISTENT_MIGRATE.get() || e == PERSISTENT_EXPORT.get());
     }

--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -1403,7 +1403,7 @@ public class VoltCompiler {
                     "Streams can't have indexes (including primary keys).");
             throw new VoltCompilerException("Streams cannot be configured with indexes");
         }
-        if (tableref.getIsreplicated()) {
+        if (tableref.getIsreplicated() && !TableType.isPersistentMigrate(tableref.getTabletype())) {
             // if you don't specify partition columns, make
             // export tables partitioned, but on no specific column (iffy)
             tableref.setIsreplicated(false);


### PR DESCRIPTION
Persistent table with migrate should not auto partitioned. This pull fixes this issue.