### PR TITLE
ENG-15591: MIGRATING SQL function

### DIFF
--- a/src/ee/expressions/functionexpression.h
+++ b/src/ee/expressions/functionexpression.h
@@ -294,6 +294,7 @@ static const int FUNC_VOLT_MAX_VALID_TIMESTAMP         = 21022;     // maximum v
 static const int FUNC_VOLT_IS_VALID_TIMESTAMP          = 21023;     // is a timestamp valid
 static const int FUNC_VOLT_MAKE_VALID_POLYGON          = 21024;     // Make a polygon valid if necessary.
 static const int FUNC_VOLT_FORMAT_TIMESTAMP            = 21025;     // Convert a timestamp to a String in a given timezone.
+static const int FUNC_VOLT_MIGRATING                   = 21026;     // Check if the row is migrating.
 
 // From Tokens.java.
 static const int SQL_TRIM_LEADING                     = 149;

--- a/src/ee/expressions/logicfunctions.h
+++ b/src/ee/expressions/logicfunctions.h
@@ -43,4 +43,11 @@ template<> inline NValue NValue::call<FUNC_DECODE>(const std::vector<NValue>& ar
     return getNullValue();
 }
 
+/*
+* implement the Volt MIGRATING function
+*/
+template<>
+inline NValue NValue::callUnary<FUNC_VOLT_MIGRATING>() const {
+    return ValueFactory::getBooleanValue(!isNull());
+}
 }

--- a/src/ee/expressions/numericfunctions.h
+++ b/src/ee/expressions/numericfunctions.h
@@ -483,5 +483,4 @@ template<> inline NValue NValue::call<FUNC_VOLT_ROUND>(const std::vector<NValue>
     return getDecimalValueFromString(rv);
 }
 
-
 }

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -372,6 +372,7 @@ public class PlannerTool {
                 // Again, plans with inferred partitioning are the only ones supported in the cache.
                 m_cache.put(sql, parsedToken, ahps, extractedLiterals, hasUserQuestionMark, planHasExceptionsWhenParameterized);
             }
+
             return ahps;
         }
         finally {

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -372,7 +372,6 @@ public class PlannerTool {
                 // Again, plans with inferred partitioning are the only ones supported in the cache.
                 m_cache.put(sql, parsedToken, ahps, extractedLiterals, hasUserQuestionMark, planHasExceptionsWhenParameterized);
             }
-
             return ahps;
         }
         finally {

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
@@ -195,6 +195,7 @@ public class FunctionForVoltDB extends FunctionSQL {
         static final int FUNC_VOLT_MAKE_VALID_POLYGON           = 21024;    // Make an invalid polygon valid by reversing rings.
                                                                             // Note: This will only correct orientation errors.
         static final int FUNC_VOLT_FORMAT_TIMESTAMP             = 21025;    // Convert a timestamp to a String in a given timezone.
+        static final int FUNC_VOLT_MIGRATING                    = 21026;    // Check if the row is migrating.
 
         /*
          * All VoltDB user-defined functions must have IDs in this range.
@@ -420,8 +421,12 @@ public class FunctionForVoltDB extends FunctionSQL {
 
             new FunctionDescriptor("format_timestamp", Type.SQL_VARCHAR, FUNC_VOLT_FORMAT_TIMESTAMP, -1,
                     new Type[]{Type.SQL_TIMESTAMP, Type.SQL_VARCHAR},
-                    doubleParamList)
+                    doubleParamList),
 
+            new FunctionDescriptor("migrating", Type.SQL_BOOLEAN, FUNC_VOLT_MIGRATING, -1,
+                    new Type[] {},
+                    emptyParamList,
+                    noParamList),
         };
 
         /**

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
@@ -3439,6 +3439,13 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         cr = client.callProcedure("@AdHoc", "select * from m2 where NOT migrating and a >= 3 order by a, b;");
         assertContentOfTable(new Object[][]{{3, 30}, {4, 40}}, cr.getResults()[0]);
 
+        // migrating with aggregate functions.
+        cr = client.callProcedure("@AdHoc", "select count(*) from m1 where NOT migrating and a >= 3 order by a, b;");
+        assertContentOfTable(new Object[][]{{2}}, cr.getResults()[0]);
+
+        cr = client.callProcedure("@AdHoc", "select count(*) from m2 where NOT migrating and a >= 3 order by a, b;");
+        assertContentOfTable(new Object[][]{{2}}, cr.getResults()[0]);
+
         // migrate() in subquery select
         cr = client.callProcedure("@AdHoc", "select t1.a from (select * from m2 where not migrating and b < 30) as t1 order by t1.a");
         assertContentOfTable(new Object[][]{{1}, {2}}, cr.getResults()[0]);

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
@@ -3408,7 +3408,8 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
                 "insert into m2 values(1, 10);",
                 "insert into m2 values(2, 20);",
                 "insert into m2 values(3, 30);",
-                "insert into m2 values(4, 40);")
+                "insert into m2 values(4, 40);",
+                "insert into p1 values(1, null, 4, 4.1);")
                 .forEachOrdered(stmt -> {
                     try {
                         final ClientResponse cr = client.callProcedure("@AdHoc", stmt);
@@ -3449,6 +3450,10 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         // migrate() in subquery select
         cr = client.callProcedure("@AdHoc", "select t1.a from (select * from m2 where not migrating and b < 30) as t1 order by t1.a");
         assertContentOfTable(new Object[][]{{1}, {2}}, cr.getResults()[0]);
+
+        // Can not apply MIGRATING function on non-migrating tables.
+        verifyProcFails(client, "Can not apply MIGRATING function on non-migrating tables.\\s*", "@AdHoc",
+                "select * from p1 where NOT migrating();");
 
         // we do not support migrating() in SELECT clause
         verifyProcFails(client, "A SELECT clause does not allow a BOOLEAN expression.\\s*", "@AdHoc",


### PR DESCRIPTION
Create a SQL function: 
```
MIGRATING()
```
that returns whether the migrating hidden column of the table is NOT NULL. It returns TRUE if the hidden column is NOT NULL, and FALSE otherwise.
The function then can be used like:
```sql
SELECT COUNT(*) FROM tbl WHERE MIGRATING() AND TTL < 1000;
SELECT TTL FROM tbl WHERE NOT MIGRATING();
```
## Limitations
Note that the `MIGRATING()` is **NOT SUPPORTED** in the SELECT clasue and Joined tables, such as
```sql
SELECT MIGRATING() FROM tbl;
SELECT * FROM t1, t2 WHERE NOT MIGRATING();
```
Why? 
Because supporting them will significantly increase the complextiy of the implementation, and there is no obvious use cases.