### PR TITLE
GCC 8 adds some new warnings

### DIFF
--- a/src/ee/storage/CopyOnWriteContext.cpp
+++ b/src/ee/storage/CopyOnWriteContext.cpp
@@ -213,8 +213,8 @@ int64_t CopyOnWriteContext::handleStreamMore(TupleOutputStreamProcessor &outputS
             size_t pendingLoadCnt = m_surgeon.getSnapshotPendingLoadBlockCount();
             if (m_tuplesRemaining > 0 || allPendingCnt > 0 || pendingLoadCnt > 0) {
 
-                char message[1024 * 16];
-                snprintf(message, 1024 * 16,
+                char message[1024 * 8];
+                snprintf(message, sizeof(message),
                          "serializeMore(): tuple count > 0 after streaming:\n"
                          "Table name: %s\n"
                          "Table type: %s\n"

--- a/src/ee/storage/ElasticIndexReadContext.cpp
+++ b/src/ee/storage/ElasticIndexReadContext.cpp
@@ -209,7 +209,7 @@ bool ElasticIndexReadContext::parseHashRange(
                                                  boost::lexical_cast<int32_t>(rangeStrings[1]));
                 success = true;
             }
-            catch(boost::bad_lexical_cast) {
+            catch(const boost::bad_lexical_cast&) {
                 char errMsg[1024 * 16];
                 snprintf(errMsg, 1024 * 16,
                          "Unable to parse ElasticIndexReadContext predicate \"%s\".",

--- a/tools/VoltDBCompilation.cmake
+++ b/tools/VoltDBCompilation.cmake
@@ -121,6 +121,7 @@ SET (VOLTDB_LINK_FLAGS ${VOLTDB_LINK_FLAGS} ${VOLTDB_LDFLAGS})
 # will build and run correctly.
 #
 ########################################################################
+SET (VOLTDB_COMPILER_GCC8   "8.0.0")
 SET (VOLTDB_COMPILER_U18p04 "7.3.0")
 SET (VOLTDB_COMPILER_U17p10 "7.2.0")
 SET (VOLTDB_COMPILER_U17p04 "6.3.0")
@@ -136,7 +137,7 @@ SET (VOLTDB_COMPILER_OLDE   "4.4.0")
 #
 # Note: Update this when adding a new compiler support.
 #
-SET (VOLTDB_COMPILER_NEWEST ${VOLTDB_COMPILER_U18p04})
+SET (VOLTDB_COMPILER_NEWEST ${VOLTDB_COMPILER_GCC8})
 #
 #
 #
@@ -147,8 +148,14 @@ IF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   VOLTDB_ADD_COMPILE_OPTIONS(-pthread -Wno-deprecated-declarations  -Wno-unknown-pragmas)
   # It turns out to be easier to go from a higher version to a lower
   # version, since we can't easily test <= and >=.
-  IF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_NEWEST )
-    # COMPILER_VERSION > 7.3.0
+  IF ( (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_GCC8)
+      OR (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL VOLTDB_COMPILER_GCC8))
+    # COMPILER_VERSION >= 8.0.0
+    MESSAGE ("GCC Version ${CMAKE_CXX_COMPILER_VERSION} is not verified for building VoltDB.")
+    VOLTDB_ADD_COMPILE_OPTIONS(-Wno-unused-local-typedefs -Wno-array-bounds -Wno-error=class-memaccess -Wno-parentheses)
+    SET (CXX_VERSION_FLAG -std=c++11)
+  ELSEIF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_U18p04)
+    # 7.3.0 < COMPILER_VERSION < 8.0.0
     MESSAGE ("GCC Version ${CMAKE_CXX_COMPILER_VERSION} is not verified for building VoltDB.")
     MESSAGE ("We're using the options for ${CMAKE_COMPILER_NEWEST}, which is the newest one we've tried.  Good Luck.")
     VOLTDB_ADD_COMPILE_OPTIONS(-Wno-unused-local-typedefs -Wno-array-bounds)


### PR DESCRIPTION
Disable warning about parentheses.
Do not error when memcpy or memset could be violating invariants of the class
Fix passing a very large string buffer as a format argument to the exception
Correct catching of polymorphic exception