### PR TITLE
Eng 14565 pending container

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -997,11 +997,10 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                         if (m_pendingContainer.get() != null) {
                             AckingContainer cont = m_pendingContainer.getAndSet(null);
                             boolean hasSchema = cont.schema() != null;
-                            exportLog.info("XXX Set poll future with pending container, hasSchema: " + hasSchema);
                             if (!hasSchema) {
+                                // Ensure this first block has a schema
                                 BBContainer schemaContainer = m_buffers.pollSchema();
                                 if (schemaContainer == null) {
-                                    exportLog.error("XXX No schema for committedSeqNo " + cont.m_commitSeqNo);
                                     pollTask.setException(new IOException("No schema for committedSeqNo " + cont.m_commitSeqNo));
                                     return;
                                 } else {

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -995,10 +995,23 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     try {
                         //If we have anything pending set that before moving to next block.
                         if (m_pendingContainer.get() != null) {
-                            pollTask.setFuture(m_pendingContainer.getAndSet(null));
+                            AckingContainer cont = m_pendingContainer.getAndSet(null);
+                            boolean hasSchema = cont.schema() != null;
+                            exportLog.info("XXX Set poll future with pending container, hasSchema: " + hasSchema);
+                            if (!hasSchema) {
+                                BBContainer schemaContainer = m_buffers.pollSchema();
+                                if (schemaContainer == null) {
+                                    exportLog.error("XXX No schema for committedSeqNo " + cont.m_commitSeqNo);
+                                    pollTask.setException(new IOException("No schema for committedSeqNo " + cont.m_commitSeqNo));
+                                    return;
+                                } else {
+                                    cont.setSchema(schemaContainer);
+                                }
+                            }
+                            pollTask.setFuture(cont);
                             if (m_pollTask != null) {
                                 if (exportLog.isDebugEnabled()) {
-                                    exportLog.debug("Pick up work from pending container, set poll future to null");
+                                    exportLog.error("Pick up work from pending container, set poll future to null");
                                 }
                                 m_pollTask = null;
                             }
@@ -1141,7 +1154,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         final long m_lastSeqNo;
         final long m_commitSeqNo;
         final BBContainer m_backingCont;
-        final BBContainer m_schemaCont;
+        BBContainer m_schemaCont;
         long m_startTime = 0;
         long m_commitSpHandle = 0;
 
@@ -1157,11 +1170,19 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             m_startTime = startTime;
         }
 
-        public ByteBuffer schema() {
+        // Synchronized because schema is settable
+        public synchronized ByteBuffer schema() {
             if (m_schemaCont == null) {
                 return null;
             }
             return m_schemaCont.b();
+        }
+
+        public synchronized void setSchema(BBContainer schemaCont) {
+            if (m_schemaCont != null) {
+                throw new IllegalStateException("Overwriting schema");
+            }
+            m_schemaCont = schemaCont;
         }
 
         public long getCommittedSeqNo() {
@@ -1181,8 +1202,10 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         void internalDiscard() {
             checkDoubleFree();
             m_backingCont.discard();
-            if (m_schemaCont != null) {
-                m_schemaCont.discard();
+            synchronized(this) {
+                if (m_schemaCont != null) {
+                    m_schemaCont.discard();
+                }
             }
         }
 
@@ -1207,8 +1230,10 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
                         try {
                              m_backingCont.discard();
-                             if (m_schemaCont != null) {
-                                 m_schemaCont.discard();
+                             synchronized(this) {
+                                 if (m_schemaCont != null) {
+                                     m_schemaCont.discard();
+                                 }
                              }
                             try {
                                 if (!m_es.isShutdown()) {
@@ -1229,7 +1254,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                   //Don't expect this to happen outside of test, but in test it's harmless
                   exportLog.info("Acking export data task rejected, this should be harmless");
                   m_backingCont.discard();
-                  m_schemaCont.discard();
+                  synchronized(this) {
+                      m_schemaCont.discard();
+                  }
             }
         }
     }

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1010,7 +1010,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                             pollTask.setFuture(cont);
                             if (m_pollTask != null) {
                                 if (exportLog.isDebugEnabled()) {
-                                    exportLog.error("Pick up work from pending container, set poll future to null");
+                                    exportLog.debug("Pick up work from pending container, set poll future to null");
                                 }
                                 m_pollTask = null;
                             }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -442,7 +442,7 @@ public class PBDRegularSegment extends PBDSegment {
         private int m_objectReadIndex = 0;
         private int m_bytesRead = 0;
         private int m_discardCount = 0;
-        private boolean m_closed = false;
+        private boolean m_readerClosed = false;
         private CRC32 m_crc32 = new CRC32();
 
         public SegmentReader(String cursorId) {
@@ -471,7 +471,7 @@ public class PBDRegularSegment extends PBDSegment {
         @Override
         public DBBPool.BBContainer poll(OutputContainerFactory factory, boolean checkCRC) throws IOException {
 
-            if (m_closed) throw new IOException("Reader closed");
+            if (m_readerClosed) throw new IOException("Reader closed");
 
             if (!hasMoreEntries()) {
                 return null;
@@ -596,7 +596,7 @@ public class PBDRegularSegment extends PBDSegment {
 
         @Override
         public DBBPool.BBContainer getSchema(boolean checkCRC) throws IOException {
-            if (m_closed) throw new IOException("Reader closed");
+            if (m_readerClosed) throw new IOException("Reader closed");
 
             final long writePos = m_fc.position();
             m_fc.position(SEGMENT_HEADER_BYTES);
@@ -642,7 +642,7 @@ public class PBDRegularSegment extends PBDSegment {
 
         @Override
         public int uncompressedBytesToRead() {
-            if (m_closed) throw new RuntimeException("Reader closed");
+            if (m_readerClosed) throw new RuntimeException("Reader closed");
 
             return m_size - m_bytesRead;
         }
@@ -664,7 +664,7 @@ public class PBDRegularSegment extends PBDSegment {
 
         @Override
         public void close() throws IOException {
-            m_closed = true;
+            m_readerClosed = true;
             m_readCursors.remove(m_cursorId);
             m_closedCursors.put(m_cursorId, this);
             if (m_readCursors.isEmpty()) {
@@ -674,7 +674,7 @@ public class PBDRegularSegment extends PBDSegment {
 
         @Override
         public boolean isClosed() {
-            return m_closed;
+            return m_readerClosed;
         }
 
         @Override
@@ -682,9 +682,11 @@ public class PBDRegularSegment extends PBDSegment {
             m_readOffset = readOffset;
         }
 
+        @Override
         public void reopen(boolean forWrite, boolean emptyFile) throws IOException {
-            if (m_closed) {
+            if (m_readerClosed) {
                 open(forWrite, emptyFile);
+                m_readerClosed = false;
             }
             if (m_cursorId != null) {
                 m_closedCursors.remove(m_cursorId);


### PR DESCRIPTION
Fixes:

1- On GuestProcessor starting after shutdown, the pending container that was processed first didn't have a schema

2- The PDBRegularSegment.SegmentReader.reopen() method was flawed because its call to PDBRegularSegment.open() didn't clear the m_closed flag of the segment reader.
