### PR TITLE
ENG-15503: fix more grammar-gen failures due to sqlcmd hanging

### DIFF
--- a/tests/sqlgrammar/run.sh
+++ b/tests/sqlgrammar/run.sh
@@ -397,7 +397,7 @@ function exit-with-code() {
         errcode=$(($errcode|$TT_EXIT_CODE))
     fi
     if [[ "$errcode" -ne "0" || (-n "$PRINT_ERROR_CODE" && "$PRINT_ERROR_CODE" -ne "0") ]]; then
-        echo "\nError code:" $errcode
+        echo -e "\nError code:" $errcode
     fi
     exit $errcode
 }

--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -1359,6 +1359,8 @@ if __name__ == "__main__":
                             ['Invalid catalog update', 'another one is in progress'],
                             ['The requested catalog change', 'not supported'],
                             ['failed to create the transaction internally'],
+                            ['ParameterValueExpression', 'cannot be cast', 'TupleValueExpression'],
+                            ['SQL Aggregate function calls with subquery expression arguments are not allowed'],
                            ]
 
     # A list of headers found in responses to valid 'show' commands: one of


### PR DESCRIPTION
... by adding 2 more missing error messages that currently go
unrecognized; also tweaked one line of run.sh (echo was missing -e).