### PR TITLE
Send remote cluster id also to DRCatalogDiffEngine so that it can use

### DIFF
--- a/src/catgen/in/javasrc/DRCatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/DRCatalogDiffEngine.java
@@ -68,14 +68,14 @@ public class DRCatalogDiffEngine extends CatalogDiffEngine {
     private boolean m_isXDCR;
     private byte m_remoteClusterId;
 
-    public DRCatalogDiffEngine(Catalog localCatalog, Catalog remoteCatalog) {
+    public DRCatalogDiffEngine(Catalog localCatalog, Catalog remoteCatalog, byte remoteClusterId) {
         super(localCatalog, remoteCatalog);
+        m_remoteClusterId = remoteClusterId;
     }
 
     @Override
     protected void initialize(Catalog prev, Catalog next) {
         m_isXDCR = prev.getClusters().get("cluster").getDrrole().equals(DrRoleType.XDCR.value());
-        m_remoteClusterId = (byte) next.getClusters().get("cluster").getDrclusterid();
     }
 
     public static DRCatalogCommands serializeCatalogCommandsForDr(Catalog catalog, int protocolVersion) {

--- a/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
@@ -810,7 +810,7 @@ public class TestDRCatalogDiffs {
 
         String commands = DRCatalogDiffEngine.serializeCatalogCommandsForDr(masterCatalog, -1).commands;
         Catalog deserializedMasterCatalog = DRCatalogDiffEngine.deserializeCatalogCommandsForDr(commands);
-        return new DRCatalogDiffEngine(replicaCatalog, deserializedMasterCatalog);
+        return new DRCatalogDiffEngine(replicaCatalog, deserializedMasterCatalog, (byte) 0);
     }
 
     private Catalog createCatalog(String schema) throws Exception {


### PR DESCRIPTION
the correct remote id.