### PR TITLE
ENG-15630: Rejoin snapshot timeout

### DIFF
--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -59,8 +59,8 @@ public class RejoinProducer extends JoinProducerBase {
     // Stores the name of the views to pause/resume during a rejoin stream snapshot restore process.
     private String m_commaSeparatedNameOfViewsToPause = null;
 
-    // True if we're handling a table-less rejoin.
-    boolean m_schemaHasNoTables = false;
+    // True if there are any persistent tables in the schema.
+    boolean m_hasPersistentTables = true;
 
     // Barrier that prevents the finish task for firing until all sites have finished the stream snapshot
     private static AtomicInteger s_streamingSiteCount;
@@ -215,12 +215,11 @@ public class RejoinProducer extends JoinProducerBase {
     void doInitiation(RejoinMessage message)
     {
         m_coordinatorHsId = message.m_sourceHSId;
-        m_schemaHasNoTables = message.schemaHasNoTables();
-        if (!m_schemaHasNoTables) {
+        m_hasPersistentTables = message.schemaHasPersistentTables();
+        if (m_hasPersistentTables) {
             m_streamSnapshotMb = VoltDB.instance().getHostMessenger().createMailbox();
             m_rejoinSiteProcessor = new StreamSnapshotSink(m_streamSnapshotMb);
-        }
-        else {
+        } else {
             m_streamSnapshotMb = null;
             m_rejoinSiteProcessor = null;
         }
@@ -304,7 +303,7 @@ public class RejoinProducer extends JoinProducerBase {
             // Set enabled to false for the views we found.
             siteConnection.setViewsEnabled(m_commaSeparatedNameOfViewsToPause, false);
         }
-        if (!m_schemaHasNoTables) {
+        if (m_hasPersistentTables) {
             boolean sourcesReady = false;
             RestoreWork rejoinWork = m_rejoinSiteProcessor.poll(m_snapshotBufferAllocator);
             if (rejoinWork != null) {
@@ -379,7 +378,7 @@ public class RejoinProducer extends JoinProducerBase {
                 long clusterCreateTime = -1;
                 try {
                     event = m_snapshotCompletionMonitor.get();
-                    if (!m_schemaHasNoTables) {
+                    if (m_hasPersistentTables) {
                         REJOINLOG.debug(m_whoami + "waiting on snapshot completion monitor.");
                         exportSequenceNumbers = event.exportSequenceNumbers;
                         m_completionAction.setSnapshotTxnId(event.multipartTxnId);
@@ -414,7 +413,7 @@ public class RejoinProducer extends JoinProducerBase {
                         exportSequenceNumbers,
                         drSequenceNumbers,
                         allConsumerSiteTrackers,
-                        m_schemaHasNoTables == false /* requireExistingSequenceNumbers */,
+                        m_hasPersistentTables /* requireExistingSequenceNumbers */,
                         clusterCreateTime);
             }
         };

--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -219,6 +219,8 @@ public class RejoinProducer extends JoinProducerBase {
         if (m_hasPersistentTables) {
             m_streamSnapshotMb = VoltDB.instance().getHostMessenger().createMailbox();
             m_rejoinSiteProcessor = new StreamSnapshotSink(m_streamSnapshotMb);
+            // Start the watchdog so if we never get data it will notice
+            kickWatchdog(true);
         } else {
             m_streamSnapshotMb = null;
             m_rejoinSiteProcessor = null;

--- a/src/frontend/org/voltdb/messaging/RejoinMessage.java
+++ b/src/frontend/org/voltdb/messaging/RejoinMessage.java
@@ -24,7 +24,6 @@ import java.util.Queue;
 import org.voltcore.messaging.Subject;
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.DBBPool.BBContainer;
-import org.voltdb.utils.FixedDBBPool;
 
 /**
  * Rejoin message used to drive the whole rejoin process. It is only sent between
@@ -54,7 +53,7 @@ public class RejoinMessage extends VoltMessage {
     private Queue<BBContainer> m_compressedDataBufferPool = null;
     // number of sources sending to this site
     private long m_snapshotSinkHSId = -1;
-    private boolean m_schemaHasNoTables = false;
+    private boolean m_schemaHasPersistentTables = true;
 
     /** Empty constructor for de-serialization */
     public RejoinMessage() {
@@ -79,13 +78,13 @@ public class RejoinMessage extends VoltMessage {
     public RejoinMessage(long sourceHSId, Type type, String snapshotNonce,
                          Queue<BBContainer> dataBufferPool,
                          Queue<BBContainer> compressedDataBufferPool,
-                         boolean schemaHasNoTables) {
+                         boolean schemaHasPersistentTables) {
         this(sourceHSId, type);
         assert(type == Type.INITIATION || type == Type.INITIATION_COMMUNITY);
         m_snapshotNonce = snapshotNonce;
         m_dataBufferPool = dataBufferPool;
         m_compressedDataBufferPool = compressedDataBufferPool;
-        m_schemaHasNoTables = schemaHasNoTables;
+        m_schemaHasPersistentTables = schemaHasPersistentTables;
     }
 
     /**
@@ -125,8 +124,8 @@ public class RejoinMessage extends VoltMessage {
         return m_compressedDataBufferPool;
     }
 
-    public boolean schemaHasNoTables() {
-        return m_schemaHasNoTables;
+    public boolean schemaHasPersistentTables() {
+        return m_schemaHasPersistentTables;
     }
 
     /**

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -122,7 +122,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
         }
     }
 
-    private void initiateRejoinOnSites(List<Long> HSIds, boolean schemaHasNoTables)
+    private void initiateRejoinOnSites(List<Long> HSIds, boolean schemaHasPersistentTables)
     {
         // We're going to share this snapshot across the provided HSIDs.
         // Steal just the first one to disabiguate it.
@@ -140,7 +140,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
                                               nonce,
                                               m_snapshotDataBufPool,
                                               m_snapshotCompressedDataBufPool,
-                                              schemaHasNoTables);
+                                              schemaHasPersistentTables);
         send(com.google_voltpatches.common.primitives.Longs.toArray(HSIds), msg);
 
         // For testing, exit if only one property is set...
@@ -192,10 +192,10 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
     @Override
     public boolean startJoin(Database catalog) {
         m_catalog = catalog;
-        boolean schemaHasNoTables = true;
+        boolean schemaHasPersistentTables = false;
         for (Table t : catalog.getTables()) {
             if (t.getTabletype() != TableType.STREAM.get() && t.getTabletype() != TableType.STREAM_VIEW_ONLY.get()) {
-                schemaHasNoTables = false;
+                schemaHasPersistentTables = true;
                 break;
             }
         }
@@ -207,7 +207,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
             m_pendingSites.clear();
         }
         REJOINLOG.info("Initiating snapshot stream to sites: " + CoreUtils.hsIdCollectionToString(firstSites));
-        initiateRejoinOnSites(firstSites, schemaHasNoTables);
+        initiateRejoinOnSites(firstSites, schemaHasPersistentTables);
 
         return true;
     }
@@ -254,7 +254,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
     }
 
     private void onSiteInitialized(long HSId, long masterHSId, long dataSinkHSId,
-                                   boolean schemaHasNoTables)
+                                   boolean schemaHasPersistentTables)
     {
         String nonce = null;
         String data = null;
@@ -281,7 +281,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
             throw new RuntimeException("Received an INITIATION_RESPONSE for an HSID for which no nonce exists: " +
                     CoreUtils.hsIdToString(HSId));
         }
-        if (data != null && !schemaHasNoTables) {
+        if (data != null && schemaHasPersistentTables) {
             REJOINLOG.debug("Snapshot request: " + data);
             SnapshotUtil.requestSnapshot(0l, "", nonce, !m_liveRejoin, SnapshotFormat.STREAM, SnapshotPathType.SNAP_NO_PATH, data,
                     SnapshotUtil.fatalSnapshotResponseHandler, true);
@@ -306,7 +306,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
             onReplayFinished(rm.m_sourceHSId);
         } else if (type == RejoinMessage.Type.INITIATION_RESPONSE) {
             onSiteInitialized(rm.m_sourceHSId, rm.getMasterHSId(), rm.getSnapshotSinkHSId(),
-                              rm.schemaHasNoTables());
+                              rm.schemaHasPersistentTables());
         } else {
             VoltDB.crashLocalVoltDB("Wrong rejoin message of type " + type +
                                     " sent to the rejoin coordinator", false, null);

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -35,9 +35,11 @@ import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.SnapshotFormat;
+import org.voltdb.TableType;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
 import org.voltdb.catalog.Database;
+import org.voltdb.catalog.Table;
 import org.voltdb.messaging.RejoinMessage;
 import org.voltdb.messaging.RejoinMessage.Type;
 import org.voltdb.sysprocs.saverestore.SnapshotPathType;
@@ -190,7 +192,13 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
     @Override
     public boolean startJoin(Database catalog) {
         m_catalog = catalog;
-        boolean schemaHasNoTables = catalog.getTables().isEmpty();
+        boolean schemaHasNoTables = true;
+        for (Table t : catalog.getTables()) {
+            if (t.getTabletype() != TableType.STREAM.get() && t.getTabletype() != TableType.STREAM_VIEW_ONLY.get()) {
+                schemaHasNoTables = false;
+                break;
+            }
+        }
         m_startTime = System.currentTimeMillis();
         List<Long> firstSites = new ArrayList<Long>();
         synchronized (m_lock) {

--- a/tests/frontend/org/voltdb/rejoin/TestIv2RejoinCoordinator.java
+++ b/tests/frontend/org/voltdb/rejoin/TestIv2RejoinCoordinator.java
@@ -185,7 +185,7 @@ public class TestIv2RejoinCoordinator {
         hsids.add(1l);
         hsids.add(2l);
         RejoinMessage msg = new RejoinMessage(10000l, RejoinMessage.Type.INITIATION_COMMUNITY, "Rejoin_3",
-                                              null, null, false);
+                                              null, null, true);
         verifySent(hsids, msg);
 
         verify(m_volt, never()).onExecutionSiteRejoinCompletion(anyLong());

--- a/tests/frontend/org/voltdb/rejoin/TestIv2RejoinCoordinatorLive.java
+++ b/tests/frontend/org/voltdb/rejoin/TestIv2RejoinCoordinatorLive.java
@@ -187,7 +187,7 @@ public class TestIv2RejoinCoordinatorLive {
         createCoordinator(true);
         m_coordinator.startJoin(m_catalog);
         RejoinMessage msg = new RejoinMessage(10000l, RejoinMessage.Type.INITIATION, "Rejoin_1",
-                                              null, null, false);
+                                              null, null, true);
         List<Long> hsids = new ArrayList<Long>();
         hsids.add(1l);
         hsids.add(2l);


### PR DESCRIPTION
Snapshot streams only send data if there are persistent tables. Rejoin handled
when there were no tables in the cluster but not when there were only streams
in the system. Instead of checking if there are tables, check if there are any
persistent tables.