### PR TITLE
Fix writeTruncatedObject to account for the ByteBuffer side-effect of…

### DIFF
--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -327,6 +327,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             }
         }
 
+        @Override
         public long getSegmentIndex() {
             synchronized(PersistentBinaryDeque.this) {
                 if (m_segment == null) {
@@ -1155,7 +1156,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
             int objectSize = m_retval.remaining();
             // write entry header
             PBDUtils.writeEntryHeader(m_crc, output, m_retval, objectSize, PBDSegment.NO_FLAGS);
-            // write entry
+            // write buffer after resetting position changed by writeEntryHeader
+            // Note: cannot do this in writeEntryHeader as it breaks JUnit tests
+            m_retval.position(0);
             output.put(m_retval);
             return objectSize;
         }

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -378,7 +378,9 @@ public class TestPersistentBinaryDeque {
         assertEquals(listing.size(), 2);
 
         for (int ii = 46; ii < 96; ii++) {
-            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
+            // Note: new segment after truncate?
+            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true,
+                    ii == 46 ? true : false);
         }
 
         reader = m_pbd.openForRead(CURSOR_ID);
@@ -452,7 +454,9 @@ public class TestPersistentBinaryDeque {
         assertEquals(listing.size(), 2);
 
         for (int ii = 46; ii < 96; ii++) {
-            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
+            // Note: new segment after truncate?
+            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true,
+                    ii == 46 ? true : false);
         }
 
         long actualSizeInBytes = 0;


### PR DESCRIPTION
… writeEntryHeader; fixed truncator test to expect a new segment after truncation (#6026)