### PR TITLE
DR PBD fixes

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1898,6 +1898,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
          * column length(4)
          *
          */
+        @Override
         public void serialize(ByteBuffer buf) throws IOException {
             buf.put((byte)StreamBlockQueue.EXPORT_BUFFER_VERSION);
             buf.putLong(m_catalogContext.m_genId);
@@ -1918,8 +1919,10 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             }
         }
 
+        @Override
         public void cancel() {}
 
+        @Override
         public int getSerializedSize() throws IOException {
             int size = 0;
             // column name length, name, type, length

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -264,11 +264,15 @@ public class StreamBlockQueue {
         }
     }
 
+    public void updateSchema(DeferredSerialization schemaSerializer) throws IOException {
+        m_persistentDeque.updateExtraHeader(schemaSerializer);
+    }
+
     /*
      * Only allow two blocks in memory, put the rest in the persistent deque
      */
-    public void offer(StreamBlock streamBlock, DeferredSerialization ds, boolean createNewFile) throws IOException {
-        m_persistentDeque.offer(streamBlock.asBBContainer(), ds, !DISABLE_COMPRESSION, createNewFile);
+    public void offer(StreamBlock streamBlock) throws IOException {
+        m_persistentDeque.offer(streamBlock.asBBContainer(), !DISABLE_COMPRESSION);
         long unreleasedSeqNo = streamBlock.unreleasedSequenceNumber();
         if (m_memoryDeque.size() < 2) {
             StreamBlock fromPBD = pollPersistentDeque(false);

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -360,9 +360,6 @@ public class StreamBlockQueue {
                         offset++;
                         // Not the row we are looking to truncate at. Skip past it (row length + row length field).
                         final int rowLength = b.getInt();
-                        if (b.position() + rowLength > b.limit()) {
-                            System.out.println(rowLength);
-                        }
                         b.position(b.position() + rowLength);
                     }
                     return null;
@@ -386,6 +383,7 @@ public class StreamBlockQueue {
         assert(m_memoryDeque.isEmpty());
         return m_persistentDeque.scanForGap(new BinaryDequeScanner() {
 
+            @Override
             public ExportSequenceNumberTracker scan(BBContainer bbc) {
                 ByteBuffer b = bbc.b();
                 ByteOrder endianness = b.order();

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -123,7 +123,7 @@ public class StreamBlockQueue {
         try {
             // Start to read a new segment
             if (m_reader.isStartOfSegment()) {
-                schemaCont = m_reader.getSchema(-1, false, false);
+                schemaCont = m_reader.getExtraHeader(-1);
             }
             cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
         } catch (IOException e) {
@@ -174,7 +174,7 @@ public class StreamBlockQueue {
             segmentIndex = sb.getSegmentIndex();
         }
         try {
-            schemaCont = m_reader.getSchema(segmentIndex, true, false);
+            schemaCont = m_reader.getExtraHeader(segmentIndex);
         } catch (IOException e) {
             exportLog.error("Failed to poll schema: " + e);
         }

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -40,6 +40,14 @@ public interface BinaryDeque {
     }
 
     /**
+     * Update the extraHeader associated with this instance.
+     *
+     * @param extraHeaderSerializer {@link DeferredSerialization} which will be used to write out the extra header.
+     * @throws IOException If an error occurs while updating the extraHeader
+     */
+    void updateExtraHeader(DeferredSerialization extraHeaderSerializer) throws IOException;
+
+    /**
      * Store a buffer chain as a single object in the deque. IOException may be thrown if the object
      * is larger then the implementation defined max. 64 megabytes in the case of PersistentBinaryDeque.
      * If there is an exception attempting to write the buffers then all the buffers will be discarded
@@ -53,11 +61,10 @@ public interface BinaryDeque {
      * is larger then the implementation defined max. 64 megabytes in the case of PersistentBinaryDeque.
      * If there is an exception attempting to write the buffers then all the buffers will be discarded
      * @param object
-     * @param ds
      * @param allowCompression
      * @throws IOException
      */
-    void offer(BBContainer object, DeferredSerialization ds, boolean allowCompression, boolean createNewFile) throws IOException;
+    void offer(BBContainer object, boolean allowCompression) throws IOException;
 
     int offer(DeferredSerialization ds) throws IOException;
 

--- a/src/frontend/org/voltdb/utils/BinaryDequeReader.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeReader.java
@@ -37,14 +37,11 @@ public interface BinaryDequeReader {
     public BBContainer poll(OutputContainerFactory ocf, boolean checkCRC) throws IOException;
 
     /**
-     * Read and return the schema of table located in the segment header
      * @param segmentIndex index of the segment to get schema from, -1 means get schema from current segment
-     * @param updateReaderOffset whether to restore reader's original read offset after polling schema
-     * @param checkCRC check PBD header CRC while getting schema
-     * @return
-     * @throws IOException
+     * @return The extra header metadata in the segment header or {@code null} if there is none
+     * @throws IOException If an error occurs reading the extra header
      */
-    public BBContainer getSchema(long segmentIndex, boolean restoreReaderOffset, boolean checkCRC) throws IOException;
+    public BBContainer getExtraHeader(long segmentIndex) throws IOException;
 
     /**
      * Number of bytes left to read for this reader.

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -54,6 +54,7 @@ public class PBDRegularSegment extends PBDSegment {
 
     private int m_numOfEntries = -1;
     private int m_size = -1;
+    private int m_extraHeaderSize = 0;
 
     private DBBPool.BBContainer m_segmentHeaderBuf = null;
     private DBBPool.BBContainer m_entryHeaderBuf = null;
@@ -102,36 +103,7 @@ public class PBDRegularSegment extends PBDSegment {
     @Override
     public int getNumEntries(boolean crcCheck) throws IOException
     {
-        boolean wasClosed = false;
-        if (m_closed) {
-            wasClosed = true;
-            open(false, false);
-        }
-        m_numOfEntries = 0;
-        m_size = 0;
-        if (m_fc.size() >= SEGMENT_HEADER_BYTES) {
-            m_segmentHeaderBuf.b().clear();
-            PBDUtils.readBufferFully(m_fc, m_segmentHeaderBuf.b(), 0);
-            if (crcCheck) {
-                int crc = m_segmentHeaderBuf.b().getInt();
-                int numOfEntries = m_segmentHeaderBuf.b().getInt();
-                int size = m_segmentHeaderBuf.b().getInt();
-                m_segmentHeaderCRC.reset();
-                m_segmentHeaderCRC.update(numOfEntries);
-                m_segmentHeaderCRC.update(size);
-                if (crc != (int)m_segmentHeaderCRC.getValue()) {
-                    LOG.warn("File corruption detected in" + m_file.getName() + ": invalid file header. ");
-                    throw new IOException("File corruption detected in" + m_file.getName() + ": invalid file header.");
-                }
-                m_numOfEntries = numOfEntries;
-                m_size = size;
-            } else {
-                // skip the checksum if don't check crc
-                m_numOfEntries = m_segmentHeaderBuf.b().getInt(HEADER_NUM_OF_ENTRY_OFFSET);
-                m_size = m_segmentHeaderBuf.b().getInt(HEADER_TOTAL_BYTES_OFFSET);
-            }
-        }
-        if (wasClosed) closeReadersAndFile();
+        initializeFromHeader(crcCheck);
         return m_numOfEntries;
     }
 
@@ -173,6 +145,11 @@ public class PBDRegularSegment extends PBDSegment {
         open(true, emptyFile);
     }
 
+    int getExtraHeaderSize() throws IOException {
+        initializeFromHeader(false);
+        return m_extraHeaderSize;
+    }
+
     private void open(boolean forWrite, boolean emptyFile) throws IOException {
         if (!m_closed) {
             throw new IOException("Segment is already opened");
@@ -203,18 +180,64 @@ public class PBDRegularSegment extends PBDSegment {
         m_closed = false;
     }
 
-    private void updateNumEntries() throws IOException {
+    private void initializeFromHeader(boolean crcCheck) throws IOException {
+        if (m_numOfEntries != -1) {
+            return;
+        }
+        boolean wasClosed = false;
+        if (m_closed) {
+            wasClosed = true;
+            open(false, false);
+        }
+        try {
+            if (m_fc.size() >= SEGMENT_HEADER_BYTES) {
+                ByteBuffer b = m_segmentHeaderBuf.b();
+                b.clear();
+                PBDUtils.readBufferFully(m_fc, b, 0);
+                int crc = b.getInt();
+                int numOfEntries = b.getInt();
+                int size = b.getInt();
+                int extraHeaderSize = b.getInt();
+                if (crcCheck) {
+                    m_segmentHeaderCRC.reset();
+                    m_segmentHeaderCRC.update(numOfEntries);
+                    m_segmentHeaderCRC.update(size);
+                    m_segmentHeaderCRC.update(extraHeaderSize);
+                    if (crc != (int) m_segmentHeaderCRC.getValue()) {
+                        LOG.warn("File corruption detected in" + m_file.getName() + ": invalid file header. ");
+                        throw new IOException(
+                                "File corruption detected in" + m_file.getName() + ": invalid file header.");
+                    }
+                }
+                m_numOfEntries = numOfEntries;
+                m_size = size;
+                m_extraHeaderSize = extraHeaderSize;
+            } else {
+                m_numOfEntries = 0;
+                m_size = 0;
+            }
+        } finally {
+            if (wasClosed) {
+                closeReadersAndFile();
+            }
+        }
+    }
+
+    private void writeOutHeader() throws IOException {
         // Update segment header CRC
         m_segmentHeaderCRC.reset();
         m_segmentHeaderCRC.update(m_numOfEntries);
         m_segmentHeaderCRC.update(m_size);
+        m_segmentHeaderCRC.update(m_extraHeaderSize);
 
-        m_segmentHeaderBuf.b().clear();
+        ByteBuffer b = m_segmentHeaderBuf.b();
+        b.clear();
         // the checksum here is really an unsigned int, store integer to save 4 bytes
-        m_segmentHeaderBuf.b().putInt((int)m_segmentHeaderCRC.getValue());
-        m_segmentHeaderBuf.b().putInt(m_numOfEntries);
-        m_segmentHeaderBuf.b().putInt(m_size);
-        m_segmentHeaderBuf.b().flip();
+        b.putInt((int) m_segmentHeaderCRC.getValue());
+        b.putInt(m_numOfEntries);
+        b.putInt(m_size);
+        b.putInt(m_extraHeaderSize);
+        b.flip();
         PBDUtils.writeBuffer(m_fc, m_segmentHeaderBuf.bDR(), PBDSegment.HEADER_CRC_OFFSET);
         m_syncedSinceLastEdit = false;
     }
@@ -223,14 +246,14 @@ public class PBDRegularSegment extends PBDSegment {
     protected void initNumEntries(int count, int size) throws IOException {
         m_numOfEntries = count;
         m_size = size;
-        updateNumEntries();
+        writeOutHeader();
     }
 
     private void incrementNumEntries(int size) throws IOException
     {
         m_numOfEntries++;
         m_size += size;
-        updateNumEntries();
+        writeOutHeader();
     }
 
     /**
@@ -430,19 +453,28 @@ public class PBDRegularSegment extends PBDSegment {
 
     @Override
     public void writeExtraHeader(DeferredSerialization ds) throws IOException {
-        DBBPool.BBContainer destBuf = DBBPool.allocateDirect(ds.getSerializedSize());
-        destBuf.b().order(ByteOrder.LITTLE_ENDIAN);
-        ds.serialize(destBuf.b());
-        destBuf.b().flip();
-        while (destBuf.b().hasRemaining()) {
-            m_fc.write(destBuf.b());
+        if (m_numOfEntries != 0 || m_extraHeaderSize != 0) {
+            throw new IllegalStateException("Extra header must be written before any entries");
         }
-        destBuf.discard();
+        int size = ds.getSerializedSize();
+        DBBPool.BBContainer destBuf = DBBPool.allocateDirect(size);
+        try {
+            ByteBuffer b = destBuf.b();
+            b.order(ByteOrder.LITTLE_ENDIAN);
+            ds.serialize(b);
+            b.flip();
+            while (b.hasRemaining()) {
+                m_fc.write(b);
+            }
+            m_extraHeaderSize = size;
+        } finally {
+            destBuf.discard();
+        }
     }
 
     private class SegmentReader implements PBDSegmentReader {
         private final String m_cursorId;
-        private long m_readOffset = SEGMENT_HEADER_BYTES;
+        private long m_readOffset;
         //Index of the next object to read, not an offset into the file
         private int m_objectReadIndex = 0;
         private int m_bytesRead = 0;
@@ -450,17 +482,10 @@ public class PBDRegularSegment extends PBDSegment {
         private boolean m_readerClosed = false;
         private CRC32 m_crc32 = new CRC32();
 
-        public SegmentReader(String cursorId) {
+        public SegmentReader(String cursorId) throws IOException {
             assert(cursorId != null);
             m_cursorId = cursorId;
-        }
-
-        private void resetReader() {
-            m_objectReadIndex = 0;
-            m_bytesRead = 0;
-            m_readOffset = SEGMENT_HEADER_BYTES;
-            m_discardCount = 0;
-            m_crc32.reset();
+            m_readOffset = SEGMENT_HEADER_BYTES + getExtraHeaderSize();
         }
 
         @Override
@@ -602,47 +627,38 @@ public class PBDRegularSegment extends PBDSegment {
         }
 
         @Override
-        public DBBPool.BBContainer getSchema(boolean checkCRC) throws IOException {
-            if (m_readerClosed) throw new IOException("Reader closed");
+        public DBBPool.BBContainer getExtraHeader() throws IOException {
+            if (m_readerClosed) {
+                throw new IOException("Reader closed");
+            }
+
+            int extraHeaderSize = getExtraHeaderSize();
+            if (extraHeaderSize == 0) {
+                return null;
+            }
 
             final long writePos = m_fc.position();
             m_fc.position(SEGMENT_HEADER_BYTES);
 
-            DBBPool.BBContainer schemaHeader = null;
+            DBBPool.BBContainer schemaBuf = null;
             try {
-                schemaHeader = DBBPool.allocateDirect(EXPORT_SCHEMA_HEADER_BYTES);
-                schemaHeader.b().order(ByteOrder.LITTLE_ENDIAN);
-                while (schemaHeader.b().hasRemaining()) {
-                    int read = m_fc.read(schemaHeader.b());
+                schemaBuf = DBBPool.allocateDirect(extraHeaderSize);
+                ByteBuffer schemaBuffer = schemaBuf.b();
+                do {
+                    int read = m_fc.read(schemaBuffer);
                     if (read == -1) {
                         throw new EOFException();
                     }
-                }
-                schemaHeader.b().flip();
-                byte exportVersion = schemaHeader.b().get();
-                long genId = schemaHeader.b().getLong();
-                int schemaSize = schemaHeader.b().getInt();
-                DBBPool.BBContainer schemaBuf = DBBPool.allocateDirect(EXPORT_SCHEMA_HEADER_BYTES + schemaSize);
-                schemaBuf.b().order(ByteOrder.LITTLE_ENDIAN);
-                schemaBuf.b().put(exportVersion);
-                schemaBuf.b().putLong(genId);
-                schemaBuf.b().putInt(schemaSize);
-                while (schemaBuf.b().hasRemaining()) {
-                    int read = m_fc.read(schemaBuf.b());
-                    if (read == -1) {
-                        throw new EOFException();
-                    }
-                }
-                schemaBuf.b().flip();
+                } while (schemaBuffer.hasRemaining());
+                schemaBuffer.order(ByteOrder.LITTLE_ENDIAN).flip();
                 return schemaBuf;
             } catch (Exception e) {
+                if (schemaBuf != null) {
+                    schemaBuf.discard();
+                }
                 LOG.error(e);
                 return null;
             } finally {
-                if (schemaHeader != null) {
-                    schemaHeader.discard();
-                }
-                m_readOffset = m_fc.position();
                 m_fc.position(writePos);
             }
         }
@@ -684,11 +700,6 @@ public class PBDRegularSegment extends PBDSegment {
         @Override
         public boolean isClosed() {
             return m_readerClosed;
-        }
-
-        @Override
-        public void setReadOffset(long readOffset) {
-            m_readOffset = readOffset;
         }
 
         @Override

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -42,7 +42,6 @@ import com.google_voltpatches.common.base.Preconditions;
  */
 public class PBDRegularSegment extends PBDSegment {
     private static final VoltLogger LOG = new VoltLogger("HOST");
-    private static final VoltLogger exportLog = new VoltLogger("EXPORT");
 
     private final Map<String, SegmentReader> m_readCursors = new HashMap<>();
     private final Map<String, SegmentReader> m_closedCursors = new HashMap<>();
@@ -194,7 +193,6 @@ public class PBDRegularSegment extends PBDSegment {
         // Those asserts ensure the file is opened with correct flag
         if (emptyFile) {
             initNumEntries(0, 0);
-
         }
         if (forWrite) {
             m_fc.position(m_fc.size());
@@ -281,7 +279,9 @@ public class PBDRegularSegment extends PBDSegment {
 
     @Override
     public void sync() throws IOException {
-        if (m_closed) throw new IOException("Segment closed");
+        if (m_closed) {
+            throw new IOException("Segment closed");
+        }
         if (!m_syncedSinceLastEdit) {
             m_fc.force(true);
         }
@@ -290,9 +290,13 @@ public class PBDRegularSegment extends PBDSegment {
 
     @Override
     public boolean hasAllFinishedReading() throws IOException {
-        if (m_closed) throw new IOException("Segment closed");
+        if (m_closed) {
+            throw new IOException("Segment closed");
+        }
 
-        if (m_readCursors.size() == 0) return false;
+        if (m_readCursors.size() == 0) {
+            return false;
+        }
 
         for (SegmentReader reader : m_readCursors.values()) {
             if (reader.m_objectReadIndex < m_numOfEntries) {
@@ -307,12 +311,18 @@ public class PBDRegularSegment extends PBDSegment {
     @Override
     public boolean offer(DBBPool.BBContainer cont, boolean compress) throws IOException
     {
-        if (m_closed) throw new IOException("Segment closed");
+        if (m_closed) {
+            throw new IOException("Segment closed");
+        }
         final ByteBuffer buf = cont.b();
         final int remaining = buf.remaining();
-        if (remaining < 32 || !buf.isDirect()) compress = false;
+        if (remaining < 32 || !buf.isDirect()) {
+            compress = false;
+        }
         final int maxCompressedSize = (compress ? CompressionService.maxCompressedLength(remaining) : remaining) + ENTRY_HEADER_BYTES;
-        if (remaining() < maxCompressedSize) return false;
+        if (remaining() < maxCompressedSize) {
+            return false;
+        }
 
         m_syncedSinceLastEdit = false;
         DBBPool.BBContainer destBuf = cont;
@@ -358,9 +368,13 @@ public class PBDRegularSegment extends PBDSegment {
     @Override
     public int offer(DeferredSerialization ds) throws IOException
     {
-        if (m_closed) throw new IOException("closed");
+        if (m_closed) {
+            throw new IOException("closed");
+        }
         final int fullSize = ds.getSerializedSize();
-        if (remaining() < fullSize) return -1;
+        if (remaining() < fullSize) {
+            return -1;
+        }
 
         m_syncedSinceLastEdit = false;
         DBBPool.BBContainer destBuf = DBBPool.allocateDirectAndPool(fullSize);
@@ -462,7 +476,9 @@ public class PBDRegularSegment extends PBDSegment {
         @Override
         public DBBPool.BBContainer poll(OutputContainerFactory factory, boolean checkCRC) throws IOException {
 
-            if (m_readerClosed) throw new IOException("Reader closed");
+            if (m_readerClosed) {
+                throw new IOException("Reader closed");
+            }
 
             if (!hasMoreEntries()) {
                 return null;
@@ -633,7 +649,9 @@ public class PBDRegularSegment extends PBDSegment {
 
         @Override
         public int uncompressedBytesToRead() {
-            if (m_readerClosed) throw new RuntimeException("Reader closed");
+            if (m_readerClosed) {
+                throw new RuntimeException("Reader closed");
+            }
 
             return m_size - m_bytesRead;
         }

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -38,11 +38,9 @@ public abstract class PBDSegment {
     private static final String SCANNER_CURSOR = "__scanner__";
     protected static final String IS_FINAL_ATTRIBUTE = "VoltDB.PBDSegment.isFinal";
 
-    static final int NO_FLAGS = 0;
-    static final int FLAG_COMPRESSED = 1;
-
     // Has to be able to hold at least one object (compressed or not)
     public static final int CHUNK_SIZE = Integer.getInteger("PBDSEGMENT_CHUNK_SIZE", 1024 * 1024 * 64);
+
     // Segment Header layout:
     //  - crc of segment header (4 bytes),
     //  - total number of entries (4 bytes),
@@ -51,6 +49,9 @@ public abstract class PBDSegment {
     public static final int HEADER_NUM_OF_ENTRY_OFFSET = 4;
     public static final int HEADER_TOTAL_BYTES_OFFSET = 8;
     static final int SEGMENT_HEADER_BYTES = 12;
+
+    static final int NO_FLAGS = 0;
+    static final int FLAG_COMPRESSED = 1;
 
     public static final int EXPORT_SCHEMA_HEADER_BYTES = 1 + //export buffer version
                                                          8 + //generation id
@@ -240,7 +241,9 @@ public abstract class PBDSegment {
      * @throws IOException
      */
     ExportSequenceNumberTracker scan(BinaryDeque.BinaryDequeScanner scanner) throws IOException {
-        if (!m_closed) throw new IOException(("Segment should not be open before truncation"));
+        if (!m_closed) {
+            throw new IOException(("Segment should not be open before truncation"));
+        }
 
         PBDSegmentReader reader = openForRead(SCANNER_CURSOR);
         ExportSequenceNumberTracker tracker = new ExportSequenceNumberTracker();

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -25,7 +25,7 @@ import org.voltcore.utils.DBBPool;
  * Represents a reader for a segment. Multiple readers may be active
  * at any point in time, reading from different locations in the segment.
  */
-public interface PBDSegmentReader {
+interface PBDSegmentReader {
     /**
      * Are there any more entries to read from this segment for this reader
      *

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -55,7 +55,12 @@ interface PBDSegmentReader {
     public DBBPool.BBContainer poll(BinaryDeque.OutputContainerFactory factory,
             boolean checkCRC) throws IOException;
 
-    public DBBPool.BBContainer getSchema(boolean checkCRC) throws IOException;
+    /**
+     * @return A {@link DBBPool.BBContainer} with the extra header supplied for the segment or {@code null} if one was
+     *         not supplied
+     * @throws IOException If an error occurs while reading the extra header
+     */
+    public DBBPool.BBContainer getExtraHeader() throws IOException;
 
     //Don't use size in bytes to determine empty, could potentially
     //diverge from object count on crash or power failure
@@ -81,11 +86,6 @@ interface PBDSegmentReader {
      * Rewinds the read offset for this reader by the specified number of bytes.
      */
     public void rewindReadOffset(int byBytes);
-
-    /**
-     * Set the current read offset for this reader in this segment to given value
-     */
-    public void setReadOffset(long readOffset);
 
     /**
      * Reopen a previously closed reader. Re-opened reader still keeps the original read offset.

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -1189,6 +1189,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         public int writeTruncatedObject(ByteBuffer output) throws IOException {
             output.position(PBDSegment.ENTRY_HEADER_BYTES);
             int bytesWritten = MiscUtils.writeDeferredSerialization(output, m_ds);
+            output.flip();
             output.position(PBDSegment.ENTRY_HEADER_BYTES);
             ByteBuffer header = output.duplicate();
             header.position(PBDSegment.ENTRY_HEADER_CRC_OFFSET);

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -294,6 +294,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             };
         }
 
+        @Override
         public boolean isStartOfSegment() throws IOException {
             synchronized(PersistentBinaryDeque.this) {
                 if (m_closed) {

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -132,8 +132,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         @Override
-        public BBContainer getSchema(long segmentIndex, boolean restoreReaderOffset, boolean checkCRC)
-                throws IOException {
+        public BBContainer getExtraHeader(long segmentIndex) throws IOException {
             synchronized (PersistentBinaryDeque.this) {
                 if (m_closed) {
                     throw new IOException("PBD.ReadCursor.poll(): " + m_cursorId + " - Reader has been closed");
@@ -152,23 +151,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
                     segment = m_segment;
                 }
 
-                long originalOffset = -1;
-                try {
-                    segmentReader = segment.getReader(m_cursorId);
-                    if (segmentReader == null) {
-                        segmentReader = segment.openForRead(m_cursorId);
-                    } else if (segmentReader.isClosed()) {
-                        segmentReader.reopen(false, false);
-                    }
-                    // need to restore the read offset
-                    originalOffset = segmentReader.readOffset();
-                    segmentReader.setReadOffset(PBDSegment.ENTRY_HEADER_BYTES);
-                    return segmentReader.getSchema(checkCRC);
-                } finally {
-                    if (segmentReader != null && restoreReaderOffset) {
-                        segmentReader.setReadOffset(originalOffset);
-                    }
+                segmentReader = segment.getReader(m_cursorId);
+                if (segmentReader == null) {
+                    segmentReader = segment.openForRead(m_cursorId);
+                } else if (segmentReader.isClosed()) {
+                    segmentReader.reopen(false, false);
                 }
+                // need to restore the read offset
+                return segmentReader.getExtraHeader();
             }
         }
 

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -354,6 +354,8 @@ public class PersistentBinaryDeque implements BinaryDeque {
     // used for a *previous* segment (or inserting a segment *before* the others.
     private long m_segmentCounter = 0L;
 
+    private DeferredSerialization m_extraHeader;
+
     /**
      * Create a persistent binary deque with the specified nonce and storage
      * back at the specified path.
@@ -374,12 +376,12 @@ public class PersistentBinaryDeque implements BinaryDeque {
      * This is a convenience method for testing so that poll with delete can be tested.
      *
      * @param nonce
-     * @param schemaDS
+     * @param extraHeader
      * @param path
      * @param deleteEmpty
      * @throws IOException
      */
-    public PersistentBinaryDeque(final String nonce, DeferredSerialization schemaDS,
+    public PersistentBinaryDeque(final String nonce, DeferredSerialization extraHeader,
             final File path, VoltLogger logger,
             final boolean deleteEmpty) throws IOException {
         NativeLibraryLoader.loadVoltDB();
@@ -405,22 +407,12 @@ public class PersistentBinaryDeque implements BinaryDeque {
         Long writeSegmentIndex = lastEntry == null ? 1L : lastEntry.getKey() + 1;
 
         String fname = getSegmentFileName(curId, prevId);
-        PBDSegment writeSegment = newSegment(writeSegmentIndex, curId, new VoltFile(m_path, fname));
-
-        PBDSegment check = m_segments.put(writeSegmentIndex, writeSegment);
-        if (check != null) {
+        m_extraHeader = extraHeader;
+        PBDSegment writeSegment = initializeNewSegment(writeSegmentIndex, curId, new VoltFile(m_path, fname),
+                "initialization");
+        if (m_segments.put(writeSegmentIndex, writeSegment) != null) {
             // Sanity check
             throw new IllegalStateException("Overwriting segment " + writeSegmentIndex);
-        }
-        writeSegment.openForWrite(true);
-        writeSegment.setFinal(false);
-        if (schemaDS != null) {
-            writeSegment.writeExtraHeader(schemaDS);
-        }
-
-        if (m_usageSpecificLog.isDebugEnabled()) {
-            m_usageSpecificLog.debug("Segment " + writeSegment.file()
-                + " (final: " + writeSegment.isFinal() + "), has been opened for writing");
         }
 
         m_numObjects = countNumObjects();
@@ -717,21 +709,32 @@ public class PersistentBinaryDeque implements BinaryDeque {
         long prevId = lastSegment == null ? getNextSegmentId() : lastSegment.segmentId();
 
         String fname = getSegmentFileName(curId, prevId);
-        PBDSegment newSegment = newSegment(newSegmentIndex, curId, new VoltFile(m_path, fname));
-        newSegment.openForWrite(true);
-        // Ensure the new segment is not final
-        newSegment.setFinal(false);
-
-        if (m_usageSpecificLog.isDebugEnabled()) {
-            m_usageSpecificLog.debug("Segment " + newSegment.file()
-            + " (final: " + newSegment.isFinal() + "), has been created by PBD truncator");
-        }
+        PBDSegment newSegment = initializeNewSegment(newSegmentIndex, curId, new VoltFile(m_path, fname),
+                "PBD truncator");
         m_segments.put(newSegment.segmentIndex(), newSegment);
         assertions();
     }
 
     private PBDSegment newSegment(long segmentIndex, long segmentId, File file) {
         return new PBDRegularSegment(segmentIndex, segmentId, file);
+    }
+
+    private PBDSegment initializeNewSegment(long segmentIndex, long segmentId, File file, String reason)
+            throws IOException {
+        PBDSegment segment = newSegment(segmentIndex, segmentId, file);
+        segment.openForWrite(true);
+        segment.setFinal(false);
+        if (m_extraHeader != null) {
+            segment.writeExtraHeader(m_extraHeader);
+        }
+
+        if (m_usageSpecificLog.isDebugEnabled()) {
+            m_usageSpecificLog.debug(
+                    "Segment " + segment.file() + " (final: " + segment.isFinal()
+                            + "), has been opened for writing because of " + reason);
+        }
+
+        return segment;
     }
 
     /**
@@ -791,15 +794,18 @@ public class PersistentBinaryDeque implements BinaryDeque {
     }
 
     @Override
-    public synchronized void offer(BBContainer object) throws IOException {
-        offer(object, null, true, false);
+    public void updateExtraHeader(DeferredSerialization extraHeaderSerializer) throws IOException {
+        m_extraHeader = extraHeaderSerializer;
+        addSegment(peekLastSegment());
     }
 
     @Override
-    public synchronized void offer( BBContainer object,
-                                    DeferredSerialization schemaDS,
-                                    boolean allowCompression,
-                                    boolean createNewFile) throws IOException {
+    public synchronized void offer(BBContainer object) throws IOException {
+        offer(object, true);
+    }
+
+    @Override
+    public synchronized void offer(BBContainer object, boolean allowCompression) throws IOException {
         assertions();
         if (m_closed) {
             throw new IOException("Closed");
@@ -807,11 +813,8 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         PBDSegment tail = peekLastSegment();
         final boolean compress = object.b().isDirect() && allowCompression;
-        if (createNewFile) {
-            tail = addSegment(tail, schemaDS);
-        }
         if (!tail.offer(object, compress)) {
-            tail = addSegment(tail, schemaDS);
+            tail = addSegment(tail);
             final boolean success = tail.offer(object, compress);
             if (!success) {
                 throw new IOException("Failed to offer object in PBD");
@@ -831,7 +834,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         PBDSegment tail = peekLastSegment();
         int written = tail.offer(ds);
         if (written < 0) {
-            tail = addSegment(tail, null);
+            tail = addSegment(tail);
             written = tail.offer(ds);
             if (written < 0) {
                 throw new IOException("Failed to offer object in PBD");
@@ -842,7 +845,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         return written;
     }
 
-    private PBDSegment addSegment(PBDSegment tail, DeferredSerialization schemaDS) throws IOException {
+    private PBDSegment addSegment(PBDSegment tail) throws IOException {
         boolean previousTailIsDeleted = false;
         //Check to see if the tail is completely consumed so we can close and delete it
         if (tail.hasAllFinishedReading() && canDeleteSegment(tail)) {
@@ -858,16 +861,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         long curId = getNextSegmentId();
         String fname = getSegmentFileName(curId, lastId);
-        PBDSegment newSegment = newSegment(nextIndex, curId, new VoltFile(m_path, fname));
-        newSegment.openForWrite(true);
-        newSegment.setFinal(false);
-        if (schemaDS != null) {
-            newSegment.writeExtraHeader(schemaDS);
-        }
-        if (m_usageSpecificLog.isDebugEnabled()) {
-            m_usageSpecificLog.debug("Segment " + newSegment.file()
-                + " (final: " + newSegment.isFinal() + "), has been created because of an offer");
-        }
+        PBDSegment newSegment = initializeNewSegment(nextIndex, curId, new VoltFile(m_path, fname), "an offer");
         closeTailAndOffer(newSegment);
         if (previousTailIsDeleted) {
             advanceCursorTo(tail, newSegment);
@@ -936,16 +930,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             long prevId = getNextSegmentId();
             String fname = getSegmentFileName(curId, prevId);
 
-            PBDSegment writeSegment =
-                newSegment(
-                        nextIndex,
-                        curId,
-                        new VoltFile(m_path, fname));
-            writeSegment.openForWrite(true);
-            writeSegment.setFinal(false);
-            if (ds != null) {
-                writeSegment.writeExtraHeader(ds);
-            }
+            PBDSegment writeSegment = initializeNewSegment(nextIndex, curId, new VoltFile(m_path, fname), "a push");
 
             // Prepare for next file
             nextIndex--;

--- a/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
+++ b/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
@@ -72,6 +72,7 @@ public class TestStreamBlockQueue extends TestCase {
                 null, g_seqNo, 1, 0L, -1, false);
     }
 
+    @Override
     @Before
     public void setUp() throws Exception {
         m_mockVoltDB = new MockVoltDB();
@@ -92,6 +93,7 @@ public class TestStreamBlockQueue extends TestCase {
         defaultBuffer.clear();
     }
 
+    @Override
     @After
     public void tearDown() throws Exception {
         try {
@@ -121,7 +123,7 @@ public class TestStreamBlockQueue extends TestCase {
         StreamBlock sb = null;
         assertTrue(m_sbq.isEmpty());
         sb = getStreamBlockWithFill((byte)1);
-        m_sbq.offer(sb, null, false);
+        m_sbq.offer(sb);
         StreamBlock fromPeek = m_sbq.peek();
         assertEquals(sb.startSequenceNumber(), fromPeek.startSequenceNumber());
         assertEquals(sb.totalSize(), fromPeek.totalSize());
@@ -176,7 +178,7 @@ public class TestStreamBlockQueue extends TestCase {
                 case 5:
                 case 0:
                     System.out.println("Iteration " + iteration + " Action offer");
-                    m_sbq.offer(getStreamBlockWithFill(zero), null, false);
+                m_sbq.offer(getStreamBlockWithFill(zero));
                     break;
                 case 1:
                     System.out.println("Iteration " + iteration + " Action sync");
@@ -216,7 +218,7 @@ public class TestStreamBlockQueue extends TestCase {
     public void testIterator() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb, null, false);
+            m_sbq.offer(sb);
             if (ii == 2) {
                 m_sbq.poll().discard();
             }
@@ -276,7 +278,7 @@ public class TestStreamBlockQueue extends TestCase {
     public void testIterator2() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb, null, false);
+            m_sbq.offer(sb);
             if (ii == 2) {
                 m_sbq.poll().discard();
                 m_sbq.poll().discard();
@@ -338,7 +340,7 @@ public class TestStreamBlockQueue extends TestCase {
     public void testIterator2WithSync() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb, null, false);
+            m_sbq.offer(sb);
             if (ii == 2) {
                 m_sbq.poll().discard();
                 m_sbq.poll().discard();
@@ -403,7 +405,7 @@ public class TestStreamBlockQueue extends TestCase {
     public void testSyncReopenThenPop() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb, null, false);
+            m_sbq.offer(sb);
             if (ii == 2) {
                 m_sbq.poll().discard();
                 m_sbq.poll().discard();
@@ -469,7 +471,7 @@ public class TestStreamBlockQueue extends TestCase {
     public void testIterator3() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb, null, false);
+            m_sbq.offer(sb);
             if (ii == 3) {
                 m_sbq.poll().discard();
                 m_sbq.poll().discard();
@@ -533,7 +535,7 @@ public class TestStreamBlockQueue extends TestCase {
     public void testIterator4() throws Exception {
         for (byte ii = 0; ii < 32; ii++) {
             StreamBlock sb = getStreamBlockWithFill(ii);
-            m_sbq.offer(sb, null, false);
+            m_sbq.offer(sb);
         }
         //Strange scenario where one block in the memory deque is persisted and the others isn't
         long weirdSizeValue = 1024 * 1024 * 2 * 32;

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -344,7 +344,7 @@ public class TestPersistentBinaryDeque {
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         for (int ii = 0; ii < 150; ii++) {
-            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
         }
 
         m_pbd.close();
@@ -383,8 +383,10 @@ public class TestPersistentBinaryDeque {
 
         for (int ii = 46; ii < 96; ii++) {
             // Note: new segment after truncate?
-            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true,
-                    ii == 46 ? true : false);
+            if (ii == 46) {
+                m_pbd.updateExtraHeader(m_ds);
+            }
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
         }
 
         reader = m_pbd.openForRead(CURSOR_ID);
@@ -421,7 +423,7 @@ public class TestPersistentBinaryDeque {
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         for (int ii = 0; ii < 160; ii++) {
-            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
         }
 
         m_pbd.close();
@@ -459,8 +461,10 @@ public class TestPersistentBinaryDeque {
 
         for (int ii = 46; ii < 96; ii++) {
             // Note: new segment after truncate?
-            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true,
-                    ii == 46 ? true : false);
+            if (ii == 46) {
+                m_pbd.updateExtraHeader(m_ds);
+            }
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
         }
 
         long actualSizeInBytes = 0;
@@ -497,14 +501,14 @@ public class TestPersistentBinaryDeque {
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
         assertTrue(reader.isEmpty());
 
-        m_pbd.offer(defaultContainer(), m_ds, true, false);
+        m_pbd.offer(defaultContainer(), true);
         assertFalse(reader.isEmpty());
         pollOnce(reader);
         assertTrue(reader.isEmpty());
 
         // more than one segment
         for (int i = 0; i < 50; i++) {
-            m_pbd.offer(defaultContainer(), m_ds, true, false);
+            m_pbd.offer(defaultContainer(), true);
         }
         assertFalse(reader.isEmpty());
         for (int i = 0; i < 50; i++) {
@@ -529,7 +533,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(count, reader1.getNumObjects());
 
         count++;
-        m_pbd.offer(defaultContainer(), m_ds, true, false);
+        m_pbd.offer(defaultContainer(), true);
         totalAdded++;
         assertEquals(count, reader1.getNumObjects());
 
@@ -547,7 +551,7 @@ public class TestPersistentBinaryDeque {
 
         // offer segments
         for (int i = 0; i < 50; i++) {
-            m_pbd.offer(defaultContainer(), m_ds, true, false);
+            m_pbd.offer(defaultContainer(), true);
             totalAdded++;
             count++;
             assertEquals(count, reader1.getNumObjects());
@@ -573,7 +577,7 @@ public class TestPersistentBinaryDeque {
 
         // offer segments with all 3 readers
         for (int i = 0; i < 50; i++) {
-            m_pbd.offer(defaultContainer(), m_ds, true, false);
+            m_pbd.offer(defaultContainer(), true);
             count++;
             assertEquals(count, reader1.getNumObjects());
             assertEquals(count, reader2.getNumObjects());
@@ -614,7 +618,7 @@ public class TestPersistentBinaryDeque {
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
 
         //Make sure a single file with the appropriate data is created
-        m_pbd.offer(defaultContainer(), m_ds, true, false);
+        m_pbd.offer(defaultContainer(), true);
         File files[] = TEST_DIR.listFiles();
         assertEquals( 1, files.length);
         assertTrue("pbd_nonce_0000000001_0000000002.pbd".equals(files[0].getName()));
@@ -633,7 +637,7 @@ public class TestPersistentBinaryDeque {
 
         //Make sure several files with the appropriate data is created
         for (int i = 0; i < total; i++) {
-            m_pbd.offer(defaultContainer(), m_ds, true, false);
+            m_pbd.offer(defaultContainer(), true);
         }
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 3);
@@ -666,7 +670,7 @@ public class TestPersistentBinaryDeque {
 
         //Make sure a single file with the appropriate data is created
         for (int i = 0; i < 5; i++) {
-            m_pbd.offer(defaultContainer(), m_ds, true, false);
+            m_pbd.offer(defaultContainer(), true);
         }
         assertEquals(1, TEST_DIR.listFiles().length);
 
@@ -674,7 +678,7 @@ public class TestPersistentBinaryDeque {
         pollOnce(reader);
 
         for (int i = 5; i < total; i++) {
-            m_pbd.offer(defaultContainer(), m_ds, true, false);
+            m_pbd.offer(defaultContainer(), true);
         }
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 3);
@@ -704,7 +708,7 @@ public class TestPersistentBinaryDeque {
         assertTrue(reader.isEmpty());
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(defaultContainer(), m_ds, true, false);
+            m_pbd.offer(defaultContainer(), true);
             assertFalse(reader.isEmpty());
         }
         File files[] = TEST_DIR.listFiles();
@@ -770,7 +774,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseThenReopen");
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(defaultContainer(), m_ds, true, false);
+            m_pbd.offer(defaultContainer(), true);
         }
         File files[] = TEST_DIR.listFiles();
         assertEquals( 3, files.length);
@@ -956,7 +960,7 @@ public class TestPersistentBinaryDeque {
     public void testNonceWithDots() throws Exception {
         System.out.println("Running testNonceWithDots");
         PersistentBinaryDeque pbd = new PersistentBinaryDeque("ha.ha", m_ds, TEST_DIR, logger);
-        pbd.offer(defaultContainer(), m_ds, true, false);
+        pbd.offer(defaultContainer(), true);
         pbd.close();
 
         pbd = new PersistentBinaryDeque("ha.ha", null, TEST_DIR, logger);
@@ -972,7 +976,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseThenReopen");
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
         }
         File files[] = TEST_DIR.listFiles();
         assertEquals(3, files.length);
@@ -986,7 +990,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(cnt, 96);
 
         for (int ii = 96; ii < 192; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
         }
         m_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1012,7 +1016,7 @@ public class TestPersistentBinaryDeque {
         PersistentBinaryDeque small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, m_ds, TEST_DIR, logger);
         //Keep in 1 segment.
         for (int ii = 0; ii < 10; ii++) {
-            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)), m_ds, true, false);
+            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)), true);
         }
         File files[] = TEST_DIR.listFiles();
         //We have the default pbd and new one.
@@ -1029,7 +1033,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(cnt, 10);
 
         for (int ii = 10; ii < 20; ii++) {
-            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)), m_ds, true, false);
+            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)), true);
         }
         small_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1063,7 +1067,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseHoleReopenOffer");
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
         }
         File files[] = TEST_DIR.listFiles();
         assertEquals(3, files.length);
@@ -1077,7 +1081,7 @@ public class TestPersistentBinaryDeque {
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
         for (int ii = 96; ii < 192; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
         }
         m_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1108,7 +1112,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(4, listing.size());
 
         for (int ii = 96; ii < 192; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), m_ds, true, false);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
         }
         m_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1157,7 +1161,7 @@ public class TestPersistentBinaryDeque {
 
         //Make sure a single file with the appropriate data is created
         for (int i = 0; i < total; i++) {
-            m_pbd.offer(defaultContainer(), m_ds, true, false);
+            m_pbd.offer(defaultContainer(), true);
         }
         assertEquals(1, TEST_DIR.listFiles().length);
 
@@ -1170,7 +1174,7 @@ public class TestPersistentBinaryDeque {
         File files[] = TEST_DIR.listFiles();
         assertEquals(1, files.length);
         assertEquals("pbd_nonce_0000000001_0000000002.pbd", files[0].getName());
-        m_pbd.offer(defaultContainer(), m_ds, true, false);
+        m_pbd.offer(defaultContainer(), true);
 
         files = TEST_DIR.listFiles();
         // Make sure a new segment was created and the old segment was deleted

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -241,8 +241,12 @@ public class TestPersistentBinaryDeque {
             }
         }
 
-        if (penultimate != null) sorted.addLast(penultimate);
-        if (lastEntry != null) sorted.addLast(lastEntry);
+        if (penultimate != null) {
+            sorted.addLast(penultimate);
+        }
+        if (lastEntry != null) {
+            sorted.addLast(lastEntry);
+        }
         return sorted;
     }
 
@@ -358,8 +362,8 @@ public class TestPersistentBinaryDeque {
                 if (b.getLong(0) != m_objectsParsed) {
                     System.out.println("asd");
                 }
-                assertEquals(b.getLong(0), m_objectsParsed);
-                assertEquals(b.remaining(), 1024 * 1024 * 2 );
+                assertEquals(m_objectsParsed, b.getLong(0));
+                assertEquals(1024 * 1024 * 2, b.remaining());
                 if (b.getLong(0) == 45) {
                     b.limit(b.remaining() / 2);
                     return PersistentBinaryDeque.fullTruncateResponse();
@@ -432,8 +436,8 @@ public class TestPersistentBinaryDeque {
             @Override
             public TruncatorResponse parse(BBContainer bbc) {
                 ByteBuffer b = bbc.b();
-                assertEquals(b.getLong(0), m_objectsParsed);
-                assertEquals(b.remaining(), 1024 * 1024 * 2 );
+                assertEquals(m_objectsParsed, b.getLong(0));
+                assertEquals(1024 * 1024 * 2, b.remaining());
                 if (b.getLong(0) == 45) {
                     b.limit(b.remaining() / 2);
                     return new PersistentBinaryDeque.ByteBufferTruncatorResponse(b.slice());

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -1182,7 +1182,7 @@ public class TestPersistentBinaryDeque {
         BBContainer schema = null;
         try {
             if (reader.isStartOfSegment()) {
-                schema = reader.getSchema(-1, false, false);
+                schema = reader.getExtraHeader(-1);
                 assertNotNull(schema);
                 assertFalse(reader.isEmpty());
             }
@@ -1199,7 +1199,7 @@ public class TestPersistentBinaryDeque {
         BBContainer retval = null;
         try {
             if (reader.isStartOfSegment()) {
-                schema = reader.getSchema(-1, false, false);
+                schema = reader.getExtraHeader(-1);
                 assertNotNull(schema);
                 assertFalse(reader.isEmpty());
             }
@@ -1219,7 +1219,7 @@ public class TestPersistentBinaryDeque {
         BBContainer retval = null;
         try {
             if (reader.isStartOfSegment()) {
-                schema = reader.getSchema(-1, false, false);
+                schema = reader.getExtraHeader(-1);
                 assertNotNull(schema);
                 assertFalse(reader.isEmpty());
             }


### PR DESCRIPTION
PersistentBinaryDeque.writeTruncatedObject(): Set limit after write
PBD: Integrate extra header metadata into segment header
PersistentBinaryDeque: Split offer from updateExtraHeader 
Add test for changing the extra header