### PR TITLE
Fix for the VoltXMLElement -> AbstractExpression conversion

### DIFF
--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -28,9 +28,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.voltdb.VoltType;
+import org.voltdb.catalog.Column;
+import org.voltdb.catalog.Database;
 import org.voltdb.compiler.VoltXMLElementHelper;
 import org.voltdb.planner.PlanningErrorException;
 import org.voltdb.types.ExpressionType;
@@ -60,7 +63,141 @@ public final class ExpressionUtil {
 
     private ExpressionUtil() {}
 
-    public static AbstractExpression from(VoltXMLElement elm) {
+    /**
+     * Helper to check if a VoltXMLElement contains parameter.
+     * @param elm element under inspection
+     * @return if elm contains parameter
+     */
+    private static boolean isParameterized(VoltXMLElement elm) {
+        final String name = elm.name;
+        if (name.equals("value")) {
+            return elm.getBoolAttribute("isparam", false);
+        } else if (name.equals("vector") || name.equals("row")) {
+            return elm.children.stream().anyMatch(ExpressionUtil::isParameterized);
+        } else if (name.equals("columnref") || name.equals("function") ||
+                name.equals("tablesubquery")) {
+            return false;
+        } else {
+            assert name.equals("operation") : "unknown VoltXMLElement type: " + name;
+            final ExpressionType op = mapOfVoltXMLOpType.get(elm.attributes.get("optype"));
+            assert op != null;
+            switch (op) {
+                case CONJUNCTION_OR:                    // two operators
+                case CONJUNCTION_AND:
+                case COMPARE_GREATERTHAN:
+                case COMPARE_LESSTHAN:
+                case COMPARE_EQUAL:
+                case COMPARE_NOTEQUAL:
+                case COMPARE_GREATERTHANOREQUALTO:
+                case COMPARE_LESSTHANOREQUALTO:
+                case OPERATOR_PLUS:
+                case OPERATOR_MINUS:
+                case OPERATOR_MULTIPLY:
+                case OPERATOR_DIVIDE:
+                case OPERATOR_CONCAT:
+                case OPERATOR_MOD:
+                case COMPARE_IN:
+                    return isParameterized(elm.children.get(0)) || isParameterized(elm.children.get(1));
+                case OPERATOR_IS_NULL:      // one operator
+                case OPERATOR_EXISTS:
+                case OPERATOR_NOT:
+                case OPERATOR_UNARY_MINUS:
+                    return isParameterized(elm.children.get(0));
+                default:
+                    assert false;
+                    return false;
+            }
+        }
+    }
+
+    /**
+     * Get the underlying type of the VoltXMLElement node. Need reference to the catalog for PVE
+     * @param db catalog
+     * @param elm element under inspection
+     * @return string representation of the element node
+     */
+    private static String getType(Database db, VoltXMLElement elm) {
+        final String type = elm.getStringAttribute("valuetype", "");
+        if (! type.isEmpty()) {
+            return type;
+        } else if (elm.name.equals("columnref")) {
+            final String tblName = elm.getStringAttribute("table", "");
+            final int colIndex = elm.getIntAttribute("index", 0);
+            return StreamSupport.stream(db.getTables().spliterator(), false)
+                    .filter(tbl -> tbl.getTypeName().equals(tblName))
+                    .findAny()
+                    .flatMap(tbl ->
+                            StreamSupport.stream(tbl.getColumns().spliterator(), false)
+                                    .filter(col -> col.getIndex() == colIndex)
+                                    .findAny())
+                    .map(Column::getType)
+                    .map(typ -> VoltType.get((byte) ((int)typ)).getName())
+                    .orElse("");
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Guess from a parent node what are the parameter type of its child node, should one of its child node
+     * contain parameter.
+     * @param db catalog
+     * @param elm node under inspection
+     * @return string representation of the type of its child node.
+     */
+    private static String guessParameterType(Database db, VoltXMLElement elm) {
+        if (! isParameterized(elm) || ! elm.name.equals("operation")) {
+            return "";
+        } else {
+            final ExpressionType op = mapOfVoltXMLOpType.get(elm.attributes.get("optype"));
+            assert op != null;
+            switch (op) {
+                case CONJUNCTION_OR:
+                case CONJUNCTION_AND:
+                case OPERATOR_NOT:
+                    return "boolean";
+                case COMPARE_GREATERTHAN: // For these 2 operator-ops, the type is what the non-parameterized part gets set to.
+                case COMPARE_LESSTHAN:
+                case COMPARE_EQUAL:
+                case COMPARE_NOTEQUAL:
+                case COMPARE_GREATERTHANOREQUALTO:
+                case COMPARE_LESSTHANOREQUALTO:
+                case OPERATOR_PLUS:
+                case OPERATOR_MINUS:
+                case OPERATOR_MULTIPLY:
+                case OPERATOR_DIVIDE:
+                case OPERATOR_CONCAT:
+                case OPERATOR_MOD:
+                case COMPARE_IN:
+                    final VoltXMLElement left = elm.children.get(0), right = elm.children.get(1);
+                    return isParameterized(left) ? getType(db, right) : getType(db, left);
+                case OPERATOR_UNARY_MINUS:
+                    return "integer";
+                case OPERATOR_IS_NULL:
+                case OPERATOR_EXISTS:
+                    return "";
+                default:
+                    assert false;
+                    return "";
+            }
+        }
+    }
+
+    /**
+     * Conversion from a VoltXMLElement node to abstract expression, done outside HSQL.
+     * We need this overhaul, because
+     * 1. We need to inspect the predicate of "MIGRATE FROM tbl WHERE ..." query for certain properties
+     * 2. We are stuck with HSQL.
+     *
+     * @param db catalog
+     * @param elm element node under inspection
+     * @return converted expression
+     */
+    public static AbstractExpression from(Database db, VoltXMLElement elm) {
+        return from(db, elm, "");
+    }
+
+    private static AbstractExpression from(Database db, VoltXMLElement elm, String typeHint) {
         if (elm == null) {
             return null;
         } else if (elm.name.equals("columnref")) {
@@ -73,20 +210,20 @@ public final class ExpressionUtil {
         } else if (elm.name.equals("value")) {
             final ConstantValueExpression expr = new ConstantValueExpression();
             expr.setValue(elm.getStringAttribute("value", ""));
-            expr.setValueType(VoltType.typeFromString(elm.getStringAttribute("valuetype", "")));
+            expr.setValueType(VoltType.typeFromString(elm.getStringAttribute("valuetype", typeHint)));
             return expr;
         } else if (elm.name.equals("vector")) {
             final VectorValueExpression expr = new VectorValueExpression();
-            expr.setArgs(elm.children.stream().map(ExpressionUtil::from).collect(Collectors.toList()));
+            expr.setArgs(elm.children.stream().map(elem -> from(db, elem, typeHint)).collect(Collectors.toList()));
             return expr;
         } else if (elm.name.equals("row")) {
-            return from(VoltXMLElementHelper.getFirstChild(elm, "columnref"));
+            return from(db, VoltXMLElementHelper.getFirstChild(elm, "columnref"), typeHint);
         } else if (elm.name.equals("function")) {
             final FunctionExpression expr = new FunctionExpression();
             expr.setAttributes(elm.getStringAttribute("name", ""),
                     elm.getStringAttribute("argument", null),
                     elm.getIntAttribute("id", 0));
-            expr.setArgs(elm.children.stream().map(ExpressionUtil::from).collect(Collectors.toList()));
+            expr.setArgs(elm.children.stream().map(elem -> from(db, elem, typeHint)).collect(Collectors.toList()));
             expr.setValueType(VoltType.typeFromString(elm.getStringAttribute("valuetype", "")));
             return expr;
         } else if (elm.name.equals("tablesubquery")) {  // e.g. where X in (SELECT ...)
@@ -96,18 +233,20 @@ public final class ExpressionUtil {
             assert elm.name.equals("operation");
             final ExpressionType op = mapOfVoltXMLOpType.get(elm.attributes.get("optype"));
             assert op != null;
+            final String hint = guessParameterType(db, elm);
             switch (op) {
                 case CONJUNCTION_OR:
                 case CONJUNCTION_AND:
-                    return new ConjunctionExpression(op, from(elm.children.get(0)), from(elm.children.get(1)));
+                    return new ConjunctionExpression(op, from(db, elm.children.get(0), hint), from(db, elm.children.get(1), hint));
                 case COMPARE_GREATERTHAN:
                 case COMPARE_LESSTHAN:
                 case COMPARE_EQUAL:
                 case COMPARE_NOTEQUAL:
                 case COMPARE_GREATERTHANOREQUALTO:
                 case COMPARE_LESSTHANOREQUALTO: {
-                    final ComparisonExpression expr =
-                            new ComparisonExpression(op, from(elm.children.get(0)), from(elm.children.get(1)));
+                    final ComparisonExpression expr = new ComparisonExpression(op,
+                            from(db, elm.children.get(0), hint),
+                            from(db, elm.children.get(1), hint));
                     expr.setQuantifier(QuantifierType.get(elm.getStringAttribute("opsubtype", "none")));
                     return expr;
                 }
@@ -117,16 +256,17 @@ public final class ExpressionUtil {
                 case OPERATOR_DIVIDE:
                 case OPERATOR_CONCAT:
                 case OPERATOR_MOD:
-                    return new OperatorExpression(op, from(elm.children.get(0)), from(elm.children.get(1)));
+                    return new OperatorExpression(op,
+                            from(db, elm.children.get(0), hint), from(db, elm.children.get(1), hint));
                 case OPERATOR_IS_NULL:
                 case OPERATOR_EXISTS:
                 case OPERATOR_NOT:
                 case OPERATOR_UNARY_MINUS:
-                    return new OperatorExpression(op, from(elm.children.get(0)), null);
+                    return new OperatorExpression(op, from(db, elm.children.get(0), hint), null);
                 case COMPARE_IN: {
                     final InComparisonExpression expr = new InComparisonExpression();
-                    expr.setLeft(from(elm.children.get(0)));
-                    expr.setRight(from(elm.children.get(1)));
+                    expr.setLeft(from(db, elm.children.get(0), hint));
+                    expr.setRight(from(db, elm.children.get(1), hint));
                     return expr;
                 }
                 default:

--- a/src/frontend/org/voltdb/planner/QueryPlanner.java
+++ b/src/frontend/org/voltdb/planner/QueryPlanner.java
@@ -215,7 +215,7 @@ public class QueryPlanner implements AutoCloseable {
             final TupleValueExpression columnExpression = new TupleValueExpression(
                     targetTable.getTypeName(), ttl.getName(), ttl.getIndex());
             if (! ExpressionUtil.collectTerminals(
-                    ExpressionUtil.from(
+                    ExpressionUtil.from(db,
                             VoltXMLElementHelper.getFirstChild(
                                     VoltXMLElementHelper.getFirstChild(xmlSQL, "condition"),
                                     "operation")))

--- a/src/frontend/org/voltdb/types/QueryType.java
+++ b/src/frontend/org/voltdb/types/QueryType.java
@@ -33,7 +33,8 @@ public enum QueryType {
     INSERT      (3),
     UPDATE      (4),
     DELETE      (5),
-    UPSERT      (6);
+    UPSERT      (6),
+    MIGRATE     (7);    // MIGRATE FROM tbl WHERE ...
 
     QueryType(int val) {
         assert (this.ordinal() == val) :
@@ -117,6 +118,9 @@ public enum QueryType {
             // motivating diving right in to the full parser/planner without this pre-check.
             // We don't want to be re-implementing the parser here -- this has already gone far enough.
             return QueryType.SELECT;
+        } else if (stmt.startsWith("migrat")) {
+            // Note that we are only comparing the first 6 characters as a hack.
+            return QueryType.MIGRATE;
         }
         // else:
         // All the known statements are handled above, so default to cataloging an invalid read-only statement


### PR DESCRIPTION
For the need of "MIGRATE TO tbl WHERE ..." statement, where we need to inspect the predicate.
The fix is needed to infer parameters that could appear in the expression, where we may need to
retrieve from the table catalog to get its type.