### PR TITLE
ENG-15158: Ensure that all fall-back ad-hoc DQL queries are indeed MP queries.

### DIFF
--- a/tests/frontend/org/voltdb/plannerv2/MPChecker.java
+++ b/tests/frontend/org/voltdb/plannerv2/MPChecker.java
@@ -1,0 +1,82 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.plannerv2;
+
+import org.voltdb.compiler.DeterminismMode;
+import org.voltdb.planner.CompiledPlan;
+
+/**
+ * A command line tool to check that the query that Calcite planner considers as MP is indeed MP and vice versa.
+ * You can use the script at tests/sqlgrammar/mp-checker to run it.
+ *
+ * usage: mp-checker
+ *  -d,--ddl <arg>     File path for the DDLs.
+ *  -f,--file <arg>    The input file path that contains SQL query statements
+ *                     (If -q/--query is used, this option will be ignored).
+ *  -q,--query <arg>   Single SQL query statement string.
+ */
+public class MPChecker extends PlanChecker {
+
+    /**
+     * Check if the MP/SP is consistent between Calcite plan and Volt plan for a single SQL statement.
+     *
+     * @param sql
+     */
+    void checkPlan(String sql) {
+        // remove the semi colon at the end of the sql statement
+        sql = sql.replaceAll(";$", "");
+
+        if (!isValid(sql)) return;
+
+        CompiledPlan calcitePlan;
+        CompiledPlan voltdbPlan;
+        try {
+            calcitePlan = compileAdHocCalcitePlan(sql, true, true, DeterminismMode.SAFER);
+            voltdbPlan = compileAdHocPlan(sql, true, true);
+        } catch (Exception e) {
+            // The SQL is invalid in VOLT or is not supported in Calcite planner, stop checking and print nothing
+            return;
+        }
+
+        if ((calcitePlan.subPlanGraph == null && voltdbPlan.subPlanGraph != null) ||
+                (calcitePlan.subPlanGraph != null && voltdbPlan.subPlanGraph == null)) {
+            // if the MP/SP is inconsistent between Calcite plan and Volt plan, print the SQL statement.
+            System.err.println(sql);
+        }
+        // if Calcite make the right decision on SP/MP, print nothing.
+    }
+
+    public static void main(String[] args) throws Exception {
+        // we can reuse the same cli config as plan-checker.
+        final PlanCheckerConfig cfg = new PlanCheckerConfig();
+        cfg.parse("mp-checker", args);
+        MPChecker mpChecker = new MPChecker();
+        mpChecker.initWithDDL(cfg.ddlFile);
+        if (!cfg.query.isEmpty()) {
+            mpChecker.checkPlan(cfg.query);
+        } else {
+            mpChecker.checkPlans(cfg.file);
+        }
+    }
+}

--- a/tests/frontend/org/voltdb/plannerv2/MPChecker.java
+++ b/tests/frontend/org/voltdb/plannerv2/MPChecker.java
@@ -49,12 +49,17 @@ public class MPChecker extends PlanChecker {
 
         if (!isValid(sql)) return;
 
-        CompiledPlan calcitePlan;
-        CompiledPlan voltdbPlan;
+        CompiledPlan calcitePlan = null;
+        CompiledPlan voltdbPlan = null;
         try {
-            calcitePlan = compileAdHocCalcitePlan(sql, true, true, DeterminismMode.SAFER);
             voltdbPlan = compileAdHocPlan(sql, true, true);
+            calcitePlan = compileAdHocCalcitePlan(sql, true, true, DeterminismMode.SAFER);
         } catch (Exception e) {
+            if (e.getMessage().contains("MP query not supported in Calcite planner") &&
+                    voltdbPlan != null && voltdbPlan.subPlanGraph == null) {
+                // if the SQL is fallback as MP in Calcite but SP in Volt, print the SQL statement.
+                System.err.println(sql);
+            }
             // The SQL is invalid in VOLT or is not supported in Calcite planner, stop checking and print nothing
             return;
         }

--- a/tests/sqlgrammar/mp-checker
+++ b/tests/sqlgrammar/mp-checker
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# This file is part of VoltDB.
+
+# Copyright (C) 2008-2019 VoltDB Inc.
+#
+# This file contains original code and/or modifications of original code.
+# Any modifications made by VoltDB Inc. are licensed under the following
+# terms and conditions:
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Original license for parts of this script copied from or influenced by
+# the Hadoop startup script:
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# The VoltDB Plan Checker Script
+
+# resolve symlinks and canonicalize the path (make it absolute)
+pushd . > /dev/null
+this=$0
+cd `dirname $this`
+this=`basename $this`
+while [ -L "$this" ]
+do
+    this=`readlink $this`
+    cd `dirname $this`
+    this=`basename $this`
+done
+this="$(pwd -P)/$this"
+popd > /dev/null
+
+# the root of the VoltDB installation
+export VOLTDB_HOME=$(dirname $(dirname $(dirname "$this")))
+
+# detect and adjust for Linux package installation vs. VoltDB distribution
+if [ -d $VOLTDB_HOME/../../lib/voltdb ]; then
+    # Linux package installation puts all libraries in /usr/lib/voltdb
+    VOLTDB_VOLTDB=$(dirname $(dirname "$VOLTDB_HOME"))/lib/voltdb
+    VOLTDB_LIB=$VOLTDB_VOLTDB
+else
+    # distribution puts third party jars in lib and voltdb libraries in voltdb
+    VOLTDB_VOLTDB=$VOLTDB_HOME/voltdb
+    VOLTDB_LIB=$VOLTDB_HOME/lib
+fi
+
+JAVA=`which java`
+
+# some Java parameters
+if [ "$JAVA_HOME" != "" ]; then
+  JAVA=$JAVA_HOME/bin/java
+fi
+
+if [ "$JAVA" = "" ]; then
+  echo "Couldn't find java version to run (make sure JAVA_HOME is set)."
+  exit 1
+fi
+
+# check envvars to see if a user overrides log4j conf
+if [ -z "${LOG4J_CONFIG_PATH}" ]; then
+  if [ -f "$VOLTDB_HOME/src/frontend/log4j.xml" ]; then
+    LOG4J_CONFIG_PATH=$VOLTDB_HOME/src/frontend/log4j.xml
+  elif [ -f "$VOLTDB_HOME/voltdb/log4j.xml" ]; then
+    LOG4J_CONFIG_PATH=$VOLTDB_HOME/voltdb/log4j.xml
+  else
+    echo "Couldn't find log4j configuration file."
+    exit 1
+  fi
+fi
+
+# add libs to CLASSPATH
+for f in $VOLTDB_LIB/*.jar; do
+  CLASSPATH=${CLASSPATH}:$f;
+done
+
+# add test classes to CLASSPATH, make sure it works either release or debug build
+# if we have both debug and release build, we will use the release one.
+CLASSPATH=${CLASSPATH}:$VOLTDB_HOME/obj/release/test:$VOLTDB_HOME/obj/debug/test
+
+# add junit jars to CLASSPATH
+CLASSPATH=${CLASSPATH}:$VOLTDB_HOME/third_party/java/jars/junit-dep-4.10.jar:$VOLTDB_HOME/third_party/java/jars/hamcrest-all-1.3.jar
+
+# run it
+export CMDVAL="$JAVA -Dlog4j.configuration=file://${LOG4J_CONFIG_PATH} "
+export CMDVAL=$CMDVAL"-classpath $CLASSPATH org.voltdb.plannerv2.MPChecker"
+
+exec $CMDVAL "$@"


### PR DESCRIPTION
A command line tool to check a query that Calcite planner considers as MP is indeed MP and vice versa. You can use the script at `tests/sqlgrammar/mp-checker` to run it.
```
usage: mp-checker
 -d,--ddl <arg>     File path for the DDLs.
 -f,--file <arg>    The input file path that contains SQL query statements
                    (If -q/--query is used, this option will be ignored).
 -q,--query <arg>   Single SQL query statement string.
```
If the query is planable and there is a difference in MP/SP decision between the orignal volt plan and the new calcite plan, it will print out the query in **STDERR**. Otherwise, it will print nothing in STDERR. For example:
```console
foo@bar:~$ mp-checker -d testcalcite-ddl.sql -f tests.sql
select * from P1 where id in (1) 
```