### PR TITLE
ENG-15696 Reversed SQL function NOT_MIGRATED() to MIGRATING

### DIFF
--- a/src/ee/expressions/functionexpression.cpp
+++ b/src/ee/expressions/functionexpression.cpp
@@ -109,17 +109,17 @@ namespace functionexpression {
             }
       };
 
-   template<> NValue ConstantFunctionExpression<FUNC_VOLT_NOT_MIGRATED>::eval(
+   template<> NValue ConstantFunctionExpression<FUNC_VOLT_MIGRATING>::eval(
          const TableTuple* tuple1, const TableTuple*) const {
-      // For NOT_MIGRATED(), check if we are evaluating on a migrating table (the table with a migrate target).
+      // For MIGRATING(), check if we are evaluating on a migrating table (the table with a migrate target).
       if (tuple1 != NULL && tuple1->getSchema()->isTableWithStream()) {
          // we have at most 3 hidden columns, DR Timestamp, count for view and transaction id for migrating
          // and transaction id for migrating is always the last one.
          return tuple1->getHiddenNValue( // use callUnary instead of callConstant since callConstant is a static method
-               tuple1->getSchema()->hiddenColumnCount() - 1).callUnary<FUNC_VOLT_NOT_MIGRATED>();
+               tuple1->getSchema()->hiddenColumnCount() - 1).callUnary<FUNC_VOLT_MIGRATING>();
       } else {
          throw SQLException(SQLException::dynamic_sql_error,
-               "Can not apply NOT_MIGRATED function on non-migrating tables.");
+               "Can not apply MIGRATING function on non-migrating tables.");
       }
    }
 
@@ -272,8 +272,8 @@ AbstractExpression* functionFactory(int functionId, const std::vector<AbstractEx
          case FUNC_VOLT_MAX_VALID_TIMESTAMP:
             ret = new ConstantFunctionExpression<FUNC_VOLT_MAX_VALID_TIMESTAMP>();
             break;
-         case FUNC_VOLT_NOT_MIGRATED:
-            ret = new ConstantFunctionExpression<FUNC_VOLT_NOT_MIGRATED>();
+         case FUNC_VOLT_MIGRATING:
+            ret = new ConstantFunctionExpression<FUNC_VOLT_MIGRATING>();
             break;
          default:
             return NULL;

--- a/src/ee/expressions/functionexpression.h
+++ b/src/ee/expressions/functionexpression.h
@@ -235,9 +235,9 @@ namespace voltdb {
    static const int FUNC_VOLT_SET_FIELD                   = 20024;
 
    static const int FUNC_VOLT_FORMAT_CURRENCY             = 20025;
-   // Check if the row has not been migrated. Returns true when the migrating column is NULL.
-   // Rows that had been migrated has that column set to txn-id of the migrating process.
-   static const int FUNC_VOLT_NOT_MIGRATED                = 21026;
+   // Check if the row has been migrated. Returns true when the migrating column is NOT NULL.
+   // Rows that had been migrating has that column set to txn-id (i.e. not null) of the migrating process.
+   static const int FUNC_VOLT_MIGRATING                   = 21026;
 
    static const int FUNC_VOLT_BITNOT                      = 20026;
    static const int FUNC_VOLT_BIT_SHIFT_LEFT              = 20027;

--- a/src/ee/expressions/logicfunctions.h
+++ b/src/ee/expressions/logicfunctions.h
@@ -44,11 +44,11 @@ template<> inline NValue NValue::call<FUNC_DECODE>(const std::vector<NValue>& ar
 }
 
 /*
-* Implement the Volt NOT_MIGRATED function.
-* Returns true if the hidden column is NULL, which means that it
-* has not been migrated.
+* Implement the Volt MIGRATING function.
+* Returns true if the hidden column is NOT NULL, which means that the
+* migrating process for this row has been started.
 */
-template<> inline NValue NValue::callUnary<FUNC_VOLT_NOT_MIGRATED>() const {
-    return ValueFactory::getBooleanValue(isNull());
+template<> inline NValue NValue::callUnary<FUNC_VOLT_MIGRATING>() const {
+    return ValueFactory::getBooleanValue(! isNull());
 }
 }

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -957,14 +957,6 @@ public abstract class AbstractParsedStmt {
         // a constant/tuple/param value operand).
         AbstractExpression leftExpr = parseExpressionNode(leftExprNode);
         assert((leftExpr != null) || (exprType == ExpressionType.AGGREGATE_COUNT));
-        // Forbid user from creating filter like NOT NOT_MIGRATED(), because this will give
-        // wrong results, due to how the partial index of MIGRATING index is created.
-        // This, however, does not do more thorough check on more complex expressions.
-        if (exprType == ExpressionType.OPERATOR_NOT && leftExpr instanceof FunctionExpression &&
-                ((FunctionExpression) leftExpr).hasFunctionId(
-                        FunctionForVoltDB.FunctionDescriptor.FUNC_VOLT_NOT_MIGRATED)) {
-            throw new PlanningErrorException("\"NOT NOT_MIGRATED()\" is an invalid predicate.");
-        }
         expr.setLeft(leftExpr);
 
         // get the second (right) node that is an element (might be null)

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
@@ -195,7 +195,7 @@ public class FunctionForVoltDB extends FunctionSQL {
         static final int FUNC_VOLT_MAKE_VALID_POLYGON           = 21024;    // Make an invalid polygon valid by reversing rings.
                                                                             // Note: This will only correct orientation errors.
         static final int FUNC_VOLT_FORMAT_TIMESTAMP             = 21025;    // Convert a timestamp to a String in a given timezone.
-        public static final int FUNC_VOLT_NOT_MIGRATED                 = 21026;    // Check if the row is migrating.
+        public static final int FUNC_VOLT_MIGRATING             = 21026;    // Check if the row is migrating.
 
         /*
          * All VoltDB user-defined functions must have IDs in this range.
@@ -424,9 +424,9 @@ public class FunctionForVoltDB extends FunctionSQL {
                     doubleParamList),
                 /**
                  * NOTE: this returns the set of rows that are currently not migrated, i.e.
-                 * whose hidden columns are NULL.
+                 * whose hidden columns are NOT NULL.
                 */
-            new FunctionDescriptor("not_migrated", Type.SQL_BOOLEAN, FUNC_VOLT_NOT_MIGRATED, -1,
+            new FunctionDescriptor("migrating", Type.SQL_BOOLEAN, FUNC_VOLT_MIGRATING, -1,
                     new Type[] {},
                     emptyParamList,
                     noParamList),

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Tokens.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Tokens.java
@@ -1149,7 +1149,7 @@ public class Tokens {
     // A VoltDB extension to support the assume unique index attribute
     public static final int ASSUMEUNIQUE                     = 1303;
     // A VoltDB extension to support the MIGRATING index attribute
-    public static final int MIGRATING                        = 1304;
+    public static final int MIGRATING                        = 1306;
     // End of VoltDB extension
     public static final int UNKNOWN                          = 298;
     public static final int UNNEST                           = 299;
@@ -1968,7 +1968,9 @@ public class Tokens {
         // A VoltDB extension to support the assume unique index attribute
         reservedKeys.put(Tokens.T_ASSUMEUNIQUE, ASSUMEUNIQUE);
         // A VoltDB extension to support the migrating index attribute
-        reservedKeys.put(Tokens.T_MIGRATING, MIGRATING);
+        // TODO: by making MIGRATING not reserved key word, we allow HSQL to parse MIGRATING as a SQL function name.
+        // In future (ENG-15699), we shall remove code introduced for CREATE MIGRATING INDEX syntax.
+        //reservedKeys.put(Tokens.T_MIGRATING, MIGRATING);
         // End of VoltDB extension
         reservedKeys.put(Tokens.T_UNKNOWN, UNKNOWN);
         reservedKeys.put(Tokens.T_UNNEST, UNNEST);


### PR DESCRIPTION
**The MIGRATING() function returns true for rows with hidden columns _NOT NULL_**.

And removed guard against "NOT" before the function
As a side-effect, the parser now rejects "CREATE MIGRATING INDEX ..."
usage, which is what we plan to deprecate: we can just create normal,
partial index like:

`CREATE INDEX ii ON tbl(ttl) WHERE NOT MIGRATING AND ttl > 50;`
which should be like what we do with migrating index:
`CREATE MIGRATING INDEX ii ON tbl(ttl) WHERE ttl > 50;` (but this is no-longer supported)