### PR TITLE
ENG-15706: CRC was not getting reset in uncompressed mode, which resu…

### DIFF
--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -585,6 +585,7 @@ public class PBDRegularSegment extends PBDSegment {
                     }
                     retcont.b().flip();
                     if (checkCRC) {
+                        m_crc32.reset();
                         m_crc32.update(length);
                         m_crc32.update(flags);
                         m_crc32.update(retcont.b());
@@ -596,6 +597,7 @@ public class PBDRegularSegment extends PBDSegment {
                             openForWrite(false);
                             initNumEntries(m_objectReadIndex, m_bytesRead);
                             m_fc.truncate(m_readOffset);
+                            retcont.discard();
                             return null;
                         }
                     }


### PR DESCRIPTION
…lted

in a CRC error. In addition, the buffer wasn't getting discarded on a CRC error,
which resulted in the error seen in the system test.