### PR TITLE
PBD harden a bit more and handle check errors

### DIFF
--- a/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
@@ -131,8 +131,12 @@ public class TaskLogImpl implements TaskLog {
 
     @Override
     public void logTask(TransactionInfoBaseMessage message) throws IOException {
-        if (message.getSpHandle() <= m_snapshotSpHandle) return;
-        if (m_closed) throw new IOException("Closed");
+        if (message.getSpHandle() <= m_snapshotSpHandle) {
+            return;
+        }
+        if (m_closed) {
+            throw new IOException("Closed");
+        }
 
         assert(message != null);
         bufferCatchup(message.getSerializedSize());
@@ -166,7 +170,9 @@ public class TaskLogImpl implements TaskLog {
      */
     @Override
     public TransactionInfoBaseMessage getNextMessage() throws IOException {
-        if (m_closed) throw new IOException("Closed");
+        if (m_closed) {
+            throw new IOException("Closed");
+        }
         if (m_head == null) {
             // Get another buffer asynchronously
             final Runnable r = new Runnable() {
@@ -241,7 +247,9 @@ public class TaskLogImpl implements TaskLog {
 
     private boolean m_closed = false;
     public void close(boolean synchronous) throws IOException {
-        if (m_closed) return;
+        if (m_closed) {
+            return;
+        }
         m_closed = true;
         m_es.shutdown();
         if (synchronous) {

--- a/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
@@ -179,7 +179,7 @@ public class TaskLogImpl implements TaskLog {
                 @Override
                 public void run() {
                     try {
-                        BBContainer cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                        BBContainer cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                         if (cont != null) {
                            m_headBuffers.offer(new RejoinTaskBuffer(cont));
                         }

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -121,7 +121,7 @@ public interface BinaryDeque {
             throw new UnsupportedOperationException("Must implement this for partial object truncation");
         }
 
-        public int writeTruncatedObject(ByteBuffer output) throws IOException {
+        public int writeTruncatedObject(ByteBuffer output, int entryId) throws IOException {
             throw new UnsupportedOperationException("Must implement this for partial object truncation");
         }
     }

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.DeferredSerialization;
 import org.voltcore.utils.Pair;
-import org.voltdb.export.ExportSequenceNumberTracker;
 
 /**
  * Specialized deque interface for storing binary objects. Objects can be provided as a buffer chain
@@ -55,16 +54,6 @@ public interface BinaryDeque {
      * @throws IOException
      */
     void offer(BBContainer object) throws IOException;
-
-    /**
-     * Store a buffer chain as a single object in the deque. IOException may be thrown if the object
-     * is larger then the implementation defined max. 64 megabytes in the case of PersistentBinaryDeque.
-     * If there is an exception attempting to write the buffers then all the buffers will be discarded
-     * @param object
-     * @param allowCompression
-     * @throws IOException
-     */
-    void offer(BBContainer object, boolean allowCompression) throws IOException;
 
     int offer(DeferredSerialization ds) throws IOException;
 
@@ -104,7 +93,7 @@ public interface BinaryDeque {
 
     public void parseAndTruncate(BinaryDequeTruncator truncator) throws IOException;
 
-    public ExportSequenceNumberTracker scanForGap(BinaryDequeScanner scanner) throws IOException;
+    public void scanEntries(BinaryDequeScanner scanner) throws IOException;
     /**
      * Release all resources (open files) held by the back store of the queue. Continuing to use the deque
      * will result in an exception
@@ -155,6 +144,6 @@ public interface BinaryDeque {
     }
 
     public interface BinaryDequeScanner {
-        public ExportSequenceNumberTracker scan(BBContainer bb);
+        public void scan(BBContainer bb);
     }
 }

--- a/src/frontend/org/voltdb/utils/BinaryDequeReader.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeReader.java
@@ -30,11 +30,10 @@ public interface BinaryDequeReader {
      * Read and return the object at the current read position of this reader.
      * The entry will be removed once all active readers have read the entry.
      * @param ocf
-     * @param checkCRC
      * @return BBContainer with the bytes read. Null if there is nothing left to read.
      * @throws IOException
      */
-    public BBContainer poll(OutputContainerFactory ocf, boolean checkCRC) throws IOException;
+    public BBContainer poll(OutputContainerFactory ocf) throws IOException;
 
     /**
      * @param segmentIndex index of the segment to get schema from, -1 means get schema from current segment

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -477,6 +477,7 @@ public class PBDRegularSegment extends PBDSegment {
                 m_fc.write(b);
             }
             m_extraHeaderSize = size;
+            writeOutHeader();
         } finally {
             destBuf.discard();
         }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -618,9 +618,8 @@ class PBDRegularSegment extends PBDSegment {
                 final int uncompressedLen;
 
                 if (length < 1 || length > PBDSegment.CHUNK_SIZE - PBDSegment.SEGMENT_HEADER_BYTES) {
-                    LOG.warn("File corruption detected in " + m_file.getName() + ": invalid entry length. "
-                            + "Truncate the file to last safe point.");
-                    truncateToCurrentReadIndex();
+                    handleCorruptHeader("File corruption detected in " + m_file.getName() + ": invalid entry length.",
+                            checkCRC);
                     return null;
                 }
 
@@ -679,6 +678,18 @@ class PBDRegularSegment extends PBDSegment {
             } finally {
                 m_readOffset = m_fc.position();
                 m_fc.position(writePos);
+            }
+        }
+
+        private void handleCorruptHeader(String message, boolean checkCrc) throws IOException {
+            if (checkCrc) {
+                message += " Truncate the file to last safe point.";
+            }
+            LOG.warn(message);
+            if (checkCrc) {
+                truncateToCurrentReadIndex();
+            } else {
+                throw new IOException(message);
             }
         }
 

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -107,8 +107,6 @@ class PBDRegularSegment extends PBDSegment {
             m_entryHeaderBuf.discard();
             m_entryHeaderBuf = null;
         }
-        m_crc.reset();
-        m_crc.reset();
     }
 
     @Override
@@ -570,7 +568,7 @@ class PBDRegularSegment extends PBDSegment {
         private int m_bytesRead = 0;
         private int m_discardCount = 0;
         private boolean m_readerClosed = false;
-        private CRC32 m_crc32 = new CRC32();
+        private CRC32 m_crcReader = new CRC32();
 
         public SegmentReader(String cursorId) throws IOException {
             assert(cursorId != null);
@@ -703,13 +701,13 @@ class PBDRegularSegment extends PBDSegment {
             entry.position(origPosition);
 
             if (checkCrc) {
-                m_crc32.reset();
-                m_crc32.update(length);
-                m_crc32.update(flags);
-                m_crc32.update(entry);
+                m_crcReader.reset();
+                m_crcReader.update(length);
+                m_crcReader.update(flags);
+                m_crcReader.update(entry);
                 entry.position(origPosition);
 
-                if (crc != (int) m_crc32.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
+                if (crc != (int) m_crcReader.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
                     LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
                             + "Truncate the file to last safe point.");
                     truncateToCurrentReadIndex();

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -561,21 +561,8 @@ public class PBDRegularSegment extends PBDSegment {
                             }
                         }
                         compressedBuf.b().flip();
-                        if (checkCRC) {
-                            m_crc32.reset();
-                            m_crc32.update(length);
-                            m_crc32.update(flags);
-                            m_crc32.update(compressedBuf.b());
-                            compressedBuf.b().flip();
-                            if (entryCRC != (int)m_crc32.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
-                                LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
-                                        + "Truncate the file to last safe point.");
-                                PBDRegularSegment.this.close();
-                                openForWrite(false);
-                                initNumEntries(m_objectReadIndex, m_bytesRead);
-                                m_fc.truncate(m_readOffset);
-                                return null;
-                            }
+                        if (checkCRC && !checkEntryCrc(length, flags, compressedBuf.b(), entryCRC)) {
+                            return null;
                         }
 
                         uncompressedLen = CompressionService.uncompressedLength(compressedBuf.bDR());
@@ -596,20 +583,9 @@ public class PBDRegularSegment extends PBDSegment {
                         }
                     }
                     retcont.b().flip();
-                    if (checkCRC) {
-                        m_crc32.update(length);
-                        m_crc32.update(flags);
-                        m_crc32.update(retcont.b());
-                        retcont.b().flip();
-                        if (entryCRC != (int)m_crc32.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
-                            LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
-                                    + "Truncate the file to last safe point.");
-                            PBDRegularSegment.this.close();
-                            openForWrite(false);
-                            initNumEntries(m_objectReadIndex, m_bytesRead);
-                            m_fc.truncate(m_readOffset);
-                            return null;
-                        }
+                    if (checkCRC && !checkEntryCrc(length, flags, retcont.b(), entryCRC)) {
+                        retcont.discard();
+                        return null;
                     }
                 }
 
@@ -636,6 +612,26 @@ public class PBDRegularSegment extends PBDSegment {
                 m_readOffset = m_fc.position();
                 m_fc.position(writePos);
             }
+        }
+
+        private boolean checkEntryCrc(int length, int flags, ByteBuffer entry, int crc) throws IOException {
+            int origPosition = entry.position();
+            m_crc32.reset();
+            m_crc32.update(length);
+            m_crc32.update(flags);
+            m_crc32.update(entry);
+            entry.position(origPosition);
+
+            if (crc != (int) m_crc32.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
+                LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
+                        + "Truncate the file to last safe point.");
+                PBDRegularSegment.this.close();
+                openForWrite(false);
+                initNumEntries(m_objectReadIndex, m_bytesRead);
+                m_fc.truncate(m_readOffset);
+                return false;
+            }
+            return true;
         }
 
         @Override

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -331,7 +331,6 @@ class PBDRegularSegment extends PBDSegment {
 
     @Override
     void closeAndDelete() throws IOException {
-        setFinal(false);
         try {
             close();
         } finally {
@@ -713,6 +712,7 @@ class PBDRegularSegment extends PBDSegment {
         private void truncateToCurrentReadIndex() throws IOException {
             PBDRegularSegment.this.close();
             openForTruncate();
+            setFinal(false);
             initNumEntries(m_objectReadIndex, m_bytesRead);
             m_fc.truncate(m_readOffset);
         }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -58,6 +58,8 @@ class PBDRegularSegment extends PBDSegment {
 
     // Persistent ID of this segment, based on managing a monotonic counter
     private final long m_id;
+    // Whether or not this is the current active segment being written to
+    boolean m_isActive = false;
 
     private int m_numOfEntries = -1;
     private int m_size = -1;
@@ -191,6 +193,7 @@ class PBDRegularSegment extends PBDSegment {
             setFinal(false);
             initNumEntries(0, 0);
             m_compress = compress;
+            m_isActive = true;
         }
         if (forWrite) {
             m_fc.position(m_fc.size());
@@ -327,6 +330,12 @@ class PBDRegularSegment extends PBDSegment {
     private int remaining() throws IOException {
         //Subtract 12 for the crc, number of entries and size prefix
         return (int)(PBDSegment.CHUNK_SIZE - m_fc.position()) - SEGMENT_HEADER_BYTES;
+    }
+
+    @Override
+    public void finalize() throws IOException {
+        m_isActive = false;
+        super.finalize();
     }
 
     @Override
@@ -782,7 +791,7 @@ class PBDRegularSegment extends PBDSegment {
             if (keep) {
                 m_closedCursors.put(m_cursorId, this);
             }
-            if (m_readCursors.isEmpty()) {
+            if (m_readCursors.isEmpty() && !m_isActive) {
                 closeReadersAndFile();
             }
         }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -20,9 +20,11 @@ package org.voltdb.utils;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.CRC32;
@@ -175,9 +177,10 @@ class PBDRegularSegment extends PBDSegment {
             }
             m_syncedSinceLastEdit = false;
         }
-        assert(m_ras == null);
-        m_ras = new RandomAccessFile( m_file, forWrite ? "rw" : "r");
-        m_fc = m_ras.getChannel();
+        assert (m_fc == null);
+        m_fc = FileChannel.open(m_file.toPath(),
+                forWrite ? EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)
+                        : EnumSet.of(StandardOpenOption.READ));
         m_segmentHeaderBuf = DBBPool.allocateDirect(SEGMENT_HEADER_BYTES);
         m_entryHeaderBuf = DBBPool.allocateDirect(ENTRY_HEADER_BYTES);
 
@@ -350,11 +353,10 @@ class PBDRegularSegment extends PBDSegment {
     private void closeReadersAndFile() throws IOException {
         m_readCursors.clear();
         try {
-            if (m_ras != null) {
-                m_ras.close();
+            if (m_fc != null) {
+                m_fc.close();
             }
         } finally {
-            m_ras = null;
             m_fc = null;
             m_closed = true;
             reset();

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -19,7 +19,6 @@ package org.voltdb.utils;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
@@ -73,7 +72,6 @@ public abstract class PBDSegment {
     protected final File m_file;
 
     protected boolean m_closed = true;
-    protected RandomAccessFile m_ras;
     protected FileChannel m_fc;
     //Avoid unnecessary sync with this flag
     protected boolean m_syncedSinceLastEdit = true;

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -299,24 +299,29 @@ public abstract class PBDSegment {
      *
      * NOTES:
      *
-     * This is a best-effort feature: On any kind of I/O failure, the exception is swallowed and the
-     * operation is a no-op: this will be the case on filesystems that do no support extended file
-     * attributes. Also note that the {@code FileStore.supportsFileAttributeView} method does not provide
-     * a reliable way to test for the availability of the extended file attributes.
+     * This is a best-effort feature: On any kind of I/O failure, the exception is swallowed and the operation is a
+     * no-op: this will be the case on filesystems that do no support extended file attributes. Also note that the
+     * {@code FileStore.supportsFileAttributeView} method does not provide a reliable way to test for the availability
+     * of the extended file attributes.
      *
-     * Must be called with 'true' by segment owner when it has filled the segment, written all segment
-     * metadata, and after it has either closed or sync'd the segment file.
+     * Must be called with 'true' by segment owner when it has filled the segment, written all segment metadata, and
+     * after it has either closed or sync'd the segment file.
      *
      * Must be called with 'false' whenever opening segment for writing new data.
      *
-     * Note that all calls to 'setFinal' are done by the class owning the segment because the segment
-     * itself generally lacks context to decide whether it's final or not.
+     * Note that all calls to 'setFinal' are done by the class owning the segment because the segment itself generally
+     * lacks context to decide whether it's final or not.
      *
-     * @param isFinal   true if segment is set to final, false otherwise
+     * @param isFinal true if segment is set to final, false otherwise
+     * @throws IOException
      */
-    void setFinal(boolean isFinal) {
+    void setFinal(boolean isFinal) throws IOException {
         if (isFinal != m_isFinal) {
             if (setFinal(m_file, isFinal)) {
+                if (!isFinal) {
+                    // It is dangerous to leave final on a segment so make sure the metadata is flushed
+                    m_fc.force(true);
+                }
                 m_isFinal = isFinal;
             }
         }

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -75,6 +75,7 @@ public abstract class PBDSegment {
     protected FileChannel m_fc;
     //Avoid unnecessary sync with this flag
     protected boolean m_syncedSinceLastEdit = true;
+    // Reusable crc calculator. Must be reset before each use
     protected CRC32 m_crc;
     // Mirror of the isFinal metadata on the filesystem
     private boolean m_isFinal;

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -90,13 +90,18 @@ interface PBDSegmentReader {
     /**
      * Reopen a previously closed reader. Re-opened reader still keeps the original read offset.
      */
-    public void reopen(boolean forWrite, boolean emptyFile) throws IOException;
+    public void reopen() throws IOException;
 
     /**
-     * Close this reader and release any resources.
-     * <code>getReader</code> will still return this reader until the segment is closed.
+     * Close this reader and release any resources. {@link PBDSegment#getReader(String)} will still return this reader
+     * until the segment is closed.
      */
     public void close() throws IOException;
+
+    /**
+     * Similar to {@link #close()} but this reader will not be returned from {@link PBDSegment#getReader(String)}
+     */
+    public void purge() throws IOException;
 
     /**
      * Has this reader been closed.

--- a/src/frontend/org/voltdb/utils/PBDUtils.java
+++ b/src/frontend/org/voltdb/utils/PBDUtils.java
@@ -46,14 +46,22 @@ public class PBDUtils {
         buf.flip();
     }
 
-    public static void writeEntryHeader(CRC32 crc, ByteBuffer headerBuf,
-            ByteBuffer destBuf, int size, char flag) {
-        crc.update(size);
-        crc.update(flag);
+    public static int calculateEntryCrc(CRC32 crc, ByteBuffer destBuf, int entryId, char flags) {
+        crc.reset();
+        crc.update(destBuf.remaining());
+        crc.update(entryId);
+        crc.update(flags);
         crc.update(destBuf);
         // the checksum here is really an unsigned int, store integer to save 4 bytes
-        headerBuf.putInt((int)crc.getValue());
-        headerBuf.putInt(size);
+        return (int) crc.getValue();
+    }
+
+    public static void writeEntryHeader(CRC32 crc, ByteBuffer headerBuf,
+            ByteBuffer destBuf, int entryId, char flag) {
+        int length = destBuf.remaining();
+        headerBuf.putInt(calculateEntryCrc(crc, destBuf, entryId, flag));
+        headerBuf.putInt(length);
+        headerBuf.putInt(entryId);
         headerBuf.putChar(flag);
     }
 }

--- a/src/frontend/org/voltdb/utils/PBDUtils.java
+++ b/src/frontend/org/voltdb/utils/PBDUtils.java
@@ -47,13 +47,13 @@ public class PBDUtils {
     }
 
     public static void writeEntryHeader(CRC32 crc, ByteBuffer headerBuf,
-            ByteBuffer destBuf, int size, int flag) {
+            ByteBuffer destBuf, int size, char flag) {
         crc.update(size);
         crc.update(flag);
         crc.update(destBuf);
         // the checksum here is really an unsigned int, store integer to save 4 bytes
         headerBuf.putInt((int)crc.getValue());
         headerBuf.putInt(size);
-        headerBuf.putInt(flag);
+        headerBuf.putChar(flag);
     }
 }

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -508,7 +508,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
             // Handle common cases: no PBD files or just one
             if (filesById.size() == 0) {
-                m_usageSpecificLog.info("No PBD segments for " + m_nonce);
+                if (m_usageSpecificLog.isDebugEnabled()) {
+                    m_usageSpecificLog.debug("No PBD segments for " + m_nonce);
+                }
                 return;
             }
 
@@ -629,7 +631,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         assertions();
         if (m_segments.isEmpty()) {
-            m_usageSpecificLog.debug("PBD " + m_nonce + " has no finished segments");
+            if (m_usageSpecificLog.isDebugEnabled()) {
+                m_usageSpecificLog.debug("PBD " + m_nonce + " has no finished segments");
+            }
             return;
         }
 
@@ -1104,7 +1108,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
         m_readCursors.clear();
 
         for (PBDSegment qs : m_segments.values()) {
-            m_usageSpecificLog.debug("Segment " + qs.file() + " has been closed and deleted due to delete all");
+            if (m_usageSpecificLog.isDebugEnabled()) {
+                m_usageSpecificLog.debug("Segment " + qs.file() + " has been closed and deleted due to delete all");
+            }
             closeAndDeleteSegment(qs);
         }
         m_segments.clear();
@@ -1245,7 +1251,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         assertions();
         if (m_segments.isEmpty()) {
-            m_usageSpecificLog.debug("PBD " + m_nonce + " has no finished segments");
+            if (m_usageSpecificLog.isDebugEnabled()) {
+                m_usageSpecificLog.debug("PBD " + m_nonce + " has no finished segments");
+            }
             return new ExportSequenceNumberTracker();
         }
 

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -1243,7 +1243,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
     }
 
     @Override
-    public ExportSequenceNumberTracker scanForGap(BinaryDequeScanner scaner) throws IOException
+    public ExportSequenceNumberTracker scanForGap(BinaryDequeScanner scanner) throws IOException
     {
         if (m_closed) {
             throw new IOException("Cannot scanForGap(): PBD has been closed");
@@ -1266,7 +1266,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
          * Iterator all the objects in all the segments and pass them to the scanner
          */
         for (PBDSegment segment : m_segments.values()) {
-            ExportSequenceNumberTracker tracker = segment.scan(scaner);
+            ExportSequenceNumberTracker tracker = segment.scan(scanner);
             gapTracker.mergeTracker(tracker);
         }
         // Reopen the last segment for write

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -829,10 +829,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             closeAndDeleteSegment(tail);
             previousTailIsDeleted = true;
         } else {
-            tail.finalize();
-            if (!tail.isBeingPolled()) {
-                tail.close();
-            }
+            tail.finalize(!tail.isBeingPolled());
 
             if (m_usageSpecificLog.isDebugEnabled()) {
                 m_usageSpecificLog.debug(
@@ -926,8 +923,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             // If this segment is to become the writing segment, don't close and
             // finalize it.
             if (!m_segments.isEmpty()) {
-                writeSegment.finalize();
-                writeSegment.close();
+                writeSegment.finalize(true);
             }
 
             if (m_usageSpecificLog.isDebugEnabled()) {
@@ -1057,8 +1053,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
             // When closing a PBD, all segments may be finalized because on
             // recover a new segment will be opened for writing
-            segment.finalize();
-            segment.close();
+            segment.finalize(true);
             if (m_usageSpecificLog.isDebugEnabled()) {
                 m_usageSpecificLog.debug("Closed segment " + segment.file()
                     + " (final: " + segment.isFinal() + "), on PBD close");

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -1107,10 +1107,10 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         @Override
-        public int writeTruncatedObject(ByteBuffer output) {
+        public int writeTruncatedObject(ByteBuffer output, int entryId) {
             int objectSize = m_retval.remaining();
             // write entry header
-            PBDUtils.writeEntryHeader(m_crc, output, m_retval, objectSize, PBDSegment.NO_FLAGS);
+            PBDUtils.writeEntryHeader(m_crc, output, m_retval, entryId, PBDSegment.NO_FLAGS);
             // write buffer after resetting position changed by writeEntryHeader
             // Note: cannot do this in writeEntryHeader as it breaks JUnit tests
             m_retval.position(0);
@@ -1140,14 +1140,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         @Override
-        public int writeTruncatedObject(ByteBuffer output) throws IOException {
+        public int writeTruncatedObject(ByteBuffer output, int entryId) throws IOException {
             output.position(PBDSegment.ENTRY_HEADER_BYTES);
             int bytesWritten = MiscUtils.writeDeferredSerialization(output, m_ds);
             output.flip();
             output.position(PBDSegment.ENTRY_HEADER_BYTES);
             ByteBuffer header = output.duplicate();
             header.position(PBDSegment.ENTRY_HEADER_START_OFFSET);
-            PBDUtils.writeEntryHeader(m_crc32, header, output, bytesWritten, PBDSegment.NO_FLAGS);
+            PBDUtils.writeEntryHeader(m_crc32, header, output, entryId, PBDSegment.NO_FLAGS);
             if (m_truncationCallback != null) {
                 m_truncationCallback.bytesWritten(bytesWritten);
             }

--- a/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
+++ b/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
@@ -57,7 +57,7 @@ public class TestPBDMultipleReaders {
             boolean done = false;
             int numRead = 0;
             for (int i=m_totalRead; i<end && !done; i++) {
-                BBContainer bbC = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                BBContainer bbC = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 if (bbC==null) {
                     done = true;
                     continue;
@@ -94,7 +94,9 @@ public class TestPBDMultipleReaders {
             for (int j=1; j<numReaders; j++) {
                 readers[j].readToEndOfSegment();
             }
-            if (i < numSegments-1) currNumSegments--;
+            if (i < numSegments-1) {
+                currNumSegments--;
+            }
             assertEquals(currNumSegments, TestPersistentBinaryDeque.getSortedDirectoryListing().size());
         }
     }
@@ -114,7 +116,7 @@ public class TestPBDMultipleReaders {
         }
 
         for (int j=0; j<numBuffers; j++) {
-            BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false );
+            BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
         }
         assertTrue(reader1.isEmpty());
@@ -143,7 +145,7 @@ public class TestPBDMultipleReaders {
         for (int i=0; i<3; i++) {
             for (int j=0; j<s_segmentFillCount; j++) {
                 m_pbd.offer( DBBPool.wrapBB(TestPersistentBinaryDeque.getFilledBuffer(j)) );
-                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
             }
             assertEquals(1, m_pbd.numOpenSegments());
@@ -165,13 +167,13 @@ public class TestPBDMultipleReaders {
         BinaryDequeReader reader = m_pbd.openForRead("reader0");
         for (int i=0; i<numSegments; i++) {
             for (int j=0; j<46; j++) {
-                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
             }
             int expected = (i == numSegments-1) ? 1 : 2;
             assertEquals(expected, m_pbd.numOpenSegments());
 
-            BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
             // there should only be 1 open because last discard closes and deletes
             assertEquals(1, m_pbd.numOpenSegments());
@@ -195,15 +197,15 @@ public class TestPBDMultipleReaders {
         // Position first reader0 on penultimate segment and reader1 on first segment
         for (int i=0; i<numSegments-1; i++) {
             for (int j=0; j<46; j++) {
-                BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
                 if (i==0) {
-                    bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                    bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                     bbC.discard();
                 }
             }
 
-            BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
             if (i==0) {
                 assertEquals(2, m_pbd.numOpenSegments());
@@ -212,7 +214,7 @@ public class TestPBDMultipleReaders {
             }
         }
 
-        BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+        BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
         bbC.discard();
         // Both readers finished reading first segment, so that is closed and deleted,
         // which reduces the # of open segments by 1
@@ -221,13 +223,13 @@ public class TestPBDMultipleReaders {
         // reader0 at penultimate. Move reader1 through segments and check open segments
         for (int i=1; i<numSegments-1; i++) {
             for (int j=0; j<46; j++) {
-                bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
             }
             int expected = (i == numSegments-2) ? 2 : 3;
             assertEquals(expected, m_pbd.numOpenSegments());
 
-            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
             expected = (i == numSegments-2) ? 1 : 2;
             assertEquals(expected, m_pbd.numOpenSegments());
@@ -235,9 +237,9 @@ public class TestPBDMultipleReaders {
 
         // read the last segment
         for (int j=0; j<s_segmentFillCount; j++) {
-            bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
-            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
         }
         assertEquals(1, m_pbd.numOpenSegments());

--- a/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
+++ b/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
@@ -39,7 +39,8 @@ public class TestPBDMultipleReaders {
 
     private final static VoltLogger logger = new VoltLogger("EXPORT");
 
-    private static final int s_segmentFillCount = 47;
+    // Number of entries which fit in a segment. 64MB segment / (2MB entries + headers) = 31 entries per segment.
+    private static final int s_segmentFillCount = 31;
     private PersistentBinaryDeque m_pbd;
 
     private class PBDReader {
@@ -166,7 +167,7 @@ public class TestPBDMultipleReaders {
 
         BinaryDequeReader reader = m_pbd.openForRead("reader0");
         for (int i=0; i<numSegments; i++) {
-            for (int j=0; j<46; j++) {
+            for (int j = 0; j < s_segmentFillCount - 1; j++) {
                 BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
             }
@@ -196,7 +197,7 @@ public class TestPBDMultipleReaders {
         BinaryDequeReader reader1 = m_pbd.openForRead("reader1");
         // Position first reader0 on penultimate segment and reader1 on first segment
         for (int i=0; i<numSegments-1; i++) {
-            for (int j=0; j<46; j++) {
+            for (int j = 0; j < s_segmentFillCount - 1; j++) {
                 BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
                 if (i==0) {
@@ -222,7 +223,7 @@ public class TestPBDMultipleReaders {
 
         // reader0 at penultimate. Move reader1 through segments and check open segments
         for (int i=1; i<numSegments-1; i++) {
-            for (int j=0; j<46; j++) {
+            for (int j = 0; j < s_segmentFillCount - 1; j++) {
                 bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
             }

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -33,13 +33,18 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.NavigableMap;
 import java.util.Random;
 import java.util.Set;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -86,7 +91,7 @@ public class TestPersistentBinaryDeque {
         VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
         m_ds = new StreamTableSchemaSerializer(
                 VoltDB.instance().getCatalogContext(), "TableName");
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, m_ds, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger, true);
     }
 
     public static void setupTestDir() throws IOException {
@@ -287,7 +292,7 @@ public class TestPersistentBinaryDeque {
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 1);
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
     }
 
     @Test
@@ -301,7 +306,7 @@ public class TestPersistentBinaryDeque {
         listing = getSortedDirectoryListing(true);
         assertEquals(listing.size(), 1);
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, m_ds, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger, true);
 
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 1);
@@ -321,7 +326,7 @@ public class TestPersistentBinaryDeque {
 
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         for (long ii = 0; ii < 96; ii++) {
-            BBContainer cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            BBContainer cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             try {
                 assertNotNull(cont);
                 assertEquals(cont.b().remaining(), 1024 * 1024 * 2);
@@ -343,15 +348,15 @@ public class TestPersistentBinaryDeque {
     public void testTruncatorWithFullTruncateReturn() throws Exception {
         System.out.println("Running testTruncatorWithFullTruncateReturn");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         for (int ii = 0; ii < 150; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
 
         m_pbd.close();
 
-        m_pbd = new PersistentBinaryDeque( TEST_NONCE, m_ds, TEST_DIR, logger );
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger, true);
 
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 5);
@@ -388,7 +393,7 @@ public class TestPersistentBinaryDeque {
             if (ii == 46) {
                 m_pbd.updateExtraHeader(m_ds);
             }
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
 
         reader = m_pbd.openForRead(CURSOR_ID);
@@ -421,10 +426,10 @@ public class TestPersistentBinaryDeque {
     public void testTruncator() throws Exception {
         System.out.println("Running testTruncator");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         for (int ii = 0; ii < 160; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
 
         m_pbd.close();
@@ -465,7 +470,7 @@ public class TestPersistentBinaryDeque {
             if (ii == 46) {
                 m_pbd.updateExtraHeader(m_ds);
             }
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
 
         long actualSizeInBytes = 0;
@@ -499,17 +504,17 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testReaderIsEmpty");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         assertTrue(reader.isEmpty());
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
         assertTrue(reader.isEmpty());
 
-        m_pbd.offer(defaultContainer(), true);
+        m_pbd.offer(defaultContainer());
         assertFalse(reader.isEmpty());
         pollOnce(reader);
         assertTrue(reader.isEmpty());
 
         // more than one segment
         for (int i = 0; i < 50; i++) {
-            m_pbd.offer(defaultContainer(), true);
+            m_pbd.offer(defaultContainer());
         }
         assertFalse(reader.isEmpty());
         for (int i = 0; i < 50; i++) {
@@ -530,11 +535,11 @@ public class TestPersistentBinaryDeque {
         int count = 0;
         int totalAdded = 0;
         assertEquals(count, reader1.getNumObjects());
-        assertNull(reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
+        assertNull(reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
         assertEquals(count, reader1.getNumObjects());
 
         count++;
-        m_pbd.offer(defaultContainer(), true);
+        m_pbd.offer(defaultContainer());
         totalAdded++;
         assertEquals(count, reader1.getNumObjects());
 
@@ -552,7 +557,7 @@ public class TestPersistentBinaryDeque {
 
         // offer segments
         for (int i = 0; i < 50; i++) {
-            m_pbd.offer(defaultContainer(), true);
+            m_pbd.offer(defaultContainer());
             totalAdded++;
             count++;
             assertEquals(count, reader1.getNumObjects());
@@ -578,7 +583,7 @@ public class TestPersistentBinaryDeque {
 
         // offer segments with all 3 readers
         for (int i = 0; i < 50; i++) {
-            m_pbd.offer(defaultContainer(), true);
+            m_pbd.offer(defaultContainer());
             count++;
             assertEquals(count, reader1.getNumObjects());
             assertEquals(count, reader2.getNumObjects());
@@ -616,10 +621,10 @@ public class TestPersistentBinaryDeque {
     public void testOfferThenPoll() throws Exception {
         System.out.println("Running testOfferThenPoll");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         //Make sure a single file with the appropriate data is created
-        m_pbd.offer(defaultContainer(), true);
+        m_pbd.offer(defaultContainer());
         File files[] = TEST_DIR.listFiles();
         assertEquals( 1, files.length);
         assertTrue("pbd_nonce_0000000001_0000000002.pbd".equals(files[0].getName()));
@@ -632,13 +637,13 @@ public class TestPersistentBinaryDeque {
     public void testCloseOldSegments() throws Exception {
         System.out.println("Running testCloseOldSegments");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         final int total = 100;
 
         //Make sure several files with the appropriate data is created
         for (int i = 0; i < total; i++) {
-            m_pbd.offer(defaultContainer(), true);
+            m_pbd.offer(defaultContainer());
         }
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 3);
@@ -665,13 +670,13 @@ public class TestPersistentBinaryDeque {
     public void testDontCloseReadSegment() throws Exception {
         System.out.println("Running testDontCloseReadSegment");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         final int total = 100;
 
         //Make sure a single file with the appropriate data is created
         for (int i = 0; i < 5; i++) {
-            m_pbd.offer(defaultContainer(), true);
+            m_pbd.offer(defaultContainer());
         }
         assertEquals(1, TEST_DIR.listFiles().length);
 
@@ -679,7 +684,7 @@ public class TestPersistentBinaryDeque {
         pollOnce(reader);
 
         for (int i = 5; i < total; i++) {
-            m_pbd.offer(defaultContainer(), true);
+            m_pbd.offer(defaultContainer());
         }
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 3);
@@ -709,7 +714,7 @@ public class TestPersistentBinaryDeque {
         assertTrue(reader.isEmpty());
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(defaultContainer(), true);
+            m_pbd.offer(defaultContainer());
             assertFalse(reader.isEmpty());
         }
         File files[] = TEST_DIR.listFiles();
@@ -775,7 +780,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseThenReopen");
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(defaultContainer(), true);
+            m_pbd.offer(defaultContainer());
         }
         File files[] = TEST_DIR.listFiles();
         assertEquals( 3, files.length);
@@ -882,7 +887,7 @@ public class TestPersistentBinaryDeque {
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         m_pbd.close();
         try {
-            reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
         } catch (IOException e) {
             return;
         }
@@ -961,7 +966,7 @@ public class TestPersistentBinaryDeque {
     public void testNonceWithDots() throws Exception {
         System.out.println("Running testNonceWithDots");
         PersistentBinaryDeque pbd = new PersistentBinaryDeque("ha.ha", m_ds, TEST_DIR, logger);
-        pbd.offer(defaultContainer(), true);
+        pbd.offer(defaultContainer());
         pbd.close();
 
         pbd = new PersistentBinaryDeque("ha.ha", null, TEST_DIR, logger);
@@ -977,7 +982,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseThenReopen");
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
         File files[] = TEST_DIR.listFiles();
         assertEquals(3, files.length);
@@ -991,7 +996,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(cnt, 96);
 
         for (int ii = 96; ii < 192; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
         m_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1017,7 +1022,7 @@ public class TestPersistentBinaryDeque {
         PersistentBinaryDeque small_pbd = new PersistentBinaryDeque(SMALL_TEST_NONCE, m_ds, TEST_DIR, logger);
         //Keep in 1 segment.
         for (int ii = 0; ii < 10; ii++) {
-            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)), true);
+            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)));
         }
         File files[] = TEST_DIR.listFiles();
         //We have the default pbd and new one.
@@ -1034,7 +1039,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(cnt, 10);
 
         for (int ii = 10; ii < 20; ii++) {
-            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)), true);
+            small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)));
         }
         small_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1068,7 +1073,7 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseHoleReopenOffer");
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
         File files[] = TEST_DIR.listFiles();
         assertEquals(3, files.length);
@@ -1077,12 +1082,12 @@ public class TestPersistentBinaryDeque {
         m_pbd = null;
         System.gc();
         System.runFinalization();
-        m_pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger, true);
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
         for (int ii = 96; ii < 192; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
         m_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1104,7 +1109,7 @@ public class TestPersistentBinaryDeque {
         List<File> listing = getSortedDirectoryListing(true);
         assertEquals(3, listing.size());
         //Reload
-        m_pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
+        m_pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger, true);
         reader = m_pbd.openForRead(CURSOR_ID);
         cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
@@ -1113,7 +1118,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(4, listing.size());
 
         for (int ii = 96; ii < 192; ii++) {
-            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)), true);
+            m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
         m_pbd.sync();
         cnt = reader.getNumObjects();
@@ -1156,13 +1161,13 @@ public class TestPersistentBinaryDeque {
     public void testDeleteOnNonEmptyNextSegment() throws Exception {
         System.out.println("Running testDeleteOnNonEmptyNextSegment");
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
-        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false));
+        assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         final int total = 47;      // Number of buffers it takes to fill a segment
 
         //Make sure a single file with the appropriate data is created
         for (int i = 0; i < total; i++) {
-            m_pbd.offer(defaultContainer(), true);
+            m_pbd.offer(defaultContainer());
         }
         assertEquals(1, TEST_DIR.listFiles().length);
 
@@ -1175,7 +1180,7 @@ public class TestPersistentBinaryDeque {
         File files[] = TEST_DIR.listFiles();
         assertEquals(1, files.length);
         assertEquals("pbd_nonce_0000000001_0000000002.pbd", files[0].getName());
-        m_pbd.offer(defaultContainer(), true);
+        m_pbd.offer(defaultContainer());
 
         files = TEST_DIR.listFiles();
         // Make sure a new segment was created and the old segment was deleted
@@ -1187,7 +1192,7 @@ public class TestPersistentBinaryDeque {
     public void testUpdateExtraHeader() throws Exception {
         for (int i = 0; i < 5; ++i) {
             for (int j = 0; j < 2; j++) {
-                m_pbd.offer(defaultContainer(), true);
+                m_pbd.offer(defaultContainer());
             }
             assertEquals(i + 1, TEST_DIR.listFiles().length);
 
@@ -1233,31 +1238,113 @@ public class TestPersistentBinaryDeque {
     }
 
     @Test
-    public void testPollingWithCrcCheck() throws Exception {
+    public void testCorruptedEntryWithParseAndTruncate() throws Exception {
+        m_pbd.offer(defaultContainer());
+        corruptLastSegment(ByteBuffer.allocateDirect(35), -35);
 
-        for (int i = 0; i < 5; ++i) {
-            m_pbd.offer(defaultContainer(), false);
-        }
-        for (int i = 0; i < 5; ++i) {
-            m_pbd.offer(defaultContainer(), true);
-        }
-        for (int i = 0; i < 10; ++i) {
-            m_pbd.offer(defaultContainer(), (i & 0x1) == 0x1);
-        }
-        BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
+        runParseAndTruncateOnNewPbd();
+    }
 
-        ByteBuffer entry = defaultBuffer();
-        for (int i = 0; i < 20; ++i) {
-            pollOnceAndVerify(reader, entry.asReadOnlyBuffer(), true);
+    @Test
+    public void testCorruptedEntryWithScanForGap() throws Exception {
+        m_pbd.offer(defaultContainer());
+        corruptLastSegment(ByteBuffer.allocateDirect(35), -35);
+
+        runScanForGapOnNewPbd();
+    }
+
+    @Test
+    public void testCorruptedEntryLengthWithParseAndTruncate() throws Exception {
+        // set no extraHeader so it is easier to find the first entry header
+        m_pbd.updateExtraHeader(null);
+
+        BBContainer container = defaultContainer();
+        int origLength = container.b().remaining();
+        m_pbd.offer(container);
+
+        ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
+        bb.putInt(origLength - 100);
+        bb.flip();
+        corruptLastSegment(bb, PBDSegment.SEGMENT_HEADER_BYTES + PBDSegment.ENTRY_HEADER_TOTAL_BYTES_OFFSET);
+
+        runParseAndTruncateOnNewPbd();
+    }
+
+    @Test
+    public void testCorruptedEntryLengthWithScanForGap() throws Exception {
+        // set no extraHeader so it is easier to find the first entry header
+        m_pbd.updateExtraHeader(null);
+
+        BBContainer container = defaultContainer();
+        int origLength = container.b().remaining();
+        m_pbd.offer(container);
+
+        ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
+        bb.putInt(origLength - 100);
+        bb.flip();
+        corruptLastSegment(bb, PBDSegment.SEGMENT_HEADER_BYTES + PBDSegment.ENTRY_HEADER_TOTAL_BYTES_OFFSET);
+
+        runScanForGapOnNewPbd();
+    }
+
+    @Test(expected = IOException.class)
+    public void testCorruptSegmentHeaderWithParseAndTruncate() throws Exception {
+        m_pbd.offer(defaultContainer());
+        ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
+        bb.putInt(100);
+        bb.flip();
+        corruptLastSegment(bb, PBDSegment.HEADER_NUM_OF_ENTRY_OFFSET);
+
+        runParseAndTruncateOnNewPbd();
+    }
+
+    @Test(expected = IOException.class)
+    public void testCorruptExtraHeaderWithParseAndTruncate() throws Exception {
+        m_pbd.offer(defaultContainer());
+        ByteBuffer bb = ByteBuffer.allocateDirect(40);
+        corruptLastSegment(bb, PBDSegment.HEADER_EXTRA_HEADER_OFFSET + 15);
+
+        runParseAndTruncateOnNewPbd();
+    }
+
+    private void runParseAndTruncateOnNewPbd() throws IOException {
+        PersistentBinaryDeque pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
+        try {
+            pbd.parseAndTruncate(b -> null);
+            pollOnceAndVerify(pbd.openForRead(CURSOR_ID), null);
+            pbd.offer(defaultContainer());
+            pollOnceAndVerify(pbd.openForRead(CURSOR_ID), defaultBuffer());
+        } finally {
+            pbd.close();
         }
-        assertNull(pollOnceWithoutDiscard(reader));
+    }
+
+    private void runScanForGapOnNewPbd() throws IOException {
+        PersistentBinaryDeque pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
+        try {
+            pbd.scanEntries(b -> {});
+            pollOnceAndVerify(pbd.openForRead(CURSOR_ID), null);
+            pbd.offer(defaultContainer());
+            pollOnceAndVerify(pbd.openForRead(CURSOR_ID), defaultBuffer());
+        } finally {
+            pbd.close();
+        }
+    }
+
+    private void corruptLastSegment(ByteBuffer corruptData, int position) throws Exception {
+        File file = getSegmentMap().lastEntry().getValue().file();
+        try (FileChannel channel = FileChannel.open(Paths.get(file.getPath()), StandardOpenOption.WRITE)) {
+            channel.write(corruptData, position < 0 ? channel.size() + position : position);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private NavigableMap<Long, PBDSegment> getSegmentMap() throws IllegalArgumentException, IllegalAccessException {
+        return ((NavigableMap<Long, PBDSegment>) FieldUtils
+                .getDeclaredField(PersistentBinaryDeque.class, "m_segments", true).get(m_pbd));
     }
 
     private BBContainer pollOnceWithoutDiscard(BinaryDequeReader reader) throws IOException {
-        return pollOnceWithoutDiscard(reader, false);
-    }
-
-    private BBContainer pollOnceWithoutDiscard(BinaryDequeReader reader, boolean checkCrc) throws IOException {
         BBContainer schema = null;
         try {
             if (reader.isStartOfSegment()) {
@@ -1265,7 +1352,7 @@ public class TestPersistentBinaryDeque {
                 assertNotNull(schema);
                 assertFalse(reader.isEmpty());
             }
-            return reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, checkCrc);
+            return reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
         } finally {
             if (schema != null) {
                 schema.discard();
@@ -1281,14 +1368,13 @@ public class TestPersistentBinaryDeque {
     }
 
     private void pollOnceAndVerify(BinaryDequeReader reader, ByteBuffer destBuf) throws IOException {
-        pollOnceAndVerify(reader, destBuf, false);
-    }
-
-    private void pollOnceAndVerify(BinaryDequeReader reader, ByteBuffer destBuf, boolean checkCrc) throws IOException {
-        BBContainer retval = pollOnceWithoutDiscard(reader, checkCrc);
+        BBContainer retval = pollOnceWithoutDiscard(reader);
         try {
-            assertNotNull(retval);
-            assertEquals(destBuf, retval.b());
+            if (destBuf == null) {
+                assertNull(retval);
+            } else {
+                assertEquals(destBuf, retval.b());
+            }
         } finally {
             if (retval != null) {
                 retval.discard();

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -1307,6 +1307,14 @@ public class TestPersistentBinaryDeque {
         runParseAndTruncateOnNewPbd();
     }
 
+    @Test
+    public void testCloseLastReader() throws Exception {
+        BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
+        pollOnceAndVerify(reader, null);
+        m_pbd.closeCursor(CURSOR_ID);
+        m_pbd.offer(defaultContainer());
+    }
+
     private void runParseAndTruncateOnNewPbd() throws IOException {
         PersistentBinaryDeque pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
         try {


### PR DESCRIPTION
Add a length and CRC field in the header for the extra header
Remove checkCRC from the poll api since the only valid places to check crc are either parseAndTruncate and scanForGap
When a CRC error is found in a segment entry report back to the PBD the number of entries truncated
Only mark a segment final if all of the data has been syned to disk and there were no errors writing the data

relates to https://github.com/VoltDB/pro/pull/2538