### PR TITLE
Reverted to disallow LIKE...ESCAPE

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLike.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLike.java
@@ -35,6 +35,7 @@ import org.hsqldb_voltpatches.lib.HsqlList;
 import org.hsqldb_voltpatches.lib.Set;
 import org.hsqldb_voltpatches.types.BinaryData;
 import org.hsqldb_voltpatches.types.Type;
+import org.voltdb.planner.PlanningErrorException;
 
 import java.util.Objects;
 
@@ -337,6 +338,10 @@ public final class ExpressionLike extends ExpressionLogical {
                 like    = true;
             }
 
+            if (!between && !larger && nodes.length > 2) {
+                throw new PlanningErrorException("ESCAPE not supported with non-constant LIKE pattern", 0);
+            }
+
             Expression leftBound =
                 new ExpressionValue(likeObject.getRangeLow(),
                                     Type.SQL_VARCHAR);
@@ -355,6 +360,9 @@ public final class ExpressionLike extends ExpressionLogical {
                 opType     = OpTypes.AND;
                 likeObject = null;
             } else if (between && like) {
+                if (nodes.length > 2) {
+                    throw new PlanningErrorException("ESCAPE not supported with non-constant LIKE pattern", 0);
+                }
                 Expression gte = new ExpressionLogical(OpTypes.GREATER_EQUAL,
                                                        nodes[LEFT], leftBound);
                 Expression lte = new ExpressionLogical(OpTypes.SMALLER_EQUAL,
@@ -377,6 +385,8 @@ public final class ExpressionLike extends ExpressionLogical {
                 nodes[LEFT]  = gte;
                 nodes[RIGHT] = newLike;
                 opType       = OpTypes.AND;
+            } else if (nodes.length > 2) {
+                throw new PlanningErrorException("ESCAPE not supported with non-constant LIKE pattern", 0);
             }
         }
     }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLike.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLike.java
@@ -35,7 +35,6 @@ import org.hsqldb_voltpatches.lib.HsqlList;
 import org.hsqldb_voltpatches.lib.Set;
 import org.hsqldb_voltpatches.types.BinaryData;
 import org.hsqldb_voltpatches.types.Type;
-import org.voltdb.planner.PlanningErrorException;
 
 import java.util.Objects;
 
@@ -339,7 +338,7 @@ public final class ExpressionLike extends ExpressionLogical {
             }
 
             if (!between && !larger && nodes.length > 2) {
-                throw new PlanningErrorException("ESCAPE not supported with non-constant LIKE pattern", 0);
+                throw new HsqlException("ESCAPE not supported with non-constant LIKE pattern", "", 0);
             }
 
             Expression leftBound =
@@ -361,7 +360,7 @@ public final class ExpressionLike extends ExpressionLogical {
                 likeObject = null;
             } else if (between && like) {
                 if (nodes.length > 2) {
-                    throw new PlanningErrorException("ESCAPE not supported with non-constant LIKE pattern", 0);
+                    throw new HsqlException("ESCAPE not supported with non-constant LIKE pattern", "", 0);
                 }
                 Expression gte = new ExpressionLogical(OpTypes.GREATER_EQUAL,
                                                        nodes[LEFT], leftBound);
@@ -386,7 +385,7 @@ public final class ExpressionLike extends ExpressionLogical {
                 nodes[RIGHT] = newLike;
                 opType       = OpTypes.AND;
             } else if (nodes.length > 2) {
-                throw new PlanningErrorException("ESCAPE not supported with non-constant LIKE pattern", 0);
+                throw new HsqlException("ESCAPE not supported with non-constant LIKE pattern", "", 0);
             }
         }
     }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLInterface.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLInterface.java
@@ -29,7 +29,6 @@ import org.hsqldb_voltpatches.lib.HashMappedList;
 import org.hsqldb_voltpatches.persist.HsqlProperties;
 import org.hsqldb_voltpatches.result.Result;
 import org.voltcore.logging.VoltLogger;
-import org.voltdb.planner.PlanningErrorException;
 
 /**
  * This class is built to create a single in-memory database
@@ -348,8 +347,6 @@ public class HSQLInterface {
             default:
                 throw new HSQLParseException("Error in \"" + sql + "\" - " + caught.getMessage(), caught);
             }
-        } catch (PlanningErrorException e) {
-           throw e;
         } catch (StackOverflowError caught) {
             // Handle this consistently in high level callers
             // regardless of where it is thrown.

--- a/tests/frontend/org/voltdb/TestLikeQueries.java
+++ b/tests/frontend/org/voltdb/TestLikeQueries.java
@@ -78,6 +78,11 @@ public class TestLikeQueries extends TestCase {
         }
     }
 
+    static class UnsupportedEscapeLikeTest extends LikeTest {
+        public UnsupportedEscapeLikeTest(String pattern, int matches, String escape) {
+            super(pattern, matches, true, false, escape);
+        }
+    }
 
     static class LikeTestData {
         public final String val;
@@ -139,15 +144,14 @@ public class TestLikeQueries extends TestCase {
             new EscapeLikeTest("abcccc|%", 1, "|"),
             new EscapeLikeTest("abc%", 2, "|"),
             new EscapeLikeTest("aaa", 0, "|"),
-            new EscapeLikeTest("abcd!%%", 0, "!"),
-            // User can choose to confuse himself
-            new EscapeLikeTest("abccccccccc%", 1, "c"),
+            new EscapeLikeTest("abccccccccc%", 1, "c"), // User can choose to confuse himself
     };
 
     static final LikeTest[] hsqlDiscrepencies = new LikeTest[] {
             // Patterns that fail on hsql (unsupported until someone fixes unicode handling).
             // We don't bother to run these in the head-to-head regression suite
             new LikeTest("â_x一xxéyyԱ", 1),
+            new UnsupportedEscapeLikeTest("abcd!%%", 0, "!"),
     };
 
     public static class LikeSuite {


### PR DESCRIPTION
unless the like pattern is constant; and made error message (hopefully) clear.

That means, should a query contain `LIKE ... ESCAPE 'x'`, the escaped string must not contain magic characters: (`_` or `%`). We still need handling of the escape mechanism in EE, and until then, either the (escaped or not) LIKE pattern must be constant, or the LIKE pattern could contain magic characters, but user cannot use ESCAPE.