### PR TITLE
ENG-15606, remove assertion generating backtrace in tests

### DIFF
--- a/src/frontend/org/voltdb/export/ExportSequenceNumberTracker.java
+++ b/src/frontend/org/voltdb/export/ExportSequenceNumberTracker.java
@@ -225,7 +225,6 @@ public class ExportSequenceNumberTracker {
      *         otherwise return null
      */
     public Pair<Long, Long> getRangeContaining(long seq) {
-        assert (!m_map.isEmpty());
         Range<Long> range = m_map.rangeContaining(seq);
         if (range != null) {
             return new Pair<Long, Long>(start(range), end(range));


### PR DESCRIPTION
Why was this assert put in? It seems we now can get gap queries when our gap tracker is empty.