### PR TITLE
ENG-15721:

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1147,6 +1147,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                                 first_unpolled_block.startSequenceNumber() + first_unpolled_block.rowCount() - 1,
                                 first_unpolled_block.committedSequenceNumber(),
                                 m_migrateRowsDeleter);
+                if (exportLog.isDebugEnabled()) {
+                    exportLog.debug("Posting Export data for " + ackingContainer.toString());
+                }
                 try {
                     pollTask.setFuture(ackingContainer);
                 } catch (RejectedExecutionException reex) {
@@ -1273,6 +1276,11 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                       m_schemaCont.discard();
                   }
             }
+        }
+
+        @Override
+        public String toString() {
+            return new String("Container: ending at " + m_lastSeqNo + " (Committed " + m_commitSeqNo + ")");
         }
     }
 

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -827,7 +827,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
                             needsConversion = SavedTableConverter.needsConversion(old_table, new_catalog_table,
                                                                                   preserveDRHiddenColumn,
                                                                                   preserveViewHiddenColumn,
-                                                                                  preserveMigrateHiddenColumn);
+                                                                                  preserveMigrateHiddenColumn,
+                                                                                  isRecover);
                         }
 
                         if (needsConversion) {
@@ -836,7 +837,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
                             table = SavedTableConverter.convertTable(old_table, new_catalog_table,
                                                                      preserveDRHiddenColumn,
                                                                      preserveViewHiddenColumn,
-                                                                     preserveMigrateHiddenColumn);
+                                                                     preserveMigrateHiddenColumn,
+                                                                     isRecover);
                         } else {
                             ByteBuffer copy = ByteBuffer.allocate(c.b().remaining());
                             copy.put(c.b());
@@ -2211,7 +2213,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         needsConversion = SavedTableConverter.needsConversion(oldTable, newCatalogTable,
                                                                               preserveDRHiddenColumn,
                                                                               preserveViewHiddenColumn,
-                                                                              preserveMigrateHiddenColumn);
+                                                                              preserveMigrateHiddenColumn,
+                                                                              isRecover);
                     }
                     final VoltTable oldTable = PrivateVoltTableFactory
                             .createVoltTableFromBuffer(c.b(), true);
@@ -2219,7 +2222,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         table = SavedTableConverter.convertTable(oldTable, newCatalogTable,
                                                                  preserveDRHiddenColumn,
                                                                  preserveViewHiddenColumn,
-                                                                 preserveMigrateHiddenColumn);
+                                                                 preserveMigrateHiddenColumn,
+                                                                 isRecover);
                     } else {
                         table = oldTable;
                     }
@@ -2411,7 +2415,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         needsConversion = SavedTableConverter.needsConversion(old_table, new_catalog_table,
                                                                               preserveDRHiddenColumn,
                                                                               preserveViewHiddenColumn,
-                                                                              preserveMigrateHiddenColumn);
+                                                                              preserveMigrateHiddenColumn,
+                                                                              isRecover);
                     }
 
                     final VoltTable old_table = PrivateVoltTableFactory.createVoltTableFromBuffer(c.b(), true);
@@ -2419,7 +2424,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         table = SavedTableConverter.convertTable(old_table, new_catalog_table,
                                                                  preserveDRHiddenColumn,
                                                                  preserveViewHiddenColumn,
-                                                                 preserveMigrateHiddenColumn);
+                                                                 preserveMigrateHiddenColumn,
+                                                                 isRecover);
                     } else {
                         table = old_table;
                     }

--- a/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
+++ b/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
@@ -270,7 +270,7 @@ public class SysProcFragmentId
     public static final int PF_cancelShutdown = 360;
     public static final int PF_cancelShutdownAggregate = 361;
 
-    // @MigrateRowsAcked_SP
+    // @MigrateRowsAcked_MP
     public static final int PF_migrateRows = 370;
     public static final int PF_migrateRowsAggregate = 371;
 

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
@@ -39,12 +39,12 @@ public abstract class SavedTableConverter
                                           Table outputTableSchema,
                                           boolean preserveDRHiddenColumn,
                                           boolean preserveViewHiddenColumn,
-                                          boolean presereMigrateHiddenColumn,
+                                          boolean preserveMigrateHiddenColumn,
                                           boolean isRecover) {
         int columnsToMatch = inputTable.getColumnCount()
                 - (preserveDRHiddenColumn ? 1 : 0)
                 - (preserveViewHiddenColumn ? 1 : 0)
-                - (presereMigrateHiddenColumn ? 1 : 0);
+                - (preserveMigrateHiddenColumn ? 1 : 0);
         // Cannot DR views! Those two flags must not be true at the same time!
         assert((preserveDRHiddenColumn && preserveViewHiddenColumn) == false);
         // We are expecting the hidden column in inputTable
@@ -68,7 +68,7 @@ public abstract class SavedTableConverter
         }
 
         // There may be more than one hidden column. The one for migrate is the last one
-        if (presereMigrateHiddenColumn) {
+        if (preserveMigrateHiddenColumn) {
            if (!isRecover) {
                // For restore we need to mutate the migrate column to nulls
                return true;

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestSavedTableConverter.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestSavedTableConverter.java
@@ -80,7 +80,8 @@ public class TestSavedTableConverter extends TestCase {
                                                       m_catalogTable,
                                                       false,
                                                       false,
-                                                      false);
+                                                      false,
+                                                      true);
         } catch (Exception e) {
             e.printStackTrace();
             fail("SavedTableConverter.convert should not have thrown here");
@@ -164,7 +165,7 @@ public class TestSavedTableConverter extends TestCase {
         boolean failed = false;
         try {
             result = SavedTableConverter.convertTable(inputTable,
-                    catalogTable, false, false, false);
+                    catalogTable, false, false, false, true);
             result.resetRowPosition();
             assertEquals(10, result.getRowCount());
         } catch (Exception e) {
@@ -192,7 +193,7 @@ public class TestSavedTableConverter extends TestCase {
         try {
             result = SavedTableConverter.convertTable(inputTable,
                                                       m_catalogTable,
-                                                      false, false, false);
+                                                      false, false, false, true);
         } catch (Exception e) {
             e.printStackTrace();
             fail("SavedTableConverter.convert should not have thrown here");
@@ -226,7 +227,7 @@ public class TestSavedTableConverter extends TestCase {
         try {
             result = SavedTableConverter.convertTable(inputTable,
                                                       m_catalogTable,
-                                                      false, false, false);
+                                                      false, false, false, true);
         } catch (Exception e) {
             e.printStackTrace();
             fail("SavedTableConverter.convert should not have thrown here");
@@ -261,7 +262,7 @@ public class TestSavedTableConverter extends TestCase {
         try {
             result = SavedTableConverter.convertTable(inputTable,
                                                       m_catalogTable,
-                                                      false, false, false);
+                                                      false, false, false, true);
         } catch (Exception e) {
             e.printStackTrace();
             fail("SavedTableConverter.convert should not have thrown here");
@@ -295,7 +296,7 @@ public class TestSavedTableConverter extends TestCase {
         }
 
         try {
-            SavedTableConverter.convertTable(inputTable, m_catalogTable, false, false, false);
+            SavedTableConverter.convertTable(inputTable, m_catalogTable, false, false, false, true);
         } catch (Exception e) {
             assertTrue(true);
             return;
@@ -310,8 +311,8 @@ public class TestSavedTableConverter extends TestCase {
                         new ColumnInfo("HAS_NULLABLE_FLOAT", VoltType.FLOAT),
                         new ColumnInfo("HAS_NADA", VoltType.FLOAT));
 
-        assertFalse(SavedTableConverter.needsConversion(inputTableWithoutDRCol, m_catalogTable, false, false, false));
-        assertTrue(SavedTableConverter.needsConversion(inputTableWithoutDRCol, m_catalogTable, true, false, false));
+        assertFalse(SavedTableConverter.needsConversion(inputTableWithoutDRCol, m_catalogTable, false, false, false, true));
+        assertTrue(SavedTableConverter.needsConversion(inputTableWithoutDRCol, m_catalogTable, true, false, false, true));
 
         for (int i = 0; i < 10; i++) {
             inputTableWithoutDRCol.addRow(i, Integer.toString(i), new Double(i), new Double(i));
@@ -319,7 +320,7 @@ public class TestSavedTableConverter extends TestCase {
 
         VoltTable result = null;
         try {
-            result = SavedTableConverter.convertTable(inputTableWithoutDRCol, m_catalogTable, true, false, false);
+            result = SavedTableConverter.convertTable(inputTableWithoutDRCol, m_catalogTable, true, false, false, true);
         } catch (Exception e) {
             e.printStackTrace();
             fail("SavedTableConverter.convert should not have thrown here");
@@ -351,10 +352,10 @@ public class TestSavedTableConverter extends TestCase {
                         new ColumnInfo(CatalogUtil.DR_HIDDEN_COLUMN_NAME, VoltType.BIGINT));
 
         // Missing HAS_NULLABLE_STRING and HAS_NULLABLE_FLOAT
-        assertTrue(SavedTableConverter.needsConversion(inputTableDifferent, m_catalogTable, false, false, false));
-        assertTrue(SavedTableConverter.needsConversion(inputTableDifferent, m_catalogTable, true, false, false));
+        assertTrue(SavedTableConverter.needsConversion(inputTableDifferent, m_catalogTable, false, false, false, true));
+        assertTrue(SavedTableConverter.needsConversion(inputTableDifferent, m_catalogTable, true, false, false, true));
         // Extra DR Column in input
-        assertTrue(SavedTableConverter.needsConversion(inputTableIdentical, m_catalogTable, false, false, false));
+        assertTrue(SavedTableConverter.needsConversion(inputTableIdentical, m_catalogTable, false, false, false, true));
 
         for (int i = 0; i < 10; i++) {
             inputTableIdentical.addRow(i, Integer.toString(i), new Double(i), new Double(i), new Long(i));
@@ -362,7 +363,7 @@ public class TestSavedTableConverter extends TestCase {
 
         VoltTable result = null;
         try {
-            result = SavedTableConverter.convertTable(inputTableIdentical, m_catalogTable, false, false, false);
+            result = SavedTableConverter.convertTable(inputTableIdentical, m_catalogTable, false, false, false, true);
         } catch (Exception e) {
             e.printStackTrace();
             fail("SavedTableConverter.convert should not have thrown here");
@@ -384,7 +385,7 @@ public class TestSavedTableConverter extends TestCase {
                         new ColumnInfo("HAS_NADA", VoltType.FLOAT),
                         new ColumnInfo(CatalogUtil.DR_HIDDEN_COLUMN_NAME, VoltType.BIGINT));
 
-        assertTrue(SavedTableConverter.needsConversion(inputTable, m_catalogTable, true, false, false));
+        assertTrue(SavedTableConverter.needsConversion(inputTable, m_catalogTable, true, false, false, true));
 
         for (int i = 0; i < 10; i++) {
             inputTable.addRow(i, new Double(i), new Long(i));
@@ -392,7 +393,7 @@ public class TestSavedTableConverter extends TestCase {
 
         VoltTable result = null;
         try {
-            result = SavedTableConverter.convertTable(inputTable, m_catalogTable, true, false, false);
+            result = SavedTableConverter.convertTable(inputTable, m_catalogTable, true, false, false, true);
         } catch (Exception e) {
             e.printStackTrace();
             fail("SavedTableConverter.convert should not have thrown here");
@@ -421,8 +422,8 @@ public class TestSavedTableConverter extends TestCase {
                         new ColumnInfo("HAS_NADA", VoltType.FLOAT),
                         new ColumnInfo(CatalogUtil.DR_HIDDEN_COLUMN_NAME, VoltType.BIGINT));
 
-        assertTrue(SavedTableConverter.needsConversion(inputTableWithDRCol, m_catalogTable, false, false, false));
-        assertFalse(SavedTableConverter.needsConversion(inputTableWithDRCol, m_catalogTable, true, false, false));
+        assertTrue(SavedTableConverter.needsConversion(inputTableWithDRCol, m_catalogTable, false, false, false, true));
+        assertFalse(SavedTableConverter.needsConversion(inputTableWithDRCol, m_catalogTable, true, false, false, true));
     }
 
     public void testViewWithoutCountStar() {
@@ -432,8 +433,8 @@ public class TestSavedTableConverter extends TestCase {
                         new ColumnInfo("HAS_NULLABLE_FLOAT", VoltType.FLOAT),
                         new ColumnInfo("HAS_NADA", VoltType.FLOAT),
                         new ColumnInfo(CatalogUtil.VIEW_HIDDEN_COLUMN_NAME, VoltType.BIGINT));
-        assertTrue(SavedTableConverter.needsConversion(inputTableWithViewCol, m_catalogTable, false, false, false));
-        assertFalse(SavedTableConverter.needsConversion(inputTableWithViewCol, m_catalogTable, false, true, false));
+        assertTrue(SavedTableConverter.needsConversion(inputTableWithViewCol, m_catalogTable, false, false, false, true));
+        assertFalse(SavedTableConverter.needsConversion(inputTableWithViewCol, m_catalogTable, false, true, false, true));
     }
 
     private MockVoltDB m_catalogCreator;


### PR DESCRIPTION
Reset back to NULL any rows that were marked as migrating in a Snapshot when that row is being Restored (as opposed to recovered) from a Snapshot.

Updated the unit test (in Pro) that verifies the row counts of non-migrating rows in the face of Joins, Rejoins, Recover, and Restore. Note that this test will break when and if the migrate index is implicitly created by the compiler as it does today for the primary key column(s) because it explicitly removes the index to hold the migrating row count constant.