### PR TITLE
PBD harden a bit more and handle check errors

### DIFF
--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -92,7 +92,7 @@ public class StreamBlockQueue {
         m_streamName = streamName;
         StreamTableSchemaSerializer ds = new StreamTableSchemaSerializer(
                 VoltDB.instance().getCatalogContext(), m_streamName);
-        m_persistentDeque = new PersistentBinaryDeque( nonce, ds, new VoltFile(path), exportLog);
+        m_persistentDeque = new PersistentBinaryDeque(nonce, ds, new VoltFile(path), exportLog, !DISABLE_COMPRESSION);
         m_path = path;
         m_nonce = nonce;
         m_reader = m_persistentDeque.openForRead(m_nonce);
@@ -125,7 +125,7 @@ public class StreamBlockQueue {
             if (m_reader.isStartOfSegment()) {
                 schemaCont = m_reader.getExtraHeader(-1);
             }
-            cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
         } catch (IOException e) {
             exportLog.error("Failed to poll from persistent binary deque:" + e);
         }
@@ -272,7 +272,7 @@ public class StreamBlockQueue {
      * Only allow two blocks in memory, put the rest in the persistent deque
      */
     public void offer(StreamBlock streamBlock) throws IOException {
-        m_persistentDeque.offer(streamBlock.asBBContainer(), !DISABLE_COMPRESSION);
+        m_persistentDeque.offer(streamBlock.asBBContainer());
         long unreleasedSeqNo = streamBlock.unreleasedSequenceNumber();
         if (m_memoryDeque.size() < 2) {
             StreamBlock fromPBD = pollPersistentDeque(false);
@@ -377,7 +377,8 @@ public class StreamBlockQueue {
         m_persistentDeque.close();
         StreamTableSchemaSerializer ds = new StreamTableSchemaSerializer(
                 VoltDB.instance().getCatalogContext(), m_streamName);
-        m_persistentDeque = new PersistentBinaryDeque(m_nonce, ds, new VoltFile(m_path), exportLog);
+        m_persistentDeque = new PersistentBinaryDeque(m_nonce, ds, new VoltFile(m_path), exportLog,
+                !DISABLE_COMPRESSION);
         m_reader = m_persistentDeque.openForRead(m_nonce);
         // temporary debug stmt
         exportLog.info("After truncate, PBD size is " + (m_reader.sizeInBytes() - (8 * m_reader.getNumObjects())));
@@ -385,22 +386,21 @@ public class StreamBlockQueue {
 
     public ExportSequenceNumberTracker scanForGap() throws IOException {
         assert(m_memoryDeque.isEmpty());
-        return m_persistentDeque.scanForGap(new BinaryDequeScanner() {
-
+        ExportSequenceNumberTracker tracker = new ExportSequenceNumberTracker();
+        m_persistentDeque.scanEntries(new BinaryDequeScanner() {
             @Override
-            public ExportSequenceNumberTracker scan(BBContainer bbc) {
+            public void scan(BBContainer bbc) {
                 ByteBuffer b = bbc.b();
                 ByteOrder endianness = b.order();
                 b.order(ByteOrder.LITTLE_ENDIAN);
                 final long startSequenceNumber = b.getLong();
                 final int tupleCount = b.getInt();
                 b.order(endianness);
-                ExportSequenceNumberTracker gapTracker = new ExportSequenceNumberTracker();
-                gapTracker.append(startSequenceNumber, startSequenceNumber + tupleCount - 1);
-                return gapTracker;
+                tracker.addRange(startSequenceNumber, startSequenceNumber + tupleCount - 1);
             }
 
         });
+        return tracker;
     }
 
     @Override

--- a/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
@@ -131,8 +131,12 @@ public class TaskLogImpl implements TaskLog {
 
     @Override
     public void logTask(TransactionInfoBaseMessage message) throws IOException {
-        if (message.getSpHandle() <= m_snapshotSpHandle) return;
-        if (m_closed) throw new IOException("Closed");
+        if (message.getSpHandle() <= m_snapshotSpHandle) {
+            return;
+        }
+        if (m_closed) {
+            throw new IOException("Closed");
+        }
 
         assert(message != null);
         bufferCatchup(message.getSerializedSize());
@@ -166,7 +170,9 @@ public class TaskLogImpl implements TaskLog {
      */
     @Override
     public TransactionInfoBaseMessage getNextMessage() throws IOException {
-        if (m_closed) throw new IOException("Closed");
+        if (m_closed) {
+            throw new IOException("Closed");
+        }
         if (m_head == null) {
             // Get another buffer asynchronously
             final Runnable r = new Runnable() {
@@ -241,7 +247,9 @@ public class TaskLogImpl implements TaskLog {
 
     private boolean m_closed = false;
     public void close(boolean synchronous) throws IOException {
-        if (m_closed) return;
+        if (m_closed) {
+            return;
+        }
         m_closed = true;
         m_es.shutdown();
         if (synchronous) {

--- a/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
@@ -179,7 +179,7 @@ public class TaskLogImpl implements TaskLog {
                 @Override
                 public void run() {
                     try {
-                        BBContainer cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                        BBContainer cont = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                         if (cont != null) {
                            m_headBuffers.offer(new RejoinTaskBuffer(cont));
                         }

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -121,7 +121,7 @@ public interface BinaryDeque {
             throw new UnsupportedOperationException("Must implement this for partial object truncation");
         }
 
-        public int writeTruncatedObject(ByteBuffer output) throws IOException {
+        public int writeTruncatedObject(ByteBuffer output, int entryId) throws IOException {
             throw new UnsupportedOperationException("Must implement this for partial object truncation");
         }
     }

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.DeferredSerialization;
 import org.voltcore.utils.Pair;
-import org.voltdb.export.ExportSequenceNumberTracker;
 
 /**
  * Specialized deque interface for storing binary objects. Objects can be provided as a buffer chain
@@ -55,16 +54,6 @@ public interface BinaryDeque {
      * @throws IOException
      */
     void offer(BBContainer object) throws IOException;
-
-    /**
-     * Store a buffer chain as a single object in the deque. IOException may be thrown if the object
-     * is larger then the implementation defined max. 64 megabytes in the case of PersistentBinaryDeque.
-     * If there is an exception attempting to write the buffers then all the buffers will be discarded
-     * @param object
-     * @param allowCompression
-     * @throws IOException
-     */
-    void offer(BBContainer object, boolean allowCompression) throws IOException;
 
     int offer(DeferredSerialization ds) throws IOException;
 
@@ -104,7 +93,7 @@ public interface BinaryDeque {
 
     public void parseAndTruncate(BinaryDequeTruncator truncator) throws IOException;
 
-    public ExportSequenceNumberTracker scanForGap(BinaryDequeScanner scanner) throws IOException;
+    public void scanEntries(BinaryDequeScanner scanner) throws IOException;
     /**
      * Release all resources (open files) held by the back store of the queue. Continuing to use the deque
      * will result in an exception
@@ -155,6 +144,6 @@ public interface BinaryDeque {
     }
 
     public interface BinaryDequeScanner {
-        public ExportSequenceNumberTracker scan(BBContainer bb);
+        public void scan(BBContainer bb);
     }
 }

--- a/src/frontend/org/voltdb/utils/BinaryDequeReader.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeReader.java
@@ -30,11 +30,10 @@ public interface BinaryDequeReader {
      * Read and return the object at the current read position of this reader.
      * The entry will be removed once all active readers have read the entry.
      * @param ocf
-     * @param checkCRC
      * @return BBContainer with the bytes read. Null if there is nothing left to read.
      * @throws IOException
      */
-    public BBContainer poll(OutputContainerFactory ocf, boolean checkCRC) throws IOException;
+    public BBContainer poll(OutputContainerFactory ocf) throws IOException;
 
     /**
      * @param segmentIndex index of the segment to get schema from, -1 means get schema from current segment

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -332,7 +332,6 @@ class PBDRegularSegment extends PBDSegment {
 
     @Override
     void closeAndDelete() throws IOException {
-        setFinal(false);
         try {
             close();
         } finally {
@@ -714,6 +713,7 @@ class PBDRegularSegment extends PBDSegment {
         private void truncateToCurrentReadIndex() throws IOException {
             PBDRegularSegment.this.close();
             openForTruncate();
+            setFinal(false);
             initNumEntries(m_objectReadIndex, m_bytesRead);
             m_fc.truncate(m_readOffset);
         }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -619,9 +619,8 @@ class PBDRegularSegment extends PBDSegment {
                 final int uncompressedLen;
 
                 if (length < 1 || length > PBDSegment.CHUNK_SIZE - PBDSegment.SEGMENT_HEADER_BYTES) {
-                    LOG.warn("File corruption detected in " + m_file.getName() + ": invalid entry length. "
-                            + "Truncate the file to last safe point.");
-                    truncateToCurrentReadIndex();
+                    handleCorruptHeader("File corruption detected in " + m_file.getName() + ": invalid entry length.",
+                            checkCRC);
                     return null;
                 }
 
@@ -680,6 +679,18 @@ class PBDRegularSegment extends PBDSegment {
             } finally {
                 m_readOffset = m_fc.position();
                 m_fc.position(writePos);
+            }
+        }
+
+        private void handleCorruptHeader(String message, boolean checkCrc) throws IOException {
+            if (checkCrc) {
+                message += " Truncate the file to last safe point.";
+            }
+            LOG.warn(message);
+            if (checkCrc) {
+                truncateToCurrentReadIndex();
+            } else {
+                throw new IOException(message);
             }
         }
 

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -68,24 +68,24 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public long segmentIndex()
+    long segmentIndex()
     {
         return m_index;
     }
 
     @Override
-    public long segmentId() {
+    long segmentId() {
         return m_id;
     }
 
     @Override
-    public File file()
+    File file()
     {
         return m_file;
     }
 
     @Override
-    public void reset()
+    void reset()
     {
         m_syncedSinceLastEdit = false;
         if (m_segmentHeaderBuf != null) {
@@ -101,25 +101,25 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public int getNumEntries(boolean crcCheck) throws IOException
+    int getNumEntries() throws IOException
     {
         initializeFromHeader(crcCheck);
         return m_numOfEntries;
     }
 
     @Override
-    public boolean isBeingPolled()
+    boolean isBeingPolled()
     {
         return !m_readCursors.isEmpty();
     }
 
     @Override
-    public boolean isOpenForReading(String cursorId) {
+    boolean isOpenForReading(String cursorId) {
         return m_readCursors.containsKey(cursorId);
     }
 
     @Override
-    public PBDSegmentReader openForRead(String cursorId) throws IOException
+    PBDSegmentReader openForRead(String cursorId) throws IOException
     {
         Preconditions.checkNotNull(cursorId, "Reader id must be non-null");
         if (m_readCursors.containsKey(cursorId) || m_closedCursors.containsKey(cursorId)) {
@@ -135,7 +135,7 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public PBDSegmentReader getReader(String cursorId) {
+    PBDSegmentReader getReader(String cursorId) {
         PBDSegmentReader reader = m_closedCursors.get(cursorId);
         return (reader == null) ? m_readCursors.get(cursorId) : reader;
     }
@@ -266,7 +266,7 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public void closeAndDelete() throws IOException {
+    void closeAndDelete() throws IOException {
         close();
         m_file.delete();
 
@@ -275,13 +275,16 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public boolean isClosed()
+    boolean isClosed()
     {
         return m_closed;
     }
 
     @Override
-    public void close() throws IOException {
+    void close() throws IOException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Close PBD Segment " + m_file.getName());
+        }
         m_closedCursors.clear();
         closeReadersAndFile();
     }
@@ -301,7 +304,7 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public void sync() throws IOException {
+    void sync() throws IOException {
         if (m_closed) {
             throw new IOException("Segment closed");
         }
@@ -312,7 +315,7 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public boolean hasAllFinishedReading() throws IOException {
+    boolean hasAllFinishedReading() throws IOException {
         if (m_closed) {
             throw new IOException("Segment closed");
         }
@@ -389,7 +392,7 @@ public class PBDRegularSegment extends PBDSegment {
 
     // Used by DR path
     @Override
-    public int offer(DeferredSerialization ds) throws IOException
+    int offer(DeferredSerialization ds) throws IOException
     {
         if (m_closed) {
             throw new IOException("closed");
@@ -428,7 +431,7 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public int size() {
+    int size() {
         return m_size;
     }
 
@@ -452,8 +455,8 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public void writeExtraHeader(DeferredSerialization ds) throws IOException {
-        if (m_numOfEntries != 0 || m_extraHeaderSize != 0) {
+    void writeExtraHeader(DeferredSerialization ds) throws IOException {
+        if (!(m_numOfEntries == 0 && m_extraHeaderSize == 0)) {
             throw new IllegalStateException("Extra header must be written before any entries");
         }
         int size = ds.getSerializedSize();
@@ -490,12 +493,12 @@ public class PBDRegularSegment extends PBDSegment {
         }
 
         @Override
-        public boolean hasMoreEntries() throws IOException {
+        public boolean hasMoreEntries() {
             return m_objectReadIndex < m_numOfEntries;
         }
 
         @Override
-        public boolean allReadAndDiscarded() throws IOException {
+        public boolean allReadAndDiscarded() {
             return m_discardCount == m_numOfEntries;
         }
 

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -108,8 +108,6 @@ class PBDRegularSegment extends PBDSegment {
             m_entryHeaderBuf.discard();
             m_entryHeaderBuf = null;
         }
-        m_crc.reset();
-        m_crc.reset();
     }
 
     @Override
@@ -571,7 +569,7 @@ class PBDRegularSegment extends PBDSegment {
         private int m_bytesRead = 0;
         private int m_discardCount = 0;
         private boolean m_readerClosed = false;
-        private CRC32 m_crc32 = new CRC32();
+        private CRC32 m_crcReader = new CRC32();
 
         public SegmentReader(String cursorId) throws IOException {
             assert(cursorId != null);
@@ -704,13 +702,13 @@ class PBDRegularSegment extends PBDSegment {
             entry.position(origPosition);
 
             if (checkCrc) {
-                m_crc32.reset();
-                m_crc32.update(length);
-                m_crc32.update(flags);
-                m_crc32.update(entry);
+                m_crcReader.reset();
+                m_crcReader.update(length);
+                m_crcReader.update(flags);
+                m_crcReader.update(entry);
                 entry.position(origPosition);
 
-                if (crc != (int) m_crc32.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
+                if (crc != (int) m_crcReader.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
                     LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
                             + "Truncate the file to last safe point.");
                     truncateToCurrentReadIndex();

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -29,6 +29,7 @@ import java.util.zip.CRC32;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.DBBPool;
+import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.DeferredSerialization;
 import org.voltdb.utils.BinaryDeque.OutputContainerFactory;
 
@@ -40,7 +41,8 @@ import com.google_voltpatches.common.base.Preconditions;
  * to insert an object that exceeds the remaining space is made. A segment can be used
  * for reading and writing, but not both at the same time.
  */
-public class PBDRegularSegment extends PBDSegment {
+class PBDRegularSegment extends PBDSegment {
+    private static final int VERSION = 2;
     private static final VoltLogger LOG = new VoltLogger("HOST");
 
     private final Map<String, SegmentReader> m_readCursors = new HashMap<>();
@@ -54,13 +56,16 @@ public class PBDRegularSegment extends PBDSegment {
 
     private int m_numOfEntries = -1;
     private int m_size = -1;
+    private boolean m_compress;
     private int m_extraHeaderSize = 0;
+    // Not guaranteed to be valid unless m_extraHeaderSize > 0
+    private int m_extraHeaderCrc = 0;
 
     private DBBPool.BBContainer m_segmentHeaderBuf = null;
     private DBBPool.BBContainer m_entryHeaderBuf = null;
     Boolean INJECT_PBD_CHECKSUM_ERROR = Boolean.getBoolean("INJECT_PBD_CHECKSUM_ERROR");
 
-    public PBDRegularSegment(Long index, long id, File file) {
+    PBDRegularSegment(Long index, long id, File file) {
         super(file);
         m_index = index;
         m_id = id;
@@ -96,14 +101,14 @@ public class PBDRegularSegment extends PBDSegment {
             m_entryHeaderBuf.discard();
             m_entryHeaderBuf = null;
         }
-        m_segmentHeaderCRC.reset();
-        m_entryCRC.reset();
+        m_crc.reset();
+        m_crc.reset();
     }
 
     @Override
     int getNumEntries() throws IOException
     {
-        initializeFromHeader(crcCheck);
+        initializeFromHeader();
         return m_numOfEntries;
     }
 
@@ -127,7 +132,7 @@ public class PBDRegularSegment extends PBDSegment {
         }
 
         if (m_closed) {
-            open(false, false);
+            open(false, false, false);
         }
         SegmentReader reader = new SegmentReader(cursorId);
         m_readCursors.put(cursorId, reader);
@@ -141,16 +146,26 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    protected void openForWrite(boolean emptyFile) throws IOException {
-        open(true, emptyFile);
+    void openForTruncate() throws IOException {
+        open(true, false, false);
+    }
+
+    @Override
+    void openNewSegment(boolean compress) throws IOException {
+        open(true, true, compress);
+    }
+
+    @Override
+    void validateHeader() throws IOException {
+        readHeader(true, true);
     }
 
     int getExtraHeaderSize() throws IOException {
-        initializeFromHeader(false);
+        initializeFromHeader();
         return m_extraHeaderSize;
     }
 
-    private void open(boolean forWrite, boolean emptyFile) throws IOException {
+    private void open(boolean forWrite, boolean emptyFile, boolean compress) throws IOException {
         if (!m_closed) {
             throw new IOException("Segment is already opened");
         }
@@ -170,6 +185,7 @@ public class PBDRegularSegment extends PBDSegment {
         // Those asserts ensure the file is opened with correct flag
         if (emptyFile) {
             initNumEntries(0, 0);
+            m_compress = compress;
         }
         if (forWrite) {
             m_fc.position(m_fc.size());
@@ -180,38 +196,65 @@ public class PBDRegularSegment extends PBDSegment {
         m_closed = false;
     }
 
-    private void initializeFromHeader(boolean crcCheck) throws IOException {
+    private void initializeFromHeader() throws IOException {
         if (m_numOfEntries != -1) {
             return;
         }
+        readHeader(!isFinal(), false);
+    }
+
+    private void readHeader(boolean crcCheck, boolean skipInitialization) throws IOException {
         boolean wasClosed = false;
         if (m_closed) {
             wasClosed = true;
-            open(false, false);
+            open(false, false, false);
         }
         try {
             if (m_fc.size() >= SEGMENT_HEADER_BYTES) {
                 ByteBuffer b = m_segmentHeaderBuf.b();
                 b.clear();
                 PBDUtils.readBufferFully(m_fc, b, 0);
+                int version = b.getInt();
+                if (version != VERSION) {
+                    String message = "File version incorrect. Detected version " + version + " requires version "
+                            + VERSION + " in file " + m_file.getName();
+                    LOG.warn(message);
+                    throw new IOException(message);
+                }
+
                 int crc = b.getInt();
                 int numOfEntries = b.getInt();
                 int size = b.getInt();
                 int extraHeaderSize = b.getInt();
+                int extraHeaderCrc = b.getInt();
                 if (crcCheck) {
-                    m_segmentHeaderCRC.reset();
-                    m_segmentHeaderCRC.update(numOfEntries);
-                    m_segmentHeaderCRC.update(size);
-                    m_segmentHeaderCRC.update(extraHeaderSize);
-                    if (crc != (int) m_segmentHeaderCRC.getValue()) {
-                        LOG.warn("File corruption detected in" + m_file.getName() + ": invalid file header. ");
+                    if (crc != calculateSegmentHeaderCrc(numOfEntries, size, extraHeaderSize, extraHeaderCrc)) {
+                        LOG.warn("File corruption detected in " + m_file.getName() + ": invalid file header. ");
                         throw new IOException(
-                                "File corruption detected in" + m_file.getName() + ": invalid file header.");
+                                "File corruption detected in " + m_file.getName() + ": invalid file header.");
                     }
+                    if (extraHeaderSize > 0) {
+                        BBContainer extraHeader = DBBPool.allocateDirect(extraHeaderSize);
+                        try {
+                            PBDUtils.readBufferFully(m_fc, extraHeader.b(), HEADER_EXTRA_HEADER_OFFSET);
+                            if (extraHeaderCrc != calculateExtraHeaderCrc(extraHeader.b())) {
+                                String message = "File corruption deteced in " + m_file.getName()
+                                        + ": invalid extended file header";
+                                LOG.warn(message);
+                                throw new IOException(message);
+                            }
+                        } finally {
+                            extraHeader.discard();
+                        }
+                    }
+                }
+                if (skipInitialization) {
+                    return;
                 }
                 m_numOfEntries = numOfEntries;
                 m_size = size;
                 m_extraHeaderSize = extraHeaderSize;
+                m_extraHeaderCrc = extraHeaderCrc;
             } else {
                 m_numOfEntries = 0;
                 m_size = 0;
@@ -224,26 +267,42 @@ public class PBDRegularSegment extends PBDSegment {
     }
 
     private void writeOutHeader() throws IOException {
-        // Update segment header CRC
-        m_segmentHeaderCRC.reset();
-        m_segmentHeaderCRC.update(m_numOfEntries);
-        m_segmentHeaderCRC.update(m_size);
-        m_segmentHeaderCRC.update(m_extraHeaderSize);
+        int crc = calculateSegmentHeaderCrc(m_numOfEntries, m_size, m_extraHeaderSize, m_extraHeaderCrc);
 
         ByteBuffer b = m_segmentHeaderBuf.b();
         b.clear();
         // the checksum here is really an unsigned int, store integer to save 4 bytes
-        b.putInt((int) m_segmentHeaderCRC.getValue());
+        b.putInt(VERSION);
+        b.putInt(crc);
         b.putInt(m_numOfEntries);
         b.putInt(m_size);
         b.putInt(m_extraHeaderSize);
+        b.putInt(m_extraHeaderCrc);
         b.flip();
-        PBDUtils.writeBuffer(m_fc, m_segmentHeaderBuf.bDR(), PBDSegment.HEADER_CRC_OFFSET);
+        PBDUtils.writeBuffer(m_fc, m_segmentHeaderBuf.bDR(), PBDSegment.HEADER_START_OFFSET);
         m_syncedSinceLastEdit = false;
     }
 
+    private int calculateSegmentHeaderCrc(int numOfEntries, int size, int extraHeaderSize, int extraHeaderCrc) {
+        m_crc.reset();
+        m_crc.update(VERSION);
+        m_crc.update(numOfEntries);
+        m_crc.update(size);
+        m_crc.update(extraHeaderSize);
+        if (extraHeaderSize > 0) {
+            m_crc.update(extraHeaderCrc);
+        }
+        return (int) m_crc.getValue();
+    }
+
+    private int calculateExtraHeaderCrc(ByteBuffer extraHeader) {
+        m_crc.reset();
+        m_crc.update(extraHeader);
+        return (int) m_crc.getValue();
+    }
+
     @Override
-    protected void initNumEntries(int count, int size) throws IOException {
+    void initNumEntries(int count, int size) throws IOException {
         m_numOfEntries = count;
         m_size = size;
         writeOutHeader();
@@ -335,16 +394,15 @@ public class PBDRegularSegment extends PBDSegment {
 
     // Used by Export path
     @Override
-    public boolean offer(DBBPool.BBContainer cont, boolean compress) throws IOException
+    boolean offer(DBBPool.BBContainer cont) throws IOException
     {
         if (m_closed) {
             throw new IOException("Segment closed");
         }
         final ByteBuffer buf = cont.b();
         final int remaining = buf.remaining();
-        if (remaining < 32 || !buf.isDirect()) {
-            compress = false;
-        }
+        boolean compress = m_compress && remaining >= 32 && buf.isDirect();
+
         final int maxCompressedSize = (compress ? CompressionService.maxCompressedLength(remaining) : remaining) + ENTRY_HEADER_BYTES;
         if (remaining() < maxCompressedSize) {
             return false;
@@ -353,18 +411,18 @@ public class PBDRegularSegment extends PBDSegment {
         m_syncedSinceLastEdit = false;
         DBBPool.BBContainer destBuf = cont;
         try {
-            m_entryCRC.reset();
+            m_crc.reset();
             m_entryHeaderBuf.b().clear();
 
             if (compress) {
                 destBuf = DBBPool.allocateDirectAndPool(maxCompressedSize);
                 final int compressedSize = CompressionService.compressBuffer(buf, destBuf.b());
                 destBuf.b().limit(compressedSize);
-                PBDUtils.writeEntryHeader(m_entryCRC, m_entryHeaderBuf.b(), destBuf.b(),
+                PBDUtils.writeEntryHeader(m_crc, m_entryHeaderBuf.b(), destBuf.b(),
                         compressedSize, FLAG_COMPRESSED);
             } else {
                 destBuf = cont;
-                PBDUtils.writeEntryHeader(m_entryCRC, m_entryHeaderBuf.b(), destBuf.b(),
+                PBDUtils.writeEntryHeader(m_crc, m_entryHeaderBuf.b(), destBuf.b(),
                         remaining, NO_FLAGS);
             }
             // Write entry header
@@ -406,12 +464,12 @@ public class PBDRegularSegment extends PBDSegment {
         DBBPool.BBContainer destBuf = DBBPool.allocateDirectAndPool(fullSize);
 
         try {
-            m_entryCRC.reset();
+            m_crc.reset();
             m_entryHeaderBuf.b().clear();
             final int written = MiscUtils.writeDeferredSerialization(destBuf.b(), ds);
             destBuf.b().flip();
             // Write entry header
-            PBDUtils.writeEntryHeader(m_entryCRC, m_entryHeaderBuf.b(), destBuf.b(),
+            PBDUtils.writeEntryHeader(m_crc, m_entryHeaderBuf.b(), destBuf.b(),
                     written, PBDSegment.NO_FLAGS);
             m_entryHeaderBuf.b().flip();
             while (m_entryHeaderBuf.b().hasRemaining()) {
@@ -466,14 +524,16 @@ public class PBDRegularSegment extends PBDSegment {
             b.order(ByteOrder.LITTLE_ENDIAN);
             ds.serialize(b);
             b.flip();
-            while (b.hasRemaining()) {
+            do {
                 m_fc.write(b);
-            }
-            m_extraHeaderSize = size;
-            writeOutHeader();
+            } while (b.hasRemaining());
+            b.flip();
+            m_extraHeaderCrc = calculateExtraHeaderCrc(b);
+            m_extraHeaderSize = b.position();
         } finally {
             destBuf.discard();
         }
+        writeOutHeader();
     }
 
     private class SegmentReader implements PBDSegmentReader {
@@ -518,27 +578,25 @@ public class PBDRegularSegment extends PBDSegment {
 
             try {
                 //Get the length and size prefix and then read the object
-                m_entryHeaderBuf.b().clear();
-                while (m_entryHeaderBuf.b().hasRemaining()) {
-                    int read = m_fc.read(m_entryHeaderBuf.b());
+                ByteBuffer b = m_entryHeaderBuf.b();
+                b.clear();
+                while (b.hasRemaining()) {
+                    int read = m_fc.read(b);
                     if (read == -1) {
                         throw new EOFException();
                     }
                 }
-                m_entryHeaderBuf.b().flip();
-                final int entryCRC = m_entryHeaderBuf.b().getInt();
-                final int length = m_entryHeaderBuf.b().getInt();
-                final int flags = m_entryHeaderBuf.b().getInt();
+                b.flip();
+                final int entryCRC = b.getInt();
+                final int length = b.getInt();
+                final char flags = b.getChar();
                 final boolean compressed = (flags & FLAG_COMPRESSED) != 0;
                 final int uncompressedLen;
 
                 if (length < 1 || length > PBDSegment.CHUNK_SIZE - PBDSegment.SEGMENT_HEADER_BYTES) {
                     LOG.warn("File corruption detected in " + m_file.getName() + ": invalid entry length. "
                             + "Truncate the file to last safe point.");
-                    PBDRegularSegment.this.close();
-                    openForWrite(false);
-                    initNumEntries(m_objectReadIndex, m_bytesRead);
-                    m_fc.truncate(m_readOffset);
+                    truncateToCurrentReadIndex();
                     return null;
                 }
 
@@ -546,14 +604,7 @@ public class PBDRegularSegment extends PBDSegment {
                 if (compressed) {
                     final DBBPool.BBContainer compressedBuf = DBBPool.allocateDirectAndPool(length);
                     try {
-                        while (compressedBuf.b().hasRemaining()) {
-                            int read = m_fc.read(compressedBuf.b());
-                            if (read == -1) {
-                                throw new EOFException();
-                            }
-                        }
-                        compressedBuf.b().flip();
-                        if (checkCRC && !checkEntryCrc(length, flags, compressedBuf.b(), entryCRC)) {
+                        if (!fillBuffer(compressedBuf.b(), flags, entryCRC, checkCRC)) {
                             return null;
                         }
 
@@ -568,14 +619,7 @@ public class PBDRegularSegment extends PBDSegment {
                     uncompressedLen = length;
                     retcont = factory.getContainer(length);
                     retcont.b().limit(length);
-                    while (retcont.b().hasRemaining()) {
-                        int read = m_fc.read(retcont.b());
-                        if (read == -1) {
-                            throw new EOFException();
-                        }
-                    }
-                    retcont.b().flip();
-                    if (checkCRC && !checkEntryCrc(length, flags, retcont.b(), entryCRC)) {
+                    if (!fillBuffer(retcont.b(), flags, entryCRC, checkCRC)) {
                         retcont.discard();
                         return null;
                     }
@@ -600,30 +644,61 @@ public class PBDRegularSegment extends PBDSegment {
                         m_discardCount++;
                     }
                 };
+            } catch (IOException e) {
+                if (checkCRC) {
+                    LOG.warn("Error reading segment " + m_file.getName() + ". Truncate the file to last safe point.",
+                            e);
+                    truncateToCurrentReadIndex();
+                    return null;
+                }
+                throw e;
             } finally {
                 m_readOffset = m_fc.position();
                 m_fc.position(writePos);
             }
         }
 
-        private boolean checkEntryCrc(int length, int flags, ByteBuffer entry, int crc) throws IOException {
+        private boolean fillBuffer(ByteBuffer entry, int flags, int crc, boolean checkCrc) throws IOException {
             int origPosition = entry.position();
-            m_crc32.reset();
-            m_crc32.update(length);
-            m_crc32.update(flags);
-            m_crc32.update(entry);
+            int length = entry.remaining();
+            while (entry.hasRemaining()) {
+                int read = m_fc.read(entry);
+                if (read == -1) {
+                    if (!checkCrc) {
+                        throw new EOFException();
+                    }
+                    LOG.warn("File corruption detected in " + m_file.getName() + ": invalid entry length. "
+                            + "Truncate the file to last safe point.");
+                    truncateToCurrentReadIndex();
+                    return false;
+                }
+            }
+
             entry.position(origPosition);
 
-            if (crc != (int) m_crc32.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
-                LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
-                        + "Truncate the file to last safe point.");
-                PBDRegularSegment.this.close();
-                openForWrite(false);
-                initNumEntries(m_objectReadIndex, m_bytesRead);
-                m_fc.truncate(m_readOffset);
-                return false;
+            if (checkCrc) {
+                m_crc32.reset();
+                m_crc32.update(length);
+                m_crc32.update(flags);
+                m_crc32.update(entry);
+                entry.position(origPosition);
+
+                if (crc != (int) m_crc32.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
+                    LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
+                            + "Truncate the file to last safe point.");
+                    truncateToCurrentReadIndex();
+                    return false;
+                }
             }
+
             return true;
+        }
+
+        private void truncateToCurrentReadIndex() throws IOException {
+            PBDRegularSegment.this.close();
+            openForTruncate();
+            initNumEntries(m_objectReadIndex, m_bytesRead);
+            m_fc.truncate(m_readOffset);
         }
 
         @Override
@@ -632,34 +707,22 @@ public class PBDRegularSegment extends PBDSegment {
                 throw new IOException("Reader closed");
             }
 
-            int extraHeaderSize = getExtraHeaderSize();
-            if (extraHeaderSize == 0) {
+            if (m_extraHeaderSize == 0) {
                 return null;
             }
 
-            final long writePos = m_fc.position();
-            m_fc.position(SEGMENT_HEADER_BYTES);
-
             DBBPool.BBContainer schemaBuf = null;
             try {
-                schemaBuf = DBBPool.allocateDirect(extraHeaderSize);
-                ByteBuffer schemaBuffer = schemaBuf.b();
-                do {
-                    int read = m_fc.read(schemaBuffer);
-                    if (read == -1) {
-                        throw new EOFException();
-                    }
-                } while (schemaBuffer.hasRemaining());
-                schemaBuffer.order(ByteOrder.LITTLE_ENDIAN).flip();
+                schemaBuf = DBBPool.allocateDirect(m_extraHeaderSize);
+                PBDUtils.readBufferFully(m_fc, schemaBuf.b().order(ByteOrder.LITTLE_ENDIAN),
+                        HEADER_EXTRA_HEADER_OFFSET);
                 return schemaBuf;
             } catch (Exception e) {
                 if (schemaBuf != null) {
                     schemaBuf.discard();
                 }
-                LOG.error(e);
+                LOG.error("Error reading extra header of file: " + m_file.getName(), e);
                 return null;
-            } finally {
-                m_fc.position(writePos);
             }
         }
 
@@ -689,9 +752,20 @@ public class PBDRegularSegment extends PBDSegment {
 
         @Override
         public void close() throws IOException {
+            close(true);
+        }
+
+        @Override
+        public void purge() throws IOException {
+            close(false);
+        }
+
+        private void close(boolean keep) throws IOException {
             m_readerClosed = true;
             m_readCursors.remove(m_cursorId);
-            m_closedCursors.put(m_cursorId, this);
+            if (keep) {
+                m_closedCursors.put(m_cursorId, this);
+            }
             if (m_readCursors.isEmpty()) {
                 closeReadersAndFile();
             }
@@ -703,9 +777,9 @@ public class PBDRegularSegment extends PBDSegment {
         }
 
         @Override
-        public void reopen(boolean forWrite, boolean emptyFile) throws IOException {
+        public void reopen() throws IOException {
             if (m_readerClosed) {
-                open(forWrite, emptyFile);
+                open(false, false, false);
                 m_readerClosed = false;
             }
             if (m_cursorId != null) {

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -22,7 +22,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.nio.file.StandardOpenOption;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -179,14 +183,13 @@ class PBDRegularSegment extends PBDSegment {
             m_syncedSinceLastEdit = false;
         }
         assert (m_fc == null);
-        m_fc = FileChannel.open(m_file.toPath(),
-                forWrite ? EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)
-                        : EnumSet.of(StandardOpenOption.READ));
+        m_fc = new FileChannelWrapper(m_file, forWrite);
         m_segmentHeaderBuf = DBBPool.allocateDirect(SEGMENT_HEADER_BYTES);
         m_entryHeaderBuf = DBBPool.allocateDirect(ENTRY_HEADER_BYTES);
 
         // Those asserts ensure the file is opened with correct flag
         if (emptyFile) {
+            setFinal(false);
             initNumEntries(0, 0);
             m_compress = compress;
         }
@@ -329,8 +332,12 @@ class PBDRegularSegment extends PBDSegment {
 
     @Override
     void closeAndDelete() throws IOException {
-        close();
-        m_file.delete();
+        setFinal(false);
+        try {
+            close();
+        } finally {
+            m_file.delete();
+        }
 
         m_numOfEntries = -1;
         m_size = -1;
@@ -536,6 +543,14 @@ class PBDRegularSegment extends PBDSegment {
             destBuf.discard();
         }
         writeOutHeader();
+    }
+
+    @Override
+    boolean canBeFinalized() {
+        if (m_fc != null) {
+            return ((FileChannelWrapper) m_fc).m_stable;
+        }
+        return false;
     }
 
     private class SegmentReader implements PBDSegmentReader {
@@ -787,6 +802,196 @@ class PBDRegularSegment extends PBDSegment {
             if (m_cursorId != null) {
                 m_closedCursors.remove(m_cursorId);
                 m_readCursors.put(m_cursorId, this);
+            }
+        }
+    }
+
+    /**
+     * A simple delegation wrapper around a {@link FileChannel} which tracks whether or not any exceptions were thrown
+     * by the delegate
+     */
+    private static final class FileChannelWrapper extends FileChannel {
+        private final FileChannel m_delegate;
+        boolean m_stable = true;
+
+        FileChannelWrapper(File file, boolean forWrite) throws IOException {
+            m_delegate = FileChannel.open(file.toPath(),
+                    forWrite ? EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)
+                            : EnumSet.of(StandardOpenOption.READ));
+        }
+
+        @Override
+        public String toString() {
+            return m_delegate.toString();
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            try {
+                return m_delegate.read(dst);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+            try {
+                return m_delegate.read(dsts, offset, length);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            try {
+                return m_delegate.write(src);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+            try {
+                return m_delegate.write(srcs, offset, length);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public long position() throws IOException {
+            try {
+                return m_delegate.position();
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public FileChannel position(long newPosition) throws IOException {
+            try {
+                return m_delegate.position(newPosition);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public long size() throws IOException {
+            try {
+                return m_delegate.size();
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public FileChannel truncate(long size) throws IOException {
+            try {
+                return m_delegate.truncate(size);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public void force(boolean metaData) throws IOException {
+            try {
+                m_delegate.force(metaData);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
+            try {
+                return m_delegate.transferTo(position, count, target);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
+            try {
+                return m_delegate.transferFrom(src, position, count);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public int read(ByteBuffer dst, long position) throws IOException {
+            try {
+                return m_delegate.read(dst, position);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public int write(ByteBuffer src, long position) throws IOException {
+            try {
+                return m_delegate.write(src, position);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+            try {
+                return m_delegate.map(mode, position, size);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public FileLock lock(long position, long size, boolean shared) throws IOException {
+            try {
+                return m_delegate.lock(position, size, shared);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+            try {
+                return m_delegate.tryLock(position, size, shared);
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
+            }
+        }
+
+        @Override
+        protected void implCloseChannel() throws IOException {
+            try {
+                m_delegate.close();
+            } catch (Throwable e) {
+                m_stable = false;
+                throw e;
             }
         }
     }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -467,6 +467,7 @@ public class PBDRegularSegment extends PBDSegment {
                 m_fc.write(b);
             }
             m_extraHeaderSize = size;
+            writeOutHeader();
         } finally {
             destBuf.discard();
         }

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -27,6 +27,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -59,8 +60,6 @@ class PBDRegularSegment extends PBDSegment {
 
     // Persistent ID of this segment, based on managing a monotonic counter
     private final long m_id;
-    // Whether or not this is the current active segment being written to
-    boolean m_isActive = false;
 
     private int m_numOfEntries = -1;
     private int m_size = -1;
@@ -334,12 +333,6 @@ class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    public void finalize() throws IOException {
-        m_isActive = false;
-        super.finalize();
-    }
-
-    @Override
     void closeAndDelete() throws IOException {
         try {
             close();
@@ -377,6 +370,11 @@ class PBDRegularSegment extends PBDSegment {
             m_closed = true;
             reset();
         }
+    }
+
+    @Override
+    void setReadOnly() throws IOException {
+        getFiileChannelWrapper().reopen(false);
     }
 
     @Override
@@ -556,9 +554,13 @@ class PBDRegularSegment extends PBDSegment {
     @Override
     boolean canBeFinalized() {
         if (m_fc != null) {
-            return ((FileChannelWrapper) m_fc).m_stable;
+            return getFiileChannelWrapper().m_stable;
         }
         return false;
+    }
+
+    private FileChannelWrapper getFiileChannelWrapper() {
+        return (FileChannelWrapper) m_fc;
     }
 
     private class SegmentReader implements PBDSegmentReader {
@@ -722,9 +724,16 @@ class PBDRegularSegment extends PBDSegment {
         private void truncateToCurrentReadIndex() throws IOException {
             PBDRegularSegment.this.close();
             openForTruncate();
-            setFinal(false);
-            initNumEntries(m_objectReadIndex, m_bytesRead);
-            m_fc.truncate(m_readOffset);
+            boolean wasReadOnly = getFiileChannelWrapper().reopen(true);
+            try {
+                setFinal(false);
+                initNumEntries(m_objectReadIndex, m_bytesRead);
+                m_fc.truncate(m_readOffset);
+            } finally {
+                if (wasReadOnly) {
+                    setReadOnly();
+                }
+            }
         }
 
         @Override
@@ -820,13 +829,30 @@ class PBDRegularSegment extends PBDSegment {
      * by the delegate
      */
     private static final class FileChannelWrapper extends FileChannel {
-        private final FileChannel m_delegate;
+        private final Path m_path;
+        private FileChannel m_delegate;
+        boolean m_writable;
         boolean m_stable = true;
 
         FileChannelWrapper(File file, boolean forWrite) throws IOException {
-            m_delegate = FileChannel.open(file.toPath(),
-                    forWrite ? EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)
-                            : EnumSet.of(StandardOpenOption.READ));
+            m_path = file.toPath();
+            open(forWrite);
+        }
+
+        boolean reopen(boolean forWrite) throws IOException {
+            if (forWrite != m_writable) {
+                m_delegate.close();
+                open(forWrite);
+                return true;
+            }
+            return false;
+        }
+
+        private void open(boolean forWrite) throws IOException {
+            m_delegate = FileChannel.open(m_path, forWrite
+                    ? EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)
+                    : EnumSet.of(StandardOpenOption.READ));
+            m_writable = forWrite;
         }
 
         @Override

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -32,6 +32,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.zip.CRC32;
 
 import org.voltcore.logging.VoltLogger;
@@ -51,6 +52,7 @@ import com.google_voltpatches.common.base.Preconditions;
 class PBDRegularSegment extends PBDSegment {
     private static final int VERSION = 2;
     private static final VoltLogger LOG = new VoltLogger("HOST");
+    private static final Random RANDOM = new Random();
 
     private final Map<String, SegmentReader> m_readCursors = new HashMap<>();
     private final Map<String, SegmentReader> m_closedCursors = new HashMap<>();
@@ -64,6 +66,7 @@ class PBDRegularSegment extends PBDSegment {
     private int m_numOfEntries = -1;
     private int m_size = -1;
     private boolean m_compress;
+    private int m_segmentRandomId;
     private int m_extraHeaderSize = 0;
     // Not guaranteed to be valid unless m_extraHeaderSize > 0
     private int m_extraHeaderCrc = 0;
@@ -192,6 +195,7 @@ class PBDRegularSegment extends PBDSegment {
             initNumEntries(0, 0);
             m_compress = compress;
             m_isActive = true;
+            m_segmentRandomId = RANDOM.nextInt();
         }
         if (forWrite) {
             m_fc.position(m_fc.size());
@@ -231,10 +235,12 @@ class PBDRegularSegment extends PBDSegment {
                 int crc = b.getInt();
                 int numOfEntries = b.getInt();
                 int size = b.getInt();
+                int segmentRandomId = b.getInt();
                 int extraHeaderSize = b.getInt();
                 int extraHeaderCrc = b.getInt();
                 if (crcCheck) {
-                    if (crc != calculateSegmentHeaderCrc(numOfEntries, size, extraHeaderSize, extraHeaderCrc)) {
+                    if (crc != calculateSegmentHeaderCrc(numOfEntries, size, segmentRandomId, extraHeaderSize,
+                            extraHeaderCrc)) {
                         LOG.warn("File corruption detected in " + m_file.getName() + ": invalid file header. ");
                         throw new IOException(
                                 "File corruption detected in " + m_file.getName() + ": invalid file header.");
@@ -259,6 +265,7 @@ class PBDRegularSegment extends PBDSegment {
                 }
                 m_numOfEntries = numOfEntries;
                 m_size = size;
+                m_segmentRandomId = segmentRandomId;
                 m_extraHeaderSize = extraHeaderSize;
                 m_extraHeaderCrc = extraHeaderCrc;
             } else {
@@ -273,7 +280,8 @@ class PBDRegularSegment extends PBDSegment {
     }
 
     private void writeOutHeader() throws IOException {
-        int crc = calculateSegmentHeaderCrc(m_numOfEntries, m_size, m_extraHeaderSize, m_extraHeaderCrc);
+        int crc = calculateSegmentHeaderCrc(m_numOfEntries, m_size, m_segmentRandomId, m_extraHeaderSize,
+                m_extraHeaderCrc);
 
         ByteBuffer b = m_segmentHeaderBuf.b();
         b.clear();
@@ -282,6 +290,7 @@ class PBDRegularSegment extends PBDSegment {
         b.putInt(crc);
         b.putInt(m_numOfEntries);
         b.putInt(m_size);
+        b.putInt(m_segmentRandomId);
         b.putInt(m_extraHeaderSize);
         b.putInt(m_extraHeaderCrc);
         b.flip();
@@ -289,11 +298,13 @@ class PBDRegularSegment extends PBDSegment {
         m_syncedSinceLastEdit = false;
     }
 
-    private int calculateSegmentHeaderCrc(int numOfEntries, int size, int extraHeaderSize, int extraHeaderCrc) {
+    private int calculateSegmentHeaderCrc(int numOfEntries, int size, int segmentRandomId, int extraHeaderSize,
+            int extraHeaderCrc) {
         m_crc.reset();
         m_crc.update(VERSION);
         m_crc.update(numOfEntries);
         m_crc.update(size);
+        m_crc.update(segmentRandomId);
         m_crc.update(extraHeaderSize);
         if (extraHeaderSize > 0) {
             m_crc.update(extraHeaderCrc);
@@ -424,19 +435,16 @@ class PBDRegularSegment extends PBDSegment {
         m_syncedSinceLastEdit = false;
         DBBPool.BBContainer destBuf = cont;
         try {
-            m_crc.reset();
             m_entryHeaderBuf.b().clear();
 
             if (compress) {
                 destBuf = DBBPool.allocateDirectAndPool(maxCompressedSize);
                 final int compressedSize = CompressionService.compressBuffer(buf, destBuf.b());
                 destBuf.b().limit(compressedSize);
-                PBDUtils.writeEntryHeader(m_crc, m_entryHeaderBuf.b(), destBuf.b(),
-                        compressedSize, FLAG_COMPRESSED);
+                writeEntryHeader(destBuf.b(), PBDSegment.FLAG_COMPRESSED);
             } else {
                 destBuf = cont;
-                PBDUtils.writeEntryHeader(m_crc, m_entryHeaderBuf.b(), destBuf.b(),
-                        remaining, NO_FLAGS);
+                writeEntryHeader(destBuf.b(), PBDSegment.NO_FLAGS);
             }
             // Write entry header
             m_entryHeaderBuf.b().flip();
@@ -477,13 +485,11 @@ class PBDRegularSegment extends PBDSegment {
         DBBPool.BBContainer destBuf = DBBPool.allocateDirectAndPool(fullSize);
 
         try {
-            m_crc.reset();
             m_entryHeaderBuf.b().clear();
             final int written = MiscUtils.writeDeferredSerialization(destBuf.b(), ds);
             destBuf.b().flip();
             // Write entry header
-            PBDUtils.writeEntryHeader(m_crc, m_entryHeaderBuf.b(), destBuf.b(),
-                    written, PBDSegment.NO_FLAGS);
+            writeEntryHeader(destBuf.b(), PBDSegment.NO_FLAGS);
             m_entryHeaderBuf.b().flip();
             while (m_entryHeaderBuf.b().hasRemaining()) {
                 m_fc.write(m_entryHeaderBuf.b());
@@ -501,19 +507,23 @@ class PBDRegularSegment extends PBDSegment {
         }
     }
 
+    private void writeEntryHeader(ByteBuffer data, char flags) {
+        PBDUtils.writeEntryHeader(m_crc, m_entryHeaderBuf.b(), data, m_segmentRandomId + m_numOfEntries + 1, flags);
+    }
+
     @Override
     int size() {
         return m_size;
     }
 
     @Override
-    protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry) throws IOException
+    protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry, int entryNumber) throws IOException
     {
         int written = 0;
         final DBBPool.BBContainer partialCont =
                 DBBPool.allocateDirect(ENTRY_HEADER_BYTES + entry.getTruncatedBuffSize());
         try {
-            written += entry.writeTruncatedObject(partialCont.b());
+            written += entry.writeTruncatedObject(partialCont.b(), m_segmentRandomId + entryNumber);
             partialCont.b().flip();
 
             while (partialCont.b().hasRemaining()) {
@@ -614,6 +624,7 @@ class PBDRegularSegment extends PBDSegment {
                 b.flip();
                 final int entryCRC = b.getInt();
                 final int length = b.getInt();
+                final int entryId = b.getInt();
                 final char flags = b.getChar();
                 final boolean compressed = (flags & FLAG_COMPRESSED) != 0;
                 final int uncompressedLen;
@@ -624,11 +635,17 @@ class PBDRegularSegment extends PBDSegment {
                     return null;
                 }
 
+                if (entryId != m_segmentRandomId + m_objectReadIndex + 1) {
+                    handleCorruptHeader("File corruption detected in " + m_file.getName() + ": invalid entry id.",
+                            checkCRC);
+                    return null;
+                }
+
                 final DBBPool.BBContainer retcont;
                 if (compressed) {
                     final DBBPool.BBContainer compressedBuf = DBBPool.allocateDirectAndPool(length);
                     try {
-                        if (!fillBuffer(compressedBuf.b(), flags, entryCRC, checkCRC)) {
+                        if (!fillBuffer(compressedBuf.b(), entryId, flags, entryCRC, checkCRC)) {
                             return null;
                         }
 
@@ -643,7 +660,7 @@ class PBDRegularSegment extends PBDSegment {
                     uncompressedLen = length;
                     retcont = factory.getContainer(length);
                     retcont.b().limit(length);
-                    if (!fillBuffer(retcont.b(), flags, entryCRC, checkCRC)) {
+                    if (!fillBuffer(retcont.b(), entryId, flags, entryCRC, checkCRC)) {
                         retcont.discard();
                         return null;
                     }
@@ -694,9 +711,9 @@ class PBDRegularSegment extends PBDSegment {
             }
         }
 
-        private boolean fillBuffer(ByteBuffer entry, int flags, int crc, boolean checkCrc) throws IOException {
+        private boolean fillBuffer(ByteBuffer entry, int entryId, char flags, int crc, boolean checkCrc)
+                throws IOException {
             int origPosition = entry.position();
-            int length = entry.remaining();
             while (entry.hasRemaining()) {
                 int read = m_fc.read(entry);
                 if (read == -1) {
@@ -713,18 +730,14 @@ class PBDRegularSegment extends PBDSegment {
             entry.position(origPosition);
 
             if (checkCrc) {
-                m_crcReader.reset();
-                m_crcReader.update(length);
-                m_crcReader.update(flags);
-                m_crcReader.update(entry);
-                entry.position(origPosition);
-
-                if (crc != (int) m_crcReader.getValue() || INJECT_PBD_CHECKSUM_ERROR) {
+                if (crc != PBDUtils.calculateEntryCrc(m_crcReader, entry, entryId, flags)
+                        || INJECT_PBD_CHECKSUM_ERROR) {
                     LOG.warn("File corruption detected in " + m_file.getName() + ": checksum error. "
                             + "Truncate the file to last safe point.");
                     truncateToCurrentReadIndex();
                     return false;
                 }
+                entry.position(origPosition);
             }
 
             return true;

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -19,7 +19,6 @@ package org.voltdb.utils;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
@@ -73,7 +72,6 @@ public abstract class PBDSegment {
     protected final File m_file;
 
     protected boolean m_closed = true;
-    protected RandomAccessFile m_ras;
     protected FileChannel m_fc;
     //Avoid unnecessary sync with this flag
     protected boolean m_syncedSinceLastEdit = true;

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -30,7 +30,6 @@ import java.util.zip.CRC32;
 
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DeferredSerialization;
-import org.voltdb.export.ExportSequenceNumberTracker;
 
 public abstract class PBDSegment {
 
@@ -42,26 +41,34 @@ public abstract class PBDSegment {
     public static final int CHUNK_SIZE = Integer.getInteger("PBDSEGMENT_CHUNK_SIZE", 1024 * 1024 * 64);
 
     // Segment Header layout:
+    // - version of segment headers (4 bytes)
     //  - crc of segment header (4 bytes),
     //  - total number of entries (4 bytes),
     //  - total bytes of data (4 bytes, uncompressed size),
-    public static final int HEADER_CRC_OFFSET = 0;
-    public static final int HEADER_NUM_OF_ENTRY_OFFSET = 4;
-    public static final int HEADER_TOTAL_BYTES_OFFSET = 8;
-    public static final int HEADER_EXTRA_HEADER_SIZE_OFFSET = 12;
-    static final int SEGMENT_HEADER_BYTES = 16;
+    //  - size in bytes of extra header ( 4 bytes )
+    //  - crc for the extra header ( 4 bytes )
+    public static final int HEADER_START_OFFSET = 0;
+    public static final int HEADER_VERSION_OFFSET = HEADER_START_OFFSET;
+    public static final int HEADER_CRC_OFFSET = HEADER_VERSION_OFFSET + 4;
+    public static final int HEADER_NUM_OF_ENTRY_OFFSET = HEADER_CRC_OFFSET + 4;
+    public static final int HEADER_TOTAL_BYTES_OFFSET = HEADER_NUM_OF_ENTRY_OFFSET + 4;
+    public static final int HEADER_EXTRA_HEADER_SIZE_OFFSET = HEADER_TOTAL_BYTES_OFFSET + 4;
+    public static final int HEADER_EXTRA_HEADER_CRC_OFFSET = HEADER_EXTRA_HEADER_SIZE_OFFSET + 4;
+    static final int SEGMENT_HEADER_BYTES = HEADER_EXTRA_HEADER_CRC_OFFSET + 4;
+    static final int HEADER_EXTRA_HEADER_OFFSET = SEGMENT_HEADER_BYTES;
 
-    static final int NO_FLAGS = 0;
-    static final int FLAG_COMPRESSED = 1;
+    static final char NO_FLAGS = 0;
+    static final char FLAG_COMPRESSED = 1;
 
     // Export Segment Entry Header layout (each segment has multiple entries):
     //  - crc of segment entry (4 bytes),
     //  - total bytes of the entry (4 bytes, compressed size if compression is enable),
-    //  - entry flag (4 bytes)
-    public static final int ENTRY_HEADER_CRC_OFFSET = 0;
-    public static final int ENTRY_HEADER_TOTAL_BYTES_OFFSET = 4;
-    public static final int ENTRY_HEADER_FLAG_OFFSET = 8;
-    public static final int ENTRY_HEADER_BYTES = 12;
+    //  - entry flag (2 bytes)
+    public static final int ENTRY_HEADER_START_OFFSET = 0;
+    public static final int ENTRY_HEADER_CRC_OFFSET = ENTRY_HEADER_START_OFFSET;
+    public static final int ENTRY_HEADER_TOTAL_BYTES_OFFSET = ENTRY_HEADER_CRC_OFFSET + 4;
+    public static final int ENTRY_HEADER_FLAG_OFFSET = ENTRY_HEADER_TOTAL_BYTES_OFFSET + 4;
+    public static final int ENTRY_HEADER_BYTES = ENTRY_HEADER_FLAG_OFFSET + 2;
 
     protected final File m_file;
 
@@ -70,14 +77,12 @@ public abstract class PBDSegment {
     protected FileChannel m_fc;
     //Avoid unnecessary sync with this flag
     protected boolean m_syncedSinceLastEdit = true;
-    protected CRC32 m_segmentHeaderCRC;
-    protected CRC32 m_entryCRC;
+    protected CRC32 m_crc;
 
     public PBDSegment(File file)
     {
         m_file = file;
-        m_segmentHeaderCRC = new CRC32();
-        m_entryCRC = new CRC32();
+        m_crc = new CRC32();
     }
 
     abstract long segmentIndex();
@@ -86,7 +91,7 @@ public abstract class PBDSegment {
 
     abstract void reset();
 
-    abstract int getNumEntries(boolean crcCheck) throws IOException;
+    abstract int getNumEntries() throws IOException;
 
     abstract boolean isBeingPolled();
 
@@ -101,11 +106,19 @@ public abstract class PBDSegment {
     abstract PBDSegmentReader getReader(String cursorId);
 
     /**
-     * @param forWrite    Open the file in read/write mode
-     * @param emptyFile   true to overwrite the header with 0 entries, essentially emptying the file
+     * Open and initialize this segment as a new segment
+     *
+     * @param compress whether or not entries should be compressed by default
      * @throws IOException
      */
-    abstract protected void openForWrite(boolean emptyFile) throws IOException;
+    abstract void openNewSegment(boolean compress) throws IOException;
+
+    /**
+     * Open the segment for read and possible truncation
+     *
+     * @throws IOException
+     */
+    abstract void openForTruncate() throws IOException;
 
     abstract void initNumEntries(int count, int size) throws IOException;
 
@@ -119,7 +132,7 @@ public abstract class PBDSegment {
 
     abstract boolean hasAllFinishedReading() throws IOException;
 
-    abstract boolean offer(DBBPool.BBContainer cont, boolean compress) throws IOException;
+    abstract boolean offer(DBBPool.BBContainer cont) throws IOException;
 
     abstract int offer(DeferredSerialization ds) throws IOException;
 
@@ -129,6 +142,13 @@ public abstract class PBDSegment {
     abstract protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry) throws IOException;
 
     abstract void writeExtraHeader(DeferredSerialization ds) throws IOException;
+
+    /**
+     * Force a read and validation of the header and any extra header metadata which might exist
+     *
+     * @throws IOException If there was an error reading or validating the header
+     */
+    abstract void validateHeader() throws IOException;
 
     /**
      * Parse the segment and truncate the file if necessary.
@@ -141,11 +161,12 @@ public abstract class PBDSegment {
         if (!m_closed) {
             close();
         }
-        openForWrite(false);
+        openForTruncate();
         PBDSegmentReader reader = openForRead(TRUNCATOR_CURSOR);
 
         // Do stuff
-        final int initialEntryCount = getNumEntries(true);
+        validateHeader();
+        final int initialEntryCount = getNumEntries();
         int entriesTruncated = 0;
         // Zero entry count means the segment is empty or corrupted, in both cases
         // the segment can be deleted.
@@ -213,68 +234,58 @@ public abstract class PBDSegment {
         int entriesScanned = reader.readIndex();
         reader.close();
         close();
-        // If we checksum the file and it looks good, mark as final
-        if (!isFinal() && entriesScanned == initialEntryCount) {
-            setFinal(true);
+        if (entriesTruncated == 0) {
+            int entriesNotScanned = initialEntryCount - entriesScanned;
+            // If we checksum the file and it looks good, mark as final
+            if (!isFinal() && entriesNotScanned == 0) {
+                setFinal(true);
+            }
+            return entriesNotScanned;
         }
 
         return entriesTruncated;
     }
 
     /**
-     * Parse the segment and truncate the file if necessary.
-     * @param truncator    A caller-supplied truncator that decides where in the segment to truncate
-     * @return The number of objects that was truncated. This number will be subtracted from the total number
-     * of available objects in the PBD. -1 means that this whole segment should be removed.
+     * Scan over all entries in a segment possibly truncating the segment if corruption is detected
+     *
+     * @param truncator A caller-supplied {@link BinaryDeque.BinaryDequeScanner} to scan the individual entries
+     * @return The number of objects that was truncated. This number will be subtracted from the total number of
+     *         available objects in the PBD.
      * @throws IOException
      */
-    ExportSequenceNumberTracker scan(BinaryDeque.BinaryDequeScanner scanner) throws IOException {
-        if (!m_closed) {
-            throw new IOException(("Segment should not be open before truncation"));
-        }
-
+    int scan(BinaryDeque.BinaryDequeScanner scanner) throws IOException {
         PBDSegmentReader reader = openForRead(SCANNER_CURSOR);
-        ExportSequenceNumberTracker tracker = new ExportSequenceNumberTracker();
-
-        DBBPool.BBContainer cont = null;
-        DBBPool.BBContainer schemaCont = null;
-        int initialEntryCount = getNumEntries(true);
-        if (initialEntryCount == 0) {
-            reader.close();
-            return tracker;
-        }
-        while (true) {
-            // Start to read a new segment
-            if (reader.readIndex() == 0) {
-                schemaCont = reader.getExtraHeader();
+        try {
+            validateHeader();
+            DBBPool.BBContainer cont = null;
+            int initialEntryCount = getNumEntries();
+            if (initialEntryCount == 0) {
+                return 0;
             }
-            cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, true);
-            if (cont == null) {
-                break;
-            }
-            try {
-                //Handoff the object to the truncator and await a decision
-                ExportSequenceNumberTracker retval = scanner.scan(cont);
-                tracker.mergeTracker(retval);
-
-            } finally {
-                cont.discard();
-                if (schemaCont != null) {
-                    schemaCont.discard();
-                    schemaCont = null;
+            while (true) {
+                cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, true);
+                if (cont == null) {
+                    break;
+                }
+                try {
+                    scanner.scan(cont);
+                } finally {
+                    cont.discard();
                 }
             }
-        }
-        int entriesScanned = reader.readIndex();
-        reader.close();
-        // Forcefully close the file
-        close();
-        // Scan through entire file, everything looks good
-        if (!isFinal() && entriesScanned == initialEntryCount) {
-            setFinal(true);
-        }
+            int entriesScanned = reader.readIndex();
 
-        return tracker;
+            // Scan through entire file, everything looks good
+            int entriesTruncated = initialEntryCount - entriesScanned;
+            if (!isFinal() && entriesTruncated == 0) {
+                setFinal(true);
+            }
+
+            return entriesTruncated;
+        } finally {
+            reader.purge();
+        }
     }
 
     /**

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -299,24 +299,29 @@ public abstract class PBDSegment {
      *
      * NOTES:
      *
-     * This is a best-effort feature: On any kind of I/O failure, the exception is swallowed and the
-     * operation is a no-op: this will be the case on filesystems that do no support extended file
-     * attributes. Also note that the {@code FileStore.supportsFileAttributeView} method does not provide
-     * a reliable way to test for the availability of the extended file attributes.
+     * This is a best-effort feature: On any kind of I/O failure, the exception is swallowed and the operation is a
+     * no-op: this will be the case on filesystems that do no support extended file attributes. Also note that the
+     * {@code FileStore.supportsFileAttributeView} method does not provide a reliable way to test for the availability
+     * of the extended file attributes.
      *
-     * Must be called with 'true' by segment owner when it has filled the segment, written all segment
-     * metadata, and after it has either closed or sync'd the segment file.
+     * Must be called with 'true' by segment owner when it has filled the segment, written all segment metadata, and
+     * after it has either closed or sync'd the segment file.
      *
      * Must be called with 'false' whenever opening segment for writing new data.
      *
-     * Note that all calls to 'setFinal' are done by the class owning the segment because the segment
-     * itself generally lacks context to decide whether it's final or not.
+     * Note that all calls to 'setFinal' are done by the class owning the segment because the segment itself generally
+     * lacks context to decide whether it's final or not.
      *
-     * @param isFinal   true if segment is set to final, false otherwise
+     * @param isFinal true if segment is set to final, false otherwise
+     * @throws IOException
      */
-    void setFinal(boolean isFinal) {
+    void setFinal(boolean isFinal) throws IOException {
         if (isFinal != m_isFinal) {
             if (setFinal(m_file, isFinal)) {
+                if (!isFinal) {
+                    // It is dangerous to leave final on a segment so make sure the metadata is flushed
+                    m_fc.force(true);
+                }
                 m_isFinal = isFinal;
             }
         }

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -75,6 +75,7 @@ public abstract class PBDSegment {
     protected FileChannel m_fc;
     //Avoid unnecessary sync with this flag
     protected boolean m_syncedSinceLastEdit = true;
+    // Reusable crc calculator. Must be reset before each use
     protected CRC32 m_crc;
     // Mirror of the isFinal metadata on the filesystem
     private boolean m_isFinal;

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -90,13 +90,18 @@ interface PBDSegmentReader {
     /**
      * Reopen a previously closed reader. Re-opened reader still keeps the original read offset.
      */
-    public void reopen(boolean forWrite, boolean emptyFile) throws IOException;
+    public void reopen() throws IOException;
 
     /**
-     * Close this reader and release any resources.
-     * <code>getReader</code> will still return this reader until the segment is closed.
+     * Close this reader and release any resources. {@link PBDSegment#getReader(String)} will still return this reader
+     * until the segment is closed.
      */
     public void close() throws IOException;
+
+    /**
+     * Similar to {@link #close()} but this reader will not be returned from {@link PBDSegment#getReader(String)}
+     */
+    public void purge() throws IOException;
 
     /**
      * Has this reader been closed.

--- a/src/frontend/org/voltdb/utils/PBDUtils.java
+++ b/src/frontend/org/voltdb/utils/PBDUtils.java
@@ -46,14 +46,22 @@ public class PBDUtils {
         buf.flip();
     }
 
-    public static void writeEntryHeader(CRC32 crc, ByteBuffer headerBuf,
-            ByteBuffer destBuf, int size, char flag) {
-        crc.update(size);
-        crc.update(flag);
+    public static int calculateEntryCrc(CRC32 crc, ByteBuffer destBuf, int entryId, char flags) {
+        crc.reset();
+        crc.update(destBuf.remaining());
+        crc.update(entryId);
+        crc.update(flags);
         crc.update(destBuf);
         // the checksum here is really an unsigned int, store integer to save 4 bytes
-        headerBuf.putInt((int)crc.getValue());
-        headerBuf.putInt(size);
+        return (int) crc.getValue();
+    }
+
+    public static void writeEntryHeader(CRC32 crc, ByteBuffer headerBuf,
+            ByteBuffer destBuf, int entryId, char flag) {
+        int length = destBuf.remaining();
+        headerBuf.putInt(calculateEntryCrc(crc, destBuf, entryId, flag));
+        headerBuf.putInt(length);
+        headerBuf.putInt(entryId);
         headerBuf.putChar(flag);
     }
 }

--- a/src/frontend/org/voltdb/utils/PBDUtils.java
+++ b/src/frontend/org/voltdb/utils/PBDUtils.java
@@ -47,13 +47,13 @@ public class PBDUtils {
     }
 
     public static void writeEntryHeader(CRC32 crc, ByteBuffer headerBuf,
-            ByteBuffer destBuf, int size, int flag) {
+            ByteBuffer destBuf, int size, char flag) {
         crc.update(size);
         crc.update(flag);
         crc.update(destBuf);
         // the checksum here is really an unsigned int, store integer to save 4 bytes
         headerBuf.putInt((int)crc.getValue());
         headerBuf.putInt(size);
-        headerBuf.putInt(flag);
+        headerBuf.putChar(flag);
     }
 }

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -508,7 +508,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
             // Handle common cases: no PBD files or just one
             if (filesById.size() == 0) {
-                m_usageSpecificLog.info("No PBD segments for " + m_nonce);
+                if (m_usageSpecificLog.isDebugEnabled()) {
+                    m_usageSpecificLog.debug("No PBD segments for " + m_nonce);
+                }
                 return;
             }
 
@@ -629,7 +631,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         assertions();
         if (m_segments.isEmpty()) {
-            m_usageSpecificLog.debug("PBD " + m_nonce + " has no finished segments");
+            if (m_usageSpecificLog.isDebugEnabled()) {
+                m_usageSpecificLog.debug("PBD " + m_nonce + " has no finished segments");
+            }
             return;
         }
 
@@ -1104,7 +1108,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
         m_readCursors.clear();
 
         for (PBDSegment qs : m_segments.values()) {
-            m_usageSpecificLog.debug("Segment " + qs.file() + " has been closed and deleted due to delete all");
+            if (m_usageSpecificLog.isDebugEnabled()) {
+                m_usageSpecificLog.debug("Segment " + qs.file() + " has been closed and deleted due to delete all");
+            }
             closeAndDeleteSegment(qs);
         }
         m_segments.clear();
@@ -1245,7 +1251,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         assertions();
         if (m_segments.isEmpty()) {
-            m_usageSpecificLog.debug("PBD " + m_nonce + " has no finished segments");
+            if (m_usageSpecificLog.isDebugEnabled()) {
+                m_usageSpecificLog.debug("PBD " + m_nonce + " has no finished segments");
+            }
             return new ExportSequenceNumberTracker();
         }
 

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -1243,7 +1243,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
     }
 
     @Override
-    public ExportSequenceNumberTracker scanForGap(BinaryDequeScanner scaner) throws IOException
+    public ExportSequenceNumberTracker scanForGap(BinaryDequeScanner scanner) throws IOException
     {
         if (m_closed) {
             throw new IOException("Cannot scanForGap(): PBD has been closed");
@@ -1266,7 +1266,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
          * Iterator all the objects in all the segments and pass them to the scanner
          */
         for (PBDSegment segment : m_segments.values()) {
-            ExportSequenceNumberTracker tracker = segment.scan(scaner);
+            ExportSequenceNumberTracker tracker = segment.scan(scanner);
             gapTracker.mergeTracker(tracker);
         }
         // Reopen the last segment for write

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -829,10 +829,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             closeAndDeleteSegment(tail);
             previousTailIsDeleted = true;
         } else {
-            tail.finalize();
-            if (!tail.isBeingPolled()) {
-                tail.close();
-            }
+            tail.finalize(!tail.isBeingPolled());
 
             if (m_usageSpecificLog.isDebugEnabled()) {
                 m_usageSpecificLog.debug(
@@ -926,8 +923,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             // If this segment is to become the writing segment, don't close and
             // finalize it.
             if (!m_segments.isEmpty()) {
-                writeSegment.finalize();
-                writeSegment.close();
+                writeSegment.finalize(true);
             }
 
             if (m_usageSpecificLog.isDebugEnabled()) {
@@ -1057,8 +1053,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
             // When closing a PBD, all segments may be finalized because on
             // recover a new segment will be opened for writing
-            segment.finalize();
-            segment.close();
+            segment.finalize(true);
             if (m_usageSpecificLog.isDebugEnabled()) {
                 m_usageSpecificLog.debug("Closed segment " + segment.file()
                     + " (final: " + segment.isFinal() + "), on PBD close");

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -1107,10 +1107,10 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         @Override
-        public int writeTruncatedObject(ByteBuffer output) {
+        public int writeTruncatedObject(ByteBuffer output, int entryId) {
             int objectSize = m_retval.remaining();
             // write entry header
-            PBDUtils.writeEntryHeader(m_crc, output, m_retval, objectSize, PBDSegment.NO_FLAGS);
+            PBDUtils.writeEntryHeader(m_crc, output, m_retval, entryId, PBDSegment.NO_FLAGS);
             // write buffer after resetting position changed by writeEntryHeader
             // Note: cannot do this in writeEntryHeader as it breaks JUnit tests
             m_retval.position(0);
@@ -1140,14 +1140,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         @Override
-        public int writeTruncatedObject(ByteBuffer output) throws IOException {
+        public int writeTruncatedObject(ByteBuffer output, int entryId) throws IOException {
             output.position(PBDSegment.ENTRY_HEADER_BYTES);
             int bytesWritten = MiscUtils.writeDeferredSerialization(output, m_ds);
             output.flip();
             output.position(PBDSegment.ENTRY_HEADER_BYTES);
             ByteBuffer header = output.duplicate();
             header.position(PBDSegment.ENTRY_HEADER_START_OFFSET);
-            PBDUtils.writeEntryHeader(m_crc32, header, output, bytesWritten, PBDSegment.NO_FLAGS);
+            PBDUtils.writeEntryHeader(m_crc32, header, output, entryId, PBDSegment.NO_FLAGS);
             if (m_truncationCallback != null) {
                 m_truncationCallback.bytesWritten(bytesWritten);
             }

--- a/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
+++ b/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
@@ -57,7 +57,7 @@ public class TestPBDMultipleReaders {
             boolean done = false;
             int numRead = 0;
             for (int i=m_totalRead; i<end && !done; i++) {
-                BBContainer bbC = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                BBContainer bbC = m_reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 if (bbC==null) {
                     done = true;
                     continue;
@@ -94,7 +94,9 @@ public class TestPBDMultipleReaders {
             for (int j=1; j<numReaders; j++) {
                 readers[j].readToEndOfSegment();
             }
-            if (i < numSegments-1) currNumSegments--;
+            if (i < numSegments-1) {
+                currNumSegments--;
+            }
             assertEquals(currNumSegments, TestPersistentBinaryDeque.getSortedDirectoryListing().size());
         }
     }
@@ -114,7 +116,7 @@ public class TestPBDMultipleReaders {
         }
 
         for (int j=0; j<numBuffers; j++) {
-            BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false );
+            BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
         }
         assertTrue(reader1.isEmpty());
@@ -143,7 +145,7 @@ public class TestPBDMultipleReaders {
         for (int i=0; i<3; i++) {
             for (int j=0; j<s_segmentFillCount; j++) {
                 m_pbd.offer( DBBPool.wrapBB(TestPersistentBinaryDeque.getFilledBuffer(j)) );
-                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
             }
             assertEquals(1, m_pbd.numOpenSegments());
@@ -165,13 +167,13 @@ public class TestPBDMultipleReaders {
         BinaryDequeReader reader = m_pbd.openForRead("reader0");
         for (int i=0; i<numSegments; i++) {
             for (int j=0; j<46; j++) {
-                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
             }
             int expected = (i == numSegments-1) ? 1 : 2;
             assertEquals(expected, m_pbd.numOpenSegments());
 
-            BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
             // there should only be 1 open because last discard closes and deletes
             assertEquals(1, m_pbd.numOpenSegments());
@@ -195,15 +197,15 @@ public class TestPBDMultipleReaders {
         // Position first reader0 on penultimate segment and reader1 on first segment
         for (int i=0; i<numSegments-1; i++) {
             for (int j=0; j<46; j++) {
-                BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
                 if (i==0) {
-                    bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                    bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                     bbC.discard();
                 }
             }
 
-            BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
             if (i==0) {
                 assertEquals(2, m_pbd.numOpenSegments());
@@ -212,7 +214,7 @@ public class TestPBDMultipleReaders {
             }
         }
 
-        BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+        BBContainer bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
         bbC.discard();
         // Both readers finished reading first segment, so that is closed and deleted,
         // which reduces the # of open segments by 1
@@ -221,13 +223,13 @@ public class TestPBDMultipleReaders {
         // reader0 at penultimate. Move reader1 through segments and check open segments
         for (int i=1; i<numSegments-1; i++) {
             for (int j=0; j<46; j++) {
-                bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+                bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
             }
             int expected = (i == numSegments-2) ? 2 : 3;
             assertEquals(expected, m_pbd.numOpenSegments());
 
-            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
             expected = (i == numSegments-2) ? 1 : 2;
             assertEquals(expected, m_pbd.numOpenSegments());
@@ -235,9 +237,9 @@ public class TestPBDMultipleReaders {
 
         // read the last segment
         for (int j=0; j<s_segmentFillCount; j++) {
-            bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
-            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             bbC.discard();
         }
         assertEquals(1, m_pbd.numOpenSegments());

--- a/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
+++ b/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
@@ -39,7 +39,8 @@ public class TestPBDMultipleReaders {
 
     private final static VoltLogger logger = new VoltLogger("EXPORT");
 
-    private static final int s_segmentFillCount = 47;
+    // Number of entries which fit in a segment. 64MB segment / (2MB entries + headers) = 31 entries per segment.
+    private static final int s_segmentFillCount = 31;
     private PersistentBinaryDeque m_pbd;
 
     private class PBDReader {
@@ -166,7 +167,7 @@ public class TestPBDMultipleReaders {
 
         BinaryDequeReader reader = m_pbd.openForRead("reader0");
         for (int i=0; i<numSegments; i++) {
-            for (int j=0; j<46; j++) {
+            for (int j = 0; j < s_segmentFillCount - 1; j++) {
                 BBContainer bbC = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
             }
@@ -196,7 +197,7 @@ public class TestPBDMultipleReaders {
         BinaryDequeReader reader1 = m_pbd.openForRead("reader1");
         // Position first reader0 on penultimate segment and reader1 on first segment
         for (int i=0; i<numSegments-1; i++) {
-            for (int j=0; j<46; j++) {
+            for (int j = 0; j < s_segmentFillCount - 1; j++) {
                 BBContainer bbC = reader0.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
                 if (i==0) {
@@ -222,7 +223,7 @@ public class TestPBDMultipleReaders {
 
         // reader0 at penultimate. Move reader1 through segments and check open segments
         for (int i=1; i<numSegments-1; i++) {
-            for (int j=0; j<46; j++) {
+            for (int j = 0; j < s_segmentFillCount - 1; j++) {
                 bbC = reader1.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
                 bbC.discard();
             }

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -1308,6 +1308,14 @@ public class TestPersistentBinaryDeque {
         runParseAndTruncateOnNewPbd();
     }
 
+    @Test
+    public void testCloseLastReader() throws Exception {
+        BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
+        pollOnceAndVerify(reader, null);
+        m_pbd.closeCursor(CURSOR_ID);
+        m_pbd.offer(defaultContainer());
+    }
+
     private void runParseAndTruncateOnNewPbd() throws IOException {
         PersistentBinaryDeque pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
         try {

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -1233,7 +1233,32 @@ public class TestPersistentBinaryDeque {
         }
     }
 
+    @Test
+    public void testPollingWithCrcCheck() throws Exception {
+
+        for (int i = 0; i < 5; ++i) {
+            m_pbd.offer(defaultContainer(), false);
+        }
+        for (int i = 0; i < 5; ++i) {
+            m_pbd.offer(defaultContainer(), true);
+        }
+        for (int i = 0; i < 10; ++i) {
+            m_pbd.offer(defaultContainer(), (i & 0x1) == 0x1);
+        }
+        BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
+
+        ByteBuffer entry = defaultBuffer();
+        for (int i = 0; i < 20; ++i) {
+            pollOnceAndVerify(reader, entry.asReadOnlyBuffer(), true);
+        }
+        assertNull(pollOnceWithoutDiscard(reader));
+    }
+
     private BBContainer pollOnceWithoutDiscard(BinaryDequeReader reader) throws IOException {
+        return pollOnceWithoutDiscard(reader, false);
+    }
+
+    private BBContainer pollOnceWithoutDiscard(BinaryDequeReader reader, boolean checkCrc) throws IOException {
         BBContainer schema = null;
         try {
             if (reader.isStartOfSegment()) {
@@ -1241,7 +1266,7 @@ public class TestPersistentBinaryDeque {
                 assertNotNull(schema);
                 assertFalse(reader.isEmpty());
             }
-            return reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            return reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, checkCrc);
         } finally {
             if (schema != null) {
                 schema.discard();
@@ -1250,42 +1275,24 @@ public class TestPersistentBinaryDeque {
     }
 
     private void pollOnce(BinaryDequeReader reader) throws IOException {
-        BBContainer schema = null;
-        BBContainer retval = null;
-        try {
-            if (reader.isStartOfSegment()) {
-                schema = reader.getExtraHeader(-1);
-                assertNotNull(schema);
-                assertFalse(reader.isEmpty());
-            }
-            retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
-        } finally {
-            if (retval != null) {
-                retval.discard();
-            }
-            if (schema != null) {
-                schema.discard();
-            }
+        BBContainer retval = pollOnceWithoutDiscard(reader);
+        if (retval != null) {
+            retval.discard();
         }
     }
 
     private void pollOnceAndVerify(BinaryDequeReader reader, ByteBuffer destBuf) throws IOException {
-        BBContainer schema = null;
-        BBContainer retval = null;
+        pollOnceAndVerify(reader, destBuf, false);
+    }
+
+    private void pollOnceAndVerify(BinaryDequeReader reader, ByteBuffer destBuf, boolean checkCrc) throws IOException {
+        BBContainer retval = pollOnceWithoutDiscard(reader, checkCrc);
         try {
-            if (reader.isStartOfSegment()) {
-                schema = reader.getExtraHeader(-1);
-                assertNotNull(schema);
-                assertFalse(reader.isEmpty());
-            }
-            retval = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, false);
+            assertNotNull(retval);
             assertEquals(destBuf, retval.b());
         } finally {
             if (retval != null) {
                 retval.discard();
-            }
-            if (schema != null) {
-                schema.discard();
             }
         }
     }


### PR DESCRIPTION
Add a length and CRC field in the header for the extra header
Remove checkCRC from the poll api since the only valid places to check crc are either parseAndTruncate and scanForGap
When a CRC error is found in a segment entry report back to the PBD the number of entries truncated
Only mark a segment final if all of the data has been syned to disk and there were no errors writing the data