### PR TITLE
ENG-15711:

### DIFF
--- a/tests/ee/storage/DRTupleStream_test.cpp
+++ b/tests/ee/storage/DRTupleStream_test.cpp
@@ -530,14 +530,14 @@ TEST_F(DRTupleStreamTest, TupleLargerThanDefaultSize)
 TEST_F(DRTupleStreamTest, BigTxnsRollBuffers)
 {
     int tuples_to_fill = (LARGE_BUFFER_SIZE - MAGIC_TRANSACTION_SIZE) / MAGIC_TUPLE_SIZE;
-    const StreamBlock *firstBlock = m_wrapper.getCurrBlockForTest();
+    const StreamBlock *firstBlock = m_wrapper.getCurrBlock();
     const StreamBlock *secondBlock = NULL;
 
     // fill one large buffer
     for (;;) {
         appendTuple(0, 1);
-        if (m_wrapper.getCurrBlockForTest() != firstBlock) {
-            secondBlock = m_wrapper.getCurrBlockForTest();
+        if (m_wrapper.getCurrBlock() != firstBlock) {
+            secondBlock = m_wrapper.getCurrBlock();
             EXPECT_EQ(LARGE_STREAM_BLOCK, secondBlock->type());
             break;
         }
@@ -553,8 +553,8 @@ TEST_F(DRTupleStreamTest, BigTxnsRollBuffers)
     m_wrapper.endTransaction(addPartitionId(2));
 
     // make sure we rolled, and the new buffer is a large buffer
-    EXPECT_NE(secondBlock, m_wrapper.getCurrBlockForTest());
-    EXPECT_EQ(LARGE_STREAM_BLOCK, m_wrapper.getCurrBlockForTest()->type());
+    EXPECT_NE(secondBlock, m_wrapper.getCurrBlock());
+    EXPECT_EQ(LARGE_STREAM_BLOCK, m_wrapper.getCurrBlock()->type());
 
     m_wrapper.periodicFlush(-1, addPartitionId(2));
 
@@ -758,8 +758,8 @@ TEST_F(DRTupleStreamTest, BigBufferAfterExtendOnBeginTxn) {
         appendTuple(1, 2);
     }
     m_wrapper.endTransaction(addPartitionId(2));
-    ASSERT_TRUE(m_wrapper.getCurrBlockForTest());
-    ASSERT_TRUE(m_wrapper.getCurrBlockForTest()->remaining() < MAGIC_BEGIN_TRANSACTION_SIZE);
+    ASSERT_TRUE(m_wrapper.getCurrBlock());
+    ASSERT_TRUE(m_wrapper.getCurrBlock()->remaining() < MAGIC_BEGIN_TRANSACTION_SIZE);
 
     appendTuple(2, 3);
 
@@ -771,7 +771,7 @@ TEST_F(DRTupleStreamTest, BigBufferAfterExtendOnBeginTxn) {
     for (int i = 1; i < tuples_to_fill; i++) {
         appendTuple(2, 3);
     }
-    ASSERT_TRUE(m_wrapper.getCurrBlockForTest()->remaining() - MAGIC_END_TRANSACTION_SIZE < MAGIC_TUPLE_SIZE);
+    ASSERT_TRUE(m_wrapper.getCurrBlock()->remaining() - MAGIC_END_TRANSACTION_SIZE < MAGIC_TUPLE_SIZE);
 
     appendTuple(2, 3);
     m_wrapper.endTransaction(addPartitionId(3));

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -642,7 +642,7 @@ TEST_F(ExportTupleStreamTest, RollbackWholeBufferRowByRow)
     }
 
     ASSERT_FALSE(m_topend.receivedExportBuffer);
-    ASSERT_EQ(m_wrapper->getCurrBlockForTest()->getRowCount(), 3);
+    ASSERT_EQ(m_wrapper->getCurrBlock()->getRowCount(), 3);
     ASSERT_TRUE(checkTargetFlushTime(1));
     periodicFlush(-1, 3);
     ASSERT_TRUE(testNoStreamsToFlush());
@@ -676,7 +676,7 @@ TEST_F(ExportTupleStreamTest, RollbackWholeBufferByTxn)
     rollbackExportTo(lastAppendTupleMarker);
 
     ASSERT_FALSE(m_topend.receivedExportBuffer);
-    ASSERT_EQ(m_wrapper->getCurrBlockForTest()->getRowCount(), 3);
+    ASSERT_EQ(m_wrapper->getCurrBlock()->getRowCount(), 3);
     ASSERT_TRUE(checkTargetFlushTime(1));
     periodicFlush(-1, 3);
     ASSERT_TRUE(testNoStreamsToFlush());
@@ -721,14 +721,14 @@ TEST_F(ExportTupleStreamTest, PartialRollback)
     m_wrapper->rollbackExportTo(mark, seqNo);
     ASSERT_TRUE(checkTargetFlushTime(1));
     commit(11);
-    EXPECT_GT(m_wrapper->getCurrBlockForTest()->getRowCount(), 0);
+    EXPECT_GT(m_wrapper->getCurrBlock()->getRowCount(), 0);
     // Commit flushes the first buffer but leaves the tail of 11 (single row) as m_currBlock
     ASSERT_TRUE(m_topend.receivedExportBuffer);
     m_wrapper->periodicFlush(-1, 11);
     ASSERT_TRUE(m_topend.receivedExportBuffer);
     boost::shared_ptr<ExportStreamBlock> results = m_topend.exportBlocks.front();
     m_topend.exportBlocks.pop_front();
-    EXPECT_EQ(m_wrapper->getCurrBlockForTest()->getRowCount(), 0);
+    EXPECT_EQ(m_wrapper->getCurrBlock()->getRowCount(), 0);
     EXPECT_EQ(results->uso(), 0);
     EXPECT_EQ(results->offset(), (m_tupleSize * m_tuplesToFill));
     EXPECT_EQ(results->getRowCount(), m_tuplesToFill);


### PR DESCRIPTION
Fix Cpp Unit tests that were using a test function but that is now used in other paths and therefore renamed.