### PR TITLE
ENG-15503: fix 2 more grammar-gen failures due to sqlcmd hanging

### DIFF
--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -1361,6 +1361,8 @@ if __name__ == "__main__":
                             ['failed to create the transaction internally'],
                             ['ParameterValueExpression', 'cannot be cast', 'TupleValueExpression'],
                             ['SQL Aggregate function calls with subquery expression arguments are not allowed'],
+                            ['Column', 'not found', 'Please update your query'],
+                            ['Index: 0, Size: 0'],    # See ENG-15736
                            ]
 
     # A list of headers found in responses to valid 'show' commands: one of


### PR DESCRIPTION
... by adding 2 more missing error messages that currently go unrecognized.