### PR TITLE
PBD quarantine unreadable

### DIFF
--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -89,13 +89,12 @@ class PBDRegularSegment extends PBDSegment {
     }
 
     @Override
-    long segmentId() {
+    public long segmentId() {
         return m_id;
     }
 
     @Override
-    File file()
-    {
+    public File file() {
         return m_file;
     }
 

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -172,9 +172,11 @@ public abstract class PBDSegment {
 
     /**
      * Parse the segment and truncate the file if necessary.
-     * @param truncator    A caller-supplied truncator that decides where in the segment to truncate
-     * @return The number of objects that was truncated. This number will be subtracted from the total number
-     * of available objects in the PBD. -1 means that this whole segment should be removed.
+     *
+     * @param truncator A caller-supplied truncator that decides where in the segment to truncate
+     * @return The number of objects that was truncated. This number will be subtracted from the total number of
+     *         available objects in the PBD. {@link Integer#MAX_VALUE} means that this whole segment should be removed.
+     *         A negative value means that the entries were truncated because of corruption and not {@code truncator}
      * @throws IOException
      */
     int parseAndTruncate(BinaryDeque.BinaryDequeTruncator truncator) throws IOException {
@@ -193,7 +195,7 @@ public abstract class PBDSegment {
         if (initialEntryCount == 0) {
             reader.close();
             close();
-            return -1;
+            return Integer.MAX_VALUE;
         }
         int sizeInBytes = 0;
 
@@ -260,7 +262,7 @@ public abstract class PBDSegment {
             if (!isFinal() && entriesNotScanned == 0) {
                 finalize(true);
             }
-            return entriesNotScanned;
+            return -entriesNotScanned;
         }
 
         close();

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -338,8 +338,11 @@ public abstract class PBDSegment {
                     // It is dangerous to leave final on a segment so make sure the metadata is flushed
                     m_fc.force(true);
                 }
-                m_isFinal = isFinal;
+            } else if (isFinal(m_file) && !isFinal) {
+                throw new IOException("Could not remove the final attribute from " + m_file.getName());
             }
+            // It is OK for m_isFinal to be true when isFinal(File) returns false but not the other way
+            m_isFinal = isFinal;
         }
     }
 
@@ -387,8 +390,8 @@ public abstract class PBDSegment {
             UserDefinedFileAttributeView view = getFileAttributeView(file);
             if (view != null) {
                 view.write(IS_FINAL_ATTRIBUTE, Charset.defaultCharset().encode(Boolean.toString(isFinal)));
+                return true;
             }
-            return true;
         } catch (IOException e) {
             // No-op
         }

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -30,7 +30,7 @@ import java.util.zip.CRC32;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DeferredSerialization;
 
-public abstract class PBDSegment {
+public abstract class PBDSegment implements PbdSegmentInfo {
 
     private static final String TRUNCATOR_CURSOR = "__truncator__";
     private static final String SCANNER_CURSOR = "__scanner__";
@@ -94,8 +94,6 @@ public abstract class PBDSegment {
     }
 
     abstract long segmentIndex();
-    abstract long segmentId();
-    abstract File file();
 
     abstract void reset();
 

--- a/src/frontend/org/voltdb/utils/PbdSegmentInfo.java
+++ b/src/frontend/org/voltdb/utils/PbdSegmentInfo.java
@@ -1,0 +1,35 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.utils;
+
+import java.io.File;
+
+/**
+ * Basic interface for segment information
+ */
+interface PbdSegmentInfo {
+    /**
+     * @return {@link File} instance for the segment
+     */
+    File file();
+
+    /**
+     * @return ID of the segment
+     */
+    long segmentId();
+}

--- a/src/frontend/org/voltdb/utils/PbdSegmentName.java
+++ b/src/frontend/org/voltdb/utils/PbdSegmentName.java
@@ -32,40 +32,65 @@ import org.voltcore.logging.VoltLogger;
  * <li>previousCounter = Value of monotonic counter at previous PBD segment creation
  * </ul>
  */
-public class PbdSegmentName {
+public class PbdSegmentName implements PbdSegmentInfo {
     private static final String PBD_SUFFIX = ".pbd";
+    private static final String PBD_QUARANTINED = "_q";
     private static final MessageFormat FORMAT = new MessageFormat(
-            "{0}_{1,number,0000000000}_{2,number,0000000000}" + PBD_SUFFIX);
+            "{0}_{1,number,0000000000}_{2,number,0000000000}{3}" + PBD_SUFFIX);
 
     private static final PbdSegmentName NOT_PBD = new PbdSegmentName(Result.NOT_PBD);
     private static final PbdSegmentName INVALID_NAME = new PbdSegmentName(Result.INVALID_NAME);
 
     /** The result of parsing a file name. The other fields are only valid if the result is {@link Result#OK} */
     public final Result m_result;
+    /** File which was parsed to generate this segment name instance */
+    public final File m_file;
     /** The nonce of the segment */
     public final String m_nonce;
     /** The id of this segment */
     public final long m_id;
     /** The id of the previous segment */
     public final long m_prevId;
+    /** Whether or not this PBD segment was marked quarantined */
+    public final boolean m_quarantined;
 
-    public static String createName(String nonce, long id, long prevId) {
-        return FORMAT.format(new Object[] { nonce, id, prevId });
+    public static String createName(String nonce, long id, long prevId, boolean quarantine) {
+        return FORMAT.format(new Object[] { nonce, id, prevId, quarantine ? PBD_QUARANTINED : "" });
+    }
+
+    public static PbdSegmentName asQuarantinedSegment(VoltLogger logger, File file) {
+        PbdSegmentName current = parseFile(logger, file);
+        if (current.m_result != Result.OK) {
+            throw new IllegalArgumentException("File is not a valid pbd: " + file);
+        }
+
+        if (current.m_quarantined) {
+            throw new IllegalArgumentException("File is already quarantined: " + file);
+        }
+
+        File quarantinedFile = new File(file.getParentFile(),
+                createName(current.m_nonce, current.m_id, current.m_prevId, true));
+        return new PbdSegmentName(quarantinedFile, current.m_nonce, current.m_id, current.m_prevId, true);
     }
 
     public static PbdSegmentName parseFile(VoltLogger logger, File file) {
-        return parseName(logger, file.getName());
-    }
-
-    public static PbdSegmentName parseName(VoltLogger logger, String fileName) {
+        String fileName = file.getName();
         if (!fileName.endsWith(PBD_SUFFIX)) {
             if (logger.isTraceEnabled()) {
                 logger.trace("File " + fileName + " is not a pbd");
             }
             return NOT_PBD;
         }
-        int fileNameLength = fileName.length() - PBD_SUFFIX.length();
-        int startOfPrevId = fileName.lastIndexOf('_');
+        int endOfPrevId = fileName.length() - PBD_SUFFIX.length();
+
+        boolean quarantined = false;
+        if (fileName.regionMatches(endOfPrevId - PBD_QUARANTINED.length(), PBD_QUARANTINED, 0,
+                PBD_QUARANTINED.length())) {
+            quarantined = true;
+            endOfPrevId -= PBD_QUARANTINED.length();
+        }
+
+        int startOfPrevId = fileName.lastIndexOf('_', endOfPrevId - 1);
         if (startOfPrevId <= 0) {
             if (logger.isTraceEnabled()) {
                 logger.trace("File " + fileName + " does not have a _ in it for previous id");
@@ -83,27 +108,41 @@ public class PbdSegmentName {
         long id, prevId;
         try {
             id = Long.parseLong(fileName.substring(startOfId + 1, startOfPrevId));
-            prevId = Long.parseLong(fileName.substring(startOfPrevId + 1, fileNameLength));
+            prevId = Long.parseLong(fileName.substring(startOfPrevId + 1, endOfPrevId));
         } catch (NumberFormatException e) {
             logger.warn("Failed to parse IDs in " + fileName);
             return INVALID_NAME;
         }
 
-        return new PbdSegmentName(fileName.substring(0, startOfId), id, prevId);
+        return new PbdSegmentName(file, fileName.substring(0, startOfId), id, prevId, quarantined);
     }
 
     private PbdSegmentName(Result result) {
-        this.m_result = result;
-        this.m_nonce = null;
-        this.m_id = -1;
-        this.m_prevId = -1;
+        m_result = result;
+        m_file = null;
+        m_nonce = null;
+        m_id = -1;
+        m_prevId = -1;
+        m_quarantined = false;
     }
 
-    private PbdSegmentName(String m_nonce, long m_id, long m_prevId) {
-        this.m_result = Result.OK;
-        this.m_nonce = m_nonce;
-        this.m_id = m_id;
-        this.m_prevId = m_prevId;
+    private PbdSegmentName(File file, String nonce, long id, long prevId, boolean quarantined) {
+        m_result = Result.OK;
+        m_file = file;
+        m_nonce = nonce;
+        m_id = id;
+        m_prevId = prevId;
+        m_quarantined = quarantined;
+    }
+
+    @Override
+    public File file() {
+        return m_file;
+    }
+
+    @Override
+    public long segmentId() {
+        return m_id;
     }
 
     public enum Result {

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -649,15 +649,17 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
             final int truncatedEntries = segment.parseAndTruncate(truncator);
 
-            if (truncatedEntries == -1) {
+            if (truncatedEntries == Integer.MAX_VALUE) {
                 // This whole segment will be truncated in the truncation loop below
                 lastSegmentIndex = segmentIndex - 1;
                 break;
-            } else if (truncatedEntries > 0) {
-                m_numObjects -= truncatedEntries;
-                //Set last segment and break the loop over this segment
-                lastSegmentIndex = segmentIndex;
-                break;
+            } else if (truncatedEntries != 0) {
+                m_numObjects -= Math.abs(truncatedEntries);
+                if (truncatedEntries > 0) {
+                    // Set last segment and break the loop over this segment
+                    lastSegmentIndex = segmentIndex;
+                    break;
+                }
             }
             // truncatedEntries == 0 means nothing is truncated in this segment,
             // should move on to the next segment.

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -50,9 +50,10 @@ import com.google_voltpatches.common.base.Throwables;
  *
  */
 public class PersistentBinaryDeque implements BinaryDeque {
-    private static final VoltLogger LOG = new VoltLogger("HOST");
 
     public static class UnsafeOutputContainerFactory implements OutputContainerFactory {
+        private static final VoltLogger LOG = new VoltLogger("HOST");
+
         @Override
         public BBContainer getContainer(int minimumSize) {
               final BBContainer origin = DBBPool.allocateUnsafeByteBuffer(minimumSize);
@@ -276,7 +277,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                                 closeAndDeleteSegment(segment);
                             }
                         } catch (IOException e) {
-                            LOG.error("Exception closing and deleting PBD segment", e);
+                            m_usageSpecificLog.error("Exception closing and deleting PBD segment", e);
                         }
                     }
                 }
@@ -544,7 +545,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 }
             }
         } catch (CyclicSequenceException e) {
-            LOG.error("Failed to parse files: " + e);
+            m_usageSpecificLog.error("Failed to parse files: " + e);
             throw new IOException(e);
         } catch (RuntimeException e) {
             if (e.getCause() instanceof IOException) {
@@ -603,7 +604,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         // Any recovered segment that is not final should be checked
         // for internal consistency.
         if (!qs.isFinal()) {
-            LOG.warn("Segment " + qs.file()
+            m_usageSpecificLog.warn("Segment " + qs.file()
             + " (final: " + qs.isFinal() + "), has been recovered but is not in a final state");
         } else if (m_usageSpecificLog.isDebugEnabled()) {
             m_usageSpecificLog.debug("Segment " + qs.file()
@@ -1000,7 +1001,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             }
         }
         catch (IOException e) {
-            LOG.error("Exception closing and deleting PBD segment", e);
+            m_usageSpecificLog.error("Exception closing and deleting PBD segment", e);
         }
     }
 

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -442,7 +442,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
      * @return  segment file name
      */
     private String getSegmentFileName(long currentId, long previousId) {
-        return PbdSegmentName.createName(m_nonce, currentId, previousId);
+        return PbdSegmentName.createName(m_nonce, currentId, previousId, false);
     }
 
     /**

--- a/tests/frontend/org/voltdb/utils/TestPbdSegmentName.java
+++ b/tests/frontend/org/voltdb/utils/TestPbdSegmentName.java
@@ -1,0 +1,103 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.voltcore.logging.VoltLogger;
+
+public class TestPbdSegmentName {
+    private static final VoltLogger LOG = new VoltLogger("DUMMY");
+
+    @Test
+    public void testValidPbdName() {
+        assertPbdSegmentNameDeserialize("abc_def_123_456.pbd", "abc_def", 123, 456, false);
+        assertPbdSegmentNameDeserialize("abc_def_123_456_q.pbd", "abc_def", 123, 456, true);
+    }
+
+    @Test
+    public void testCreateParseName() {
+        long id = 987654156L;
+        long prevId = 21654564L;
+        assertPbdSegmentNameSerializeDeserialize("this_is_my_nonce", id, prevId, false);
+        assertPbdSegmentNameSerializeDeserialize("this_is_my_nonce", id, prevId, true);
+    }
+
+    @Test
+    public void testNotPbd() {
+        for (String name : new String[] { "dkjashfdkjasfkldsjf;dsfja", "dkjashfdkjasf.pbdkldsjf;dsfja",
+                "dkjashfdkjasfkldsjf;dsfja.pb", "dkjashfdkjasfkldsjf;dsfja.pbda", "", "dkjashfdkjasfkldsjf;dsfjapbd",
+                "pbd" }) {
+            assertResult(PbdSegmentName.Result.NOT_PBD, name);
+        }
+    }
+
+    @Test
+    public void testInvalidName() {
+        for (String name : new String[] { ".pbd", "abc.pbd", "abc_123.pbd", "abc_abc_123.pbd",
+                "nonce_1234_456_a.pbd" }) {
+            assertResult(PbdSegmentName.Result.INVALID_NAME, name);
+        }
+    }
+
+    @Test
+    public void testAsQuarantinedFile() {
+        assertEquals(new File("a/b/c/abc_def_0000000123_0000000456_q.pbd"),
+                PbdSegmentName.asQuarantinedSegment(LOG, new File("a/b/c/abc_def_123_456.pbd")).file());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testQuarantineNonPbd() {
+        PbdSegmentName.asQuarantinedSegment(LOG, new File("abc_def_123_456.exe"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testQuarantineQuarantinedSegment() {
+        PbdSegmentName.asQuarantinedSegment(LOG, new File("abc_def_123_456_q.pbd"));
+    }
+
+    private static void assertPbdSegmentNameSerializeDeserialize(String nonce, long id, long prevId,
+            boolean quarantine) {
+        assertPbdSegmentNameDeserialize(PbdSegmentName.createName(nonce, id, prevId, quarantine), nonce, id, prevId,
+                quarantine);
+    }
+
+    private static void assertPbdSegmentNameDeserialize(String name, String nonce, long id, long prevId,
+            boolean quarantine) {
+        PbdSegmentName pbdSegmentName = assertResult(PbdSegmentName.Result.OK, name);
+        assertEquals(nonce, pbdSegmentName.m_nonce);
+        assertEquals(id, pbdSegmentName.m_id);
+        assertEquals(prevId, pbdSegmentName.m_prevId);
+        assertEquals(quarantine, pbdSegmentName.m_quarantined);
+    }
+
+    private static PbdSegmentName assertResult(PbdSegmentName.Result expected, String name) {
+        PbdSegmentName pbdSegmentName = PbdSegmentName.parseFile(LOG, new File(name));
+        assertEquals(name, expected, pbdSegmentName.m_result);
+        return pbdSegmentName;
+    }
+}

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -33,18 +33,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.FileChannel;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.NavigableMap;
 import java.util.Random;
 import java.util.Set;
 
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,11 +64,11 @@ public class TestPersistentBinaryDeque {
     private static final String CURSOR_ID = "testPBD";
     private final static VoltLogger logger = new VoltLogger("EXPORT");
 
-    private static ByteBuffer defaultBuffer() {
+    static ByteBuffer defaultBuffer() {
         return getFilledBuffer(42);
     }
 
-    private static BBContainer defaultContainer() {
+    static BBContainer defaultContainer() {
         return DBBPool.wrapBB(defaultBuffer());
     }
 
@@ -1239,76 +1234,6 @@ public class TestPersistentBinaryDeque {
     }
 
     @Test
-    public void testCorruptedEntryWithParseAndTruncate() throws Exception {
-        m_pbd.offer(defaultContainer());
-        corruptLastSegment(ByteBuffer.allocateDirect(35), -35);
-
-        runParseAndTruncateOnNewPbd();
-    }
-
-    @Test
-    public void testCorruptedEntryWithScanForGap() throws Exception {
-        m_pbd.offer(defaultContainer());
-        corruptLastSegment(ByteBuffer.allocateDirect(35), -35);
-
-        runScanForGapOnNewPbd();
-    }
-
-    @Test
-    public void testCorruptedEntryLengthWithParseAndTruncate() throws Exception {
-        // set no extraHeader so it is easier to find the first entry header
-        m_pbd.updateExtraHeader(null);
-
-        BBContainer container = defaultContainer();
-        int origLength = container.b().remaining();
-        m_pbd.offer(container);
-
-        ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
-        bb.putInt(origLength - 100);
-        bb.flip();
-        corruptLastSegment(bb, PBDSegment.SEGMENT_HEADER_BYTES + PBDSegment.ENTRY_HEADER_TOTAL_BYTES_OFFSET);
-
-        runParseAndTruncateOnNewPbd();
-    }
-
-    @Test
-    public void testCorruptedEntryLengthWithScanForGap() throws Exception {
-        // set no extraHeader so it is easier to find the first entry header
-        m_pbd.updateExtraHeader(null);
-
-        BBContainer container = defaultContainer();
-        int origLength = container.b().remaining();
-        m_pbd.offer(container);
-
-        ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
-        bb.putInt(origLength - 100);
-        bb.flip();
-        corruptLastSegment(bb, PBDSegment.SEGMENT_HEADER_BYTES + PBDSegment.ENTRY_HEADER_TOTAL_BYTES_OFFSET);
-
-        runScanForGapOnNewPbd();
-    }
-
-    @Test
-    public void testCorruptSegmentHeaderWithParseAndTruncate() throws Exception {
-        m_pbd.offer(defaultContainer());
-        ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
-        bb.putInt(100);
-        bb.flip();
-        corruptLastSegment(bb, PBDSegment.HEADER_NUM_OF_ENTRY_OFFSET);
-
-        runParseAndTruncateOnNewPbd();
-    }
-
-    @Test
-    public void testCorruptExtraHeaderWithParseAndTruncate() throws Exception {
-        m_pbd.offer(defaultContainer());
-        ByteBuffer bb = ByteBuffer.allocateDirect(40);
-        corruptLastSegment(bb, PBDSegment.HEADER_EXTRA_HEADER_OFFSET + 15);
-
-        runParseAndTruncateOnNewPbd();
-    }
-
-    @Test
     public void testCloseLastReader() throws Exception {
         BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
         pollOnceAndVerify(reader, null);
@@ -1316,44 +1241,7 @@ public class TestPersistentBinaryDeque {
         m_pbd.offer(defaultContainer());
     }
 
-    private void runParseAndTruncateOnNewPbd() throws IOException {
-        PersistentBinaryDeque pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
-        try {
-            pbd.parseAndTruncate(b -> null);
-            pollOnceAndVerify(pbd.openForRead(CURSOR_ID), null);
-            pbd.offer(defaultContainer());
-            pollOnceAndVerify(pbd.openForRead(CURSOR_ID), defaultBuffer());
-        } finally {
-            pbd.close();
-        }
-    }
-
-    private void runScanForGapOnNewPbd() throws IOException {
-        PersistentBinaryDeque pbd = new PersistentBinaryDeque(TEST_NONCE, m_ds, TEST_DIR, logger);
-        try {
-            pbd.scanEntries(b -> {});
-            pollOnceAndVerify(pbd.openForRead(CURSOR_ID), null);
-            pbd.offer(defaultContainer());
-            pollOnceAndVerify(pbd.openForRead(CURSOR_ID), defaultBuffer());
-        } finally {
-            pbd.close();
-        }
-    }
-
-    private void corruptLastSegment(ByteBuffer corruptData, int position) throws Exception {
-        File file = getSegmentMap().lastEntry().getValue().file();
-        try (FileChannel channel = FileChannel.open(Paths.get(file.getPath()), StandardOpenOption.WRITE)) {
-            channel.write(corruptData, position < 0 ? channel.size() + position : position);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private NavigableMap<Long, PBDSegment> getSegmentMap() throws IllegalArgumentException, IllegalAccessException {
-        return ((NavigableMap<Long, PBDSegment>) FieldUtils
-                .getDeclaredField(PersistentBinaryDeque.class, "m_segments", true).get(m_pbd));
-    }
-
-    private BBContainer pollOnceWithoutDiscard(BinaryDequeReader reader) throws IOException {
+    static BBContainer pollOnceWithoutDiscard(BinaryDequeReader reader) throws IOException {
         BBContainer schema = null;
         try {
             if (reader.isStartOfSegment()) {
@@ -1369,14 +1257,14 @@ public class TestPersistentBinaryDeque {
         }
     }
 
-    private void pollOnce(BinaryDequeReader reader) throws IOException {
+    static void pollOnce(BinaryDequeReader reader) throws IOException {
         BBContainer retval = pollOnceWithoutDiscard(reader);
         if (retval != null) {
             retval.discard();
         }
     }
 
-    private void pollOnceAndVerify(BinaryDequeReader reader, ByteBuffer destBuf) throws IOException {
+    static void pollOnceAndVerify(BinaryDequeReader reader, ByteBuffer destBuf) throws IOException {
         BBContainer retval = pollOnceWithoutDiscard(reader);
         try {
             if (destBuf == null) {

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -1288,7 +1288,7 @@ public class TestPersistentBinaryDeque {
         runScanForGapOnNewPbd();
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testCorruptSegmentHeaderWithParseAndTruncate() throws Exception {
         m_pbd.offer(defaultContainer());
         ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
@@ -1299,7 +1299,7 @@ public class TestPersistentBinaryDeque {
         runParseAndTruncateOnNewPbd();
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testCorruptExtraHeaderWithParseAndTruncate() throws Exception {
         m_pbd.offer(defaultContainer());
         ByteBuffer bb = ByteBuffer.allocateDirect(40);

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDequeCorruption.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDequeCorruption.java
@@ -1,0 +1,428 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.voltdb.utils.TestPersistentBinaryDeque.defaultBuffer;
+import static org.voltdb.utils.TestPersistentBinaryDeque.defaultContainer;
+import static org.voltdb.utils.TestPersistentBinaryDeque.pollOnceAndVerify;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.NavigableMap;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.voltcore.logging.VoltLogger;
+import org.voltcore.utils.DBBPool.BBContainer;
+import org.voltcore.utils.DeferredSerialization;
+import org.voltdb.test.utils.RandomTestRule;
+
+import com.google_voltpatches.common.collect.ImmutableList;
+
+/**
+ * Test handling of different types of PBD corruption using the two detection mechanisms
+ * {@link PersistentBinaryDeque#parseAndTruncate(org.voltdb.utils.BinaryDeque.BinaryDequeTruncator)} and
+ * {@link PersistentBinaryDeque#scanEntries(org.voltdb.utils.BinaryDeque.BinaryDequeScanner)}
+ */
+@RunWith(Parameterized.class)
+public class TestPersistentBinaryDequeCorruption {
+    private static final VoltLogger LOG = new VoltLogger("TEST");
+    private static final String TEST_NONCE = "pbd_nonce";
+    private static final String CURSOR_ID = "TestPersistentBinaryDequeCorruption";
+
+    private static int ENTRY_COUNT = 10;
+    private static int ENTRY_FIRST = 1;
+    private static int ENTRY_MIDDLE = ENTRY_COUNT / 2;
+    private static int ENTRY_LAST = ENTRY_COUNT;
+
+    @Rule
+    public final TemporaryFolder testDir = new TemporaryFolder();
+
+    @Rule
+    public final RandomTestRule random = new RandomTestRule();
+
+    private final CorruptionChecker m_checker;
+    private PersistentBinaryDeque m_pbd;
+    private DeferredSerialization m_ds;
+
+    @Parameters
+    public static Collection<Object[]> parameters() {
+        CorruptionChecker scanEntries = pbd -> pbd.scanEntries(b -> {});
+        CorruptionChecker parseAndTruncate = pbd -> pbd.parseAndTruncate(b -> null);
+        return ImmutableList.of(new Object[] { scanEntries }, new Object[] { parseAndTruncate });
+    }
+
+    public TestPersistentBinaryDequeCorruption(CorruptionChecker checker) {
+        m_checker = checker;
+    }
+
+    @Before
+    public void setup() throws IOException {
+        m_ds = new DeferredSerialization() {
+            private final ByteBuffer data = ByteBuffer.allocate(245);
+
+            {
+                random.nextBytes(data.array());
+            }
+
+            @Override
+            public void serialize(ByteBuffer buf) throws IOException {
+                data.rewind();
+                buf.put(data);
+            }
+
+            @Override
+            public int getSerializedSize() throws IOException {
+                return data.limit();
+            }
+
+            @Override
+            public void cancel() {}
+        };
+        m_pbd = newPbd();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        m_pbd.close();
+    }
+
+    /**
+     * Test handling of a corrupt entry at start of segment
+     */
+    @Test
+    public void testCorruptedEntryFirst() throws Exception {
+        testCorruptedEntry(ENTRY_FIRST);
+    }
+
+    /**
+     * Test handling of a corrupt entry in the middle of the segment
+     */
+    @Test
+    public void testCorruptedEntryMiddle() throws Exception {
+        testCorruptedEntry(ENTRY_MIDDLE);
+    }
+
+    /**
+     * Test handling of a corrupt entry at the end of the segment
+     */
+    @Test
+    public void testCorruptedEntryLast() throws Exception {
+        testCorruptedEntry(ENTRY_LAST);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the first entry is shorter
+     */
+    @Test
+    public void testCorruptedEntryLengthShorterFirstEntry() throws Exception {
+        testCorruptedLength(ENTRY_FIRST, -100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the first entry is longer than the remainder of the
+     * file
+     */
+    @Test
+    public void testCorruptedEntryLengthLongerFirstEntry() throws Exception {
+        testCorruptedLength(ENTRY_FIRST, 100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the first entry is negative
+     */
+    @Test
+    public void testCorruptedEntryLengthNegativeFirstEntry() throws Exception {
+        testCorruptedLength(ENTRY_FIRST, -100, true);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the first entry is way too big
+     */
+    @Test
+    public void testCorruptedEntryLengthTooLongFirstEntry() throws Exception {
+        testCorruptedLength(ENTRY_FIRST, Integer.MAX_VALUE / 2, true);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the middle entry is shorter
+     */
+    @Test
+    public void testCorruptedEntryLengthShorterMiddleEntry() throws Exception {
+        testCorruptedLength(ENTRY_MIDDLE, -100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the middle entry is longer than the remainder of the
+     * file
+     */
+    @Test
+    public void testCorruptedEntryLengthLongerMiddleEntry() throws Exception {
+        testCorruptedLength(ENTRY_MIDDLE, 100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the middle entry is negative
+     */
+    @Test
+    public void testCorruptedEntryLengthNegativeMiddleEntry() throws Exception {
+        testCorruptedLength(ENTRY_MIDDLE, -100, true);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the middle entry is way too big
+     */
+    @Test
+    public void testCorruptedEntryLengthTooLongMiddleEntry() throws Exception {
+        testCorruptedLength(ENTRY_MIDDLE, Integer.MAX_VALUE / 2, true);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the last entry is shorter
+     */
+    @Test
+    public void testCorruptedEntryLengthShorterLastEntry() throws Exception {
+        testCorruptedLength(ENTRY_LAST, -100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the last entry is longer than the remainder of the
+     * file
+     */
+    @Test
+    public void testCorruptedEntryLengthLongerLastEntry() throws Exception {
+        testCorruptedLength(ENTRY_LAST, 100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the last entry is negative
+     */
+    @Test
+    public void testCorruptedEntryLengthNegativeLastEntry() throws Exception {
+        testCorruptedLength(ENTRY_LAST, -100, true);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the last entry is way too big
+     */
+    @Test
+    public void testCorruptedEntryLengthTooLongLastEntry() throws Exception {
+        testCorruptedLength(ENTRY_LAST, Integer.MAX_VALUE / 2, true);
+    }
+
+    /**
+     * Test handling of a corrupt segment header
+     */
+    @Test
+    public void testCorruptSegmentHeader() throws Exception {
+        m_pbd.offer(defaultContainer());
+        ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
+        bb.putInt(100);
+        bb.flip();
+        corruptLastSegment(bb, PBDSegment.HEADER_NUM_OF_ENTRY_OFFSET);
+
+        verifySegmentCount(1, 0);
+        runCheckerNewPbd(ENTRY_FIRST);
+        verifySegmentCount(1, 0);
+    }
+
+    /**
+     * Test handling of a corrupt segment extra header data
+     */
+    @Test
+    public void testCorruptExtraHeader() throws Exception {
+        m_pbd.offer(defaultContainer());
+        ByteBuffer bb = ByteBuffer.allocateDirect(40);
+        corruptLastSegment(bb, PBDSegment.HEADER_EXTRA_HEADER_OFFSET + 15);
+
+        verifySegmentCount(1, 0);
+        runCheckerNewPbd(ENTRY_FIRST);
+        verifySegmentCount(1, 0);
+    }
+
+    /**
+     * Test that quarantined files are cleaned up when they are passed by all readers
+     */
+    @Test
+    public void testQuarantinedFileDeletedWhenPassed() throws Exception {
+        ByteBuffer data = defaultBuffer();
+        for (int i = 0; i < 5; ++i) {
+            for (int j = 0; j < 5; ++j) {
+                m_pbd.offer(defaultContainer());
+            }
+            m_pbd.updateExtraHeader(m_ds);
+        }
+        assertEquals(6, testDir.getRoot().list().length);
+
+        int i = 0;
+        for (PBDSegment segment : getSegmentMap().values()) {
+            switch (i++) {
+            case 1:
+                corruptSegment(segment, ByteBuffer.allocateDirect(10), PBDSegment.HEADER_NUM_OF_ENTRY_OFFSET);
+                break;
+            case 3:
+                corruptSegment(segment, ByteBuffer.allocateDirect(10), PBDSegment.HEADER_EXTRA_HEADER_OFFSET + 20);
+                break;
+            }
+        }
+
+        verifySegmentCount(6, 0);
+
+        m_checker.run(m_pbd);
+        BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader reader2 = m_pbd.openForRead(CURSOR_ID + 2);
+
+        verifySegmentCount(6, 2);
+
+        for (i = 0; i < 15; ++i) {
+            pollOnceAndVerify(reader2, data);
+        }
+        pollOnceAndVerify(reader2, null);
+
+        for (i = 0; i < 3; ++i) {
+            for (int j = 0; j < 5; ++j) {
+                pollOnceAndVerify(reader, data);
+                if (j == 0) {
+                    assertEquals(6 - (i * 2), testDir.getRoot().list().length);
+                }
+            }
+        }
+        pollOnceAndVerify(reader, null);
+
+        assertEquals(1, testDir.getRoot().list().length);
+    }
+
+    private int putInitialEntries() throws IOException {
+        int entryLength = -1;
+        for (int i = 0; i < ENTRY_COUNT; ++i) {
+            BBContainer container = defaultContainer();
+            entryLength = container.b().remaining();
+            m_pbd.offer(container);
+        }
+        return entryLength;
+    }
+
+    private int startOfEntry(int entryNumber, int entrySize) throws IOException {
+        return PBDSegment.SEGMENT_HEADER_BYTES + m_ds.getSerializedSize()
+                + ((entryNumber - 1) * (entrySize + PBDSegment.ENTRY_HEADER_BYTES));
+    }
+
+    private void testCorruptedLength(int entryToCorrupt, int lengthModifier, boolean absolute) throws Exception {
+        int origLength = putInitialEntries();
+
+        ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
+        bb.putInt(absolute ? lengthModifier : origLength + lengthModifier);
+        bb.flip();
+        corruptLastSegment(bb,
+                startOfEntry(entryToCorrupt, origLength) + PBDSegment.ENTRY_HEADER_TOTAL_BYTES_OFFSET);
+
+        runCheckerNewPbd(entryToCorrupt);
+    }
+
+    private void testCorruptedEntry(int entryToCorrupt) throws Exception {
+        int entryLength = putInitialEntries();
+
+        corruptLastSegment(ByteBuffer.allocateDirect(35), startOfEntry(entryToCorrupt, entryLength) + 35);
+
+        runCheckerNewPbd(entryToCorrupt);
+    }
+
+    private void verifySegmentCount(int segmentCount, int expectedQuarantinedCount) {
+        int quarantinedCount = 0;
+        File[] entries = testDir.getRoot().listFiles();
+        assertEquals(Arrays.toString(entries), segmentCount, entries.length);
+        for (File entry : entries) {
+            if (PbdSegmentName.parseFile(null, entry).m_quarantined) {
+                ++quarantinedCount;
+            }
+        }
+
+        assertEquals(Arrays.toString(entries), expectedQuarantinedCount, quarantinedCount);
+    }
+
+    private void runCheckerNewPbd(int corruptedEntry) throws IOException {
+        // Use a parallel PBD instance since PBD finalizes all entries on close and that is not wanted
+        verifySegmentCount(1, 0);
+        PersistentBinaryDeque pbd = newPbd();
+        BinaryDequeReader reader = pbd.openForRead(CURSOR_ID);
+        try {
+            ByteBuffer data = defaultBuffer();
+            m_checker.run(pbd);
+            verifySegmentCount(2, corruptedEntry == ENTRY_FIRST ? 1 : 0);
+            for (int i = 0; i < corruptedEntry - 1; ++i) {
+                pollOnceAndVerify(reader, data);
+            }
+            pollOnceAndVerify(reader, null);
+            if (corruptedEntry == ENTRY_FIRST) {
+                verifySegmentCount(2, 1);
+            } else {
+                verifySegmentCount(1, 0);
+            }
+            pbd.offer(defaultContainer());
+            pollOnceAndVerify(reader, data);
+            verifySegmentCount(1, 0);
+        } finally {
+            pbd.close();
+        }
+    }
+
+    private void corruptLastSegment(ByteBuffer corruptData, int position) throws Exception {
+        corruptSegment(getSegmentMap().lastEntry().getValue(), corruptData, position);
+    }
+
+    private static void corruptSegment(PBDSegment segment, ByteBuffer corruptData, int position) throws IOException {
+        File file = segment.file();
+        try (FileChannel channel = FileChannel.open(Paths.get(file.getPath()), StandardOpenOption.WRITE)) {
+            channel.write(corruptData, position);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private NavigableMap<Long, PBDSegment> getSegmentMap() throws IllegalArgumentException, IllegalAccessException {
+        return ((NavigableMap<Long, PBDSegment>) FieldUtils
+                .getDeclaredField(PersistentBinaryDeque.class, "m_segments", true).get(m_pbd));
+    }
+
+    private PersistentBinaryDeque newPbd() throws IOException {
+        return new PersistentBinaryDeque(TEST_NONCE, m_ds, testDir.getRoot(), LOG);
+    }
+
+    private interface CorruptionChecker {
+        void run(PersistentBinaryDeque pbd) throws IOException;
+    }
+}


### PR DESCRIPTION
Add an optional flag encoded into a segment name to mark the segment as quarantined
If there is an IOError reading a segment header or crc checksum fails mark the segment as quarantined. If all readers poll beyond the quarantined segment delete it.
Add a little more paranoia around the isFinal flag