### PR TITLE
ENG-15337:

### DIFF
--- a/tests/frontend/org/voltdb/TestExportLiveDDLSuite.java
+++ b/tests/frontend/org/voltdb/TestExportLiveDDLSuite.java
@@ -185,8 +185,8 @@ public class TestExportLiveDDLSuite extends TestExportBaseSocketExport {
             response = client.callProcedure("@AdHoc", "drop stream " + tab);
             assertEquals(response.getStatus(), ClientResponse.SUCCESS);
         }
-        //We should consume all again.
-        waitForStreamedTargetAllocatedMemoryZero(client);
+        //After drop there should be no stats rows for export.
+        waitForStreamedTargetDeallocated(client);
 
         //recreate tables and export again
         for (int i = 0; i < numOfStreams; i++) {

--- a/tests/frontend/org/voltdb/TestExportLiveDDLSuiteLegacy.java
+++ b/tests/frontend/org/voltdb/TestExportLiveDDLSuiteLegacy.java
@@ -165,8 +165,8 @@ public class TestExportLiveDDLSuiteLegacy extends TestExportBaseSocketExport {
             response = client.callProcedure("@AdHoc", "drop stream " + tab);
             assertEquals(response.getStatus(), ClientResponse.SUCCESS);
         }
-        //We should consume all again.
-        waitForStreamedTargetAllocatedMemoryZero(client);
+        //After drop there should be no stats rows for export.
+        waitForStreamedTargetDeallocated(client);
 
         //recreate tables and export again
         for (int i = 0; i < numOfStreams; i++) {

--- a/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
+++ b/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
@@ -306,7 +306,6 @@ public class TestExportBaseSocketExport extends RegressionSuite {
         // Wait 10 mins only
         long end = System.currentTimeMillis() + (10 * 60 * 1000);
         while (true) {
-            stats = client.callProcedure("@Statistics", "export", 0).getResults()[0];
             boolean passedThisTime = true;
             long ctime = System.currentTimeMillis();
             if (ctime > end) {
@@ -319,6 +318,7 @@ public class TestExportBaseSocketExport extends RegressionSuite {
                 st = System.currentTimeMillis();
             }
             long ts = 0;
+            stats = client.callProcedure("@Statistics", "export", 0).getResults()[0];
             while (stats.advanceRow()) {
                 Long tts = stats.getLong("TIMESTAMP");
                 // Get highest timestamp and watch is change
@@ -376,12 +376,10 @@ public class TestExportBaseSocketExport extends RegressionSuite {
         System.out.println("Quiesce done....");
 
         VoltTable stats = null;
-        long ftime = 0;
         long st = System.currentTimeMillis();
         // Wait 10 mins only
         long end = System.currentTimeMillis() + (10 * 60 * 1000);
         while (true) {
-            stats = client.callProcedure("@Statistics", "export", 0).getResults()[0];
             boolean passedThisTime = true;
             long ctime = System.currentTimeMillis();
             if (ctime > end) {
@@ -393,6 +391,7 @@ public class TestExportBaseSocketExport extends RegressionSuite {
                 System.out.println(stats);
                 st = System.currentTimeMillis();
             }
+            stats = client.callProcedure("@Statistics", "export", 0).getResults()[0];
             while (stats.advanceRow()) {
                 passedThisTime = false;
                 String target = stats.getString("TARGET");
@@ -438,7 +437,6 @@ public class TestExportBaseSocketExport extends RegressionSuite {
         // Wait 10 mins only
         long end = System.currentTimeMillis() + (10 * 60 * 1000);
         while (true) {
-            stats = client.callProcedure("@Statistics", "table", 0).getResults()[0];
             boolean passedThisTime = true;
             long ctime = System.currentTimeMillis();
             if (ctime > end) {
@@ -451,6 +449,7 @@ public class TestExportBaseSocketExport extends RegressionSuite {
                 st = System.currentTimeMillis();
             }
             long ts = 0;
+            stats = client.callProcedure("@Statistics", "table", 0).getResults()[0];
             while (stats.advanceRow()) {
                 String ttype = stats.getString("TABLE_TYPE");
                 String ttable = stats.getString("TABLE_NAME");


### PR DESCRIPTION
There are some tests that wait for tuple counts to go to 0, in the Export Statistics after the Export Stream is dropped. However, when the stream is dropped the EDS and PBD is immediately removed and therefore the stats will have no rows for the Stream. The tests that look for rows have been updated to look for no rows instead.