### PR TITLE
Fix BBContainer leak on integration branch

### DIFF
--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -45,8 +45,7 @@ import org.voltdb.utils.VoltFile;
  *
  * Export PBD buffer layout:
  *    -- Segment Header ---
- *    version(4) + crc(4) + numberOfEntries(4) + totalBytes(4) + segmentRandomId(4) +
- *    extraHeaderSize(4) + extraHeaderCrc(4)
+ *    (defined in PBDSegment.java, see comments for segment header layout)
  *
  *    -- Export Extra Segment Header ---
  *    exportVersion(1) + generationId(8) + schemaLen(4) + tupleSchema(var length) +
@@ -54,7 +53,7 @@ import org.voltdb.utils.VoltFile;
  *    colType(1) + colLength(4) + ...
  *
  *    --- Common Entry Header   ---
- *    crc(4) + length(4) + entryId(4) + flags(2)
+ *   (defined in PBDSegment.java, see comments for entry header layout)
  *
  *    --- Export Entry Header   ---
  *    seqNo(8) + committedSeqNo(8) + tupleCount(4) + uniqueId(8)

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -325,8 +325,9 @@ public class GuestProcessor implements ExportDataProcessor {
         fut.addListener(new Runnable() {
             @Override
             public void run() {
+                AckingContainer cont = null;
                 try {
-                    AckingContainer cont = fut.get();
+                    cont = fut.get();
                     if (cont == null) {
                         return;
                     }
@@ -471,6 +472,7 @@ public class GuestProcessor implements ExportDataProcessor {
                     } finally {
                         if (cont != null) {
                             cont.discard();
+                            cont = null;
                         }
                     }
                 } catch (Exception e) {
@@ -480,6 +482,11 @@ public class GuestProcessor implements ExportDataProcessor {
 
                     } else {
                         m_logger.error("Error processing export block, continuing processing: ", e);
+                    }
+                } finally {
+                    if (cont != null) {
+                        cont.discard();
+                        cont = null;
                     }
                 }
                 if (!m_shutdown) {


### PR DESCRIPTION
… it's possible for the decoder thread to queue two poll requests on EDS thread's task queue. When EDS thread detects reentrant poll it throws ReentrantPollException which is captured by decoder thread, try hard to not leak BBContainer in this scenario.

Change-Id: I660c8c0ba7fff4cc72540bd849e33c8d15537573