### PR TITLE
PBD quarantine unreadable

### DIFF
--- a/src/frontend/org/voltcore/utils/DBBPool.java.template
+++ b/src/frontend/org/voltcore/utils/DBBPool.java.template
@@ -237,6 +237,20 @@ public final class DBBPool {
             DBBPool.cleanByteBuffer(buf);
         }
     }
+    
+    public static class DBBDelegateContainer extends BBContainer {
+        protected final BBContainer m_delegate;
+        
+        protected DBBDelegateContainer(BBContainer delegate) {
+            super(delegate.b());
+            m_delegate = delegate;
+        }
+
+        @Override
+        public void discard() {
+            m_delegate.discard();
+        }
+    }
 
     public static class MBBContainer extends BBContainer {
         private MBBContainer(MappedByteBuffer buf) {

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -178,7 +178,7 @@ class PBDRegularSegment extends PBDSegment {
             m_syncedSinceLastEdit = false;
         }
         assert (m_fc == null);
-        m_fc = new FileChannelWrapper(m_file, forWrite);
+        m_fc = openFile(m_file, forWrite);
         m_segmentHeaderBuf = DBBPool.allocateDirect(SEGMENT_HEADER_BYTES);
         m_entryHeaderBuf = DBBPool.allocateDirect(ENTRY_HEADER_BYTES);
 
@@ -197,6 +197,10 @@ class PBDRegularSegment extends PBDSegment {
         }
 
         m_closed = false;
+    }
+
+    FileChannelWrapper openFile(File file, boolean forWrite) throws IOException {
+        return new FileChannelWrapper(file, forWrite);
     }
 
     private void initializeFromHeader() throws IOException {
@@ -1060,7 +1064,7 @@ class PBDRegularSegment extends PBDSegment {
      * A simple delegation wrapper around a {@link FileChannel} which tracks whether or not any exceptions were thrown
      * by the delegate
      */
-    private static final class FileChannelWrapper extends FileChannel {
+    static class FileChannelWrapper extends FileChannel {
         private final Path m_path;
         private FileChannel m_delegate;
         boolean m_writable;

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -943,7 +943,8 @@ class PBDRegularSegment extends PBDSegment {
         @Override
         public FileChannel position(long newPosition) throws IOException {
             try {
-                return m_delegate.position(newPosition);
+                m_delegate.position(newPosition);
+                return this;
             } catch (Throwable e) {
                 m_stable = false;
                 throw e;

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -786,8 +786,8 @@ class PBDRegularSegment extends PBDSegment {
         }
 
         @Override
-        public boolean allReadAndDiscarded() {
-            return m_discardCount == m_numOfEntries;
+        public boolean anyReadAndDiscarded() {
+            return m_discardCount > 0;
         }
 
         @Override

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -20,21 +20,16 @@ package org.voltdb.utils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.List;
-import java.util.zip.CRC32;
 
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DeferredSerialization;
 
 public abstract class PBDSegment {
-
-    private static final String TRUNCATOR_CURSOR = "__truncator__";
-    private static final String SCANNER_CURSOR = "__scanner__";
-    protected static final String IS_FINAL_ATTRIBUTE = "VoltDB.PBDSegment.isFinal";
+    private static final String IS_FINAL_ATTRIBUTE = "VoltDB.PBDSegment.isFinal";
 
     // Has to be able to hold at least one object (compressed or not)
     public static final int CHUNK_SIZE = Integer.getInteger("PBDSEGMENT_CHUNK_SIZE", 1024 * 1024 * 64);
@@ -73,31 +68,30 @@ public abstract class PBDSegment {
     public static final int ENTRY_HEADER_FLAG_OFFSET = ENTRY_HEADER_ENTRY_ID_OFFSET + 4;
     public static final int ENTRY_HEADER_BYTES = ENTRY_HEADER_FLAG_OFFSET + 2;
 
-    protected final File m_file;
+    final File m_file;
+    // Index of this segment in the in-memory segment map
+    final long m_index;
+    // Persistent ID of this segment, based on managing a monotonic counter
+    final long m_id;
 
-    protected boolean m_closed = true;
-    protected FileChannel m_fc;
-    //Avoid unnecessary sync with this flag
-    protected boolean m_syncedSinceLastEdit = true;
-    // Reusable crc calculator. Must be reset before each use
-    protected CRC32 m_crc;
-    // Mirror of the isFinal metadata on the filesystem
-    private boolean m_isFinal;
-    // Whether or not this is the current active segment being written to
-    boolean m_isActive = false;
-
-    public PBDSegment(File file)
-    {
+    PBDSegment(File file, long index, long id) {
+        super();
         m_file = file;
-        m_crc = new CRC32();
-        m_isFinal = isFinal(m_file);
+        m_index = index;
+        m_id = id;
     }
 
-    abstract long segmentIndex();
-    abstract long segmentId();
-    abstract File file();
+    long segmentIndex() {
+        return m_index;
+    }
 
-    abstract void reset();
+    long segmentId() {
+        return m_id;
+    }
+
+    File file() {
+        return m_file;
+    }
 
     abstract int getNumEntries() throws IOException;
 
@@ -108,8 +102,8 @@ public abstract class PBDSegment {
     abstract PBDSegmentReader openForRead(String cursorId) throws IOException;
 
     /**
-     * Returns the reader opened for the given cursor id.
-     * This may return a closed reader if the reader has already finished reading this segment.
+     * Returns the reader opened for the given cursor id. This may return a closed reader if the reader has already
+     * finished reading this segment.
      */
     abstract PBDSegmentReader getReader(String cursorId);
 
@@ -128,8 +122,6 @@ public abstract class PBDSegment {
      */
     abstract void openForTruncate() throws IOException;
 
-    abstract void initNumEntries(int count, int size) throws IOException;
-
     abstract void closeAndDelete() throws IOException;
 
     abstract boolean isClosed();
@@ -147,21 +139,7 @@ public abstract class PBDSegment {
     // TODO: javadoc
     abstract int size();
 
-    abstract protected int writeTruncatedEntry(BinaryDeque.TruncatorResponse entry, int entryNumber) throws IOException;
-
     abstract void writeExtraHeader(DeferredSerialization ds) throws IOException;
-
-    /**
-     * Force a read and validation of the header and any extra header metadata which might exist
-     *
-     * @throws IOException If there was an error reading or validating the header
-     */
-    abstract void validateHeader() throws IOException;
-
-    /**
-     * @return {@code true} if this segment is eligible for finalization
-     */
-    abstract boolean canBeFinalized();
 
     /**
      * Update the segment to be read only
@@ -179,96 +157,7 @@ public abstract class PBDSegment {
      *         A negative value means that the entries were truncated because of corruption and not {@code truncator}
      * @throws IOException
      */
-    int parseAndTruncate(BinaryDeque.BinaryDequeTruncator truncator) throws IOException {
-        if (!m_closed) {
-            close();
-        }
-        openForTruncate();
-        PBDSegmentReader reader = openForRead(TRUNCATOR_CURSOR);
-
-        // Do stuff
-        validateHeader();
-        final int initialEntryCount = getNumEntries();
-        int entriesTruncated = 0;
-        // Zero entry count means the segment is empty or corrupted, in both cases
-        // the segment can be deleted.
-        if (initialEntryCount == 0) {
-            reader.close();
-            close();
-            return Integer.MAX_VALUE;
-        }
-        int sizeInBytes = 0;
-
-        DBBPool.BBContainer cont;
-        while (true) {
-            final long beforePos = reader.readOffset();
-
-            cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, !isFinal());
-            if (cont == null) {
-                break;
-            }
-
-            final int compressedLength = (int) (reader.readOffset() - beforePos - ENTRY_HEADER_BYTES);
-            final int uncompressedLength = cont.b().limit();
-
-            try {
-                //Handoff the object to the truncator and await a decision
-                BinaryDeque.TruncatorResponse retval = truncator.parse(cont);
-                if (retval == null) {
-                    //Nothing to do, leave the object alone and move to the next
-                    sizeInBytes += uncompressedLength;
-                } else {
-                    //If the returned bytebuffer is empty, remove the object and truncate the file
-                    if (retval.status == BinaryDeque.TruncatorResponse.Status.FULL_TRUNCATE) {
-                        if (reader.readIndex() == 1) {
-                            /*
-                             * If truncation is occurring at the first object
-                             * Whammo! Delete the file.
-                             */
-                            entriesTruncated = -1;
-                        } else {
-                            entriesTruncated = initialEntryCount - (reader.readIndex() - 1);
-
-                            //Don't forget to update the number of entries in the file
-                            initNumEntries(reader.readIndex() - 1, sizeInBytes);
-                            m_fc.truncate(reader.readOffset() - (compressedLength + ENTRY_HEADER_BYTES));
-                        }
-                    } else {
-                        assert retval.status == BinaryDeque.TruncatorResponse.Status.PARTIAL_TRUNCATE;
-                        entriesTruncated = initialEntryCount - reader.readIndex();
-                        //Partial object truncation
-                        reader.rewindReadOffset(compressedLength + ENTRY_HEADER_BYTES);
-                        final long partialEntryBeginOffset = reader.readOffset();
-                        m_fc.position(partialEntryBeginOffset);
-
-                        final int written = writeTruncatedEntry(retval, reader.readIndex());
-                        sizeInBytes += written;
-                        initNumEntries(reader.readIndex(), sizeInBytes);
-                        m_fc.truncate(partialEntryBeginOffset + written + ENTRY_HEADER_BYTES);
-                    }
-
-                    break;
-                }
-            } finally {
-                cont.discard();
-            }
-        }
-        int entriesScanned = reader.readIndex();
-        reader.close();
-
-        if (entriesTruncated == 0) {
-            int entriesNotScanned = initialEntryCount - entriesScanned;
-            // If we checksum the file and it looks good, mark as final
-            if (!isFinal() && entriesNotScanned == 0) {
-                finalize(true);
-            }
-            return -entriesNotScanned;
-        }
-
-        close();
-
-        return entriesTruncated;
-    }
+    abstract int parseAndTruncate(BinaryDeque.BinaryDequeTruncator truncator) throws IOException;
 
     /**
      * Scan over all entries in a segment possibly truncating the segment if corruption is detected
@@ -278,75 +167,15 @@ public abstract class PBDSegment {
      *         available objects in the PBD.
      * @throws IOException
      */
-    int scan(BinaryDeque.BinaryDequeScanner scanner) throws IOException {
-        PBDSegmentReader reader = openForRead(SCANNER_CURSOR);
-        try {
-            validateHeader();
-            DBBPool.BBContainer cont = null;
-            int initialEntryCount = getNumEntries();
-            if (initialEntryCount == 0) {
-                return 0;
-            }
-            while (true) {
-                cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY, true);
-                if (cont == null) {
-                    break;
-                }
-                try {
-                    scanner.scan(cont);
-                } finally {
-                    cont.discard();
-                }
-            }
-            int entriesScanned = reader.readIndex();
-
-            // Scan through entire file, everything looks good
-            int entriesTruncated = initialEntryCount - entriesScanned;
-            if (!m_isActive && !isFinal() && entriesTruncated == 0) {
-                finalize(false);
-            }
-
-            return entriesTruncated;
-        } finally {
-            reader.purge();
-        }
-    }
+    abstract int scan(BinaryDeque.BinaryDequeScanner scanner) throws IOException;
 
     /**
-     * Set or clear segment as 'final', i.e. whether segment is complete and logically immutable.
+     * Returns whether the file is final
      *
-     * NOTES:
-     *
-     * This is a best-effort feature: On any kind of I/O failure, the exception is swallowed and the operation is a
-     * no-op: this will be the case on filesystems that do no support extended file attributes. Also note that the
-     * {@code FileStore.supportsFileAttributeView} method does not provide a reliable way to test for the availability
-     * of the extended file attributes.
-     *
-     * Must be called with 'true' by segment owner when it has filled the segment, written all segment metadata, and
-     * after it has either closed or sync'd the segment file.
-     *
-     * Must be called with 'false' whenever opening segment for writing new data.
-     *
-     * Note that all calls to 'setFinal' are done by the class owning the segment because the segment itself generally
-     * lacks context to decide whether it's final or not.
-     *
-     * @param isFinal true if segment is set to final, false otherwise
-     * @throws IOException
+     * @see notes on {@code setFinal}
+     * @return true if file is final, false otherwise
      */
-    void setFinal(boolean isFinal) throws IOException {
-        if (isFinal != m_isFinal) {
-            if (setFinal(m_file, isFinal)) {
-                if (!isFinal) {
-                    // It is dangerous to leave final on a segment so make sure the metadata is flushed
-                    m_fc.force(true);
-                }
-            } else if (isFinal(m_file) && !isFinal) {
-                throw new IOException("Could not remove the final attribute from " + m_file.getName());
-            }
-            // It is OK for m_isFinal to be true when isFinal(File) returns false but not the other way
-            m_isFinal = isFinal;
-        }
-    }
+    abstract boolean isFinal();
 
     /**
      * If this segment is in a good condition the data will be flushed to disk and the segment will either be closed or
@@ -355,36 +184,7 @@ public abstract class PBDSegment {
      * @param close If {@code true} this segment will be closed otherwise it will be made read only
      * @throws IOException
      */
-    void finalize(boolean close) throws IOException {
-        m_isActive = false;
-        IOException exception = null;
-        try {
-            if (canBeFinalized()) {
-                sync();
-                setFinal(true);
-            }
-        } catch (IOException e) {
-            exception = e;
-        } finally {
-            try {
-                if (close) {
-                    close();
-                } else {
-                    setReadOnly();
-                }
-            } catch (IOException e) {
-                if (exception == null) {
-                    exception = e;
-                } else {
-                    exception.addSuppressed(e);
-                }
-            }
-
-            if (exception != null) {
-                throw exception;
-            }
-        }
-    }
+    abstract void finalize(boolean close) throws IOException;
 
     public static boolean setFinal(File file, boolean isFinal) {
 
@@ -398,16 +198,6 @@ public abstract class PBDSegment {
             // No-op
         }
         return false;
-    }
-
-    /**
-     * Returns whether the file is final
-     *
-     * @see notes on {@code setFinal}
-     * @return true if file is final, false otherwise
-     */
-    public boolean isFinal() {
-        return m_isFinal;
     }
 
     public static boolean isFinal(File file) {
@@ -431,7 +221,7 @@ public abstract class PBDSegment {
         return ret;
     }
 
-    protected static UserDefinedFileAttributeView getFileAttributeView(File file) {
+    static UserDefinedFileAttributeView getFileAttributeView(File file) {
         return Files.getFileAttributeView(file.toPath(), UserDefinedFileAttributeView.class);
     }
 }

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -172,9 +172,11 @@ public abstract class PBDSegment {
 
     /**
      * Parse the segment and truncate the file if necessary.
-     * @param truncator    A caller-supplied truncator that decides where in the segment to truncate
-     * @return The number of objects that was truncated. This number will be subtracted from the total number
-     * of available objects in the PBD. -1 means that this whole segment should be removed.
+     *
+     * @param truncator A caller-supplied truncator that decides where in the segment to truncate
+     * @return The number of objects that was truncated. This number will be subtracted from the total number of
+     *         available objects in the PBD. {@link Integer#MAX_VALUE} means that this whole segment should be removed.
+     *         A negative value means that the entries were truncated because of corruption and not {@code truncator}
      * @throws IOException
      */
     int parseAndTruncate(BinaryDeque.BinaryDequeTruncator truncator) throws IOException {
@@ -193,7 +195,7 @@ public abstract class PBDSegment {
         if (initialEntryCount == 0) {
             reader.close();
             close();
-            return -1;
+            return Integer.MAX_VALUE;
         }
         int sizeInBytes = 0;
 
@@ -260,7 +262,7 @@ public abstract class PBDSegment {
             if (!isFinal() && entriesNotScanned == 0) {
                 finalize(true);
             }
-            return entriesNotScanned;
+            return -entriesNotScanned;
         }
 
         close();

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -338,8 +338,11 @@ public abstract class PBDSegment {
                     // It is dangerous to leave final on a segment so make sure the metadata is flushed
                     m_fc.force(true);
                 }
-                m_isFinal = isFinal;
+            } else if (isFinal(m_file) && !isFinal) {
+                throw new IOException("Could not remove the final attribute from " + m_file.getName());
             }
+            // It is OK for m_isFinal to be true when isFinal(File) returns false but not the other way
+            m_isFinal = isFinal;
         }
     }
 
@@ -387,8 +390,8 @@ public abstract class PBDSegment {
             UserDefinedFileAttributeView view = getFileAttributeView(file);
             if (view != null) {
                 view.write(IS_FINAL_ATTRIBUTE, Charset.defaultCharset().encode(Boolean.toString(isFinal)));
+                return true;
             }
-            return true;
         } catch (IOException e) {
             // No-op
         }

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -35,13 +35,9 @@ interface PBDSegmentReader {
     public boolean hasMoreEntries() throws IOException;
 
     /**
-     * Have all the entries in this segment been read by this reader and
-     * acknowledged as ready for discarding.
-     *
-     * @return true if all entries have been read and discarded by this reader. False otherwise.
-     * @throws IOException if the reader was closed
+     * @return {@code true} if any entries have been read and discarded from this segment
      */
-    public boolean allReadAndDiscarded() throws IOException;
+    public boolean anyReadAndDiscarded();
 
     /**
      * Read the next entry from the segment for this reader.

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -44,12 +44,10 @@ interface PBDSegmentReader {
      * Returns null if all entries in this segment were already read by this reader.
      *
      * @param factory
-     * @param checkCRC
-     * @return BBContainer with the bytes read
+     * @return BBContainer with the bytes read or {@code null} if all entries have been consumed
      * @throws IOException
      */
-    public DBBPool.BBContainer poll(BinaryDeque.OutputContainerFactory factory,
-            boolean checkCRC) throws IOException;
+    public DBBPool.BBContainer poll(BinaryDeque.OutputContainerFactory factory) throws IOException;
 
     /**
      * @return A {@link DBBPool.BBContainer} with the extra header supplied for the segment or {@code null} if one was

--- a/src/frontend/org/voltdb/utils/PbdQuarantinedSegment.java
+++ b/src/frontend/org/voltdb/utils/PbdQuarantinedSegment.java
@@ -1,0 +1,186 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.utils;
+
+import java.io.File;
+
+import org.voltcore.utils.DBBPool.BBContainer;
+import org.voltcore.utils.DeferredSerialization;
+import org.voltdb.utils.BinaryDeque.BinaryDequeScanner;
+import org.voltdb.utils.BinaryDeque.BinaryDequeTruncator;
+import org.voltdb.utils.BinaryDeque.OutputContainerFactory;
+
+/**
+ * Dummy PBDSegment which represents a quarantined segment. A quarantined segment cannot be read because of header
+ * corruption but is kept around in case any data in the segment is needed to recover data.
+ */
+class PbdQuarantinedSegment extends PBDSegment {
+    PbdQuarantinedSegment(File file, long index, long id) {
+        super(file, index, id);
+    }
+
+    @Override
+    int getNumEntries() {
+        return 0;
+    }
+
+    @Override
+    boolean isBeingPolled() {
+        return false;
+    }
+
+    @Override
+    boolean isOpenForReading(String cursorId) {
+        return true;
+    }
+
+    @Override
+    PBDSegmentReader openForRead(String cursorId) {
+        return getReader(cursorId);
+    }
+
+    @Override
+    PBDSegmentReader getReader(String cursorId) {
+        return READER;
+    }
+
+    @Override
+    void openNewSegment(boolean compress) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void openForTruncate() {
+    }
+
+    @Override
+    void closeAndDelete() {
+        m_file.delete();
+    }
+
+    @Override
+    boolean isClosed() {
+        return true;
+    }
+
+    @Override
+    void close() {}
+
+    @Override
+    void sync() {}
+
+    @Override
+    boolean hasAllFinishedReading() {
+        return true;
+    }
+
+    @Override
+    boolean offer(BBContainer cont) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    int offer(DeferredSerialization ds) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    int size() {
+        return 0;
+    }
+
+    @Override
+    void writeExtraHeader(DeferredSerialization ds) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void setReadOnly() {}
+
+    @Override
+    int parseAndTruncate(BinaryDequeTruncator truncator) {
+        return 0;
+    }
+
+    @Override
+    int scan(BinaryDequeScanner scanner) {
+        return 0;
+    }
+
+    @Override
+    boolean isFinal() {
+        return false;
+    }
+
+    @Override
+    void finalize(boolean close) {}
+
+    private static final PBDSegmentReader READER = new PBDSegmentReader() {
+        @Override
+        public int uncompressedBytesToRead() {
+            return 0;
+        }
+
+        @Override
+        public void rewindReadOffset(int byBytes) {}
+
+        @Override
+        public void reopen() {}
+
+        @Override
+        public long readOffset() {
+            return 0;
+        }
+
+        @Override
+        public int readIndex() {
+            return 0;
+        }
+
+        @Override
+        public void purge() {}
+
+        @Override
+        public BBContainer poll(OutputContainerFactory factory) {
+            return null;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public boolean hasMoreEntries() {
+            return false;
+        }
+
+        @Override
+        public BBContainer getExtraHeader() {
+            return null;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public boolean anyReadAndDiscarded() {
+            return false;
+        }
+    };
+}

--- a/src/frontend/org/voltdb/utils/PbdSegmentName.java
+++ b/src/frontend/org/voltdb/utils/PbdSegmentName.java
@@ -25,47 +25,73 @@ import org.voltcore.logging.VoltLogger;
 /**
  * Utility class for generating and parsing the names of segment files
  * <p>
- * File name structure = "nonce_currentCounter_previousCounter.pbd"<br>
+ * File name structure = "nonce_currentCounter_previousCounter[_quarantine].pbd"<br>
  * Where:
  * <ul>
  * <li>currentCounter = Value of monotonic counter at PBD segment creation
  * <li>previousCounter = Value of monotonic counter at previous PBD segment creation
+ * <li>quarantine = A flag at the end of the file which indicates if this segment was quarantined
  * </ul>
  */
-public class PbdSegmentName {
+public final class PbdSegmentName {
     private static final String PBD_SUFFIX = ".pbd";
+    private static final String PBD_QUARANTINED = "_q";
     private static final MessageFormat FORMAT = new MessageFormat(
-            "{0}_{1,number,0000000000}_{2,number,0000000000}" + PBD_SUFFIX);
+            "{0}_{1,number,0000000000}_{2,number,0000000000}{3}" + PBD_SUFFIX);
 
     private static final PbdSegmentName NOT_PBD = new PbdSegmentName(Result.NOT_PBD);
     private static final PbdSegmentName INVALID_NAME = new PbdSegmentName(Result.INVALID_NAME);
 
     /** The result of parsing a file name. The other fields are only valid if the result is {@link Result#OK} */
     public final Result m_result;
+    /** File which was parsed to generate this segment name instance */
+    public final File m_file;
     /** The nonce of the segment */
     public final String m_nonce;
     /** The id of this segment */
     public final long m_id;
     /** The id of the previous segment */
     public final long m_prevId;
+    /** Whether or not this PBD segment was marked quarantined */
+    public final boolean m_quarantined;
 
-    public static String createName(String nonce, long id, long prevId) {
-        return FORMAT.format(new Object[] { nonce, id, prevId });
+    public static String createName(String nonce, long id, long prevId, boolean quarantine) {
+        return FORMAT.format(new Object[] { nonce, id, prevId, quarantine ? PBD_QUARANTINED : "" });
+    }
+
+    public static PbdSegmentName asQuarantinedSegment(VoltLogger logger, File file) {
+        PbdSegmentName current = parseFile(logger, file);
+        if (current.m_result != Result.OK) {
+            throw new IllegalArgumentException("File is not a valid pbd: " + file);
+        }
+
+        if (current.m_quarantined) {
+            throw new IllegalArgumentException("File is already quarantined: " + file);
+        }
+
+        File quarantinedFile = new File(file.getParentFile(),
+                createName(current.m_nonce, current.m_id, current.m_prevId, true));
+        return new PbdSegmentName(quarantinedFile, current.m_nonce, current.m_id, current.m_prevId, true);
     }
 
     public static PbdSegmentName parseFile(VoltLogger logger, File file) {
-        return parseName(logger, file.getName());
-    }
-
-    public static PbdSegmentName parseName(VoltLogger logger, String fileName) {
+        String fileName = file.getName();
         if (!fileName.endsWith(PBD_SUFFIX)) {
             if (logger.isTraceEnabled()) {
                 logger.trace("File " + fileName + " is not a pbd");
             }
             return NOT_PBD;
         }
-        int fileNameLength = fileName.length() - PBD_SUFFIX.length();
-        int startOfPrevId = fileName.lastIndexOf('_');
+        int endOfPrevId = fileName.length() - PBD_SUFFIX.length();
+
+        boolean quarantined = false;
+        if (fileName.regionMatches(endOfPrevId - PBD_QUARANTINED.length(), PBD_QUARANTINED, 0,
+                PBD_QUARANTINED.length())) {
+            quarantined = true;
+            endOfPrevId -= PBD_QUARANTINED.length();
+        }
+
+        int startOfPrevId = fileName.lastIndexOf('_', endOfPrevId - 1);
         if (startOfPrevId <= 0) {
             if (logger.isTraceEnabled()) {
                 logger.trace("File " + fileName + " does not have a _ in it for previous id");
@@ -83,27 +109,31 @@ public class PbdSegmentName {
         long id, prevId;
         try {
             id = Long.parseLong(fileName.substring(startOfId + 1, startOfPrevId));
-            prevId = Long.parseLong(fileName.substring(startOfPrevId + 1, fileNameLength));
+            prevId = Long.parseLong(fileName.substring(startOfPrevId + 1, endOfPrevId));
         } catch (NumberFormatException e) {
             logger.warn("Failed to parse IDs in " + fileName);
             return INVALID_NAME;
         }
 
-        return new PbdSegmentName(fileName.substring(0, startOfId), id, prevId);
+        return new PbdSegmentName(file, fileName.substring(0, startOfId), id, prevId, quarantined);
     }
 
     private PbdSegmentName(Result result) {
-        this.m_result = result;
-        this.m_nonce = null;
-        this.m_id = -1;
-        this.m_prevId = -1;
+        m_result = result;
+        m_file = null;
+        m_nonce = null;
+        m_id = -1;
+        m_prevId = -1;
+        m_quarantined = false;
     }
 
-    private PbdSegmentName(String m_nonce, long m_id, long m_prevId) {
-        this.m_result = Result.OK;
-        this.m_nonce = m_nonce;
-        this.m_id = m_id;
-        this.m_prevId = m_prevId;
+    private PbdSegmentName(File file, String nonce, long id, long prevId, boolean quarantined) {
+        m_result = Result.OK;
+        m_file = file;
+        m_nonce = nonce;
+        m_id = id;
+        m_prevId = prevId;
+        m_quarantined = quarantined;
     }
 
     public enum Result {

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -787,7 +787,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         assertions();
     }
 
-    private PBDSegment newSegment(long segmentIndex, long segmentId, File file) {
+    PBDSegment newSegment(long segmentIndex, long segmentId, File file) {
         return new PBDRegularSegment(segmentIndex, segmentId, file, m_usageSpecificLog);
     }
 

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -649,15 +649,17 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
             final int truncatedEntries = segment.parseAndTruncate(truncator);
 
-            if (truncatedEntries == -1) {
+            if (truncatedEntries == Integer.MAX_VALUE) {
                 // This whole segment will be truncated in the truncation loop below
                 lastSegmentIndex = segmentIndex - 1;
                 break;
-            } else if (truncatedEntries > 0) {
-                m_numObjects -= truncatedEntries;
-                //Set last segment and break the loop over this segment
-                lastSegmentIndex = segmentIndex;
-                break;
+            } else if (truncatedEntries != 0) {
+                m_numObjects -= Math.abs(truncatedEntries);
+                if (truncatedEntries > 0) {
+                    // Set last segment and break the loop over this segment
+                    lastSegmentIndex = segmentIndex;
+                    break;
+                }
             }
             // truncatedEntries == 0 means nothing is truncated in this segment,
             // should move on to the next segment.

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -50,9 +50,10 @@ import com.google_voltpatches.common.base.Throwables;
  *
  */
 public class PersistentBinaryDeque implements BinaryDeque {
-    private static final VoltLogger LOG = new VoltLogger("HOST");
 
     public static class UnsafeOutputContainerFactory implements OutputContainerFactory {
+        private static final VoltLogger LOG = new VoltLogger("HOST");
+
         @Override
         public BBContainer getContainer(int minimumSize) {
               final BBContainer origin = DBBPool.allocateUnsafeByteBuffer(minimumSize);
@@ -276,7 +277,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                                 closeAndDeleteSegment(segment);
                             }
                         } catch (IOException e) {
-                            LOG.error("Exception closing and deleting PBD segment", e);
+                            m_usageSpecificLog.error("Exception closing and deleting PBD segment", e);
                         }
                     }
                 }
@@ -544,7 +545,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 }
             }
         } catch (CyclicSequenceException e) {
-            LOG.error("Failed to parse files: " + e);
+            m_usageSpecificLog.error("Failed to parse files: " + e);
             throw new IOException(e);
         } catch (RuntimeException e) {
             if (e.getCause() instanceof IOException) {
@@ -603,7 +604,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         // Any recovered segment that is not final should be checked
         // for internal consistency.
         if (!qs.isFinal()) {
-            LOG.warn("Segment " + qs.file()
+            m_usageSpecificLog.warn("Segment " + qs.file()
             + " (final: " + qs.isFinal() + "), has been recovered but is not in a final state");
         } else if (m_usageSpecificLog.isDebugEnabled()) {
             m_usageSpecificLog.debug("Segment " + qs.file()
@@ -1000,7 +1001,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             }
         }
         catch (IOException e) {
-            LOG.error("Exception closing and deleting PBD segment", e);
+            m_usageSpecificLog.error("Exception closing and deleting PBD segment", e);
         }
     }
 

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -788,7 +788,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
     }
 
     private PBDSegment newSegment(long segmentIndex, long segmentId, File file) {
-        return new PBDRegularSegment(segmentIndex, segmentId, file);
+        return new PBDRegularSegment(segmentIndex, segmentId, file, m_usageSpecificLog);
     }
 
     private PBDSegment initializeNewSegment(long segmentIndex, long segmentId, File file, String reason)

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -442,7 +442,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
      * @return  segment file name
      */
     private String getSegmentFileName(long currentId, long previousId) {
-        return PbdSegmentName.createName(m_nonce, currentId, previousId);
+        return PbdSegmentName.createName(m_nonce, currentId, previousId, false);
     }
 
     /**

--- a/tests/frontend/org/voltdb/utils/TestPbdSegmentName.java
+++ b/tests/frontend/org/voltdb/utils/TestPbdSegmentName.java
@@ -1,0 +1,103 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.voltcore.logging.VoltLogger;
+
+public class TestPbdSegmentName {
+    private static final VoltLogger LOG = new VoltLogger("DUMMY");
+
+    @Test
+    public void testValidPbdName() {
+        assertPbdSegmentNameDeserialize("abc_def_123_456.pbd", "abc_def", 123, 456, false);
+        assertPbdSegmentNameDeserialize("abc_def_123_456_q.pbd", "abc_def", 123, 456, true);
+    }
+
+    @Test
+    public void testCreateParseName() {
+        long id = 987654156L;
+        long prevId = 21654564L;
+        assertPbdSegmentNameSerializeDeserialize("this_is_my_nonce", id, prevId, false);
+        assertPbdSegmentNameSerializeDeserialize("this_is_my_nonce", id, prevId, true);
+    }
+
+    @Test
+    public void testNotPbd() {
+        for (String name : new String[] { "dkjashfdkjasfkldsjf;dsfja", "dkjashfdkjasf.pbdkldsjf;dsfja",
+                "dkjashfdkjasfkldsjf;dsfja.pb", "dkjashfdkjasfkldsjf;dsfja.pbda", "", "dkjashfdkjasfkldsjf;dsfjapbd",
+                "pbd" }) {
+            assertResult(PbdSegmentName.Result.NOT_PBD, name);
+        }
+    }
+
+    @Test
+    public void testInvalidName() {
+        for (String name : new String[] { ".pbd", "abc.pbd", "abc_123.pbd", "abc_abc_123.pbd",
+                "nonce_1234_456_a.pbd" }) {
+            assertResult(PbdSegmentName.Result.INVALID_NAME, name);
+        }
+    }
+
+    @Test
+    public void testAsQuarantinedFile() {
+        assertEquals(new File("a/b/c/abc_def_0000000123_0000000456_q.pbd"),
+                PbdSegmentName.asQuarantinedSegment(LOG, new File("a/b/c/abc_def_123_456.pbd")).m_file);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testQuarantineNonPbd() {
+        PbdSegmentName.asQuarantinedSegment(LOG, new File("abc_def_123_456.exe"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testQuarantineQuarantinedSegment() {
+        PbdSegmentName.asQuarantinedSegment(LOG, new File("abc_def_123_456_q.pbd"));
+    }
+
+    private static void assertPbdSegmentNameSerializeDeserialize(String nonce, long id, long prevId,
+            boolean quarantine) {
+        assertPbdSegmentNameDeserialize(PbdSegmentName.createName(nonce, id, prevId, quarantine), nonce, id, prevId,
+                quarantine);
+    }
+
+    private static void assertPbdSegmentNameDeserialize(String name, String nonce, long id, long prevId,
+            boolean quarantine) {
+        PbdSegmentName pbdSegmentName = assertResult(PbdSegmentName.Result.OK, name);
+        assertEquals(nonce, pbdSegmentName.m_nonce);
+        assertEquals(id, pbdSegmentName.m_id);
+        assertEquals(prevId, pbdSegmentName.m_prevId);
+        assertEquals(quarantine, pbdSegmentName.m_quarantined);
+    }
+
+    private static PbdSegmentName assertResult(PbdSegmentName.Result expected, String name) {
+        PbdSegmentName pbdSegmentName = PbdSegmentName.parseFile(LOG, new File(name));
+        assertEquals(name, expected, pbdSegmentName.m_result);
+        return pbdSegmentName;
+    }
+}

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDequeCorruption.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDequeCorruption.java
@@ -1,0 +1,429 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.voltdb.utils.TestPersistentBinaryDeque.defaultBuffer;
+import static org.voltdb.utils.TestPersistentBinaryDeque.defaultContainer;
+import static org.voltdb.utils.TestPersistentBinaryDeque.pollOnceAndVerify;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.NavigableMap;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.voltcore.logging.VoltLogger;
+import org.voltcore.utils.DBBPool.BBContainer;
+import org.voltcore.utils.DeferredSerialization;
+import org.voltdb.test.utils.RandomTestRule;
+
+import com.google_voltpatches.common.collect.ImmutableList;
+
+/**
+ * Test handling of different types of PBD corruption using the two detection mechanisms
+ * {@link PersistentBinaryDeque#parseAndTruncate(org.voltdb.utils.BinaryDeque.BinaryDequeTruncator)} and
+ * {@link PersistentBinaryDeque#scanEntries(org.voltdb.utils.BinaryDeque.BinaryDequeScanner)}
+ */
+@RunWith(Parameterized.class)
+public class TestPersistentBinaryDequeCorruption {
+    private static final VoltLogger LOG = new VoltLogger("TEST");
+    private static final String TEST_NONCE = "pbd_nonce";
+    private static final String CURSOR_ID = "TestPersistentBinaryDequeCorruption";
+
+    private static int ENTRY_COUNT = 10;
+    private static int ENTRY_FIRST = 1;
+    private static int ENTRY_MIDDLE = ENTRY_COUNT / 2;
+    private static int ENTRY_LAST = ENTRY_COUNT;
+
+    @Rule
+    public final TemporaryFolder testDir = new TemporaryFolder();
+
+    @Rule
+    public final RandomTestRule random = new RandomTestRule();
+
+    private final CorruptionChecker m_checker;
+    private PersistentBinaryDeque m_pbd;
+    private DeferredSerialization m_ds;
+
+    @Parameters
+    public static Collection<Object[]> parameters() {
+        CorruptionChecker scanEntries = pbd -> pbd.scanEntries(b -> {});
+        CorruptionChecker parseAndTruncate = pbd -> pbd.parseAndTruncate(b -> null);
+        return ImmutableList.of(new Object[] { scanEntries }, new Object[] { parseAndTruncate });
+    }
+
+    public TestPersistentBinaryDequeCorruption(CorruptionChecker checker) {
+        m_checker = checker;
+    }
+
+    @Before
+    public void setup() throws IOException {
+        m_ds = new DeferredSerialization() {
+            private final ByteBuffer data = ByteBuffer.allocate(245);
+
+            {
+                random.nextBytes(data.array());
+            }
+
+            @Override
+            public void serialize(ByteBuffer buf) throws IOException {
+                data.rewind();
+                buf.put(data);
+            }
+
+            @Override
+            public int getSerializedSize() throws IOException {
+                return data.limit();
+            }
+
+            @Override
+            public void cancel() {}
+        };
+        m_pbd = newPbd();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        m_pbd.close();
+    }
+
+    /**
+     * Test handling of a corrupt entry at start of segment
+     */
+    @Test
+    public void testCorruptedEntryFirst() throws Exception {
+        testCorruptedEntry(ENTRY_FIRST);
+    }
+
+    /**
+     * Test handling of a corrupt entry in the middle of the segment
+     */
+    @Test
+    public void testCorruptedEntryMiddle() throws Exception {
+        testCorruptedEntry(ENTRY_MIDDLE);
+    }
+
+    /**
+     * Test handling of a corrupt entry at the end of the segment
+     */
+    @Test
+    public void testCorruptedEntryLast() throws Exception {
+        testCorruptedEntry(ENTRY_LAST);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the first entry is shorter
+     */
+    @Test
+    public void testCorruptedEntryLengthShorterFirstEntry() throws Exception {
+        testCorruptedLength(ENTRY_FIRST, -100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the first entry is longer than the remainder of the
+     * file
+     */
+    @Test
+    public void testCorruptedEntryLengthLongerFirstEntry() throws Exception {
+        testCorruptedLength(ENTRY_FIRST, 100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the first entry is negative
+     */
+    @Test
+    public void testCorruptedEntryLengthNegativeFirstEntry() throws Exception {
+        testCorruptedLength(ENTRY_FIRST, -100, true);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the first entry is way too big
+     */
+    @Test
+    public void testCorruptedEntryLengthTooLongFirstEntry() throws Exception {
+        testCorruptedLength(ENTRY_FIRST, Integer.MAX_VALUE / 2, true);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the middle entry is shorter
+     */
+    @Test
+    public void testCorruptedEntryLengthShorterMiddleEntry() throws Exception {
+        testCorruptedLength(ENTRY_MIDDLE, -100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the middle entry is longer than the remainder of the
+     * file
+     */
+    @Test
+    public void testCorruptedEntryLengthLongerMiddleEntry() throws Exception {
+        testCorruptedLength(ENTRY_MIDDLE, 100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the middle entry is negative
+     */
+    @Test
+    public void testCorruptedEntryLengthNegativeMiddleEntry() throws Exception {
+        testCorruptedLength(ENTRY_MIDDLE, -100, true);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the middle entry is way too big
+     */
+    @Test
+    public void testCorruptedEntryLengthTooLongMiddleEntry() throws Exception {
+        testCorruptedLength(ENTRY_MIDDLE, Integer.MAX_VALUE / 2, true);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the last entry is shorter
+     */
+    @Test
+    public void testCorruptedEntryLengthShorterLastEntry() throws Exception {
+        testCorruptedLength(ENTRY_LAST, -100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the last entry is longer than the remainder of the
+     * file
+     */
+    @Test
+    public void testCorruptedEntryLengthLongerLastEntry() throws Exception {
+        testCorruptedLength(ENTRY_LAST, 100, false);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the last entry is negative
+     */
+    @Test
+    public void testCorruptedEntryLengthNegativeLastEntry() throws Exception {
+        testCorruptedLength(ENTRY_LAST, -100, true);
+    }
+
+    /**
+     * Test handling of a corrupt entry length when the length of the last entry is way too big
+     */
+    @Test
+    public void testCorruptedEntryLengthTooLongLastEntry() throws Exception {
+        testCorruptedLength(ENTRY_LAST, Integer.MAX_VALUE / 2, true);
+    }
+
+    /**
+     * Test handling of a corrupt segment header
+     */
+    @Test
+    public void testCorruptSegmentHeader() throws Exception {
+        m_pbd.offer(defaultContainer());
+        ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
+        bb.putInt(100);
+        bb.flip();
+        corruptLastSegment(bb, PBDSegment.HEADER_NUM_OF_ENTRY_OFFSET);
+
+        verifySegmentCount(1, 0);
+        runCheckerNewPbd(ENTRY_FIRST);
+        verifySegmentCount(1, 0);
+    }
+
+    /**
+     * Test handling of a corrupt segment extra header data
+     */
+    @Test
+    public void testCorruptExtraHeader() throws Exception {
+        m_pbd.offer(defaultContainer());
+        ByteBuffer bb = ByteBuffer.allocateDirect(40);
+        corruptLastSegment(bb, PBDSegment.HEADER_EXTRA_HEADER_OFFSET + 15);
+
+        verifySegmentCount(1, 0);
+        runCheckerNewPbd(ENTRY_FIRST);
+        verifySegmentCount(1, 0);
+    }
+
+    /**
+     * Test that quarantined files are cleaned up when they are passed by all readers
+     */
+    @Test
+    public void testQuarantinedFileDeletedWhenPassed() throws Exception {
+        ByteBuffer data = defaultBuffer();
+        for (int i = 0; i < 5; ++i) {
+            for (int j = 0; j < 5; ++j) {
+                m_pbd.offer(defaultContainer());
+            }
+            m_pbd.updateExtraHeader(m_ds);
+        }
+        assertEquals(6, testDir.getRoot().list().length);
+
+        int i = 0;
+        for (PBDSegment segment : getSegmentMap().values()) {
+            switch (i++) {
+            case 1:
+                corruptSegment(segment, ByteBuffer.allocateDirect(10), PBDSegment.HEADER_NUM_OF_ENTRY_OFFSET);
+                break;
+            case 3:
+                corruptSegment(segment, ByteBuffer.allocateDirect(10), PBDSegment.HEADER_EXTRA_HEADER_OFFSET + 20);
+                break;
+            }
+        }
+
+        verifySegmentCount(6, 0);
+
+        m_checker.run(m_pbd);
+        BinaryDequeReader reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader reader2 = m_pbd.openForRead(CURSOR_ID + 2);
+
+        verifySegmentCount(6, 2);
+
+        for (i = 0; i < 15; ++i) {
+            pollOnceAndVerify(reader2, data);
+        }
+        pollOnceAndVerify(reader2, null);
+
+        for (i = 0; i < 3; ++i) {
+            for (int j = 0; j < 5; ++j) {
+                pollOnceAndVerify(reader, data);
+                if (j == 0) {
+                    assertEquals(6 - (i * 2), testDir.getRoot().list().length);
+                }
+            }
+        }
+        pollOnceAndVerify(reader, null);
+
+        verifySegmentCount(2, 0);
+        m_pbd.offer(defaultContainer());
+        pollOnceAndVerify(reader, data);
+        verifySegmentCount(2, 0);
+        pollOnceAndVerify(reader2, data);
+        verifySegmentCount(1, 0);
+    }
+
+    private int putInitialEntries() throws IOException {
+        int entryLength = -1;
+        for (int i = 0; i < ENTRY_COUNT; ++i) {
+            BBContainer container = defaultContainer();
+            entryLength = container.b().remaining();
+            m_pbd.offer(container);
+        }
+        return entryLength;
+    }
+
+    private int startOfEntry(int entryNumber, int entrySize) throws IOException {
+        return PBDSegment.SEGMENT_HEADER_BYTES + m_ds.getSerializedSize()
+                + ((entryNumber - 1) * (entrySize + PBDSegment.ENTRY_HEADER_BYTES));
+    }
+
+    private void testCorruptedLength(int entryToCorrupt, int lengthModifier, boolean absolute) throws Exception {
+        int origLength = putInitialEntries();
+
+        ByteBuffer bb = ByteBuffer.allocateDirect(Integer.BYTES);
+        bb.putInt(absolute ? lengthModifier : origLength + lengthModifier);
+        bb.flip();
+        corruptLastSegment(bb,
+                startOfEntry(entryToCorrupt, origLength) + PBDSegment.ENTRY_HEADER_TOTAL_BYTES_OFFSET);
+
+        runCheckerNewPbd(entryToCorrupt);
+    }
+
+    private void testCorruptedEntry(int entryToCorrupt) throws Exception {
+        int entryLength = putInitialEntries();
+
+        corruptLastSegment(ByteBuffer.allocateDirect(35), startOfEntry(entryToCorrupt, entryLength) + 35);
+
+        runCheckerNewPbd(entryToCorrupt);
+    }
+
+    private void verifySegmentCount(int segmentCount, int expectedQuarantinedCount) {
+        int quarantinedCount = 0;
+        File[] entries = testDir.getRoot().listFiles();
+        assertEquals(Arrays.toString(entries), segmentCount, entries.length);
+        for (File entry : entries) {
+            if (PbdSegmentName.parseFile(null, entry).m_quarantined) {
+                ++quarantinedCount;
+            }
+        }
+
+        assertEquals(Arrays.toString(entries), expectedQuarantinedCount, quarantinedCount);
+    }
+
+    private void runCheckerNewPbd(int corruptedEntry) throws IOException {
+        // Use a parallel PBD instance since PBD finalizes all entries on close and that is not wanted
+        verifySegmentCount(1, 0);
+        PersistentBinaryDeque pbd = newPbd();
+        BinaryDequeReader reader = pbd.openForRead(CURSOR_ID);
+        try {
+            ByteBuffer data = defaultBuffer();
+            m_checker.run(pbd);
+            verifySegmentCount(2, corruptedEntry == ENTRY_FIRST ? 1 : 0);
+            for (int i = 0; i < corruptedEntry - 1; ++i) {
+                pollOnceAndVerify(reader, data);
+            }
+            pollOnceAndVerify(reader, null);
+            verifySegmentCount(2, corruptedEntry == ENTRY_FIRST ? 1 : 0);
+            pbd.offer(defaultContainer());
+            pollOnceAndVerify(reader, data);
+            verifySegmentCount(1, 0);
+        } finally {
+            pbd.close();
+        }
+    }
+
+    private void corruptLastSegment(ByteBuffer corruptData, int position) throws Exception {
+        corruptSegment(getSegmentMap().lastEntry().getValue(), corruptData, position);
+    }
+
+    private static void corruptSegment(PBDSegment segment, ByteBuffer corruptData, int position) throws IOException {
+        File file = segment.file();
+        try (FileChannel channel = FileChannel.open(Paths.get(file.getPath()), StandardOpenOption.WRITE)) {
+            channel.write(corruptData, position);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private NavigableMap<Long, PBDSegment> getSegmentMap() throws IllegalArgumentException, IllegalAccessException {
+        return ((NavigableMap<Long, PBDSegment>) FieldUtils
+                .getDeclaredField(PersistentBinaryDeque.class, "m_segments", true).get(m_pbd));
+    }
+
+    private PersistentBinaryDeque newPbd() throws IOException {
+        return new PersistentBinaryDeque(TEST_NONCE, m_ds, testDir.getRoot(), LOG);
+    }
+
+    private interface CorruptionChecker {
+        void run(PersistentBinaryDeque pbd) throws IOException;
+    }
+}

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDequeCorruption.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDequeCorruption.java
@@ -332,6 +332,17 @@ public class TestPersistentBinaryDequeCorruption {
         verifySegmentCount(1, 0);
     }
 
+    @Test
+    public void testFileShorterThanExpectedFirst() throws Exception {
+        m_pbd.offer(defaultContainer());
+        File segment = getSegmentMap().lastEntry().getValue().file();
+        m_pbd.close();
+        try (FileChannel channel = FileChannel.open(segment.toPath(), StandardOpenOption.WRITE)) {
+            channel.truncate(channel.size() - 45);
+        }
+        runCheckerNewPbd(ENTRY_FIRST);
+    }
+
     private int putInitialEntries() throws IOException {
         int entryLength = -1;
         for (int i = 0; i < ENTRY_COUNT; ++i) {


### PR DESCRIPTION
Add an optional flag encoded into a segment name to mark the segment as quarantined
If there is an IOError reading a segment header or crc checksum fails mark the segment as quarantined. Change deletion of segment to be when all readers discard the first entry from the next segment.
Add a little more paranoia around the isFinal flag

This is the successor to https://github.com/VoltDB/voltdb/pull/6076