### PR TITLE
ENG-15740, bug fix, when stream is dropped it's PBDs are also removed…

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -2123,13 +2123,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             int size = 0;
             // column name length, name, type, length
             Table streamTable = m_catalogContext.database.getTables().get(m_streamName);
-            ////////////////////// debug code ////////////////////////
-            StringBuilder sb = new StringBuilder();
-            for (Table table : m_catalogContext.database.getTables()) {
-                sb.append(table.getTypeName()).append(" ");
-            }
-            ///////////////////////////////////////////////////////////
-            assert streamTable != null : "Failed to find stream " + m_streamName + " in the catalog {" + sb.toString() + "}";
+            assert streamTable != null : "Failed to find stream " + m_streamName + " in catalog";
             for (Column c : CatalogUtil.getSortedCatalogItems(streamTable.getColumns(), "index")) {
                 size += 4 + c.getName().length() + 1 + 4;
             }

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
@@ -49,13 +50,11 @@ import org.voltcore.zk.ZKUtil;
 import org.voltdb.CatalogContext;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
 import org.voltdb.RealVoltDB;
-import org.voltdb.TableType;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltZK;
 import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Connector;
-import org.voltdb.catalog.ConnectorTableInfo;
 import org.voltdb.catalog.Table;
 import org.voltdb.common.Constants;
 import org.voltdb.exportclient.ExportClientBase;
@@ -63,6 +62,8 @@ import org.voltdb.iv2.SpInitiator;
 import org.voltdb.messaging.LocalMailbox;
 import org.voltdb.sysprocs.ExportControl.OperationMode;
 import org.voltdb.utils.CatalogUtil;
+import org.voltdb.utils.PbdSegmentName;
+import org.voltdb.utils.PbdSegmentName.Result;
 
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.Sets;
@@ -158,16 +159,10 @@ public class ExportGeneration implements Generation {
             long genId) {
 
         List<Integer> onDiskPartitions = new ArrayList<Integer>();
+        NavigableSet<Table> streams = CatalogUtil.getExportTablesExcludeViewOnly(connectors);
         Set<String> exportedTables = new HashSet<>();
-        for (Connector conn : connectors) {
-            for (ConnectorTableInfo ti : conn.getTableinfo()) {
-                Table table = ti.getTable();
-                if (table.getTabletype() == TableType.STREAM_VIEW_ONLY.get()) {
-                    // Skip view-only streams
-                    continue;
-                }
-                exportedTables.add(table.getTypeName());
-            }
+        for (Table stream : streams) {
+            exportedTables.add(stream.getTypeName());
         }
         /*
          * Find all the data files. Once one is found, extract the nonce
@@ -177,25 +172,28 @@ public class ExportGeneration implements Generation {
         Map<String, File> dataFiles = new HashMap<>();
         for (File data: files) {
             if (data.getName().endsWith(".pbd")) {
-                // Naming convention for pdb file: [table name]_[partition]_[segmentId]_[prevId].pdb,
-                // so cut out 2 last segments starting with '_'.
-                String nonce = data.getName().substring(0, data.getName().lastIndexOf('_'));
-                nonce = nonce.substring(0, nonce.lastIndexOf('_'));
-                String streamName = nonce.substring(0, nonce.indexOf('_'));
-                if (exportedTables.contains(streamName)) {
-                    dataFiles.put(nonce, data);
-                } else {
-                    // ENG-15740, stream can be dropped while node is offline, delete .pbd files
-                    // if stream is no longer in catalog
-                    data.delete();
+                PbdSegmentName pbdName = PbdSegmentName.parseFile(exportLog, data);
+                if (pbdName.m_nonce != null) {
+                    String nonce = pbdName.m_nonce;
+                    String streamName = getStreamNameFromNonce(nonce);
+                    if (exportedTables.contains(streamName)) {
+                        dataFiles.put(nonce, data);
+                    } else {
+                        // ENG-15740, stream can be dropped while node is offline, delete .pbd files
+                        // if stream is no longer in catalog
+                        data.delete();
+                    }
+                } else if (pbdName.m_result == Result.NOT_PBD) {
+                    exportLog.warn(data.getAbsolutePath() + " is not a PBD file.");
+                } else if (pbdName.m_result == Result.INVALID_NAME) {
+                    exportLog.warn(data.getAbsolutePath() + " doesn't have valid PBD name.");
                 }
 
             }
         }
         for (File ad: files) {
             if (ad.getName().endsWith(".ad")) {
-                // Naming convention for ad file, [table name]_[partition].ad
-                String nonce = ad.getName().substring(0, ad.getName().lastIndexOf('.'));
+                String nonce = getNonceFromAdFile(ad);
                 File dataFile = dataFiles.get(nonce);
                 if (dataFile != null) {
                     try {
@@ -268,19 +266,13 @@ public class ExportGeneration implements Generation {
                 localPartitionsToSites.stream().map(p -> p.getFirst()).collect(Collectors.toSet());
 
         boolean createdSources = false;
-        List<String> exportedTables = new ArrayList<>();
-        for (Connector conn : connectors) {
-            for (ConnectorTableInfo ti : conn.getTableinfo()) {
-                Table table = ti.getTable();
-                if (table.getTabletype() == TableType.STREAM_VIEW_ONLY.get()) {
-                    // Skip view-only streams
-                    continue;
-                }
-                addDataSources(table, hostId, localPartitionsToSites, partitionsInUse,
-                        processor, catalogContext.m_genId);
-                createdSources = true;
-                exportedTables.add(table.getTypeName());
-            }
+        NavigableSet<Table> streams = CatalogUtil.getExportTablesExcludeViewOnly(connectors);
+        Set<String> exportedTables = new HashSet<>();
+        for (Table stream : streams) {
+            addDataSources(stream, hostId, localPartitionsToSites, partitionsInUse,
+                    processor, catalogContext.m_genId);
+            exportedTables.add(stream.getTypeName());
+            createdSources = true;
         }
 
         updateStreamStatus(exportedTables);
@@ -298,7 +290,7 @@ public class ExportGeneration implements Generation {
     }
 
     // Mark a DataSource as dropped if its not present in the connectors.
-    private void updateStreamStatus( List<String> exportedTables) {
+    private void updateStreamStatus( Set<String> exportedTables) {
         synchronized(m_dataSourcesByPartition) {
             for (Iterator<Map<String, ExportDataSource>> it = m_dataSourcesByPartition.values().iterator(); it.hasNext();) {
                 Map<String, ExportDataSource> sources = it.next();
@@ -1105,6 +1097,16 @@ public class ExportGeneration implements Generation {
                 }
             }
         }
+    }
+
+    // Naming convention for export pdb file: [table name]_[partition]_[segmentId]_[prevId].pdb,
+    private static String getStreamNameFromNonce(String nonce) {
+        return nonce.substring(0, nonce.indexOf('_'));
+    }
+
+    // Naming convention for ad file, [table name]_[partition].ad
+    private static String getNonceFromAdFile(File ad) {
+        return ad.getName().substring(0, ad.getName().lastIndexOf('.'));
     }
 
     @Override

--- a/tests/frontend/org/voltdb/TestExportConstraintsSuite.java
+++ b/tests/frontend/org/voltdb/TestExportConstraintsSuite.java
@@ -23,7 +23,6 @@
 
 package org.voltdb;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,11 +32,11 @@ import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.ExportDataProcessor;
+import org.voltdb.export.ExportLocalClusterBase;
 import org.voltdb.export.ExportTestExpectedData;
 import org.voltdb.export.TestExportBaseSocketExport;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
-import org.voltdb.utils.VoltFile;
 
 /**
  * End to end Export tests using the injected custom export.
@@ -55,9 +54,7 @@ public class TestExportConstraintsSuite extends TestExportBaseSocketExport {
     {
         m_username = "default";
         m_password = "password";
-        VoltFile.recursivelyDelete(new File("/tmp/" + System.getProperty("user.name")));
-        File f = new File("/tmp/" + System.getProperty("user.name"));
-        f.mkdirs();
+        ExportLocalClusterBase.resetDir();
         super.setUp();
 
         startListener();

--- a/tests/frontend/org/voltdb/TestExportLiveDDLSuite.java
+++ b/tests/frontend/org/voltdb/TestExportLiveDDLSuite.java
@@ -23,7 +23,6 @@
 
 package org.voltdb;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,12 +33,12 @@ import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.ExportDataProcessor;
+import org.voltdb.export.ExportLocalClusterBase;
 import org.voltdb.export.ExportTestExpectedData;
 import org.voltdb.export.TestExportBaseSocketExport;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
 import org.voltdb.utils.MiscUtils;
-import org.voltdb.utils.VoltFile;
 
 /**
  * End to end Export tests using the injected custom export.
@@ -57,9 +56,7 @@ public class TestExportLiveDDLSuite extends TestExportBaseSocketExport {
     {
         m_username = "default";
         m_password = "password";
-        VoltFile.recursivelyDelete(new File("/tmp/" + System.getProperty("user.name")));
-        File f = new File("/tmp/" + System.getProperty("user.name"));
-        f.mkdirs();
+        ExportLocalClusterBase.resetDir();
         super.setUp();
 
         startListener();

--- a/tests/frontend/org/voltdb/TestExportLiveDDLSuiteLegacy.java
+++ b/tests/frontend/org/voltdb/TestExportLiveDDLSuiteLegacy.java
@@ -23,7 +23,6 @@
 
 package org.voltdb;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,12 +31,12 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.ExportDataProcessor;
+import org.voltdb.export.ExportLocalClusterBase;
 import org.voltdb.export.ExportTestExpectedData;
 import org.voltdb.export.TestExportBaseSocketExport;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
 import org.voltdb.utils.MiscUtils;
-import org.voltdb.utils.VoltFile;
 
 /**
  * End to end Export tests using the injected custom export.
@@ -58,9 +57,7 @@ public class TestExportLiveDDLSuiteLegacy extends TestExportBaseSocketExport {
     {
         m_username = "default";
         m_password = "password";
-        VoltFile.recursivelyDelete(new File("/tmp/" + System.getProperty("user.name")));
-        File f = new File("/tmp/" + System.getProperty("user.name"));
-        f.mkdirs();
+        ExportLocalClusterBase.resetDir();
         super.setUp();
 
         startListener();

--- a/tests/frontend/org/voltdb/TestExportRejoinWithView.java
+++ b/tests/frontend/org/voltdb/TestExportRejoinWithView.java
@@ -23,7 +23,6 @@
 
 package org.voltdb;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -32,12 +31,12 @@ import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.ExportDataProcessor;
+import org.voltdb.export.ExportLocalClusterBase;
 import org.voltdb.export.ExportTestClient;
 import org.voltdb.export.ExportTestVerifier;
 import org.voltdb.export.TestExportBase;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
-import org.voltdb.utils.VoltFile;
 
 /**
  * Export to nowhere and build view. Rejoin nodes and verify view is intact.
@@ -50,9 +49,7 @@ public class TestExportRejoinWithView extends TestExportBase {
     {
         m_username = "default";
         m_password = "password";
-        VoltFile.recursivelyDelete(new File("/tmp/" + System.getProperty("user.name")));
-        File f = new File("/tmp/" + System.getProperty("user.name"));
-        f.mkdirs();
+        ExportLocalClusterBase.resetDir();
         super.setUp();
 
     }

--- a/tests/frontend/org/voltdb/TestExportSPIMigration.java
+++ b/tests/frontend/org/voltdb/TestExportSPIMigration.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.ServerSocket;
@@ -50,6 +49,7 @@ import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.ExportDataProcessor;
+import org.voltdb.export.ExportLocalClusterBase;
 import org.voltdb.regressionsuites.JUnit4LocalClusterTest;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.utils.VoltFile;
@@ -65,15 +65,9 @@ public class TestExportSPIMigration extends JUnit4LocalClusterTest
     private static int PORT = 5001;
     private volatile Set<String> exportMessageSet = null;
 
-    static void resetDir() throws IOException {
-        File f = new File("/tmp/" + System.getProperty("user.name"));
-         VoltFile.recursivelyDelete(f);
-         f.mkdirs();
-    }
-
     @Test
     public void testFlushEEBufferWhenRejoin() throws Exception {
-        resetDir();
+        ExportLocalClusterBase.resetDir();
         m_serverSocket = new ServerListener(5001);
         m_serverSocket.start();
         VoltFile.resetSubrootForThisProcess();

--- a/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExport.java
+++ b/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExport.java
@@ -23,7 +23,6 @@
 
 package org.voltdb;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -37,10 +36,10 @@ import org.voltdb.client.ClientConfigForTest;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.ExportDataProcessor;
+import org.voltdb.export.ExportLocalClusterBase;
 import org.voltdb.export.TestExportBase;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
-import org.voltdb.utils.VoltFile;
 
 /**
  * Listens for connections from socket export and then counts expected rows.
@@ -57,9 +56,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
     public void setUp() throws Exception {
         m_username = "default";
         m_password = "password";
-        VoltFile.recursivelyDelete(new File("/tmp/" + System.getProperty("user.name")));
-        File f = new File("/tmp/" + System.getProperty("user.name"));
-        f.mkdirs();
+        ExportLocalClusterBase.resetDir();
         super.setUp();
         m_serverSocket = new ServerListener(5001);
         m_serverSocket.start();

--- a/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExportRecover.java
+++ b/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExportRecover.java
@@ -23,7 +23,6 @@
 
 package org.voltdb;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -34,11 +33,11 @@ import org.voltdb.FlakyTestRule.Flaky;
 import org.voltdb.client.Client;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.ExportDataProcessor;
+import org.voltdb.export.ExportLocalClusterBase;
 import org.voltdb.export.TestExportBase;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
 import org.voltdb.utils.MiscUtils;
-import org.voltdb.utils.VoltFile;
 
 /**
  * Listens for connections from socket export and then counts expected rows.
@@ -56,9 +55,7 @@ public class TestExportSuiteReplicatedSocketExportRecover extends TestExportBase
     {
         m_username = "default";
         m_password = "password";
-        VoltFile.recursivelyDelete(new File("/tmp/" + System.getProperty("user.name")));
-        File f = new File("/tmp/" + System.getProperty("user.name"));
-        f.mkdirs();
+        ExportLocalClusterBase.resetDir();
         super.setUp();
         m_serverSocket = new ServerListener(5001);
         m_serverSocket.start();

--- a/tests/frontend/org/voltdb/TestExportView.java
+++ b/tests/frontend/org/voltdb/TestExportView.java
@@ -23,7 +23,6 @@
 
 package org.voltdb;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -33,10 +32,10 @@ import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.ExportDataProcessor;
+import org.voltdb.export.ExportLocalClusterBase;
 import org.voltdb.export.TestExportBase;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
-import org.voltdb.utils.VoltFile;
 
 /**
  * Listens for connections from socket export and then counts expected rows.
@@ -51,9 +50,7 @@ public class TestExportView extends TestExportBase {
     {
         m_username = "default";
         m_password = "password";
-        VoltFile.recursivelyDelete(new File("/tmp/" + System.getProperty("user.name")));
-        File f = new File("/tmp/" + System.getProperty("user.name"));
-        f.mkdirs();
+        ExportLocalClusterBase.resetDir();
         super.setUp();
     }
 

--- a/tests/frontend/org/voltdb/TestPrepareShutdownWithExport.java
+++ b/tests/frontend/org/voltdb/TestPrepareShutdownWithExport.java
@@ -23,20 +23,20 @@
 
 package org.voltdb;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+
 import org.voltdb.client.ArbitraryDurationProc;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.ExportDataProcessor;
+import org.voltdb.export.ExportLocalClusterBase;
 import org.voltdb.export.TestExportBase;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
-import org.voltdb.utils.VoltFile;
 
 public class TestPrepareShutdownWithExport extends TestExportBase
 {
@@ -49,9 +49,7 @@ public class TestPrepareShutdownWithExport extends TestExportBase
     public void setUp() throws Exception {
         m_username = "default";
         m_password = "password";
-        VoltFile.recursivelyDelete(new File("/tmp/" + System.getProperty("user.name")));
-        File f = new File("/tmp/" + System.getProperty("user.name"));
-        f.mkdirs();
+        ExportLocalClusterBase.resetDir();
         super.setUp();
         m_serverSocket = new ServerListener(5001);
         m_serverSocket.start();

--- a/tests/frontend/org/voltdb/export/ExportLocalClusterBase.java
+++ b/tests/frontend/org/voltdb/export/ExportLocalClusterBase.java
@@ -99,7 +99,7 @@ public class ExportLocalClusterBase extends JUnit4LocalClusterTest {
         return client;
     }
 
-    static void resetDir() throws IOException {
+    public static void resetDir() throws IOException {
         File f = new File("/tmp/" + System.getProperty("user.name"));
          VoltFile.recursivelyDelete(f);
          f.mkdirs();

--- a/tests/frontend/org/voltdb/export/ExportLocalClusterBase.java
+++ b/tests/frontend/org/voltdb/export/ExportLocalClusterBase.java
@@ -23,6 +23,7 @@
 
 package org.voltdb.export;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +36,7 @@ import org.voltdb.client.ClientImpl;
 import org.voltdb.export.TestExportBaseSocketExport.ServerListener;
 import org.voltdb.regressionsuites.JUnit4LocalClusterTest;
 import org.voltdb.regressionsuites.LocalCluster;
+import org.voltdb.utils.VoltFile;
 
 /**
  * A convenient base class to write export end-to-end test case by using local cluster. Comparing
@@ -95,5 +97,28 @@ public class ExportLocalClusterBase extends JUnit4LocalClusterTest {
             throw new IOException("Failed to Initialize Hashinator.");
         }
         return client;
+    }
+
+    static void resetDir() throws IOException {
+        File f = new File("/tmp/" + System.getProperty("user.name"));
+         VoltFile.recursivelyDelete(f);
+         f.mkdirs();
+    }
+
+    protected void insertToStream(String streamName, int startPkey, int numberOfRows, Client client, Object[] params) throws Exception {
+        for (int i = startPkey; i < startPkey + numberOfRows; i++) {
+            params[1] = i; // Pkey column
+            m_verifier.addRow(client, streamName, i, params);
+            client.callProcedure("@AdHoc", "insert into "+ streamName + " values(" + i + ", 1)");
+        }
+    }
+
+    protected void insertToStreamWithNewColumn(String streamName, int startPkey, int numberOfRows, Client client, Object[] params) throws Exception {
+        for (int i = startPkey; i < startPkey + numberOfRows; i++) {
+            params[1] = i; // Pkey column
+            params[2] = i; // new column
+            m_verifier.addRow(client, streamName, i, params);
+            client.callProcedure("@AdHoc", "insert into " + streamName + " values(" + i + "," + i + ",1)");
+        }
     }
 }

--- a/tests/frontend/org/voltdb/export/TestExportEndToEnd.java
+++ b/tests/frontend/org/voltdb/export/TestExportEndToEnd.java
@@ -23,116 +23,119 @@
 
 package org.voltdb.export;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.voltdb.BackendTarget;
 import org.voltdb.client.Client;
-import org.voltdb.client.ClientConfig;
-import org.voltdb.client.ClientFactory;
-import org.voltdb.client.ProcCallException;
+import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.TestExportBaseSocketExport.ServerListener;
-import org.voltdb.regressionsuites.JUnit4LocalClusterTest;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.utils.VoltFile;
 
-public class TestExportEndToEnd extends JUnit4LocalClusterTest {
+public class TestExportEndToEnd extends ExportLocalClusterBase {
 
-    private ServerListener m_serverSocket;
-    private LocalCluster m_cluster = null;
+    private LocalCluster m_cluster;
+
+    private static int KFACTOR = 1;
+    private static final String SCHEMA =
+            "CREATE STREAM t1 "
+            + "PARTITION ON COLUMN a "
+            + "EXPORT TO TARGET export_target_a ("
+            + "     a integer not null, "
+            + "     b integer not null"
+            + ");"
+            + "CREATE STREAM t2 "
+            + "EXPORT TO TARGET export_target_b ("
+            + "     a integer not null, "
+            + "     b integer not null"
+            + ");";
 
     @Before
-    public void setUp() {
-        try {
-            VoltFile.recursivelyDelete(new File("/tmp/" + System.getProperty("user.name")));
-            File f = new File("/tmp/" + System.getProperty("user.name"));
-            f.mkdirs();
-            VoltFile.resetSubrootForThisProcess();
-        } catch (IOException e) {
-            fail();
-        }
-    }
-
-    @After
-    public void tearDown() {
-        try {
-            m_cluster.shutDown();
-            TestExportBaseSocketExport.closeSocketExporterClientAndServer();
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    @Test
-    public void testExportRollingRejoin() throws UnknownHostException, IOException, InterruptedException
+    public void setUp() throws Exception
     {
-        m_serverSocket = new ServerListener(5001);
-        m_serverSocket.start();
+        resetDir();
+        VoltFile.resetSubrootForThisProcess();
 
+        VoltProjectBuilder builder = null;
+        builder = new VoltProjectBuilder();
+        builder.addLiteralSchema(SCHEMA);
+        builder.setUseDDLSchema(true);
+        builder.setPartitionDetectionEnabled(true);
+        builder.setDeadHostTimeout(30);
+        // Each stream needs an exporter configuration
+        builder.addExport(true /* enabled */,
+                         "custom", /* custom exporter:  org.voltdb.exportclient.SocketExporter*/
+                         createSocketExportProperties("t1", false /* is replicated stream? */),
+                         "export_target_a");
+        builder.addExport(true /* enabled */,
+                "custom", /* custom exporter:  org.voltdb.exportclient.SocketExporter*/
+                createSocketExportProperties("t2", false /* is replicated stream? */),
+                "export_target_b");
+        // Start socket exporter client
+        startListener();
 
-        Client client = null;
-
-        // Use socket exporter
-        System.setProperty(ExportDataProcessor.EXPORT_TO_TYPE, "org.voltdb.exportclient.SocketExporter");
+        // A test hack to use socket exporter
         Map<String, String> additionalEnv = new HashMap<String, String>();
+        System.setProperty(ExportDataProcessor.EXPORT_TO_TYPE, "org.voltdb.exportclient.SocketExporter");
         additionalEnv.put(ExportDataProcessor.EXPORT_TO_TYPE, "org.voltdb.exportclient.SocketExporter");
-        TestExportBaseSocketExport.project = new VoltProjectBuilder();
-        TestExportBaseSocketExport.project.addLiteralSchema("CREATE STREAM export_table"
-                            + " PARTITION ON COLUMN a ("
-                            + "  a integer not null,"
-                            + "  b varchar(32)"
-                            + ");");
-        TestExportBaseSocketExport.wireupExportTableToSocketExport("export_table");
-        m_cluster = new LocalCluster("testExportRollingRejoin.jar", 2, 2, 1, BackendTarget.NATIVE_EE_JNI);
+
+        m_cluster = new LocalCluster("testFlushExportBuffer.jar", 2, 2, KFACTOR, BackendTarget.NATIVE_EE_JNI);
         m_cluster.setNewCli(true);
         m_cluster.setHasLocalServer(false);
         m_cluster.overrideAnyRequestForValgrind();
-        boolean success = m_cluster.compile(TestExportBaseSocketExport.project);
+        // Config custom socket exporter
+        boolean success = m_cluster.compile(builder);
         assertTrue(success);
         m_cluster.startUp(true);
 
-        ClientConfig config = new ClientConfig();
-        config.setClientAffinity(true);
-        config.setTopologyChangeAware(true);
-        config.setConnectionResponseTimeout(4*60*1000);
-        config.setProcedureCallTimeout(4*60*1000);
-        client = ClientFactory.createClient(config);
-        client.createConnection(m_cluster.getListenerAddress(0));
+        // TODO: verifier should be created based on socket exporter settings
+        m_verifier = new ExportTestExpectedData(m_serverSockets, false /*is replicated stream? */, true, KFACTOR + 1);
+    }
 
-        // create some data into pdb
-        for (int i = 0; i < 1000; i++) {
-            try {
-                client.callProcedure("export_table.insert", i, "deadbeef");
-            } catch (ProcCallException e) {
-                fail();
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Shutting down client and server");
+        for (Entry<String, ServerListener> entry : m_serverSockets.entrySet()) {
+            ServerListener serverSocket = entry.getValue();
+            if (serverSocket != null) {
+                serverSocket.closeClient();
+                serverSocket.close();
             }
         }
+        m_cluster.shutDown();
+    }
+
+    @Test
+    public void testExportRejoinThenDropStream_ENG_15740() throws Exception
+    {
+        Client client = getClient(m_cluster);
+        // Generate PBD files
+        Object[] data = new Object[3];
+        Arrays.fill(data, 1);
+        insertToStream("t1", 0, 100, client, data);
 
         // kill one node
         m_cluster.killSingleHost(1);
-        // Keep inserting data
-        for (int i = 1000; i < 2000; i++) {
-            try {
-                client.callProcedure("export_table.insert", i, "deadbeef");
-            } catch (ProcCallException e) {
-                fail();
-            }
-        }
-        // Still have problem in rejoin
-//        m_cluster.rejoinOne(1);
 
-        // wait for partition migration finishes
+        // drop stream
+        ClientResponse response = client.callProcedure("@AdHoc", "DROP STREAM t1");
+        assertEquals(ClientResponse.SUCCESS, response.getStatus());
 
-        // check masters on host 1 to see if they detect the gap
+        // rejoin node back
+        m_cluster.rejoinOne(1);
+
+        client.drain();
+        TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
+        assertEquals(2, m_cluster.getLiveNodeCount());
     }
 }

--- a/tests/frontend/org/voltdb/export/TestMigrateExport.java
+++ b/tests/frontend/org/voltdb/export/TestMigrateExport.java
@@ -26,7 +26,6 @@ package org.voltdb.export;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -37,9 +36,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.voltdb.BackendTarget;
 import org.voltdb.SQLStmt;
+import org.voltdb.VoltDB.Configuration;
 import org.voltdb.VoltProcedure;
 import org.voltdb.VoltTable;
-import org.voltdb.VoltDB.Configuration;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientImpl;
 import org.voltdb.client.ClientResponse;
@@ -114,12 +113,6 @@ public class TestMigrateExport extends ExportLocalClusterBase {
                     "PARTITION PROCEDURE TestMigrateExport$UpdateConstraintProc ON TABLE NIBBLE_EXPORT COLUMN PKEY;" +
                     "CREATE PROCEDURE FROM CLASS org.voltdb.export.TestMigrateExport$DeleteConstraintProc;" +
                     "PARTITION PROCEDURE TestMigrateExport$DeleteConstraintProc ON TABLE NIBBLE_EXPORT COLUMN PKEY;";
-
-    static void resetDir() throws IOException {
-        File f = new File("/tmp/" + System.getProperty("user.name"));
-        VoltFile.recursivelyDelete(f);
-        f.mkdirs();
-    }
 
     private static final int k_factor = 1;
 


### PR DESCRIPTION
…, but for rejoined node with old PBDs of dropped stream it causes trouble because dropped stream doesn't exist in catalog, PBD doesn't know how to generate schema header for it.

During initialization ExportGeneration shouldn't create streams that doesn't exist in catalog, delete underlying PBD files of those dropped streams.

Change-Id: I75ba5da97e8310b564deb2139b8178ea326d2a3d

Pro side: https://github.com/VoltDB/pro/pull/2554
