### PR TITLE
ENG-15714:

### DIFF
--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -606,20 +606,23 @@ enum DRConflictOnPK {
 };
 
 enum TableType {
+     // This will be unset and hence 0 for pre-9.0 catalogs
+     INVALID = 0,
+
       // Regular PersistentTable
-     PERSISTENT = 0,
+     PERSISTENT = 1,
 
       // StreamTable without ExportTupleStream (Views only)
-     STREAM_VIEW_ONLY =1,
+     STREAM_VIEW_ONLY = 2,
 
      // StreamTable with ExportTupleStream
-     STREAM = 2,
+     STREAM = 3,
 
      // PersistentTable with associated Stream for migrating DELETES
-     PERSISTENT_MIGRATE  = 3,
+     PERSISTENT_MIGRATE  = 4,
 
      // PersistentTable with associated Stream for linking INSERTS
-     PERSISTENT_EXPORT = 4,
+     PERSISTENT_EXPORT = 5,
 };
 
 inline bool isStream(TableType tableType) {

--- a/src/frontend/org/voltdb/TableType.java
+++ b/src/frontend/org/voltdb/TableType.java
@@ -23,11 +23,12 @@ package org.voltdb;
  *            Values are serialized through JNI and IPC as integers.
  */
 public enum TableType {
-    PERSISTENT(0),              // Regular PersistentTable
-    STREAM_VIEW_ONLY(1),        // StreamTable without ExportTupleStream (Views only)
-    STREAM(2),                  // StreamTable with ExportTupleStream
-    PERSISTENT_MIGRATE(3),      // PersistentTable with associated Stream for migrating DELETES
-    PERSISTENT_EXPORT(4);       // PersistentTable with associated Stream for linking INSERTS
+    INVALID_TYPE(0),
+    PERSISTENT(1),              // Regular PersistentTable
+    STREAM_VIEW_ONLY(2),        // StreamTable without ExportTupleStream (Views only)
+    STREAM(3),                  // StreamTable with ExportTupleStream
+    PERSISTENT_MIGRATE(4),      // PersistentTable with associated Stream for migrating DELETES
+    PERSISTENT_EXPORT(5);       // PersistentTable with associated Stream for linking INSERTS
 
     final int type;
     TableType(int type) {
@@ -47,6 +48,10 @@ public enum TableType {
 
     public static boolean needsMigrateHiddenColumn(int e) {
         return (e == PERSISTENT_MIGRATE.get() || e == PERSISTENT_EXPORT.get());
+    }
+
+    public static boolean isInvalidType(int e) {
+        return e == INVALID_TYPE.type;
     }
 }
 

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -645,19 +645,24 @@ public abstract class CatalogUtil {
      */
     public static boolean isTableExportOnly(org.voltdb.catalog.Database database,
                                             org.voltdb.catalog.Table table) {
-        // This implementation uses connectors instead of just looking at the tableType
-        // because snapshots or catalogs from pre-9.0 versions (DR) will not have this new tableType field.
-        for (Connector connector : database.getConnectors()) {
-            // iterate the connector tableinfo list looking for tableIndex
-            // tableInfo has a reference to a table - can compare the reference
-            // to the desired table by looking at the relative index. ick.
-            for (ConnectorTableInfo tableInfo : connector.getTableinfo()) {
-                if (tableInfo.getTable().getRelativeIndex() == table.getRelativeIndex()) {
-                    return true;
+        if (TableType.isInvalidType(table.getTabletype())) {
+            // This implementation uses connectors instead of just looking at the tableType
+            // because snapshots or catalogs from pre-9.0 versions (DR) will not have this new tableType field.
+            for (Connector connector : database.getConnectors()) {
+                // iterate the connector tableinfo list looking for tableIndex
+                // tableInfo has a reference to a table - can compare the reference
+                // to the desired table by looking at the relative index. ick.
+                for (ConnectorTableInfo tableInfo : connector.getTableinfo()) {
+                    if (tableInfo.getTable().getRelativeIndex() == table.getRelativeIndex()) {
+                        return true;
+                    }
                 }
             }
+            // Found no connectors
+            return false;
+        } else {
+            return TableType.isStream(table.getTabletype());
         }
-        return false;
     }
 
     public static boolean isExportEnabled() {

--- a/tests/sqlcmd/baselines/sysproc/explaincatalog.outbaseline
+++ b/tests/sqlcmd/baselines/sysproc/explaincatalog.outbaseline
@@ -52,7 +52,7 @@ set $PREV materializer null
 set $PREV signature "EMPLOYEES|vii"
 set $PREV tuplelimit 2147483647
 set $PREV isDRed false
-set $PREV tableType 0
+set $PREV tableType 1
 add /clusters#cluster/databases#database/tables#EMPLOYEES columns EMP_ID
 set /clusters#cluster/databases#database/tables#EMPLOYEES/columns#EMP_ID index 1
 set $PREV type 5


### PR DESCRIPTION
Make the default table type of 0 an invalid value.
This way we can distinguish between unset table types
from tables from older version snapshots and tables that
are actually persistent tables.