### PR TITLE
ENG-15746, add debug message to capture future NPE in quiesce(). Fix …

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2259,6 +2259,16 @@ void VoltDBEngine::tick(int64_t timeInMillis, int64_t lastCommittedSpHandle) {
 void VoltDBEngine::quiesce(int64_t lastCommittedSpHandle) {
     m_executorContext->setupForQuiesce(lastCommittedSpHandle);
     for (auto const &streamTable : m_exportingTables) {
+#ifndef NDEBUG
+        if (streamTable.second == NULL) {
+            Table* table = getTableByName(streamTable.first);
+            TableCatalogDelegate* tcd = getTableDelegate(streamTable.first);
+            throw std::runtime_error("Failed to quiesce stream due to null pointer (Name="
+                    + streamTable.first + ", tableType="
+                    + (tcd != NULL ? std::to_string(tcd->getTableType()) : "NULL") + ", tableInfo="
+                    + (table != NULL ? table->debug() : "NULL") + ")");
+        }
+#endif
         if (streamTable.second->getWrapper()) {
 #ifndef NDEBUG
             // A quiesce should be transactional so periodicFlush should always succeed

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1600,6 +1600,10 @@ bool PersistentTable::equals(PersistentTable* other) {
 std::string PersistentTable::debug(const std::string& spacer) const {
     std::ostringstream buffer;
     buffer << Table::debug(spacer);
+    if (m_shadowStream) {
+        std::string infoSpacer = spacer + "  |";
+        buffer << infoSpacer << "\tSHADOW STREAM: " << m_shadowStream->debug() << "\n";
+    }
 #ifdef VOLT_TRACE_ENABLED
     std::string infoSpacer = spacer + "  |";
     buffer << infoSpacer << "\tINDEXES: " << m_indexes.size() << "\n";

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -1101,7 +1101,8 @@ public class ExportGeneration implements Generation {
 
     // Naming convention for export pdb file: [table name]_[partition]_[segmentId]_[prevId].pdb,
     private static String getStreamNameFromNonce(String nonce) {
-        return nonce.substring(0, nonce.indexOf('_'));
+        // it's possible the stream name contains underscore
+        return nonce.substring(0, nonce.lastIndexOf('_'));
     }
 
     // Naming convention for ad file, [table name]_[partition].ad


### PR DESCRIPTION
…a bug that stream name containing underscore may not be initialized from disk.

Change-Id: Ic911dead39f22b896ce604bed297255be3968cfb