### PR TITLE
ENG-15741, unregister the mailbox id from export generation mailboxes…

### DIFF
--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -329,9 +329,11 @@ public class ExportGeneration implements Generation {
                         byte stringBytes[] = new byte[length];
                         buf.get(stringBytes);
                         String tableName = new String(stringBytes, Constants.UTF8ENCODING);
-                        if (partitionSources == null && !m_removingPartitions.contains(partition)) {
-                            exportLog.error("Received an export message " + msgType + " for partition " + partition +
-                                    " which does not exist on this node");
+                        if (partitionSources == null) {
+                            if (!m_removingPartitions.contains(partition)) {
+                                exportLog.error("Received an export message " + msgType + " for partition " + partition +
+                                        " which does not exist on this node");
+                            }
                             return;
                         }
                         final ExportDataSource eds = partitionSources.get(tableName);
@@ -847,8 +849,10 @@ public class ExportGeneration implements Generation {
             Map<String, ExportDataSource> sources = m_dataSourcesByPartition.get(partitionId);
 
             if (sources == null) {
-                exportLog.warn("Could not find export data sources for partition "
-                        + partitionId + ". The export cleanup stream is being discarded.");
+                if (!m_removingPartitions.contains(partitionId)) {
+                     exportLog.error("Could not find export data sources for partition "
+                            + partitionId + ". The export cleanup stream is being discarded.");
+                }
                 return;
             }
 

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -842,9 +842,6 @@ public class ExportGeneration implements Generation {
      */
     @Override
     public void onSourceDrained(int partitionId, String tableName) {
-
-        assert(m_dataSourcesByPartition.containsKey(partitionId));
-        assert(m_dataSourcesByPartition.get(partitionId).containsKey(tableName));
         ExportDataSource source;
         synchronized(m_dataSourcesByPartition) {
             Map<String, ExportDataSource> sources = m_dataSourcesByPartition.get(partitionId);

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
 
@@ -99,6 +100,8 @@ public class ExportGeneration implements Generation {
 
     private Mailbox m_mbox = null;
 
+    private final HostMessenger m_messenger;
+
     private volatile boolean m_shutdown = false;
 
     private static final ListeningExecutorService m_childUpdatingThread =
@@ -107,13 +110,16 @@ public class ExportGeneration implements Generation {
     // The version of the current catalog
     public volatile int m_catalogVersion;
 
+    private Set<Integer> m_removingPartitions = ConcurrentHashMap.newKeySet();
+
     /**
      * Constructor to create a new generation of export data
      * @param exportOverflowDirectory
      * @throws IOException
      */
-    public ExportGeneration(File exportOverflowDirectory) throws IOException {
+    public ExportGeneration(File exportOverflowDirectory, HostMessenger messenger) throws IOException {
         m_directory = exportOverflowDirectory;
+        m_messenger = messenger;
         if (!m_directory.canWrite()) {
             if (!m_directory.mkdirs()) {
                 throw new IOException("Could not create " + m_directory);
@@ -125,8 +131,7 @@ public class ExportGeneration implements Generation {
         }
     }
 
-    void initialize(HostMessenger messenger,
-            int hostId,
+    void initialize(int hostId,
             CatalogContext catalogContext,
             final CatalogMap<Connector> connectors,
             final ExportDataProcessor processor,
@@ -135,10 +140,9 @@ public class ExportGeneration implements Generation {
     {
         File files[] = exportOverflowDirectory.listFiles();
         if (files != null) {
-            initializeGenerationFromDisk(connectors, messenger, processor, files, localPartitionsToSites, catalogContext.m_genId);
+            initializeGenerationFromDisk(connectors, processor, files, localPartitionsToSites, catalogContext.m_genId);
         }
-        initializeGenerationFromCatalog(catalogContext, connectors, processor, hostId, messenger, localPartitionsToSites);
-
+        initializeGenerationFromCatalog(catalogContext, connectors, processor, hostId, localPartitionsToSites);
     }
 
     /**
@@ -153,7 +157,6 @@ public class ExportGeneration implements Generation {
      * @param localPartitionsToSites
      */
     private void initializeGenerationFromDisk(final CatalogMap<Connector> connectors,
-            HostMessenger messenger,
             final ExportDataProcessor processor,
             File[] files, List<Pair<Integer, Integer>> localPartitionsToSites,
             long genId) {
@@ -216,7 +219,7 @@ public class ExportGeneration implements Generation {
         onDIskPartitionsSet.removeAll(allLocalPartitions);
         // One export mailbox per node, since we only keep one generation
         if (!onDIskPartitionsSet.isEmpty()) {
-            createAckMailboxesIfNeeded(messenger, onDIskPartitionsSet);
+            createAckMailboxesIfNeeded(onDIskPartitionsSet);
         }
     }
 
@@ -238,7 +241,6 @@ public class ExportGeneration implements Generation {
             final CatalogMap<Connector> connectors,
             final ExportDataProcessor processor,
             int hostId,
-            HostMessenger messenger,
             List<Pair<Integer, Integer>> localPartitionsToSites)
     {
         // Update catalog version so that datasources use this version when propagating acks
@@ -286,7 +288,7 @@ public class ExportGeneration implements Generation {
         }
 
         //Only populate partitions in use if export is actually happening
-        createAckMailboxesIfNeeded(messenger, createdSources ? partitionsInUse : new HashSet<Integer>());
+        createAckMailboxesIfNeeded(createdSources ? partitionsInUse : new HashSet<Integer>());
     }
 
     // Mark a DataSource as dropped if its not present in the connectors.
@@ -308,13 +310,12 @@ public class ExportGeneration implements Generation {
 
     /**
      * Create export ack mailbox during generation initialization, do nothing if generation has already initialized.
-     * @param messenger  HostMessenger
      * @param localPartitions  locally covered partitions
      */
-    public void createAckMailboxesIfNeeded(HostMessenger messenger, final Set<Integer> localPartitions) {
+    private void createAckMailboxesIfNeeded(final Set<Integer> localPartitions) {
         m_mailboxesZKPath = VoltZK.exportGenerations + "/" + "mailboxes";
         if (m_mbox == null) {
-            m_mbox = new LocalMailbox(messenger) {
+            m_mbox = new LocalMailbox(m_messenger) {
                 @Override
                 public void deliver(VoltMessage message) {
                     if (message instanceof BinaryPayloadMessage) {
@@ -328,9 +329,9 @@ public class ExportGeneration implements Generation {
                         byte stringBytes[] = new byte[length];
                         buf.get(stringBytes);
                         String tableName = new String(stringBytes, Constants.UTF8ENCODING);
-                        if (partitionSources == null) {
-                            exportLog.error("Received an export ack for partition " + partition +
-                                    " which does not exist on this node, partitions = " + m_dataSourcesByPartition);
+                        if (partitionSources == null && !m_removingPartitions.contains(partition)) {
+                            exportLog.error("Received an export message " + msgType + " for partition " + partition +
+                                    " which does not exist on this node");
                             return;
                         }
                         final ExportDataSource eds = partitionSources.get(tableName);
@@ -434,7 +435,7 @@ public class ExportGeneration implements Generation {
                     }
                 }
             };
-            messenger.createMailbox(null, m_mbox);
+            m_messenger.createMailbox(null, m_mbox);
         }
 
         // Rejoining node may receives gap query message before childUpdating thread gets back result,
@@ -443,7 +444,7 @@ public class ExportGeneration implements Generation {
             updateAckMailboxes(partition, null);
         }
         // Update latest replica list to each data source.
-        updateReplicaList(messenger, localPartitions);
+        updateReplicaList(localPartitions);
     }
 
     // Auto reply a response when the requested stream is no longer exists
@@ -489,14 +490,29 @@ public class ExportGeneration implements Generation {
         }
     }
 
-    private void updateReplicaList(HostMessenger messenger, Set<Integer> localPartitions) {
+    private void removeMailbox(int partition) {
+        final String partitionDN =  m_mailboxesZKPath + "/" + partition;
+        m_removingPartitions.add(partition);
+        AsyncCallback.VoidCallback cb = new ZKUtil.VoidCallback() {
+            @Override
+            public void processResult(int rc, String path, Object ctx) {
+                super.processResult(rc, path, ctx);
+                // Now the mailbox is gone
+                m_removingPartitions.remove(partition);
+            }
+        };
+        m_messenger.getZK().delete(partitionDN + "/" + m_mbox.getHSId(), -1, cb, null);
+        m_replicasHSIds.remove(partition);
+    }
+
+    private void updateReplicaList(Set<Integer> newPartitions) {
         //If we have new partitions create mailbox paths.
-        for (Integer partition : localPartitions) {
+        for (Integer partition : newPartitions) {
             final String partitionDN =  m_mailboxesZKPath + "/" + partition;
-            ZKUtil.asyncMkdirs(messenger.getZK(), partitionDN);
+            ZKUtil.asyncMkdirs(m_messenger.getZK(), partitionDN);
 
             ZKUtil.StringCallback cb = new ZKUtil.StringCallback();
-            messenger.getZK().create(
+            m_messenger.getZK().create(
                     partitionDN + "/" + m_mbox.getHSId(),
                     null,
                     Ids.OPEN_ACL_UNSAFE,
@@ -510,11 +526,11 @@ public class ExportGeneration implements Generation {
             public void run() {
                 List<Pair<Integer,ZKUtil.ChildrenCallback>> callbacks =
                         new ArrayList<Pair<Integer, ZKUtil.ChildrenCallback>>();
-                for (Integer partition : localPartitions) {
+                for (Integer partition : newPartitions) {
                     ZKUtil.ChildrenCallback callback = new ZKUtil.ChildrenCallback();
-                    messenger.getZK().getChildren(
+                    m_messenger.getZK().getChildren(
                             m_mailboxesZKPath + "/" + partition,
-                            constructMailboxChildWatcher(messenger),
+                            constructMailboxChildWatcher(),
                             callback,
                             null);
                     callbacks.add(Pair.of(partition, callback));
@@ -549,7 +565,7 @@ public class ExportGeneration implements Generation {
         }
     }
 
-    private Watcher constructMailboxChildWatcher(final HostMessenger messenger) {
+    private Watcher constructMailboxChildWatcher() {
         if (m_shutdown) {
             return null;
         }
@@ -561,7 +577,7 @@ public class ExportGeneration implements Generation {
                     @Override
                     public void run() {
                         try {
-                            handleChildUpdate(event, messenger);
+                            handleChildUpdate(event);
                         } catch (Throwable t) {
                             VoltDB.crashLocalVoltDB("Error in export ack handling", true, t);
                         }
@@ -572,9 +588,14 @@ public class ExportGeneration implements Generation {
         };
     }
 
-    private void handleChildUpdate(final WatchedEvent event, final HostMessenger messenger) {
-        if (m_shutdown) return;
-        messenger.getZK().getChildren(event.getPath(), constructMailboxChildWatcher(messenger), constructChildRetrievalCallback(), null);
+    private void handleChildUpdate(final WatchedEvent event) {
+        if (m_shutdown) {
+            return;
+        }
+        m_messenger.getZK().getChildren(event.getPath(),
+                constructMailboxChildWatcher(),
+                constructChildRetrievalCallback(),
+                null);
     }
 
     private AsyncCallback.ChildrenCallback constructChildRetrievalCallback() {
@@ -589,7 +610,9 @@ public class ExportGeneration implements Generation {
                     @Override
                     public void run() {
                         try {
-                            if (m_shutdown) return;
+                            if (m_shutdown) {
+                                return;
+                            }
                             KeeperException.Code code = KeeperException.Code.get(rc);
                             //Other node must have drained so ignore.
                             if (code == KeeperException.Code.NONODE) {
@@ -602,14 +625,25 @@ public class ExportGeneration implements Generation {
                             }
                             final String split[] = path.split("/");
                             final int partition = Integer.valueOf(split[split.length - 1]);
+                            ImmutableList<Long> existingReplicas = m_replicasHSIds.get(partition);
+                            if (existingReplicas == null) {
+                                // Dangling data source is drained and removed from datasource map.
+                                // This host no longer accepts/sends message for this partition.
+                                return;
+                            }
+                            if (exportLog.isDebugEnabled()) {
+                                exportLog.debug("Process children change: " + path);
+                            }
                             ImmutableList.Builder<Long> mailboxes = ImmutableList.builder();
                             for (String child : children) {
-                                if (child.equals(Long.toString(m_mbox.getHSId()))) continue;
+                                if (child.equals(Long.toString(m_mbox.getHSId()))) {
+                                    continue;
+                                }
                                 mailboxes.add(Long.valueOf(child));
                             }
                             ImmutableList<Long> mailboxHsids = mailboxes.build();
                             Set<Long> newHSIds = Sets.difference(new HashSet<Long>(mailboxHsids),
-                                    new HashSet<Long>(m_replicasHSIds.get(partition)));
+                                    new HashSet<Long>(existingReplicas));
                             if (exportLog.isDebugEnabled()) {
                                 Set<Long> removedHSIds = Sets.difference(new HashSet<Long>(m_replicasHSIds.get(partition)),
                                         new HashSet<Long>(mailboxHsids));
@@ -832,6 +866,7 @@ public class ExportGeneration implements Generation {
             sources.remove(tableName);
             if (sources.isEmpty()) {
                 m_dataSourcesByPartition.remove(partitionId);
+                removeMailbox(partitionId);
             }
         }
 
@@ -878,16 +913,16 @@ public class ExportGeneration implements Generation {
                 tupleCount, uniqueId, genId, buffer, sync);
     }
 
-    private void cleanup(final HostMessenger messenger) {
+    private void cleanup() {
         m_shutdown = true;
         //We need messenger NULL guard for tests.
-        if (m_mbox != null && messenger != null) {
+        if (m_mbox != null && m_messenger != null) {
             synchronized(m_dataSourcesByPartition) {
                 for (Integer partition : m_dataSourcesByPartition.keySet()) {
                     final String partitionDN =  m_mailboxesZKPath + "/" + partition;
                     String path = partitionDN + "/" + m_mbox.getHSId();
                     try {
-                        messenger.getZK().delete(path, 0);
+                        m_messenger.getZK().delete(path, 0);
                     } catch (InterruptedException ex) {
                         ;
                     } catch (KeeperException ex) {
@@ -895,7 +930,7 @@ public class ExportGeneration implements Generation {
                     }
                 }
             }
-            messenger.removeMailbox(m_mbox);
+            m_messenger.removeMailbox(m_mbox);
         }
     }
 
@@ -968,7 +1003,7 @@ public class ExportGeneration implements Generation {
     }
 
     @Override
-    public void close(final HostMessenger messenger) {
+    public void close() {
         List<ListenableFuture<?>> tasks = new ArrayList<ListenableFuture<?>>();
         synchronized(m_dataSourcesByPartition) {
             for (Map<String, ExportDataSource> sources : m_dataSourcesByPartition.values()) {
@@ -986,7 +1021,7 @@ public class ExportGeneration implements Generation {
         }
         //Do this before so no watchers gets created.
         m_shutdown = true;
-        cleanup(messenger);
+        cleanup();
     }
 
     public void unacceptMastership() {

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -362,10 +362,6 @@ public class ExportManager
         exportLog.info(String.format("Export is enabled and can overflow to %s.", VoltDB.instance().getExportOverflowPath()));
     }
 
-    public HostMessenger getHostMessenger() {
-        return m_messenger;
-    }
-
     private void clearOverflowData() throws ExportManager.SetupException {
         String overflowDir = VoltDB.instance().getExportOverflowPath();
         try {
@@ -474,8 +470,8 @@ public class ExportManager
             m_processor.set(newProcessor);
 
             File exportOverflowDirectory = new File(VoltDB.instance().getExportOverflowPath());
-            ExportGeneration generation = new ExportGeneration(exportOverflowDirectory);
-            generation.initialize(m_messenger, m_hostId, catalogContext,
+            ExportGeneration generation = new ExportGeneration(exportOverflowDirectory, m_messenger);
+            generation.initialize(m_hostId, catalogContext,
                     connectors, newProcessor, localPartitionsToSites, exportOverflowDirectory);
 
             m_generation.set(generation);
@@ -523,7 +519,7 @@ public class ExportManager
         if (m_generation.get() == null) {
             File exportOverflowDirectory = new File(VoltDB.instance().getExportOverflowPath());
             try {
-                ExportGeneration gen = new ExportGeneration(exportOverflowDirectory);
+                ExportGeneration gen = new ExportGeneration(exportOverflowDirectory, m_messenger);
                 m_generation.set(gen);
             } catch (IOException crash) {
                 //This means durig UAC we had a bad disk on a node or bad directory.
@@ -545,7 +541,7 @@ public class ExportManager
                 ExportDataProcessor newProcessor = getNewProcessorWithProcessConfigSet(m_processorConfig);
                 m_processor.set(newProcessor);
                 generation.initializeGenerationFromCatalog(catalogContext,
-                        connectors, newProcessor, m_hostId, m_messenger, localPartitionsToSites);
+                        connectors, newProcessor, m_hostId, localPartitionsToSites);
                 if (exportLog.isDebugEnabled()) {
                     exportLog.debug("Creating connector " + m_loaderClass);
                 }
@@ -607,7 +603,7 @@ public class ExportManager
             ExportDataProcessor newProcessor = getNewProcessorWithProcessConfigSet(config);
             //Load any missing tables.
             generation.initializeGenerationFromCatalog(catalogContext, connectors, newProcessor,
-                    m_hostId, m_messenger, partitions);
+                    m_hostId, partitions);
             for (Pair<Integer, Integer> partition : partitions) {
                 generation.updateAckMailboxes(partition.getFirst(), null);
             }
@@ -638,7 +634,7 @@ public class ExportManager
     public void shutdown() {
         ExportGeneration generation = m_generation.getAndSet(null);
         if (generation != null) {
-            generation.close(m_messenger);
+            generation.close();
         }
         ExportDataProcessor proc = m_processor.getAndSet(null);
         if (proc != null) {

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -20,7 +20,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
-import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.Pair;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
 
@@ -31,7 +30,7 @@ import org.voltdb.ExportStatsBase.ExportStatsRow;
 public interface Generation {
 
     public void acceptMastership(int partitionId);
-    public void close(final HostMessenger messenger);
+    public void close();
 
     public List<ExportStatsRow> getStats(boolean interval);
     public void onSourceDrained(int partitionId, String tableName);

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -23,8 +23,8 @@
 
 package org.voltdb.export;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -52,7 +52,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.voltcore.messaging.BinaryPayloadMessage;
-import org.voltcore.messaging.HostMessenger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
@@ -107,7 +106,7 @@ public class TestExportDataSource extends TestCase {
         }
 
         @Override
-        public void close(HostMessenger messenger) {
+        public void close() {
         }
 
         @Override

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -164,10 +164,10 @@ public class TestExportGeneration {
 
         VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
 
-        m_exportGeneration = new ExportGeneration(m_dataDirectory);
+        m_exportGeneration = new ExportGeneration(m_dataDirectory, m_mockVoltDB.getHostMessenger());
 
         m_exportGeneration.initializeGenerationFromCatalog(m_mockVoltDB.getCatalogContext(),
-                m_connectors, getProcessor(), m_mockVoltDB.m_hostId, m_mockVoltDB.getHostMessenger(),
+                m_connectors, getProcessor(), m_mockVoltDB.m_hostId,
                 ImmutableList.of(Pair.of(m_part, CoreUtils.getSiteIdFromHSId(m_site))));
 
         m_mbox = new LocalMailbox(m_mockVoltDB.getHostMessenger()) {
@@ -212,7 +212,7 @@ public class TestExportGeneration {
 
     @After
     public void tearDown() throws Exception {
-        m_exportGeneration.close(null);
+        m_exportGeneration.close();
         m_mockVoltDB.shutdown(null);
         VoltDB.replaceVoltDBInstanceForTest(null);
     }


### PR DESCRIPTION
… when the last data source for given partition is drained.

.. Keep a reference of HostMessenger in ExportGeneration to avoid excessive parameter passing.

Change-Id: I788a0ff307fa98bf97c2ddf9681b0264bc60766e