### PR TITLE
AbstractDRTupleStream: Do not extend buffer when opened and null currBlock

### DIFF
--- a/src/ee/storage/AbstractDRTupleStream.cpp
+++ b/src/ee/storage/AbstractDRTupleStream.cpp
@@ -129,9 +129,13 @@ void AbstractDRTupleStream::fatalDRErrorWithPoisonPill(int64_t spHandle, int64_t
     std::string failureMessageForVoltLogger = reallysuperbig_failure_message;
     ExecutorContext::getPhysicalTopend()->pushPoisonPill(m_partitionId, failureMessageForVoltLogger, m_currBlock);
     m_currBlock = NULL;
+
+    bool wasOpened = m_opened;
+
+    commitTransactionCommon();
     extendBufferChain(0);
-    if (m_opened) {
-        commitTransactionCommon();
+
+    if (wasOpened) {
         ++m_openSequenceNumber;
         if (m_enabled) {
             beginTransaction(m_openSequenceNumber, spHandle, uniqueId);
@@ -139,9 +143,6 @@ void AbstractDRTupleStream::fatalDRErrorWithPoisonPill(int64_t spHandle, int64_t
         else {
             openTransactionCommon(spHandle, uniqueId);
         }
-    }
-    else {
-        commitTransactionCommon();
     }
 }
 


### PR DESCRIPTION
extendBufferChain() calls checkOpenTransaction which basically asserts that if
m_opened than m_currBlock is not null and m_currBlock->hasDRBeginTxn() is true.
AbstractTupleStream::fatalDRErrorWithPoisonPill() was setting m_currBlock to
NULL and immediately calling extendBufferChain which was causing this assert to
be hit on a debug build. Instead of calling extendBufferChain immediatly call
it after committing the current transaction which sets m_opened to false.