### PR TITLE
ENG-15780:

### DIFF
--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -366,14 +366,7 @@ public class ExportGeneration implements Generation {
                                             " from " + CoreUtils.hsIdToString(message.m_sourceHSId) +
                                             " to " + CoreUtils.hsIdToString(m_mbox.getHSId()));
                                 }
-                                if (catalogVersion < eds.getCatalogVersionCreated()) {
-                                    exportLog.warn("Received stale export RELEASE_BUFFER sent in version " +
-                                            catalogVersion + ", for partition " +
-                                            partition + " source " + tableName +
-                                            ", created in version " + + eds.getCatalogVersionCreated());
-                                } else {
-                                    eds.remoteAck(seqNo);
-                                }
+                                eds.remoteAck(seqNo);
                             } catch (RejectedExecutionException ignoreIt) {
                                 // ignore it: as it is already shutdown
                             }


### PR DESCRIPTION
Disable Catalog Version Check. It prevents rejoin nodes from draining because they are not synced with other nodes on the current catalog version.