### PR TITLE
Aggregate distribution

### DIFF
--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalAggregate.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalAggregate.java
@@ -17,10 +17,16 @@
 
 package org.voltdb.plannerv2.rel.logical;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
@@ -49,23 +55,45 @@ public class VoltLogicalAggregate extends Aggregate implements VoltLogicalRel {
      * @param aggCalls  Array of aggregates to compute, not null
      */
     public VoltLogicalAggregate(
-            RelOptCluster cluster,
-            RelTraitSet traitSet,
-            RelNode child,
-            ImmutableBitSet groupSet,
-            List<ImmutableBitSet> groupSets,
-            List<AggregateCall> aggCalls) {
+            RelOptCluster cluster, RelTraitSet traitSet, RelNode child, ImmutableBitSet groupSet,
+            List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
         super(cluster,
-                traitSet.replace(RelDistributions.SINGLETON),   // The result of aggregation always has SINGLETON distribution
+                updateTraitSet(aggCalls, traitSet, child),
                 child, false /*indicator*/, groupSet, groupSets, aggCalls);
         Preconditions.checkArgument(getConvention() == VoltLogicalRel.CONVENTION);
     }
 
-    @Override public VoltLogicalAggregate copy(RelTraitSet traitSet, RelNode input,
-                                 boolean indicator, ImmutableBitSet groupSet,
-                                 List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
-        return new VoltLogicalAggregate(
-                getCluster(), traitSet, input,
-                groupSet, groupSets, aggCalls);
+    /**
+     * Update trait set, by inspecting all the aggregation function arguments when the child is HASH_DISTRIBUTED:
+     * change it to SINGLETON distribution only when all aggregation function arguments are partition columns.
+     * @param aggs aggregation functions
+     * @param traitSet source trait set
+     * @param child child node whose distribution we inspect, and act upon
+     * @return converted distribution.
+     */
+    private static RelTraitSet updateTraitSet(List<AggregateCall> aggs, RelTraitSet traitSet, RelNode child) {
+        if (! aggs.isEmpty()) {       // not a "true" aggregate
+            final RelDistribution childDist = child.getTraitSet().getTrait(RelDistributionTraitDef.INSTANCE);
+            if (childDist != null) {
+                final Set<Integer> partCols = new HashSet<>(childDist.getKeys());
+                if (aggs.stream().flatMap(call -> {
+                    assert call.getArgList().size() <= 1;
+                    if (call.getArgList().isEmpty()) {  // COUNT removes argument
+                        return Stream.empty();
+                    } else {
+                        return Stream.of(call.getArgList().get(0));
+                    }
+                }).allMatch(partCols::contains)) {
+                    return traitSet.replace(RelDistributions.SINGLETON.with(null, true));
+                }
+            }
+        }
+        return traitSet;
+    }
+
+    @Override public VoltLogicalAggregate copy(
+            RelTraitSet traitSet, RelNode input, boolean indicator, ImmutableBitSet groupSet,
+            List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
+        return new VoltLogicalAggregate(getCluster(), traitSet, input, groupSet, groupSets, aggCalls);
     }
 }

--- a/src/frontend/org/voltdb/plannerv2/rules/PlannerRules.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/PlannerRules.java
@@ -41,16 +41,7 @@ import org.voltdb.plannerv2.rules.inlining.VoltPhysicalLimitSerialAggregateMerge
 import org.voltdb.plannerv2.rules.inlining.VoltPhysicalLimitSortMergeRule;
 import org.voltdb.plannerv2.rules.inlining.VoltPhysicalLimitScanMergeRule;
 import org.voltdb.plannerv2.rules.inlining.VoltPhysicalCalcScanMergeRule;
-import org.voltdb.plannerv2.rules.logical.MPJoinQueryFallBackRule;
-import org.voltdb.plannerv2.rules.logical.MPQueryFallBackRule;
-import org.voltdb.plannerv2.rules.logical.MPSetOpsQueryFallBackRule;
-import org.voltdb.plannerv2.rules.logical.VoltLAggregateRule;
-import org.voltdb.plannerv2.rules.logical.VoltLCalcRule;
-import org.voltdb.plannerv2.rules.logical.VoltLJoinRule;
-import org.voltdb.plannerv2.rules.logical.VoltLSetOpsRule;
-import org.voltdb.plannerv2.rules.logical.VoltLSortRule;
-import org.voltdb.plannerv2.rules.logical.VoltLTableScanRule;
-import org.voltdb.plannerv2.rules.logical.VoltLValuesRule;
+import org.voltdb.plannerv2.rules.logical.*;
 import org.voltdb.plannerv2.rules.physical.VoltPAggregateRule;
 import org.voltdb.plannerv2.rules.physical.VoltPCalcRule;
 import org.voltdb.plannerv2.rules.physical.VoltPJoinRule;

--- a/tests/frontend/org/voltdb/plannerv2/TestMPQueryFallbackRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestMPQueryFallbackRules.java
@@ -381,8 +381,6 @@ public class TestMPQueryFallbackRules extends Plannerv2TestCase {
         m_tester.sql("select si from P1 where i in (1,2) or i not in (1,3)").fail();
         // calcite will use Join to rewrite IN (sub query)
         m_tester.sql("select si from P1 where si in (select i from R1)").fail();
-
-        m_tester.sql("select i from R1 where i in (select si from P1)").fail();
     }
 
     public void testPartitionKeyEqualToTableColumn() {

--- a/tests/frontend/org/voltdb/plannerv2/TestMPQueryFallbackRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestMPQueryFallbackRules.java
@@ -365,7 +365,7 @@ public class TestMPQueryFallbackRules extends Plannerv2TestCase {
 
     public void testIn() {
         // NOTE: This is a good example that Calcite rewrites to table join operation.
-        m_tester.sql("select i from R1 where i in (select si from P1)").fail();
+        m_tester.sql("select i from R1 where i in (select si from P1)").pass();
 
         // calcite will use equal to rewrite IN
         m_tester.sql("select * from P1 where i in (16)").pass();


### PR DESCRIPTION
Update distribution trait of aggregation:
Set distribution trait to SINGLETON (corresponding to replicated table) only if all the aggregation function appeared in the aggregation node refer to the partition column(s) of the child distribution.