### PR TITLE
ENG-15741, unregister the mailbox id from export generation mailboxes…

### DIFF
--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -20,7 +20,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
-import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.Pair;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
 
@@ -31,7 +30,7 @@ import org.voltdb.ExportStatsBase.ExportStatsRow;
 public interface Generation {
 
     public void acceptMastership(int partitionId);
-    public void close(final HostMessenger messenger);
+    public void close();
 
     public List<ExportStatsRow> getStats(boolean interval);
     public void onSourceDone(int partitionId, String signature);

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -48,7 +48,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.voltcore.messaging.BinaryPayloadMessage;
-import org.voltcore.messaging.HostMessenger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
@@ -101,7 +100,7 @@ public class TestExportDataSource extends TestCase {
         }
 
         @Override
-        public void close(HostMessenger messenger) {
+        public void close() {
         }
 
         @Override


### PR DESCRIPTION
…… (#6112)

Unregister the mailbox id from export generation mailboxes when the last data source for given partition is drained.
Keep a reference of HostMessenger in ExportGeneration to avoid excessive parameter passing.
Discard ACKs and suppress the error message if dangling data source is unregistering export mailbox.
Fix a test issue that causing NPE in testExportGeneration.

Change-Id: I319e2aae21cadd6b8d508a39bef88b48c3eab210