### PR TITLE
ENG-15792: Handle null host site ID

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -2258,7 +2258,13 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
         }
 
         boolean transactionStarted = false;
-        long targetHSId = m_cartographer.getHSIDForPartitionHost(targetHostId, partitionId);
+        Long targetHSId = m_cartographer.getHSIDForPartitionHost(targetHostId, partitionId);
+        if (targetHSId == null) {
+            if (tmLog.isDebugEnabled()) {
+                tmLog.debug(String.format("Partition %d is no longer on host %d", partitionId, targetHostId));
+            }
+            return;
+        }
         try {
             SimpleClientResponseAdapter.SyncCallback cb = new SimpleClientResponseAdapter.SyncCallback();
             final String procedureName = "@MigratePartitionLeader";
@@ -2356,9 +2362,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
             }
 
             if (!migrationComplete) {
-                notifyPartitionMigrationStatus(partitionId,
-                        m_cartographer.getHSIDForPartitionHost(targetHostId, partitionId),
-                        true);
+                notifyPartitionMigrationStatus(partitionId, targetHSId, true);
             }
         }
     }


### PR DESCRIPTION
Cartogropher.getHSIDForPartitionHost(long, long) returns a Long and can
return null if the given partition does not exist on on the given host
or the host is down.

Handle when the host site ID is null by returning from the method and
letting the next pass handle any changes.