### PR TITLE
ENG-15233:

### DIFF
--- a/src/frontend/org/voltdb/iv2/CompleteTransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/CompleteTransactionTask.java
@@ -267,7 +267,8 @@ public class CompleteTransactionTask extends TransactionTask
             sb.append("  SP HANDLE: ").append(TxnEgo.txnIdToString(getSpHandle()));
             sb.append("  UNDO TOKEN: ").append(m_txnState.getBeginUndoToken());
         }
-        sb.append("  MSG: ").append(m_completeMsg.toString());
+        sb.append("  MSG:\n    ");
+        m_completeMsg.indentedString(sb, 8);
         return sb.toString();
     }
 

--- a/src/frontend/org/voltdb/iv2/RepairLog.java
+++ b/src/frontend/org/voltdb/iv2/RepairLog.java
@@ -18,6 +18,7 @@
 package org.voltdb.iv2;
 
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
@@ -336,5 +337,28 @@ public class RepairLog
     void registerTransactionCommitInterest(TransactionCommitInterest interest)
     {
         m_txnCommitInterests.add(interest);
+    }
+
+    private void logSummary(StringBuilder sb, Deque<Item> log, String indentStr) {
+        final int txnIdsPerLine = 15;
+        Iterator<Item> itemator = log.iterator();
+        for (int lineCnt = 0; lineCnt <= (log.size() / txnIdsPerLine); lineCnt++) {
+            sb.append(indentStr);
+            for(int i = 0; i < txnIdsPerLine; i++) {
+                if (itemator.hasNext()) {
+                    sb.append(" ").append(TxnEgo.txnIdSeqToString(itemator.next().getTxnId()));
+                }
+            }
+        }
+    }
+
+    public void indentedString(StringBuilder sb, int indentCnt) {
+        char[] array = new char[indentCnt-1];
+        Arrays.fill(array, ' ');
+        String indentStr = new String("\n" + new String(array));
+        sb.append(indentStr).append("MP RepairLog:");
+        logSummary(sb, m_logMP, indentStr);
+        sb.append(indentStr).append("SP RepairLog:");
+        logSummary(sb, m_logSP, indentStr);
     }
 }

--- a/src/frontend/org/voltdb/iv2/ReplaySequencer.java
+++ b/src/frontend/org/voltdb/iv2/ReplaySequencer.java
@@ -73,8 +73,6 @@ import org.voltdb.messaging.MultiPartitionParticipantMessage;
  */
 public class ReplaySequencer
 {
-    static final VoltLogger hostLog = new VoltLogger("HOST");
-
     // place holder that associates sentinel, first fragment and
     // work that follows in the transaction sequence.
     private class ReplayEntry {
@@ -364,17 +362,17 @@ public class ReplaySequencer
         return true;
     }
 
-    public void dump(long hsId)
+    public void dump(long hsId, StringBuilder sb)
     {
         final String who = CoreUtils.hsIdToString(hsId);
-        hostLog.warn(String.format("%s: REPLAY SEQUENCER DUMP, LAST POLLED FRAGMENT %d (%s), LAST SEEN TXNID %d (%s), %s%s",
+        sb.append(String.format("%s: REPLAY SEQUENCER DUMP, LAST POLLED FRAGMENT %d (%s), LAST SEEN TXNID %d (%s), %s%s",
                                  who,
                                  m_lastPolledFragmentUniqueId, TxnEgo.txnIdToString(m_lastPolledFragmentUniqueId),
                                  m_lastSeenUniqueId, TxnEgo.txnIdToString(m_lastSeenUniqueId),
                                  m_mpiEOLReached ? "MPI EOL, " : "",
                                  m_mustDrain ? "MUST DRAIN" : ""));
         for (Entry<Long, ReplayEntry> e : m_replayEntries.entrySet()) {
-            hostLog.warn(String.format("%s: REPLAY ENTRY %s: %s", who, e.getKey(), e.getValue()));
+            sb.append(String.format("\n    %s: REPLAY ENTRY %s: %s", who, e.getKey(), e.getValue()));
         }
     }
 }

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1646,9 +1646,12 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
     @Override
     public void dump()
     {
-        m_replaySequencer.dump(m_mailbox.getHSId());
-        hostLog.warn("[dump] current truncation handle: " + TxnEgo.txnIdToString(m_repairLogTruncationHandle) + " "
+        StringBuilder sb = new StringBuilder();
+        m_replaySequencer.dump(m_mailbox.getHSId(), sb);
+        sb.append("\n    current truncation handle: " + TxnEgo.txnIdToString(m_repairLogTruncationHandle) + " "
                 + m_bufferedReadLog.toString());
+        m_repairLog.indentedString(sb, 5);
+        hostLog.warn(sb.toString());
     }
 
     private void updateMaxScheduledTransactionSpHandle(long newSpHandle) {

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -478,7 +478,7 @@ public class TransactionTaskQueue
         sb.append("\tSIZE: ").append(size());
         if (!m_backlog.isEmpty()) {
             Iterator<TransactionTask> it = m_backlog.iterator();
-            sb.append("\tHEAD: ").append(it.next());
+            sb.append("  HEAD: ").append(it.next());
             // Print out any other MPs that are in the backlog
             while (it.hasNext()) {
                 TransactionTask tt = it.next();

--- a/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
+++ b/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
@@ -19,6 +19,7 @@ package org.voltdb.messaging;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.utils.CoreUtils;
@@ -172,43 +173,50 @@ public class CompleteTransactionMessage extends TransactionInfoBaseMessage
         assert(buf.capacity() == buf.position());
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-
+    public void indentedString(StringBuilder sb, int indentCnt) {
+        char[] array = new char[indentCnt];
+        Arrays.fill(array, ' ');
+        String indent = new String("\n" + new String(array));
         sb.append("COMPLETE_TRANSACTION (FROM COORD: ");
         sb.append(CoreUtils.hsIdToString(m_coordinatorHSId));
         sb.append(") FOR TXN ");
         sb.append(TxnEgo.txnIdToString(m_txnId) + "(" + m_txnId + ")");
-        sb.append("\n SP HANDLE: ");
+        sb.append(indent).append("SP HANDLE: ");
         sb.append(TxnEgo.txnIdToString(getSpHandle()));
-        sb.append("\n  FLAGS: ").append(m_flags);
+        sb.append(indent).append("FLAGS: ").append(m_flags);
 
         if (isNPartTxn())
-            sb.append("\n  ").append(" N Partition TXN");
+            sb.append(indent).append("  N Partition TXN");
 
-        sb.append("\n  TIMESTAMP: ");
+        sb.append(indent).append("TIMESTAMP: ");
         MpRestartSequenceGenerator.restartSeqIdToString(m_timestamp, sb);
-        sb.append("\n  TRUNCATION HANDLE:" + TxnEgo.txnIdToString(getTruncationHandle()));
-        sb.append("\n  HASH: " + String.valueOf(m_hash));
+        sb.append(indent).append("TRUNCATION HANDLE:" + TxnEgo.txnIdToString(getTruncationHandle()));
+        sb.append(indent).append("HASH: " + String.valueOf(m_hash));
 
         if (isRollback())
-            sb.append("\n  THIS IS AN ROLLBACK REQUEST");
+            sb.append(indent).append("THIS IS AN ROLLBACK REQUEST");
 
         if (requiresAck())
-            sb.append("\n  THIS MESSAGE REQUIRES AN ACK");
+            sb.append(indent).append("THIS MESSAGE REQUIRES AN ACK");
 
         if (isRestart()) {
-            sb.append("\n  THIS IS A TRANSACTION RESTART");
+            sb.append(indent).append("THIS IS A TRANSACTION RESTART");
         }
 
         if (!isForReplica()) {
-            sb.append("\n  SEND TO LEADER");
+            sb.append(indent).append("SEND TO LEADER");
         }
 
         if(isAbortDuringRepair()) {
-            sb.append("\n  THIS IS NOT RESTARTABLE (ABORT) REPAIR");
+            sb.append(indent).append("THIS IS NOT RESTARTABLE (ABORT) REPAIR");
         }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        indentedString(sb, 5);
         return sb.toString();
     }
 }

--- a/tests/frontend/org/voltdb/iv2/TestReplaySequencer.java
+++ b/tests/frontend/org/voltdb/iv2/TestReplaySequencer.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.messaging.CompleteTransactionMessage;
@@ -38,6 +39,7 @@ import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.messaging.MultiPartitionParticipantMessage;
 
 public class TestReplaySequencer {
+    static final VoltLogger hostLog = new VoltLogger("HOST");
 
     TransactionInfoBaseMessage makeIv2InitTask(long unused)
     {
@@ -104,6 +106,7 @@ public class TestReplaySequencer {
     @Test
     public void testOfferSentinelThenFragments()
     {
+        StringBuilder sb = new StringBuilder();
         boolean result;
         ReplaySequencer dut = new ReplaySequencer();
 
@@ -112,7 +115,7 @@ public class TestReplaySequencer {
         TransactionInfoBaseMessage frag2 = makeFragment(1L);
 
         result = dut.offer(1L, sntl);
-        try { dut.dump(1); } catch (Exception e) { fail(e.getMessage()); } // toString should not throw
+        try { dut.dump(1, sb); hostLog.warn(sb.toString()); } catch (Exception e) { fail(e.getMessage()); } // toString should not throw
         result = dut.offer(1L, frag);
         Assert.assertEquals(true, result);
         Assert.assertEquals(frag, dut.poll());
@@ -128,6 +131,7 @@ public class TestReplaySequencer {
     @Test
     public void testOfferFragmentThenSentinel()
     {
+        StringBuilder sb = new StringBuilder();
         boolean result;
         ReplaySequencer dut = new ReplaySequencer();
 
@@ -137,7 +141,7 @@ public class TestReplaySequencer {
         result = dut.offer(1L, frag);
         Assert.assertEquals(true, result);
         Assert.assertEquals(null, dut.poll());
-        try { dut.dump(1); } catch (Exception e) { fail(e.getMessage()); } // toString should not throw
+        try { dut.dump(1, sb); hostLog.warn(sb.toString()); } catch (Exception e) { fail(e.getMessage()); } // toString should not throw
 
         result = dut.offer(1L, sntl);
         Assert.assertEquals(true, result);


### PR DESCRIPTION
Log messages from MP dump messages (after a possible MP Deadlock) don't include the current repair log. This makes it harder to detect inconsistencies between the repair log and the transaction task queue. This branch adds additional log output as well as cleaning the formatting of some of the more common task messages that are logged.