### PR TITLE
 ENG-15826: Access to m_hasMoreChunks and m_buffers

### DIFF
--- a/src/frontend/org/voltcore/utils/DBBPool.java.template
+++ b/src/frontend/org/voltcore/utils/DBBPool.java.template
@@ -166,14 +166,14 @@ public final class DBBPool {
 
         public final void tag(final String tag) {
 #ifndef NO_MEMCHECK
-            StringBuilder sb = new StringBuilder(1024);
-            sb.append("<<TAG:").append(m_tags.size()).append(">> ");
-            sb.append(tag).append("\n");
-            sb.append(CoreUtils.throwableToString(new Throwable()));
             synchronized(this) {
                 if (m_tags == null) {
                     m_tags = new ArrayList<String>();
                 }
+                StringBuilder sb = new StringBuilder(1024);
+                sb.append("<<TAG:").append(m_tags.size()).append(">> ");
+                sb.append(tag).append("\n");
+                sb.append(CoreUtils.throwableToString(new Throwable()));
                 m_tags.add(sb.toString());
             }
 #endif

--- a/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFile.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFile.java
@@ -74,10 +74,12 @@ public class TableSaveFile
         @Override
         public void discard() {
             checkDoubleFree();
-            if (m_hasMoreChunks.get() == false) {
-                m_origin.discard();
-            } else {
-                m_buffers.add(m_origin);
+            synchronized (TableSaveFile.this) {
+                if (m_hasMoreChunks.get() == false) {
+                    m_origin.discard();
+                } else {
+                    m_buffers.add(m_origin);
+                }
             }
         }
 

--- a/tests/ee/catalog/ExportTupleStreamTest.cpp
+++ b/tests/ee/catalog/ExportTupleStreamTest.cpp
@@ -88,7 +88,7 @@ TEST_F(ExportTupleStreamTest, TestExportTableChange) {
     initParamsBuffer();
     voltdb::ReferenceSerializeInputBE params(m_parameter_buffer.get(), m_smallBufferSize);
     // The insert statement does not have any query parameters.
-    boost::scoped_ptr<fragmentId_t> scopedPlanfragmentIds(new fragmentId_t[4]);
+    boost::scoped_array<fragmentId_t> scopedPlanfragmentIds(new fragmentId_t[4]);
     fragmentId_t* planfragmentIds = scopedPlanfragmentIds.get();
     for (int i = 0; i < 4; i++) {
         planfragmentIds[i] = insertPlanId;


### PR DESCRIPTION
There is a race between TableSaveFile.close() discarding all buffers and
TableSaveFile.Container.discard(). discard() can m_hasMoreChunks prior to
close() setting it to false but insert the buffer into m_buffers after close()
has drained m_buffers(). By synchronizing the body of discard() that race goes
away and the buffers is guaranteed to be discarded and not leaked.