### PR TITLE
ENG-15811, fix an edge case that causing ReentrantPollException.

### DIFF
--- a/src/frontend/org/voltdb/export/AckingContainer.java
+++ b/src/frontend/org/voltdb/export/AckingContainer.java
@@ -44,7 +44,7 @@ public class AckingContainer extends BBContainer {
         m_schemaCont = schemaCont;
     }
 
-    public static AckingContainer of(ExportDataSource source,
+    public static AckingContainer create(ExportDataSource source,
                                      StreamBlock sb,
                                      StreamBlockQueue sbq,
                                      boolean forcePollSchema) {

--- a/src/frontend/org/voltdb/export/AckingContainer.java
+++ b/src/frontend/org/voltdb/export/AckingContainer.java
@@ -1,0 +1,137 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb.export;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.voltcore.logging.VoltLogger;
+import org.voltcore.utils.DBBPool.BBContainer;
+
+public class AckingContainer extends BBContainer {
+    ExportDataSource m_source;
+    final long m_startSeqNo;
+    final long m_lastSeqNo;
+    final long m_commitSeqNo;
+    final BBContainer m_backingCont;
+    BBContainer m_schemaCont;
+    long m_startTime = 0;
+    long m_commitSpHandle = 0;
+    private static VoltLogger EXPORT_LOG = new VoltLogger("EXPORT");
+
+    private AckingContainer(ExportDataSource source, BBContainer cont,
+                            BBContainer schemaCont, long startSeqNo, long lastSeqNo, long commitSeq) {
+        super(cont.b());
+        m_source = source;
+        m_startSeqNo = startSeqNo;
+        m_lastSeqNo = lastSeqNo;
+        m_commitSeqNo = commitSeq;
+        m_backingCont = cont;
+        m_schemaCont = schemaCont;
+    }
+
+    public static AckingContainer of(ExportDataSource source,
+                                     StreamBlock sb,
+                                     StreamBlockQueue sbq,
+                                     boolean forcePollSchema) {
+        BBContainer schemaContainer = null;
+        if (forcePollSchema) {
+            schemaContainer = sbq.pollSchema();
+        } else {
+            schemaContainer = sb.getSchemaContainer();
+        }
+        return new AckingContainer(source,
+                        sb.unreleasedContainer(),
+                        schemaContainer,
+                        sb.startSequenceNumber(),
+                        sb.startSequenceNumber() + sb.rowCount() - 1,
+                        sb.committedSequenceNumber());
+    }
+
+    public void updateStartTime(long startTime) {
+        m_startTime = startTime;
+    }
+
+    // Synchronized because schema is settable
+    public synchronized ByteBuffer schema() {
+        if (m_schemaCont == null) {
+            return null;
+        }
+        return m_schemaCont.b();
+    }
+
+    public synchronized void setSchema(BBContainer schemaCont) {
+        if (m_schemaCont != null) {
+            throw new IllegalStateException("Overwriting schema");
+        }
+        m_schemaCont = schemaCont;
+    }
+
+    public long getCommittedSeqNo() {
+        return m_commitSeqNo;
+    }
+
+    public void setCommittedSpHandle(long spHandle) {
+        m_commitSpHandle = spHandle;
+    }
+
+    long getStartSeqNo() {
+        return m_startSeqNo;
+    }
+
+    // Package private
+    long getLastSeqNo() {
+        return m_lastSeqNo;
+    }
+
+    private void internalDiscard(boolean checkDoubleFree) {
+        if (checkDoubleFree) {
+            checkDoubleFree();
+        }
+        m_backingCont.discard();
+        synchronized(this) {
+            if (m_schemaCont != null) {
+                m_schemaCont.discard();
+            }
+        }
+    }
+    // Package private
+    void internalDiscard() {
+        internalDiscard(true);
+    }
+
+    @Override
+    // Invoked from GuestProcessor after the container is delivered.
+    public void discard() {
+        checkDoubleFree();
+        try {
+            m_source.advance(m_lastSeqNo, m_commitSeqNo, m_commitSpHandle, m_startTime);
+        } catch (RejectedExecutionException rej) {
+            //Don't expect this to happen outside of test, but in test it's harmless
+            if (EXPORT_LOG.isDebugEnabled()) {
+                EXPORT_LOG.debug("Acking export data task rejected, this should be harmless");
+            }
+        } finally {
+            internalDiscard(false);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return new String("Container: ending at " + m_lastSeqNo + " (Committed " + m_commitSeqNo + ")");
+    }
+}

--- a/src/frontend/org/voltdb/export/ExportDataProcessor.java
+++ b/src/frontend/org/voltdb/export/ExportDataProcessor.java
@@ -45,8 +45,6 @@ public interface ExportDataProcessor  {
      */
     void addLogger(VoltLogger logger);
 
-    void setExportGeneration(ExportGeneration generation);
-
     /**
      * Get export client from processor, used by initializing export data source
      * @param tableName
@@ -55,9 +53,9 @@ public interface ExportDataProcessor  {
     public ExportClientBase getExportClient(String tableName);
 
     /**
-     * Inform the processor that initialization is complete; commence work.
+     * Inform the processor that initialization of given data source is complete; commence work.
      */
-    public void readyForData();
+    public void setupDataSource(ExportDataSource source);
 
     /**
      * Allows processor to initiate polling

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -695,6 +695,7 @@ public class ExportGeneration implements Generation {
         adFilePartitions.add(source.getPartitionId());
         int migrateBatchSize = CatalogUtil.getPersistentMigrateBatchSize(source.getTableName());
         source.setupMigrateRowsDeleter(migrateBatchSize);
+        processor.setupDataSource(source);
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("Creating " + source.toString() + " for " + adFile + " bytes " + source.sizeInBytes());
         }
@@ -763,7 +764,7 @@ public class ExportGeneration implements Generation {
                                     + " partition " + partition + " site " + siteId);
                         }
                         dataSourcesForPartition.put(key, exportDataSource);
-
+                        processor.setupDataSource(exportDataSource);
                     } else {
                         // Associate any existing EDS to the export client in the new processor
                         ExportDataSource eds = dataSourcesForPartition.get(key);
@@ -778,7 +779,7 @@ public class ExportGeneration implements Generation {
                             eds.setClient(null);
                             eds.setRunEveryWhere(false);
                         }
-
+                        processor.setupDataSource(eds);
                         // Mark in catalog only if partition is in use
                         eds.markInCatalog(partitionsInUse.contains(partition));
                     }

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -501,7 +501,8 @@ public class GuestProcessor implements ExportDataProcessor {
                     }
                 }
                 if (!m_shutdown) {
-                    addBlockListener(source, source.poll(false), edb);
+                    ListenableFuture<AckingContainer> nextCont = source.poll(false);
+                    addBlockListener(source, nextCont, edb);
                 }
             }
         }, edb.getExecutor());

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -255,7 +255,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
                     synchronized(PersistentBinaryDeque.this) {
                         checkDoubleFree();
                         retcont.discard();
-                        assert(m_closed || m_segments.containsKey(segment.segmentIndex()));
+                        assert(m_closed || m_segments.containsKey(segment.segmentIndex())) :
+                            "m_closed=" + m_closed + " m_segments={" + m_segments.keySet() + "}" +
+                            " segmentIndex=" + segment.segmentIndex();
 
                         // Only continue if open there is another segment and this is the first entry of a segment
                         if (m_closed || m_segments.size() == 1

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -60,7 +60,6 @@ import org.voltdb.MockVoltDB;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.Table;
-import org.voltdb.export.ExportDataSource.AckingContainer;
 import org.voltdb.export.ExportDataSource.ReentrantPollException;
 import org.voltdb.export.processors.GuestProcessor;
 import org.voltdb.sysprocs.ExportControl.OperationMode;

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -62,7 +62,6 @@ import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Connector;
 import org.voltdb.compiler.VoltCompiler;
 import org.voltdb.dtxn.SiteTracker;
-import org.voltdb.export.ExportDataSource.AckingContainer;
 import org.voltdb.export.ExportMatchers.AckPayloadMessage;
 import org.voltdb.export.processors.GuestProcessor;
 import org.voltdb.messaging.LocalMailbox;


### PR DESCRIPTION
When stream hits a gap, it may poll a stream block but doesn't assign it to first_unpolled_block or m_pendingContainer, because of that, first_unpolled_block is null in pollImpl() and m_pollTask is set. The next time the stream becomes master again, guest processor tries to poll data source but because m_pollTask is not null EDS throws ReentrantPollException.

Also moving AckingContainer class out of ExportDataSource.

Change-Id: I985d0928eea664c962f07efbce12c74f4c0a6751