### PR TITLE
ENG-15809 migrating index on rejoining streamed tuples

### DIFF
--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1706,6 +1706,15 @@ void PersistentTable::loadTuplesForLoadTable(SerializeInputBE &serialInput,
         }
         processLoadedTuple(target, uniqueViolationOutput, serializedTupleCount, tupleCountPosition,
                            shouldDRStreamRows, ignoreTupleLimit);
+
+        // from stream snapshot/rejoin, add it to migrating index
+        if (!elastic && m_shadowStream != nullptr) {
+              uint16_t migrateColumnIndex = getMigrateColumnIndex();
+              NValue txnId = target.getHiddenNValue(migrateColumnIndex);
+              if(!txnId.isNull()){
+                  migratingAdd(ValuePeeker::peekBigInt(txnId), target);
+              }
+           }
     }
 
     //If unique constraints are being handled, write the length/size of constraints that occured

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -2478,6 +2478,7 @@ bool PersistentTable::migratingRemove(int64_t txnId, TableTuple& tuple) {
     assert(m_shadowStream != nullptr);
     MigratingRows::iterator it = m_migratingRows.find(txnId);
     if (it == m_migratingRows.end()) {
+        assert(false);
         return false;
     }
 
@@ -2485,6 +2486,7 @@ bool PersistentTable::migratingRemove(int64_t txnId, TableTuple& tuple) {
     if (it->second.empty()) {
         m_migratingRows.erase(it);
     }
+    assert(found == 1);
     return found == 1;
 }
 

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -871,8 +871,7 @@ void PersistentTable::doInsertTupleCommon(TableTuple& source, TableTuple& target
 
         // from stream snapshot/rejoin, add it to migrating index
         if (m_shadowStream != nullptr) {
-            uint16_t migrateColumnIndex = getMigrateColumnIndex();
-            NValue txnId = target.getHiddenNValue(migrateColumnIndex);
+            NValue txnId = target.getHiddenNValue(getMigrateColumnIndex());
             if(!txnId.isNull()){
                migratingAdd(ValuePeeker::peekBigInt(txnId), target);
             }
@@ -1430,8 +1429,7 @@ void PersistentTable::deleteTupleForUndo(char* tupleData, bool skipLookup) {
 
     // The inserted tuple could have been migrated from stream snapshot/rejoin, undo the migrating indexes
     if (m_shadowStream != nullptr) {
-        uint16_t migrateColumnIndex = getMigrateColumnIndex();
-        NValue txnId = target.getHiddenNValue(migrateColumnIndex);
+        NValue txnId = target.getHiddenNValue(getMigrateColumnIndex());
         if(!txnId.isNull()){
             migratingRemove(ValuePeeker::peekBigInt(txnId), target);
         }


### PR DESCRIPTION
Add tuples loaded from stream snapshot to migrating index if the tuples have been migrated  to avoid data divergence which causes hash mismatch.