### PR TITLE
ENG-15811, change the initialization order so that export mailbox is …

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataProcessor.java
+++ b/src/frontend/org/voltdb/export/ExportDataProcessor.java
@@ -45,8 +45,6 @@ public interface ExportDataProcessor  {
      */
     void addLogger(VoltLogger logger);
 
-    void setExportGeneration(ExportGeneration generation);
-
     /**
      * Get export client from processor, used by initializing export data source
      * @param tableName
@@ -55,9 +53,9 @@ public interface ExportDataProcessor  {
     public ExportClientBase getExportClient(String tableName);
 
     /**
-     * Inform the processor that initialization is complete; commence work.
+     * Inform the processor that initialization of given data source is complete; commence work.
      */
-    public void readyForData();
+    public void setupDataSource(ExportDataSource source);
 
     /**
      * Allows processor to initiate polling

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -695,6 +695,7 @@ public class ExportGeneration implements Generation {
         adFilePartitions.add(source.getPartitionId());
         int migrateBatchSize = CatalogUtil.getPersistentMigrateBatchSize(source.getTableName());
         source.setupMigrateRowsDeleter(migrateBatchSize);
+        processor.setupDataSource(source);
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("Creating " + source.toString() + " for " + adFile + " bytes " + source.sizeInBytes());
         }
@@ -763,7 +764,7 @@ public class ExportGeneration implements Generation {
                                     + " partition " + partition + " site " + siteId);
                         }
                         dataSourcesForPartition.put(key, exportDataSource);
-
+                        processor.setupDataSource(exportDataSource);
                     } else {
                         // Associate any existing EDS to the export client in the new processor
                         ExportDataSource eds = dataSourcesForPartition.get(key);
@@ -778,7 +779,7 @@ public class ExportGeneration implements Generation {
                             eds.setClient(null);
                             eds.setRunEveryWhere(false);
                         }
-
+                        processor.setupDataSource(eds);
                         // Mark in catalog only if partition is in use
                         eds.markInCatalog(partitionsInUse.contains(partition));
                     }

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -40,7 +40,6 @@ import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.export.ExportDataSource;
 import org.voltdb.export.ExportDataSource.AckingContainer;
 import org.voltdb.export.ExportDataSource.ReentrantPollException;
-import org.voltdb.export.ExportGeneration;
 import org.voltdb.export.StreamBlockQueue;
 import org.voltdb.exportclient.ExportClientBase;
 import org.voltdb.exportclient.ExportDecoderBase;
@@ -54,8 +53,6 @@ public class GuestProcessor implements ExportDataProcessor {
 
     public static final String EXPORT_TO_TYPE = "__EXPORT_TO_TYPE__";
 
-    // FIXME - replace with fixed list of ExportDataSource. That is all we need from m_generation.
-    private ExportGeneration m_generation;
     private volatile boolean m_shutdown = false;
     private VoltLogger m_logger;
 
@@ -106,6 +103,8 @@ public class GuestProcessor implements ExportDataProcessor {
             }
             configProcessed.put(targetName, new Properties(properties));
         }
+        //This will log any targets that are not there but draining datasources will keep them in list.
+        m_logger.info("Active Targets are: " + m_clientsByTarget.keySet().toString());
     }
 
     @Override
@@ -130,34 +129,27 @@ public class GuestProcessor implements ExportDataProcessor {
     }
 
     @Override
-    public void readyForData() {
-        for (Map<String, ExportDataSource> sources : m_generation.getDataSourceByPartition().values()) {
-
-            for (final ExportDataSource source : sources.values()) {
-                synchronized(GuestProcessor.this) {
-                    if (m_shutdown) {
-                        if (m_logger.isDebugEnabled()) {
-                            m_logger.info("Skipping mastership notification for export because processor has been shut down.");
-                        }
-                        return;
-                    }
-                    String tableName = source.getTableName().toLowerCase();
-                    String groupName = m_targetsByTableName.get(tableName);
-                    if (source.getClient() == null) {
-                        m_logger.warn("Table " + tableName + " has no configured connector.");
-                        continue;
-                    }
-                    //If we configured a new client we already mapped it if not old client will be placed for cleanup at shutdown.
-                    m_clientsByTarget.putIfAbsent(groupName, source.getClient());
-                    ExportRunner runner = new ExportRunner(m_targetsByTableName.get(tableName), source.getClient(), source);
-                    // DataSource should start polling only after command log replay on a recover
-                    source.setReadyForPolling(m_startPolling);
-                    source.setOnMastership(runner);
+    public void setupDataSource(ExportDataSource source) {
+        synchronized(GuestProcessor.this) {
+            if (m_shutdown) {
+                if (m_logger.isDebugEnabled()) {
+                    m_logger.info("Skipping mastership notification for export because processor has been shut down.");
                 }
+                return;
             }
+            String tableName = source.getTableName().toLowerCase();
+            String groupName = m_targetsByTableName.get(tableName);
+            if (source.getClient() == null) {
+                m_logger.warn("Table " + tableName + " has no configured connector.");
+                return;
+            }
+            //If we configured a new client we already mapped it if not old client will be placed for cleanup at shutdown.
+            m_clientsByTarget.putIfAbsent(groupName, source.getClient());
+            ExportRunner runner = new ExportRunner(m_targetsByTableName.get(tableName), source.getClient(), source);
+            // DataSource should start polling only after command log replay on a recover
+            source.setReadyForPolling(m_startPolling);
+            source.setOnMastership(runner);
         }
-        //This will log any targets that are not there but draining datasources will keep them in list.
-        m_logger.info("Active Targets are: " + m_clientsByTarget.keySet().toString());
     }
 
     /**
@@ -175,12 +167,6 @@ public class GuestProcessor implements ExportDataProcessor {
         } catch(Throwable t) {
             throw new RuntimeException(t);
         }
-    }
-
-    @Override
-    public void setExportGeneration(ExportGeneration generation) {
-        assert generation != null;
-        m_generation = generation;
     }
 
     private class ExportRunner implements Runnable {
@@ -553,7 +539,6 @@ public class GuestProcessor implements ExportDataProcessor {
         }
         m_clientsByTarget.clear();
         m_targetsByTableName.clear();
-        m_generation = null;
     }
 
 }


### PR DESCRIPTION
…registered after setting up export runner in export data source.

When node rejoins back the all stream's export mailboxes is registered before readyForData() is called, which means it's possible the GIVE_MASTERSHIP message can arrive early but stream is not ready to accept mastership.

Change-Id: Id7c3bd1c8fbfcfd6957089bcca2c8d93384e4f17