### PR TITLE
Fixed ENG-15734

### DIFF
--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -46,10 +46,12 @@
 #include <cassert>
 #include <boost/scoped_ptr.hpp>
 #include <boost/foreach.hpp>
+#include <set>
 
 #include "updateexecutor.h"
 
 #include "common/ExecuteWithMpMemory.h"
+#include "expressions/expressionutil.h"
 #include "plannodes/updatenode.h"
 #include "plannodes/projectionnode.h"
 #include "storage/tablefactory.h"
@@ -149,28 +151,18 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
             //
             // Shouldn't this be done in p_init?  See ticket ENG-8668.
             std::vector<TableIndex*> indexesToUpdate;
-            const std::vector<TableIndex*>& allIndexes = targetTable->allIndexes();
-            BOOST_FOREACH(TableIndex *index, allIndexes) {
-                if (index->isMigratingIndex()) {
-                    indexesToUpdate.push_back(index);
-                } else {
-                    bool indexKeyUpdated = false;
-                    BOOST_FOREACH(int colIndex, index->getAllColumnIndices()) {
-                        std::pair<int, int> updateColInfo; // needs to be here because of macro failure
-                        BOOST_FOREACH(updateColInfo, m_inputTargetMap) {
-                           if (updateColInfo.second == colIndex) {
-                               indexKeyUpdated = true;
-                               break;
-                           }
-                        }
-                        if (indexKeyUpdated) {
-                            break;
-                        }
-                    }
-                    if (indexKeyUpdated) {
-                        indexesToUpdate.push_back(index);
-                    }
-                }
+            for(auto* index : targetTable->allIndexes()) {
+               if (index->isMigratingIndex()) {
+                  indexesToUpdate.push_back(index);
+               } else {
+                  auto const indicesArray = index->getAllColumnIndices();
+                  std::set<int> const colIndices(indicesArray.cbegin(), indicesArray.cend());
+                  if (m_inputTargetMap.cend() !=
+                        std::find_if(m_inputTargetMap.cbegin(), m_inputTargetMap.cend(),
+                           [&colIndices](std::pair<int, int> const& col) {return colIndices.count(col.second);})) {
+                     indexesToUpdate.push_back(index);
+                  }
+               }
             }
 
             assert(m_inputTuple.columnCount() == m_inputTable->columnCount());
@@ -222,8 +214,7 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
             if (m_replicatedTableOperation) {
                 s_modifiedTuples = modified_tuples;
             }
-        }
-        else {
+        } else {
             if (s_modifiedTuples == -1) {
                 // An exception was thrown on the lowest site thread and we need to throw here as well so
                 // all threads are in the same state

--- a/src/ee/executors/updateexecutor.h
+++ b/src/ee/executors/updateexecutor.h
@@ -81,7 +81,7 @@ protected:
 
     UpdatePlanNode* m_node;
 
-    std::vector<std::pair<int, int> > m_inputTargetMap;
+    std::vector<std::pair<int, int>> m_inputTargetMap;
     int m_inputTargetMapSize;
 
     AbstractTempTable* m_inputTable;

--- a/src/ee/expressions/abstractexpression.cpp
+++ b/src/ee/expressions/abstractexpression.cpp
@@ -50,6 +50,7 @@
 
 namespace voltdb {
 
+const std::vector<AbstractExpression*> AbstractExpression::empty_expression;
 // ------------------------------------------------------------------
 // AbstractExpression
 // ------------------------------------------------------------------

--- a/src/ee/expressions/abstractexpression.h
+++ b/src/ee/expressions/abstractexpression.h
@@ -136,6 +136,11 @@ class AbstractExpression {
         return m_right;
     }
 
+    virtual const std::vector<AbstractExpression*> getArgs() const {
+       // Only FunctionExpression has children (as function arguments).
+       return empty_expression;
+    }
+
   protected:
     AbstractExpression();
     AbstractExpression(ExpressionType type);
@@ -145,6 +150,7 @@ class AbstractExpression {
 
   private:
     static AbstractExpression* buildExpressionTree_recurse(PlannerDomValue obj);
+    static const std::vector<AbstractExpression*> empty_expression;
     bool initParamShortCircuits();
 
   protected:

--- a/src/ee/expressions/expressionutil.cpp
+++ b/src/ee/expressions/expressionutil.cpp
@@ -629,22 +629,26 @@ boost::shared_array<int> ExpressionUtil::convertIfAllParameterValues(
     return ret;
 }
 
-void ExpressionUtil::extractTupleValuesColumnIdx(
-      const AbstractExpression* expr, std::vector<int> &columnIds) {
-    if (expr == NULL)
-    {
-        return;
-    }
-    if(expr->getExpressionType() == EXPRESSION_TYPE_VALUE_TUPLE)
-    {
-        const TupleValueExpression* tve = dynamic_cast<const TupleValueExpression*>(expr);
-        assert(tve != NULL);
-        columnIds.push_back(tve->getColumnId());
-        return;
-    }
-    // Recurse
-    ExpressionUtil::extractTupleValuesColumnIdx(expr->getLeft(), columnIds);
-    ExpressionUtil::extractTupleValuesColumnIdx(expr->getRight(), columnIds);
+void ExpressionUtil::extractTupleValuesColumnIdx(const AbstractExpression* expr, std::vector<int> &columnIds) {
+   if (expr != nullptr) {
+      if(expr->getExpressionType() == EXPRESSION_TYPE_VALUE_TUPLE) {
+         auto const* tve = dynamic_cast<const TupleValueExpression*>(expr);
+         assert(tve != NULL);
+         columnIds.emplace_back(tve->getColumnId());
+      } else {
+         ExpressionUtil::extractTupleValuesColumnIdx(expr->getLeft(), columnIds);
+         ExpressionUtil::extractTupleValuesColumnIdx(expr->getRight(), columnIds);
+         for(auto const* e : expr->getArgs()) {
+            ExpressionUtil::extractTupleValuesColumnIdx(e, columnIds);
+         }
+      }
+   }
+}
+
+std::vector<int> ExpressionUtil::extractTupleValuesColumnIdx(const AbstractExpression* expr) {
+   std::vector<int> columnIds;
+   extractTupleValuesColumnIdx(expr, columnIds);
+   return columnIds;
 }
 
 void ExpressionUtil::loadIndexedExprsFromJson(

--- a/src/ee/expressions/expressionutil.h
+++ b/src/ee/expressions/expressionutil.h
@@ -82,7 +82,8 @@ public:
     convertIfAllParameterValues(const std::vector<voltdb::AbstractExpression*> &expressions);
 
     /** Returns ColumnIds of TupleValueExpression expressions from passed axpression.*/
-    static void extractTupleValuesColumnIdx(const AbstractExpression* expr, std::vector<int> &columnIds);
+    static void extractTupleValuesColumnIdx(const AbstractExpression* expr, std::vector<int>&);
+    static std::vector<int> extractTupleValuesColumnIdx(const AbstractExpression* expr);
 
     static AbstractExpression* operatorFactory(ExpressionType et, AbstractExpression *lc, AbstractExpression *rc);
 

--- a/src/ee/expressions/functionexpression.cpp
+++ b/src/ee/expressions/functionexpression.cpp
@@ -143,6 +143,10 @@ namespace functionexpression {
             return m_child->hasParameter();
          }
 
+         const std::vector<AbstractExpression*> getArgs() const override {
+            return std::vector<AbstractExpression*>(1, m_child);
+         }
+
          NValue eval(const TableTuple *tuple1, const TableTuple *tuple2) const {
             assert (m_child);
             return (m_child->eval(tuple1, tuple2)).callUnary<F>();
@@ -178,6 +182,10 @@ namespace functionexpression {
                   }
                }
                return false;
+            }
+
+            const std::vector<AbstractExpression*> getArgs() const override {
+               return m_args;
             }
 
             NValue eval(const TableTuple *tuple1, const TableTuple *tuple2) const {
@@ -226,6 +234,10 @@ namespace functionexpression {
                }
             }
             return false;
+         }
+
+         const std::vector<AbstractExpression*> getArgs() const override {
+            return m_args;
          }
 
          NValue eval(const TableTuple *tuple1, const TableTuple *tuple2) const {

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -78,14 +78,12 @@ class CompactingTreeMultiMapIndex : public TableIndex
         return *reinterpret_cast<MapIterator*> (cursor.m_keyEndIter);
     }
 
-    void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple)
-    {
+    void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple) {
         ++m_inserts;
         m_entries.insert(setKeyFromTuple(tuple), tuple->address());
     }
 
-    bool deleteEntryDo(const TableTuple *tuple)
-    {
+    bool deleteEntryDo(const TableTuple *tuple) {
         ++m_deletes;
         MapIterator iter = findTuple(*tuple);
         if (iter.isEnd()) {
@@ -391,8 +389,7 @@ class CompactingTreeMultiMapIndex : public TableIndex
         return MapIterator();
     }
 
-    MapIterator findTuple(const TableTuple &originalTuple) const
-    {
+    MapIterator findTuple(const TableTuple &originalTuple) const {
         // TODO: couldn't remove this, because of CompactingTreeMultiIndexTest in eecheck
         // code will force to use non-pointer-key.
         if (KeyType::keyDependsOnTupleAddress()) {

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -294,8 +294,7 @@ public:
      *      data, but chosen values for this index.  So, searchKey has
      *      to contain values in this index's entry order.
      */
-    virtual void moveToKeyOrGreater(const TableTuple *searchKey, IndexCursor& cursor) const
-    {
+    virtual void moveToKeyOrGreater(const TableTuple *searchKey, IndexCursor& cursor) const {
         throwFatalException("Invoked TableIndex virtual method moveToKeyOrGreater which has no implementation");
     };
 
@@ -307,29 +306,23 @@ public:
      *      data, but chosen values for this index.  So, searchKey has
      *      to contain values in this index's entry order.
      */
-    virtual bool moveToGreaterThanKey(const TableTuple *searchKey, IndexCursor& cursor) const
-    {
+    virtual bool moveToGreaterThanKey(const TableTuple *searchKey, IndexCursor& cursor) const {
         throwFatalException("Invoked TableIndex virtual method moveToGreaterThanKey which has no implementation");
     };
 
-    virtual void moveToLessThanKey(const TableTuple *searchKey, IndexCursor& cursor) const
-    {
+    virtual void moveToLessThanKey(const TableTuple *searchKey, IndexCursor& cursor) const {
         throwFatalException("Invoked TableIndex virtual method moveToLessThanKey which has no implementation");
     };
 
-    virtual bool moveToCoveringCell(const TableTuple* searchKey,
-                                    IndexCursor &cursor) const
-    {
+    virtual bool moveToCoveringCell(const TableTuple* searchKey, IndexCursor &cursor) const {
         throwFatalException("Invoked TableIndex virtual method moveToCoveringCell which has no implementation");
     }
 
-    virtual void moveToBeforePriorEntry(IndexCursor& cursor) const
-    {
+    virtual void moveToBeforePriorEntry(IndexCursor& cursor) const {
         throwFatalException("Invoked TableIndex virtual method moveToBeforePriorEntry which has no implementation");
     }
 
-    virtual void moveToPriorEntry(IndexCursor& cursor) const
-    {
+    virtual void moveToPriorEntry(IndexCursor& cursor) const {
         throwFatalException("Invoked TableIndex virtual method moveToPriorEntry which has no implementation");
     }
 
@@ -339,8 +332,7 @@ public:
      *
      * @see begin true to move to the beginning, false to the end.
      */
-    virtual void moveToEnd(bool begin, IndexCursor& cursor) const
-    {
+    virtual void moveToEnd(bool begin, IndexCursor& cursor) const {
         throwFatalException("Invoked TableIndex virtual method moveToEnd which has no implementation");
     }
 
@@ -352,8 +344,7 @@ public:
      * @return true if any entry to return, false if reached the end
      * of this index.
      */
-    virtual TableTuple nextValue(IndexCursor& cursor) const
-    {
+    virtual TableTuple nextValue(IndexCursor& cursor) const {
         throwFatalException("Invoked TableIndex virtual method nextValue which has no implementation");
     };
 
@@ -380,16 +371,14 @@ public:
      *
      * @return true if any entry to return, false if not.
      */
-    virtual bool advanceToNextKey(IndexCursor& cursor) const
-    {
+    virtual bool advanceToNextKey(IndexCursor& cursor) const {
         throwFatalException("Invoked TableIndex virtual method advanceToNextKey which has no implementation");
     };
 
     /** retrieves from a primary key index the persistent tuple
      *  matching the given temp tuple.  The tuple's schema should be
      *  the table's schema, not the index's key schema.  */
-    virtual TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const
-    {
+    virtual TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const {
         throwFatalException("Invoked TableIndex virtual method uniqueMatchingTuple which has no use on a non-unique index");
     };
 
@@ -404,15 +393,13 @@ public:
      * We might have to make a different class in future for maximizing
      * performance of UniqueIndex.
      */
-    inline bool isUniqueIndex() const
-    {
+    inline bool isUniqueIndex() const {
         return m_scheme.unique;
     }
     /**
      * Same as isUniqueIndex...
      */
-    inline bool isCountableIndex() const
-    {
+    inline bool isCountableIndex() const {
         return m_scheme.countable;
     }
 
@@ -423,8 +410,7 @@ public:
     /**
      * Return TRUE if the index has a predicate.
      */
-    bool isPartialIndex() const
-    {
+    bool isPartialIndex() const {
         return getPredicate() != NULL;
     }
 
@@ -475,8 +461,7 @@ public:
      * @param cursor IndexCursor object
      * @return true if it finds tuple with the dense rank value, otherwise false
      */
-    virtual bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const
-    {
+    virtual bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const {
         throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
     }
 
@@ -486,14 +471,12 @@ public:
     // index.
     virtual int64_t getMemoryEstimate() const = 0;
 
-    const std::vector<int>& getColumnIndices() const
-    {
+    const std::vector<int>& getColumnIndices() const {
         return m_scheme.columnIndices;
     }
 
     // Return all column indicies including the predicate ones
-    const std::vector<int>& getAllColumnIndices() const
-    {
+    const std::vector<int>& getAllColumnIndices() const {
         return m_scheme.allColumnIndices;
     }
 
@@ -503,18 +486,15 @@ public:
         return emptyExpressionVector;
     }
 
-    const std::vector<AbstractExpression*>& getIndexedExpressions() const
-    {
+    const std::vector<AbstractExpression*>& getIndexedExpressions() const {
         return m_scheme.indexedExpressions;
     }
 
-    const AbstractExpression* getPredicate() const
-    {
+    const AbstractExpression* getPredicate() const {
         return m_scheme.predicate;
     }
 
-    const std::string& getName() const
-    {
+    const std::string& getName() const {
         return m_scheme.name;
     }
 
@@ -528,13 +508,11 @@ public:
         }
     }
 
-    const std::string& getId() const
-    {
+    const std::string& getId() const {
         return m_id;
     }
 
-    const TupleSchema *getKeySchema() const
-    {
+    const TupleSchema *getKeySchema() const {
         return m_keySchema;
     }
 
@@ -551,8 +529,7 @@ public:
 
     virtual voltdb::IndexStats* getIndexStats();
 
-    const TupleSchema *getTupleSchema() const
-    {
+    const TupleSchema *getTupleSchema() const {
         return m_scheme.tupleSchema;
     }
 

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1053,13 +1053,12 @@ void PersistentTable::updateTupleWithSpecificIndexes(TableTuple& targetTupleToUp
     /**
      * Remove the current tuple from any indexes.
      */
-    bool someIndexGotUpdated = false;
+    const bool someIndexGotUpdated = !indexesToUpdate.empty();
     bool indexRequiresUpdate[indexesToUpdate.size()];
     if (indexesToUpdate.size()) {
-        someIndexGotUpdated = true;
         for (int i = 0; i < indexesToUpdate.size(); i++) {
             TableIndex* index = indexesToUpdate[i];
-            if (!index->keyUsesNonInlinedMemory()) {
+            if (!index->keyUsesNonInlinedMemory() || index->isPartialIndex()) {
                 if (!index->checkForIndexChange(&targetTupleToUpdate, &sourceTupleWithNewValues)) {
                     indexRequiresUpdate[i] = false;
                     continue;


### PR DESCRIPTION
that crashes when removing a tuple not present in some partial index

Renamed the branch, since branch name containing `.` confuses Jenkins (hence previous PR was automatically closed).