### PR TITLE
Fix re-using variable between methods

### DIFF
--- a/tools/docker/docker-entrypoint.sh
+++ b/tools/docker/docker-entrypoint.sh
@@ -27,9 +27,9 @@ function init() {
         DEPLOYMENT=${DEFAULT_DEPLOYMENT}
     fi
 
-    OPTIONS="-C ${DEPLOYMENT} -D ${DIRECTORY_SPEC}"
-    echo "Run voltdb init $OPTIONS"
-    bin/voltdb init ${OPTIONS}
+    INIT_OPTIONS="-C ${DEPLOYMENT} -D ${DIRECTORY_SPEC}"
+    echo "Run voltdb init $INIT_OPTIONS"
+    bin/voltdb init ${INIT_OPTIONS}
 }
 
 function execVoltdbStart() {


### PR DESCRIPTION
Fix re-using variable between methods. Stops the no such option -C if not yet initialized
This is due to the OPTIONS variable being used several places (could also be local variable, but i changed it to INIT_OPTIONS)