### PR TITLE
ENG-15819 check snapshot for uac

### DIFF
--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.zookeeper_voltpatches.CreateMode;
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
@@ -611,5 +610,19 @@ public class VoltZK {
             zk.delete(migrate_partition_leader_info, -1);
         } catch (KeeperException | InterruptedException e) {
         }
+    }
+
+    /**
+     * @param zk ZooKeeper
+     * @return true if any hosts work on snapshot
+     */
+    public static boolean hasHostsSnapshotting(ZooKeeper zk) {
+        try {
+            List<String> nodesSnapshotting = zk.getChildren(VoltZK.nodes_currently_snapshotting, false);
+            return (!nodesSnapshotting.isEmpty());
+        } catch (KeeperException | InterruptedException e) {
+            VoltDB.crashLocalVoltDB("Unable to read snapshotting hosts.", true, e);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
If uac kicks in after a rejoining node fails but before its stream snapshot is completed, uac could be blocked by the stream snapshot, which may trigger mp deadlock warning if uac is blocked by more than 5 min.  If the uac requires snapshot isolation and snapshot is in progress, abort the uac.