### PR TITLE
ENG-15853, skip emptiness check for creating view on stream and alter…

### DIFF
--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -605,6 +605,9 @@ enum DRConflictOnPK {
     CONFLICT_ON_PK,
 };
 
+/*
+ * Keep it sync with frontend/org/voltdb/TableType.java
+ */
 enum TableType {
      // This will be unset and hence 0 for pre-9.0 catalogs
      INVALID = 0,
@@ -612,8 +615,8 @@ enum TableType {
       // Regular PersistentTable
      PERSISTENT = 1,
 
-      // StreamTable without ExportTupleStream (Views only)
-     STREAM_VIEW_ONLY = 2,
+      // StreamTable without ExportTupleStream
+     CONNECTOR_LESS_STREAM = 2,
 
      // StreamTable with ExportTupleStream
      STREAM = 3,
@@ -629,13 +632,13 @@ inline bool tableTypeIsExportStream(TableType tableType) {
     return tableType == STREAM;
 }
 
-inline bool tableTypeIsViewStream(TableType tableType) {
-    return tableType == STREAM_VIEW_ONLY;
+inline bool tableTypeIsConnectorLessStream(TableType tableType) {
+    return tableType == CONNECTOR_LESS_STREAM;
 }
 
 inline bool tableTypeIsStream(TableType tableType) {
     return tableTypeIsExportStream(tableType) ||
-            tableTypeIsViewStream(tableType);
+            tableTypeIsConnectorLessStream(tableType);
 }
 
 inline bool isTableWithExport(TableType tableType) {

--- a/src/frontend/org/voltdb/TableType.java
+++ b/src/frontend/org/voltdb/TableType.java
@@ -25,7 +25,7 @@ package org.voltdb;
 public enum TableType {
     INVALID_TYPE(0),
     PERSISTENT(1),              // Regular PersistentTable
-    STREAM_VIEW_ONLY(2),        // StreamTable without ExportTupleStream (Views only)
+    CONNECTOR_LESS_STREAM(2),        // StreamTable without ExportTupleStream (Views only)
     STREAM(3),                  // StreamTable with ExportTupleStream
     PERSISTENT_MIGRATE(4),      // PersistentTable with associated Stream for migrating DELETES
     PERSISTENT_EXPORT(5);       // PersistentTable with associated Stream for linking INSERTS
@@ -38,12 +38,12 @@ public enum TableType {
         return type;
     }
 
-    public static boolean isStreamViewOnly(int e) {
-        return (e == STREAM_VIEW_ONLY.get());
+    public static boolean isConnectorLessStream(int e) {
+        return (e == CONNECTOR_LESS_STREAM.get());
     }
 
     public static boolean isStream(int e) {
-        return (e == STREAM.get() || e == STREAM_VIEW_ONLY.get());
+        return (e == STREAM.get() || e == CONNECTOR_LESS_STREAM.get());
     }
 
     public static boolean isPersistentMigrate(int e) {

--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -20,8 +20,21 @@ package org.voltdb.compiler;
 import java.io.IOException;
 import java.io.Reader;
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.stream.StreamSupport;
 
@@ -67,8 +80,12 @@ import org.voltdb.compiler.statements.ReplicateTable;
 import org.voltdb.compiler.statements.SetGlobalParam;
 import org.voltdb.compiler.statements.VoltDBStatementProcessor;
 import org.voltdb.compilereport.TableAnnotation;
-import org.voltdb.expressions.*;
+import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.AbstractExpression.UnsafeOperatorsForDDL;
+import org.voltdb.expressions.ExpressionUtil;
+import org.voltdb.expressions.FunctionExpression;
+import org.voltdb.expressions.OperatorExpression;
+import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.parser.HSQLLexer;
 import org.voltdb.parser.SQLLexer;
 import org.voltdb.parser.SQLParser;
@@ -1315,7 +1332,7 @@ public class DDLCompiler {
             if(streamTarget != null && !Constants.DEFAULT_EXPORT_CONNECTOR_NAME.equals(streamTarget)) {
                 table.setTabletype(TableType.STREAM.get());
             } else {
-                table.setTabletype(TableType.STREAM_VIEW_ONLY.get());
+                table.setTabletype(TableType.CONNECTOR_LESS_STREAM.get());
             }
         }
         // map of index replacements for later constraint fixup

--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -1394,7 +1394,7 @@ public class VoltCompiler {
             }
             // This is used to enforce default connectors assigned to streams through the Java Property
             // for streams that don't have the Export To Target clause
-            if (TableType.isStreamViewOnly(tableref.getTabletype()) && System.getProperty(ExportDataProcessor.EXPORT_TO_TYPE) != null) {
+            if (TableType.isConnectorLessStream(tableref.getTabletype()) && System.getProperty(ExportDataProcessor.EXPORT_TO_TYPE) != null) {
                 tableref.setTabletype(TableType.STREAM.get());
             }
         }

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -195,7 +195,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
         m_catalog = catalog;
         boolean schemaHasPersistentTables = false;
         for (Table t : catalog.getTables()) {
-            if (t.getTabletype() != TableType.STREAM.get() && t.getTabletype() != TableType.STREAM_VIEW_ONLY.get()) {
+            if (t.getTabletype() != TableType.STREAM.get() && t.getTabletype() != TableType.CONNECTOR_LESS_STREAM.get()) {
                 schemaHasPersistentTables = true;
                 break;
             }

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -19,7 +19,6 @@ package org.voltdb.sysprocs;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -632,7 +632,7 @@ public abstract class CatalogUtil {
         for (Connector connector : connectors) {
             for (ConnectorTableInfo tinfo : connector.getTableinfo()) {
                 Table t = tinfo.getTable();
-                if (t.getTabletype() == TableType.STREAM_VIEW_ONLY.get()) {
+                if (t.getTabletype() == TableType.CONNECTOR_LESS_STREAM.get()) {
                     // Skip view-only streams
                     continue;
                 }
@@ -705,7 +705,8 @@ public abstract class CatalogUtil {
      */
     public static boolean isTableExportOnly(org.voltdb.catalog.Database database,
                                             org.voltdb.catalog.Table table) {
-        if (TableType.isInvalidType(table.getTabletype())) {
+        int type = table.getTabletype();
+        if (TableType.isInvalidType(type)) {
             // This implementation uses connectors instead of just looking at the tableType
             // because snapshots or catalogs from pre-9.0 versions (DR) will not have this new tableType field.
             for (Connector connector : database.getConnectors()) {
@@ -721,7 +722,7 @@ public abstract class CatalogUtil {
             // Found no connectors
             return false;
         } else {
-            return TableType.isStream(table.getTabletype());
+            return TableType.isStream(type);
         }
     }
 

--- a/tests/frontend/org/voltdb/TestStreamView.java
+++ b/tests/frontend/org/voltdb/TestStreamView.java
@@ -27,7 +27,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.util.Properties;
+import java.util.Random;
 
 import org.junit.After;
 import org.junit.Before;
@@ -35,6 +37,8 @@ import org.junit.Test;
 import org.voltdb.VoltDB.Configuration;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientFactory;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.client.NoConnectionsException;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.export.ExportDataProcessor;
@@ -49,6 +53,46 @@ public class TestStreamView
     private VoltDB.Configuration m_config;
     private ServerThread m_localServer;
     private Client m_client;
+
+    @Test
+    public void testStreamViewOnCatalogUpdate() throws NoConnectionsException, IOException, ProcCallException {
+        String createStream = "CREATE STREAM ddata_stream "
+                + "PARTITION ON COLUMN vin "
+                + "EXPORT TO TARGET ddata_stream_target "
+                + "( "
+                + "     VIN VARCHAR(18) NOT NULL, "
+                + "     PRICE INTEGER NOT NULL,"
+                + "     COLLECT_DATE TIMESTAMP NOT NULL,"
+                + ");";
+        ClientResponse response = m_client.callProcedure("@AdHoc", createStream);
+        assertEquals(ClientResponse.SUCCESS, response.getStatus());
+        String createStreamView = "CREATE VIEW message_count_by_vin AS "
+                + "SELECT VIN, dayofweek(collect_date), count(*) how_many, sum(price), min(price), max(price) "
+                + "FROM ddata_stream "
+                + "GROUP BY VIN, dayofweek(collect_date);";
+        response = m_client.callProcedure("@AdHoc", createStreamView);
+        assertEquals(ClientResponse.SUCCESS, response.getStatus());
+
+        VoltTable[] results;
+        Random r = new Random();
+        // insert into stream make sure you get more blocks
+        for (int i=0; i < 1000; i++) {
+            String vin = String.valueOf(Math.abs(r.nextInt()));
+            int price = Math.abs(r.nextInt(10_000));
+            String insertStmt = "insert into ddata_stream VALUES ('%s', '%d', now);";
+            String q = String.format(insertStmt, vin, price);
+            results = m_client.callProcedure("@AdHoc", q).getResults();
+            assertEquals(1, results[0].asScalarLong());
+        }
+        response = m_client.callProcedure("@AdHoc", "alter stream ddata_stream add column d int not null;");
+        assertEquals(ClientResponse.SUCCESS, response.getStatus());
+        response = m_client.callProcedure("@AdHoc", "alter stream ddata_stream alter column d varchar(32) not null;");
+        assertEquals(ClientResponse.SUCCESS, response.getStatus());
+        response = m_client.callProcedure("@AdHoc", "alter stream ddata_stream drop column d;");
+        assertEquals(ClientResponse.SUCCESS, response.getStatus());
+        results = m_client.callProcedure("@AdHoc", "select * from message_count_by_vin;").getResults();
+        assertTrue(results[0].m_rowCount > 1);
+    }
 
     @Test
     public void testDeleteAll() throws Exception
@@ -323,7 +367,6 @@ public class TestStreamView
             results = m_client.callProcedure("@AdHoc", "select count(*) from bidask_minmax").getResults();
             assertEquals(0, results[0].asScalarLong());
         }
-
     }
 
     @Before
@@ -345,6 +388,7 @@ public class TestStreamView
 
         Properties props = new Properties();
         project.addExport(true, "custom", props, "noop");
+        project.setUseDDLSchema(true);
 
         boolean compiled = project.compile(Configuration.getPathToCatalogForTest("test-stream-view.jar"), 1, 1, 0);
         assertTrue(compiled);


### PR DESCRIPTION
…ing stream schema.

The reason is that CatalogDiffEngine wants to check whether view based on stream or stream table itself is empty during catalog update, which is unnecessary because stream table is always empty. Change CatalogDiffEngine to skip those types of view/table.

Meanwhile rename the table type STREAM_VIEW_ONLY to CONNECTOR_LESS_STREAM to avoid ambiguity.

Change-Id: I334a70cd15adcdbe0223207a151a961c19569837