### PR TITLE
Fix hang when importing >1MB VARCHAR/STRING columns (#6148)

### DIFF
--- a/src/frontend/org/voltdb/client/VoltBulkLoader/PerPartitionTable.java
+++ b/src/frontend/org/voltdb/client/VoltBulkLoader/PerPartitionTable.java
@@ -277,13 +277,13 @@ public class PerPartitionTable {
                     row_args[i] = ParameterConverter.tryToMakeCompatible(type.classFromType(),
                             currRow.m_rowData[i]);
                 }
+                m_table.addRow(row_args);
             } catch (Exception e) {
                 loader.generateError(currRow.m_rowHandle, currRow.m_rowData, e.getMessage());
                 loader.m_outstandingRowCount.decrementAndGet();
                 it.remove();
                 continue;
             }
-            m_table.addRow(row_args);
 
             Long prevValue;
             if ((prevValue = batchSizes.put(loader, 1L)) != null) {

--- a/tests/frontend/org/voltdb/utils/TestCSVLoader.java
+++ b/tests/frontend/org/voltdb/utils/TestCSVLoader.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import com.google_voltpatches.common.base.Strings;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -1785,6 +1786,34 @@ public class TestCSVLoader {
         String currentTime = new TimestampType().toString();
         String []myData = {
                 "1 ,1,1,11111111,first,2000000000000000000000000000000.000000000000,1.11,"+currentTime+",POINT(1 1),\"POLYGON((0 0, 1 0, 0 1, 0 0))\"",
+        };
+        int invalidLineCnt = 1;
+        int validLineCnt = 0;
+
+        test_Interface(myOptions, myData, invalidLineCnt, validLineCnt);
+    }
+
+    @Test(timeout=2000)
+    public void testBadString() throws Exception {
+        String []myOptions = {
+                "-f" + path_csv,
+                "--reportdir=" + reportDir,
+                "--maxerrors=50",
+                "--user=",
+                "--password=",
+                "--port=",
+                "--separator=,",
+                "--quotechar=\"",
+                "--escape=\\",
+                "--skip=0",
+                "--limitrows=100",
+                "BlAh"
+        };
+        String currentTime = new TimestampType().toString();
+        String longString = Strings.repeat("a", (1024*1024)+1);
+        assertTrue(longString.length() > (1024*1024));
+        String []myData = {
+                "1 ,1,1,11111111,\""+longString+"\",2.0,1.11,"+currentTime+",POINT(1 1),\"POLYGON((0 0, 1 0, 0 1, 0 0))\"",
         };
         int invalidLineCnt = 1;
         int validLineCnt = 0;


### PR DESCRIPTION
* Fix hang when importing >1MB VARCHAR/STRING columns

Fixes an issue in PerPartitionTable.buildTable() where VARCHAR/STRING
column values >1MB result in the bulk loader (and by relation the CSV
loader) hanging indefinitely during drain while waiting for
m_outstandingRowCount to be decremented to zero.

* Switch to the patched version of Guava's Strings class