### PR TITLE
ENG-15883: On error and recovery handle fully migrated partitions

### DIFF
--- a/src/frontend/org/voltdb/TheHashinator.java
+++ b/src/frontend/org/voltdb/TheHashinator.java
@@ -176,6 +176,13 @@ public abstract class TheHashinator {
     abstract protected boolean pIsPristine();
     abstract public int getPartitionFromHashedToken(int hashedToken);
 
+    /**
+     * @return {@link Set} of partitions which are in this hashinator
+     */
+    public Set<Integer> getPartitions() {
+        return pGetPartitions();
+    }
+
     static public void resetElasticallyModifiedForTest() {
         m_elasticallyModified = false;
     }
@@ -325,7 +332,9 @@ public abstract class TheHashinator {
         if (existingHashinator == null) {
             existingHashinator = constructHashinator(hashinatorImplementation, configBytes, cooked);
             TheHashinator tempVal = m_cachedHashinators.putIfAbsent( version, existingHashinator);
-            if (tempVal != null) existingHashinator = tempVal;
+            if (tempVal != null) {
+                existingHashinator = tempVal;
+            }
         }
 
         //Do a CAS loop to maintain a global instance
@@ -466,10 +475,16 @@ public abstract class TheHashinator {
                 Set<Integer> partitions = TheHashinator.this.pGetPartitions();
 
                 for (int ii = 0; ii < 500000; ii++) {
-                    if (partitions.isEmpty()) break;
+                    if (partitions.isEmpty()) {
+                        break;
+                    }
                     Object value = null;
-                    if (type == VoltType.INTEGER) value = ii;
-                    if (type == VoltType.STRING) value = String.valueOf(ii);
+                    if (type == VoltType.INTEGER) {
+                        value = ii;
+                    }
+                    if (type == VoltType.STRING) {
+                        value = String.valueOf(ii);
+                    }
                     if (type == VoltType.VARBINARY) {
                         ByteBuffer buf = ByteBuffer.allocate(4);
                         buf.putInt(ii);

--- a/src/frontend/org/voltdb/elastic/ElasticService.java
+++ b/src/frontend/org/voltdb/elastic/ElasticService.java
@@ -49,4 +49,12 @@ public interface ElasticService {
      * @param failedHostIds {@link Collection} of host IDs which failed
      */
     void hostsFailed(Collection<Integer> failedHostIds);
+
+    /**
+     * During some elastic operations partitions might exist which are not on the hash ring but they cannot be removed
+     * from the system. This method is a way to test if any partitions can be removed from the system.
+     *
+     * @return {@code true} if partitions can be removed from the system
+     */
+    boolean canRemovePartitions();
 }

--- a/src/frontend/org/voltdb/iv2/LeaderAppointer.java
+++ b/src/frontend/org/voltdb/iv2/LeaderAppointer.java
@@ -573,6 +573,7 @@ public class LeaderAppointer implements Promotable
         Map<Integer, Host> hostLeaderMap = Maps.newHashMap();
         ImmutableMap<Integer, Long> masters = m_iv2masters.pointInTimeCache();
         final long statTs = System.currentTimeMillis();
+        Set<Integer> partitionsOnHashRing = TheHashinator.getCurrentHashinator().getPartitions();
         for (Cartographer.AsyncPartition partition : partitions) {
             int pid = partition.getPid();
 
@@ -583,7 +584,7 @@ public class LeaderAppointer implements Promotable
                 if (!partition.isInitialized()) {
                     continue;
                 }
-                final boolean partitionNotOnHashRing = partitionNotOnHashRing(pid);
+                final boolean partitionNotOnHashRing = !partitionsOnHashRing.contains(pid);
 
                 List<String> replicas = partition.getReplicas();
 
@@ -689,10 +690,6 @@ public class LeaderAppointer implements Promotable
         } catch (Exception e) {
             tmLog.error(WHOMIM + "Error removing partition info", e);
         }
-    }
-
-    private static boolean partitionNotOnHashRing(int pid) {
-        return TheHashinator.getRanges(pid).isEmpty();
     }
 
     /**

--- a/src/frontend/org/voltdb/iv2/LeaderAppointer.java
+++ b/src/frontend/org/voltdb/iv2/LeaderAppointer.java
@@ -588,7 +588,7 @@ public class LeaderAppointer implements Promotable
                 List<String> replicas = partition.getReplicas();
 
                 if (replicas.isEmpty()) {
-                    if (partitionNotOnHashRing) {
+                    if (partitionNotOnHashRing && VoltDB.instance().getElasticService().canRemovePartitions()) {
                         // no replica for the new partition, clean it up
                         removeAndCleanupPartition(pid);
                         continue;


### PR DESCRIPTION
On some error and recovery paths completed migrated partitions were not being correctly handled while an elastic remove operation was on going. Prevent the removal of partitions until elastic remove is ready for them to occur and be able to determine easily which partitions are part of the system but not in the hashinator.