### PR TITLE
ENG-15816, fix a sharp edge when @SnapshotRestore fails on path check.

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -486,8 +486,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                     String errorMsg = null;
                     if (!outputPath.exists()) {
                         errorMsg = "Output path for Json duplicatesPath \"" + outputPath + "\" does not exist";
-                    }
-                    if (!outputPath.canExecute()) {
+                    } else if (!outputPath.canExecute()) {
                         errorMsg = "Output path for Json duplicatesPath \"" + outputPath + "\" is not executable";
                     }
                     // error check and early return

--- a/src/frontend/org/voltdb/sysprocs/saverestore/ClusterSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/ClusterSaveFileState.java
@@ -87,6 +87,12 @@ public class ClusterSaveFileState
         long txnId = -1;
         while (saveFileState.advanceRow())
         {
+            long originalHostId = saveFileState.getLong("ORIGINAL_HOST_ID");
+            // it means we couldn't find snapshot file on this node, ignore it now,
+            // @SnapshotRestore will check completion of the snapshot later
+            if (originalHostId == ClusterSaveFileState.ERROR_CODE) {
+                continue;
+            }
             checker.checkRow(saveFileState); // throws if inconsistent
             String table_name = saveFileState.getString("TABLE");
 


### PR DESCRIPTION
1) Add warning messages for @SnapshotRestore response if path to snapshot files doesn't exist or not executable.
Currently if path to snapshot files doesn't exist, server will stop restoring snapshot regardless there are following checks on
snapshot consistency and integrity. Since this may not be fatal, lower it to warning and append the warning message to response.

2) Error message `Path doesn't exist` should supersede other minor issues like `Path is not executable`.
