### PR TITLE
ENG-15584 shutdown rejoining node without going through agreement process

### DIFF
--- a/src/frontend/org/voltcore/agreement/AgreementSite.java
+++ b/src/frontend/org/voltcore/agreement/AgreementSite.java
@@ -57,6 +57,7 @@ import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.RateLimitedLogger;
+import org.voltdb.VoltDB;
 
 import com.google_voltpatches.common.collect.ImmutableSet;
 
@@ -620,6 +621,13 @@ public class AgreementSite implements org.apache.zookeeper_voltpatches.server.Zo
                     false,
                     null);
         }
+
+        // Don't try to go through agreement process for a rejoining node.
+        if (VoltDB.instance().rejoining()) {
+            VoltDB.crashLocalVoltDB("Another node failed before this node could finish rejoining. " +
+                    "As a result, the rejoin operation has been canceled. Please try again.");
+        }
+
         Set<Long> unknownFaultedHosts = new TreeSet<>();
 
         // This one line is a biggie. Gets agreement on what the post-fault cluster will be.

--- a/src/frontend/org/voltcore/agreement/AgreementSite.java
+++ b/src/frontend/org/voltcore/agreement/AgreementSite.java
@@ -60,6 +60,7 @@ import org.voltcore.utils.RateLimitedLogger;
 import org.voltdb.VoltDB;
 
 import com.google_voltpatches.common.collect.ImmutableSet;
+import com.google_voltpatches.common.collect.Sets;
 
 /*
  * A wrapper around a single node ZK server. The server is a modified version of ZK that speaks the ZK
@@ -623,10 +624,8 @@ public class AgreementSite implements org.apache.zookeeper_voltpatches.server.Zo
         }
 
         // Don't try to go through agreement process for a rejoining node.
-        if (VoltDB.instance().rejoining()) {
-            VoltDB.crashLocalVoltDB("Another node failed before this node could finish rejoining. " +
-                    "As a result, the rejoin operation has been canceled. Please try again.");
-        }
+        // Check out if the current host is rejoining, if so shut itself down.
+        m_failedHostsCallback.disconnect(null);
 
         Set<Long> unknownFaultedHosts = new TreeSet<>();
 

--- a/src/frontend/org/voltcore/agreement/AgreementSite.java
+++ b/src/frontend/org/voltcore/agreement/AgreementSite.java
@@ -57,10 +57,7 @@ import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.RateLimitedLogger;
-import org.voltdb.VoltDB;
-
 import com.google_voltpatches.common.collect.ImmutableSet;
-import com.google_voltpatches.common.collect.Sets;
 
 /*
  * A wrapper around a single node ZK server. The server is a modified version of ZK that speaks the ZK

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1762,6 +1762,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     return;
                 }
 
+                if (failedHosts == null) {
+                    return;
+                }
+
                 //create a blocker for repair if this is a MP leader and partition leaders change
                 if (m_leaderAppointer.isLeader() && m_cartographer.hasPartitionMastersOnHosts(failedHosts)) {
                     VoltZK.createActionBlocker(m_messenger.getZK(), VoltZK.mpRepairInProgress,


### PR DESCRIPTION
A rejoining node could still wait for stream snapshot from a failed node and end up 60 second no-data timeout.  Shutdown it early to avoid the error warning.