### PR TITLE
ENG-15786: Crash with terminate after 'second parameter' error

### DIFF
--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -1334,7 +1334,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             }
             return false;
         } else if (hasUserDefinedFunctionExpression()) {
-            msg.append("cannot contain calls to user defined functions.");
+            assert false; // cannot reach here
             return false;
         } else {
             return true;

--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -1317,7 +1317,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
                 msg.append("cannot include the function STR.");
                 return false;
             } else {
-                msg.append("cannot include invalid function.");
+                assert false; // cannot reach here
                 return false;
             }
         } else if (hasAnySubexpressionOfClass(AggregateExpression.class)) {
@@ -1334,7 +1334,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             }
             return false;
         } else if (hasUserDefinedFunctionExpression()) {
-            assert false; // cannot reach here
+            msg.append("cannot contain calls to user defined functions.");
             return false;
         } else {
             return true;
@@ -1445,10 +1445,6 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
      * @return If found, return the functionId. Otherwise, return -1
      */
     private int containsFunctionByIds(Set<Integer> functionIds) {
-        if (this instanceof AbstractValueExpression) {
-            return -1;
-        }
-
         List<AbstractExpression> functionsList = findAllFunctionSubexpressions();
         for (AbstractExpression funcExpr : functionsList) {
             assert (funcExpr instanceof FunctionExpression);

--- a/src/frontend/org/voltdb/expressions/FunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/FunctionExpression.java
@@ -106,6 +106,10 @@ public class FunctionExpression extends AbstractExpression {
 
     public boolean hasFunctionId(int functionId) { return m_functionId == functionId; }
 
+    public int getFunctionId() {
+        return m_functionId;
+    }
+
     public void setResultTypeParameterIndex(int resultTypeParameterIndex) {
         m_resultTypeParameterIndex = resultTypeParameterIndex;
     }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/FunctionForVoltDB.java
@@ -157,7 +157,7 @@ public class FunctionForVoltDB extends FunctionSQL {
         static final int FUNC_VOLT_REGEXP_POSITION        = 20041;
 
         static final int FUNC_VOLT_ROUND                  = 20042;
-        static final int FUNC_VOLT_STR                    = 20043;
+        public static final int FUNC_VOLT_STR             = 20043;
 
         // our local functions for networking
         static final int FUNC_VOLT_INET_NTOA                   = 20044;

--- a/tests/frontend/org/voltdb/TestAdhocCreateDropIndex.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateDropIndex.java
@@ -455,7 +455,8 @@ public class TestAdhocCreateDropIndex extends AdhocDDLTestBase {
                     Pair.of("CREATE INDEX PI31 ON P5(i) WHERE j > 0;", true),               // partial index with columns and safe predicate on non-empty table: passes
                     Pair.of("CREATE INDEX PI21 ON P5(i, LOG10(j));", false),                 // normal index with unsafe expression on non-empty table: rejected
                     Pair.of("CREATE INDEX PI41 ON P5(i) WHERE LOG(j) > 1 OR j <= 0;", false),// partial index with columns and unsafe predicate on non-empty table: rejected
-                    Pair.of("CREATE INDEX PI51 ON P5(LOG(i)) WHERE LOG(j) > 1 OR j <= 0;", false))  // partial index with unsafe expression and unsafe predicate on non-empty table: rejected
+                    Pair.of("CREATE INDEX PI51 ON P5(LOG(i)) WHERE LOG(j) > 1 OR j <= 0;", false),  // partial index with unsafe expression and unsafe predicate on non-empty table: rejected
+                    Pair.of("CREATE INDEX PI6 ON P5(i) WHERE 'ABC' > STR(i, i);", false))   // STR function is invalid in expressions for indexes
                     .forEachOrdered(stmtAndShouldPass -> {
                         final String stmt = stmtAndShouldPass.getFirst();
                         final boolean shouldPass = stmtAndShouldPass.getSecond();


### PR DESCRIPTION
The cause of the problem is that we are trying to create an index based on [STR](https://docs.voltdb.com/UsingVoltDB/sqlfuncstr.php) function.
The second argument of **STR** must be an integer between 0 and 38. An insertion/update of the table will fail if it hit the index and fail to meet the 0~38 constraint.

This fix disallows **STR** in index expressions.