### PR TITLE
Revert "ENG-15584 shutdown rejoining node without going through agreement process"

### DIFF
--- a/src/frontend/org/voltcore/agreement/AgreementSite.java
+++ b/src/frontend/org/voltcore/agreement/AgreementSite.java
@@ -57,6 +57,7 @@ import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.RateLimitedLogger;
+
 import com.google_voltpatches.common.collect.ImmutableSet;
 
 /*
@@ -619,11 +620,6 @@ public class AgreementSite implements org.apache.zookeeper_voltpatches.server.Zo
                     false,
                     null);
         }
-
-        // Don't try to go through agreement process for a rejoining node.
-        // Check out if the current host is rejoining, if so shut itself down.
-        m_failedHostsCallback.disconnect(null);
-
         Set<Long> unknownFaultedHosts = new TreeSet<>();
 
         // This one line is a biggie. Gets agreement on what the post-fault cluster will be.

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1737,10 +1737,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     return;
                 }
 
-                if (failedHosts == null) {
-                    return;
-                }
-
                 //create a blocker for repair if this is a MP leader and partition leaders change
                 if (m_leaderAppointer.isLeader() && m_cartographer.hasPartitionMastersOnHosts(failedHosts)) {
                     VoltZK.createActionBlocker(m_messenger.getZK(), VoltZK.mpRepairInProgress,


### PR DESCRIPTION
Reverts VoltDB/voltdb#6167

Change was causing NPE in implementation of disconnect which assumed that failed hosts could not be null