### PR TITLE
ENG-15854: Remove deprecated "EXPORT" with updated STREAM syntax

### DIFF
--- a/examples/bank-offers/ddl.sql
+++ b/examples/bank-offers/ddl.sql
@@ -87,7 +87,13 @@ CREATE TABLE offers_given(
 );
 PARTITION TABLE offers_given ON COLUMN acc_no;
 CREATE INDEX idx_offers_given ON offers_given (offer_ts);
-EXPORT TABLE offers_given TO TARGET table_test;
+
+CREATE STREAM offers_given_export PARTITION ON COLUMN acc_no EXPORT TO TARGET table_test (
+  acc_no BIGINT NOT NULL,
+  vendor_id INTEGER,
+  offer_ts TIMESTAMP NOT NULL,
+  offer_text VARCHAR(200)
+);
 
 --------- VIEWS ---------------------------
 
@@ -103,7 +109,7 @@ GROUP BY acc_no, vendor_id;
 
 CREATE VIEW total_offers AS
 SELECT TRUNCATE(SECOND,offer_ts) AS offer_ts, acc_no, COUNT(*) as total_offers
-FROM offers_given
+FROM offers_given_export
 GROUP BY TRUNCATE(SECOND,offer_ts), acc_no;
 
 --------- PROCEDURES ----------------------

--- a/examples/bank-offers/procedures/bankoffers/CheckForOffers.java
+++ b/examples/bank-offers/procedures/bankoffers/CheckForOffers.java
@@ -54,6 +54,8 @@ public class CheckForOffers extends VoltProcedure {
 
     public final SQLStmt insertOffer = new SQLStmt(
         "INSERT INTO offers_given VALUES (?,?,NOW,?);");
+    public final SQLStmt insertOffer_export = new SQLStmt(
+            "INSERT INTO offers_given_export VALUES (?,?,NOW,?);");
 
     public long run(long txnId,
                     long acctNo,
@@ -75,6 +77,7 @@ public class CheckForOffers extends VoltProcedure {
         if (results0[1].getRowCount() > 0) {
             String offerText = results0[1].fetchRow(0).getString(0);
             voltQueueSQL(insertOffer, acctNo, vendorId, offerText);
+            voltQueueSQL(insertOffer_export, acctNo, vendorId, offerText);
             voltExecuteSQL();
         }
 


### PR DESCRIPTION
Old schema exported a table AND ran selects on it.

Added parallel stream and updated Java proc to insert into both tables.

Tested run.sh and with apprunner.