### PR TITLE
ENG-15765 Change Data Capture

### DIFF
--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -625,7 +625,31 @@ enum TableType {
      PERSISTENT_MIGRATE  = 4,
 
      // PersistentTable with associated Stream for linking INSERTS
-     PERSISTENT_EXPORT = 5,
+     PERSISTENT_EXPORT_INSERT = 8,
+     PERSISTENT_EXPORT_DELETE = 16,
+     PERSISTENT_EXPORT_UPDATEold = 32,
+     PERSISTENT_EXPORT_UPDATEnew = 64,
+     PERSISTENT_EXPORT_INSERT_DELETE = PERSISTENT_EXPORT_INSERT +
+                                       PERSISTENT_EXPORT_DELETE,
+     PERSISTENT_EXPORT_INSERT_UPDATEold = PERSISTENT_EXPORT_INSERT +
+                                          PERSISTENT_EXPORT_UPDATEold,
+     PERSISTENT_EXPORT_DELETE_UPDATEold = PERSISTENT_EXPORT_DELETE +
+                                          PERSISTENT_EXPORT_UPDATEold,
+     PERSISTENT_EXPORT_INSERT_DELETE_UPDATEold = PERSISTENT_EXPORT_INSERT_DELETE +
+                                                 PERSISTENT_EXPORT_UPDATEold,
+     PERSISTENT_EXPORT_INSERT_UPDATEnew = PERSISTENT_EXPORT_INSERT +
+                                          PERSISTENT_EXPORT_UPDATEnew,
+     PERSISTENT_EXPORT_DELETE_UPDATEnew = PERSISTENT_EXPORT_DELETE +
+                                          PERSISTENT_EXPORT_UPDATEnew,
+     PERSISTENT_EXPORT_INSERT_DELETE_UPDATEnew = PERSISTENT_EXPORT_INSERT_DELETE +
+                                                 PERSISTENT_EXPORT_UPDATEnew,
+     PERSISTENT_EXPORT_UPDATE = PERSISTENT_EXPORT_UPDATEold + PERSISTENT_EXPORT_UPDATEnew,
+     PERSISTENT_EXPORT_INSERT_UPDATE = PERSISTENT_EXPORT_INSERT +
+                                       PERSISTENT_EXPORT_UPDATE,
+     PERSISTENT_EXPORT_DELETE_UPDATE = PERSISTENT_EXPORT_DELETE +
+                                       PERSISTENT_EXPORT_UPDATE,
+     PERSISTENT_EXPORT_INSERT_DELETE_UPDATE = PERSISTENT_EXPORT_INSERT_DELETE +
+                                              PERSISTENT_EXPORT_UPDATE,
 };
 
 inline bool tableTypeIsExportStream(TableType tableType) {
@@ -642,11 +666,27 @@ inline bool tableTypeIsStream(TableType tableType) {
 }
 
 inline bool isTableWithExport(TableType tableType) {
-    return tableType == PERSISTENT_EXPORT;
+    return tableType >= PERSISTENT_EXPORT_INSERT;
+}
+
+inline bool isTableWithExportInserts(TableType tableType) {
+    return static_cast<int>(tableType) & static_cast<int>(PERSISTENT_EXPORT_INSERT);
+}
+
+inline bool isTableWithExportDeletes(TableType tableType) {
+    return static_cast<int>(tableType) & static_cast<int>(PERSISTENT_EXPORT_DELETE);
+}
+
+inline bool isTableWithExportUpdateOld(TableType tableType) {
+    return static_cast<int>(tableType) & static_cast<int>(PERSISTENT_EXPORT_UPDATEold);
+}
+
+inline bool isTableWithExportUpdateNew(TableType tableType) {
+    return static_cast<int>(tableType) & static_cast<int>(PERSISTENT_EXPORT_UPDATEnew);
 }
 
 inline bool isTableWithStream(TableType tableType) {
-    return tableType == PERSISTENT_MIGRATE || tableType == PERSISTENT_EXPORT;
+    return tableType == PERSISTENT_MIGRATE || tableType >= PERSISTENT_EXPORT_INSERT;
 }
 
 inline bool tableTypeNeedsTupleStream(TableType tableType) {

--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -627,23 +627,23 @@ enum TableType {
      // PersistentTable with associated Stream for linking INSERTS
      PERSISTENT_EXPORT_INSERT = 8,
      PERSISTENT_EXPORT_DELETE = 16,
-     PERSISTENT_EXPORT_UPDATEold = 32,
-     PERSISTENT_EXPORT_UPDATEnew = 64,
+     PERSISTENT_EXPORT_UPDATE_OLD = 32,
+     PERSISTENT_EXPORT_UPDATE_NEW = 64,
      PERSISTENT_EXPORT_INSERT_DELETE = PERSISTENT_EXPORT_INSERT +
                                        PERSISTENT_EXPORT_DELETE,
      PERSISTENT_EXPORT_INSERT_UPDATEold = PERSISTENT_EXPORT_INSERT +
-                                          PERSISTENT_EXPORT_UPDATEold,
+                                          PERSISTENT_EXPORT_UPDATE_OLD,
      PERSISTENT_EXPORT_DELETE_UPDATEold = PERSISTENT_EXPORT_DELETE +
-                                          PERSISTENT_EXPORT_UPDATEold,
+                                          PERSISTENT_EXPORT_UPDATE_OLD,
      PERSISTENT_EXPORT_INSERT_DELETE_UPDATEold = PERSISTENT_EXPORT_INSERT_DELETE +
-                                                 PERSISTENT_EXPORT_UPDATEold,
+                                                 PERSISTENT_EXPORT_UPDATE_OLD,
      PERSISTENT_EXPORT_INSERT_UPDATEnew = PERSISTENT_EXPORT_INSERT +
-                                          PERSISTENT_EXPORT_UPDATEnew,
+                                          PERSISTENT_EXPORT_UPDATE_NEW,
      PERSISTENT_EXPORT_DELETE_UPDATEnew = PERSISTENT_EXPORT_DELETE +
-                                          PERSISTENT_EXPORT_UPDATEnew,
+                                          PERSISTENT_EXPORT_UPDATE_NEW,
      PERSISTENT_EXPORT_INSERT_DELETE_UPDATEnew = PERSISTENT_EXPORT_INSERT_DELETE +
-                                                 PERSISTENT_EXPORT_UPDATEnew,
-     PERSISTENT_EXPORT_UPDATE = PERSISTENT_EXPORT_UPDATEold + PERSISTENT_EXPORT_UPDATEnew,
+                                                 PERSISTENT_EXPORT_UPDATE_NEW,
+     PERSISTENT_EXPORT_UPDATE = PERSISTENT_EXPORT_UPDATE_OLD + PERSISTENT_EXPORT_UPDATE_NEW,
      PERSISTENT_EXPORT_INSERT_UPDATE = PERSISTENT_EXPORT_INSERT +
                                        PERSISTENT_EXPORT_UPDATE,
      PERSISTENT_EXPORT_DELETE_UPDATE = PERSISTENT_EXPORT_DELETE +
@@ -678,11 +678,11 @@ inline bool isTableWithExportDeletes(TableType tableType) {
 }
 
 inline bool isTableWithExportUpdateOld(TableType tableType) {
-    return static_cast<int>(tableType) & static_cast<int>(PERSISTENT_EXPORT_UPDATEold);
+    return static_cast<int>(tableType) & static_cast<int>(PERSISTENT_EXPORT_UPDATE_OLD);
 }
 
 inline bool isTableWithExportUpdateNew(TableType tableType) {
-    return static_cast<int>(tableType) & static_cast<int>(PERSISTENT_EXPORT_UPDATEnew);
+    return static_cast<int>(tableType) & static_cast<int>(PERSISTENT_EXPORT_UPDATE_NEW);
 }
 
 inline bool isTableWithStream(TableType tableType) {

--- a/src/ee/executors/deleteexecutor.h
+++ b/src/ee/executors/deleteexecutor.h
@@ -65,10 +65,12 @@ class DeleteExecutor : public AbstractExecutor
 {
 public:
     DeleteExecutor(VoltDBEngine *engine, AbstractPlanNode* abstract_node)
-        : AbstractExecutor(engine, abstract_node)
+        : AbstractExecutor(engine, abstract_node),
+          m_node(NULL),
+          m_truncate(false),
+          m_inputTable(NULL),
+          m_inputTuple()
     {
-        m_inputTable = NULL;
-        m_engine = engine;
     }
 
 protected:
@@ -86,9 +88,6 @@ private:
     TableTuple m_inputTuple;
 
     static int64_t s_modifiedTuples;
-    /** reference to the engine/context to store the number of
-        modified tuples */
-    VoltDBEngine* m_engine;
 };
 
 }

--- a/src/ee/executors/insertexecutor.h
+++ b/src/ee/executors/insertexecutor.h
@@ -84,8 +84,8 @@ class InsertExecutor : public AbstractExecutor
         m_upsertTuple(),
         m_templateTuple(),
         m_tempPool(NULL)
-            {
-            }
+    {
+    }
 
     /**
      * Return false iff all the work is done in init.  Inserting

--- a/src/ee/executors/updateexecutor.h
+++ b/src/ee/executors/updateexecutor.h
@@ -66,12 +66,15 @@ class UpdateExecutor : public AbstractExecutor
 {
 public:
     UpdateExecutor(VoltDBEngine *engine, AbstractPlanNode* abstract_node)
-        : AbstractExecutor(engine, abstract_node)
+        : AbstractExecutor(engine, abstract_node),
+          m_node(NULL),
+          m_inputTargetMap(),
+          m_inputTargetMapSize(-1),
+          m_inputTable(NULL),
+          m_inputTuple(),
+          m_partitionColumn(-1),
+          m_partitionColumnIsString(false)
     {
-        m_inputTargetMapSize = -1;
-        m_inputTable = NULL;
-        m_engine = engine;
-        m_partitionColumn = -1;
     }
 
 protected:
@@ -91,9 +94,6 @@ protected:
     bool m_partitionColumnIsString;
 
     static int64_t s_modifiedTuples;
-
-    /** reference to the engine/context to store the number of modified tuples */
-    VoltDBEngine* m_engine;
 };
 
 }

--- a/src/ee/storage/ExportTupleStream.cpp
+++ b/src/ee/storage/ExportTupleStream.cpp
@@ -67,7 +67,7 @@ size_t ExportTupleStream::appendTuple(
         int64_t uniqueId,
         const TableTuple &tuple,
         int partitionColumn,
-        ExportTupleStream::Type type)
+        ExportTupleStream::STREAM_ROW_TYPE type)
 {
     size_t streamHeaderSz = 0;
     size_t tupleMaxLength = 0;
@@ -118,8 +118,8 @@ size_t ExportTupleStream::appendTuple(
     io.writeLong(seqNo);
     io.writeLong(m_partitionId);
     io.writeLong(m_siteId);
-    // use 1 for INSERT EXPORT op, 0 for DELETE EXPORT op
-    io.writeByte(static_cast<int8_t>((type == INSERT) ? 1L : 0L));
+    // use 1 for INSERT EXPORT op
+    io.writeByte(static_cast<int8_t>(type));
     // write the tuple's data
     tuple.serializeToExport(io, METADATA_COL_CNT, nullArray);
 

--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -41,7 +41,7 @@ class ExportTupleStream : public voltdb::TupleStreamBase<ExportStreamBlock> {
     friend class StreamBlock;
 
 public:
-    enum Type { INSERT, DELETE };
+    enum STREAM_ROW_TYPE { INVALID, INSERT, DELETE, UPDATE_OLD, UPDATE_NEW, MIGRATE };
 
     ExportTupleStream(CatalogId partitionId, int64_t siteId, int64_t generation, const std::string &tableName);
 
@@ -92,7 +92,7 @@ public:
             int64_t uniqueId,
             const TableTuple &tuple,
             int partitionColumn,
-            ExportTupleStream::Type type);
+            ExportTupleStream::STREAM_ROW_TYPE type);
 
     /** Close Txn and send full buffers with committed data to the top end. */
     void commit(VoltDBEngine* engine, int64_t spHandle, int64_t uniqueId);

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -479,7 +479,7 @@ public:
     void setDR(bool flag) { m_drEnabled = (flag && !m_isMaterialized); }
 
     void setTupleLimit(int32_t newLimit) { m_tupleLimit = newLimit; }
-
+    void setTableType(TableType tableType) { m_tableType = tableType; }
     bool isPersistentTableEmpty() const {
         // The narrow usage of this function (while updating the catalog)
         // suggests that it could also mean "table is new and never had tuples".
@@ -580,6 +580,10 @@ public:
                                 bool ignoreTupleLimit = true,
                                 bool elastic = false);
 
+    inline TableType getTableType() const {
+        return m_tableType;
+    }
+
     /**
      * IW-ENG14804
      * Set a companion streamed table to export tuples
@@ -605,7 +609,12 @@ public:
 
 private:
     // Zero allocation size uses defaults.
-    PersistentTable(int partitionColumn, char const* signature, bool isMaterialized, int tableAllocationTargetSize = 0, int tuplelimit = INT_MAX, bool drEnabled = false, bool isReplicated = false);
+    PersistentTable(int partitionColumn, char const* signature, bool isMaterialized,
+            int tableAllocationTargetSize = 0,
+            int tuplelimit = INT_MAX,
+            bool drEnabled = false,
+            bool isReplicated = false,
+            TableType tableType = PERSISTENT);
 
     /**
      * Prepare table for streaming from serialized data (internal for tests).
@@ -879,6 +888,7 @@ private:
     SynchronizedDummyUndoQuantumReleaseInterest m_releaseDummyReplicated;
 
     // Pointer to Shadow streamed table (For Migrate) or nullptr
+    TableType m_tableType;
     StreamedTable* m_shadowStream;
     typedef std::set<void*> MigratingBatch;
     typedef std::map<int64_t, MigratingBatch> MigratingRows;

--- a/src/ee/storage/streamedtable.h
+++ b/src/ee/storage/streamedtable.h
@@ -67,7 +67,7 @@ public:
     // GENERIC TABLE OPERATIONS
     // ------------------------------------------------------------------
     virtual void deleteAllTuples(bool freeAllocatedStrings, bool=true);
-    // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
+    void streamTuple(TableTuple &source, ExportTupleStream::STREAM_ROW_TYPE type);
     virtual bool insertTuple(TableTuple &tuple);
 
     virtual void loadTuplesFrom(SerializeInputBE &serialize_in, Pool *stringPool = NULL);
@@ -94,7 +94,6 @@ public:
 
     //Override and say how many bytes are in Java and C++
     int64_t allocatedTupleMemory() const;
-    bool shouldStreamToExport();
 
 
     /**

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -80,7 +80,8 @@ Table* TableFactory::getPersistentTable(
                                                       tableAllocationTargetSize,
                                                       tupleLimit,
                                                       drEnabled,
-                                                      isReplicated);
+                                                      isReplicated,
+                                                      tableType);
     }
 
     initCommon(databaseId,

--- a/src/frontend/org/voltdb/TableType.java
+++ b/src/frontend/org/voltdb/TableType.java
@@ -16,8 +16,9 @@
  */
 package org.voltdb;
 
-import java.util.Collections;
 import java.util.List;
+
+import com.google_voltpatches.common.collect.ImmutableMap;
 
 /*
  * Define the different modes of operation for table streams.
@@ -48,6 +49,26 @@ public enum TableType {
     PERSISTENT_EXPORT_DELETE_UPDATE(112),
     PERSISTENT_EXPORT_INSERT_DELETE_UPDATE(120);
 
+    public static final ImmutableMap<Integer, String> typeToString;
+    static {
+        ImmutableMap.Builder<Integer, String> builder = ImmutableMap.builder();
+        builder.put(PERSISTENT_EXPORT_INSERT.get(), "INSERT");
+        builder.put(PERSISTENT_EXPORT_DELETE.get(), "DELETE");
+        builder.put(PERSISTENT_EXPORT_UPDATEOLD.get(), "UPDATE_OLD");
+        builder.put(PERSISTENT_EXPORT_UPDATENEW.get(), "UPDATE_NEW");
+        builder.put(PERSISTENT_EXPORT_INSERT_DELETE.get(), "INSERT,DELETE");
+        builder.put(PERSISTENT_EXPORT_INSERT_UPDATEOLD.get(), "INSERT,UPDATE_OLD");
+        builder.put(PERSISTENT_EXPORT_DELETE_UPDATEOLD.get(), "DELETE,UPDATE_OLD");
+        builder.put(PERSISTENT_EXPORT_INSERT_DELETE_UPDATEOLD.get(), "INSERT,DELETE,UPDATE_OLD");
+        builder.put(PERSISTENT_EXPORT_INSERT_UPDATENEW.get(), "INSERT,UPDATE_NEW");
+        builder.put(PERSISTENT_EXPORT_DELETE_UPDATENEW.get(), "DELETE,UPDATE_NEW");
+        builder.put(PERSISTENT_EXPORT_INSERT_DELETE_UPDATENEW.get(), "INSERT,DELETE,UPDATE_NEW");
+        builder.put(PERSISTENT_EXPORT_UPDATE.get(), "UPDATE");
+        builder.put(PERSISTENT_EXPORT_INSERT_UPDATE.get(), "INSERT,UPDATE");
+        builder.put(PERSISTENT_EXPORT_DELETE_UPDATE.get(), "DELETE,UPDATE");
+        builder.put(PERSISTENT_EXPORT_INSERT_DELETE_UPDATE.get(), "INSERT,DELETE,UPDATE");
+        typeToString = builder.build();
+    }
     final int type;
     TableType(int type) {
         this.type = type;
@@ -82,17 +103,16 @@ public enum TableType {
 
     public static int getPeristentExportTrigger(List<String> triggers) {
         int tableType = 0;
-        Collections.sort(triggers);
         for (String trigger : triggers) {
-            if(trigger.equals("INSERT")) {
+            if(trigger.equalsIgnoreCase("INSERT")) {
                 tableType += TableType.PERSISTENT_EXPORT_INSERT.get();
-            } else if(trigger.equals("DELETE")) {
+            } else if(trigger.equalsIgnoreCase("DELETE")) {
                 tableType += TableType.PERSISTENT_EXPORT_DELETE.get();
-            } else if(trigger.equals("UPDATE_OLD")) {
+            } else if(trigger.equalsIgnoreCase("UPDATE_OLD")) {
                 tableType += TableType.PERSISTENT_EXPORT_UPDATEOLD.get();
-            } else if(trigger.equals("UPDATE_NEW")) {
+            } else if(trigger.equalsIgnoreCase("UPDATE_NEW")) {
                 tableType += TableType.PERSISTENT_EXPORT_UPDATENEW.get();
-            } else if (trigger.equals("UPDATE")) {
+            } else if (trigger.equalsIgnoreCase("UPDATE")) {
                 tableType += TableType.PERSISTENT_EXPORT_UPDATE.get();
             }
         }
@@ -100,36 +120,8 @@ public enum TableType {
     }
 
     public static String toPersistentExportString(int tableType) {
-        if (tableType== PERSISTENT_EXPORT_INSERT.get()){
-            return "INSERT";
-        } else if (tableType == PERSISTENT_EXPORT_DELETE.get()) {
-            return "DELETE";
-        } else if (tableType == PERSISTENT_EXPORT_UPDATEOLD.get()) {
-            return "UPDATE_OLD";
-        } else if (tableType == PERSISTENT_EXPORT_UPDATENEW.get()) {
-            return "UPDATE_NEW";
-        } else if (tableType == PERSISTENT_EXPORT_INSERT_DELETE.get()) {
-            return "INSERT,DELETE";
-        } else if (tableType == PERSISTENT_EXPORT_INSERT_UPDATEOLD.get()) {
-            return "INSERT,UPDATE_OLD";
-        } else if (tableType == PERSISTENT_EXPORT_DELETE_UPDATEOLD.get()) {
-            return "DELETE,UPDATE_OLD";
-        } else if (tableType == PERSISTENT_EXPORT_INSERT_DELETE_UPDATEOLD.get()) {
-            return "INSERT,DELETE,UPFDATE_OLD";
-        } else if (tableType == PERSISTENT_EXPORT_INSERT_UPDATENEW.get()) {
-            return "INSERT,UPDATE_NEW";
-        } else if (tableType == PERSISTENT_EXPORT_DELETE_UPDATENEW.get()) {
-            return "DELETE,UPDATE_NEW";
-        } else if (tableType == PERSISTENT_EXPORT_INSERT_DELETE_UPDATENEW.get()) {
-            return "INSERT,DELETE,UPDATE_NEW";
-        } else if (tableType == PERSISTENT_EXPORT_UPDATE.get()) {
-            return "UPDATE";
-        } else if (tableType == PERSISTENT_EXPORT_INSERT_UPDATE.get()) {
-            return "INSERT,UPDATE";
-        } else if (tableType == PERSISTENT_EXPORT_DELETE_UPDATE.get()) {
-            return "DELETE,UPDATE";
-        } else if (tableType == PERSISTENT_EXPORT_INSERT_DELETE_UPDATE.get()) {
-            return "INSERT,DELETE,UPDATE";
+        if (isPersistentExport(tableType)) {
+            return typeToString.get(tableType);
         }
         return "";
     }

--- a/src/frontend/org/voltdb/TableType.java
+++ b/src/frontend/org/voltdb/TableType.java
@@ -16,6 +16,9 @@
  */
 package org.voltdb;
 
+import java.util.Collections;
+import java.util.List;
+
 /*
  * Define the different modes of operation for table streams.
  *
@@ -25,10 +28,25 @@ package org.voltdb;
 public enum TableType {
     INVALID_TYPE(0),
     PERSISTENT(1),              // Regular PersistentTable
-    CONNECTOR_LESS_STREAM(2),        // StreamTable without ExportTupleStream (Views only)
+    CONNECTOR_LESS_STREAM(2),   // StreamTable without ExportTupleStream (Views only)
     STREAM(3),                  // StreamTable with ExportTupleStream
     PERSISTENT_MIGRATE(4),      // PersistentTable with associated Stream for migrating DELETES
-    PERSISTENT_EXPORT(5);       // PersistentTable with associated Stream for linking INSERTS
+    // PersistentTable with associated Stream for linking INSERTS
+    PERSISTENT_EXPORT_INSERT(8),
+    PERSISTENT_EXPORT_DELETE(16),
+    PERSISTENT_EXPORT_UPDATEOLD(32),
+    PERSISTENT_EXPORT_UPDATENEW(64),
+    PERSISTENT_EXPORT_INSERT_DELETE(24),
+    PERSISTENT_EXPORT_INSERT_UPDATEOLD(40),
+    PERSISTENT_EXPORT_DELETE_UPDATEOLD(50),
+    PERSISTENT_EXPORT_INSERT_DELETE_UPDATEOLD(60),
+    PERSISTENT_EXPORT_INSERT_UPDATENEW(72),
+    PERSISTENT_EXPORT_DELETE_UPDATENEW(80),
+    PERSISTENT_EXPORT_INSERT_DELETE_UPDATENEW(88),
+    PERSISTENT_EXPORT_UPDATE(96),
+    PERSISTENT_EXPORT_INSERT_UPDATE(104),
+    PERSISTENT_EXPORT_DELETE_UPDATE(112),
+    PERSISTENT_EXPORT_INSERT_DELETE_UPDATE(120);
 
     final int type;
     TableType(int type) {
@@ -50,12 +68,70 @@ public enum TableType {
         return (e == PERSISTENT_MIGRATE.get());
     }
 
-    public static boolean needsMigrateHiddenColumn(int e) {
-        return (e == PERSISTENT_MIGRATE.get() || e == PERSISTENT_EXPORT.get());
+    public static boolean needsShadowStream(int e) {
+        return (e >= PERSISTENT_MIGRATE.get() && e <= PERSISTENT_EXPORT_INSERT_DELETE_UPDATE.get());
+    }
+
+    public static boolean isPersistentExport(int e) {
+        return (e >= PERSISTENT_EXPORT_INSERT.get() && e <= PERSISTENT_EXPORT_INSERT_DELETE_UPDATE.get());
     }
 
     public static boolean isInvalidType(int e) {
         return e == INVALID_TYPE.type;
+    }
+
+    public static int getPeristentExportTrigger(List<String> triggers) {
+        int tableType = 0;
+        Collections.sort(triggers);
+        for (String trigger : triggers) {
+            if(trigger.equals("INSERT")) {
+                tableType += TableType.PERSISTENT_EXPORT_INSERT.get();
+            } else if(trigger.equals("DELETE")) {
+                tableType += TableType.PERSISTENT_EXPORT_DELETE.get();
+            } else if(trigger.equals("UPDATE_OLD")) {
+                tableType += TableType.PERSISTENT_EXPORT_UPDATEOLD.get();
+            } else if(trigger.equals("UPDATE_NEW")) {
+                tableType += TableType.PERSISTENT_EXPORT_UPDATENEW.get();
+            } else if (trigger.equals("UPDATE")) {
+                tableType += TableType.PERSISTENT_EXPORT_UPDATE.get();
+            }
+        }
+        return tableType;
+    }
+
+    public static String toPersistentExportString(int tableType) {
+        if (tableType== PERSISTENT_EXPORT_INSERT.get()){
+            return "INSERT";
+        } else if (tableType == PERSISTENT_EXPORT_DELETE.get()) {
+            return "DELETE";
+        } else if (tableType == PERSISTENT_EXPORT_UPDATEOLD.get()) {
+            return "UPDATE_OLD";
+        } else if (tableType == PERSISTENT_EXPORT_UPDATENEW.get()) {
+            return "UPDATE_NEW";
+        } else if (tableType == PERSISTENT_EXPORT_INSERT_DELETE.get()) {
+            return "INSERT,DELETE";
+        } else if (tableType == PERSISTENT_EXPORT_INSERT_UPDATEOLD.get()) {
+            return "INSERT,UPDATE_OLD";
+        } else if (tableType == PERSISTENT_EXPORT_DELETE_UPDATEOLD.get()) {
+            return "DELETE,UPDATE_OLD";
+        } else if (tableType == PERSISTENT_EXPORT_INSERT_DELETE_UPDATEOLD.get()) {
+            return "INSERT,DELETE,UPFDATE_OLD";
+        } else if (tableType == PERSISTENT_EXPORT_INSERT_UPDATENEW.get()) {
+            return "INSERT,UPDATE_NEW";
+        } else if (tableType == PERSISTENT_EXPORT_DELETE_UPDATENEW.get()) {
+            return "DELETE,UPDATE_NEW";
+        } else if (tableType == PERSISTENT_EXPORT_INSERT_DELETE_UPDATENEW.get()) {
+            return "INSERT,DELETE,UPDATE_NEW";
+        } else if (tableType == PERSISTENT_EXPORT_UPDATE.get()) {
+            return "UPDATE";
+        } else if (tableType == PERSISTENT_EXPORT_INSERT_UPDATE.get()) {
+            return "INSERT,UPDATE";
+        } else if (tableType == PERSISTENT_EXPORT_DELETE_UPDATE.get()) {
+            return "DELETE,UPDATE";
+        } else if (tableType == PERSISTENT_EXPORT_INSERT_DELETE_UPDATE.get()) {
+            return "INSERT,DELETE,UPDATE";
+        }
+        return "";
     }
 }
 

--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -1409,7 +1409,7 @@ public class VoltCompiler {
                     "Streams can't have indexes (including primary keys).");
             throw new VoltCompilerException("Streams cannot be configured with indexes");
         }
-        if (tableref.getIsreplicated() && !TableType.isPersistentMigrate(tableref.getTabletype())) {
+        if (tableref.getIsreplicated() && !TableType.needsShadowStream(tableref.getTabletype())) {
             // if you don't specify partition columns, make
             // export tables partitioned, but on no specific column (iffy)
             tableref.setIsreplicated(false);

--- a/src/frontend/org/voltdb/exportclient/ExportRow.java
+++ b/src/frontend/org/voltdb/exportclient/ExportRow.java
@@ -56,6 +56,8 @@ public class ExportRow {
     public String tableName;
     public final long generation;
     public static final int INTERNAL_FIELD_COUNT = 6;
+    public static final int INTERNAL_OPERATION_COLUMN = 5;
+    public enum ROW_OPERATION { INVALID, INSERT, DELETE, UPDATE_OLD, UPDATE_NEW, MIGRATE };
 
     public ExportRow(String tableName, List<String> columnNames, List<VoltType> t, List<Integer> l,
             Object[] vals, Object pval, int partitionColIndex, int pid, long generation) {
@@ -76,6 +78,10 @@ public class ExportRow {
              return names.get(partitionColIndex);
          }
         return "";
+    }
+
+    public ROW_OPERATION getOperation() {
+        return ROW_OPERATION.values()[(byte)values[INTERNAL_OPERATION_COLUMN]];
     }
 
     public static ExportRow decodeBufferSchema(ByteBuffer bb, int schemaSize,

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -811,7 +811,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         DrRoleType.XDCR.value().equals(m_cluster.getDrrole())
                         && new_catalog_table.getIsdred();
                 final boolean preserveViewHiddenColumn = CatalogUtil.needsViewHiddenColumn(new_catalog_table);
-                final boolean preserveMigrateHiddenColumn = TableType.needsMigrateHiddenColumn(new_catalog_table.getTabletype());
+                final boolean preserveMigrateHiddenColumn = TableType.isPersistentMigrate(new_catalog_table.getTabletype());
 
                 Boolean needsConversion = null;
                 while (savefile.hasMoreChunks()) {
@@ -2168,7 +2168,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
         final boolean preserveDRHiddenColumn =
             DrRoleType.XDCR.value().equals(m_cluster.getDrrole()) && newCatalogTable.getIsdred();
         final boolean preserveViewHiddenColumn = CatalogUtil.needsViewHiddenColumn(newCatalogTable);
-        final boolean preserveMigrateHiddenColumn = TableType.needsMigrateHiddenColumn(newCatalogTable.getTabletype());
+        final boolean preserveMigrateHiddenColumn = TableType.isPersistentMigrate(newCatalogTable.getTabletype());
 
         Boolean needsConversion = null;
         Map<Long, Integer> sitesToPartitions = null;
@@ -2389,7 +2389,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
             final boolean preserveDRHiddenColumn =
                 DrRoleType.XDCR.value().equals(m_cluster.getDrrole()) && new_catalog_table.getIsdred();
             final boolean preserveViewHiddenColumn = CatalogUtil.needsViewHiddenColumn(new_catalog_table);
-            final boolean preserveMigrateHiddenColumn = TableType.needsMigrateHiddenColumn(new_catalog_table.getTabletype());
+            final boolean preserveMigrateHiddenColumn = TableType.isPersistentMigrate(new_catalog_table.getTabletype());
             while (hasMoreChunks()) {
                 VoltTable table = null;
 

--- a/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
@@ -283,7 +283,7 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
 
         if (isActiveActiveDRed && table.getIsdred()) {
             VoltTable tbl;
-            if (TableType.needsMigrateHiddenColumn(table.getTabletype())) {
+            if (TableType.isPersistentMigrate(table.getTabletype())) {
                 tbl = CatalogUtil.getVoltTable(table, CatalogUtil.DR_HIDDEN_COLUMN_INFO, CatalogUtil.MIGRATE_HIDDEN_COLUMN_INFO);
             } else {
                 tbl = CatalogUtil.getVoltTable(table, CatalogUtil.DR_HIDDEN_COLUMN_INFO);
@@ -302,11 +302,8 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
         }
         else if (CatalogUtil.needsViewHiddenColumn(table)) {
             VoltTable tbl;
-            if (TableType.needsMigrateHiddenColumn(table.getTabletype())) {
-                tbl = CatalogUtil.getVoltTable(table, CatalogUtil.VIEW_HIDDEN_COLUMN_INFO, CatalogUtil.MIGRATE_HIDDEN_COLUMN_INFO);
-            } else {
-                tbl = CatalogUtil.getVoltTable(table, CatalogUtil.VIEW_HIDDEN_COLUMN_INFO);
-            }
+            assert(!TableType.needsShadowStream(table.getTabletype()));
+            tbl = CatalogUtil.getVoltTable(table, CatalogUtil.VIEW_HIDDEN_COLUMN_INFO);
 
             sdt = new DefaultSnapshotDataTarget(saveFilePath,
                     hostId,
@@ -319,7 +316,7 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan
                     tbl,
                     txnId,
                     timestamp);
-        } else if (TableType.needsMigrateHiddenColumn(table.getTabletype())) {
+        } else if (TableType.isPersistentMigrate(table.getTabletype())) {
             sdt = new DefaultSnapshotDataTarget(saveFilePath,
                     hostId,
                     clusterName,

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
@@ -135,7 +135,7 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan
         boolean XDCR = DrRoleType.XDCR.value().equals(context.getCluster().getDrrole());
         for (final Table table : config.tables) {
             VoltTable schemaTable;
-            final boolean preserveMigrateHiddenColumn = TableType.needsMigrateHiddenColumn(table.getTabletype());
+            final boolean preserveMigrateHiddenColumn = TableType.isPersistentMigrate(table.getTabletype());
             if (XDCR && table.getIsdred()) {
                 if (preserveMigrateHiddenColumn) {
                     schemaTable = CatalogUtil.getVoltTable(table, CatalogUtil.DR_HIDDEN_COLUMN_INFO, CatalogUtil.MIGRATE_HIDDEN_COLUMN_INFO);

--- a/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
+++ b/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
@@ -338,6 +338,12 @@ public abstract class CatalogSchemaTools {
                     table_sb.append(" MIGRATE TO TARGET " + ttl.getMigrationtarget() + " ");
                 }
             }
+            else if (TableType.isPersistentExport(catalog_tbl.getTabletype())) {
+                table_sb.append(" EXPORT TO TARGET ");
+                table_sb.append(streamTarget);
+                table_sb.append(" ON (" + TableType.toPersistentExportString(catalog_tbl.getTabletype()));
+                table_sb.append(")");
+            }
             table_sb.append(";\n");
         }
 

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -1049,7 +1049,7 @@ public class ParserDDL extends ParserRoutine {
                     triggers.add(Tokens.T_UPDATEOLD);
                 } else if (token.tokenType == Tokens.UPDATENEW) {
                     triggers.add(Tokens.T_UPDATENEW);
-                } else {
+                } else if (token.tokenType != Tokens.COMMA){
                     throw unexpectedToken();
                 }
                 read();

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -1040,19 +1040,17 @@ public class ParserDDL extends ParserRoutine {
             while (token.tokenType != Tokens.CLOSEBRACKET) {
                 if (token.tokenType == Tokens.DELETE) {
                     triggers.add(Tokens.T_DELETE);
-                }
-                if (token.tokenType == Tokens.INSERT) {
+                } else if (token.tokenType == Tokens.INSERT) {
                     triggers.add(Tokens.T_INSERT);
-                }
-                if (token.tokenType == Tokens.UPDATE) {
+                } else if (token.tokenType == Tokens.UPDATE) {
                     hasUpdate = true;
                     triggers.add(Tokens.T_UPDATE);
-                }
-                if (token.tokenType == Tokens.UPDATEOLD) {
+                } else if (token.tokenType == Tokens.UPDATEOLD) {
                     triggers.add(Tokens.T_UPDATEOLD);
-                }
-                if (token.tokenType == Tokens.UPDATENEW) {
+                } else if (token.tokenType == Tokens.UPDATENEW) {
                     triggers.add(Tokens.T_UPDATENEW);
+                } else {
+                    throw unexpectedToken();
                 }
                 read();
                 tokenCount--;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/PersistentExport.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/PersistentExport.java
@@ -1,0 +1,46 @@
+/* Copyright (c) 2001-2009, The HSQL Development Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of the HSQL Development Group nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL HSQL DEVELOPMENT GROUP, HSQLDB.ORG,
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hsqldb_voltpatches;
+
+import java.util.ArrayList;
+import java.util.List;
+
+//VoltDB extension to support data capture
+public class PersistentExport {
+
+    public final static String PERSISTENT_EXPORT = "PersistentExport";
+    final List<String> triggers = new ArrayList<>();
+    final String target;
+    public PersistentExport(String exportTarget, List<String> operationTriggers) {
+        target = exportTarget;
+        triggers.addAll(operationTriggers);
+    }
+}

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/StatementSchema.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/StatementSchema.java
@@ -31,6 +31,8 @@
 
 package org.hsqldb_voltpatches;
 
+import java.util.List;
+
 import org.hsqldb_voltpatches.HsqlNameManager.HsqlName;
 import org.hsqldb_voltpatches.lib.HsqlArrayList;
 import org.hsqldb_voltpatches.lib.OrderedHashSet;
@@ -111,6 +113,7 @@ public class StatementSchema extends Statement {
             case StatementTypes.ALTER_TABLE :
             case StatementTypes.ALTER_TRANSFORM :
             case StatementTypes.ALTER_TTL :
+            case StatementTypes.ALTER_EXPORT :
                 group = StatementTypes.X_SQL_SCHEMA_MANIPULATION;
                 break;
 
@@ -429,6 +432,21 @@ public class StatementSchema extends Statement {
                     checkSchemaUpdateAuthorisation(session, table.getSchemaName());
                     session.commit(false);
                     table.dropTTL();
+                    break;
+                } catch (HsqlException e) {
+                    return Result.newErrorResult(e, sql);
+                }
+            }
+            case StatementTypes.ALTER_EXPORT : {
+                try {
+                    HsqlName name       = (HsqlName) arguments[0];
+                    Table table = session.database.schemaManager.getUserTable(session, name);
+                    checkSchemaUpdateAuthorisation(session, table.getSchemaName());
+                    session.commit(false);
+                    String target = (String)arguments[1];
+                    @SuppressWarnings("unchecked")
+                    List<String> triggers = (List<String>)arguments[2];
+                    table.addPersistentExport(target, triggers);
                     break;
                 } catch (HsqlException e) {
                     return Result.newErrorResult(e, sql);

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/StatementTypes.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/StatementTypes.java
@@ -84,6 +84,8 @@ public interface StatementTypes {
     int DROP_TTL                         = 200;
     int ALTER_TTL                        = 201;
     int MIGRATE_WHERE                    = 202;
+    int DROP_EXPORT                      = 203;
+    int ALTER_EXPORT                     = 204;
     //end of VoltDB extension
     int DYNAMIC_CLOSE                    = 37;
     int DYNAMIC_DELETE_CURSOR            = 38;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Table.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Table.java
@@ -67,6 +67,7 @@
 package org.hsqldb_voltpatches;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.hsqldb_voltpatches.HSQLInterface.HSQLParseException;
@@ -149,6 +150,7 @@ public class Table extends TableBase implements SchemaObject {
     protected int[] defaultColumnMap;          // fred - holding 0,1,2,3,...
     private boolean hasDefaultValues;          //fredt - shortcut for above
     TimeToLiveVoltDB      timeToLive;          //time to live (VOLTDB)
+    PersistentExport      persistentExport;    //export to target(VOLTDB)
     private boolean isStream = false;          //is this a stream (VOLTDB)
     //
     public Table(Database database, HsqlName name, int type) {
@@ -2740,6 +2742,12 @@ public class Table extends TableBase implements SchemaObject {
         }
         assert(indexConstraintMap.isEmpty());
 
+        if (persistentExport != null) {
+            VoltXMLElement pe = new VoltXMLElement(PersistentExport.PERSISTENT_EXPORT);
+            pe.attributes.put("target", persistentExport.target);
+            pe.attributes.put("triggers", String.join(",", persistentExport.triggers));
+            table.children.add(pe);
+        }
         return table;
     }
 
@@ -2786,6 +2794,18 @@ public class Table extends TableBase implements SchemaObject {
 
     public void dropTTL() {
         timeToLive = null;
+    }
+
+    public void addPersistentExport(String target, List<String> triggers) {
+        persistentExport = new PersistentExport(target, triggers);
+    }
+
+    public PersistentExport getPersistentExport() {
+        return persistentExport;
+    }
+
+    public void dropPersistentExport() {
+        persistentExport = null;
     }
     // End of VoltDB extension
 

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Tokens.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Tokens.java
@@ -343,7 +343,10 @@ public class Tokens {
     static final String        T_TABLE             = "TABLE";
     static final String        T_TABLESAMPLE       = "TABLESAMPLE";
     // A VoltDB extension NIBBLE EXPORT
+    static final String        T_EXPORT            = "EXPORT";
     static final String        T_TARGET            = "TARGET";
+    static final String        T_UPDATEOLD         = "UPDATE_OLD";
+    static final String        T_UPDATENEW         = "UPDATE_NEW";
     // End of VoltDB extension
     static final String        T_THEN              = "THEN";
     public static final String T_TIME              = "TIME";
@@ -1123,6 +1126,9 @@ public class Tokens {
     public static final int STREAM                           = 1305;
     public static final int MIGRATE                          = 1400;
     public static final int TARGET                           = 1401;
+    public static final int EXPORT                           = 1402;
+    public static final int UPDATEOLD                        = 1403;
+    public static final int UPDATENEW                        = 1404;
     // End of VoltDB extension
     public static final int TABLE                            = 276;
     public static final int TABLESAMPLE                      = 277;
@@ -1942,6 +1948,9 @@ public class Tokens {
         reservedKeys.put(Tokens.T_STREAM, STREAM);
         reservedKeys.put(Tokens.T_MIGRATE, MIGRATE);
         reservedKeys.put(Tokens.T_TARGET, TARGET);
+        reservedKeys.put(Tokens.T_EXPORT, EXPORT);
+        reservedKeys.put(Tokens.T_UPDATEOLD, UPDATEOLD);
+        reservedKeys.put(Tokens.T_UPDATENEW, UPDATENEW);
         // End of VoltDB extension
         reservedKeys.put(Tokens.T_TABLE, TABLE);
         reservedKeys.put(Tokens.T_TABLESAMPLE, TABLESAMPLE);

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -177,7 +177,10 @@ public:
 
 
         m_table = dynamic_cast<voltdb::PersistentTable*>(
-                voltdb::TableFactory::getPersistentTable(m_tableId, "Foo", m_tableSchema, m_columnNames, signature));
+                voltdb::TableFactory::getPersistentTable(m_tableId, "Foo", m_tableSchema, m_columnNames, signature,
+                        false,
+                        0,
+                        PERSISTENT_MIGRATE));
         // Set a dummy StreamedTable to avoid asserts in the main path
         m_table->setStreamedTable((StreamedTable*) 1);
 

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -130,7 +130,7 @@ public:
                                int64_t uniqueId,
                                const TableTuple &tuple,
                                int partitionColumn,
-                               ExportTupleStream::Type type) {
+                               ExportTupleStream::STREAM_ROW_TYPE type) {
         receivedTuples.push_back(tuple);
         return ExportTupleStream::appendTuple(m_engine, spHandle, seqNo,
                                               uniqueId, tuple, partitionColumn, type);

--- a/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
@@ -774,6 +774,22 @@ public class TestCatalogDiffs extends TestCase {
         assertFalse("Failed to compile schema", builder.compile(testDir + File.separator + "testAlterTableTTL3.jar"));
     }
 
+    public void testPeristentExport() throws IOException {
+        String testDir = BuildDirectoryUtils.getBuildDirectoryPath();
+
+        // start with a table
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        builder.addLiteralSchema("\nCREATE TABLE A (C1 BIGINT NOT NULL, C2 BIGINT NOT NULL, PRIMARY KEY(C1)) EXPORT TO TARGET FOO ON(INSERT);");
+        builder.addPartitionInfo("A", "C1");
+        assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "testPeristentExport1.jar"));
+        Catalog catOriginal = catalogForJar(testDir + File.separator + "testPeristentExport1.jar");
+
+        builder.addLiteralSchema("\nALTER TABLE A EXPORT TO TARGET FOO ON(DELETE);");
+        assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "testPeristentExport2.jar"));
+        Catalog catUpdated = catalogForJar(testDir + File.separator + "testPeristentExport2.jar");
+        verifyDiff(catOriginal, catUpdated, false, null, true, true, true);
+    }
+
     public void testAlterStreamTTL() throws IOException {
         String testDir = BuildDirectoryUtils.getBuildDirectoryPath();
 

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -90,6 +90,33 @@ public class TestVoltCompiler extends TestCase {
         File tjar = new File(testout_jar);
         tjar.delete();
     }
+    public void testExportTarget() throws Exception {
+        String ddl = "create table foo (a integer NOT NULL, b integer, PRIMARY KEY(a)) EXPORT TO TARGET foo ON(INSERT,DELETE,UPDATE);\n";
+        VoltProjectBuilder pb = new VoltProjectBuilder();
+        pb.addLiteralSchema(ddl);
+        assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testExportTarget.jar")));
+
+        ddl = "create table foo (a integer NOT NULL, b integer, PRIMARY KEY(a)) EXPORT TO TARGET foo ON(INSERT,DELETE,UPDATE_NEW);\n";
+        pb = new VoltProjectBuilder();
+        pb.addLiteralSchema(ddl);
+        assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testExportTarget.jar")));
+
+        ddl = "create table foo (a integer NOT NULL, b integer, PRIMARY KEY(a)) EXPORT TO TARGET foo ON(INSERT,DELETE,UPDATE,UPDATE_NEW);\n";
+        pb = new VoltProjectBuilder();
+        pb.addLiteralSchema(ddl);
+        assertFalse(pb.compile(Configuration.getPathToCatalogForTest("testExportTarget.jar")));
+
+        ddl = "create table foo (a integer NOT NULL, b integer, PRIMARY KEY(a)) EXPORT TO TARGET foo ON(UPDATE_OLD,UPDATE_NEW);\n";
+        pb = new VoltProjectBuilder();
+        pb.addLiteralSchema(ddl);
+        assertFalse(pb.compile(Configuration.getPathToCatalogForTest("testExportTarget.jar")));
+
+        ddl = "create table foo (a integer NOT NULL, b integer, PRIMARY KEY(a)) EXPORT TO TARGET foo ON(UPDATE_OLD);\n" +
+        "alter table foo EXPORT TO TARGET foo ON(UPDATE_NEW);\n";
+        pb = new VoltProjectBuilder();
+        pb.addLiteralSchema(ddl);
+        assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testExportTarget.jar")));
+    }
 
     /*public void testDDLCompilerTTL() throws Exception {
         String ddl = "create table ttl (a integer NOT NULL, b integer, PRIMARY KEY(a)) USING TTL 10 SECONDS ON COLUMN a;\n" +

--- a/tests/frontend/org/voltdb/export/ExportTestExpectedData.java
+++ b/tests/frontend/org/voltdb/export/ExportTestExpectedData.java
@@ -106,8 +106,9 @@ public class ExportTestExpectedData {
                 if (m_replicated) {
                     assertEquals(m_copies, f.getValue().getCount(rowSeq));
                 }
-
-                assertThat( next, verifier.isExpectedRow(m_verifySequenceNumber));
+                if (verifier != null) {
+                    assertThat( next, verifier.isExpectedRow(m_verifySequenceNumber));
+                }
             }
         }
     }

--- a/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
+++ b/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
@@ -168,6 +168,7 @@ public class TestExportBaseSocketExport extends RegressionSuite {
                             }
                             if (line == null)
                                 continue;
+
                             String parts[] = m_parser.parseLine(line);
                             if (parts == null) {
                                 System.out.println("Failed to parse exported data.");

--- a/tests/frontend/org/voltdb/export/TestPersistentExport.java
+++ b/tests/frontend/org/voltdb/export/TestPersistentExport.java
@@ -1,0 +1,196 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.export;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.voltdb.BackendTarget;
+import org.voltdb.VoltTable;
+import org.voltdb.client.Client;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.compiler.deploymentfile.ServerExportEnum;
+import org.voltdb.export.TestExportBaseSocketExport.ServerListener;
+import org.voltdb.regressionsuites.LocalCluster;
+import org.voltdb.utils.VoltFile;
+
+public class TestPersistentExport extends ExportLocalClusterBase {
+    private LocalCluster m_cluster;
+
+    private static int KFACTOR = 1;
+    private static final String SCHEMA =
+            "CREATE TABLE T1 (a integer not null, b integer not nulL) EXPORT TO TARGET FOO1 ON(INSERT, DELETE);" +
+            " PARTITION table T1 ON COLUMN a;" +
+            "CREATE TABLE T2 (a integer not null, b integer not nulL) EXPORT TO TARGET FOO2 ON(UPDATE);" +
+            " PARTITION table T2 ON COLUMN a;" +
+            "CREATE TABLE T3 (a integer not null, b integer not nulL) EXPORT TO TARGET FOO3 ON(UPDATE);";
+
+    @Before
+    public void setUp() throws Exception
+    {
+        resetDir();
+        VoltFile.resetSubrootForThisProcess();
+
+        VoltProjectBuilder builder = null;
+        builder = new VoltProjectBuilder();
+        builder.addLiteralSchema(SCHEMA);
+        builder.setUseDDLSchema(true);
+        builder.setPartitionDetectionEnabled(true);
+        builder.setDeadHostTimeout(30);
+        builder.addExport(true /* enabled */,
+                         ServerExportEnum.CUSTOM, "org.voltdb.exportclient.SocketExporter",
+                         createSocketExportProperties("T1", false /* is replicated stream? */),
+                         "FOO1");
+        builder.addExport(true /* enabled */,
+                ServerExportEnum.CUSTOM, "org.voltdb.exportclient.SocketExporter",
+                createSocketExportProperties("T2", false /* is replicated stream? */),
+                "FOO2");
+
+        builder.addExport(true /* enabled */,
+                ServerExportEnum.CUSTOM, "org.voltdb.exportclient.SocketExporter",
+                createSocketExportProperties("T3", false /* is replicated stream? */),
+                "FOO3");
+
+        // Start socket exporter client
+        startListener();
+
+        m_cluster = new LocalCluster("TestPersistentExport.jar", 3, 2, KFACTOR, BackendTarget.NATIVE_EE_JNI);
+        m_cluster.setNewCli(true);
+        m_cluster.setHasLocalServer(false);
+        m_cluster.overrideAnyRequestForValgrind();
+        boolean success = m_cluster.compile(builder);
+        assertTrue(success);
+        m_cluster.startUp(true);
+        m_verifier = new ExportTestExpectedData(m_serverSockets, false /*is replicated stream? */, true, KFACTOR + 1);
+        m_verifier.m_verifySequenceNumber = false;
+        m_verifier.m_verbose = false;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Shutting down client and server");
+        for (Entry<String, ServerListener> entry : m_serverSockets.entrySet()) {
+            ServerListener serverSocket = entry.getValue();
+            if (serverSocket != null) {
+                serverSocket.closeClient();
+                serverSocket.close();
+            }
+        }
+        m_cluster.shutDown();
+    }
+
+    @Test
+    public void testInsertDelete() throws Exception {
+        Client client = getClient(m_cluster);
+
+        //add data to stream table
+        Object[] data = new Object[3];
+        Arrays.fill(data, 1);
+        insertToStream("T1", 0, 100, client, data);
+        client.callProcedure("@AdHoc", "delete from T1 where a < 10000;");
+        client.drain();
+        TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
+        checkTupleCount(client, "T1", 200);
+        m_verifier.verifyRows();
+    }
+
+    @Test
+    public void testUpdateWithAlter() throws Exception {
+        Client client = getClient(m_cluster);
+
+        //add data to stream table
+        Object[] data = new Object[3];
+        Arrays.fill(data, 1);
+        insertToStream("T2", 0, 100, client, data);
+        client.callProcedure("@AdHoc", "update T2 set b = 100 where a < 10000;");
+        client.drain();
+        TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
+        checkTupleCount(client, "T2", 200);
+
+        // Change trigger to update_new
+        client.callProcedure("@AdHoc", "ALTER TABLE T2 EXPORT TO TARGET FOO2 ON (UPDATE_NEW)");
+        client.callProcedure("@AdHoc", "update T2 set b = 200 where a < 10000;");
+        client.drain();
+        TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
+        checkTupleCount(client, "T2", 300);
+    }
+
+    @Test
+    public void testReplicaTableWithAlter() throws Exception {
+        Client client = getClient(m_cluster);
+
+        //add data to stream table
+        Object[] data = new Object[3];
+        Arrays.fill(data, 1);
+        insertToStream("T3", 0, 100, client, data);
+        client.callProcedure("@AdHoc", "update T3 set b = 100 where a < 10000;");
+        client.drain();
+        TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
+        checkTupleCount(client, "T3", 200);
+
+        // Change trigger to update_new
+        client.callProcedure("@AdHoc", "ALTER TABLE T3 EXPORT TO TARGET FOO3 ON (UPDATE_NEW)");
+        client.callProcedure("@AdHoc", "update T3 set b = 200 where a < 10000;");
+        client.drain();
+        TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
+        checkTupleCount(client, "T3", 300);
+    }
+
+
+    private static void checkTupleCount(Client client, String tableName, long expectedCount){
+
+        //allow time to get the stats
+        final long maxSleep = TimeUnit.MINUTES.toMillis(2);
+        boolean success = false;
+        long start = System.currentTimeMillis();
+        while (!success) {
+            try {
+                VoltTable vt = client.callProcedure("@Statistics", "EXPORT").getResults()[0];
+                long count = 0;
+                while (vt.advanceRow()) {
+                    if (tableName.equalsIgnoreCase(vt.getString("SOURCE"))
+                            && "TRUE".equalsIgnoreCase(vt.getString("ACTIVE"))) {
+                        count +=vt.getLong("TUPLE_COUNT");
+                    }
+                }
+                if (count == expectedCount) {
+                    return;
+                }
+                if (maxSleep < (System.currentTimeMillis() - start)) {
+                    break;
+                }
+                try { Thread.sleep(5000); } catch (Exception ignored) { }
+
+            } catch (Exception e) {
+            }
+        }
+        assert(false);
+    }
+}

--- a/tests/frontend/org/voltdb/export/TestPersistentExport.java
+++ b/tests/frontend/org/voltdb/export/TestPersistentExport.java
@@ -107,7 +107,7 @@ public class TestPersistentExport extends ExportLocalClusterBase {
     }
 
     @Test
-    public void testInsertDelete() throws Exception {
+    public void testInsertDeleteUpdate() throws Exception {
         Client client = getClient(m_cluster);
 
         //add data to stream table
@@ -119,15 +119,7 @@ public class TestPersistentExport extends ExportLocalClusterBase {
         TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
         checkTupleCount(client, "T1", 200, false);
         m_verifier.verifyRows();
-    }
 
-    @Test
-    public void testUpdateWithAlter() throws Exception {
-        Client client = getClient(m_cluster);
-
-        //add data to stream table
-        Object[] data = new Object[3];
-        Arrays.fill(data, 1);
         insertToStream("T2", 0, 100, client, data);
         client.callProcedure("@AdHoc", "update T2 set b = 100 where a < 10000;");
         client.drain();
@@ -140,15 +132,8 @@ public class TestPersistentExport extends ExportLocalClusterBase {
         client.drain();
         TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
         checkTupleCount(client, "T2", 300, false);
-    }
 
-    @Test
-    public void testReplicaTableWithAlter() throws Exception {
-        Client client = getClient(m_cluster);
-
-        //add data to stream table
-        Object[] data = new Object[3];
-        Arrays.fill(data, 1);
+        // On replicated table
         insertToStream("T3", 0, 100, client, data);
         client.callProcedure("@AdHoc", "update T3 set b = 100 where a < 10000;");
         client.drain();
@@ -162,7 +147,6 @@ public class TestPersistentExport extends ExportLocalClusterBase {
         TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
         checkTupleCount(client, "T3", 300, true);
     }
-
 
     private static void checkTupleCount(Client client, String tableName, long expectedCount, boolean replicated){
 

--- a/tests/frontend/org/voltdb/fullddlfeatures/fullDDL.sql
+++ b/tests/frontend/org/voltdb/fullddlfeatures/fullDDL.sql
@@ -1140,6 +1140,15 @@ ALTER TABLE T64 ADD
     USING TTL 10 SECONDS ON COLUMN C3
     BATCH_SIZE 100 MAX_FREQUENCY 1;
 
+CREATE TABLE T65
+(
+   C1 INTEGER,
+   C2 INTEGER,
+   C3 INTEGER NOT NULL,
+   PRIMARY KEY (C3)
+) EXPORT TO TARGET FOO ON(INSERT,DELETE);
+
+ALTER TABLE T65 EXPORT TO TARGET FOO ON(UPDATE);
 -- These statements were added when use of some Volt-specific functions or ||
 -- or NULL in indexed expressions was discovered to be mishandled (ENG-7792).
 -- They showed that views and procs did NOT share these problems,

--- a/tests/frontend/org/voltdb/fullddlfeatures/fullDDL.sql
+++ b/tests/frontend/org/voltdb/fullddlfeatures/fullDDL.sql
@@ -1140,15 +1140,6 @@ ALTER TABLE T64 ADD
     USING TTL 10 SECONDS ON COLUMN C3
     BATCH_SIZE 100 MAX_FREQUENCY 1;
 
-CREATE TABLE T65
-(
-   C1 INTEGER,
-   C2 INTEGER,
-   C3 INTEGER NOT NULL,
-   PRIMARY KEY (C3)
-) EXPORT TO TARGET FOO ON(INSERT,DELETE);
-
-ALTER TABLE T65 EXPORT TO TARGET FOO ON(UPDATE);
 -- These statements were added when use of some Volt-specific functions or ||
 -- or NULL in indexed expressions was discovered to be mishandled (ENG-7792).
 -- They showed that views and procs did NOT share these problems,


### PR DESCRIPTION
Introduce new ddl syntax for data migration:
CREATE TABLE {table-name} EXPORT TO TARGET <TARGET> ON {triggers};
triggers = ([INSERT|UPDATE|DELETE|UPDATE_OLD|UPDATE_NEW]);

Rows will be exported from persistent table on triggers.