### PR TITLE
ENG-15765:

### DIFF
--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -129,8 +129,6 @@ public:
 
     ~CompactionTest() {
         delete m_engine;
-        // Clear the dummy StreamedTable so that PersistentTable is deallocated cleanly.
-        m_table->setStreamedTable(NULL);
         delete m_table;
         voltdb::globalDestroyOncePerProcess();
     }
@@ -181,8 +179,6 @@ public:
                         false,
                         0,
                         PERSISTENT_MIGRATE));
-        // Set a dummy StreamedTable to avoid asserts in the main path
-        m_table->setStreamedTable((StreamedTable*) 1);
 
         TableIndex *pkeyIndex = TableIndexFactory::getInstance(indexScheme);
         assert(pkeyIndex);


### PR DESCRIPTION
Remove dummy assignment of ShadowStream in compaction test because tablefactory now creates it explicitly when the tableType requires it.