### PR TITLE
OptimizedProjector: Comparison functions must be const

### DIFF
--- a/src/ee/executors/OptimizedProjector.cpp
+++ b/src/ee/executors/OptimizedProjector.cpp
@@ -187,7 +187,7 @@ private:
 // for ordering: fields in source tuple may be referenced more
 // than once, or projection expression may not be a TVE.
 struct StepComparator {
-    bool operator() (const ProjectStep& lhs, const ProjectStep& rhs) {
+    bool operator() (const ProjectStep& lhs, const ProjectStep& rhs) const {
         return lhs.dstFieldIndex() < rhs.dstFieldIndex();
     }
 };


### PR DESCRIPTION
When using c++17 and gcc8 comparison functions must be declared as
consts otherwise a static assert is thrown.