### PR TITLE
ENG-15498: Limit mp responses

### DIFF
--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -36,6 +36,7 @@ import java.util.Random;
 import java.util.concurrent.ExecutionException;
 
 import org.voltcore.logging.VoltLogger;
+import org.voltcore.network.VoltPort;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.StatementStats.SingleCallStatsToken;
 import org.voltdb.VoltProcedure.VoltAbortException;
@@ -1430,7 +1431,7 @@ public class ProcedureRunner {
         final VoltTable[] m_results;
 
         BatchState(int batchSize, MpTransactionState txnState, long siteId, boolean finalTask, String procedureName,
-                byte[] procToLoad, boolean perFragmentStatsRecording) {
+                byte[] procToLoad, boolean perFragmentStatsRecording, int maxMpResponseSize) {
             m_batchSize = batchSize;
             m_txnState = txnState;
 
@@ -1453,6 +1454,8 @@ public class ProcedureRunner {
             m_distributedTask.setProcNameToLoad(procToLoad);
             m_distributedTask.setBatchTimeout(m_txnState.getInvocation().getBatchTimeout());
             m_distributedTask.setPerFragmentStatsRecording(perFragmentStatsRecording);
+
+            m_distributedTask.setMaxResponseSize(maxMpResponseSize);
         }
 
         /*
@@ -1508,8 +1511,10 @@ public class ProcedureRunner {
     VoltTable[] executeSlowHomogeneousBatch(final List<QueuedSQL> batch, final boolean finalTask) {
         MpTransactionState txnState = (MpTransactionState)m_txnState;
         assert(txnState != null);
+        long perPartitionMaxResponse = m_site.getMaxTotalMpResponseSize() / txnState.getMasterHSIDs().size();
         BatchState state = new BatchState(batch.size(), txnState, m_site.getCorrespondingSiteId(), finalTask,
-                m_procedureName, m_procNameToLoadForFragmentTasks, m_perCallStats.samplingStmts());
+                m_procedureName, m_procNameToLoadForFragmentTasks, m_perCallStats.samplingStmts(),
+                (int) Math.min(perPartitionMaxResponse, VoltPort.MAX_MESSAGE_LENGTH - 1024));
 
         // iterate over all sql in the batch, filling out the above data
         // structures

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -287,4 +287,9 @@ public interface SiteProcedureConnection {
      * @return true if external streams are enabled for this site, false otherwise.
      */
     public boolean externalStreamsEnabled();
+
+    /**
+     * @return the max size for all MP responses
+     */
+    public long getMaxTotalMpResponseSize();
 }

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -45,7 +45,7 @@ import org.voltdb.rejoin.TaskLog;
  */
 public abstract class BaseInitiator<S extends Scheduler> implements Initiator
 {
-    VoltLogger tmLog = new VoltLogger("TM");
+    static VoltLogger tmLog = new VoltLogger("TM");
 
     // External references/config
     protected final HostMessenger m_messenger;

--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -277,6 +277,7 @@ public class FragmentTask extends FragmentTaskBase
             }
         }
 
+        int totalTableSize = 0;
         int drBufferChanged = 0;
         boolean exceptionThrown = false;
         boolean exceptionCaught = false;
@@ -358,6 +359,15 @@ public class FragmentTask extends FragmentTaskBase
                         // read the dependencyId() -1;
                         fragResult.readInt();
                         tableSize = fragResult.readInt();
+
+                        if ((totalTableSize += tableSize) > m_fragmentMsg.getMaxResponseSize()) {
+                            hostLog.warn(String.format(
+                                    "Total table size (%d bytes) for mp response to %s is larger than max %d",
+                                    totalTableSize, m_fragmentMsg.getProcedureName(),
+                                    m_fragmentMsg.getMaxResponseSize()));
+                            throw new EEException(ExecutionEngine.ERRORCODE_ERROR);
+                        }
+
                         fullBacking = new byte[tableSize];
                         // get a copy of the buffer
                         fragResult.readFully(fullBacking);

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -770,4 +770,9 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     public boolean externalStreamsEnabled() {
         throw new RuntimeException("externalStreamsEnabled should not be called on MpRoSite");
     }
+
+    @Override
+    public long getMaxTotalMpResponseSize() {
+        return MpTransactionState.MP_MAX_TOTAL_RESP_SIZE / MpRoSitePool.MAX_POOL_SIZE;
+    }
 }

--- a/src/frontend/org/voltdb/iv2/MpRoSitePool.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSitePool.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadFactory;
+
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.BackendTarget;
@@ -41,8 +42,8 @@ import org.voltdb.StarvationTracker;
 class MpRoSitePool {
     final static VoltLogger tmLog = new VoltLogger("TM");
 
-    static int DEFAULT_MAX_POOL_SIZE = 20;
-    static int INITIAL_POOL_SIZE = 1;
+    static final int MAX_POOL_SIZE = Integer.getInteger("MPI_READ_POOL_SIZE", 3);
+    static final int INITIAL_POOL_SIZE = 1;
 
     class MpRoSiteContext {
         final private SiteTaskerQueue m_queue;
@@ -110,7 +111,6 @@ class MpRoSitePool {
     private final InitiatorMailbox m_initiatorMailbox;
     private CatalogContext m_catalogContext;
     private ThreadFactory m_poolThreadFactory;
-    private final int m_poolSize;
     private volatile boolean m_shuttingDown = false;
 
     MpRoSitePool(
@@ -129,12 +129,7 @@ class MpRoSitePool {
             CoreUtils.getThreadFactory("RO MP Site - " + CoreUtils.hsIdToString(m_siteId),
                     CoreUtils.MEDIUM_STACK_SIZE);
 
-        Integer poolSize = Integer.getInteger("mpiReadPoolSize");
-        if (poolSize == null) {
-            poolSize = DEFAULT_MAX_POOL_SIZE;
-        }
-        m_poolSize = poolSize;
-        tmLog.info("Setting maximum size of MPI read pool to: " + m_poolSize);
+        tmLog.info("Setting maximum size of MPI read pool to: " + MAX_POOL_SIZE);
 
         // Construct the initial pool
         for (int i = 0; i < INITIAL_POOL_SIZE; i++) {
@@ -208,7 +203,7 @@ class MpRoSitePool {
         if (m_shuttingDown) {
             return false;
         }
-        return (!m_idleSites.isEmpty() || m_busySites.size() < m_poolSize);
+        return (!m_idleSites.isEmpty() || m_busySites.size() < MAX_POOL_SIZE);
     }
 
     /**

--- a/src/frontend/org/voltdb/iv2/MpTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionState.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
-import com.google_voltpatches.common.collect.Lists;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.messaging.TransactionInfoBaseMessage;
@@ -36,8 +35,8 @@ import org.voltdb.PartitionDRGateway;
 import org.voltdb.PartitionDRGateway.DRRecordType;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.StoredProcedureInvocation;
-import org.voltdb.VoltTable;
 import org.voltdb.VoltDB;
+import org.voltdb.VoltTable;
 import org.voltdb.dtxn.TransactionState;
 import org.voltdb.exceptions.ReplicatedTableException;
 import org.voltdb.exceptions.SQLException;
@@ -54,6 +53,7 @@ import org.voltdb.utils.VoltTableUtil;
 import org.voltdb.utils.VoltTrace;
 
 import com.google_voltpatches.common.base.Preconditions;
+import com.google_voltpatches.common.collect.Lists;
 import com.google_voltpatches.common.collect.Maps;
 
 public class MpTransactionState extends TransactionState
@@ -61,6 +61,11 @@ public class MpTransactionState extends TransactionState
     static VoltLogger tmLog = new VoltLogger("TM");
 
     public static final int DR_MAX_AGGREGATE_BUFFERSIZE = Integer.getInteger("DR_MAX_AGGREGATE_BUFFERSIZE", (45 * 1024 * 1024) + 4096);
+    public static final long MP_MAX_TOTAL_RESP_SIZE = calculateMpMaxTotalResponse();
+
+    static final long MP_MAX_TOTAL_RESP_SIZE_MIN = 50 * 1024 * 1024; // 50MB
+    static final String MP_MAX_TOTAL_RESP_SIZE_KEY = "MP_MAX_TOTAL_RESP_SIZE";
+
     private static final String dr_max_consumer_partitionCount_str = "DR_MAX_CONSUMER_PARTITIONCOUNT";
     private static final String dr_max_consumer_messageheader_room_str = "DR_MAX_CONSUMER_MESSAGEHEADER_ROOM";
     private static final String volt_output_buffer_overflow = "V0001";
@@ -173,6 +178,47 @@ public class MpTransactionState extends TransactionState
                 + 1 + 4;                                                            // extraParameters byte[0]
 
         return serializedParamSize;
+    }
+
+    static long calculateMpMaxTotalResponse() {
+        String key = MP_MAX_TOTAL_RESP_SIZE_KEY;
+        String mpHeapString = System.getProperty(key, System.getenv(key));
+        long maxTotalResponse = 0;
+        if (mpHeapString != null) {
+            try {
+                if (mpHeapString.endsWith("%")) {
+                    double percent = Double.parseDouble(mpHeapString.substring(0, mpHeapString.length() - 1));
+                    if (percent > 0) {
+                        maxTotalResponse = percentOfTotalHeap(percent);
+                    }
+                } else {
+                    maxTotalResponse = Long.parseLong(mpHeapString);
+                }
+
+                if (maxTotalResponse < MP_MAX_TOTAL_RESP_SIZE_MIN) {
+                    tmLog.warn(String.format(
+                            "Invalid value, '%s', provided for config  %s. Value must result in a size greater than %d : %d",
+                            mpHeapString, key, MP_MAX_TOTAL_RESP_SIZE, maxTotalResponse));
+                    return MP_MAX_TOTAL_RESP_SIZE_MIN;
+                }
+                tmLog.info(String.format("Config %s set to %s evaluated to max mp response total of %d", key,
+                        mpHeapString, maxTotalResponse));
+                return maxTotalResponse;
+            } catch (NumberFormatException e) {
+                tmLog.warn(String.format("Could not parse value for config %s: '%s'", key, mpHeapString));
+            }
+        }
+
+        maxTotalResponse = percentOfTotalHeap(65.0);
+        if (tmLog.isDebugEnabled()) {
+            tmLog.debug("Using default mp max total response of " + maxTotalResponse);
+        }
+        return maxTotalResponse;
+    }
+
+    private static long percentOfTotalHeap(double percent) {
+        double percentOfMemory = Runtime.getRuntime().maxMemory() * percent / 100;
+        return (long) Math.min(percentOfMemory, Long.MAX_VALUE);
     }
 
     public void updateMasters(List<Long> masters, Map<Integer, Long> partitionMasters)

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1901,4 +1901,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             ComparisonOperation op) {
         return m_loadedProcedures.getMigrateProcRunner(procName, catTable, column, op);
     }
+
+    @Override
+    public long getMaxTotalMpResponseSize() {
+        return MpTransactionState.MP_MAX_TOTAL_RESP_SIZE;
+    }
 }

--- a/src/frontend/org/voltdb/messaging/FragmentTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/FragmentTaskMessage.java
@@ -180,6 +180,8 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
     // Only used by SpScheduler.updateReplicas during a SnapshotSave
     long m_lastSpUniqueId;
 
+    int m_maxResponseSize = Integer.MAX_VALUE;
+
     public void setPerFragmentStatsRecording(boolean value) {
         m_perFragmentStatsRecording = value;
     }
@@ -262,6 +264,7 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
             m_initiateTaskBuffer = ftask.m_initiateTaskBuffer.duplicate();
         }
         m_lastSpUniqueId = ftask.m_lastSpUniqueId;
+        m_maxResponseSize = ftask.m_maxResponseSize;
         assert(selfCheck());
     }
 
@@ -427,6 +430,7 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
         m_batchTimeout = batchTimeout;
     }
 
+    @Override
     public long getLastSpUniqueId() {
         return m_lastSpUniqueId;
     }
@@ -646,7 +650,7 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
         int msgsize = super.getSerializedSize();
 
         // Fixed header
-        msgsize += 2 + 2 + 1 + 1 + 1 + 1 + 1 + 2 + 1 + 8 + 8;
+        msgsize += 2 + 2 + 1 + 1 + 1 + 1 + 1 + 2 + 1 + 8 + 8 + 4;
 
         // procname to load str if any
         if (m_procNameToLoad != null) {
@@ -805,6 +809,7 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
         buf.putLong(m_restartTimestamp);
 
         buf.putLong(m_lastSpUniqueId);
+        buf.putInt(m_maxResponseSize);
 
         // Plan Hash block
         for (FragmentData item : m_items) {
@@ -940,6 +945,7 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
         // timestamp for restarted transaction
         m_restartTimestamp = buf.getLong();
         m_lastSpUniqueId = buf.getLong();
+        m_maxResponseSize = buf.getInt();
 
         m_items = new ArrayList<FragmentData>(fragCount);
 
@@ -1169,5 +1175,14 @@ public class FragmentTaskMessage extends TransactionInfoBaseMessage
 
     public long getTimestamp() {
         return m_restartTimestamp;
+    }
+
+    public void setMaxResponseSize(int maxResponseSize) {
+        assert maxResponseSize > 0;
+        m_maxResponseSize = maxResponseSize;
+    }
+
+    public int getMaxResponseSize() {
+        return m_maxResponseSize;
     }
 }

--- a/tests/frontend/org/voltdb/iv2/TestMaxMpResponseSize.java
+++ b/tests/frontend/org/voltdb/iv2/TestMaxMpResponseSize.java
@@ -1,0 +1,150 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.iv2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.voltdb.BackendTarget;
+import org.voltdb.client.Client;
+import org.voltdb.client.ClientConfig;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.client.ProcCallException;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.regressionsuites.LocalCluster;
+
+public class TestMaxMpResponseSize {
+    @Test
+    public void calculateMpMaxTotalResponse() {
+        long systemMemory = Runtime.getRuntime().maxMemory();
+        long defaultMax = (long) (systemMemory * 0.65D);
+        assertEquals(defaultMax, MpTransactionState.calculateMpMaxTotalResponse());
+
+        // Test static size
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, Long.toString(512L * 1024 * 1024));
+        assertEquals(512L * 1024 * 1024, MpTransactionState.calculateMpMaxTotalResponse());
+
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, Long.toString(5L * 1024 * 1024 * 1024));
+        assertEquals(5L * 1024 * 1024 * 1024, MpTransactionState.calculateMpMaxTotalResponse());
+
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, Long.toString(100));
+        assertEquals(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_MIN, MpTransactionState.calculateMpMaxTotalResponse());
+
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, Long.toString(Long.MAX_VALUE));
+        assertEquals(Long.MAX_VALUE, MpTransactionState.calculateMpMaxTotalResponse());
+
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, Long.toString(-5L * 1024 * 1024 * 1024));
+        assertEquals(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_MIN, MpTransactionState.calculateMpMaxTotalResponse());
+
+        // Test percentage of heap
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, "30%");
+        assertEquals((long) (systemMemory * 0.30D), MpTransactionState.calculateMpMaxTotalResponse());
+
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, "130%");
+        assertEquals((long) (systemMemory * 1.30D), MpTransactionState.calculateMpMaxTotalResponse());
+
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, "9999999999999999999%");
+        assertEquals(Long.MAX_VALUE, MpTransactionState.calculateMpMaxTotalResponse());
+
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, "-20%");
+        assertEquals(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_MIN, MpTransactionState.calculateMpMaxTotalResponse());
+
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, "0.5%");
+        assertEquals(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_MIN, MpTransactionState.calculateMpMaxTotalResponse());
+
+        // Test not numbers should always return default
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, "7897a456");
+        assertEquals(defaultMax, MpTransactionState.calculateMpMaxTotalResponse());
+
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, "7897a456%");
+        assertEquals(defaultMax, MpTransactionState.calculateMpMaxTotalResponse());
+
+        System.setProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY, "7897.456");
+        assertEquals(defaultMax, MpTransactionState.calculateMpMaxTotalResponse());
+    }
+
+    @Test
+    public void largeMpResponsesFail() throws Exception {
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        builder.setUseDDLSchema(true);
+        LocalCluster cluster = new LocalCluster("mp_max_transaction.jar", 12, 1, 0, BackendTarget.NATIVE_EE_JNI);
+        Client client = null;
+        try {
+            builder.addLiteralSchema("CREATE TABLE my_table (key INT NOT NULL, value VARCHAR(4096) NOT NULL);"
+                    + "PARTITION TABLE my_table ON COLUMN key;"
+                    + "CREATE PROCEDURE Insert PARTITION ON TABLE my_table COLUMN key AS INSERT INTO my_table (key, value) VALUES (?, ?);");
+            cluster.setHasLocalServer(false);
+            cluster.compile(builder);
+            cluster.startCluster();
+
+            ClientConfig config = new ClientConfig();
+            config.setTopologyChangeAware(true);
+            config.setClientAffinity(true);
+            client = cluster.createClient(config);
+
+            AtomicInteger failures = new AtomicInteger();
+            // Load cluster with data
+            for (int i = 0; i < 4096; ++i) {
+                client.callProcedure(r -> {
+                    if (r.getStatus() != ClientResponse.SUCCESS) {
+                        failures.getAndIncrement();
+                    }
+                }, "Insert", i, RandomStringUtils.random(4096));
+            }
+            client.drain();
+
+            assertEquals("Some inserts failed", 0, failures.get());
+
+            // Should succeed with default mp max response size
+            client.callProcedure("@AdHoc", "SELECT COUNT(DISTINCT value) FROM my_table");
+
+            client.close();
+            client = null;
+
+            cluster.shutdownSave(cluster.createAdminClient(new ClientConfig()));
+            cluster.waitForNodesToShutdown();
+
+            // Reduce max mp max response size to minimum
+            cluster.setJavaProperty(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_KEY,
+                    Long.toString(MpTransactionState.MP_MAX_TOTAL_RESP_SIZE_MIN));
+
+            cluster.startUp(false);
+            client = cluster.createClient(config);
+
+            try {
+                client.callProcedure("@AdHoc", "SELECT COUNT(DISTINCT value) FROM my_table");
+                fail("Should not have been able to perform transaction");
+            } catch (ProcCallException e) {}
+        } finally {
+            if (client != null) {
+                client.close();
+            }
+            cluster.shutDown();
+        }
+    }
+}


### PR DESCRIPTION
Add response size limit to each fragment task request so that no single partition can return a response which is too large. Be default the total max response size is 65% of heap. That value is then divided by the number of partitions involved in the transaction and that value is divided by 3 if the transaction is a read only mp in case multiple ro transactions are being performed. The value can be changed by setting the environment variable or java property MP_MAX_TOTAL_RESP_SIZE. The value can either be a percentage of heap or an absolute number of bytes.