### PR TITLE
Eng 15944 port conflict

### DIFF
--- a/deployment.xml
+++ b/deployment.xml
@@ -1,0 +1,3 @@
+<deployment>
+<cluster hostcount="1" sitesperhost="1" kfactor="0" />
+</deployment>

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.InetAddress;
+import java.net.Socket;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
@@ -110,6 +111,7 @@ import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.collect.ImmutableSet;
 import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
+import com.google.common.net.InetAddresses;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.ssl.SslContext;
@@ -308,8 +310,22 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                 try {
                     if (m_interface != null) {
                         m_serverSocket.socket().bind(new InetSocketAddress(m_interface, m_port));
+                        /*byte[] addr = m_interface.getAddress();
+                        Inet6Address ipv6_address = Inet6Address.getByAddress("localhost", addr, 0);
+                        Inet4Address ipv4_address = InetAddresses.getCompatIPv4Address(ipv6_address);
+                        byte[] new_addr = ipv4_address.getAddress();
+                        InetAddress new_m_interface = InetAddress.getByAddress(new_addr);
+                        m_serverSocket.socket().bind(new InetSocketAddress(new_m_interface, m_port));*/
+                        //(new Socket(m_interface, m_port)).close();
                     } else {
+                        System.setProperty("java.net.preferIPv4Stack" , "true");
+                        System.setProperty("java.net.preferIPv6Addresses", "false");
                         m_serverSocket.socket().bind(new InetSocketAddress(m_port));
+                        //(new Socket("localhost", m_port)).close();
+                        // VoltDB.crashLocalVoltDB(m_serverSocket.socket().getInetAddress().getHostName(),
+                        //     false, new IOException());
+                        // (new Socket(m_serverSocket.socket().getInetAddress(), m_port)).close();
+
                     }
                 }
                 catch (IOException e) {

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3216,8 +3216,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             (new Socket(hostname, m_config.m_port)).close();
             consoleLog.info("There is already a connection on this port");
             System.exit(-1);
-        } catch (Exception e) {
-           consoleLog.info("There is not a connection on this port yet");     
+        } catch (Exception e) {  
+        
         }
            
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -40,6 +40,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.Socket;
 import java.net.URL;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -3210,6 +3211,15 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         HostAndPort hostAndPort = criteria.getLeader();
         String hostname = hostAndPort.getHost();
         int port = hostAndPort.getPort();
+        
+        try {
+            (new Socket(hostname, m_config.m_port)).close();
+            consoleLog.info("There is already a connection on this port");
+            System.exit(-1);
+        } catch (Exception e) {
+           consoleLog.info("There is not a connection on this port yet");     
+        }
+           
 
         org.voltcore.messaging.HostMessenger.Config hmconfig;
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -40,7 +40,6 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
-import java.net.Socket;
 import java.net.URL;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -3212,13 +3211,13 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         String hostname = hostAndPort.getHost();
         int port = hostAndPort.getPort();
         
-        try {
-            (new Socket(hostname, m_config.m_port)).close();
-            consoleLog.info("There is already a connection on this port");
-            System.exit(-1);
-        } catch (Exception e) {  
+        // try {
+        //     (new Socket(hostname, m_config.m_port)).close();
+        //     consoleLog.info("There is already a connection on this port");
+        //     System.exit(-1);
+        // } catch (Exception e) {  
         
-        }
+        // }
            
 
         org.voltcore.messaging.HostMessenger.Config hmconfig;


### PR DESCRIPTION
Someone started VoltDB on a laptop, but then got this when he tried to use sqlcmd:
Unable to connect to VoltDB cluster
localhost:21212 - Authentication timed out

On further examination it turned out that 'trinket-agent' was running on port 21212. VoltDB did not produce any warnings and the web gui worked fine, but it was not possible to connect.

This is problematic because from the customers viewpoint VoltDB 'stops working' without any visible reason why.

I fixed this by checking if the client port is already in use when user called "voltdb start", and it would output "There is already a connection on this port". User would not even be able to call "sqlcmd", thus it would prevent the weird error above from happening. 

