### PR TITLE
ENG-15989:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ BANNER("Configuring the VoltDB Execution Engine."
        "VOLTDB_CORE_COUNT:      ${VOLTDB_CORE_COUNT}"
        "VOLT_LOG_LEVEL:         ${VOLT_LOG_LEVEL}"
        "VOLT_POOL_CHECKING:     ${VOLT_POOL_CHECKING}"
+       "VOLT_TRACE_ALLOCATIONS: ${VOLT_TRACE_ALLOCATIONS}"
        "VOLT_TIMER_ENABLED:     ${VOLT_TIMER_ENABLED}"
    )
 

--- a/build.xml
+++ b/build.xml
@@ -155,6 +155,11 @@
     <not><isset property="VOLT_POOL_CHECKING"/></not>
 </condition>
 
+<!-- By default, do not do record stack traces for each EE memory pool allocation  -->
+<condition property="VOLT_TRACE_ALLOCATIONS" value="false">
+    <not><isset property="VOLT_TRACE_ALLOCATIONS"/></not>
+</condition>
+
 <!-- By default, do not do execution timings  -->
 <condition property="VOLT_TIMER_ENABLED" value="false">
     <not><isset property="VOLT_TIMER_ENABLED"/></not>
@@ -1527,6 +1532,7 @@ NATIVE EE STUFF
         <arg line="--build-type='${build}'" />
     	<arg line="--log-level='${VOLT_LOG_LEVEL}'" />
         <arg line="--pool-checking='${VOLT_POOL_CHECKING}'" />
+        <arg line="--trace-pools='${VOLT_TRACE_ALLOCATIONS}'" />
         <arg line="--timer-enabled='${VOLT_TIMER_ENABLED}'" />
         <arg line="--max-processors=${cmake.build.maxcores}" />
         <arg line="--verbose-build='${cmake.verbose.build}'" />
@@ -1548,6 +1554,7 @@ NATIVE EE STUFF
         <arg line="--build-type='${build}'" />
     	<arg line="--log-level='${VOLT_LOG_LEVEL}'" />
         <arg line="--pool-checking='${VOLT_POOL_CHECKING}'" />
+        <arg line="--trace-pools='${VOLT_TRACE_ALLOCATIONS}'" />
         <arg line="--timer-enabled='${VOLT_TIMER_ENABLED}'" />
         <arg line="--max-processors=${cmake.build.maxcores}" />
         <arg line="--verbose-build='${cmake.verbose.build}'" />
@@ -1567,6 +1574,7 @@ NATIVE EE STUFF
         <arg line="--build-type='${build}'" />
     	<arg line="--log-level='${VOLT_LOG_LEVEL}'" />
         <arg line="--pool-checking='${VOLT_POOL_CHECKING}'" />
+        <arg line="--trace-pools='${VOLT_TRACE_ALLOCATIONS}'" />
         <arg line="--timer-enabled='${VOLT_TIMER_ENABLED}'" />
         <arg line="--max-processors=${cmake.build.maxcores}" />
         <arg line="--verbose-build='${cmake.verbose.build}'" />
@@ -1586,6 +1594,7 @@ NATIVE EE STUFF
         <arg line="--build-type=${build}" />
         <arg line="--log-level='${VOLT_LOG_LEVEL}'" />
         <arg line="--pool-checking='${VOLT_POOL_CHECKING}'" />
+        <arg line="--trace-pools='${VOLT_TRACE_ALLOCATIONS}'" />
         <arg line="--timer-enabled='${VOLT_TIMER_ENABLED}'" />
         <arg line="--max-processors=${cmake.build.maxcores}" />
         <arg line="--verbose-build='${cmake.verbose.build}'" />
@@ -1606,6 +1615,7 @@ NATIVE EE STUFF
         <arg line="--build-type=${build}" />
         <arg line="--log-level='${VOLT_LOG_LEVEL}'" />
         <arg line="--pool-checking='${VOLT_POOL_CHECKING}'" />
+        <arg line="--trace-pools='${VOLT_TRACE_ALLOCATIONS}'" />
         <arg line="--timer-enabled='${VOLT_TIMER_ENABLED}'" />
         <arg line="--max-processors=${cmake.build.maxcores}" />
         <arg line="--verbose-build='${cmake.verbose.build}'" />

--- a/src/ee/CMakeLists.txt
+++ b/src/ee/CMakeLists.txt
@@ -63,6 +63,7 @@ BANNER("Configuring the VoltDB Execution Engine Runtime."
        "VOLTDB_BUILD_TYPE:      ${VOLTDB_BUILD_TYPE}"
        "VOLT_LOG_LEVEL:         ${VOLT_LOG_LEVEL}"
        "VOLT_POOL_CHECKING:     ${VOLT_POOL_CHECKING}"
+       "VOLT_TRACE_ALLOCATIONS: ${VOLT_TRACE_ALLOCATIONS}"
        "VOLT_TIMER_ENABLED:     ${VOLT_TIMER_ENABLED}"
    )
 

--- a/tools/build_cmake.py
+++ b/tools/build_cmake.py
@@ -89,6 +89,12 @@ def makeParser():
                         help='''
                         Turns on conditionally compiled code to verify usage of memory
                         pools in the EE.''')
+    parser.add_argument('--trace-pools',
+                        action=OnOffAction,
+                        default='OFF',
+                        help='''
+                        Turns on conditionally compiled code to save stack traces for memory
+                        pool allocations in the EE.''')
     parser.add_argument('--timer-enabled',
                         action=OnOffAction,
                         default='OFF',
@@ -300,6 +306,7 @@ def configureCommandString(config):
             '-DVOLTDB_USE_PROFILING=%s '  # profile
             '-DVOLT_LOG_LEVEL=%s '        # config.log_level
             '-DVOLT_POOL_CHECKING=%s '    # pool_checking
+            '-DVOLT_TRACE_ALLOCATIONS=%s '# trace_pools
             '-DVOLT_TIMER_ENABLED=%s '    # timer_enabled
             '-DVOLTDB_CORE_COUNT=%d '     # number of processors
             '%s')                         # config.srcdir
@@ -311,6 +318,7 @@ def configureCommandString(config):
                 profile,
                 config.log_level,
                 config.pool_checking,
+                config.trace_pools,
                 config.timer_enabled,
                 getNumberProcessors(config),
                 config.srcdir))


### PR DESCRIPTION
To get better memory leak analysis tools during tests, we have a mechanism for tracking each allocation. However, the option is not available through the build tool. This commit enables direct manipulation of the compile time otion with the following config:
-DVOLT_TRACE_ALLOCATIONS=true