### PR TITLE
ENG-15923: Explain a calcite plan

### DIFF
--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -305,8 +305,8 @@ public class PlannerTool {
         plan.sql = task.getSQL();
         CorePlan core = new CorePlan(plan, m_catalogHash);
         // TODO: enable when we are ready
-//        throw new PlannerFallbackException("planSqlCalcite not ready");
-        return new AdHocPlannedStatement(plan, core);
+        throw new PlannerFallbackException("planSqlCalcite not ready");
+//        return new AdHocPlannedStatement(plan, core);
     }
 
     public synchronized AdHocPlannedStatement planSql(String sql, StatementPartitioning partitioning,

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -305,8 +305,8 @@ public class PlannerTool {
         plan.sql = task.getSQL();
         CorePlan core = new CorePlan(plan, m_catalogHash);
         // TODO: enable when we are ready
-        throw new PlannerFallbackException("planSqlCalcite not ready");
-//        return new AdHocPlannedStatement(plan, core);
+//        throw new PlannerFallbackException("planSqlCalcite not ready");
+        return new AdHocPlannedStatement(plan, core);
     }
 
     public synchronized AdHocPlannedStatement planSql(String sql, StatementPartitioning partitioning,

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -306,7 +306,7 @@ public class PlannerTool {
         CorePlan core = new CorePlan(plan, m_catalogHash);
         // TODO: enable when we are ready
         throw new PlannerFallbackException("planSqlCalcite not ready");
-        //return new AdHocPlannedStatement(plan, core);
+//        return new AdHocPlannedStatement(plan, core);
     }
 
     public synchronized AdHocPlannedStatement planSql(String sql, StatementPartitioning partitioning,

--- a/src/frontend/org/voltdb/sysprocs/AdHoc.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc.java
@@ -71,7 +71,7 @@ public class AdHoc extends AdHocNTBase {
         try {
             // We do not need to worry about the ParameterSet,
             // AdHocAcceptancePolicy will sanitize the parameters ahead of time.
-            batch = SqlBatch.from(params, m_context);
+            batch = SqlBatch.from(params, m_context, ExplainMode.NONE);
             return batch.execute();
         } catch (PlannerFallbackException | SqlParseException ex) {
             // Use the legacy planner to run this.

--- a/src/frontend/org/voltdb/sysprocs/AdHoc.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc.java
@@ -204,28 +204,11 @@ public class AdHoc extends AdHocNTBase {
      * @author Yiqun Zhang
      * @since 9.0
      */
-    private class AdHocContext implements SqlBatch.Context {
+    private class AdHocContext extends AdHocNTBaseContext {
 
         @Override public CompletableFuture<ClientResponse> runDDLBatch(List<String> sqlStatements,
                 List<SqlNode> sqlNodes) {
             return AdHoc.this.runDDLBatch(sqlStatements, sqlNodes);
-        }
-
-        @Override public void logBatch(CatalogContext context, AdHocPlannedStmtBatch batch, Object[] userParams) {
-            AdHoc.this.logBatch(context, batch, userParams);
-        }
-
-        @Override public VoltLogger getLogger() {
-            return adhocLog;
-        }
-
-        @Override public long getClientHandle() {
-            return AdHoc.this.getClientHandle();
-        }
-
-        @Override public CompletableFuture<ClientResponse> createAdHocTransaction(
-                AdHocPlannedStmtBatch plannedStmtBatch) throws VoltTypeException {
-            return AdHoc.this.createAdHocTransaction(plannedStmtBatch, false);
         }
     }
 

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
@@ -118,7 +118,7 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
         EMPTY,
         ALL_DML_OR_DQL,
         ALL_DDL,
-        MIXED;
+        MIXED
     }
 
     /**
@@ -146,7 +146,7 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
             String ddlToken = SQLLexer.extractDDLToken(stmt);
 
             if (hasDDL == null) {
-                hasDDL = (ddlToken != null) ? true : false;
+                hasDDL = ddlToken != null;
             }
             else if ((hasDDL && ddlToken == null) || (!hasDDL && ddlToken != null)) {
                 return AdHocSQLMix.MIXED;
@@ -572,6 +572,10 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
         @Override public CompletableFuture<ClientResponse> createAdHocTransaction(
                 AdHocPlannedStmtBatch plannedStmtBatch) throws VoltTypeException {
             return AdHocNTBase.this.createAdHocTransaction(plannedStmtBatch, false);
+        }
+
+        @Override public CompletableFuture<ClientResponse> processExplainPlannedStmtBatch(AdHocPlannedStmtBatch plannedStmtBatch) {
+            return AdHocNTBase.processExplainPlannedStmtBatch(plannedStmtBatch);
         }
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.calcite.sql.SqlNode;
 import org.apache.commons.lang3.StringUtils;
 import org.voltcore.logging.VoltLogger;
 import org.voltdb.BackendTarget;
@@ -44,6 +45,7 @@ import org.voltdb.compiler.PlannerTool;
 import org.voltdb.exceptions.PlanningErrorException;
 import org.voltdb.parser.SQLLexer;
 import org.voltdb.planner.StatementPartitioning;
+import org.voltdb.plannerv2.SqlBatch;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltTrace;
 
@@ -541,4 +543,35 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
                                          userParams);
     }
 
+    /**
+     * The {@link org.voltdb.plannerv2.SqlBatch} was designed to be
+     * self-contained. However, this is not entirely true due to the way that
+     * the legacy code was organized. Until I have further reshaped the legacy
+     * code path, I will leave this interface to call back into the private
+     * methods of {@link org.voltdb.sysprocs.AdHocNTBase}.
+     */
+    class AdHocNTBaseContext implements SqlBatch.Context {
+
+        @Override public CompletableFuture<ClientResponse> runDDLBatch(List<String> sqlStatements,
+                                                                       List<SqlNode> sqlNodes) {
+            throw new UnsupportedOperationException("Not Implemented.");
+        }
+
+        @Override public void logBatch(CatalogContext context, AdHocPlannedStmtBatch batch, Object[] userParams) {
+            AdHocNTBase.this.logBatch(context, batch, userParams);
+        }
+
+        @Override public VoltLogger getLogger() {
+            return adhocLog;
+        }
+
+        @Override public long getClientHandle() {
+            return AdHocNTBase.this.getClientHandle();
+        }
+
+        @Override public CompletableFuture<ClientResponse> createAdHocTransaction(
+                AdHocPlannedStmtBatch plannedStmtBatch) throws VoltTypeException {
+            return AdHocNTBase.this.createAdHocTransaction(plannedStmtBatch, false);
+        }
+    }
 }

--- a/src/frontend/org/voltdb/sysprocs/Explain.java
+++ b/src/frontend/org/voltdb/sysprocs/Explain.java
@@ -22,58 +22,44 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.calcite.sql.parser.SqlParseException;
 import org.voltdb.ClientInterface.ExplainMode;
 import org.voltdb.ParameterSet;
 import org.voltdb.VoltDB;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.plannerv2.SqlBatch;
+import org.voltdb.plannerv2.guards.PlannerFallbackException;
 
 public class Explain extends AdHocNTBase {
     private AdHocNTBaseContext m_context = new AdHocNTBaseContext();
 
+    /**
+     * Run an AdHoc explain batch through Calcite parser and planner. If there is
+     * anything that Calcite cannot handle, we will let it fall back to the
+     * legacy parser and planner.
+     *
+     * @param params
+     *            the user parameters. The first parameter is always the query
+     *            text. The rest parameters are the ones used in the queries.
+     *            </br>
+     * @return the client response.
+     * @since 9.0
+     * @author Chao Zhou
+     */
     public CompletableFuture<ClientResponse> run(ParameterSet params) {
-
-        // dispatch common
-
-        Object[] paramArray = params.toArray();
-        String sql = (String) paramArray[0];
-        Object[] userParams = null;
-        if (params.size() > 1) {
-            userParams = Arrays.copyOfRange(paramArray, 1, paramArray.length);
+        SqlBatch batch;
+        try {
+            // We do not need to worry about the ParameterSet,
+            // AdHocAcceptancePolicy will sanitize the parameters ahead of time.
+            batch = SqlBatch.from(params, m_context, ExplainMode.EXPLAIN_ADHOC);
+            return batch.execute();
+        } catch (PlannerFallbackException | SqlParseException ex) {
+            // Use the legacy planner to run this.
+            return runFallback(params);
+        } catch (Exception ex) {
+            // For now, let's just fail the batch if any error happens.
+            return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, ex.getMessage());
         }
-
-        List<String> sqlStatements = new ArrayList<>();
-        AdHocSQLMix mix = processAdHocSQLStmtTypes(sql, sqlStatements);
-
-        if (mix == AdHocSQLMix.EMPTY) {
-            // we saw neither DDL or DQL/DML.  Make sure that we get a
-            // response back to the client
-            return makeQuickResponse(
-                    ClientResponse.GRACEFUL_FAILURE,
-                    "Failed to plan, no SQL statement provided.");
-        }
-
-        else if (mix == AdHocSQLMix.MIXED) {
-            // No mixing DDL and DML/DQL.  Turn this into an error returned to client.
-            return makeQuickResponse(
-                    ClientResponse.GRACEFUL_FAILURE,
-                    "DDL mixed with DML and queries is unsupported.");
-        }
-
-        else if (mix == AdHocSQLMix.ALL_DDL) {
-            return makeQuickResponse(
-                    ClientResponse.GRACEFUL_FAILURE,
-                    "Explain doesn't support DDL.");
-        }
-
-        // assume all DML/DQL at this point
-        return runNonDDLAdHoc(VoltDB.instance().getCatalogContext(),
-                              sqlStatements,
-                              true, // infer partitioning
-                              null, // no partition key
-                              ExplainMode.EXPLAIN_ADHOC,
-                              false, // not a large query
-                              false, // not swap tables
-                              userParams);
     }
 
     public CompletableFuture<ClientResponse> runFallback(ParameterSet params) {
@@ -119,5 +105,4 @@ public class Explain extends AdHocNTBase {
                 false, // not swap tables
                 userParams);
     }
-
 }

--- a/src/frontend/org/voltdb/sysprocs/Explain.java
+++ b/src/frontend/org/voltdb/sysprocs/Explain.java
@@ -28,6 +28,7 @@ import org.voltdb.VoltDB;
 import org.voltdb.client.ClientResponse;
 
 public class Explain extends AdHocNTBase {
+    private AdHocNTBaseContext m_context = new AdHocNTBaseContext();
 
     public CompletableFuture<ClientResponse> run(ParameterSet params) {
 
@@ -73,6 +74,50 @@ public class Explain extends AdHocNTBase {
                               false, // not a large query
                               false, // not swap tables
                               userParams);
+    }
+
+    public CompletableFuture<ClientResponse> runFallback(ParameterSet params) {
+        // dispatch common
+        Object[] paramArray = params.toArray();
+        String sql = (String) paramArray[0];
+        Object[] userParams = null;
+        if (params.size() > 1) {
+            userParams = Arrays.copyOfRange(paramArray, 1, paramArray.length);
+        }
+
+        List<String> sqlStatements = new ArrayList<>();
+        AdHocSQLMix mix = processAdHocSQLStmtTypes(sql, sqlStatements);
+
+        if (mix == AdHocSQLMix.EMPTY) {
+            // we saw neither DDL or DQL/DML.  Make sure that we get a
+            // response back to the client
+            return makeQuickResponse(
+                    ClientResponse.GRACEFUL_FAILURE,
+                    "Failed to plan, no SQL statement provided.");
+        }
+
+        else if (mix == AdHocSQLMix.MIXED) {
+            // No mixing DDL and DML/DQL.  Turn this into an error returned to client.
+            return makeQuickResponse(
+                    ClientResponse.GRACEFUL_FAILURE,
+                    "DDL mixed with DML and queries is unsupported.");
+        }
+
+        else if (mix == AdHocSQLMix.ALL_DDL) {
+            return makeQuickResponse(
+                    ClientResponse.GRACEFUL_FAILURE,
+                    "Explain doesn't support DDL.");
+        }
+
+        // assume all DML/DQL at this point
+        return runNonDDLAdHoc(VoltDB.instance().getCatalogContext(),
+                sqlStatements,
+                true, // infer partitioning
+                null, // no partition key
+                ExplainMode.EXPLAIN_ADHOC,
+                false, // not a large query
+                false, // not swap tables
+                userParams);
     }
 
 }

--- a/src/frontend/org/voltdb/sysprocs/Explain.java
+++ b/src/frontend/org/voltdb/sysprocs/Explain.java
@@ -38,13 +38,12 @@ public class Explain extends AdHocNTBase {
      * anything that Calcite cannot handle, we will let it fall back to the
      * legacy parser and planner.
      *
-     * @param params
-     *            the user parameters. The first parameter is always the query
-     *            text. The rest parameters are the ones used in the queries.
-     *            </br>
+     * @param params the user parameters. The first parameter is always the query
+     *               text. The rest parameters are the ones used in the queries.
+     *               </br>
      * @return the client response.
-     * @since 9.0
      * @author Chao Zhou
+     * @since 9.1
      */
     public CompletableFuture<ClientResponse> run(ParameterSet params) {
         SqlBatch batch;

--- a/tests/frontend/org/voltdb/regressionsuites/TestExplainCommandSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestExplainCommandSuite.java
@@ -46,7 +46,7 @@ public class TestExplainCommandSuite extends RegressionSuite {
         Client client = getClient();
         VoltTable vt = null;
 
-        String[] strs = {"SELECT COUNT(*) FROM T1 order by A_INT", "SELECT COUNT(*) FROM T1 order by A_INT"};
+        String[] strs = {"SELECT COUNT(*) FROM T1", "SELECT COUNT(*) FROM T1"};
 
         vt = client.callProcedure("@Explain", (Object[]) strs ).getResults()[0];
         while (vt.advanceRow()) {


### PR DESCRIPTION
Change the behavior of EXPLAIN_ADHOC to uses Calcite planner to generate the plan and print the explained plan, instead of the old code path.

Note: we currently always fallback at the end of the calcite planner, you can only see the plan difference if you comment out the fallback  https://github.com/VoltDB/voltdb/blob/1e27131d9f052cdae584a390361760718b08f9a4/src/frontend/org/voltdb/compiler/PlannerTool.java#L308.