### PR TITLE
ENG-15945: On rejoin always monitor snapshot

### DIFF
--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -360,8 +360,6 @@ public class RejoinProducer extends JoinProducerBase {
         }
         else {
             doFinishingTask(siteConnection);
-            // Remove the completion monitor for an empty (zero table) rejoin.
-            m_snapshotCompletionMonitor.set(null);
         }
     }
 
@@ -400,18 +398,16 @@ public class RejoinProducer extends JoinProducerBase {
                 long clusterCreateTime = -1;
                 try {
                     event = m_snapshotCompletionMonitor.get();
-                    if (m_hasPersistentTables) {
-                        REJOINLOG.debug(m_whoami + "waiting on snapshot completion monitor.");
-                        exportSequenceNumbers = event.exportSequenceNumbers;
-                        m_completionAction.setSnapshotTxnId(event.multipartTxnId);
+                    REJOINLOG.debug(m_whoami + " waiting on snapshot completion monitor.");
+                    exportSequenceNumbers = event.exportSequenceNumbers;
+                    m_completionAction.setSnapshotTxnId(event.multipartTxnId);
 
-                        drSequenceNumbers = event.drSequenceNumbers;
-                        allConsumerSiteTrackers = event.drMixedClusterSizeConsumerState;
-                        clusterCreateTime = event.clusterCreateTime;
+                    drSequenceNumbers = event.drSequenceNumbers;
+                    allConsumerSiteTrackers = event.drMixedClusterSizeConsumerState;
+                    clusterCreateTime = event.clusterCreateTime;
 
-                        // Tells EE which DR version going to use
-                        siteConnection.setDRProtocolVersion(event.drVersion);
-                    }
+                    // Tells EE which DR version going to use
+                    siteConnection.setDRProtocolVersion(event.drVersion);
 
                     REJOINLOG.debug(m_whoami + " monitor completed. Sending SNAPSHOT_FINISHED "
                             + "and handing off to site.");

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -254,9 +254,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
         }
     }
 
-    private void onSiteInitialized(long HSId, long masterHSId, long dataSinkHSId,
-                                   boolean schemaHasPersistentTables)
-    {
+    private void onSiteInitialized(long HSId, long masterHSId, long dataSinkHSId) {
         String nonce = null;
         String data = null;
         synchronized(m_lock) {
@@ -282,7 +280,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
             throw new RuntimeException("Received an INITIATION_RESPONSE for an HSID for which no nonce exists: " +
                     CoreUtils.hsIdToString(HSId));
         }
-        if (data != null && schemaHasPersistentTables) {
+        if (data != null) {
             REJOINLOG.debug("Snapshot request: " + data);
             SnapshotUtil.requestSnapshot(0l, "", nonce, !m_liveRejoin, SnapshotFormat.STREAM, SnapshotPathType.SNAP_NO_PATH, data,
                     SnapshotUtil.fatalSnapshotResponseHandler, true);
@@ -306,8 +304,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
             assert(m_catalog != null);
             onReplayFinished(rm.m_sourceHSId);
         } else if (type == RejoinMessage.Type.INITIATION_RESPONSE) {
-            onSiteInitialized(rm.m_sourceHSId, rm.getMasterHSId(), rm.getSnapshotSinkHSId(),
-                              rm.schemaHasPersistentTables());
+            onSiteInitialized(rm.m_sourceHSId, rm.getMasterHSId(), rm.getSnapshotSinkHSId());
         } else {
             VoltDB.crashLocalVoltDB("Wrong rejoin message of type " + type +
                                     " sent to the rejoin coordinator", false, null);

--- a/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
+++ b/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Test;
@@ -44,6 +45,8 @@ import org.voltdb.client.ProcedureCallback;
 import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
+import org.voltdb.export.SocketExportTestServer;
+import org.voltdb.exportclient.SocketExporter;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.RegressionSuite;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
@@ -1089,23 +1092,43 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         cluster.shutDown();
     }
 
-    @Test
+    @Test(timeout = 60_000)
     public void testRejoinWithOnlyAStream() throws Exception {
-        LocalCluster lc = new LocalCluster("rejoin.jar", 2, 3, 1, BackendTarget.NATIVE_EE_JNI);
+        SocketExportTestServer socketServer = new SocketExportTestServer(5001);
+
+        LocalCluster lc = new LocalCluster("rejoin.jar", 1, 2, 1, BackendTarget.NATIVE_EE_JNI);
         lc.overrideAnyRequestForValgrind();
         VoltProjectBuilder vpb = new VoltProjectBuilder();
         vpb.setUseDDLSchema(true);
+        vpb.addExport(true, ServerExportEnum.CUSTOM, SocketExporter.class.getName(), new Properties(),
+                "exporter");
         assertTrue(lc.compile(vpb));
         lc.setHasLocalServer(false);
         try {
+            socketServer.start();
             lc.startUp();
             Client client = lc.createClient(new ClientConfig());
             client.callProcedure("@AdHoc", "CREATE STREAM stream_towns PARTITION ON COLUMN state "
-                    + "EXPORT TO TARGET stream_test1 (town VARCHAR(64), state VARCHAR(2) not null);");
-            lc.killSingleHost(1);
-            lc.recoverOne(1, 0, "");
+                    + "EXPORT TO TARGET exporter (town VARCHAR(64), state VARCHAR(2) not null);");
+            for (int i = 0; i < 20; ++i) {
+                client.callProcedure("@AdHoc", "INSERT INTO stream_towns VALUES ('" + i + "', 'MA');");
+            }
+            for (int i = 0; i < 2; ++i) {
+                lc.killSingleHost(i);
+                lc.rejoinOne(i);
+            }
+
+            client.close();
+            client = lc.createClient(new ClientConfig());
+
+            for (int i = 0; i < 5; ++i) {
+                client.callProcedure("@AdHoc", "INSERT INTO stream_towns VALUES ('" + i + "', 'MA');");
+            }
+
+            socketServer.verifyExportedTuples(25, 30_000);
         } finally {
             lc.shutDown();
+            socketServer.shutdown();
         }
     }
 


### PR DESCRIPTION
On rejoin without any persistent tables the snapshot completion event was
not being processed. When the system does not have persistent tables
only skip waiting for streams from other hosts but not processing the
snapshot completion.

Update rejoin with only stream tests to confirm that the sequence id
continues to increase.