### PR TITLE
Fix for ENG-15989

### DIFF
--- a/src/ee/common/tabletuple.cpp
+++ b/src/ee/common/tabletuple.cpp
@@ -48,6 +48,7 @@
 #include "common/tabletuple.h"
 
 namespace voltdb {
+Json::FastWriter TableTuple::s_writer{};
 
 std::string TableTuple::debug(const std::string& tableName,
                               bool skipNonInline) const {

--- a/src/ee/common/tabletuple.cpp
+++ b/src/ee/common/tabletuple.cpp
@@ -48,7 +48,6 @@
 #include "common/tabletuple.h"
 
 namespace voltdb {
-Json::FastWriter TableTuple::s_writer{};
 
 std::string TableTuple::debug(const std::string& tableName,
                               bool skipNonInline) const {

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -448,8 +448,7 @@ public:
         for (int i = 0; i < totalColumns; i++) {
            array.append({getNValue(i).toString()});
         }
-        const auto result = writeJson(array);
-        return result;
+        return writeJson(array);
     }
 
     std::string toJsonString(const std::vector<std::string>& columnNames) const {
@@ -506,10 +505,10 @@ public:
     size_t hashCode() const;
 
 private:
+    static Json::FastWriter s_writer;
     static string writeJson(Json::Value const& val) {
-       static Json::FastWriter writer{};
-       writer.omitEndingLineFeed();
-       return writer.write(val);
+       s_writer.omitEndingLineFeed();
+       return std::string{s_writer.write(val)};
     }
     inline void setActiveTrue() {
         // treat the first "value" as a boolean flag

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -505,10 +505,11 @@ public:
     size_t hashCode() const;
 
 private:
-    static Json::FastWriter s_writer;
     static string writeJson(Json::Value const& val) {
-       s_writer.omitEndingLineFeed();
-       return std::string{s_writer.write(val)};
+       // ENG-15989: FastWriter is not thread-safe, and therefore cannot be made static.
+       Json::FastWriter writer;
+       writer.omitEndingLineFeed();
+       return writer.write(val);
     }
     inline void setActiveTrue() {
         // treat the first "value" as a boolean flag


### PR DESCRIPTION
"Double free or corruption". The stacktrace leads to my recent changes on
JSON serialization, and I think it could have been because of the static
local variable scope, hence changed to static member variable.

Pending system test. @jwiebema1 