### PR TITLE
ENG-16016: Reset throughput when stats are initialized

### DIFF
--- a/src/frontend/org/voltdb/elastic/BalancePartitionsStatistics.java
+++ b/src/frontend/org/voltdb/elastic/BalancePartitionsStatistics.java
@@ -78,6 +78,7 @@ public class BalancePartitionsStatistics extends StatsSource {
         this.totalRangeSize = totalRangeSize;
         this.lastReportTime = overallStats.getStartTimeNanos();
         this.lastBalanceDuration = 0;
+        this.throughput = 0;
 
         startInterval();
 

--- a/src/frontend/org/voltdb/elastic/BalancePartitionsStatistics.java
+++ b/src/frontend/org/voltdb/elastic/BalancePartitionsStatistics.java
@@ -97,9 +97,8 @@ public class BalancePartitionsStatistics extends StatsSource {
         final long balanceEnd = System.nanoTime();
         lastBalanceDuration = balanceEnd - balanceStart;
 
-        final long now = System.nanoTime();
-        final long aSecondAgo = now - TimeUnit.SECONDS.toNanos(1);
-        bytesTransferredInLastSec.put(now, bytesTransferred);
+        final long aSecondAgo = balanceEnd - TimeUnit.SECONDS.toNanos(1);
+        bytesTransferredInLastSec.put(balanceEnd, bytesTransferred);
 
         // remove entries older than a second
         throughput += bytesTransferred;
@@ -129,8 +128,8 @@ public class BalancePartitionsStatistics extends StatsSource {
         markStatsPoint();
 
         // Close out the interval and log statistics every logIntervalSeconds seconds.
-        if (now - lastReportTime > logIntervalNanos && now != lastReportTime) {
-            lastReportTime = now;
+        if (balanceEnd - lastReportTime > logIntervalNanos && balanceEnd != lastReportTime) {
+            lastReportTime = balanceEnd;
             endInterval();
         }
     }
@@ -435,7 +434,7 @@ public class BalancePartitionsStatistics extends StatsSource {
         public double getAverageInvocationLatency()
         {
             //Convert to floating point millis
-            return invocationCount == 0 ? 0.0 : getInvocationLatencyMillis() / (double)invocationCount;
+            return invocationCount == 0 ? 0.0 : getInvocationLatencyMillis() / invocationCount;
         }
 
         public double getAverageInvocationTime() {

--- a/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
+++ b/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
@@ -1092,7 +1092,7 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         cluster.shutDown();
     }
 
-    @Test(timeout = 60_000)
+    @Test(timeout = 120_000)
     public void testRejoinWithOnlyAStream() throws Exception {
         SocketExportTestServer socketServer = new SocketExportTestServer(5001);
 


### PR DESCRIPTION
Throughput was not reset when the stats were initialized causing previous throughput to roll into next run. This made the current runs throughput seem much higher and caused the throttling to kick in and slow down balance partitions.

Also, some minor improvements to the stats class including reusing result of nanoTime() and a deque instead of TreeMap