### PR TITLE
ENG-16009, drop buffers detected as duplicates on push

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -763,6 +763,17 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 return;
             }
 
+            // Drop duplicate buffer
+            if (!m_gapTracker.isEmpty() && lastSequenceNumber <= m_gapTracker.getLastSeqNo()) {
+                if (exportLog.isDebugEnabled()) {
+                    exportLog.debug("Dropping duplicate buffer. " +
+                            " Buffer info: [" + startSequenceNumber + "," + lastSequenceNumber + "] Size: " + tupleCount +
+                            " tracker last seqNo: " + m_gapTracker.getLastSeqNo());
+                }
+                cont.discard();
+                return;
+            }
+
             // We should never try to push data on a source that is not in catalog
             if (!inCatalog()) {
                 exportLog.warn("Source not in catalog, dropping buffer. " +


### PR DESCRIPTION
In recovery scenarios, the following can happen:

- the ExportDataSource starting up can recover PBD segment(s) containing rows that were already exported and acknowledged in the previous execution

- the same rows may be pushed again by the EE

This results in inserting duplicate buffers in the PBD and when the first copies of the buffers are acknowledged, this may result in PBD segments being closed before the in-memory buffers are discarded. This condition is detected by code assertions.

These fix prevents the insertion of duplicate buffers in the PBD.
