### PR TITLE
ENG-16021: Auto-filer tweak 2

### DIFF
--- a/tools/jenkins/jenkinsbot.py
+++ b/tools/jenkins/jenkinsbot.py
@@ -1219,9 +1219,15 @@ tr:hover{
 
         if ticket_to_modify and not DRY_RUN:
             # Update the Jira ticket's summary, description, etc.
-            previous_summary = ticket_to_modify.fields.summary
-            old_description  = ticket_to_modify.fields.description
-            new_description  = self.get_modified_description(old_description, descriptions)
+            previous_summary  = ticket_to_modify.fields.summary
+            old_description   = ticket_to_modify.fields.description
+            new_description   = self.get_modified_description(old_description, descriptions)
+            previous_priority = ticket_to_modify.fields.priority
+#             logging.info('previous_priority: '+str(previous_priority))
+            # If ticket has been marked as a "Blocker" (presumably manually),
+            # then do not downgrade it
+            if previous_priority == 'Blocker':
+                priority = previous_priority
             try:
                 ticket_to_modify.update(fields={'summary'    : summary,
                                                 'description': new_description,


### PR DESCRIPTION
Modified to recognize the "type" (e.g. CONSISTENT, INTERMITTENT) of
older Jira tickets; and to not "downgrade" tickets that are already
marked as "Blocker" (presumably manually).