### PR TITLE
ENG-16034: Use recoverOne instead of rejoinOne

### DIFF
--- a/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
+++ b/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
@@ -1115,7 +1115,7 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
             }
             for (int i = 0; i < 2; ++i) {
                 lc.killSingleHost(i);
-                lc.rejoinOne(i);
+                lc.recoverOne(i, (i + 1) % 2, "");
             }
 
             client.close();


### PR DESCRIPTION
rejoinOne does not work with old cli and is not actually doing a rejoin. Use
recover to do a rejoin.