### PR TITLE
ENG-15991: Call notifyTupleInsert after indexing

### DIFF
--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -856,16 +856,6 @@ void PersistentTable::doInsertTupleCommon(TableTuple& source, TableTuple& target
     target.setInlinedDataIsVolatileFalse();
     target.setNonInlinedDataIsVolatileFalse();
 
-    /**
-     * Inserts never "dirty" a tuple since the tuple is new, but...  The
-     * COWIterator may still be scanning and if the tuple came from the free
-     * list then it may need to be marked as dirty so it will be skipped. If COW
-     * is on have it decide. COW should always set the dirty to false unless the
-     * tuple is in a to be scanned area.
-     */
-    if (m_tableStreamer == NULL || !m_tableStreamer->notifyTupleInsert(target)) {
-        target.setDirtyFalse();
-    }
 
     TableTuple conflict(m_schema);
     try {
@@ -887,6 +877,18 @@ void PersistentTable::doInsertTupleCommon(TableTuple& source, TableTuple& target
         throw ConstraintFailureException(this, source, conflict, CONSTRAINT_TYPE_UNIQUE,
                 delayTupleDelete ? &m_surgeon : NULL);
     }
+
+    /**
+     * Inserts never "dirty" a tuple since the tuple is new, but...  The
+     * COWIterator may still be scanning and if the tuple came from the free
+     * list then it may need to be marked as dirty so it will be skipped. If COW
+     * is on have it decide. COW should always set the dirty to false unless the
+     * tuple is in a to be scanned area.
+     */
+    if (m_tableStreamer == NULL || !m_tableStreamer->notifyTupleInsert(target)) {
+        target.setDirtyFalse();
+    }
+
 
     // this is skipped for inserts that are never expected to fail,
     // like some (initially, all) cases of tuple migration on schema change


### PR DESCRIPTION
notifyTupleInsert is used to notify table streams of tuples which were
inserted. However this method was being called prior to inserting the tuple
into the indexes. If the tuple violated any unique constraints of an index then
the tuple would be removed from the index but the table stream would not be
notified. This is an issue for elastic operations since notifyTupleInsert adds
the tuple into the elastic index.

Moving the call notifyTupleInsert to after index insertion guarantees that the
tuples in the elastic index are all valid tuples part of a table and two
entries in the index do not point to the same tuple.