### PR TITLE
ENG-11701: Supporting table alias in DELETE statements

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDQL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDQL.java
@@ -1493,18 +1493,17 @@ public class ParserDQL extends ParserBase {
         Table      table = readTableName();
         SimpleName alias = null;
 
-        if (operation != StatementTypes.DELETE_WHERE) {
-            if (token.tokenType == Tokens.AS) {
-                read();
-                checkIsNonCoreReservedIdentifier();
-            }
+        //if (operation != StatementTypes.DELETE_WHERE) {
+        if (token.tokenType == Tokens.AS) {
+            read();
+            checkIsNonCoreReservedIdentifier();
+        }
 
-            if (isNonCoreReservedIdentifier()) {
-                alias = HsqlNameManager.getSimpleName(token.tokenString,
-                                                      isDelimitedIdentifier());
+        if (isNonCoreReservedIdentifier()) {
+            alias = HsqlNameManager.getSimpleName(token.tokenString,
+                                                  isDelimitedIdentifier());
 
-                read();
-            }
+            read();
         }
 
         if (table.isView) {

--- a/tests/hsqldb/org/hsqldb_voltpatches/TestHSQLDB.java
+++ b/tests/hsqldb/org/hsqldb_voltpatches/TestHSQLDB.java
@@ -326,6 +326,78 @@ public class TestHSQLDB extends TestCase {
         }
     }
 
+    public void testDeleteTableAliasPass() {
+        HSQLInterface hsql = setupTPCCDDL();
+
+        // No aliasing
+        String sql = "DELETE FROM ORDERS WHERE O_W_ID = ?;";
+        VoltXMLElement xml = null;
+        try {
+            xml = hsql.getXMLCompiledStatement(sql);
+            assertNotNull(xml);
+        } catch (HSQLParseException e1) {
+            e1.printStackTrace();
+            fail();
+        }
+
+        // Aliasing in FROM without AS, refer to a column in WHERE without the alias
+        sql = "DELETE FROM ORDERS O WHERE O_W_ID = ?;";
+        xml = null;
+        try {
+            xml = hsql.getXMLCompiledStatement(sql);
+            assertNotNull(xml);
+        } catch (HSQLParseException e1) {
+            e1.printStackTrace();
+            fail();
+        }
+
+        // Aliasing in FROM with AS, refer to a column in WHERE with the alias
+        sql = "DELETE FROM ORDERS AS O WHERE O.O_W_ID = ?;";
+        xml = null;
+        try {
+            xml = hsql.getXMLCompiledStatement(sql);
+            assertNotNull(xml);
+        } catch (HSQLParseException e1) {
+            e1.printStackTrace();
+            fail();
+        }
+
+        // Aliasing in FROM without AS, refer to a column in WHERE without the alias
+        sql = "DELETE FROM ORDERS O WHERE O_W_ID = ?;";
+        xml = null;
+        try {
+            xml = hsql.getXMLCompiledStatement(sql);
+            assertNotNull(xml);
+        } catch (HSQLParseException e1) {
+            e1.printStackTrace();
+            fail();
+        }
+
+        // Aliasing in FROM with AS, refer to a column in WHERE with the alias
+        sql = "DELETE FROM ORDERS AS O WHERE O.O_W_ID = ?;";
+        xml = null;
+        try {
+            xml = hsql.getXMLCompiledStatement(sql);
+            assertNotNull(xml);
+        } catch (HSQLParseException e1) {
+            e1.printStackTrace();
+            fail();
+        }
+    }
+
+    public void testDeleteTableAliasFail() {
+        HSQLInterface hsql = setupTPCCDDL();
+
+        // Aliasing in FROM without AS, refer to a column in WHERE with the original table
+        expectFailStmt(hsql,  "DELETE FROM ORDERS O WHERE ORDERS.O_W_ID = ?;",
+                "object not found: ORDERS.O_W_ID");
+
+        // Aliasing in FROM with AS, refer to a column in WHERE with the original table
+        expectFailStmt(hsql,  "DELETE FROM ORDERS AS O WHERE ORDERS.O_W_ID = ?;",
+                "object not found: ORDERS.O_W_ID");
+
+    }
+
     /*public void testSimpleSQL() {
         HSQLInterface hsql = setupTPCCDDL();
 

--- a/tests/hsqldb/org/hsqldb_voltpatches/TestHSQLDB.java
+++ b/tests/hsqldb/org/hsqldb_voltpatches/TestHSQLDB.java
@@ -329,12 +329,19 @@ public class TestHSQLDB extends TestCase {
     public void testDeleteTableAliasPass() {
         HSQLInterface hsql = setupTPCCDDL();
 
+        // Parsed result without a table alias
+        String no_alias = "";
+
+        // Parsed result with a table alias
+        String alias_ref = "";
+
         // No aliasing
         String sql = "DELETE FROM ORDERS WHERE O_W_ID = ?;";
         VoltXMLElement xml = null;
         try {
             xml = hsql.getXMLCompiledStatement(sql);
             assertNotNull(xml);
+            no_alias = xml.toString();
         } catch (HSQLParseException e1) {
             e1.printStackTrace();
             fail();
@@ -346,6 +353,20 @@ public class TestHSQLDB extends TestCase {
         try {
             xml = hsql.getXMLCompiledStatement(sql);
             assertNotNull(xml);
+            alias_ref = xml.toString();
+
+            // Check the parsed result for the correct table alias
+            assertTrue(alias_ref.contains("tablealias=\"O\""));
+
+            // Create a new string that have tablealias entries replaced by whitespaces
+            String alias_modified = alias_ref.replace("tablealias=\"O\"", " ");
+
+            // The parsed results with and without a table alias should only be different by the tablealias field.
+            // i.e. For this particular statement, the parsed result without table alias should be "...table=\"ORDERS\"..."
+            // the parsed result with table alias should be "...table=\"ORDERS\"...tablealias=\"O\"..."
+            assertTrue(no_alias.replaceAll("[\\s+\n+]", "").equals(alias_modified.replaceAll("[\\s+\\n+]", "")));
+
+
         } catch (HSQLParseException e1) {
             e1.printStackTrace();
             fail();
@@ -357,6 +378,9 @@ public class TestHSQLDB extends TestCase {
         try {
             xml = hsql.getXMLCompiledStatement(sql);
             assertNotNull(xml);
+
+            // All statements that have a table alias should be parsed into the same result
+            assertTrue(xml.toString().equals(alias_ref));
         } catch (HSQLParseException e1) {
             e1.printStackTrace();
             fail();
@@ -368,6 +392,9 @@ public class TestHSQLDB extends TestCase {
         try {
             xml = hsql.getXMLCompiledStatement(sql);
             assertNotNull(xml);
+
+            // All statements that have a table alias should be parsed into the same result
+            assertTrue(xml.toString().equals(alias_ref));
         } catch (HSQLParseException e1) {
             e1.printStackTrace();
             fail();
@@ -379,6 +406,9 @@ public class TestHSQLDB extends TestCase {
         try {
             xml = hsql.getXMLCompiledStatement(sql);
             assertNotNull(xml);
+
+            // All statements that have a table alias should be parsed into the same result
+            assertTrue(xml.toString().equals(alias_ref));
         } catch (HSQLParseException e1) {
             e1.printStackTrace();
             fail();


### PR DESCRIPTION
This PR implements the following features:

According to the SQL-99 standard, the following delete statements are valid:
DELETE FROM x y WHERE key = 2;
DELETE FROM x y WHERE y.key = 2;
DELETE FROM x AS y WHERE key = 2;
DELETE FROM x AS y WHERE y.key = 2;
and they should just work like:
DELETE FROM x WHERE key = 2;

They following should be errors in the WHERE clause with error messages saying X.KEY cannot be found:
DELETE FROM x y WHERE x.key = 2;
DELETE FROM x AS y WHERE x.key = 2;