### PR TITLE
Eng 11701 support table alias in delete statements

### DIFF
--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteRebalanceStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteRebalanceStats.java
@@ -23,27 +23,22 @@
 
 package org.voltdb.regressionsuites.statistics;
 
-import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Test;
+import org.junit.Test;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 
 import org.voltdb.elastic.BalancePartitionsStatistics;
-import org.voltdb.regressionsuites.StatisticsTestSuiteBase;
 
-public class TestStatisticsSuiteRebalanceStats extends StatisticsTestSuiteBase {
-
-    public TestStatisticsSuiteRebalanceStats(String name) {
-        super(name);
-    }
+public class TestStatisticsSuiteRebalanceStats {
 
     class RebalanceStatsChecker
     {
         final double fuzzFactor;
         final int rangesToMove;
 
-        long tStartMS;
         long rangesMoved = 0;
         long bytesMoved = 0;
         long rowsMoved = 0;
@@ -54,7 +49,6 @@ public class TestStatisticsSuiteRebalanceStats extends StatisticsTestSuiteBase {
         {
             this.fuzzFactor = fuzzFactor;
             this.rangesToMove = rangesToMove;
-            this.tStartMS = System.currentTimeMillis();
         }
 
         void update(int ranges, int bytes, int rows)
@@ -65,36 +59,29 @@ public class TestStatisticsSuiteRebalanceStats extends StatisticsTestSuiteBase {
             invocations++;
         }
 
-        void checkFuzz(double expected, double actual)
-        {
-            double delta = Math.abs((expected - actual) / expected);
-            if (delta > fuzzFactor) {
-                assertFalse(Math.abs((expected - actual) / expected) > fuzzFactor);
-            }
-        }
-
         void check(BalancePartitionsStatistics.StatsPoint stats)
         {
-            double totalTimeS = (System.currentTimeMillis() - tStartMS) / 1000.0;
+            double totalTimeS = (stats.getEndTimeMillis() - stats.getStartTimeMillis()) / 1000.0;
             double statsRangesMoved1 = (stats.getPercentageMoved() / 100.0) * rangesToMove;
-            checkFuzz(rangesMoved, statsRangesMoved1);
+            assertEquals(rangesMoved, statsRangesMoved1, rangesMoved*fuzzFactor);
             double statsRangesMoved2 = stats.getRangesPerSecond() * totalTimeS;
-            checkFuzz(rangesMoved, statsRangesMoved2);
+            assertEquals(rangesMoved, statsRangesMoved2, rangesMoved*fuzzFactor);
             double statsBytesMoved = stats.getMegabytesPerSecond() * 1000000.0 * totalTimeS;
-            checkFuzz(bytesMoved, statsBytesMoved);
+            assertEquals(bytesMoved, statsBytesMoved, bytesMoved*fuzzFactor);
             double statsRowsMoved = stats.getRowsPerSecond() * totalTimeS;
-            checkFuzz(rowsMoved, statsRowsMoved);
+            assertEquals(rowsMoved, statsRowsMoved, rowsMoved*fuzzFactor);
             double statsInvocations = stats.getInvocationsPerSecond() * totalTimeS;
-            checkFuzz(invocations, statsInvocations);
+            assertEquals(invocations, statsInvocations, invocations*fuzzFactor);
             double statsInvTimeMS = stats.getAverageInvocationTime() * invocations;
             assertTrue(Math.abs((totalInvTimeMS - statsInvTimeMS) / totalInvTimeMS) <= fuzzFactor);
-            checkFuzz(totalInvTimeMS, statsInvTimeMS);
+            assertEquals(totalInvTimeMS, statsInvTimeMS, totalInvTimeMS*fuzzFactor);
             double estTimeRemainingS = totalTimeS * (rangesToMove / (double)rangesMoved - 1.0);
             double statsEstTimeRemainingS = stats.getEstimatedRemaining() / 1000.0;
-            checkFuzz(estTimeRemainingS, statsEstTimeRemainingS);
+            assertEquals(estTimeRemainingS, statsEstTimeRemainingS, estTimeRemainingS*fuzzFactor);
         }
     }
 
+    @Test
     public void testRebalanceStats() throws Exception {
         System.out.println("testRebalanceStats");
         // Test constants
@@ -128,14 +115,5 @@ public class TestStatisticsSuiteRebalanceStats extends StatisticsTestSuiteBase {
         }
         // Check the results with fuzzing to avoid rounding errors.
         checker.check(bps.getOverallStats());
-    }
-
-    //
-    // Build a list of the tests to be run. Use the regression suite
-    // helpers to allow multiple backends.
-    // JUnit magic that uses the regression suite helper classes.
-    //
-    static public Test suite() throws IOException {
-        return StatisticsTestSuiteBase.suite(TestStatisticsSuiteRebalanceStats.class, false);
     }
 }

--- a/tests/hsqldb/org/hsqldb_voltpatches/TestHSQLDB.java
+++ b/tests/hsqldb/org/hsqldb_voltpatches/TestHSQLDB.java
@@ -329,6 +329,8 @@ public class TestHSQLDB extends TestCase {
     public void testDeleteTableAliasPass() {
         HSQLInterface hsql = setupTPCCDDL();
 
+        // Test cases where the usages of table alias in delete statement are valid
+
         // Parsed result without a table alias
         String no_alias = "";
 
@@ -365,8 +367,6 @@ public class TestHSQLDB extends TestCase {
             // i.e. For this particular statement, the parsed result without table alias should be "...table=\"ORDERS\"..."
             // the parsed result with table alias should be "...table=\"ORDERS\"...tablealias=\"O\"..."
             assertTrue(no_alias.replaceAll("[\\s+\n+]", "").equals(alias_modified.replaceAll("[\\s+\\n+]", "")));
-
-
         } catch (HSQLParseException e1) {
             e1.printStackTrace();
             fail();
@@ -417,6 +417,8 @@ public class TestHSQLDB extends TestCase {
 
     public void testDeleteTableAliasFail() {
         HSQLInterface hsql = setupTPCCDDL();
+
+        // Test cases where the usages of table alias in delete statement are invalid
 
         // Aliasing in FROM without AS, refer to a column in WHERE with the original table
         expectFailStmt(hsql,  "DELETE FROM ORDERS O WHERE ORDERS.O_W_ID = ?;",


### PR DESCRIPTION
This PR implements the following features:

According to the SQL-99 standard, the following delete statements are valid:
DELETE FROM x y WHERE key = 2;
DELETE FROM x y WHERE y.key = 2;
DELETE FROM x AS y WHERE key = 2;
DELETE FROM x AS y WHERE y.key = 2;
and they should just work like:
DELETE FROM x WHERE key = 2;

They following should be errors in the WHERE clause with error messages saying X.KEY cannot be found:
DELETE FROM x y WHERE x.key = 2;
DELETE FROM x AS y WHERE x.key = 2;