### PR TITLE
ENG-15918 Constraint violation while restoring joined views from snapshot

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1672,6 +1672,19 @@ VoltDBEngine::loadTable(int32_t tableId,
     ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory
             (table->isReplicatedTable(), isLowestSite(), &s_loadTableException, VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
     if (possiblySynchronizedUseMpMemory.okToExecute()) {
+        // Joined views are special. If any of the source table(s) are not empty, we cannot restore the view content
+        // from a snapshot. The Java top-end has no way to know this so it still tries  to tell the EE
+        // to pause the view on a snapshot restore. When EE finds out that any of the source tables are not empty, it
+        // will ignore the request and let the view stay active. In this case, loadTable() should no longer import
+        // the data from the snapshot to the view table. - ENG-15918
+        auto handler = table->materializedViewHandler();
+        if (handler && handler->snapshotable() && handler->isEnabled()) {
+            char msg[256];
+            snprintf(msg, sizeof(msg), "Materialized view %s joining multiple tables was skipped in the snapshot restore because it is not paused.",
+                     table->name().c_str());
+            LogManager::getThreadLogger(LOGGERID_HOST)->log(LOGLEVEL_INFO, msg);
+            return true;
+        }
         try {
             table->loadTuplesForLoadTable(serializeIn,
                                           NULL,

--- a/src/ee/storage/MaterializedViewHandler.h
+++ b/src/ee/storage/MaterializedViewHandler.h
@@ -87,6 +87,7 @@ public:
     virtual void pollute() { m_dirty = true; }
     virtual void setEnabled(bool enabled);
     virtual bool isEnabled() { return m_enabled; }
+    virtual bool snapshotable() { return m_supportSnapshot; }
 
     // handleTupleInsert and handleTupleDelete are event handlers.
     // They are called when a source table has data being inserted / deleted.
@@ -193,6 +194,7 @@ public:
     virtual void pollute() { m_partitionedHandler->pollute(); }
     virtual void setEnabled(bool enabled) { m_partitionedHandler->setEnabled(enabled); }
     virtual bool isEnabled() { return m_partitionedHandler->isEnabled(); }
+    virtual bool snapshotable() { return m_partitionedHandler->snapshotable(); }
 
     virtual void handleTupleInsert(PersistentTable *sourceTable, bool fallible);
     virtual void handleTupleDelete(PersistentTable *sourceTable, bool fallible);

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -31,12 +31,15 @@ import org.voltdb.SiteProcedureConnection;
 import org.voltdb.SnapshotCompletionInterest.SnapshotCompletionEvent;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
+import org.voltdb.catalog.Database;
+import org.voltdb.catalog.Table;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.messaging.Iv2InitiateTaskMessage;
 import org.voltdb.messaging.RejoinMessage;
 import org.voltdb.rejoin.StreamSnapshotSink;
 import org.voltdb.rejoin.StreamSnapshotSink.RestoreWork;
 import org.voltdb.rejoin.TaskLog;
+import org.voltdb.utils.CatalogUtil;
 
 public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
     private static final VoltLogger ELASTICLOG = new VoltLogger("ELASTIC");
@@ -109,7 +112,9 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
     private void applyPerPartitionTxnId(SiteProcedureConnection connection) {
         //If there was no ID nothing to do
         long partitionTxnIds[] = fetchPerPartitionTxnId();
-        if (partitionTxnIds == null) return;
+        if (partitionTxnIds == null) {
+            return;
+        }
         connection.setPerPartitionTxnIds(partitionTxnIds, true);
     }
 
@@ -195,6 +200,9 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
                                     event.drMixedClusterSizeConsumerState,
                                     false /* requireExistingSequenceNumbers */,
                                     event.clusterCreateTime);
+                    assert(m_commaSeparatedNameOfViewsToPause != null);
+                    // Resume the views.
+                    siteConnection.setViewsEnabled(m_commaSeparatedNameOfViewsToPause, true);
                 } catch (InterruptedException e) {
                     // isDone() already returned true, this shouldn't happen
                     VoltDB.crashLocalVoltDB("Impossible interruption happend", true, e);
@@ -260,6 +268,27 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
 
             applyPerPartitionTxnId(siteConnection);
         } else {
+            if (m_commaSeparatedNameOfViewsToPause == null) {
+                // The very first execution of runForRejoin will lead us here.
+                StringBuilder commaSeparatedViewNames = new StringBuilder();
+                Database db = VoltDB.instance().getCatalogContext().database;
+                for (Table table : VoltDB.instance().getCatalogContext().tables) {
+                    if (table.getIsreplicated() && CatalogUtil.isSnapshotablePersistentTableView(db, table)) {
+                        // If the table is a snapshotted persistent table view, we will try to
+                        // temporarily disable its maintenance job to boost restore performance.
+                        // Only replicated table views are considered here.
+                        // Partitioned ones are going to be taken care of by BalancePartition.
+                        commaSeparatedViewNames.append(table.getTypeName()).append(",");
+                    }
+                }
+                // Get rid of the trailing comma.
+                if (commaSeparatedViewNames.length() > 0) {
+                    commaSeparatedViewNames.setLength(commaSeparatedViewNames.length() - 1);
+                }
+                m_commaSeparatedNameOfViewsToPause = commaSeparatedViewNames.toString();
+                // Set enabled to false for the views we found.
+                siteConnection.setViewsEnabled(m_commaSeparatedNameOfViewsToPause, false);
+            }
             runForBlockingDataTransfer(siteConnection);
             return;
         }

--- a/src/frontend/org/voltdb/iv2/JoinProducerBase.java
+++ b/src/frontend/org/voltdb/iv2/JoinProducerBase.java
@@ -48,6 +48,8 @@ public abstract class JoinProducerBase extends SiteTasker {
     protected long m_coordinatorHsId = Long.MIN_VALUE;
     protected JoinCompletionAction m_completionAction = null;
     protected TaskLog m_taskLog;
+    // Stores the name of the views to pause/resume during a rejoin stream snapshot restore process.
+    protected String m_commaSeparatedNameOfViewsToPause = null;
     private String m_snapshotNonce = null;
 
     /**

--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -58,8 +58,6 @@ public class RejoinProducer extends JoinProducerBase {
     private static ScheduledFuture<?> m_timeFuture;
     private Mailbox m_streamSnapshotMb = null;
     private StreamSnapshotSink m_rejoinSiteProcessor = null;
-    // Stores the name of the views to pause/resume during a rejoin stream snapshot restore process.
-    private String m_commaSeparatedNameOfViewsToPause = null;
 
     // True if there are any persistent tables in the schema.
     boolean m_hasPersistentTables = true;

--- a/tests/frontend/org/voltdb/TestSnapshotWithViews.java
+++ b/tests/frontend/org/voltdb/TestSnapshotWithViews.java
@@ -297,6 +297,8 @@ public class TestSnapshotWithViews extends TestExportBase {
         assertEquals(response.getResults()[0].asScalarLong(), 5000);
         response = client.callProcedure("@AdHoc", "select count(*) from v_ex_np");
         assertEquals(response.getResults()[0].asScalarLong(), 5000);
+        System.out.println("Snapshot Restore for the second time...........");
+        client.callProcedure("@SnapshotRestore", "/tmp/" + System.getProperty("user.name"), "testnonce");
     }
 
     public TestSnapshotWithViews(final String name) {


### PR DESCRIPTION
This pull request fixes two issues:
* Materialized views that are included in the elastic join stream snapshots are not paused during stream snapshot restore.
* EE ignores the view pause request for joined views in snapshot restore if any of the view source tables are not empty. But the loadTable() request is not ignored in this case where it should be.