### PR TITLE
ENG-16029: Defined NEW_CLI java property name string as a constant so…

### DIFF
--- a/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
+++ b/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
@@ -71,7 +71,6 @@ public class TestExportBaseSocketExport extends RegressionSuite {
     protected static ExportTestExpectedData m_verifier;
     protected static int m_portCount = 5001;
     protected static VoltProjectBuilder project;
-    protected boolean isNewCli = Boolean.valueOf(System.getenv("NEW_CLI") == null ? "true" : System.getenv("NEW_CLI"));
 
     public static class ServerListener extends Thread {
 

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -186,9 +186,7 @@ public class LocalCluster extends VoltServerConfig {
     // with the port numbers and command line parameter value specific to that
     // instance.
     private final CommandLine templateCmdLine = new CommandLine(StartAction.CREATE);
-    //NEW_CLI can be picked up from env var or -D to JVM.
-    private boolean isNewCli = Boolean
-            .parseBoolean(System.getProperty("NEW_CLI", MoreObjects.firstNonNull(System.getenv("NEW_CLI"), "true")));
+    private boolean isNewCli = true;
     public boolean isNewCli() { return isNewCli; };
     public void setNewCli(boolean flag) {
         isNewCli = flag;


### PR DESCRIPTION
Cannot change the heading. The change is not what is described in the heading. The change is to ignore environment value and system property value and use new CLI regardless.