### PR TITLE
Make cpu estimates to be equal row count for all logical rels to make…

### DIFF
--- a/src/frontend/org/voltdb/compiler/MaterializedViewProcessor.java
+++ b/src/frontend/org/voltdb/compiler/MaterializedViewProcessor.java
@@ -29,6 +29,7 @@ import org.hsqldb_voltpatches.HSQLInterface.HSQLParseException;
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
+import org.voltcore.utils.Pair;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Column;
@@ -943,10 +944,11 @@ public class MaterializedViewProcessor {
                     return null;
                 }
                 String predicatejson = index.getPredicatejson();
-                if ( ! predicatejson.isEmpty() &&
-                        ! SubPlanAssembler.isPartialIndexPredicateCovered(
+                Pair<Boolean, AbstractExpression> partialIndexInfo =
+                        SubPlanAssembler.evaluatePartialIndexPredicate(
                                 tableScan, coveringExprs,
-                                predicatejson, exactMatchCoveringExprs)) {
+                                predicatejson, exactMatchCoveringExprs);
+                if ( ! partialIndexInfo.getFirst()) {
                     // the partial index predicate does not match the MatView's
                     // where clause -- give up on this index
                     continue;

--- a/src/frontend/org/voltdb/planner/AccessPath.java
+++ b/src/frontend/org/voltdb/planner/AccessPath.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.voltdb.catalog.Index;
 import org.voltdb.expressions.AbstractExpression;
+import org.voltdb.expressions.ExpressionUtil;
 import org.voltdb.types.IndexLookupType;
 import org.voltdb.types.SortDirectionType;
 
@@ -77,6 +78,9 @@ public class AccessPath {
     // if there is no index in this access path.
     //
     final List<AbstractExpression> m_finalExpressionOrder = new ArrayList<>();
+
+    // Partial Index predicates if any
+    final List<AbstractExpression> m_partialIndexPredicate = new ArrayList<>();
 
     /**
      * For Calcite
@@ -178,6 +182,14 @@ public class AccessPath {
 
     public List<AbstractExpression> getOtherExprs() {
         return otherExprs;
+    }
+
+    public void setPartialIndexExpression(AbstractExpression partialPredicate) {
+        m_partialIndexPredicate.addAll(ExpressionUtil.uncombineAny(partialPredicate));
+    }
+
+    public List<AbstractExpression> getPartialIndexExpression() {
+        return m_partialIndexPredicate;
     }
 
     public Index getIndex() {

--- a/src/frontend/org/voltdb/planner/SubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SubPlanAssembler.java
@@ -22,6 +22,7 @@ import java.util.*;
 import com.google_voltpatches.common.base.Preconditions;
 import org.hsqldb_voltpatches.FunctionForVoltDB;
 import org.json_voltpatches.JSONException;
+import org.voltcore.utils.Pair;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.ColumnRef;
@@ -144,17 +145,15 @@ public abstract class SubPlanAssembler {
             // are tracked in exactMatchCoveringExprs so that they
             // can be eliminated from the post-filter expressions.
             final List<AbstractExpression> exactMatchCoveringExprs = new ArrayList<>();
-            boolean hasCoveredPredicate = false;
             String predicatejson = index.getPredicatejson();
-            if (path == null) {
-                if (predicatejson.isEmpty()) {
-                    // Skip the uselessly irrelevant whole-table index.
-                    continue;
-                }
-                hasCoveredPredicate = isPartialIndexPredicateCovered(
+            Pair<Boolean, AbstractExpression> partialIndexInfo =
+                    evaluatePartialIndexPredicate(
                             tableScan, allExprs,
                             predicatejson, exactMatchCoveringExprs);
-                if ( ! hasCoveredPredicate) {
+            boolean hasCoveredPredicate = partialIndexInfo.getFirst();
+            if (path == null) {
+                if (partialIndexInfo.getSecond() == null || ! hasCoveredPredicate) {
+                    // Skip the uselessly irrelevant whole-table index.
                     // Skip the index with the inapplicable predicate.
                     continue;
                 }
@@ -168,18 +167,18 @@ public abstract class SubPlanAssembler {
                 path = getRelevantNaivePath(allJoinExprs, filterExprs);
                 path.index = index;
                 path.lookupType = IndexLookupType.GTE;
+                path.setPartialIndexExpression(partialIndexInfo.getSecond());
             } else {
                 assert(path.index != null);
                 assert(path.index == index);
                 // This index on relevant column(s) may need to be rejected if
                 // its predicate is not applicable.
-                if ( ! predicatejson.isEmpty()) {
-                    hasCoveredPredicate = isPartialIndexPredicateCovered(
-                            tableScan, allExprs, predicatejson, exactMatchCoveringExprs);
+                if ( partialIndexInfo.getSecond() != null) {
                     if ( ! hasCoveredPredicate) {
                         // Skip the index with the inapplicable predicate.
                         continue;
                     }
+                    path.setPartialIndexExpression(partialIndexInfo.getSecond());
                 }
             }
 
@@ -218,20 +217,17 @@ public abstract class SubPlanAssembler {
      * @param filterExprs
      * @return
      */
-    public static AccessPath processPartialIndex(
+    public static AccessPath verifyIfPartialIndex(
             Index index, StmtTableScan tableScan, AccessPath path, Collection<AbstractExpression> allExprs,
             Collection<AbstractExpression> allJoinExprs, Collection<AbstractExpression> filterExprs) {
         final List<AbstractExpression> exactMatchCoveringExprs = new ArrayList<>();
-        boolean hasCoveredPredicate = false;
         final String predicatejson = index.getPredicatejson();
+        Pair<Boolean, AbstractExpression> partialIndexInfo =
+                evaluatePartialIndexPredicate(tableScan, allExprs, predicatejson, exactMatchCoveringExprs);
+        boolean hasCoveredPredicate = partialIndexInfo.getFirst();
         if (path == null) {
-            if (predicatejson.isEmpty()) {
+            if (partialIndexInfo.getSecond() == null || ! hasCoveredPredicate) {
                 // Skip the uselessly irrelevant whole-table index.
-                return null;
-            }
-            hasCoveredPredicate = isPartialIndexPredicateCovered(
-                        tableScan, allExprs, predicatejson, exactMatchCoveringExprs);
-            if ( ! hasCoveredPredicate) {
                 // Skip the index with the inapplicable predicate.
                 return null;
             }
@@ -249,15 +245,13 @@ public abstract class SubPlanAssembler {
             assert path.index == index;
             // This index on relevant column(s) may need to be rejected if
             // its predicate is not applicable.
-            if (! predicatejson.isEmpty()) {
-                hasCoveredPredicate = isPartialIndexPredicateCovered(
-                        tableScan, allExprs, predicatejson, exactMatchCoveringExprs);
-                if ( ! hasCoveredPredicate) {
-                    // Skip the index with the inapplicable predicate.
-                    return null;
-                }
+            if (partialIndexInfo.getSecond() != null && ! hasCoveredPredicate) {
+                // Skip the index with the inapplicable predicate.
+                return null;
             }
         }
+
+        path.setPartialIndexExpression(partialIndexInfo.getSecond());
 
         if (hasCoveredPredicate) {
             filterPostPredicateForPartialIndex(path, exactMatchCoveringExprs);
@@ -404,12 +398,17 @@ public abstract class SubPlanAssembler {
      * @param index The partial index to cover.
      * @param exactMatchCoveringExprs The output subset of the query predicates that EXACTLY match the
      *        index predicate expression(s)
-     * @return TRUE if the index has a predicate that is completely covered by the query expressions.
+     * @return Pair<Boolean, AbstractExpression>
+     *         TRUE if the index has a predicate that is completely covered by the query expressions.
+     *         Partial Predicate or NULL
      */
-    public static boolean isPartialIndexPredicateCovered(
+    public static Pair<Boolean, AbstractExpression> evaluatePartialIndexPredicate(
             StmtTableScan tableScan, Collection<AbstractExpression> coveringExprs,
             String predicatejson, List<AbstractExpression> exactMatchCoveringExprs) {
-        Preconditions.checkArgument(! predicatejson.isEmpty(), "Precondition JSON cannot be empty");
+        if (predicatejson.isEmpty()) {
+            // Skip the uselessly irrelevant whole-table index.
+            return Pair.of(false,  null);
+        }
         final AbstractExpression indexPredicate;
         try {
             indexPredicate = AbstractExpression.fromJSONString(predicatejson, tableScan);
@@ -443,7 +442,8 @@ public abstract class SubPlanAssembler {
 
         // Handle the remaining NOT NULL index predicate expressions that can be covered by NULL rejecting expressions
         // All index predicate expressions must be covered for index to be selected
-        return removeNotNullCoveredExpressions(tableScan, coveringExprs, exprsToCover).isEmpty();
+        boolean isIndexPredicateCovered = removeNotNullCoveredExpressions(tableScan, coveringExprs, exprsToCover).isEmpty();
+        return Pair.of(isIndexPredicateCovered, indexPredicate);
     }
 
     private static final class AccessPathLoopHelper {

--- a/src/frontend/org/voltdb/planner/SubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SubPlanAssembler.java
@@ -1849,7 +1849,11 @@ public abstract class SubPlanAssembler {
                 result = null;
             } else if (coveringExpr == null) {
                 // Match only the table's column that has the coveringColId
-                if ((indexableExpr.getExpressionType() != ExpressionType.VALUE_TUPLE)) {
+                // There could be a CAST operator on the indexable expression side. Skip it
+                if (indexableExpr.getExpressionType() == ExpressionType.OPERATOR_CAST) {
+                    indexableExpr = indexableExpr.getLeft();
+                }
+                if (indexableExpr.getExpressionType() != ExpressionType.VALUE_TUPLE) {
                     result = null;
                 } else if ((coveringColId == ((TupleValueExpression) indexableExpr).getColumnIndex()) &&
                         (tableScan.getTableAlias().equals(((TupleValueExpression) indexableExpr).getTableAlias()))) {

--- a/src/frontend/org/voltdb/plannerv2/VoltRelOptCost.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltRelOptCost.java
@@ -108,9 +108,7 @@ public class VoltRelOptCost implements RelOptCost, Comparator<VoltRelOptCost> {
     }
 
     @Override public boolean isLt(RelOptCost other) {
-        // TODO: Fix the cost calculation!
-        //return compare(this, (VoltRelOptCost) other) < 0;
-        return getRows() < other.getRows();
+        return compare(this, (VoltRelOptCost) other) < 0;
     }
 
     @Override public boolean equals(RelOptCost other) {

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalAggregate.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalAggregate.java
@@ -20,10 +20,13 @@ package org.voltdb.plannerv2.rel.logical;
 import java.util.List;
 
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.util.ImmutableBitSet;
 
 import com.google.common.base.Preconditions;
@@ -59,4 +62,11 @@ public class VoltLogicalAggregate extends Aggregate implements VoltLogicalRel {
             List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
         return new VoltLogicalAggregate(getCluster(), traitSet, input, groupSet, groupSets, aggCalls);
     }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        RelOptCost cost = super.computeSelfCost(planner, mq);
+        return planner.getCostFactory().makeCost(cost.getRows(), cost.getRows(), cost.getIo());
+    }
+
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalCalc.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalCalc.java
@@ -19,9 +19,12 @@ package org.voltdb.plannerv2.rel.logical;
 
 import java.util.Set;
 
-import org.apache.calcite.plan.*;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.Calc;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
@@ -67,4 +70,11 @@ public class VoltLogicalCalc extends Calc implements VoltLogicalRel{
         }
         variableSet.addAll(vuv.variables);
     }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        RelOptCost cost = super.computeSelfCost(planner, mq);
+        return planner.getCostFactory().makeCost(cost.getRows(), cost.getRows(), cost.getIo());
+    }
+
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalIntersect.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalIntersect.java
@@ -20,9 +20,12 @@ package org.voltdb.plannerv2.rel.logical;
 import java.util.List;
 
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Intersect;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 
 import com.google.common.base.Preconditions;
 
@@ -54,6 +57,12 @@ public class VoltLogicalIntersect extends Intersect implements VoltLogicalRel {
 
     @Override public VoltLogicalIntersect copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
         return new VoltLogicalIntersect(getCluster(), traitSet, inputs, all);
+    }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        RelOptCost cost = super.computeSelfCost(planner, mq);
+        return planner.getCostFactory().makeCost(cost.getRows(), cost.getRows(), cost.getIo());
     }
 
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalJoin.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalJoin.java
@@ -22,12 +22,15 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexNode;
 
@@ -101,4 +104,11 @@ public class VoltLogicalJoin extends Join implements VoltLogicalRel {
     @Override public List<RelDataTypeField> getSystemFieldList() {
         return systemFieldList;
     }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        RelOptCost cost = super.computeSelfCost(planner, mq);
+        return planner.getCostFactory().makeCost(cost.getRows(), cost.getRows(), cost.getIo());
+    }
+
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalLimit.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalLimit.java
@@ -20,10 +20,13 @@ package org.voltdb.plannerv2.rel.logical;
 import java.util.List;
 
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
 
 import com.google.common.base.Preconditions;
@@ -86,4 +89,11 @@ public class VoltLogicalLimit extends SingleRel implements VoltLogicalRel {
                 .itemIf("limit", m_limit, m_limit != null)
                 .itemIf("offset", m_offset, m_offset != null);
     }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        RelOptCost cost = super.computeSelfCost(planner, mq);
+        return planner.getCostFactory().makeCost(cost.getRows(), cost.getRows(), cost.getIo());
+    }
+
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalMinus.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalMinus.java
@@ -20,9 +20,12 @@ package org.voltdb.plannerv2.rel.logical;
 import java.util.List;
 
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Minus;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 
 import com.google.common.base.Preconditions;
 
@@ -54,6 +57,12 @@ public class VoltLogicalMinus extends Minus implements VoltLogicalRel {
 
     @Override public VoltLogicalMinus copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
         return new VoltLogicalMinus(getCluster(), traitSet, inputs, all);
+    }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        RelOptCost cost = super.computeSelfCost(planner, mq);
+        return planner.getCostFactory().makeCost(cost.getRows(), cost.getRows(), cost.getIo());
     }
 
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalSort.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalSort.java
@@ -18,10 +18,13 @@
 package org.voltdb.plannerv2.rel.logical;
 
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
 
 import com.google.common.base.Preconditions;
@@ -58,4 +61,16 @@ public class VoltLogicalSort extends Sort implements VoltLogicalRel {
                             RexNode fetch) {
         return new VoltLogicalSort(getCluster(), traitSet, input, collation);
     }
+
+    @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+        return getInput(0).estimateRowCount(mq);
+     }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        RelOptCost cost = super.computeSelfCost(planner, mq);
+        return planner.getCostFactory().makeCost(cost.getRows(), cost.getRows(), cost.getIo());
+    }
+
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalTableScan.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalTableScan.java
@@ -21,13 +21,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.voltdb.plannerv2.VoltTable;
 import org.voltdb.plannerv2.rel.AbstractVoltTableScan;
+import org.voltdb.plannerv2.rules.physical.Constants;
 
 /**
  * Relational expression representing a scan of a {@link VoltTable}, in the logical phase.
@@ -70,4 +74,16 @@ public class VoltLogicalTableScan extends AbstractVoltTableScan implements VoltL
         return new VoltLogicalTableScan(
                 getCluster(), traits, getTable(), getVoltTable());
     }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        RelOptCost cost = super.computeSelfCost(planner, mq);
+        return planner.getCostFactory().makeCost(cost.getRows(), cost.getRows(), cost.getIo());
+    }
+
+    @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+        return Constants.MAX_TABLE_ROW_COUNT;
+    }
+
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalUnion.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalUnion.java
@@ -20,9 +20,12 @@ package org.voltdb.plannerv2.rel.logical;
 import java.util.List;
 
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 
 import com.google.common.base.Preconditions;
 
@@ -54,6 +57,12 @@ public class VoltLogicalUnion extends Union implements VoltLogicalRel {
 
     @Override public VoltLogicalUnion copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
         return new VoltLogicalUnion(getCluster(), traitSet, inputs, all);
+    }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        RelOptCost cost = super.computeSelfCost(planner, mq);
+        return planner.getCostFactory().makeCost(cost.getRows(), cost.getRows(), cost.getIo());
     }
 
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalValues.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalValues.java
@@ -20,10 +20,13 @@ package org.voltdb.plannerv2.rel.logical;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Values;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 
@@ -46,5 +49,16 @@ public class VoltLogicalValues extends Values implements VoltLogicalRel {
     @Override
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
         return new VoltLogicalValues(getCluster(), traitSet, rowType, tuples);
+    }
+
+    @Override
+    public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+        RelOptCost cost = super.computeSelfCost(planner, mq);
+        return planner.getCostFactory().makeCost(cost.getRows(), cost.getRows(), cost.getIo());
+    }
+
+    @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+        return 1.;
     }
 }

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalSort.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalSort.java
@@ -21,14 +21,12 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCost;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.plan.volcano.RelSubset;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexNode;
-import org.voltdb.plannerv2.rel.logical.VoltLogicalCalc;
 import org.voltdb.plannerv2.utils.VoltRexUtil;
 import org.voltdb.plannodes.AbstractPlanNode;
 import org.voltdb.plannodes.LimitPlanNode;
@@ -92,7 +90,6 @@ public class VoltPhysicalSort extends Sort implements VoltPhysicalRel {
     public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
         double rowCount = estimateRowCount(mq);
         //the worst-case time complexity is mandated to be O(nlogn)
-        // TODO: should we set it to 1 when index is available?
         double cpu = rowCount * Math.log(rowCount);
         return planner.getCostFactory().makeCost(rowCount, cpu, 0);
     }

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalTableIndexScan.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalTableIndexScan.java
@@ -137,9 +137,17 @@ public class VoltPhysicalTableIndexScan extends VoltPhysicalTableScan {
     }
 
     @Override
+    public double estimateRowCount(RelMetadataQuery mq) {
+        double rowCount = super.estimateRowCount(mq);
+        // reduce number of returned rows for a partial index based on the number of it's predicates
+        rowCount = PlanCostUtil.discountPartialIndexRowCount(rowCount, m_accessPath);
+        return rowCount;
+    }
+
+    @Override
     public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
         double rowCount = estimateRowCount(mq);
-        double cpu = PlanCostUtil.computeIndexCost(m_index, m_accessPath, estimateInitialRowCount(mq), mq);
+        double cpu = PlanCostUtil.computeIndexCost(m_index, m_accessPath, rowCount, mq);
         return planner.getCostFactory().makeCost(rowCount, cpu, 0.);
     }
 

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/RelDistributionUtils.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/RelDistributionUtils.java
@@ -21,7 +21,6 @@ import com.google_voltpatches.common.collect.Sets;
 import org.apache.calcite.plan.hep.HepRelVertex;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelDistributionTraitDef;
-import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Calc;
 import org.apache.calcite.rel.core.TableScan;

--- a/src/frontend/org/voltdb/plannerv2/utils/IndexUtil.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/IndexUtil.java
@@ -71,7 +71,7 @@ public class IndexUtil {
                             program, numOuterFieldsForJoin, isInnerTable));
             final StmtTableScan tableScan = new StmtTargetTableScan(table, table.getTypeName(), 0);
             // Partial Index Check
-            return SubPlanAssembler.processPartialIndex(index, tableScan,
+            return SubPlanAssembler.verifyIfPartialIndex(index, tableScan,
                     SubPlanAssembler.getRelevantAccessPathForIndexForCalcite(
                             tableScan, voltSubExprs, index, sortDirection),
                     voltSubExprs, null, null);

--- a/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
@@ -740,5 +740,4 @@ public class TestLogicalRules extends Plannerv2TestCase {
         .pass();
     }
 
-
 }

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalIndexSelection.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalIndexSelection.java
@@ -32,7 +32,7 @@ public class TestPhysicalIndexSelection extends Plannerv2TestCase {
     @Override
     protected void setUp() throws Exception {
         setupSchema(TestValidation.class.getResource(
-                "testcalcite-ddl.sql"), "testcalcite", false);
+                "testcalcite-indexselection-ddl.sql"), "testcalcite", false);
         init();
         m_tester.phase(PlannerRules.Phase.PHYSICAL_CONVERSION);
     }
@@ -45,45 +45,495 @@ public class TestPhysicalIndexSelection extends Plannerv2TestCase {
     public void testUniqueWin() {
         // Unique Index RI5_UNIQUE_IND_I wins over the non-unique one RI5_IND_I
         m_tester.sql("SELECT * FROM RI5 where I = 8")
-                .transform("VoltPhysicalTableIndexScan(table=[[public, RI5]], split=[1], expr#0..2=[{inputs}], " +
-                        "expr#3=[8], expr#4=[=($t0, $t3)], proj#0..2=[{exprs}], $condition=[$t4], " +
-                        "index=[RI5_UNIQUE_IND_I_INVALIDEQ1_1])\n")
-                .pass();
+        .transform("VoltPhysicalTableIndexScan(table=[[public, RI5]], split=[1], expr#0..2=[{inputs}], expr#3=[8], expr#4=[=($t0, $t3)], proj#0..2=[{exprs}], $condition=[$t4], index=[RI5_UNIQUE_IND_I_INVALIDEQ1_1])\n")
+        .pass();
     }
 
     public void testUniqueWin1() {
         // Unique Index RI5_UNIQUE_IND_I wins over the non-unique one RI5_IND_I
         m_tester.sql("SELECT * FROM RI5 where I > 8")
-        .transform("VoltPhysicalTableIndexScan(table=[[public, RI5]], split=[1], expr#0..2=[{inputs}], expr#3=[8], " +
-                "expr#4=[>($t0, $t3)], proj#0..2=[{exprs}], $condition=[$t4], index=[RI5_UNIQUE_IND_I_INVALIDGT1_0])\n")
-                .pass();
+        .transform("VoltPhysicalTableIndexScan(table=[[public, RI5]], split=[1], expr#0..2=[{inputs}], expr#3=[8], expr#4=[>($t0, $t3)], proj#0..2=[{exprs}], $condition=[$t4], index=[RI5_UNIQUE_IND_I_INVALIDGT1_0])\n")
+        .pass();
     }
 
     public void testMultiColumnWin() {
         // Two column Index RI5_IND_II_III wins over the single column RI5_IND_III
         m_tester.sql("SELECT * FROM RI5 where II = 3 and III = 4")
-        .transform("VoltPhysicalTableIndexScan(table=[[public, RI5]], split=[1], expr#0..2=[{inputs}], expr#3=[3], " +
-                "expr#4=[=($t1, $t3)], expr#5=[4], expr#6=[=($t2, $t5)], expr#7=[AND($t4, $t6)], proj#0..2=[{exprs}], " +
-                "$condition=[$t7], index=[RI5_IND_II_III_INVALIDEQ2_2])\n")
-                .pass();
+        .transform("VoltPhysicalTableIndexScan(table=[[public, RI5]], split=[1], expr#0..2=[{inputs}], expr#3=[3], expr#4=[=($t1, $t3)], expr#5=[4], expr#6=[=($t2, $t5)], expr#7=[AND($t4, $t6)], proj#0..2=[{exprs}], $condition=[$t7], index=[RI5_IND_II_III_INVALIDEQ2_2])\n")
+        .pass();
     }
 
     public void testMultiColumnWin1() {
         // Single column RI5_IND_III wins over not-fully covered Two column Index RI5_IND_II_III
         m_tester.sql("SELECT * FROM RI5 where II = 3")
-        .transform("VoltPhysicalTableIndexScan(table=[[public, RI5]], split=[1], expr#0..2=[{inputs}], expr#3=[3], " +
-                "expr#4=[=($t1, $t3)], proj#0..2=[{exprs}], $condition=[$t4], index=[RI5_IND_II_INVALIDEQ1_1])\n")
-                .pass();
+        .transform("VoltPhysicalTableIndexScan(table=[[public, RI5]], split=[1], expr#0..2=[{inputs}], expr#3=[3], expr#4=[=($t1, $t3)], proj#0..2=[{exprs}], $condition=[$t4], index=[RI5_IND_II_INVALIDEQ1_1])\n")
+        .pass();
     }
 
     public void testPartialWin() {
         // Partial RI5_IND_II_PART wins over aregular one RI5_IND_II
         m_tester.sql("SELECT * FROM RI5 where II = 3 and ABS(I) > 8")
-        .transform("VoltPhysicalTableIndexScan(table=[[public, RI5]], split=[1], expr#0..2=[{inputs}], expr#3=[3], " +
-                "expr#4=[=($t1, $t3)], expr#5=[ABS($t0)], expr#6=[8], expr#7=[>($t5, $t6)], expr#8=[AND($t4, $t7)], " +
-                "proj#0..2=[{exprs}], $condition=[$t8], index=[RI5_IND_II_PART_INVALIDEQ1_1])\n")
-                .pass();
+        .transform("VoltPhysicalTableIndexScan(table=[[public, RI5]], split=[1], expr#0..2=[{inputs}], expr#3=[3], expr#4=[=($t1, $t3)], expr#5=[ABS($t0)], expr#6=[8], expr#7=[>($t5, $t6)], expr#8=[AND($t4, $t7)], proj#0..2=[{exprs}], $condition=[$t8], index=[RI5_IND_II_PART_INVALIDEQ1_1])\n")
+        .pass();
+    }
+
+    // This tests recognition of covering parameters to prefer a hash index that would use a
+    // greater number of key components than a competing tree index.
+    // Not sure how this relates to ENG-931?
+    public void testEng931Plan() {
+        // Volt Planner picks IDX_1_HASH index
+        m_tester.sql("select a from t where a = ? and b = ? and c = ? and d = ? " +
+                "and e >= ? and e <= ?")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, T]], split=[1], expr#0..4=[{inputs}], expr#5=[?0], expr#6=[=($t0, $t5)], expr#7=[?1], expr#8=[=($t1, $t7)], expr#9=[?2], expr#10=[=($t2, $t9)], expr#11=[?3], expr#12=[=($t3, $t11)], expr#13=[?4], expr#14=[>=($t4, $t13)], expr#15=[?5], expr#16=[<=($t4, $t15)], expr#17=[AND($t6, $t8, $t10, $t12, $t14, $t16)], A=[$t0], $condition=[$t17], index=[IDX_1_HASH_INVALIDEQ4_4])\n")
+        .pass();
+    }
+
+    // This tests recognition of prefix parameters and constants to prefer an index that
+    // would use a greater number of key components AND would give the desired ordering.
+    public void testEng2541Plan() {
+        // Volt Planner picks IDX_B index vs Calcite's VOLTDB_AUTOGEN_CONSTRAINT_IDX_PK_LOG
+        m_tester.sql("select * from l where lname=? and b=0 order by id asc limit ?")
+        .transform("")
+        .pass();
+    }
+
+    // This tests recognition of a prefix parameter and upper bound to prefer an index that would
+    // use a greater number of key components even though another index would give the desired ordering.
+    public void testEng4792PlanWithCompoundEQLTEOrderedByPK() {
+        // Volt Planner picks DELETED_SINCE_IDX vs Calcite's VOLTDB_AUTOGEN_CONSTRAINT_IDX_ID
+        m_tester.sql("select id from a where deleted=? and updated_date <= ? order by id limit ?")
+        .transform("")
+        .pass();
+    }
+
+    //    // @TODO DECODE function is not supported yet
+    //    public void testFixedPlanWithExpressionIndexAndAlias() {
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l aliased where b = ? and DECODE(a, null, 0, a) = 0 and id = ?")
+    //        .transform("")
+    //                .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l aliased, l where l.b = ? and DECODE(l.a, null, 0, l.a) = 0 and l.id = ? and l.lname = aliased.lname")
+    //        .transform("")
+    //                .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l x, l where x.b = ? and DECODE(x.a, null, 0, x.a) = 0 and x.id = ? and l.lname = x.lname")
+    //        .transform("")
+    //                .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l x, l where x.b = ? and DECODE(x.a, null, 0, x.a) = 0 and x.id = ? and l.lname = x.lname")
+    //        .transform("")
+    //        .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l x, l where l.b = ? and DECODE(x.a, null, 0, x.a) = 0 and x.id = ? and l.lname = x.lname")
+    //        .transform("")
+    //                .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l x, l where l.b = ? and DECODE(x.a, null, 0, x.a) = 0 and l.id = ? and l.lname = x.lname")
+    //        .transform("")
+    //                .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l x, l where x.b = ? and DECODE(l.a, null, 0, l.a) = 0 and x.id = ? and l.lname = x.lname")
+    //        .transform("")
+    //                .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l x, l where l.b = ? and DECODE(x.a, null, 0, x.a) = 0 and l.id = ? and l.lname = x.lname")
+    //        .transform("")
+    //                .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l x, l where x.b = ? and DECODE(l.a, null, 0, x.a) = 0 and x.id = ? and l.lname = x.lname")
+    //        .transform("")
+    //                .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l x, l where l.b = ? and DECODE(x.a, null, 0, l.a) = 0 and l.id = ? and l.lname = x.lname")
+    //        .transform("")
+    //                .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l x, l where x.b = ? and DECODE(l.a, null, 0, x.a) = 0 and x.id = ? and l.lname = x.lname")
+    //        .transform("")
+    //                .fail();
+    //
+    //        // Volt Planner picks DECODE_IDX3
+    //        m_tester.sql("select * from l x, l where l.b = ? and DECODE(x.a, null, 0, l.a) = 0 and x.id = ? and l.lname = x.lname")
+    //        .transform("")
+    //                .fail();
+    //
+    //    }
+
+    public void testCaseWhenIndex1() {
+        // Volt planner picks CASEWHEN_IDX1
+        m_tester.sql("select * from l where CASE WHEN a > b THEN a ELSE b END > 8")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, L]], split=[1], expr#0..3=[{inputs}], expr#4=[>($t2, $t3)], expr#5=[CASE($t4, $t2, $t3)], expr#6=[8], expr#7=[>($t5, $t6)], proj#0..3=[{exprs}], $condition=[$t7], index=[CASEWHEN_IDX1_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testCaseWhenIndex2() {
+        // Volt planner picks CASEWHEN_IDX2
+        m_tester.sql("select * from l WHERE CASE WHEN a < 10 THEN a*5 ELSE a + 5 END > 2")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, L]], split=[1], expr#0..3=[{inputs}], expr#4=[10], expr#5=[<($t2, $t4)], expr#6=[5], expr#7=[*($t2, $t6)], expr#8=[+($t2, $t6)], expr#9=[CASE($t5, $t7, $t8)], expr#10=[2], expr#11=[>($t9, $t10)], proj#0..3=[{exprs}], $condition=[$t11], index=[CASEWHEN_IDX2_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testCaseWhenIndex3() {
+        // Volt planner picks PK for deterministic order only (micro optimization)
+        m_tester.sql("select * from l WHERE CASE WHEN a < 10 THEN a*2 ELSE a + 5 END > 2")
+        .transform("VoltPhysicalCalc(expr#0..3=[{inputs}], expr#4=[10], expr#5=[<($t2, $t4)], expr#6=[2], expr#7=[*($t2, $t6)], expr#8=[5], expr#9=[+($t2, $t8)], expr#10=[CASE($t5, $t7, $t9)], expr#11=[>($t10, $t6)], proj#0..3=[{exprs}], $condition=[$t11], split=[1])\n" +
+                "  VoltPhysicalTableSequentialScan(table=[[public, L]], split=[1], expr#0..3=[{inputs}], proj#0..3=[{exprs}])\n")
+        .pass();
+    }
+
+    public void testPartialIndexNULLPredicate1() {
+        // Volt planner picks Z_FULL_IDX_A
+        m_tester.sql("select * from c where a > 0")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t0, $t7)], proj#0..6=[{exprs}], $condition=[$t8], index=[Z_FULL_IDX_A_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexNULLPredicate2() {
+        // Volt planner picks PARTIAL_IDX_NULL_E, Calcite - Z_FULL_IDX_A
+        m_tester.sql("select * from c where a > 0 and e is NULL")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t0, $t7)], expr#9=[IS NULL($t4)], expr#10=[AND($t8, $t9)], proj#0..6=[{exprs}], $condition=[$t10], index=[PARTIAL_IDX_NULL_E_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexNULLPredicate3() {
+        // Volt planner picks A_PARTIAL_IDX_NOT_NULL_E, Calcite - Z_FULL_IDX_A
+        m_tester.sql("select * from c where a > 0 and e is not NULL")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t0, $t7)], expr#9=[IS NOT NULL($t4)], expr#10=[AND($t8, $t9)], proj#0..6=[{exprs}], $condition=[$t10], index=[A_PARTIAL_IDX_NOT_NULL_E_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexNULLPredicate4() {
+        // Volt planner picks A_PARTIAL_IDX_NOT_NULL_E vs Calcite's Z_FULL_IDX_A
+        // Filter e = 0 does satisfy the partial index's predicate E IS NOT NULL
+        // but this index predicate does not eliminate the need for the filter
+        // and the partial index does not get any additional discount.
+        // The cost for the A_PARTIAL_IDX_NOT_NULL_E and the Z_FULL_IDX_A is the same
+        // but the number of rows returned by the partial index is less
+        m_tester.sql("select * from c where a > 0 and e = 0")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t0, $t7)], expr#9=[0], expr#10=[=($t4, $t9)], expr#11=[AND($t8, $t10)], proj#0..6=[{exprs}], $condition=[$t11], index=[A_PARTIAL_IDX_NOT_NULL_E_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexNULLPredicate5() {
+        // Volt planner picks A_PARTIAL_IDX_NOT_NULL_E vs Calcite's Z_FULL_IDX_A
+        // Filter e = 0 does satisfy the partial index's predicate E IS NOT NULL
+        // but this index predicate does not eliminate the need for the filter
+        // and the partial index does not get any additional discount.
+        // The cost for the A_PARTIAL_IDX_NOT_NULL_E and the Z_FULL_IDX_A is the same
+        // but the number of rows returned by the partial index is less
+        m_tester.sql("select * from c where a > 0 and 0 = abs(e + b)")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t0, $t7)], expr#9=[0], expr#10=[+($t4, $t1)], expr#11=[ABS($t10)], expr#12=[=($t9, $t11)], expr#13=[AND($t8, $t12)], proj#0..6=[{exprs}], $condition=[$t13], index=[A_PARTIAL_IDX_NOT_NULL_E_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexNULLPredicate6() {
+        m_tester.sql("select * from c where a = 0 and e = 0")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[=($t0, $t7)], expr#9=[=($t4, $t7)], expr#10=[AND($t8, $t9)], proj#0..6=[{exprs}], $condition=[$t10], index=[Z_FULL_IDX_A_INVALIDEQ1_1])\n")
+        .pass();
+    }
+
+    public void testPartialIndexArbitraryPredicate1() {
+        // CREATE INDEX partial_idx_or_expr ON c (f) where e > 0 or d < 5;PARTIAL_IDX_OR_EXPR
+        // Volt planner picks PARTIAL_IDX_OR_EXPR, Calcite picks PARTIAL_IDX_4
+        m_tester.sql("select * from c where f > 0 and (e > 0 or d < 5)")
+        .transform("")
+        .pass();
+    }
+
+    public void testPartialIndexArbitraryPredicate2() {
+        // ENG-15719
+        // CREATE INDEX partial_idx_8 ON c (b) WHERE abs(a) > 0; PARTIAL_IDX_8
+        m_tester.sql("SELECT COUNT(b) FROM c WHERE abs(a) > 0")
+        .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT()], split=[1], coordinator=[false], type=[serial])\n" +
+                "  VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[ABS($t0)], expr#8=[0], expr#9=[>($t7, $t8)], B=[$t1], $condition=[$t9], index=[PARTIAL_IDX_8_INVALIDGTE0_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateExactMatch1() {
+        // CREATE INDEX partial_idx_or_expr ON c (a) where e > 0 or d < 5; -- expression trees differ Z_FULL_IDX_A
+        // Calcite picks A_PARTIAL_IDX_NOT_NULL_E
+        m_tester.sql("select * from c where a > 0 and e > 0 or d < 5")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t0, $t7)], expr#9=[>($t4, $t7)], expr#10=[AND($t8, $t9)], expr#11=[5], expr#12=[<($t3, $t11)], expr#13=[OR($t10, $t12)], proj#0..6=[{exprs}], $condition=[$t13], index=[A_PARTIAL_IDX_NOT_NULL_E_INVALIDGTE0_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateExactMatch2() {
+        // CREATE INDEX partial_idx_1 ON c (abs(b)) where abs(e) > 1; PARTIAL_IDX_1
+        m_tester.sql("select * from c where abs(b) = 1 and abs(e) > 1")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[ABS($t1)], expr#8=[1], expr#9=[=($t7, $t8)], expr#10=[ABS($t4)], expr#11=[1], expr#12=[>($t10, $t11)], expr#13=[AND($t9, $t12)], proj#0..6=[{exprs}], $condition=[$t13], index=[PARTIAL_IDX_1_INVALIDEQ1_1])\n")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateExactMatch3() {
+        // CREATE INDEX partial_idx_1 ON c (abs(b)) where abs(e) > 1; PARTIAL_IDX_1
+        m_tester.sql("select * from c where abs(b) > 1 and 1 < abs(e)")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[ABS($t1)], expr#8=[1], expr#9=[>($t7, $t8)], expr#10=[ABS($t4)], expr#11=[<($t8, $t10)], expr#12=[AND($t9, $t11)], proj#0..6=[{exprs}], $condition=[$t12], index=[PARTIAL_IDX_1_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateExactMatch4() {
+        // CREATE INDEX partial_idx_2 ON c (b) where d > 0 and d < 5;
+        // CREATE INDEX partial_idx_3 ON c (b) where d > 0; is also a match
+        // but has higher cost because of the extra post filter. PARTIAL_IDX_2
+        m_tester.sql("select * from c where b > 0 and d > 0 and d < 5")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t1, $t7)], expr#9=[>($t3, $t7)], expr#10=[5], expr#11=[<($t3, $t10)], expr#12=[AND($t8, $t9, $t11)], proj#0..6=[{exprs}], $condition=[$t12], index=[PARTIAL_IDX_2_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateExactMatch5() {
+        // CREATE INDEX partial_idx_2 ON c (b) where d > 0 and d < 5; PARTIAL_IDX_2
+        m_tester.sql("select * from c where b > 0 and d < 5 and 0 < d")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t1, $t7)], expr#9=[5], expr#10=[<($t3, $t9)], expr#11=[<($t7, $t3)], expr#12=[AND($t8, $t10, $t11)], proj#0..6=[{exprs}], $condition=[$t12], index=[PARTIAL_IDX_2_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateExactMatch6() {
+        // Volt planner picks PARTIAL_IDX_4, Calcite - Z_FULL_IDX_A
+        // CREATE INDEX partial_idx_4 ON c (a, b) where 0 < f; PARTIAL_IDX_4
+        m_tester.sql("select * from c where a > 0 and b > 0 and f > 0")
+        .transform("")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateExactMatch7() {
+        // Volt planner picks PARTIAL_IDX_4, Calcite - Z_FULL_IDX_A
+        // CREATE INDEX partial_idx_4 ON c (a, b) where 0 < f; PARTIAL_IDX_4
+        m_tester.sql("select * from c where a > 0 and b > 0 and 0 < f")
+        .transform("")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateExactMatch8() {
+        // CREATE INDEX partial_idx_5 ON c (b) where d > f; PARTIAL_IDX_5
+        m_tester.sql("select * from c where b > 0 and d > f")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t1, $t7)], expr#9=[>($t3, $t5)], expr#10=[AND($t8, $t9)], proj#0..6=[{exprs}], $condition=[$t10], index=[PARTIAL_IDX_5_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateExactMatch9() {
+        // CREATE INDEX partial_idx_5 ON c (b) where d > f; PARTIAL_IDX_5
+        m_tester.sql("select * from c where b > 0 and f < d")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t1, $t7)], expr#9=[<($t5, $t3)], expr#10=[AND($t8, $t9)], proj#0..6=[{exprs}], $condition=[$t10], index=[PARTIAL_IDX_5_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+//  // @TODO Geo Indexes are not supported yet
+//    public void testENG15616PenalizeGeoIndex() {
+//        m_tester.sql("SELECT R.VCHAR_INLINE_MAX FROM R WHERE NOT R.TINY = R.TINY")
+//        .transform("")
+//        .pass();
+//    }
+//
+//    public void testGeoIndex1() {
+//        // Volt planner picks POLYPOINTSPOLY
+//        m_tester.sql(
+//                "select polys.point " +
+//                "from polypoints polys " +
+//                "where contains(polys.poly, ?)")
+//        .transform("")
+//        .pass();
+//    }
+//
+//    public void testGeoIndex2() {
+//        // Volt planner picks POLYPOINTSPOLY
+//        m_tester.sql(
+//                "select polys.poly, points.point " +
+//                        "from polypoints polys, polypoints points " +
+//                        "where contains(polys.poly, points.point)")
+//        .transform("")
+//        .pass();
+//    }
+//
+//    public void testGeoIndex3() {
+//        // Volt planner picks POLYPOINTSPOLY
+//        m_tester.sql(
+//                "select polys.point " +
+//                "from polypoints polys " +
+//                "where contains(polys.poly, ?)")
+//        .transform("")
+//        .pass();
+//    }
+
+    // This tests recognition of a complex expression value
+    // -- an addition -- used as an indexable join key's search key value.
+    // Some time ago, this would throw a casting error in the planner.
+    public void testEng3850ComplexIndexablePlan() {
+        m_tester.sql("select id from a, t where a.id < (t.a + ?)")
+        .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], ID=[$t1], split=[1])\n" +
+                "  VoltPhysicalNestLoopIndexJoin(condition=[<($1, +($0, ?0))], joinType=[inner], split=[1], innerIndex=[VOLTDB_AUTOGEN_CONSTRAINT_IDX_ID])\n" +
+                "    VoltPhysicalCalc(expr#0..4=[{inputs}], A=[$t0], split=[1])\n" +
+                "      VoltPhysicalTableSequentialScan(table=[[public, T]], split=[1], expr#0..4=[{inputs}], proj#0..4=[{exprs}])\n" +
+                "    VoltPhysicalCalc(expr#0..2=[{inputs}], ID=[$t0], split=[1])\n" +
+                "      VoltPhysicalTableIndexScan(table=[[public, A]], split=[1], expr#0..2=[{inputs}], proj#0..2=[{exprs}], index=[VOLTDB_AUTOGEN_CONSTRAINT_IDX_ID_INVALIDLT1_0])\n")
+        .pass();
+    }
+
+    public void testParameterizedQueryPartialIndex1() {
+        // Volt picks A_PARTIAL_IDX_NOT_NULL_E, Calcite - Z_FULL_IDX_A
+        // CREATE INDEX a_partial_idx_not_null_e ON c (a) where e is not null;
+        // range-scan covering from (A > 0) to end Z_FULL_IDX_A has higher cost
+        m_tester.sql("select * from c where a > 0 and e = ?")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t0, $t7)], expr#9=[?0], expr#10=[=($t4, $t9)], expr#11=[AND($t8, $t10)], proj#0..6=[{exprs}], $condition=[$t11], index=[Z_FULL_IDX_A_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testParameterizedQueryPartialIndex2() {
+        // CREATE INDEX partial_idx_4 ON c (a, b) where 0 < f; - not selected because of the parameter
+        m_tester.sql("select * from c where a > 0 and b > 0 and ? < f")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t0, $t7)], expr#9=[>($t1, $t7)], expr#10=[?0], expr#11=[<($t10, $t5)], expr#12=[AND($t8, $t9, $t11)], proj#0..6=[{exprs}], $condition=[$t12], index=[Z_FULL_IDX_A_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testParameterizedQueryPartialIndex3() {
+        // Volt picks Z_FULL_IDX_A Calcite - A_PARTIAL_IDX_NOT_NULL_E
+        // CREATE INDEX partial_idx_1 ON c (abs(b)) where abs(e) > 1; not selected because of the parameter
+        m_tester.sql("select * from c where abs(b) = 1 and abs(e) > ?")
+        .transform("")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateNonExactMatch1() {
+
+        // At the moment an index filter must exactly match a
+        // query filter expression (or sub-expression) to be selected
+
+        // Volt - Z_FULL_IDX_A, Calcite - A_PARTIAL_IDX_NOT_NULL_E
+        // CREATE INDEX partial_idx_1 ON c (abs(b)) where abs(e) > 1; Not exact match
+        m_tester.sql("select * from c where abs(b) > 1 and 2 <  abs(e)")
+        .transform("")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateNonExactMatch2() {
+
+        // Volt - Z_FULL_IDX_A (micro-optimization, Calcite - Sequential scan
+        // CREATE INDEX partial_idx_3 ON c (b) where d > 0; Not exact match
+        m_tester.sql("select * from c where b > 0 and d > 3")
+        .transform("VoltPhysicalCalc(expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t1, $t7)], expr#9=[3], expr#10=[>($t3, $t9)], expr#11=[AND($t8, $t10)], proj#0..6=[{exprs}], $condition=[$t11], split=[1])\n" +
+                "  VoltPhysicalTableSequentialScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], proj#0..6=[{exprs}])\n")
+        .pass();
+    }
+
+    public void testPartialIndexComparisonPredicateNonExactMatch3() {
+
+        // Volt - Z_FULL_IDX_A (micro-optimization, Calcite - Sequential scan
+        // CREATE INDEX partial_idx_5 ON c (b) where d > f;  Not exact match
+        m_tester.sql("select * from c where b > 0 and f + 1 < d")
+        .transform("VoltPhysicalCalc(expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t1, $t7)], expr#9=[1], expr#10=[+($t5, $t9)], expr#11=[<($t10, $t3)], expr#12=[AND($t8, $t11)], proj#0..6=[{exprs}], $condition=[$t12], split=[1])\n" +
+                "  VoltPhysicalTableSequentialScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], proj#0..6=[{exprs}])\n")
+        .pass();
+    }
+
+    public void testPartialIndexPredicateOnly1() {
+
+        // Partial index can be used solely to eliminate a post-filter
+        // even when the indexed columns are irrelevant
+
+        // CREATE INDEX partial_idx_3 ON c (b)  where d > 0;
+        m_tester.sql("select * from c where d > 0")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t3, $t7)], proj#0..6=[{exprs}], $condition=[$t8], index=[PARTIAL_IDX_3_INVALIDGTE0_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexPredicateOnly2() {
+
+        // CREATE UNIQUE INDEX z_full_idx_a ON c (a); takes precedence over the partial_idx_3
+        // because indexed column (A) is part of the WHERE expressions
+        m_tester.sql("select * from c where d > 0 and a < 0")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t3, $t7)], expr#9=[<($t0, $t7)], expr#10=[AND($t8, $t9)], proj#0..6=[{exprs}], $condition=[$t10], index=[Z_FULL_IDX_A_INVALIDLT1_0])\n")
+        .pass();
+    }
+
+    public void testPartialIndexPredicateOnly3() {
+        // CREATE INDEX partial_idx_3 ON c (b)  where d > 0;
+        m_tester.sql("select c.d from a join c on a.id = c.e and d > 0")
+        .transform("VoltPhysicalCalc(expr#0..3=[{inputs}], D=[$t1], split=[1])\n" +
+                "  VoltPhysicalNestLoopIndexJoin(condition=[AND(=($0, $2), $3)], joinType=[inner], split=[1], innerIndex=[PARTIAL_IDX_3])\n" +
+                "    VoltPhysicalCalc(expr#0..2=[{inputs}], ID=[$t0], split=[1])\n" +
+                "      VoltPhysicalTableSequentialScan(table=[[public, A]], split=[1], expr#0..2=[{inputs}], proj#0..2=[{exprs}])\n" +
+                "    VoltPhysicalCalc(expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t3, $t7)], D=[$t3], E=[$t4], $f7=[$t8], split=[1])\n" +
+                "      VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], proj#0..6=[{exprs}], index=[PARTIAL_IDX_3_INVALIDGTE0_0])\n")
+        .pass();
+    }
+
+    public void testSkipNullPartialIndex1() {
+
+        //CREATE INDEX partial_idx_7 ON c (g) where g is not null;
+        // skipNull predicate is redundant and eliminated
+        m_tester.sql("select count(*) from c where g > 0")
+        .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT()], split=[1], coordinator=[false], type=[serial])\n" +
+                "  VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t6, $t7)], $f0=[$t7], $condition=[$t8], index=[PARTIAL_IDX_7_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testSkipNullPartialIndex2() {
+        //CREATE INDEX partial_idx_7 ON c (g) where g is not null;
+        // skipNull predicate is redundant and eliminated
+        m_tester.sql("select e from c where g > 0")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t6, $t7)], E=[$t4], $condition=[$t8], index=[PARTIAL_IDX_7_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testSkipNullPartialIndex3() {
+        //CREATE INDEX partial_idx_6 ON c (g) where g < 0;
+        // skipNull predicate is redundant and eliminated
+        m_tester.sql("select count(*) from c where g < 0")
+        .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT()], split=[1], coordinator=[false], type=[serial])\n" +
+                "  VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[<($t6, $t7)], $f0=[$t7], $condition=[$t8], index=[PARTIAL_IDX_6_INVALIDLT1_0])\n")
+        .pass();
+    }
+
+    public void testSkipNullPartialIndex4() {
+        //CREATE INDEX partial_idx_6 ON c (g) where g < 0;
+        // skipNull predicate is redundant and eliminated
+        m_tester.sql("select g from c where g < 0")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[<($t6, $t7)], G=[$t6], $condition=[$t8], index=[PARTIAL_IDX_6_INVALIDLT1_0])\n")
+        .pass();
+    }
+
+    public void testSkipNullPartialIndex5() {
+        // CREATE UNIQUE INDEX z_full_idx_a ON c (a);
+        // skipNull is required - full index
+        m_tester.sql("select count(*) from c where a > 0")
+        .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT()], split=[1], coordinator=[false], type=[serial])\n" +
+                "  VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t0, $t7)], $f0=[$t7], $condition=[$t8], index=[Z_FULL_IDX_A_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testSkipNullPartialIndex6() {
+        // CREATE UNIQUE INDEX z_full_idx_a ON c (a);
+        // skipNull is required - full index
+        m_tester.sql("select e from c where a > 0")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t0, $t7)], E=[$t4], $condition=[$t8], index=[Z_FULL_IDX_A_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testSkipNullPartialIndex7() {
+        // CREATE INDEX partial_idx_3 ON c (b) where d > 0;
+        // skipNull is required - index predicate is not NULL-rejecting for column B
+        m_tester.sql("select count(*) from c where b > 0 and d > 0")
+        .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[COUNT()], split=[1], coordinator=[false], type=[serial])\n" +
+                "  VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t1, $t7)], expr#9=[>($t3, $t7)], expr#10=[AND($t8, $t9)], $f0=[$t7], $condition=[$t10], index=[PARTIAL_IDX_3_INVALIDGT1_0])\n")
+        .pass();
+    }
+
+    public void testSkipNullPartialIndex8() {
+        // CREATE INDEX partial_idx_3 ON c (b) where d > 0;
+        // skipNull is required - index predicate is not NULL-rejecting for column B
+        m_tester.sql("select b from c where b > 0 and d > 0")
+        .transform("VoltPhysicalTableIndexScan(table=[[public, C]], split=[1], expr#0..6=[{inputs}], expr#7=[0], expr#8=[>($t1, $t7)], expr#9=[>($t3, $t7)], expr#10=[AND($t8, $t9)], B=[$t1], $condition=[$t10], index=[PARTIAL_IDX_3_INVALIDGT1_0])\n")
+        .pass();
     }
 
 }
-

--- a/tests/frontend/org/voltdb/plannerv2/testcalcite-indexselection-ddl.sql
+++ b/tests/frontend/org/voltdb/plannerv2/testcalcite-indexselection-ddl.sql
@@ -1,0 +1,78 @@
+
+create table RI5 (
+    i integer,
+    ii integer,
+    iii integer);
+
+CREATE UNIQUE INDEX RI5_UNIQUE_IND_I ON RI5 (i);
+CREATE INDEX RI5_IND_I ON RI5 (i);
+CREATE INDEX RI5_IND_II_III ON RI5 (ii, iii);
+CREATE INDEX RI5_IND_II ON RI5 (ii);
+CREATE INDEX RI5_IND_II_PART ON RI5 (ii) WHERE ABS(I) > 8;
+
+create table t (
+  a bigint not null,
+  b bigint not null,
+  c bigint not null,
+  d bigint not null,
+  e bigint not null
+);
+
+create index idx_1_hash on t (a, b, c, d);
+create index idx_2_TREE on t (e, a, b, c, d);
+
+create index cover2_TREE on t (a, b);
+create index cover3_TREE on t (a, c, b);
+
+create table l
+(
+    id bigint NOT NULL,
+    lname varchar(32) NOT NULL,
+    a tinyint NOT NULL,
+    b tinyint NOT NULL,
+    CONSTRAINT PK_LOG PRIMARY KEY ( lname, id )
+);
+
+create index idx_c on l (lname, a, b, id);
+create index idx_b on l (lname, b, id);
+create index idx_a on l (lname, a, id);
+
+CREATE INDEX casewhen_idx1 ON l (CASE WHEN a > b THEN a ELSE b END);
+CREATE INDEX casewhen_idx2 ON l (CASE WHEN a < 10 THEN a*5 ELSE a + 5 END);
+
+CREATE INDEX decode_idx3 ON l (b, DECODE(a, null, 0, a), id);
+
+CREATE TABLE a
+(
+    id BIGINT NOT NULL,
+    deleted TINYINT NOT NULL,
+    updated_date BIGINT NOT NULL,
+    CONSTRAINT id PRIMARY KEY (id)
+);
+
+CREATE INDEX deleted_since_idx ON a (deleted, updated_date, id);
+
+CREATE TABLE c
+(
+  a bigint not null,
+  b bigint not null,
+  c bigint not null,
+  d bigint not null,
+  e bigint,
+  f bigint not null,
+  g bigint
+);
+CREATE INDEX a_partial_idx_not_null_e ON c (a) where e is not null;
+CREATE INDEX a_partial_idx_not_null_d_e ON c (a + b) where (d + e) is not null;
+CREATE UNIQUE INDEX z_full_idx_a ON c (a);
+CREATE INDEX partial_idx_not_null_e_dup ON c (a) where e is not null;
+CREATE INDEX partial_idx_null_e ON c (a) where e is null;
+CREATE INDEX partial_idx_or_expr ON c (f) where e > 0 or d < 5;
+CREATE INDEX partial_idx_1 ON c (abs(b)) where abs(e) > 1;
+CREATE INDEX partial_idx_2 ON c (b) where d > 0 and d < 5;
+CREATE INDEX partial_idx_3 ON c (b) where d > 0;
+CREATE INDEX partial_idx_4 ON c (a, b) where 0 < f;
+CREATE INDEX partial_idx_5 ON c (b) where d > f;
+CREATE INDEX partial_idx_6 ON c (g) where g < 0;
+CREATE INDEX partial_idx_7 ON c (g) where g is not null;
+CREATE INDEX partial_idx_8 ON c (b) WHERE abs(a) > 0;

--- a/tests/frontend/org/voltdb/plannerv2/testcalcite-indexselection-ddl.sql
+++ b/tests/frontend/org/voltdb/plannerv2/testcalcite-indexselection-ddl.sql
@@ -76,3 +76,36 @@ CREATE INDEX partial_idx_5 ON c (b) where d > f;
 CREATE INDEX partial_idx_6 ON c (g) where g < 0;
 CREATE INDEX partial_idx_7 ON c (g) where g is not null;
 CREATE INDEX partial_idx_8 ON c (b) WHERE abs(a) > 0;
+
+CREATE TABLE polypoints (
+  poly geography(1024),
+  point geography_point,
+  primarykey int primary key, -- index 1
+  uniquekey int unique, -- index 2
+  uniquehashable int,
+  nonuniquekey int,
+  component1 int,
+  component2unique int,
+  component2non int);
+
+-- index 3
+CREATE INDEX polypointspoly ON polypoints ( poly );
+-- index 4
+CREATE INDEX nonunique ON polypoints ( nonuniquekey );
+
+-- index 5
+CREATE UNIQUE INDEX compoundunique ON polypoints ( component1, component2unique );
+-- index 6
+CREATE INDEX compoundnon ON polypoints ( component1, component2non );
+-- index 7
+CREATE UNIQUE INDEX HASHUNIQUEHASH ON polypoints ( uniquehashable );
+
+CREATE TABLE R (
+  ID      INTEGER  DEFAULT 0,
+  TINY    TINYINT  DEFAULT 0,
+  VCHAR_INLINE_MAX  VARCHAR(63 BYTES) DEFAULT '0',
+  VCHAR_OUTLINE_MIN VARCHAR(64 BYTES) DEFAULT '0' NOT NULL,
+  POLYGON GEOGRAPHY,
+  PRIMARY KEY (ID, VCHAR_OUTLINE_MIN));
+
+CREATE INDEX IDX ON R (R.POLYGON) WHERE NOT R.TINY IS NULL;


### PR DESCRIPTION
Added a computeSelfCost override to each and every Logical relation to make sure the new VoltRelOptCost produce the same result as the default RelOptCost provided by Calcite - the cpu estimates are set to be equal the row count.
Minor bug fix for the PlanCostUtil.computeIndexCost