### PR TITLE
ENG-16085 synchronize the leader migration state change 

### DIFF
--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -250,6 +250,9 @@ class Distributer {
 
         @Override
         public void clientCallback(ClientResponse response) throws Exception {
+            if (m_shutdown.get()) {
+                return;
+            }
             //Pre 4.1 clusers don't know about subscribe, don't stress over it.
             if (response.getStatusString() != null &&
                 response.getStatusString().contains("@Subscribe was not found")) {
@@ -258,9 +261,7 @@ class Distributer {
                 }
                 return;
             }
-            if (m_shutdown.get()) {
-                return;
-            }
+
             //Fast path subscribing retry if the connection was lost before getting a response
             if (response.getStatus() == ClientResponse.CONNECTION_LOST ) {
                 if (!m_connections.isEmpty()) {
@@ -1614,7 +1615,7 @@ class Distributer {
                         "Fails to queue the partition update query, please try later."));
             }
             if (!topologyUpdate) {
-                latch.await();
+                latch.await(1, TimeUnit.MINUTES);
             }
             m_lastPartitionKeyFetched.set(System.currentTimeMillis());
         } catch (InterruptedException | IOException e) {

--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -1597,6 +1597,9 @@ class Distributer {
      */
     private void refreshPartitionKeys(boolean topologyUpdate)  {
 
+        if (m_shutdown.get()) {
+            return;
+        }
         long interval = System.currentTimeMillis() - m_lastPartitionKeyFetched.get();
         if (!m_useClientAffinity && interval < PARTITION_KEYS_INFO_REFRESH_FREQUENCY) {
             return;

--- a/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
@@ -102,6 +102,8 @@ public class InitiatorMailbox implements Mailbox
     private AtomicReference<LeaderMigrationState> m_leaderMigrationState =
             new AtomicReference<LeaderMigrationState>();
 
+    private final Object m_leaderMigrationStateLock = new Object();
+
     /*
      * Hacky global map of initiator mailboxes to support assertions
      * that verify the locking is kosher
@@ -659,45 +661,56 @@ public class InitiatorMailbox implements Mailbox
     // that previous partition leader has drained its txns
     private void setLeaderMigrationState(MigratePartitionLeaderMessage message) {
 
-        // The host with old partition leader is down.
-        if (message.isStatusReset()) {
-            m_leaderMigrationState.set(LeaderMigrationState.TXN_DRAINED);
-            m_newLeaderHSID.set(Long.MIN_VALUE);
-            return;
-        }
+        // Synchronize the leader migration state since the state updates are async
+        synchronized(m_leaderMigrationStateLock) {
+            // The host with old partition leader is down.
+            if (message.isStatusReset()) {
+                if ( m_leaderMigrationState.get() == LeaderMigrationState.TXN_RESTART) {
+                    m_leaderMigrationState.compareAndSet(LeaderMigrationState.TXN_DRAINED ,LeaderMigrationState.NONE);
+                } else {
+                    m_leaderMigrationState.set(LeaderMigrationState.TXN_DRAINED);
+                }
+                m_newLeaderHSID.set(Long.MIN_VALUE);
+                tmLog.info("MigratePartitionLeader " +
+                        CoreUtils.hsIdToString(m_hsId) + " is reset to state:" + m_leaderMigrationState);
+                return;
+            }
 
-        if (m_leaderMigrationState.get() == LeaderMigrationState.NONE) {
-            //txn draining notification from the old leader arrives before this site is promoted
-            m_leaderMigrationState.compareAndSet(LeaderMigrationState.NONE ,LeaderMigrationState.TXN_DRAINED);
-        } else if (m_leaderMigrationState.get() == LeaderMigrationState.TXN_RESTART) {
-            //if the new leader has been promoted, stop restarting txns.
-            m_leaderMigrationState.compareAndSet(LeaderMigrationState.TXN_RESTART ,LeaderMigrationState.NONE);
-        }
+            if (m_leaderMigrationState.get() == LeaderMigrationState.NONE) {
+                //txn draining notification from the old leader arrives before this site is promoted
+                m_leaderMigrationState.compareAndSet(LeaderMigrationState.NONE ,LeaderMigrationState.TXN_DRAINED);
+            } else if (m_leaderMigrationState.get() == LeaderMigrationState.TXN_RESTART) {
+                //if the new leader has been promoted, stop restarting txns.
+                m_leaderMigrationState.compareAndSet(LeaderMigrationState.TXN_RESTART ,LeaderMigrationState.NONE);
+            }
 
-        tmLog.info("MigratePartitionLeader new leader " +
-                CoreUtils.hsIdToString(m_hsId) + " is notified by previous leader " +
-                CoreUtils.hsIdToString(message.getPriorLeaderHSID()) + ". status:" + m_leaderMigrationState);
+            tmLog.info("MigratePartitionLeader new leader " +
+                    CoreUtils.hsIdToString(m_hsId) + " is notified by previous leader " +
+                    CoreUtils.hsIdToString(message.getPriorLeaderHSID()) + ". state:" + m_leaderMigrationState);
+        }
     }
 
     // The site for new partition leader
     public void setLeaderMigrationState(boolean migratePartitionLeader) {
-        if (!migratePartitionLeader) {
-            m_leaderMigrationState.set(LeaderMigrationState.NONE);
-            m_newLeaderHSID.set(Long.MIN_VALUE);
-            return;
-        }
+        synchronized(m_leaderMigrationStateLock) {
+            if (!migratePartitionLeader) {
+                m_leaderMigrationState.set(LeaderMigrationState.NONE);
+                m_newLeaderHSID.set(Long.MIN_VALUE);
+                return;
+            }
 
-        // The previous leader has already drained all txns
-        if (m_leaderMigrationState.get() == LeaderMigrationState.TXN_DRAINED) {
-            m_leaderMigrationState.compareAndSet(LeaderMigrationState.TXN_DRAINED ,LeaderMigrationState.NONE);
-            tmLog.info("MigratePartitionLeader transactions on previous partition leader are drained. New leader:" +
-                            CoreUtils.hsIdToString(m_hsId) + " status:" + m_leaderMigrationState);
-            return;
-        }
+            // The previous leader has already drained all txns
+            if (m_leaderMigrationState.get() == LeaderMigrationState.TXN_DRAINED) {
+                m_leaderMigrationState.compareAndSet(LeaderMigrationState.TXN_DRAINED ,LeaderMigrationState.NONE);
+                tmLog.info("MigratePartitionLeader transactions on previous partition leader are drained. New leader:" +
+                        CoreUtils.hsIdToString(m_hsId) + " state:" + m_leaderMigrationState);
+                return;
+            }
 
-        // Wait for the notification from old partition leader
-        m_leaderMigrationState.set(LeaderMigrationState.TXN_RESTART);
-        tmLog.info("MigratePartitionLeader restart txns on new leader:" + CoreUtils.hsIdToString(m_hsId) + " status:" + m_leaderMigrationState);
+            // Wait for the notification from old partition leader
+            m_leaderMigrationState.set(LeaderMigrationState.TXN_RESTART);
+            tmLog.info("MigratePartitionLeader restart txns on new leader:" + CoreUtils.hsIdToString(m_hsId) + " state:" + m_leaderMigrationState);
+        }
     }
 
     // Old master notifies new master that the transactions before the checkpoint on old master have been drained.
@@ -720,7 +733,7 @@ public class InitiatorMailbox implements Mailbox
         m_leaderMigrationState.set(LeaderMigrationState.NONE);
         m_repairLog.setLeaderState(false);
         tmLog.info("MigratePartitionLeader previous leader " + CoreUtils.hsIdToString(m_hsId) + " notifies new leader " +
-                CoreUtils.hsIdToString(m_newLeaderHSID.get()) + " transactions are drained." + " status:" + m_leaderMigrationState);
+                CoreUtils.hsIdToString(m_newLeaderHSID.get()) + " transactions are drained." + " state:" + m_leaderMigrationState);
         m_newLeaderHSID.set(Long.MIN_VALUE);
     }
 

--- a/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
@@ -666,7 +666,7 @@ public class InitiatorMailbox implements Mailbox
             // The host with old partition leader is down.
             if (message.isStatusReset()) {
                 if ( m_leaderMigrationState.get() == LeaderMigrationState.TXN_RESTART) {
-                    m_leaderMigrationState.compareAndSet(LeaderMigrationState.TXN_DRAINED ,LeaderMigrationState.NONE);
+                    m_leaderMigrationState.compareAndSet(LeaderMigrationState.TXN_RESTART ,LeaderMigrationState.NONE);
                 } else {
                     m_leaderMigrationState.set(LeaderMigrationState.TXN_DRAINED);
                 }

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -23,7 +23,7 @@
             value="%p: %m%n"/>
         </layout>
         <filter class="org.apache.log4j.varia.LevelRangeFilter">
-            <param name="levelMin" value="WARN"/>
+            <param name="levelMin" value="DEBUG"/>
             <param name="levelMax" value="FATAL"/>
         </filter>
     </appender>
@@ -44,9 +44,9 @@
         <level value="INFO"/>
     </logger -->
 
-    <!-- logger name="HOST">
-        <level value="INFO"/>
-    </logger -->
+    <logger name="HOST">
+        <level value="DEBUG"/>
+    </logger>
 
     <!-- logger name="NETWORK">
         <level value="INFO"/>
@@ -64,9 +64,9 @@
         <level value="INFO"/>
     </logger -->
 
-    <logger name="EXPORT">
+    <!-- logger name="EXPORT">
         <level value="DEBUG"/>
-    </logger>
+    </logger -->
 
     <!-- logger name="IMPORT">
         <level value="INFO"/>
@@ -80,10 +80,12 @@
         <level value="TRACE"/>
     </logger -->
 
-    <!-- logger name="TM">
-        <level value="INFO"/>
-    </logger -->
-
+    <logger name="TM">
+        <level value="DEBUG"/>
+    </logger>
+    <logger name="REPAIR">
+        <level value="DEBUG"/>
+    </logger>
     <!-- logger name="REJOIN">
         <level value="INFO"/>
     </logger -->

--- a/voltdb/log4j.xml
+++ b/voltdb/log4j.xml
@@ -23,7 +23,7 @@
             value="%p: %m%n"/>
         </layout>
         <filter class="org.apache.log4j.varia.LevelRangeFilter">
-            <param name="levelMin" value="DEBUG"/>
+            <param name="levelMin" value="WARN"/>
             <param name="levelMax" value="FATAL"/>
         </filter>
     </appender>
@@ -44,9 +44,9 @@
         <level value="INFO"/>
     </logger -->
 
-    <logger name="HOST">
-        <level value="DEBUG"/>
-    </logger>
+    <!-- logger name="HOST">
+        <level value="INFO"/>
+    </logger -->
 
     <!-- logger name="NETWORK">
         <level value="INFO"/>
@@ -64,9 +64,9 @@
         <level value="INFO"/>
     </logger -->
 
-    <!-- logger name="EXPORT">
+    <logger name="EXPORT">
         <level value="DEBUG"/>
-    </logger -->
+    </logger>
 
     <!-- logger name="IMPORT">
         <level value="INFO"/>
@@ -80,12 +80,10 @@
         <level value="TRACE"/>
     </logger -->
 
-    <logger name="TM">
-        <level value="DEBUG"/>
-    </logger>
-    <logger name="REPAIR">
-        <level value="DEBUG"/>
-    </logger>
+    <!-- logger name="TM">
+        <level value="INFO"/>
+    </logger -->
+
     <!-- logger name="REJOIN">
         <level value="INFO"/>
     </logger -->


### PR DESCRIPTION
There could be a small window with leader promotion and host failure, within which a site could end up rerouting transactions. Now the state update is synchronized to eliminate the window.