### PR TITLE
 ENG-16194: Allow licensecheck to allow range of years

### DIFF
--- a/tests/ee/test_utils/testing_topend.h
+++ b/tests/ee/test_utils/testing_topend.h
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */#ifndef TESTS_EE_TEST_UTILS_TESTING_TOPEND_H_
+ */
+#ifndef TESTS_EE_TEST_UTILS_TESTING_TOPEND_H_
 #define TESTS_EE_TEST_UTILS_TESTING_TOPEND_H_
 #include <map>
 #include "common/Topend.h"

--- a/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloatInHaving.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloatInHaving.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package org.voltdb.compiler.procedures;
+ */
+package org.voltdb.compiler.procedures;
 
 import org.voltdb.SQLStmt;
 import org.voltdb.VoltProcedure;

--- a/tests/frontend/org/voltdb/planner/TestPlansCommonTableExpression.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansCommonTableExpression.java
@@ -39,49 +39,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- *//* This file is part of VoltDB.
- * Copyright (C) 2008-2017 VoltDB Inc.
- *
- * This file contains original code and/or modifications of original code.
- * Any modifications made by VoltDB Inc. are licensed under the following
- * terms and conditions:
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
  */
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.voltdb.planner;
 
 import static org.hamcrest.xml.HasXPath.hasXPath;

--- a/tests/frontend/org/voltdb/planner/TestPlansENG10022.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansENG10022.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package org.voltdb.planner;
+ */
+package org.voltdb.planner;
 
 /**
  * This class does not actually test much.  It is used to generate a

--- a/tests/frontend/org/voltdb/planner/TestPlansInsertIntoSelect.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansInsertIntoSelect.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package org.voltdb.planner;
+ */
+package org.voltdb.planner;
 
 import org.voltdb.types.PlanNodeType;
 

--- a/tests/frontend/org/voltdb/planner/TestValidatePlan.java
+++ b/tests/frontend/org/voltdb/planner/TestValidatePlan.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package org.voltdb.planner;
+ */
+package org.voltdb.planner;
 
 import org.voltdb.types.PlanNodeType;
 

--- a/tests/frontend/org/voltdb/planner/eegentests/EEPlanGenerator.java
+++ b/tests/frontend/org/voltdb/planner/eegentests/EEPlanGenerator.java
@@ -39,48 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- *//* This file is part of VoltDB.
- * Copyright (C) 2008-2016 VoltDB Inc.
- *
- * This file contains original code and/or modifications of original code.
- * Any modifications made by VoltDB Inc. are licensed under the following
- * terms and conditions:
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
  */
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */package org.voltdb.planner.eegentests;
+package org.voltdb.planner.eegentests;
 
 import java.io.*;
 import java.net.URL;

--- a/tests/frontend/org/voltdb/regressionsuites/TestCommonTableExpressionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCommonTableExpressionsSuite.java
@@ -39,48 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- *//* This file is part of VoltDB.
- * Copyright (C) 2008-2017 VoltDB Inc.
- *
- * This file contains original code and/or modifications of original code.
- * Any modifications made by VoltDB Inc. are licensed under the following
- * terms and conditions:
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
  */
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */package org.voltdb.regressionsuites;
+package org.voltdb.regressionsuites;
 
 import java.io.IOException;
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionSuite.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package org.voltdb.regressionsuites;
+ */
+package org.voltdb.regressionsuites;
 
 import java.io.IOException;
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionSuiteMinMaxSum.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionSuiteMinMaxSum.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package org.voltdb.regressionsuites;
+ */
+package org.voltdb.regressionsuites;
 
 import java.io.IOException;
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionsWithIndexes.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionsWithIndexes.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package org.voltdb.regressionsuites;
+ */
+package org.voltdb.regressionsuites;
 
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/tests/frontend/org/voltdb/regressionsuites/ValgrindXMLParser.java
+++ b/tests/frontend/org/voltdb/regressionsuites/ValgrindXMLParser.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package org.voltdb.regressionsuites;
+ */
+package org.voltdb.regressionsuites;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/tests/frontend/org/voltdb/types/TestDateParsing.java
+++ b/tests/frontend/org/voltdb/types/TestDateParsing.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package org.voltdb.types;
+ */
+package org.voltdb.types;
 
 import java.util.Calendar;
 

--- a/tests/frontend/org/voltdb/utils/TestValgrindParser.java
+++ b/tests/frontend/org/voltdb/utils/TestValgrindParser.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package org.voltdb.utils;
+ */
+package org.voltdb.utils;
 
 
 import static org.junit.Assert.assertEquals;

--- a/tests/test_apps/polygonBenchmark/procedures/polygonBenchmark/InsertPolygonAsObject.java
+++ b/tests/test_apps/polygonBenchmark/procedures/polygonBenchmark/InsertPolygonAsObject.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package polygonBenchmark;
+ */
+package polygonBenchmark;
 
 import org.voltdb.SQLStmt;
 import org.voltdb.VoltProcedure;

--- a/tests/test_apps/polygonBenchmark/procedures/polygonBenchmark/InsertPolygonAsString.java
+++ b/tests/test_apps/polygonBenchmark/procedures/polygonBenchmark/InsertPolygonAsString.java
@@ -39,7 +39,8 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */package polygonBenchmark;
+ */
+package polygonBenchmark;
 
 import org.voltdb.SQLStmt;
 import org.voltdb.VoltProcedure;

--- a/tools/approved_licenses/gpl3_base64_and_voltdb.txt
+++ b/tools/approved_licenses/gpl3_base64_and_voltdb.txt
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) $copyrightYear VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/approved_licenses/gpl3_evanjones_and_voltdb.txt
+++ b/tools/approved_licenses/gpl3_evanjones_and_voltdb.txt
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) $copyrightYear VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/approved_licenses/gpl3_hstore_and_voltdb.txt
+++ b/tools/approved_licenses/gpl3_hstore_and_voltdb.txt
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) $copyrightYear VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/approved_licenses/gpl3_voltdb.txt
+++ b/tools/approved_licenses/gpl3_voltdb.txt
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) $copyrightYear VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/approved_licenses/gpl3_voltdb_python.txt
+++ b/tools/approved_licenses/gpl3_voltdb_python.txt
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) $copyrightYear VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tools/approved_licenses/mit_x11_evanjones_and_voltdb.txt
+++ b/tools/approved_licenses/mit_x11_evanjones_and_voltdb.txt
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) $copyrightYear VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/approved_licenses/mit_x11_hstore_and_voltdb.txt
+++ b/tools/approved_licenses/mit_x11_hstore_and_voltdb.txt
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) $copyrightYear VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/approved_licenses/mit_x11_michaelmccanna_and_voltdb.txt
+++ b/tools/approved_licenses/mit_x11_michaelmccanna_and_voltdb.txt
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) $copyrightYear VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/approved_licenses/mit_x11_voltdb.txt
+++ b/tools/approved_licenses/mit_x11_voltdb.txt
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) $copyrightYear VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tools/approved_licenses/mit_x11_voltdb_and_apache.txt
+++ b/tools/approved_licenses/mit_x11_voltdb_and_apache.txt
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) $copyrightYear VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/approved_licenses/mit_x11_voltdb_and_clearspring.txt
+++ b/tools/approved_licenses/mit_x11_voltdb_and_clearspring.txt
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) $copyrightYear VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/approved_licenses/mit_x11_voltdb_python.txt
+++ b/tools/approved_licenses/mit_x11_voltdb_python.txt
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) $copyrightYear VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the


### PR DESCRIPTION
Interpret the approved licenses as templetes with template variables for the
start and end year for the copyright. Allow the start year to be any value
between 2008 and the current year and allow the end value to be any year
between 2019 and the current year.