### PR TITLE
ENG-16199 TTL migrate: only insert to shadow stream on partition 0 from replicated source table

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1723,11 +1723,11 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
     }
 
-    public void setupMigrateRowsDeleter(int batchSize) {
+    public void setupMigrateRowsDeleter(int batchSize, int partitionId) {
         if (batchSize > 0) {
-            m_migrateRowsDeleter = new MigrateRowsDeleter(m_tableName, m_partitionId, batchSize);
+            m_migrateRowsDeleter = new MigrateRowsDeleter(m_tableName, partitionId, batchSize);
             if (exportLog.isDebugEnabled()) {
-                exportLog.debug("MigrateRowsDeleter has been initialized for table: " + m_tableName + ", partition:" + m_partitionId);
+                exportLog.debug("MigrateRowsDeleter has been initialized for table: " + m_tableName + ", partition:" + partitionId);
             }
         }
     }

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -63,6 +63,7 @@ import org.voltdb.catalog.Connector;
 import org.voltdb.catalog.Table;
 import org.voltdb.common.Constants;
 import org.voltdb.exportclient.ExportClientBase;
+import org.voltdb.iv2.MpInitiator;
 import org.voltdb.iv2.SpInitiator;
 import org.voltdb.messaging.LocalMailbox;
 import org.voltdb.sysprocs.ExportControl.OperationMode;
@@ -618,7 +619,9 @@ public class ExportGeneration implements Generation {
         source.setCoordination(m_messenger.getZK(), m_messenger.getHostId());
         adFilePartitions.add(source.getPartitionId());
         int migrateBatchSize = CatalogUtil.getPersistentMigrateBatchSize(source.getTableName());
-        source.setupMigrateRowsDeleter(migrateBatchSize);
+        source.setupMigrateRowsDeleter(migrateBatchSize,
+                CatalogUtil.getIsreplicated(source.getTableName()) ? MpInitiator.MP_INIT_PID : source.getPartitionId());
+
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("Creating " + source.toString() + " for " + adFile + " bytes " + source.sizeInBytes());
         }
@@ -683,7 +686,7 @@ public class ExportGeneration implements Generation {
                                 m_directory.getPath());
                         exportDataSource.setCoordination(m_messenger.getZK(), m_messenger.getHostId());
                         int migrateBatchSize = CatalogUtil.getPersistentMigrateBatchSize(key);
-                        exportDataSource.setupMigrateRowsDeleter(migrateBatchSize);
+                        exportDataSource.setupMigrateRowsDeleter(migrateBatchSize, table.getIsreplicated() ? MpInitiator.MP_INIT_PID : exportDataSource.getPartitionId());
                         if (exportLog.isDebugEnabled()) {
                             exportLog.debug("Creating ExportDataSource for table in catalog " + key
                                     + " partition " + partition + " site " + siteId);

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -3260,4 +3260,11 @@ public abstract class CatalogUtil {
         }
         return -1;
     }
+    public static boolean getIsreplicated(String tableName) {
+        Table table = VoltDB.instance().getCatalogContext().tables.get(tableName);
+        if (table != null) {
+            return table.getIsreplicated();
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Updates migrating indexes after constraint violation is checked. Also used MP partition id as a partition key for migrated row deletion. 