### PR TITLE
ENG-16140: Move "MIGRATE TO" of TTL table DDL to before column declaration

### DIFF
--- a/src/catgen/in/javasrc/CatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/CatalogDiffEngine.java
@@ -1037,6 +1037,13 @@ public class CatalogDiffEngine {
                     return null;
                 }
             }
+
+            if (field.equals("migrationTarget")) {
+                if (prevType != null && ((Table) suspect).getMigrationtarget() != ((Table) prevType).getMigrationtarget()) {
+                    m_requiresNewExportGeneration = true;
+                }
+                return null;
+            }
             // Always allow disabling DR on table
             if (field.equalsIgnoreCase("isdred")) {
                 Boolean isDRed = (Boolean) suspect.getField(field);

--- a/src/catgen/in/javasrc/CatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/CatalogDiffEngine.java
@@ -929,18 +929,8 @@ public class CatalogDiffEngine {
             suspect instanceof GroupRef ||
             suspect instanceof ColumnRef ||
             suspect instanceof Statement ||
-            suspect instanceof PlanFragment) {
-            return null;
-        }
-
-        if (suspect instanceof TimeToLive) {
-            TimeToLive current = (TimeToLive)suspect;
-            if (prevType != null) {
-                TimeToLive previous = (TimeToLive)prevType;
-                if (previous.getMigrationtarget() == null && current.getMigrationtarget() != null) {
-                    m_requiresNewExportGeneration= true;
-                }
-            }
+            suspect instanceof PlanFragment ||
+            suspect instanceof TimeToLive) {
             return null;
         }
 

--- a/src/catgen/spec.txt
+++ b/src/catgen/spec.txt
@@ -176,7 +176,6 @@ begin TimeToLive javaonly             "Time to Live (TTL), limits the life span 
   Column? ttlColumn                   "A column used to determine the duration of data"
   int batchSize                       "Number of tuples to be deleted in a batch. default: 1000"
   int maxFrequency                    "Maximal number of times of deleting batchSize rows per second.default: 1"
-  string migrationTarget              "The target where the data are migrated to"
 end
 
 begin MaterializedViewHandlerInfo       "Information used to build and update a materialized view"

--- a/src/catgen/spec.txt
+++ b/src/catgen/spec.txt
@@ -167,6 +167,7 @@ begin Table                                  "A table (relation) in the database
   Statement* tuplelimitDeleteStmt            "Delete statement to execute if tuple limit will be exceeded"
   TimeToLive* timeToLive                     "Time to live"
   int tableType                              "Types: no stream(persistent), view-only stream, stream with target, persistent table for export and migration"
+  string migrationTarget                     "The target where the data are migrated to"
 end
 
 begin TimeToLive javaonly             "Time to Live (TTL), limits the life span of data"

--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -715,31 +715,6 @@ public class DDLCompiler {
         }
     }
 
-    private void processTableExportStatement(DDLStatement stmt, Database db, boolean alterTable) throws VoltCompilerException {
-        String statement = stmt.statement;
-        Matcher statementMatcher;
-        if (alterTable) {
-            statementMatcher = SQLParser.matchAlterTTL(statement);
-        } else {
-            statementMatcher = SQLParser.matchCreateTable(statement);
-        }
-        if (statementMatcher.matches()) {
-            String tableName = checkIdentifierStart(statementMatcher.group(1), statement);
-            VoltXMLElement tableXML = m_schema.findChild("table", tableName.toUpperCase());
-            if (tableXML != null) {
-                for (VoltXMLElement subNode : tableXML.children) {
-                    if (subNode.name.equalsIgnoreCase(TimeToLiveVoltDB.TTL_NAME)) {
-                        final String migrationTarget = subNode.attributes.get("migrationTarget");
-                        if (!StringUtil.isEmpty(migrationTarget)) {
-                            tableXML.attributes.put("migrateExport", migrationTarget);
-                        }
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
     private void checkValidPartitionTableIndex(Index index, Column partitionCol, String tableName)
             throws VoltCompilerException {
         // skip checking for non-unique indexes.
@@ -2289,11 +2264,6 @@ public class DDLCompiler {
                         ddlStmtInfo.noun.equals(HSQLDDLInfo.Noun.TABLE);
                 if (createTable) {
                     processCreateTableStatement(stmt);
-                }
-                boolean alterTable = ddlStmtInfo.verb.equals(HSQLDDLInfo.Verb.ALTER) &&
-                        ddlStmtInfo.noun.equals(HSQLDDLInfo.Noun.TABLE);
-                if (createTable || alterTable) {
-                    processTableExportStatement(stmt, db, alterTable);
                 }
             } catch (HSQLParseException e) {
                 String msg = "DDL Error: \"" + e.getMessage() + "\" in statement starting on lineno: " + stmt.lineNo;

--- a/src/frontend/org/voltdb/parser/SQLParser.java
+++ b/src/frontend/org/voltdb/parser/SQLParser.java
@@ -122,7 +122,7 @@ public class SQLParser extends SQLPatternFactory
      *  (1) table name
      *  [(2) target name]
      */
-    private static final Pattern PAT_CREATE_TABLE_MIGRATE_TO =
+    private static final Pattern PAT_CREATE_TABLE =
             SPF.statement(
                     SPF.token("create"), SPF.token("table"),
                     SPF.capture("tableName", SPF.databaseObjectName()),
@@ -132,22 +132,7 @@ public class SQLParser extends SQLPatternFactory
                     new SQLPatternPartString("\\s*"), // see ENG-11862 for reason about adding this pattern
                     SPF.anyColumnFields().withFlags(ADD_LEADING_SPACE_TO_CHILD),
                     SPF.anythingOrNothing().withFlags(ADD_LEADING_SPACE_TO_CHILD)
-            ).compile("PAT_CREATE_TABLE_MIGRATE_TO");
-
-    /**
-     * Pattern: CREATE TABLE tablename
-     *
-     *
-     * Capture groups:
-     *  (1) table name
-     */
-    private static final Pattern PAT_CREATE_TABLE =
-        SPF.statement(
-            SPF.token("create"), SPF.token("table"), SPF.capture("name", SPF.databaseObjectName()),
-            new SQLPatternPartString("\\s*"),
-            SPF.anyColumnFields().withFlags(ADD_LEADING_SPACE_TO_CHILD),
-            SPF.anythingOrNothing().withFlags(ADD_LEADING_SPACE_TO_CHILD)
-        ).compile("PAT_CREATE_TABLE");
+            ).compile("PAT_CREATE_TABLE");
 
     /**
      * Pattern: CREATE TABLE tablename
@@ -762,11 +747,6 @@ public class SQLParser extends SQLPatternFactory
      * @return          pattern matcher object
      */
     public static Matcher matchCreateTableMigrateTo(String statement) {
-        return PAT_CREATE_TABLE_MIGRATE_TO.matcher(statement);
-    }
-
-    public static Matcher matchCreateTable(String statement)
-    {
         return PAT_CREATE_TABLE.matcher(statement);
     }
 

--- a/src/frontend/org/voltdb/planner/QueryPlanner.java
+++ b/src/frontend/org/voltdb/planner/QueryPlanner.java
@@ -221,7 +221,7 @@ public class QueryPlanner implements AutoCloseable {
                                     "operation")))
                     .contains(columnExpression)) {
                 throw new PlanningErrorException(String.format(
-                        "%s: Cannot migrate from table %s because the WHERE caluse does not contain TTL column %s",
+                        "%s: Cannot migrate from table %s because the WHERE clause does not contain TTL column %s",
                         sql, targetTable.getTypeName(), ttl.getName()));
             }
         }

--- a/src/frontend/org/voltdb/sysprocs/SwapTables.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTables.java
@@ -50,8 +50,7 @@ public class SwapTables extends AdHocNTBase {
         Map<String, Table> ttlTables = CatalogUtil.getTimeToLiveTables(context.database);
         Table ttlTable = ttlTables.get(theTable.toUpperCase());
         if (ttlTable != null) {
-            TimeToLive ttl = ttlTable.getTimetolive().get(TimeToLiveVoltDB.TTL_NAME);
-            if (!StringUtil.isEmpty(ttl.getMigrationtarget())) {
+            if (!StringUtil.isEmpty(ttlTable.getMigrationtarget())) {
                 return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE,
                         String.format("Table %s cannot be swapped since it uses TTL.",theTable));
             }

--- a/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
+++ b/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
@@ -126,7 +126,7 @@ public abstract class CatalogSchemaTools {
             } else {
                 table_sb.append("CREATE TABLE ").append(catalog_tbl.getTypeName());
                 if (!StringUtil.isEmpty(catalog_tbl.getMigrationtarget())) {
-                    table_sb.append("MIGRATE TO TARGET ").append(catalog_tbl.getMigrationtarget());
+                    table_sb.append(" MIGRATE TO TARGET ").append(catalog_tbl.getMigrationtarget());
                 }
             }
             table_sb.append(" (");

--- a/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
+++ b/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.hsqldb_voltpatches.HSQLInterface;
 import org.hsqldb_voltpatches.TimeToLiveVoltDB;
+import org.hsqldb_voltpatches.lib.StringUtil;
 import org.json_voltpatches.JSONException;
 import org.voltdb.TableType;
 import org.voltdb.VoltDB;
@@ -124,6 +125,9 @@ public abstract class CatalogSchemaTools {
                 }
             } else {
                 table_sb.append("CREATE TABLE ").append(catalog_tbl.getTypeName());
+                if (!StringUtil.isEmpty(catalog_tbl.getMigrationtarget())) {
+                    table_sb.append("MIGRATE TO TARGET ").append(catalog_tbl.getMigrationtarget());
+                }
             }
             table_sb.append(" (");
         }

--- a/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
+++ b/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
@@ -332,11 +332,6 @@ public abstract class CatalogSchemaTools {
                 table_sb.append(" ON COLUMN " + ttl.getTtlcolumn().getTypeName());
                 table_sb.append(" BATCH_SIZE " + ttl.getBatchsize());
                 table_sb.append(" MAX_FREQUENCY " + ttl.getMaxfrequency() + " ");
-
-                if (ttl.getMigrationtarget() != null && !"".equals(ttl.getMigrationtarget())) {
-                    assert(TableType.isPersistentMigrate(catalog_tbl.getTabletype()));
-                    table_sb.append(" MIGRATE TO TARGET " + ttl.getMigrationtarget() + " ");
-                }
             }
             else if (TableType.isPersistentExport(catalog_tbl.getTabletype())) {
                 table_sb.append(" EXPORT TO TARGET ");

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -3254,7 +3254,7 @@ public abstract class CatalogUtil {
         Table table = VoltDB.instance().getCatalogContext().tables.get(tableName);
         if (table != null && table.getTimetolive() != null ) {
             TimeToLive ttl = table.getTimetolive().get(TimeToLiveVoltDB.TTL_NAME);
-            if (ttl != null && !StringUtil.isEmpty(ttl.getMigrationtarget())) {
+            if (ttl != null && !StringUtil.isEmpty(table.getMigrationtarget())) {
                 return ttl.getBatchsize();
             }
         }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -1319,6 +1319,7 @@ public class ParserDDL extends ParserRoutine {
 
         table.setHasMigrationTarget(token.tokenType == Tokens.MIGRATE);
         // skip "migrate to target" statement, it will be handled later in DDLCompiler.processCreateTableStatement
+        // We can collect the ttl first in order to decide if its a ttl migration or general migration.
         readUntilThis(Tokens.OPENBRACKET);
 
         readThis(Tokens.OPENBRACKET);

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -1344,6 +1344,8 @@ public class ParserDDL extends ParserRoutine {
         }
 
         int position = getPosition();
+        // skip "migrate to target" statement, it will be handled later in DDLCompiler.processCreateTableStatement
+        readUntilThis(Tokens.OPENBRACKET);
 
         readThis(Tokens.OPENBRACKET);
 

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/StatementSchema.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/StatementSchema.java
@@ -463,8 +463,7 @@ public class StatementSchema extends Statement {
                     String ttlColumn = (String)arguments[3];
                     int batchSize = (Integer) arguments[4];
                     int maxFrequency = (Integer) arguments[5];
-                    String stream = (String)arguments[6];
-                    table.alterTTL(ttlValue, ttlUnit, ttlColumn, batchSize, maxFrequency, stream);
+                    table.alterTTL(ttlValue, ttlUnit, ttlColumn, batchSize, maxFrequency);
                     break;
                 } catch (HsqlException e) {
                     return Result.newErrorResult(e, sql);

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Table.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Table.java
@@ -152,6 +152,7 @@ public class Table extends TableBase implements SchemaObject {
     TimeToLiveVoltDB      timeToLive;          //time to live (VOLTDB)
     PersistentExport      persistentExport;    //export to target(VOLTDB)
     private boolean isStream = false;          //is this a stream (VOLTDB)
+    private boolean hasMigrationTarget = false; // does the table has a migration target (VOLTDB)
     //
     public Table(Database database, HsqlName name, int type) {
 
@@ -2737,7 +2738,6 @@ public class Table extends TableBase implements SchemaObject {
             ttl.attributes.put("column", timeToLive.ttlColumn.getNameString());
             ttl.attributes.put("maxFrequency", Integer.toString(timeToLive.maxFrequency));
             ttl.attributes.put("batchSize", Integer.toString(timeToLive.batchSize));
-            ttl.attributes.put("migrationTarget", timeToLive.migrationTarget);
             table.children.add(ttl);
         }
         assert(indexConstraintMap.isEmpty());
@@ -2777,10 +2777,10 @@ public class Table extends TableBase implements SchemaObject {
 
     // A VoltDB extension to support TTL
     public void addTTL(int ttlValue, String ttlUnit, String ttlColumn, int batchSize,
-            int maxFrequency, String streamName) {
+            int maxFrequency) {
         dropTTL();
         timeToLive = new TimeToLiveVoltDB(ttlValue, ttlUnit, getColumn(findColumn(ttlColumn)),
-                batchSize, maxFrequency, streamName);
+                batchSize, maxFrequency);
     }
 
     public TimeToLiveVoltDB getTTL() {
@@ -2788,8 +2788,8 @@ public class Table extends TableBase implements SchemaObject {
     }
 
     public void alterTTL(int ttlValue, String ttlUnit, String ttlColumn,
-            int batchSize, int maxFrequency, String streamName) {
-        addTTL(ttlValue, ttlUnit, ttlColumn, batchSize, maxFrequency, streamName);
+            int batchSize, int maxFrequency) {
+        addTTL(ttlValue, ttlUnit, ttlColumn, batchSize, maxFrequency);
     }
 
     public void dropTTL() {
@@ -2825,7 +2825,11 @@ public class Table extends TableBase implements SchemaObject {
         this.isStream = isStream;
     }
 
-    public boolean isForMigration() {
-        return (timeToLive != null && !StringUtil.isEmpty(timeToLive.migrationTarget));
+    public boolean hasMigrationTarget() {
+        return hasMigrationTarget;
+    }
+
+    public void setHasMigrationTarget(boolean hasMigrationTarget) {
+        this.hasMigrationTarget = hasMigrationTarget;
     }
 }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/TimeToLiveVoltDB.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/TimeToLiveVoltDB.java
@@ -38,15 +38,14 @@ public class TimeToLiveVoltDB {
     final ColumnSchema ttlColumn;
     final int batchSize;
     final int maxFrequency;
-    final String migrationTarget;
+
     public TimeToLiveVoltDB(int value, String unit, ColumnSchema column,
-            int batchSize, int maxFrequency, String migrationTarget) {
+            int batchSize, int maxFrequency) {
         ttlValue = value;
         ttlUnit = unit;
         ttlColumn = column;
         this.batchSize = batchSize;
         this.maxFrequency = maxFrequency;
-        this.migrationTarget = migrationTarget;
     }
 
     @Override
@@ -60,12 +59,7 @@ public class TimeToLiveVoltDB {
                 return false;
             }
 
-            if (ttl.migrationTarget != null && migrationTarget == null) {
-                return true;
-            }
-            if (ttl.migrationTarget != null && ttl.migrationTarget.equals(migrationTarget)){
-                return true;
-            }
+            return true;
         }
         return false;
     }

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -3680,8 +3680,8 @@ public class TestVoltCompiler extends TestCase {
     }
 
     public void testDDLCompilerStreamType() {
-        String ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-                " USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATE TO TARGET TEST;\n" +
+        String ddl = "create table ttl MIGRATE TO TARGET TEST (a integer not null, b integer, PRIMARY KEY(a)) " +
+                " USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3;\n" +
                 "partition table ttl on column a;" +
                 "ALTER TABLE TTL DROP COLUMN B;";
         Database db = checkDDLAgainstGivenSchema(null,
@@ -3949,31 +3949,22 @@ public class TestVoltCompiler extends TestCase {
     }
 
     public void testDDLCompilerNibbleExport() throws Exception {
-        String ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-                " USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATE TO TARGET TEST;\n";
+        String ddl = "create table ttl MIGRATE TO TARGET TEST (a integer not null, b integer, PRIMARY KEY(a)) " +
+                " USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3;\n";
         VoltProjectBuilder pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);
         assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
 
-        ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-                "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATE TO TARGET TEST;\n" +
-                "alter table ttl USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 200 MAX_FREQUENCY 20 MIGRATE TO TARGET TEST;\n";
+        ddl = "create table ttl MIGRATE TO TARGET TEST (a integer not null, b integer, PRIMARY KEY(a)) " +
+                "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3;\n" +
+                "alter table ttl USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 200 MAX_FREQUENCY 20;\n";
         pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);
         // does not alter target but other params
         assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
 
-
-        ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-              "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATE TO TARGET TEST;\n" +
-              "alter table ttl USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATE TO TARGET NO_TEST;\n";
-        pb = new VoltProjectBuilder();
-        pb.addLiteralSchema(ddl);
-        // can not alter target
-        assertFalse(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
-
-        ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-              "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATE TO TARGET TEST;\n" +
+        ddl = "create table ttl MIGRATE TO TARGET TEST (a integer not null, b integer, PRIMARY KEY(a)) " +
+              "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3;\n" +
               "partition table ttl on column a;\n" +
               "dr table ttl;";
         pb = new VoltProjectBuilder();
@@ -3982,8 +3973,8 @@ public class TestVoltCompiler extends TestCase {
         // can not create target via alter
         assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
 
-        ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-              "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATE TO TARGET TEST;\n" +
+        ddl = "create table ttl MIGRATE TO TARGET TEST (a integer not null, b integer, PRIMARY KEY(a)) " +
+              "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3;\n" +
               "partition table ttl on column a;\n" +
               "alter table ttl drop TTL;\n";
         pb = new VoltProjectBuilder();
@@ -3992,29 +3983,29 @@ public class TestVoltCompiler extends TestCase {
         // can not drop target
         assertFalse(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
 
-        ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-              "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATE TO TARGET TEST;\n" +
+        ddl = "create table ttl MIGRATE TO TARGET TEST (a integer not null, b integer, PRIMARY KEY(a)) " +
+              "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3;\n" +
               "partition table ttl on column a;\n";
                 pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);
         assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
 
-        ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-                "USING TTL 20 MINUTES ON COLUMN a MIGRATE TO TARGET TEST;\n" +
+        ddl = "create table ttl MIGRATE TO TARGET TEST (a integer not null, b integer, PRIMARY KEY(a)) " +
+                "USING TTL 20 MINUTES ON COLUMN a;\n" +
                 "partition table ttl on column a;\n";
         pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);
         assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
 
-        ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-                "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MIGRATE TO TARGET TEST;\n" +
+        ddl = "create table ttl MIGRATE TO TARGET TEST (a integer not null, b integer, PRIMARY KEY(a)) " +
+                "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10;\n" +
                 "partition table ttl on column a;\n";
         pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);
         assertTrue(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
 
-        ddl = "create table ttl (a integer not null, b integer, PRIMARY KEY(a)) " +
-                "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MIGRATE TO TEST;\n" +
+        ddl = "create table ttl MIGRATE TO TEST (a integer not null, b integer, PRIMARY KEY(a)) " +
+                "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10;\n" +
                 "partition table ttl on column a;\n";
         pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
@@ -118,15 +118,15 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
                 "  PRIMARY KEY(ID))\n" +
                 ";\n" +
 
-                "create table M1(" +
+                "create table M1 MIGRATE TO TARGET archiver (" +
                 "a int not null, " +
                 "b int not null) " +
-                "USING TTL 10 minutes ON COLUMN a MIGRATE TO TARGET archiver;" +
+                "USING TTL 10 minutes ON COLUMN a;" +
 
-                "create table M2(" +
+                "create table M2 MIGRATE TO TARGET archiver (" +
                 "a int not null, " +
                 "b int not null) " +
-                "USING TTL 10 minutes ON COLUMN a MIGRATE TO TARGET archiver;" +
+                "USING TTL 10 minutes ON COLUMN a;" +
                 "PARTITION TABLE M2 ON COLUMN a;\n" +
 
                 "CREATE PROCEDURE IdFieldProc AS\n" +

--- a/tests/test_apps/genqa/ddl-all-nocat-migrate.sql
+++ b/tests/test_apps/genqa/ddl-all-nocat-migrate.sql
@@ -48,7 +48,7 @@ AS
  GROUP BY rowid_group;
 
 -- Export Table for Partitioned Data Table deletions
-CREATE TABLE export_partitioned_table
+CREATE TABLE export_partitioned_table MIGRATE TO TARGET abc
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -73,11 +73,11 @@ CREATE TABLE export_partitioned_table
 , type_not_null_varchar128  VARCHAR(128)  NOT NULL
 , type_null_varchar1024     VARCHAR(1024)
 , type_not_null_varchar1024 VARCHAR(1024) NOT NULL
-) USING TTL 5 SECONDS ON COLUMN type_not_null_timestamp MIGRATE TO TARGET abc ;
+) USING TTL 5 SECONDS ON COLUMN type_not_null_timestamp;
 PARTITION TABLE export_partitioned_table ON COLUMN rowid;
 CREATE INDEX export_partitioned_table_idx ON  export_partitioned_table(type_not_null_timestamp)  where not migrating;
 
-CREATE TABLE export_partitioned_table_foo
+CREATE TABLE export_partitioned_table_foo MIGRATE TO TARGET foo
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -102,11 +102,11 @@ CREATE TABLE export_partitioned_table_foo
 , type_not_null_varchar128  VARCHAR(128)  NOT NULL
 , type_null_varchar1024     VARCHAR(1024)
 , type_not_null_varchar1024 VARCHAR(1024) NOT NULL
-) USING TTL 5 SECONDS ON COLUMN type_not_null_timestamp MIGRATE TO TARGET foo ;
+) USING TTL 5 SECONDS ON COLUMN type_not_null_timestamp;
 PARTITION TABLE export_partitioned_table_foo ON COLUMN rowid;
 CREATE INDEX export_partitioned_table_foo_idx ON  export_partitioned_table_foo(type_not_null_timestamp)  where not migrating;
 
-CREATE TABLE export_partitioned_table2
+CREATE TABLE export_partitioned_table2 MIGRATE TO TARGET default1
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -131,7 +131,7 @@ CREATE TABLE export_partitioned_table2
 , type_not_null_varchar128  VARCHAR(128)  NOT NULL
 , type_null_varchar1024     VARCHAR(1024)
 , type_not_null_varchar1024 VARCHAR(1024) NOT NULL
-) USING TTL 5 SECONDS ON COLUMN type_not_null_timestamp MIGRATE TO TARGET default1;
+) USING TTL 5 SECONDS ON COLUMN type_not_null_timestamp;
 PARTITION TABLE export_partitioned_table2 ON COLUMN rowid;
 CREATE INDEX export_partitioned_table2_idx ON  export_partitioned_table2(type_not_null_timestamp)  where not migrating;
 
@@ -246,7 +246,7 @@ AS
  GROUP BY rowid_group;
 
 -- Export Table for Replicated Data Table deletions
-CREATE TABLE  export_replicated_table
+CREATE TABLE  export_replicated_table MIGRATE TO TARGET abc
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -271,10 +271,10 @@ CREATE TABLE  export_replicated_table
 , type_not_null_varchar128  VARCHAR(128)  NOT NULL
 , type_null_varchar1024     VARCHAR(1024)
 , type_not_null_varchar1024 VARCHAR(1024) NOT NULL
-) USING TTL 5 SECONDS ON COLUMN type_not_null_timestamp MIGRATE TO TARGET abc;
+) USING TTL 5 SECONDS ON COLUMN type_not_null_timestamp;
 CREATE INDEX export_replicated_table_idx ON  export_replicated_table(type_not_null_timestamp)  where not migrating;
 
-CREATE TABLE export_replicated_table_foo
+CREATE TABLE export_replicated_table_foo MIGRATE TO TARGET foo
 (
   txnid                     BIGINT        NOT NULL
 , rowid                     BIGINT        NOT NULL
@@ -299,7 +299,7 @@ CREATE TABLE export_replicated_table_foo
 , type_not_null_varchar128  VARCHAR(128)  NOT NULL
 , type_null_varchar1024     VARCHAR(1024)
 , type_not_null_varchar1024 VARCHAR(1024) NOT NULL
-) USING TTL 5 SECONDS ON COLUMN type_not_null_timestamp MIGRATE TO TARGET foo;
+) USING TTL 5 SECONDS ON COLUMN type_not_null_timestamp;
 CREATE INDEX export_replicated_table_foo_idx ON  export_replicated_table_foo(type_not_null_timestamp)  where not migrating;
 
 CREATE STREAM export_skinny_partitioned_table  PARTITION ON COLUMN rowid EXPORT TO TARGET abc


### PR DESCRIPTION
The v9.0 syntax:
```sql
CREATE TABLE tbl (...) USING TTL ... MIGRATE TO TARGET target;
```
The new syntax:
```sql
CREATE TABLE tbl MIGRATE TO TARGET target (...) USING TTL...;
```
I also move the attribute `migrationTarget` from `TimeToLive` catalog to `Table` catalog, which will make it cleaner when implementing the non-ttl migration feature.

- JUnit tests are updated with the new syntax.

- System tests updated.