### PR TITLE
ENG-16231: Bundle extra header with entry on poll

### DIFF
--- a/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
@@ -43,8 +43,8 @@ public class TaskLogImpl implements TaskLog {
             Long.parseLong(System.getProperty("REJOIN_OVERFLOW_LIMIT", "102400"));
 
     private final int m_partitionId;
-    private final BinaryDeque m_buffers;
-    private final BinaryDequeReader m_reader;
+    private final BinaryDeque<?> m_buffers;
+    private final BinaryDequeReader<?> m_reader;
     private RejoinTaskBuffer m_tail = null;
     private RejoinTaskBuffer m_head = null;
     //Not using as a bounded queue
@@ -78,8 +78,8 @@ public class TaskLogImpl implements TaskLog {
 
         m_partitionId = partitionId;
         m_cursorId = "TaskLog-" + partitionId;
-        m_buffers = new PersistentBinaryDeque(
-                Integer.toString(partitionId), null, overflowDir, new VoltLogger("REJOIN"));
+        m_buffers = PersistentBinaryDeque.builder(Integer.toString(partitionId), overflowDir, new VoltLogger("REJOIN"))
+                .build();
         m_reader = m_buffers.openForRead(m_cursorId);
         m_es = CoreUtils.getSingleThreadExecutor("TaskLog partition " + partitionId);
     }

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -24,12 +24,12 @@ import org.voltcore.utils.DeferredSerialization;
 import org.voltcore.utils.Pair;
 
 /**
- * Specialized deque interface for storing binary objects. Objects can be provided as a buffer chain
- * and will be returned as a single buffer. Technically not a deque because removal at
- * the end is not supported.
+ * Specialized deque interface for storing binary objects. Objects can be provided as a buffer chain and will be
+ * returned as a single buffer. Technically not a deque because removal at the end is not supported.
  *
+ * @param <M> Type of extra header metadata which can be associated with entries
  */
-public interface BinaryDeque {
+public interface BinaryDeque<M> {
     /*
      * Allocator for storage coming out of the BinaryDeque. Only
      * used if copying is necessary, otherwise a slice is returned
@@ -39,12 +39,13 @@ public interface BinaryDeque {
     }
 
     /**
-     * Update the extraHeader associated with this instance.
+     * Update the extraHeader associated with this instance. This updated metadata will be associated with all entries
+     * added after this point but does not affect entries previously written.
      *
-     * @param extraHeaderSerializer {@link DeferredSerialization} which will be used to write out the extra header.
+     * @param extraHeader new extra header metadata.
      * @throws IOException If an error occurs while updating the extraHeader
      */
-    void updateExtraHeader(DeferredSerialization extraHeaderSerializer) throws IOException;
+    void updateExtraHeader(M extraHeader) throws IOException;
 
     /**
      * Store a buffer chain as a single object in the deque. IOException may be thrown if the object
@@ -76,7 +77,7 @@ public interface BinaryDeque {
      * @return a BinaryDequeReader for this cursorId
      * @throws IOException on any errors trying to read the PBD files
      */
-    public BinaryDequeReader openForRead(String cursorId) throws IOException;
+    public BinaryDequeReader<M> openForRead(String cursorId) throws IOException;
 
     /**
      * Close a BinaryDequeReader for reader, also close the SegmentReader for the segment if it is reading one

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -59,16 +59,29 @@ public interface BinaryDeque<M> {
     int offer(DeferredSerialization ds) throws IOException;
 
     /**
-     * A push creates a new file each time to be "the head" so it is more efficient to pass
-     * in all the objects you want to push at once so that they can be packed into
-     * as few files as possible. IOException may be thrown if the object
-     * is larger then the implementation defined max. 64 megabytes in the case of PersistentBinaryDeque.
-     * If there is an exception attempting to write the buffers then all the buffers will be discarded
+     * A push creates a new file each time to be "the head" so it is more efficient to pass in all the objects you want
+     * to push at once so that they can be packed into as few files as possible. IOException may be thrown if the object
+     * is larger then the implementation defined max. 64 megabytes in the case of PersistentBinaryDeque. If there is an
+     * exception attempting to write the buffers then all the buffers will be discarded
+     * <p>
+     * The current extraHeader metadata if any will be associated with these entries.
+     *
      * @param objects Array of buffers representing the objects to be pushed to the head of the queue
-     * @param DeferredSerialization serializer method to write subsystem-specific meta data.
+     * @throws IOException
+     */
+    public void push(BBContainer objects[]) throws IOException;
+
+    /**
+     * A push creates a new file each time to be "the head" so it is more efficient to pass in all the objects you want
+     * to push at once so that they can be packed into as few files as possible. IOException may be thrown if the object
+     * is larger then the implementation defined max. 64 megabytes in the case of PersistentBinaryDeque. If there is an
+     * exception attempting to write the buffers then all the buffers will be discarded
+     *
+     * @param objects     Array of buffers representing the objects to be pushed to the head of the queue
+     * @param extraHeader header metadata to associate with entries.
      * @throws java.io.IOException
      */
-    public void push(BBContainer objects[], DeferredSerialization ds) throws IOException;
+    public void push(BBContainer objects[], M extraHeader) throws IOException;
 
     /**
      * Start a BinaryDequeReader for reading, positioned at the start of the deque.

--- a/src/frontend/org/voltdb/utils/BinaryDequeReader.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeReader.java
@@ -17,7 +17,9 @@
 package org.voltdb.utils;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
+import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.utils.BinaryDeque.OutputContainerFactory;
 
@@ -25,7 +27,7 @@ import org.voltdb.utils.BinaryDeque.OutputContainerFactory;
  * Reader interface used to read entries from the deque. Multiple readers may be active at the same time,
  * each of them maintaining their own read location within the deque.
  */
-public interface BinaryDequeReader {
+public interface BinaryDequeReader<M> {
     /**
      * Read and return the object at the current read position of this reader.
      * The entry will be removed once all active readers have read the entry.
@@ -36,10 +38,23 @@ public interface BinaryDequeReader {
     public BBContainer poll(OutputContainerFactory ocf) throws IOException;
 
     /**
+     * Read and return the full entry at the current read position of this reader. The entry will be removed once all
+     * active readers have read the entry.
+     *
+     * @param ocf Factory used to create {@link DBBPool.BBContainer} as destinations for the entry data
+     * @return {@link Entry} containing data entry and any extra header associated with it or {@code null} if there is
+     *         no entry
+     * @throws IOException
+     */
+    public Entry<M> pollEntry(OutputContainerFactory ocf) throws IOException;
+
+    /**
      * @param segmentIndex index of the segment to get schema from, -1 means get schema from current segment
      * @return The extra header metadata in the segment header or {@code null} if there is none
      * @throws IOException If an error occurs reading the extra header
+     * @deprecated use {@link #pollEntry(OutputContainerFactory)} to retrieve full entry
      */
+    @Deprecated
     public BBContainer getExtraHeader(long segmentIndex) throws IOException;
 
     /**
@@ -68,11 +83,36 @@ public interface BinaryDequeReader {
      * @return true if the object this reader going to read is the first object of segment
      * throws IOException
      */
+    @Deprecated
     public boolean isStartOfSegment() throws IOException;
 
     /**
      * Returns the index of the segment that reader currently reads on
      * @return
      */
+    @Deprecated
     public long getSegmentIndex();
+
+    /**
+     * Entry class to hold all metadata and data associated with an entry in a {@link BinaryDeque}
+     *
+     * @param <M> Type of extra header metadata
+     */
+    public interface Entry<M> {
+        /**
+         * @return any associated extra header metadata. May return {@code null} if there was none
+         */
+        M getExtraHeader();
+
+        /**
+         * @return A {@link ByteBuffer} holding the entry data
+         */
+        ByteBuffer getData();
+
+        /**
+         * Indicates that this entry has been consumed and is eligible for deletion with respect to the
+         * {@link BinaryDequeReader} which returned this entry.
+         */
+        void release();
+    }
 }

--- a/src/frontend/org/voltdb/utils/BinaryDequeSerializer.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeSerializer.java
@@ -1,0 +1,48 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.utils;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Interface for reading and writing objects of a specific type.
+ *
+ * @param <T> Type of object which this serializer reads and writes
+ */
+public interface BinaryDequeSerializer<T> {
+    /**
+     * @param object to be written
+     * @return The maximum size of the buffer required by {@link #write(Object, ByteBuffer)} to write {@code object}
+     */
+    int getMaxSize(T object) throws IOException;
+
+    /**
+     * Write {@code object} to {@code buffer}
+     *
+     * @param object to write
+     * @param buffer buffer to hold serialized data
+     */
+    void write(T object, ByteBuffer buffer) throws IOException;
+
+    /**
+     * @param buffer from which to read object
+     * @return instance of {@code T} read from {@code buffer}
+     */
+    T read(ByteBuffer buffer) throws IOException;
+}

--- a/src/frontend/org/voltdb/utils/DeferredSerializationBinaryDequeSerializer.java
+++ b/src/frontend/org/voltdb/utils/DeferredSerializationBinaryDequeSerializer.java
@@ -1,0 +1,41 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.utils;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.voltcore.utils.DeferredSerialization;
+
+/**
+ * Simple base class for handling the writing of any {@link DeferredSerialization} object
+ *
+ * @param <T> Type of {@link DeferredSerialization} which this serializer operates on
+ */
+public abstract class DeferredSerializationBinaryDequeSerializer<T extends DeferredSerialization>
+        implements BinaryDequeSerializer<T> {
+    @Override
+    public int getMaxSize(T object) throws IOException {
+        return object.getSerializedSize();
+    };
+
+    @Override
+    public void write(T object, ByteBuffer buffer) throws IOException {
+        object.serialize(buffer);
+    }
+}

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -28,7 +28,7 @@ import java.util.List;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DeferredSerialization;
 
-public abstract class PBDSegment {
+public abstract class PBDSegment<M> {
     private static final String IS_FINAL_ATTRIBUTE = "VoltDB.PBDSegment.isFinal";
 
     // Has to be able to hold at least one object (compressed or not)
@@ -99,13 +99,13 @@ public abstract class PBDSegment {
 
     abstract boolean isOpenForReading(String cursorId);
 
-    abstract PBDSegmentReader openForRead(String cursorId) throws IOException;
+    abstract PBDSegmentReader<M> openForRead(String cursorId) throws IOException;
 
     /**
      * Returns the reader opened for the given cursor id. This may return a closed reader if the reader has already
      * finished reading this segment.
      */
-    abstract PBDSegmentReader getReader(String cursorId);
+    abstract PBDSegmentReader<M> getReader(String cursorId);
 
     /**
      * Open and initialize this segment as a new segment
@@ -139,7 +139,7 @@ public abstract class PBDSegment {
     // TODO: javadoc
     abstract int size();
 
-    abstract void writeExtraHeader(DeferredSerialization ds) throws IOException;
+    abstract void writeExtraHeader(M extraHeader) throws IOException;
 
     /**
      * Update the segment to be read only
@@ -176,6 +176,8 @@ public abstract class PBDSegment {
      * @return true if file is final, false otherwise
      */
     abstract boolean isFinal();
+
+    abstract M getExtraHeader() throws IOException;
 
     /**
      * If this segment is in a good condition the data will be flushed to disk and the segment will either be closed or

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -25,7 +25,7 @@ import org.voltcore.utils.DBBPool;
  * Represents a reader for a segment. Multiple readers may be active
  * at any point in time, reading from different locations in the segment.
  */
-interface PBDSegmentReader {
+interface PBDSegmentReader<M> {
     /**
      * Are there any more entries to read from this segment for this reader
      *
@@ -54,6 +54,7 @@ interface PBDSegmentReader {
      *         not supplied
      * @throws IOException If an error occurs while reading the extra header
      */
+    @Deprecated
     public DBBPool.BBContainer getExtraHeader() throws IOException;
 
     //Don't use size in bytes to determine empty, could potentially

--- a/src/frontend/org/voltdb/utils/PbdQuarantinedSegment.java
+++ b/src/frontend/org/voltdb/utils/PbdQuarantinedSegment.java
@@ -29,7 +29,7 @@ import org.voltdb.utils.BinaryDeque.OutputContainerFactory;
  * Dummy PBDSegment which represents a quarantined segment. A quarantined segment cannot be read because of header
  * corruption but is kept around in case any data in the segment is needed to recover data.
  */
-class PbdQuarantinedSegment extends PBDSegment {
+class PbdQuarantinedSegment<M> extends PBDSegment<M> {
     PbdQuarantinedSegment(File file, long index, long id) {
         super(file, index, id);
     }
@@ -50,13 +50,14 @@ class PbdQuarantinedSegment extends PBDSegment {
     }
 
     @Override
-    PBDSegmentReader openForRead(String cursorId) {
+    PBDSegmentReader<M> openForRead(String cursorId) {
         return getReader(cursorId);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    PBDSegmentReader getReader(String cursorId) {
-        return READER;
+    PBDSegmentReader<M> getReader(String cursorId) {
+        return (PBDSegmentReader<M>) READER;
     }
 
     @Override
@@ -105,7 +106,7 @@ class PbdQuarantinedSegment extends PBDSegment {
     }
 
     @Override
-    void writeExtraHeader(DeferredSerialization ds) {
+    void writeExtraHeader(M extraHeader) {
         throw new UnsupportedOperationException();
     }
 
@@ -130,7 +131,12 @@ class PbdQuarantinedSegment extends PBDSegment {
     @Override
     void finalize(boolean close) {}
 
-    private static final PBDSegmentReader READER = new PBDSegmentReader() {
+    @Override
+    M getExtraHeader() {
+        return null;
+    }
+
+    private static final PBDSegmentReader<Void> READER = new PBDSegmentReader<Void>() {
         @Override
         public int uncompressedBytesToRead() {
             return 0;

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -16,6 +16,8 @@
  */
 package org.voltdb.utils;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -42,16 +44,17 @@ import org.voltdb.utils.PairSequencer.CyclicSequenceException;
 import com.google_voltpatches.common.base.Throwables;
 
 /**
- * A deque that specializes in providing persistence of binary objects to disk. Any object placed
- * in the deque will be persisted to disk asynchronously. Objects placed in the deque can
- * be persisted synchronously by invoking sync. The files backing this deque all start with a nonce
- * provided at construction time followed by a segment index that is stored in the filename. Files grow to
- * a maximum size of 64 megabytes and then a new segment is created. The index starts at 0. Segments are deleted
- * once all objects from the segment have been polled and all the containers returned by poll have been discarded.
- * Push is implemented by creating new segments at the head of the deque containing the objects to be pushed.
+ * A deque that specializes in providing persistence of binary objects to disk. Any object placed in the deque will be
+ * persisted to disk asynchronously. Objects placed in the deque can be persisted synchronously by invoking sync. The
+ * files backing this deque all start with a nonce provided at construction time followed by a segment index that is
+ * stored in the filename. Files grow to a maximum size of 64 megabytes and then a new segment is created. The index
+ * starts at 0. Segments are deleted once all objects from the segment have been polled and all the containers returned
+ * by poll have been discarded. Push is implemented by creating new segments at the head of the deque containing the
+ * objects to be pushed.
  *
+ * @param M Type of extra header metadata stored in the PBD
  */
-public class PersistentBinaryDeque implements BinaryDeque {
+public class PersistentBinaryDeque<M> implements BinaryDeque<M> {
 
     public static class UnsafeOutputContainerFactory implements OutputContainerFactory {
         private static final VoltLogger LOG = new VoltLogger("HOST");
@@ -81,9 +84,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
      * Used to read entries from the PBD. Multiple readers may be active at the same time,
      * but only one read or write may happen concurrently.
      */
-    private class ReadCursor implements BinaryDequeReader {
+    private class ReadCursor implements BinaryDequeReader<M> {
         private final String m_cursorId;
-        private PBDSegment m_segment;
+        private PBDSegment<M> m_segment;
         // Number of objects out of the total
         //that were deleted at the time this cursor was created
         private final int m_numObjectsDeleted;
@@ -106,7 +109,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 assertions();
 
                 moveToValidSegment();
-                PBDSegmentReader segmentReader = m_segment.getReader(m_cursorId);
+                PBDSegmentReader<M> segmentReader = m_segment.getReader(m_cursorId);
                 if (segmentReader == null) {
                     segmentReader = m_segment.openForRead(m_cursorId);
                 }
@@ -137,13 +140,43 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         @Override
+        public BinaryDequeReader.Entry<M> pollEntry(OutputContainerFactory ocf) throws IOException {
+            synchronized (PersistentBinaryDeque.this) {
+                BBContainer retcont = poll(ocf);
+                if (retcont == null) {
+                    return null;
+                }
+
+                M extraHeader = m_segment.getExtraHeader();
+
+                return new BinaryDequeReader.Entry<M>() {
+                    @Override
+                    public M getExtraHeader() {
+                        return extraHeader;
+                    }
+
+                    @Override
+                    public ByteBuffer getData() {
+                        return retcont.b();
+                    }
+
+                    @Override
+                    public void release() {
+                        retcont.discard();
+                    }
+                };
+            }
+        }
+
+        @Deprecated
+        @Override
         public BBContainer getExtraHeader(long segmentIndex) throws IOException {
             synchronized (PersistentBinaryDeque.this) {
                 if (m_cursorClosed) {
                     throw new IOException("PBD.ReadCursor.poll(): " + m_cursorId + " - Reader has been closed");
                 }
-                PBDSegmentReader segmentReader = null;
-                PBDSegment segment = null;
+                PBDSegmentReader<M> segmentReader = null;
+                PBDSegment<M> segment = null;
                 moveToValidSegment();
                 if (segmentIndex != -1) {
                     // looking for schema from a specific segment
@@ -167,7 +200,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             }
         }
 
-        void rewindTo(PBDSegment segment) {
+        void rewindTo(PBDSegment<M> segment) {
             if (m_rewoundFromId == -1 && m_segment != null) {
                 m_rewoundFromId = m_segment.segmentId();
             }
@@ -175,7 +208,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         private void moveToValidSegment() {
-            PBDSegment firstSegment = peekFirstSegment();
+            PBDSegment<M> firstSegment = peekFirstSegment();
             // It is possible that m_segment got closed and removed
             if (m_segment == null || m_segment.segmentIndex() < firstSegment.segmentIndex()) {
                 m_segment = firstSegment;
@@ -214,7 +247,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                     inclusive = false;
                 }
                 // Get the size of all unread segments
-                for (PBDSegment currSegment : m_segments.tailMap(m_segment.segmentIndex(), inclusive).values()) {
+                for (PBDSegment<M> currSegment : m_segments.tailMap(m_segment.segmentIndex(), inclusive).values()) {
                     size += currSegment.size();
                 }
                 return size;
@@ -239,7 +272,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                     inclusive = false;
                 }
 
-                for (PBDSegment currSegment : m_segments.tailMap(m_segment.segmentIndex(), inclusive).values()) {
+                for (PBDSegment<M> currSegment : m_segments.tailMap(m_segment.segmentIndex(), inclusive).values()) {
                     if (currSegment.getNumEntries() > 0) {
                         return false;
                     }
@@ -249,7 +282,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             }
         }
 
-        private BBContainer wrapRetCont(PBDSegment segment, int entryNumber, final BBContainer retcont) {
+        private BBContainer wrapRetCont(PBDSegment<M> segment, int entryNumber, final BBContainer retcont) {
             return new BBContainer(retcont.b()) {
                 @Override
                 public void discard() {
@@ -270,10 +303,10 @@ public class PersistentBinaryDeque implements BinaryDeque {
                         }
 
                         try {
-                            Iterator<PBDSegment> iter = m_segments.headMap(segment.segmentIndex(), false).values()
+                            Iterator<PBDSegment<M>> iter = m_segments.headMap(segment.segmentIndex(), false).values()
                                     .iterator();
                             while (iter.hasNext()) {
-                                PBDSegment earlierSegment = iter.next();
+                                PBDSegment<M> earlierSegment = iter.next();
                                 iter.remove();
                                 if (m_usageSpecificLog.isDebugEnabled()) {
                                     m_usageSpecificLog.debug("Segment " + earlierSegment.file()
@@ -297,7 +330,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 }
                 assertions();
                 moveToValidSegment();
-                PBDSegmentReader segmentReader = m_segment.getReader(m_cursorId);
+                PBDSegmentReader<M> segmentReader = m_segment.getReader(m_cursorId);
                 // push to PBD will rewind cursors. So, this cursor may have already opened this segment
                 if (segmentReader == null) {
                     segmentReader = m_segment.openForRead(m_cursorId);
@@ -335,7 +368,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         void close() {
             if (m_segment != null) {
-                PBDSegmentReader reader = m_segment.getReader(m_cursorId);
+                PBDSegmentReader<M> reader = m_segment.getReader(m_cursorId);
                 if (reader != null) {
                     try {
                         reader.close();
@@ -360,11 +393,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
     private final File m_path;
     private final String m_nonce;
     private final boolean m_compress;
+    private final PBDSegmentFactory m_pbdSegmentFactory;
     private boolean m_initializedFromExistingFiles = false;
+
+    private final BinaryDequeSerializer<M> m_extraHeaderSerializer;
 
     //Segments that are no longer being written to and can be polled
     //These segments are "immutable". They will not be modified until deletion
-    private final TreeMap<Long, PBDSegment> m_segments = new TreeMap<>();
+    private final TreeMap<Long, PBDSegment<M>> m_segments = new TreeMap<>();
     private volatile boolean m_closed = false;
     private final HashMap<String, ReadCursor> m_readCursors = new HashMap<>();
     private int m_numObjects;
@@ -374,44 +410,32 @@ public class PersistentBinaryDeque implements BinaryDeque {
     // used for a *previous* segment (or inserting a segment *before* the others.
     private long m_segmentCounter = 0L;
 
-    private DeferredSerialization m_extraHeader;
+    private M m_extraHeader;
 
     /**
-     * Create a persistent binary deque with the specified nonce and storage
-     * back at the specified path.
+     * Create a persistent binary deque with the specified nonce and storage back at the specified path. This is a
+     * convenience method for testing so that poll with delete can be tested.
      *
-     * @param nonce
-     * @param schemaDS
-     * @param path
-     * @param logger
-     * @throws IOException
-     */
-    public PersistentBinaryDeque(final String nonce, DeferredSerialization schemaDS,
-            final File path, VoltLogger logger) throws IOException {
-        this(nonce, schemaDS, path, logger, false);
-    }
-
-    /**
-     * Create a persistent binary deque with the specified nonce and storage back at the specified path.
-     * This is a convenience method for testing so that poll with delete can be tested.
-     *
-     * @param nonce
+     * @param m_nonce
      * @param extraHeader
-     * @param path
+     * @param m_path
      * @param deleteEmpty
      * @throws IOException
      */
-    public PersistentBinaryDeque(final String nonce, DeferredSerialization extraHeader,
-            final File path, VoltLogger logger,
-            final boolean compress) throws IOException {
+    private PersistentBinaryDeque(Builder<M> builder) throws IOException {
         NativeLibraryLoader.loadVoltDB();
-        m_path = path;
-        m_nonce = nonce;
-        m_usageSpecificLog = logger;
-        m_compress = compress;
+        m_path = builder.m_path;
+        m_nonce = builder.m_nonce;
+        m_usageSpecificLog = builder.m_logger;
+        m_compress = builder.m_useCompression;
+        m_extraHeader = builder.m_initialExtraHeader;
+        m_extraHeaderSerializer = builder.m_extraHeaderSerializer;
+        m_pbdSegmentFactory = builder.m_pbdSegmentFactory;
 
-        if (!path.exists() || !path.canRead() || !path.canWrite() || !path.canExecute() || !path.isDirectory()) {
-            throw new IOException(path + " is not usable ( !exists || !readable " +
+        if (!m_path.exists() || !m_path.canRead() || !m_path.canWrite() || !m_path.canExecute()
+                || !m_path.isDirectory()) {
+            throw new IOException(
+                    m_path + " is not usable ( !exists || !readable " +
                     "|| !writable || !executable || !directory)");
         }
 
@@ -421,15 +445,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
         // writing segment is not final
 
         long curId = getNextSegmentId();
-        Map.Entry<Long, PBDSegment> lastEntry = m_segments.lastEntry();
+        Map.Entry<Long, PBDSegment<M>> lastEntry = m_segments.lastEntry();
 
         // Note: the "previous" id value may be > "current" id value
         long prevId = lastEntry == null ? getNextSegmentId() : lastEntry.getValue().segmentId();
         Long writeSegmentIndex = lastEntry == null ? 1L : lastEntry.getKey() + 1;
 
         String fname = getSegmentFileName(curId, prevId);
-        m_extraHeader = extraHeader;
-        PBDSegment writeSegment = initializeNewSegment(writeSegmentIndex, curId, new VoltFile(m_path, fname),
+        PBDSegment<M> writeSegment = initializeNewSegment(writeSegmentIndex, curId, new VoltFile(m_path, fname),
                 "initialization");
         if (m_segments.put(writeSegmentIndex, writeSegment) != null) {
             // Sanity check
@@ -597,7 +620,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             PBDSegment.setFinal(file, false);
             if (m_usageSpecificLog.isDebugEnabled()) {
                 m_usageSpecificLog.debug("Segment " + file.getName()
-                + " (final: " + PBDSegment.isFinal(file) + "), will be closed and deleted during init");
+                        + " (final: " + PBDSegment.isFinal(file) + "), will be closed and deleted during init");
             }
             file.delete();
         } catch (Exception e) {
@@ -615,7 +638,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
      * @param prevEntry {@link Map.Entry} from {@link #m_segments} to quarantine
      * @throws IOException
      */
-    private void quarantineSegment(Map.Entry<Long, PBDSegment> prevEntry) throws IOException {
+    private void quarantineSegment(Map.Entry<Long, PBDSegment<M>> prevEntry) throws IOException {
         quarantineSegment(prevEntry, prevEntry.getValue(), prevEntry.getValue().getNumEntries());
     }
 
@@ -625,11 +648,12 @@ public class PersistentBinaryDeque implements BinaryDeque {
      * @param segment
      * @throws IOException
      */
-    private void quarantineSegment(PBDSegment segment) throws IOException {
+    private void quarantineSegment(PBDSegment<M> segment) throws IOException {
         quarantineSegment(null, segment, 0);
     }
 
-    private void quarantineSegment(Map.Entry<Long, PBDSegment> prevEntry, PBDSegment segment, int decrementEntryCount)
+    private void quarantineSegment(Map.Entry<Long, PBDSegment<M>> prevEntry, PBDSegment<M> segment,
+            int decrementEntryCount)
             throws IOException {
         try {
             PbdSegmentName quarantinedSegment = PbdSegmentName.asQuarantinedSegment(m_usageSpecificLog, segment.file());
@@ -637,14 +661,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 throw new IOException("Failed to quarantine segment: " + segment.file());
             }
 
-            PBDSegment quarantined = new PbdQuarantinedSegment(quarantinedSegment.m_file, segment.segmentIndex(),
+            PBDSegment<M> quarantined = new PbdQuarantinedSegment<>(quarantinedSegment.m_file, segment.segmentIndex(),
                     segment.segmentId());
 
             if (prevEntry == null) {
-                PBDSegment prev = m_segments.put(segment.segmentIndex(), quarantined);
+                PBDSegment<M> prev = m_segments.put(segment.segmentIndex(), quarantined);
                 assert prev == null;
             } else {
-                PBDSegment prev = prevEntry.setValue(quarantined);
+                PBDSegment<M> prev = prevEntry.setValue(quarantined);
                 assert segment == prev;
             }
             m_numObjects -= decrementEntryCount;
@@ -661,11 +685,12 @@ public class PersistentBinaryDeque implements BinaryDeque {
      * @throws IOException
      */
     private void recoverSegment(long segmentIndex, long segmentId, PbdSegmentName segmentName) throws IOException {
-        PBDSegment segment;
+        PBDSegment<M> segment;
         if (segmentName.m_quarantined) {
-            segment = new PbdQuarantinedSegment(segmentName.m_file, segmentIndex, segmentId);
+            segment = new PbdQuarantinedSegment<>(segmentName.m_file, segmentIndex, segmentId);
         } else {
-            segment = newSegment(segmentIndex, segmentId, segmentName.m_file);
+            segment = m_pbdSegmentFactory.create(segmentIndex, segmentId, segmentName.m_file, m_usageSpecificLog,
+                    m_extraHeaderSerializer);
 
             try {
                 if (segment.getNumEntries() == 0) {
@@ -703,7 +728,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
     private int countNumObjects() throws IOException {
         int numObjects = 0;
-        for (PBDSegment segment : m_segments.values()) {
+        for (PBDSegment<M> segment : m_segments.values()) {
             numObjects += segment.getNumEntries();
         }
 
@@ -732,8 +757,8 @@ public class PersistentBinaryDeque implements BinaryDeque {
          * When it finds the truncation point
          */
         Long lastSegmentIndex = null;
-        for (Map.Entry<Long, PBDSegment> entry : m_segments.entrySet()) {
-            PBDSegment segment = entry.getValue();
+        for (Map.Entry<Long, PBDSegment<M>> entry : m_segments.entrySet()) {
+            PBDSegment<M> segment = entry.getValue();
             final long segmentIndex = segment.segmentIndex();
 
             final int truncatedEntries;
@@ -771,7 +796,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
          */
         if (lastSegmentIndex == null)  {
             // Reopen the last segment for write - ensure it is not final
-            PBDSegment lastSegment = peekLastSegment();
+            PBDSegment<M> lastSegment = peekLastSegment();
             assert lastSegment.getNumEntries() == 0 : "Segment has entries: " + lastSegment.file();
             lastSegment.openNewSegment(m_compress);
 
@@ -784,9 +809,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
         /*
          * Now truncate all the segments after the truncation point.
          */
-        Iterator<PBDSegment> iterator = m_segments.tailMap(lastSegmentIndex, false).values().iterator();
+        Iterator<PBDSegment<M>> iterator = m_segments.tailMap(lastSegmentIndex, false).values().iterator();
         while (iterator.hasNext()) {
-            PBDSegment segment = iterator.next();
+            PBDSegment<M> segment = iterator.next();
             m_numObjects -= segment.getNumEntries();
             iterator.remove();
 
@@ -804,24 +829,21 @@ public class PersistentBinaryDeque implements BinaryDeque {
          */
         long curId = getNextSegmentId();
 
-        PBDSegment lastSegment = peekLastSegment();
+        PBDSegment<M> lastSegment = peekLastSegment();
         Long newSegmentIndex = lastSegment == null ? 1L : lastSegment.segmentIndex() + 1;
         long prevId = lastSegment == null ? getNextSegmentId() : lastSegment.segmentId();
 
         String fname = getSegmentFileName(curId, prevId);
-        PBDSegment newSegment = initializeNewSegment(newSegmentIndex, curId, new VoltFile(m_path, fname),
+        PBDSegment<M> newSegment = initializeNewSegment(newSegmentIndex, curId, new VoltFile(m_path, fname),
                 "PBD truncator");
         m_segments.put(newSegment.segmentIndex(), newSegment);
         assertions();
     }
 
-    PBDSegment newSegment(long segmentIndex, long segmentId, File file) {
-        return new PBDRegularSegment(segmentIndex, segmentId, file, m_usageSpecificLog);
-    }
-
-    private PBDSegment initializeNewSegment(long segmentIndex, long segmentId, File file, String reason)
+    private PBDSegment<M> initializeNewSegment(long segmentIndex, long segmentId, File file, String reason)
             throws IOException {
-        PBDSegment segment = newSegment(segmentIndex, segmentId, file);
+        PBDSegment<M> segment = m_pbdSegmentFactory.create(segmentIndex, segmentId, file, m_usageSpecificLog,
+                m_extraHeaderSerializer);
         try {
             segment.openNewSegment(m_compress);
             if (m_extraHeader != null) {
@@ -840,21 +862,21 @@ public class PersistentBinaryDeque implements BinaryDeque {
         return segment;
     }
 
-    private PBDSegment peekFirstSegment() {
-        Map.Entry<Long, PBDSegment> entry = m_segments.firstEntry();
+    private PBDSegment<M> peekFirstSegment() {
+        Map.Entry<Long, PBDSegment<M>> entry = m_segments.firstEntry();
         // entry may be null in ctor and while we are manipulating m_segments in addSegment, for example
         return (entry==null) ? null : entry.getValue();
     }
 
-    private PBDSegment peekLastSegment() {
-        Map.Entry<Long, PBDSegment> entry = m_segments.lastEntry();
+    private PBDSegment<M> peekLastSegment() {
+        Map.Entry<Long, PBDSegment<M>> entry = m_segments.lastEntry();
         // entry may be null in ctor and while we are manipulating m_segments in addSegment, for example
         return (entry==null) ? null : entry.getValue();
     }
 
     @Override
-    public void updateExtraHeader(DeferredSerialization extraHeaderSerializer) throws IOException {
-        m_extraHeader = extraHeaderSerializer;
+    public void updateExtraHeader(M extraHeader) throws IOException {
+        m_extraHeader = extraHeader;
         addSegment(peekLastSegment());
     }
 
@@ -865,7 +887,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             throw new IOException("Closed");
         }
 
-        PBDSegment tail = peekLastSegment();
+        PBDSegment<M> tail = peekLastSegment();
         if (!tail.offer(object)) {
             tail = addSegment(tail);
             final boolean success = tail.offer(object);
@@ -884,7 +906,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             throw new IOException("Cannot offer(): PBD has been Closed");
         }
 
-        PBDSegment tail = peekLastSegment();
+        PBDSegment<M> tail = peekLastSegment();
         int written = tail.offer(ds);
         if (written < 0) {
             tail = addSegment(tail);
@@ -898,7 +920,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         return written;
     }
 
-    private PBDSegment addSegment(PBDSegment tail) throws IOException {
+    private PBDSegment<M> addSegment(PBDSegment<M> tail) throws IOException {
         //Check to see if the tail is completely consumed so we can close and delete it
         tail.finalize(!tail.isBeingPolled());
 
@@ -911,13 +933,13 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         long curId = getNextSegmentId();
         String fname = getSegmentFileName(curId, lastId);
-        PBDSegment newSegment = initializeNewSegment(nextIndex, curId, new VoltFile(m_path, fname), "an offer");
+        PBDSegment<M> newSegment = initializeNewSegment(nextIndex, curId, new VoltFile(m_path, fname), "an offer");
         m_segments.put(newSegment.segmentIndex(), newSegment);
 
         return newSegment;
     }
 
-    private void closeAndDeleteSegment(PBDSegment segment) throws IOException {
+    private void closeAndDeleteSegment(PBDSegment<M> segment) throws IOException {
         int toDelete = segment.getNumEntries();
         if (m_usageSpecificLog.isDebugEnabled()) {
             m_usageSpecificLog.debug("Closing and deleting segment " + segment.file()
@@ -939,7 +961,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
 
         //Take the objects that were provided and separate them into deques of objects
         //that will fit in a single write segment
-        int maxObjectSize = PBDSegment.CHUNK_SIZE - PBDSegment.SEGMENT_HEADER_BYTES ;
+        int maxObjectSize = PBDSegment.CHUNK_SIZE - PBDSegment.SEGMENT_HEADER_BYTES;
         if (ds != null) {
             maxObjectSize -= ds.getSerializedSize();
         }
@@ -964,7 +986,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         assert(segments.size() > 0);
 
         // Calculate first index to push
-        PBDSegment first = peekFirstSegment();
+        PBDSegment<M> first = peekFirstSegment();
         Long nextIndex = first == null ? 1L : first.segmentIndex() - 1;
 
         // The first segment id is either the "previous" of the current head
@@ -977,7 +999,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
             long prevId = getNextSegmentId();
             String fname = getSegmentFileName(curId, prevId);
 
-            PBDSegment writeSegment = initializeNewSegment(nextIndex, curId, new VoltFile(m_path, fname), "a push");
+            PBDSegment<M> writeSegment = initializeNewSegment(nextIndex, curId, new VoltFile(m_path, fname), "a push");
 
             // Prepare for next file
             nextIndex--;
@@ -1007,14 +1029,14 @@ public class PersistentBinaryDeque implements BinaryDeque {
     }
 
     private void rewindCursors() {
-        PBDSegment firstSegment = peekFirstSegment();
+        PBDSegment<M> firstSegment = peekFirstSegment();
         for (ReadCursor cursor : m_readCursors.values()) {
             cursor.rewindTo(firstSegment);
         }
     }
 
     @Override
-    public synchronized BinaryDequeReader openForRead(String cursorId) throws IOException {
+    public synchronized BinaryDequeReader<M> openForRead(String cursorId) throws IOException {
         if (m_closed) {
             throw new IOException("Cannot openForRead(): PBD has been Closed");
         }
@@ -1047,9 +1069,9 @@ public class PersistentBinaryDeque implements BinaryDeque {
         // file
         try {
             boolean deleteSegment = false;
-            Iterator<PBDSegment> iter = m_segments.descendingMap().values().iterator();
+            Iterator<PBDSegment<M>> iter = m_segments.descendingMap().values().iterator();
             while (iter.hasNext()) {
-                PBDSegment segment = iter.next();
+                PBDSegment<M> segment = iter.next();
                 if (deleteSegment) {
                     closeAndDeleteSegment(segment);
                     iter.remove();
@@ -1062,7 +1084,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
     }
 
-    private boolean canDeleteSegmentsBefore(PBDSegment segment) {
+    private boolean canDeleteSegmentsBefore(PBDSegment<M> segment) {
         for (ReadCursor cursor : m_readCursors.values()) {
             if (cursor.m_segment == null) {
                 return false;
@@ -1074,7 +1096,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 return false;
             }
 
-            PBDSegmentReader segmentReader = segment.getReader(cursor.m_cursorId);
+            PBDSegmentReader<M> segmentReader = segment.getReader(cursor.m_cursorId);
             if (segmentReader == null) {
                 return false;
             } else if (!segmentReader.anyReadAndDiscarded()) {
@@ -1089,7 +1111,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         if (m_closed) {
             throw new IOException("Cannot sync(): PBD has been Closed");
         }
-        for (PBDSegment segment : m_segments.values()) {
+        for (PBDSegment<M> segment : m_segments.values()) {
             if (!segment.isClosed()) {
                 segment.sync();
             }
@@ -1105,7 +1127,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
     public synchronized Pair<Integer, Long> getBufferCountAndSize() throws IOException {
         int count = 0;
         long size = 0;
-        for (PBDSegment segment : m_segments.values()) {
+        for (PBDSegment<M> segment : m_segments.values()) {
             count += segment.getNumEntries();
             size += segment.size();
         }
@@ -1124,7 +1146,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
         m_readCursors.values().forEach(ReadCursor::close);
         m_readCursors.clear();
 
-        for (PBDSegment segment : m_segments.values()) {
+        for (PBDSegment<M> segment : m_segments.values()) {
             if (delete) {
                 closeAndDeleteSegment(segment);
             } else {
@@ -1229,8 +1251,8 @@ public class PersistentBinaryDeque implements BinaryDeque {
         for (ReadCursor cursor : m_readCursors.values()) {
             int numObjects = 0;
             try {
-                for (PBDSegment segment : m_segments.values()) {
-                    PBDSegmentReader reader = segment.getReader(cursor.m_cursorId);
+                for (PBDSegment<M> segment : m_segments.values()) {
+                    PBDSegmentReader<M> reader = segment.getReader(cursor.m_cursorId);
                     if (reader == null) {
                         numObjects += segment.getNumEntries();
                     } else {
@@ -1239,7 +1261,8 @@ public class PersistentBinaryDeque implements BinaryDeque {
                 }
                 assert numObjects == cursor.getNumObjects() : numObjects + " != " + cursor.getNumObjects();
             } catch (Exception e) {
-                Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }
@@ -1251,7 +1274,7 @@ public class PersistentBinaryDeque implements BinaryDeque {
     // Used by test only
     int numOpenSegments() {
         int numOpen = 0;
-        for (PBDSegment segment : m_segments.values()) {
+        for (PBDSegment<M> segment : m_segments.values()) {
             if (!segment.isClosed()) {
                 numOpen++;
             }
@@ -1278,8 +1301,8 @@ public class PersistentBinaryDeque implements BinaryDeque {
         /*
          * Iterator all the objects in all the segments and pass them to the scanner
          */
-        for (Map.Entry<Long, PBDSegment> entry : m_segments.entrySet()) {
-            PBDSegment segment = entry.getValue();
+        for (Map.Entry<Long, PBDSegment<M>> entry : m_segments.entrySet()) {
+            PBDSegment<M> segment = entry.getValue();
             try {
                 int truncatedEntries = segment.scan(scanner);
                 if (truncatedEntries > 0) {
@@ -1296,5 +1319,115 @@ public class PersistentBinaryDeque implements BinaryDeque {
         }
 
         return;
+    }
+
+    /**
+     * Create a new builder for constructing instances of {@link PersistentBinaryDeque}
+     *
+     * @param nonce  To be used by the {@link PersistentBinaryDeque}
+     * @param path   to a directory where the {@link PersistentBinaryDeque} files will be stored
+     * @param logger to use to log any messages generated by the {@link PersistentBinaryDeque} instance
+     * @throws NullPointerException if any parameters are {@code null}
+     */
+    public static Builder<Void> builder(String nonce, File path, VoltLogger logger) {
+        return new Builder<>(nonce, path, logger);
+    }
+
+    /**
+     * Builder class for constructing an instance of a {@link PersistentBinaryDeque}
+     *
+     * @param <M> Type of extra header metadata used with this PBD
+     */
+    public static final class Builder<M> {
+        final String m_nonce;
+        final File m_path;
+        final VoltLogger m_logger;
+        boolean m_useCompression = false;
+        BinaryDequeSerializer<M> m_extraHeaderSerializer;
+        M m_initialExtraHeader;
+        PBDSegmentFactory m_pbdSegmentFactory = PBDRegularSegment::new;
+
+        private Builder(String nonce, File path, VoltLogger logger) {
+            super();
+            m_nonce = requireNonNull(nonce, "nonce");
+            m_path = requireNonNull(path, "path");
+            m_logger = requireNonNull(logger, "logger");
+        }
+
+        private Builder(Builder<?> builder, M extraHeader, BinaryDequeSerializer<M> serializer) {
+            this(builder.m_nonce, builder.m_path, builder.m_logger);
+            m_useCompression = builder.m_useCompression;
+            m_initialExtraHeader = extraHeader;
+            m_extraHeaderSerializer = serializer;
+            m_pbdSegmentFactory = builder.m_pbdSegmentFactory;
+        }
+
+        /**
+         * Set whether compression should be enabled or not.
+         * <p>
+         * Default: {@code false}
+         *
+         * @param enabled {@code true} if compression should be used.
+         * @return An updated {@link Builder} instance
+         */
+        public Builder<M> compression(boolean enabled) {
+            m_useCompression = enabled;
+            return this;
+        }
+
+        /**
+         * Add extra header metadata which can be written but not read. This means
+         * {@link BinaryDequeReader#pollEntry(org.voltdb.utils.BinaryDeque.OutputContainerFactory)} method can not be
+         * used.
+         *
+         * @param extraHeader Instance of extra header metadata
+         * @return An updated {@link Builder} instance
+         * @deprecated use {@link #initialExtraHeader(Object, BinaryDequeSerializer)
+         */
+        @Deprecated
+        public Builder<DeferredSerialization> initialExtraHeader(DeferredSerialization extraHeader) {
+            return initialExtraHeader(extraHeader,
+                    new DeferredSerializationBinaryDequeSerializer<DeferredSerialization>() {
+                        @Override
+                        public DeferredSerialization read(ByteBuffer buffer) throws IOException {
+                            throw new UnsupportedOperationException();
+                        }
+                    });
+        }
+
+        /**
+         * Set the initial extra header metadata to be stored with entries as well as a {@link BinaryDequeSerializer} to
+         * write and read that type of metadata.
+         * <p>
+         * Default: {@code null}
+         *
+         * @param <T>         Type of extra header metadata
+         * @param extraHeader Instance of extra header metadata
+         * @param serializer  {@link BinaryDequeSerializer} used write and read the extra header
+         * @return An updated {@link Builder} instance
+         * @throws NullPointerException if {@code serializer} is {@code null}
+         */
+        public <T> Builder<T> initialExtraHeader(T extraHeader, BinaryDequeSerializer<T> serializer) {
+            return new Builder<>(this, extraHeader, requireNonNull(serializer, "serializer"));
+        }
+
+        /**
+         * @return A new instance of {@link PersistentBinaryDeque} constructed by this builder
+         * @throws IOException If there was an error constructing the instance
+         */
+        public PersistentBinaryDeque<M> build() throws IOException {
+            return new PersistentBinaryDeque<>(this);
+        }
+
+        Builder<M> pbdSegmentFactory(PBDSegmentFactory pbdSegmentFactory) {
+            m_pbdSegmentFactory = requireNonNull(pbdSegmentFactory);
+            return this;
+        }
+    }
+
+    /** Internal interface for a factory to create {@link PBDSegment}s */
+    interface PBDSegmentFactory {
+        <M> PBDSegment<M> create(long segmentIndex, long segmentId, File file, VoltLogger logger,
+                BinaryDequeSerializer<M> extraHeaderSerializer);
     }
 }

--- a/tests/frontend/org/voltdb/test/utils/RandomTestRule.java
+++ b/tests/frontend/org/voltdb/test/utils/RandomTestRule.java
@@ -23,6 +23,7 @@
 
 package org.voltdb.test.utils;
 
+import java.nio.ByteBuffer;
 import java.util.Random;
 
 import org.junit.rules.TestRule;
@@ -46,6 +47,19 @@ public class RandomTestRule extends Random implements TestRule {
         initializeSeed(seed);
     }
 
+    public void nextBytes(ByteBuffer buffer) {
+        while (buffer.remaining() > Integer.BYTES) {
+            buffer.putInt(nextInt());
+        }
+        if (buffer.hasRemaining()) {
+            int value = nextInt();
+            do {
+                buffer.put((byte) value);
+                value >>>= Byte.SIZE;
+            } while (buffer.hasRemaining());
+        }
+    }
+
     /**
      * @param origin inclusive lower bound of the returned value
      * @param bound  exclusive upper bound of the returned value
@@ -61,13 +75,7 @@ public class RandomTestRule extends Random implements TestRule {
     @Override
     public Statement apply(Statement base, Description description) {
         m_name = description.getDisplayName();
-
-        return new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                base.evaluate();
-            }
-        };
+        return base;
     }
 
     @Override

--- a/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
+++ b/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
@@ -41,12 +41,12 @@ public class TestPBDMultipleReaders {
 
     private final static VoltLogger logger = new VoltLogger("EXPORT");
 
-    private PersistentBinaryDeque m_pbd;
+    private PersistentBinaryDeque<?> m_pbd;
 
     private class PBDReader {
         private String m_readerId;
         private int m_totalRead;
-        private BinaryDequeReader m_reader;
+        private BinaryDequeReader<?> m_reader;
 
         public PBDReader(String readerId) throws IOException {
             m_readerId = readerId;
@@ -108,9 +108,9 @@ public class TestPBDMultipleReaders {
     @Test
     public void testOpenReaders() throws Exception {
         String cursorId = "reader";
-        BinaryDequeReader reader1 = m_pbd.openForRead(cursorId);
-        BinaryDequeReader reader2 = m_pbd.openForRead(cursorId);
-        BinaryDequeReader another = m_pbd.openForRead("another");
+        BinaryDequeReader<?> reader1 = m_pbd.openForRead(cursorId);
+        BinaryDequeReader<?> reader2 = m_pbd.openForRead(cursorId);
+        BinaryDequeReader<?> another = m_pbd.openForRead("another");
         assertTrue(reader1==reader2);
         assertFalse(reader1==another);
 
@@ -140,8 +140,8 @@ public class TestPBDMultipleReaders {
             assertEquals(1, m_pbd.numOpenSegments());
         }
 
-        BinaryDequeReader reader0 = m_pbd.openForRead("reader0");
-        BinaryDequeReader reader1 = m_pbd.openForRead("reader1");
+        BinaryDequeReader<?> reader0 = m_pbd.openForRead("reader0");
+        BinaryDequeReader<?> reader1 = m_pbd.openForRead("reader1");
         // Position first reader0 on penultimate segment and reader1 on first segment
         for (int i=0; i<numSegments-1; i++) {
             for (int j = 0; j < SEGMENT_FILL_COUNT - (i == 0 ? 0 : 1); j++) {
@@ -193,7 +193,8 @@ public class TestPBDMultipleReaders {
     @Before
     public void setUp() throws Exception {
         TestPersistentBinaryDeque.setupTestDir();
-        m_pbd = new PersistentBinaryDeque(TestPersistentBinaryDeque.TEST_NONCE, null, TestPersistentBinaryDeque.TEST_DIR, logger );
+        m_pbd = PersistentBinaryDeque
+                .builder(TestPersistentBinaryDeque.TEST_NONCE, TestPersistentBinaryDeque.TEST_DIR, logger).build();
     }
 
     @After

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -32,7 +32,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -42,18 +43,13 @@ import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
-import org.voltcore.utils.DeferredSerialization;
 import org.voltcore.utils.Pair;
-import org.voltdb.CatalogContext;
-import org.voltdb.MockVoltDB;
-import org.voltdb.VoltDB;
-import org.voltdb.VoltType;
-import org.voltdb.catalog.Table;
-import org.voltdb.export.ExportDataSource.StreamTableSchemaSerializer;
+import org.voltdb.test.utils.RandomTestRule;
 import org.voltdb.utils.BinaryDeque.BinaryDequeTruncator;
 import org.voltdb.utils.BinaryDeque.TruncatorResponse;
 
@@ -68,6 +64,9 @@ public class TestPersistentBinaryDeque {
     private static final String CURSOR_ID = "testPBD";
     private final static VoltLogger logger = new VoltLogger("EXPORT");
 
+    @Rule
+    public final RandomTestRule m_random = new RandomTestRule();
+
     static ByteBuffer defaultBuffer() {
         return getFilledBuffer(42);
     }
@@ -76,23 +75,15 @@ public class TestPersistentBinaryDeque {
         return DBBPool.wrapBB(defaultBuffer());
     }
 
-    private PersistentBinaryDeque<DeferredSerialization> m_pbd;
-    private MockVoltDB m_mockVoltDB;
-    StreamTableSchemaSerializer m_ds;
+    private PersistentBinaryDeque<ExtraHeaderMetadata> m_pbd;
+    ExtraHeaderMetadata m_metadata;
 
     @Before
     public void setUp() throws Exception {
         setupTestDir();
-        m_mockVoltDB = new MockVoltDB();
-        m_mockVoltDB.addTable("TableName", false);
-        m_mockVoltDB.addColumnToTable("TableName", "COL1", VoltType.INTEGER, false, null, VoltType.INTEGER);
-        m_mockVoltDB.addColumnToTable("TableName", "COL2", VoltType.STRING, false, null, VoltType.STRING);
-        VoltDB.replaceVoltDBInstanceForTest(m_mockVoltDB);
-        CatalogContext catalogContext = VoltDB.instance().getCatalogContext();
-        Table streamTable = VoltDB.instance().getCatalogContext().database.getTables().get("TableName");
-        m_ds = new StreamTableSchemaSerializer(streamTable, "TableName", catalogContext.m_genId);
+        m_metadata = new ExtraHeaderMetadata(m_random);
         m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).compression(true)
-                .initialExtraHeader(m_ds).build();
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
     }
 
     public static void setupTestDir() throws IOException {
@@ -108,14 +99,13 @@ public class TestPersistentBinaryDeque {
     @After
     public void tearDown() throws Exception {
         try {
-            m_mockVoltDB.shutdown(null);
             m_pbd.close();
         } catch (Exception e) {}
         try {
             tearDownTestDir();
         } finally {
             m_pbd = null;
-            m_ds = null;
+            m_metadata = null;
         }
         System.gc();
         System.runFinalization();
@@ -263,7 +253,8 @@ public class TestPersistentBinaryDeque {
         listing = getSortedDirectoryListing(true);
         assertEquals(listing.size(), 4);
 
-        m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).initialExtraHeader(m_ds).build();
+        m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger)
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
 
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 5);
@@ -278,7 +269,7 @@ public class TestPersistentBinaryDeque {
 
         listing = getSortedDirectoryListing();
         assertEquals(1, listing.size());
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
     }
 
@@ -294,7 +285,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(listing.size(), 1);
 
         m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).compression(true)
-                .initialExtraHeader(m_ds).build();
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
 
         listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 1);
@@ -312,7 +303,7 @@ public class TestPersistentBinaryDeque {
             m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)) );
         }
 
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         for (long ii = 0; ii < 96; ii++) {
             BBContainer cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
             try {
@@ -335,7 +326,7 @@ public class TestPersistentBinaryDeque {
     @Test
     public void testTruncatorWithFullTruncateReturn() throws Exception {
         System.out.println("Running testTruncatorWithFullTruncateReturn");
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         for (int ii = 0; ii < 150; ii++) {
@@ -345,7 +336,7 @@ public class TestPersistentBinaryDeque {
         m_pbd.close();
 
         m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).compression(true)
-                .initialExtraHeader(m_ds).build();
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
 
         List<File> listing = getSortedDirectoryListing();
         assertEquals(listing.size(), 5);
@@ -380,7 +371,7 @@ public class TestPersistentBinaryDeque {
         for (int ii = 46; ii < 96; ii++) {
             // Note: new segment after truncate?
             if (ii == 46) {
-                m_pbd.updateExtraHeader(m_ds);
+                m_pbd.updateExtraHeader(new ExtraHeaderMetadata(m_random));
             }
             m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
@@ -389,10 +380,10 @@ public class TestPersistentBinaryDeque {
         long actualSizeInBytes = 0;
         long reportedSizeInBytes = reader.sizeInBytes();
         long blocksFound = 0;
-        BBContainer cont = null;
-        while ((cont = pollOnceWithoutDiscard(reader)) != null) {
+        BinaryDequeReader.Entry<ExtraHeaderMetadata> entry = null;
+        while ((entry = pollOnceWithoutDiscard(reader)) != null) {
             try {
-                ByteBuffer buffer = cont.b();
+                ByteBuffer buffer = entry.getData();
                 if (blocksFound == 45) {
                     blocksFound++;//white lie, so we expect the right block contents
                 }
@@ -404,7 +395,7 @@ public class TestPersistentBinaryDeque {
                 }
             } finally {
                 blocksFound++;
-                cont.discard();
+                entry.release();
             }
         }
         assertEquals(actualSizeInBytes, reportedSizeInBytes);
@@ -414,7 +405,7 @@ public class TestPersistentBinaryDeque {
     @Test
     public void testTruncator() throws Exception {
         System.out.println("Running testTruncator");
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         for (int ii = 0; ii < 160; ii++) {
@@ -423,7 +414,8 @@ public class TestPersistentBinaryDeque {
 
         m_pbd.close();
 
-        m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).initialExtraHeader(m_ds).build();
+        m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger)
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
         ;
 
         List<File> listing = getSortedDirectoryListing();
@@ -458,7 +450,7 @@ public class TestPersistentBinaryDeque {
         for (int ii = 46; ii < 96; ii++) {
             // Note: new segment after truncate?
             if (ii == 46) {
-                m_pbd.updateExtraHeader(m_ds);
+                m_pbd.updateExtraHeader(new ExtraHeaderMetadata(m_random));
             }
             m_pbd.offer(DBBPool.wrapBB(getFilledBuffer(ii)));
         }
@@ -466,10 +458,10 @@ public class TestPersistentBinaryDeque {
         long actualSizeInBytes = 0;
         long reportedSizeInBytes = reader.sizeInBytes();
         long blocksFound = 0;
-        BBContainer cont = null;
-        while ((cont = pollOnceWithoutDiscard(reader)) != null) {
+        BinaryDequeReader.Entry<ExtraHeaderMetadata> entry = null;
+        while ((entry = pollOnceWithoutDiscard(reader)) != null) {
             try {
-                ByteBuffer buffer = cont.b();
+                ByteBuffer buffer = entry.getData();
                 if (blocksFound == 45) {
                     assertEquals(buffer.remaining(), 1024 * 1024);
                 } else {
@@ -482,7 +474,7 @@ public class TestPersistentBinaryDeque {
                 }
             } finally {
                 blocksFound++;
-                cont.discard();
+                entry.release();
             }
         }
         assertEquals(actualSizeInBytes, reportedSizeInBytes);
@@ -492,7 +484,7 @@ public class TestPersistentBinaryDeque {
     @Test
     public void testReaderIsEmpty() throws Exception {
         System.out.println("Running testReaderIsEmpty");
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         assertTrue(reader.isEmpty());
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
         assertTrue(reader.isEmpty());
@@ -521,7 +513,7 @@ public class TestPersistentBinaryDeque {
     public void testReaderNumObjects() throws Exception {
         System.out.println("Running testReaderNumObjects");
         String cursor1 = "testPBD1";
-        BinaryDequeReader<DeferredSerialization> reader1 = m_pbd.openForRead(cursor1);
+        BinaryDequeReader<ExtraHeaderMetadata> reader1 = m_pbd.openForRead(cursor1);
         int count = 0;
         int totalAdded = 0;
         assertEquals(count, reader1.getNumObjects());
@@ -535,7 +527,7 @@ public class TestPersistentBinaryDeque {
 
         // a second reader
         String cursor2 = "testPBD2";
-        BinaryDequeReader<DeferredSerialization> reader2 = m_pbd.openForRead(cursor2);
+        BinaryDequeReader<ExtraHeaderMetadata> reader2 = m_pbd.openForRead(cursor2);
 
         pollOnce(reader1);
         assertEquals(count-1, reader1.getNumObjects());
@@ -567,7 +559,7 @@ public class TestPersistentBinaryDeque {
         final int segmentfullCount = 47;
         // start a 3rd reader after segments have been deleted
         String cursor3 = "testPBD3";
-        BinaryDequeReader<DeferredSerialization> lateReader = m_pbd.openForRead(cursor3);
+        BinaryDequeReader<ExtraHeaderMetadata> lateReader = m_pbd.openForRead(cursor3);
         int toAddForLate = totalAdded%segmentfullCount;
         assertEquals(count+toAddForLate, lateReader.getNumObjects());
 
@@ -610,7 +602,7 @@ public class TestPersistentBinaryDeque {
     @Test
     public void testOfferThenPoll() throws Exception {
         System.out.println("Running testOfferThenPoll");
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         //Make sure a single file with the appropriate data is created
@@ -626,7 +618,7 @@ public class TestPersistentBinaryDeque {
     @Test
     public void testCloseOldSegments() throws Exception {
         System.out.println("Running testCloseOldSegments");
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         final int total = 100;
@@ -659,7 +651,7 @@ public class TestPersistentBinaryDeque {
     @Test
     public void testDontCloseReadSegment() throws Exception {
         System.out.println("Running testDontCloseReadSegment");
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         assertNull(reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY));
 
         final int total = 100;
@@ -700,7 +692,7 @@ public class TestPersistentBinaryDeque {
     @Test
     public void testOfferThenPushThenPoll() throws Exception {
         System.out.println("Running testOfferThenPushThenPoll");
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         assertTrue(reader.isEmpty());
         //Make it create two full segments
         for (int ii = 0; ii < 96; ii++) {
@@ -717,7 +709,7 @@ public class TestPersistentBinaryDeque {
         pushContainers[0] = DBBPool.dummyWrapBB(buffer1);
         pushContainers[1] = DBBPool.dummyWrapBB(buffer2);
 
-        m_pbd.push(pushContainers, m_ds);
+        m_pbd.push(pushContainers, m_metadata);
 
         //Expect this to create a single new file
         List<File> listing = getSortedDirectoryListing();
@@ -782,9 +774,10 @@ public class TestPersistentBinaryDeque {
         m_pbd.sync();
         m_pbd.close();
 
-        m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).initialExtraHeader(m_ds).build();
+        m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger)
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
         ;
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
 
         ByteBuffer defaultBuffer = defaultBuffer();
         //Now poll all of it and make sure the data is correct
@@ -811,7 +804,8 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testInvalidDirectory");
         m_pbd.close();
         try {
-            m_pbd = PersistentBinaryDeque.builder("foo", new File("/usr/bin"), logger).initialExtraHeader(m_ds).build();
+            m_pbd = PersistentBinaryDeque.builder("foo", new File("/usr/bin"), logger)
+                    .initialExtraHeader(m_metadata, SERIALIZER).build();
         } catch (IOException e) {
             return;
         }
@@ -837,7 +831,8 @@ public class TestPersistentBinaryDeque {
         assertTrue(toDelete.exists());
         assertTrue(toDelete.delete());
         try {
-            m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).initialExtraHeader(m_ds).build();
+            m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger)
+                    .initialExtraHeader(m_metadata, SERIALIZER).build();
             ;
         } catch (IOException e) {
             return;
@@ -866,7 +861,7 @@ public class TestPersistentBinaryDeque {
         m_pbd.close();
         BBContainer objs[] = new BBContainer[] { DBBPool.wrapBB(ByteBuffer.allocate(20)) };
         try {
-            m_pbd.push(objs, m_ds);
+            m_pbd.push(objs);
         } catch (IOException e) {
             return;
         } finally {
@@ -881,14 +876,13 @@ public class TestPersistentBinaryDeque {
         m_pbd.push(new BBContainer[] {
                 DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)) ,
                 DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)) ,
-                DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)) },
-                m_ds);
+                DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)) });
     }
 
     @Test
     public void testPollWhileClosed() throws Exception {
         System.out.println("Running testPollWhileClosed");
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         m_pbd.close();
         try {
             reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
@@ -913,7 +907,7 @@ public class TestPersistentBinaryDeque {
     @Test
     public void testIsEmptyWhileClosed() throws Exception {
         System.out.println("Running testIsEmptyWhileClosed");
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         m_pbd.close();
         try {
             reader.isEmpty();
@@ -929,7 +923,7 @@ public class TestPersistentBinaryDeque {
         BBContainer objs[] = new BBContainer[] {
                 DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 64)) };
         try {
-            m_pbd.push(objs, m_ds);
+            m_pbd.push(objs);
         } catch (IOException e) {
             return;
         } finally {
@@ -956,14 +950,16 @@ public class TestPersistentBinaryDeque {
     public void testOverlappingNonces() throws Exception {
         System.out.println("Running testOverlappingNonces");
         for (int i = 0; i < 20; i++) {
-            PersistentBinaryDeque<DeferredSerialization> pbd =  PersistentBinaryDeque.builder(
-                    Integer.toString(i), TEST_DIR, logger).initialExtraHeader(m_ds).build();
+            PersistentBinaryDeque<ExtraHeaderMetadata> pbd = PersistentBinaryDeque
+                    .builder(
+                    Integer.toString(i), TEST_DIR, logger)
+                    .initialExtraHeader(m_metadata, SERIALIZER).build();
             pbd.offer(defaultContainer());
             pbd.close();
         }
 
-        PersistentBinaryDeque<DeferredSerialization> pbd = PersistentBinaryDeque.builder("1", TEST_DIR, logger)
-                .initialExtraHeader(m_ds)
+        PersistentBinaryDeque<ExtraHeaderMetadata> pbd = PersistentBinaryDeque.builder("1", TEST_DIR, logger)
+                .initialExtraHeader(m_metadata, SERIALIZER)
                 .build();
         pbd.close();
     }
@@ -971,14 +967,13 @@ public class TestPersistentBinaryDeque {
     @Test
     public void testNonceWithDots() throws Exception {
         System.out.println("Running testNonceWithDots");
-        PersistentBinaryDeque<?> pbd = PersistentBinaryDeque.builder("ha.ha", TEST_DIR, logger)
-                .initialExtraHeader(m_ds)
-                .build();
+        PersistentBinaryDeque<ExtraHeaderMetadata> pbd = PersistentBinaryDeque.builder("ha.ha", TEST_DIR, logger)
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
         pbd.offer(defaultContainer());
         pbd.close();
 
-        pbd = PersistentBinaryDeque.builder("ha.ha", TEST_DIR, logger).build();
-        BinaryDequeReader<?> reader = pbd.openForRead(CURSOR_ID);
+        pbd = PersistentBinaryDeque.builder("ha.ha", TEST_DIR, logger).initialExtraHeader(null, SERIALIZER).build();
+        BinaryDequeReader<ExtraHeaderMetadata> reader = pbd.openForRead(CURSOR_ID);
         ByteBuffer defaultBuffer = defaultBuffer();
         defaultBuffer.clear();
         pollOnceAndVerify(reader, defaultBuffer);
@@ -998,8 +993,9 @@ public class TestPersistentBinaryDeque {
         m_pbd.sync();
         m_pbd.close();
 
-        m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).initialExtraHeader(m_ds).build();
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger)
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
 
@@ -1027,9 +1023,9 @@ public class TestPersistentBinaryDeque {
         System.out.println("Running testOfferCloseReopenOfferSmall");
         final String SMALL_TEST_NONCE = "asmall_pbd_nonce";
 
-        PersistentBinaryDeque<DeferredSerialization> small_pbd = PersistentBinaryDeque
+        PersistentBinaryDeque<ExtraHeaderMetadata> small_pbd = PersistentBinaryDeque
                 .builder(SMALL_TEST_NONCE, TEST_DIR, logger)
-                .initialExtraHeader(m_ds).build();
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
         //Keep in 1 segment.
         for (int ii = 0; ii < 10; ii++) {
             small_pbd.offer(DBBPool.wrapBB(getFilledSmallBuffer(ii)));
@@ -1043,8 +1039,9 @@ public class TestPersistentBinaryDeque {
         System.gc();
         System.runFinalization();
 
-        small_pbd = PersistentBinaryDeque.builder(SMALL_TEST_NONCE, TEST_DIR, logger).initialExtraHeader(m_ds).build();
-        BinaryDequeReader<DeferredSerialization> reader = small_pbd.openForRead(CURSOR_ID);
+        small_pbd = PersistentBinaryDeque.builder(SMALL_TEST_NONCE, TEST_DIR, logger)
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
+        BinaryDequeReader<ExtraHeaderMetadata> reader = small_pbd.openForRead(CURSOR_ID);
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 10);
 
@@ -1063,7 +1060,8 @@ public class TestPersistentBinaryDeque {
         files = TEST_DIR.listFiles();
         assertEquals(3, files.length);
 
-        small_pbd = PersistentBinaryDeque.builder(SMALL_TEST_NONCE, TEST_DIR, logger).initialExtraHeader(m_ds).build();
+        small_pbd = PersistentBinaryDeque.builder(SMALL_TEST_NONCE, TEST_DIR, logger)
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
         reader = small_pbd.openForRead(CURSOR_ID);
         //Now poll all of it and make sure the data is correct dont poll everything out.
         for (int ii = 0; ii < 10; ii++) {
@@ -1093,8 +1091,8 @@ public class TestPersistentBinaryDeque {
         System.gc();
         System.runFinalization();
         m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).compression(true)
-                .initialExtraHeader(m_ds).build();
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         int cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
         for (int ii = 96; ii < 192; ii++) {
@@ -1120,7 +1118,7 @@ public class TestPersistentBinaryDeque {
         assertEquals(3, listing.size());
         //Reload
         m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).compression(true)
-                .initialExtraHeader(m_ds).build();
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
         reader = m_pbd.openForRead(CURSOR_ID);
         cnt = reader.getNumObjects();
         assertEquals(cnt, 96);
@@ -1163,7 +1161,7 @@ public class TestPersistentBinaryDeque {
             DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)),
             DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32)),
             DBBPool.wrapBB(ByteBuffer.allocateDirect(1024 * 1024 * 32))};
-        m_pbd.push(objs, m_ds);
+        m_pbd.push(objs);
         listing = getSortedDirectoryListing();
         assertEquals(4, listing.size());
 
@@ -1177,56 +1175,48 @@ public class TestPersistentBinaryDeque {
 
     @Test
     public void testUpdateExtraHeader() throws Exception {
+        List<ExtraHeaderMetadata> extraHeaders = new ArrayList<>();
+        extraHeaders.add(m_metadata);
         for (int i = 0; i < 5; ++i) {
             for (int j = 0; j < 2; j++) {
                 m_pbd.offer(defaultContainer());
             }
             assertEquals(i + 1, TEST_DIR.listFiles().length);
 
-            final int headerData = i;
-            m_pbd.updateExtraHeader(new DeferredSerialization() {
-                @Override
-                public void serialize(ByteBuffer buf) throws IOException {
-                    buf.putInt(headerData);
-                }
-
-                @Override
-                public int getSerializedSize() throws IOException {
-                    return Integer.BYTES;
-                }
-
-                @Override
-                public void cancel() {}
-            });
+            ExtraHeaderMetadata ehm = new ExtraHeaderMetadata(m_random);
+            extraHeaders.add(ehm);
+            m_pbd.updateExtraHeader(ehm);
         }
         assertEquals(6, TEST_DIR.listFiles().length);
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
-        BBContainer container = reader.getExtraHeader(1);
-        try {
-            assertNotNull(container);
-            ByteBuffer expected = ByteBuffer.allocate(m_ds.getSerializedSize());
-            expected.order(ByteOrder.LITTLE_ENDIAN);
-            m_ds.serialize(expected);
-            expected.rewind();
-            assertEquals(expected, container.b());
-        } finally {
-            container.discard();
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
+        // Open second reader to prevent segments from being deleted
+        m_pbd.openForRead(CURSOR_ID + 1);
+
+        ByteBuffer expectedData = defaultBuffer();
+        for (int i = 0; i< 5 ;++i) {
+            ExtraHeaderMetadata expectedMetadata = extraHeaders.get(i);
+            for (int j = 0; j < 2; j++) {
+                pollOnceAndVerify(reader, expectedData.asReadOnlyBuffer(), expectedMetadata);
+            }
         }
+
+        m_pbd.sync();
+        m_pbd.close();
+        m_pbd = PersistentBinaryDeque.builder(TEST_NONCE, TEST_DIR, logger).compression(true)
+                .initialExtraHeader(m_metadata, SERIALIZER).build();
+
+        reader = m_pbd.openForRead(CURSOR_ID);
         for (int i = 0; i < 5; ++i) {
-            container = reader.getExtraHeader(i + 2);
-            try {
-                assertNotNull(container);
-                assertEquals(i, container.b().getInt());
-                assertFalse(container.b().hasRemaining());
-            } finally {
-                container.discard();
+            ExtraHeaderMetadata expectedMetadata = extraHeaders.get(i);
+            for (int j = 0; j < 2; j++) {
+                pollOnceAndVerify(reader, expectedData.asReadOnlyBuffer(), expectedMetadata);
             }
         }
     }
 
     @Test
     public void testCloseLastReader() throws Exception {
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead(CURSOR_ID);
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
         pollOnceAndVerify(reader, null);
         m_pbd.closeCursor(CURSOR_ID);
         m_pbd.offer(defaultContainer());
@@ -1248,7 +1238,7 @@ public class TestPersistentBinaryDeque {
     @Test
     public void testSegmentClosingWriterReaderLockStep() throws Exception {
         assertEquals(1, m_pbd.numOpenSegments());
-        BinaryDequeReader<DeferredSerialization> reader = m_pbd.openForRead("reader0");
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead("reader0");
 
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < SEGMENT_FILL_COUNT; j++) {
@@ -1260,46 +1250,114 @@ public class TestPersistentBinaryDeque {
         }
     }
 
-    static BBContainer pollOnceWithoutDiscard(BinaryDequeReader<?> reader) throws IOException {
-        BBContainer schema = null;
-        try {
-            if (reader.isStartOfSegment()) {
-                schema = reader.getExtraHeader(-1);
-                assertNotNull(schema);
-                assertFalse(reader.isEmpty());
-            }
-            return reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
-        } finally {
-            if (schema != null) {
-                schema.discard();
+    static <M> BinaryDequeReader.Entry<M> pollOnceWithoutDiscard(BinaryDequeReader<M> reader) throws IOException {
+        BinaryDequeReader.Entry<M> entry = reader
+                .pollEntry(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        if (entry != null) {
+            try {
+                assertNotNull(entry.getExtraHeader());
+            } catch (Throwable t) {
+                entry.release();
+                throw t;
             }
         }
+        return entry;
     }
 
-    static void pollOnce(BinaryDequeReader<?> reader) throws IOException {
-        BBContainer retval = pollOnceWithoutDiscard(reader);
+    static void pollOnce(BinaryDequeReader<ExtraHeaderMetadata> reader) throws IOException {
+        BinaryDequeReader.Entry<ExtraHeaderMetadata> retval = pollOnceWithoutDiscard(reader);
         if (retval != null) {
-            retval.discard();
+            retval.release();
         }
     }
 
-    static void pollOnceAndVerify(BinaryDequeReader<?> reader, ByteBuffer destBuf)
+    void pollOnceAndVerify(BinaryDequeReader<ExtraHeaderMetadata> reader, ByteBuffer destBuf) throws IOException {
+        pollOnceAndVerify(reader, destBuf, m_metadata);
+    }
+
+    static <M> void pollOnceAndVerify(BinaryDequeReader<M> reader, ByteBuffer expectedData, M expectedMetadata)
             throws IOException {
-        BBContainer retval = pollOnceWithoutDiscard(reader);
+        BinaryDequeReader.Entry<M> retval = pollOnceWithoutDiscard(reader);
         try {
-            if (destBuf == null) {
+            if (expectedData == null) {
                 assertNull(retval);
             } else {
-                assertEquals(destBuf, retval.b());
+                assertEquals(expectedMetadata, retval.getExtraHeader());
+                assertEquals(expectedData, retval.getData());
             }
         } finally {
             if (retval != null) {
-                retval.discard();
+                retval.release();
             }
         }
     }
 
-    private String createSegmentName(long id, long prevId) {
+    private static String createSegmentName(long id, long prevId) {
         return PbdSegmentName.createName(TEST_NONCE, id, prevId, false);
     }
+
+    static class ExtraHeaderMetadata {
+        final int m_int;
+        final long m_long;
+        final byte[] m_bytes;
+
+        ExtraHeaderMetadata(Random random) {
+            m_int = random.nextInt();
+            m_long = random.nextLong();
+            m_bytes = new byte[random.nextInt(256)];
+            random.nextBytes(m_bytes);
+        }
+
+        ExtraHeaderMetadata(ByteBuffer buffer) {
+            m_int = buffer.getInt();
+            m_long = buffer.getLong();
+            m_bytes = new byte[buffer.getInt()];
+            buffer.get(m_bytes);
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Arrays.hashCode(m_bytes);
+            result = prime * result + m_int;
+            result = prime * result + (int) (m_long ^ (m_long >>> 32));
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            ExtraHeaderMetadata other = (ExtraHeaderMetadata) obj;
+            return m_int == other.m_int && m_long == other.m_long && Arrays.equals(m_bytes, other.m_bytes);
+        }
+    }
+
+    static final BinaryDequeSerializer<ExtraHeaderMetadata> SERIALIZER = new BinaryDequeSerializer<ExtraHeaderMetadata>() {
+        @Override
+        public int getMaxSize(ExtraHeaderMetadata object) throws IOException {
+            return Integer.BYTES + Long.BYTES + Integer.BYTES + object.m_bytes.length;
+        }
+
+        @Override
+        public void write(ExtraHeaderMetadata object, ByteBuffer buffer) throws IOException {
+            buffer.putInt(object.m_int);
+            buffer.putLong(object.m_long);
+            buffer.putInt(object.m_bytes.length);
+            buffer.put(object.m_bytes);
+        }
+
+        @Override
+        public ExtraHeaderMetadata read(ByteBuffer buffer) throws IOException {
+            return new ExtraHeaderMetadata(buffer);
+        }
+    };
 }


### PR DESCRIPTION
Instead of a separate getter for the extra header add a new pollEntry
method which returns an entry object that bundles any associated extra
header metadata with the data entry.

Add generic support for the extra header metadata so that the update
method and the Entry instance consumes and returns a specified type.

Use a builder to create a PersistentBinaryDeque instead of adding more
constructors with different optional arguments.