### PR TITLE
Eng 15885 filter stale acks

### DIFF
--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -70,13 +70,12 @@ namespace voltdb {
     }
 
     void DummyTopend::pushExportBuffer(int32_t partitionId, std::string signature,
-            ExportStreamBlock *block, int64_t generationId) {
+            ExportStreamBlock *block) {
         if (!block) {
             return;
         }
         partitionIds.push(partitionId);
         signatures.push(signature);
-        generationIds.push(generationId);
         exportBlocks.push_back(boost::shared_ptr<ExportStreamBlock>(new ExportStreamBlock(block)));
         data.push_back(boost::shared_array<char>(block->rawPtr()));
         receivedExportBuffer = true;

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -67,8 +67,7 @@ class Topend {
     virtual void pushExportBuffer(
             int32_t partitionId,
             std::string tableName,
-            ExportStreamBlock *block,
-            int64_t generationId) = 0;
+            ExportStreamBlock *block) = 0;
     // Not used right now and will be removed or altered after a decision has been made on how Schema changes
     // are managed (they really don't belong in row buffers).
     virtual void pushEndOfStream(
@@ -136,7 +135,7 @@ public:
     void crashVoltDB(voltdb::FatalException e);
 
     int64_t getFlushedExportBytes(int32_t partitionId);
-    virtual void pushExportBuffer(int32_t partitionId, std::string signature, ExportStreamBlock *block, int64_t generationId);
+    virtual void pushExportBuffer(int32_t partitionId, std::string signature, ExportStreamBlock *block);
     virtual void pushEndOfStream(int32_t partitionId, std::string signature);
 
     int64_t pushDRBuffer(int32_t partitionId, DrStreamBlock *block);
@@ -164,7 +163,6 @@ public:
 
     std::queue<int32_t> partitionIds;
     std::queue<std::string> signatures;
-    std::queue<int64_t> generationIds;
     std::deque<boost::shared_ptr<DrStreamBlock> > drBlocks;
     std::deque<boost::shared_ptr<ExportStreamBlock> > exportBlocks;
     std::deque<boost::shared_array<char> > data;

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -160,7 +160,7 @@ JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecuti
     m_pushExportBufferMID = m_jniEnv->GetStaticMethodID(
             m_exportManagerClass,
             "pushExportBuffer",
-            "(ILjava/lang/String;JJJJJJLjava/nio/ByteBuffer;)V");
+            "(ILjava/lang/String;JJJJJLjava/nio/ByteBuffer;)V");
     if (m_pushExportBufferMID == NULL) {
         m_jniEnv->ExceptionDescribe();
         assert(m_pushExportBufferMID != NULL);
@@ -536,8 +536,7 @@ JNITopend::~JNITopend() {
 void JNITopend::pushExportBuffer(
         int32_t partitionId,
         string tableName,
-        ExportStreamBlock *block,
-        int64_t generationId) {
+        ExportStreamBlock *block) {
     jstring tableNameString = m_jniEnv->NewStringUTF(tableName.c_str());
 
     if (block != NULL) {
@@ -555,7 +554,6 @@ void JNITopend::pushExportBuffer(
                 block->getCommittedSequenceNumber(),
                 block->getRowCount(),
                 block->lastSpUniqueId(),
-                generationId,
                 reinterpret_cast<jlong>(block->rawPtr()),
                 buffer);
         m_jniEnv->DeleteLocalRef(buffer);
@@ -569,7 +567,6 @@ void JNITopend::pushExportBuffer(
                 static_cast<int64_t>(0),
                 static_cast<int64_t>(0),
                 static_cast<int64_t>(0),
-                generationId,
                 NULL,
                 NULL);
     }

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -48,8 +48,7 @@ public:
     void pushExportBuffer(
             int32_t partitionId,
             std::string signature,
-            ExportStreamBlock *block,
-            int64_t generationId);
+            ExportStreamBlock *block);
     void pushEndOfStream(
             int32_t partitionId,
             std::string signature);

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -493,15 +493,16 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         /**
          * Perform an action on behalf of Export.
          *
-         * @param if syncAction is true, the stream offset being set for a table
-         * @param the reference to the USO of the next row inserted in the stream
-         * @param the reference to the sequenceNumber of the next inserted row
-         * @param the name of the stream we want to update the state for
+         * @param syncAction if syncAction is true, the stream offset being set for a table
+         * @param ackOffset the reference to the USO of the next row inserted in the stream
+         * @param seqNo the reference to the sequenceNumber of the next inserted row
+         * @param generationIdCreated the reference to the initial creation generation ID of the export stream
+         * @param streamName the name of the stream we want to update the state for
          * @return the universal offset for any poll results
          * (results returned separately via QueryResults buffer)
          */
         int64_t exportAction(bool syncAction, int64_t ackOffset, int64_t seqNo,
-                             std::string streamName);
+                             int64_t generationIdCreated, std::string streamName);
 
         /**
          * Complete the deletion of the Migrated Table rows.
@@ -518,7 +519,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         int32_t deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_t uniqueId,
                 std::string tableName, int64_t deletableTxnId, int32_t maxRowCount, int64_t undoToken);
 
-        void getUSOForExportTable(size_t& ackOffset, int64_t& seqNo, std::string streamName);
+        void getUSOForExportTable(size_t& ackOffset, int64_t& seqNo, int64_t &genId, std::string streamName);
 
         /**
          * Retrieve a hash code for the specified table

--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -48,7 +48,7 @@ public:
     virtual ~ExportTupleStream() {
     }
 
-    void setGeneration(int64_t generation);
+    void setGenerationIdCreated(int64_t generation);
 
     /** Read the total bytes used over the life of the stream */
     size_t bytesUsed() {
@@ -57,6 +57,10 @@ public:
 
     int64_t getSequenceNumber() {
         return m_nextSequenceNumber;
+    }
+
+    int64_t getGenerationIdCreated() {
+        return m_generationIdCreated;
     }
 
     /** Set the total number of bytes used and starting sequence number for new buffer (for rejoin/recover) */
@@ -150,7 +154,8 @@ private:
     const CatalogId m_partitionId;
     const int64_t m_siteId;
 
-    int64_t m_generation;
+    // The creation timestamp of export stream, this value should weather recovers and rejoins
+    int64_t m_generationIdCreated;
     const std::string m_tableName;
 
     int64_t m_nextSequenceNumber;

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -211,15 +211,6 @@ void StreamedTable::flushOldTuples(int64_t timeInMillis) {
     }
 }
 
-/**
- * Inform the tuple stream wrapper of the table's delegate id
- */
-void StreamedTable::setGeneration(int64_t generation) {
-    if (m_wrapper) {
-        m_wrapper->setGeneration(generation);
-    }
-}
-
 void StreamedTable::undo(size_t mark, int64_t seqNo) {
     if (m_wrapper) {
         assert(seqNo == m_sequenceNo);
@@ -253,10 +244,11 @@ int64_t StreamedTable::allocatedTupleMemory() const {
  * Get the current offset in bytes of the export stream for this Table
  * since startup.
  */
-void StreamedTable::getExportStreamPositions(int64_t &seqNo, size_t &streamBytesUsed) {
+void StreamedTable::getExportStreamPositions(int64_t &seqNo, size_t &streamBytesUsed, int64_t &genIdCreated) {
     seqNo = m_sequenceNo;
     if (m_wrapper) {
         streamBytesUsed = m_wrapper->bytesUsed();
+        genIdCreated = m_wrapper->getGenerationIdCreated();
     }
 }
 
@@ -264,11 +256,12 @@ void StreamedTable::getExportStreamPositions(int64_t &seqNo, size_t &streamBytes
  * Set the current offset in bytes of the export stream for this Table
  * since startup (used for rejoin/recovery).
  */
-void StreamedTable::setExportStreamPositions(int64_t seqNo, size_t streamBytesUsed) {
+void StreamedTable::setExportStreamPositions(int64_t seqNo, size_t streamBytesUsed, int64_t generationIdCreated) {
     // assume this only gets called from a fresh rejoined node or after the reset of a wrapper
     assert(m_sequenceNo == 0 || seqNo == 0);
     m_sequenceNo = seqNo;
     if (m_wrapper) {
         m_wrapper->setBytesUsed(seqNo, streamBytesUsed);
+        m_wrapper->setGenerationIdCreated(generationIdCreated);
     }
 }

--- a/src/ee/storage/streamedtable.h
+++ b/src/ee/storage/streamedtable.h
@@ -114,13 +114,13 @@ public:
      * Get the current offset in bytes of the export stream for this Table
      * since startup.
      */
-    void getExportStreamPositions(int64_t &seqNo, size_t &streamBytesUsed);
+    void getExportStreamPositions(int64_t &seqNo, size_t &streamBytesUsed, int64_t &genId);
 
     /**
      * Set the current offset in bytes of the export stream for this Table
      * since startup (used for rejoin/recovery).
      */
-    void setExportStreamPositions(int64_t seqNo, size_t streamBytesUsed);
+    void setExportStreamPositions(int64_t seqNo, size_t streamBytesUsed, int64_t generationIdCreated);
 
     int partitionColumn() const { return m_partitionColumn; }
 

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -233,7 +233,7 @@ class Table {
      * Set the current offset in bytes of the export stream for this Table
      * since startup (used for rejoin/recovery).
      */
-    virtual void setExportStreamPositions(int64_t seqNo, size_t streamBytesUsed) {
+    virtual void setExportStreamPositions(int64_t seqNo, size_t streamBytesUsed, int64_t generationIdCreated) {
         // this should be overidden by any table involved in an export
         assert(false);
     }
@@ -242,7 +242,7 @@ class Table {
      * Get the current offset in bytes of the export stream for this Table
      * since startup (used for rejoin/recovery).
      */
-    virtual void getExportStreamPositions(int64_t& seqNo, size_t& streamBytesUsed) {
+    virtual void getExportStreamPositions(int64_t& seqNo, size_t& streamBytesUsed, int64_t &genId) {
         // this should be overidden by any table involved in an export
         assert(false);
     }

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -144,7 +144,7 @@ public:
     void terminate();
 
     int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);
-    void pushExportBuffer(int32_t partitionId, std::string signature, voltdb::ExportStreamBlock *block, int64_t generationId);
+    void pushExportBuffer(int32_t partitionId, std::string signature, voltdb::ExportStreamBlock *block);
     void pushEndOfStream(int32_t partitionId, std::string signature);
 
     int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, voltdb::DRRecordType action,
@@ -359,6 +359,7 @@ typedef struct {
     int32_t isSync;
     int64_t offset;
     int64_t seqNo;
+    int64_t genId;
     int32_t tableSignatureLength;
     char tableSignature[0];
 }__attribute__((packed)) export_action;
@@ -1520,6 +1521,7 @@ void VoltDBIPC::exportAction(struct ipc_command *cmd) {
     int64_t result = m_engine->exportAction(action->isSync,
                                             static_cast<int64_t>(ntohll(action->offset)),
                                             static_cast<int64_t>(ntohll(action->seqNo)),
+                                            static_cast<int64_t>(ntohll(action->genId)),
                                             tableSignature);
 
     // write offset across bigendian.
@@ -1553,7 +1555,8 @@ void VoltDBIPC::getUSOForExportTable(struct ipc_command *cmd) {
 
     size_t ackOffset;
     int64_t seqNo;
-    m_engine->getUSOForExportTable(ackOffset, seqNo, streamNameStr);
+    int64_t genId;
+    m_engine->getUSOForExportTable(ackOffset, seqNo, genId, streamNameStr);
 
     // write offset across bigendian.
     int64_t ackOffsetI64 = static_cast<int64_t>(ackOffset);
@@ -1563,6 +1566,9 @@ void VoltDBIPC::getUSOForExportTable(struct ipc_command *cmd) {
     // write the poll data. It is at least 4 bytes of length prefix.
     seqNo = htonll(seqNo);
     writeOrDie(m_fd, (unsigned char*)&seqNo, sizeof(seqNo));
+
+    genId = htonll(genId);
+    writeOrDie(m_fd, (unsigned char*)&genId, sizeof(genId));
 }
 
 void VoltDBIPC::hashinate(struct ipc_command* cmd) {
@@ -1641,8 +1647,7 @@ void VoltDBIPC::threadLocalPoolAllocations() {
 void VoltDBIPC::pushExportBuffer(
         int32_t partitionId,
         std::string signature,
-        voltdb::ExportStreamBlock *block,
-        int64_t generationId) {
+        voltdb::ExportStreamBlock *block) {
     int32_t index = 0;
     m_reusedResultBuffer[index++] = kErrorCode_pushExportBuffer;
     *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonl(partitionId);
@@ -1663,7 +1668,6 @@ void VoltDBIPC::pushExportBuffer(
         *reinterpret_cast<int64_t*>(&m_reusedResultBuffer[index+24]) = 0;
     }
     index += 32;
-    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonll(generationId);
     if (block != NULL) {
         *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonl(block->rawLength());
         writeOrDie(m_fd, (unsigned char*)m_reusedResultBuffer, index + 4);

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1125,6 +1125,7 @@ SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExpo
    jboolean syncAction,
    jlong ackOffset,
    jlong seqNo,
+   jlong genId,
    jbyteArray streamName) {
     VOLT_DEBUG("nativeExportAction in C++ called");
     VoltDBEngine *engine = castToEngine(engine_ptr);
@@ -1138,6 +1139,7 @@ SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExpo
             return engine->exportAction(syncAction,
                                         static_cast<int64_t>(ackOffset),
                                         static_cast<int64_t>(seqNo),
+                                        static_cast<int64_t>(genId),
                                         streamNameStr);
         } catch (const SQLException &e) {
             throwFatalException("%s", e.message().c_str());
@@ -1207,14 +1209,16 @@ SHAREDLIB_JNIEXPORT jlongArray JNICALL Java_org_voltdb_jni_ExecutionEngine_nativ
     std::string streamNameStr(reinterpret_cast<char *>(streamNameChars), env->GetArrayLength(streamName));
     env->ReleaseByteArrayElements(streamName, streamNameChars, JNI_ABORT);
     try {
-        jlong data[2];
+        jlong data[3];
         size_t ackOffset;
         int64_t seqNo;
-        engine->getUSOForExportTable(ackOffset, seqNo, streamNameStr);
+        int64_t generationId;
+        engine->getUSOForExportTable(ackOffset, seqNo, generationId, streamNameStr);
         data[0] = ackOffset;
         data[1] = seqNo;
-        jlongArray retval = env->NewLongArray(2);
-        env->SetLongArrayRegion(retval, 0, 2, data);
+        data[2] = generationId;
+        jlongArray retval = env->NewLongArray(3);
+        env->SetLongArrayRegion(retval, 0, 3, data);
         return retval;
     }
     catch (const FatalException &e) {

--- a/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
+++ b/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
@@ -30,21 +30,44 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltcore.logging.VoltLogger;
-import org.voltcore.utils.Pair;
 import org.voltdb.DRConsumerDrIdTracker.DRSiteDrIdTracker;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.iv2.MpInitiator;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 
 public class ExtensibleSnapshotDigestData {
-    //JSON property names for export values stored in the snapshot json
-    public static final String EXPORT_SEQUENCE_NUMBER_ARR = "exportSequenceNumbers";
-    public static final String EXPORT_TABLE_NAME = "exportTableName";
-    public static final String SEQUENCE_NUM_PER_PARTITION = "sequenceNumberPerPartition";
-    public static final String PARTITION = "partition";
+    /*
+     * WARNNING: DON'T change the following JSON property names for snapshot backward-compatibility,
+     *           adding new property is allowed.
+     */
+
+    // Export
+    //JSON property names for export values stored in the snapshot json digest
+    public static final String EXPORT_PARTITION = "partition";
     public static final String EXPORT_SEQUENCE_NUMBER = "exportSequenceNumber";
     public static final String EXPORT_USO = "exportUso";
+    public static final String EXPORT_GENERATION_ID = "exportGenerationId";
+    public static final String EXPORT_SEQUENCE_NUMBER_ARR = "exportSequenceNumbers";
+    public static final String EXPORT_TABLE_NAME = "exportTableName";
+    public static final String EXPORT_SEQUENCE_NUM_PER_PARTITION = "sequenceNumberPerPartition";
+    public static final String EXPORT_DISABLED_EXTERNAL_STREAMS = "disabledExternalStreams";
+    public static final String EXPORT_MERGED_USO = "ackOffset";
+    public static final String EXPORT_MERGED_SEQNO = "sequenceNumber";
+    public static final String EXPORT_MERGED_GENERATION_ID = "generationId";
 
-    public static final String DISABLED_EXTERNAL_STREAMS = "disabledExternalStreams";
+    // DR
+    // JSON property names for export values stored in the snapshot json digest
+    public static final String DR_VERSION = "drVersion";
+    public static final String DR_TUPLE_STREAM_STATE_INFO = "drTupleStreamStateInfo";
+    public static final String DR_ID = "sequenceNumber";
+    public static final String DR_CLUSTER_CREATION_TIME = "clusterCreateTime";
+    public static final String DR_SP_UNIQUE_ID = "spUniqueId";
+    public static final String DR_MP_UNIQUE_ID = "mpUniqueId";
+    public static final String DR_MIXED_CLUSTER_SIZE_CONSUMER_STATE = "drMixedClusterSizeConsumerState";
+
+    //////////////////////////////////////////////////////////////
+    // Make sure you've seen the warning at beginning of the class.
+    //////////////////////////////////////////////////////////////
 
     /**
      * This field is the same values as m_exportSequenceNumbers once they have been extracted
@@ -53,7 +76,7 @@ public class ExtensibleSnapshotDigestData {
      * m_exportSequenceNumbers and kept until the next snapshot is started in which case they are repopulated.
      * Decoupling them seems like a good idea in case snapshot code is every re-organized.
      */
-    private final Map<String, Map<Integer, Pair<Long, Long>>> m_exportSequenceNumbers;
+    private final Map<String, Map<Integer, ExportSnapshotTuple>> m_exportSequenceNumbers;
 
     /**
      * Same as m_exportSequenceNumbersToLogOnCompletion, but for m_drTupleStreamInfo
@@ -81,7 +104,7 @@ public class ExtensibleSnapshotDigestData {
     private final JSONObject m_elasticOperationMetadata;
 
     public ExtensibleSnapshotDigestData(
-            Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
+            Map<String, Map<Integer, ExportSnapshotTuple>> exportSequenceNumbers,
             Map<Integer, TupleStreamStateInfo> drTupleStreamInfo,
             Map<Integer, JSONObject> drMixedClusterSizeConsumerState,
             JSONObject elasticOperationMetadata, final JSONObject jsData) {
@@ -98,16 +121,17 @@ public class ExtensibleSnapshotDigestData {
 
     private void writeExportSequencesToSnapshot(JSONStringer stringer) throws JSONException {
             stringer.key(EXPORT_SEQUENCE_NUMBER_ARR).array();
-            for (Map.Entry<String, Map<Integer, Pair<Long, Long>>> entry : m_exportSequenceNumbers.entrySet()) {
+            for (Map.Entry<String, Map<Integer, ExportSnapshotTuple>> entry : m_exportSequenceNumbers.entrySet()) {
                 stringer.object();
 
                 stringer.keySymbolValuePair(EXPORT_TABLE_NAME, entry.getKey());
-                stringer.key(SEQUENCE_NUM_PER_PARTITION).array();
-                for (Map.Entry<Integer, Pair<Long,Long>> sequenceNumber : entry.getValue().entrySet()) {
+                stringer.key(EXPORT_SEQUENCE_NUM_PER_PARTITION).array();
+                for (Map.Entry<Integer, ExportSnapshotTuple> sequenceNumber : entry.getValue().entrySet()) {
                     stringer.object();
-                    stringer.keySymbolValuePair(PARTITION, sequenceNumber.getKey());
-                    stringer.keySymbolValuePair(EXPORT_USO, sequenceNumber.getValue().getFirst());
-                    stringer.keySymbolValuePair(EXPORT_SEQUENCE_NUMBER, sequenceNumber.getValue().getSecond());
+                    stringer.keySymbolValuePair(EXPORT_PARTITION, sequenceNumber.getKey());
+                    stringer.keySymbolValuePair(EXPORT_USO, sequenceNumber.getValue().getAckOffset());
+                    stringer.keySymbolValuePair(EXPORT_SEQUENCE_NUMBER, sequenceNumber.getValue().getSequenceNumber());
+                    stringer.keySymbolValuePair(EXPORT_GENERATION_ID, sequenceNumber.getValue().getGenerationId());
                     stringer.endObject();
                 }
                 stringer.endArray();
@@ -131,7 +155,7 @@ public class ExtensibleSnapshotDigestData {
             jsonObj.put(EXPORT_SEQUENCE_NUMBER_ARR, tableSequenceMap);
         }
 
-        for (Map.Entry<String, Map<Integer, Pair<Long, Long>>> tableEntry : m_exportSequenceNumbers.entrySet()) {
+        for (Map.Entry<String, Map<Integer, ExportSnapshotTuple>> tableEntry : m_exportSequenceNumbers.entrySet()) {
             JSONObject sequenceNumbers;
             final String tableName = tableEntry.getKey();
             if (tableSequenceMap.has(tableName)) {
@@ -141,11 +165,12 @@ public class ExtensibleSnapshotDigestData {
                 tableSequenceMap.put(tableName, sequenceNumbers);
             }
 
-            for (Map.Entry<Integer, Pair<Long, Long>> partitionEntry : tableEntry.getValue().entrySet()) {
+            for (Map.Entry<Integer, ExportSnapshotTuple> partitionEntry : tableEntry.getValue().entrySet()) {
                 final Integer partitionId = partitionEntry.getKey();
                 final String partitionIdString = partitionId.toString();
-                final Long ackOffset = partitionEntry.getValue().getFirst();
-                final Long partitionSequenceNumber = partitionEntry.getValue().getSecond();
+                final Long ackOffset = partitionEntry.getValue().getAckOffset();
+                final Long partitionSequenceNumber = partitionEntry.getValue().getSequenceNumber();
+                final Long generationId = partitionEntry.getValue().getGenerationId();
 
                 /*
                  * Check that the sequence number is the same everywhere and log if it isn't.
@@ -153,7 +178,7 @@ public class ExtensibleSnapshotDigestData {
                  */
                 if (sequenceNumbers.has(partitionIdString)) {
                     JSONObject existingEntry = sequenceNumbers.getJSONObject(partitionIdString);
-                    Long existingSequenceNumber = existingEntry.getLong("sequenceNumber");
+                    Long existingSequenceNumber = existingEntry.getLong(EXPORT_MERGED_SEQNO);
                     if (!existingSequenceNumber.equals(partitionSequenceNumber)) {
                         log.debug("Found a mismatch in export sequence numbers of export table " + tableName +
                                 " while recording snapshot metadata for partition " + partitionId +
@@ -162,12 +187,15 @@ public class ExtensibleSnapshotDigestData {
                     }
                     existingEntry.put(partitionIdString, Math.max(existingSequenceNumber, partitionSequenceNumber));
 
-                    Long existingAckOffset = existingEntry.getLong("ackOffset");
-                    existingEntry.put("ackOffset", Math.max(ackOffset, existingAckOffset));
+                    Long existingAckOffset = existingEntry.getLong(EXPORT_MERGED_USO);
+                    existingEntry.put(EXPORT_MERGED_USO, Math.max(ackOffset, existingAckOffset));
+                    Long existingGenerationId = existingEntry.getLong(EXPORT_MERGED_GENERATION_ID);
+                    existingEntry.put(EXPORT_MERGED_GENERATION_ID, Math.max(generationId, existingGenerationId));
                 } else {
                     JSONObject newObj = new JSONObject();
-                    newObj.put("sequenceNumber", partitionSequenceNumber);
-                    newObj.put("ackOffset", ackOffset);
+                    newObj.put(EXPORT_MERGED_SEQNO, partitionSequenceNumber);
+                    newObj.put(EXPORT_MERGED_USO, ackOffset);
+                    newObj.put(EXPORT_MERGED_GENERATION_ID, generationId);
                     sequenceNumbers.put(partitionIdString, newObj);
                 }
             }
@@ -177,14 +205,14 @@ public class ExtensibleSnapshotDigestData {
     private void mergeExternalStreamStatesToZK(JSONObject jsonObj, VoltLogger log) throws JSONException {
         JSONArray jsonPartitions;
         Set<Integer> disabledStreamsInJson = new HashSet<>();
-        if (jsonObj.has(DISABLED_EXTERNAL_STREAMS)) {
-            jsonPartitions = jsonObj.getJSONArray(DISABLED_EXTERNAL_STREAMS);
+        if (jsonObj.has(EXPORT_DISABLED_EXTERNAL_STREAMS)) {
+            jsonPartitions = jsonObj.getJSONArray(EXPORT_DISABLED_EXTERNAL_STREAMS);
             for (int i=0; i<jsonPartitions.length(); i++) {
                 disabledStreamsInJson.add(jsonPartitions.getInt(i));
             }
         } else {
             jsonPartitions = new JSONArray();
-            jsonObj.put(DISABLED_EXTERNAL_STREAMS, jsonPartitions);
+            jsonObj.put(EXPORT_DISABLED_EXTERNAL_STREAMS, jsonPartitions);
         }
 
         for (Integer partition : m_disabledExternalStreams) {
@@ -201,19 +229,19 @@ public class ExtensibleSnapshotDigestData {
     }
 
     private void writeDRTupleStreamInfoToSnapshot(JSONStringer stringer) throws JSONException {
-        stringer.key("drTupleStreamStateInfo");
+        stringer.key(DR_TUPLE_STREAM_STATE_INFO);
         stringer.object();
         for (Map.Entry<Integer, TupleStreamStateInfo> e : m_drTupleStreamInfo.entrySet()) {
             stringer.key(e.getKey().toString());
             stringer.object();
             if (e.getKey() != MpInitiator.MP_INIT_PID) {
-                stringer.keySymbolValuePair("sequenceNumber", e.getValue().partitionInfo.drId);
-                stringer.keySymbolValuePair("spUniqueId", e.getValue().partitionInfo.spUniqueId);
-                stringer.keySymbolValuePair("mpUniqueId", e.getValue().partitionInfo.mpUniqueId);
+                stringer.keySymbolValuePair(DR_ID, e.getValue().partitionInfo.drId);
+                stringer.keySymbolValuePair(DR_SP_UNIQUE_ID, e.getValue().partitionInfo.spUniqueId);
+                stringer.keySymbolValuePair(DR_MP_UNIQUE_ID, e.getValue().partitionInfo.mpUniqueId);
             } else {
-                stringer.keySymbolValuePair("sequenceNumber", e.getValue().replicatedInfo.drId);
-                stringer.keySymbolValuePair("spUniqueId", e.getValue().replicatedInfo.spUniqueId);
-                stringer.keySymbolValuePair("mpUniqueId", e.getValue().replicatedInfo.mpUniqueId);
+                stringer.keySymbolValuePair(DR_ID, e.getValue().replicatedInfo.drId);
+                stringer.keySymbolValuePair(DR_SP_UNIQUE_ID, e.getValue().replicatedInfo.spUniqueId);
+                stringer.keySymbolValuePair(DR_MP_UNIQUE_ID, e.getValue().replicatedInfo.mpUniqueId);
             }
             stringer.endObject();
         }
@@ -224,13 +252,13 @@ public class ExtensibleSnapshotDigestData {
         JSONObject stateInfoMap;
         // clusterCreateTime should be same across the cluster
         long clusterCreateTime = VoltDB.instance().getClusterCreateTime();
-        assert (!jsonObj.has("clusterCreateTime") || (clusterCreateTime == jsonObj.getLong("clusterCreateTime")));
-        jsonObj.put("clusterCreateTime", clusterCreateTime);
-        if (jsonObj.has("drTupleStreamStateInfo")) {
-            stateInfoMap = jsonObj.getJSONObject("drTupleStreamStateInfo");
+        assert (!jsonObj.has(DR_CLUSTER_CREATION_TIME) || (clusterCreateTime == jsonObj.getLong(DR_CLUSTER_CREATION_TIME)));
+        jsonObj.put(DR_CLUSTER_CREATION_TIME, clusterCreateTime);
+        if (jsonObj.has(DR_TUPLE_STREAM_STATE_INFO)) {
+            stateInfoMap = jsonObj.getJSONObject(DR_TUPLE_STREAM_STATE_INFO);
         } else {
             stateInfoMap = new JSONObject();
-            jsonObj.put("drTupleStreamStateInfo", stateInfoMap);
+            jsonObj.put(DR_TUPLE_STREAM_STATE_INFO, stateInfoMap);
         }
 
         for (Map.Entry<Integer, TupleStreamStateInfo> e : m_drTupleStreamInfo.entrySet()) {
@@ -246,22 +274,22 @@ public class ExtensibleSnapshotDigestData {
             if (existingStateInfo == null) {
                 addEntry = true;
             }
-            else if (partitionStateInfo.drId != existingStateInfo.getLong("sequenceNumber")) {
-                if (partitionStateInfo.drId > existingStateInfo.getLong("sequenceNumber")) {
+            else if (partitionStateInfo.drId != existingStateInfo.getLong(DR_ID)) {
+                if (partitionStateInfo.drId > existingStateInfo.getLong(DR_ID)) {
                     addEntry = true;
                 }
                 log.debug("Found a mismatch in dr sequence numbers for partition " + partitionId +
                         " the DRId should be the same at all replicas, but one node had " +
-                        DRLogSegmentId.getDebugStringFromDRId(existingStateInfo.getLong("sequenceNumber")) +
+                        DRLogSegmentId.getDebugStringFromDRId(existingStateInfo.getLong(DR_ID)) +
                         " and the local node reported " + DRLogSegmentId.getDebugStringFromDRId(partitionStateInfo.drId));
             }
 
             if (addEntry) {
                 JSONObject stateInfo = new JSONObject();
-                stateInfo.put("sequenceNumber", partitionStateInfo.drId);
-                stateInfo.put("spUniqueId", partitionStateInfo.spUniqueId);
-                stateInfo.put("mpUniqueId", partitionStateInfo.mpUniqueId);
-                stateInfo.put("drVersion", e.getValue().drVersion);
+                stateInfo.put(DR_ID, partitionStateInfo.drId);
+                stateInfo.put(DR_SP_UNIQUE_ID, partitionStateInfo.spUniqueId);
+                stateInfo.put(DR_MP_UNIQUE_ID, partitionStateInfo.mpUniqueId);
+                stateInfo.put(DR_VERSION, e.getValue().drVersion);
                 stateInfoMap.put(partitionId, stateInfo);
             }
         }
@@ -314,11 +342,11 @@ public class ExtensibleSnapshotDigestData {
         //DR ids/unique ids for remote partitions indexed by remote datacenter id,
         //each DC has a full partition set
         JSONObject dcIdMap;
-        if (jsonObj.has("drMixedClusterSizeConsumerState")) {
-            dcIdMap = jsonObj.getJSONObject("drMixedClusterSizeConsumerState");
+        if (jsonObj.has(DR_MIXED_CLUSTER_SIZE_CONSUMER_STATE)) {
+            dcIdMap = jsonObj.getJSONObject(DR_MIXED_CLUSTER_SIZE_CONSUMER_STATE);
         } else {
             dcIdMap = new JSONObject();
-            jsonObj.put("drMixedClusterSizeConsumerState", dcIdMap);
+            jsonObj.put(DR_MIXED_CLUSTER_SIZE_CONSUMER_STATE, dcIdMap);
         }
 
         for (Map.Entry<Integer, JSONObject> dcEntry : m_drMixedClusterSizeConsumerState.entrySet()) {
@@ -332,14 +360,14 @@ public class ExtensibleSnapshotDigestData {
 
     private void writeDRStateToSnapshot(JSONStringer stringer) throws JSONException {
         long clusterCreateTime = VoltDB.instance().getClusterCreateTime();
-        stringer.keySymbolValuePair("clusterCreateTime", clusterCreateTime);
+        stringer.keySymbolValuePair(DR_CLUSTER_CREATION_TIME, clusterCreateTime);
 
         Iterator<Entry<Integer, TupleStreamStateInfo>> iter = m_drTupleStreamInfo.entrySet().iterator();
         if (iter.hasNext()) {
-            stringer.keySymbolValuePair("drVersion", iter.next().getValue().drVersion);
+            stringer.keySymbolValuePair(DR_VERSION, iter.next().getValue().drVersion);
         }
         writeDRTupleStreamInfoToSnapshot(stringer);
-        stringer.key("drMixedClusterSizeConsumerState");
+        stringer.key(DR_MIXED_CLUSTER_SIZE_CONSUMER_STATE);
         stringer.object();
         for (Entry<Integer, JSONObject> e : m_drMixedClusterSizeConsumerState.entrySet()) {
             stringer.key(e.getKey().toString()); // Consumer partitionId
@@ -363,7 +391,7 @@ public class ExtensibleSnapshotDigestData {
      * Writes external streams state for partitions into snapshot digest.
      */
     private void writeExternalStreamStates(JSONStringer stringer) throws JSONException {
-            stringer.key(DISABLED_EXTERNAL_STREAMS).array();
+            stringer.key(EXPORT_DISABLED_EXTERNAL_STREAMS).array();
             for (int partition : m_disabledExternalStreams) {
                 stringer.value(partition);
             }

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -23,8 +23,8 @@ import java.util.concurrent.Future;
 
 import javax.annotation_voltpatches.Nullable;
 
-import org.voltcore.utils.Pair;
 import org.voltdb.DRConsumerDrIdTracker.DRSiteDrIdTracker;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.VoltProcedure.VoltAbortException;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.Table;
@@ -215,7 +215,7 @@ public interface SiteProcedureConnection {
      */
     public void setRejoinComplete(
             JoinProducerBase.JoinCompletionAction action,
-            Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
+            Map<String, Map<Integer, ExportSnapshotTuple>> exportSequenceNumbers,
             Map<Integer, Long> drSequenceNumbers,
             Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,
             boolean requireExistingSequenceNumbers,
@@ -234,8 +234,7 @@ public interface SiteProcedureConnection {
     public void quiesce();
 
     public void exportAction(boolean syncAction,
-                             long uso,
-                             Long sequenceNumber,
+                             ExportSnapshotTuple sequences,
                              Integer partitionId,
                              String tableSignature);
 

--- a/src/frontend/org/voltdb/SnapshotCompletionInterest.java
+++ b/src/frontend/org/voltdb/SnapshotCompletionInterest.java
@@ -20,8 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
-import org.voltcore.utils.Pair;
 import org.voltdb.DRConsumerDrIdTracker.DRSiteDrIdTracker;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.sysprocs.saverestore.SnapshotPathType;
 
 public interface SnapshotCompletionInterest {
@@ -36,7 +36,7 @@ public interface SnapshotCompletionInterest {
         public final boolean truncationSnapshot;
         public final boolean didSucceed;
         public final String requestId;
-        public final Map<String, Map<Integer, Pair<Long,Long>>> exportSequenceNumbers;
+        public final Map<String, Map<Integer, ExportSnapshotTuple>> exportSequenceNumbers;
         public final Map<Integer, Long> drSequenceNumbers;
         public final Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> drMixedClusterSizeConsumerState;
         public final int drVersion;
@@ -51,7 +51,7 @@ public interface SnapshotCompletionInterest {
                 final boolean truncationSnapshot,
                 final boolean didSucceed,
                 final String requestId,
-                final Map<String, Map<Integer, Pair<Long,Long>>> exportSequenceNumbers,
+                final Map<String, Map<Integer, ExportSnapshotTuple>> exportSequenceNumbers,
                 final Map<Integer, Long> drSequenceNumbers,
                 final Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> drMixedClusterSizeConsumerState,
                 final int drVersion,

--- a/src/frontend/org/voltdb/SnapshotCompletionMonitor.java
+++ b/src/frontend/org/voltdb/SnapshotCompletionMonitor.java
@@ -16,6 +16,10 @@
  */
 package org.voltdb;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -36,13 +40,12 @@ import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONObject;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
-import org.voltcore.utils.Pair;
 import org.voltdb.DRConsumerDrIdTracker.DRSiteDrIdTracker;
 import org.voltdb.SnapshotCompletionInterest.SnapshotCompletionEvent;
+import org.voltdb.sysprocs.saverestore.SnapshotPathType;
+import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 
 import com.google_voltpatches.common.collect.ImmutableMap;
-import org.voltdb.sysprocs.saverestore.SnapshotUtil;
-import org.voltdb.sysprocs.saverestore.SnapshotPathType;
 
 public class SnapshotCompletionMonitor {
     private static final VoltLogger SNAP_LOG = new VoltLogger("SNAPSHOT");
@@ -71,6 +74,52 @@ public class SnapshotCompletionMonitor {
             }
         }
     };
+
+    public static class ExportSnapshotTuple implements Serializable {
+        private long m_ackOffset;
+        private long m_sequenceNumber;
+        private long m_generationId;
+
+        public ExportSnapshotTuple(long uso, long seqNo, long timestamp) {
+            m_ackOffset = uso;
+            m_sequenceNumber = seqNo;
+            m_generationId = timestamp;
+        }
+
+        public ExportSnapshotTuple() {
+            this(0L, 0L, 0L);
+        }
+
+        public long getAckOffset() {
+            return m_ackOffset;
+        }
+
+        public long getSequenceNumber() {
+            return m_sequenceNumber;
+        }
+
+        public long getGenerationId() {
+            return m_generationId;
+        }
+
+        /**
+         * Serialize this {@code ExportSnapshotTuple} instance.
+         *
+         * @serialData The USO of export stream ({@code long}) (ack offset) and export sequence number ({@code long}) is emitted , followed by size of
+         * generation id ({@code long}) (timestamp of most recent catalog update in snapshot).
+         */
+         private void writeObject(ObjectOutputStream out) throws IOException {
+             out.writeLong(m_ackOffset);
+             out.writeLong(m_sequenceNumber);
+             out.writeLong(m_generationId);
+         }
+
+         private void readObject(ObjectInputStream in) throws IOException {
+             m_ackOffset = in.readLong();
+             m_sequenceNumber = in.readLong();
+             m_generationId = in.readLong();
+         }
+    }
 
     /*
      * For every snapshot, the local sites will log their partition specific txnids here
@@ -176,40 +225,41 @@ public class SnapshotCompletionMonitor {
              * Convert the JSON object containing the export sequence numbers for each
              * table and partition to a regular map
              */
-            Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers = null;
-            final JSONObject exportSequenceJSON = jsonObj.getJSONObject("exportSequenceNumbers");
-            final ImmutableMap.Builder<String, Map<Integer, Pair<Long, Long>>> builder =
+            Map<String, Map<Integer, ExportSnapshotTuple>> exportSequenceNumbers = null;
+            final JSONObject exportSequenceJSON = jsonObj.getJSONObject(ExtensibleSnapshotDigestData.EXPORT_SEQUENCE_NUMBER_ARR);
+            final ImmutableMap.Builder<String, Map<Integer, ExportSnapshotTuple>> builder =
                     ImmutableMap.builder();
             @SuppressWarnings("unchecked")
             final Iterator<String> tableKeys = exportSequenceJSON.keys();
             while (tableKeys.hasNext()) {
                 final String tableName = tableKeys.next();
                 final JSONObject tableSequenceNumbers = exportSequenceJSON.getJSONObject(tableName);
-                ImmutableMap.Builder<Integer, Pair<Long, Long>> tableBuilder = ImmutableMap.builder();
+                ImmutableMap.Builder<Integer, ExportSnapshotTuple> tableBuilder = ImmutableMap.builder();
                 @SuppressWarnings("unchecked")
                 final Iterator<String> partitionKeys = tableSequenceNumbers.keys();
                 while (partitionKeys.hasNext()) {
                     final String partitionString = partitionKeys.next();
                     final Integer partitionId = Integer.valueOf(partitionString);
                     JSONObject sequenceNumbers = tableSequenceNumbers.getJSONObject(partitionString);
-                    final Long ackOffset = sequenceNumbers.getLong("ackOffset");
-                    final Long sequenceNumber = sequenceNumbers.getLong("sequenceNumber");
-                    tableBuilder.put(partitionId, Pair.of(ackOffset, sequenceNumber));
+                    final Long ackOffset = sequenceNumbers.getLong(ExtensibleSnapshotDigestData.EXPORT_MERGED_USO);
+                    final Long sequenceNumber = sequenceNumbers.getLong(ExtensibleSnapshotDigestData.EXPORT_MERGED_SEQNO);
+                    final Long generationId = sequenceNumbers.getLong(ExtensibleSnapshotDigestData.EXPORT_MERGED_GENERATION_ID);
+                    tableBuilder.put(partitionId, new ExportSnapshotTuple(ackOffset, sequenceNumber, generationId));
                 }
                 builder.put(tableName, tableBuilder.build());
             }
             exportSequenceNumbers = builder.build();
 
-            long clusterCreateTime = jsonObj.optLong("clusterCreateTime", -1);
+            long clusterCreateTime = jsonObj.optLong(ExtensibleSnapshotDigestData.DR_CLUSTER_CREATION_TIME, -1);
             Map<Integer, Long> drSequenceNumbers = new HashMap<>();
-            JSONObject drTupleStreamJSON = jsonObj.getJSONObject("drTupleStreamStateInfo");
+            JSONObject drTupleStreamJSON = jsonObj.getJSONObject(ExtensibleSnapshotDigestData.DR_TUPLE_STREAM_STATE_INFO);
             Iterator<String> partitionKeys = drTupleStreamJSON.keys();
             int drVersion = 0;
             while (partitionKeys.hasNext()) {
                 String partitionIdString = partitionKeys.next();
                 JSONObject stateInfo = drTupleStreamJSON.getJSONObject(partitionIdString);
-                drVersion = (int)stateInfo.getLong("drVersion");
-                drSequenceNumbers.put(Integer.valueOf(partitionIdString), stateInfo.getLong("sequenceNumber"));
+                drVersion = (int)stateInfo.getLong(ExtensibleSnapshotDigestData.DR_VERSION);
+                drSequenceNumbers.put(Integer.valueOf(partitionIdString), stateInfo.getLong(ExtensibleSnapshotDigestData.DR_ID));
             }
 
             Map<Integer, Long> partitionTxnIdsMap = ImmutableMap.of();
@@ -226,7 +276,7 @@ public class SnapshotCompletionMonitor {
              * data
              */
             Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> drMixedClusterSizeConsumerState = new HashMap<>();
-            JSONObject consumerPartitions = jsonObj.getJSONObject("drMixedClusterSizeConsumerState");
+            JSONObject consumerPartitions = jsonObj.getJSONObject(ExtensibleSnapshotDigestData.DR_MIXED_CLUSTER_SIZE_CONSUMER_STATE);
             Iterator<String> cpKeys = consumerPartitions.keys();
             while (cpKeys.hasNext()) {
                 final String consumerPartitionIdStr = cpKeys.next();

--- a/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
+++ b/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
@@ -59,6 +59,8 @@ public interface SystemProcedureExecutionContext {
 
     public int getCatalogVersion();
 
+    public long getGenerationId();
+
     public byte[] getCatalogHash();
 
     public byte[] getDeploymentHash();

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -100,7 +100,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     private final String m_tableName;
     private final byte [] m_signatureBytes;
     private final int m_partitionId;
-    private final int m_catalogVersionCreated;
 
     // For stats
     private final int m_siteId;
@@ -156,11 +155,12 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     // This flag is specifically added for XDCR conflicts stream, which export conflict logs
     // on every host. Every data source with this flag set to true is an export master.
     private boolean m_runEveryWhere = false;
-    // *Generation Id* is actually a timestamp generated during catalog update(UpdateApplicationBase.java)
-    // genId in this class represents the genId of the most recent pushed buffer. If a new buffer contains
-    // different genId than the previous value, the new buffer needs to be written to new PBD segment.
-    //
-    private long m_previousGenId;
+    // *Generation ID* is actually a timestamp generated during catalog update(UpdateApplicationBase.java)
+    // If a catalog update occurs, the generation ID will be updated and a new buffer needs to be
+    // written to new PBD segment.
+    private long m_generationId;
+    // This is the generation ID when the stream was initially created
+    private long m_generationIdCreated;
 
     private ExportSequenceNumberTracker m_gapTracker = new ExportSequenceNumberTracker();
 
@@ -233,9 +233,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             String overflowPath
             ) throws IOException
     {
-        m_previousGenId = genId;
         m_generation = generation;
-        m_catalogVersionCreated = m_generation == null ? 0 : m_generation.getCatalogVersion();
         m_format = ExportFormat.SEVENDOTX;
         m_database = db;
         m_tableName = tableName;
@@ -244,7 +242,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         m_committedBuffers = new StreamBlockQueue(overflowPath, nonce, m_tableName, partitionId);
         m_gapTracker = m_committedBuffers.scanForGap();
         // Pretend it's rejoin so we set first unpolled to a safe place
-        resetStateInRejoinOrRecover(0L, true);
+        resetStateInRejoinOrRecover(0L, genId, true);
 
         /*
          * This is not the catalog relativeIndex(). This ID incorporates
@@ -333,9 +331,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             List<Pair<Integer, Integer>> localPartitionsToSites,
             final ExportDataProcessor processor,
             final long genId) throws IOException {
-        m_previousGenId = genId;
         m_generation = generation;
-        m_catalogVersionCreated = m_generation == null ? 0 : m_generation.getCatalogVersion();
         m_adFile = adFile;
         String overflowPath = adFile.getParent();
         byte data[] = Files.toByteArray(adFile);
@@ -390,7 +386,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         m_gapTracker = m_committedBuffers.scanForGap();
 
         // Pretend it's rejoin so we set first unpolled to a safe place
-        resetStateInRejoinOrRecover(0L, true);
+        resetStateInRejoinOrRecover(0L, genId, true);
         if (exportLog.isDebugEnabled()) {
             exportLog.debug(toString() + " at AD file reads gap tracker from PBD:" + m_gapTracker.toString());
         }
@@ -453,12 +449,8 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         return m_isInCatalog;
     }
 
-    public int getCatalogVersionCreated() {
-        return m_catalogVersionCreated;
-    }
-
-    private int getGenerationCatalogVersion() {
-        return m_generation == null ? 0 : m_generation.getCatalogVersion();
+    public long getGenerationIdCreated() {
+        return m_generationIdCreated;
     }
 
     // Package private as only used for tests
@@ -726,7 +718,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             long committedSequenceNumber,
             int tupleCount,
             long uniqueId,
-            long genId,
             ByteBuffer buffer,
             boolean poll) throws Exception {
         long lastSequenceNumber = calcEndSequenceNumber(startSequenceNumber, tupleCount);
@@ -825,7 +816,6 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             final long committedSequenceNumber,
             final int tupleCount,
             final long uniqueId,
-            final long genId,
             final ByteBuffer buffer) {
         try {
             m_bufferPushPermits.acquire();
@@ -845,7 +835,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     try {
                         if (!m_closed) {
                             pushExportBufferImpl(startSequenceNumber, committedSequenceNumber,
-                                    tupleCount, uniqueId, genId, buffer, m_readyForPolling);
+                                    tupleCount, uniqueId, buffer, m_readyForPolling);
                         } else {
                             exportLogLimited.log("Closed: ignoring export buffer with " + tupleCount + " rows",
                                     EstTime.currentTimeMillis());
@@ -864,7 +854,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
     }
 
-    public ListenableFuture<?> truncateExportToSeqNo(boolean isRecover, boolean isRejoin, long sequenceNumber) {
+    public ListenableFuture<?> truncateExportToSeqNo(boolean isRecover, boolean isRejoin, long sequenceNumber, long generationId) {
         return m_es.submit(new Runnable() {
             @Override
             public void run() {
@@ -885,7 +875,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                         }
                     }
                     // Need to update pending tuples in rejoin
-                    resetStateInRejoinOrRecover(sequenceNumber, isRejoin);
+                    resetStateInRejoinOrRecover(sequenceNumber, generationId, isRejoin);
                     // Need to handle drained source if truncate emptied the buffers
                     // Note, this always happen before the first poll
                     handleDrainedSource(null);
@@ -1307,7 +1297,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         buf.putInt(m_signatureBytes.length);
         buf.put(m_signatureBytes);
         buf.putLong(m_committedSeqNo);
-        buf.putInt(getGenerationCatalogVersion());
+        buf.putLong(m_generationIdCreated);
 
         BinaryPayloadMessage bpm = new BinaryPayloadMessage(new byte[0], buf.array());
         return bpm;
@@ -1335,6 +1325,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             if (exportLog.isDebugEnabled()) {
                 exportLog.debug("Send RELEASE_BUFFER to " + toString()
                         + " with sequence number " + m_committedSeqNo
+                        + ", generation ID " + m_generationIdCreated
                         + " from " + CoreUtils.hsIdToString(mbx.getHSId())
                         + " to " + CoreUtils.hsIdCollectionToString(p.getSecond()));
             }
@@ -1368,6 +1359,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     if (exportLog.isDebugEnabled()) {
                         exportLog.debug("Send RELEASE_BUFFER to " + toString()
                                 + " with sequence number " + m_committedSeqNo
+                                + ", generation ID " + m_generationIdCreated
                                 + " from " + CoreUtils.hsIdToString(mbx.getHSId())
                                 + " to " + CoreUtils.hsIdCollectionToString(newReplicas));
                     }
@@ -1378,8 +1370,8 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
     private int getAckMessageLength() {
         // msg type(1) + partition:int(4) + length:int(4) +
-        // signaturesBytes.length + ackUSO:long(8) + catalogVersion:int(4).
-        final int msgLen = 1 + 4 + 4 + m_signatureBytes.length + 8 + 4;
+        // signaturesBytes.length + ackUSO:long(8) + genIdCreated:long(8).
+        final int msgLen = 1 + 4 + 4 + m_signatureBytes.length + 8 + 8;
         return msgLen;
     }
 
@@ -1567,7 +1559,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 .append(getTableName())
                 .append(" partition ")
                 .append(getPartitionId())
-                .append("(")
+                .append(" (")
                 .append(m_status)
                 ;
         if (m_coordinator != null) {
@@ -1584,9 +1576,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     // During rejoin it's possible that the stream is blocked by a gap before the export
     // sequence number carried by rejoin snapshot, so we couldn't trust the sequence number
     // in snapshot to find where to poll next buffer. The right thing to do should be setting
-    // the firstUnpolled to a safe point in case of releasing a gap prematurely, waits for
+    // the firstUnpolled to a safe point to avoid releasing a gap prematurely, waits for
     // current master to tell us where to poll next buffer.
-    private void resetStateInRejoinOrRecover(long initialSequenceNumber, boolean isRejoin) {
+    private void resetStateInRejoinOrRecover(long initialSequenceNumber, long genId, boolean isRejoin) {
         if (isRejoin) {
             if (!m_gapTracker.isEmpty()) {
                 m_lastReleasedSeqNo = Math.max(m_lastReleasedSeqNo, m_gapTracker.getFirstSeqNo() - 1);
@@ -1597,11 +1589,13 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         // Rejoin or recovery should be on a transaction boundary (except maybe in a gap situation)
         m_committedSeqNo = m_lastReleasedSeqNo;
         m_firstUnpolledSeqNo =  m_lastReleasedSeqNo + 1;
+        m_generationId = genId;
+        m_generationIdCreated = genId;
         m_tuplesPending.set(m_gapTracker.sizeInSequence());
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("Reset state in " + (isRejoin ? "REJOIN" : "RECOVER")
                     + ", initial seqNo " + initialSequenceNumber + ", last released/committed " + m_lastReleasedSeqNo
-                    + ", first unpolled " + m_firstUnpolledSeqNo);
+                    + ", first unpolled " + m_firstUnpolledSeqNo + ", generation ID " + genId);
         }
     }
 
@@ -1703,20 +1697,20 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
     public void updateCatalog(Table table, long genId) {
         // Skip unneeded catalog update
-        if (m_previousGenId >= genId || m_closed) {
+        if (m_generationId >= genId || m_closed) {
             return;
         }
         m_es.execute(new Runnable() {
             @Override
             public void run() {
-                if (m_previousGenId < genId) {
+                if (m_generationId < genId) {
                     try {
                         ExportRowSchema schema = ExportRowSchema.create(table, m_partitionId, genId);
                         m_committedBuffers.updateSchema(schema);
                     } catch (IOException e) {
                         VoltDB.crashLocalVoltDB("Unable to write PBD export header.", true, e);
                     }
-                    m_previousGenId = genId;
+                    m_generationId = genId;
                 }
             }
         });
@@ -1724,7 +1718,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
 
     // This is called when schema update doesn't affect export
     public void updateGenerationId(long genId) {
-        m_previousGenId = genId;
+        m_generationId = genId;
     }
 
     // Called from {@code ExportCoordinator}, returns duplicate of tracker

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -55,6 +55,7 @@ import org.voltcore.zk.ZKUtil;
 import org.voltdb.CatalogContext;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
 import org.voltdb.RealVoltDB;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltZK;
@@ -358,11 +359,20 @@ public class ExportGeneration implements Generation {
 
                         if (msgType == ExportManager.RELEASE_BUFFER) {
                             final long seqNo = buf.getLong();
-                            final long catalogVersion = buf.getInt();
+                            final long generationIdCreated = buf.getLong();
                             try {
+                                if (generationIdCreated < eds.getGenerationIdCreated()) {
+                                    if (exportLog.isDebugEnabled()) {
+                                        exportLog.debug("Ignored staled RELEASE_BUFFER message for " + eds.toString() +
+                                                " , sequence number: " + seqNo + ", generationIdCreated: " + generationIdCreated +
+                                                " from " + CoreUtils.hsIdToString(message.m_sourceHSId) +
+                                                " to " + CoreUtils.hsIdToString(m_mbox.getHSId()));
+                                    }
+                                    return;
+                                }
                                 if (exportLog.isDebugEnabled()) {
                                     exportLog.debug("Received RELEASE_BUFFER message for " + eds.toString() +
-                                            " , sequence number: " + seqNo + ", catalogVersion: " + catalogVersion +
+                                            " , sequence number: " + seqNo + ", generationIdCreated: " + generationIdCreated +
                                             " from " + CoreUtils.hsIdToString(message.m_sourceHSId) +
                                             " to " + CoreUtils.hsIdToString(m_mbox.getHSId()));
                                 }
@@ -808,7 +818,7 @@ public class ExportGeneration implements Generation {
     @Override
     public void pushExportBuffer(int partitionId, String tableName,
             long startSequenceNumber, long committedSequenceNumber,
-            int tupleCount, long uniqueId, long genId, ByteBuffer buffer) {
+            int tupleCount, long uniqueId, ByteBuffer buffer) {
 
         Map<String, ExportDataSource> sources = m_dataSourcesByPartition.get(partitionId);
 
@@ -839,7 +849,7 @@ public class ExportGeneration implements Generation {
         }
 
         source.pushExportBuffer(startSequenceNumber, committedSequenceNumber,
-                tupleCount, uniqueId, genId, buffer);
+                tupleCount, uniqueId, buffer);
     }
 
     private void cleanup() {
@@ -866,7 +876,7 @@ public class ExportGeneration implements Generation {
     @Override
     public void updateInitialExportStateToSeqNo(int partitionId, String streamName,
                                                 boolean isRecover, boolean isRejoin,
-                                                Map<Integer, Pair<Long, Long>> sequenceNumberPerPartition,
+                                                Map<Integer, ExportSnapshotTuple> sequenceNumberPerPartition,
                                                 boolean isLowestSite) {
         // pre-iv2, the truncation point is the snapshot transaction id.
         // In iv2, truncation at the per-partition txn id recorded in the snapshot.
@@ -876,9 +886,9 @@ public class ExportGeneration implements Generation {
         if (dataSource != null) {
             ExportDataSource source = dataSource.get(streamName);
             if (source != null) {
-                Pair<Long, Long> usoAndSeq = sequenceNumberPerPartition.get(partitionId);
-                if (usoAndSeq != null) {
-                    ListenableFuture<?> task = source.truncateExportToSeqNo(isRecover, isRejoin, usoAndSeq.getSecond());
+                ExportSnapshotTuple sequences = sequenceNumberPerPartition.get(partitionId);
+                if (sequences != null) {
+                    ListenableFuture<?> task = source.truncateExportToSeqNo(isRecover, isRejoin, sequences.getSequenceNumber(), sequences.getGenerationId());
                     tasks.add(task);
                 }
             }
@@ -890,9 +900,9 @@ public class ExportGeneration implements Generation {
                 for (Map<String, ExportDataSource> dataSources : m_dataSourcesByPartition.values()) {
                     for (ExportDataSource source : dataSources.values()) {
                         if (!source.inCatalog()) {
-                            Pair<Long, Long> pair = sequenceNumberPerPartition.get(source.getPartitionId());
-                            if (pair != null) {
-                                ListenableFuture<?> task = source.truncateExportToSeqNo(isRecover, isRejoin, pair.getSecond());
+                            ExportSnapshotTuple sequences = sequenceNumberPerPartition.get(source.getPartitionId());
+                            if (sequences != null) {
+                                ListenableFuture<?> task = source.truncateExportToSeqNo(isRecover, isRejoin, sequences.getSequenceNumber(), sequences.getGenerationId());
                                 tasks.add(task);
                             }
                         }

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -42,6 +42,7 @@ import org.voltdb.ExportStatsBase;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
 import org.voltdb.RealVoltDB;
 import org.voltdb.SimpleClientResponseAdapter;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.StatsSelector;
 import org.voltdb.TTLManager;
 import org.voltdb.VoltDB;
@@ -624,7 +625,6 @@ public class ExportManager
             long committedSequenceNumber,
             long tupleCount,
             long uniqueId,
-            long genId,
             long bufferPtr,
             ByteBuffer buffer) {
         //For validating that the memory is released
@@ -640,7 +640,7 @@ public class ExportManager
             }
             generation.pushExportBuffer(partitionId, tableName,
                     startSequenceNumber, committedSequenceNumber,
-                    (int)tupleCount, uniqueId, genId, buffer);
+                    (int)tupleCount, uniqueId, buffer);
         } catch (Exception e) {
             //Don't let anything take down the execution site thread
             exportLog.error("Error pushing export buffer", e);
@@ -649,7 +649,7 @@ public class ExportManager
 
     public void updateInitialExportStateToSeqNo(int partitionId, String signature,
                                                 boolean isRecover, boolean isRejoin,
-                                                Map<Integer, Pair<Long, Long>> sequenceNumberPerPartition,
+                                                Map<Integer, ExportSnapshotTuple> sequenceNumberPerPartition,
                                                 boolean isLowestSite) {
         //If the generation was completely drained, wait for the task to finish running
         //by waiting for the permit that will be generated

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -20,8 +20,8 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
-import org.voltcore.utils.Pair;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 
 /**
  * Export data from a single catalog version and database instance.
@@ -37,10 +37,10 @@ public interface Generation {
 
     public void pushExportBuffer(int partitionId, String signature,
                                 long seqNo, long committedSeqNo, int tupleCount,
-                                 long uniqueId, long genId, ByteBuffer buffer);
+                                 long uniqueId, ByteBuffer buffer);
     public void updateInitialExportStateToSeqNo(int partitionId, String signature,
                                                 boolean isRecover, boolean isRejoin,
-                                                Map<Integer, Pair<Long, Long>> sequenceNumberPerPartition,
+                                                Map<Integer, ExportSnapshotTuple> sequenceNumberPerPartition,
                                                 boolean isLowestSite);
 
     public Map<Integer, Map<String, ExportDataSource>> getDataSourceByPartition();

--- a/src/frontend/org/voltdb/iv2/JoinProducerBase.java
+++ b/src/frontend/org/voltdb/iv2/JoinProducerBase.java
@@ -23,10 +23,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.voltcore.logging.VoltLogger;
-import org.voltcore.utils.Pair;
 import org.voltdb.DRConsumerDrIdTracker.DRSiteDrIdTracker;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.SnapshotCompletionInterest;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.VoltDB;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Table;
@@ -185,7 +185,7 @@ public abstract class JoinProducerBase extends SiteTasker {
 
     // Completed all criteria: Kill the watchdog and inform the site.
     protected void setJoinComplete(SiteProcedureConnection siteConnection,
-                                   Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
+                                   Map<String, Map<Integer, ExportSnapshotTuple>> exportSequenceNumbers,
                                    Map<Integer, Long> drSequenceNumbers,
                                    Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,
                                    boolean requireExistingSequenceNumbers,

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -41,6 +41,7 @@ import org.voltdb.PostgreSQLBackend;
 import org.voltdb.ProcedureRunner;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.SiteSnapshotConnection;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.StatsSelector;
 import org.voltdb.SystemProcedureExecutionContext;
 import org.voltdb.TableStreamType;
@@ -199,6 +200,11 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
         @Override
         public int getCatalogVersion() {
             return m_context.catalogVersion;
+        }
+
+        @Override
+        public long getGenerationId() {
+            return m_context.m_genId;
         }
 
         @Override
@@ -562,8 +568,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
 
     @Override
     public void exportAction(boolean syncAction,
-                             long uso,
-                             Long sequenceNumber,
+                             ExportSnapshotTuple sequences,
                              Integer partitionId, String tableSignature)
     {
         throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
@@ -596,7 +601,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     @Override
     public void setRejoinComplete(
             JoinProducerBase.JoinCompletionAction replayComplete,
-            Map<String, Map<Integer, Pair<Long, Long>>> exportSequenceNumbers,
+            Map<String, Map<Integer, ExportSnapshotTuple>> exportSequenceNumbers,
             Map<Integer, Long> drSequenceNumbers,
             Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers,
             boolean requireExistingSequenceNumbers,

--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -29,10 +29,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
-import org.voltcore.utils.Pair;
 import org.voltdb.DRConsumerDrIdTracker.DRSiteDrIdTracker;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.SnapshotCompletionInterest.SnapshotCompletionEvent;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.SnapshotSaveAPI;
 import org.voltdb.VoltDB;
 import org.voltdb.messaging.RejoinMessage;
@@ -373,7 +373,7 @@ public class RejoinProducer extends JoinProducerBase {
                 // Resume the views.
                 siteConnection.setViewsEnabled(m_commaSeparatedNameOfViewsToPause, true);
                 SnapshotCompletionEvent event = null;
-                Map<String, Map<Integer, Pair<Long,Long>>> exportSequenceNumbers = null;
+                Map<String, Map<Integer, ExportSnapshotTuple>> exportSequenceNumbers = null;
                 Map<Integer, Long> drSequenceNumbers = null;
                 Map<Integer, Map<Integer, Map<Integer, DRSiteDrIdTracker>>> allConsumerSiteTrackers = null;
                 long clusterCreateTime = -1;
@@ -405,7 +405,7 @@ public class RejoinProducer extends JoinProducerBase {
                 }
                 if (exportSequenceNumbers == null) {
                     // Send empty sequence number map if the schema is empty (no tables).
-                    exportSequenceNumbers = new HashMap<String, Map<Integer, Pair<Long,Long>>>();
+                    exportSequenceNumbers = new HashMap<String, Map<Integer, ExportSnapshotTuple>>();
                 }
                 setJoinComplete(
                         siteConnection,

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -36,6 +36,7 @@ import org.voltdb.CatalogContext;
 import org.voltdb.PlannerStatsCollector;
 import org.voltdb.PlannerStatsCollector.CacheUse;
 import org.voltdb.PrivateVoltTableFactory;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.StatsAgent;
 import org.voltdb.StatsSelector;
 import org.voltdb.TableStreamType;
@@ -795,7 +796,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * Execute an Export action against the execution engine.
      */
     public abstract void exportAction( boolean syncAction,
-            long uso, long seqNo, int partitionId, String streamName);
+            ExportSnapshotTuple sequences, int partitionId, String streamName);
 
     /**
      * Execute an Delete of migrated rows in the execution engine.
@@ -1162,6 +1163,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * results buffer. A single action may encompass both a poll and ack.
      * @param pointer Pointer to an engine instance
      * @param mAckOffset The offset being ACKd.
+     * @param seqNo The current export sequence number
+     * @param generationId The timestamp from the most-recently restored snapshot
      * @param mStreamName Name of the stream being acted against
      * @return
      */
@@ -1170,6 +1173,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             boolean syncAction,
             long mAckOffset,
             long seqNo,
+            long generationId,
             byte mStreamName[]);
 
     /**

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -34,6 +34,7 @@ import org.voltcore.utils.Pair;
 import org.voltdb.BackendTarget;
 import org.voltdb.ParameterSet;
 import org.voltdb.PrivateVoltTableFactory;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.StatsSelector;
 import org.voltdb.TableStreamType;
 import org.voltdb.TheHashinator.HashinatorConfig;
@@ -442,7 +443,6 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                     long committedSequenceNumber = getBytes(8).getLong();
                     long tupleCount = getBytes(8).getLong();
                     long uniqueId = getBytes(8).getLong();
-                    long genId = getBytes(8).getLong();
                     int length = getBytes(4).getInt();
                     ExportManager.pushExportBuffer(
                             partitionId,
@@ -451,7 +451,6 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                             committedSequenceNumber,
                             tupleCount,
                             uniqueId,
-                            genId,
                             0,
                             length == 0 ? null : getBytes(length));
                 }
@@ -1550,14 +1549,15 @@ public class ExecutionEngineIPC extends ExecutionEngine {
     }
 
     @Override
-    public void exportAction(boolean syncAction,
-            long uso, long seqNo, int partitionId, String mStreamName) {
+    public void exportAction(boolean syncAction, ExportSnapshotTuple sequences,
+            int partitionId, String mStreamName) {
         try {
             m_data.clear();
             m_data.putInt(Commands.ExportAction.m_id);
             m_data.putInt(syncAction ? 1 : 0);
-            m_data.putLong(uso);
-            m_data.putLong(seqNo);
+            m_data.putLong(sequences.getAckOffset());
+            m_data.putLong(sequences.getSequenceNumber());
+            m_data.putLong(sequences.getGenerationId());
             if (mStreamName == null) {
                 m_data.putInt(-1);
             } else {
@@ -1575,7 +1575,9 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             long result_offset = results.getLong();
             if (result_offset < 0) {
                 System.out.println("exportAction failed!  syncAction: " + syncAction + ", Uso: " +
-                    uso + ", seqNo: " + seqNo + ", partitionId: " + partitionId +
+                    sequences.getAckOffset() + ", seqNo: " + sequences.getSequenceNumber() +
+                    ", generationId: " + sequences.getGenerationId() +
+                    ", partitionId: " + partitionId +
                     ", streamName: " + mStreamName);
             }
         } catch (final IOException e) {

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -27,6 +27,7 @@ import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
 import org.voltdb.ParameterSet;
 import org.voltdb.PrivateVoltTableFactory;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.StatsSelector;
 import org.voltdb.TableStreamType;
 import org.voltdb.TheHashinator.HashinatorConfig;
@@ -678,20 +679,26 @@ public class ExecutionEngineJNI extends ExecutionEngine {
      * data is returned in the usual results buffer, length preceded as usual.
      */
     @Override
-    public void exportAction(boolean syncAction,
-            long uso, long seqNo, int partitionId, String streamName)
+    public void exportAction(boolean syncAction, ExportSnapshotTuple sequences,
+            int partitionId, String streamName)
     {
         if (EXPORT_LOG.isDebugEnabled()) {
             EXPORT_LOG.debug("exportAction on partition " + partitionId + " syncAction: " + syncAction + ", uso: " +
-                    uso + ", seqNo: " + seqNo + ", streamName: " + streamName);
+                    sequences.getAckOffset() + ", seqNo: " + sequences.getSequenceNumber() +
+                    ", generationId:" + sequences.getGenerationId() + ", streamName: " + streamName);
         }
         //Clear is destructive, do it before the native call
         m_nextDeserializer.clear();
         long retval = nativeExportAction(pointer,
-                                         syncAction, uso, seqNo, getStringBytes(streamName));
+                                         syncAction,
+                                         sequences.getAckOffset(),
+                                         sequences.getSequenceNumber(),
+                                         sequences.getGenerationId(),
+                                         getStringBytes(streamName));
         if (retval < 0) {
             LOG.info("exportAction failed.  syncAction: " + syncAction + ", uso: " +
-                    uso + ", seqNo: " + seqNo + ", partitionId: " + partitionId +
+                    sequences.getAckOffset() + ", seqNo: " + sequences.getSequenceNumber() +
+                    ", generationId:" + sequences.getGenerationId() + ", partitionId: " + partitionId +
                     ", streamName: " + streamName);
         }
     }

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -26,6 +26,7 @@ import java.util.Random;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
 import org.voltdb.ParameterSet;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.StatsSelector;
 import org.voltdb.TableStreamType;
 import org.voltdb.TheHashinator;
@@ -197,8 +198,8 @@ public class MockExecutionEngine extends ExecutionEngine {
     }
 
     @Override
-    public void exportAction(boolean syncAction,
-            long uso, long seqNo, int partitionId, String mStreamName) {
+    public void exportAction(boolean syncAction, ExportSnapshotTuple sequences,
+            int partitionId, String mStreamName) {
     }
 
     @Override

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
@@ -111,6 +111,7 @@ public class SnapshotUtil {
     public static final String JSON_TABLES = "tables";
     public static final String JSON_SKIPTABLES = "skiptables";
     public static final String JSON_ELASTIC_OPERATION = "elasticOperationMetadata";
+
     /**
      * milestone used to mark a shutdown save snapshot
      */

--- a/tests/ee/catalog/ExportTupleStreamTest.cpp
+++ b/tests/ee/catalog/ExportTupleStreamTest.cpp
@@ -51,8 +51,9 @@ public:
         }
         int64_t seqNo;
         size_t streamBytesUsed;
+        int64_t generationId;
         int64_t nextSeqNoFromWrapper = wrapper->getSequenceNumber();
-        streamedTable->getExportStreamPositions(seqNo, streamBytesUsed);
+        streamedTable->getExportStreamPositions(seqNo, streamBytesUsed, generationId);
         // Verify the sequence number.
         ASSERT_EQ(seqNo + 1, nextSeqNoFromWrapper);
     }

--- a/tests/frontend/org/voltdb/export/ExportLocalClusterBase.java
+++ b/tests/frontend/org/voltdb/export/ExportLocalClusterBase.java
@@ -31,6 +31,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.voltdb.client.Client;
+import org.voltdb.client.ClientConfig;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.client.ClientImpl;
 import org.voltdb.export.TestExportBaseSocketExport.ServerListener;
@@ -82,8 +83,12 @@ public class ExportLocalClusterBase extends JUnit4LocalClusterTest {
     }
 
     public Client getClient(LocalCluster cluster) throws IOException {
-        Client client = ClientFactory.createClient();
-        client.createConnection(cluster.getListenerAddress(0));
+        ClientConfig config = new ClientConfig();
+        config.setTopologyChangeAware(true);
+        Client client = ClientFactory.createClient(config);
+        for (String connectStr : cluster.getListenerAddresses()) {
+            client.createConnection(connectStr);
+        }
         int sleptTimes = 0;
         while (!((ClientImpl) client).isHashinatorInitialized() && sleptTimes < 60000) {
             try {

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -60,6 +60,7 @@ import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.Pair;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
 import org.voltdb.MockVoltDB;
+import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.CatalogMap;
@@ -127,13 +128,13 @@ public class TestExportDataSource extends TestCase {
         @Override
         public void pushExportBuffer(int partitionId, String signature,
                 long seqNo, long committedSeqNo, int tupleCount,
-                long uniqueId, long genId, ByteBuffer buffer) {
+                long uniqueId, ByteBuffer buffer) {
         }
 
         @Override
         public void updateInitialExportStateToSeqNo(int partitionId,
                 String signature, boolean isRecover, boolean isRejoin,
-                Map<Integer, Pair<Long, Long>> sequenceNumberPerPartition,
+                Map<Integer, ExportSnapshotTuple> sequenceNumberPerPartition,
                 boolean isLowestSite) {
         }
 
@@ -273,23 +274,23 @@ public class TestExportDataSource extends TestCase {
             int buffSize = 20 + StreamBlock.HEADER_SIZE;
             ByteBuffer foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(1, 1, 1, 0, 0, foo);
+            s.pushExportBuffer(1, 1, 1, 0, foo);
             assertEquals(s.sizeInBytes(), 20 );
 
             //Push it twice more to check stats calc
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(2, 2, 1, 0, 0, foo);
+            s.pushExportBuffer(2, 2, 1, 0, foo);
             assertEquals(s.sizeInBytes(), 40);
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(3, 3, 1, 0, 0, foo);
+            s.pushExportBuffer(3, 3, 1, 0, foo);
 
             assertEquals(s.sizeInBytes(), 60);
 
             //Sync which flattens them all, but then pulls the first two back in memory
             //resulting in no change
-            s.pushExportBuffer(3, -1L, 1, 0, 0, null);
+            s.pushExportBuffer(3, -1L, 1, 0, null);
 
             assertEquals( 60, s.sizeInBytes());
 
@@ -368,7 +369,7 @@ public class TestExportDataSource extends TestCase {
             // Push a first buffer - and read it back
             ByteBuffer foo0 = ByteBuffer.allocateDirect(buffSize);
             foo0.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(1, 1, 1, 0, 0, foo0);
+            s.pushExportBuffer(1, 1, 1, 0, foo0);
 
             AckingContainer cont0 = s.poll().get();
             cont0.updateStartTime(System.currentTimeMillis());
@@ -399,7 +400,7 @@ public class TestExportDataSource extends TestCase {
             // Push a buffer - should satisfy fut1
             ByteBuffer foo1 = ByteBuffer.allocateDirect(buffSize);
             foo1.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(2, 2, 1, 0, 0, foo1);
+            s.pushExportBuffer(2, 2, 1, 0, foo1);
 
             // Verify the pushed buffer can be got
             AckingContainer cont1 = fut1.get();
@@ -446,22 +447,22 @@ public class TestExportDataSource extends TestCase {
         foo.duplicate().put(new byte[20]);
         // we are not purposely starting at 0, because on rejoin
         // we may start at non zero offsets
-        s.pushExportBuffer(1, 1, 1, 0, 0, foo);
+        s.pushExportBuffer(1, 1, 1, 0, foo);
         assertEquals(s.sizeInBytes(), 20 );
 
         //Push it twice more to check stats calc
         foo = ByteBuffer.allocateDirect(20 + StreamBlock.HEADER_SIZE);
         foo.duplicate().put(new byte[20]);
-        s.pushExportBuffer(2, 2, 1, 0, 0, foo);
+        s.pushExportBuffer(2, 2, 1, 0, foo);
         assertEquals(s.sizeInBytes(), 40 );
         foo = ByteBuffer.allocateDirect(20 + StreamBlock.HEADER_SIZE);
         foo.duplicate().put(new byte[20]);
-        s.pushExportBuffer(3, 3, 1, 0, 0, foo);
+        s.pushExportBuffer(3, 3, 1, 0, foo);
 
         assertEquals(s.sizeInBytes(), 60);
 
         //Sync which flattens them all
-        s.pushExportBuffer(3, -1L, 1, 0, 0, null);
+        s.pushExportBuffer(3, -1L, 1, 0, null);
 
         //flattened size
         assertEquals( 60, s.sizeInBytes());
@@ -486,7 +487,7 @@ public class TestExportDataSource extends TestCase {
 
         verify(mockedMbox, times(1)).send(
                 eq(42L),
-                argThat(ackPayloadIs(m_part, table.getSignature(), 1, 0))
+                argThat(ackPayloadIs(m_part, table.getSignature(), 1, s.getGenerationIdCreated()))
                 );
 
         // Poll and discard buffer 2, too
@@ -534,7 +535,7 @@ public class TestExportDataSource extends TestCase {
             //Push and sync
             ByteBuffer foo = ByteBuffer.allocateDirect(200 + StreamBlock.HEADER_SIZE);
             foo.duplicate().put(new byte[200]);
-            s.pushExportBuffer(101, 101, 1, 0, 0, foo);
+            s.pushExportBuffer(101, 101, 1, 0, foo);
             long sz = s.sizeInBytes();
             assertEquals(200, sz);
             listing = getSortedDirectoryListingSegments();
@@ -550,7 +551,7 @@ public class TestExportDataSource extends TestCase {
             //Push again and sync to test files.
             ByteBuffer foo2 = ByteBuffer.allocateDirect(900 + StreamBlock.HEADER_SIZE);
             foo2.duplicate().put(new byte[900]);
-            s.pushExportBuffer(111, 111, 1, 0, 0, foo2);
+            s.pushExportBuffer(111, 111, 1, 0, foo2);
             sz = s.sizeInBytes();
             assertEquals(900, sz);
             listing = getSortedDirectoryListingSegments();
@@ -608,18 +609,18 @@ public class TestExportDataSource extends TestCase {
             int buffSize = 20 + StreamBlock.HEADER_SIZE;
             ByteBuffer foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(1, 1, 1, 0, 0, foo);
+            s.pushExportBuffer(1, 1, 1, 0, foo);
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(2, 2, 1, 0, 0, foo);
+            s.pushExportBuffer(2, 2, 1, 0, foo);
 
             // Push 2 more creating a gap
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(10, 10, 1, 0, 0, foo);
+            s.pushExportBuffer(10, 10, 1, 0, foo);
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(11, 11, 1, 0, 0, foo);
+            s.pushExportBuffer(11, 11, 1, 0, foo);
 
             // Poll the 2 first buffers
             AckingContainer cont = s.poll().get();
@@ -684,16 +685,16 @@ public class TestExportDataSource extends TestCase {
             int buffSize = 20 + StreamBlock.HEADER_SIZE;
             ByteBuffer foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(1, 1, 1, 0, 0, foo);
+            s.pushExportBuffer(1, 1, 1, 0, foo);
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(2, 2, 1, 0, 0, foo);
+            s.pushExportBuffer(2, 2, 1, 0, foo);
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(3, 3, 1, 0, 0, foo);
+            s.pushExportBuffer(3, 3, 1, 0, foo);
             foo = ByteBuffer.allocateDirect(buffSize);
             foo.duplicate().put(new byte[buffSize]);
-            s.pushExportBuffer(4, 4, 1, 0, 0, foo);
+            s.pushExportBuffer(4, 4, 1, 0, foo);
 
             // Poll the 2 first buffers
             AckingContainer cont = s.poll().get();

--- a/tests/frontend/org/voltdb/export/TestExportEndToEnd.java
+++ b/tests/frontend/org/voltdb/export/TestExportEndToEnd.java
@@ -27,12 +27,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.voltdb.BackendTarget;
+import org.voltdb.VoltTable;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.VoltProjectBuilder;
@@ -41,23 +44,29 @@ import org.voltdb.export.TestExportBaseSocketExport.ServerListener;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.utils.VoltFile;
 
+import com.google_voltpatches.common.collect.Maps;
+
 public class TestExportEndToEnd extends ExportLocalClusterBase {
 
     private LocalCluster m_cluster;
 
     private static int KFACTOR = 1;
-    private static final String SCHEMA =
+    private static int HOST_COUNT = 3;
+    private static int SPH = 2;
+    private static final String T1_SCHEMA =
             "CREATE STREAM t_1 "
             + "PARTITION ON COLUMN a "
             + "EXPORT TO TARGET export_target_a ("
             + "     a integer not null, "
             + "     b integer not null"
-            + ");"
-            + "CREATE STREAM t_2 "
-            + "EXPORT TO TARGET export_target_b ("
-            + "     a integer not null, "
-            + "     b integer not null"
             + ");";
+
+    private static final String T2_SCHEMA =
+                "CREATE STREAM t_2 "
+                + "EXPORT TO TARGET export_target_b ("
+                + "     a integer not null, "
+                + "     b integer not null"
+                + ");";
 
     @Before
     public void setUp() throws Exception
@@ -67,7 +76,8 @@ public class TestExportEndToEnd extends ExportLocalClusterBase {
 
         VoltProjectBuilder builder = null;
         builder = new VoltProjectBuilder();
-        builder.addLiteralSchema(SCHEMA);
+        builder.addLiteralSchema(T1_SCHEMA);
+        builder.addLiteralSchema(T2_SCHEMA);
         builder.setUseDDLSchema(true);
         builder.setPartitionDetectionEnabled(true);
         builder.setDeadHostTimeout(30);
@@ -83,7 +93,7 @@ public class TestExportEndToEnd extends ExportLocalClusterBase {
         // Start socket exporter client
         startListener();
 
-        m_cluster = new LocalCluster("testFlushExportBuffer.jar", 2, 2, KFACTOR, BackendTarget.NATIVE_EE_JNI);
+        m_cluster = new LocalCluster("testFlushExportBuffer.jar", SPH, HOST_COUNT, KFACTOR, BackendTarget.NATIVE_EE_JNI);
         m_cluster.setNewCli(true);
         m_cluster.setHasLocalServer(false);
         m_cluster.overrideAnyRequestForValgrind();
@@ -128,9 +138,65 @@ public class TestExportEndToEnd extends ExportLocalClusterBase {
 
         // rejoin node back
         m_cluster.rejoinOne(1);
-
         client.drain();
+
+        client = getClient(m_cluster);
         TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
-        assertEquals(2, m_cluster.getLiveNodeCount());
+        assertEquals(3, m_cluster.getLiveNodeCount());
+    }
+
+    @Test
+    @Ignore
+    public void testExportRejoinOldGenerationStream_ENG_16239() throws Exception
+    {
+        Client client = getClient(m_cluster);
+        // Generate PBD files
+        Object[] data = new Object[3];
+        Arrays.fill(data, 1);
+        int pkeyStart = 0;
+        insertToStream("t_1", pkeyStart, 1000, client, data);
+
+        // Write some data to PBD then kill one node
+        client.drain();
+        client.callProcedure("@Quiesce");
+        m_cluster.killSingleHost(0);
+
+        // drop stream
+        ClientResponse response = client.callProcedure("@AdHoc", "DROP STREAM t_1");
+        assertEquals(ClientResponse.SUCCESS, response.getStatus());
+        response = client.callProcedure("@AdHoc", T1_SCHEMA);
+        assertEquals(ClientResponse.SUCCESS, response.getStatus());
+
+        pkeyStart = 1000;
+        insertToStream("t_1", pkeyStart, 100, client, data);
+        client.drain();
+        // rejoin node back
+        m_cluster.rejoinOne(0);
+
+        client = getClient(m_cluster);
+        client.drain();
+        client.callProcedure("@Quiesce");
+        TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
+        // make sure no partition has more than active stream
+        VoltTable stats = client.callProcedure("@Statistics", "export", 0).getResults()[0];
+        Map<String, Integer> masterCounters = Maps.newHashMap();
+        while (stats.advanceRow()) {
+            String target = stats.getString("TARGET");
+            String ttable = stats.getString("SOURCE");
+            String isMaster = stats.getString("ACTIVE");
+            Long pid = stats.getLong("PARTITION_ID");
+            String key = "TARGET: " + target + " SOURCE: " + ttable + " PARTITION_ID: " + pid + " ACTIVE: " + isMaster;
+            Integer count = masterCounters.get(key);
+            if (count == null) {
+                masterCounters.put(key, 1);
+            } else {
+                masterCounters.put(key, count + 1);
+            }
+        }
+        for (Entry<String, Integer> e : masterCounters.entrySet()) {
+            if (e.getValue() > 1) {
+                assertEquals("Stream (" + e.getKey() + ") has more than one master", 1, (int)e.getValue());
+            }
+        }
     }
 }


### PR DESCRIPTION
Pro side signature change: https://github.com/VoltDB/pro/pull/2625

This change introduces a new filed "generationId" in snapshot digest (and also in ExportTupleStream and ExportDataSource), this value is the timestamp of when the stream is initially created, so it keeps constant across rejoins or recovers as long as stream is not dropped and recreated.

Every RELEASE_BUFFER message that EDS sends to its replicas contains the initial generation ID, on receiver side replica uses generation ID to check whether this ACK message is staled.

This is a known issue (https://issues.voltdb.com/browse/ENG-16239?filter=-2) but I'll defer to fix it until the ongoing PBD refactor finishes.