### PR TITLE
ENG-16252: Handle migration failures

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -2166,7 +2166,16 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                     final int interval = Integer.parseInt(System.getProperty("MIGRATE_PARTITION_LEADER_INTERVAL", "1"));
                     final int delay = Integer.parseInt(System.getProperty("MIGRATE_PARTITION_LEADER_DELAY", "1"));
                     m_migratePartitionLeaderExecutor.scheduleAtFixedRate(
-                            () -> startMigratePartitionLeader(message.isForStopNode()),
+                            () -> {
+                                try {
+                                    startMigratePartitionLeader(message.isForStopNode());
+                                } catch (Exception e) {
+                                    tmLog.error("Migrate partition leader encountered unexpected error", e);
+                                } catch (Throwable t) {
+                                    VoltDB.crashLocalVoltDB("Migrate partition leader encountered unexpected error",
+                                            true, t);
+                                }
+                            },
                             delay, interval, TimeUnit.SECONDS);
                 }
                 hostLog.info("MigratePartitionLeader task is started.");

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -905,6 +905,9 @@ public class Cartographer extends StatsSource
 
         // Sort the hosts by partition leader count, descending
         LinkedList<Host> hostList = getHostsByPartionMasterCount();
+        if (hostList == null) {
+            return Pair.of(-1, -1);
+        }
 
         // only move SPI from the one with most partition leaders
         // The local ClientInterface will pick it up and start @MigratePartitionLeader
@@ -1005,6 +1008,9 @@ public class Cartographer extends StatsSource
 
         // Sort the hosts by partition leader count, descending
         LinkedList<Host> hostList = getHostsByPartionMasterCount();
+        if (hostList == null) {
+            return Pair.of(-1, -1);
+        }
         Host srcHost = null;
         for (Host host : hostList) {
             if (host.m_hostId == localHostId && !host.m_masterPartitionIDs.isEmpty()) {


### PR DESCRIPTION
Catch all exceptions from startMigratePartitionLeader and handle them. Handle null return from Cartogropher.getHostsByPartionMasterCount() and some minor Cartogropher cleanup changes.