### PR TITLE
ENG-16302: Partition masters can be removed

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -2018,9 +2018,13 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
      * @param partitionId
      */
     public void sendEOLMessage(int partitionId) {
-        final long initiatorHSId = m_cartographer.getHSIdForMaster(partitionId);
-        Iv2EndOfLogMessage message = new Iv2EndOfLogMessage(partitionId);
-        m_mailbox.send(initiatorHSId, message);
+        final Long initiatorHSId = m_cartographer.getHSIdForMaster(partitionId);
+        if (initiatorHSId == null) {
+            log.warn("ClientInterface.sendEOLMessage: Master does not exist for partition: " + partitionId);
+        } else {
+            Iv2EndOfLogMessage message = new Iv2EndOfLogMessage(partitionId);
+            m_mailbox.send(initiatorHSId, message);
+        }
     }
 
     public List<Iterator<Map.Entry<Long, Map<String, InvocationInfo>>>> getIV2InitiatorStats() {
@@ -2340,7 +2344,13 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                 } catch (InterruptedException ignoreIt) {
                 }
                 remainingWaitTime -= waitingInterval;
-                if (CoreUtils.getHostIdFromHSId(m_cartographer.getHSIdForMaster(partitionId)) == targetHostId) {
+                Long hsId = m_cartographer.getHSIdForMaster(partitionId);
+                if (hsId == null) {
+                    log.warn("ClientInterface.startMigratePartitionLeader: Master does not exist for partition: "
+                            + partitionId);
+                    break;
+                }
+                if (CoreUtils.getHostIdFromHSId(hsId) == targetHostId) {
                     migrationComplete = true;
                     break;
                 }

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -803,8 +802,8 @@ public final class InvocationDispatcher {
 
            // shutdown partition leader migration
            MigratePartitionLeaderMessage message = new MigratePartitionLeaderMessage(ihid, Integer.MIN_VALUE);
-           for (Iterator<Integer> it = liveHids.iterator(); it.hasNext();) {
-               m_mailbox.send(CoreUtils.getHSIdFromHostAndSite(it.next(),
+           for (Integer integer : liveHids) {
+               m_mailbox.send(CoreUtils.getHSIdFromHostAndSite(integer,
                            HostMessenger.CLIENT_INTERFACE_SITE_ID), message);
            }
 
@@ -896,8 +895,12 @@ public final class InvocationDispatcher {
      * @param partitionId
      */
     public final void sendSentinel(long txnId, int partitionId) {
-        final long initiatorHSId = m_cartographer.getHSIdForSinglePartitionMaster(partitionId);
-        sendSentinel(txnId, initiatorHSId, -1, -1, true);
+        final Long initiatorHSId = m_cartographer.getHSIdForSinglePartitionMaster(partitionId);
+        if (initiatorHSId == null) {
+            log.error("InvocationDispatcher.sendSentinel: Master does not exist for partition: " + partitionId);
+        } else {
+            sendSentinel(txnId, initiatorHSId, -1, -1, true);
+        }
     }
 
     private final void sendSentinel(long txnId, long initiatorHSId, long ciHandle,

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -321,7 +321,7 @@ public class Cartographer extends StatsSource
     /**
      * Convenience method: Get the HSID of the master for the specified partition ID, SP or MP
      */
-    public long getHSIdForMaster(int partitionId)
+    public Long getHSIdForMaster(int partitionId)
     {
         if (partitionId == MpInitiator.MP_INIT_PID) {
             return getHSIdForMultiPartitionInitiator();
@@ -354,7 +354,7 @@ public class Cartographer extends StatsSource
     /**
      * Get the HSID of the single partition master for the specified partition ID
      */
-    public long getHSIdForSinglePartitionMaster(int partitionId)
+    public Long getHSIdForSinglePartitionMaster(int partitionId)
     {
         return m_iv2Masters.get(partitionId);
     }


### PR DESCRIPTION
With elastic remove it is now normal for there to be no partition master for a
partition which use to exist. Update the methods in Cartogropher
getHSIdForSinglePartitionMaster and getHSIdForMaster to return a Long and let
the callers handle the missing master. This prevents a NullPointerException
from being thrown when an auto unboxing would occur trying to return a long.