### PR TITLE
ENG-15570 migrate delete one batch at a time

### DIFF
--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -1161,13 +1161,6 @@ inline void TableTuple::deserializeFromDR(voltdb::SerializeInputLE &tupleIn,  Po
                             hiddenColumnInfo->getVoltType(), hiddenColumnInfo->inlined,
                             static_cast<int32_t>(hiddenColumnInfo->length), hiddenColumnInfo->inBytes);
     }
-
-    // Null the column
-    if (m_schema->isTableWithStream()) {
-         const TupleSchema::ColumnInfo * hiddenColumnInfo = m_schema->getHiddenColumnInfo(hiddenColumnCount);
-         NValue value = NValue::getNullValue(hiddenColumnInfo->getVoltType());
-         setNValue(hiddenColumnInfo->offset, value);
-    }
 }
 
 inline void TableTuple::serializeTo(voltdb::SerializeOutput &output, bool includeHiddenColumns) const {

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2629,8 +2629,8 @@ int64_t VoltDBEngine::exportAction(bool syncAction,
     return 0;
 }
 
-int32_t VoltDBEngine::deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_t uniqueId,
-        std::string tableName, int64_t deletableTxnId, int32_t maxRowCount, int64_t undoToken) {
+bool VoltDBEngine::deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_t uniqueId,
+        std::string tableName, int64_t deletableTxnId, int64_t undoToken) {
     PersistentTable* table = dynamic_cast<PersistentTable*>(getTableByName(tableName));
     if (table) {
         setUndoToken(undoToken);
@@ -2644,9 +2644,9 @@ int32_t VoltDBEngine::deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory
                 (table->isReplicatedTable(), isLowestSite(), &s_loadTableException, VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
-            int32_t rowsToBeDeleted = 0;
+            bool rowsToBeDeleted;
             try {
-                rowsToBeDeleted = table->deleteMigratedRows(deletableTxnId, maxRowCount);
+                rowsToBeDeleted = table->deleteMigratedRows(deletableTxnId);
             }
             catch (const SQLException &sqe) {
                 s_loadTableException = VOLT_EE_EXCEPTION_TYPE_SQL;
@@ -2688,7 +2688,7 @@ int32_t VoltDBEngine::deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_
         LogManager::getThreadLogger(LOGGERID_HOST)->log(LOGLEVEL_DEBUG, msg);
     }
 
-    return 0;
+    return false;
 }
 
 void VoltDBEngine::getUSOForExportTable(size_t &ackOffset, int64_t &seqNo, std::string streamName) {

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -511,12 +511,11 @@ class __attribute__((visibility("default"))) VoltDBEngine {
          * @param uniqueId The uniqueId of the currently executing stored procedure
          * @param mTableName The name of the table that the deletes should be applied to
          * @param deletableTxnId The transactionId of the last row that can be deleted
-         * @param maxRowCount The upper bound on the number of rows that can be deleted (batch size)
          * @param undoToken Commit/Rollback token for this delete call
-         * @return number of rows to be deleted
+         * @return true if more rows to be deleted
          */
-        int32_t deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_t uniqueId,
-                std::string tableName, int64_t deletableTxnId, int32_t maxRowCount, int64_t undoToken);
+        bool deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_t uniqueId,
+                std::string tableName, int64_t deletableTxnId, int64_t undoToken);
 
         void getUSOForExportTable(size_t& ackOffset, int64_t& seqNo, std::string streamName);
 

--- a/src/ee/executors/migrateexecutor.cpp
+++ b/src/ee/executors/migrateexecutor.cpp
@@ -107,7 +107,6 @@ bool MigrateExecutor::p_execute(const NValueArray &params) {
     VOLT_TRACE("TARGET TABLE - BEFORE: %s\n", targetTable->debug("").c_str());
 
     int64_t migrated_tuples = 0;
-
     {
         assert(m_replicatedTableOperation == targetTable->isReplicatedTable());
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
@@ -120,7 +119,6 @@ bool MigrateExecutor::p_execute(const NValueArray &params) {
             BOOST_FOREACH(TableIndex *index, allIndexes) {
                 if (index->isMigratingIndex()) {
                     indexesToUpdate.push_back(index);
-                    VOLT_DEBUG("MigrateExecutor: updating migrating index.");
                 }
             }
 

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -605,7 +605,7 @@ public:
     /**
      * Delete the rows that have completed the migration process
      */
-    int32_t deleteMigratedRows(int64_t deletableTxnId, int32_t maxRowCount);
+    bool deleteMigratedRows(int64_t deletableTxnId);
 
 private:
     // Zero allocation size uses defaults.

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -1537,7 +1537,6 @@ void VoltDBIPC::deleteMigratedRows(struct ipc_command *cmd) {
                                                static_cast<int64_t>(ntohll(migrate_msg->uniqueId)),
                                                tableName,
                                                static_cast<int64_t>(ntohll(migrate_msg->deletableTxnId)),
-                                               static_cast<int32_t>(ntohl(migrate_msg->maxRowCount)),
                                                static_cast<int64_t>(ntohll(migrate_msg->undoToken)));
     char response[1];
     response[0] = result ? 1 : 0;

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1162,7 +1162,7 @@ SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExpo
  * @param deletableTxnId The transactionId of the last row that can be deleted
  * @param maxRowCount The upper bound on the number of rows that can be deleted (batch size)
  * @param undoToken The token marking the rollback point for this transaction
- * @return number of rows to be deleted
+ * @return true if more rows to be deleted
  */
 SHAREDLIB_JNIEXPORT jboolean JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeDeleteMigratedRows(
         JNIEnv *env, jobject obj, jlong engine_ptr,

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1162,10 +1162,10 @@ SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExpo
  * @param undoToken The token marking the rollback point for this transaction
  * @return number of rows to be deleted
  */
-SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeDeleteMigratedRows(
+SHAREDLIB_JNIEXPORT jboolean JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeDeleteMigratedRows(
         JNIEnv *env, jobject obj, jlong engine_ptr,
         jlong txnId, jlong spHandle, jlong uniqueId,
-        jbyteArray tableName, jlong deletableTxnId, jint maxRowCount, jlong undoToken)
+        jbyteArray tableName, jlong deletableTxnId, jlong undoToken)
 {
     VOLT_DEBUG("nativeDeleteMigratedRows in C++ called");
     VoltDBEngine *engine = castToEngine(engine_ptr);
@@ -1181,7 +1181,6 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeDelet
                                               static_cast<int64_t>(uniqueId),
                                               tableNameStr,
                                               static_cast<int64_t>(deletableTxnId),
-                                              static_cast<int32_t>(maxRowCount),
                                               static_cast<int64_t>(undoToken));
         } catch (const SQLException &e) {
             throwFatalException("%s", e.message().c_str());

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -239,8 +239,8 @@ public interface SiteProcedureConnection {
                              Integer partitionId,
                              String tableSignature);
 
-    public int deleteMigratedRows(long txnid, long spHandle, long uniqueId,
-            String tableName, long deletableTxnId, int maxRowCount);
+    public boolean deleteMigratedRows(long txnid, long spHandle, long uniqueId,
+            String tableName, long deletableTxnId);
 
     public VoltTable[] getStats(StatsSelector selector, int[] locators,
                                 boolean interval, Long now);

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1722,12 +1722,10 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
     }
 
-    public void setupMigrateRowsDeleter(int batchSize, int partitionId) {
-        if (batchSize > 0) {
-            m_migrateRowsDeleter = new MigrateRowsDeleter(m_tableName, partitionId, batchSize);
-            if (exportLog.isDebugEnabled()) {
-                exportLog.debug("MigrateRowsDeleter has been initialized for table: " + m_tableName + ", partition:" + partitionId);
-            }
+    public void setupMigrateRowsDeleter(int partitionId) {
+        m_migrateRowsDeleter = new MigrateRowsDeleter(m_tableName, partitionId);
+        if (exportLog.isDebugEnabled()) {
+            exportLog.debug("MigrateRowsDeleter has been initialized for table: " + m_tableName + ", partition:" + partitionId);
         }
     }
 

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1315,7 +1315,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 try {
                     localAck(commitSeqNo, lastSeqNo);
                     forwardAckToOtherReplicas();
-                    if (m_migrateRowsDeleter != null && m_coordinator.isMaster()) {
+                    if (m_migrateRowsDeleter != null && commitSpHandle > 0 && m_coordinator.isMaster()) {
                         m_migrateRowsDeleter.delete(commitSpHandle);
                     }
                 } catch (Exception e) {

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -618,8 +618,7 @@ public class ExportGeneration implements Generation {
         ExportDataSource source = new ExportDataSource(this, adFile, localPartitionsToSites, processor, genId);
         source.setCoordination(m_messenger.getZK(), m_messenger.getHostId());
         adFilePartitions.add(source.getPartitionId());
-        int migrateBatchSize = CatalogUtil.getPersistentMigrateBatchSize(source.getTableName());
-        source.setupMigrateRowsDeleter(migrateBatchSize,
+        source.setupMigrateRowsDeleter(
                 CatalogUtil.getIsreplicated(source.getTableName()) ? MpInitiator.MP_INIT_PID : source.getPartitionId());
 
         if (exportLog.isDebugEnabled()) {
@@ -685,8 +684,7 @@ public class ExportGeneration implements Generation {
                                 table.getPartitioncolumn(),
                                 m_directory.getPath());
                         exportDataSource.setCoordination(m_messenger.getZK(), m_messenger.getHostId());
-                        int migrateBatchSize = CatalogUtil.getPersistentMigrateBatchSize(key);
-                        exportDataSource.setupMigrateRowsDeleter(migrateBatchSize, table.getIsreplicated() ? MpInitiator.MP_INIT_PID : exportDataSource.getPartitionId());
+                        exportDataSource.setupMigrateRowsDeleter(table.getIsreplicated() ? MpInitiator.MP_INIT_PID : exportDataSource.getPartitionId());
                         if (exportLog.isDebugEnabled()) {
                             exportLog.debug("Creating ExportDataSource for table in catalog " + key
                                     + " partition " + partition + " site " + siteId);

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -688,8 +688,8 @@ public class ExportManager
         m_ci.bindAdapter(m_adapter, null);
     }
 
-    public void invokeMigrateRowsDelete(int partition, String tableName, int batchSize, long deletableTxnId,  ProcedureCallback cb) {
+    public void invokeMigrateRowsDelete(int partition, String tableName, long deletableTxnId,  ProcedureCallback cb) {
         m_ci.getDispatcher().getInternelAdapterNT().callProcedure(m_ci.getInternalUser(), true, TTLManager.NT_PROC_TIMEOUT, cb,
-                "@MigrateRowsDeleterNT", new Object[] {partition, tableName, deletableTxnId, batchSize});
+                "@MigrateRowsDeleterNT", new Object[] {partition, tableName, deletableTxnId});
     }
 }

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -570,12 +570,11 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     }
 
     @Override
-    public int deleteMigratedRows(long txnid,
+    public boolean deleteMigratedRows(long txnid,
                                       long spHandle,
                                       long uniqueId,
                                       String tableName,
-                                      long deletableTxnId,
-                                      int maxRowCount)
+                                      long deletableTxnId)
     {
         throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
     }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1429,15 +1429,14 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
-    public int deleteMigratedRows(long txnid,
+    public boolean deleteMigratedRows(long txnid,
                                       long spHandle,
                                       long uniqueId,
                                       String tableName,
-                                      long deletableTxnId,
-                                      int maxRowCount)
+                                      long deletableTxnId)
     {
         return m_ee.deleteMigratedRows(txnid, spHandle, uniqueId,
-                tableName, deletableTxnId, maxRowCount, getNextUndoToken(m_currentTxnId));
+                tableName, deletableTxnId, getNextUndoToken(m_currentTxnId));
     }
 
     @Override

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -800,9 +800,9 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
     /**
      * Execute an Delete of migrated rows in the execution engine.
      */
-    public abstract int deleteMigratedRows(
+    public abstract boolean deleteMigratedRows(
             long txnid, long spHandle, long uniqueId,
-            String tableName, long deletableTxnId, int maxRowCount, long undoToken);
+            String tableName, long deletableTxnId, long undoToken);
 
     /**
      * Get the seqNo and offset for an export table.
@@ -1180,13 +1180,12 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * @param uniqueId The uniqueId of the currently executing stored procedure
      * @param mTableName The name of the table that the deletes should be applied to.
      * @param deletableTxnId The transactionId of the last row that can be deleted
-     * @param maxRowCount The upper bound on the number of rows that can be deleted (batch size)
      * @param undoToken The token marking the rollback point for this transaction
-     * @return number of rows to be deleted
+     * @return true if all tuples are deleted less than or equals to deletableTxnId
      */
-    protected native int nativeDeleteMigratedRows(long pointer,
+    protected native boolean nativeDeleteMigratedRows(long pointer,
             long txnid, long spHandle, long uniqueId,
-            byte mTableName[], long deletableTxnId, int maxRowCount, long undoToken);
+            byte mTableName[], long deletableTxnId, long undoToken);
 
     protected native void nativeSetViewsEnabled(long pointer, byte[] viewNamesAsBytes, boolean enabled);
 

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -1185,7 +1185,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * @param mTableName The name of the table that the deletes should be applied to.
      * @param deletableTxnId The transactionId of the last row that can be deleted
      * @param undoToken The token marking the rollback point for this transaction
-     * @return true if all tuples are deleted less than or equals to deletableTxnId
+     * @return true if more rows to be deleted
      */
     protected native boolean nativeDeleteMigratedRows(long pointer,
             long txnid, long spHandle, long uniqueId,

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -1584,8 +1584,8 @@ public class ExecutionEngineIPC extends ExecutionEngine {
     }
 
     @Override
-    public int deleteMigratedRows(long txnid, long spHandle, long uniqueId,
-            String tableName, long deletableTxnId, int maxRowCount, long undoToken) {
+    public boolean deleteMigratedRows(long txnid, long spHandle, long uniqueId,
+            String tableName, long deletableTxnId, long undoToken) {
         try {
             m_data.clear();
             m_data.putInt(Commands.DeleteMigratedRows.m_id);
@@ -1594,7 +1594,6 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             m_data.putLong(uniqueId);
             m_data.putLong(deletableTxnId);
             m_data.putLong(undoToken);
-            m_data.putInt(maxRowCount);
             m_data.putInt(tableName.getBytes("UTF-8").length);
             m_data.put(tableName.getBytes("UTF-8"));
             m_data.flip();
@@ -1605,7 +1604,8 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                 m_connection.m_socketChannel.read(results);
             }
             results.flip();
-            return results.get();
+
+            return (results.getInt() == 1);
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -697,11 +697,11 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     }
 
     @Override
-    public int deleteMigratedRows(long txnid, long spHandle, long uniqueId,
-            String tableName, long deletableTxnId, int maxRowCount, long undoToken) {
+    public boolean deleteMigratedRows(long txnid, long spHandle, long uniqueId,
+            String tableName, long deletableTxnId, long undoToken) {
         m_nextDeserializer.clear();
-        int txnFullyDeleted = nativeDeleteMigratedRows(pointer, txnid, spHandle, uniqueId,
-                getStringBytes(tableName), deletableTxnId, maxRowCount, undoToken);
+        boolean txnFullyDeleted = nativeDeleteMigratedRows(pointer, txnid, spHandle, uniqueId,
+                getStringBytes(tableName), deletableTxnId, undoToken);
         return txnFullyDeleted;
     }
 

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -202,9 +202,9 @@ public class MockExecutionEngine extends ExecutionEngine {
     }
 
     @Override
-    public int deleteMigratedRows(long txnid, long spHandle, long uniqueId,
-            String tableName, long deletableTxnId, int maxRowCount, long undoToken) {
-        return 0;
+    public boolean deleteMigratedRows(long txnid, long spHandle, long uniqueId,
+            String tableName, long deletableTxnId, long undoToken) {
+        return false;
     }
 
     @Override

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_MP.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_MP.java
@@ -57,7 +57,7 @@ public class MigrateRowsAcked_MP extends VoltSystemProcedure {
                 boolean txnRemainingDeleted = context.getSiteProcedureConnection().deleteMigratedRows(
                         txnState.txnId, txnState.m_spHandle, txnState.uniqueId,
                         tableName, deletableTxnId);
-                VoltTable results = new VoltTable(new ColumnInfo("RowsRemainingDeleted", VoltType.BIGINT));
+                VoltTable results = new VoltTable(new ColumnInfo(MigrateRowsDeleterNT.ROWS_TO_BE_DELETED, VoltType.BIGINT));
                 results.addRow(txnRemainingDeleted ? 1 : 0);
                 return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_migrateRows, results);
             }
@@ -72,10 +72,14 @@ public class MigrateRowsAcked_MP extends VoltSystemProcedure {
         return null;
     }
 
-    public VoltTable run(SystemProcedureExecutionContext ctx,
-                           String tableName,            // Name of table that can have rows deleted
-                           long deletableTxnId          // All rows with TxnIds before this can be deleted
-                          ) {
+    /**
+    *
+    * @param ctx execution context
+    * @param tableName Name of table that can have rows deleted
+    * @param deletableTxnId All rows with this transaction or the first transaction before this can be deleted
+    * @return
+    */
+    public VoltTable run(SystemProcedureExecutionContext ctx, String tableName, long deletableTxnId) {
         VoltTable result = null;
 
         try {

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_SP.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_SP.java
@@ -54,13 +54,17 @@ public class MigrateRowsAcked_SP extends VoltSystemProcedure {
         return null;
     }
 
-    public VoltTable run(SystemProcedureExecutionContext context,
-                           int partitionParam,          // Partition parameter
-                           String tableName,            // Name of table that can have rows deleted
-                           long deletableTxnId         // All rows with TxnIds before this can be deleted
-                           )
+    /**
+    *
+    * @param ctx execution context
+    * @param partitionParam partition parameter
+    * @param tableName Name of table that can have rows deleted
+    * @param deletableTxnId All rows with this transaction or the first transaction before this can be deleted
+    * @return
+    */
+    public VoltTable run(SystemProcedureExecutionContext context, int partitionParam, String tableName, long deletableTxnId)
     {
-        VoltTable result = new VoltTable(new ColumnInfo("RowsRemainingDeleted", VoltType.BIGINT));
+        VoltTable result = new VoltTable(new ColumnInfo(MigrateRowsDeleterNT.ROWS_TO_BE_DELETED, VoltType.BIGINT));
         try {
             final TransactionState txnState = m_runner.getTxnState();
             boolean txnRemainingDeleted = context.getSiteProcedureConnection().deleteMigratedRows(

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsBase.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsBase.java
@@ -35,6 +35,7 @@ import org.voltdb.catalog.Index;
 import org.voltdb.catalog.Procedure;
 import org.voltdb.catalog.Statement;
 import org.voltdb.catalog.Table;
+import org.voltdb.iv2.TxnEgo;
 import org.voltdb.sysprocs.LowImpactDeleteNT.ComparisonOperation;
 import org.voltdb.VoltTable.ColumnInfo;
 
@@ -209,8 +210,9 @@ public class MigrateRowsBase extends VoltSystemProcedure {
         long rowCount = result.asScalarLong();
         if (exportLog.isDebugEnabled()) {
             exportLog.debug("Migrate on table " + tableName +
-                    (replicated ? "" : " on partition " + ctx.getPartitionId()) +
-                    " reported " + rowCount + " matching rows");
+                    " on partition " + ctx.getPartitionId() +
+                    " reported " + rowCount + " matching rows. txnid:" + TxnEgo.txnIdToString(m_runner.getTxnState().txnId) + " sphandle:" +
+                    m_runner.getTxnState().m_spHandle);
         }
 
         // If number of rows meet the criteria is more than chunk size, pick the column value

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsDeleterNT.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsDeleterNT.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
+import org.voltdb.TTLManager;
 import org.voltdb.TheHashinator;
 import org.voltdb.VoltNTSystemProcedure;
 import org.voltdb.VoltProcedure;
@@ -82,7 +83,7 @@ public class MigrateRowsDeleterNT extends VoltNTSystemProcedure {
         } else {
             cf = callProcedure("@MigrateRowsAcked_SP", getHashinatorPartitionKey(partitionId), tableName, deletableTxnId);
         }
-        ClientResponse resp = cf.get(5, TimeUnit.MINUTES);
+        ClientResponse resp = cf.get(TTLManager.NT_PROC_TIMEOUT, TimeUnit.SECONDS);
         if (resp.getStatus() == ClientResponse.TXN_MISPARTITIONED){
             if (resp.getStatus() != ClientResponse.SUCCESS) {
                 exportLog.rateLimitedLog(LOG_SUPPRESSION_INTERVAL_SECONDS, Level.WARN, null,

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsDeleterNT.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsDeleterNT.java
@@ -16,32 +16,26 @@
  */
 package org.voltdb.sysprocs;
 
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
-import org.voltcore.utils.CoreUtils;
 import org.voltdb.TheHashinator;
 import org.voltdb.VoltNTSystemProcedure;
+import org.voltdb.VoltProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.iv2.MpInitiator;
+import org.voltdb.iv2.TxnEgo;
 
 public class MigrateRowsDeleterNT extends VoltNTSystemProcedure {
 
     private static final VoltLogger exportLog = new VoltLogger("EXPORT");
     static final long TIMEOUT = TimeUnit.MINUTES.toMillis(Integer.getInteger("TIME_TO_LIVE_TIMEOUT", 2));
     static final int LOG_SUPPRESSION_INTERVAL_SECONDS = 60;
-
+    public static final String ROWS_TO_BE_DELETED = "RowsRemainingDeleted";
     static int getHashinatorPartitionKey(int partitionId) {
         VoltTable partitionKeys = TheHashinator.getPartitionKeys(VoltType.INTEGER);
         while (partitionKeys.advanceRow()) {
@@ -52,100 +46,60 @@ public class MigrateRowsDeleterNT extends VoltNTSystemProcedure {
         return Integer.MIN_VALUE;
     }
 
-    public VoltTable run(
-            int partitionId,             // Partition parameter
-            String tableName,            // Name of table that can have rows deleted
-            long deletableTxnId,         // All rows with TxnIds before this can be deleted
-            int maxRowCount)             // Maximum rows to be deleted that will fit in a DR buffer
+    /**
+     *
+     * @param partitionId Partition parameter
+     * @param tableName Name of table that can have rows deleted
+     * @param deletableTxnId All rows with this transaction or the first transaction before this can be deleted
+     * @return
+     */
+    public VoltTable run(int partitionId, String tableName, long deletableTxnId)
     {
         if (exportLog.isDebugEnabled()) {
-            exportLog.debug(String.format("Deleting migrated rows, batch size %d on table %s.txn id: %d",
-                    maxRowCount, tableName, deletableTxnId));
+            exportLog.debug(String.format("Deleting migrated rows on table %s.txn id: %s",
+                    tableName, TxnEgo.txnIdToString(deletableTxnId)));
         }
 
-        VoltTable ret = new VoltTable(  new ColumnInfo("ROWS_LEFT", VoltType.BIGINT),
-                                        new ColumnInfo("STATUS", VoltType.BIGINT),
+        VoltTable result = new VoltTable(  new ColumnInfo("STATUS", VoltType.BIGINT),
                                         new ColumnInfo("MESSAGE", VoltType.STRING));
-        long rowsRemaining = Long.MIN_VALUE;
+        boolean rowsRemaining = true;
         try {
-            ClientResponse resp = deleteRows(partitionId, tableName, deletableTxnId, maxRowCount);
-            if (resp.getStatus() == ClientResponse.TXN_MISPARTITIONED){
-                resp = deleteRows(partitionId, tableName, deletableTxnId, maxRowCount);
-                if (resp.getStatus() != ClientResponse.SUCCESS) {
-                    exportLog.rateLimitedLog(LOG_SUPPRESSION_INTERVAL_SECONDS, Level.WARN, null,
-                            "Errors on deleting migrated row on table %s: %s", tableName, resp.getStatusString());
-                    ret.addRow((rowsRemaining != Long.MIN_VALUE) ? rowsRemaining : -1, ClientResponse.UNEXPECTED_FAILURE, resp.getAppStatusString());
-                    return ret;
-                }
-            } else if (resp.getStatus() != ClientResponse.SUCCESS) {
-                exportLog.rateLimitedLog(LOG_SUPPRESSION_INTERVAL_SECONDS, Level.WARN, null,
-                        "Errors on deleting migrated row on table %s: %s", tableName, resp.getStatusString());
-                ret.addRow((rowsRemaining != Long.MIN_VALUE) ? rowsRemaining : -1, ClientResponse.UNEXPECTED_FAILURE, resp.getAppStatusString());
-                return ret;
-            }
-            VoltTable vt = resp.getResults()[0];
-            if (vt.advanceRow()) {
-                rowsRemaining = vt.getLong("RowsRemainingDeleted");
-            }
-            if (exportLog.isDebugEnabled()) {
-                exportLog.debug(String.format("Deleting migrated rows, batch size %d, remaining %d on table %s.txn id: %d",
-                        maxRowCount, rowsRemaining, tableName, deletableTxnId));
-            }
-            if (rowsRemaining > 0) {
-                int attemptsLeft = (int)Math.ceil((double)rowsRemaining/(double)maxRowCount);
-                ScheduledExecutorService es = Executors.newSingleThreadScheduledExecutor(CoreUtils.getThreadFactory("MigrateDeleter"));
-                CountDownLatch latch = new CountDownLatch(attemptsLeft);
-                String[] errors = new String[attemptsLeft];
-                Arrays.fill(errors, "");
-                class Task implements Runnable {
-                    final int attempt;
-                    public Task(int attempt) {
-                        this.attempt = attempt;
-                    }
-                    @Override
-                    public void run() {
-                        try {
-                            ClientResponse resp = deleteRows(partitionId, tableName, deletableTxnId, maxRowCount);
-                            if (resp.getStatus() != ClientResponse.SUCCESS) {
-                                errors[attempt] = resp.getStatusString();
-                            }
-                        } catch (Exception e) {
-                            exportLog.warn("Migrate delete error:" + e.getMessage());
-                        } finally {
-                            latch.countDown();
-                        }
-                    }
-                }
-                int attempts = 0;
-                final long delay = 20;
-                while (attempts < attemptsLeft) {
-                    Task task = new Task(attempts);
-                    es.schedule(task, delay * attempts, TimeUnit.MILLISECONDS);
-                    attempts++;
-                }
-                try {
-                    latch.await(TIMEOUT, TimeUnit.MILLISECONDS);
-                } catch (InterruptedException e) {
-                    exportLog.warn("Migrate delete interrupted" + e.getMessage());
-                } finally {
-                    es.shutdownNow();
-                }
+            while (rowsRemaining) {
+                rowsRemaining = deleteRows(partitionId, tableName, deletableTxnId);
             }
         } catch (Exception ex) {
-            ret.addRow((rowsRemaining != Long.MAX_VALUE) ? rowsRemaining : -1, ClientResponse.UNEXPECTED_FAILURE, ex.getMessage());
-            return ret;
+            result.addRow(ClientResponse.UNEXPECTED_FAILURE, ex.getMessage());
+            return result;
         }
-        ret.addRow(rowsRemaining, ClientResponse.SUCCESS, "");
-        return ret;
+        result.addRow(ClientResponse.SUCCESS, "");
+        return result;
     }
 
-    private ClientResponse deleteRows(int partitionId, String tableName, long deletableTxnId, int maxRowCount) throws InterruptedException, ExecutionException, TimeoutException {
+    private boolean deleteRows(int partitionId, String tableName, long deletableTxnId) throws Exception {
         CompletableFuture<ClientResponse> cf = null;
         if (partitionId == MpInitiator.MP_INIT_PID) {
-            cf = callProcedure("@MigrateRowsAcked_MP", tableName, deletableTxnId, maxRowCount);
+            cf = callProcedure("@MigrateRowsAcked_MP", tableName, deletableTxnId);
         } else {
-            cf = callProcedure("@MigrateRowsAcked_SP", getHashinatorPartitionKey(partitionId), tableName, deletableTxnId, maxRowCount);
+            cf = callProcedure("@MigrateRowsAcked_SP", getHashinatorPartitionKey(partitionId), tableName, deletableTxnId);
         }
-        return cf.get(5, TimeUnit.MINUTES);
+        ClientResponse resp = cf.get(5, TimeUnit.MINUTES);
+        if (resp.getStatus() == ClientResponse.TXN_MISPARTITIONED){
+            if (resp.getStatus() != ClientResponse.SUCCESS) {
+                exportLog.rateLimitedLog(LOG_SUPPRESSION_INTERVAL_SECONDS, Level.WARN, null,
+                        "Errors on deleting migrated row on table %s: %s", tableName, resp.getStatusString());
+                return true;
+            }
+        } else if (resp.getStatus() != ClientResponse.SUCCESS) {
+            exportLog.rateLimitedLog(LOG_SUPPRESSION_INTERVAL_SECONDS, Level.WARN, null,
+                    "Errors on deleting migrated row on table %s: %s", tableName, resp.getStatusString());
+            throw new VoltProcedure.VoltAbortException(resp.getAppStatusString());
+        }
+        VoltTable vt = resp.getResults()[0];
+        while(vt.advanceRow()) {
+            if (vt.getLong(ROWS_TO_BE_DELETED) == 1) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/tests/ee/catalog/ExportTupleStreamTest.cpp
+++ b/tests/ee/catalog/ExportTupleStreamTest.cpp
@@ -102,7 +102,7 @@ TEST_F(ExportTupleStreamTest, TestExportTableChange) {
     m_engine->releaseUndoToken(2, false);
     checkExportTupleStream(&wrapper, 2);
     // Delete migrate rows
-    m_engine->deleteMigratedRows(3000, 2000, 2000, "A", 2000, 10, 3);
+    m_engine->deleteMigratedRows(3000, 2000, 2000, "A", 2000, 3);
     m_engine->releaseUndoToken(3, false);
     checkExportTupleStream(&wrapper, 2);
 


### PR DESCRIPTION
The data in the persistent source table are deleted when external system acknowledges that the data have been received.  Export system sends one block of data at a time to external systems. The data from multiple transactions (migrations) could be accumulated into one single block. The acknowledgement is only issued with the last committed transaction, even a block contains multiple transactions.  Thus the tuples migrated in multiple transactions could be deleted  in one batch, which could pose issues with 50 MB DR size limit. The issue is resolved by deleting the migrated tuples with transaction awareness, matching migrated batch to delete batch.  