### PR TITLE
fix broken sqlcmdtest

### DIFF
--- a/tests/sqlcmd/baselines/sysproc/explaincatalog.outbaseline
+++ b/tests/sqlcmd/baselines/sysproc/explaincatalog.outbaseline
@@ -53,6 +53,7 @@ set $PREV signature "EMPLOYEES|vii"
 set $PREV tuplelimit 2147483647
 set $PREV isDRed false
 set $PREV tableType 1
+set $PREV migrationTarget ""
 add /clusters#cluster/databases#database/tables#EMPLOYEES columns EMP_ID
 set /clusters#cluster/databases#database/tables#EMPLOYEES/columns#EMP_ID index 1
 set $PREV type 5


### PR DESCRIPTION
Update the `explaincatalog.outbaseline` since I have added the `migrationTarget` attribute to the Table catalog.