### PR TITLE
ENG-16021: Fourth set of tweaks to the JUnit Auto-filer:

### DIFF
--- a/tools/jenkins/jenkinsbot.py
+++ b/tools/jenkins/jenkinsbot.py
@@ -45,11 +45,6 @@ JIRA_PASS = os.environ.get('jirapass', None)
 # TODO: change this back to 'ENG', before merging to master
 JIRA_PROJECT = os.environ.get('jiraproject', 'ENG')
 
-# Used to help prevent a Jira ticket from exceeding Jira's maximum
-# description size (32,767 characters, total)
-MAX_NUM_CHARS_PER_JIRA_DESCRIPTION  = 32767
-MAX_NUM_CHARS_PER_DESCRIPTION_PIECE = 2000
-
 # Queries
 
 # System Leaderboard - Leaderboard for master system tests on apprunner.
@@ -924,9 +919,7 @@ tr:hover{
                are marked 'is related to'.
         :param summary: The Summary to be used in the Jira ticket that is to
                be created.
-        :param description: One or more pieces of the Description to be added to
-               the Jira ticket; each one will be checked separately for being too
-               long (more than MAX_NUM_CHARS_PER_DESCRIPTION_PIECE characters).
+        :param description: The Description for the new Jira ticket.
         :param version: The (VoltDB) Version that this bug affects.
         :param labels: The Labels to list in the Jira ticket.
         :param priority: The Priority of the Jira ticket.
@@ -962,15 +955,12 @@ tr:hover{
         issue_dict = {
             'project': project,
             'summary': summary,
+            'description': description,
             'issuetype': {
                 'name': 'Bug'
             },
             'labels': labels
         }
-
-        if isinstance(description, list):
-            description = self.get_modified_description('', description)
-        issue_dict['description'] = description
 
         issue_dict['components'] = self.get_jira_component_list(jira, component, project)
         issue_dict['versions']   = self.get_jira_version_list(jira, version, project)
@@ -1045,120 +1035,6 @@ tr:hover{
         return new_issue
 
 
-    def get_modified_description(self, old_description, new_description_pieces,
-                                 num_chars_for_partial_match=12,
-                                 ignore_partial_match_for_last_n_pieces=1):
-        """Interweaves an old (Jira bug ticket) description with new description
-           pieces; essentially, parts of the old description that match new
-           description pieces will remain unchanged, but preceded first by parts
-           of the old description that preceded it and then by pieces of the new
-           description that preceded the matching piece.
-        """
-        # Original, very simple version, without interweaving:
-#         new_description = old_description
-# 
-#         for dp in new_description_pieces:
-#             if not (dp in old_description):
-#                 new_description = new_description + dp
-
-        logging.info('In [old] get_modified_description')
-        logging.debug('    old_description:\n'+str(old_description))
-        logging.debug('    new_description_pieces:\n'+str(new_description_pieces))
-
-        # Find the new_description_pieces that match parts of the old_description,
-        # both full and partial matches; the first num_chars_for_partial_match
-        # (~12) non-trivial characters are used for a partial match; for a partial
-        # match, the final ignore_partial_match_for_last_n_pieces (~1) elements of
-        # new_description_pieces are not checked, but just appended to the end of
-        # the new description (if they don't match fully)
-        matching_substring_indexes = []
-        for i in range(len(new_description_pieces)):
-            dp = new_description_pieces[i]
-            if dp in old_description:
-                start = old_description.index(dp)
-                end   = start + len(dp)
-                # keys: ndpi for 'new_description_pieces index';
-                # odsi for 'old_description start index';
-                # odei for 'old_description end index';
-                # full: True for a full (not partial) match
-                matching_substring_indexes.append({'ndpi':i,   'odsi':start,
-                                                   'odei':end, 'full':True })
-            elif i < len(new_description_pieces) - ignore_partial_match_for_last_n_pieces:
-                # In determining the number of characters to check for a partial
-                # match, don't count very common characters like '-', '\n', '\'
-                dpr = dp.replace('-', '').replace('\n', '').replace('\\', '')
-                if len(dpr) < 1:
-                    continue
-                dpi = dp.index(dpr[0]) + num_chars_for_partial_match
-                if dp[:dpi] in old_description:
-                    start = old_description.index(dp[:dpi])
-                    # keys: as above, but 'odei' is not used
-                    matching_substring_indexes.append({'ndpi':i, 'odsi':start,
-                                                       'odei':0, 'full':False })
-
-        # If every one of the new_description_pieces was found in the
-        # old_description, just return the old_description unaltered
-        if ( len(matching_substring_indexes) == len(new_description_pieces) and
-                all(msi['full'] for msi in matching_substring_indexes) ):
-            return old_description
-
-        # Interweave the non-matching and matching old_description parts
-        # and new_description_pieces
-        new_description = ''
-        old_desc_index = 0    # index in a string (of characters)
-        new_desc_index = 0    # index in a list (of strings)
-        for msi in matching_substring_indexes:
-            logging.debug('    msi: '+str(msi))
-
-            new_desc_end_index = msi['ndpi'] + 1
-            # Special case: if a partially matching new_description_piece is
-            # extremely long, skip it; this can sometimes avoid exceeding Jira's
-            # maximum description size (32,767 characters)
-            if ( not msi['full'] and len(new_description_pieces[msi['ndpi']])
-                                         > MAX_NUM_CHARS_PER_DESCRIPTION_PIECE ):
-                new_desc_end_index = msi['ndpi']
-                skipped_ndp = new_description_pieces[msi['ndpi']]
-                logging.warn('Ignoring the following description piece, because '
-                             'it partly matches the old description and has a '
-                             'length of %d characters:\n    %s'
-                             % (len(skipped_ndp), skipped_ndp) )
-
-            # Add in any parts of the old_description that we haven't used yet,
-            # and which precede the current match (full or partial); and elements
-            # of the new_description_pieces that we haven't used yet, up to and
-            # including the one that matches (fully or partially)
-            new_description = ( new_description
-                + old_description[old_desc_index:msi['odsi']]
-                + ''.join(new_description_pieces[i][:MAX_NUM_CHARS_PER_DESCRIPTION_PIECE]
-                          for i in range(new_desc_index, new_desc_end_index)) )
-            # henceforth, ignore the new_description_pieces that we've now used
-            new_desc_index = msi['ndpi'] + 1
-            # henceforth, ignore the parts of the old_description that we've now used...
-            if msi['full']:
-                old_desc_index = msi['odei']  # ... including a full match
-            else:
-                old_desc_index = msi['odsi']  # ... excluding a partial match
-            logging.debug('    old_desc_index, new_desc_index: '+str(old_desc_index)+', '+str(new_desc_index))
-
-        # Append any old_description parts and new_description_pieces after
-        # the last matching ones
-        new_description = (new_description
-            + old_description[old_desc_index:]
-            + ''.join(new_description_pieces[i] for i in range(new_desc_index, len(new_description_pieces) )) )
-        logging.debug('    new_description:\n'+str(new_description))
-
-        if len(new_description) > MAX_NUM_CHARS_PER_JIRA_DESCRIPTION:
-            suffix = '\n[Truncated]'
-            last_char_index = MAX_NUM_CHARS_PER_JIRA_DESCRIPTION - len(suffix)
-            logging.warn('Updated Jira description truncated to:\n    %s'
-                         % new_description[:last_char_index] )
-            logging.warn('This part was left out of the truncated Jira description:\n    %s'
-                         % new_description[last_char_index:] )
-            return new_description[:last_char_index] + suffix
-
-        return new_description
-
-
     def summary_differs_significantly(self, old_summary, new_summary):
         """Determines whether the old and new (Jira ticket) summaries are
            'significantly' different: if they are identical, or if they are
@@ -1196,8 +1072,7 @@ tr:hover{
                be created or modified
         :param jenkins_job ????: One or more substrings of the Summary, used to
                determine whether a Jira ticket already exists for this issue
-        :param description: One or more pieces of the Description for the
-               modified Jira ticket.
+        :param description: The Description for the modified Jira ticket.
         :param version ???: The (VoltDB) Version that this bug affects
         :param labels ??: The Labels to list in the Jira ticket
         :param priority: The Priority of the Jira ticket
@@ -1242,8 +1117,6 @@ tr:hover{
             # Update the Jira ticket's summary, description, etc.
             previous_summary  = ticket_to_modify.fields.summary
             old_description   = ticket_to_modify.fields.description
-            if isinstance(description, list):
-                description = self.get_modified_description(old_description, description)
             previous_priority = ticket_to_modify.fields.priority
 
             # If ticket has been marked as a "Blocker" (presumably manually),
@@ -1334,10 +1207,7 @@ tr:hover{
         :param summary: The Summary to be used in the Jira ticket that is to
                be created or modified.
         :param jenkins_job ????
-        :param description: One or more pieces of the Description to be used
-               in (or added to) the Jira ticket; if there is an existing bug
-               ticket that gets modified, the pieces that already exist in the
-               existing ticket do not get added, to avoid redundancy.
+        :param description: The Description for the new or modified Jira ticket.
         :param version: The (VoltDB) Version that this bug affects.
         :param labels: The Labels to list in the Jira ticket.
         :param priority: The Priority of the Jira ticket.


### PR DESCRIPTION
In junit-stats.py:
Added new and improved get_modified_description function (and
truncate_if_needed, used by it), which does a much better job of
combining the old, existing description for a Jira ticket and the new
pieces we want to add based on the latest failure; and modified
file_jira_issue, etc., to make use of it.
Changed the failure percentage format so that single-digit percentages
are preceded by a 0, e.g. Summaries with: "INTERMITTENT 08% ..." rather
than "INTERMITTENT 8% ...", which should result in better sorting.

In jenkinsbot.py:
In find_jira_bug_tickets, changed ORDER BY from DESC to ASC, so that
when there is more than one relevant ticket, the older one will be
chosen: this is a partial fix for a problem where failing tests that
have essentially the same class and method name (e.g.
TestLeaderElections.testLeaderElections or
TestMigrateExport.testMigrateExport - Jira searches are case
insensitive) get confused with other failing tests in the same class,
and take over Jira tickets that were originally intended for the other
test.
In modify_jira_bug_ticket, added notify=false, so that we will not get
email every time a ticket is modified - only when it is created or
closed (I think). [Note: this only works because Ruth gave the
auto-filer's Jira user Project Admin privileges.]