### PR TITLE
Allow users to pass in startup options as an environment variable

### DIFF
--- a/tools/docker/docker-entrypoint.sh
+++ b/tools/docker/docker-entrypoint.sh
@@ -39,7 +39,7 @@ function execVoltdbStart() {
     fi
 
     if [ -n "${HOST_COUNT}" ]; then
-        OPTIONS=" -c $HOST_COUNT"
+        OPTIONS="$OPTIONS -c $HOST_COUNT"
     fi
 
     if [ -n "${HOSTS}" ]; then


### PR DESCRIPTION
This PR allows users to pass in any startup options they want via the "OPTIONS" environment variable