### PR TITLE
ENG-16168: Handle completion tasks better

### DIFF
--- a/src/frontend/org/voltcore/zk/LeaderElector.java
+++ b/src/frontend/org/voltcore/zk/LeaderElector.java
@@ -149,6 +149,13 @@ public class LeaderElector {
         }
     }
 
+    public int getLeaderId() {
+        if (node == null) {
+            throw new IllegalStateException("LeaderElector must be started");
+        }
+        return Integer.parseInt(node.substring(node.lastIndexOf('_') + 1));
+    }
+
     /**
      * Start participation in a leader election.
      *

--- a/src/frontend/org/voltdb/GlobalServiceElector.java
+++ b/src/frontend/org/voltdb/GlobalServiceElector.java
@@ -97,4 +97,8 @@ class GlobalServiceElector implements LeaderNoticeHandler
             VoltDB.crashLocalVoltDB("Error shutting down GlobalServiceElector's LeaderElector", true, e);
         }
     }
+
+    public int getLeaderId() {
+        return m_leaderElector.getLeaderId();
+    }
 }

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1306,7 +1306,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                         localHSIds.add(ii.getInitiatorHSId());
                     }
 
-                    m_MPI = new MpInitiator(m_messenger, localHSIds, getStatsAgent());
+                    m_MPI = new MpInitiator(m_messenger, localHSIds, getStatsAgent(),
+                            m_globalServiceElector.getLeaderId());
                     m_iv2Initiators.put(MpInitiator.MP_INIT_PID, m_MPI);
                 }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2338,6 +2338,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         return m_iv2Initiators.size() - (m_eligibleAsLeader ? 1 : 0);
     }
 
+    @Override
     public boolean isClusterComplete() {
         return (m_config.m_hostCount == m_messenger.getLiveHostIds().size());
     }

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -80,21 +80,7 @@ public abstract class BaseInitiator<S extends Scheduler> implements Initiator
             joinProducer = null;
         }
 
-        if (m_partitionId == MpInitiator.MP_INIT_PID) {
-            m_initiatorMailbox = new MpInitiatorMailbox(
-                    m_partitionId,
-                    m_scheduler,
-                    m_messenger,
-                    m_repairLog,
-                    joinProducer);
-        } else {
-            m_initiatorMailbox = new InitiatorMailbox(
-                    m_partitionId,
-                    m_scheduler,
-                    m_messenger,
-                    m_repairLog,
-                    joinProducer);
-        }
+        m_initiatorMailbox = createInitiatorMailbox(joinProducer);
 
         // Now publish the initiator mailbox to friends and family
         m_messenger.createMailbox(null, m_initiatorMailbox);
@@ -239,4 +225,6 @@ public abstract class BaseInitiator<S extends Scheduler> implements Initiator
             return null;
         }
     }
+
+    protected abstract InitiatorMailbox createInitiatorMailbox(JoinProducerBase joinProducer);
 }

--- a/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
@@ -84,8 +84,8 @@ public class InitiatorMailbox implements Mailbox
         }
     }
 
-    VoltLogger hostLog = new VoltLogger("HOST");
-    VoltLogger tmLog = new VoltLogger("TM");
+    final VoltLogger hostLog = new VoltLogger("HOST");
+    final VoltLogger tmLog = new VoltLogger("TM");
 
     protected final int m_partitionId;
     protected final Scheduler m_scheduler;

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -237,4 +237,9 @@ public class MpInitiator extends BaseInitiator<MpScheduler> implements Promotabl
     public void enableWritingIv2FaultLog() {
         m_initiatorMailbox.enableWritingIv2FaultLog();
     }
+
+    @Override
+    protected InitiatorMailbox createInitiatorMailbox(JoinProducerBase joinProducer) {
+        return new MpInitiatorMailbox(m_partitionId, m_scheduler, m_messenger, m_repairLog, joinProducer);
+    }
 }

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -51,7 +51,7 @@ public class MpInitiator extends BaseInitiator<MpScheduler> implements Promotabl
 {
     public static final int MP_INIT_PID = TxnEgo.PARTITIONID_MAX_VALUE;
 
-    public MpInitiator(HostMessenger messenger, List<Long> buddyHSIds, StatsAgent agent)
+    public MpInitiator(HostMessenger messenger, List<Long> buddyHSIds, StatsAgent agent, int leaderId)
     {
         super(VoltZK.iv2mpi,
                 messenger,
@@ -60,7 +60,7 @@ public class MpInitiator extends BaseInitiator<MpScheduler> implements Promotabl
                     MP_INIT_PID,
                     buddyHSIds,
                     new SiteTaskerQueue(MP_INIT_PID),
-                    messenger.getHostId()),
+                    leaderId),
                 "MP",
                 agent,
                 StartAction.CREATE /* never for rejoin */);
@@ -169,8 +169,9 @@ public class MpInitiator extends BaseInitiator<MpScheduler> implements Promotabl
                         m_initiatorMailbox.repairReplicasWith(null, firstMsg);
                     }
                     tmLog.info(m_whoami
-                             + "finished leader promotion. Took "
-                             + (System.currentTimeMillis() - startTime) + " ms.");
+                            + "finished leader promotion. Took "
+                            + (System.currentTimeMillis() - startTime) + " ms. Leader ID: "
+                            + m_scheduler.getLeaderId());
 
                     // THIS IS where map cache should be updated, not
                     // in the promotion algorithm.

--- a/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
@@ -200,8 +200,7 @@ public class MpInitiatorMailbox extends InitiatorMailbox
             JoinProducerBase rejoinProducer)
     {
         super(partitionId, scheduler, messenger, repairLog, rejoinProducer);
-        m_restartSeqGenerator = new MpRestartSequenceGenerator(
-                ((MpScheduler)m_scheduler).getHostId(), false);
+        m_restartSeqGenerator = new MpRestartSequenceGenerator(((MpScheduler)m_scheduler).getLeaderId(), false);
         m_taskThread.start();
         m_sendThread.start();
     }

--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -63,7 +63,7 @@ public class MpProcedureTask extends ProcedureTask
 
     MpProcedureTask(Mailbox mailbox, String procName, TransactionTaskQueue queue,
                   Iv2InitiateTaskMessage msg, List<Long> pInitiators, Map<Integer, Long> partitionMasters,
-                  long buddyHSId, boolean isRestart, int leaderNodeId, boolean nPartTxn)
+                  long buddyHSId, boolean isRestart, int leaderId, boolean nPartTxn)
     {
         super(mailbox, procName,
               new MpTransactionState(mailbox, msg, pInitiators, partitionMasters,
@@ -74,7 +74,7 @@ public class MpProcedureTask extends ProcedureTask
         m_initiatorHSIds.addAll(pInitiators);
         m_restartMasters.set(new ArrayList<Long>());
         m_restartMastersMap.set(new HashMap<Integer, Long>());
-        m_restartSeqGenerator = new MpRestartSequenceGenerator(leaderNodeId, true);
+        m_restartSeqGenerator = new MpRestartSequenceGenerator(leaderId, true);
     }
 
     /**

--- a/src/frontend/org/voltdb/iv2/MpRestartSequenceGenerator.java
+++ b/src/frontend/org/voltdb/iv2/MpRestartSequenceGenerator.java
@@ -25,19 +25,19 @@ public class MpRestartSequenceGenerator {
     // signed / unsigned conversions easier.
     // having MPI promotions for up to 1,000,000 Rejoined nodes, should be enough
     // for now. Restart flag reset means that this came from a SPI leader promotion
-    static final long NODEID_BITS = 20;
+    static final long LEADERID_BITS = 20;
     static final long RESTART_BITS = 1;
     static final long COUNTER_BITS = 42;
 
-    static final long NODEID_MAX_VALUE = (1L << NODEID_BITS) - 1L;
+    static final long LEADERID_MAX_VALUE = (1L << LEADERID_BITS) - 1L;
     static final long RESTART_MAX_VALUE = (1L << RESTART_BITS) - 1L;
     static final long COUNTER_MAX_VALUE = (1L << COUNTER_BITS) - 1L;
     private final long m_highOrderFields;
     private long m_counter = 0;
 
-    public MpRestartSequenceGenerator(int nodeId, boolean forRestart) {
-        assert (nodeId <= NODEID_MAX_VALUE);
-        m_highOrderFields = ((long)nodeId << (COUNTER_BITS + RESTART_BITS))
+    public MpRestartSequenceGenerator(int leaderId, boolean forRestart) {
+        assert (leaderId <= LEADERID_MAX_VALUE);
+        m_highOrderFields = ((long)leaderId << (COUNTER_BITS + RESTART_BITS))
                           | (forRestart ? (1L << COUNTER_BITS) : 0);
     }
 
@@ -62,7 +62,7 @@ public class MpRestartSequenceGenerator {
         return ((restartSeqId >> COUNTER_BITS) & RESTART_MAX_VALUE) == 1;
     }
 
-    public static int getNodeId(long restartSeqId) {
+    public static int getLeaderId(long restartSeqId) {
         return (int) (restartSeqId >> (COUNTER_BITS + RESTART_BITS));
     }
 
@@ -71,7 +71,7 @@ public class MpRestartSequenceGenerator {
         if (restartSeqId == CompleteTransactionMessage.INITIAL_TIMESTAMP) {
             return "(INITIAL)";
         }
-        return "(" + MpRestartSequenceGenerator.getNodeId(restartSeqId) + ":" +
+        return "(" + MpRestartSequenceGenerator.getLeaderId(restartSeqId) + ":" +
                 MpRestartSequenceGenerator.getSequence(restartSeqId) + (isForRestart(restartSeqId) ? "R)" : ")");
     }
 
@@ -81,7 +81,7 @@ public class MpRestartSequenceGenerator {
             sb.append("(INITIAL)");
             return;
         }
-        sb.append("(").append(MpRestartSequenceGenerator.getNodeId(restartSeqId)).append(":");
+        sb.append("(").append(MpRestartSequenceGenerator.getLeaderId(restartSeqId)).append(":");
         sb.append(MpRestartSequenceGenerator.getSequence(restartSeqId));
         if (isForRestart(restartSeqId)) {
             sb.append("R)");

--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -86,8 +86,10 @@ public class Scoreboard {
             nextTaskCounter.txnId = next.getFirst().getMsgTxnId();
             nextTaskCounter.completionCount++;
             nextTaskCounter.timestamp = next.getFirst().getTimestamp();
+            nextTaskCounter.missingTxn |= next.getSecond() || next.getFirst().m_txnState.isDone();
         } else if (nextTaskCounter.txnId == next.getFirst().getMsgTxnId() &&
                 nextTaskCounter.timestamp == next.getFirst().getTimestamp()) {
+            nextTaskCounter.missingTxn |= next.getSecond();
             nextTaskCounter.completionCount++;
         }
         return pair;

--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -17,6 +17,7 @@
 
 package org.voltdb.iv2;
 
+import java.util.Map;
 import java.util.TreeMap;
 
 import org.voltcore.logging.VoltLogger;
@@ -144,16 +145,11 @@ public class Scoreboard {
 
     // Only match CompleteTransactionTask at head of the queue
     public boolean matchCompleteTransactionTask(long txnId, long timestamp) {
-        if (!m_compTasks.isEmpty()) {
-            long lowestTxnId = m_compTasks.firstKey();
-            if (txnId == lowestTxnId) {
-                Pair<CompleteTransactionTask, Boolean> pair = m_compTasks.get(lowestTxnId);
-                return timestamp == pair.getFirst().getTimestamp();
-            }
-        }
-        return false;
+        Map.Entry<Long, Pair<CompleteTransactionTask, Boolean>> entry = m_compTasks.firstEntry();
+        return entry != null && entry.getKey() == txnId && entry.getValue().getFirst().getTimestamp() == timestamp;
     }
 
+    @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
         if (!m_compTasks.isEmpty()){

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -365,4 +365,9 @@ public class SpInitiator extends BaseInitiator<SpScheduler> implements Promotabl
         }
         m_scheduler.forwardPendingTaskToRejoinNode(replicasAdded, snapshotTransactionState.m_spHandle);
     }
+
+    @Override
+    protected InitiatorMailbox createInitiatorMailbox(JoinProducerBase joinProducer) {
+        return new InitiatorMailbox(m_partitionId, m_scheduler, m_messenger, m_repairLog, joinProducer);
+    }
 }

--- a/tests/frontend/org/voltdb/iv2/TestMpRestartSequenceGenerator.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpRestartSequenceGenerator.java
@@ -35,7 +35,7 @@ public class TestMpRestartSequenceGenerator extends TestCase {
         MpRestartSequenceGenerator seqGen = new MpRestartSequenceGenerator(0, forRestart);
         long seq = seqGen.getNextSeqNum();
         assertEquals(forRestart, MpRestartSequenceGenerator.isForRestart(seq));
-        assertEquals(0, MpRestartSequenceGenerator.getNodeId(seq));
+        assertEquals(0, MpRestartSequenceGenerator.getLeaderId(seq));
         assertEquals(1, MpRestartSequenceGenerator.getSequence(seq));
     }
 
@@ -45,7 +45,7 @@ public class TestMpRestartSequenceGenerator extends TestCase {
         MpRestartSequenceGenerator seqGen = new MpRestartSequenceGenerator(12, forRestart);
         long seq = seqGen.getNextSeqNum();
         assertEquals(forRestart, MpRestartSequenceGenerator.isForRestart(seq));
-        assertEquals(12, MpRestartSequenceGenerator.getNodeId(seq));
+        assertEquals(12, MpRestartSequenceGenerator.getLeaderId(seq));
         assertEquals(1, MpRestartSequenceGenerator.getSequence(seq));
     }
 }


### PR DESCRIPTION
1. The method TranstactionTaskQueue.coordinatedTaskQueueOffer is suppose to
complete the task for the passed in task and any other fully completed tasks
behind it. However that wouldn't happen.
RelativeSiteOffset.releaseStashedCompleteTxns would return true if the next
task in all the Scoreboards was the same. That result would then be assigned to
the done variable and cause nothing else to be processed.

Instead of returning a boolean keep releasing completed transactions until they
are all gone or one is encountered which is not completed on all sites.

2. The global leader elector uses a different sequence ID than host ID. Because
they are different it could mean the leader selected does not have the lowest
host ID. When the leader fails the new leader could have a lower host ID which
is an issue for MpRestartSequenceGenerator which makes the assumption that new
leaders always have higher host IDs.

Instead of using the host ID in MpRestartSequenceGenerator use the leader ID
from the elector. This ID is guaranteed to only increase. Pass the leader ID
from the elector into the MpInitiator to use instead of hostId.