### PR TITLE
Eng 16336 tsv escape bugs

### DIFF
--- a/src/frontend/org/voltdb/exportclient/ExportToFileClient.java
+++ b/src/frontend/org/voltdb/exportclient/ExportToFileClient.java
@@ -417,7 +417,7 @@ public class ExportToFileClient extends ExportClientBase {
                 }
                 else {
                     // TSV
-                    writer = CSVWriter.getStrictTSVWriter(new BufferedWriter(osw, 4096 * 4));
+                    writer = CSVWriter.getTSVWriter(new BufferedWriter(osw, 4096 * 4));
                 }
             }
             catch (Exception e) {

--- a/third_party/java/src/au/com/bytecode/opencsv_voltpatches/CSVWriter.java
+++ b/third_party/java/src/au/com/bytecode/opencsv_voltpatches/CSVWriter.java
@@ -280,19 +280,22 @@ public class CSVWriter implements Closeable {
                 sb.append(escapechar).append(nextChar);
                 continue;
             }
-            if (extraEscapeChars != null) {
+            if (escapechar != NO_ESCAPE_CHARACTER && extraEscapeChars != null) {
+                boolean matched = false;
                 for (char eec : extraEscapeChars) {
                     if (nextChar == eec) {
                         sb.append(escapechar).append(nextChar);
+                        matched = true;
                         break;
                     }
                 }
-                continue;
+                if (matched) {
+                    continue;
+                }
             }
-            // else
+            // else not escaped
             sb.append(nextChar);
         }
-
         return sb;
     }
 

--- a/third_party/java/src/au/com/bytecode/opencsv_voltpatches/CSVWriter.java
+++ b/third_party/java/src/au/com/bytecode/opencsv_voltpatches/CSVWriter.java
@@ -165,9 +165,16 @@ public class CSVWriter implements Closeable {
         this.lineEnd = lineEnd;
     }
 
+    // TSV writer escaping carriage return and newline characters
     public static CSVWriter getStrictTSVWriter(Writer writer) {
         CSVWriter retval = new CSVWriter(writer, '\t', NO_QUOTE_CHARACTER, '\\', DEFAULT_LINE_END);
         retval.extraEscapeChars = new char[] { '\r', '\n' };
+        return retval;
+    }
+
+    // TSV writer escaping nothing
+    public static CSVWriter getTSVWriter(Writer writer) {
+        CSVWriter retval = new CSVWriter(writer, '\t', NO_QUOTE_CHARACTER, NO_ESCAPE_CHARACTER, DEFAULT_LINE_END);
         return retval;
     }
 


### PR DESCRIPTION
Fixing this ticket with 2 separate commits:
1- fix the handling of extra escape characters, which was totally busted
2- change export to use a TSV writer doing no escaping at all, which allows preserving JSON contents:

Thus if you insert this:

2> insert into stream_towns (town, state) values ('{"foo":"bar","bar":"glo\n"}', '01');
(Returned 1 rows in 0.00s)

You get that 
3619631923494912	1199506655149680	8	0	0	1	{"foo":"bar","bar":"glo\n"}	  01


