### PR TITLE
ENG-15983: Add delta to ledger before sending data

### DIFF
--- a/src/frontend/org/voltcore/network/TLSEncryptionAdapter.java
+++ b/src/frontend/org/voltcore/network/TLSEncryptionAdapter.java
@@ -186,6 +186,7 @@ public class TLSEncryptionAdapter {
                 if (m_inflightMessages == null) {
                     break;
                 }
+                delta += m_inflightMessages.m_delta;
             }
 
             bytesWritten += m_inflightMessages.write(channel);
@@ -193,7 +194,6 @@ public class TLSEncryptionAdapter {
                 break;
             }
 
-            delta += m_inflightMessages.m_delta;
             messagesWritten += m_inflightMessages.m_count;
             m_inflightMessages.m_messages.release();
             m_inflightMessages = null;


### PR DESCRIPTION
VoltTLSNIOWriteStream.drainTo maintains the backpressure with the assumption
that the delta is always reported upfront. To maintian that behavior add the
delta when the next buffer to send is retrieved from the queue.