### PR TITLE
ENG-16414: ensure stale buffers are cleaned before we start polling t…

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -444,16 +444,19 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
         }
     }
 
-    // In truncateExportToSeqNo() we try to cleanup stale PBD segments. If it isn't invoked
-    // due to empty snapshot or missing stream in snapshot, this is our last chance to clean
-    // stale PBD segments.
-    public void cleanupStaleBuffers() {
-        m_es.execute(new Runnable() {
+    // In truncateExportToSeqNo() we try to cleanup stale PBD segments. If truncation isn't invoked
+    // due to an empty snapshot or stream not present in snapshot, this is our last chance to clean
+    // stale PBD segments. This MUST be called before the {@code GuestProcessor} starts polling.
+    public ListenableFuture<?> cleanupStaleBuffers() {
+        return m_es.submit(new Runnable() {
+            @Override
             public void run() {
                 // *Created* generation id is either from EDS constructor or from export buffer
                 // truncation (which comes from loading snapshot)
                 long generationIdCreated = m_committedBuffers.getGenerationIdCreated();
                 try {
+                    assert(!m_readyForPolling);
+
                     if (m_committedBuffers.deleteStaleBlocks(generationIdCreated)) {
                         // Stale export buffers are deleted , re-create the tracker.
                         m_gapTracker = m_committedBuffers.scanForGap();

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -332,7 +332,7 @@ public class ExportManager
 
         // Notify export datasources to check the *generation* of export buffers,
         // delete buffers older than current generation number or generation number
-        // from snapshot.
+        // from snapshot. This must be done before the processor starts polling.
         cleanupStaleBuffers();
 
         processor.startPolling();

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -384,6 +384,7 @@ public class StreamBlockQueue {
     public boolean deleteStaleBlocks(long generationId) throws IOException {
         boolean didCleanup = m_persistentDeque.deletePBDSegment(new BinaryDequeValidator<ExportRowSchema>() {
 
+            @Override
             public boolean isStale(ExportRowSchema extraHeader) {
                 assert (extraHeader != null);
                 boolean fromOlderGeneration = extraHeader.initialGenerationId < generationId;
@@ -403,8 +404,8 @@ public class StreamBlockQueue {
             }
         }
         if (didCleanup) {
-            // Clear cache in case of any memory copy of stale data is stored in memory deque
-            m_memoryDeque.clear();
+            // Close and reopen
+            close();
             CatalogContext catalogContext = VoltDB.instance().getCatalogContext();
             constructPBD(catalogContext.m_genId);
         }


### PR DESCRIPTION
…he export data source

The fix has been validated by running the following test:

./apprunner.py -w Recover-Txnid2 --name=Recovertxnid2 --disabledthreads=partttlMigratelt,replttlMigratelt --output=savedlogs --config=/var/lib/apprunner/configs/../config/randomize.py --duration=900 --nostats --commandlogging=on --case=18eaabc81ce6d0f4c2b6cf

NOTE: the '--disabledthreads' argument is added to work around a new bug in TTL migrate; a different ticket will be opened shortly.
