### PR TITLE
ENG-16399:

### DIFF
--- a/src/frontend/org/voltdb/exceptions/SerializableException.java
+++ b/src/frontend/org/voltdb/exceptions/SerializableException.java
@@ -27,6 +27,7 @@ import org.json_voltpatches.JSONString;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.ClientResponseImpl;
 import org.voltdb.VoltProcedure;
+import org.voltdb.client.ClientResponse;
 
 /**
  * Base class for runtime exceptions that can be serialized to ByteBuffers without involving Java's
@@ -240,6 +241,11 @@ public class SerializableException extends VoltProcedure.VoltAbortException impl
         final int ordinal = b.get();
         assert (ordinal != SerializableExceptions.None.ordinal());
         return SerializableExceptions.values()[ordinal].deserializeException(b);
+    }
+
+    @Override
+    public byte getClientResponseStatus() {
+        return ClientResponse.UNEXPECTED_FAILURE;
     }
 
     @Override

--- a/src/frontend/org/voltdb/exceptions/SpecifiedException.java
+++ b/src/frontend/org/voltdb/exceptions/SpecifiedException.java
@@ -85,7 +85,8 @@ public class SpecifiedException extends SerializableException {
         return new String(m_statusStringBytes, Charsets.UTF_8);
     }
 
-    public byte getStatus() {
+    @Override
+    public byte getClientResponseStatus() {
         return m_status;
     }
 }


### PR DESCRIPTION
Before changed for ENG-15731, VoltAbortException super class would return
client response status of USER_ABORT and its subclass SerializableException
would return UNEXPECTED_ERROR. After the change, SerializableException also started
return USER_ABORT status, which was indicating some failures as aborts to stats.
Fixed that to keep the original behaviour.