### PR TITLE
ENG-16021: Sixth set of tweaks to the JUnit Auto-filer:

### DIFF
--- a/tools/jenkins/junit-stats.py
+++ b/tools/jenkins/junit-stats.py
@@ -1727,6 +1727,11 @@ if __name__ == '__main__':
                          post_to_slack, file_jira_ticket=not DRY_RUN)
 
     if ERROR_COUNT:
+        # Check for any /tmp/*.tmp files, which a JIRAError sometimes creates
+        for file in os.listdir('/tmp'):
+            if file.endswith('.tmp'):
+                contents = open('/tmp/'+file, 'r')
+                logging.info('Contents of %s:\n%s' % (str(file), contents.read()) )
         logging.info("Processing of Jenkins builds failed with %d ERROR(s) "
                      "(and %d WARNING(s))" % (ERROR_COUNT, WARNING_COUNT) )
         sys.exit(11)


### PR DESCRIPTION
In jenkinsbot.py: change modify_jira_bug_ticket, to try twice to update
the Jira ticket: once without email notification, and if that does not
work (as seems to happen sporadically), a second time with email
notification. Also, modify that function, and also
create_jira_bug_ticket and close_jira_bug_ticket, to re-raise the caught
exception, if the basic functionality does not work, so that the Jenkins
build will fail.
In junit-stats.py: check for any /tmp/*.tmp files (which a JIRAError
sometimes leaves behind), and if found, print their contents.