### PR TITLE
ENG-16463: NPE in MIGRATE FROM

### DIFF
--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -61,6 +61,7 @@ public final class ExpressionUtil {
        put("subtract", ExpressionType.OPERATOR_MINUS);
        put("multiply", ExpressionType.OPERATOR_MULTIPLY);
        put("divide", ExpressionType.OPERATOR_DIVIDE);
+       put("is_null", ExpressionType.OPERATOR_IS_NULL);
     }};
 
     private ExpressionUtil() {}

--- a/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
@@ -76,7 +76,12 @@ public class TestAdhocMigrateTable extends AdhocDDLTestBase {
                         Pair.of("MIGRATE FROM with_ttl WHERE not not migrating;", false),
                         Pair.of("MIGRATE FROM with_ttl WHERE migrating() and j > 0;", false),
                         // we don't prevent user from doing this
-                        Pair.of("MIGRATE FROM with_ttl WHERE not (not migrating);", true)
+                        Pair.of("MIGRATE FROM with_ttl WHERE not (not migrating);", true),
+                        // ENG-16463
+                        Pair.of("MIGRATE FROM without_ttl where j is not null;", false),
+                        Pair.of("MIGRATE FROM without_ttl where j is null;", false),
+                        Pair.of("MIGRATE FROM without_ttl where j is not null and not migrating;", true),
+                        Pair.of("MIGRATE FROM without_ttl where j is null and not migrating;", true)
                 ).collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
The XML attribute -> OPERATOR_TYPE mapping:
`"is_null" -> OPERATOR_IS_NULL` is missing.