### PR TITLE
Eng 15612 - Fix "Alter Table Alter Using MigrateTarget" bug

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -906,6 +906,9 @@ public class ParserDDL extends ParserRoutine {
                         checkIsSimpleName();
 
                         return compileAlterTableAddColumn(t);
+
+                    // As for now we cannot alter TTL if having migrate target
+                    // This restriction may be removed in the future
                     case Tokens.USING :
                         if (t.getTTL() != null) {
                             throw Error.error(ErrorCode.X_42504);
@@ -1075,6 +1078,9 @@ public class ParserDDL extends ParserRoutine {
         //syntax: USING TTL 10 SECONDS ON COLUMN a BATCH_SIZE 1000 MAX_FREQUENCY 1 MIGRATE TO TARGET <TARGET NAME>
         if (!alter && token.tokenType != Tokens.USING) {
             return null;
+        }
+        if (alter && table.hasMigrationTarget()) {
+            throw Error.error(ErrorCode.X_42581, "May not alter TTL column");
         }
         int timeLiveValue = 0;
         String ttlUnit = "SECONDS";

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -977,9 +977,14 @@ public class ParserDDL extends ParserRoutine {
             case Tokens.ALTER : {
                 read();
 
-                if (token.tokenType == Tokens.EXPORT ) {
+                if (token.tokenType == Tokens.EXPORT) {
                     return readPersistentExport(t, true);
                 }
+
+                if (token.tokenType == Tokens.USING) {
+                    return readTimeToLive(t, true);
+                }
+
                 if (token.tokenType == Tokens.COLUMN) {
                     read();
                 }
@@ -990,9 +995,6 @@ public class ParserDDL extends ParserRoutine {
                 read();
 
                 return compileAlterColumn(t, column, columnIndex);
-            }
-            case Tokens.USING : {
-                return readTimeToLive(t, true);
             }
             default : {
                 throw unexpectedToken();

--- a/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
@@ -748,17 +748,17 @@ public class TestCatalogDiffs extends TestCase {
         Catalog catOriginal = catalogForJar(testDir + File.separator + "testAlterTableTTL1.jar");
 
         // alter TTL
-        builder.addLiteralSchema("\nALTER TABLE A USING TTL 20 MINUTES ON COLUMN C2;");
+        builder.addLiteralSchema("\nALTER TABLE A ALTER USING TTL 20 MINUTES ON COLUMN C2;");
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "testAlterTableTTL2.jar"));
         Catalog catUpdated = catalogForJar(testDir + File.separator + "testAlterTableTTL2.jar");
         verifyDiff(catOriginal, catUpdated, false, null, true, false, true);
 
-        builder.addLiteralSchema("\nALTER TABLE A USING TTL 20 MINUTES ON COLUMN C2 MAX_FREQUENCY 1;");
+        builder.addLiteralSchema("\nALTER TABLE A ALTER USING TTL 20 MINUTES ON COLUMN C2 MAX_FREQUENCY 1;");
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "testAlterTableTTL21.jar"));
         Catalog catUpdated1 = catalogForJar(testDir + File.separator + "testAlterTableTTL21.jar");
         verifyDiff(catUpdated, catUpdated1, false, null, true, false, true);
 
-        builder.addLiteralSchema("\nALTER TABLE A USING TTL 20 MINUTES ON COLUMN C2 BATCH_SIZE 10 MAX_FREQUENCY 3;");
+        builder.addLiteralSchema("\nALTER TABLE A ALTER USING TTL 20 MINUTES ON COLUMN C2 BATCH_SIZE 10 MAX_FREQUENCY 3;");
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "testAlterTableTTL22.jar"));
         Catalog catUpdated2 = catalogForJar(testDir + File.separator + "testAlterTableTTL22.jar");
         verifyDiff(catUpdated1, catUpdated2, false, null, true, false, true);
@@ -768,7 +768,7 @@ public class TestCatalogDiffs extends TestCase {
         Catalog catTTlDropped = catalogForJar(testDir + File.separator + "testAlterTableTTL3.jar");
         verifyDiff(catUpdated, catTTlDropped, false, null, true, false, true);
 
-        builder.addLiteralSchema("\nALTER TABLE A USING TTL 20 MINUTES ON COLUMN C2 BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATION TO TARGET X;");
+        builder.addLiteralSchema("\nALTER TABLE A ALTER USING TTL 20 MINUTES ON COLUMN C2 BATCH_SIZE 10 MAX_FREQUENCY 3 MIGRATION TO TARGET X;");
         assertFalse("Failed to compile schema", builder.compile(testDir + File.separator + "testAlterTableTTL3.jar"));
     }
 
@@ -798,7 +798,7 @@ public class TestCatalogDiffs extends TestCase {
         Catalog catOriginal = catalogForJar(testDir + File.separator + "testAlterStreamTTL1.jar");
 
         // add TTL, not supported, failed in DiffEngine
-        builder.addLiteralSchema("\nALTER TABLE A USING TTL 20 MINUTES ON COLUMN C2;");
+        builder.addLiteralSchema("\nALTER TABLE A ALTER USING TTL 20 MINUTES ON COLUMN C2;");
         assertTrue("Failed to compile schema", builder.compile(testDir + File.separator + "testAlterStreamTTL2.jar"));
         Catalog catUpdated = catalogForJar(testDir + File.separator + "testAlterStreamTTL2.jar");
         verifyDiffRejected(catOriginal, catUpdated);

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -127,14 +127,14 @@ public class TestVoltCompiler extends TestCase {
 
     public void testDDLCompilerTTL() throws Exception {
         String ddl = "create table ttl (a integer NOT NULL, b integer, PRIMARY KEY(a)) USING TTL 10 SECONDS ON COLUMN a;\n" +
-                     "alter table ttl USING TTL 20 MINUTES ON COLUMN a;\n" +
-                     "alter table ttl USING TTL 20 ON COLUMN a;\n" +
-                     "alter table ttl USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10;\n" +
-                     "alter table ttl USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 10;\n" +
-                     "alter table ttl USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 1;\n" +
-                     "alter table ttl USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 3 BATCH_SIZE 1;\n" +
-                     "alter table ttl USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 3;\n" +
-                     "alter table ttl USING TTL 20 ON COLUMN a BATCH_SIZE 10;\n" +
+                     "alter table ttl alter USING TTL 20 MINUTES ON COLUMN a;\n" +
+                     "alter table ttl alter USING TTL 20 ON COLUMN a;\n" +
+                     "alter table ttl alter USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10;\n" +
+                     "alter table ttl alter USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 10;\n" +
+                     "alter table ttl alter USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 1;\n" +
+                     "alter table ttl alter USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 3 BATCH_SIZE 1;\n" +
+                     "alter table ttl alter USING TTL 20 MINUTES ON COLUMN a MAX_FREQUENCY 3;\n" +
+                     "alter table ttl alter USING TTL 20 ON COLUMN a BATCH_SIZE 10;\n" +
                      "alter table ttl drop TTL;\n" +
                      "alter table ttl ADD USING TTL 20 ON COLUMN a BATCH_SIZE 10;\n";
         VoltProjectBuilder pb = new VoltProjectBuilder();
@@ -150,7 +150,7 @@ public class TestVoltCompiler extends TestCase {
 
         // max_fequency must be positive integer
         ddl = "create table ttl (a integer NOT NULL, b integer, PRIMARY KEY(a)) USING TTL 10 SECONDS ON COLUMN a;\n" +
-              "alter table ttl USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 0;\n";
+              "alter table ttl alter USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 0;\n";
         pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);
         assertFalse(pb.compile(Configuration.getPathToCatalogForTest("testout.jar")));
@@ -3964,7 +3964,7 @@ public class TestVoltCompiler extends TestCase {
 
         ddl = "create table ttl MIGRATE TO TARGET TEST (a integer not null, b integer, PRIMARY KEY(a)) " +
                 "USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 10 MAX_FREQUENCY 3;\n" +
-                "alter table ttl USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 200 MAX_FREQUENCY 20;\n";
+                "alter table ttl alter USING TTL 20 MINUTES ON COLUMN a BATCH_SIZE 200 MAX_FREQUENCY 20;\n";
         pb = new VoltProjectBuilder();
         pb.addLiteralSchema(ddl);
         // does not alter target but other params


### PR DESCRIPTION
This PR concludes the DDL feature for **Migrate Table**.
The latest syntax rule will be: You cannot alter the MIGRATE TO TARGET attribute of the table. You also cannot alter any attributes of the table that affect migration. For example, you cannot add, drop, or alter the USING TTL clause if the table is declared with MIGRATE TO TARGET. And if the table has both MIGRATE TO TARGET and USING TTL, you cannot add, drop, or alter the TTL column. However, you can alter the TTL value, batch size and frequency.