### PR TITLE
Eng 16508 - Fix "Create procedure as Migrate from" bug 

### DIFF
--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -211,6 +211,10 @@ public final class ExpressionUtil {
             assert !colName.isEmpty();
             return new TupleValueExpression(tblName, colName, colIndex);
         } else if (elm.name.equals("value")) {
+            // add support for dyanmic parameter
+            if (elm.getStringAttribute("isparam", "").equals("true")) {
+                return new ParameterValueExpression();
+            }
             final ConstantValueExpression expr = new ConstantValueExpression();
             expr.setValue(elm.getStringAttribute("value", ""));
             expr.setValueType(VoltType.typeFromString(elm.getStringAttribute("valuetype", typeHint)));

--- a/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
@@ -113,15 +113,9 @@ public class TestAdhocMigrateTable extends AdhocDDLTestBase {
     // test sql funtion contains ?
     public void testENG16508() throws Exception {
         String ddl = "CREATE TABLE without_ttl migrate to target foo (i int NOT NULL, j FLOAT, ts TIMESTAMP);\n";
-        try {
-            setup(ddl);
-            ClientResponse res = m_client.callProcedure("@Adhoc", "MIGRATE FROM without_ttl where not migrating and ts < dateAdd(second, ?, now);", 1);
-            assertEquals(res.getStatus(), ClientResponse.SUCCESS);
-        } catch (Exception e) {
-            //  Auto-generated catch block
-        } finally {
-            teardownSystem();
-        }
-
+        setup(ddl);
+        ClientResponse res = m_client.callProcedure("@AdHoc", "MIGRATE FROM without_ttl where not migrating and ts < dateAdd(second, ?, now);", 1);
+        assertEquals(res.getStatus(), ClientResponse.SUCCESS);
+        teardownSystem();
     }
 }

--- a/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
@@ -23,19 +23,21 @@
 
 package org.voltdb;
 
-import org.junit.Test;
-import org.voltcore.utils.Pair;
-import org.voltdb.VoltDB.Configuration;
-import org.voltdb.client.ProcCallException;
-import org.voltdb.compiler.VoltProjectBuilder;
-import org.voltdb.utils.MiscUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.voltcore.utils.Pair;
+import org.voltdb.VoltDB.Configuration;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.client.ProcCallException;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.utils.MiscUtils;
 
 public class TestAdhocMigrateTable extends AdhocDDLTestBase {
     private void setup(String ddl) throws Exception {
@@ -59,9 +61,9 @@ public class TestAdhocMigrateTable extends AdhocDDLTestBase {
     public void testSimple() throws Exception {
         testMigrate(
                 "CREATE TABLE with_ttl migrate to target foo (i int NOT NULL, j FLOAT) USING TTL 1 minutes ON COLUMN i;\n" +
-                        "CREATE TABLE without_ttl migrate to target foo (i int NOT NULL, j FLOAT);\n" +
-                        "CREATE TABLE with_ttl_no_target(i int NOT NULL, j FLOAT) USING TTL 1 minutes ON COLUMN i;\n" +
-                        "CREATE TABLE without_ttl_no_target(i int NOT NULL, j FLOAT);",
+                "CREATE TABLE without_ttl migrate to target foo (i int NOT NULL, j FLOAT);\n" +
+                "CREATE TABLE with_ttl_no_target(i int NOT NULL, j FLOAT) USING TTL 1 minutes ON COLUMN i;\n" +
+                "CREATE TABLE without_ttl_no_target(i int NOT NULL, j FLOAT);\n",
                 Stream.of(
                         Pair.of("MIGRATE FROM without_ttl;", false),
                         Pair.of("MIGRATE FROM without_ttl WHERE not migrating;", true),
@@ -107,4 +109,19 @@ public class TestAdhocMigrateTable extends AdhocDDLTestBase {
         }
     }
 
+    @Test
+    // test sql funtion contains ?
+    public void testENG16508() throws Exception {
+        String ddl = "CREATE TABLE without_ttl migrate to target foo (i int NOT NULL, j FLOAT, ts TIMESTAMP);\n";
+        try {
+            setup(ddl);
+            ClientResponse res = m_client.callProcedure("@Adhoc", "MIGRATE FROM without_ttl where not migrating and ts < dateAdd(second, ?, now);", 1);
+            assertEquals(res.getStatus(), ClientResponse.SUCCESS);
+        } catch (Exception e) {
+            //  Auto-generated catch block
+        } finally {
+            teardownSystem();
+        }
+
+    }
 }


### PR DESCRIPTION
This pr added support for dynamic parameter used in sql function when running `"create procedure .. as migrate from .." ` 