### PR TITLE
ENG-16415 & ENG-16440: Balance partitions fixes

### DIFF
--- a/src/ee/common/TupleSchema.cpp
+++ b/src/ee/common/TupleSchema.cpp
@@ -125,7 +125,7 @@ TupleSchema* TupleSchema::createTupleSchema(const std::vector<ValueType>& column
                                             const std::vector<int32_t>&   hiddenColumnSizes,
                                             const std::vector<bool>&      hiddenAllowNull,
                                             const std::vector<bool>&      hiddenColumnInBytes,
-                                            const bool isTableWithStream)
+                                            const bool isTableWithMigrate)
 {
     const uint16_t uninlineableObjectColumnCount =
       TupleSchema::countUninlineableObjectColumns(columnTypes, columnSizes, columnInBytes);
@@ -144,7 +144,7 @@ TupleSchema* TupleSchema::createTupleSchema(const std::vector<ValueType>& column
     retval->m_uninlinedObjectColumnCount = uninlineableObjectColumnCount;
     retval->m_hiddenColumnCount = hiddenColumnCount;
     retval->m_isHeaderless = false;
-    retval->m_isTableWithStream = isTableWithStream;
+    retval->m_isTableWithMigrate = isTableWithMigrate;
     uint16_t uninlinedObjectColumnIndex = 0;
     for (uint16_t ii = 0; ii < columnCount; ii++) {
         const ValueType type = columnTypes[ii];

--- a/src/ee/common/TupleSchema.h
+++ b/src/ee/common/TupleSchema.h
@@ -91,7 +91,7 @@ public:
                                           const std::vector<int32_t>&   hiddenColumnSizes,
                                           const std::vector<bool>&      hiddenAllowNull,
                                           const std::vector<bool>&      hiddenColumnInBytes,
-                                          const bool isTableWithStream);
+                                          const bool isTableWithMigrate);
 
     /** Static factory method to create a TupleSchema for index keys */
     static TupleSchema* createKeySchema(const std::vector<ValueType>&   columnTypes,
@@ -152,7 +152,7 @@ public:
     inline uint16_t hiddenColumnCount() const;
 
     /** Return true if there is a hidden column on the table with stream. */
-    inline bool isTableWithStream() const;
+    inline bool isTableWithMigrate() const;
 
     /** Return true if tuples with this schema do not have an accessible header byte. */
     inline bool isHeaderless() const {
@@ -275,8 +275,8 @@ private:
     // Whether or not the tuples using this schema have a header byte
     bool m_isHeaderless;
 
-    // has a hidden column for table with stream
-    bool m_isTableWithStream;
+    // has a hidden column for table with migrate
+    bool m_isTableWithMigrate;
 
     /*
      * Data storage for:
@@ -311,8 +311,8 @@ inline uint16_t TupleSchema::hiddenColumnCount() const {
     return m_hiddenColumnCount;
 }
 
-inline bool TupleSchema::isTableWithStream() const {
-    return m_isTableWithStream;
+inline bool TupleSchema::isTableWithMigrate() const {
+    return m_isTableWithMigrate;
 }
 
 inline uint16_t TupleSchema::totalColumnCount() const {

--- a/src/ee/common/TupleSchemaBuilder.h
+++ b/src/ee/common/TupleSchemaBuilder.h
@@ -49,7 +49,7 @@ public:
         , m_hiddenSizes(0)
         , m_hiddenAllowNullFlags(0)
         , m_hiddenInBytesFlags(0)
-        , m_isTableWithStream(false)
+        , m_isTableWithMigrate(false)
     {
     }
 
@@ -64,7 +64,7 @@ public:
         , m_hiddenSizes(numHiddenCols)
         , m_hiddenAllowNullFlags(numHiddenCols)
         , m_hiddenInBytesFlags(numHiddenCols)
-        , m_isTableWithStream(false)
+        , m_isTableWithMigrate(false)
     {
     }
 
@@ -105,10 +105,10 @@ public:
                                  int32_t colSize,
                                  bool allowNull,
                                  bool inBytes,
-                                 bool isTableWithStream)
+                                 bool isTableWithMigrate)
      {
          setHiddenColumnAtIndex(index, valueType, colSize, allowNull, inBytes);
-         m_isTableWithStream = isTableWithStream;
+         m_isTableWithMigrate = isTableWithMigrate;
      }
     /** Finally, build the schema with the attributes specified. */
     TupleSchema* build() const
@@ -121,7 +121,7 @@ public:
                                               m_hiddenSizes,
                                               m_hiddenAllowNullFlags,
                                               m_hiddenInBytesFlags,
-                                              m_isTableWithStream);
+                                              m_isTableWithMigrate);
     }
 
     /** A special build method for index keys, which use "headerless" tuples */
@@ -223,7 +223,7 @@ private:
     std::vector<int32_t> m_hiddenSizes;
     std::vector<bool> m_hiddenAllowNullFlags;
     std::vector<bool> m_hiddenInBytesFlags;
-    bool m_isTableWithStream;
+    bool m_isTableWithMigrate;
 };
 
 } // end namespace voltdb

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -641,7 +641,7 @@ private:
     inline void serializeHiddenColumnsToDR(ExportSerializeOutput &io) const {
         // Exclude the hidden column for persistent table with stream
         uint16_t hiddenColumnCount = m_schema->hiddenColumnCount();
-        if (m_schema->isTableWithStream()) {
+        if (m_schema->isTableWithMigrate()) {
             hiddenColumnCount--;
         }
         for (int colIdx = 0; colIdx < hiddenColumnCount; colIdx++) {
@@ -1093,7 +1093,7 @@ inline void TableTuple::deserializeFrom(voltdb::SerializeInputBE &tupleIn, Pool 
                 columnInfo->inlined, static_cast<int32_t>(columnInfo->length), columnInfo->inBytes);
     }
 
-    bool hiddenColumnMigrateElastic = (elastic ? m_schema->isTableWithStream() : false);
+    bool hiddenColumnMigrateElastic = (elastic ? m_schema->isTableWithMigrate() : false);
     for (int j = 0; j < hiddenColumnCount; ++j) {
         const TupleSchema::ColumnInfo *columnInfo = m_schema->getHiddenColumnInfo(j);
 
@@ -1151,11 +1151,11 @@ inline void TableTuple::deserializeFromDR(voltdb::SerializeInputLE &tupleIn,  Po
     }
 
     int32_t hiddenColumnCount = m_schema->hiddenColumnCount();
-    bool isTableWithStream = m_schema->isTableWithStream();
+    bool isTableWithMigrate = m_schema->isTableWithMigrate();
 
     for (int i = 0; i < hiddenColumnCount; i++) {
         const TupleSchema::ColumnInfo * hiddenColumnInfo = m_schema->getHiddenColumnInfo(i);
-        if (isTableWithStream && i == hiddenColumnCount - 1) {
+        if (isTableWithMigrate && i == hiddenColumnCount - 1) {
             // Set the hidden column for persistent table to null
             NValue value = NValue::getNullValue(hiddenColumnInfo->getVoltType());
             setHiddenNValue(i, value);

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -1096,21 +1096,26 @@ inline void TableTuple::deserializeFrom(voltdb::SerializeInputBE &tupleIn, Pool 
     bool hiddenColumnMigrateElastic = (elastic ? m_schema->isTableWithStream() : false);
     for (int j = 0; j < hiddenColumnCount; ++j) {
         const TupleSchema::ColumnInfo *columnInfo = m_schema->getHiddenColumnInfo(j);
+
+        // tupleIn may not have hidden column
+        if (!tupleIn.hasRemaining()) {
+            std::ostringstream message;
+            message << "TableTuple::deserializeFrom table tuple doesn't have enough space to deserialize the hidden column "
+                    << "(index=" << j << ")"
+                    << "hidden column count=" << m_schema->hiddenColumnCount()
+                    << std::endl;
+            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message.str().c_str());
+        }
+
         if (hiddenColumnMigrateElastic && j == hiddenColumnCount -1) {
+            vassert(columnInfo->getVoltType() == VALUE_TYPE_BIGINT);
+            // TableTuple::serializeTo includes the migrate column so just discard it
+            tupleIn.readLong();
+
             NValue value = NValue::getNullValue(columnInfo->getVoltType());
-            setHiddenNValue(j, value);
+            setNValue(columnInfo, value, false);
             VOLT_DEBUG("Deserializing migrate hidden column for elastic operation");
         } else {
-            // tupleIn may not have hidden column
-            if (!tupleIn.hasRemaining()) {
-                std::ostringstream message;
-                message << "TableTuple::deserializeFrom table tuple doesn't have enough space to deserialize the hidden column "
-                        << "(index=" << j << ")"
-                        << "hidden column count=" << m_schema->hiddenColumnCount()
-                        << std::endl;
-                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message.str().c_str());
-            }
-
             char *dataPtr = getWritableDataPtr(columnInfo);
             NValue::deserializeFrom(tupleIn, dataPool, dataPtr, columnInfo->getVoltType(),
                 columnInfo->inlined, static_cast<int32_t>(columnInfo->length), columnInfo->inBytes);

--- a/src/ee/expressions/functionexpression.cpp
+++ b/src/ee/expressions/functionexpression.cpp
@@ -112,7 +112,7 @@ namespace functionexpression {
    template<> NValue ConstantFunctionExpression<FUNC_VOLT_MIGRATING>::eval(
          const TableTuple* tuple1, const TableTuple*) const {
       // For MIGRATING(), check if we are evaluating on a migrating table (the table with a migrate target).
-      if (tuple1 != NULL && tuple1->getSchema()->isTableWithStream()) {
+      if (tuple1 != NULL && tuple1->getSchema()->isTableWithMigrate()) {
          // we have at most 3 hidden columns, DR Timestamp, count for view and transaction id for migrating
          // and transaction id for migrating is always the last one.
          return tuple1->getHiddenNValue( // use callUnary instead of callConstant since callConstant is a static method

--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -82,7 +82,7 @@ TupleSchema* TableCatalogDelegate::createTupleSchema(catalog::Table const& catal
     auto numColumns = catalogTable.columns().size();
     bool needsDRTimestamp = isXDCR && catalogTable.isDRed();
     bool needsHiddenCountForView = false;
-    bool needsHiddenCloumnTableWithStream = isTableWithStream(static_cast<TableType>(catalogTable.tableType()));
+    bool needsHiddenCloumnTableWithMigrate = isTableWithMigrate(static_cast<TableType>(catalogTable.tableType()));
     std::map<std::string, catalog::Column*>::const_iterator colIterator;
 
     // only looking for potential existing table count(*) when this is a Materialized view table
@@ -104,7 +104,7 @@ TupleSchema* TableCatalogDelegate::createTupleSchema(catalog::Table const& catal
     // DR timestamp and hidden COUNT(*) should not appear at the same time
     vassert(!(needsDRTimestamp && needsHiddenCountForView));
     int numHiddenColumns = (needsDRTimestamp || needsHiddenCountForView) ? 1 : 0;
-    if (needsHiddenCloumnTableWithStream) {
+    if (needsHiddenCloumnTableWithMigrate) {
          numHiddenColumns++;
     }
     TupleSchemaBuilder schemaBuilder(numColumns, numHiddenColumns);
@@ -143,7 +143,7 @@ TupleSchema* TableCatalogDelegate::createTupleSchema(catalog::Table const& catal
 
     // Always create the hidden column for migrate last so the hidden columns can be handled correctly on java side
     // for snapshot write plans.
-    if (needsHiddenCloumnTableWithStream) {
+    if (needsHiddenCloumnTableWithMigrate) {
         VOLT_DEBUG("Adding hidden column for migrate table %s index %d", catalogTable.name().c_str(), hiddenIndex);
         schemaBuilder.setHiddenColumnAtIndex(hiddenIndex, VALUE_TYPE_BIGINT, 8, true, false, true);
     }

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -152,9 +152,9 @@ void PersistentTable::initializeWithColumns(TupleSchema* schema,
                                             int32_t compactionThreshold) {
     vassert(schema != NULL);
     uint16_t hiddenColumnCount = schema->hiddenColumnCount();
-    bool isTableWithStream = schema->isTableWithStream();
-    if (! m_isMaterialized && ((hiddenColumnCount == 1 && !isTableWithStream) ||
-        (hiddenColumnCount == 2 && isTableWithStream))) {
+    bool isTableWithMigrate = schema->isTableWithMigrate();
+    if (! m_isMaterialized && ((hiddenColumnCount == 1 && !isTableWithMigrate) ||
+        (hiddenColumnCount == 2 && isTableWithMigrate))) {
         m_drTimestampColumnIndex = 0; // The first hidden column
         // At some point if we have more than one hidden column in a table,
         // we'll need a system for keeping track of which are which.

--- a/src/frontend/org/voltcore/utils/DBBPool.java.template
+++ b/src/frontend/org/voltcore/utils/DBBPool.java.template
@@ -209,6 +209,10 @@ public final class DBBPool {
             }
         }
 #endif
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + ": " + b;
+        }
     }
 
     /**

--- a/src/frontend/org/voltcore/utils/Pair.java
+++ b/src/frontend/org/voltcore/utils/Pair.java
@@ -17,6 +17,8 @@
 
 package org.voltcore.utils;
 
+import java.util.Objects;
+
 /**
  * Class representing a pair of generic-ized types. Supports equality, hashing
  * and all that other nice Java stuff. Based on STL's pair class in C++.
@@ -44,17 +46,22 @@ public class Pair<T, U> implements java.io.Serializable {
         this(first, second, true);
     }
 
+    @Override
     public String toString() {
-        return "<" + m_first.toString() + ", " + m_second.toString() + ">";
+        return "<" + m_first + ", " + m_second + ">";
     }
 
+    @Override
     public int hashCode() {
         return m_hash;
     }
 
     public Object get(int idx) {
-        if (idx == 0) return m_first;
-        else if (idx == 1) return m_second;
+        if (idx == 0) {
+            return m_first;
+        } else if (idx == 1) {
+            return m_second;
+        }
         return null;
     }
 
@@ -63,12 +70,10 @@ public class Pair<T, U> implements java.io.Serializable {
      * @return Is the object equal to a value in the pair.
      */
     public boolean contains(Object o) {
-        if ((m_first != null) && (m_first.equals(o))) return true;
-        if ((m_second != null) && (m_second.equals(o))) return true;
-        if (o != null) return false;
-        return ((m_first == null) || (m_second == null));
+        return Objects.equals(o, m_first) || Objects.equals(o, m_second);
     }
 
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotAckReceiver.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotAckReceiver.java
@@ -35,6 +35,8 @@ import com.google_voltpatches.common.base.Preconditions;
 public class StreamSnapshotAckReceiver implements Runnable {
     public static interface AckCallback {
         public void receiveAck(int blockIndex);
+
+        public void receiveError(Exception exception);
     }
 
     private static final VoltLogger rejoinLog = new VoltLogger("REJOIN");
@@ -43,8 +45,8 @@ public class StreamSnapshotAckReceiver implements Runnable {
     private final StreamSnapshotBase.MessageFactory m_msgFactory;
     private final Map<Long, AckCallback> m_callbacks;
     private final AtomicInteger m_expectedEOFs;
-
-    volatile Exception m_lastException = null;
+    private volatile boolean stopped = false;
+    private volatile Thread m_thread;
 
     public StreamSnapshotAckReceiver(Mailbox mb)
     {
@@ -64,14 +66,34 @@ public class StreamSnapshotAckReceiver implements Runnable {
         m_callbacks.put(targetId, callback);
     }
 
+    public void forceStop() {
+        stopped = true;
+        Thread thread = this.m_thread;
+        if (thread != null) {
+            // Interrupt the thread to wake up the call to recvBlocking
+            thread.interrupt();
+        }
+    }
+
     @Override
     public void run() {
+        m_thread = Thread.currentThread();
         rejoinLog.trace("Starting ack receiver thread");
 
         try {
             while (true) {
+                if (stopped) {
+                    rejoinLog.debug("Ack reciever thread stopped");
+                    return;
+                }
+
                 rejoinLog.trace("Blocking on receiving mailbox");
                 VoltMessage msg = m_mb.recvBlocking(10 * 60 * 1000); // Wait for 10 minutes
+                if (stopped) {
+                    rejoinLog.debug("Ack reciever thread stopped");
+                    return;
+                }
+
                 if (msg == null) {
                     rejoinLog.warn("No stream snapshot ack message was received in the past 10 minutes" +
                                    " or the thread was interrupted (expected eofs: " + m_expectedEOFs.get() + ")" );
@@ -85,17 +107,20 @@ public class StreamSnapshotAckReceiver implements Runnable {
 
                 SerializableException se = m_msgFactory.getException(msg);
                 if (se != null) {
-                    m_lastException = se;
-                    rejoinLog.error("Received exception in ack receiver", se);
+                    handleException("Received exception in ack receiver", se);
                     return;
                 }
 
                 AckCallback ackCallback = m_callbacks.get(m_msgFactory.getAckTargetId(msg));
                 if (ackCallback == null) {
-                    rejoinLog.error("Unknown target ID " + m_msgFactory.getAckTargetId(msg) +
-                                    " in stream snapshot ack message");
-                } else if (m_msgFactory.getAckBlockIndex(msg) != -1) {
-                    ackCallback.receiveAck(m_msgFactory.getAckBlockIndex(msg));
+                    rejoinLog.warn("Unknown target ID " + m_msgFactory.getAckTargetId(msg)
+                            + " in stream snapshot ack message");
+                    continue;
+                }
+
+                int ackBlockIndex = m_msgFactory.getAckBlockIndex(msg);
+                if (ackBlockIndex != -1) {
+                    ackCallback.receiveAck(ackBlockIndex);
                 }
 
                 if (m_msgFactory.isAckEOS(msg)) {
@@ -109,10 +134,15 @@ public class StreamSnapshotAckReceiver implements Runnable {
                 }
             }
         } catch (Exception e) {
-            m_lastException = e;
-            rejoinLog.error("Error reading a message from a recovery stream", e);
+            handleException("Error reading a message from a recovery stream", e);
         } finally {
+            m_thread = null;
             rejoinLog.trace("Ack receiver thread exiting");
         }
+    }
+
+    private void handleException(String message, Exception exception) {
+        rejoinLog.error(message, exception);
+        m_callbacks.values().forEach(c -> c.receiveError(exception));
     }
 }


### PR DESCRIPTION
When deserializing a tuple for balance partitions if there is a migrate column consume the value from the input array but discard it and set the column in the tuple to null.

When balance partitions times out make sure the ack receiver is stopped so that two ack receivers are not running concurrently possibly consuming the messages intended for the new new receiver.

Other clean up includes using a queue which can efficiently calculate size and using the term isTableWithMigrate instead of isTableWithStream