### PR TITLE
ENG-15836: Wrong answer with "IN", and "<=" when index is present

### DIFF
--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -2691,6 +2691,8 @@ inline int NValue::compare(const NValue& rhs) const {
 inline int NValue::compareNullAsMax(const NValue& rhs) const {
     int hasNullCompare = compareNull(rhs);
     if (hasNullCompare != VALUE_COMPARE_INVALID) {
+        // VALUE_COMPARE_EQUAL indicates lhs == null && rhs == null, do nothing.
+        // VALUE_COMPARE_LESSTHAN indicates lhs == null && rhs != null, do nothing.
         // VALUE_COMPARE_GREATERTHAN indicates lhs != null && rhs == null, flip the result.
         return hasNullCompare == VALUE_COMPARE_GREATERTHAN ? VALUE_COMPARE_LESSTHAN : hasNullCompare;
     }

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -2688,7 +2688,7 @@ inline int NValue::compare(const NValue& rhs) const {
 inline int NValue::compareNullAsMax(const NValue& rhs) const {
     int hasNullCompare = compareNull(rhs);
     if (hasNullCompare != VALUE_COMPARE_INVALID) {
-        return -hasNullCompare;
+        return hasNullCompare == VALUE_COMPARE_GREATERTHAN ? VALUE_COMPARE_LESSTHAN : hasNullCompare;
     }
 
     return compare_withoutNull(rhs);

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -2685,9 +2685,13 @@ inline int NValue::compare(const NValue& rhs) const {
     return compare_withoutNull(rhs);
 }
 
+/**
+ * Compare two NValues. Null value in the rhs will be treated as maximum.
+ */
 inline int NValue::compareNullAsMax(const NValue& rhs) const {
     int hasNullCompare = compareNull(rhs);
     if (hasNullCompare != VALUE_COMPARE_INVALID) {
+        // VALUE_COMPARE_GREATERTHAN indicates lhs != null && rhs == null, flip the result.
         return hasNullCompare == VALUE_COMPARE_GREATERTHAN ? VALUE_COMPARE_LESSTHAN : hasNullCompare;
     }
 

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -346,6 +346,7 @@ class NValue {
      */
     int compareNull(const NValue& rhs) const;
     int compare(const NValue& rhs) const;
+    int compareNullAsMax(const NValue& rhs) const;
     int compare_withoutNull(const NValue& rhs) const;
 
     /* Return a boolean NValue with the comparison result */
@@ -2679,6 +2680,15 @@ inline int NValue::compare(const NValue& rhs) const {
     int hasNullCompare = compareNull(rhs);
     if (hasNullCompare != VALUE_COMPARE_INVALID) {
         return hasNullCompare;
+    }
+
+    return compare_withoutNull(rhs);
+}
+
+inline int NValue::compareNullAsMax(const NValue& rhs) const {
+    int hasNullCompare = compareNull(rhs);
+    if (hasNullCompare != VALUE_COMPARE_INVALID) {
+        return -hasNullCompare;
     }
 
     return compare_withoutNull(rhs);

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -1275,6 +1275,9 @@ inline int TableTuple::compare(const TableTuple &other) const {
     return VALUE_COMPARE_EQUAL;
 }
 
+/**
+ * Compare two tuples. Null value in the rhs tuple will be treated as maximum.
+ */
 inline int TableTuple::compareNullAsMax(const TableTuple &other) const {
     const int columnCount = m_schema->columnCount();
     int diff;

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -489,6 +489,7 @@ public:
     bool equalsNoSchemaCheck(const TableTuple &other, bool includeHiddenColumns = false) const;
 
     int compare(const TableTuple &other) const;
+    int compareNullAsMax(const TableTuple &other) const;
 
     void deserializeFrom(voltdb::SerializeInputBE &tupleIn, Pool *stringPool);
     void deserializeFrom(voltdb::SerializeInputBE &tupleIn, Pool *stringPool, bool elasticJoin);
@@ -1267,6 +1268,20 @@ inline int TableTuple::compare(const TableTuple &other) const {
         const NValue lhs = getNValue(ii);
         const NValue rhs = other.getNValue(ii);
         diff = lhs.compare(rhs);
+        if (diff) {
+            return diff;
+        }
+    }
+    return VALUE_COMPARE_EQUAL;
+}
+
+inline int TableTuple::compareNullAsMax(const TableTuple &other) const {
+    const int columnCount = m_schema->columnCount();
+    int diff;
+    for (int ii = 0; ii < columnCount; ii++) {
+        const NValue lhs = getNValue(ii);
+        const NValue rhs = other.getNValue(ii);
+        diff = lhs.compareNullAsMax(rhs);
         if (diff) {
             return diff;
         }

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -1280,10 +1280,11 @@ inline int TableTuple::compare(const TableTuple &other) const {
  */
 inline int TableTuple::compareNullAsMax(const TableTuple &other) const {
     const int columnCount = m_schema->columnCount();
+    assert(columnCount == other.m_schema->columnCount());
     int diff;
     for (int ii = 0; ii < columnCount; ii++) {
-        const NValue lhs = getNValue(ii);
-        const NValue rhs = other.getNValue(ii);
+        const NValue& lhs = getNValue(ii);
+        const NValue& rhs = other.getNValue(ii);
         diff = lhs.compareNullAsMax(rhs);
         if (diff) {
             return diff;

--- a/src/ee/executors/indexscanexecutor.cpp
+++ b/src/ee/executors/indexscanexecutor.cpp
@@ -467,7 +467,7 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
             tableIndex->moveToLessThanKey(&searchKey, indexCursor);
         }
         else if (localLookupType == INDEX_LOOKUP_TYPE_LTE) {
-            // find the entry whose key is less or equal than search key
+            // find the entry whose key is less than or equal to search key
             // as the start point to do a reverse scan
             tableIndex->moveToKeyOrLess(&searchKey, indexCursor);
         }

--- a/src/ee/executors/indexscanexecutor.cpp
+++ b/src/ee/executors/indexscanexecutor.cpp
@@ -470,23 +470,7 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
             // find the entry whose key is greater than search key,
             // do a forward scan using initialExpr to find the correct
             // start point to do reverse scan
-            bool isEnd = tableIndex->moveToGreaterThanKey(&searchKey, indexCursor);
-            if (isEnd) {
-                tableIndex->moveToEnd(false, indexCursor);
-            }
-            else {
-                while (!(tuple = tableIndex->nextValue(indexCursor)).isNullTuple()) {
-                    pmp.countdownProgress();
-                    if (initial_expression != NULL && !initial_expression->eval(&tuple, NULL).isTrue()) {
-                        // just passed the first failed entry, so move 2 backward
-                        tableIndex->moveToBeforePriorEntry(indexCursor);
-                        break;
-                    }
-                }
-                if (tuple.isNullTuple()) {
-                    tableIndex->moveToEnd(false, indexCursor);
-                }
-            }
+            tableIndex->moveToKeyOrLess(&searchKey, indexCursor);
         }
         else if (localLookupType == INDEX_LOOKUP_TYPE_GEO_CONTAINS) {
             tableIndex->moveToCoveringCell(&searchKey, indexCursor);

--- a/src/ee/executors/indexscanexecutor.cpp
+++ b/src/ee/executors/indexscanexecutor.cpp
@@ -467,9 +467,8 @@ bool IndexScanExecutor::p_execute(const NValueArray &params)
             tableIndex->moveToLessThanKey(&searchKey, indexCursor);
         }
         else if (localLookupType == INDEX_LOOKUP_TYPE_LTE) {
-            // find the entry whose key is greater than search key,
-            // do a forward scan using initialExpr to find the correct
-            // start point to do reverse scan
+            // find the entry whose key is less or equal than search key
+            // as the start point to do a reverse scan
             tableIndex->moveToKeyOrLess(&searchKey, indexCursor);
         }
         else if (localLookupType == INDEX_LOOKUP_TYPE_GEO_CONTAINS) {

--- a/src/ee/executors/nestloopindexexecutor.cpp
+++ b/src/ee/executors/nestloopindexexecutor.cpp
@@ -431,13 +431,8 @@ bool NestLoopIndexExecutor::p_execute(const NValueArray &params)
                             index->moveToEnd(false, indexCursor);
                         }
                         else {
-                            while (!(inner_tuple = index->nextValue(indexCursor)).isNullTuple()) {
-                                pmp.countdownProgress();
-                                if (initial_expression != NULL && !initial_expression->eval(&outer_tuple, &inner_tuple).isTrue()) {
-                                    // just passed the first failed entry, so move 2 backward
-                                    index->moveToBeforePriorEntry(indexCursor);
-                                    break;
-                                }
+                            if (!(inner_tuple = index->nextValue(indexCursor)).isNullTuple()) {
+                                index->moveToBeforePriorEntry(indexCursor);
                             }
                             if (inner_tuple.isNullTuple()) {
                                 index->moveToEnd(false, indexCursor);

--- a/src/ee/executors/nestloopindexexecutor.cpp
+++ b/src/ee/executors/nestloopindexexecutor.cpp
@@ -429,9 +429,10 @@ bool NestLoopIndexExecutor::p_execute(const NValueArray &params)
                         bool isEnd = index->moveToGreaterThanKey(&index_values, indexCursor);
                         if (isEnd) {
                             index->moveToEnd(false, indexCursor);
-                        }
-                        else {
+                        } else {
                             if (!(inner_tuple = index->nextValue(indexCursor)).isNullTuple()) {
+                                pmp.countdownProgress();
+                                // move to the valid upperbound as the starting point
                                 index->moveToBeforePriorEntry(indexCursor);
                             }
                             if (inner_tuple.isNullTuple()) {

--- a/src/ee/executors/nestloopindexexecutor.cpp
+++ b/src/ee/executors/nestloopindexexecutor.cpp
@@ -426,19 +426,7 @@ bool NestLoopIndexExecutor::p_execute(const NValueArray &params)
                         // find the entry whose key is greater than search key,
                         // do a forward scan using initialExpr to find the correct
                         // start point to do reverse scan
-                        bool isEnd = index->moveToGreaterThanKey(&index_values, indexCursor);
-                        if (isEnd) {
-                            index->moveToEnd(false, indexCursor);
-                        } else {
-                            if (!(inner_tuple = index->nextValue(indexCursor)).isNullTuple()) {
-                                pmp.countdownProgress();
-                                // move to the valid upperbound as the starting point
-                                index->moveToBeforePriorEntry(indexCursor);
-                            }
-                            if (inner_tuple.isNullTuple()) {
-                                index->moveToEnd(false, indexCursor);
-                            }
-                        }
+                        index->moveToKeyOrLess(&index_values, indexCursor);
                     }
                     else if (localLookupType == INDEX_LOOKUP_TYPE_GEO_CONTAINS) {
                         index->moveToCoveringCell(&index_values, indexCursor);

--- a/src/ee/executors/nestloopindexexecutor.cpp
+++ b/src/ee/executors/nestloopindexexecutor.cpp
@@ -423,7 +423,7 @@ bool NestLoopIndexExecutor::p_execute(const NValueArray &params)
                         index->moveToLessThanKey(&index_values, indexCursor);
                     }
                     else if (localLookupType == INDEX_LOOKUP_TYPE_LTE) {
-                        // find the entry whose key is less or equal than search key
+                        // find the entry whose key is less than or equal to search key
                         // as the start point to do a reverse scan
                         index->moveToKeyOrLess(&index_values, indexCursor);
                     }

--- a/src/ee/executors/nestloopindexexecutor.cpp
+++ b/src/ee/executors/nestloopindexexecutor.cpp
@@ -423,9 +423,8 @@ bool NestLoopIndexExecutor::p_execute(const NValueArray &params)
                         index->moveToLessThanKey(&index_values, indexCursor);
                     }
                     else if (localLookupType == INDEX_LOOKUP_TYPE_LTE) {
-                        // find the entry whose key is greater than search key,
-                        // do a forward scan using initialExpr to find the correct
-                        // start point to do reverse scan
+                        // find the entry whose key is less or equal than search key
+                        // as the start point to do a reverse scan
                         index->moveToKeyOrLess(&index_values, indexCursor);
                     }
                     else if (localLookupType == INDEX_LOOKUP_TYPE_GEO_CONTAINS) {

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -190,6 +190,11 @@ class CompactingTreeMultiMapIndex : public TableIndex
     }
 
     void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) {
+        // do moveToGreaterThanKey(), null values in the search key will be treated as maximum
+
+        // IntsKey will pack the key data into uint64, so we can not tell if it is
+        // a NULL value then (a TINYINT NULL is a valid value in INT).
+        // In that case, we will change all numeric null key values into maximum.
         for (int i = 0; i < searchKey->getSchema()->totalColumnCount(); i++) {
             if (searchKey->getNValue(i).isNull()) {
                 const ValueType valueType = searchKey->getSchema()->columnType(i);
@@ -211,7 +216,6 @@ class CompactingTreeMultiMapIndex : public TableIndex
                 }
             }
         }
-        // do moveToGreaterThanKey()
         MapIterator &mapIter = castToIter(cursor);
         mapIter = m_entries.upperBoundNullAsMax(KeyType(searchKey));
         // find prev entry

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -189,6 +189,20 @@ class CompactingTreeMultiMapIndex : public TableIndex
         }
     }
 
+    void moveToKeyOrLess(const TableTuple *searchKey, IndexCursor& cursor) const
+    {
+        // do moveToGreaterThanKey()
+        MapIterator &mapIter = castToIter(cursor);
+        mapIter = m_entries.upperBound(KeyType(searchKey));
+        // find prev entry
+        if (mapIter.isEnd()) {
+            moveToEnd(false, cursor);
+        } else {
+            cursor.m_forward = false;
+            mapIter.movePrev();
+        }
+    }
+
     // only be called after moveToGreaterThanKey() for LTE case
     void moveToBeforePriorEntry(IndexCursor& cursor) const
     {

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -189,11 +189,31 @@ class CompactingTreeMultiMapIndex : public TableIndex
         }
     }
 
-    void moveToKeyOrLess(const TableTuple *searchKey, IndexCursor& cursor) const
-    {
+    void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) {
+        for (int i = 0; i < searchKey->getSchema()->totalColumnCount(); i++) {
+            if (searchKey->getNValue(i).isNull()) {
+                const ValueType valueType = searchKey->getSchema()->columnType(i);
+                switch (valueType) {
+                    case VALUE_TYPE_BIGINT:
+                        searchKey->setNValue(i, ValueFactory::getBigIntValue(INT64_MAX));
+                        break;
+                    case VALUE_TYPE_INTEGER:
+                        searchKey->setNValue(i, ValueFactory::getIntegerValue(INT32_MAX));
+                        break;
+                    case VALUE_TYPE_SMALLINT:
+                        searchKey->setNValue(i, ValueFactory::getSmallIntValue(INT16_MAX));
+                        break;
+                    case VALUE_TYPE_TINYINT:
+                        searchKey->setNValue(i, ValueFactory::getTinyIntValue(INT8_MAX));
+                        break;
+                    default: // other null types will be handled in GenericComparator
+                        break;
+                }
+            }
+        }
         // do moveToGreaterThanKey()
         MapIterator &mapIter = castToIter(cursor);
-        mapIter = m_entries.upperBound(KeyType(searchKey));
+        mapIter = m_entries.upperBoundNullAsMax(KeyType(searchKey));
         // find prev entry
         if (mapIter.isEnd()) {
             moveToEnd(false, cursor);

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -187,6 +187,21 @@ class CompactingTreeUniqueIndex : public TableIndex
         }
     }
 
+    void moveToKeyOrLess(const TableTuple *searchKey, IndexCursor& cursor) const
+    {
+        // do moveToGreaterThanKey()
+        MapIterator &mapIter = castToIter(cursor);
+        mapIter = m_entries.upperBound(KeyType(searchKey));
+
+        // find prev entry
+        if (mapIter.isEnd()) {
+            moveToEnd(false, cursor);
+        } else {
+            cursor.m_forward = false;
+            mapIter.movePrev();
+        }
+    }
+
     // only be called after moveToGreaterThanKey() for LTE case
     void moveToBeforePriorEntry(IndexCursor& cursor) const
     {

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -188,6 +188,11 @@ class CompactingTreeUniqueIndex : public TableIndex
     }
 
     void moveToKeyOrLess(TableTuple *searchKey, IndexCursor &cursor) {
+        // do moveToGreaterThanKey(), null values in the search key will be treated as maximum
+
+        // IntsKey will pack the key data into uint64, so we can not tell if it is
+        // a NULL value then (a TINYINT NULL is a valid value in INT).
+        // In that case, we will change all numeric null key values into maximum.
         for (int i = 0; i < searchKey->getSchema()->totalColumnCount(); i++) {
             if (searchKey->getNValue(i).isNull()) {
                 const ValueType valueType = searchKey->getSchema()->columnType(i);
@@ -209,7 +214,6 @@ class CompactingTreeUniqueIndex : public TableIndex
                 }
             }
         }
-        // do moveToGreaterThanKey()
         MapIterator &mapIter = castToIter(cursor);
         mapIter = m_entries.upperBoundNullAsMax(KeyType(searchKey));
         // find prev entry

--- a/src/ee/indexes/indexkey.h
+++ b/src/ee/indexes/indexkey.h
@@ -379,8 +379,8 @@ struct IntsComparator
 
     // IntsComparator not really has a NullAsMaxComparator, we can pre-process the data and
     // convert the NULLs into maximums.
-    const IntsComparator *getNullAsMaxComparator() const {
-        return this;
+    const IntsComparator getNullAsMaxComparator() const {
+        return *this;
     }
 
 protected:
@@ -643,9 +643,8 @@ struct GenericComparator
         return operator()(lhs, rhs);
     }
 
-    const std::unique_ptr<GenericNullAsMaxComparator<keySize>> getNullAsMaxComparator() const {
-        return std::unique_ptr<GenericNullAsMaxComparator<keySize>>(
-                new GenericNullAsMaxComparator<keySize>(m_keySchema));
+    const GenericNullAsMaxComparator<keySize> getNullAsMaxComparator() const {
+        return GenericNullAsMaxComparator<keySize>(m_keySchema);
     }
 
 protected:
@@ -846,9 +845,8 @@ struct TupleKeyComparator
         return operator()(lhs, rhs);
     }
 
-    const std::unique_ptr<TupleKeyNullAsMaxComparator> getNullAsMaxComparator() const {
-        return std::unique_ptr<TupleKeyNullAsMaxComparator>(
-                new TupleKeyNullAsMaxComparator(m_keySchema));
+    const TupleKeyNullAsMaxComparator getNullAsMaxComparator() const {
+        return TupleKeyNullAsMaxComparator(m_keySchema);
     }
 
 protected:
@@ -928,13 +926,13 @@ struct NullAsMaxComparatorWithPointer : public KeyType::KeyComparator {
             : KeyType::KeyComparator(keySchema) {}
 
     int operator()(const KeyWithPointer<KeyType> &lhs, const KeyWithPointer<KeyType> &rhs) const {
-        int rv = (*KeyType::KeyComparator::getNullAsMaxComparator())(lhs, rhs);
+        int rv = KeyType::KeyComparator::getNullAsMaxComparator()(lhs, rhs);
         return rv == 0 ? comparePointer(lhs.m_keyTuple, rhs.m_keyTuple) : rv;
     }
 
     // Do a comparison, but don't compare pointers to tuple storage.
     int compareWithoutPointer(const KeyWithPointer<KeyType> &lhs, const KeyWithPointer<KeyType> &rhs) const {
-        return (*KeyType::KeyComparator::getNullAsMaxComparator())(lhs, rhs);
+        return KeyType::KeyComparator::getNullAsMaxComparator()(lhs, rhs);
     }
 };
 
@@ -953,9 +951,8 @@ struct ComparatorWithPointer : public KeyType::KeyComparator {
         return KeyType::KeyComparator::operator()(lhs, rhs);
     }
 
-    const std::unique_ptr<NullAsMaxComparatorWithPointer<KeyType>> getNullAsMaxComparator() const {
-        return std::unique_ptr<NullAsMaxComparatorWithPointer<KeyType>>(
-                new NullAsMaxComparatorWithPointer<KeyType>(this->m_keySchema));
+    const NullAsMaxComparatorWithPointer<KeyType> getNullAsMaxComparator() const {
+        return NullAsMaxComparatorWithPointer<KeyType>(this->m_keySchema);
     }
 
 };

--- a/src/ee/indexes/indexkey.h
+++ b/src/ee/indexes/indexkey.h
@@ -377,7 +377,9 @@ struct IntsComparator
         return operator()(lhs, rhs);
     }
 
-    const IntsComparator * getNullAsMaxComparator() const {
+    // IntsComparator not really has a NullAsMaxComparator, we can pre-process the data and
+    // convert the NULLs into maximums.
+    const IntsComparator *getNullAsMaxComparator() const {
         return this;
     }
 

--- a/src/ee/indexes/indexkey.h
+++ b/src/ee/indexes/indexkey.h
@@ -953,7 +953,7 @@ struct ComparatorWithPointer : public KeyType::KeyComparator {
 
     const std::unique_ptr<NullAsMaxComparatorWithPointer<KeyType>> getNullAsMaxComparator() const {
         return std::unique_ptr<NullAsMaxComparatorWithPointer<KeyType>>(
-                new NullAsMaxComparatorWithPointer<KeyType>(m_keySchema));
+                new NullAsMaxComparatorWithPointer<KeyType>(this->m_keySchema));
     }
 
 };

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -314,6 +314,10 @@ public:
         throwFatalException("Invoked TableIndex virtual method moveToLessThanKey which has no implementation");
     };
 
+    virtual void moveToKeyOrLess(const TableTuple *searchKey, IndexCursor& cursor) const {
+        throwFatalException("Invoked TableIndex virtual method moveToKeyOrLess which has no implementation");
+    };
+
     virtual bool moveToCoveringCell(const TableTuple* searchKey, IndexCursor &cursor) const {
         throwFatalException("Invoked TableIndex virtual method moveToCoveringCell which has no implementation");
     }

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -314,7 +314,7 @@ public:
         throwFatalException("Invoked TableIndex virtual method moveToLessThanKey which has no implementation");
     };
 
-    virtual void moveToKeyOrLess(const TableTuple *searchKey, IndexCursor& cursor) const {
+    virtual void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) {
         throwFatalException("Invoked TableIndex virtual method moveToKeyOrLess which has no implementation");
     };
 

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -314,6 +314,7 @@ public:
         throwFatalException("Invoked TableIndex virtual method moveToLessThanKey which has no implementation");
     };
 
+    // move the cursor to the first tuple less than or equal to the given key.
     virtual void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) {
         throwFatalException("Invoked TableIndex virtual method moveToKeyOrLess which has no implementation");
     };

--- a/src/ee/storage/MaterializedViewTriggerForWrite.cpp
+++ b/src/ee/storage/MaterializedViewTriggerForWrite.cpp
@@ -242,8 +242,7 @@ NValue MaterializedViewTriggerForWrite::findMinMaxFallbackValueIndexed(const Tab
         }
         else {
             // max()
-            selectedIndex->moveToGreaterThanKey(&m_minMaxSearchKeyTuple, minMaxCursor);
-            selectedIndex->moveToPriorEntry(minMaxCursor);
+            selectedIndex->moveToKeyOrLess(&m_minMaxSearchKeyTuple, minMaxCursor);
         }
         while ( ! (tuple = selectedIndex->nextValue(minMaxCursor)).isNullTuple() ) {
             // If the cursor already moved out of the dest group range, exit the loop.

--- a/src/ee/storage/MaterializedViewTriggerForWrite.cpp
+++ b/src/ee/storage/MaterializedViewTriggerForWrite.cpp
@@ -242,7 +242,8 @@ NValue MaterializedViewTriggerForWrite::findMinMaxFallbackValueIndexed(const Tab
         }
         else {
             // max()
-            selectedIndex->moveToKeyOrLess(&m_minMaxSearchKeyTuple, minMaxCursor);
+            selectedIndex->moveToGreaterThanKey(&m_minMaxSearchKeyTuple, minMaxCursor);
+            selectedIndex->moveToPriorEntry(minMaxCursor);
         }
         while ( ! (tuple = selectedIndex->nextValue(minMaxCursor)).isNullTuple() ) {
             // If the cursor already moved out of the dest group range, exit the loop.

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -431,7 +431,7 @@ CompactingMap<KeyValuePair, Compare, hasRank>::upperBoundNullAsMax(const Key &ke
     TreeNode *x = m_root;
     TreeNode *y = const_cast<TreeNode *>(&NIL);
     while (x != &NIL) {
-        int cmp = (*m_comper.getNullAsMaxComparator())(x->key(), tmpKey);
+        int cmp = m_comper.getNullAsMaxComparator()(x->key(), tmpKey);
         if (cmp <= 0) {
             x = x->right;
         } else {

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -429,9 +429,6 @@ CompactingMap<KeyValuePair, Compare, hasRank>::upperBoundNullAsMax(const Key &ke
     setPointerValue(tmpKey, MAXPOINTER);
     TreeNode *x = m_root;
     TreeNode *y = const_cast<TreeNode *>(&NIL);
-    std::cout<<typeid(tmpKey).name() << std::endl;
-    std::cout<<typeid(m_comper).name() << std::endl;
-    std::cout<<typeid(m_comper.getNullAsMaxComparator()).name() << std::endl;
     while (x != &NIL) {
         int cmp = (*m_comper.getNullAsMaxComparator())(x->key(), tmpKey);
         if (cmp <= 0) {

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -221,6 +221,7 @@ public:
 
     iterator lowerBound(const Key &key) const;
     iterator upperBound(const Key &key) const;
+    // do upperBound(key) but treat null values in key as maximum
     iterator upperBoundNullAsMax(const Key &key) const;
 
     std::pair<iterator, iterator> equalRange(const Key &key) const;

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -429,6 +429,9 @@ CompactingMap<KeyValuePair, Compare, hasRank>::upperBoundNullAsMax(const Key &ke
     setPointerValue(tmpKey, MAXPOINTER);
     TreeNode *x = m_root;
     TreeNode *y = const_cast<TreeNode *>(&NIL);
+    std::cout<<typeid(tmpKey).name() << std::endl;
+    std::cout<<typeid(m_comper).name() << std::endl;
+    std::cout<<typeid(m_comper.getNullAsMaxComparator()).name() << std::endl;
     while (x != &NIL) {
         int cmp = (*m_comper.getNullAsMaxComparator())(x->key(), tmpKey);
         if (cmp <= 0) {

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -221,6 +221,7 @@ public:
 
     iterator lowerBound(const Key &key) const;
     iterator upperBound(const Key &key) const;
+    iterator upperBoundNullAsMax(const Key &key) const;
 
     std::pair<iterator, iterator> equalRange(const Key &key) const;
 
@@ -419,6 +420,25 @@ CompactingMap<KeyValuePair, Compare, hasRank>::upperBound(const Key &key) const
     }
     return iterator(this, y);
 
+}
+
+template<typename KeyValuePair, typename Compare, bool hasRank>
+typename CompactingMap<KeyValuePair, Compare, hasRank>::iterator
+CompactingMap<KeyValuePair, Compare, hasRank>::upperBoundNullAsMax(const Key &key) const {
+    Key tmpKey(key);
+    setPointerValue(tmpKey, MAXPOINTER);
+    TreeNode *x = m_root;
+    TreeNode *y = const_cast<TreeNode *>(&NIL);
+    while (x != &NIL) {
+        int cmp = (*m_comper.getNullAsMaxComparator())(x->key(), tmpKey);
+        if (cmp <= 0) {
+            x = x->right;
+        } else {
+            y = x;
+            x = x->left;
+        }
+    }
+    return iterator(this, y);
 }
 
 template<typename KeyValuePair, typename Compare, bool hasRank>


### PR DESCRIPTION
The root cause is a bug in the `nestloopindexexecuter`,  literally the `initial_expression`.
### what is `initial_expression`
We extract all the predicate exprs that have the indexed column and concatenate them with **AND** to build the `initial_expression`.
### when `initial_expression` is used?
When we doing an index scan with a LTE(less than or equal to) operator, we find the entry whose key is greater than search key, then do a forward scan using `initial_expression`(we evaluate the `initial_expression` for each input tuple, move forward until it returns false, indicate that we just pass the first failed entry, then we move 1 step backward) to find the correct start point to do a reverse scan.
### the bug
```sql
CREATE TABLE T1 (
    a integer NOT NULL,
    b INTEGER,
 );

 CREATE INDEX T1_IDX ON T1 (a, b);

INSERT INTO T1 VALUES( -1, 9);
INSERT INTO T1 VALUES( 0, 1);
INSERT INTO T1 VALUES( 0, 2);
INSERT INTO T1 VALUES( 1, 3);

SELECT * FROM T1 WHERE a IN (-1, 0, 1) AND b <= 100;
```
the query will be planed as an index nested loop join of table T1 and the in-list(-1,0,1).
```
RETURN RESULTS TO STORED PROCEDURE
 NESTLOOP INDEX INNER JOIN
  inline INDEX SCAN of "T1" using "T1_IDX"
  reverse range-scan covering from (A = column#0) AND (B <= ?0) while (inner-table.column#0 = column#0), filter by (NOT (inner-table.column#1 IS NULL))
  MATERIALIZED SCAN of SQL-IN-LIST (Sort INVALID)
```
and the `inital_expression` is
```
+ Expression[CONJUNCTION_AND, 20]
   ConjunctionExpression
   left:  
   + Expression[COMPARE_LESSTHANOREQUALTO, 14]
      ComparisonExpression
      left:  
      + Expression[VALUE_TUPLE, 32]
         Optimized Column Reference[1, 1]
      right: 
      + Expression[VALUE_PARAMETER, 31]
         OptimizedParameter[0]
   right: 
   + Expression[COMPARE_IN, 17]
      ComparisonExpression
      left:  
      + Expression[VALUE_TUPLE, 32]
         Optimized Column Reference[1, 0]
      right: 
      + Expression[VALUE_VECTOR, 35]
         VectorExpression
```
note that the `initial expression` is always comparing the T1.a with **IN** [-1,0,1].
Let's say if the outer table(in-list) is at tuple (-1), and the inner table(T1) is at tuple (0,1); obviously -1!=0,
it is not a match, but the  `initial expression` is comparing T1.a(0) with the list [-1,0,1] (not -1), so it will return true (indicate a good match) which is wrong!
### fix
Rewriting the initial expression is complicated and may hit other edge cases, so I deprecated the `initial expression` with a series of NullAsMaxComparators in EE which treat NULL values(in the search key) as maximum other than the minimum. Then we can find the LTE entry without `initial expression`.

I will write another ticket to remove the initial expression both from the code and the plans after I merged this.