### PR TITLE
ENG-16548: Do not always call setDRProtocolVersion on restore

### DIFF
--- a/src/ee/storage/AbstractDRTupleStream.h
+++ b/src/ee/storage/AbstractDRTupleStream.h
@@ -140,7 +140,7 @@ public:
         return (m_committedSequenceNumber >= 0);
     }
 
-    virtual void setDrProtocolVersion(uint8_t drProtocolVersion) {
+    void setDrProtocolVersion(uint8_t drProtocolVersion) {
         m_drProtocolVersion = drProtocolVersion;
     }
 

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -103,10 +103,6 @@ public:
                                    long startSequenceNumber,
                                    char *out);
 
-    void setDrProtocolVersion(uint8_t drProtocolVersion) {
-            m_drProtocolVersion = drProtocolVersion;
-    }
-
     const uint64_t getOpenUniqueIdForTest() const {
         return m_openUniqueId;
     }

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -41,12 +41,12 @@ public:
     // Also update DRProducerProtocol.java if version changes
     // whenever PROTOCOL_VERSION changes, check if DRBufferParser needs to be updated,
     // check if unit tests that use MockPartitionQueue and getTestDRBuffer() need to be updated
-    static const uint8_t PROTOCOL_VERSION = 8;
     static const uint8_t COMPATIBLE_PROTOCOL_VERSION = 7;
 
     static const uint8_t ELASTICADD_PROTOCOL_VERSION = 8;
+    static const uint8_t LATEST_PROTOCOL_VERSION = ELASTICADD_PROTOCOL_VERSION;
 
-    DRTupleStream(int partitionId, size_t defaultBufferSize, uint8_t drProtocolVersion=PROTOCOL_VERSION);
+    DRTupleStream(int partitionId, size_t defaultBufferSize, uint8_t drProtocolVersion=0);
 
     virtual ~DRTupleStream() {}
 

--- a/src/frontend/org/voltdb/PartitionDRGateway.java
+++ b/src/frontend/org/voltdb/PartitionDRGateway.java
@@ -241,4 +241,8 @@ public class PartitionDRGateway implements DurableUniqueIdListener, TransactionC
 
     @Override
     public void transactionCommitted(long spHandle) {}
+
+    public boolean isActive() {
+        return false;
+    }
 }

--- a/src/frontend/org/voltdb/SnapshotCompletionMonitor.java
+++ b/src/frontend/org/voltdb/SnapshotCompletionMonitor.java
@@ -229,13 +229,11 @@ public class SnapshotCompletionMonitor {
             final JSONObject exportSequenceJSON = jsonObj.getJSONObject(ExtensibleSnapshotDigestData.EXPORT_SEQUENCE_NUMBER_ARR);
             final ImmutableMap.Builder<String, Map<Integer, ExportSnapshotTuple>> builder =
                     ImmutableMap.builder();
-            @SuppressWarnings("unchecked")
             final Iterator<String> tableKeys = exportSequenceJSON.keys();
             while (tableKeys.hasNext()) {
                 final String tableName = tableKeys.next();
                 final JSONObject tableSequenceNumbers = exportSequenceJSON.getJSONObject(tableName);
                 ImmutableMap.Builder<Integer, ExportSnapshotTuple> tableBuilder = ImmutableMap.builder();
-                @SuppressWarnings("unchecked")
                 final Iterator<String> partitionKeys = tableSequenceNumbers.keys();
                 while (partitionKeys.hasNext()) {
                     final String partitionString = partitionKeys.next();

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -219,8 +219,9 @@ public class SnapshotSiteProcessor {
         SiteProcedureConnection spc = context.getSiteProcedureConnection();
 
         for (Table t : database.getTables()) {
-            if (!CatalogUtil.isTableExportOnly(database, t))
+            if (!CatalogUtil.isTableExportOnly(database, t)) {
                 continue;
+            }
 
             Map<Integer, ExportSnapshotTuple> sequenceNumbers = s_exportSequenceNumbers.get(t.getTypeName());
             if (sequenceNumbers == null) {
@@ -530,7 +531,9 @@ public class SnapshotSiteProcessor {
             if (desired > available) {
                 return null;
             }
-            if (m_availableSnapshotBuffers.compareAndSet(available, available - desired)) break;
+            if (m_availableSnapshotBuffers.compareAndSet(available, available - desired)) {
+                break;
+            }
         }
 
         List<BBContainer> outputBuffers = new ArrayList<BBContainer>(tableTasks.size());

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1260,6 +1260,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     @Override
     public TupleStreamStateInfo getDRTupleStreamStateInfo()
     {
+        if (m_drGateway == null || !m_drGateway.isActive()) {
+            return null;
+        }
         // Set the psetBuffer buffer capacity and clear the buffer
         m_ee.getParamBufferForExecuteTask(0);
         ByteBuffer resultBuffer = ByteBuffer.wrap(m_ee.executeTask(TaskType.GET_DR_TUPLESTREAM_STATE, ByteBuffer.allocate(0)));

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1272,7 +1272,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         int drVersion = resultBuffer.getInt();
         DRLogSegmentId partitionInfo = new DRLogSegmentId(partitionSequenceNumber, partitionSpUniqueId, partitionMpUniqueId);
         byte hasReplicatedStateInfo = resultBuffer.get();
-        TupleStreamStateInfo info = null;
+        TupleStreamStateInfo info;
         if (hasReplicatedStateInfo != 0) {
             long replicatedSequenceNumber = resultBuffer.getLong();
             long replicatedSpUniqueId = resultBuffer.getLong();

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
@@ -77,13 +77,15 @@ public class ExecuteTask extends VoltSystemProcedure
             {
                 TupleStreamStateInfo stateInfo = context.getSiteProcedureConnection().getDRTupleStreamStateInfo();
                 result = createDRTupleStreamStateResultTable();
-                result.addRow(context.getHostId(), context.getPartitionId(), 0,
-                        stateInfo.partitionInfo.drId, stateInfo.partitionInfo.spUniqueId, stateInfo.partitionInfo.mpUniqueId,
-                        stateInfo.drVersion);
-                if (stateInfo.containsReplicatedStreamInfo) {
-                    result.addRow(context.getHostId(), context.getPartitionId(), 1,
-                            stateInfo.replicatedInfo.drId, stateInfo.replicatedInfo.spUniqueId, stateInfo.replicatedInfo.mpUniqueId,
+                if (stateInfo != null) {
+                    result.addRow(context.getHostId(), context.getPartitionId(), 0, stateInfo.partitionInfo.drId,
+                            stateInfo.partitionInfo.spUniqueId, stateInfo.partitionInfo.mpUniqueId,
                             stateInfo.drVersion);
+                    if (stateInfo.containsReplicatedStreamInfo) {
+                        result.addRow(context.getHostId(), context.getPartitionId(), 1, stateInfo.replicatedInfo.drId,
+                                stateInfo.replicatedInfo.spUniqueId, stateInfo.replicatedInfo.mpUniqueId,
+                                stateInfo.drVersion);
+                    }
                 }
                 break;
             }

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -17,6 +17,8 @@
 
 package org.voltdb.sysprocs;
 
+import static org.voltdb.ExtensibleSnapshotDigestData.DR_TUPLE_STREAM_STATE_INFO;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -1753,8 +1755,8 @@ public class SnapshotRestore extends VoltSystemProcedure {
                         }
                     }
                 }
-                if (digest.has("drTupleStreamStateInfo")) {
-                    JSONObject stateInfo = digest.getJSONObject("drTupleStreamStateInfo");
+                if (digest.has(DR_TUPLE_STREAM_STATE_INFO)) {
+                    JSONObject stateInfo = digest.getJSONObject(DR_TUPLE_STREAM_STATE_INFO);
                     Iterator<String> keys = stateInfo.keys();
                     while (keys.hasNext()) {
                         String partitionIdString = keys.next();

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -271,10 +271,10 @@ public:
 class DRBinaryLogTest : public Test {
 public:
     DRBinaryLogTest()
-      : m_drStream(0, 64*1024),
-        m_drReplicatedStream(16383, 64*1024),
-        m_drStreamReplica(0, 64*1024),
-        m_drReplicatedStreamReplica(16383, 64*1024),
+      : m_drStream(0, 64*1024, DRTupleStream::LATEST_PROTOCOL_VERSION),
+        m_drReplicatedStream(16383, 64*1024, DRTupleStream::LATEST_PROTOCOL_VERSION),
+        m_drStreamReplica(0, 64*1024, DRTupleStream::LATEST_PROTOCOL_VERSION),
+        m_drReplicatedStreamReplica(16383, 64*1024, DRTupleStream::LATEST_PROTOCOL_VERSION),
         m_undoToken(0),
         m_spHandleReplica(0)
     {

--- a/tests/ee/storage/table_and_indexes_test.cpp
+++ b/tests/ee/storage/table_and_indexes_test.cpp
@@ -92,8 +92,8 @@ private:
 class TableAndIndexTest : public Test {
     public:
         TableAndIndexTest()
-            : drStream(44, 64*1024),
-              drReplicatedStream(16383, 64*1024) {
+            : drStream(44, 64*1024, DRTupleStream::LATEST_PROTOCOL_VERSION),
+              drReplicatedStream(16383, 64*1024, DRTupleStream::LATEST_PROTOCOL_VERSION) {
             mockEngine = new MockVoltDBEngine();
             eContext = new ExecutorContext(0, 0, NULL, &topend, &pool, mockEngine, "", 0, &drStream, &drReplicatedStream, 0);
             mem = 0;

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2235,6 +2236,14 @@ public class LocalCluster extends VoltServerConfig {
         File retval[] = new File[m_subRoots.size()];
         for (int ii = 0; ii < m_subRoots.size(); ii++) {
             retval[ii] = new File(m_subRoots.get(ii), path.getPath());
+        }
+        return retval;
+    }
+
+    public Path[] getPathInSubroots(String path) {
+        Path retval[] = new Path[m_subRoots.size()];
+        for (int ii = 0; ii < m_subRoots.size(); ii++) {
+            retval[ii] = Paths.get(m_subRoots.get(ii).getPath(), path);
         }
         return retval;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
@@ -23,6 +23,8 @@
 
 package org.voltdb.regressionsuites;
 
+import static org.junit.Assert.assertNotEquals;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -34,6 +36,10 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -88,7 +94,6 @@ import org.voltdb.utils.SnapshotVerifier;
 import org.voltdb.utils.VoltFile;
 
 import com.google_voltpatches.common.collect.Sets;
-import com.google_voltpatches.common.io.Files;
 
 /**
  * Test the SnapshotSave and SnapshotRestore system procedures
@@ -658,13 +663,12 @@ public class TestSaveRestoreSysprocSuite extends SaveRestoreBase {
             lc.shutDown();
         }
 
-        //Copy over snapshot data from removed node
-        for (File f : lc.getPathInSubroots(new File(TMPDIR))[1].listFiles()) {
-            if (f.getName().startsWith(TESTNONCE)) {
-                File dest = new File(lc.getPathInSubroots(new File(TMPDIR))[0], f.getName());
-                System.out.println("Copying " + f.getPath() + " to " + dest.getPath());
-                Files.copy(f, dest);
-            }
+        // Copy over snapshot data from removed node
+        Path[] dirs = lc.getPathInSubroots(TMPDIR);
+        for (Path p : Files.newDirectoryStream(dirs[1], TESTNONCE + "*")) {
+            Path dest = dirs[0].resolve(p.getFileName());
+            System.out.println("Copying " + p + " to " + dest);
+            Files.copy(p, dest, StandardCopyOption.REPLACE_EXISTING);
         }
 
         // Restore snapshot to 1 nodes 1 sites/host cluster.
@@ -751,12 +755,11 @@ public class TestSaveRestoreSysprocSuite extends SaveRestoreBase {
 
         System.out.println("testRestoreWithGhostPartitionAndJoin - Copy over snapshot data from removed node");
         //Copy over snapshot data from removed node
-        for (File f : lc.getPathInSubroots(new File(TMPDIR))[1].listFiles()) {
-            if (f.getName().startsWith(TESTNONCE)) {
-                File dest = new File(lc.getPathInSubroots(new File(TMPDIR))[0], f.getName());
-                System.out.println("Copying " + f.getPath() + " to " + dest.getPath());
-                Files.copy(f, dest);
-            }
+        Path[] dirs = lc.getPathInSubroots(TMPDIR);
+        for (Path p : Files.newDirectoryStream(dirs[1], TESTNONCE + "*")) {
+            Path dest = dirs[0].resolve(p.getFileName());
+            System.out.println("Copying " + p + " to " + dest);
+            Files.copy(p, dest, StandardCopyOption.REPLACE_EXISTING);
         }
 
         // Restore snapshot to 1 nodes 1 sites/host cluster.
@@ -3408,9 +3411,24 @@ public class TestSaveRestoreSysprocSuite extends SaveRestoreBase {
                 assertEquals(2000, reptableRows);
                 long parttableRows = client.callProcedure("@AdHoc", "select count(*) from PARTITION_TESTER").getResults()[0].asScalarLong();
                 assertEquals(252, parttableRows);
+
+                saveTablesWithPath(client, TESTNONCE + 2, snapshotsPath);
             } finally {
                 client.close();
             }
+
+            // ENG-16548 Validate that the digest is the same size for all snapshots
+            Path snapshotDir = Paths.get(snapshotsPath);
+            long referenceSize = -1;
+            for (Path file : Files.newDirectoryStream(snapshotDir, "*.digest")) {
+                long size = Files.size(file);
+                if (referenceSize < 0) {
+                    referenceSize = size;
+                } else {
+                    assertEquals(referenceSize, size);
+                }
+            }
+            assertNotEquals(-1, referenceSize);
 
         } finally {
             lc.shutDown();


### PR DESCRIPTION
Because the drVersion in the snapshot digest was not zero setDRProtocolVersion is called which initializes the replicated DR stream. When the DR replicated stream is initialized it is then included in the snapshot digest.

To avoid this happening initialize the DR version to 0 so that it is only not 0 when dr is enabled. Also, do not even include and of the DR tuple stream state info if DR is not active.