### PR TITLE
Calcite add plan switch

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -57,6 +57,7 @@
 <!-- allow env.VOLTBUILD to override "build" property -->
 <envdefault prop="build" var="VOLTBUILD" default="release" />
 <envdefault prop="jmemcheck" var="JMEMCHECK" default="memcheck" />
+<envdefault prop="calcite" var="calcite" default="false" />
 
 <!-- enable code coverage for JUnit's if USE_JACOCO in environment-->
 <condition property="use_jacoco" value="true">
@@ -1797,6 +1798,7 @@ TEST CASES
             <jvmarg value="-Dtestcount=${testcount}" />
             <jvmarg value="-Drun.flaky.tests=${run.flaky.tests}" />
             <jvmarg value="-Drun.flaky.tests.debug=${run.flaky.tests.debug}" />
+            <jvmarg value="-DPLAN_WITH_CALCITE=${calcite}" />
 
             <!-- write per-testcase output to console if verbose mode -->
             <formatter type="plain" usefile="false" if="verbosereport"/>

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -136,7 +136,7 @@ public class SystemProcedureCatalog {
 
     static {
         // special-case replica acceptability by DR version
-        ImmutableMap.Builder<String, Config> builder = ImmutableMap.builder();
+        final ImmutableMap.Builder<String, Config> builder = ImmutableMap.builder();
         builder.put("@AdHoc_RW_MP",
                 new Config("org.voltdb.sysprocs.AdHoc_RW_MP",
                         false, false, false, 0, VoltType.INVALID,

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -66,20 +66,10 @@ public class SystemProcedureCatalog {
         // whether restartable
         public final boolean restartable;
 
-        public Config(String className,
-                      boolean singlePartition,
-                      boolean readOnly,
-                      boolean everySite,
-                      int partitionParam,
-                      VoltType partitionParamType,
-                      boolean commercial,
-                      boolean terminatesReplication,
-                      boolean allowedInReplica,
-                      boolean durable,
-                      boolean allowedInShutdown,
-                      boolean transactional,
-                      boolean restartable)
-        {
+        public Config(
+                String className, boolean singlePartition, boolean readOnly, boolean everySite, int partitionParam,
+                VoltType partitionParamType, boolean commercial, boolean terminatesReplication, boolean allowedInReplica,
+                boolean durable, boolean allowedInShutdown, boolean transactional, boolean restartable) {
             this.className = className;
             this.singlePartition = singlePartition;
             this.readOnly = readOnly;
@@ -144,91 +134,390 @@ public class SystemProcedureCatalog {
 
     public static final ImmutableMap<String, Config> listing;
 
-    static {                                                                                            // SP     RO     Every  Param ParamType           PRO    killDR replica-ok durable allowedInShutdown transactional restartable
+    static {
         // special-case replica acceptability by DR version
         ImmutableMap.Builder<String, Config> builder = ImmutableMap.builder();
-        builder.put("@AdHoc_RW_MP",             new Config("org.voltdb.sysprocs.AdHoc_RW_MP",              false, false, false, 0,    VoltType.INVALID,   false, false, false,     true,   false,            true,         true  ));
-        builder.put("@AdHoc_RW_SP",             new Config("org.voltdb.sysprocs.AdHoc_RW_SP",              true,  false, false, 0,    VoltType.VARBINARY, false, false, false,     true,   false,            true,         true  ));
-        builder.put("@AdHoc_RO_MP",             new Config("org.voltdb.sysprocs.AdHoc_RO_MP",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         true  ));
-        builder.put("@MigratePartitionLeader",  new Config("org.voltdb.sysprocs.MigratePartitionLeader",   true,  true,  false, 0,    VoltType.BIGINT,    false, true,  false,     false,  false,            true,         false  ));
-        builder.put("@AdHoc_RO_SP",             new Config("org.voltdb.sysprocs.AdHoc_RO_SP",              true,  true,  false, 0,    VoltType.VARBINARY, false, false, true,      false,  false,            true,         true  ));
-        builder.put("@JStack",                  new Config(null,                                           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true,             true,         false ));
-        builder.put("@Pause",                   new Config("org.voltdb.sysprocs.Pause",                    false, false, true,  0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@Resume",                  new Config("org.voltdb.sysprocs.Resume",                   false, false, true,  0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@Quiesce",                 new Config("org.voltdb.sysprocs.Quiesce",                  false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
-        builder.put("@SnapshotSave",            new Config("org.voltdb.sysprocs.SnapshotSave",             false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
-        builder.put("@SnapshotRestore",         new Config("org.voltdb.sysprocs.SnapshotRestore",          false, false, false, 0,    VoltType.INVALID,   false, true,  false,     false,  false,            true,         false ));
-        builder.put("@SnapshotStatus",          new Config("org.voltdb.sysprocs.SnapshotStatus",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@SnapshotScan",            new Config("org.voltdb.sysprocs.SnapshotScan",             false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@SnapshotDelete",          new Config("org.voltdb.sysprocs.SnapshotDelete",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@Shutdown",                new Config("org.voltdb.sysprocs.Shutdown",                 false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
-        builder.put("@ProfCtl",                 new Config("org.voltdb.sysprocs.ProfCtl",                  false, false, true,  0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@Statistics",              new Config("org.voltdb.sysprocs.Statistics",               false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
-        builder.put("@SystemCatalog",           new Config("org.voltdb.sysprocs.SystemCatalog",            true,  true,  false, 0,    VoltType.STRING,    false, false, true,      false,  false,            true,         false ));
-        builder.put("@SystemInformation",       new Config("org.voltdb.sysprocs.SystemInformation",        false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@UpdateLogging",           new Config("org.voltdb.sysprocs.UpdateLogging",            false, false, true,  0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@BalancePartitions",       new Config("org.voltdb.sysprocs.BalancePartitions",        false, false, false, 0,    VoltType.INVALID,   true,  false, false,     true,   false,            true,         false ));
-        builder.put("@UpdateCore",              new Config("org.voltdb.sysprocs.UpdateCore",               false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         true  ));
-        builder.put("@VerifyCatalogAndWriteJar",new Config("org.voltdb.sysprocs.VerifyCatalogAndWriteJar", false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            false,        false ));
-        builder.put("@UpdateApplicationCatalog",new Config("org.voltdb.sysprocs.UpdateApplicationCatalog", false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            false,        false ));
-        builder.put("@UpdateClasses",           new Config("org.voltdb.sysprocs.UpdateClasses",            false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            false,        false ));
-        builder.put("@LoadMultipartitionTable", new Config("org.voltdb.sysprocs.LoadMultipartitionTable",  false, false, false, 0,    VoltType.INVALID,   false, false, false,     true,   false,            true,         true  ));
-        builder.put("@LoadSinglepartitionTable",new Config("org.voltdb.sysprocs.LoadSinglepartitionTable", true,  false, false, 0,    VoltType.VARBINARY, false, false, false,     true,   false,            true,         false ));
-        builder.put("@Promote",                 new Config("org.voltdb.sysprocs.Promote",                  false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
-        builder.put("@ValidatePartitioning",    new Config("org.voltdb.sysprocs.ValidatePartitioning",     false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@GetHashinatorConfig",     new Config("org.voltdb.sysprocs.GetHashinatorConfig",      false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@ApplyBinaryLogSP",        new Config("org.voltdb.sysprocs.ApplyBinaryLogSP",         true,  false, false, 0,    VoltType.VARBINARY, true,  false, true,      true,   false,            true,         false ));
-        builder.put("@ApplyBinaryLogMP",        new Config("org.voltdb.sysprocs.ApplyBinaryLogMP",         false, false, false, 0,    VoltType.INVALID,   true,  false, true,      true,   false,            true,         true  ));
-        builder.put("@LoadVoltTableSP",         new Config("org.voltdb.sysprocs.LoadVoltTableSP",          true,  false, false, 0,    VoltType.VARBINARY, true,  false, true,      true,   false,            true,         false ));
-        builder.put("@LoadVoltTableMP",         new Config("org.voltdb.sysprocs.LoadVoltTableMP",          false, false, false, 0,    VoltType.INVALID,   true,  false, true,      true,   false,            true,         false ));
-        builder.put("@ResetDR",                 new Config("org.voltdb.sysprocs.ResetDR",                  false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            true,         false ));
-        //------------------------------------------------------------------------------------------------ SP     RO     Every  Param ParamType           PRO    killDR replica-ok durable allowedInShutdown transactional restartable
+        builder.put("@AdHoc_RW_MP",
+                new Config("org.voltdb.sysprocs.AdHoc_RW_MP",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, false, true,
+                        false, true, true));
+        builder.put("@AdHoc_RW_SP",
+                new Config("org.voltdb.sysprocs.AdHoc_RW_SP",
+                        true,  false, false, 0, VoltType.VARBINARY,
+                        false, false, false,true,
+                        false, true, true));
+        builder.put("@AdHoc_RO_MP",
+                new Config("org.voltdb.sysprocs.AdHoc_RO_MP",
+                        false, true,  false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, true));
+        builder.put("@MigratePartitionLeader",
+                new Config("org.voltdb.sysprocs.MigratePartitionLeader",
+                        true, true, false, 0, VoltType.BIGINT,
+                        false, true,  false,false,
+                        false, true, false));
+        builder.put("@AdHoc_RO_SP",
+                new Config("org.voltdb.sysprocs.AdHoc_RO_SP",
+                        true,  true,  false, 0, VoltType.VARBINARY,
+                        false, false, true,false,
+                        false, true, true));
+        builder.put("@JStack",
+                new Config(null,
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        true, true, false));
+        builder.put("@Pause",
+                new Config("org.voltdb.sysprocs.Pause",
+                        false, false, true,  0, VoltType.INVALID,
+                        false, false, true,false,
+                        false, true, false));
+        builder.put("@Resume",
+                new Config("org.voltdb.sysprocs.Resume",
+                        false, false, true,  0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@Quiesce",
+                new Config("org.voltdb.sysprocs.Quiesce",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        true, true, false));
+        builder.put("@SnapshotSave",
+                new Config("org.voltdb.sysprocs.SnapshotSave",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        true, true, false));
+        builder.put("@SnapshotRestore",
+                new Config("org.voltdb.sysprocs.SnapshotRestore",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, true,false, false,
+                        false, true, false ));
+        builder.put("@SnapshotStatus",
+                new Config("org.voltdb.sysprocs.SnapshotStatus",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@SnapshotScan",
+                new Config("org.voltdb.sysprocs.SnapshotScan",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@SnapshotDelete",
+                new Config("org.voltdb.sysprocs.SnapshotDelete",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@Shutdown",
+                new Config("org.voltdb.sysprocs.Shutdown",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        true, true, false));
+        builder.put("@ProfCtl",
+                new Config("org.voltdb.sysprocs.ProfCtl",
+                        false, false, true, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@Statistics",
+                new Config("org.voltdb.sysprocs.Statistics",
+                        false, true, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        true, true, false));
+        builder.put("@SystemCatalog",
+                new Config("org.voltdb.sysprocs.SystemCatalog",
+                        true, true, false, 0, VoltType.STRING,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@SystemInformation",
+                new Config("org.voltdb.sysprocs.SystemInformation",
+                        false, true, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@UpdateLogging",
+                new Config("org.voltdb.sysprocs.UpdateLogging",
+                        false, false, true, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@BalancePartitions",
+                new Config("org.voltdb.sysprocs.BalancePartitions",
+                        false, false, false, 0, VoltType.INVALID,
+                        true, false, false, true,
+                        false, true, false));
+        builder.put("@UpdateCore",
+                new Config("org.voltdb.sysprocs.UpdateCore",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, true,
+                        false, true, true));
+        builder.put("@VerifyCatalogAndWriteJar",
+                new Config("org.voltdb.sysprocs.VerifyCatalogAndWriteJar",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, true,
+                        false, false, false));
+        builder.put("@UpdateApplicationCatalog",
+                new Config("org.voltdb.sysprocs.UpdateApplicationCatalog",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, true,
+                        false, false, false));
+        builder.put("@UpdateClasses",
+                new Config("org.voltdb.sysprocs.UpdateClasses",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, true,
+                        false, false, false));
+        builder.put("@LoadMultipartitionTable",
+                new Config("org.voltdb.sysprocs.LoadMultipartitionTable",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, false, true,
+                        false, true, true));
+        builder.put("@LoadSinglepartitionTable",
+                new Config("org.voltdb.sysprocs.LoadSinglepartitionTable",
+                        true,  false, false, 0, VoltType.VARBINARY,
+                        false, false, false, true,
+                        false, true, false ));
+        builder.put("@Promote",
+                new Config("org.voltdb.sysprocs.Promote",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, false, false));
+        builder.put("@ValidatePartitioning",
+                new Config("org.voltdb.sysprocs.ValidatePartitioning",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@GetHashinatorConfig",
+                new Config("org.voltdb.sysprocs.GetHashinatorConfig",
+                        false, true,  false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@ApplyBinaryLogSP",
+                new Config("org.voltdb.sysprocs.ApplyBinaryLogSP",
+                        true,  false, false, 0, VoltType.VARBINARY,
+                        true, false, true, true,
+                        false, true, false));
+        builder.put("@ApplyBinaryLogMP",
+                new Config("org.voltdb.sysprocs.ApplyBinaryLogMP",
+                        false, false, false, 0, VoltType.INVALID,
+                        true, false, true, true,
+                        false, true, true));
+        builder.put("@LoadVoltTableSP",
+                new Config("org.voltdb.sysprocs.LoadVoltTableSP",
+                        true,  false, false, 0, VoltType.VARBINARY,
+                        true, false, true, true,
+                        false, true, false));
+        builder.put("@LoadVoltTableMP",
+                new Config("org.voltdb.sysprocs.LoadVoltTableMP",
+                        false, false, false, 0, VoltType.INVALID,
+                        true, false, true, true,
+                        false, true, false));
+        builder.put("@ResetDR",
+                new Config("org.voltdb.sysprocs.ResetDR",
+                        false, false, false, 0, VoltType.INVALID,
+                        true, false, true, false,
+                        false, true, false));
         /* @ExecuteTask is a all-in-one system store procedure and should be ONLY used for internal purpose */
-        builder.put("@ExecuteTask",             new Config("org.voltdb.sysprocs.ExecuteTask",              false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         true  ));
-        builder.put("@ExecuteTask_SP",          new Config("org.voltdb.sysprocs.ExecuteTask_SP",           true,  false, false, 0,    VoltType.VARBINARY, false, false, true,      true,   false,            true,         false ));
-        builder.put("@UpdateSettings",          new Config("org.voltdb.sysprocs.UpdateSettings",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         false ));
-        builder.put("@Ping",                    new Config(null,                                           false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  true,             true,         false ));
-        builder.put("@PingPartitions",          new Config("org.voltdb.sysprocs.PingPartitions",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         true  ));
-        builder.put("@GetPartitionKeys",        new Config(null,                                           false, true,  true,  0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@Subscribe",               new Config(null,                                           false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@GC",                      new Config("org.voltdb.sysprocs.GC",                       false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
-        builder.put("@AdHoc",                   new Config("org.voltdb.sysprocs.AdHoc",                    false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        true  ));
-        builder.put("@AdHocSpForTest",          new Config("org.voltdb.sysprocs.AdHocSpForTest",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        true  ));
-        builder.put("@AdHocLarge",              new Config("org.voltdb.sysprocs.AdHocLarge",               false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        true  ));
-        builder.put("@StopNode",                new Config(null,                                           true,  false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@PrepareStopNode",         new Config(null,                                           true,  false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@Explain",                 new Config("org.voltdb.sysprocs.Explain",                  false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
-        builder.put("@ExplainProc",             new Config("org.voltdb.sysprocs.ExplainProc",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
-        builder.put("@ExplainView",             new Config("org.voltdb.sysprocs.ExplainView",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
-        builder.put("@ExplainJSON",             new Config("org.voltdb.sysprocs.ExplainJSON",              false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
-        builder.put("@ExplainCatalog",          new Config("org.voltdb.sysprocs.ExplainCatalog",           false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            false,        false ));
-        builder.put("@SendSentinel",            new Config(null,                                           true,  false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            true,         false ));
-        builder.put("@PrepareShutdown",         new Config("org.voltdb.sysprocs.PrepareShutdown",          false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
-        builder.put("@CancelShutdown",          new Config("org.voltdb.sysprocs.CancelShutdown",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  true ,            true,         false ));
-        builder.put("@SwapTables",              new Config("org.voltdb.sysprocs.SwapTables",               false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            false,        false ));
-        builder.put("@SwapTablesCore",          new Config("org.voltdb.sysprocs.SwapTablesCore",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         false ));
-        builder.put("@Trace",                   new Config(null,                                           false, true,  false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@CheckUpgradePlanNT",      new Config("org.voltdb.sysprocs.CheckUpgradePlanNT",       true,  false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
-        builder.put("@PrerequisitesCheckNT",    new Config("org.voltdb.sysprocs.CheckUpgradePlanNT$PrerequisitesCheckNT",
-                                                                                                           false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
-        builder.put("@RestartDRConsumerNT",     new Config("org.voltdb.sysprocs.RestartDRConsumerNT",      false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
-        builder.put("@ShutdownNodeDRConsumerNT", new Config("org.voltdb.sysprocs.RestartDRConsumerNT$ShutdownNodeDRConsumerNT",
-                                                                                                           false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
-        builder.put("@StartNodeDRConsumerNT",   new Config("org.voltdb.sysprocs.RestartDRConsumerNT$StartNodeDRConsumerNT",
-                                                                                                           false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
-        builder.put("@NibbleDeleteSP",          new Config("org.voltdb.sysprocs.NibbleDeleteSP",           true,  false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         true  ));
-        builder.put("@NibbleDeleteMP",          new Config("org.voltdb.sysprocs.NibbleDeleteMP",           false, false, false, 0,    VoltType.INVALID,   false, false, true,      true,   false,            true,         true  ));
-        builder.put("@LowImpactDeleteNT",       new Config("org.voltdb.sysprocs.LowImpactDeleteNT",        true,  false, false, 0,    VoltType.INVALID,   false, false, false,     false,  false,            false,        false ));
-        builder.put("@ExportControl",           new Config("org.voltdb.sysprocs.ExportControl",            false, false, false, 0,    VoltType.INVALID,   false, false, true,      false,  false,            true,         false ));
-        builder.put("@MigrateRowsAcked_SP",     new Config("org.voltdb.sysprocs.MigrateRowsAcked_SP",      true,  false, false, 0,    VoltType.INVALID,   false, false, false,     true,   true,             true,         true  ));
-        builder.put("@MigrateRowsAcked_MP",     new Config("org.voltdb.sysprocs.MigrateRowsAcked_MP",      false, false, false, 0,    VoltType.VARBINARY, false, false, false,     true,   true,             true,         false ));
-        builder.put("@MigrateRowsSP",           new Config("org.voltdb.sysprocs.MigrateRowsSP",            true,  false, false, 0,    VoltType.INVALID,   false, false, false,     true,   false,            true,         true  ));
-        builder.put("@MigrateRowsMP",           new Config("org.voltdb.sysprocs.MigrateRowsMP",            false, false, false, 0,    VoltType.VARBINARY, false, false, false,     true,   false,            true,         false ));
-        builder.put("@MigrateRowsNT",           new Config("org.voltdb.sysprocs.MigrateRowsNT",            true,  false, false, 0,    VoltType.INVALID,   false, false, false,     true,   false,            false,        false ));
-        builder.put("@MigrateRowsDeleterNT",    new Config("org.voltdb.sysprocs.MigrateRowsDeleterNT",     true,  false, false, 0,    VoltType.INVALID,   false, false, false,     true,   true,             false,        false ));
-        builder.put("@ElasticRemoveNT",         new Config("org.voltdb.sysprocs.ElasticRemoveNT",          false, false, false, 0,    VoltType.INVALID,   true,  false, true,      false,  false,            false,        false ));
-        builder.put("@ElasticRemove",           new Config("org.voltdb.sysprocs.ElasticRemove",            false, false, false, 0,    VoltType.INVALID,   true,  false, false,     true,   false,            true,         true ));
-
+        builder.put("@ExecuteTask",
+                new Config("org.voltdb.sysprocs.ExecuteTask",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, true,
+                        false, true, true));
+        builder.put("@ExecuteTask_SP",
+                new Config("org.voltdb.sysprocs.ExecuteTask_SP",
+                        true, false, false, 0, VoltType.VARBINARY,
+                        false, false, true, true,
+                        false, true, false));
+        builder.put("@UpdateSettings",
+                new Config("org.voltdb.sysprocs.UpdateSettings",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, true,
+                        false, true, false));
+        builder.put("@Ping",
+                new Config(null,
+                        false, true,  false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        true, true, false));
+        builder.put("@PingPartitions",
+                new Config("org.voltdb.sysprocs.PingPartitions",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, true));
+        builder.put("@GetPartitionKeys",
+                new Config(null,
+                        false, true,  true,  0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@Subscribe",
+                new Config(null,
+                        false, true,  false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@GC",
+                new Config("org.voltdb.sysprocs.GC",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, false, false));
+        builder.put("@AdHoc",
+                new Config("org.voltdb.sysprocs.AdHoc",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, false, true));
+        builder.put("@AdHocSpForTest",
+                new Config("org.voltdb.sysprocs.AdHocSpForTest",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, false, true));
+        builder.put("@AdHocLarge",
+                new Config("org.voltdb.sysprocs.AdHocLarge",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, false, true));
+        builder.put("@StopNode",
+                new Config(null,
+                        true,  false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@PrepareStopNode",
+                new Config(null,
+                        true,  false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@Explain",
+                new Config("org.voltdb.sysprocs.Explain",
+                        false, true, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, false, false));
+        builder.put("@ExplainProc",
+                new Config("org.voltdb.sysprocs.ExplainProc",
+                        false, true,  false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, false, false));
+        builder.put("@ExplainView",
+                new Config("org.voltdb.sysprocs.ExplainView",
+                        false, true,  false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, false, false));
+        builder.put("@ExplainJSON",
+                new Config("org.voltdb.sysprocs.ExplainJSON",
+                        false, true,  false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, false, false));
+        builder.put("@ExplainCatalog",
+                new Config("org.voltdb.sysprocs.ExplainCatalog",
+                        false, true,  false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, false, false));
+        builder.put("@SendSentinel",
+                new Config(null,
+                        true,  false, false, 0, VoltType.INVALID,
+                        true, false, true, false,
+                        false, true, false));
+        builder.put("@PrepareShutdown",
+                new Config("org.voltdb.sysprocs.PrepareShutdown",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        true, true, false));
+        builder.put("@CancelShutdown",
+                new Config("org.voltdb.sysprocs.CancelShutdown",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        true, true, false));
+        builder.put("@SwapTables",
+                new Config("org.voltdb.sysprocs.SwapTables",
+                        false, false, false, 0,    VoltType.INVALID,
+                        false, false, true, true,
+                        false, false, false));
+        builder.put("@SwapTablesCore",
+                new Config("org.voltdb.sysprocs.SwapTablesCore",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, true,
+                        false, true, false));
+        builder.put("@Trace",
+                new Config(null,
+                        false, true,  false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@CheckUpgradePlanNT",
+                new Config("org.voltdb.sysprocs.CheckUpgradePlanNT",
+                        true,  false, false, 0, VoltType.INVALID,
+                        true, false, true, false,
+                        false, false, false));
+        builder.put("@PrerequisitesCheckNT",
+                new Config("org.voltdb.sysprocs.CheckUpgradePlanNT$PrerequisitesCheckNT",
+                        false, false, false, 0, VoltType.INVALID,
+                        true, false, true, false,
+                        false, false, false));
+        builder.put("@RestartDRConsumerNT",
+                new Config("org.voltdb.sysprocs.RestartDRConsumerNT",
+                        false, false, false, 0, VoltType.INVALID,
+                        true, false, true, false,
+                        false, false, false));
+        builder.put("@ShutdownNodeDRConsumerNT",
+                new Config("org.voltdb.sysprocs.RestartDRConsumerNT$ShutdownNodeDRConsumerNT",
+                        false, false, false, 0, VoltType.INVALID,
+                        true, false, true, false,
+                        false, false, false));
+        builder.put("@StartNodeDRConsumerNT",
+                new Config("org.voltdb.sysprocs.RestartDRConsumerNT$StartNodeDRConsumerNT",
+                        false, false, false, 0, VoltType.INVALID,
+                        true, false, true, false,
+                        false, false, false));
+        builder.put("@NibbleDeleteSP",
+                new Config("org.voltdb.sysprocs.NibbleDeleteSP",
+                        true, false, false, 0, VoltType.INVALID,
+                        false, false, true, true,
+                        false, true, true));
+        builder.put("@NibbleDeleteMP",
+                new Config("org.voltdb.sysprocs.NibbleDeleteMP",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, true,
+                        false, true, true));
+        builder.put("@LowImpactDeleteNT",
+                new Config("org.voltdb.sysprocs.LowImpactDeleteNT",
+                        true, false, false, 0, VoltType.INVALID,
+                        false, false, false, false,
+                        false, false, false));
+        builder.put("@ExportControl",
+                new Config("org.voltdb.sysprocs.ExportControl",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, false,
+                        false, true, false));
+        builder.put("@MigrateRowsAcked_SP",
+                new Config("org.voltdb.sysprocs.MigrateRowsAcked_SP",
+                        true, false, false, 0, VoltType.INVALID,
+                        false, false, false, true,
+                        true, true, true));
+        builder.put("@MigrateRowsAcked_MP",
+                new Config("org.voltdb.sysprocs.MigrateRowsAcked_MP",
+                        false, false, false, 0, VoltType.VARBINARY,
+                        false, false, false, true,
+                        true, true, false));
+        builder.put("@MigrateRowsSP",
+                new Config("org.voltdb.sysprocs.MigrateRowsSP",
+                        true, false, false, 0, VoltType.INVALID,
+                        false, false, false, true,
+                        false, true, true));
+        builder.put("@MigrateRowsMP",
+                new Config("org.voltdb.sysprocs.MigrateRowsMP",
+                        false, false, false, 0, VoltType.VARBINARY,
+                        false, false, false, true,
+                        false, true,false));
+        builder.put("@MigrateRowsNT",
+                new Config("org.voltdb.sysprocs.MigrateRowsNT",
+                        true, false, false, 0, VoltType.INVALID,
+                        false, false, false, true,
+                        false, false, false));
+        builder.put("@MigrateRowsDeleterNT",
+                new Config("org.voltdb.sysprocs.MigrateRowsDeleterNT",
+                        true, false, false, 0, VoltType.INVALID,
+                        false, false, false, true,
+                        true, false, false));
+        builder.put("@ElasticRemoveNT",
+                new Config("org.voltdb.sysprocs.ElasticRemoveNT",
+                        false, false, false, 0, VoltType.INVALID,
+                        true, false, true, false,
+                        false, false, false ));
+        builder.put("@ElasticRemove",
+                new Config("org.voltdb.sysprocs.ElasticRemove",
+                        false, false, false, 0, VoltType.INVALID,
+                        true, false, false, true,
+                        false, true, true));
         listing = builder.build();
     }
 }

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -112,7 +112,7 @@ public class VoltDB {
 
     public static final String DISABLE_PLACEMENT_RESTORE = "DISABLE_PLACEMENT_RESTORE";
 
-    // if VoltDB is running in your process, prepare to use UTC (GMT) timezone
+    // TODO: if VoltDB is running in your process, prepare to use UTC (GMT) timezone
     public synchronized static void setDefaultTimezone() {
         TimeZone.setDefault(GMT_TIMEZONE);
     }
@@ -172,14 +172,22 @@ public class VoltDB {
         public SslContext m_sslClientContext = null;
 
         /** enable ssl */
-        public boolean m_sslEnable = Boolean.valueOf(System.getenv("ENABLE_SSL") == null ? Boolean.toString(Boolean.getBoolean("ENABLE_SSL")) : System.getenv("ENABLE_SSL"));
+        public boolean m_sslEnable = System.getenv("ENABLE_SSL") == null ?
+                Boolean.getBoolean("ENABLE_SSL") :
+                Boolean.parseBoolean(System.getenv("ENABLE_SSL"));
 
         /** enable ssl for external (https, client and admin port*/
-        public boolean m_sslExternal = Boolean.valueOf(System.getenv("ENABLE_SSL") == null ? Boolean.toString(Boolean.getBoolean("ENABLE_SSL")) : System.getenv("ENABLE_SSL"));
+        public boolean m_sslExternal = System.getenv("ENABLE_SSL") == null ?
+                Boolean.getBoolean("ENABLE_SSL") :
+                Boolean.parseBoolean(System.getenv("ENABLE_SSL"));
 
-        public boolean m_sslDR = Boolean.valueOf(System.getenv("ENABLE_DR_SSL") == null ? Boolean.toString(Boolean.getBoolean("ENABLE_DR_SSL")) : System.getenv("ENABLE_DR_SSL"));
+        public boolean m_sslDR = System.getenv("ENABLE_DR_SSL") == null ?
+                Boolean.getBoolean("ENABLE_DR_SSL") :
+                Boolean.parseBoolean(System.getenv("ENABLE_DR_SSL"));
 
-        public boolean m_sslInternal = Boolean.valueOf(System.getenv("ENABLE_INTERNAL_SSL") == null ? Boolean.toString(Boolean.getBoolean("ENABLE_INTERNAL_SSL")) : System.getenv("ENABLE_INTERNAL_SSL"));
+        public boolean m_sslInternal = System.getenv("ENABLE_INTERNAL_SSL") == null ?
+                Boolean.getBoolean("ENABLE_INTERNAL_SSL") :
+                Boolean.parseBoolean(System.getenv("ENABLE_INTERNAL_SSL"));
 
         /** port number to use to build intra-cluster mesh */
         public int m_internalPort = org.voltcore.common.Constants.DEFAULT_INTERNAL_PORT;
@@ -365,8 +373,7 @@ public class VoltDB {
                 arg = args[i];
                 // Some LocalCluster ProcessBuilder instances can result in an empty string
                 // in the array args.  Ignore them.
-                if (arg.equals(""))
-                {
+                if (arg.isEmpty()) {
                     continue;
                 }
 
@@ -381,31 +388,21 @@ public class VoltDB {
 
                 if (arg.equals("noloadlib")) {
                     m_noLoadLibVOLTDB = true;
-                }
-                else if (arg.equals("ipc")) {
+                } else if (arg.equals("ipc")) {
                     m_backend = BackendTarget.NATIVE_EE_IPC;
-                }
-                else if (arg.equals("jni")) {
+                } else if (arg.equals("jni")) {
                     m_backend = BackendTarget.NATIVE_EE_JNI;
-                }
-                else if (arg.equals("hsqldb")) {
+                } else if (arg.equals("hsqldb")) {
                     m_backend = BackendTarget.HSQLDB_BACKEND;
-                }
-                else if (arg.equals("postgresql")) {
+                } else if (arg.equals("postgresql")) {
                     m_backend = BackendTarget.POSTGRESQL_BACKEND;
-                }
-                else if (arg.equals("postgis")) {
+                } else if (arg.equals("postgis")) {
                     m_backend = BackendTarget.POSTGIS_BACKEND;
-                }
-                else if (arg.equals("valgrind")) {
+                } else if (arg.equals("valgrind")) {
                     m_backend = BackendTarget.NATIVE_EE_VALGRIND_IPC;
-                }
-                else if (arg.equals("quietadhoc"))
-                {
+                } else if (arg.equals("quietadhoc")) {
                     m_quietAdhoc = true;
-                }
-                // handle from the command line as two strings <catalog> <filename>
-                else if (arg.equals("port")) {
+                } else if (arg.equals("port")) { // handle from the command line as two strings <catalog> <filename>
                     String portStr = args[++i];
                     if (portStr.indexOf(':') != -1) {
                         HostAndPort hap = MiscUtils.getHostAndPortFromHostnameColonPort(portStr, m_port);
@@ -497,28 +494,23 @@ public class VoltDB {
                     m_publicInterface = arg.substring("publicinterface ".length()).trim();
                 } else if (arg.equals("externalinterface")) {
                     m_externalInterface = args[++i].trim();
-                }
-                else if (arg.startsWith("externalinterface ")) {
+                } else if (arg.startsWith("externalinterface ")) {
                     m_externalInterface = arg.substring("externalinterface ".length()).trim();
-                }
-                else if (arg.equals("internalinterface")) {
+                } else if (arg.equals("internalinterface")) {
                     m_internalInterface = args[++i].trim();
-                }
-                else if (arg.startsWith("internalinterface ")) {
+                } else if (arg.startsWith("internalinterface ")) {
                     m_internalInterface = arg.substring("internalinterface ".length()).trim();
                 } else if (arg.startsWith("networkbindings")) {
                     for (String core : args[++i].split(",")) {
                         m_networkCoreBindings.offer(core);
                     }
                     System.out.println("Network bindings are " + m_networkCoreBindings);
-                }
-                else if (arg.startsWith("computationbindings")) {
+                } else if (arg.startsWith("computationbindings")) {
                     for (String core : args[++i].split(",")) {
                         m_computationCoreBindings.offer(core);
                     }
                     System.out.println("Computation bindings are " + m_computationCoreBindings);
-                }
-                else if (arg.startsWith("executionbindings")) {
+                } else if (arg.startsWith("executionbindings")) {
                     for (String core : args[++i].split(",")) {
                         m_executionCoreBindings.offer(core);
                     }
@@ -530,42 +522,31 @@ public class VoltDB {
                     }
                     m_commandLogBinding = binding;
                     System.out.println("Commanglog binding is " + m_commandLogBinding);
-                }
-                else if (arg.equals("host") || arg.equals("leader")) {
+                } else if (arg.equals("host") || arg.equals("leader")) {
                     m_leader = args[++i].trim();
                 } else if (arg.startsWith("host")) {
                     m_leader = arg.substring("host ".length()).trim();
                 } else if (arg.startsWith("leader")) {
                     m_leader = arg.substring("leader ".length()).trim();
-                }
-                // synonym for "rejoin host" for backward compatibility
-                else if (arg.equals("rejoinhost")) {
+                } else if (arg.equals("rejoinhost")) { // synonym for "rejoin host" for backward compatibility
                     m_startAction = StartAction.REJOIN;
                     m_leader = args[++i].trim();
-                }
-                else if (arg.startsWith("rejoinhost ")) {
+                } else if (arg.startsWith("rejoinhost ")) {
                     m_startAction = StartAction.REJOIN;
                     m_leader = arg.substring("rejoinhost ".length()).trim();
-                }
-
-                else if (arg.equals("initialize")) {
+                } else if (arg.equals("initialize")) {
                     m_startAction = StartAction.INITIALIZE;
-                }
-                else if (arg.equals("probe")) {
+                } else if (arg.equals("probe")) {
                     m_startAction = StartAction.PROBE;
-                    if (   args.length > i + 1
-                            && args[i+1].trim().equals("safemode")) {
-                            i += 1;
-                            m_safeMode = true;
-                        }
-                }
-                else if (arg.equals("create")) {
+                    if (args.length > i + 1 && args[i+1].trim().equals("safemode")) {
+                        i += 1;
+                        m_safeMode = true;
+                    }
+                } else if (arg.equals("create")) {
                     m_startAction = StartAction.CREATE;
-                }
-                else if (arg.equals("recover")) {
+                } else if (arg.equals("recover")) {
                     m_startAction = StartAction.RECOVER;
-                    if (   args.length > i + 1
-                        && args[i+1].trim().equals("safemode")) {
+                    if (args.length > i + 1 && args[i+1].trim().equals("safemode")) {
                         m_startAction = StartAction.SAFE_RECOVER;
                         i += 1;
                         m_safeMode = true;
@@ -589,51 +570,32 @@ public class VoltDB {
                     referToDocAndExit();
                 } else if (arg.equals("dragentportstart")) {
                     m_drAgentPortStart = Integer.parseInt(args[++i]);
-                }
-
-                // handle timestampsalt
-                else if (arg.equals("timestampsalt")) {
+                } else if (arg.equals("timestampsalt")) { // handle timestampsalt
                     m_timestampTestingSalt = Long.parseLong(args[++i]);
-                }
-                else if (arg.startsWith("timestampsalt ")) {
+                } else if (arg.startsWith("timestampsalt ")) {
                     m_timestampTestingSalt = Long.parseLong(arg.substring("timestampsalt ".length()));
-                }
-
-                // handle behaviorless tag field
-                else if (arg.equals("tag")) {
+                } else if (arg.equals("tag")) { // handle behaviorless tag field
                     m_tag = args[++i];
-                }
-                else if (arg.startsWith("tag ")) {
+                } else if (arg.startsWith("tag ")) {
                     m_tag = arg.substring("tag ".length());
-                }
-
-                else if (arg.equals("catalog")) {
+                } else if (arg.equals("catalog")) {
                     m_pathToCatalog = args[++i];
-                }
-                // and from ant as a single string "m_catalog filename"
-                else if (arg.startsWith("catalog ")) {
+                } else if (arg.startsWith("catalog ")) { // and from ant as a single string "m_catalog filename"
                     m_pathToCatalog = arg.substring("catalog ".length());
-                }
-                else if (arg.equals("deployment")) {
+                } else if (arg.equals("deployment")) {
                     m_pathToDeployment = args[++i];
-                }
-                else if (arg.equals("license")) {
+                } else if (arg.equals("license")) {
                     m_pathToLicense = args[++i];
-                }
-                else if (arg.equalsIgnoreCase("ipcport")) {
+                } else if (arg.equalsIgnoreCase("ipcport")) {
                     String portStr = args[++i];
                     m_ipcPort = Integer.valueOf(portStr);
-                }
-                else if (arg.equals("forcecatalogupgrade")) {
+                } else if (arg.equals("forcecatalogupgrade")) {
                     System.out.println("Forced catalog upgrade will occur due to command line option.");
                     m_forceCatalogUpgrade = true;
-                }
-                // version string override for testing online upgrade
-                else if (arg.equalsIgnoreCase("versionoverride")) {
+                } else if (arg.equalsIgnoreCase("versionoverride")) { // version string override for testing online upgrade
                     m_versionStringOverrideForTest = args[++i].trim();
                     m_versionCompatibilityRegexOverrideForTest = args[++i].trim();
-                }
-                else if (arg.equalsIgnoreCase("buildstringoverride")) {
+                } else if (arg.equalsIgnoreCase("buildstringoverride")) {
                     m_buildStringOverrideForTest = args[++i].trim();
                 } else if (arg.equalsIgnoreCase("placementgroup")) {
                     m_placementGroup = args[++i].trim();
@@ -708,8 +670,7 @@ public class VoltDB {
                             referToDocAndExit();
                         }
                         if (!userSchema.isFile()) {
-                            System.err
-                                    .println("FATAL: Supplied schema file " + userSchema + " is not an ordinary file.");
+                            System.err.println("FATAL: Supplied schema file " + userSchema + " is not an ordinary file.");
                             referToDocAndExit();
                         }
                         if (m_userSchemas == null) {
@@ -820,7 +781,7 @@ public class VoltDB {
             if (!m_voltdbRoot.exists()) {
                 try {
                     parentPath = m_voltdbRoot.getCanonicalFile().getParent();
-                } catch (IOException io) {}
+                } catch (IOException ignored) {}
                 System.err.println("FATAL: " + parentPath + " does not contain a "
                         + "valid database root directory. Use the --dir option to specify the path to the root.");
                 referToDocAndExit();
@@ -845,13 +806,13 @@ public class VoltDB {
                     if (!catalogFH.exists()) {
                         try {
                             parentPath = m_voltdbRoot.getCanonicalFile().getParent();
-                        } catch (IOException io) {}
-                        System.err.println("FATAL: "+ m_getOption.name().toUpperCase() + " not found in the provided database directory " + parentPath  +
+                        } catch (IOException ignored) {}
+                        System.err.println("FATAL: "+ m_getOption.name().toUpperCase() +
+                                " not found in the provided database directory " + parentPath  +
                                 ". Make sure the database has been started ");
                         referToDocAndExit();
                     }
                     m_pathToCatalog = catalogFH.getAbsolutePath();
-                    return;
                 }
             }
         }
@@ -879,11 +840,8 @@ public class VoltDB {
                 currDir = new File("").getCanonicalFile();
                 voltdbroot = m_voltdbRoot.getCanonicalFile();
             } catch (IOException e) {
-                throw new SettingsException(
-                        "Failed to relativize voltdbroot " +
-                        m_voltdbRoot.getPath() +
-                        ". Reason: " +
-                        e.getMessage());
+                throw new SettingsException("Failed to relativize voltdbroot " +
+                        m_voltdbRoot.getPath() + ". Reason: " + e.getMessage());
             }
             String relativePath = currDir.toPath().relativize(voltdbroot.toPath()).toString();
             return ImmutableMap.<String, String>builder()
@@ -1150,13 +1108,10 @@ public class VoltDB {
             writer.flush();
             writer.close();
         } catch (Exception e) {
-            try
-            {
+            try {
                 VoltLogger log = new VoltLogger("HOST");
                 log.error("Error while dropping stack trace for \"" + message + "\"", e);
-            }
-            catch (RuntimeException rt_ex)
-            {
+            } catch (RuntimeException rt_ex) {
                 e.printStackTrace();
             }
         }
@@ -1192,8 +1147,7 @@ public class VoltDB {
 
         writer.println("****** All Threads ******");
         Iterator<Thread> it = traces.keySet().iterator();
-        while (it.hasNext())
-        {
+        while (it.hasNext()) {
             Thread key = it.next();
             writer.println();
             StackTraceElement[] st = traces.get(key);
@@ -1265,14 +1219,14 @@ public class VoltDB {
         }
         try {
             OnDemandBinaryLogger.flush();
-        } catch (Throwable e) {}
+        } catch (Throwable ignored) {}
 
         /*
          * InvocationTargetException suppresses information about the cause, so unwrap until
          * we get to the root cause
          */
         while (thrown instanceof InvocationTargetException) {
-            thrown = ((InvocationTargetException)thrown).getCause();
+            thrown = thrown.getCause();
         }
 
         // for test code
@@ -1304,7 +1258,7 @@ public class VoltDB {
                 try {
                     VoltTrace.closeAllAndShutdown(new File(instance().getVoltDBRootPath(), "trace_logs").getAbsolutePath(),
                                                   TimeUnit.SECONDS.toMillis(10));
-                } catch (IOException e) {}
+                } catch (IOException ignored) {}
 
                 // Even if the logger is null, don't stop.  We want to log the stack trace and
                 // any other pertinent information to a .dmp file for crash diagnosis
@@ -1312,8 +1266,7 @@ public class VoltDB {
                 currentStacktrace.add("Stack trace from crashLocalVoltDB() method:");
 
                 // Create a special dump file to hold the stack trace
-                try
-                {
+                try {
                     TimestampType ts = new TimestampType(new java.util.Date());
                     CatalogContext catalogContext = VoltDB.instance().getCatalogContext();
                     String root = catalogContext != null ? VoltDB.instance().getVoltDBRootPath() + File.separator : "";
@@ -1337,23 +1290,17 @@ public class VoltDB {
 
                     printStackTraces(writer, currentStacktrace);
                     writer.close();
-                }
-                catch (Throwable err)
-                {
+                } catch (Throwable err) {
                     // shouldn't fail, but..
                     err.printStackTrace();
                 }
 
                 VoltLogger log = null;
-                try
-                {
+                try {
                     log = new VoltLogger("HOST");
-                }
-                catch (RuntimeException rt_ex)
-                { /* ignore */ }
+                } catch (RuntimeException ignored) { }
 
-                if (log != null)
-                {
+                if (log != null) {
                     if (logFatal) {
                         log.fatal(errMsg);
                     }
@@ -1386,13 +1333,11 @@ public class VoltDB {
                         }
                     }
                 }
-            }
-            finally {
+            } finally {
                 System.err.println("VoltDB has encountered an unrecoverable error and is exiting.");
                 System.err.println("The log may contain additional information.");
             }
-        }
-        finally {
+        } finally {
             ShutdownHooks.useOnlyCrashHooks();
             System.exit(-1);
         }
@@ -1437,7 +1382,9 @@ public class VoltDB {
         } catch (Exception e) {
             e.printStackTrace();
             // sleep even on exception in case the pill got sent before the exception
-            try { Thread.sleep(500); } catch (InterruptedException e2) {}
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException ignored) {}
         }
         // finally block does its best to ensure death, no matter what context this
         // is called in
@@ -1456,16 +1403,13 @@ public class VoltDB {
         try {
             if (!config.validate()) {
                 System.exit(-1);
+            } else if (config.m_startAction == StartAction.GET) {
+                cli(config);
             } else {
-                if (config.m_startAction == StartAction.GET) {
-                    cli(config);
-                } else {
-                    initialize(config);
-                    instance().run();
-                }
+                initialize(config);
+                instance().run();
             }
-        }
-        catch (OutOfMemoryError e) {
+        } catch (OutOfMemoryError e) {
             String errmsg = "VoltDB Main thread: ran out of Java memory. This node will shut down.";
             VoltDB.crashLocalVoltDB(errmsg, false, e);
         }
@@ -1512,7 +1456,7 @@ public class VoltDB {
     }
 
     public static String getPublicReplicationInterface() {
-        return (m_config.m_drPublicHost == null || m_config.m_drPublicHost.isEmpty()) ?
+        return m_config.m_drPublicHost == null || m_config.m_drPublicHost.isEmpty() ?
                 "" : m_config.m_drPublicHost;
     }
 
@@ -1528,12 +1472,10 @@ public class VoltDB {
         if (m_config.m_drInterface == null || m_config.m_drInterface.isEmpty()) {
             if (m_config.m_externalInterface == null) {
                 return "";
-            }
-            else {
+            } else {
                 return m_config.m_externalInterface;
             }
-        }
-        else {
+        } else {
             return m_config.m_drInterface;
         }
     }
@@ -1541,8 +1483,7 @@ public class VoltDB {
     public static int getReplicationPort(int deploymentFilePort) {
         if (m_config.m_drAgentPortStart != -1) {
             return m_config.m_drAgentPortStart;
-        }
-        else {
+        } else {
             return deploymentFilePort;
         }
     }

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -87,7 +87,9 @@ public class PlannerTool {
     // If the test is started by ant and -Dlarge_mode_ratio is not set, it will take a default value "-1" which
     // we should ignore.
     private final double m_largeModeRatio = Double.valueOf((System.getenv("LARGE_MODE_RATIO") == null ||
-            System.getenv("LARGE_MODE_RATIO").equals("-1")) ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
+            System.getenv("LARGE_MODE_RATIO").equals("-1")) ?
+            System.getProperty("LARGE_MODE_RATIO", "0") :
+            System.getenv("LARGE_MODE_RATIO"));
 
     public PlannerTool(final Database database, byte[] catalogHash) {
         assert(database != null);
@@ -186,8 +188,7 @@ public class PlannerTool {
             planner.parse();
             plan = planner.plan();
             assert(plan != null);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             /*
              * Don't log PlanningErrorExceptions or HSQLParseExceptions, as they
              * are at least somewhat expected.

--- a/src/frontend/org/voltdb/plannerv2/NonDdlBatchPlanner.java
+++ b/src/frontend/org/voltdb/plannerv2/NonDdlBatchPlanner.java
@@ -75,7 +75,6 @@ public class NonDdlBatchPlanner {
         for (final SqlTask task : m_batch) {
             try {
                 final AdHocPlannedStatement result = planTask(task);
-                // System.err.println(result.core.toString().replace("{\"ID\":", "\n{\"ID\":"));
                 if (m_batch.inferPartitioning()) {
                     // The planning tool may have optimized for the single partition case
                     // and generated a partition parameter.
@@ -135,6 +134,7 @@ public class NonDdlBatchPlanner {
         final PlannerTool ptool = m_catalogContext.m_ptool;
         assert(ptool != null);
         try {
+            //ptool.planSql(task.getSQL(), )
             return ptool.planSqlCalcite(task);
         } catch (PlannerFallbackException ex) {
             // Let go the PlannerFallbackException so we can fall back to the legacy planner.

--- a/src/frontend/org/voltdb/plannerv2/NonDdlBatchPlanner.java
+++ b/src/frontend/org/voltdb/plannerv2/NonDdlBatchPlanner.java
@@ -134,10 +134,8 @@ public class NonDdlBatchPlanner {
         final PlannerTool ptool = m_catalogContext.m_ptool;
         assert(ptool != null);
         try {
-            //ptool.planSql(task.getSQL(), )
             return ptool.planSqlCalcite(task);
-        } catch (PlannerFallbackException ex) {
-            // Let go the PlannerFallbackException so we can fall back to the legacy planner.
+        } catch (PlannerFallbackException ex) { // Let go the PlannerFallbackException so we can fall back to the legacy planner.
             throw ex;
         } catch (Exception ex) {
             Throwable cause = ex.getCause();

--- a/src/frontend/org/voltdb/plannerv2/NonDdlBatchPlanner.java
+++ b/src/frontend/org/voltdb/plannerv2/NonDdlBatchPlanner.java
@@ -49,7 +49,7 @@ public class NonDdlBatchPlanner {
      */
     private final CatalogContext m_catalogContext;
 
-    public NonDdlBatchPlanner(NonDdlBatch batch) {
+    NonDdlBatchPlanner(NonDdlBatch batch) {
         m_batch = batch;
         m_catalogContext = VoltDB.instance().getCatalogContext();
     }
@@ -102,13 +102,9 @@ public class NonDdlBatchPlanner {
             throw new PlanningErrorException(errorSummary);
         }
 
-        AdHocPlannedStmtBatch plannedStmtBatch = new AdHocPlannedStmtBatch(
-                m_batch.getUserParameters(),
-                plannedStmts,
-                partitionParamIndex,
-                partitionParamType,
-                partitionParamValue,
-                m_batch.getUserPartitioningKeys());
+        final AdHocPlannedStmtBatch plannedStmtBatch = new AdHocPlannedStmtBatch(
+                m_batch.getUserParameters(), plannedStmts, partitionParamIndex,
+                partitionParamType, partitionParamValue, m_batch.getUserPartitioningKeys());
         if (m_batch.getContext().getLogger().isDebugEnabled()) {
             m_batch.getContext().logBatch(m_catalogContext, plannedStmtBatch, m_batch.getUserParameters());
         }
@@ -144,8 +140,8 @@ public class NonDdlBatchPlanner {
             }
             throw new PlanningErrorException(ex.getMessage(), cause);
         } catch (StackOverflowError error) {
-            // TODO: This is from AdHocNTBase.compileAdHocSQL()
-            // Maybe it is not needed any more in Calcite.
+            // NOTE: This is from AdHocNTBase.compileAdHocSQL()
+            // We need it, as long as Calcite could fall back.
 
             /*
              * Overly long predicate expressions can cause a StackOverflowError in various

--- a/src/frontend/org/voltdb/sysprocs/AdHoc.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc.java
@@ -28,18 +28,12 @@ import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.parser.SqlParseException;
-import org.voltcore.logging.VoltLogger;
-import org.voltdb.CatalogContext;
 import org.voltdb.ClientInterface.ExplainMode;
 import org.voltdb.ParameterSet;
 import org.voltdb.VoltDB;
-import org.voltdb.VoltTypeException;
 import org.voltdb.client.ClientResponse;
-import org.voltdb.compiler.AdHocPlannedStmtBatch;
 import org.voltdb.parser.SQLLexer;
 import org.voltdb.plannerv2.SqlBatch;
-import org.voltdb.plannerv2.guards.PlannerFallbackException;
 
 public class AdHoc extends AdHocNTBase {
 
@@ -56,7 +50,8 @@ public class AdHoc extends AdHocNTBase {
      * @since 9.0
      * @author Yiqun Zhang
      */
-    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+    @Override
+    protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) {
         // TRAIL [Calcite-AdHoc-DQL/DML:0] AdHoc.run()
         // TRAIL [Calcite-AdHoc-DDL:0] AdHoc.run()
         /**
@@ -68,80 +63,57 @@ public class AdHoc extends AdHocNTBase {
          * framework.
          */
         SqlBatch batch;
-        try {
-            // We do not need to worry about the ParameterSet,
+        try { // We do not need to worry about the ParameterSet;
             // AdHocAcceptancePolicy will sanitize the parameters ahead of time.
             batch = SqlBatch.from(params, m_context, ExplainMode.NONE);
             return batch.execute();
-        } catch (PlannerFallbackException | SqlParseException ex) {
-            // Use the legacy planner to run this.
-            return runFallback(params);
-        } catch (Exception ex) {
-            // For now, let's just fail the batch if any error happens.
+        } catch (Exception ex) {        // For now, let's just fail the batch if any error happens.
             return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, ex.getMessage());
         }
     }
 
-    public CompletableFuture<ClientResponse> runFallback(ParameterSet params) {
+    @Override
+    protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
         if (params.size() == 0) {
             return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE,
                     "Adhoc system procedure requires at least the query parameter.");
         }
 
-        Object[] paramArray = params.toArray();
-        String sql = (String) paramArray[0];
-        Object[] userParams = null;
-        if (params.size() > 1) {
-            userParams = Arrays.copyOfRange(paramArray, 1, paramArray.length);
-        }
+        final Object[] paramArray = params.toArray();
+        final String sql = (String) paramArray[0];
+        final Object[] userParams = params.size() > 1 ? Arrays.copyOfRange(paramArray, 1, paramArray.length) : null;
 
-        List<String> sqlStatements = new ArrayList<>();
-        AdHocSQLMix mix = processAdHocSQLStmtTypes(sql, sqlStatements);
-        if (mix == AdHocSQLMix.EMPTY) {
-            // we saw neither DDL or DQL/DML. Make sure that we get a
-            // response back to the client
-            return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "Failed to plan, no SQL statement provided.");
+        final List<String> sqlStatements = new ArrayList<>();
+        switch (processAdHocSQLStmtTypes(sql, sqlStatements)) {
+            case EMPTY:                 // we saw neither DDL or DQL/DML. Make sure that we get a response back to the client
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "Failed to plan, no SQL statement provided.");
+            case MIXED:                 // No mixing DDL and DML/DQL. Turn this into an error returned to client.
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "DDL mixed with DML and queries is unsupported.");
+            case ALL_DML_OR_DQL:        // this is where we run non-DDL sql statements
+                return runNonDDLAdHoc(VoltDB.instance().getCatalogContext(), sqlStatements, true,
+                        null, // no partition key
+                        ExplainMode.NONE, m_backendTargetType.isLargeTempTableTarget, // back end dependent
+                        false, // is not swap tables
+                        userParams);
+            case ALL_DDL:               // Since we are not going through Calcite, there is no need to update CalciteSchema.
+                return runDDLBatch(sqlStatements, Collections.emptyList());
+            default:                    // should never reach here
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "Unsupported/unknown SQL statement type.");
         }
-
-        else if (mix == AdHocSQLMix.MIXED) {
-            // No mixing DDL and DML/DQL. Turn this into an error returned to
-            // client.
-            return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "DDL mixed with DML and queries is unsupported.");
-        }
-
-        else if (mix == AdHocSQLMix.ALL_DML_OR_DQL) {
-            // this is where we run non-DDL sql statements
-            return runNonDDLAdHoc(VoltDB.instance().getCatalogContext(), sqlStatements, true, // infer
-                                                                                              // partitioning
-                    null, // no partition key
-                    ExplainMode.NONE, m_backendTargetType.isLargeTempTableTarget, // back
-                                                                                  // end
-                                                                                  // dependent.
-                    false, // is not swap tables
-                    userParams);
-        }
-
-        // at this point assume all DDL
-        assert (mix == AdHocSQLMix.ALL_DDL);
-        // Since we are not going through Calcite, there is no need to update
-        // CalciteSchema.
-        return runDDLBatch(sqlStatements, Collections.emptyList());
     }
 
     private CompletableFuture<ClientResponse> runDDLBatch(List<String> sqlStatements, List<SqlNode> sqlNodes) {
-        // conflictTables tracks dropped tables before removing the ones that
-        // don't have CREATEs.
-        SortedSet<String> conflictTables = new TreeSet<>();
-        Set<String> createdTables = new HashSet<>();
+        // conflictTables tracks dropped tables before removing the ones that don't have CREATEs.
+        final SortedSet<String> conflictTables = new TreeSet<>();
+        final Set<String> createdTables = new HashSet<>();
 
-        for (String stmt : sqlStatements) {
-            // check that the DDL is allowed
+        for (String stmt : sqlStatements) {         // check that the DDL is allowed
             String rejectionExplanation = SQLLexer.checkPermitted(stmt);
             if (rejectionExplanation != null) {
                 return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, rejectionExplanation);
             }
 
-            String ddlToken = SQLLexer.extractDDLToken(stmt);
+            final String ddlToken = SQLLexer.extractDDLToken(stmt);
             // make sure not to mix drop and create in the same batch for the
             // same table
             if (ddlToken.equals("drop")) {
@@ -156,7 +128,6 @@ public class AdHoc extends AdHocNTBase {
                 }
             }
         }
-
         // check for conflicting DDL create/drop table statements.
         // unhappy if the intersection is empty
         conflictTables.retainAll(createdTables);
@@ -170,28 +141,25 @@ public class AdHoc extends AdHocNTBase {
             sb.append("\nYou cannot DROP and ADD a table with the same name in a single batch "
                     + "(via @AdHoc). Issue the DROP and ADD statements as separate commands.");
             return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, sb.toString());
-        }
-
-        if (!allowPausedModeWork(false, isAdminConnection())) {
+        } else if (!allowPausedModeWork(false, isAdminConnection())) {
             return makeQuickResponse(ClientResponse.SERVER_UNAVAILABLE,
                     "Server is paused and is available in read-only mode - please try again later.");
+        } else {
+            final boolean useAdhocDDL = VoltDB.instance().getCatalogContext().cluster.getUseddlschema();
+            if (!useAdhocDDL) {
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE,
+                        "Cluster is configured to use @UpdateApplicationCatalog "
+                                + "to change application schema.  AdHoc DDL is forbidden.");
+            } else {
+                logCatalogUpdateInvocation("@AdHoc");
+                return updateApplication("@AdHoc", null, /* operationBytes */
+                        null, /* operationString */
+                        sqlStatements.toArray(new String[0]), /* adhocDDLStmts */
+                        sqlNodes, null, /* replayHashOverride */
+                        false, /* isPromotion */
+                        true); /* useAdhocDDL */
+            }
         }
-
-        boolean useAdhocDDL = VoltDB.instance().getCatalogContext().cluster.getUseddlschema();
-        if (!useAdhocDDL) {
-            return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE,
-                    "Cluster is configured to use @UpdateApplicationCatalog "
-                            + "to change application schema.  AdHoc DDL is forbidden.");
-        }
-
-        logCatalogUpdateInvocation("@AdHoc");
-
-        return updateApplication("@AdHoc", null, /* operationBytes */
-                null, /* operationString */
-                sqlStatements.toArray(new String[0]), /* adhocDDLStmts */
-                sqlNodes, null, /* replayHashOverride */
-                false, /* isPromotion */
-                true); /* useAdhocDDL */
     }
 
     /**
@@ -205,7 +173,6 @@ public class AdHoc extends AdHocNTBase {
      * @since 9.0
      */
     private class AdHocContext extends AdHocNTBaseContext {
-
         @Override public CompletableFuture<ClientResponse> runDDLBatch(List<String> sqlStatements,
                 List<SqlNode> sqlNodes) {
             return AdHoc.this.runDDLBatch(sqlStatements, sqlNodes);

--- a/src/frontend/org/voltdb/sysprocs/AdHocLarge.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocLarge.java
@@ -29,6 +29,11 @@ import org.voltdb.client.ClientResponse;
 
 public class AdHocLarge extends AdHocNTBase {
     @Override
+    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+        return runInternal(params);
+    }
+
+    @Override
     protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) {
         return runUsingLegacy(params);
     }

--- a/src/frontend/org/voltdb/sysprocs/AdHocLarge.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocLarge.java
@@ -28,7 +28,13 @@ import org.voltdb.VoltDB;
 import org.voltdb.client.ClientResponse;
 
 public class AdHocLarge extends AdHocNTBase {
-    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+    @Override
+    protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) {
+        return runUsingLegacy(params);
+    }
+
+    @Override
+    protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
         if (params.size() == 0) {
             return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE,
                     "Adhoc system procedure requires at least the query parameter.");

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
@@ -70,17 +70,14 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
     protected final static MiscUtils.BooleanSystemProperty DEBUG_MODE =
             new MiscUtils.BooleanSystemProperty("asynccompilerdebug");
 
-    private boolean m_usingCalcite = true; // TODO: do we need to control this switch for testing purpose?
+    private final boolean m_usingCalcite =
+            Boolean.parseBoolean(System.getProperty("PLAN_WITH_CALCITE", "false"));
 
     BackendTarget m_backendTargetType = VoltDB.instance().getBackendTargetType();
-    boolean m_isConfiguredForNonVoltDBBackend =
+    private final boolean m_isConfiguredForNonVoltDBBackend =
         m_backendTargetType == BackendTarget.HSQLDB_BACKEND ||
         m_backendTargetType == BackendTarget.POSTGRESQL_BACKEND ||
         m_backendTargetType == BackendTarget.POSTGIS_BACKEND;
-
-    protected void setUsingCalcite(boolean usingCalcite) {
-        m_usingCalcite = usingCalcite;
-    }
 
     abstract protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) throws SqlParseException;
     abstract protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params);

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
@@ -185,7 +185,7 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
      * Compile a batch of one or more SQL statements into a set of plans.
      * Parameters are valid iff there is exactly one DML/DQL statement.
      */
-    public static AdHocPlannedStatement compileAdHocSQL(
+    private static AdHocPlannedStatement compileAdHocSQL(
             PlannerTool plannerTool, String sqlStatement, boolean inferPartitioning,
             Object userPartitionKey, ExplainMode explainMode, boolean isLargeQuery,
             boolean isSwapTables, Object[] userParamSet) throws PlanningErrorException {

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTExplain.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTExplain.java
@@ -17,7 +17,6 @@
 
 package org.voltdb.sysprocs;
 
-import org.apache.calcite.sql.parser.SqlParseException;
 import org.voltdb.ParameterSet;
 import org.voltdb.client.ClientResponse;
 
@@ -29,8 +28,14 @@ import java.util.concurrent.CompletableFuture;
 abstract public class AdHocNTExplain extends AdHocNTBase {
     abstract public CompletableFuture<ClientResponse> run(String fullViewNames);
 
+    protected String stringOf(ParameterSet params) {
+        assert params.size() == 1;
+        assert params.getParam(0) instanceof String;
+        return (String) params.getParam(0);
+    }
+
     @Override
-    protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) throws SqlParseException {
+    protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) {
         return runUsingLegacy(params);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTExplain.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTExplain.java
@@ -1,0 +1,36 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.sysprocs;
+
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.voltdb.ParameterSet;
+import org.voltdb.client.ClientResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Used by Explain, ExplainJSON, ExplainView and ExplainProc as base class.
+ */
+abstract public class AdHocNTExplain extends AdHocNTBase {
+    abstract public CompletableFuture<ClientResponse> run(String fullViewNames);
+
+    @Override
+    protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) throws SqlParseException {
+        return runUsingLegacy(params);
+    }
+}

--- a/src/frontend/org/voltdb/sysprocs/AdHocSpForTest.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocSpForTest.java
@@ -35,6 +35,11 @@ import org.voltdb.parser.SQLLexer;
  */
 public class AdHocSpForTest extends AdHocNTBase {
     @Override
+    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+        return runInternal(params);
+    }
+
+    @Override
     protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) {
         return runUsingLegacy(params);
     }

--- a/src/frontend/org/voltdb/sysprocs/AdHocSpForTest.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocSpForTest.java
@@ -64,8 +64,7 @@ public class AdHocSpForTest extends AdHocNTBase {
 
         final List<String> sqlStatements = SQLLexer.splitStatements(sql).getCompletelyParsedStmts();
         if (sqlStatements.size() != 1) {
-            return makeQuickResponse(
-                    ClientResponse.GRACEFUL_FAILURE,
+            return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE,
                     "@AdHocSpForTest expects precisely one statement (no batching).");
         }
 
@@ -76,9 +75,7 @@ public class AdHocSpForTest extends AdHocNTBase {
             }
             String ddlToken = SQLLexer.extractDDLToken(stmt);
             if (ddlToken != null) {
-                return makeQuickResponse(
-                        ClientResponse.GRACEFUL_FAILURE,
-                        "@AdHocSpForTest doesn't support DDL.");
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "@AdHocSpForTest doesn't support DDL.");
             }
         }
         return runNonDDLAdHoc(VoltDB.instance().getCatalogContext(), sqlStatements, false, userPartitionKey,

--- a/src/frontend/org/voltdb/sysprocs/Explain.java
+++ b/src/frontend/org/voltdb/sysprocs/Explain.java
@@ -27,11 +27,16 @@ import org.voltdb.ClientInterface.ExplainMode;
 import org.voltdb.ParameterSet;
 import org.voltdb.VoltDB;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.exceptions.PlanningErrorException;
 import org.voltdb.plannerv2.SqlBatch;
-import org.voltdb.plannerv2.guards.PlannerFallbackException;
 
-public class Explain extends AdHocNTBase {
+public class Explain extends AdHocNTExplain {
     private AdHocNTBaseContext m_context = new AdHocNTBaseContext();
+
+    @Override
+    public CompletableFuture<ClientResponse> run(String sql) {
+        throw new PlanningErrorException("Unsupported operation");
+    }
 
     /**
      * Run an AdHoc explain batch through Calcite parser and planner. If there is
@@ -45,63 +50,42 @@ public class Explain extends AdHocNTBase {
      * @author Chao Zhou
      * @since 9.1
      */
-    public CompletableFuture<ClientResponse> run(ParameterSet params) {
-        SqlBatch batch;
+    @Override
+    protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) throws SqlParseException {
         try {
             // We do not need to worry about the ParameterSet,
             // AdHocAcceptancePolicy will sanitize the parameters ahead of time.
-            batch = SqlBatch.from(params, m_context, ExplainMode.EXPLAIN_ADHOC);
-            return batch.execute();
-        } catch (PlannerFallbackException | SqlParseException ex) {
-            // Use the legacy planner to run this.
-            return runFallback(params);
-        } catch (Exception ex) {
-            // For now, let's just fail the batch if any error happens.
+            return SqlBatch.from(params, m_context, ExplainMode.EXPLAIN_ADHOC).execute();
+        } catch (Exception ex) { // For now, let's just fail the batch if any error happens.
             return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, ex.getMessage());
         }
     }
 
-    public CompletableFuture<ClientResponse> runFallback(ParameterSet params) {
+    @Override
+    protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
         // dispatch common
-        Object[] paramArray = params.toArray();
-        String sql = (String) paramArray[0];
-        Object[] userParams = null;
+        final Object[] paramArray = params.toArray();
+        final String sql = (String) paramArray[0];
+        final Object[] userParams;
         if (params.size() > 1) {
             userParams = Arrays.copyOfRange(paramArray, 1, paramArray.length);
+        } else {
+            userParams = null;
         }
-
-        List<String> sqlStatements = new ArrayList<>();
-        AdHocSQLMix mix = processAdHocSQLStmtTypes(sql, sqlStatements);
-
-        if (mix == AdHocSQLMix.EMPTY) {
-            // we saw neither DDL or DQL/DML.  Make sure that we get a
-            // response back to the client
-            return makeQuickResponse(
-                    ClientResponse.GRACEFUL_FAILURE,
-                    "Failed to plan, no SQL statement provided.");
+        final List<String> sqlStatements = new ArrayList<>();
+        switch (processAdHocSQLStmtTypes(sql, sqlStatements)) {
+            case EMPTY: // we saw neither DDL or DQL/DML.  Make sure that we get a response back to the client
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "Failed to plan, no SQL statement provided.");
+            case MIXED: // No mixing DDL and DML/DQL.  Turn this into an error returned to client.
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "DDL mixed with DML and queries is unsupported.");
+            case ALL_DDL:
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "Explain doesn't support DDL.");
+            case ALL_DML_OR_DQL:
+                return runNonDDLAdHoc(VoltDB.instance().getCatalogContext(), sqlStatements,
+                        true, null, ExplainMode.EXPLAIN_ADHOC, false, false,
+                        userParams);
+            default:
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "Unsupported/unknown SQL statement type.");
         }
-
-        else if (mix == AdHocSQLMix.MIXED) {
-            // No mixing DDL and DML/DQL.  Turn this into an error returned to client.
-            return makeQuickResponse(
-                    ClientResponse.GRACEFUL_FAILURE,
-                    "DDL mixed with DML and queries is unsupported.");
-        }
-
-        else if (mix == AdHocSQLMix.ALL_DDL) {
-            return makeQuickResponse(
-                    ClientResponse.GRACEFUL_FAILURE,
-                    "Explain doesn't support DDL.");
-        }
-
-        // assume all DML/DQL at this point
-        return runNonDDLAdHoc(VoltDB.instance().getCatalogContext(),
-                sqlStatements,
-                true, // infer partitioning
-                null, // no partition key
-                ExplainMode.EXPLAIN_ADHOC,
-                false, // not a large query
-                false, // not swap tables
-                userParams);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/Explain.java
+++ b/src/frontend/org/voltdb/sysprocs/Explain.java
@@ -34,6 +34,11 @@ public class Explain extends AdHocNTExplain {
     private AdHocNTBaseContext m_context = new AdHocNTBaseContext();
 
     @Override
+    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+        return runInternal(params);
+    }
+
+    @Override
     public CompletableFuture<ClientResponse> run(String sql) {
         throw new PlanningErrorException("Unsupported operation");
     }

--- a/src/frontend/org/voltdb/sysprocs/ExplainCatalog.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainCatalog.java
@@ -25,14 +25,20 @@ import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.exceptions.PlanningErrorException;
 
-public class ExplainCatalog extends AdHocNTBase {
+public class ExplainCatalog extends AdHocNTExplain {
 
-    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+    @Override
+    public CompletableFuture<ClientResponse> run(String sql) {
+        throw new PlanningErrorException("Unsupported operation");
+    }
+
+    @Override
+    protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
         VoltTable[] ret = new VoltTable[] { new VoltTable(new VoltTable.ColumnInfo("CATALOG", VoltType.STRING)) };
         ret[0].addRow(VoltDB.instance().getCatalogContext().catalog.serialize());
-        ClientResponseImpl response =
-                new ClientResponseImpl(ClientResponseImpl.SUCCESS, ret, null);
+        ClientResponseImpl response = new ClientResponseImpl(ClientResponseImpl.SUCCESS, ret, null);
         CompletableFuture<ClientResponse> fut = new CompletableFuture<>();
         fut.complete(response);
         return fut;

--- a/src/frontend/org/voltdb/sysprocs/ExplainCatalog.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainCatalog.java
@@ -30,6 +30,11 @@ import org.voltdb.exceptions.PlanningErrorException;
 public class ExplainCatalog extends AdHocNTExplain {
 
     @Override
+    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+        return runInternal(params);
+    }
+
+    @Override
     public CompletableFuture<ClientResponse> run(String sql) {
         throw new PlanningErrorException("Unsupported operation");
     }

--- a/src/frontend/org/voltdb/sysprocs/ExplainJSON.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainJSON.java
@@ -26,9 +26,8 @@ import org.voltdb.ClientInterface.ExplainMode;
 import org.voltdb.ParameterSet;
 import org.voltdb.VoltDB;
 import org.voltdb.client.ClientResponse;
-import org.voltdb.exceptions.PlanningErrorException;
 
-public class ExplainJSON extends AdHocNTExplain {
+public class ExplainJSON extends AdHocNTBase {
 
     @Override
     public CompletableFuture<ClientResponse> run(ParameterSet params) {
@@ -36,8 +35,8 @@ public class ExplainJSON extends AdHocNTExplain {
     }
 
     @Override
-    public CompletableFuture<ClientResponse> run(String sql) {
-        throw new PlanningErrorException("Unsupported operation");
+    protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) {
+        return runUsingLegacy(params);
     }
 
     @Override

--- a/src/frontend/org/voltdb/sysprocs/ExplainJSON.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainJSON.java
@@ -26,51 +26,43 @@ import org.voltdb.ClientInterface.ExplainMode;
 import org.voltdb.ParameterSet;
 import org.voltdb.VoltDB;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.exceptions.PlanningErrorException;
 
-public class ExplainJSON extends AdHocNTBase {
+public class ExplainJSON extends AdHocNTExplain {
 
-    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+    @Override
+    public CompletableFuture<ClientResponse> run(String sql) {
+        throw new PlanningErrorException("Unsupported operation");
+    }
 
+    @Override
+    protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
         // dispatch common
-        Object[] paramArray = params.toArray();
-        String sql = (String) paramArray[0];
-        Object[] userParams = null;
+        final Object[] paramArray = params.toArray();
+        final String sql = (String) paramArray[0];
+        final Object[] userParams;
         if (params.size() > 1) {
             userParams = Arrays.copyOfRange(paramArray, 1, paramArray.length);
+        } else {
+            userParams = null;
         }
 
-        List<String> sqlStatements = new ArrayList<>();
-        AdHocSQLMix mix = processAdHocSQLStmtTypes(sql, sqlStatements);
-
-        if (mix == AdHocSQLMix.EMPTY) {
-            // we saw neither DDL or DQL/DML.  Make sure that we get a
-            // response back to the client
-            return makeQuickResponse(
-                    ClientResponse.GRACEFUL_FAILURE,
-                    "Failed to plan, no SQL statement provided.");
+        final List<String> sqlStatements = new ArrayList<>();
+        switch (processAdHocSQLStmtTypes(sql, sqlStatements)) {
+            case EMPTY:
+                // we saw neither DDL or DQL/DML.  Make sure that we get a
+                // response back to the client
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "Failed to plan, no SQL statement provided.");
+            case MIXED:
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE,
+                        "DDL mixed with DML and queries is unsupported.");
+            case ALL_DDL:
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "Explain doesn't support DDL.");
+            case ALL_DML_OR_DQL:
+                return runNonDDLAdHoc(VoltDB.instance().getCatalogContext(), sqlStatements, true, null,
+                        ExplainMode.EXPLAIN_JSON, false, false, userParams);
+            default:
+                return makeQuickResponse(ClientResponse.GRACEFUL_FAILURE, "Unsupported/unknown SQL statement type.");
         }
-
-        else if (mix == AdHocSQLMix.MIXED) {
-            // No mixing DDL and DML/DQL.  Turn this into an error returned to client.
-            return makeQuickResponse(
-                    ClientResponse.GRACEFUL_FAILURE,
-                    "DDL mixed with DML and queries is unsupported.");
-        }
-
-        else if (mix == AdHocSQLMix.ALL_DDL) {
-            return makeQuickResponse(
-                    ClientResponse.GRACEFUL_FAILURE,
-                    "Explain doesn't support DDL.");
-        }
-
-        // assume all DML/DQL at this point
-        return runNonDDLAdHoc(VoltDB.instance().getCatalogContext(),
-                              sqlStatements,
-                              true,
-                              null,
-                              ExplainMode.EXPLAIN_JSON,
-                              false,
-                              false,
-                              userParams);
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/ExplainJSON.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainJSON.java
@@ -31,6 +31,11 @@ import org.voltdb.exceptions.PlanningErrorException;
 public class ExplainJSON extends AdHocNTExplain {
 
     @Override
+    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+        return runInternal(params);
+    }
+
+    @Override
     public CompletableFuture<ClientResponse> run(String sql) {
         throw new PlanningErrorException("Unsupported operation");
     }

--- a/src/frontend/org/voltdb/sysprocs/ExplainProc.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainProc.java
@@ -21,21 +21,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import org.voltdb.CatalogContext;
+import org.voltdb.*;
 import org.voltdb.ClientInterface.ExplainMode;
-import org.voltdb.ClientResponseImpl;
-import org.voltdb.DefaultProcedureManager;
-import org.voltdb.VoltDB;
-import org.voltdb.VoltTable;
-import org.voltdb.VoltType;
 import org.voltdb.catalog.Procedure;
 import org.voltdb.catalog.Statement;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.exceptions.PlanningErrorException;
 import org.voltdb.parser.SQLLexer;
 import org.voltdb.utils.Encoder;
 
-public class ExplainProc extends AdHocNTBase {
+public class ExplainProc extends AdHocNTExplain {
 
+    @Override
+    protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
+        throw new PlanningErrorException("Unsupported operation");
+    }
+
+    @Override
     public CompletableFuture<ClientResponse> run(String procedureNames) {
         // Go to the catalog and fetch all the "explain plan" strings of the queries in the procedure.
 
@@ -52,7 +54,6 @@ public class ExplainProc extends AdHocNTBase {
 
         for (int i = 0; i < size; i++) {
             String procName = procNames.get(i);
-
             // look in the catalog
             Procedure proc = context.procedures.get(procName);
             if (proc == null) {
@@ -68,32 +69,22 @@ public class ExplainProc extends AdHocNTBase {
                     String sql = DefaultProcedureManager.sqlForDefaultProc(proc);
                     List<String> sqlStatements = new ArrayList<>(1);
                     sqlStatements.add(sql);
-                    return runNonDDLAdHoc(context,
-                            sqlStatements,
-                            true, // infer partitioning
-                            null, // no partition key
-                            ExplainMode.EXPLAIN_DEFAULT_PROC,
-                            false, // not a large query
-                            false, // not swap tables
-                            new Object[0]);
+                    return runNonDDLAdHoc(context, sqlStatements, true, null,
+                            ExplainMode.EXPLAIN_DEFAULT_PROC, false, false, new Object[0]);
                 }
 
             }
-
             vt[i] = new VoltTable(new VoltTable.ColumnInfo("STATEMENT_NAME", VoltType.STRING),
                                   new VoltTable.ColumnInfo("SQL_STATEMENT", VoltType.STRING),
                                   new VoltTable.ColumnInfo("EXECUTION_PLAN", VoltType.STRING));
-
             for(Statement stmt : proc.getStatements()) {
                 vt[i].addRow(stmt.getTypeName(), stmt.getSqltext(), Encoder.hexDecodeToString(stmt.getExplainplan()));
             }
         }
 
-        ClientResponseImpl response = new ClientResponseImpl(ClientResponseImpl.SUCCESS,
-                                                             ClientResponse.UNINITIALIZED_APP_STATUS_CODE,
-                                                             null,
-                                                             vt,
-                                                             null);
+        final ClientResponseImpl response = new ClientResponseImpl(
+                ClientResponseImpl.SUCCESS, ClientResponse.UNINITIALIZED_APP_STATUS_CODE, null,
+                vt, null);
 
         CompletableFuture<ClientResponse> fut = new CompletableFuture<>();
         fut.complete(response);

--- a/src/frontend/org/voltdb/sysprocs/ExplainProc.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainProc.java
@@ -26,7 +26,6 @@ import org.voltdb.ClientInterface.ExplainMode;
 import org.voltdb.catalog.Procedure;
 import org.voltdb.catalog.Statement;
 import org.voltdb.client.ClientResponse;
-import org.voltdb.exceptions.PlanningErrorException;
 import org.voltdb.parser.SQLLexer;
 import org.voltdb.utils.Encoder;
 
@@ -39,7 +38,7 @@ public class ExplainProc extends AdHocNTExplain {
 
     @Override
     protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
-        throw new PlanningErrorException("Unsupported operation");
+        return run(stringOf(params));
     }
 
     @Override

--- a/src/frontend/org/voltdb/sysprocs/ExplainProc.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainProc.java
@@ -33,6 +33,11 @@ import org.voltdb.utils.Encoder;
 public class ExplainProc extends AdHocNTExplain {
 
     @Override
+    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+        return runInternal(params);
+    }
+
+    @Override
     protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
         throw new PlanningErrorException("Unsupported operation");
     }

--- a/src/frontend/org/voltdb/sysprocs/ExplainView.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainView.java
@@ -33,6 +33,11 @@ import org.voltdb.parser.SQLLexer;
 public class ExplainView extends AdHocNTExplain {
 
     @Override
+    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+        return runInternal(params);
+    }
+
+    @Override
     protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
         throw new PlanningErrorException("Unsupported operation");
     }

--- a/src/frontend/org/voltdb/sysprocs/ExplainView.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainView.java
@@ -26,7 +26,6 @@ import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Table;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.compilereport.ViewExplainer;
-import org.voltdb.exceptions.PlanningErrorException;
 import org.voltdb.parser.SQLLexer;
 
 //Go to the catalog and fetch all the "explain plan" strings of the queries in the view.
@@ -39,7 +38,7 @@ public class ExplainView extends AdHocNTExplain {
 
     @Override
     protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
-        throw new PlanningErrorException("Unsupported operation");
+        return run(stringOf(params));
     }
 
     @Override

--- a/src/frontend/org/voltdb/sysprocs/SwapTables.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTables.java
@@ -52,10 +52,13 @@ public class SwapTables extends AdHocNTBase {
     }
     @Override
     protected CompletableFuture<ClientResponse> runUsingLegacy(ParameterSet params) {
-        throw new PlanningErrorException("Unsupported operation");
+        assert params.size() == 2;
+        assert params.getParam(0) instanceof String &&
+                params.getParam(1) instanceof String;
+        return run((String) params.getParam(0), (String) params.getParam(1));
     }
 
-    public CompletableFuture<ClientResponse> run(String theTable, String otherTable) {
+    private CompletableFuture<ClientResponse> run(String theTable, String otherTable) {
         final String sql = "@SwapTables " + theTable + " " + otherTable;
         final Object[] userParams = null;
         final CatalogContext context = VoltDB.instance().getCatalogContext();

--- a/src/frontend/org/voltdb/sysprocs/SwapTables.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTables.java
@@ -42,6 +42,11 @@ import org.voltdb.utils.CatalogUtil;
 public class SwapTables extends AdHocNTBase {
 
     @Override
+    public CompletableFuture<ClientResponse> run(ParameterSet params) {
+        return runInternal(params);
+    }
+
+    @Override
     protected CompletableFuture<ClientResponse> runUsingCalcite(ParameterSet params) {
         return runUsingLegacy(params);
     }

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -19,17 +19,14 @@ package org.voltdb.sysprocs;
 
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
+import com.google_voltpatches.common.base.Preconditions;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.zookeeper_voltpatches.CreateMode;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
@@ -73,7 +70,7 @@ import com.google_voltpatches.common.base.Stopwatch;
  *
  */
 public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
-    protected static final VoltLogger compilerLog = new VoltLogger("COMPILER");
+    private static final VoltLogger compilerLog = new VoltLogger("COMPILER");
     protected static final VoltLogger hostLog = new VoltLogger("HOST");
 
     private static final AtomicLong m_generationId = new AtomicLong(0);
@@ -89,14 +86,14 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
      * For UpdateClasses, this will contain the class deletion patterns
      * For AdHoc DDL work, this will be null
      */
-    public static CatalogChangeResult prepareApplicationCatalogDiff(
+    private static CatalogChangeResult prepareApplicationCatalogDiff(
             String invocationName, final byte[] operationBytes, final String operationString,
             final String[] adhocDDLStmts, final List<SqlNode> sqlNodes, final byte[] replayHashOverride,
             final boolean isPromotion, final boolean useAdhocDDL, String hostname, String user) {
         final DrRoleType drRole = DrRoleType.fromValue(VoltDB.instance().getCatalogContext().getCluster().getDrrole());
 
         // create the change result and set up all the boiler plate
-        CatalogChangeResult retval = new CatalogChangeResult();
+        final CatalogChangeResult retval = new CatalogChangeResult();
         retval.tablesThatMustBeEmpty = new String[0]; // ensure non-null
         retval.hasSchemaChange = true;
         if (replayHashOverride != null) {
@@ -105,80 +102,79 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
 
         try {
             // catalog change specific boiler plate
-            CatalogContext context = VoltDB.instance().getCatalogContext();
+            final CatalogContext context = VoltDB.instance().getCatalogContext();
             // Start by assuming we're doing an @UpdateApplicationCatalog.  If-ladder below
             // will complete with newCatalogBytes actually containing the bytes of the
             // catalog to be applied, and deploymentString will contain an actual deployment string,
             // or null if it still needs to be filled in.
             InMemoryJarfile newCatalogJar = null;
-            InMemoryJarfile oldJar = context.getCatalogJar().deepCopy();
+            final InMemoryJarfile oldJar = context.getCatalogJar().deepCopy();
             String deploymentString = operationString;
-            if ("@UpdateApplicationCatalog".equals(invocationName)) {
-                compilerLog.info("@UpdateApplicationCatalog is invoked, current catalog version: " + context.catalogVersion);
-                // Grab the current catalog bytes if @UAC had a null catalog from deployment-only update
-                if ((operationBytes == null) || (operationBytes.length == 0)) {
-                    newCatalogJar = oldJar;
-                } else {
-                    newCatalogJar = CatalogUtil.loadInMemoryJarFile(operationBytes);
-                }
-                // If the deploymentString is null, we'll fill it in with current deployment later
-                // Otherwise, deploymentString has the right contents, don't need to touch it
-            } else if ("@UpdateClasses".equals(invocationName)) {
-                compilerLog.info("@UpdateClasses is invoked, modifying catalog classes: " + context.catalogVersion);
-                // provided operationString is really a String with class patterns to delete,
-                // provided newCatalogJar is the jarfile with the new classes
-                if (operationBytes != null) {
-                    newCatalogJar = new InMemoryJarfile(operationBytes);
-                }
-                try {
-                    // Create a new hsql session to update classes, because it may races with
-                    // @LoadSinglepartitionTable in Site thread
-                    InMemoryJarfile modifiedJar = modifyCatalogClasses(context.catalog, oldJar, operationString,
-                            newCatalogJar, drRole == DrRoleType.XDCR, context.m_ptool.getHSQLInterface());
-                    if (modifiedJar == null) {
+            switch (invocationName) {
+                case "@UpdateApplicationCatalog":
+                    compilerLog.info("@UpdateApplicationCatalog is invoked, current catalog version: " + context.catalogVersion);
+                    // Grab the current catalog bytes if @UAC had a null catalog from deployment-only update
+                    if ((operationBytes == null) || (operationBytes.length == 0)) {
                         newCatalogJar = oldJar;
                     } else {
-                        newCatalogJar = modifiedJar;
+                        newCatalogJar = CatalogUtil.loadInMemoryJarFile(operationBytes);
                     }
-                } catch (ClassNotFoundException e) {
-                    retval.errorMsg = "Classes not found in @UpdateClasses jar: " + e.getMessage();
-                    return retval;
-                }
-                // Real deploymentString should be the current deployment, just set it to null
-                // here and let it get filled in correctly later.
-                deploymentString = null;
+                    // If the deploymentString is null, we'll fill it in with current deployment later
+                    // Otherwise, deploymentString has the right contents, don't need to touch it
+                    break;
+                case "@UpdateClasses":
+                    compilerLog.info("@UpdateClasses is invoked, modifying catalog classes: " + context.catalogVersion);
+                    // provided operationString is really a String with class patterns to delete,
+                    // provided newCatalogJar is the jarfile with the new classes
+                    if (operationBytes != null) {
+                        newCatalogJar = new InMemoryJarfile(operationBytes);
+                    }
+                    try {
+                        // Create a new hsql session to update classes, because it may races with
+                        // @LoadSinglepartitionTable in Site thread
+                        final InMemoryJarfile modifiedJar = modifyCatalogClasses(
+                                context.catalog, oldJar, operationString, newCatalogJar,
+                                drRole == DrRoleType.XDCR, context.m_ptool.getHSQLInterface());
+                        if (modifiedJar == null) {
+                            newCatalogJar = oldJar;
+                        } else {
+                            newCatalogJar = modifiedJar;
+                        }
+                    } catch (ClassNotFoundException e) {
+                        retval.errorMsg = "Classes not found in @UpdateClasses jar: " + e.getMessage();
+                        return retval;
+                    }
+                    // Real deploymentString should be the current deployment, just set it to null
+                    // here and let it get filled in correctly later.
+                    deploymentString = null;
 
-                // mark it as non-schema change
-                retval.hasSchemaChange = false;
-            } else if ("@AdHoc".equals(invocationName)) {
-                // work.adhocDDLStmts should be applied to the current catalog
-                try {
-                    newCatalogJar = addDDLToCatalog(context.catalog, oldJar, adhocDDLStmts, sqlNodes, drRole == DrRoleType.XDCR);
-                } catch (IOException | VoltCompilerException e) {
-                    retval.errorMsg = e.getMessage();
+                    // mark it as non-schema change
+                    retval.hasSchemaChange = false;
+                    break;
+                case "@AdHoc":
+                    // work.adhocDDLStmts should be applied to the current catalog
+                    try {
+                        newCatalogJar = addDDLToCatalog(context.catalog, oldJar, adhocDDLStmts, sqlNodes, drRole == DrRoleType.XDCR);
+                    } catch (IOException | VoltCompilerException e) {
+                        retval.errorMsg = e.getMessage();
+                        return retval;
+                    } catch (Exception ex) {
+                        retval.errorMsg = "Unexpected condition occurred applying DDL statements: " + ex.getMessage();
+                        return retval;
+                    }
+                    // Real deploymentString should be the current deployment, just set it to null
+                    // here and let it get filled in correctly later.
+                    deploymentString = null;
+                    break;
+                default: // Shouldn't ever get here
+                    retval.errorMsg = invocationName + " is not supported";
                     return retval;
-                } catch (Exception ex) {
-                    retval.errorMsg = "Unexpected condition occurred applying DDL statements: " + ex.getMessage();
-                    return retval;
-                }
-                // Real deploymentString should be the current deployment, just set it to null
-                // here and let it get filled in correctly later.
-                deploymentString = null;
-            } else {
-                // Shouldn't ever get here
-                retval.errorMsg = invocationName + " is not supported";
-                return retval;
             }
-
-            if (newCatalogJar == null) {
-                // Shouldn't ever get here
-                retval.errorMsg = "Unexpected failure during compiling the new catalog";
-                return retval;
-            }
+            Preconditions.checkNotNull(newCatalogJar, "Unexpected failure during compiling the new catalog");
 
             // get the diff between catalogs
             // try to get the new catalog from the params
-            Pair<InMemoryJarfile, String> loadResults = null;
+            final Pair<InMemoryJarfile, String> loadResults;
             try {
                 loadResults = CatalogUtil.loadAndUpgradeCatalogFromJar(newCatalogJar, drRole == DrRoleType.XDCR);
             } catch (IOException ioe) {
@@ -194,22 +190,17 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
                 retval.catalogHash = replayHashOverride;
             }
 
-            String newCatalogCommands = CatalogUtil.getSerializedCatalogStringFromJar(loadResults.getFirst());
-            if (newCatalogCommands == null) {
-                retval.errorMsg = "Unable to read from catalog bytes";
-                return retval;
-            }
+            final String newCatalogCommands = CatalogUtil.getSerializedCatalogStringFromJar(loadResults.getFirst());
+            Preconditions.checkNotNull(newCatalogCommands, "Unable to read from catalog bytes");
             retval.upgradedFromVersion = loadResults.getSecond();
 
-            Catalog newCatalog = new Catalog();
+            final Catalog newCatalog = new Catalog();
             try {
                 newCatalog.execute(newCatalogCommands);
             } catch (CatalogException e) {
                 retval.errorMsg = e.getLocalizedMessage();
                 return retval;
             }
-
-
             // Retrieve the original deployment string, if necessary
             if (deploymentString == null) {
                 // Go get the deployment string from the current catalog context
@@ -227,7 +218,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
             // this is necessary, even for @UpdateClasses that does not change deployment
             // because the catalog bytes does not contain any deployments but only schema related contents
             // the command log reply needs it to generate a correct catalog diff
-            DeploymentType dt  = CatalogUtil.parseDeploymentFromString(deploymentString);
+            final DeploymentType dt  = CatalogUtil.parseDeploymentFromString(deploymentString);
             if (dt == null) {
                 retval.errorMsg = "Unable to update deployment configuration: Error parsing deployment string";
                 return retval;
@@ -240,7 +231,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
                 dt.getDr().setRole(DrRoleType.MASTER);
             }
 
-            String result = CatalogUtil.compileDeployment(newCatalog, dt, false);
+            final String result = CatalogUtil.compileDeployment(newCatalog, dt, false);
             if (result != null) {
                 retval.errorMsg = "Unable to update deployment configuration: " + result;
                 return retval;
@@ -277,7 +268,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
             // since diff commands can be stupidly big, compress them here
             retval.encodedDiffCommands = CompressionService.compressAndBase64Encode(commands);
             retval.diffCommandsLength = commands.length();
-            String emptyTablesAndReasons[][] = diff.tablesThatMustBeEmpty();
+            String[][] emptyTablesAndReasons = diff.tablesThatMustBeEmpty();
             assert(emptyTablesAndReasons.length == 2);
             assert(emptyTablesAndReasons[0].length == emptyTablesAndReasons[1].length);
             retval.tablesThatMustBeEmpty = emptyTablesAndReasons[0];
@@ -298,9 +289,8 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
      * jarfile
      * @throws VoltCompilerException
      */
-    protected static InMemoryJarfile addDDLToCatalog(Catalog oldCatalog, InMemoryJarfile jarfile,
-            String[] adhocDDLStmts, List<SqlNode> sqlNodes, boolean isXDCR)
-            throws IOException, VoltCompilerException {
+    private static InMemoryJarfile addDDLToCatalog(Catalog oldCatalog, InMemoryJarfile jarfile,
+            String[] adhocDDLStmts, List<SqlNode> sqlNodes, boolean isXDCR) throws IOException, VoltCompilerException {
         StringBuilder sb = new StringBuilder();
         compilerLog.info("Applying the following DDL to cluster:");
         for (String stmt : adhocDDLStmts) {
@@ -328,7 +318,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
             throws IOException, ClassNotFoundException, VoltCompilerException {
         // modify the old jar in place based on the @UpdateClasses inputs, and then
         // recompile it if necessary
-        boolean deletedClasses = false;
+        boolean deletedClasses = false, foundClasses = false;
         if (deletePatterns != null) {
             String[] patterns = deletePatterns.split(",");
             ClassMatcher matcher = new ClassMatcher();
@@ -349,17 +339,14 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
                 jarfile.removeClassFromJar(classname);
             }
         }
-        boolean foundClasses = false;
         if (newJarfile != null) {
             for (Entry<String, byte[]> e : newJarfile.entrySet()) {
-                String filename = e.getKey();
+                final String filename = e.getKey();
                 // Ignore root level, non-class file names
-                boolean isRootFile = Paths.get(filename).getNameCount() == 1;
-                if (isRootFile && !filename.endsWith(".class")) {
-                    continue;
+                if (Paths.get(filename).getNameCount() == 1 || filename.endsWith(".class")) {
+                    foundClasses = true;
+                    jarfile.put(e.getKey(), e.getValue());
                 }
-                foundClasses = true;
-                jarfile.put(e.getKey(), e.getValue());
             }
         }
         if (!deletedClasses && !foundClasses) {
@@ -367,18 +354,12 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
         }
 
         compilerLog.info("Updating java classes available to stored procedures");
-        VoltCompiler compiler = new VoltCompiler(isXDCR);
-        try {
-            compiler.compileInMemoryJarfileForUpdateClasses(jarfile, catalog, hsql);
-        } catch (ClassNotFoundException | VoltCompilerException | IOException ex) {
-            throw ex;
-        }
-
+        new VoltCompiler(isXDCR).compileInMemoryJarfileForUpdateClasses(jarfile, catalog, hsql);
         return jarfile;
     }
 
     /** Check if something should run based on admin/paused/internal status */
-    static protected boolean allowPausedModeWork(boolean internalCall, boolean adminConnection) {
+    static boolean allowPausedModeWork(boolean internalCall, boolean adminConnection) {
         return (VoltDB.instance().getMode() != OperationMode.PAUSED || internalCall || adminConnection);
     }
 
@@ -395,7 +376,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
      * Check the results map from every host and return error message if needed.
      * @return  A String describing the error messages. If all hosts return success, NULL is returned.
      */
-    protected String verifyAndWriteCatalogJar(CatalogChangeResult ccr) {
+    private String verifyAndWriteCatalogJar(CatalogChangeResult ccr) {
         String procedureName = "@VerifyCatalogAndWriteJar";
 
         CompletableFuture<Map<Integer,ClientResponse>> cf =
@@ -410,8 +391,8 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
 
         try {
             Stopwatch sw = Stopwatch.createStarted();
-            long elapsed = 0;
-            while ((elapsed = sw.elapsed(TimeUnit.SECONDS)) < (timeoutSeconds)) {
+            long elapsed;
+            while ((elapsed = sw.elapsed(TimeUnit.SECONDS)) < timeoutSeconds) {
                 resultMapByHost = cf.getNow(null);
                 if (resultMapByHost != null) {
                     sw.stop();
@@ -444,7 +425,6 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
                 err = "The response from host " + entry.getKey().toString() +
                       " for " + procedureName + " returned failures: " + entry.getValue().getStatusString();
                 compilerLog.info(err);
-
                 // hide the internal NT-procedure @VerifyCatalogAndWriteJar from the client message
                 return err;
             }
@@ -462,20 +442,19 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
         try {
             return UniqueIdGenerator.makeIdFromComponents(System.currentTimeMillis(),
                     m_generationId.incrementAndGet(), MpInitiator.MP_INIT_PID);
-        } catch (Throwable t) {
-            // Try resetting the generation
+        } catch (Throwable t) { // Try resetting the generation
             m_generationId.set(0L);
             return UniqueIdGenerator.makeIdFromComponents(System.currentTimeMillis(),
                     m_generationId.incrementAndGet(), MpInitiator.MP_INIT_PID);
         }
     }
 
-    protected CompletableFuture<ClientResponse> updateApplication(
+    CompletableFuture<ClientResponse> updateApplication(
             String invocationName, final byte[] operationBytes, final String operationString,
             final String[] adhocDDLStmts, final List<SqlNode> sqlNodes, final byte[] replayHashOverride,
             final boolean isPromotion, final boolean useAdhocDDL) {
-        ZooKeeper zk = VoltDB.instance().getHostMessenger().getZK();
-        CatalogChangeResult ccr = null;
+        final ZooKeeper zk = VoltDB.instance().getHostMessenger().getZK();
+        final CatalogChangeResult ccr;
 
         String errMsg = VoltZK.createActionBlocker(zk, VoltZK.catalogUpdateInProgress, CreateMode.EPHEMERAL,
                 hostLog, "catalog update(" + invocationName + ")" );
@@ -504,7 +483,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
         }
         if (ccr.encodedDiffCommands.trim().length() == 0) {
             VoltZK.removeActionBlocker(zk, VoltZK.catalogUpdateInProgress, hostLog);
-            String msg = invocationName + " with no catalog changes was skipped.";
+            final String msg = invocationName + " with no catalog changes was skipped.";
             compilerLog.info(msg);
             return makeQuickResponse(ClientResponseImpl.SUCCESS, msg);
         } else if (isRestoring() && !isPromotion && "UpdateApplicationCatalog".equals(invocationName)) {
@@ -528,7 +507,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
         }
 
         // ENG-14511 on assertion failures in test environment, ensure removal of action blocker
-        long genId = 0L;
+        final long genId;
         try {
             genId = getNextGenerationId();
         } catch (Exception ex) {
@@ -546,23 +525,20 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
                 ccr.hasSchemaChange ?  1 : 0, ccr.requiresNewExportGeneration ? 1 : 0,
                 ccr.hasSecurityUserChange ? 1 : 0);
         // inject unlocking callback
-        CompletableFuture<ClientResponse> second = first.thenCompose(f -> CompletableFuture.supplyAsync(()-> {
+        return first.thenCompose(f -> CompletableFuture.supplyAsync(()-> {
             // holds the lock until now to guarantee sequential execution
             VoltZK.removeActionBlocker(zk, VoltZK.catalogUpdateInProgress, hostLog);
             return f;
-        }))
-        .exceptionally(e -> {
+        })).exceptionally(e -> {
             VoltZK.removeActionBlocker(zk, VoltZK.catalogUpdateInProgress, hostLog);
             return null;
         });
-        return second;
     }
 
-    protected void logCatalogUpdateInvocation(String procName) {
+    void logCatalogUpdateInvocation(String procName) {
         if (getProcedureRunner().isUserAuthEnabled()) {
-            String warnMsg = "A user from " + getProcedureRunner().getConnectionIPAndPort() +
-                             " issued a " + procName + " to update the catalog.";
-            hostLog.info(warnMsg);
+            hostLog.info("A user from " + getProcedureRunner().getConnectionIPAndPort() +
+                    " issued a " + procName + " to update the catalog.");
         }
     }
 

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -86,7 +86,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
      * For UpdateClasses, this will contain the class deletion patterns
      * For AdHoc DDL work, this will be null
      */
-    private static CatalogChangeResult prepareApplicationCatalogDiff(
+    public static CatalogChangeResult prepareApplicationCatalogDiff(
             String invocationName, final byte[] operationBytes, final String operationString,
             final String[] adhocDDLStmts, final List<SqlNode> sqlNodes, final byte[] replayHashOverride,
             final boolean isPromotion, final boolean useAdhocDDL, String hostname, String user) {

--- a/tests/frontend/org/voltdb/catalog/TestResourcesInUpdateClasses.java
+++ b/tests/frontend/org/voltdb/catalog/TestResourcesInUpdateClasses.java
@@ -113,8 +113,7 @@ public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
             client.updateClasses(ucChange1.getFirst(), "");
 
             // create the procedure from loaded jar
-            ClientResponse cr = client.callProcedure(
-                    "@AdHoc",
+            ClientResponse cr = client.callProcedure("@AdHoc",
                     "create procedure from class org.voltdb_testprocs.catalog.resourceuse.UseResourceProc;");
             assertEquals(ClientResponse.SUCCESS, cr.getStatus());
 
@@ -128,8 +127,7 @@ public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
             assertEquals(VoltType.STRING, t.getColumnType(0));
 
             VoltTableRow row = t.fetchRow(0);
-            String resourceContentsStringRT = row.getString(0);
-            assertEquals(resourceContentsStringRT, ucChange1.getSecond());
+            assertEquals(ucChange1.getSecond(), row.getString(0));
 
             // load the second jar to replace the resource
             client.updateClasses(ucChange2.getFirst(), "");
@@ -144,8 +142,7 @@ public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
             assertEquals(VoltType.STRING, t.getColumnType(0));
 
             row = t.fetchRow(0);
-            resourceContentsStringRT = row.getString(0);
-            assertEquals(resourceContentsStringRT, ucChange2.getSecond());
+            assertEquals(ucChange2.getSecond(), row.getString(0));
         } finally {
             if (client != null) {
                 client.close();

--- a/tests/frontend/org/voltdb/catalog/TestResourcesInUpdateClasses.java
+++ b/tests/frontend/org/voltdb/catalog/TestResourcesInUpdateClasses.java
@@ -23,10 +23,6 @@
 
 package org.voltdb.catalog;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.net.URL;
 
@@ -51,9 +47,12 @@ import org.voltdb_testprocs.catalog.resourceuse.UseResourceProc;
 import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.io.Resources;
 
+import static org.junit.Assert.*;
+
 public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
 
-    private Pair<InMemoryJarfile, String> buildInMemoryJar(byte[] rawCatalog, String resourceFileVersion, boolean useVersionInName) throws Exception {
+    private Pair<InMemoryJarfile, String> buildInMemoryJar(
+            byte[] rawCatalog, String resourceFileVersion, boolean useVersionInName) throws Exception {
         // turn it into an in memory JarFile
         InMemoryJarfile IMJF = new InMemoryJarfile(rawCatalog);
 
@@ -63,14 +62,14 @@ public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
         String resourceContentsString = Resources.toString(resourceURL, Charsets.UTF_8);
         if (useVersionInName) {
             IMJF.put("org/voltdb_testprocs/catalog/resourceuse/catalog_resource" + resourceFileVersion + ".txt", resourceContents);
-        }
-        else {
+        } else {
             IMJF.put("org/voltdb_testprocs/catalog/resourceuse/resource.txt", resourceContents);
         }
         return Pair.of(IMJF, resourceContentsString);
     }
 
-    private Pair<File, String> buildJarFile(byte[] rawCatalog, String resourceFileVersion, boolean useVersionInName) throws Exception {
+    private Pair<File, String> buildJarFile(
+            byte[] rawCatalog, String resourceFileVersion, boolean useVersionInName) throws Exception {
         Pair<InMemoryJarfile, String> rslt = buildInMemoryJar(rawCatalog, resourceFileVersion, useVersionInName);
         // write the new jar to disk
         File jarPath = new File(Configuration.getPathToCatalogForTest("jarWithResource" + resourceFileVersion + ".jar"));
@@ -78,7 +77,8 @@ public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
         return Pair.of(jarPath, rslt.getSecond());
     }
 
-    private Pair<byte[], String> buildJarBytes(byte[] rawCatalog, String resourceFileVersion, boolean useVersionInName) throws Exception {
+    private Pair<byte[], String> buildJarBytes(
+            byte[] rawCatalog, String resourceFileVersion, boolean useVersionInName) throws Exception {
         Pair<InMemoryJarfile, String> rslt = buildInMemoryJar(rawCatalog, resourceFileVersion, useVersionInName);
         return Pair.of(rslt.getFirst().getFullJarBytes(), rslt.getSecond());
     }
@@ -92,7 +92,7 @@ public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
 
         Pair<File, String> ucChange1 = buildJarFile(rawCatalog, "1", false);
         Pair<File, String> ucChange2 = buildJarFile(rawCatalog, "2", false);
-        assertFalse(ucChange1.getSecond().equals(ucChange2.getSecond()));
+        assertNotEquals(ucChange2.getSecond(), ucChange1.getSecond());
 
         // start voltdb
         VoltProjectBuilder vpb = new VoltProjectBuilder();
@@ -129,7 +129,7 @@ public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
 
             VoltTableRow row = t.fetchRow(0);
             String resourceContentsStringRT = row.getString(0);
-            assertTrue(ucChange1.getSecond().equals(resourceContentsStringRT));
+            assertEquals(resourceContentsStringRT, ucChange1.getSecond());
 
             // load the second jar to replace the resource
             client.updateClasses(ucChange2.getFirst(), "");
@@ -145,9 +145,8 @@ public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
 
             row = t.fetchRow(0);
             resourceContentsStringRT = row.getString(0);
-            assertTrue(ucChange2.getSecond().equals(resourceContentsStringRT));
-        }
-        finally {
+            assertEquals(resourceContentsStringRT, ucChange2.getSecond());
+        } finally {
             if (client != null) {
                 client.close();
             }
@@ -197,7 +196,7 @@ public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
 
             VoltTableRow row = t.fetchRow(0);
             String resourceContentsStringRT = row.getString(0);
-            assertTrue(ucChange1.getSecond().equals(resourceContentsStringRT));
+            assertEquals(resourceContentsStringRT, ucChange1.getSecond());
 
             // load the second jar to replace the resource
             client.callProcedure("@UpdateApplicationCatalog", ucChange2.getFirst(), null);
@@ -213,9 +212,8 @@ public class TestResourcesInUpdateClasses extends JUnit4LocalClusterTest {
 
             row = t.fetchRow(0);
             resourceContentsStringRT = row.getString(0);
-            assertTrue(ucChange2.getSecond().equals(resourceContentsStringRT));
-        }
-        finally {
+            assertEquals(resourceContentsStringRT, ucChange2.getSecond());
+        } finally {
             if (client != null) {
                 client.close();
             }

--- a/tests/frontend/org/voltdb/regressionsuites/CatalogChangeSingleProcessServer.java
+++ b/tests/frontend/org/voltdb/regressionsuites/CatalogChangeSingleProcessServer.java
@@ -25,22 +25,17 @@ package org.voltdb.regressionsuites;
 
 import org.voltdb.BackendTarget;
 import org.voltdb.compiler.VoltProjectBuilder;
-import org.voltdb.regressionsuites.LocalSingleProcessServer;
 
 /**
  * Implementation of a LocalSingleProcessServer that supports changing the
  * VoltProjectBuilder used to construct the catalog
  */
 @SuppressWarnings("deprecation")
-public class CatalogChangeSingleProcessServer extends LocalSingleProcessServer
-{
+public class CatalogChangeSingleProcessServer extends LocalSingleProcessServer {
     VoltProjectBuilder m_origBuilder;
     private int m_originalSiteCount = 0;
 
-    public CatalogChangeSingleProcessServer(String jarFileName,
-                                            int siteCount,
-                                            BackendTarget target)
-    {
+    public CatalogChangeSingleProcessServer(String jarFileName, int siteCount, BackendTarget target) {
         super(jarFileName, siteCount, target);
     }
 
@@ -52,15 +47,13 @@ public class CatalogChangeSingleProcessServer extends LocalSingleProcessServer
         return compiled;
     }
 
-    public boolean recompile(VoltProjectBuilder builder)
-    {
+    public boolean recompile(VoltProjectBuilder builder) {
         boolean compiled = builder.compile(m_jarFileName, m_siteCount, 0);
         m_pathToDeployment = builder.getPathToDeployment();
         return compiled;
     }
 
-    public boolean recompile(int siteCount)
-    {
+    public boolean recompile(int siteCount) {
         m_originalSiteCount = m_siteCount;
         m_siteCount = siteCount;
         boolean compiled = m_origBuilder.compile(m_jarFileName, siteCount, 0);
@@ -68,8 +61,7 @@ public class CatalogChangeSingleProcessServer extends LocalSingleProcessServer
         return compiled;
     }
 
-    public boolean recompile(VoltProjectBuilder builder, int siteCount)
-    {
+    public boolean recompile(VoltProjectBuilder builder, int siteCount) {
         m_originalSiteCount = m_siteCount;
         m_siteCount = siteCount;
         boolean compiled = builder.compile(m_jarFileName, siteCount, 0);
@@ -77,8 +69,7 @@ public class CatalogChangeSingleProcessServer extends LocalSingleProcessServer
         return compiled;
     }
 
-    public boolean revertCompile()
-    {
+    public boolean revertCompile() {
         if (m_originalSiteCount > 0) {
             m_siteCount = m_originalSiteCount;
         }

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -229,97 +229,52 @@ public class LocalCluster extends VoltServerConfig {
         }
     }
 
-    public LocalCluster(String jarFileName,
-                        int siteCount,
-                        int hostCount,
-                        int kfactor,
-                        BackendTarget target)
-    {
+    public LocalCluster(
+            String jarFileName, int siteCount, int hostCount, int kfactor, BackendTarget target) {
         this(jarFileName, siteCount, hostCount, kfactor, target, null);
     }
 
-    public LocalCluster(String jarFileName,
-            int siteCount,
-            int hostCount,
-            int kfactor,
-            BackendTarget target,
-            int inactiveCount)
-{
-       this(jarFileName, siteCount, hostCount, kfactor, target, null);
-       this.m_missingHostCount = inactiveCount;
-}
-
-    public LocalCluster(String jarFileName,
-                        int siteCount,
-                        int hostCount,
-                        int kfactor,
-                        BackendTarget target,
-                        Map<String, String> env)
-    {
-        this(jarFileName, siteCount, hostCount, kfactor, target,
-                FailureState.ALL_RUNNING, false, env);
-
+    public LocalCluster(
+            String jarFileName, int siteCount, int hostCount, int kfactor, BackendTarget target, int inactiveCount) {
+        this(jarFileName, siteCount, hostCount, kfactor, target, null);
+        this.m_missingHostCount = inactiveCount;
     }
 
-    public LocalCluster(String jarFileName,
-            int siteCount,
-            int hostCount,
-            int kfactor,
-            int clusterId,
-            BackendTarget target)
-    {
-        this(jarFileName, siteCount, hostCount, kfactor, clusterId, target,
-            FailureState.ALL_RUNNING, false, null);
-    }
-
-    public LocalCluster(String jarFileName,
-                        int siteCount,
-                        int hostCount,
-                        int kfactor,
-                        BackendTarget target,
-                        FailureState failureState,
-                        boolean debug)
-    {
-        this(jarFileName, siteCount, hostCount, kfactor, target,
-                failureState, debug, null);
-    }
-
-    public LocalCluster(String jarFileName,
-                        int siteCount,
-                        int hostCount,
-                        int kfactor,
-                        BackendTarget target,
-                        FailureState failureState,
-                        boolean debug,
-                        Map<String, String> env) {
-        this(jarFileName, siteCount, hostCount, kfactor, 0, target,
-                failureState, debug, env);
-    }
-
-    public LocalCluster(String jarFileName,
-            int siteCount,
-            int hostCount,
-            int kfactor,
-            int clusterId,
-            BackendTarget target,
-            FailureState failureState,
-            boolean debug,
+    public LocalCluster(
+            String jarFileName, int siteCount, int hostCount, int kfactor, BackendTarget target,
             Map<String, String> env) {
-        this(null, null, jarFileName, siteCount, hostCount, kfactor, clusterId, target, failureState, debug, env);
+        this(jarFileName, siteCount, hostCount, kfactor, target, FailureState.ALL_RUNNING, false, env);
     }
 
-    public LocalCluster(String schemaToStage,
-                        String classesJarToStage,
-                        String catalogJarFileName,
-                        int siteCount,
-                        int hostCount,
-                        int kfactor,
-                        int clusterId,
-                        BackendTarget target,
-                        FailureState failureState,
-                        boolean debug,
-                        Map<String, String> env)
-    {
+    public LocalCluster(
+            String jarFileName, int siteCount, int hostCount, int kfactor, int clusterId, BackendTarget target) {
+        this(jarFileName, siteCount, hostCount, kfactor, clusterId, target,
+                FailureState.ALL_RUNNING, false, null);
+    }
+
+    public LocalCluster(
+            String jarFileName, int siteCount, int hostCount, int kfactor, BackendTarget target,
+            FailureState failureState, boolean debug) {
+        this(jarFileName, siteCount, hostCount, kfactor, target, failureState, debug, null);
+    }
+
+    public LocalCluster(
+            String jarFileName, int siteCount, int hostCount, int kfactor, BackendTarget target,
+            FailureState failureState, boolean debug, Map<String, String> env) {
+        this(jarFileName, siteCount, hostCount, kfactor, 0, target, failureState, debug, env);
+    }
+
+    public LocalCluster(
+            String jarFileName, int siteCount, int hostCount, int kfactor, int clusterId, BackendTarget target,
+            FailureState failureState, boolean debug, Map<String, String> env) {
+        this(null, null, jarFileName, siteCount, hostCount,
+                kfactor, clusterId, target, failureState, debug, env);
+    }
+
+    public LocalCluster(
+            String schemaToStage, String classesJarToStage, String catalogJarFileName, int siteCount, int hostCount,
+            int kfactor, int clusterId, BackendTarget target, FailureState failureState, boolean debug,
+            Map<String, String> env) {
         m_usesStagedSchema = schemaToStage != null || classesJarToStage != null;
         setNewCli(isNewCli() || m_usesStagedSchema);
 
@@ -350,7 +305,7 @@ public class LocalCluster extends VoltServerConfig {
         m_callingMethodName = traces[i].getMethodName();
 
         if (catalogJarFileName == null) {
-            if (m_usesStagedSchema == false) {
+            if (! m_usesStagedSchema) {
                 log.info("Instantiating empty LocalCluster with class.method: " +
                         m_callingClassName + "." + m_callingMethodName);
             } else {
@@ -358,7 +313,7 @@ public class LocalCluster extends VoltServerConfig {
                         m_callingClassName + "." + m_callingMethodName);
             }
         } else {
-            assert m_usesStagedSchema == false : "Cannot use OldCLI catalog with staged schema and/or classes";
+            assert !m_usesStagedSchema : "Cannot use OldCLI catalog with staged schema and/or classes";
             log.info("Instantiating LocalCluster for " + catalogJarFileName + " with class.method: " +
                     m_callingClassName + "." + m_callingMethodName);
         }
@@ -398,8 +353,7 @@ public class LocalCluster extends VoltServerConfig {
         // For now only one host works.
         if (isMemcheckDefined() && target.isValgrindable && m_hostCount == 1) {
             m_target = BackendTarget.NATIVE_EE_VALGRIND_IPC;
-        }
-        else {
+        } else {
             m_target = target;
         }
 
@@ -426,8 +380,7 @@ public class LocalCluster extends VoltServerConfig {
         String javaLibraryPath = System.getProperty("java.library.path");
         if (javaLibraryPath == null || javaLibraryPath.trim().length() == 0) {
             javaLibraryPath = buildDir + "/nativelibs";
-        }
-        else {
+        } else {
             javaLibraryPath += ":" + buildDir + "/nativelibs";
         }
 
@@ -571,8 +524,7 @@ public class LocalCluster extends VoltServerConfig {
     }
 
     @Override
-    public boolean compileWithAdminMode(VoltProjectBuilder builder, int adminPort, boolean adminOnStartup)
-    {
+    public boolean compileWithAdminMode(VoltProjectBuilder builder, int adminPort, boolean adminOnStartup) {
         if (adminOnStartup) {
             setToStartPaused();
         }
@@ -611,8 +563,7 @@ public class LocalCluster extends VoltServerConfig {
         m_filePrefix = filePrefix;
     }
 
-    public void setHostCount(int hostCount)
-    {
+    public void setHostCount(int hostCount) {
         m_hostCount = hostCount;
         if (hostCount < numberOfCoordinators) {
             numberOfCoordinators = hostCount;
@@ -641,7 +592,7 @@ public class LocalCluster extends VoltServerConfig {
         startLocalServer(hostId, clearLocalDataDirectories, templateCmdLine.m_startAction);
     }
 
-    private void startLocalServer(int hostId, boolean clearLocalDataDirectories, StartAction action) throws IOException {
+    private void startLocalServer(int hostId, boolean clearLocalDataDirectories, StartAction action) {
         // Generate a new root for the in-process server if clearing directories.
         File subroot = null;
         if (!isNewCli) {
@@ -649,19 +600,16 @@ public class LocalCluster extends VoltServerConfig {
                 if (m_filePrefix != null) {
                     subroot = m_filePrefix;
                     m_subRoots.add(subroot);
-                }
-                else if (clearLocalDataDirectories) {
+                } else if (clearLocalDataDirectories) {
                     subroot = VoltFile.initNewSubrootForThisProcess();
                     m_subRoots.add(subroot);
-                }
-                else {
+                } else {
                     if (m_subRoots.size() <= hostId) {
                         m_subRoots.add(VoltFile.initNewSubrootForThisProcess());
                     }
                     subroot = m_subRoots.get(hostId);
                 }
-            }
-            catch (IOException e) {
+            } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -749,10 +697,9 @@ public class LocalCluster extends VoltServerConfig {
             if (!m_hostRoots.containsKey(hostId)) {
                 throw new IllegalArgumentException("getServerSpecificRoot possibly called before cluster has started.");
             }
-            assert( new File(m_hostRoots.get(hostId)).getName().equals(Constants.DBROOT) == false ) : m_hostRoots.get(hostId);
+            assert(! new File(m_hostRoots.get(hostId)).getName().equals(Constants.DBROOT)) : m_hostRoots.get(hostId);
             return m_hostRoots.get(hostId) + File.separator + Constants.DBROOT;
-        }
-        else {
+        } else {
             for (CommandLine cl : m_cmdLines) {
                 if (cl.getJavaProperty(clusterHostIdProperty).equals(hostId)) {
                     return cl.voltRoot().toString();
@@ -782,15 +729,13 @@ public class LocalCluster extends VoltServerConfig {
         //If we are initializing lets wait for it to finish.
         ServerThread th = new ServerThread(cmdln);
         File root = VoltFile.getServerSpecificRoot(String.valueOf(hostId), clearLocalDataDirectories);
-        assert( root.getName().equals(Constants.DBROOT) == false ) : root.getAbsolutePath();
+        assert(! root.getName().equals(Constants.DBROOT)) : root.getAbsolutePath();
         cmdln.voltdbRoot(new File(root, Constants.DBROOT));
         try {
             th.initialize();
-        }
-        catch (VoltDB.SimulatedExitException expected) {
+        } catch (VoltDB.SimulatedExitException expected) {
             //All ok
-        }
-        catch (Exception ex) {
+        } catch (Exception ex) {
             log.error("Failed to initialize cluster process:" + ex.getMessage(), ex);
             assert (false);
         }
@@ -799,8 +744,7 @@ public class LocalCluster extends VoltServerConfig {
         m_hostRoots.put(hostIdStr, root.getAbsolutePath());
     }
 
-    private boolean waitForAllReady()
-    {
+    private boolean waitForAllReady() {
         if (!m_expectedToInitialize) {
             return true;
         }
@@ -822,10 +766,7 @@ public class LocalCluster extends VoltServerConfig {
                         // dead process means the other pipes won't start,
                         // so bail here
                         return false;
-                    }
-
-                    // if eof, then no point in waiting around
-                    if (pipeToFile.m_eof.get()) {
+                    } else if (pipeToFile.m_eof.get()) { // if eof, then no point in waiting around
                         continue;
                     }
 
@@ -834,8 +775,7 @@ public class LocalCluster extends VoltServerConfig {
                         try {
                             // use a timeout to prevent a forever hang
                             pipeToFile.wait(250);
-                        }
-                        catch (InterruptedException ex) {
+                        } catch (InterruptedException ex) {
                             log.error(ex.toString(), ex);
                         }
                         allReady = false;
@@ -926,8 +866,7 @@ public class LocalCluster extends VoltServerConfig {
                 ++oopStartIndex;
             }
             try {
-                // Init
-                if (isNewCli && !skipInit) {
+                if (isNewCli && !skipInit) { // Init
                     initLocalServer(oopStartIndex, clearLocalDataDirectories);
                 }
                 startLocalServer(oopStartIndex, clearLocalDataDirectories);
@@ -956,11 +895,10 @@ public class LocalCluster extends VoltServerConfig {
                 if (m_delayBetweenNodeStartupMS > 0) {
                     try {
                         Thread.sleep(m_delayBetweenNodeStartupMS);
-                    } catch (InterruptedException e) {
+                    } catch (InterruptedException ignored) {
                     }
                 }
-            }
-            catch (IOException ioe) {
+            } catch (IOException ioe) {
                 throw new RuntimeException(ioe);
             }
         }
@@ -983,22 +921,18 @@ public class LocalCluster extends VoltServerConfig {
             // poke all the external processes to die (no guarantees)
             for (Process proc : m_cluster) {
                 if (proc != null) {
-                    try { proc.destroy(); } catch (Exception e) {}
+                    try { proc.destroy(); } catch (Exception ignored) {}
                 }
             }
 
             if (downProcesses > 0) {
                 int expectedProcesses = m_hostCount - (m_hasLocalServer ? 1 : 0);
                 if (!m_expectedToCrash) {
-                    throw new RuntimeException(
-                            String.format("%d/%d external processes failed to start",
+                    throw new RuntimeException( String.format("%d/%d external processes failed to start",
                             downProcesses, expectedProcesses));
                 }
-            }
-            // this error case should only be from a timeout
-            else if (!allReady) {
-                throw new RuntimeException(
-                        "One or more external processes failed to complete initialization.");
+            } else if (! allReady) { // this error case should only be from a timeout
+                throw new RuntimeException("One or more external processes failed to complete initialization.");
             }
         }
 
@@ -1037,11 +971,9 @@ public class LocalCluster extends VoltServerConfig {
             retval = proc.waitFor();
             EEProcess eeProc = m_eeProcs.get(procIndex);
             valgrindOutputFile = eeProc.waitForShutdown();
-        }
-        catch (InterruptedException e) {
+        } catch (InterruptedException e) {
             log.info("External VoltDB process is acting crazy.");
-        }
-        finally {
+        } finally {
             m_cluster.set(procIndex, null);
         }
 
@@ -1099,8 +1031,7 @@ public class LocalCluster extends VoltServerConfig {
             if (dir.exists()) {
                 assert (dir.isDirectory());
             } else {
-                boolean status = dir.mkdirs();
-                assert (status);
+                assert dir.mkdirs();
             }
 
             File dirFile = new VoltFile(testoutputdir);
@@ -1125,35 +1056,22 @@ public class LocalCluster extends VoltServerConfig {
             System.out.println("Process output can be found in: " + fileName);
 
             if (m_logMessageMatchPatterns == null) {
-                ptf = new PipeToFile(
-                        fileName,
-                        proc.getInputStream(),
-                        String.valueOf(hostId),
-                        false,
-                        proc);
+                ptf = new PipeToFile(fileName, proc.getInputStream(), String.valueOf(hostId), false, proc);
             } else {
                 if (m_logMessageMatchResults.get(hostId) == null) {
                     m_logMessageMatchResults.put(hostId, Collections.newSetFromMap(new ConcurrentHashMap<>()));
                 }
-                ptf = new PipeToFile(
-                        fileName,
-                        proc.getInputStream(),
-                        String.valueOf(hostId),
-                        false,
-                        proc,
-                        m_logMessageMatchPatterns,
-                        m_logMessageMatchResults.get(hostId));
+                ptf = new PipeToFile(fileName, proc.getInputStream(), String.valueOf(hostId), false,
+                        proc, m_logMessageMatchPatterns, m_logMessageMatchResults.get(hostId));
                 ptf.setHostId(hostId);
             }
             ptf.setName("ClusterPipe:" + String.valueOf(hostId));
             ptf.start();
             proc.waitFor(); // Wait for the server initialization to finish ?
-        }
-        catch (IOException ex) {
+        } catch (IOException ex) {
             log.error("Failed to start cluster process:" + ex.getMessage(), ex);
             assert (false);
-        }
-        catch (InterruptedException ex) {
+        } catch (InterruptedException ex) {
             log.error("Failed to start cluster process:" + ex.getMessage(), ex);
             assert (false);
         }
@@ -1164,15 +1082,13 @@ public class LocalCluster extends VoltServerConfig {
     }
 
     void startOne(int hostId, boolean clearLocalDataDirectories,
-            StartAction startAction, boolean waitForReady, String placementGroup) throws IOException
-    {
+            StartAction startAction, boolean waitForReady, String placementGroup) {
         startOne(hostId, clearLocalDataDirectories, startAction, waitForReady, placementGroup, false);
     }
 
     void startOne(int hostId, boolean clearLocalDataDirectories,
             StartAction startAction, boolean waitForReady, String placementGroup,
-            boolean resetLogMessageMatchResults) throws IOException
-    {
+            boolean resetLogMessageMatchResults) {
         PipeToFile ptf = null;
         CommandLine cmdln = (templateCmdLine.makeCopy());
         cmdln.setJavaProperty(clusterHostIdProperty, String.valueOf(hostId));
@@ -1296,10 +1212,8 @@ public class LocalCluster extends VoltServerConfig {
             File dir = new File(testoutputdir);
             if (dir.exists()) {
                 assert (dir.isDirectory());
-            }
-            else {
-                boolean status = dir.mkdirs();
-                assert (status);
+            } else {
+                assert dir.mkdirs();
             }
 
             File dirFile = new VoltFile(testoutputdir);
@@ -1324,12 +1238,7 @@ public class LocalCluster extends VoltServerConfig {
             System.out.println("Process output can be found in: " + fileName);
 
             if (m_logMessageMatchPatterns == null) {
-                ptf = new PipeToFile(
-                        fileName,
-                        proc.getInputStream(),
-                        PipeToFile.m_initToken,
-                        false,
-                        proc);
+                ptf = new PipeToFile(fileName, proc.getInputStream(), PipeToFile.m_initToken, false, proc);
             } else {
                 if (m_logMessageMatchResults.containsKey(hostId)) {
                     if (resetLogMessageMatchResults) {
@@ -1338,27 +1247,21 @@ public class LocalCluster extends VoltServerConfig {
                 } else {
                     m_logMessageMatchResults.put(hostId, Collections.newSetFromMap(new ConcurrentHashMap<>()));
                 }
-                ptf = new PipeToFile(
-                        fileName,
-                        proc.getInputStream(),
-                        PipeToFile.m_initToken,
-                        false,
-                        proc,
-                        m_logMessageMatchPatterns,
-                        m_logMessageMatchResults.get(hostId));
+                ptf = new PipeToFile(fileName, proc.getInputStream(), PipeToFile.m_initToken, false,
+                        proc, m_logMessageMatchPatterns, m_logMessageMatchResults.get(hostId));
                 ptf.setHostId(hostId);
             }
 
             m_pipes.add(ptf);
-            ptf.setName("ClusterPipe:" + String.valueOf(hostId));
+            ptf.setName("ClusterPipe:" + hostId);
             ptf.start();
-        }
-        catch (IOException ex) {
+        } catch (IOException ex) {
             log.error("Failed to start cluster process:" + ex.getMessage(), ex);
             assert (false);
         }
 
-        if (waitForReady && (startAction == StartAction.JOIN || startAction == StartAction.PROBE || startAction == StartAction.REJOIN)) {
+        if (waitForReady && (startAction == StartAction.JOIN || startAction == StartAction.PROBE ||
+                startAction == StartAction.REJOIN)) {
             waitOnPTFReady(ptf, true, System.currentTimeMillis(), System.currentTimeMillis(), hostId);
         }
 
@@ -1391,21 +1294,14 @@ public class LocalCluster extends VoltServerConfig {
         try {
             p.exitValue();
             return true; // if no exception, process died
-        }
-        catch (IllegalThreadStateException e) {
+        } catch (IllegalThreadStateException e) {
             return false; // process is still alive
         }
     }
 
     public boolean recoverOne(int hostId, Integer portOffset, String rejoinHost, boolean liveRejoin) {
         StartAction startAction = isNewCli ? StartAction.PROBE : (liveRejoin ? StartAction.LIVE_REJOIN : StartAction.REJOIN);
-        return recoverOne(
-                false,
-                0,
-                hostId,
-                portOffset,
-                rejoinHost,
-                startAction);
+        return recoverOne(false, 0, hostId, portOffset, rejoinHost, startAction);
     }
 
     public void joinOne(int hostId) {
@@ -1414,8 +1310,7 @@ public class LocalCluster extends VoltServerConfig {
                 initLocalServer(hostId, true);
             }
             startOne(hostId, true, StartAction.JOIN, true, null);
-        }
-        catch (IOException ioe) {
+        } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }
     }
@@ -1426,8 +1321,7 @@ public class LocalCluster extends VoltServerConfig {
                 initLocalServer(hostId, true);
             }
             startOne(hostId, true, StartAction.JOIN, true, placementGroup);
-        }
-        catch (IOException ioe) {
+        } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }
     }
@@ -1443,8 +1337,7 @@ public class LocalCluster extends VoltServerConfig {
                 initLocalServer(hostId, true);
             }
             startOne(hostId, clearLocalDataDirectories, StartAction.REJOIN, true, null);
-        }
-        catch (IOException ioe) {
+        } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }
     }
@@ -1460,8 +1353,7 @@ public class LocalCluster extends VoltServerConfig {
                     initLocalServer(hostId, true);
                 }
                 startOne(hostId, true, StartAction.JOIN, false, null);
-            }
-            catch (IOException ioe) {
+            } catch (IOException ioe) {
                 throw new RuntimeException(ioe);
             }
         }
@@ -1482,7 +1374,7 @@ public class LocalCluster extends VoltServerConfig {
                 if (m_delayBetweenNodeStartupMS > 0) {
                     try {
                         Thread.sleep(m_delayBetweenNodeStartupMS);
-                    } catch (InterruptedException e) {
+                    } catch (InterruptedException ignored) {
                     }
                 }
             }
@@ -1529,12 +1421,8 @@ public class LocalCluster extends VoltServerConfig {
 
         if (hostId == 0 && m_hasLocalServer) {
             templateCmdLine.leaderPort(portNoToRejoin);
-            try {
-                startLocalServer(rejoinHostId, false, startAction);
-                m_localServer.waitForRejoin();
-            } catch (IOException ioe) {
-                throw new RuntimeException(ioe);
-            }
+            startLocalServer(rejoinHostId, false, startAction);
+            m_localServer.waitForRejoin();
             return true;
         }
 
@@ -1546,7 +1434,7 @@ public class LocalCluster extends VoltServerConfig {
         // rebuild the EE proc set.
         if (templateCmdLine.target().isIPC && m_eeProcs.size() < hostId) {
             EEProcess eeProc = m_eeProcs.get(hostId);
-            File valgrindOutputFile = null;
+            File valgrindOutputFile;
             try {
                 valgrindOutputFile = eeProc.waitForShutdown();
             } catch (InterruptedException e) {
@@ -1625,8 +1513,7 @@ public class LocalCluster extends VoltServerConfig {
             File dir = new File(testoutputdir);
             if (dir.exists()) {
                 assert(dir.isDirectory());
-            }
-            else {
+            } else {
                 boolean status = dir.mkdirs();
                 assert(status);
             }
@@ -1640,26 +1527,15 @@ public class LocalCluster extends VoltServerConfig {
                               ".rejoined.txt";
 
             if (m_logMessageMatchPatterns == null) {
-                ptf = new PipeToFile(
-                        filePath,
-                        proc.getInputStream(),
-                        PipeToFile.m_initToken,
-                        false,
-                        proc);
+                ptf = new PipeToFile(filePath, proc.getInputStream(), PipeToFile.m_initToken, false, proc);
             } else {
                 if (m_logMessageMatchResults.containsKey(hostId)) {
                     resetLogMessageMatchResults(hostId);
                 } else {
                     m_logMessageMatchResults.put(hostId, Collections.newSetFromMap(new ConcurrentHashMap<>()));
                 }
-                ptf = new PipeToFile(
-                        filePath,
-                        proc.getInputStream(),
-                        PipeToFile.m_initToken,
-                        false,
-                        proc,
-                        m_logMessageMatchPatterns,
-                        m_logMessageMatchResults.get(hostId));
+                ptf = new PipeToFile(filePath, proc.getInputStream(), PipeToFile.m_initToken, false,
+                        proc, m_logMessageMatchPatterns, m_logMessageMatchResults.get(hostId));
                 ptf.setHostId(hostId);
             }
 
@@ -1672,8 +1548,7 @@ public class LocalCluster extends VoltServerConfig {
             Thread t = new Thread(ptf);
             t.setName("ClusterPipe:" + String.valueOf(hostId));
             t.start();
-        }
-        catch (IOException ex) {
+        } catch (IOException ex) {
             log.error("Failed to start recovering cluster process:" + ex.getMessage(), ex);
             assert (false);
         }
@@ -1704,8 +1579,7 @@ public class LocalCluster extends VoltServerConfig {
                 try {
                     // wait for explicit notification
                     ptf.wait(1000);
-                }
-                catch (InterruptedException ex) {
+                } catch (InterruptedException ex) {
                     log.error(ex.toString(), ex);
                 }
             }
@@ -1720,8 +1594,7 @@ public class LocalCluster extends VoltServerConfig {
         log.info("Recovering process exited before recovery completed");
         try {
             silentKillSingleHost(hostId, true);
-        }
-        catch (InterruptedException e) {
+        } catch (InterruptedException e) {
             e.printStackTrace();
         }
         return false;
@@ -1757,19 +1630,15 @@ public class LocalCluster extends VoltServerConfig {
             System.out.printf("Outstanding transactions: %d, buffer bytes :%d, response messages:%d\n", trxn, bytes, msg);
             try {
                 Thread.sleep(2000);
-            } catch (InterruptedException ex) {
-                ;
-            }
+            } catch (InterruptedException ignored) { }
         }
         if (sum != 0) {
             throw new IOException("Failed to clear any pending transactions.");
         }
 
         try{
-            resp = adminClient.callProcedure("@Shutdown", sigil);
-        } catch (ProcCallException e) {
-            ;
-        }
+            adminClient.callProcedure("@Shutdown", sigil);
+        } catch (ProcCallException ignored) { }
         System.out.println("@Shutdown: cluster has been shutdown via admin mode and last snapshot saved.");
     }
 
@@ -1783,25 +1652,20 @@ public class LocalCluster extends VoltServerConfig {
             if (m_localServer != null) {
                 m_localServer.shutdown();
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             log.error("Failure to shutdown LocalCluster's in-process VoltDB server.", e);
-        }
-        finally {
+        } finally {
             m_running = false;
         }
         shutDownExternal();
-
         VoltServerConfig.removeInstance(this);
     }
 
-    public void killSingleHost(int hostNum) throws InterruptedException
-    {
+    public void killSingleHost(int hostNum) throws InterruptedException {
         log.info("Killing " + hostNum);
         if (hostNum == 0 && m_localServer != null) {
             m_localServer.shutdown();
-        }
-        else {
+        } else {
             silentKillSingleHost(hostNum, false);
         }
     }
@@ -1858,13 +1722,11 @@ public class LocalCluster extends VoltServerConfig {
                 int retval = 0;
                 try {
                     retval = proc.waitFor();
-                }
-                catch (InterruptedException e) {
+                } catch (InterruptedException e) {
                     log.error("Unable to wait for Localcluster process to die: " + proc.toString(), e);
                 }
                 // exit code 143 is the forcible shutdown code from .destroy()
-                if (retval != 0 && retval != 143)
-                {
+                if (retval != 0 && retval != 143) {
                     log.error("External VoltDB process terminated abnormally with return: " + retval);
                 }
             }
@@ -1878,8 +1740,7 @@ public class LocalCluster extends VoltServerConfig {
             File valgrindOutputFile = null;
             try {
                 valgrindOutputFile = proc.waitForShutdown();
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 log.error("Unable to wait for EEProcess to die: " + proc.toString(), e);
             }
 
@@ -1892,8 +1753,7 @@ public class LocalCluster extends VoltServerConfig {
 
     }
 
-    public synchronized void shutDownExternal(boolean forceKillEEProcs)
-    {
+    public synchronized void shutDownExternal(boolean forceKillEEProcs) {
         if (m_cluster != null) {
             // kill all procs
             for (Process proc : m_cluster) {
@@ -1984,9 +1844,7 @@ public class LocalCluster extends VoltServerConfig {
         if (m_failureState == FailureState.ONE_RECOVERING) {
             prefix += "OneRecov";
         }
-        return prefix +
-            "-" + String.valueOf(m_siteCount) +
-            "-" + String.valueOf(m_hostCount) +
+        return prefix + "-" + m_siteCount + "-" + m_hostCount +
             "-" + templateCmdLine.target().display.toUpperCase();
     }
 
@@ -1998,9 +1856,7 @@ public class LocalCluster extends VoltServerConfig {
         if (m_failureState == FailureState.ONE_RECOVERING) {
             prefix += "-OneRecov";
         }
-        return prefix +
-            "-" + String.valueOf(m_siteCount) +
-            "-" + String.valueOf(m_hostCount) +
+        return prefix + "-" + m_siteCount + "-" + m_hostCount +
             "-" + templateCmdLine.target().display.toUpperCase();
     }
 
@@ -2016,35 +1872,26 @@ public class LocalCluster extends VoltServerConfig {
                 if (proc != null) {
                     proc.exitValue();
                 }
-            }
-            catch (IllegalThreadStateException ex) {
+            } catch (IllegalThreadStateException ex) {
                 return false;
             }
         }
         return true;
     }
 
-    public int getLiveNodeCount()
-    {
+    public int getLiveNodeCount() {
         int count = 0;
-        if (m_hasLocalServer)
-        {
+        if (m_hasLocalServer) {
             count++;
         }
 
-        if (m_cluster != null)
-        {
-            for (Process proc : m_cluster)
-            {
-                try
-                {
-                    if (proc != null)
-                    {
+        if (m_cluster != null) {
+            for (Process proc : m_cluster) {
+                try {
+                    if (proc != null) {
                         proc.exitValue();
                     }
-                }
-                catch (IllegalThreadStateException ex)
-                {
+                } catch (IllegalThreadStateException ex) {
                     // not dead yet!
                     count++;
                 }
@@ -2073,8 +1920,7 @@ public class LocalCluster extends VoltServerConfig {
     public void finalize() throws Throwable {
         try {
             shutDownExternal();
-        }
-        finally {
+        } finally {
             super.finalize();
         }
     }
@@ -2309,15 +2155,15 @@ public class LocalCluster extends VoltServerConfig {
                 failString = failString + "\n" +  error;
             }
             org.junit.Assert.fail(failString);
-        }
-        else {
+        } else {
             valgrindOutputFile.delete();
         }
     }
 
-    public static LocalCluster createOnly(String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
-                                          int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
-                                          DrRoleType drRole, boolean hasLocalServer) throws IOException {
+    public static LocalCluster createOnly(
+            String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
+            int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
+            DrRoleType drRole, boolean hasLocalServer) throws IOException {
         VoltProjectBuilder builder = new VoltProjectBuilder();
         LocalCluster lc = compileBuilder(schemaDDL, siteCount, hostCount, kfactor, clusterId,
                 replicationPort, remoteReplicationPort, pathToVoltDBRoot, jar, drRole, builder, null, null);
@@ -2341,29 +2187,34 @@ public class LocalCluster extends VoltServerConfig {
     }
 
     // Use this for optionally enabling localServer in one of the DR clusters (usually for debugging)
-    public static LocalCluster createLocalCluster(String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
-                                                  int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
-                                                  DrRoleType drRole, boolean hasLocalServer) throws IOException {
+    public static LocalCluster createLocalCluster(
+            String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
+            int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
+            DrRoleType drRole, boolean hasLocalServer) throws IOException {
         return createLocalCluster(schemaDDL, siteCount, hostCount, kfactor, clusterId, replicationPort, remoteReplicationPort,
                 pathToVoltDBRoot, jar, drRole, hasLocalServer, null, null);
     }
 
-    public static LocalCluster createLocalCluster(String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
-                                                  int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
-                                                  DrRoleType drRole, boolean hasLocalServer, VoltProjectBuilder builder) throws IOException {
+    public static LocalCluster createLocalCluster(
+            String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
+            int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
+            DrRoleType drRole, boolean hasLocalServer, VoltProjectBuilder builder) throws IOException {
         return createLocalCluster(schemaDDL, siteCount, hostCount, kfactor, clusterId, replicationPort, remoteReplicationPort,
                 pathToVoltDBRoot, jar, drRole, hasLocalServer, builder, null);
     }
 
-    public static LocalCluster createLocalCluster(String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
-                                                  int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
-                                                  DrRoleType drRole, boolean hasLocalServer, VoltProjectBuilder builder,
-                                                  String callingMethodName) throws IOException {
+    public static LocalCluster createLocalCluster(
+            String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
+            int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
+            DrRoleType drRole, boolean hasLocalServer, VoltProjectBuilder builder,
+            String callingMethodName) throws IOException {
         return createLocalCluster(schemaDDL, siteCount, hostCount, kfactor, clusterId, replicationPort, remoteReplicationPort,
-                           pathToVoltDBRoot, jar, drRole, hasLocalServer, builder, callingMethodName, false, null);
+                pathToVoltDBRoot, jar, drRole, hasLocalServer, builder, callingMethodName,
+                false, null);
     }
 
-    public static LocalCluster createLocalCluster(String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
+    public static LocalCluster createLocalCluster(
+            String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
             int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar, DrRoleType drRole,
             boolean hasLocalServer, VoltProjectBuilder builder, String callingMethodName, boolean enableSPIMigration,
             Map<String, String> javaProps) throws IOException {
@@ -2372,13 +2223,12 @@ public class LocalCluster extends VoltServerConfig {
                 callingMethodName, enableSPIMigration, javaProps);
     }
 
-    public static LocalCluster createLocalCluster(String schemaDDL, int siteCount, int hostCount, int kfactor,
-                                                  int clusterId,
-                                                  int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
-                                                  DrRoleType drRole, boolean hasLocalServer, VoltProjectBuilder builder,
-                                                  String callingClassName, String callingMethodName,
-                                                  boolean enableSPIMigration,
-                                                  Map<String, String> javaProps) throws IOException {
+    public static LocalCluster createLocalCluster(
+            String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId,
+            int replicationPort, int remoteReplicationPort, String pathToVoltDBRoot, String jar,
+            DrRoleType drRole, boolean hasLocalServer, VoltProjectBuilder builder,
+            String callingClassName, String callingMethodName,
+            boolean enableSPIMigration, Map<String, String> javaProps) throws IOException {
         if (builder == null) {
             builder = new VoltProjectBuilder();
         }
@@ -2422,11 +2272,10 @@ public class LocalCluster extends VoltServerConfig {
         m_compiled = true;
     }
 
-    private static LocalCluster compileBuilder(String schemaDDL, int siteCount, int hostCount,
-                                              int kfactor, int clusterId, int replicationPort,
-                                              int remoteReplicationPort, String pathToVoltDBRoot, String jar,
-                                              DrRoleType drRole, VoltProjectBuilder builder,
-                                              String callingClassName, String callingMethodName) throws IOException {
+    private static LocalCluster compileBuilder(
+            String schemaDDL, int siteCount, int hostCount, int kfactor, int clusterId, int replicationPort,
+            int remoteReplicationPort, String pathToVoltDBRoot, String jar, DrRoleType drRole, VoltProjectBuilder builder,
+            String callingClassName, String callingMethodName) throws IOException {
         builder.addLiteralSchema(schemaDDL);
         if (drRole == DrRoleType.REPLICA) {
             builder.setDrReplica();

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -219,6 +219,11 @@ public class LocalCluster extends VoltServerConfig {
     }
     public int getHttpOverridePort() { return m_httpOverridePort; };
 
+    @Override
+    public boolean isUsingCalcite() {
+        return false;
+    }
+
     /*
      * Enable pre-compiled regex search in logs
      */
@@ -409,7 +414,7 @@ public class LocalCluster extends VoltServerConfig {
             pathToLicense(ServerThread.getTestLicensePath()).
             log4j(log4j).
             setForceVoltdbCreate(true);
-        if (javaLibraryPath!=null) {
+        if (javaLibraryPath != null) {
             templateCmdLine.javaLibraryPath(javaLibraryPath);
         }
         this.templateCmdLine.m_noLoadLibVOLTDB = m_target == BackendTarget.HSQLDB_BACKEND;
@@ -424,7 +429,7 @@ public class LocalCluster extends VoltServerConfig {
      * @param mismatchSchema schema to put on one node, or null if node should be empty
      * @param nodeID node to put the mismatch, or null to re-enable matched schemas
      */
-    public void setMismatchSchemaForInit( String mismatchSchema, Integer nodeID ){
+    public void setMismatchSchemaForInit( String mismatchSchema, Integer nodeID) {
         assert isNewCli();
         assert m_usesStagedSchema;
         m_mismatchSchema = mismatchSchema;
@@ -450,10 +455,9 @@ public class LocalCluster extends VoltServerConfig {
     }
 
     public void overrideStartCommandVerb(String verb) {
-        if (verb == null || verb.trim().isEmpty()) {
-            return;
+        if (verb != null && !verb.trim().isEmpty()) {
+            templateCmdLine.startCommand(verb);
         }
-        this.templateCmdLine.startCommand(verb);
     }
 
     public void setCustomCmdLn(String customCmdLn) {

--- a/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
@@ -92,6 +92,12 @@ public class RegressionSuite extends TestCase {
     // shutdown the cluster completely after finishing the test.
     boolean m_completeShutdown;
     boolean m_fatalFailure;
+    /**
+     * We sometimes need to take different actions, i.e. skip a test, change error message, etc. depending on
+     * the actual parser/planner being in use. Eventually when we fully integrate with Calcite and replace our
+     * legacy planner, we don't need to take branches on those test logic.
+     */
+    final boolean m_usingCalcite = Boolean.parseBoolean(System.getProperty("PLAN_WITH_CALCITE", "false"));
 
     /**
      * Trivial constructor that passes parameter on to superclass.

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
@@ -213,7 +213,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         try {
             project.addLiteralSchema(literalSchema);
         } catch (IOException e) {
-            assertFalse(true);
+            fail();
         }
 
         // load the procedures for the test
@@ -326,14 +326,12 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         project.addProcedure(BadParamTypesForTimestamp.class);
     }
 
-    public void testExplicitErrorUDF() throws Exception
-    {
+    public void testExplicitErrorUDF() throws Exception {
         System.out.println("STARTING testExplicitErrorUDF");
         Client client = getClient();
         ProcedureCallback callback = new ProcedureCallback() {
             @Override
-            public void clientCallback(ClientResponse clientResponse)
-                    throws Exception {
+            public void clientCallback(ClientResponse clientResponse) {
                 if (clientResponse.getStatus() != ClientResponse.SUCCESS) {
                     throw new RuntimeException("Failed with response: " + clientResponse.getStatusString());
                 }
@@ -379,8 +377,8 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         ClientResponse cr;
         VoltTable result;
 
-        cr = client.callProcedure("P1.insert", 1, "贾鑫Vo", 10, 1.1);
-        cr = client.callProcedure("P1.insert", 2, "Xin", 10, 1.1);
+        client.callProcedure("P1.insert", 1, "贾鑫Vo", 10, 1.1);
+        client.callProcedure("P1.insert", 2, "Xin", 10, 1.1);
         cr = client.callProcedure("P1.insert", 3, null, 10, 1.1);
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
 
@@ -425,8 +423,8 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         ClientResponse cr;
         VoltTable result;
 
-        cr = client.callProcedure("P1.insert", 1, "贾鑫Vo", 10, 1.1);
-        cr = client.callProcedure("P1.insert", 2, "Xin@Volt", 10, 1.1);
+        client.callProcedure("P1.insert", 1, "贾鑫Vo", 10, 1.1);
+        client.callProcedure("P1.insert", 2, "Xin@Volt", 10, 1.1);
         cr = client.callProcedure("P1.insert", 3, null, 10, 1.1);
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
 
@@ -516,11 +514,11 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
             client.callProcedure("@AdHoc",
                     "select bdata, CHAR_LENGTH(bdata) from BINARYTEST where ID = 1");
           fail("char_length on columns which are not string expression is not supported");
-        }
-        catch (ProcCallException pce) {
-            final String msg = pce.getMessage();
-            assertTrue(msg
-                    .contains("Cannot apply 'CHAR_LENGTH' to arguments of type 'CHAR_LENGTH(<VARBINARY(256)>)'. Supported form(s): 'CHAR_LENGTH(<CHARACTER>)'"));
+        } catch (ProcCallException pce) {
+            assertTrue(pce.getMessage().contains(
+                    m_usingCalcite ?
+                            "Cannot apply 'CHAR_LENGTH' to arguments of type 'CHAR_LENGTH(<VARBINARY(256)>)'. Supported form(s): 'CHAR_LENGTH(<CHARACTER>)'" :
+                            "incompatible data type in operation"));
         }
 
     }
@@ -541,11 +539,11 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         ClientResponse cr;
         VoltTable result;
 
-        cr = client.callProcedure("@AdHoc", "Delete from P1;");
-        cr = client.callProcedure("P1.insert", 1, "IBM", 10, 1.1);
-        cr = client.callProcedure("P1.insert", 2, "Microsoft", 10, 1.1);
-        cr = client.callProcedure("P1.insert", 3, "Hewlett Packard", 10, 1.1);
-        cr = client.callProcedure("P1.insert", 4, "Gateway", 10, 1.1);
+        client.callProcedure("@AdHoc", "Delete from P1;");
+        client.callProcedure("P1.insert", 1, "IBM", 10, 1.1);
+        client.callProcedure("P1.insert", 2, "Microsoft", 10, 1.1);
+        client.callProcedure("P1.insert", 3, "Hewlett Packard", 10, 1.1);
+        client.callProcedure("P1.insert", 4, "Gateway", 10, 1.1);
         cr = client.callProcedure("P1.insert", 5, null, 10, 1.1);
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
 
@@ -637,9 +635,9 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         ClientResponse cr;
         VoltTable result;
 
-        cr = client.callProcedure("@AdHoc", "Delete from P1;");
-        cr = client.callProcedure("P1.insert", 1, "zheng", 10, 1.1);
-        cr = client.callProcedure("P1.insert", 2, "li", 10, 1.1);
+        client.callProcedure("@AdHoc", "Delete from P1;");
+        client.callProcedure("P1.insert", 1, "zheng", 10, 1.1);
+        client.callProcedure("P1.insert", 2, "li", 10, 1.1);
         cr = client.callProcedure("P1.insert", 3, null, 10, 1.1);
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
 
@@ -649,7 +647,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         result = cr.getResults()[0];
         assertEquals(1, result.getRowCount());
         assertTrue(result.advanceRow());
-        assertEquals(null,result.getString(1));
+        assertNull(result.getString(1));
     }
 
     private void subtestDECODEVeryLong() throws IOException, ProcCallException {
@@ -658,9 +656,9 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         ClientResponse cr;
         VoltTable result;
 
-        cr = client.callProcedure("@AdHoc", "Delete from P1;");
-        cr = client.callProcedure("P1.insert", 1, "zheng", 10, 1.1);
-        cr = client.callProcedure("P1.insert", 2, "li", 10, 1.1);
+        client.callProcedure("@AdHoc", "Delete from P1;");
+        client.callProcedure("P1.insert", 1, "zheng", 10, 1.1);
+        client.callProcedure("P1.insert", 2, "li", 10, 1.1);
         cr = client.callProcedure("P1.insert", 3, null, 10, 1.1);
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
 
@@ -679,7 +677,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         ClientResponse cr;
         VoltTable result;
 
-        cr = client.callProcedure("@AdHoc", "Delete from P3_INLINE_DESC;");
+        client.callProcedure("@AdHoc", "Delete from P3_INLINE_DESC;");
         cr = client.callProcedure("P3_INLINE_DESC.insert", 1, "zheng", "zheng2", 10, 1.1);
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
 
@@ -724,8 +722,6 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
             assertEquals(1, result.getRowCount());
             assertTrue(result.advanceRow());
             assertEquals("zheng",result.getString(0));
-
-
         } catch (ProcCallException pce) {
             System.out.println(pce);
             fail("Looks like a regression of ENG-5078 inline varchar column pass-through by decode");
@@ -738,9 +734,9 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         ClientResponse cr;
         VoltTable result;
 
-        cr = client.callProcedure("@AdHoc", "Delete from P1;");
-        cr = client.callProcedure("P1.insert", 1, "zheng", 10, 1.1);
-        cr = client.callProcedure("P1.insert", 2, "li", 10, 1.1);
+        client.callProcedure("@AdHoc", "Delete from P1;");
+        client.callProcedure("P1.insert", 1, "zheng", 10, 1.1);
+        client.callProcedure("P1.insert", 2, "li", 10, 1.1);
         cr = client.callProcedure("P1.insert", 3, null, 10, 1.1);
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
 
@@ -858,8 +854,8 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
                 "null ratio", "null tm", "null var", "null dec"});
 
 
-        cr = client.callProcedure("P2.insert", 1, new Timestamp(1000L));
-        cr = client.callProcedure("P2.insert", 2, null);
+        client.callProcedure("P2.insert", 1, new Timestamp(1000L));
+        client.callProcedure("P2.insert", 2, null);
         // Test timestamp
         cr = client.callProcedure("TestDecodeNullTimestamp", 1);
         checkDecodeNullResult(cr, new String[]{"2013-07-18 02:00:00.123457"});
@@ -877,7 +873,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         // Test Null return type
         cr = client.callProcedure("@AdHoc","select DECODE(tiny, 4, 5, NULL, NULL, 10) " +
                 " from R3 where id = 2");
-        assertTrue(cr.getResults()[0].getRowCount() == 1);
+        assertEquals(1, cr.getResults()[0].getRowCount());
         assertTrue(cr.getResults()[0].advanceRow());
         assertEquals(Integer.MIN_VALUE, cr.getResults()[0].getLong(0));
 
@@ -923,7 +919,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
 
         // Test user error input, Only accept JDBC's timestamp format: YYYY-MM-DD-SS.sss.
         try {
-            cr = client.callProcedure("@AdHoc", "select SINCE_EPOCH (MICROS, 'I am a timestamp')  from P2 where id = 5");
+            client.callProcedure("@AdHoc", "select SINCE_EPOCH (MICROS, 'I am a timestamp')  from P2 where id = 5");
             fail();
         } catch (Exception ex) {
             assertTrue(ex.getMessage().contains("SQL error while compiling query"));
@@ -1016,57 +1012,40 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         VoltTable result;
 
         // Test user-found anomaly around complex filter using functions
-        try {
-            cr = client.callProcedure("@Explain",
-                    "SELECT TOP ? * FROM PAULTEST WHERE NAME IS NOT NULL AND " +
-                    "    ( LOCK_TIME IS NULL OR " +
-                    "      SINCE_EPOCH(MILLIS,CURRENT_TIMESTAMP)-? < SINCE_EPOCH(MILLIS,LOCK_TIME) );",
-                    10, 5000);
-            //* enable for debug */ System.out.println(cr.getResults()[0]);
-        } catch (Exception ex) {
-            fail();
-        }
+        client.callProcedure("@Explain",
+                "SELECT TOP ? * FROM PAULTEST WHERE NAME IS NOT NULL AND " +
+                        "    ( LOCK_TIME IS NULL OR " +
+                        "      SINCE_EPOCH(MILLIS,CURRENT_TIMESTAMP)-? < SINCE_EPOCH(MILLIS,LOCK_TIME) );",
+                10, 5000);
+        //* enable for debug */ System.out.println(cr.getResults()[0]);
 
-        try {
-            cr = client.callProcedure("@AdHoc",
-                    "SELECT TOP ? * FROM PAULTEST WHERE NAME IS NOT NULL AND " +
-                    "    ( LOCK_TIME IS NULL OR " +
-                    "      SINCE_EPOCH(MILLIS,CURRENT_TIMESTAMP)-? < SINCE_EPOCH(MILLIS,LOCK_TIME) );",
-                    10, 10000);
-            result = cr.getResults()[0];
-            assertEquals(0, result.getRowCount());
-            //* enable for debug */ System.out.println(result);
-        } catch (Exception ex) {
-            fail();
-        }
+        cr = client.callProcedure("@AdHoc",
+                "SELECT TOP ? * FROM PAULTEST WHERE NAME IS NOT NULL AND " +
+                        "    ( LOCK_TIME IS NULL OR " +
+                        "      SINCE_EPOCH(MILLIS,CURRENT_TIMESTAMP)-? < SINCE_EPOCH(MILLIS,LOCK_TIME) );",
+                10, 10000);
+        result = cr.getResults()[0];
+        assertEquals(0, result.getRowCount());
+        //* enable for debug */ System.out.println(result);
 
-        try {
-            cr = client.callProcedure("GOT_BAD_PARAM_COUNTS_INLINE", 10, 10000);
-            result = cr.getResults()[0];
-            assertEquals(0, result.getRowCount());
-            //* enable for debug */ System.out.println(result);
-        } catch (Exception ex) {
-            fail();
-        }
+        cr = client.callProcedure("GOT_BAD_PARAM_COUNTS_INLINE", 10, 10000);
+        result = cr.getResults()[0];
+        assertEquals(0, result.getRowCount());
+        //* enable for debug */ System.out.println(result);
 
-        try {
-            cr = client.callProcedure("GotBadParamCountsInJava", 10, 10000);
-            result = cr.getResults()[0];
-            assertEquals(0, result.getRowCount());
-            //* enable for debug */ System.out.println(result);
-        } catch (Exception ex) {
-            fail();
-        }
+        cr = client.callProcedure("GotBadParamCountsInJava", 10, 10000);
+        result = cr.getResults()[0];
+        assertEquals(0, result.getRowCount());
+        //* enable for debug */ System.out.println(result);
 
         try {
             // Purposely neglecting to list an select columns or '*'.
-            cr = client.callProcedure("@Explain", "SELECT TOP ? FROM PAULTEST WHERE NAME IS NOT NULL AND (LOCK_TIME IS NULL OR SINCE_EPOCH(MILLIS,CURRENT_TIMESTAMP)-? < SINCE_EPOCH(MILLIS,LOCK_TIME));");
+            client.callProcedure("@Explain", "SELECT TOP ? FROM PAULTEST WHERE NAME IS NOT NULL AND (LOCK_TIME IS NULL OR SINCE_EPOCH(MILLIS,CURRENT_TIMESTAMP)-? < SINCE_EPOCH(MILLIS,LOCK_TIME));");
             //* enable for debug */ System.out.println(cr.getResults()[0]);
             fail("Expected to detect missing SELECT columns");
         } catch (Exception ex) {
             assertTrue(ex.getMessage().contains("SQL error while compiling query"));
             assertTrue(ex.getMessage().contains("unexpected token: FROM"));
-            return;
         }
         //* enable for debug */ System.out.println(cr.getResults()[0]);
     }
@@ -1077,10 +1056,10 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         ClientResponse cr;
         VoltTable result;
 
-        cr = client.callProcedure("P2.insert", 0, new Timestamp(0L));
-        cr = client.callProcedure("P2.insert", 1, new Timestamp(1L));
-        cr = client.callProcedure("P2.insert", 2, new Timestamp(1000L));
-        cr = client.callProcedure("P2.insert", 3, new Timestamp(-1000L));
+        client.callProcedure("P2.insert", 0, new Timestamp(0L));
+        client.callProcedure("P2.insert", 1, new Timestamp(1L));
+        client.callProcedure("P2.insert", 2, new Timestamp(1000L));
+        client.callProcedure("P2.insert", 3, new Timestamp(-1000L));
 
         // Test AdHoc
         cr = client.callProcedure("@AdHoc", "select to_timestamp(second, 1372640523) from P2 limit 1");
@@ -1092,7 +1071,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
 
         // Test string input number, expect error
         try {
-            cr = client.callProcedure("@AdHoc", "select to_timestamp(second, '1372640523') from P2 limit 1");
+            client.callProcedure("@AdHoc", "select to_timestamp(second, '1372640523') from P2 limit 1");
             fail();
         } catch (Exception ex) {
             assertTrue(ex.getMessage().contains("SQL error while compiling query"));
@@ -1196,7 +1175,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         // Test Standard TRUNCATE function for floating numbers
         Exception ex = null;
         try {
-            cr = client.callProcedure("@AdHoc", "select TRUNCATE (1.2, 1), TM from P2 where id = 0");
+            client.callProcedure("@AdHoc", "select TRUNCATE (1.2, 1), TM from P2 where id = 0");
         } catch (Exception e) {
             System.out.println(e.getMessage());
             ex = e;
@@ -1212,7 +1191,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
 
         ex = null;
         try {
-            cr = client.callProcedure("TRUNCATE", 0);
+            client.callProcedure("TRUNCATE", 0);
         } catch (Exception e) {
             System.out.println(e.getMessage());
             ex = e;
@@ -1389,41 +1368,36 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
 
         for (String procname : jsonProcs) {
             try {
-                cr = client.callProcedure(procname, 1, "id", "1");
+                client.callProcedure(procname, 1, "id", "1");
                 fail("document validity check failed for " + procname);
-            }
-            catch(ProcCallException pcex) {
+            } catch(ProcCallException pcex) {
                 assertTrue(pcex.getMessage().contains("Invalid JSON * Line 1, Column 9"));
             }
 
             try {
-                cr = client.callProcedure(procname, 2, "id", "2");
+                client.callProcedure(procname, 2, "id", "2");
                 fail("document validity check failed for " + procname);
-            }
-            catch(ProcCallException pcex) {
+            } catch(ProcCallException pcex) {
                 assertTrue(pcex.getMessage().contains("Invalid JSON * Line 1, Column 16"));
             }
 
             try {
-                cr = client.callProcedure(procname, 3, "id", "3");
+                client.callProcedure(procname, 3, "id", "3");
                 fail("document validity check failed for " + procname);
-            }
-            catch(ProcCallException pcex) {
+            } catch(ProcCallException pcex) {
                 assertTrue(pcex.getMessage().contains("Invalid JSON * Line 1, Column 30"));
             }
 
             try {
-                cr = client.callProcedure(procname, 4, "id", "4");
+                client.callProcedure(procname, 4, "id", "4");
                 fail("document validity check failed for " + procname);
-            }
-            catch(ProcCallException pcex) {
+            } catch(ProcCallException pcex) {
                 assertTrue(pcex.getMessage().contains("Invalid JSON * Line 1, Column 11"));
             }
         }
     }
 
-    public void testFormatCurrency() throws Exception
-    {
+    public void testFormatCurrency() throws Exception {
         System.out.println("STARTING testFormatCurrency");
         Client client = getClient();
         ClientResponse cr = null;
@@ -1597,14 +1571,13 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
 
         // out of int64_t range
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(dec, 2) from D1 where id = 8");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(dec, 2) from D1 where id = 8");
             fail("range validity check failed for FORMAT_CURRENCY");
-        }
-        catch (ProcCallException pcex) {
+        } catch (ProcCallException pcex) {
             assertTrue(pcex.getMessage().contains("out of range"));
         }
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(dec, 2) from D1 where id = 9");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(dec, 2) from D1 where id = 9");
             fail("range validity check failed for FORMAT_CURRENCY");
         }
         catch (ProcCallException pcex) {
@@ -1613,50 +1586,50 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
 
         // check invalid type
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(id, 2) from R3 where id = 1");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(id, 2) from R3 where id = 1");
             fail("type validity check failed for FORMAT_CURRENCY");
         } catch (ProcCallException pcex){
             assertTrue(pcex.getMessage().contains("can't be cast as DECIMAL"));
         }
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(tiny, 2) from R3 where id = 1");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(tiny, 2) from R3 where id = 1");
             fail("type validity check failed for FORMAT_CURRENCY");
         } catch (ProcCallException pcex){
             assertTrue(pcex.getMessage().contains("can't be cast as DECIMAL"));
         }
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(small, 2) from R3 where id = 1");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(small, 2) from R3 where id = 1");
             fail("type validity check failed for FORMAT_CURRENCY");
         } catch (ProcCallException pcex){
             assertTrue(pcex.getMessage().contains("can't be cast as DECIMAL"));
         }
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(num, 2) from R3 where id = 1");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(num, 2) from R3 where id = 1");
             fail("type validity check failed for FORMAT_CURRENCY");
         } catch (ProcCallException pcex){
             assertTrue(pcex.getMessage().contains("can't be cast as DECIMAL"));
         }
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(big, 2) from R3 where id = 1");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(big, 2) from R3 where id = 1");
             fail("type validity check failed for FORMAT_CURRENCY");
         } catch (ProcCallException pcex){
             assertTrue(pcex.getMessage().contains("can't be cast as DECIMAL"));
         }
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(ratio, 2) from R3 where id = 1");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(ratio, 2) from R3 where id = 1");
             fail("type validity check failed for FORMAT_CURRENCY");
         } catch (ProcCallException pcex){
             assertTrue(pcex.getMessage().contains("can't be cast as DECIMAL"));
         }
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(tm, 2) from R3 where id = 1");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(tm, 2) from R3 where id = 1");
             fail("type validity check failed for FORMAT_CURRENCY");
         } catch (ProcCallException pcex){
             // TODO: I have no idea why the exception is different
             assertTrue(pcex.getMessage().contains("incompatible data type in operation"));
         }
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(var, 2) from R3 where id = 1");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(var, 2) from R3 where id = 1");
             fail("type validity check failed for FORMAT_CURRENCY");
         } catch (ProcCallException pcex){
             assertTrue(pcex.getMessage().contains("incompatible data type in operation"));
@@ -1703,7 +1676,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         }
         // it will go out of the range of int64_t
         try {
-            cr = client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(DEC, -19) from D1 where id = 12");
+            client.callProcedure("@AdHoc", "select FORMAT_CURRENCY(DEC, -19) from D1 where id = 12");
             fail("type validity check failed for FORMAT_CURRENCY");
         } catch (ProcCallException pcex){
             assertTrue(pcex.getMessage().contains("out of range"));
@@ -1754,16 +1727,13 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         }
 
         // check the validity of the second parameter
-        verifyStmtFails(client,
-                        "select FORMAT_CURRENCY(DEC, 15) from D1 where id = 0",
-                        "the second parameter");
-        verifyStmtFails(client,
-                        "select FORMAT_CURRENCY(DEC, -26) from D1 where id = 0",
-                        "the second parameter");
+        verifyStmtFails(client, "select FORMAT_CURRENCY(DEC, 15) from D1 where id = 0",
+                "the second parameter");
+        verifyStmtFails(client, "select FORMAT_CURRENCY(DEC, -26) from D1 where id = 0",
+                "the second parameter");
     }
 
-    public void testFunc_Str() throws Exception
-    {
+    public void testFunc_Str() throws Exception {
         System.out.println("STARTING testFunc_Str");
         Client client = getClient();
         ClientResponse cr = null;
@@ -1837,8 +1807,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         verifyStmtFails(client, "select STR(DEC, -19) from D1 where id = 12", "the second parameter should be <= 38 and > 0");
     }
 
-    public void testRound() throws Exception
-    {
+    public void testRound() throws Exception {
         System.out.println("STARTING testRound");
         Client client = getClient();
         ClientResponse cr = null;
@@ -2014,40 +1983,24 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         verifyStmtFails(client, "select ROUND(dec, 2) from D1 where id = 8", "out of range");
 
         // check invalid type
-        verifyStmtFails(client,
-                        "select ROUND(id, 2) from R3 where id = 1",
+        verifyStmtFails(client, "select ROUND(id, 2) from R3 where id = 1", "can't be cast as DECIMAL");
+        verifyStmtFails(client, "select ROUND(tiny, 2) from R3 where id = 1",
                         "can't be cast as DECIMAL");
-        verifyStmtFails(client,
-                        "select ROUND(tiny, 2) from R3 where id = 1",
-                        "can't be cast as DECIMAL");
-        verifyStmtFails(client,
-                        "select ROUND(small, 2) from R3 where id = 1",
-                        "can't be cast as DECIMAL");
-        verifyStmtFails(client,
-                        "select ROUND(num, 2) from R3 where id = 1",
-                        "can't be cast as DECIMAL");
-        verifyStmtFails(client,
-                        "select ROUND(big, 2) from R3 where id = 1",
-                        "can't be cast as DECIMAL");
-        verifyStmtFails(client,
-                        "select ROUND(tm, 2) from R3 where id = 1",
-                        "Cannot apply 'ROUND' to arguments of type");
-        verifyStmtFails(client,
-                        "select ROUND(var, 2) from R3 where id = 1",
-                        "Cannot apply 'ROUND' to arguments of type");
-        verifyStmtFails(client,
-                        "select ROUND(DEC, -19) from D1 where id = 12",
-                        "out of range");
+        verifyStmtFails(client, "select ROUND(small, 2) from R3 where id = 1", "can't be cast as DECIMAL");
+        verifyStmtFails(client, "select ROUND(num, 2) from R3 where id = 1", "can't be cast as DECIMAL");
+        verifyStmtFails(client, "select ROUND(big, 2) from R3 where id = 1", "can't be cast as DECIMAL");
+        verifyStmtFails(client, "select ROUND(tm, 2) from R3 where id = 1",
+                m_usingCalcite ? "Cannot apply 'ROUND' to arguments of type" : "incompatible data type in operation" );
+        verifyStmtFails(client, "select ROUND(var, 2) from R3 where id = 1",
+                m_usingCalcite ? "Cannot apply 'ROUND' to arguments of type" : "incompatible data type in operation" );
+        verifyStmtFails(client, "select ROUND(DEC, -19) from D1 where id = 12", "out of range");
         // check the validity of the second parameter
-        verifyStmtFails(client,
-                        "select ROUND(DEC, 15) from D1 where id = 0",
-                        "the second parameter");
-        verifyStmtFails(client,
-                        "select ROUND(DEC, -26) from D1 where id = 0",
-                        "the second parameter");
+        verifyStmtFails(client, "select ROUND(DEC, 15) from D1 where id = 0", "the second parameter");
+        verifyStmtFails(client, "select ROUND(DEC, -26) from D1 where id = 0",
+                "the second parameter");
     }
 
-    public void testConcat() throws NoConnectionsException, IOException, ProcCallException {
+    public void testConcat() throws IOException, ProcCallException {
         System.out.println("STARTING test Concat and its Operator");
         Client client = getClient();
         ClientResponse cr;
@@ -2125,7 +2078,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         validateTableColumnOfScalarVarchar(result, 1, new String[]{"Yetian@VoltDB1"});
 
         try {
-            cr = client.callProcedure("@AdHoc", "select CONCAT('a', 'b', id) from p1 where id = 1");
+            client.callProcedure("@AdHoc", "select CONCAT('a', 'b', id) from p1 where id = 1");
         } catch (ProcCallException pcex){
             assertTrue(pcex.getMessage().contains("can't be cast as VARCHAR"));
         }
@@ -2153,8 +2106,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
 
         int i = 0;
         for (long val : bitnotInterestingValues) {
-            client.callProcedure("@AdHoc", "insert into R3(id, big) values (?, ?)",
-                    i, val);
+            client.callProcedure("@AdHoc", "insert into R3(id, big) values (?, ?)", i, val);
             ++i;
         }
 
@@ -2204,7 +2156,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
 
         // bitnot(null) produces null
         long val = result.getLong(0);
-        assertEquals(true, result.wasNull());
+        assertTrue(result.wasNull());
         assertEquals(Long.MIN_VALUE, val);
 
         // bitnot(MAX_VALUE) produces MIN_VALUE, which would be
@@ -2364,14 +2316,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
 
         // normal tests
         long[] binInterestingValues = new long[] {
-            Long.MIN_VALUE + 1,
-            Long.MIN_VALUE + 1000,
-            -1,
-            0,
-            1,
-            1000,
-            Long.MAX_VALUE - 1,
-            Long.MAX_VALUE
+                Long.MIN_VALUE + 1, Long.MIN_VALUE + 1000, -1, 0, 1, 1000, Long.MAX_VALUE - 1, Long.MAX_VALUE
         };
 
         int i = 0;
@@ -2476,8 +2421,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
         if (ipVersion.length() == 0) {
             cr = client.callProcedure(tableName.toUpperCase() + ".INSERT", presentation, 0x0);
-        }
-        else {
+        } else {
             byte[] zeros = new byte[16];
             cr = client.callProcedure(tableName.toUpperCase() + ".INSERT", presentation, zeros);
         }
@@ -2487,11 +2431,9 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
             String sql = String.format("select inet%s_aton(pres) from %s;", ipVersion, tableName);
             cr = client.callProcedure("@AdHoc", sql);
             fail(String.format("Expected inet address %s to fail.", presentation));
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             ex = e;
-        }
-        finally {
+        } finally {
             assertNotNull(ex);
             assertTrue("Expected a SQL ERROR here", ex.getMessage().contains("SQL ERROR"));
         }
@@ -2538,8 +2480,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         if (bytes != null) {
             assertEquals(bytes.length, actual.length);
             assertEqualByteArrays(bytes, actual);
-        }
-        else {
+        } else {
             assertTrue(vt.wasNull());
         }
 
@@ -2550,8 +2491,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         actual_str = vt.getString(0);
         if (presentation != null) {
             assertEquals(presentation, actual_str);
-        }
-        else {
+        } else {
             assertTrue(vt.wasNull());
         }
 
@@ -2562,8 +2502,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         actual_str = vt.getString(0);
         if (presentation != null) {
             assertEquals(presentation, actual_str);
-        }
-        else {
+        } else {
             assertTrue(vt.wasNull());
         }
 
@@ -2574,8 +2513,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         actual = vt.getVarbinary(0);
         if (bytes != null) {
             assertEqualByteArrays(bytes, actual);
-        }
-        else {
+        } else {
             assertTrue(vt.wasNull());
         }
     }
@@ -2584,47 +2522,17 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         Client client = getClient();
 
         validateIPv4Addr(client, "INET4_TEST", null, null);
-        validateIPv4Addr(client,
-                         "INET4_TEST",
-                         "127.0.0.1",
-                         0x7f000001L);
-        validateIPv4Addr(client,
-                         "INET4_TEST_PPRES",
-                         "127.0.0.1",
-                         0x7f000001L);
-        validateIPv4Addr(client,
-                         "INET4_TEST",
-                         "192.168.7.40",
-                         0xc0a80728L);
-        validateIPv4Addr(client,
-                         "INET4_TEST_PPRES",
-                         "192.168.7.40",
-                         0xc0a80728L);
-        validateIPv4Addr(client,
-                         "INET4_TEST",
-                         "1.1.1.1",
-                         0x01010101L);
-        validateIPv4Addr(client,
-                         "INET4_TEST",
-                         "1.1.1.1",
-                         0x01010101L);
-        validateIPv4Addr(client,
-                         "INET4_TEST",
-                         "1.2.3.4",
-                         0x01020304L);
-        validateIPv4Addr(client,
-                         "INET4_TEST_PPRES",
-                         "1.2.3.4",
-                         0x01020304L);
-        invalidIPAddr(client,
-                        "INET4_TEST",
-                        "01.02.03.04");
-        invalidIPAddr(client,
-                        "INET4_TEST",
-                        "arglebargle");
-        invalidIPAddr(client,
-                        "INET4_TEST",
-                        "192.168.7.6/24");
+        validateIPv4Addr(client, "INET4_TEST", "127.0.0.1", 0x7f000001L);
+        validateIPv4Addr(client, "INET4_TEST_PPRES", "127.0.0.1", 0x7f000001L);
+        validateIPv4Addr(client, "INET4_TEST", "192.168.7.40", 0xc0a80728L);
+        validateIPv4Addr(client, "INET4_TEST_PPRES", "192.168.7.40", 0xc0a80728L);
+        validateIPv4Addr(client, "INET4_TEST", "1.1.1.1", 0x01010101L);
+        validateIPv4Addr(client, "INET4_TEST", "1.1.1.1", 0x01010101L);
+        validateIPv4Addr(client, "INET4_TEST", "1.2.3.4", 0x01020304L);
+        validateIPv4Addr(client, "INET4_TEST_PPRES", "1.2.3.4", 0x01020304L);
+        invalidIPAddr(client, "INET4_TEST", "01.02.03.04");
+        invalidIPAddr(client, "INET4_TEST", "arglebargle");
+        invalidIPAddr(client, "INET4_TEST", "192.168.7.6/24");
 
         // Only test for nulls on INET6_TEST and not the
         // partitioned table, since we can't insert a null
@@ -2633,90 +2541,38 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         // The function inet_ntop does not put leading zeros
         // in any of these numbers.  So "::0102:" would
         // fail.
-        validateIPv6Addr(client,
-                         "INET6_TEST",
-                         "ab01:cd12:ef21:1ab:12cd:34ef:a01b:c23d",
-                         new short[] {
-                                 (short)0xab01,
-                                 (short)0xcd12,
-                                 (short)0xef21,
-                                 (short)0x01ab,
-                                 (short)0x12cd,
-                                 (short)0x34ef,
-                                 (short)0xa01b,
-                                 (short)0xc23d
-                         });
-        validateIPv6Addr(client,
-                         "INET6_TEST_PPRES",
-                         "ab01:cd12:ef21:1ab:12cd:34ef:a01b:c23d",
-                         new short[] {
-                                 (short)0xab01,
-                                 (short)0xcd12,
-                                 (short)0xef21,
-                                 (short)0x01ab,
-                                 (short)0x12cd,
-                                 (short)0x34ef,
-                                 (short)0xa01b,
-                                 (short)0xc23d
-                         });
-        validateIPv6Addr(client,
-                         "INET6_TEST",
-                         "::",
-                         new short[] {
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000
-                         });
-        validateIPv6Addr(client,
-                         "INET6_TEST_PPRES",
-                         "::",
-                         new short[] {
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000
-                         });
-        validateIPv6Addr(client,
-                         "INET6_TEST",
-                         "::1",
-                         new short[] {
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0001
-                         });
-        validateIPv6Addr(client,
-                         "INET6_TEST_PPRES",
-                         "::1",
-                         new short[] {
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0000,
-                                 (short)0x0001
-                         });
-        invalidIPAddr(client,
-                        "INET6_TEST",
-                        ":::");
-        invalidIPAddr(client,
-                        "INET6_TEST",
-                        "arglebargle");
+        validateIPv6Addr(client, "INET6_TEST", "ab01:cd12:ef21:1ab:12cd:34ef:a01b:c23d",
+                new short[] {
+                        (short)0xab01, (short)0xcd12, (short)0xef21, (short)0x01ab,
+                        (short)0x12cd, (short)0x34ef, (short)0xa01b, (short)0xc23d
+                });
+        validateIPv6Addr(client, "INET6_TEST_PPRES", "ab01:cd12:ef21:1ab:12cd:34ef:a01b:c23d",
+                new short[] {
+                        (short)0xab01, (short)0xcd12, (short)0xef21, (short)0x01ab,
+                        (short)0x12cd, (short)0x34ef, (short)0xa01b, (short)0xc23d
+                });
+        validateIPv6Addr(client, "INET6_TEST", "::",
+                new short[] {
+                        (short)0x0000, (short)0x0000, (short)0x0000, (short)0x0000,
+                        (short)0x0000, (short)0x0000, (short)0x0000, (short)0x0000
+                });
+        validateIPv6Addr(client, "INET6_TEST_PPRES", "::",
+                new short[] {
+                        (short)0x0000, (short)0x0000, (short)0x0000, (short)0x0000,
+                        (short)0x0000, (short)0x0000, (short)0x0000, (short)0x0000
+                });
+        validateIPv6Addr(client, "INET6_TEST", "::1",
+                new short[] {
+                        (short)0x0000, (short)0x0000, (short)0x0000, (short)0x0000,
+                        (short)0x0000, (short)0x0000, (short)0x0000, (short)0x0001
+                });
+        validateIPv6Addr(client, "INET6_TEST_PPRES", "::1",
+                new short[] {
+                        (short)0x0000, (short)0x0000, (short)0x0000, (short)0x0000,
+                        (short)0x0000, (short)0x0000, (short)0x0000, (short)0x0001
+                });
+        invalidIPAddr(client, "INET6_TEST", ":::");
+        invalidIPAddr(client, "INET6_TEST", "arglebargle");
     }
 
     public void testDateadd() throws IOException, ProcCallException {
@@ -2730,8 +2586,8 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
                 "PARTITION TABLE P2 ON COLUMN ID;\n" +
          */
         Client client = getClient();
-        ClientResponse cr = null;
-        VoltTable vt = null;
+        ClientResponse cr;
+        VoltTable vt;
 
         cr = client.callProcedure("@AdHoc", "INSERT INTO P2 (ID, TM) VALUES (10000, '2000-01-01 01:00:00.000000');");
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
@@ -2931,15 +2787,15 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
                         + "DATEADD(SECOND, NULL,TM), DATEADD(MILLISECOND, NULL,TM), "
                         + "DATEADD(MICROSECOND, NULL,TM) FROM P2 WHERE ID = 20005;").getResults()[0];
         assertTrue(vt.advanceRow());
-        assertEquals(null, vt.getTimestampAsTimestamp(0));
-        assertEquals(null, vt.getTimestampAsTimestamp(1));
-        assertEquals(null, vt.getTimestampAsTimestamp(2));
-        assertEquals(null, vt.getTimestampAsTimestamp(3));
-        assertEquals(null, vt.getTimestampAsTimestamp(4));
-        assertEquals(null, vt.getTimestampAsTimestamp(5));
-        assertEquals(null, vt.getTimestampAsTimestamp(6));
-        assertEquals(null, vt.getTimestampAsTimestamp(7));
-        assertEquals(null, vt.getTimestampAsTimestamp(8));
+        assertNull(vt.getTimestampAsTimestamp(0));
+        assertNull(vt.getTimestampAsTimestamp(1));
+        assertNull(vt.getTimestampAsTimestamp(2));
+        assertNull(vt.getTimestampAsTimestamp(3));
+        assertNull(vt.getTimestampAsTimestamp(4));
+        assertNull(vt.getTimestampAsTimestamp(5));
+        assertNull(vt.getTimestampAsTimestamp(6));
+        assertNull(vt.getTimestampAsTimestamp(7));
+        assertNull(vt.getTimestampAsTimestamp(8));
 
         // Test null timestamp
         cr = client.callProcedure("@AdHoc", "INSERT INTO P2 (ID, TM) VALUES (20006, null)");
@@ -2952,15 +2808,15 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
                         + "DATEADD(SECOND, 1, TM), DATEADD(MILLISECOND, 1, TM), "
                         + "DATEADD(MICROSECOND, 1, TM) FROM P2 WHERE ID = 20006;").getResults()[0];
         assertTrue(vt.advanceRow());
-        assertEquals(null, vt.getTimestampAsTimestamp(0));
-        assertEquals(null, vt.getTimestampAsTimestamp(1));
-        assertEquals(null, vt.getTimestampAsTimestamp(2));
-        assertEquals(null, vt.getTimestampAsTimestamp(3));
-        assertEquals(null, vt.getTimestampAsTimestamp(4));
-        assertEquals(null, vt.getTimestampAsTimestamp(5));
-        assertEquals(null, vt.getTimestampAsTimestamp(6));
-        assertEquals(null, vt.getTimestampAsTimestamp(7));
-        assertEquals(null, vt.getTimestampAsTimestamp(8));
+        assertNull(vt.getTimestampAsTimestamp(0));
+        assertNull(vt.getTimestampAsTimestamp(1));
+        assertNull(vt.getTimestampAsTimestamp(2));
+        assertNull(vt.getTimestampAsTimestamp(3));
+        assertNull(vt.getTimestampAsTimestamp(4));
+        assertNull(vt.getTimestampAsTimestamp(5));
+        assertNull(vt.getTimestampAsTimestamp(6));
+        assertNull(vt.getTimestampAsTimestamp(7));
+        assertNull(vt.getTimestampAsTimestamp(8));
 
         // Test null or illegal datepart
         boolean throwed = false;
@@ -3199,36 +3055,43 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
             "PRIMARY KEY (ID) ); " +
          */
 
-       cr = client.callProcedure("@AdHoc", "INSERT INTO P1 (ID, DESC) VALUES (200, 'TEST reGexp_poSiTion123456Test')");
+       cr = client.callProcedure("@AdHoc",
+               "INSERT INTO P1 (ID, DESC) VALUES (200, 'TEST reGexp_poSiTion123456Test')");
         assertEquals(ClientResponse.SUCCESS, cr.getStatus());
 
-        vt = client.callProcedure("@AdHoc", "SELECT REGEXP_POSITION(DESC, 'TEST') FROM P1 WHERE REGEXP_POSITION(DESC, 'TEST') > 0;").getResults()[0];
+        vt = client.callProcedure("@AdHoc",
+                "SELECT REGEXP_POSITION(DESC, 'TEST') FROM P1 WHERE REGEXP_POSITION(DESC, 'TEST') > 0;").getResults()[0];
         assertTrue(vt.advanceRow());
         assertEquals(1, vt.asScalarLong());
 
-        vt = client.callProcedure("@AdHoc", "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]') > 0").getResults()[0];
+        vt = client.callProcedure("@AdHoc",
+                "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]') > 0").getResults()[0];
         assertFalse(vt.advanceRow());
 
-        vt = client.callProcedure("@AdHoc", "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[A-Z]') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[A-Z]') > 0").getResults()[0];
+        vt = client.callProcedure("@AdHoc",
+                "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[A-Z]') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[A-Z]') > 0").getResults()[0];
         assertTrue(vt.advanceRow());
         assertEquals(20, vt.asScalarLong());
 
-        vt = client.callProcedure("@AdHoc", "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]', 'i') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]', 'i') > 0").getResults()[0];
+        vt = client.callProcedure("@AdHoc",
+                "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]', 'i') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]', 'i') > 0").getResults()[0];
         assertTrue(vt.advanceRow());
         assertEquals(20, vt.asScalarLong());
 
-        vt = client.callProcedure("@AdHoc", "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]', 'ci') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[A-Z]') > 0").getResults()[0];
+        vt = client.callProcedure("@AdHoc",
+                "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]', 'ci') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[A-Z]') > 0").getResults()[0];
         assertTrue(vt.advanceRow());
         assertEquals(20, vt.asScalarLong());
 
-        vt = client.callProcedure("@AdHoc", "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]', 'iiccii') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[A-Z]') > 0").getResults()[0];
+        vt = client.callProcedure("@AdHoc",
+                "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[a-z]', 'iiccii') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[A-Z]') > 0").getResults()[0];
         assertTrue(vt.advanceRow());
         assertEquals(20, vt.asScalarLong());
 
         boolean expectedExceptionThrowed = false;
         try {
             client.callProcedure("@AdHoc", "SELECT REGEXP_POSITION(DESC, '[a-z](a]') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](a]') > 0");
-            assertFalse("Expected exception for illegal regular expression in regexp_position.", true);
+            fail("Expected exception for illegal regular expression in regexp_position.");
         } catch (ProcCallException e) {
             assertEquals(ClientResponse.GRACEFUL_FAILURE, e.getClientResponse().getStatus());
             assertTrue(e.getClientResponse().getStatusString().contains("Regular Expression Compilation Error: missing closing parenthesis"));
@@ -3239,7 +3102,7 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         expectedExceptionThrowed = false;
         try {
             client.callProcedure("@AdHoc", "SELECT REGEXP_POSITION(DESC, '[a-z](\\d+)[A-Z]', 'k') FROM P1 WHERE REGEXP_POSITION(DESC, '[a-z](\\d+)[A-Z]', 'k') > 0");
-            assertFalse("Expected exception for illegal match flag in regexp_position.", true);
+            fail("Expected exception for illegal match flag in regexp_position.");
         } catch (ProcCallException e) {
             assertEquals(ClientResponse.GRACEFUL_FAILURE, e.getClientResponse().getStatus());
             assertTrue(e.getClientResponse().getStatusString().contains("Illegal Match Flags"));
@@ -3336,20 +3199,13 @@ public class TestFunctionsForVoltDBSuite extends RegressionSuite {
         doTestIsValidTimestamp(202, true);
 
         // How these functions might typically be used:
-        validateTableOfLongs(client,
-                "update p2 "
-                + "set tm = min_valid_timestamp() "
-                + "where tm < min_valid_timestamp()",
+        validateTableOfLongs(client, "update p2 set tm = min_valid_timestamp() where tm < min_valid_timestamp()",
                 new long[][] {{1}});
-        validateTableOfLongs(client,
-                "update p2 "
-                + "set tm = max_valid_timestamp() "
-                + "where tm > max_valid_timestamp()",
+        validateTableOfLongs(client, "update p2 set tm = max_valid_timestamp() where tm > max_valid_timestamp()",
                 new long[][] {{1}});
 
         // No more invalid timestamps
-        validateTableOfLongs(client,
-                "select * from p2 where not is_valid_timestamp(tm)",
+        validateTableOfLongs(client, "select * from p2 where not is_valid_timestamp(tm)",
                 new long[][] {});
     }
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -917,7 +917,9 @@ public class TestFunctionsSuite extends RegressionSuite {
             doTestThreeColCoalesce(cl, "S1", "I2", "V3", "100");
             fail();
         } catch (ProcCallException pcex){
-            assertTrue(pcex.getMessage().contains("Illegal mixing of types in CASE or COALESCE statement"));
+            assertTrue(pcex.getMessage().contains(
+                    m_usingCalcite ? "Illegal mixing of types in CASE or COALESCE statement" :
+                            "incompatible data types in combination"));
         }
         try {
             doTestThreeColCoalesce(cl, "S1", "I2", "T3", "100");

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite2.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite2.java
@@ -189,10 +189,14 @@ public class TestFunctionsSuite2 extends RegressionSuite {
         verifyStmtFails(client, "select MOD(NULL, NULL) from R1", "data type cast needed for parameter or null literal");
 
         // Mix of decimal and ints
-        verifyStmtFails(client, "select MOD(25.32, 2) from R1", "Cannot apply 'MOD' to arguments of type");
-        verifyStmtFails(client, "select MOD(2, 25.32) from R1", "Cannot apply 'MOD' to arguments of type");
-        verifyStmtFails(client, "select MOD('-25.32', 2.5) from R1", "Cannot apply 'MOD' to arguments of type");
-        verifyStmtFails(client, "select MOD(-25.32, ratio) from R1", "Cannot apply 'MOD' to arguments of type");
+        verifyStmtFails(client, "select MOD(25.32, 2) from R1",
+                m_usingCalcite ? "Cannot apply 'MOD' to arguments of type" : "incompatible data type in operation");
+        verifyStmtFails(client, "select MOD(2, 25.32) from R1",
+                m_usingCalcite ? "Cannot apply 'MOD' to arguments of type" : "incompatible data type in operation");
+        verifyStmtFails(client, "select MOD('-25.32', 2.5) from R1",
+                m_usingCalcite ? "Cannot apply 'MOD' to arguments of type" : "incompatible data type in operation");
+        verifyStmtFails(client, "select MOD(-25.32, ratio) from R1",
+                m_usingCalcite ? "Cannot apply 'MOD' to arguments of type" : "incompatible data type in operation");
     }
 
     @Test
@@ -231,7 +235,8 @@ public class TestFunctionsSuite2 extends RegressionSuite {
         assertEquals( 0, r.get("C1", VoltType.INTEGER));
 
         // invalid data type for unary minus
-        verifyStmtFails(client, "select -desc from P1", "Cannot apply '-' to arguments of type");
+        verifyStmtFails(client, "select -desc from P1",
+                m_usingCalcite ? "Cannot apply '-' to arguments of type" : "incompatible data type in operation");
 
         // check -(-var) = var
         cr = client.callProcedure("@AdHoc", "select num, -(-num) from P1");
@@ -799,14 +804,15 @@ public class TestFunctionsSuite2 extends RegressionSuite {
         r.advanceToRow(4);
         resultB = r.getLong(0);
         assertEquals(10, resultB);
+        final String expectedErrorMessage = m_usingCalcite ?
+                    "Cannot apply 'ABS' to arguments of type" : "incompatible data type in operation";
 
         boolean caught = false;
         try {
             cr = client.callProcedure("@AdHoc", "select count(*) from P1 where not ABS(DESC) > 9");
             assertTrue(cr.getStatus() != ClientResponse.SUCCESS);
         } catch (ProcCallException e) {
-            String msg = e.getMessage();
-            assertTrue(msg.contains("Cannot apply 'ABS' to arguments of type"));
+            assertTrue(e.getMessage().contains(expectedErrorMessage));
             caught = true;
         }
         assertTrue(caught);
@@ -816,8 +822,7 @@ public class TestFunctionsSuite2 extends RegressionSuite {
             cr = client.callProcedure("@AdHoc", "select count(*) from P1 where not ABS(DESC) > 'ABC'");
             assertTrue(cr.getStatus() != ClientResponse.SUCCESS);
         } catch (ProcCallException e) {
-            String msg = e.getMessage();
-            assertTrue(msg.contains("Cannot apply 'ABS' to arguments of type"));
+            assertTrue(e.getMessage().contains(expectedErrorMessage));
             caught = true;
         }
         assertTrue(caught);
@@ -970,12 +975,13 @@ public class TestFunctionsSuite2 extends RegressionSuite {
         assertTrue(caught);
 
         caught = false;
+        final String expectedErrorMessage = m_usingCalcite ?
+                    "Cannot apply 'SUBSTRING' to arguments of type" : "incompatible data type in operation";
         try {
             cr = client.callProcedure("@AdHoc", "select count(*) from P1 where not SUBSTRING (1 FROM 2) > 9");
             assertTrue(cr.getStatus() != ClientResponse.SUCCESS);
         } catch (ProcCallException e) {
-            String msg = e.getMessage();
-            assertTrue(msg.contains("Cannot apply 'SUBSTRING' to arguments of type"));
+            assertTrue(e.getMessage().contains(expectedErrorMessage));
             caught = true;
         }
         assertTrue(caught);
@@ -985,8 +991,7 @@ public class TestFunctionsSuite2 extends RegressionSuite {
             cr = client.callProcedure("@AdHoc", "select count(*) from P1 where not SUBSTRING (1 FROM DESC) > '9'");
             assertTrue(cr.getStatus() != ClientResponse.SUCCESS);
         } catch (ProcCallException e) {
-            String msg = e.getMessage();
-            assertTrue(msg.contains("Cannot apply 'SUBSTRING' to arguments of type"));
+            assertTrue(e.getMessage().contains(expectedErrorMessage));
             caught = true;
         }
         assertTrue(caught);
@@ -996,8 +1001,7 @@ public class TestFunctionsSuite2 extends RegressionSuite {
             cr = client.callProcedure("@AdHoc", "select count(*) from P1 where not SUBSTRING (DESC FROM DESC) > 'ABC'");
             assertTrue(cr.getStatus() != ClientResponse.SUCCESS);
         } catch (ProcCallException e) {
-            String msg = e.getMessage();
-            assertTrue(msg.contains("Cannot apply 'SUBSTRING' to arguments of type"));
+            assertTrue(e.getMessage().contains(expectedErrorMessage));
             caught = true;
         }
         assertTrue(caught);

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyPointValue.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyPointValue.java
@@ -45,10 +45,7 @@ public class TestGeographyPointValue extends RegressionSuite {
 
     private int fillTable(Client client, int startPk) throws Exception {
         validateTableOfScalarLongs(client,
-                "insert into t values "
-                        + "(" + startPk + ", "
-                        + "'Bedford', "
-                        + "pointfromtext('" + BEDFORD_PT.toString() + "'));",
+                "insert into t values (" + startPk + ", 'Bedford', pointfromtext('" + BEDFORD_PT.toString() + "'));",
                 new long[] {1});
         startPk++;
 
@@ -58,8 +55,7 @@ public class TestGeographyPointValue extends RegressionSuite {
                 .getResults()[0];
         validateTableOfScalarLongs(vt, new long[] {1});
         startPk++;
-        validateTableOfScalarLongs(client,
-                "insert into t values (" + startPk + ", 'Atlantis', null);",
+        validateTableOfScalarLongs(client, "insert into t values (" + startPk + ", 'Atlantis', null);",
                 new long[] {1});
         startPk++;
         return startPk;
@@ -68,15 +64,12 @@ public class TestGeographyPointValue extends RegressionSuite {
     public void testInsertDefaultNull() throws IOException, ProcCallException {
         Client client = getClient();
 
-        validateTableOfScalarLongs(client,
-                "insert into t (pk) values (1);",
-                new long[] {1});
+        validateTableOfScalarLongs(client, "insert into t (pk) values (1);", new long[] {1});
 
         VoltTable vt = client.callProcedure("@AdHoc", "select pk, pt from t;").getResults()[0];
         String actual = vt.toString();
         String expectedPart = "NULL";
-        assertTrue(actual + " does not contain " + expectedPart,
-                actual.contains(expectedPart));
+        assertTrue(actual + " does not contain " + expectedPart, actual.contains(expectedPart));
 
         assertTrue(vt.advanceRow());
         long id = vt.getLong(0);
@@ -100,9 +93,7 @@ public class TestGeographyPointValue extends RegressionSuite {
     public void testPointFromText() throws Exception {
         Client client = getClient();
 
-        validateTableOfScalarLongs(client,
-                "insert into t (pk) values (1);",
-                new long[] {1});
+        validateTableOfScalarLongs(client, "insert into t (pk) values (1);", new long[] {1});
 
         VoltTable vt = client.callProcedure("@AdHoc",
                 "select pointfromtext('point (-71.2767 42.4906)') from t;").getResults()[0];
@@ -121,22 +112,19 @@ public class TestGeographyPointValue extends RegressionSuite {
 
         // Self join to test EQ operator
         VoltTable vt = client.callProcedure("@AdHoc",
-                "select t1.pk, t1.name, t1.pt "
-                + "from t as t1, t as t2 "
-                + "where t1.pt = t2.pt "
-                + "order by t1.pk;").getResults()[0];
+                "select t1.pk, t1.name, t1.pt from t as t1, t as t2 where t1.pt = t2.pt order by t1.pk;")
+                .getResults()[0];
 
         assertApproximateContentOfTable(new Object[][] {
                 {0, "Bedford", BEDFORD_PT},
-                {1, "Santa Clara", SANTA_CLARA_PT}},
+                {1, "Santa Clara", SANTA_CLARA_PT}
+                },
                 vt, EPSILON);
 
         // Self join to test not equals operator
         vt = client.callProcedure("@AdHoc",
-                "select t1.pk, t1.pt, t2.pt "
-                + "from t as t1, t as t2 "
-                + "where t1.pt <> t2.pt "
-                + "order by t1.pk, t1.pt;").getResults()[0];
+                "select t1.pk, t1.pt, t2.pt from t as t1, t as t2 where t1.pt <> t2.pt order by t1.pk, t1.pt;")
+                .getResults()[0];
 
         assertApproximateContentOfTable (new Object[][] {
                 {0, BEDFORD_PT, SANTA_CLARA_PT},
@@ -145,21 +133,16 @@ public class TestGeographyPointValue extends RegressionSuite {
 
         // Self join to test < operator
         vt = client.callProcedure("@AdHoc",
-                "select t1.pk, t1.pt, t2.pt "
-                + "from t as t1, t as t2 "
-                + "where t1.pt < t2.pt "
-                + "order by t1.pk, t1.pt;").getResults()[0];
+                "select t1.pk, t1.pt, t2.pt from t as t1, t as t2 where t1.pt < t2.pt order by t1.pk, t1.pt;")
+                .getResults()[0];
 
-        assertApproximateContentOfTable (new Object[][] {
-                {1, SANTA_CLARA_PT, BEDFORD_PT}},
+        assertApproximateContentOfTable (new Object[][] {{1, SANTA_CLARA_PT, BEDFORD_PT}},
                 vt, EPSILON);
 
         // Self join to test <= operator
         vt = client.callProcedure("@AdHoc",
-                "select t1.pk, t1.pt, t2.pt "
-                + "from t as t1, t as t2 "
-                + "where t1.pt <= t2.pt "
-                + "order by t1.pk, t1.pt, t2.pt;").getResults()[0];
+                "select t1.pk, t1.pt, t2.pt from t as t1, t as t2 where t1.pt <= t2.pt order by t1.pk, t1.pt, t2.pt;")
+                .getResults()[0];
 
         assertApproximateContentOfTable (new Object[][] {
                 {0, BEDFORD_PT, BEDFORD_PT},
@@ -169,21 +152,15 @@ public class TestGeographyPointValue extends RegressionSuite {
 
         // Self join to test > operator
         vt = client.callProcedure("@AdHoc",
-                "select t1.pk, t1.pt, t2.pt "
-                + "from t as t1, t as t2 "
-                + "where t1.pt > t2.pt "
-                + "order by t1.pk, t1.pt;").getResults()[0];
+                "select t1.pk, t1.pt, t2.pt from t as t1, t as t2 where t1.pt > t2.pt order by t1.pk, t1.pt;")
+                .getResults()[0];
 
-        assertApproximateContentOfTable (new Object[][] {
-                {0, BEDFORD_PT, SANTA_CLARA_PT}},
-                vt, EPSILON);
+        assertApproximateContentOfTable (new Object[][] {{0, BEDFORD_PT, SANTA_CLARA_PT}}, vt, EPSILON);
 
         // Self join to test >= operator
         vt = client.callProcedure("@AdHoc",
-                "select t1.pk, t1.pt, t2.pt "
-                + "from t as t1, t as t2 "
-                + "where t1.pt >= t2.pt "
-                + "order by t1.pk, t1.pt, t2.pt;").getResults()[0];
+                "select t1.pk, t1.pt, t2.pt from t as t1, t as t2 where t1.pt >= t2.pt order by t1.pk, t1.pt, t2.pt;")
+                .getResults()[0];
 
         assertApproximateContentOfTable (new Object[][] {
                 {0, BEDFORD_PT, SANTA_CLARA_PT},
@@ -193,25 +170,17 @@ public class TestGeographyPointValue extends RegressionSuite {
 
         // Test IS NULL
         vt = client.callProcedure("@AdHoc",
-                "select t1.pk, t1.name, t1.pt "
-                + "from t as t1 "
-                + "where t1.pt is null "
-                + "order by t1.pk, t1.pt;").getResults()[0];
+                "select t1.pk, t1.name, t1.pt from t as t1 where t1.pt is null order by t1.pk, t1.pt;")
+                .getResults()[0];
 
-        assertApproximateContentOfTable (new Object[][] {
-                {2, "Atlantis", null}},
-                vt, EPSILON);
+        assertApproximateContentOfTable (new Object[][] {{2, "Atlantis", null}}, vt, EPSILON);
 
         // Test IS NOT NULL
         vt = client.callProcedure("@AdHoc",
-                "select t1.pk, t1.name, t1.pt "
-                + "from t as t1 "
-                + "where t1.pt is not null "
-                + "order by t1.pk, t1.pt;").getResults()[0];
+                "select t1.pk, t1.name, t1.pt from t as t1 where t1.pt is not null order by t1.pk, t1.pt;")
+                .getResults()[0];
 
-        assertApproximateContentOfTable (new Object[][] {
-                {0, "Bedford", BEDFORD_PT},
-                {1, "Santa Clara", SANTA_CLARA_PT}},
+        assertApproximateContentOfTable (new Object[][] {{0, "Bedford", BEDFORD_PT}, {1, "Santa Clara", SANTA_CLARA_PT}},
                 vt, EPSILON);
     }
 
@@ -251,16 +220,10 @@ public class TestGeographyPointValue extends RegressionSuite {
         fillTableWithFunnyPoints(client);
 
         VoltTable vt;
-        String query = "select t2.name "
-                + "from t as t1 inner join t as t2 "
-                + "  on t1.pt = t2.pt "
-                + "where t1.name = ? "
-                + "order by t2.pk";
+        String query = "select t2.name from t as t1 inner join t as t2   on t1.pt = t2.pt where t1.name = ? order by t2.pk";
 
         vt = client.callProcedure("@AdHoc", query, "point").getResults()[0];
-        assertContentOfTable(new Object[][] {
-                {"point"},
-                {"closePoint"}},
+        assertContentOfTable(new Object[][] {{"point"}, {"closePoint"}},
                 vt);
 
         vt = client.callProcedure("@AdHoc", query, "northPole1").getResults()[0];
@@ -304,20 +267,15 @@ public class TestGeographyPointValue extends RegressionSuite {
         int pk = 0;
         pk = fillTable(client, pk);
         pk = fillTable(client, pk);
-        pk = fillTable(client, pk);
+        fillTable(client, pk);
 
         VoltTable vt = client.callProcedure("@AdHoc",
-                "select pt, count(*) "
-                + "from t "
-                + "group by pt "
-                + "order by pt asc")
+                "select pt, count(*) from t group by pt order by pt asc")
                 .getResults()[0];
 
-        assertApproximateContentOfTable (new Object[][] {
-            {null, 3},
-            {SANTA_CLARA_PT, 3},
-            {BEDFORD_PT, 3}},
-            vt, EPSILON);
+        assertApproximateContentOfTable(new Object[][] {
+            {null, 3}, {SANTA_CLARA_PT, 3}, {BEDFORD_PT, 3}
+            }, vt, EPSILON);
     }
 
     public void testPointUpdate() throws Exception {
@@ -329,10 +287,7 @@ public class TestGeographyPointValue extends RegressionSuite {
         final GeographyPointValue SAN_JOSE_PT = new GeographyPointValue(-121.8906, 37.3362);
 
         validateTableOfScalarLongs(client,
-                "update t set "
-                + "name = 'Cambridge', "
-                + "pt = pointfromtext('" + CAMBRIDGE_PT + "') "
-                + "where pk = 0",
+                "update t set name = 'Cambridge', pt = pointfromtext('" + CAMBRIDGE_PT + "') where pk = 0",
                 new long[] {1});
 
         validateTableOfScalarLongs(client,
@@ -354,24 +309,18 @@ public class TestGeographyPointValue extends RegressionSuite {
     }
 
     public void testPointArithmetic() throws Exception {
-        Client client = getClient();
-
+        final Client client = getClient();
         fillTable(client, 0);
-
-        verifyStmtFails(client,
-                "select pk, pt + pt from t order by pk",
-                "Cannot apply '\\+' to arguments of type");
-
-        verifyStmtFails(client,
-                "select pk, pt + 1 from t order by pk",
-                "Cannot apply '\\+' to arguments of type");
+        final String expectedErrorMessage =
+                m_usingCalcite ? "Cannot apply '\\+' to arguments of type" : "incompatible data types in combination";
+        verifyStmtFails(client, "select pk, pt + pt from t order by pk", expectedErrorMessage);
+        verifyStmtFails(client, "select pk, pt + 1 from t order by pk", expectedErrorMessage);
     }
 
     public void testPointNotNull() throws Exception {
         Client client = getClient();
 
-        verifyStmtFails(client,
-                "insert into t_not_null (pk, name) values (0, 'Westchester')",
+        verifyStmtFails(client, "insert into t_not_null (pk, name) values (0, 'Westchester')",
                 "Column PT has no default and is not nullable");
 
         verifyStmtFails(client,
@@ -419,9 +368,8 @@ public class TestGeographyPointValue extends RegressionSuite {
 
     static public junit.framework.Test suite() {
 
-        VoltServerConfig config = null;
-        MultiConfigSuiteBuilder builder =
-            new MultiConfigSuiteBuilder(TestGeographyPointValue.class);
+        VoltServerConfig config;
+        MultiConfigSuiteBuilder builder = new MultiConfigSuiteBuilder(TestGeographyPointValue.class);
         boolean success;
 
         VoltProjectBuilder project = new VoltProjectBuilder();
@@ -445,12 +393,12 @@ public class TestGeographyPointValue extends RegressionSuite {
                 ;
         try {
             project.addLiteralSchema(literalSchema);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             fail();
         }
 
-        config = new LocalCluster("point-type-onesite.jar", 1, 1, 0, BackendTarget.NATIVE_EE_JNI);
+        config = new LocalCluster("point-type-onesite.jar", 1, 1, 0,
+                BackendTarget.NATIVE_EE_JNI);
         success = config.compile(project);
         assertTrue(success);
         builder.addServerConfig(config);

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
@@ -252,10 +252,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
 
             // equals
             VoltTable vt = client.callProcedure("@AdHoc",
-                    "select t1.pk, t1.name, t1.poly "
-                            + "from " + tbl + " as t1, t as t2 "
-                            + "where t1.poly = t2.poly "
-                            + "order by t1.pk").getResults()[0];
+                    "select t1.pk, t1.name, t1.poly from " + tbl +
+                            " as t1, t as t2 where t1.poly = t2.poly order by t1.pk").getResults()[0];
             assertContentOfTable(new Object[][] {
                     {0, "Bermuda Triangle", BERMUDA_TRIANGLE_POLY},
                     {1, "Bermuda Triangle with a hole", BERMUDA_TRIANGLE_HOLE_POLY},
@@ -265,10 +263,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
 
             // not equals
             vt = client.callProcedure("@AdHoc",
-                    "select t1.pk, t1.name, t2.pk, t2.name "
-                            + "from " + tbl + " as t1, t as t2 "
-                            + "where t1.poly != t2.poly "
-                            + "order by t1.pk, t2.pk").getResults()[0];
+                    "select t1.pk, t1.name, t2.pk, t2.name from " + tbl +
+                            " as t1, t as t2 where t1.poly != t2.poly order by t1.pk, t2.pk").getResults()[0];
             assertContentOfTable(new Object[][] {
                     {0, "Bermuda Triangle", 1, "Bermuda Triangle with a hole"},
                     {0, "Bermuda Triangle", 2, "Billerica Triangle"},
@@ -286,10 +282,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
 
             // less than
             vt = client.callProcedure("@AdHoc",
-                    "select t1.pk, t1.name, t2.pk, t2.name "
-                            + "from " + tbl + " as t1, t as t2 "
-                            + "where t1.poly < t2.poly "
-                            + "order by t1.pk, t2.pk").getResults()[0];
+                    "select t1.pk, t1.name, t2.pk, t2.name from " + tbl +
+                            " as t1, t as t2 where t1.poly < t2.poly order by t1.pk, t2.pk").getResults()[0];
             assertContentOfTable(new Object[][] {
                     {0, "Bermuda Triangle", 1, "Bermuda Triangle with a hole"},
                     {0, "Bermuda Triangle", 3, "Lowell Square"},
@@ -301,10 +295,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
 
             // less than or equal to
             vt = client.callProcedure("@AdHoc",
-                    "select t1.pk, t1.name, t2.pk, t2.name "
-                            + "from " + tbl + " as t1, t as t2 "
-                            + "where t1.poly <= t2.poly "
-                            + "order by t1.pk, t2.pk").getResults()[0];
+                    "select t1.pk, t1.name, t2.pk, t2.name from " + tbl +
+                            " as t1, t as t2 where t1.poly <= t2.poly order by t1.pk, t2.pk").getResults()[0];
             assertContentOfTable(new Object[][] {
                     {0, "Bermuda Triangle", 0, "Bermuda Triangle"},
                     {0, "Bermuda Triangle", 1, "Bermuda Triangle with a hole"},
@@ -320,10 +312,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
 
             // greater than
             vt = client.callProcedure("@AdHoc",
-                    "select t1.pk, t1.name, t2.pk, t2.name "
-                            + "from " + tbl + " as t1, t as t2 "
-                            + "where t1.poly > t2.poly "
-                            + "order by t1.pk, t2.pk").getResults()[0];
+                    "select t1.pk, t1.name, t2.pk, t2.name from " + tbl +
+                            " as t1, t as t2 where t1.poly > t2.poly order by t1.pk, t2.pk").getResults()[0];
             assertContentOfTable(new Object[][] {
                     {0, "Bermuda Triangle", 2, "Billerica Triangle"},
                     {1, "Bermuda Triangle with a hole", 0, "Bermuda Triangle"},
@@ -335,10 +325,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
 
             // greater than or equal to
             vt = client.callProcedure("@AdHoc",
-                    "select t1.pk, t1.name, t2.pk, t2.name "
-                            + "from " + tbl + " as t1, t as t2 "
-                            + "where t1.poly >= t2.poly "
-                            + "order by t1.pk, t2.pk").getResults()[0];
+                    "select t1.pk, t1.name, t2.pk, t2.name from " + tbl +
+                            " as t1, t as t2 where t1.poly >= t2.poly order by t1.pk, t2.pk").getResults()[0];
             assertContentOfTable(new Object[][] {
                     {0, "Bermuda Triangle", 0, "Bermuda Triangle"},
                     {0, "Bermuda Triangle", 2, "Billerica Triangle"},
@@ -354,20 +342,12 @@ public class TestGeographyValueQueries extends RegressionSuite {
 
             // is null
             vt = client.callProcedure("@AdHoc",
-                    "select pk, name "
-                            + "from " + tbl + " "
-                            + "where poly is null "
-                            + "order by pk").getResults()[0];
-            assertContentOfTable(new Object[][] {
-                    {4, "null poly"}},
-                    vt);
+                    "select pk, name from " + tbl + " where poly is null order by pk").getResults()[0];
+            assertContentOfTable(new Object[][] {{4, "null poly"}}, vt);
 
             // is not null
             vt = client.callProcedure("@AdHoc",
-                    "select pk, name "
-                            + "from " + tbl + " "
-                            + "where poly is not null "
-                            + "order by pk").getResults()[0];
+                    "select pk, name from " + tbl + " where poly is not null order by pk").getResults()[0];
             assertContentOfTable(new Object[][] {
                     {0, "Bermuda Triangle"},
                     {1, "Bermuda Triangle with a hole"},
@@ -378,15 +358,12 @@ public class TestGeographyValueQueries extends RegressionSuite {
     }
 
     public void testArithmetic() throws Exception {
-        Client client = getClient();
-
+        final Client client = getClient();
         fillTable(client, "t", 0);
-
-        verifyStmtFails(client, "select pk, poly + poly from t order by pk",
-                "Cannot apply '\\+' to arguments of type");
-
-        verifyStmtFails(client, "select pk, poly + 1 from t order by pk",
-                "Cannot apply '\\+' to arguments of type");
+        final String expectedErrorMessage =
+                m_usingCalcite ? "Cannot apply '\\+' to arguments of type" : "incompatible data types in combination";
+        verifyStmtFails(client, "select pk, poly + poly from t order by pk", expectedErrorMessage);
+        verifyStmtFails(client, "select pk, poly + 1 from t order by pk", expectedErrorMessage);
     }
 
     // The shell is 5 fixed but arbitrarily selected points.
@@ -427,14 +404,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
         }
         String cheesyOrigin = "POINT(0.0 0.0)";
         String cheesyInHole = "POINT(15  15)";
-        List<String> exteriorPoints = Arrays.asList("POINT( 60  60)",
-                                                    "POINT( 60 -60)",
-                                                    "POINT(-60 -60)",
-                                                    "POINT(-60  60)");
-        List<String> centers = Arrays.asList("POINT( 11  11)",
-                                             "POINT( 11 -11)",
-                                             "POINT(-11 -11)",
-                                             "POINT(-11  11)");
+        List<String> exteriorPoints = Arrays.asList("POINT( 60  60)", "POINT( 60 -60)", "POINT(-60 -60)", "POINT(-60  60)");
+        List<String> centers = Arrays.asList("POINT( 11  11)", "POINT( 11 -11)", "POINT(-11 -11)", "POINT(-11  11)");
         client.callProcedure("T.INSERT", 0, "SHELL", cheesyShellPolygon);
         client.callProcedure("T.INSERT", 1, "Formaggio", cheesyPolygon);
         for (int idx = 0; idx < cheesyHoles.size(); idx += 1) {
@@ -455,7 +426,7 @@ public class TestGeographyValueQueries extends RegressionSuite {
         // Make sure that all the polygons
         // are valid.
         VoltTable vt = client.callProcedure("@AdHoc", "select t.pk from t where not isValid(t.poly) order by t.pk").getResults()[0];
-        assertTrue("fillCheesyTable: " + vt.getRowCount() + " invalid polygons.", vt.getRowCount() == 0);
+        assertEquals("fillCheesyTable: " + vt.getRowCount() + " invalid polygons.", 0, vt.getRowCount());
     }
 
     // This is mostly a planner test, as the planner had problems recognizing that geo types
@@ -536,16 +507,9 @@ public class TestGeographyValueQueries extends RegressionSuite {
         // Also, none of the exterior points are contained in
         // the shell or cheesy polygon.
         VoltTable vt = client.callProcedure("@AdHoc",
-                "select t.pk, location.pk "
-                + "from t, location "
-                + "  where location.pk < 300 and t.pk < 100 "
-                + "        and contains(t.poly, location.loc_point) "
-                + "  order by t.pk, location.pk;").getResults()[0];
-        Object [][] expectedQ1 = new Object[][] {
-            {0, 0},
-            {0, 1},
-            {1, 0},
-        };
+                "select t.pk, location.pk from t, location   where location.pk < 300 and t.pk < 100 "
+                + "        and contains(t.poly, location.loc_point) order by t.pk, location.pk;").getResults()[0];
+        Object [][] expectedQ1 = new Object[][] {{0, 0}, {0, 1}, {1, 0}};
         assertContentOfTable(expectedQ1, vt);
     }
 
@@ -597,7 +561,7 @@ public class TestGeographyValueQueries extends RegressionSuite {
             } else if (polyKey == 1) {
                 cheeseMap.put(ptKey, distance);
             } else {
-                assertTrue("Unexpected polygon : " + polyKey, false);
+                fail("Unexpected polygon : " + polyKey);
             }
             indices.add(ptKey);
         }
@@ -613,10 +577,8 @@ public class TestGeographyValueQueries extends RegressionSuite {
         // each 20degrees on a side, and all symmetric around
         // the origin (longitude = latitude = 0.0).
         vt = client.callProcedure("@AdHoc",
-                "select l.pk, distance(l.loc_point, t.poly) "
-                + "from t, location as l "
-                + "  where t.pk = 1 and 300 <= l.pk "
-                + "  order by l.pk;").getResults()[0];
+                "select l.pk, distance(l.loc_point, t.poly) from t, location as l where t.pk = 1 and 300 <= l.pk order by l.pk;")
+                .getResults()[0];
         double dist = -1;
         while (vt.advanceRow()) {
             if (dist < 0) {
@@ -634,13 +596,10 @@ public class TestGeographyValueQueries extends RegressionSuite {
             int pk = 0;
             pk = fillTable(client, tbl, pk);
             pk = fillTable(client, tbl, pk);
-            pk = fillTable(client, tbl, pk);
+            fillTable(client, tbl, pk);
 
             VoltTable vt = client.callProcedure("@AdHoc",
-                    "select poly, count(*) "
-                            + "from " + tbl + " "
-                            + "group by poly "
-                            + "order by poly asc")
+                    "select poly, count(*) from " + tbl + " group by poly order by poly asc")
                             .getResults()[0];
             assertContentOfTable(new Object[][] {
                     {null, 3},
@@ -733,10 +692,7 @@ public class TestGeographyValueQueries extends RegressionSuite {
             VoltTable vt = client.callProcedure("select_in_" + tbl,
                     (Object)(new GeographyValue[] {BERMUDA_TRIANGLE_POLY, null, LOWELL_SQUARE_POLY}))
                     .getResults()[0];
-            assertContentOfTable(new Object[][] {
-                    {0},
-                    {3}},
-                    vt);
+            assertContentOfTable(new Object[][] {{0}, {3}}, vt);
 
             try {
                 client.callProcedure("select_in_" + tbl,

--- a/tests/frontend/org/voltdb/regressionsuites/VoltServerConfig.java
+++ b/tests/frontend/org/voltdb/regressionsuites/VoltServerConfig.java
@@ -62,6 +62,8 @@ public abstract class VoltServerConfig {
      */
     public abstract boolean compile(VoltProjectBuilder builder);
 
+    public abstract boolean isUsingCalcite();
+
     /**
      * Start the instance of VoltDB.
      */
@@ -139,8 +141,7 @@ public abstract class VoltServerConfig {
     public abstract boolean isDebug();
 
     abstract boolean compileWithPartitionDetection(VoltProjectBuilder builder,
-            String snapshotPath,
-            String ppdPrefix);
+            String snapshotPath, String ppdPrefix);
 
     abstract boolean compileWithAdminMode(VoltProjectBuilder builder, int adminPort, boolean adminOnStartup);
 
@@ -186,34 +187,25 @@ public abstract class VoltServerConfig {
     }
 
     protected static void addInstance(VoltServerConfig config) {
-        if (! config.isValgrind()) {
-            return;
+        if (config.isValgrind()) {
+            org.junit.Assert.assertTrue("JUnit tests that instantiate instances of LocalCluster must either a) inherit from RegressionSuite, "
+                            + "or b) be a JUnit 4-style unit test that inherits from JUnit4LocalClusterTest.  "
+                            + "These super classes ensure unconditional deterministic shutdown of clusters "
+                            + "so that memory errors will be detected and cause JUnit tests to fail.  "
+                            + "Your cooperation is appreciated to ensure product quality!",
+                    s_instanceSet != null);
+            s_instanceSet.add(config);
         }
-
-        org.junit.Assert.assertTrue("JUnit tests that instantiate instances of LocalCluster must either a) inherit from RegressionSuite, "
-                + "or b) be a JUnit 4-style unit test that inherits from JUnit4LocalClusterTest.  "
-                + "These super classes ensure unconditional deterministic shutdown of clusters "
-                + "so that memory errors will be detected and cause JUnit tests to fail.  "
-                + "Your cooperation is appreciated to ensure product quality!",
-                s_instanceSet != null);
-        s_instanceSet.add(config);
     }
 
     protected static void removeInstance(VoltServerConfig config) {
-        if (! config.isValgrind()) {
-            return;
+        if (config.isValgrind()) {
+            s_instanceSet.remove(config);
         }
-
-        s_instanceSet.remove(config);
     }
 
     protected static void shutDownClusters() throws InterruptedException {
-        List<VoltServerConfig> instancesCopy = new ArrayList<>();
-        for (VoltServerConfig config : s_instanceSet) {
-            instancesCopy.add(config);
-        }
-
-        for (VoltServerConfig config : instancesCopy) {
+        for (VoltServerConfig config : new ArrayList<VoltServerConfig>() {{ addAll(s_instanceSet); }}) {
             config.shutDown();
         }
     }


### PR DESCRIPTION
Added switch to source code, and `build.xml` so that now you can control running JUnit test with calcite or legacy code path by:
`$ ant junitclass -Dcalcite=true -Djunitclass=TestAdHocQueries -Dbuild=debug` or
`$ ant junitclass -Dcalcite=false -Djunitclass=TestAdHocQueries -Dbuild=debug`

Still in progress: got current JUnit test pass. Plan to merge into integration branch before further work listed below:

1. Make build.xml more intelligent, by checking if current git branch name, if any, contains "calcite-", and only test using calcite code path if it does.
2. Going through all JUnit tests we have commented, and make them run in legacy code path, controlled by Java property.