### PR TITLE
ENG-16577 add retries to remove action blocker

### DIFF
--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -34,7 +34,6 @@ import org.apache.zookeeper_voltpatches.ZooDefs.Ids;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
-import org.voltcore.logging.Level;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.Pair;
 import org.voltcore.zk.CoreZK;

--- a/src/frontend/org/voltdb/iv2/MpRepairTask.java
+++ b/src/frontend/org/voltdb/iv2/MpRepairTask.java
@@ -81,17 +81,9 @@ public class MpRepairTask extends SiteTasker
                     try {
                         algo.start().get();
                         repairLogger.info(whoami + "finished repair.");
-
-                        if (!m_leaderMigration && m_mailbox.m_messenger != null) {
-                            // Determine if all the partition leaders are on live hosts
-                            Set<Integer> partitionLeaderHosts = CoreUtils.getHostIdsFromHSIDs(m_spMasters);
-                            partitionLeaderHosts.removeAll(((MpInitiatorMailbox)m_mailbox).m_messenger.getLiveHostIds());
-
-                            // At this point, all the repairs are completed. This should be the final repair task
-                            // in the repair process. Remove the mp repair blocker
-                            if (partitionLeaderHosts.isEmpty()) {
-                                VoltZK.removeActionBlocker(m_mailbox.m_messenger.getZK(), VoltZK.mpRepairInProgress, repairLogger);
-                            }
+                        if (!m_leaderMigration) {
+                            // At this point, all sp repairs are completed. Remove the mp repair blocker
+                            VoltZK.removeActionBlocker(m_mailbox.m_messenger.getZK(), VoltZK.mpRepairInProgress, repairLogger);
                         }
                     } catch (CancellationException e) {
                         repairLogger.info(whoami + "interrupted during repair.  Retrying.");

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -183,13 +183,9 @@ public class MpScheduler extends Scheduler
                 }
             }
         }
-        // Determine if all the partition leaders are on live hosts, that is, all partitions have promoted
-        // their leaders.
-        Set<Integer> partitionLeaderHosts = CoreUtils.getHostIdsFromHSIDs(m_iv2Masters);
-        partitionLeaderHosts.removeAll(((MpInitiatorMailbox)m_mailbox).m_messenger.getLiveHostIds());
 
         // This is a non MPI Promotion (but SPI Promotion) path for repairing outstanding MP Txns
-        MpRepairTask repairTask = new MpRepairTask((InitiatorMailbox)m_mailbox, replicas, balanceSPI, partitionLeaderHosts.isEmpty());
+        MpRepairTask repairTask = new MpRepairTask((InitiatorMailbox)m_mailbox, replicas, balanceSPI);
         m_pendingTasks.repair(repairTask, replicas, partitionMasters, balanceSPI);
         return new long[0];
     }


### PR DESCRIPTION
Action blockers are not removed cleanly under some circumstances. In the presence of  some action blockers, further actions, such as UAC or rejoining,  may be blocked.   Add a retry mechanism to ensure their removal.