### PR TITLE
ENG-16441  durable fragments to be replayed from TaskLog on rejoining to avoid mp deadlock

### DIFF
--- a/src/frontend/org/voltdb/LoadedProcedureSet.java
+++ b/src/frontend/org/voltdb/LoadedProcedureSet.java
@@ -250,13 +250,13 @@ public class LoadedProcedureSet {
                     if (fragIds != null && fragIds.length > 0) {
                         durableFragments.addAll(Arrays.stream(fragIds).boxed().collect(Collectors.toList()));
                     }
-                    if (procedure.shouldProcForReplay()) {
+                    if (procedure.allowableSysprocForTaskLog()) {
                         replayableProcs.add("@" + runner.m_procedureName);
                     }
                 }
             }
         }
-        SystemProcedureCatalog.collectSysFragmentOrProcForReplay(durableFragments, replayableProcs);
+        SystemProcedureCatalog.setupAllowableSysprocFragsInTaskLog(durableFragments, replayableProcs);
         return builder.build();
     }
 

--- a/src/frontend/org/voltdb/LoadedProcedureSet.java
+++ b/src/frontend/org/voltdb/LoadedProcedureSet.java
@@ -245,7 +245,7 @@ public class LoadedProcedureSet {
                 }
 
                 builder.put(entry.getKey().intern(), runner);
-                if (!sysProc.singlePartition) {
+                if (!sysProc.singlePartition  && sysProc.isDurable()) {
                     long[] fragIds =  procedure.getAllowableSysprocFragIdsInTaskLog();
                     if (fragIds != null && fragIds.length > 0) {
                         durableFragments.addAll(Arrays.stream(fragIds).boxed().collect(Collectors.toList()));

--- a/src/frontend/org/voltdb/LoadedProcedureSet.java
+++ b/src/frontend/org/voltdb/LoadedProcedureSet.java
@@ -185,6 +185,7 @@ public class LoadedProcedureSet {
         ImmutableMap.Builder<String, ProcedureRunner> builder = ImmutableMap.<String, ProcedureRunner>builder();
 
         List<Long> durableFragments = Lists.newArrayList();
+        List<String> replayableProcs = Lists.newArrayList();
         Set<Entry<String,Config>> entrySet = SystemProcedureCatalog.listing.entrySet();
         for (Entry<String, Config> entry : entrySet) {
             Config sysProc = entry.getValue();
@@ -249,10 +250,13 @@ public class LoadedProcedureSet {
                     if (fragIds != null && fragIds.length > 0) {
                         durableFragments.addAll(Arrays.stream(fragIds).boxed().collect(Collectors.toList()));
                     }
+                    if (procedure.shouldProcForReplay()) {
+                        replayableProcs.add("@" + runner.m_procedureName);
+                    }
                 }
             }
         }
-        SystemProcedureCatalog.collectDurableSysProcFragments(durableFragments);
+        SystemProcedureCatalog.collectSysFragmentOrProcForReplay(durableFragments, replayableProcs);
         return builder.build();
     }
 

--- a/src/frontend/org/voltdb/LoadedProcedureSet.java
+++ b/src/frontend/org/voltdb/LoadedProcedureSet.java
@@ -245,8 +245,8 @@ public class LoadedProcedureSet {
                 }
 
                 builder.put(entry.getKey().intern(), runner);
-                if (!sysProc.singlePartition && sysProc.durable) {
-                    long[] fragIds =  procedure.getDurablePlanFragmentIds();
+                if (!sysProc.singlePartition) {
+                    long[] fragIds =  procedure.getAllowableSysprocFragIdsInTaskLog();
                     if (fragIds != null && fragIds.length > 0) {
                         durableFragments.addAll(Arrays.stream(fragIds).boxed().collect(Collectors.toList()));
                     }

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -248,7 +248,6 @@ public class SystemProcedureCatalog {
                 if (s_allowableSysprocFragsInTaskLog == null && s_allowableSysprocsInTaskLog == null) {
                     s_allowableSysprocFragsInTaskLog = ImmutableSet.<Long>builder().addAll(fragments).build();
                     s_allowableSysprocsInTaskLog = ImmutableSet.<String>builder().addAll(procs).build();
-                    System.out.println("*****" + s_allowableSysprocFragsInTaskLog + "||||" + s_allowableSysprocsInTaskLog);
                 }
             }
         }

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -256,9 +256,13 @@ public class SystemProcedureCatalog {
     // return true if the fragment or the system procedure is allowed to be replayed in TaskLog
     public static boolean isAllowableInTaskLog(Long fragId, String procName) {
         assert(s_allowableSysprocFragsInTaskLog != null && s_allowableSysprocsInTaskLog != null);
+
+        // Check specified fragment IDs
         if (s_allowableSysprocFragsInTaskLog.contains(fragId)) {
             return true;
         }
+
+        // If fragId is not in the allowed list, check proc name.
         if (procName != null) {
             return s_allowableSysprocsInTaskLog.contains(procName);
         }

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -22,6 +22,8 @@ import java.util.List;
 import org.voltdb.CatalogContext.ProcedurePartitionInfo;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.Procedure;
+import org.voltdb.messaging.FragmentTaskMessage;
+
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableSet;
 
@@ -254,7 +256,7 @@ public class SystemProcedureCatalog {
     }
 
     // return true if the fragment or the system procedure is allowed to be replayed in TaskLog
-    public static boolean isAllowableInTaskLog(Long fragId, String procName) {
+    public static boolean isAllowableInTaskLog(Long fragId, FragmentTaskMessage msg) {
         assert(s_allowableSysprocFragsInTaskLog != null && s_allowableSysprocsInTaskLog != null);
 
         // Check specified fragment IDs
@@ -263,6 +265,7 @@ public class SystemProcedureCatalog {
         }
 
         // If fragId is not in the allowed list, check proc name.
+        String procName = msg.getProcedureName();
         if (procName != null) {
             return s_allowableSysprocsInTaskLog.contains(procName);
         }

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -248,6 +248,7 @@ public class SystemProcedureCatalog {
                 if (s_allowableSysprocFragsInTaskLog == null && s_allowableSysprocsInTaskLog == null) {
                     s_allowableSysprocFragsInTaskLog = ImmutableSet.<Long>builder().addAll(fragments).build();
                     s_allowableSysprocsInTaskLog = ImmutableSet.<String>builder().addAll(procs).build();
+                    System.out.println("*****" + s_allowableSysprocFragsInTaskLog + "||||" + s_allowableSysprocsInTaskLog);
                 }
             }
         }

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -118,10 +118,10 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
     abstract public long[] getPlanFragmentIds();
 
     /**
-     * return all SysProc durable plan fragments that needs to be registered
+     * return all SysProc plan fragments that needs to be registered
      * These fragments will be replayed in rejoining process.
      */
-    public long[] getDurablePlanFragmentIds() {
+    public long[] getAllowableSysprocFragIdsInTaskLog() {
         return new long[]{};
     }
 

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -128,7 +128,7 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
     /**
      * @return true if the procedure should not be skipped from TaskLog replay
      */
-    public boolean shouldProcForReplay() {
+    public boolean allowableSysprocForTaskLog() {
         return false;
     }
 

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -117,6 +117,14 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
      */
     abstract public long[] getPlanFragmentIds();
 
+    /**
+     * return all SysProc durable plan fragments that needs to be registered
+     * These fragments will be replayed in rejoining process.
+     */
+    public long[] getDurablePlanFragmentIds() {
+        return new long[]{};
+    }
+
     /** Bundles the data needed to describe a plan fragment. */
     public static class SynthesizedPlanFragment {
         public long siteId = -1;

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -125,6 +125,13 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
         return new long[]{};
     }
 
+    /**
+     * @return true if the procedure should not be skiped from TaskLog replay
+     */
+    public boolean shouldProcForReplay() {
+        return false;
+    }
+
     /** Bundles the data needed to describe a plan fragment. */
     public static class SynthesizedPlanFragment {
         public long siteId = -1;

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -126,7 +126,7 @@ public abstract class VoltSystemProcedure extends VoltProcedure {
     }
 
     /**
-     * @return true if the procedure should not be skiped from TaskLog replay
+     * @return true if the procedure should not be skipped from TaskLog replay
      */
     public boolean shouldProcForReplay() {
         return false;

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1001,6 +1001,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         if (!msg.isSysProcTask()) {
             return true;
         }
+
+        // fragId is not always available before FragmentTask is executed. In this case, check sysproc name.
         long fragId = VoltSystemProcedure.hashToFragId(msg.getPlanHash(0));
         return (SystemProcedureCatalog.isAllowableInTaskLog(fragId, msg.getProcedureName()));
     }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1005,7 +1005,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                 return false;
             }
             long fragId = VoltSystemProcedure.hashToFragId(msg.getPlanHash(0));
-            return !(SystemProcedureCatalog.isFragmentOrProcForReplay(fragId, msg.getProcedureName()));
+            return !(SystemProcedureCatalog.isAllowableInTaskLog(fragId, msg.getProcedureName()));
         } else if (tibm instanceof Iv2InitiateTaskMessage) {
             Iv2InitiateTaskMessage itm = (Iv2InitiateTaskMessage) tibm;
             final SystemProcedureCatalog.Config sysproc = SystemProcedureCatalog.listing.get(itm.getStoredProcedureName());

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1001,10 +1001,13 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         // Multi part AdHoc Does not need to be checked because its an alias and runs procedure as planned.
         if (tibm instanceof FragmentTaskMessage) {
             FragmentTaskMessage msg = (FragmentTaskMessage)tibm;
-            long fragId = VoltSystemProcedure.hashToFragId(msg.getPlanHash(0));
-            if (msg.isSysProcTask() && !SystemProcedureCatalog.isFragmentDurableForReplay(fragId)) {
-                return true;
+
+            // @AdHoc_RW_MP fragments should not be filtered out
+            if (!msg.isSysProcTask() || "AdHoc_RW_MP".equalsIgnoreCase(msg.getProcedureName())) {
+                return false;
             }
+            long fragId = VoltSystemProcedure.hashToFragId(msg.getPlanHash(0));
+            return !(SystemProcedureCatalog.isFragmentDurableForReplay(fragId));
         } else if (tibm instanceof Iv2InitiateTaskMessage) {
             Iv2InitiateTaskMessage itm = (Iv2InitiateTaskMessage) tibm;
             final SystemProcedureCatalog.Config sysproc = SystemProcedureCatalog.listing.get(itm.getStoredProcedureName());

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1001,8 +1001,6 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         // Multi part AdHoc Does not need to be checked because its an alias and runs procedure as planned.
         if (tibm instanceof FragmentTaskMessage) {
             FragmentTaskMessage msg = (FragmentTaskMessage)tibm;
-
-            // @AdHoc_RW_MP fragments should not be filtered out
             if (!msg.isSysProcTask()) {
                 return false;
             }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1003,11 +1003,11 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
             FragmentTaskMessage msg = (FragmentTaskMessage)tibm;
 
             // @AdHoc_RW_MP fragments should not be filtered out
-            if (!msg.isSysProcTask() || "AdHoc_RW_MP".equalsIgnoreCase(msg.getProcedureName())) {
+            if (!msg.isSysProcTask()) {
                 return false;
             }
             long fragId = VoltSystemProcedure.hashToFragId(msg.getPlanHash(0));
-            return !(SystemProcedureCatalog.isFragmentDurableForReplay(fragId));
+            return !(SystemProcedureCatalog.isFragmentOrProcForReplay(fragId, msg.getProcedureName()));
         } else if (tibm instanceof Iv2InitiateTaskMessage) {
             Iv2InitiateTaskMessage itm = (Iv2InitiateTaskMessage) tibm;
             final SystemProcedureCatalog.Config sysproc = SystemProcedureCatalog.listing.get(itm.getStoredProcedureName());

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1004,7 +1004,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
 
         // fragId is not always available before FragmentTask is executed. In this case, check sysproc name.
         long fragId = VoltSystemProcedure.hashToFragId(msg.getPlanHash(0));
-        return (SystemProcedureCatalog.isAllowableInTaskLog(fragId, msg.getProcedureName()));
+        return (SystemProcedureCatalog.isAllowableInTaskLog(fragId, msg));
     }
 
     public static boolean allowInitiateTask(Iv2InitiateTaskMessage msg){

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -38,7 +38,6 @@ import org.voltdb.exceptions.EEException;
 import org.voltdb.exceptions.ReplicatedTableException;
 import org.voltdb.exceptions.SQLException;
 import org.voltdb.exceptions.SerializableException;
-import org.voltdb.exceptions.SpecifiedException;
 import org.voltdb.messaging.FragmentResponseMessage;
 import org.voltdb.messaging.FragmentTaskMessage;
 import org.voltdb.rejoin.TaskLog;

--- a/src/frontend/org/voltdb/sysprocs/AdHoc_RW_MP.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc_RW_MP.java
@@ -43,7 +43,7 @@ public class AdHoc_RW_MP extends AdHocBase {
     }
 
     @Override
-    public boolean shouldProcForReplay() {
+    public boolean allowableSysprocForTaskLog() {
         return true;
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/AdHoc_RW_MP.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc_RW_MP.java
@@ -42,4 +42,8 @@ public class AdHoc_RW_MP extends AdHocBase {
         return runAdHoc(ctx, serializedBatchData);
     }
 
+    @Override
+    public boolean shouldProcForReplay() {
+        return true;
+    }
 }

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
@@ -61,7 +61,7 @@ public class ExecuteTask extends VoltSystemProcedure
     }
 
     @Override
-    public long[] getDurablePlanFragmentIds() {
+    public long[] getAllowableSysprocFragIdsInTaskLog() {
         return new long[] { SysProcFragmentId.PF_executeTask};
     }
 

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
@@ -61,6 +61,11 @@ public class ExecuteTask extends VoltSystemProcedure
     }
 
     @Override
+    public long[] getDurablePlanFragmentIds() {
+        return new long[] { SysProcFragmentId.PF_executeTask};
+    }
+
+    @Override
     public DependencyPair executePlanFragment(
             Map<Integer, List<VoltTable>> dependencies, long fragmentId,
             ParameterSet params, SystemProcedureExecutionContext context) {

--- a/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
+++ b/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
@@ -50,7 +50,7 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
     }
 
     @Override
-    public long[] getDurablePlanFragmentIds() {
+    public long[] getAllowableSysprocFragIdsInTaskLog() {
         return new long[]{SysProcFragmentId.PF_distribute};
     }
 

--- a/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
+++ b/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
@@ -49,6 +49,10 @@ public class LoadMultipartitionTable extends VoltSystemProcedure
         return new long[]{SysProcFragmentId.PF_distribute, SysProcFragmentId.PF_aggregate};
     }
 
+    @Override
+    public long[] getDurablePlanFragmentIds() {
+        return new long[]{SysProcFragmentId.PF_distribute};
+    }
 
     @Override
     public DependencyPair executePlanFragment(

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_MP.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_MP.java
@@ -45,7 +45,7 @@ public class MigrateRowsAcked_MP extends VoltSystemProcedure {
     }
 
     @Override
-    public long[] getDurablePlanFragmentIds() {
+    public long[] getAllowableSysprocFragIdsInTaskLog() {
         return new long[]{SysProcFragmentId.PF_migrateRows};
     }
 

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_MP.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_MP.java
@@ -45,6 +45,11 @@ public class MigrateRowsAcked_MP extends VoltSystemProcedure {
     }
 
     @Override
+    public long[] getDurablePlanFragmentIds() {
+        return new long[]{SysProcFragmentId.PF_migrateRows};
+    }
+
+    @Override
     public DependencyPair executePlanFragment(Map<Integer,List<VoltTable>> dependencies,
         long fragmentId, ParameterSet params, SystemProcedureExecutionContext context)
     {

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsMP.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsMP.java
@@ -22,15 +22,20 @@ import org.voltdb.VoltTable;
 
 public class MigrateRowsMP extends MigrateRowsBase {
 
-        public VoltTable run(SystemProcedureExecutionContext ctx,
-                             String tableName, String columnName,
-                             String compStr, VoltTable parameter, long chunksize) {
-            return migrateRowsCommon(ctx,
-                                      tableName,
-                                      columnName,
-                                      compStr,
-                                      parameter,
-                                      chunksize,
-                                      true);
-        }
+    public VoltTable run(SystemProcedureExecutionContext ctx,
+            String tableName, String columnName,
+            String compStr, VoltTable parameter, long chunksize) {
+        return migrateRowsCommon(ctx,
+                tableName,
+                columnName,
+                compStr,
+                parameter,
+                chunksize,
+                true);
+    }
+
+    @Override
+    public boolean shouldProcForReplay() {
+        return true;
+    }
 }

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsMP.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsMP.java
@@ -35,7 +35,7 @@ public class MigrateRowsMP extends MigrateRowsBase {
     }
 
     @Override
-    public boolean shouldProcForReplay() {
+    public boolean allowableSysprocForTaskLog() {
         return true;
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/NibbleDeleteMP.java
+++ b/src/frontend/org/voltdb/sysprocs/NibbleDeleteMP.java
@@ -48,4 +48,8 @@ public class NibbleDeleteMP extends NibbleDeleteBase {
                                   true);
     }
 
+    @Override
+    public boolean shouldProcForReplay() {
+        return true;
+    }
 }

--- a/src/frontend/org/voltdb/sysprocs/NibbleDeleteMP.java
+++ b/src/frontend/org/voltdb/sysprocs/NibbleDeleteMP.java
@@ -49,7 +49,7 @@ public class NibbleDeleteMP extends NibbleDeleteBase {
     }
 
     @Override
-    public boolean shouldProcForReplay() {
+    public boolean allowableSysprocForTaskLog() {
         return true;
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/SwapTables.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTables.java
@@ -22,13 +22,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import org.hsqldb_voltpatches.TimeToLiveVoltDB;
 import org.hsqldb_voltpatches.lib.StringUtil;
 import org.voltdb.CatalogContext;
 import org.voltdb.ClientInterface.ExplainMode;
 import org.voltdb.VoltDB;
 import org.voltdb.catalog.Table;
-import org.voltdb.catalog.TimeToLive;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.utils.CatalogUtil;
 

--- a/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
@@ -42,7 +42,7 @@ public class SwapTablesCore extends AdHocBase {
     }
 
     @Override
-    public long[] getDurablePlanFragmentIds() {
+    public long[] getAllowableSysprocFragIdsInTaskLog() {
         return new long[] { SysProcFragmentId.PF_swapTables};
     }
 

--- a/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
@@ -42,6 +42,11 @@ public class SwapTablesCore extends AdHocBase {
     }
 
     @Override
+    public long[] getDurablePlanFragmentIds() {
+        return new long[] { SysProcFragmentId.PF_swapTables};
+    }
+
+    @Override
     public DependencyPair executePlanFragment(Map<Integer, List<VoltTable>> dependencies, long fragmentId, ParameterSet params, SystemProcedureExecutionContext context) {
         VoltTable dummy = new VoltTable(STATUS_SCHEMA);
         dummy.addRow(STATUS_OK);

--- a/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
+++ b/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
@@ -86,7 +86,9 @@ public class SysProcFragmentId
                 fragId == PF_balancePartitionsData ||
                 fragId == PF_balancePartitionsClearIndex ||
                 fragId == PF_distribute ||
-                fragId == PF_applyBinaryLog);
+                fragId == PF_applyBinaryLog ||
+                fragId == PF_migrateRows ||
+                fragId == PF_migrateRowsAggregate);
     }
 
     // @LoadMultipartitionTable

--- a/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
+++ b/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
@@ -77,19 +77,6 @@ public class SysProcFragmentId
         return isSnapshotSaveFragment(planHash);
     }
 
-    //This method exists because there is no procedure name in fragment task message
-    // for sysprocs and we cant distinguish if this needs to be replayed or not.
-    public static boolean isDurableFragment(byte[] planHash) {
-        long fragId = VoltSystemProcedure.hashToFragId(planHash);
-        return (fragId == PF_prepBalancePartitions  ||
-                fragId == PF_balancePartitions ||
-                fragId == PF_balancePartitionsData ||
-                fragId == PF_balancePartitionsClearIndex ||
-                fragId == PF_distribute ||
-                fragId == PF_applyBinaryLog ||
-                fragId == PF_migrateRows);
-    }
-
     // @LoadMultipartitionTable
     public static final int PF_distribute = 50;
     public static final int PF_aggregate = 51;

--- a/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
+++ b/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
@@ -87,8 +87,7 @@ public class SysProcFragmentId
                 fragId == PF_balancePartitionsClearIndex ||
                 fragId == PF_distribute ||
                 fragId == PF_applyBinaryLog ||
-                fragId == PF_migrateRows ||
-                fragId == PF_migrateRowsAggregate);
+                fragId == PF_migrateRows);
     }
 
     // @LoadMultipartitionTable

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -70,7 +70,7 @@ public class UpdateCore extends VoltSystemProcedure {
     }
 
     @Override
-    public long[] getDurablePlanFragmentIds() {
+    public long[] getAllowableSysprocFragIdsInTaskLog() {
         return new long[]{
             SysProcFragmentId.PF_updateCatalogPrecheckAndSync,
             SysProcFragmentId.PF_updateCatalog};

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -69,6 +69,13 @@ public class UpdateCore extends VoltSystemProcedure {
             SysProcFragmentId.PF_updateCatalogAggregate};
     }
 
+    @Override
+    public long[] getDurablePlanFragmentIds() {
+        return new long[]{
+            SysProcFragmentId.PF_updateCatalogPrecheckAndSync,
+            SysProcFragmentId.PF_updateCatalog};
+    }
+
     /**
      * Use EE stats to get the row counts for all tables in this partition.
      * Check the provided list of tables that need to be empty against actual

--- a/src/frontend/org/voltdb/sysprocs/UpdateLogging.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateLogging.java
@@ -52,6 +52,11 @@ public class UpdateLogging extends VoltSystemProcedure
     }
 
     @Override
+    public boolean allowableSysprocForTaskLog() {
+        return true;
+    }
+
+    @Override
     public DependencyPair executePlanFragment(
             Map<Integer, List<VoltTable>> dependencies, long fragmentId,
             ParameterSet params, SystemProcedureExecutionContext context)

--- a/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
@@ -55,6 +55,14 @@ public class UpdateSettings extends VoltSystemProcedure {
         };
     }
 
+    @Override
+    public long[] getDurablePlanFragmentIds() {
+        return new long[]{
+                SysProcFragmentId.PF_updateSettingsBarrier,
+                SysProcFragmentId.PF_updateSettingsBarrierAggregate,
+                SysProcFragmentId.PF_updateSettings};
+    }
+
     public UpdateSettings() {
     }
 

--- a/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
@@ -56,7 +56,7 @@ public class UpdateSettings extends VoltSystemProcedure {
     }
 
     @Override
-    public long[] getDurablePlanFragmentIds() {
+    public long[] getAllowableSysprocFragIdsInTaskLog() {
         return new long[]{
                 SysProcFragmentId.PF_updateSettingsBarrier,
                 SysProcFragmentId.PF_updateSettingsBarrierAggregate,

--- a/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
@@ -55,14 +55,6 @@ public class UpdateSettings extends VoltSystemProcedure {
         };
     }
 
-    @Override
-    public long[] getAllowableSysprocFragIdsInTaskLog() {
-        return new long[]{
-                SysProcFragmentId.PF_updateSettingsBarrier,
-                SysProcFragmentId.PF_updateSettingsBarrierAggregate,
-                SysProcFragmentId.PF_updateSettings};
-    }
-
     public UpdateSettings() {
     }
 


### PR DESCRIPTION
During rejoining, sites may have different loads, some sites may enter normal running state to process tasks while other sites still replay tasks from TaskLog.  Within this window, a MP transaction could send fragments to a rejoining node and release fragments from scoreboard.  The fragments will be processed right away on those sites which have entered normal running state. The fragments must be specifically instructed to be processed on those sites which are still replaying.  If any MP fragment is not replayed, the  mp transaction is dead locked.  The fragments which require replay are cached during boot up and used for lookup.  