### PR TITLE
ENG-16021: Fixed the "global name 'jenkins_job' is not defined" failure

### DIFF
--- a/tools/jenkins/junit-stats.py
+++ b/tools/jenkins/junit-stats.py
@@ -1063,8 +1063,9 @@ class Stats(object):
             JENKINSBOT = JenkinsBot()
 
         summary_keys = [issue['className'], issue['testName']]
-        channel      = issue['channel']
-        build_number = issue['build']
+        channel      = issue.get('channel')
+        jenkins_job  = issue.get('job', 'Unknown job')
+        build_number = issue.get('build', 'Unknown build')
         labels       = issue.get('labels', [JIRA_LABEL_FOR_AUTO_FILING])
 
         closed_issue_url = None


### PR DESCRIPTION
issue (in junit-stats.py's close_jira_issue function).