### PR TITLE
ENG-16576: TLSPicoNetwork Error shutting down Volt Network

### DIFF
--- a/src/frontend/org/voltcore/network/TLSEncryptionAdapter.java
+++ b/src/frontend/org/voltcore/network/TLSEncryptionAdapter.java
@@ -239,6 +239,9 @@ public class TLSEncryptionAdapter {
 
     // Called from synchronized block only
     void shutdown() {
+        if (m_isShutdown) { // make sure we only shutdown once.
+            return;
+        }
         m_isShutdown = true;
         try {
             int waitFor = 1 - Math.min(m_inFlight.availablePermits(), -4);
@@ -260,7 +263,7 @@ public class TLSEncryptionAdapter {
                 messages.m_messages.release();
             }
 
-            if (m_inflightMessages != null) {
+            if (m_inflightMessages != null && m_inflightMessages.m_messages.refCnt() > 0) {
                 m_inflightMessages.m_messages.release();
             }
         } finally {

--- a/src/frontend/org/voltcore/network/TLSEncryptionAdapter.java
+++ b/src/frontend/org/voltcore/network/TLSEncryptionAdapter.java
@@ -263,7 +263,7 @@ public class TLSEncryptionAdapter {
                 messages.m_messages.release();
             }
 
-            if (m_inflightMessages != null && m_inflightMessages.m_messages.refCnt() > 0) {
+            if (m_inflightMessages != null && m_inflightMessages.m_messages != null && m_inflightMessages.m_messages.refCnt() > 0) {
                 m_inflightMessages.m_messages.release();
             }
         } finally {

--- a/src/frontend/org/voltcore/network/TLSEncryptionAdapter.java
+++ b/src/frontend/org/voltcore/network/TLSEncryptionAdapter.java
@@ -263,7 +263,8 @@ public class TLSEncryptionAdapter {
                 messages.m_messages.release();
             }
 
-            if (m_inflightMessages != null && m_inflightMessages.m_messages != null && m_inflightMessages.m_messages.refCnt() > 0) {
+            if (m_inflightMessages != null) {
+                assert (m_inflightMessages.m_messages != null && m_inflightMessages.m_messages.refCnt() > 0);
                 m_inflightMessages.m_messages.release();
             }
         } finally {


### PR DESCRIPTION
The cause is we shut down the same `TLSEncryptionAdapter` more than once and double release the message buffer.

Guard added.