### PR TITLE
ENG-16610:

### DIFF
--- a/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
+++ b/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
@@ -379,6 +379,10 @@ public class SynchronizedStatesManager {
             addIfMissing(m_lockPath, CreateMode.PERSISTENT, null);
             addIfMissing(m_barrierParticipantsPath, CreateMode.PERSISTENT, null);
             lockLocalState();
+            // Make sure the child count is correct so that an init does not race with a released lock where the
+            // results have not been processed yet. If it is non-zero, it means results still need to be collected
+            // by some nodes even if the distributed lock list is empty.
+            m_currentParticipants = m_zk.getChildren(m_barrierParticipantsPath, null).size();
             boolean ownDistributedLock = requestDistributedLock();
             ByteBuffer startStates = buildProposal(REQUEST_TYPE.INITIALIZING,
                     m_requestedInitialState.asReadOnlyBuffer(), m_requestedInitialState.asReadOnlyBuffer());


### PR DESCRIPTION
When a new member joins the state machine, it could join just as a previous task or state change has completed but before all the nodes have processed the change. At this point in time the Initializing node might grab the distributed lock and request the current state from other members before they are ready causing a number of different failure conditions including multiple results from the same state machine instance and multiple participant nodes from the same state machine instance. The fix is for a newly initializing member to initialize the local participant count before attempting to grab the distributed lock. That way even if it is the lowest lock, it won't be successful until the participant node count goes to zero.