### PR TITLE
ENG-12484 Fixed NPE in Migrate using <>

### DIFF
--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -54,6 +54,7 @@ public final class ExpressionUtil {
        put("greaterthanorequalto", ExpressionType.COMPARE_GREATERTHANOREQUALTO);
        put("lessthanorequalto", ExpressionType.COMPARE_LESSTHANOREQUALTO);
        put("equal", ExpressionType.COMPARE_EQUAL);
+       put("notequal", ExpressionType.COMPARE_NOTEQUAL);
        put("in", ExpressionType.COMPARE_IN);
        put("not", ExpressionType.OPERATOR_NOT);
        put("exists", ExpressionType.OPERATOR_EXISTS);

--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -252,6 +252,7 @@ public final class ExpressionUtil {
                 case COMPARE_LESSTHAN:
                 case COMPARE_EQUAL:
                 case COMPARE_NOTEQUAL:
+                case COMPARE_NOTDISTINCT:
                 case COMPARE_GREATERTHANOREQUALTO:
                 case COMPARE_LESSTHANOREQUALTO: {
                     final ComparisonExpression expr = new ComparisonExpression(op,

--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -55,6 +55,7 @@ public final class ExpressionUtil {
        put("lessthanorequalto", ExpressionType.COMPARE_LESSTHANOREQUALTO);
        put("equal", ExpressionType.COMPARE_EQUAL);
        put("notequal", ExpressionType.COMPARE_NOTEQUAL);
+       put("notdistinct", ExpressionType.COMPARE_NOTDISTINCT);
        put("in", ExpressionType.COMPARE_IN);
        put("not", ExpressionType.OPERATOR_NOT);
        put("exists", ExpressionType.OPERATOR_EXISTS);
@@ -92,6 +93,7 @@ public final class ExpressionUtil {
                 case COMPARE_LESSTHAN:
                 case COMPARE_EQUAL:
                 case COMPARE_NOTEQUAL:
+                case COMPARE_NOTDISTINCT:
                 case COMPARE_GREATERTHANOREQUALTO:
                 case COMPARE_LESSTHANOREQUALTO:
                 case OPERATOR_PLUS:


### PR DESCRIPTION
This NPE is happening because `<>` (not equal) is used but not registered in `ExpressionUtil :: mapOfVoltXMLOpType`. The fix includes only 1-line change that adds `<>` operation type.
Also added `is not distinct from` into op map.