### PR TITLE
ENG-16879 Fixed NPE when order by NULL

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/QuerySpecification.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/QuerySpecification.java
@@ -626,6 +626,10 @@ public class QuerySpecification extends QueryExpression {
             throw Error.error(ErrorCode.X_42576);
         }
 
+        if (e.getDataType() == null) {
+            return;
+        }
+
         if (e.getType() != OpTypes.VALUE) {
             return;
         }

--- a/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
@@ -25,6 +25,7 @@ package org.voltdb;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.List;
@@ -127,6 +128,7 @@ public class TestAdhocMigrateTable extends AdhocDDLTestBase {
             m_client.callProcedure("@AdHoc", "MIGRATE FROM without_ttl WHERE NOT MIGRATING() \n" +
                                              "AND without_ttl.i < (SELECT MIN(i) FROM without_ttl \n" +
                                              "WHERE FLOOR(without_ttl.j) <> without_ttl.j ORDER BY NULL, without_ttl.i);");
+            fail("Hsql parser should fail when parsing this sql query.");
         } catch (ProcCallException e) {
             assertTrue(e.getMessage().contains("Expression is too complicated"));
         } finally {


### PR DESCRIPTION
The root cause is there is no null checking when `ORDER BY NULL` is being parsed.
Fix includes adding a null checking.