### PR TITLE
ENG-13412 For self-join, throw an error when no table name alias is used

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
@@ -2061,7 +2061,6 @@ public class Expression {
         exp.children.clear();
 
         // There should be at least 2 columnref expressions
-        assert(uniqueColumnrefs.size() > 1);
         if (uniqueColumnrefs.size() <= 1) {
             throw Error.error(ErrorCode.X_42581, "There should be at least 2 unique table/alias");
         }

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
@@ -2031,7 +2031,7 @@ public class Expression {
 
     // A VoltDB extension to convert columnref expression for a column that is part of the USING clause
     // into a COALESCE expression
-    // columnref                    operation operator_case_when
+    //      columnref                   operation operator_case_when
     //      columnref T1.C      ->      operation is_null
     //      columnref T2.C                  columnref T1.C
     //                                  operation operator_alternative
@@ -2062,6 +2062,9 @@ public class Expression {
 
         // There should be at least 2 columnref expressions
         assert(uniqueColumnrefs.size() > 1);
+        if (uniqueColumnrefs.size() <= 1) {
+            throw Error.error(ErrorCode.X_42581, "There should be at least 2 unique table/alias");
+        }
         VoltXMLElement lastAlternativeExpr = null;
         VoltXMLElement resultColaesceExpr = null;
         while (true) {

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
@@ -2061,7 +2061,7 @@ public class Expression {
         exp.children.clear();
 
         // There should be at least 2 columnref expressions
-        if (uniqueColumnrefs.size() <= 1) {
+        if (uniqueColumnrefs.size() < 2) {
             throw Error.error(ErrorCode.X_42581, "There should be at least 2 unique table/alias");
         }
         VoltXMLElement lastAlternativeExpr = null;

--- a/tests/frontend/org/voltdb/planner/TestSelfJoins.java
+++ b/tests/frontend/org/voltdb/planner/TestSelfJoins.java
@@ -104,6 +104,10 @@ public class TestSelfJoins  extends PlannerTestCase {
             TupleValueExpression tve = (TupleValueExpression) e;
             assertNotSame(-1, tve.getColumnIndex());
         }
+
+        // if no alias is used, self join should fail
+        failToCompile("select * from R1 JOIN R1 USING(A)",
+                      "There should be at least 2 unique table/alias");
     }
 
     public void testOuterSelfJoin() {


### PR DESCRIPTION
This fix handles NPE when self join is used without aliasing the table name differently. 
For example, `SELECT * FROM R1 JOIN R1 USING (ID);` is not valid since compiler can only find 1 column reference: R1.ID. 
The correctly way is to use alias after the table name. `SELECT * FROM R1 a JOIN R1 b USING (ID);`