### PR TITLE
ENG-16899, fix a race condition when assigning network thread to remote HSIDs.

### DIFF
--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -149,9 +149,9 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
             m_remoteHostAndAddressAndPort = remoteHost + m_remoteHostAndAddressAndPort;
         }
         if (isSecondary) {
-            m_threadName = super.toString() + ":" + m_remoteHostAndAddressAndPort + "(s)";
+            m_threadName = remoteHost + "(s)";
         } else {
-            m_threadName = super.toString() + ":" + m_remoteHostAndAddressAndPort;
+            m_threadName = remoteHost;
         }
 
         m_thread = new Thread(this, "Pico Network - " + m_threadName);

--- a/src/frontend/org/voltdb/iv2/SpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/SpProcedureTask.java
@@ -76,7 +76,7 @@ public class SpProcedureTask extends ProcedureTask
         }
         final VoltTrace.TraceEventBatch traceLog = VoltTrace.log(VoltTrace.Category.SPI);
         if (traceLog != null) {
-            traceLog.add(() -> VoltTrace.beginDuration("runsptask",
+            traceLog.add(() -> VoltTrace.beginDuration("runSpTask",
                                                        "txnId", TxnEgo.txnIdToString(getTxnId()),
                                                        "partition", Integer.toString(siteConnection.getCorrespondingPartitionId())));
         }
@@ -108,6 +108,11 @@ public class SpProcedureTask extends ProcedureTask
             m_txnState.setNeedsRollback(true);
         }
         completeInitiateTask(siteConnection);
+        if (traceLog != null) {
+            traceLog.add(() -> VoltTrace.endDuration("runSpTask",
+                                                       "txnId", TxnEgo.txnIdToString(getTxnId()),
+                                                       "partition", Integer.toString(siteConnection.getCorrespondingPartitionId())));
+        }
         response.m_sourceHSId = m_initiator.getHSId();
         if (txnState.m_initiationMsg != null && !(txnState.m_initiationMsg.isForReplica())) {
             response.setExecutedOnPreviousLeader(true);

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -648,7 +648,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             traceLog.add(() -> VoltTrace.meta("process_name", "name", CoreUtils.getHostnameOrAddress()))
                     .add(() -> VoltTrace.meta("thread_name", "name", threadName))
                     .add(() -> VoltTrace.meta("thread_sort_index", "sort_index", Integer.toString(10000)))
-                    .add(() -> VoltTrace.beginAsync("initsp",
+                    .add(() -> VoltTrace.beginAsync("localSp",
                                                     MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), m_mailbox.getHSId(), msg.getSpHandle(), msg.getClientInterfaceHandle()),
                                                     "ciHandle", msg.getClientInterfaceHandle(),
                                                     "txnId", TxnEgo.txnIdToString(msg.getTxnId()),
@@ -805,7 +805,7 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         // Also, don't update the truncation handle, since it won't have meaning for anyone.
         if (message.isReadOnly()) {
             if (traceLog != null) {
-                traceLog.add(() -> VoltTrace.endAsync("initsp", MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle(), message.getClientInterfaceHandle())));
+                traceLog.add(() -> VoltTrace.endAsync("localSp", MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle(), message.getClientInterfaceHandle())));
             }
 
             // InvocationDispatcher routes SAFE reads to SPI only
@@ -814,17 +814,16 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             return;
         }
 
+        if (traceLog != null && message.m_sourceHSId == m_mailbox.getHSId()) {
+            traceLog.add(() -> VoltTrace.endAsync("localSp", MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle(), message.getClientInterfaceHandle())/*,
+                                                      "hash", message.getClientResponseData().getHashes()[0]*/));
+        }
+        if (traceLog != null && message.m_sourceHSId != m_mailbox.getHSId()) {
+            traceLog.add(() -> VoltTrace.endAsync("replicateSP",
+                                                    MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle(), message.getClientInterfaceHandle())/*,
+                                                  "hash", message.getClientResponseData().getHashes()[0]*/));
+        }
         if (counter != null) {
-            String traceName = "initsp";
-            if (message.m_sourceHSId != m_mailbox.getHSId()) {
-                traceName = "replicatesp";
-            }
-            String finalTraceName = traceName;
-            if (traceLog != null) {
-                traceLog.add(() -> VoltTrace.endAsync(finalTraceName, MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle(), message.getClientInterfaceHandle()),
-                                                      "hash", message.getClientResponseData().getHashes()[0]));
-            }
-
             int result = counter.offer(message);
             if (result == DuplicateCounter.DONE) {
                 m_duplicateCounters.remove(dcKey);
@@ -859,9 +858,6 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
             }
         }
         else {
-            if (traceLog != null) {
-                traceLog.add(() -> VoltTrace.endAsync("initsp", MiscUtils.hsIdPairTxnIdToString(m_mailbox.getHSId(), message.m_sourceHSId, message.getSpHandle(), message.getClientInterfaceHandle())));
-            }
             // the initiatorHSId is the ClientInterface mailbox.
             // this will be on SPI without k-safety or replica only with k-safety
             assert(!message.isReadOnly());


### PR DESCRIPTION
I found two issues in HostMessenger.presend():
1. AtomicInteger.getAndIncrement() doesn't guarantee each caller to get an unique integer because integer increments atomically doesn't mean get() is synchronized. It's possible to have multiple thread get the same value at same time then increment atomically. This issue leads to uneven distribution of hsid to network thread.
2. Only network threads talk to the same node should be bound evenly,  if we use a global counter it may also lead to uneven distribution of hsid to network thread.