### PR TITLE
Eng 16925 - Fix NPE when join + group by

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
@@ -2062,7 +2062,8 @@ public class Expression {
 
         // There should be at least 2 columnref expressions
         if (uniqueColumnrefs.size() < 2) {
-            throw Error.error(ErrorCode.X_42581, "There should be at least 2 unique table/alias");
+            throw Error.error(ErrorCode.X_42581, "Cannot distinguish column reference between two tables. "
+                    + "Use fully qualified names including the table name or alias to avoid ambiguous references");
         }
         VoltXMLElement lastAlternativeExpr = null;
         VoltXMLElement resultColaesceExpr = null;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionColumn.java
@@ -652,7 +652,10 @@ public class ExpressionColumn extends Expression {
                 return "*";
 
             case OpTypes.COALESCE :
-                return alias.getStatementName();
+                if (alias != null) {
+                    return alias.getStatementName();
+                }
+                return columnName;
 
             case OpTypes.VARIABLE :
             case OpTypes.PARAMETER :

--- a/tests/frontend/org/voltdb/planner/TestSelfJoins.java
+++ b/tests/frontend/org/voltdb/planner/TestSelfJoins.java
@@ -107,7 +107,7 @@ public class TestSelfJoins  extends PlannerTestCase {
 
         // if no alias is used, self join should fail
         failToCompile("select * from R1 JOIN R1 USING(A)",
-                      "There should be at least 2 unique table/alias");
+                      "Use fully qualified names including the table name or alias to avoid ambiguous referencess");
     }
 
     public void testOuterSelfJoin() {

--- a/tests/frontend/org/voltdb/planner/TestSelfJoins.java
+++ b/tests/frontend/org/voltdb/planner/TestSelfJoins.java
@@ -107,7 +107,7 @@ public class TestSelfJoins  extends PlannerTestCase {
 
         // if no alias is used, self join should fail
         failToCompile("select * from R1 JOIN R1 USING(A)",
-                      "Use fully qualified names including the table name or alias to avoid ambiguous referencess");
+                      "Use fully qualified names including the table name or alias to avoid ambiguous references");
     }
 
     public void testOuterSelfJoin() {

--- a/tests/frontend/org/voltdb/regressionsuites/TestGroupBySuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGroupBySuite.java
@@ -183,6 +183,21 @@ public class TestGroupBySuite extends RegressionSuite {
         }
     }
 
+    /** select PK from T1 group by A1, invalid */
+    public void testSelectPKGroupbyA() throws IOException, ProcCallException {
+        Client client = this.getClient();
+
+        loaderNxN(client, 0);
+
+        // execute the query, expected to fail
+        try {
+            client.callProcedure("@AdHoc", "SELECT PKEY from T1 group by A1");
+            fail("Select list should match group by list");
+        } catch (Exception e){
+            assertTrue(e.getMessage().contains("expression not in aggregate or GROUP BY columns"));
+        }
+    }
+
     /** select B_VAL1 from B group by B_VAL1 */
     public void testSelectGroupbyVarbinary() throws IOException, ProcCallException {
         Client client = this.getClient();


### PR DESCRIPTION
This PR fixed the NPE caused by queries like:
`SELECT * FROM R1 A JOIN R2 B USING (ID) GROUP BY A.BIG;`
This query should fail because **select list** should **match group by list**
The NPE is caused by lack of null check for alias.