### PR TITLE
ENG-16589: change segment discard logic

### DIFF
--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -862,7 +862,12 @@ class PBDRegularSegment<M> extends PBDSegment<M> {
 
         @Override
         public boolean anyReadAndDiscarded() {
-            return m_discardCount > 0;
+            /*
+             * This method is called to determine whether the segment can be
+             * deleted; reply true if we have discarded at least the number of
+             * entries (ENG-16589)
+             */
+            return m_discardCount >= m_numOfEntries;
         }
 
         @Override


### PR DESCRIPTION
The test case testOneUnreleasedContainerDiscard() is the one that reproduced the assertion failure at the root of the double free.