### PR TITLE
ENG-15602: Tweak grammar-gen for recent MIGRATE / DDL / pro work

### DIFF
--- a/tests/sqlgrammar/run.sh
+++ b/tests/sqlgrammar/run.sh
@@ -67,9 +67,9 @@ function build() {
 # Build VoltDB: 'pro' version
 function build-pro() {
     echo -e "\n$0 performing: build-pro $BUILD_ARGS"
-    test-tools-build-pro $BUILD_ARGS
-    # For now, the same deployment file is used for 'community' and 'pro'
+    # For now, the same deployment file is used for 'pro' as for 'community'
     DEPLOYMENT_FILE=$SQLGRAMMAR_DIR/deployment.xml
+    test-tools-build-pro $BUILD_ARGS
     code[0]=$code_tt_build
 }
 
@@ -173,6 +173,8 @@ function jars-if-needed() {
 
 # Start the VoltDB server: 'community', open-source version
 function server() {
+    find-directories-if-needed
+    build-if-needed
     echo -e "\n$0 performing: server"
     test-tools-server
     code[3]=${code_tt_server}
@@ -180,10 +182,12 @@ function server() {
 
 # Start the VoltDB server: 'pro' version
 function server-pro() {
+    find-directories-if-needed
+    build-pro-if-needed
     echo -e "\n$0 performing: server-pro"
-    test-tools-server-pro
-    # For now, the same deployment file is used for 'community' and 'pro'
+    # For now, the same deployment file is used for 'pro' as for 'community'
     DEPLOYMENT_FILE=$SQLGRAMMAR_DIR/deployment.xml
+    test-tools-server-pro
     code[3]=${code_tt_server}
 }
 
@@ -357,7 +361,7 @@ function all() {
 function all-pro() {
     echo -e "\n$0 performing: all-pro$ARGS"
     prepare-pro
-    tests
+    tests-pro
     shutdown
 }
 

--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -423,6 +423,8 @@ def print_file_tail_and_errors(from_file, to_file, number_of_lines=50):
                                 'ClassCastException',
                                 'SAXParseException',
                                 'RuntimeException',
+                                'IllegalStateException',
+                                'JSONException',
                                 'VoltTypeException']},
                     {'type':'ERROR', 'title':"'ERROR'",
                     'subtypes':['Error compiling query',
@@ -1394,6 +1396,9 @@ if __name__ == "__main__":
                             ['PARTITION has unknown COLUMN'],
                             ['Invalid use of PRIMARY KEY'],
                             ['Invalid use of UNIQUE'],
+                            ['Stream configured with materialized view without partitioned column'],
+                            ['Invalid parameter count for procedure'],
+                            ['Schema file ended mid-statement'],
                            ]
 
     # A list of headers found in responses to valid 'show' commands: one of

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -597,7 +597,7 @@ function test-tools-shutdown() {
     fi
 
     # Stop the VoltDB server (& kill any stragglers)
-    $VOLTDB_BIN_DIR/voltadmin shutdown
+    $VOLTDB_BIN_DIR/voltadmin shutdown --force
     code_tt_shutdown=$?
     cd $VOLTDB_COM_DIR
     ant killstragglers


### PR DESCRIPTION
Just a few small changes to follow-up on the ENG-15602 work:
In sql_grammar_generator.py, added 3 new, now-common error messages to
known_error_messages; and IllegalStateException and JSONException to the
list of Java Exceptions to look for in the VolDB log (& on the console).
In run.sh, minor tweaks to make sure that the various '...-pro' options
work well together.
In test-tools.sh, just added '--force' to the 'shutdown' option.