### PR TITLE
ENG-16950: skip set IntialSequenceNumber for snapshot Restore path

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -917,7 +917,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     if (action == StreamStartAction.RECOVER || action == StreamStartAction.REJOIN) {
                         seqNo = sequenceNumber;
                     }
-                    m_coordinator.setInitialSequenceNumber(seqNo);
+                    if (action != StreamStartAction.SNAPSHOT_RESTORE) {
+                        m_coordinator.setInitialSequenceNumber(seqNo);
+                    }
                     m_tupleCount = seqNo;
                     // Need to update pending tuples in rejoin
                     resetStateInRejoinOrRecover(seqNo, action);

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -916,10 +916,9 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     long seqNo = 0L;
                     if (action == StreamStartAction.RECOVER || action == StreamStartAction.REJOIN) {
                         seqNo = sequenceNumber;
-                    }
-                    if (action != StreamStartAction.SNAPSHOT_RESTORE) {
                         m_coordinator.setInitialSequenceNumber(seqNo);
                     }
+
                     m_tupleCount = seqNo;
                     // Need to update pending tuples in rejoin
                     resetStateInRejoinOrRecover(seqNo, action);


### PR DESCRIPTION
@SnapshotRestore would trigger truncateExportToSeqNo on existing Eds.
Since restore can act  upon empty stream, the InitialSequenceNumber should be 0L, no need to set again. Skip the set to avoid an assertion that assume ExportCoordination haven't been initialized.

Not sure other side affects in truncateExportToSeqNo() are necessary for the restore path.