### PR TITLE
ENG-17024 alter persistent table

### DIFF
--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -177,9 +177,6 @@ public class DDLCompiler {
     // The varchar column contains JSON representation of original data
     public static String DR_TUPLE_COLUMN_NAME = "TUPLE";
 
-    private static final String INVALID_CREATE_EXPORT = "Invalid CREATE TABLE statement: %s "
-            + "expected syntax: CREATE TABLE <table> [EXPORT TO TARGET <target> ON <OPERATIONS> (column datatype, ...);" +
-            " Only INSERT, DELETE, UPDATE (or one of UPDATE_NEW, UPDATE_OLD) are allowed for OPERATIONS.";
     static final String [][] DR_CONFLICTS_EXPORT_TABLE_META_COLUMNS = {
         {DR_ROW_TYPE_COLUMN_NAME, "VARCHAR(3 BYTES) NOT NULL"},
         {DR_LOG_ACTION_COLUMN_NAME, "VARCHAR(1 BYTES) NOT NULL"},
@@ -738,68 +735,11 @@ public class DDLCompiler {
 
         // if we have export to target clause
         statementMatcher = SQLParser.matchCreateTableExportTo(statement);
-        if (statementMatcher.matches()) {
-            int groups = statementMatcher.groupCount();
-            if (groups > 1 && statementMatcher.group(2) != null && !statementMatcher.group(2).isEmpty()) {
-                String tableName = checkIdentifierStart(statementMatcher.group(1), statement);
-                String targetName = checkIdentifierStart(statementMatcher.group(2), statement);
-                VoltXMLElement tableXML = m_schema.findChild("table", tableName.toUpperCase());
-                if (tableXML == null) {
-                    throw m_compiler.new VoltCompilerException(String.format(
-                            "Invalid DDL statement: table %s does not exist", tableName));
-                }
-
-                List<String> triggers = new ArrayList<>();
-                if (groups > 2 && statementMatcher.group(3) != null && !statementMatcher.group(3).isEmpty()) {
-                    String exportTrigger = checkIdentifierStart(statementMatcher.group(3), statement);
-                    triggers = validateExportTriggers(exportTrigger);
-                }
-                if (triggers.isEmpty()) {
-                    triggers = Arrays.asList("INSERT");
-                }
-                targetName = targetName.toUpperCase();
-                tableName = tableName.toUpperCase();
-                VoltXMLElement pe = new VoltXMLElement(PersistentExport.PERSISTENT_EXPORT);
-                pe.attributes.put("target", targetName);
-                pe.attributes.put("triggers", String.join(",", triggers));
-                tableXML.children.add(pe);
-
-                // update export to target in the cached schema
-                VoltXMLElement lastSchema = m_hsql.getLastSchema(tableName.toLowerCase());
-                if (lastSchema != null) {
-                    VoltXMLElement lastXml = lastSchema.findChild("table", tableName);
-                    if (lastXml != null) {
-                        lastXml.children.add(pe.duplicate());
-                    }
-                }
-            }
-        } else {
+        if (!statementMatcher.matches()) {
             throw m_compiler.new VoltCompilerException(String.format("Invalid CREATE TABLE statement: \"%s\", "
                             + "expected syntax: CREATE TABLE <table> [MIGRATE/EXPORT TO TARGET <target>] (column datatype, ...); ",
                     statement.substring(0, statement.length() - 1)));
         }
-    }
-
-    private List<String> validateExportTriggers(String triggers) throws VoltCompilerException {
-        triggers = triggers.toUpperCase();
-        List<String> exportTriggers = Arrays.asList(triggers.split(","));
-        Set<String> triggerSets = new HashSet<String>(exportTriggers);
-        if (exportTriggers.size() != triggerSets.size() || exportTriggers.size() > 3) {
-            throw m_compiler.new VoltCompilerException(String.format(INVALID_CREATE_EXPORT, triggers));
-        }
-
-        triggerSets.remove("INSERT");
-        triggerSets.remove("DELETE");
-        if (triggerSets.contains("UPDATE")) {
-            triggerSets.remove("UPDATE");
-            if (!triggerSets.isEmpty()) {
-                throw m_compiler.new VoltCompilerException(String.format(INVALID_CREATE_EXPORT, triggers));
-            }
-        }
-        if (triggerSets.contains("UPDATE_NEW") && triggerSets.contains("UPDATE_OLD")) {
-            throw m_compiler.new VoltCompilerException(String.format(INVALID_CREATE_EXPORT, triggers));
-        }
-        return exportTriggers;
     }
 
     private void checkValidPartitionTableIndex(Index index, Column partitionCol, String tableName)

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDDL.java
@@ -1026,38 +1026,7 @@ public class ParserDDL extends ParserRoutine {
             return;
         }
         String target = readMigrateTarget();
-        List<String> triggers = new ArrayList<>();
-        read();
-        if (token.tokenType == Tokens.ON) {
-            read();
-            while (token.tokenType != Tokens.OPENBRACKET) {
-                if (token.tokenType == Tokens.DELETE) {
-                    triggers.add(Tokens.T_DELETE);
-                } else if (token.tokenType == Tokens.INSERT) {
-                    triggers.add(Tokens.T_INSERT);
-                } else if (token.tokenType == Tokens.UPDATE) {
-                    triggers.add(Tokens.T_UPDATE);
-                } else if (token.tokenType == Tokens.UPDATEOLD) {
-                    triggers.add(Tokens.T_UPDATEOLD);
-                } else if (token.tokenType == Tokens.UPDATENEW) {
-                    triggers.add(Tokens.T_UPDATENEW);
-                } else if (token.tokenType != Tokens.COMMA){
-                    throw unexpectedToken();
-                }
-                read();
-            }
-            if (triggers.contains(Tokens.T_UPDATE) && (triggers.contains(Tokens.T_UPDATEOLD) || triggers.contains(Tokens.T_UPDATENEW))){
-                throw unexpectedToken("Cann't combine " + Tokens.T_UPDATE + " with " + Tokens.T_UPDATEOLD +
-                        " or " + Tokens.T_UPDATENEW);
-            }
-            if (triggers.contains(Tokens.T_UPDATEOLD) && triggers.contains(Tokens.T_UPDATENEW)) {
-                throw unexpectedToken("Use " + Tokens.T_UPDATE + " instead of both " + Tokens.T_UPDATEOLD +
-                        " and " + Tokens.T_UPDATENEW);
-            }
-        }
-        if (triggers.isEmpty()) {
-            triggers= Arrays.asList("INSERT");
-        }
+        List<String> triggers = readExportTrigger(false);
         target = target.toUpperCase();
         PersistentExport export = new PersistentExport(target, triggers);
         table.persistentExport = export;
@@ -1070,39 +1039,7 @@ public class ParserDDL extends ParserRoutine {
         }
         String target = readMigrateTarget();
         // read triggers
-        List<String> triggers = new ArrayList<>();
-        read();
-        if (token.tokenType == Tokens.ON) {
-            read();
-            while (token.tokenType != Tokens.SEMICOLON) {
-                if (token.tokenType == Tokens.DELETE) {
-                    triggers.add(Tokens.T_DELETE);
-                } else if (token.tokenType == Tokens.INSERT) {
-                    triggers.add(Tokens.T_INSERT);
-                } else if (token.tokenType == Tokens.UPDATE) {
-                    triggers.add(Tokens.T_UPDATE);
-                } else if (token.tokenType == Tokens.UPDATEOLD) {
-                    triggers.add(Tokens.T_UPDATEOLD);
-                } else if (token.tokenType == Tokens.UPDATENEW) {
-                    triggers.add(Tokens.T_UPDATENEW);
-                } else if (token.tokenType != Tokens.COMMA){
-                    throw unexpectedToken();
-                }
-                read();
-            }
-            if (triggers.contains(Tokens.T_UPDATE) && (triggers.contains(Tokens.T_UPDATEOLD) || triggers.contains(Tokens.T_UPDATENEW))){
-                throw unexpectedToken("Cann't combine " + Tokens.T_UPDATE + " with " + Tokens.T_UPDATEOLD +
-                        " or " + Tokens.T_UPDATENEW);
-            }
-            if (triggers.contains(Tokens.T_UPDATEOLD) && triggers.contains(Tokens.T_UPDATENEW)) {
-                throw unexpectedToken("Use " + Tokens.T_UPDATE + " instead of both " + Tokens.T_UPDATEOLD +
-                        " and " + Tokens.T_UPDATENEW);
-            }
-        }
-        if (triggers.isEmpty()) {
-            triggers= Arrays.asList("INSERT");
-        }
-
+        List<String> triggers = readExportTrigger(true);
         Object[] args = new Object[] {
                 table.getName(),
                 target.toUpperCase(),
@@ -1114,6 +1051,66 @@ public class ParserDDL extends ParserRoutine {
                                        null, table.getName());
     }
 
+    private List<String> readExportTrigger(boolean alter) {
+        List<String> triggers = new ArrayList<>();
+        read();
+        if (token.tokenType == Tokens.ON) {
+            read();
+            int lastTokenType = token.tokenType;
+            int endToken = (alter ? Tokens.SEMICOLON : Tokens.OPENBRACKET);
+            while (token.tokenType != endToken) {
+                String theToken = null;;
+                switch(token.tokenType) {
+                case Tokens.DELETE:
+                    theToken = Tokens.T_DELETE;
+                    break;
+                case Tokens.INSERT:
+                    theToken = Tokens.T_INSERT;
+                    break;
+                case Tokens.UPDATE:
+                    theToken = Tokens.T_UPDATE;
+                    break;
+                case Tokens.UPDATEOLD:
+                    theToken = Tokens.T_UPDATEOLD;
+                    break;
+                case Tokens.UPDATENEW:
+                    theToken = Tokens.T_UPDATENEW;
+                    break;
+                default:
+                    if (token.tokenType != Tokens.COMMA){
+                        throw unexpectedToken();
+                    }
+                }
+                if (theToken != null) {
+                    if (triggers.contains(theToken)) {
+                        throw unexpectedToken();
+                    }
+                    triggers.add(theToken);
+                }
+                read();
+
+                // Cannot have two same tokens in a row
+                if (lastTokenType == token.tokenType) {
+                    throw unexpectedToken();
+                }
+                lastTokenType = token.tokenType;
+            }
+        }
+        if (triggers.contains(Tokens.T_UPDATE) && (triggers.contains(Tokens.T_UPDATEOLD) || triggers.contains(Tokens.T_UPDATENEW))){
+            throw unexpectedToken("Cann't combine " + Tokens.T_UPDATE + " with " + Tokens.T_UPDATEOLD +
+                    " or " + Tokens.T_UPDATENEW);
+        }
+        if (triggers.contains(Tokens.T_UPDATEOLD) && triggers.contains(Tokens.T_UPDATENEW)) {
+            throw unexpectedToken("Use " + Tokens.T_UPDATE + " instead of both " + Tokens.T_UPDATEOLD +
+                    " and " + Tokens.T_UPDATENEW);
+        }
+
+        if (triggers.isEmpty()) {
+            triggers= Arrays.asList("INSERT");
+        }
+
+        return triggers;
+    }
     private Statement readTimeToLive(Table table, boolean alter) {
         //syntax: USING TTL 10 SECONDS ON COLUMN a BATCH_SIZE 1000 MAX_FREQUENCY 1 MIGRATE TO TARGET <TARGET NAME>
         if (!alter && token.tokenType != Tokens.USING) {

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Table.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Table.java
@@ -1009,6 +1009,7 @@ public class Table extends TableBase implements SchemaObject {
             tn.persistenceScope = persistenceScope;
         }
 
+        tn.persistentExport = this.persistentExport;
         for (int i = 0; i < getColumnCount(); i++) {
             ColumnSchema col = (ColumnSchema) columnList.get(i);
 

--- a/tests/frontend/org/voltdb/export/TestPersistentExport.java
+++ b/tests/frontend/org/voltdb/export/TestPersistentExport.java
@@ -139,6 +139,14 @@ public class TestPersistentExport extends ExportLocalClusterBase {
         client.drain();
         TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
         checkTupleCount(client, "T3", 400, true);
+
+        //test alter table add column
+        client.callProcedure("@AdHoc",  "ALTER TABLE T3 ADD COLUMN tweaked SMALLINT DEFAULT 0;");
+        client.callProcedure("@AdHoc", "ALTER TABLE T3 ALTER EXPORT TO TARGET FOO3 ON INSERT;");
+        insertToStreamWithNewColumn("T3", 600, 100, client, data);
+        client.drain();
+        TestExportBaseSocketExport.waitForStreamedTargetAllocatedMemoryZero(client);
+        checkTupleCount(client, "T3", 500, true);
     }
 
     private static void checkTupleCount(Client client, String tableName, long expectedCount, boolean replicated){

--- a/tests/frontend/org/voltdb/export/TestPersistentExport.java
+++ b/tests/frontend/org/voltdb/export/TestPersistentExport.java
@@ -141,7 +141,7 @@ public class TestPersistentExport extends ExportLocalClusterBase {
         checkTupleCount(client, "T3", 400, true);
 
         //test alter table add column
-        client.callProcedure("@AdHoc",  "ALTER TABLE T3 ADD COLUMN tweaked SMALLINT DEFAULT 0;");
+        client.callProcedure("@AdHoc", "ALTER TABLE T3 ADD COLUMN tweaked SMALLINT DEFAULT 0;");
         client.callProcedure("@AdHoc", "ALTER TABLE T3 ALTER EXPORT TO TARGET FOO3 ON INSERT;");
         insertToStreamWithNewColumn("T3", 600, 100, client, data);
         client.drain();


### PR DESCRIPTION
Export connectors are dropped while adding new column to persistent export tables because the export clause is processed after tables are parsed and hold on session.  Now the export clause is parsed while tables are created to prevent  export connector  from being dropped. 