### PR TITLE
ENG-16468: Fix grammar-gen to not run 'voltdb init' twice

### DIFF
--- a/tests/sqlgrammar/run.sh
+++ b/tests/sqlgrammar/run.sh
@@ -237,7 +237,7 @@ function ddl-if-needed() {
 function ddl-pro() {
     ddl-if-needed
 
-    echo -e "\n$0 performing: ddl; running (in sqlcmd): $SQLGRAMMAR_DIR/DDL-pro.sql"
+    echo -e "\n$0 performing: ddl-pro; running (in sqlcmd): $SQLGRAMMAR_DIR/DDL-pro.sql"
     $VOLTDB_BIN_DIR/sqlcmd < $SQLGRAMMAR_DIR/DDL-pro.sql
     code4e=$?
 

--- a/tests/sqlgrammar/run.sh
+++ b/tests/sqlgrammar/run.sh
@@ -67,9 +67,9 @@ function build() {
 # Build VoltDB: 'pro' version
 function build-pro() {
     echo -e "\n$0 performing: build-pro $BUILD_ARGS"
-    test-tools-build-pro $BUILD_ARGS
-    # For now, the same deployment file is used for 'community' and 'pro'
+    # For now, the same deployment file is used for 'pro' as for 'community'
     DEPLOYMENT_FILE=$SQLGRAMMAR_DIR/deployment.xml
+    test-tools-build-pro $BUILD_ARGS
     code[0]=$code_tt_build
 }
 
@@ -173,6 +173,8 @@ function jars-if-needed() {
 
 # Start the VoltDB server: 'community', open-source version
 function server() {
+    find-directories-if-needed
+    build-if-needed
     echo -e "\n$0 performing: server"
     test-tools-server
     code[3]=${code_tt_server}
@@ -180,10 +182,12 @@ function server() {
 
 # Start the VoltDB server: 'pro' version
 function server-pro() {
+    find-directories-if-needed
+    build-pro-if-needed
     echo -e "\n$0 performing: server-pro"
-    test-tools-server-pro
-    # For now, the same deployment file is used for 'community' and 'pro'
+    # For now, the same deployment file is used for 'pro' as for 'community'
     DEPLOYMENT_FILE=$SQLGRAMMAR_DIR/deployment.xml
+    test-tools-server-pro
     code[3]=${code_tt_server}
 }
 
@@ -357,7 +361,7 @@ function all() {
 function all-pro() {
     echo -e "\n$0 performing: all-pro$ARGS"
     prepare-pro
-    tests
+    tests-pro
     shutdown
 }
 

--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -423,6 +423,8 @@ def print_file_tail_and_errors(from_file, to_file, number_of_lines=50):
                                 'ClassCastException',
                                 'SAXParseException',
                                 'RuntimeException',
+                                'IllegalStateException',
+                                'JSONException',
                                 'VoltTypeException']},
                     {'type':'ERROR', 'title':"'ERROR'",
                     'subtypes':['Error compiling query',
@@ -1394,6 +1396,9 @@ if __name__ == "__main__":
                             ['PARTITION has unknown COLUMN'],
                             ['Invalid use of PRIMARY KEY'],
                             ['Invalid use of UNIQUE'],
+                            ['Stream configured with materialized view without partitioned column'],
+                            ['Invalid parameter count for procedure'],
+                            ['Schema file ended mid-statement'],
                            ]
 
     # A list of headers found in responses to valid 'show' commands: one of

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -575,9 +575,7 @@ function test-tools-server-pro() {
 # Ubuntu-14.04 machines; and 'jps' no longer seems to work either.
 function test-tools-server-count() {
     COUNT_VOLTDB_PROCESSES=`ps -ef | grep -v grep | grep -vi SQLCommand | grep -cE 'voltdb/voltdb-[1-9]?[0-9](.[0-9])+.jar'`
-    if [[ "$TT_DEBUG" -ge "2" ]]; then
-        echo -e "\n$0 performing: test-tools-server-count: $COUNT_VOLTDB_PROCESSES"
-    fi
+    echo -e "\n$0 performing: test-tools-server-count: $COUNT_VOLTDB_PROCESSES"
     return $COUNT_VOLTDB_PROCESSES
 }
 
@@ -586,13 +584,9 @@ function test-tools-server-if-needed() {
     test-tools-server-count
     RETURN_CODE=$?
     if [[ "$RETURN_CODE" -gt "0" ]]; then
-        if [[ "$TT_DEBUG" -ge "2" ]]; then
-            echo -e "Not (re-)starting a VoltDB server, because 'ps -ef' now includes a VoltDB process."
-        fi
+        echo -e "Not (re-)starting a VoltDB server, because 'ps -ef' now includes a VoltDB process."
     else
-        if [[ "$TT_DEBUG" -ge "2" ]]; then
-            echo -e "A VoltDB server will be started, because 'ps -ef' does not include a VoltDB process."
-        fi
+        echo -e "A VoltDB server will be started, because 'ps -ef' does not include a VoltDB process."
         test-tools-server
     fi
 }

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -596,13 +596,9 @@ function test-tools-server-pro-if-needed() {
     test-tools-server-count
     RETURN_CODE=$?
     if [[ "$RETURN_CODE" -gt "0" ]]; then
-        if [[ "$TT_DEBUG" -ge "2" ]]; then
-            echo -e "Not (re-)starting a VoltDB server, because 'ps -ef' now includes a VoltDB process."
-        fi
+        echo -e "Not (re-)starting a VoltDB (pro) server, because 'ps -ef' now includes a VoltDB process."
     else
-        if [[ "$TT_DEBUG" -ge "2" ]]; then
-            echo -e "A VoltDB server will be started, because 'ps -ef' does not include a VoltDB process."
-        fi
+        echo -e "A VoltDB (pro) server will be started, because 'ps -ef' does not include a VoltDB process."
         test-tools-server-pro
     fi
 }

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -615,7 +615,7 @@ function test-tools-shutdown() {
     fi
 
     # Stop the VoltDB server (& kill any stragglers)
-    $VOLTDB_BIN_DIR/voltadmin shutdown
+    $VOLTDB_BIN_DIR/voltadmin shutdown --force
     code_tt_shutdown=$?
     cd $VOLTDB_COM_DIR
     ant killstragglers


### PR DESCRIPTION
Added new function test-tools-server-count to test-tools.sh; and now use
it in test-tools-server-if-needed and test-tools-server-pro-if-needed,
to more reliably detect whether a VoltDB server is already running. Also
added improved error messages, particularly in
test-tools-wait-for-server-to-start (& its call to tt-exit-script).