### PR TITLE
ENG-17013 Fix Crash When Companion Stream Dropped in non-stream Catalog Update

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1217,7 +1217,7 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
             }
             if (streamedTable) {
                 //Dont update and roll generation if this is just a non stream table update.
-                if (isStreamUpdate) {
+                if (isStreamUpdate || persistentTable->getStreamedTable()) {
                     const std::string& name = streamedTable->name();
                     if (tableTypeNeedsTupleStream(tcd->getTableType())) {
                         attachTupleStream(streamedTable, name, purgedStreams, timestamp);

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1209,6 +1209,11 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
                 streamedTable = persistentTable->getStreamedTable();
                 if (streamedTable) {
                     VOLT_DEBUG("Updating companion stream for %s", persistentTable->name().c_str());
+                    const std::string& name = streamedTable->name();
+                    if (tableTypeNeedsTupleStream(tcd->getTableType())) {
+                        attachTupleStream(streamedTable, name, purgedStreams, timestamp);
+                        tableSchemaChanged = haveDifferentSchema(catalogTable, streamedTable, false);
+                    }
                 }
                 tableSchemaChanged = haveDifferentSchema(catalogTable, persistentTable, true);
 
@@ -1217,7 +1222,7 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
             }
             if (streamedTable) {
                 //Dont update and roll generation if this is just a non stream table update.
-                if (isStreamUpdate || persistentTable->getStreamedTable()) {
+                if (isStreamUpdate) {
                     const std::string& name = streamedTable->name();
                     if (tableTypeNeedsTupleStream(tcd->getTableType())) {
                         attachTupleStream(streamedTable, name, purgedStreams, timestamp);


### PR DESCRIPTION
This crash happens when EE is updating catalog and replaying the SQL Statement, migrate table's companion stream might be dropped if the table is empty. 

Will add a test case.