### PR TITLE
Eng 17049 - Fix NPE when LIKE "%" used in migrate statement

### DIFF
--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -64,6 +64,7 @@ public final class ExpressionUtil {
        put("multiply", ExpressionType.OPERATOR_MULTIPLY);
        put("divide", ExpressionType.OPERATOR_DIVIDE);
        put("is_null", ExpressionType.OPERATOR_IS_NULL);
+       put("like", ExpressionType.COMPARE_LIKE);
     }};
 
     private ExpressionUtil() {}
@@ -103,6 +104,7 @@ public final class ExpressionUtil {
                 case OPERATOR_CONCAT:
                 case OPERATOR_MOD:
                 case COMPARE_IN:
+                case COMPARE_LIKE:
                     return isParameterized(elm.children.get(0)) || isParameterized(elm.children.get(1));
                 case OPERATOR_IS_NULL:      // one operator
                 case OPERATOR_EXISTS:
@@ -254,7 +256,8 @@ public final class ExpressionUtil {
                 case COMPARE_NOTEQUAL:
                 case COMPARE_NOTDISTINCT:
                 case COMPARE_GREATERTHANOREQUALTO:
-                case COMPARE_LESSTHANOREQUALTO: {
+                case COMPARE_LESSTHANOREQUALTO:
+                case COMPARE_LIKE: {
                     final ComparisonExpression expr = new ComparisonExpression(op,
                             from(db, elm.children.get(0), hint),
                             from(db, elm.children.get(1), hint));

--- a/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
@@ -62,13 +62,15 @@ public class TestAdhocMigrateTable extends AdhocDDLTestBase {
     public void testSimple() throws Exception {
         testMigrate(
                 "CREATE TABLE with_ttl migrate to target foo (i int NOT NULL, j FLOAT) USING TTL 1 minutes ON COLUMN i;\n" +
-                "CREATE TABLE without_ttl migrate to target foo (i int NOT NULL, j FLOAT);\n" +
+                "CREATE TABLE without_ttl migrate to target foo (i int NOT NULL, j FLOAT, k VARCHAR(20));\n" +
                 "CREATE TABLE with_ttl_no_target(i int NOT NULL, j FLOAT) USING TTL 1 minutes ON COLUMN i;\n" +
                 "CREATE TABLE without_ttl_no_target(i int NOT NULL, j FLOAT);\n",
                 Stream.of(
                         Pair.of("MIGRATE FROM without_ttl;", false),
                         Pair.of("MIGRATE FROM without_ttl WHERE not migrating;", true),
                         Pair.of("MIGRATE FROM without_ttl WHERE i < 0 and not migrating;", true),
+                        // ENG-17049 add support for like ''
+                        Pair.of("MIGRATE FROM without_ttl where k Like 'sss%' and not migrating", true),
                         Pair.of("MIGRATE FROM with_ttl;", false),
                         Pair.of("MIGRATE FROM with_ttl WHERE j > 0;", false),
                         Pair.of("MIGRATE FROM with_ttl WHERE not migrating;", true),
@@ -93,6 +95,7 @@ public class TestAdhocMigrateTable extends AdhocDDLTestBase {
             setup(ddl);
             queries.forEach(stmtAndExpected -> {
                 final String stmt = stmtAndExpected.getFirst();
+                System.out.println(stmt);
                 final boolean pass = stmtAndExpected.getSecond();
                 try {
                     m_client.callProcedure("@AdHoc", stmt);

--- a/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
@@ -95,7 +95,6 @@ public class TestAdhocMigrateTable extends AdhocDDLTestBase {
             setup(ddl);
             queries.forEach(stmtAndExpected -> {
                 final String stmt = stmtAndExpected.getFirst();
-                System.out.println(stmt);
                 final boolean pass = stmtAndExpected.getSecond();
                 try {
                     m_client.callProcedure("@AdHoc", stmt);


### PR DESCRIPTION
Add like operator in `XMLOpType` map and switch statement so statement 
`MIGRATE FROM TABLE WHERE COL LIKE "SSS%"` 
won't throw NPE