### PR TITLE
Eng 17049 - Fix NPE when LIKE "%" used in migrate statement 

### DIFF
--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -17,12 +17,20 @@
 
 package org.voltdb.expressions;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import com.google_voltpatches.common.collect.Lists;
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.voltcore.utils.Pair;
 import org.voltdb.VoltType;
@@ -32,6 +40,8 @@ import org.voltdb.compiler.VoltXMLElementHelper;
 import org.voltdb.exceptions.PlanningErrorException;
 import org.voltdb.types.ExpressionType;
 import org.voltdb.types.QuantifierType;
+
+import com.google_voltpatches.common.collect.Lists;
 
 /**
  *
@@ -56,6 +66,7 @@ public final class ExpressionUtil {
        put("multiply", ExpressionType.OPERATOR_MULTIPLY);
        put("divide", ExpressionType.OPERATOR_DIVIDE);
        put("is_null", ExpressionType.OPERATOR_IS_NULL);
+       put("like", ExpressionType.COMPARE_LIKE);
     }};
 
     private ExpressionUtil() {}
@@ -95,6 +106,7 @@ public final class ExpressionUtil {
                 case OPERATOR_CONCAT:
                 case OPERATOR_MOD:
                 case COMPARE_IN:
+                case COMPARE_LIKE:
                     return isParameterized(elm.children.get(0)) || isParameterized(elm.children.get(1));
                 case OPERATOR_IS_NULL:      // one operator
                 case OPERATOR_EXISTS:
@@ -252,7 +264,8 @@ public final class ExpressionUtil {
                         case COMPARE_NOTEQUAL:
                         case COMPARE_NOTDISTINCT:
                         case COMPARE_GREATERTHANOREQUALTO:
-                        case COMPARE_LESSTHANOREQUALTO: {
+                        case COMPARE_LESSTHANOREQUALTO:
+                        case COMPARE_LIKE: {
                             final ComparisonExpression expr = new ComparisonExpression(op,
                                     from(db, elm.children.get(0), hint),
                                     from(db, elm.children.get(1), hint));

--- a/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
@@ -62,13 +62,15 @@ public class TestAdhocMigrateTable extends AdhocDDLTestBase {
     public void testSimple() throws Exception {
         testMigrate(
                 "CREATE TABLE with_ttl migrate to target foo (i int NOT NULL, j FLOAT) USING TTL 1 minutes ON COLUMN i;\n" +
-                "CREATE TABLE without_ttl migrate to target foo (i int NOT NULL, j FLOAT);\n" +
+                "CREATE TABLE without_ttl migrate to target foo (i int NOT NULL, j FLOAT, k VARCHAR(20));\n" +
                 "CREATE TABLE with_ttl_no_target(i int NOT NULL, j FLOAT) USING TTL 1 minutes ON COLUMN i;\n" +
                 "CREATE TABLE without_ttl_no_target(i int NOT NULL, j FLOAT);\n",
                 Stream.of(
                         Pair.of("MIGRATE FROM without_ttl;", false),
                         Pair.of("MIGRATE FROM without_ttl WHERE not migrating;", true),
                         Pair.of("MIGRATE FROM without_ttl WHERE i < 0 and not migrating;", true),
+                         // ENG-17049 add support for like ''
+                        Pair.of("MIGRATE FROM without_ttl WHERE k Like 'sss%' and not migrating;", true),
                         Pair.of("MIGRATE FROM with_ttl;", false),
                         Pair.of("MIGRATE FROM with_ttl WHERE j > 0;", false),
                         Pair.of("MIGRATE FROM with_ttl WHERE not migrating;", true),


### PR DESCRIPTION
Add like operator in `XMLOpType` map and switch statement so statement 
`MIGRATE FROM TABLE WHERE COL LIKE "SSS%"` 
won't throw NPE