### PR TITLE
Fix broken pool build

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.cpp
+++ b/src/ee/common/SynchronizedThreadLock.cpp
@@ -112,8 +112,7 @@ void SynchronizedThreadLock::init(int32_t sitesPerHost, EngineLocals& newEngineL
 
             delete s_mpEngine.stringData;
             s_mpEngine.stringData = new CompactingStringStorage();
-
-            s_mpEngine.allocated = 0;
+            s_mpEngine.allocated = new size_t(0);   // NOTE: cannot delete allocated here
         }
     }
 }
@@ -135,11 +134,11 @@ void SynchronizedThreadLock::resetMemory(int32_t partitionId) {
             s_mpEngine.stringData = NULL;
             delete s_mpEngine.enginePartitionId;
             s_mpEngine.enginePartitionId = NULL;
+            delete s_mpEngine.allocated;
+            s_mpEngine.allocated = nullptr;
             s_mpEngine.context = NULL;
 #ifdef VOLT_POOL_CHECKING
-            pthread_mutex_lock(&s_sharedEngineMutex);
             ThreadLocalPool::SizeBucketMap_t& mapBySize = ThreadLocalPool::s_allocations[s_mpMemoryPartitionId];
-            pthread_mutex_unlock(&s_sharedEngineMutex);
             auto mapForAdd = mapBySize.begin();
             while (mapForAdd != mapBySize.end()) {
                 auto& allocMap = mapForAdd->second;

--- a/src/ee/common/SynchronizedThreadLock.cpp
+++ b/src/ee/common/SynchronizedThreadLock.cpp
@@ -137,12 +137,12 @@ void SynchronizedThreadLock::resetMemory(int32_t partitionId) {
             s_mpEngine.enginePartitionId = NULL;
             s_mpEngine.context = NULL;
 #ifdef VOLT_POOL_CHECKING
-            pthread_mutex_lock(&ThreadLocalPool::s_sharedMemoryMutex);
+            pthread_mutex_lock(&s_sharedEngineMutex);
             ThreadLocalPool::SizeBucketMap_t& mapBySize = ThreadLocalPool::s_allocations[s_mpMemoryPartitionId];
-            pthread_mutex_unlock(&ThreadLocalPool::s_sharedMemoryMutex);
-            ThreadLocalPool::SizeBucketMap_t::iterator mapForAdd = mapBySize.begin();
+            pthread_mutex_unlock(&s_sharedEngineMutex);
+            auto mapForAdd = mapBySize.begin();
             while (mapForAdd != mapBySize.end()) {
-                ThreadLocalPool::AllocTraceMap_t& allocMap = mapForAdd->second;
+                auto& allocMap = mapForAdd->second;
                 mapForAdd++;
                 if (!allocMap.empty()) {
                     ThreadLocalPool::AllocTraceMap_t::iterator nextAlloc = allocMap.begin();

--- a/src/ee/common/ThreadLocalPool.cpp
+++ b/src/ee/common/ThreadLocalPool.cpp
@@ -37,7 +37,7 @@ thread_local CompactingStringStorage* m_stringKey = nullptr;
 /**
  * Thread local key for storing integer value of amount of memory allocated
  */
-thread_local size_t m_allocated = 0;
+thread_local size_t* m_allocated = nullptr;
 thread_local int32_t* m_threadPartitionIdPtr = nullptr;
 thread_local int32_t* m_enginePartitionIdPtr = nullptr;
 
@@ -48,7 +48,7 @@ ThreadLocalPool::PartitionBucketMap_t ThreadLocalPool::s_allocations;
 
 ThreadLocalPool::ThreadLocalPool() {
     if (m_key == nullptr) {
-        m_allocated = 0;
+        m_allocated = new size_t(0);
         // Since these are int32_t values we can't just
         // put them into the void* pointer which is the thread
         // local data.  We have to allocate an int32_t
@@ -120,8 +120,10 @@ ThreadLocalPool::~ThreadLocalPool() {
         delete m_stringKey;
         delete m_key->second;
         delete m_key;
+        delete m_allocated;
         m_stringKey = nullptr;
         m_key = nullptr;
+        m_allocated = nullptr;
         m_enginePartitionIdPtr = m_threadPartitionIdPtr = nullptr;
     } else {
         m_key->first--;
@@ -472,11 +474,11 @@ void ThreadLocalPool::freeExactSizedObject(std::size_t sz, void* object) {
 }
 
 // internal non-member helper function for calcuate Pool allocation Size
-std::size_t getPoolAllocationSize_internal(size_t bytes, CompactingStringStorage *poolMap) {
+std::size_t getPoolAllocationSize_internal(size_t *bytes, CompactingStringStorage *poolMap) {
     // For relocatable objects, each object-size-specific pool
     // -- or actually, its ContiguousAllocator -- tracks its own memory
     // allocation, so sum them, here.
-    return std::accumulate(poolMap->cbegin(), poolMap->cend(), bytes,
+    return std::accumulate(poolMap->cbegin(), poolMap->cend(), *bytes,
             [](size_t acc, typename CompactingStringStorage::value_type const& cur) {
             return acc + cur.second->getBytesAllocated();
             });
@@ -544,14 +546,14 @@ int32_t ThreadLocalPool::getEnginePartitionIdWithNullCheck() {
 }
 
 char* voltdb_pool_allocator_new_delete::malloc(const size_t bytes) {
-    m_allocated += bytes + sizeof(std::size_t);
+    *m_allocated += bytes + sizeof(std::size_t);
     char *retval = new char[bytes + sizeof(std::size_t)];
     *reinterpret_cast<std::size_t*>(retval) = bytes + sizeof(std::size_t);
     return &retval[sizeof(std::size_t)];
 }
 
 void voltdb_pool_allocator_new_delete::free(char *const block) {
-    m_allocated -= *reinterpret_cast<std::size_t*>(block - sizeof(std::size_t));
+    *m_allocated -= *reinterpret_cast<std::size_t*>(block - sizeof(std::size_t));
     delete [](block - sizeof(std::size_t));
 }
 

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -51,7 +51,7 @@ struct PoolLocals {
 
     PoolPairType* poolData = nullptr;
     CompactingStringStorage* stringData = nullptr;
-    std::size_t allocated;
+    std::size_t* allocated;
     int32_t* enginePartitionId = nullptr;
 };
 


### PR DESCRIPTION
Fixed broken build with `-DVOLT_POOL_CHECKING=true`.
Reverted my change on `ThreadLocals::allocated` from type `size_t` back to `size_t*`.
Passed tests on my local machine:
1. regular eecheck; 
2. memcheck (`ant -Dbuild=memcheck -DVOLT_REGRESSIONS=local -DtimeoutLength=1500000 eecheck killstragglers junit_lite_sql`); 
3. pool check (`ant -Djmemcheck=NO_MEMCHECK -DVOLT_POOL_CHECKING=true eecheck -Dbuild=debug`);
4. trace-allocation check (`ant -Djmemcheck=NO_MEMCHECK eecheck -DVOLT_POOL_CHECKING=true -DVOLT_TRACE_ALLOCATIONS=true -Dbuild=debug`).

Waiting on system test with build of 3, 4.