### PR TITLE
Added stack trace to Volt exceptions

### DIFF
--- a/src/catgen/in/cppsrc/catalog.cpp
+++ b/src/catgen/in/cppsrc/catalog.cpp
@@ -75,7 +75,9 @@ void Catalog::purgeDeletions() {
         boost::unordered_map<std::string, CatalogType*>::iterator object = m_allCatalogObjects.find(*i);
         if (object == m_allCatalogObjects.end()) {
             std::string errmsg = "Catalog reference for " + (*i) + " not found.";
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, errmsg);
+            throw SerializableEEException(
+                    VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                    errmsg);
         }
         delete object->second;
     }
@@ -91,8 +93,9 @@ void Catalog::execute(const string &stmts) {
     }
 
     if (m_unresolved.size() > 0) {
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                      "failed to execute catalog");
+        throw SerializableEEException(
+                VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                "failed to execute catalog");
     }
 }
 
@@ -194,8 +197,9 @@ void Catalog::executeOne(const string &stmt) {
         }
     }
     else {
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                      "Invalid catalog command.");
+        throw SerializableEEException(
+                VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                "Invalid catalog command.");
     }
 }
 
@@ -310,8 +314,9 @@ Catalog::addChild(const string &collectionName, const string &childName) {
     if (collectionName.compare("clusters") == 0) {
         CatalogType *exists = m_clusters.get(childName);
         if (exists) {
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                          "trying to add a duplicate value.");
+            throw SerializableEEException(
+                    VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                    "trying to add a duplicate value.");
         }
         return m_clusters.add(childName);
     }

--- a/src/catgen/in/cppsrc/catalogtype.cpp
+++ b/src/catgen/in/cppsrc/catalogtype.cpp
@@ -82,8 +82,8 @@ void CatalogType::set(const string &field, const string &value) {
         val.intValue = atoi(value.c_str());
     else {
         string msg = "Invalid value '" + value + "' for field '" + field + "'";
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                      msg.c_str());
+        throw SerializableEEException(
+                VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg.c_str());
     }
 
     m_fields[field] = val;

--- a/src/ee/common/InterruptException.cpp
+++ b/src/ee/common/InterruptException.cpp
@@ -20,7 +20,7 @@
 using namespace voltdb;
 
 InterruptException::InterruptException(std::string message) :
-    SerializableEEException(VOLT_EE_EXCEPTION_TYPE_INTERRUPT, message) {
+    SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_INTERRUPT, message) {
 }
 
 void InterruptException::p_serialize(ReferenceSerializeOutput *output) const {

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -2597,11 +2597,9 @@ inline uint16_t NValue::getTupleStorageSize(const ValueType type) {
       case VALUE_TYPE_POINT:
         return sizeof(GeographyPointValue);
       default:
-          char message[128];
-          snprintf(message, 128, "NValue::getTupleStorageSize() unsupported type '%s'",
-                   getTypeName(type).c_str());
-          throw SerializableEEException(
-                  VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+          throwSerializableEEException(
+                  "NValue::getTupleStorageSize() unsupported type '%s'",
+                  getTypeName(type).c_str());
     }
 }
 
@@ -3006,11 +3004,8 @@ template <TupleSerializationFormat F, Endianess E> inline void NValue::deseriali
     default:
         break;
     }
-    char message[128];
-    snprintf(message, 128, "NValue::deserializeFrom() unrecognized type '%s'",
-             getTypeName(type).c_str());
-    throw SerializableEEException(
-            VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+    throwSerializableEEException(
+            "NValue::deserializeFrom() unrecognized type '%s'", getTypeName(type).c_str());
 }
 
 /**
@@ -3233,18 +3228,13 @@ inline size_t NValue::serializeToExport_withoutNull(ExportSerializeOutput &io) c
     case VALUE_TYPE_ADDRESS:
     case VALUE_TYPE_ARRAY:
     case VALUE_TYPE_FOR_DIAGNOSTICS_ONLY_NUMERIC: {
-        char message[128];
-        snprintf(message, sizeof(message), "Invalid type in serializeToExport: %s",
-                 getTypeName(getValueType()).c_str());
-        throw SerializableEEException(
-                VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throwSerializableEEException(
+                "Invalid type in serializeToExport: %s", getTypeName(getValueType()).c_str());
     }
     default:
         break;
     }
-    throw SerializableEEException(
-            VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-            "Invalid type in serializeToExport");
+    throw SerializableEEException("Invalid type in serializeToExport");
 }
 
 /** Reformat an object-typed value from its current form to its

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -2600,8 +2600,8 @@ inline uint16_t NValue::getTupleStorageSize(const ValueType type) {
           char message[128];
           snprintf(message, 128, "NValue::getTupleStorageSize() unsupported type '%s'",
                    getTypeName(type).c_str());
-          throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                        message);
+          throw SerializableEEException(
+                  VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
     }
 }
 
@@ -3009,8 +3009,8 @@ template <TupleSerializationFormat F, Endianess E> inline void NValue::deseriali
     char message[128];
     snprintf(message, 128, "NValue::deserializeFrom() unrecognized type '%s'",
              getTypeName(type).c_str());
-    throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                  message);
+    throw SerializableEEException(
+            VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
 }
 
 /**
@@ -3236,13 +3236,15 @@ inline size_t NValue::serializeToExport_withoutNull(ExportSerializeOutput &io) c
         char message[128];
         snprintf(message, sizeof(message), "Invalid type in serializeToExport: %s",
                  getTypeName(getValueType()).c_str());
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throw SerializableEEException(
+                VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
     }
     default:
         break;
     }
-    throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                  "Invalid type in serializeToExport");
+    throw SerializableEEException(
+            VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+            "Invalid type in serializeToExport");
 }
 
 /** Reformat an object-typed value from its current form to its

--- a/src/ee/common/PlannerDomValue.cpp
+++ b/src/ee/common/PlannerDomValue.cpp
@@ -22,8 +22,7 @@ using namespace voltdb;
 Json::Value PlannerDomRoot::fromJSONString(char const* json) {
    Json::Value document;
    if(! Json::Reader().parse(json, json + strlen(json), document)) {
-      PlannerDomValue::throwTypeException(
-            std::string("JSON parse failure: ").append(json).c_str());
+      throw SerializableEEException(std::string("JSON parse failure: ").append(json).c_str());
    }
    return document;
 }

--- a/src/ee/common/PlannerDomValue.h
+++ b/src/ee/common/PlannerDomValue.h
@@ -33,27 +33,23 @@ namespace voltdb {
    class PlannerDomValue {
       Json::Value const m_value;
       public:
-      static void throwTypeException(char const* msg) {
-         throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
-      }
-
       PlannerDomValue(Json::Value const &value) : m_value(value) {}
 
       int32_t asInt() const {
          if (m_value.isNull()) {
-            throwTypeException("PlannerDomValue: int value is null");
+            throw SerializableEEException("PlannerDomValue: int value is null");
          } else if (m_value.isInt()) {
             return m_value.asInt();
          } else if (m_value.isString()) {
             return (int32_t) strtoimax(m_value.asCString(), NULL, 10);
          }
-         throwTypeException("PlannerDomValue: int value is not an integer");
+         throw SerializableEEException("PlannerDomValue: int value is not an integer");
          return 0;
       }
 
       int64_t asInt64() const {
          if (m_value.isNull()) {
-            throwTypeException("PlannerDomValue: int64 value is null");
+            throw SerializableEEException("PlannerDomValue: int64 value is null");
          } else if (m_value.isInt64()) {
             return m_value.asInt64();
          } else if (m_value.isInt()) {
@@ -61,13 +57,13 @@ namespace voltdb {
          } else if (m_value.isString()) {
             return (int64_t) strtoimax(m_value.asCString(), NULL, 10);
          }
-         throwTypeException("PlannerDomValue: int64 value is non-integral");
+         throw SerializableEEException("PlannerDomValue: int64 value is non-integral");
          return 0;
       }
 
       double asDouble() const {
          if (m_value.isNull()) {
-            throwTypeException("PlannerDomValue: double value is null");
+            throw SerializableEEException("PlannerDomValue: double value is null");
          } else if (m_value.isDouble()) {
             return m_value.asDouble();
          } else if (m_value.isInt()) {
@@ -77,20 +73,20 @@ namespace voltdb {
          } else if (m_value.isString()) {
             return std::strtod(m_value.asCString(), NULL);
          }
-         throwTypeException("PlannerDomValue: double value is not a number");
+         throw SerializableEEException("PlannerDomValue: double value is not a number");
          return 0;
       }
 
       bool asBool() const {
          if (m_value.isNull() || ! m_value.isBool()) {
-            throwTypeException("PlannerDomValue: value is null or not a bool");
+            throw SerializableEEException("PlannerDomValue: value is null or not a bool");
          }
          return m_value.asBool();
       }
 
       std::string asStr() const {
          if (m_value.isNull() || ! m_value.isString()) {
-            throwTypeException("PlannerDomValue: value is null or not a string");
+            throw SerializableEEException("PlannerDomValue: value is null or not a string");
          }
          return m_value.asString();
       }
@@ -106,23 +102,21 @@ namespace voltdb {
       PlannerDomValue valueForKey(const char *key) const {
          auto const value = m_value[key];
          if (value.isNull()) {
-            char msg[1024];
-            snprintf(msg, sizeof msg, "PlannerDomValue: %s key is null or missing", key);
-            throwTypeException(msg);
+            throwSerializableEEException("PlannerDomValue: %s key is null or missing", key);
          }
          return {PlannerDomValue(value)};
       }
 
       int arrayLen() const {
          if (! m_value.isArray()) {
-            throwTypeException("PlannerDomValue: value is not an array");
+            throw SerializableEEException("PlannerDomValue: value is not an array");
          }
          return m_value.size();
       }
 
       PlannerDomValue valueAtIndex(int index) const {
          if (! m_value.isArray()) {
-            throwTypeException("PlannerDomValue: value is not an array");
+            throw SerializableEEException("PlannerDomValue: value is not an array");
          }
          return {m_value[index]};
       }

--- a/src/ee/common/PlannerDomValue.h
+++ b/src/ee/common/PlannerDomValue.h
@@ -34,7 +34,7 @@ namespace voltdb {
       Json::Value const m_value;
       public:
       static void throwTypeException(char const* msg) {
-         throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
+         throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
       }
 
       PlannerDomValue(Json::Value const &value) : m_value(value) {}

--- a/src/ee/common/SQLException.cpp
+++ b/src/ee/common/SQLException.cpp
@@ -41,28 +41,27 @@ const char* SQLException::volt_temp_table_memory_overflow = "V0002";
 const char* SQLException::volt_decimal_serialization_error = "V0003";
 const char* SQLException::volt_user_defined_function_error = "V0004";
 
-namespace {
-    std::string make_error_message(int error_no, std::string const&message) {
-        std::stringstream sb;
-        sb << message << ": ";
-        const char *strerror_msg = strerror(errno);
-        if (strerror_msg != NULL) {
-            sb << strerror_msg;
-        } else {
-            sb << "Unknown error " << error_no;
-        }
-        return sb.str();
+static std::string make_error_message(int error_no, std::string const&message) {
+    std::stringstream sb;
+    sb << message << ": ";
+    const char *strerror_msg = strerror(errno);
+    if (strerror_msg != NULL) {
+        sb << strerror_msg;
+    } else {
+        sb << "Unknown error " << error_no;
     }
+    return sb.str();
 }
 
 SQLException::SQLException(std::string const& sqlState, std::string const& message) :
-    SerializableEEException(VOLT_EE_EXCEPTION_TYPE_SQL, message),
+    SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_SQL, message),
     m_sqlState(sqlState), m_internalFlags(0) {
     vassert(m_sqlState.length() == 5);
 }
 
 SQLException::SQLException(std::string const& sqlState, int error_no, std::string const& message) :
-    SerializableEEException(VOLT_EE_EXCEPTION_TYPE_SQL, make_error_message(error_no, message)),
+    SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_SQL,
+            make_error_message(error_no, message)),
     m_sqlState(sqlState), m_internalFlags(0) {
     vassert(m_sqlState.length() == 5);
 }
@@ -74,7 +73,7 @@ SQLException::SQLException(std::string const& sqlState, std::string const& messa
 }
 
 SQLException::SQLException(std::string const& sqlState, std::string const& message, int internalFlags) :
-    SerializableEEException(VOLT_EE_EXCEPTION_TYPE_SQL, message),
+    SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_SQL, message),
     m_sqlState(sqlState), m_internalFlags(internalFlags) {
     vassert(m_sqlState.length() == 5);
 }

--- a/src/ee/common/SQLException.h
+++ b/src/ee/common/SQLException.h
@@ -15,12 +15,16 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SQLEXCEPTION_H_
-#define SQLEXCEPTION_H_
+#pragma once
 
 #include "common/SerializableEEException.h"
 
-#define throwDynamicSQLException(...) { char reallysuperbig_nonce_message[8192]; snprintf(reallysuperbig_nonce_message, 8192, __VA_ARGS__); throw voltdb::SQLException( SQLException::dynamic_sql_error, reallysuperbig_nonce_message); }
+#define throwDynamicSQLException(...) {                                                         \
+    char reallysuperbig_nonce_message[8192];                                                    \
+    snprintf(reallysuperbig_nonce_message, 8192, __VA_ARGS__);                                  \
+    throw voltdb::SQLException( SQLException::dynamic_sql_error, reallysuperbig_nonce_message); \
+}
+
 namespace voltdb {
 class ReferenceSerializeOutput;
 
@@ -73,4 +77,3 @@ private:
 };
 }
 
-#endif /* SQLEXCEPTION_H_ */

--- a/src/ee/common/SerializableEEException.h
+++ b/src/ee/common/SerializableEEException.h
@@ -19,10 +19,11 @@
 #include <string>
 #include <stdexcept>
 
-#define throwSerializableEEException(...) do {                            \
-   char msg[8192]; snprintf(msg, 8192, __VA_ARGS__);                      \
-   throw voltdb::SerializableEEException(                                 \
-           VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg); \
+#define throwSerializableEEException(...) do {                  \
+   char msg[8192];                                              \
+   snprintf(msg, sizeof msg, __VA_ARGS__);                      \
+   msg[sizeof msg - 1] = '\0';                                  \
+   throw voltdb::SerializableEEException(msg);                  \
 } while (false)
 
 namespace voltdb {

--- a/src/ee/common/SerializableEEException.h
+++ b/src/ee/common/SerializableEEException.h
@@ -26,6 +26,13 @@
    throw voltdb::SerializableEEException(msg);                  \
 } while (false)
 
+#define throwSerializableTypedEEException(type, ...) do {       \
+   char msg[8192];                                              \
+   snprintf(msg, sizeof msg, __VA_ARGS__);                      \
+   msg[sizeof msg - 1] = '\0';                                  \
+   throw voltdb::SerializableEEException(type, msg);            \
+} while (false)
+
 namespace voltdb {
 
 class ReferenceSerializeOutput;

--- a/src/ee/common/SerializableEEException.h
+++ b/src/ee/common/SerializableEEException.h
@@ -19,16 +19,17 @@
 #include <string>
 #include <stdexcept>
 
-#define throwSerializableEEException(...) do {                                     \
-   char msg[8192]; snprintf(msg, 8192, __VA_ARGS__);                               \
-   throw voltdb::SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg); \
+#define throwSerializableEEException(...) do {                            \
+   char msg[8192]; snprintf(msg, 8192, __VA_ARGS__);                      \
+   throw voltdb::SerializableEEException(                                 \
+           VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg); \
 } while (false)
 
 namespace voltdb {
 
 class ReferenceSerializeOutput;
 
-enum VoltEEExceptionType {
+enum class VoltEEExceptionType {
     VOLT_EE_EXCEPTION_TYPE_NONE = 0,
     VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION = 1,
     VOLT_EE_EXCEPTION_TYPE_SQL = 2,
@@ -55,6 +56,10 @@ enum VoltEEExceptionType {
  * this exception.
  */
 class SerializableEEException : public std::runtime_error {
+    const VoltEEExceptionType m_exceptionType;
+    std::string m_message;
+protected:
+    virtual void p_serialize(ReferenceSerializeOutput *output) const {};
 public:
     /*
      * Constructor that performs the serialization to the engines
@@ -68,11 +73,6 @@ public:
     virtual std::string message() const { return m_message; }
     VoltEEExceptionType getType() const { return m_exceptionType; }
     void appendContextToMessage(const std::string& more) { m_message += more; }
-protected:
-    virtual void p_serialize(ReferenceSerializeOutput *output) const {};
-private:
-    const VoltEEExceptionType m_exceptionType;
-    std::string m_message;
 };
 
 class UnexpectedEEException : public SerializableEEException {

--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -214,11 +214,9 @@ UniqueTempTableResult ExecutorContext::executeExecutors(
                 }
                 InsertExecutor* insertExecutor = dynamic_cast<InsertExecutor*>(executor);
                 if (insertExecutor != nullptr && insertExecutor->exceptionMessage() != nullptr) {
-                   throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                         insertExecutor->exceptionMessage());
+                   throw SerializableEEException(insertExecutor->exceptionMessage());
                 } else {
-                   throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                         "Unspecified execution error detected");
+                   throw SerializableEEException("Unspecified execution error detected");
                 }
             }
 

--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -214,10 +214,10 @@ UniqueTempTableResult ExecutorContext::executeExecutors(
                 }
                 InsertExecutor* insertExecutor = dynamic_cast<InsertExecutor*>(executor);
                 if (insertExecutor != nullptr && insertExecutor->exceptionMessage() != nullptr) {
-                   throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                   throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                          insertExecutor->exceptionMessage());
                 } else {
-                   throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                   throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                          "Unspecified execution error detected");
                 }
             }

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -1115,7 +1115,8 @@ inline void TableTuple::deserializeFrom(voltdb::SerializeInputBE &tupleIn, Pool 
                         << "(index=" << j << ")"
                         << "hidden column count=" << m_schema->hiddenColumnCount()
                         << std::endl;
-                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message.str().c_str());
+                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                        message.str().c_str());
             }
 
             char *dataPtr = getWritableDataPtr(columnInfo);

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -1115,7 +1115,7 @@ inline void TableTuple::deserializeFrom(voltdb::SerializeInputBE &tupleIn, Pool 
                         << "(index=" << j << ")"
                         << "hidden column count=" << m_schema->hiddenColumnCount()
                         << std::endl;
-                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                throw SerializableEEException(
                         message.str().c_str());
             }
 

--- a/src/ee/execution/ExecutorVector.cpp
+++ b/src/ee/execution/ExecutorVector.cpp
@@ -67,22 +67,17 @@ boost::shared_ptr<ExecutorVector> ExecutorVector::fromJsonPlan(
     } catch (SerializableEEException&) {
         throw;
     } catch (std::exception const& e) {
-        char msg[1024 * 100];
-        snprintf(msg, sizeof msg,
+        throwSerializableEEException(
                 "Unable to initialize PlanNodeFragment for PlanFragment '%jd' with plan:\n%s: what(): %s",
                 (intmax_t)fragId, jsonPlan.c_str(), e.what());
-        VOLT_ERROR("%s", msg);
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
     }
     VOLT_TRACE("\n%s\n", pnf->debug().c_str());
     vassert(pnf->getRootNode());
 
     if (!pnf->getRootNode()) {
-        char msg[1024];
-        snprintf(msg, 1024, "Deserialized PlanNodeFragment for PlanFragment '%jd' does not have a root PlanNode",
-                 (intmax_t)fragId);
-        VOLT_ERROR("%s", msg);
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
+        throwSerializableEEException(
+                "Deserialized PlanNodeFragment for PlanFragment '%jd' does not have a root PlanNode",
+                (intmax_t)fragId);
     }
 
     int64_t tempTableLogLimit = engine->tempTableLogLimit();
@@ -138,11 +133,9 @@ void ExecutorVector::initPlanNode(VoltDBEngine* engine, AbstractPlanNode* node) 
     // plannode so that it can cache anything for the plannode
     AbstractExecutor* executor = getNewExecutor(engine, node, isLargeQuery());
     if (executor == NULL) {
-        char message[256];
-        snprintf(message, sizeof(message),
+        throwSerializableEEException(
                 "Unexpected error. Invalid statement plan. A fragment (%jd) has an unknown plan node type (%d)",
-                 (intmax_t)m_fragId, (int)node->getPlanNodeType());
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+                (intmax_t)m_fragId, (int)node->getPlanNodeType());
     }
     node->setExecutor(executor);
 
@@ -155,12 +148,9 @@ void ExecutorVector::initPlanNode(VoltDBEngine* engine, AbstractPlanNode* node) 
 
     // Now use the plannode to initialize the executor for execution later on
     if (! executor->init(engine, *this)) {
-        char msg[1024 * 10];
-        snprintf(msg, sizeof(msg),
+        throwSerializableEEException(
                 "The executor failed to initialize for PlanNode '%s' for PlanFragment '%jd'",
                 node->debug().c_str(), (intmax_t)m_fragId);
-        VOLT_ERROR("%s", msg);
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
     }
 }
 

--- a/src/ee/execution/ExecutorVector.cpp
+++ b/src/ee/execution/ExecutorVector.cpp
@@ -68,10 +68,11 @@ boost::shared_ptr<ExecutorVector> ExecutorVector::fromJsonPlan(
         throw;
     } catch (std::exception const& e) {
         char msg[1024 * 100];
-        snprintf(msg, 1024 * 100, "Unable to initialize PlanNodeFragment for PlanFragment '%jd' with plan:\n%s: what(): %s",
-                 (intmax_t)fragId, jsonPlan.c_str(), e.what());
+        snprintf(msg, sizeof msg,
+                "Unable to initialize PlanNodeFragment for PlanFragment '%jd' with plan:\n%s: what(): %s",
+                (intmax_t)fragId, jsonPlan.c_str(), e.what());
         VOLT_ERROR("%s", msg);
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
     }
     VOLT_TRACE("\n%s\n", pnf->debug().c_str());
     vassert(pnf->getRootNode());
@@ -81,7 +82,7 @@ boost::shared_ptr<ExecutorVector> ExecutorVector::fromJsonPlan(
         snprintf(msg, 1024, "Deserialized PlanNodeFragment for PlanFragment '%jd' does not have a root PlanNode",
                  (intmax_t)fragId);
         VOLT_ERROR("%s", msg);
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
     }
 
     int64_t tempTableLogLimit = engine->tempTableLogLimit();
@@ -141,7 +142,7 @@ void ExecutorVector::initPlanNode(VoltDBEngine* engine, AbstractPlanNode* node) 
         snprintf(message, sizeof(message),
                 "Unexpected error. Invalid statement plan. A fragment (%jd) has an unknown plan node type (%d)",
                  (intmax_t)m_fragId, (int)node->getPlanNodeType());
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
     }
     node->setExecutor(executor);
 
@@ -159,7 +160,7 @@ void ExecutorVector::initPlanNode(VoltDBEngine* engine, AbstractPlanNode* node) 
                 "The executor failed to initialize for PlanNode '%s' for PlanFragment '%jd'",
                 node->debug().c_str(), (intmax_t)m_fragId);
         VOLT_ERROR("%s", msg);
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
     }
 }
 

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1915,13 +1915,9 @@ void VoltDBEngine::setExecutorVectorForFragmentId(int64_t fragId) {
 
     PlanSet& plans = *m_plans;
     std::string plan = m_topend->planForFragmentId(fragId);
-    if (plan.length() == 0) {
-        char msg[1024];
-        snprintf(msg, 1024, "Fetched empty plan from frontend for PlanFragment '%jd'",
-                 (intmax_t)fragId);
-        VOLT_ERROR("%s", msg);
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                msg);
+    if (plan.empty()) {
+        throwSerializableEEException(
+                "Fetched empty plan from frontend for PlanFragment '%jd'", (intmax_t)fragId);
     }
 
     boost::shared_ptr<ExecutorVector> ev_guard = ExecutorVector::fromJsonPlan(this, plan, fragId);
@@ -2248,11 +2244,9 @@ int VoltDBEngine::getStats(int selector, int locators[], int numLocators,
         CatalogId locator = static_cast<CatalogId>(locators[ii]);
         Table* t = getTableById(locator);
         if (!t) {
-            char message[256];
-            snprintf(message, 256,  "getStats() called with selector %d, and"
-                    " an invalid locator %d that does not correspond to"
-                    " a table", selector, locator);
-            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+            throwSerializableEEException(
+                    "getStats() called with selector %d, and an invalid locator %d that does not correspond to a table",
+                    selector, locator);
         }
         auto streamTable = dynamic_cast<StreamedTable*>(t);
         if (streamTable == NULL || streamTable->getWrapper() == NULL) {
@@ -2277,11 +2271,8 @@ int VoltDBEngine::getStats(int selector, int locators[], int numLocators,
                     locatorIds, interval, now);
             break;
         default:
-            char message[256];
-            snprintf(message, 256, "getStats() called with an unrecognized selector"
-                    " %d", selector);
-            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                          message);
+            throwSerializableEEException(
+                    "getStats() called with an unrecognized selector %d", selector);
         }
     } catch (const SerializableEEException &e) {
         serializeException(e);

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -142,17 +142,15 @@ typedef boost::multi_index::multi_index_container<
     boost::multi_index::indexed_by<
         boost::multi_index::sequenced<>,
         boost::multi_index::hashed_unique<
-            boost::multi_index::const_mem_fun<ExecutorVector,int64_t,&ExecutorVector::getFragId>
-        >
-    >
-> PlanSet;
+            boost::multi_index::const_mem_fun<ExecutorVector,int64_t,&ExecutorVector::getFragId>>>> PlanSet;
 
 int32_t s_exportFlushTimeout=4000;  // export/tuple flush interval ms setting
 
 /// This class wrapper around a typedef allows forward declaration as in scoped_ptr<EnginePlanSet>.
 class EnginePlanSet : public PlanSet { };
 
-VoltEEExceptionType VoltDBEngine::s_loadTableException = VOLT_EE_EXCEPTION_TYPE_NONE;
+VoltEEExceptionType VoltDBEngine::s_loadTableException =
+    VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_NONE;
 int VoltDBEngine::s_drHiddenColumnSize = 0;
 
 VoltDBEngine::VoltDBEngine(Topend* topend, LogProxy* logProxy)
@@ -176,8 +174,7 @@ VoltDBEngine::VoltDBEngine(Topend* topend, LogProxy* logProxy)
       m_drReplicatedConflictStreamedTable(NULL),
       m_drStream(NULL),
       m_drReplicatedStream(NULL),
-      m_currExecutorVec(NULL)
-{
+      m_currExecutorVec(NULL) {
     loadBuiltInJavaFunctions();
 }
 
@@ -193,8 +190,7 @@ VoltDBEngine::initialize(int32_t clusterIndex,
                          int64_t tempTableMemoryLimit,
                          bool isLowestSiteId,
                          int32_t compactionThreshold,
-                         int32_t exportFlushTimeout)
-{
+                         int32_t exportFlushTimeout) {
     m_clusterIndex = clusterIndex;
     m_siteId = siteId;
     m_isLowestSite = isLowestSiteId;
@@ -239,17 +235,8 @@ VoltDBEngine::initialize(int32_t clusterIndex,
     m_drStream = new DRTupleStream(partitionId, static_cast<size_t>(defaultDrBufferSize));
 
     // required for catalog loading.
-    m_executorContext = new ExecutorContext(siteId,
-                                            m_partitionId,
-                                            m_currentUndoQuantum,
-                                            getTopend(),
-                                            &m_stringPool,
-                                            this,
-                                            hostname,
-                                            hostId,
-                                            m_drStream,
-                                            m_drReplicatedStream,
-                                            drClusterId);
+    m_executorContext = new ExecutorContext(siteId, m_partitionId, m_currentUndoQuantum, getTopend(),
+            &m_stringPool, this, hostname, hostId, m_drStream, m_drReplicatedStream, drClusterId);
     // Add the engine to the global list tracking replicated tables
     SynchronizedThreadLock::lockReplicatedResourceForInit();
     ThreadLocalPool::setPartitionIds(m_partitionId);
@@ -293,11 +280,9 @@ VoltDBEngine::~VoltDBEngine() {
             bool deleteWithMpPool = false;
             if (!table) {
                 VOLT_DEBUG("Partition %d Deallocating %s table", m_partitionId, eraseThis->second->getTable()->name().c_str());
-            }
-            else if(!table->isReplicatedTable()) {
+            } else if(!table->isReplicatedTable()) {
                 VOLT_DEBUG("Partition %d Deallocating partitioned table %s", m_partitionId, eraseThis->second->getTable()->name().c_str());
-            }
-            else {
+            } else {
                 deleteWithMpPool = true;
                 VOLT_DEBUG("Partition %d Deallocating replicated table %s", m_partitionId, eraseThis->second->getTable()->name().c_str());
             }
@@ -308,8 +293,7 @@ VoltDBEngine::~VoltDBEngine() {
                     ExecuteWithMpMemory usingMpMemory;
                     delete eraseThis->second;
                 }
-            }
-            else {
+            } else {
                 delete eraseThis->second;
             }
 
@@ -319,11 +303,11 @@ VoltDBEngine::~VoltDBEngine() {
         if (m_isLowestSite) {
             SynchronizedThreadLock::resetMemory(SynchronizedThreadLock::s_mpMemoryPartitionId);
         }
-        BOOST_FOREACH (TID tid, m_snapshottingTables) {
+        for (TID tid : m_snapshottingTables) {
             tid.second->decrementRefcount();
         }
 
-        BOOST_FOREACH (auto labeledInfo, m_functionInfo) {
+        for (auto labeledInfo: m_functionInfo) {
             delete labeledInfo.second;
         }
 
@@ -362,7 +346,7 @@ TableCatalogDelegate* VoltDBEngine::getTableDelegate(const std::string& name) co
 
 catalog::Table* VoltDBEngine::getCatalogTable(const std::string& name) const {
     // iterate over all of the tables in the new catalog
-    BOOST_FOREACH (LabeledTable labeledTable, m_database->tables()) {
+    for (LabeledTable labeledTable : m_database->tables()) {
         auto catalogTable = labeledTable.second;
         if (catalogTable->name() == name) {
             return catalogTable;
@@ -422,12 +406,8 @@ int VoltDBEngine::executePlanFragments(
     setUndoToken(undoToken);
 
     // configure the execution context.
-    m_executorContext->setupForPlanFragments(getCurrentUndoQuantum(),
-                                             txnId,
-                                             spHandle,
-                                             lastCommittedSpHandle,
-                                             uniqueId,
-                                             traceOn);
+    m_executorContext->setupForPlanFragments(getCurrentUndoQuantum(), txnId, spHandle,
+            lastCommittedSpHandle, uniqueId, traceOn);
 
     bool hasDRBinaryLog = m_executorContext->checkTransactionForDR();
 
@@ -438,8 +418,8 @@ int VoltDBEngine::executePlanFragments(
     // All the time measurements use nanoseconds.
     std::chrono::high_resolution_clock::time_point startTime, endTime;
     std::chrono::duration<int64_t, std::nano> elapsedNanoseconds;
-    ReferenceSerializeInputBE perFragmentStatsBufferIn(getPerFragmentStatsBuffer(),
-                                                       getPerFragmentStatsBufferCapacity());
+    ReferenceSerializeInputBE perFragmentStatsBufferIn(
+            getPerFragmentStatsBuffer(), getPerFragmentStatsBufferCapacity());
     // There is a byte at the very begining of the per-fragment stats buffer indicating
     // whether the time measurements should be enabled for the current batch.
     // If the current procedure invocation is not sampled, all its batches will not be timed.
@@ -531,10 +511,7 @@ int VoltDBEngine::executePlanFragments(
     return failures;
 }
 
-int VoltDBEngine::executePlanFragment(int64_t planfragmentId,
-                                      int64_t inputDependencyId,
-                                      bool traceOn)
-{
+int VoltDBEngine::executePlanFragment(int64_t planfragmentId, int64_t inputDependencyId, bool traceOn) {
     vassert(planfragmentId != 0);
 
     m_currentInputDepId = static_cast<int32_t>(inputDependencyId);
@@ -560,8 +537,7 @@ int VoltDBEngine::executePlanFragment(int64_t planfragmentId,
         vassert(m_currExecutorVec);
 
         executePlanFragment(m_currExecutorVec, &tuplesModified);
-    }
-    catch (const SerializableEEException &e) {
+    } catch (const SerializableEEException &e) {
         serializeException(e);
         m_currExecutorVec = NULL;
         m_currentInputDepId = -1;
@@ -613,8 +589,7 @@ UniqueTempTableResult VoltDBEngine::executePlanFragment(ExecutorVector* executor
         // Launch the target plan through its top-most executor list.
         executorVector->setupContext(m_executorContext);
         result = m_executorContext->executeExecutors(0);
-    }
-    catch (const SerializableEEException &e) {
+    } catch (const SerializableEEException &e) {
         m_executorContext->resetExecutionMetadata(executorVector);
         throw;
     }
@@ -681,8 +656,7 @@ NValue VoltDBEngine::callJavaUserDefinedFunction(int32_t functionId, std::vector
         NValue retval = ValueFactory::getNValueOfType(info->returnType);
         retval.deserializeFromAllocateForStorage(udfResultIn, &m_stringPool);
         return retval;
-    }
-    else {
+    } else {
         // Error handling
         std::string errorMsg = udfResultIn.readTextString();
         throw SQLException(SQLException::volt_user_defined_function_error, errorMsg);
@@ -704,8 +678,7 @@ void VoltDBEngine::releaseUndoToken(int64_t undoToken, bool isEmptyDRTxn) {
             m_executorContext->drReplicatedStream()->rollbackDrTo(m_executorContext->drReplicatedStream()->getCommittedUso(),
                                                                 SIZE_MAX);
         }
-    }
-    else {
+    } else {
         if (m_executorContext->drStream()) {
             m_executorContext->drStream()->endTransaction(m_executorContext->currentUniqueId());
         }
@@ -855,8 +828,7 @@ bool VoltDBEngine::loadCatalog(const int64_t timestamp, const std::string &catal
  */
 void
 VoltDBEngine::processCatalogDeletes(int64_t timestamp, bool updateReplicated,
-        std::map<std::string, ExportTupleStream*> & purgedStreams)
-{
+        std::map<std::string, ExportTupleStream*> & purgedStreams) {
     std::vector<std::string> deletion_vector;
     m_catalog->getDeletedPaths(deletion_vector);
     std::set<std::string> deletions(deletion_vector.begin(), deletion_vector.end());
@@ -884,7 +856,7 @@ VoltDBEngine::processCatalogDeletes(int64_t timestamp, bool updateReplicated,
     // delete any empty persistent tables, forcing them to be rebuilt
     // (Unless the are actually being deleted -- then this does nothing)
 
-    BOOST_FOREACH (LabeledTCD delegatePair, m_catalogDelegates) {
+    for (LabeledTCD delegatePair : m_catalogDelegates) {
         auto tcd = delegatePair.second;
         Table* table = tcd->getTable();
 
@@ -991,8 +963,7 @@ VoltDBEngine::processCatalogDeletes(int64_t timestamp, bool updateReplicated,
                 VOLT_TRACE("delete a REPLICATED table %s", tcd->getTable()->name().c_str());
                 ExecuteWithMpMemory usingMpMemory;
                 delete tcd;
-            }
-            else {
+            } else {
                 VOLT_TRACE("delete a PARTITIONED table %s", tcd->getTable()->name().c_str());
                 delete tcd;
             }
@@ -1021,8 +992,7 @@ static bool haveDifferentSchema(catalog::Table* srcTable, voltdb::Table* targetT
         PersistentTable* persistentTable = dynamic_cast<PersistentTable *>(targetTable);
         if (srcTable->isDRed() != persistentTable->isDREnabled()) {
             return true;
-        }
-        if ((static_cast<TableType>(srcTable->tableType())) != persistentTable->getTableType()) {
+        } else if ((static_cast<TableType>(srcTable->tableType())) != persistentTable->getTableType()) {
            return true;
         }
     }
@@ -1047,9 +1017,7 @@ static bool haveDifferentSchema(catalog::Table* srcTable, voltdb::Table* targetT
 
         if (columnInfo->allowNull != nullable) {
             return true;
-        }
-
-        if (columnInfo->getVoltType() != type) {
+        } else if (columnInfo->getVoltType() != type) {
             return true;
         }
 
@@ -1057,8 +1025,7 @@ static bool haveDifferentSchema(catalog::Table* srcTable, voltdb::Table* targetT
         if ((type == VALUE_TYPE_VARCHAR) || (type == VALUE_TYPE_VARBINARY)) {
             if (columnInfo->length != size) {
                 return true;
-            }
-            if (columnInfo->inBytes != inBytes) {
+            } else if (columnInfo->inBytes != inBytes) {
                 vassert(type == VALUE_TYPE_VARCHAR);
                 return true;
             }
@@ -1078,8 +1045,7 @@ static bool haveDifferentSchema(catalog::Table* srcTable, voltdb::Table* targetT
  */
 bool
 VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
-        bool isStreamUpdate, std::map<std::string, ExportTupleStream*> & purgedStreams)
-{
+        bool isStreamUpdate, std::map<std::string, ExportTupleStream*> & purgedStreams) {
     // iterate over all of the tables in the new catalog
     BOOST_FOREACH (LabeledTable labeledTable, m_database->tables()) {
         // get the catalog's table object
@@ -1114,8 +1080,7 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
                 if (!tcd) {
                     continue;
                 }
-            }
-            else {
+            } else {
                 if (updateReplicated) {
                     continue;
                 }
@@ -1143,8 +1108,7 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
                 const std::string& name = streamedTable->name();
                 if (tableTypeNeedsTupleStream(tcd->getTableType())) {
                     attachTupleStream(streamedTable, name, purgedStreams, timestamp);
-                }
-                else {
+                } else {
                     // The table/stream type has been changed
                     streamedTable->setWrapper(NULL);
                     streamedTable->setExportStreamPositions(0, 0, 0);
@@ -1179,13 +1143,11 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
                     obsoleteViews.push_back(currView);
                 }
 
-                BOOST_FOREACH (auto toDrop, obsoleteViews) {
+                for (auto toDrop : obsoleteViews) {
                     streamedTable->dropMaterializedView(toDrop);
                 }
-
             }
-        }
-        else {
+        } else {
             if (catalogTable->isreplicated() != updateReplicated) {
                 // replicated tables should only be processed once for the entire cluster
                 continue;
@@ -1261,7 +1223,7 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
                     obsoleteViews.push_back(currView);
                 }
 
-                BOOST_FOREACH (auto toDrop, obsoleteViews) {
+                for (auto toDrop : obsoleteViews) {
                     streamedTable->dropMaterializedView(toDrop);
                 }
                 // note, this is the end of the line for export tables for now,
@@ -1320,14 +1282,14 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
             {
                 ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(persistentTable->isReplicatedTable());
                 // iterate over indexes for this table in the catalog
-                BOOST_FOREACH (LabeledIndex labeledIndex, catalogTable->indexes()) {
+                for (LabeledIndex labeledIndex : catalogTable->indexes()) {
                     auto foundIndex = labeledIndex.second;
                     std::string indexName = foundIndex->name();
                     std::string catalogIndexId = TableCatalogDelegate::getIndexIdString(*foundIndex);
 
                     // Look for an index on the table to match the catalog index
                     bool found = false;
-                    BOOST_FOREACH (TableIndex* currIndex, currentIndexes) {
+                    for (TableIndex* currIndex : currentIndexes) {
                         std::string currentIndexId = currIndex->getId();
                         if (catalogIndexId == currentIndexId) {
                             // rename the index if needed (or even if not)
@@ -1373,13 +1335,13 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
                 //////////////////////////////////////////
 
                 // iterate through all of the existing indexes
-                BOOST_FOREACH (TableIndex* currIndex, currentIndexes) {
+                for (TableIndex* currIndex : currentIndexes) {
                     std::string currentIndexId = currIndex->getId();
 
                     bool found = false;
                     // iterate through all of the catalog indexes,
                     //  looking for a match.
-                    BOOST_FOREACH (LabeledIndex labeledIndex, catalogTable->indexes()) {
+                    for (LabeledIndex labeledIndex : catalogTable->indexes()) {
                         std::string catalogIndexId =
                             TableCatalogDelegate::getIndexIdString(*(labeledIndex.second));
                         if (catalogIndexId == currentIndexId) {
@@ -1395,7 +1357,7 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
                         // Remove the same index structure from the delta table.
                         if (deltaTable) {
                             const std::vector<TableIndex*> currentDeltaIndexes = deltaTable->allIndexes();
-                            BOOST_FOREACH (TableIndex* currDeltaIndex, currentDeltaIndexes) {
+                            for (TableIndex* currDeltaIndex : currentDeltaIndexes) {
                                 if (currDeltaIndex->getId() == currentIndexId) {
                                     deltaTable->removeIndex(currDeltaIndex);
                                     break;
@@ -1455,14 +1417,14 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
 
             {
                 ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(persistentTable->isReplicatedTable());
-                BOOST_FOREACH (auto toDrop, obsoleteViews) {
+                for (auto toDrop : obsoleteViews) {
                     persistentTable->dropMaterializedView(toDrop);
                 }
             }
         }
     }
 
-    BOOST_FOREACH (LabeledFunction labeledFunction, m_database->functions()) {
+    for (LabeledFunction labeledFunction : m_database->functions()) {
         auto catalogFunction = labeledFunction.second;
         UserDefinedFunctionInfo *info = new UserDefinedFunctionInfo();
         info->returnType = (ValueType) catalogFunction->returnType();
@@ -1487,10 +1449,8 @@ VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplicated,
     return true;
 }
 
-void VoltDBEngine::attachTupleStream(StreamedTable* streamedTable,
-                                     const std::string& streamName,
-                                     std::map<std::string, ExportTupleStream*> & purgedStreams,
-                                     int64_t timestamp) {
+void VoltDBEngine::attachTupleStream(StreamedTable* streamedTable, const std::string& streamName,
+        std::map<std::string, ExportTupleStream*> & purgedStreams, int64_t timestamp) {
     m_exportingTables[streamName] = streamedTable;
     ExportTupleStream* wrapper = streamedTable->getWrapper();
     if (wrapper == NULL) {
@@ -1592,7 +1552,7 @@ bool VoltDBEngine::updateCatalog(int64_t timestamp, bool isStreamUpdate, std::st
 
 void
 VoltDBEngine::purgeMissingStreams(std::map<std::string, ExportTupleStream*> & purgedStreams) {
-    BOOST_FOREACH (LabeledStreamWrapper entry, purgedStreams) {
+    for (LabeledStreamWrapper entry : purgedStreams) {
         if (entry.second) {
             // purgedStreams should have been flushed by quiesce
             assert(!entry.second->testFlushPending());
@@ -1601,24 +1561,16 @@ VoltDBEngine::purgeMissingStreams(std::map<std::string, ExportTupleStream*> & pu
     }
 }
 
-bool
-VoltDBEngine::loadTable(int32_t tableId,
-                        ReferenceSerializeInputBE &serializeIn,
-                        int64_t txnId, int64_t spHandle, int64_t lastCommittedSpHandle,
-                        int64_t uniqueId,
-                        int64_t undoToken,
-                        const LoadTableCaller &caller) {
+bool VoltDBEngine::loadTable(int32_t tableId, ReferenceSerializeInputBE &serializeIn,
+        int64_t txnId, int64_t spHandle, int64_t lastCommittedSpHandle,
+        int64_t uniqueId, int64_t undoToken, const LoadTableCaller &caller) {
     //Not going to thread the unique id through.
     //The spHandle and lastCommittedSpHandle aren't really used in load table
     //since their only purpose as of writing this (1/2013) they are only used
     //for export data and we don't technically support loading into an export table
     setUndoToken(undoToken);
-    m_executorContext->setupForPlanFragments(getCurrentUndoQuantum(),
-                                             txnId,
-                                             spHandle,
-                                             lastCommittedSpHandle,
-                                             uniqueId,
-                                             false);
+    m_executorContext->setupForPlanFragments(getCurrentUndoQuantum(), txnId, spHandle,
+            lastCommittedSpHandle, uniqueId, false);
 
     if (caller.shouldDrStream()) {
         m_executorContext->checkTransactionForDR();
@@ -1661,7 +1613,8 @@ VoltDBEngine::loadTable(int32_t tableId,
     //   Perhaps we cannot be ensured of data integrity for other kinds of exceptions?
 
     ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory
-            (table->isReplicatedTable(), isLowestSite(), &s_loadTableException, VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
+            (table->isReplicatedTable(), isLowestSite(), &s_loadTableException,
+             VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
     if (possiblySynchronizedUseMpMemory.okToExecute()) {
         // Joined views are special. If any of the source table(s) are not empty, we cannot restore the view content
         // from a snapshot. The Java top-end has no way to know this so it still tries to tell the EE
@@ -1677,30 +1630,24 @@ VoltDBEngine::loadTable(int32_t tableId,
             return true;
         }
         try {
-            table->loadTuplesForLoadTable(serializeIn,
-                                          NULL,
-                                          caller.returnConflictRows() ? &m_resultOutput : NULL,
-                                          caller);
-        }
-        catch (const ConstraintFailureException &cfe) {
-            s_loadTableException = VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION;
+            table->loadTuplesForLoadTable(serializeIn, NULL,
+                    caller.returnConflictRows() ? &m_resultOutput : NULL, caller);
+        } catch (const ConstraintFailureException &cfe) {
+            s_loadTableException = VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION;
             if (caller.returnConflictRows()) {
                 // This should not happen because all errors are swallowed and constraint violations are returned
                 // as failed rows in the result
                 throw;
-            }
-            else {
+            } else {
                 // pre-serialize the exception here since we need to cleanup tuple memory within this sync block
                 resetReusedResultOutputBuffer();
                 cfe.serialize(getExceptionOutputSerializer());
                 return false;
             }
-        }
-        catch (const SQLException &sqe) {
-            s_loadTableException = VOLT_EE_EXCEPTION_TYPE_SQL;
+        } catch (const SQLException &sqe) {
+            s_loadTableException = VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_SQL;
             throw;
-        }
-        catch (const SerializableEEException& serializableExc) {
+        } catch (const SerializableEEException& serializableExc) {
             // Exceptions that are not constraint failures or sql exeception are treated as fatal.
             // This is legacy behavior.  Perhaps we cannot be ensured of data integrity for some mysterious
             // other kind of exception?
@@ -1720,9 +1667,8 @@ VoltDBEngine::loadTable(int32_t tableId,
         }
 
         // Indicate to other threads that load happened successfully.
-        s_loadTableException = VOLT_EE_EXCEPTION_TYPE_NONE;
-    }
-    else if (s_loadTableException == VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION) {
+        s_loadTableException = VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_NONE;
+    } else if (s_loadTableException == VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION) {
         // An constraint failure exception was thrown on the lowest site thread and
         // handle it on the other threads too.
         if (!caller.returnConflictRows()) {
@@ -1730,28 +1676,27 @@ VoltDBEngine::loadTable(int32_t tableId,
             oss << "Replicated load table failed (constraint violation) on other thread for table \""
                 << table->name() << "\".\n";
             VOLT_DEBUG("%s", oss.str().c_str());
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, oss.str().c_str());
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE,
+                    oss.str().c_str());
         }
         // Offending rows will be serialized on lowest site thread.
         return false;
-    }
-    else if (s_loadTableException == VOLT_EE_EXCEPTION_TYPE_SQL) {
+    } else if (s_loadTableException == VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_SQL) {
         // An sql exception was thrown on the lowest site thread and
         // handle it on the other threads too.
         std::ostringstream oss;
         oss << "Replicated load table failed (sql exception) on other thread for table \""
             << table->name() << "\".\n";
         VOLT_DEBUG("%s", oss.str().c_str());
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, oss.str().c_str());
-    }
-    else if (s_loadTableException != VOLT_EE_EXCEPTION_TYPE_NONE) { // some other kind of exception occurred on lowest site thread
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE,
+                oss.str().c_str());
+    } else if (s_loadTableException != VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_NONE) { // some other kind of exception occurred on lowest site thread
         // This is fatal.
         std::ostringstream oss;
         oss << "An unknown exception occurred on another thread when loading table \"" << table->name() << "\".";
         VOLT_DEBUG("%s", oss.str().c_str());
         throwFatalException("%s", oss.str().c_str());
     }
-
     return true;
 }
 
@@ -1805,8 +1750,7 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
                     currEngine->m_tablesByName[tableName] = localTable;
                 }
             }
-        }
-        else if (! updateReplicated) {
+        } else if (! updateReplicated) {
             m_tables[relativeIndexOfTable] = localTable;
             m_tablesByName[tableName] = localTable;
         }
@@ -1827,8 +1771,7 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
                             currEngine->m_tablesBySignatureHash[hash] = persistentTable;
                         }
                     }
-                }
-                else if (! updateReplicated) {
+                } else if (! updateReplicated) {
                     m_tablesBySignatureHash[hash] = persistentTable;
                 }
             }
@@ -1844,39 +1787,33 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
                         SynchronizedThreadLock::assumeSpecificSiteContext(curr);
                         if (! fromScratch) {
                             // This is a swap or truncate and we need to clear the old index stats sources for this table
-                            currEngine->getStatsManager().unregisterStatsSource(STATISTICS_SELECTOR_TYPE_TABLE,
-                                                                                relativeIndexOfTable);
-                            currEngine->getStatsManager().unregisterStatsSource(STATISTICS_SELECTOR_TYPE_INDEX,
-                                                                                relativeIndexOfTable);
+                            currEngine->getStatsManager().unregisterStatsSource(
+                                    STATISTICS_SELECTOR_TYPE_TABLE, relativeIndexOfTable);
+                            currEngine->getStatsManager().unregisterStatsSource(
+                                    STATISTICS_SELECTOR_TYPE_INDEX, relativeIndexOfTable);
                         }
-                        BOOST_FOREACH (auto index, tindexes) {
-                            currEngine->getStatsManager().registerStatsSource(STATISTICS_SELECTOR_TYPE_INDEX,
-                                                                              relativeIndexOfTable,
-                                                                              index->getIndexStats());
+                        for (auto index : tindexes) {
+                            currEngine->getStatsManager().registerStatsSource(
+                                    STATISTICS_SELECTOR_TYPE_INDEX, relativeIndexOfTable, index->getIndexStats());
                         }
-                        currEngine->getStatsManager().registerStatsSource(STATISTICS_SELECTOR_TYPE_TABLE,
-                                                                          relativeIndexOfTable,
-                                                                          stats);
+                        currEngine->getStatsManager().registerStatsSource(
+                                STATISTICS_SELECTOR_TYPE_TABLE, relativeIndexOfTable, stats);
                     }
                 }
-            }
-            else if (! updateReplicated) {
+            } else if (! updateReplicated) {
                 if (! fromScratch) {
                     // This is a swap or truncate and we need to clear the old index stats sources for this table
                     getStatsManager().unregisterStatsSource(STATISTICS_SELECTOR_TYPE_TABLE, relativeIndexOfTable);
                     getStatsManager().unregisterStatsSource(STATISTICS_SELECTOR_TYPE_INDEX, relativeIndexOfTable);
                 }
-                BOOST_FOREACH (auto index, tindexes) {
+                for (auto index : tindexes) {
                     getStatsManager().registerStatsSource(STATISTICS_SELECTOR_TYPE_INDEX,
-                                                          relativeIndexOfTable,
-                                                          index->getIndexStats());
+                            relativeIndexOfTable, index->getIndexStats());
                 }
                 getStatsManager().registerStatsSource(STATISTICS_SELECTOR_TYPE_TABLE,
-                                                      relativeIndexOfTable,
-                                                      stats);
+                        relativeIndexOfTable, stats);
             }
-        }
-        else {
+        } else {
             // Streamed tables are all partitioned.
             if (updateReplicated) {
                 continue;
@@ -1885,11 +1822,10 @@ void VoltDBEngine::rebuildTableCollections(bool updateReplicated, bool fromScrat
             // table stats map in a not-from-scratch mode.
             // Before this rebuildTableCollections() is called, pre-built DR conflict tables
             // (which are also streamed tables) should have already been instantiated.
-            if (fromScratch) {
+            else if (fromScratch) {
                 stats = tcd->getStreamedTable()->getTableStats();
                 getStatsManager().registerStatsSource(STATISTICS_SELECTOR_TYPE_TABLE,
-                                                      relativeIndexOfTable,
-                                                      stats);
+                        relativeIndexOfTable, stats);
             }
         }
     }
@@ -1931,12 +1867,10 @@ void VoltDBEngine::swapDRActions(PersistentTable* table1, PersistentTable* table
 
     quiesce(lastCommittedSpHandle);
     if (m_executorContext->drStream()->drStreamStarted()) {
-        m_executorContext->drStream()->generateDREvent(SWAP_TABLE,
-                spHandle, uniqueId, payload);
+        m_executorContext->drStream()->generateDREvent(SWAP_TABLE, spHandle, uniqueId, payload);
     }
     if (m_executorContext->drReplicatedStream() && m_executorContext->drReplicatedStream()->drStreamStarted()) {
-        m_executorContext->drReplicatedStream()->generateDREvent(SWAP_TABLE,
-                spHandle, uniqueId, payload);
+        m_executorContext->drReplicatedStream()->generateDREvent(SWAP_TABLE, spHandle, uniqueId, payload);
     }
 }
 
@@ -1954,8 +1888,7 @@ void VoltDBEngine::resetDRConflictStreamedTables() {
         m_drReplicatedConflictStreamedTable =
             dynamic_cast<StreamedTable*>(wellKnownTable);
         vassert(m_drReplicatedConflictStreamedTable == wellKnownTable);
-    }
-    else {
+    } else {
         m_drPartitionedConflictStreamedTable = NULL;
         m_drReplicatedConflictStreamedTable = NULL;
     }
@@ -1976,8 +1909,7 @@ void VoltDBEngine::setExecutorVectorForFragmentId(int64_t fragId) {
             m_currExecutorVec->setupContext(m_executorContext);
             return;
         }
-    }
-    else {
+    } else {
         m_plans.reset(new EnginePlanSet());
     }
 
@@ -1988,7 +1920,8 @@ void VoltDBEngine::setExecutorVectorForFragmentId(int64_t fragId) {
         snprintf(msg, 1024, "Fetched empty plan from frontend for PlanFragment '%jd'",
                  (intmax_t)fragId);
         VOLT_ERROR("%s", msg);
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, msg);
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                msg);
     }
 
     boost::shared_ptr<ExecutorVector> ev_guard = ExecutorVector::fromJsonPlan(this, plan, fragId);
@@ -2017,12 +1950,11 @@ void VoltDBEngine::setExecutorVectorForFragmentId(int64_t fragId) {
 // MaterializedViewTriggerForWrite for views on persistent tables.
 template <class MATVIEW>
 static bool updateMaterializedViewDestTable(std::vector<MATVIEW*> & views,
-                                              PersistentTable* target,
-                                              catalog::MaterializedViewInfo* targetMvInfo) {
+        PersistentTable* target, catalog::MaterializedViewInfo* targetMvInfo) {
     std::string targetName = target->name();
 
     // find the materialized view that uses the table or its precursor (by the same name).
-    BOOST_FOREACH(MATVIEW* currView, views) {
+    for(MATVIEW* currView : views) {
         PersistentTable* currTarget = currView->destTable();
         std::string currName = currTarget->name();
         if (currName != targetName) {
@@ -2044,8 +1976,7 @@ static bool updateMaterializedViewDestTable(std::vector<MATVIEW*> & views,
 // in the future if there are different view types with different
 // triggered behavior defined on the same class of table.
 template<class TABLE> void VoltDBEngine::initMaterializedViews(catalog::Table* catalogTable,
-                                                               TABLE* storageTable,
-                                                               bool updateReplicated) {
+        TABLE* storageTable, bool updateReplicated) {
     // walk views
     VOLT_DEBUG("Processing views for table %s", storageTable->name().c_str());
     BOOST_FOREACH (LabeledView labeledView, catalogTable->views()) {
@@ -2062,9 +1993,8 @@ template<class TABLE> void VoltDBEngine::initMaterializedViews(catalog::Table* c
         // OR create a new materialized view link to connect the tables
         // if there is not one already with a matching target table name.
         ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(updateReplicated);
-        if ( ! updateMaterializedViewDestTable(storageTable->views(),
-                                               destTable,
-                                               catalogView)) {
+        if ( ! updateMaterializedViewDestTable(
+                    storageTable->views(), destTable, catalogView)) {
             // This is a new view, a connection needs to be made using a new MaterializedViewTrigger..
             TABLE::MatViewType::build(storageTable, destTable, catalogView);
         }
@@ -2081,10 +2011,8 @@ template<class TABLE> void VoltDBEngine::initMaterializedViews(catalog::Table* c
             // The newly-added handler will at the same time trigger
             // the uninstallation of the previous (if exists) handler.
             VOLT_DEBUG("Creating view handler for table %s", destTable->name().c_str());
-            auto handler = new MaterializedViewHandler(destTable,
-                                                       mvHandlerInfo,
-                                                       mvHandlerInfo->groupByColumnCount(),
-                                                       this);
+            auto handler = new MaterializedViewHandler(destTable, mvHandlerInfo,
+                    mvHandlerInfo->groupByColumnCount(), this);
             if (destTable->isPersistentTableEmpty()) {
                 handler->catchUpWithExistingData(false);
             }
@@ -2117,28 +2045,24 @@ void VoltDBEngine::initMaterializedViewsAndLimitDeletePlans(bool updateReplicate
                 std::string const& b64String = stmt->fragments().begin()->second->plannodetree();
                 std::string jsonPlan = getTopend()->decodeBase64AndDecompress(b64String);
                 ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(updateReplicated);
-                boost::shared_ptr<ExecutorVector> vec = ExecutorVector::fromJsonPlan(this,
-                                                                                     jsonPlan,
-                                                                                     -1);
+                boost::shared_ptr<ExecutorVector> vec = ExecutorVector::fromJsonPlan(this, jsonPlan, -1);
                 const std::vector<AbstractExecutor*>& execs = vec->getExecutorList();
                 // Since purge executors are only called from insert, there is no need to coordinate
                 // the execution of the delete across sites because we are already running on the lowest
                 // site during insert::p_execute. Disabling the replicated flag will avoid the inner
                 // coordination.
-                BOOST_FOREACH(AbstractExecutor* exec, execs) {
+                for(AbstractExecutor* exec : execs) {
                     exec->disableReplicatedFlag();
                 }
                 persistentTable->swapPurgeExecutorVector(vec);
-            }
-            else {
+            } else {
                 ConditionalExecuteWithMpMemory useMpMemoryIfReplicated(updateReplicated);
                 // get rid of the purge fragment from the persistent
                 // table if it has been removed from the catalog
                 boost::shared_ptr<ExecutorVector> nullPtr;
                 persistentTable->swapPurgeExecutorVector(nullPtr);
             }
-        }
-        else {
+        } else {
             auto streamedTable = dynamic_cast<StreamedTable*>(table);
             vassert(streamedTable);
             initMaterializedViews(catalogTable, streamedTable, updateReplicated);
@@ -2220,8 +2144,7 @@ void VoltDBEngine::tick(int64_t timeInMillis, int64_t lastCommittedSpHandle) {
     // the process it is debugging. Here, we call the same function again to override
     // the exception port for EXC_BAD_ACCESS, so that it won't be passed to LLDB.
     // int mute_exc_bad_access_for_debugging =
-    task_set_exception_ports(mach_task_self(), EXC_MASK_BAD_ACCESS,
-                             MACH_PORT_NULL, EXCEPTION_DEFAULT, 0);
+    task_set_exception_ports(mach_task_self(), EXC_MASK_BAD_ACCESS, MACH_PORT_NULL, EXCEPTION_DEFAULT, 0);
     #endif
     m_executorContext->setupForTick(lastCommittedSpHandle);
     //Push tuples for exporting streams.
@@ -2240,8 +2163,7 @@ void VoltDBEngine::tick(int64_t timeInMillis, int64_t lastCommittedSpHandle) {
                 m_oldestExportStreamWithPendingRows->appendToList(&oldestUnflushed, &newestUnflushed);
             }
             m_oldestExportStreamWithPendingRows = nextStreamToFlush;
-        }
-        else {
+        } else {
             // We tried to flush a stream that has not yet hit it's flush timer,
             // this stream is now at the head of the list.
             nextStreamToFlush->setPrevFlushStream(NULL);
@@ -2253,17 +2175,13 @@ void VoltDBEngine::tick(int64_t timeInMillis, int64_t lastCommittedSpHandle) {
             // We stopped flushing in the middle of the list. If there are any skipped streams stitch them together
             vassert(m_oldestExportStreamWithPendingRows);
             newestUnflushed->stitchToNextNode(m_oldestExportStreamWithPendingRows);
-        }
-        else {
+        } else {
             // We went through the whole list but skipped streams in the middle of an MP.
             m_newestExportStreamWithPendingRows = newestUnflushed;
         }
         m_oldestExportStreamWithPendingRows = oldestUnflushed;
-    }
-    else {
-        if (m_oldestExportStreamWithPendingRows == NULL) {
-            m_newestExportStreamWithPendingRows = NULL;
-        }
+    } else if (m_oldestExportStreamWithPendingRows == NULL) {
+        m_newestExportStreamWithPendingRows = NULL;
     }
 
     m_executorContext->drStream()->periodicFlush(timeInMillis, lastCommittedSpHandle);
@@ -2298,7 +2216,7 @@ std::string VoltDBEngine::debug(void) const {
     PlanSet& plans = *m_plans;
     std::ostringstream output;
 
-    BOOST_FOREACH (boost::shared_ptr<ExecutorVector> ev_guard, plans) {
+    for (boost::shared_ptr<ExecutorVector> ev_guard : plans) {
         ev_guard->debug();
     }
 
@@ -2334,8 +2252,7 @@ int VoltDBEngine::getStats(int selector, int locators[], int numLocators,
             snprintf(message, 256,  "getStats() called with selector %d, and"
                     " an invalid locator %d that does not correspond to"
                     " a table", selector, locator);
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                          message);
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
         }
         auto streamTable = dynamic_cast<StreamedTable*>(t);
         if (streamTable == NULL || streamTable->getWrapper() == NULL) {
@@ -2363,11 +2280,10 @@ int VoltDBEngine::getStats(int selector, int locators[], int numLocators,
             char message[256];
             snprintf(message, 256, "getStats() called with an unrecognized selector"
                     " %d", selector);
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                           message);
         }
-    }
-    catch (const SerializableEEException &e) {
+    } catch (const SerializableEEException &e) {
         serializeException(e);
         return -1;
     }
@@ -2375,11 +2291,11 @@ int VoltDBEngine::getStats(int selector, int locators[], int numLocators,
     if (resultTable != NULL) {
         resultTable->serializeTo(m_resultOutput);
         m_resultOutput.writeIntAt(lengthPosition,
-                                  static_cast<int32_t>(m_resultOutput.size()
-                                                       - sizeof(int32_t)));
+                static_cast<int32_t>(m_resultOutput.size() - sizeof(int32_t)));
         return 1;
+    } else {
+        return 0;
     }
-    return 0;
 }
 
 
@@ -2404,12 +2320,8 @@ void VoltDBEngine::updateExecutorContextUndoQuantumForTest() {
  *  string: predicate #2
  *  ...
  */
-bool VoltDBEngine::activateTableStream(
-        const CatalogId tableId,
-        TableStreamType streamType,
-        HiddenColumnFilter::Type hiddenColumnFilter,
-        int64_t undoToken,
-        ReferenceSerializeInputBE &serializeIn) {
+bool VoltDBEngine::activateTableStream(const CatalogId tableId, TableStreamType streamType,
+        HiddenColumnFilter::Type hiddenColumnFilter, int64_t undoToken, ReferenceSerializeInputBE &serializeIn) {
     Table* found = getTableById(tableId);
     if (! found) {
         return false;
@@ -2448,8 +2360,7 @@ bool VoltDBEngine::activateTableStream(
  * Return remaining tuple count, 0 if done, or TABLE_STREAM_SERIALIZATION_ERROR on error.
  */
 int64_t VoltDBEngine::tableStreamSerializeMore(const CatalogId tableId,
-                                               const TableStreamType streamType,
-                                               ReferenceSerializeInputBE &serialInput) {
+        const TableStreamType streamType, ReferenceSerializeInputBE &serialInput) {
     int64_t remaining = TABLE_STREAM_SERIALIZATION_ERROR;
     try {
         std::vector<int> positions;
@@ -2472,8 +2383,7 @@ int64_t VoltDBEngine::tableStreamSerializeMore(const CatalogId tableId,
         }
         VOLT_DEBUG("tableStreamSerializeMore: deserialized %d buffers, %ld remaining",
                    (int)positions.size(), (long)remaining);
-    }
-    catch (SerializableEEException &e) {
+    } catch (SerializableEEException &e) {
         serializeException(e);
         remaining = TABLE_STREAM_SERIALIZATION_ERROR;
     }
@@ -2541,8 +2451,7 @@ int64_t VoltDBEngine::tableStreamSerializeMore(
                 table->decrementRefcount();
             }
         }
-    }
-    else if (tableStreamTypeIsStreamIndexing(streamType)) {
+    } else if (tableStreamTypeIsStreamIndexing(streamType)) {
         Table* found = getTableById(tableId);
         if (found == NULL) {
             return TABLE_STREAM_SERIALIZATION_ERROR;
@@ -2569,8 +2478,7 @@ int64_t VoltDBEngine::tableStreamSerializeMore(
             VOLT_DEBUG("tableStreamSerializeMore: type %s, null the previous truncate table pointer",
                     tableStreamTypeToString(streamType).c_str());
         }
-    }
-    else {
+    } else {
         Table* found = getTableById(tableId);
         if (found == NULL) {
             return TABLE_STREAM_SERIALIZATION_ERROR;
@@ -2583,11 +2491,8 @@ int64_t VoltDBEngine::tableStreamSerializeMore(
     return remaining;
 }
 
-int64_t VoltDBEngine::exportAction(bool syncAction,
-                                   int64_t uso,
-                                   int64_t seqNo,
-                                   int64_t generationIdCreated,
-                                   std::string streamName) {
+int64_t VoltDBEngine::exportAction(bool syncAction, int64_t uso,
+        int64_t seqNo, int64_t generationIdCreated, std::string streamName) {
     std::map<std::string, StreamedTable*>::iterator pos = m_exportingTables.find(streamName);
 
     // return no data and polled offset for unavailable tables.
@@ -2600,8 +2505,7 @@ int64_t VoltDBEngine::exportAction(bool syncAction,
         m_resultOutput.writeInt(0);
         if (uso < 0) {
             return 0;
-        }
-        else {
+        } else {
             return uso;
         }
     }
@@ -2618,25 +2522,20 @@ bool VoltDBEngine::deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_t u
     PersistentTable* table = dynamic_cast<PersistentTable*>(getTableByName(tableName));
     if (table) {
         setUndoToken(undoToken);
-        m_executorContext->setupForPlanFragments(getCurrentUndoQuantum(),
-                                                 txnId,
-                                                 spHandle,
-                                                 -1,
-                                                 uniqueId,
-                                                 false);
+        m_executorContext->setupForPlanFragments(getCurrentUndoQuantum(), txnId,
+                spHandle, -1, uniqueId, false);
 
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory
-                (table->isReplicatedTable(), isLowestSite(), &s_loadTableException, VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
+                (table->isReplicatedTable(), isLowestSite(), &s_loadTableException,
+                 VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
             bool rowsToBeDeleted;
             try {
                 rowsToBeDeleted = table->deleteMigratedRows(deletableTxnId);
-            }
-            catch (const SQLException &sqe) {
-                s_loadTableException = VOLT_EE_EXCEPTION_TYPE_SQL;
+            } catch (const SQLException &sqe) {
+                s_loadTableException = VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_SQL;
                 throw;
-            }
-            catch (const SerializableEEException& serializableExc) {
+            } catch (const SerializableEEException& serializableExc) {
                 // Exceptions that are not constraint failures or sql exeception are treated as fatal.
                 // This is legacy behavior.  Perhaps we cannot be ensured of data integrity for some mysterious
                 // other kind of exception?
@@ -2645,19 +2544,18 @@ bool VoltDBEngine::deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_t u
             }
 
             // Indicate to other threads that load happened successfully.
-            s_loadTableException = VOLT_EE_EXCEPTION_TYPE_NONE;
+            s_loadTableException = VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_NONE;
             return rowsToBeDeleted;
-        }
-        else if (s_loadTableException == VOLT_EE_EXCEPTION_TYPE_SQL) {
+        } else if (s_loadTableException == VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_SQL) {
             // An sql exception was thrown on the lowest site thread and
             // handle it on the other threads too.
             std::ostringstream oss;
             oss << "Replicated table deleteMigratedRows failed (sql exception) on other thread for table \""
                 << table->name() << "\".\n";
             VOLT_DEBUG("%s", oss.str().c_str());
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, oss.str().c_str());
-        }
-        else if (s_loadTableException != VOLT_EE_EXCEPTION_TYPE_NONE) { // some other kind of exception occurred on lowest site thread
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE,
+                    oss.str().c_str());
+        } else if (s_loadTableException != VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_NONE) { // some other kind of exception occurred on lowest site thread
             // This is fatal.
             std::ostringstream oss;
             oss << "An unknown exception occurred on another thread calling deleteMigratedRows \"" << table->name() << "\".";
@@ -2675,7 +2573,8 @@ bool VoltDBEngine::deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_t u
     return false;
 }
 
-void VoltDBEngine::getUSOForExportTable(size_t &ackOffset, int64_t &seqNo, int64_t &genId, std::string streamName) {
+void VoltDBEngine::getUSOForExportTable(size_t &ackOffset, int64_t &seqNo, int64_t &genId,
+        std::string streamName) {
 
     // defaults mean failure
     ackOffset = 0;
@@ -2702,8 +2601,7 @@ size_t VoltDBEngine::tableHashCode(int32_t tableId) {
 
     PersistentTable *table = dynamic_cast<PersistentTable*>(found);
     if (table == NULL) {
-        throwFatalException(
-                "Tried to calculate a hash code for a table that is not a persistent table id %d\n",
+        throwFatalException("Tried to calculate a hash code for a table that is not a persistent table id %d\n",
                 tableId);
     }
     return table->hashCode();
@@ -2732,7 +2630,7 @@ void VoltDBEngine::dispatchValidatePartitioningTask(ReferenceSerializeInputBE &t
 
     std::vector<int64_t> mispartitionedRowCounts;
 
-    BOOST_FOREACH (CatalogId tableId, tableIds) {
+    for (CatalogId tableId : tableIds) {
         std::map<CatalogId, Table*>::iterator table = m_tables.find(tableId);
         if (table == m_tables.end()) {
             throwFatalException("Unknown table id %d", tableId);
@@ -2743,7 +2641,7 @@ void VoltDBEngine::dispatchValidatePartitioningTask(ReferenceSerializeInputBE &t
 
     m_resultOutput.writeInt(static_cast<int32_t>(sizeof(int64_t) * numTables));
 
-    BOOST_FOREACH (int64_t mispartitionedRowCount, mispartitionedRowCounts) {
+    for (int64_t mispartitionedRowCount : mispartitionedRowCounts) {
         m_resultOutput.writeLong(mispartitionedRowCount);
     }
 }
@@ -2765,19 +2663,13 @@ void VoltDBEngine::collectDRTupleStreamStateInfo() {
         m_resultOutput.writeLong(drInfo.seqNum);
         m_resultOutput.writeLong(drInfo.spUniqueId);
         m_resultOutput.writeLong(drInfo.mpUniqueId);
-    }
-    else {
+    } else {
         m_resultOutput.writeByte(static_cast<int8_t>(0));
     }
 }
 
-int64_t VoltDBEngine::applyBinaryLog(int64_t txnId,
-        int64_t spHandle,
-        int64_t lastCommittedSpHandle,
-        int64_t uniqueId,
-        int32_t remoteClusterId,
-        int64_t undoToken,
-        const char *logs) {
+int64_t VoltDBEngine::applyBinaryLog(int64_t txnId, int64_t spHandle, int64_t lastCommittedSpHandle,
+        int64_t uniqueId, int32_t remoteClusterId, int64_t undoToken, const char *logs) {
     DRTupleStreamDisableGuard guard(m_executorContext, !m_isActiveActiveDREnabled);
     setUndoToken(undoToken);
     m_executorContext->setupForPlanFragments(getCurrentUndoQuantum(),
@@ -2866,8 +2758,7 @@ void VoltDBEngine::executePurgeFragment(PersistentTable* table) {
 
     try {
         m_executorContext->executeExecutors(0);
-    }
-    catch (const SerializableEEException &e) {
+    } catch (const SerializableEEException &e) {
         // restore original DML statement state.
         m_currExecutorVec->setupContext(m_executorContext);
         m_executorContext->popModifiedTupleCounter();
@@ -2933,18 +2824,15 @@ void VoltDBEngine::setViewsEnabled(const std::string& viewNames, bool value) {
                     // We do not look at export tables.
                     // We should have prevented this in the Java layer.
                     continue;
-                }
-                if (persistentTable->isReplicatedTable() != updateReplicated) {
+                } else if (persistentTable->isReplicatedTable() != updateReplicated) {
                     VOLT_TRACE("[Partition %d] skip %s\n", m_partitionId, persistentTable->name().c_str());
                     continue;
-                }
-                if (persistentTable->materializedViewTrigger()) {
+                } else if (persistentTable->materializedViewTrigger()) {
                     VOLT_TRACE("[Partition %d] %s->materializedViewTrigger()->setEnabled(%s)\n",
                                m_partitionId, persistentTable->name().c_str(), value?"true":"false");
                     // Single table view
                     persistentTable->materializedViewTrigger()->setEnabled(value);
-                }
-                else if (persistentTable->materializedViewHandler()) {
+                } else if (persistentTable->materializedViewHandler()) {
                     VOLT_TRACE("[Partition %d] %s->materializedViewHandler()->setEnabled(%s)\n",
                                m_partitionId, persistentTable->name().c_str(), value?"true":"false");
                     // Joined view.

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -43,8 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef VOLTDBENGINE_H
-#define VOLTDBENGINE_H
+#pragma once
 
 #include "common/Pool.hpp"
 #include "common/serializeio.h"
@@ -297,7 +296,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
                                                      m_exceptionBufferCapacity,
                                                      startingPosition);
             *reinterpret_cast<int32_t*>(m_exceptionBuffer) =
-                    voltdb::VOLT_EE_EXCEPTION_TYPE_NONE;
+                    static_cast<int32_t>(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_NONE);
 
         }
 
@@ -848,4 +847,3 @@ inline bool startsWith(const string& s1, const string& s2) {
 
 } // namespace voltdb
 
-#endif // VOLTDBENGINE_H

--- a/src/ee/executors/aggregateexecutor.cpp
+++ b/src/ee/executors/aggregateexecutor.cpp
@@ -522,11 +522,7 @@ inline Agg* getAggInstance(Pool& memoryPool, ExpressionType agg_type, bool isDis
     case EXPRESSION_TYPE_AGGREGATE_HYPERLOGLOGS_TO_CARD:
         return new (memoryPool) HyperLogLogsToCardAgg();
     default:
-        {
-            char message[128];
-            snprintf(message, sizeof(message), "Unknown aggregate type %d", agg_type);
-            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
-        }
+        throwSerializableEEException("Unknown aggregate type %d", agg_type);
     }
 }
 

--- a/src/ee/executors/aggregateexecutor.cpp
+++ b/src/ee/executors/aggregateexecutor.cpp
@@ -525,7 +525,7 @@ inline Agg* getAggInstance(Pool& memoryPool, ExpressionType agg_type, bool isDis
         {
             char message[128];
             snprintf(message, sizeof(message), "Unknown aggregate type %d", agg_type);
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
         }
     }
 }

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -142,11 +142,9 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
         } else if (s_modifiedTuples == -1) {
             // An exception was thrown on the lowest site thread and we need to throw here as well so
             // all threads are in the same state
-            char msg[1024];
-            snprintf(msg, 1024, "Replicated table delete threw an unknown exception on other thread for table %s",
+            throwSerializableTypedEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE,
+                    "Replicated table delete threw an unknown exception on other thread for table %s",
                     targetTable->name().c_str());
-            VOLT_DEBUG("%s", msg);
-            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
         }
     }
     if (m_replicatedTableOperation) {

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -146,7 +146,7 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
             snprintf(msg, 1024, "Replicated table delete threw an unknown exception on other thread for table %s",
                     targetTable->name().c_str());
             VOLT_DEBUG("%s", msg);
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
         }
     }
     if (m_replicatedTableOperation) {

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -359,7 +359,7 @@ void InsertExecutor::p_execute_tuple(TableTuple &tuple) {
             snprintf(msg, 1024, "Replicated table insert threw an unknown exception on other thread for table %s",
                     m_targetTable->name().c_str());
             VOLT_DEBUG("%s", msg);
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
         }
     }
 }
@@ -423,7 +423,7 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
          }
          VOLT_DEBUG("%s", msg);
          // NOTE!!! Cannot throw any other types like ConstraintFailureException
-         throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
+         throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
       }
    }
 

--- a/src/ee/executors/migrateexecutor.cpp
+++ b/src/ee/executors/migrateexecutor.cpp
@@ -146,11 +146,9 @@ bool MigrateExecutor::p_execute(const NValueArray &params) {
             if (s_modifiedTuples == -1) {
                 // An exception was thrown on the lowest site thread and we need to throw here as well so
                 // all threads are in the same state
-                char msg[1024];
-                snprintf(msg, 1024, "Replicated table update threw an unknown exception on other thread for table %s",
+                throwSerializableTypedEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE,
+                        "Replicated table update threw an unknown exception on other thread for table %s",
                         targetTable->name().c_str());
-                VOLT_DEBUG("%s", msg);
-                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
             }
         }
     }

--- a/src/ee/executors/migrateexecutor.cpp
+++ b/src/ee/executors/migrateexecutor.cpp
@@ -150,7 +150,7 @@ bool MigrateExecutor::p_execute(const NValueArray &params) {
                 snprintf(msg, 1024, "Replicated table update threw an unknown exception on other thread for table %s",
                         targetTable->name().c_str());
                 VOLT_DEBUG("%s", msg);
-                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
+                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
             }
         }
     }

--- a/src/ee/executors/swaptablesexecutor.cpp
+++ b/src/ee/executors/swaptablesexecutor.cpp
@@ -119,7 +119,7 @@ bool SwapTablesExecutor::p_execute(NValueArray const& params) {
                 snprintf(msg, 1024, "Replicated table swap threw an unknown exception on other thread for table %s",
                         theTargetTable->name().c_str());
                 VOLT_DEBUG("%s", msg);
-                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
+                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
             }
         }
     }

--- a/src/ee/executors/swaptablesexecutor.cpp
+++ b/src/ee/executors/swaptablesexecutor.cpp
@@ -115,11 +115,9 @@ bool SwapTablesExecutor::p_execute(NValueArray const& params) {
             if (s_modifiedTuples == -1) {
                 // An exception was thrown on the lowest site thread and we need to throw here as well so
                 // all threads are in the same state
-                char msg[1024];
-                snprintf(msg, 1024, "Replicated table swap threw an unknown exception on other thread for table %s",
+                throwSerializableTypedEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE,
+                        "Replicated table swap threw an unknown exception on other thread for table %s",
                         theTargetTable->name().c_str());
-                VOLT_DEBUG("%s", msg);
-                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
             }
         }
     }

--- a/src/ee/executors/tablecountexecutor.cpp
+++ b/src/ee/executors/tablecountexecutor.cpp
@@ -54,8 +54,7 @@ bool TableCountExecutor::p_execute(const NValueArray &params) {
         vassert(input_table);
         AbstractTempTable* temp_table = dynamic_cast<AbstractTempTable*>(input_table);
         if ( ! temp_table) {
-            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                    "May not iterate a streamed table.");
+            throw SerializableEEException("May not iterate a streamed table.");
         }
         rowCounts = temp_table->tempTableTupleCount();
     } else {

--- a/src/ee/executors/tablecountexecutor.cpp
+++ b/src/ee/executors/tablecountexecutor.cpp
@@ -54,7 +54,7 @@ bool TableCountExecutor::p_execute(const NValueArray &params) {
         vassert(input_table);
         AbstractTempTable* temp_table = dynamic_cast<AbstractTempTable*>(input_table);
         if ( ! temp_table) {
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                     "May not iterate a streamed table.");
         }
         rowCounts = temp_table->tempTableTupleCount();

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -220,7 +220,7 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
                 snprintf(msg, 1024, "Replicated table update threw an unknown exception on other thread for table %s",
                         targetTable->name().c_str());
                 VOLT_DEBUG("%s", msg);
-                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
+                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
             }
         }
     }

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -216,11 +216,9 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
             if (s_modifiedTuples == -1) {
                 // An exception was thrown on the lowest site thread and we need to throw here as well so
                 // all threads are in the same state
-                char msg[1024];
-                snprintf(msg, 1024, "Replicated table update threw an unknown exception on other thread for table %s",
+                throwSerializableTypedEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE,
+                        "Replicated table update threw an unknown exception on other thread for table %s",
                         targetTable->name().c_str());
-                VOLT_DEBUG("%s", msg);
-                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
             }
         }
     }

--- a/src/ee/executors/windowfunctionexecutor.cpp
+++ b/src/ee/executors/windowfunctionexecutor.cpp
@@ -517,7 +517,7 @@ inline WindowAggregate* getWindowedAggInstance(Pool& memoryPool,
         answer = new (memoryPool) WindowedSumAgg();
         break;
     default:
-        throwSerializableEEException( "Unknown aggregate type %d", agg_type);
+        throwSerializableEEException("Unknown aggregate type %d", agg_type);
     }
     return answer;
 }

--- a/src/ee/executors/windowfunctionexecutor.cpp
+++ b/src/ee/executors/windowfunctionexecutor.cpp
@@ -517,12 +517,7 @@ inline WindowAggregate* getWindowedAggInstance(Pool& memoryPool,
         answer = new (memoryPool) WindowedSumAgg();
         break;
     default:
-        {
-            char message[128];
-            snprintf(message, sizeof(message), "Unknown aggregate type %d", agg_type);
-            throw SerializableEEException(
-                    VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
-        }
+        throwSerializableEEException( "Unknown aggregate type %d", agg_type);
     }
     return answer;
 }

--- a/src/ee/executors/windowfunctionexecutor.cpp
+++ b/src/ee/executors/windowfunctionexecutor.cpp
@@ -520,7 +520,8 @@ inline WindowAggregate* getWindowedAggInstance(Pool& memoryPool,
         {
             char message[128];
             snprintf(message, sizeof(message), "Unknown aggregate type %d", agg_type);
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+            throw SerializableEEException(
+                    VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
         }
     }
     return answer;

--- a/src/ee/expressions/expressionutil.cpp
+++ b/src/ee/expressions/expressionutil.cpp
@@ -77,8 +77,7 @@ static AbstractExpression* subqueryFactory(ExpressionType subqueryType, PlannerD
         int paramSize = params.arrayLen();
         paramIdxs.reserve(paramSize);
         if (args.size() != paramSize) {
-            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                      "subqueryFactory: parameter indexes/tve count mismatch");
+            throw SerializableEEException("subqueryFactory: parameter indexes/tve count mismatch");
         }
         for (int i = 0; i < paramSize; ++i) {
             int paramIdx = params.valueAtIndex(i).asInt();
@@ -128,11 +127,9 @@ inline AbstractExpression* subqueryComparisonFactory(ExpressionType const c,
          // LIKE operator only works when inner relation is not a tuple
       case EXPRESSION_TYPE_COMPARE_STARTSWITH:  // likewise for startswith
       default:
-         char message[256];
-         snprintf(message, 256, "Invalid ExpressionType '%s' called"
-               " for VectorComparisonExpression",
-               expressionToString(c).c_str());
-         throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+         throwSerializableEEException(
+                 "Invalid ExpressionType '%s' called for VectorComparisonExpression",
+                 expressionToString(c).c_str());
    }
 }
 
@@ -199,11 +196,9 @@ static AbstractExpression* getGeneral(ExpressionType c, AbstractExpression *l, A
     case (EXPRESSION_TYPE_COMPARE_NOTDISTINCT):
         return new ComparisonExpression<CmpNotDistinct>(c, l, r);
     default:
-        char message[256];
-        snprintf(message, 256, "Invalid ExpressionType '%s' called"
-                " for ComparisonExpression",
+        throwSerializableEEException(
+                "Invalid ExpressionType '%s' called for ComparisonExpression",
                 expressionToString(c).c_str());
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
     }
 }
 
@@ -235,10 +230,9 @@ static AbstractExpression* getMoreSpecialized(ExpressionType c, L* l, R* r)
     case (EXPRESSION_TYPE_COMPARE_NOTDISTINCT):
         return new InlinedComparisonExpression<CmpNotDistinct, L, R>(c, l, r);
     default:
-        char message[256];
-        snprintf(message, 256, "Invalid ExpressionType '%s' called for"
-                " ComparisonExpression",expressionToString(c).c_str());
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throwSerializableEEException(
+                "Invalid ExpressionType '%s' called for ComparisonExpression",
+                expressionToString(c).c_str());
     }
 }
 
@@ -296,11 +290,9 @@ static AbstractExpression* constantValueFactory(
 
     switch (vt) {
     case VALUE_TYPE_INVALID:
-       throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-             "constantValueFactory: Value type should never be VALUE_TYPE_INVALID");
+       throw SerializableEEException("constantValueFactory: Value type should never be VALUE_TYPE_INVALID");
     case VALUE_TYPE_NULL:
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-              "constantValueFactory: And they should be never be this either! VALUE_TYPE_NULL");
+        throw SerializableEEException("constantValueFactory: And they should be never be this either! VALUE_TYPE_NULL");
     case VALUE_TYPE_TINYINT:
         newvalue = ValueFactory::getTinyIntValue(static_cast<int8_t>(valueValue.asInt64()));
         break;
@@ -333,8 +325,7 @@ static AbstractExpression* constantValueFactory(
         newvalue = ValueFactory::getBooleanValue(valueValue.asBool());
         break;
     default:
-        throw SerializableEEException(
-              VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, "constantValueFactory: Unrecognized value type");
+        throw SerializableEEException("constantValueFactory: Unrecognized value type");
     }
 
     return new ConstantValueExpression(newvalue);
@@ -353,7 +344,7 @@ static void raiseFunctionFactoryError(
          "in VoltDB (or may have been incorrectly parsed)",
          nameString.c_str(), functionId, args.size());
    DEBUG_ASSERT_OR_THROW_OR_CRASH(false, fn_message);
-   throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, fn_message);
+   throw SerializableEEException(fn_message);
 }
 
 AbstractExpression* ExpressionUtil::vectorFactory(
@@ -365,8 +356,7 @@ static AbstractExpression* caseWhenFactory(ValueType vt, AbstractExpression *lc,
 
     OperatorAlternativeExpression* alternative = dynamic_cast<OperatorAlternativeExpression*> (rc);
     if (!rc) {
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                      "operator case when has incorrect expression");
+        throw SerializableEEException("operator case when has incorrect expression");
     }
     return new OperatorCaseWhenExpression(vt, lc, alternative);
 }
@@ -532,11 +522,9 @@ AbstractExpression* ExpressionUtil::expressionFactory(
 
          // must handle all known expressions in this factory
       default:
-
-         char message[256];
-         snprintf(message,256, "Invalid ExpressionType '%s' (%d) requested from factory",
-               expressionToString(et).c_str(), (int)et);
-         throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+         throwSerializableEEException(
+                 "Invalid ExpressionType '%s' (%d) requested from factory",
+                 expressionToString(et).c_str(), (int)et);
    }
    ret->setValueType(vt);
    ret->setValueSize(vs);
@@ -584,16 +572,13 @@ AbstractExpression* ExpressionUtil::operatorFactory(ExpressionType et, AbstractE
          break;
 
      case (EXPRESSION_TYPE_OPERATOR_MOD):
-       throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                     "Mod operator is not yet supported.");
+       throw SerializableEEException("Mod operator is not yet supported.");
 
      case (EXPRESSION_TYPE_OPERATOR_CONCAT):
-       throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                     "Concat operator not yet supported.");
+       throw SerializableEEException("Concat operator not yet supported.");
 
      default:
-       throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                     "operator ctor helper out of sync");
+       throw SerializableEEException("operator ctor helper out of sync");
    }
    return ret;
 }

--- a/src/ee/expressions/expressionutil.cpp
+++ b/src/ee/expressions/expressionutil.cpp
@@ -77,7 +77,7 @@ static AbstractExpression* subqueryFactory(ExpressionType subqueryType, PlannerD
         int paramSize = params.arrayLen();
         paramIdxs.reserve(paramSize);
         if (args.size() != paramSize) {
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                       "subqueryFactory: parameter indexes/tve count mismatch");
         }
         for (int i = 0; i < paramSize; ++i) {
@@ -132,7 +132,7 @@ inline AbstractExpression* subqueryComparisonFactory(ExpressionType const c,
          snprintf(message, 256, "Invalid ExpressionType '%s' called"
                " for VectorComparisonExpression",
                expressionToString(c).c_str());
-         throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+         throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
    }
 }
 
@@ -203,7 +203,7 @@ static AbstractExpression* getGeneral(ExpressionType c, AbstractExpression *l, A
         snprintf(message, 256, "Invalid ExpressionType '%s' called"
                 " for ComparisonExpression",
                 expressionToString(c).c_str());
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
     }
 }
 
@@ -238,7 +238,7 @@ static AbstractExpression* getMoreSpecialized(ExpressionType c, L* l, R* r)
         char message[256];
         snprintf(message, 256, "Invalid ExpressionType '%s' called for"
                 " ComparisonExpression",expressionToString(c).c_str());
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
     }
 }
 
@@ -296,10 +296,10 @@ static AbstractExpression* constantValueFactory(
 
     switch (vt) {
     case VALUE_TYPE_INVALID:
-       throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+       throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
              "constantValueFactory: Value type should never be VALUE_TYPE_INVALID");
     case VALUE_TYPE_NULL:
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
               "constantValueFactory: And they should be never be this either! VALUE_TYPE_NULL");
     case VALUE_TYPE_TINYINT:
         newvalue = ValueFactory::getTinyIntValue(static_cast<int8_t>(valueValue.asInt64()));
@@ -334,7 +334,7 @@ static AbstractExpression* constantValueFactory(
         break;
     default:
         throw SerializableEEException(
-              VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, "constantValueFactory: Unrecognized value type");
+              VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, "constantValueFactory: Unrecognized value type");
     }
 
     return new ConstantValueExpression(newvalue);
@@ -353,7 +353,7 @@ static void raiseFunctionFactoryError(
          "in VoltDB (or may have been incorrectly parsed)",
          nameString.c_str(), functionId, args.size());
    DEBUG_ASSERT_OR_THROW_OR_CRASH(false, fn_message);
-   throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, fn_message);
+   throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, fn_message);
 }
 
 AbstractExpression* ExpressionUtil::vectorFactory(
@@ -365,7 +365,7 @@ static AbstractExpression* caseWhenFactory(ValueType vt, AbstractExpression *lc,
 
     OperatorAlternativeExpression* alternative = dynamic_cast<OperatorAlternativeExpression*> (rc);
     if (!rc) {
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                       "operator case when has incorrect expression");
     }
     return new OperatorCaseWhenExpression(vt, lc, alternative);
@@ -536,7 +536,7 @@ AbstractExpression* ExpressionUtil::expressionFactory(
          char message[256];
          snprintf(message,256, "Invalid ExpressionType '%s' (%d) requested from factory",
                expressionToString(et).c_str(), (int)et);
-         throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+         throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
    }
    ret->setValueType(vt);
    ret->setValueSize(vs);
@@ -584,15 +584,15 @@ AbstractExpression* ExpressionUtil::operatorFactory(ExpressionType et, AbstractE
          break;
 
      case (EXPRESSION_TYPE_OPERATOR_MOD):
-       throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+       throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                      "Mod operator is not yet supported.");
 
      case (EXPRESSION_TYPE_OPERATOR_CONCAT):
-       throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+       throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                      "Concat operator not yet supported.");
 
      default:
-       throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+       throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                      "operator ctor helper out of sync");
    }
    return ret;

--- a/src/ee/expressions/hashrangeexpression.h
+++ b/src/ee/expressions/hashrangeexpression.h
@@ -53,9 +53,7 @@ public:
         vassert(tuple1);
         if ( ! tuple1 ) {
             throw SerializableEEException(
-                    "TupleValueExpression::"
-                    "eval:"
-                    " Couldn't find tuple 1 (possible index scan planning error)");
+                    "TupleValueExpression::eval: Couldn't find tuple 1 (possible index scan planning error)");
         }
         const int32_t hash = tuple1->getNValue(this->value_idx).murmurHash3();
 

--- a/src/ee/expressions/scalarvalueexpression.cpp
+++ b/src/ee/expressions/scalarvalueexpression.cpp
@@ -35,10 +35,7 @@ voltdb::NValue ScalarValueExpression::eval(const TableTuple *tuple1, const Table
     Table* table = exeContext->getSubqueryOutputTable(subqueryId);
     vassert(table != NULL);
     if (table->activeTupleCount() > 1) {
-        // throw runtime exception
-        char message[256];
-        snprintf(message, 256, "More than one row returned by a scalar/row subquery");
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throw SerializableEEException("More than one row returned by a scalar/row subquery");
     }
     TableIterator iterator = table->iterator();
     TableTuple tuple(table->schema());

--- a/src/ee/expressions/scalarvalueexpression.cpp
+++ b/src/ee/expressions/scalarvalueexpression.cpp
@@ -38,7 +38,7 @@ voltdb::NValue ScalarValueExpression::eval(const TableTuple *tuple1, const Table
         // throw runtime exception
         char message[256];
         snprintf(message, 256, "More than one row returned by a scalar/row subquery");
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
     }
     TableIterator iterator = table->iterator();
     TableTuple tuple(table->schema());

--- a/src/ee/expressions/tuplevalueexpression.h
+++ b/src/ee/expressions/tuplevalueexpression.h
@@ -43,8 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef HSTORETUPLEVALUEEXPRESSION_H
-#define HSTORETUPLEVALUEEXPRESSION_H
+#pragma once
 
 #include "expressions/abstractexpression.h"
 #include "common/tabletuple.h"
@@ -57,27 +56,23 @@ namespace voltdb {
 class TupleValueExpression : public AbstractExpression {
   public:
     TupleValueExpression(const int tableIdx, const int valueIdx)
-        : AbstractExpression(EXPRESSION_TYPE_VALUE_TUPLE), tuple_idx(tableIdx), value_idx(valueIdx)
-    {
+        : AbstractExpression(EXPRESSION_TYPE_VALUE_TUPLE), tuple_idx(tableIdx), value_idx(valueIdx) {
         VOLT_TRACE("OptimizedTupleValueExpression %d using tupleIdx %d valueIdx %d", m_type, tableIdx, valueIdx);
     };
 
     virtual voltdb::NValue eval(const TableTuple *tuple1, const TableTuple *tuple2) const {
         if (tuple_idx == 0) {
             vassert(tuple1);
-            if ( ! tuple1 ) {
-                throw SerializableEEException("TupleValueExpression::"
-                                              "eval:"
-                                              " Couldn't find tuple 1 (possible index scan planning error)");
+            if (! tuple1 ) {
+                throw SerializableEEException(
+                        "TupleValueExpression::eval: Couldn't find tuple 1 (possible index scan planning error)");
             }
             return tuple1->getNValue(value_idx);
-        }
-        else {
+        } else {
             vassert(tuple2);
-            if ( ! tuple2 ) {
-                throw SerializableEEException("TupleValueExpression::"
-                                              "eval:"
-                                              " Couldn't find tuple 2 (possible index scan planning error)");
+            if (! tuple2 ) {
+                throw SerializableEEException(
+                        "TupleValueExpression::eval: Couldn't find tuple 2 (possible index scan planning error)");
             }
             return tuple2->getNValue(value_idx);
         }
@@ -98,4 +93,3 @@ class TupleValueExpression : public AbstractExpression {
 };
 
 }
-#endif

--- a/src/ee/expressions/vectorcomparisonexpression.hpp
+++ b/src/ee/expressions/vectorcomparisonexpression.hpp
@@ -315,7 +315,7 @@ NValue VectorComparisonExpression<OP, ValueExtractorOuter, ValueExtractorInner>:
         // throw runtime exception
         char message[256];
         snprintf(message, 256, "More than one row returned by a scalar/row subquery");
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
     }
 
     // Evaluate the inner_expr. The return value is a subquery id or a value as well
@@ -325,7 +325,7 @@ NValue VectorComparisonExpression<OP, ValueExtractorOuter, ValueExtractorInner>:
         // throw runtime exception
         char message[256];
         snprintf(message, 256, "More than one row returned by a scalar/row subquery");
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
     }
 
     if (innerExtractor.resultSize() == 0) {

--- a/src/ee/expressions/vectorcomparisonexpression.hpp
+++ b/src/ee/expressions/vectorcomparisonexpression.hpp
@@ -312,20 +312,14 @@ NValue VectorComparisonExpression<OP, ValueExtractorOuter, ValueExtractorInner>:
     NValue lvalue = m_left->eval(tuple1, tuple2);
     ValueExtractorOuter outerExtractor(lvalue);
     if (outerExtractor.resultSize() > 1) {
-        // throw runtime exception
-        char message[256];
-        snprintf(message, 256, "More than one row returned by a scalar/row subquery");
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throw SerializableEEException("More than one row returned by a scalar/row subquery");
     }
 
     // Evaluate the inner_expr. The return value is a subquery id or a value as well
     NValue rvalue = m_right->eval(tuple1, tuple2);
     ValueExtractorInner innerExtractor(rvalue);
     if (m_quantifier == QUANTIFIER_TYPE_NONE && innerExtractor.resultSize() > 1) {
-        // throw runtime exception
-        char message[256];
-        snprintf(message, 256, "More than one row returned by a scalar/row subquery");
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION, message);
+        throw SerializableEEException("More than one row returned by a scalar/row subquery");
     }
 
     if (innerExtractor.resultSize() == 0) {

--- a/src/ee/plannodes/abstractplannode.cpp
+++ b/src/ee/plannodes/abstractplannode.cpp
@@ -435,7 +435,7 @@ void AbstractPlanNode::loadSortListFromJSONObject(
         }
 
         if (!(hasExpression && hasDirection)) {
-            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+            throw SerializableEEException(
                     "OrderByPlanNode::loadFromJSONObject: Does not have expression and direction.");
         }
     }

--- a/src/ee/plannodes/abstractplannode.cpp
+++ b/src/ee/plannodes/abstractplannode.cpp
@@ -435,9 +435,8 @@ void AbstractPlanNode::loadSortListFromJSONObject(
         }
 
         if (!(hasExpression && hasDirection)) {
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                          "OrderByPlanNode::loadFromJSONObject:"
-                                          " Does not have expression and direction.");
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                    "OrderByPlanNode::loadFromJSONObject: Does not have expression and direction.");
         }
     }
 }

--- a/src/ee/plannodes/aggregatenode.cpp
+++ b/src/ee/plannodes/aggregatenode.cpp
@@ -117,9 +117,8 @@ void AggregatePlanNode::loadFromJSONObject(PlannerDomValue obj)
         }
 
         if(!(containsType && containsDistinct && containsOutputColumn)) {
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                      "AggregatePlanNode::loadFromJSONObject:"
-                                      " Missing type, distinct, or outputcolumn.");
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                    "AggregatePlanNode::loadFromJSONObject: Missing type, distinct, or outputcolumn.");
         }
         if ( ! containsExpression) {
             m_aggregateInputExpressions.push_back(NULL);

--- a/src/ee/plannodes/aggregatenode.cpp
+++ b/src/ee/plannodes/aggregatenode.cpp
@@ -117,8 +117,7 @@ void AggregatePlanNode::loadFromJSONObject(PlannerDomValue obj)
         }
 
         if(!(containsType && containsDistinct && containsOutputColumn)) {
-            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                    "AggregatePlanNode::loadFromJSONObject: Missing type, distinct, or outputcolumn.");
+            throw SerializableEEException("AggregatePlanNode::loadFromJSONObject: Missing type, distinct, or outputcolumn.");
         }
         if ( ! containsExpression) {
             m_aggregateInputExpressions.push_back(NULL);

--- a/src/ee/plannodes/unionnode.cpp
+++ b/src/ee/plannodes/unionnode.cpp
@@ -52,15 +52,13 @@ UnionPlanNode::~UnionPlanNode() { }
 
 PlanNodeType UnionPlanNode::getPlanNodeType() const { return PLAN_NODE_TYPE_UNION; }
 
-std::string UnionPlanNode::debugInfo(const std::string &spacer) const
-{
+std::string UnionPlanNode::debugInfo(const std::string &spacer) const {
     std::ostringstream buffer;
     buffer << spacer << "UnionType[" << m_unionType << "]\n";
     return buffer.str();
 }
 
-void UnionPlanNode::loadFromJSONObject(PlannerDomValue obj)
-{
+void UnionPlanNode::loadFromJSONObject(PlannerDomValue obj) {
     std::string unionTypeStr = obj.valueForKey("UNION_TYPE").asStr();
     if (unionTypeStr == "UNION") {
         m_unionType = UNION_TYPE_UNION;
@@ -77,10 +75,9 @@ void UnionPlanNode::loadFromJSONObject(PlannerDomValue obj)
     } else if (unionTypeStr == "NOUNION") {
         m_unionType = UNION_TYPE_NOUNION;
     } else {
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                      "UnionPlanNode::loadFromJSONObject:"
-                                      " Unsupported UNION_TYPE value " +
-                                      unionTypeStr);
+        throw SerializableEEException(
+                VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                "UnionPlanNode::loadFromJSONObject: Unsupported UNION_TYPE value " + unionTypeStr);
     }
 }
 

--- a/src/ee/plannodes/unionnode.cpp
+++ b/src/ee/plannodes/unionnode.cpp
@@ -75,9 +75,9 @@ void UnionPlanNode::loadFromJSONObject(PlannerDomValue obj) {
     } else if (unionTypeStr == "NOUNION") {
         m_unionType = UNION_TYPE_NOUNION;
     } else {
-        throw SerializableEEException(
-                VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                "UnionPlanNode::loadFromJSONObject: Unsupported UNION_TYPE value " + unionTypeStr);
+        throwSerializableEEException(
+                "UnionPlanNode::loadFromJSONObject: Unsupported UNION_TYPE value %s",
+                unionTypeStr.c_str());
     }
 }
 

--- a/src/ee/plannodes/windowfunctionnode.cpp
+++ b/src/ee/plannodes/windowfunctionnode.cpp
@@ -106,10 +106,8 @@ void WindowFunctionPlanNode::loadFromJSONObject(PlannerDomValue obj) {
             if (!containsExpressions) {
                 buffer << sep << "Aggregate Argument Expressions";
             }
-            throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                      "WindowFunctionPlanNode::loadFromJSONObject:"
-                                      " Aggregate missing components: "
-                                      + buffer.str());
+            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                    "WindowFunctionPlanNode::loadFromJSONObject: Aggregate missing components: " + buffer.str());
         }
 
     }
@@ -133,10 +131,8 @@ void WindowFunctionPlanNode::loadFromJSONObject(PlannerDomValue obj) {
             buffer << sep << "Order By List";
             sep = ", ";
         }
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                  "WindowFunctionPlanNode::loadFromJSONObject:"
-                                  " Missing components: "
-                                  + buffer.str());
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                "WindowFunctionPlanNode::loadFromJSONObject: Missing components: " + buffer.str());
     }
 }
 

--- a/src/ee/plannodes/windowfunctionnode.cpp
+++ b/src/ee/plannodes/windowfunctionnode.cpp
@@ -22,13 +22,9 @@
 #include <sstream>
 
 namespace voltdb {
-WindowFunctionPlanNode::~WindowFunctionPlanNode()
-{
+WindowFunctionPlanNode::~WindowFunctionPlanNode() { }
 
-}
-
-PlanNodeType WindowFunctionPlanNode::getPlanNodeType() const
-{
+PlanNodeType WindowFunctionPlanNode::getPlanNodeType() const {
     return PLAN_NODE_TYPE_WINDOWFUNCTION;
 }
 
@@ -106,8 +102,9 @@ void WindowFunctionPlanNode::loadFromJSONObject(PlannerDomValue obj) {
             if (!containsExpressions) {
                 buffer << sep << "Aggregate Argument Expressions";
             }
-            throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                    "WindowFunctionPlanNode::loadFromJSONObject: Aggregate missing components: " + buffer.str());
+            throwSerializableEEException(
+                    "WindowFunctionPlanNode::loadFromJSONObject: Aggregate missing components: %s",
+                    buffer.str().c_str());
         }
 
     }
@@ -131,8 +128,9 @@ void WindowFunctionPlanNode::loadFromJSONObject(PlannerDomValue obj) {
             buffer << sep << "Order By List";
             sep = ", ";
         }
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                "WindowFunctionPlanNode::loadFromJSONObject: Missing components: " + buffer.str());
+        throwSerializableEEException(
+                "WindowFunctionPlanNode::loadFromJSONObject: Missing components: %s",
+                buffer.str().c_str());
     }
 }
 

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -840,8 +840,9 @@ int64_t BinaryLogSink::applyTxn(BinaryLog *log, boost::unordered_map<int64_t, Pe
             if (canSkip) {
                 skipRow = true;
             } else {
-                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED,
-                    "Binary log txns were sent to the wrong partition");
+                throw SerializableEEException(
+                        VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED,
+                        "Binary log txns were sent to the wrong partition");
             }
         }
         rowCount += applyRecord(log, type, tables, pool, engine, remoteClusterId, replicatedTable, skipRow);
@@ -868,7 +869,8 @@ int64_t BinaryLogSink::applyReplicatedTxn(BinaryLog *log, boost::unordered_map<i
     } else if (!s_replicatedApplySuccess) {
         const char* msg = "Replicated table apply binary log threw an unknown exception on other thread.";
         VOLT_DEBUG("%s", msg);
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
+        throw SerializableEEException(
+                VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE, msg);
     } else {
         VOLT_TRACE("Skipping applyBinaryLogMP for replicated table");
         log->skipRecordsAndValidateTxn();

--- a/src/ee/storage/ConstraintFailureException.cpp
+++ b/src/ee/storage/ConstraintFailureException.cpp
@@ -23,14 +23,11 @@ using namespace voltdb;
 using std::string;
 
 ConstraintFailureException::ConstraintFailureException(
-        Table *table,
-        TableTuple tuple,
-        TableTuple otherTuple,
-        ConstraintType type,
-        PersistentTableSurgeon *surgeon) :
+        Table *table, TableTuple tuple, TableTuple otherTuple,
+        ConstraintType type, PersistentTableSurgeon *surgeon) :
     SQLException(SQLException::integrity_constraint_violation,
             "Attempted violation of constraint",
-            VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION),
+            VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION),
     m_table(table),
     m_tuple(tuple),
     m_otherTuple(otherTuple),
@@ -48,13 +45,12 @@ ConstraintFailureException::ConstraintFailureException(
         SQLException(
                 SQLException::integrity_constraint_violation,
                 message,
-                VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION),
+                VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_CONSTRAINT_VIOLATION),
     m_table(table),
     m_tuple(tuple),
     m_otherTuple(TableTuple()),
     m_type(CONSTRAINT_TYPE_PARTITIONING),
-    m_surgeon(surgeon)
-{
+    m_surgeon(surgeon) {
     vassert(table);
     vassert(!tuple.isNullTuple());
 }

--- a/src/ee/storage/DRTableNotFoundException.cpp
+++ b/src/ee/storage/DRTableNotFoundException.cpp
@@ -21,7 +21,7 @@
 using namespace voltdb;
 
 DRTableNotFoundException::DRTableNotFoundException(int64_t hash, std::string const& message) :
-    SerializableEEException(VOLT_EE_EXCEPTION_TYPE_DR_TABLE_NOT_FOUND, message),
+    SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_DR_TABLE_NOT_FOUND, message),
     m_hash(hash)
 { }
 

--- a/src/ee/storage/MaterializedViewHandler.cpp
+++ b/src/ee/storage/MaterializedViewHandler.cpp
@@ -200,8 +200,8 @@ namespace voltdb {
                     char message[128];
                     snprintf(message, 128, "Error in materialized view aggregation %d expression type %s",
                              (int)aggIndex, expressionToString(m_aggTypes[aggIndex]).c_str());
-                    throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                                  message);
+                    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                            message);
                 }
             }
         }

--- a/src/ee/storage/MaterializedViewHandler.cpp
+++ b/src/ee/storage/MaterializedViewHandler.cpp
@@ -196,13 +196,10 @@ namespace voltdb {
                 case EXPRESSION_TYPE_AGGREGATE_MIN:
                 case EXPRESSION_TYPE_AGGREGATE_MAX:
                     break; // legal value
-                default: {
-                    char message[128];
-                    snprintf(message, 128, "Error in materialized view aggregation %d expression type %s",
-                             (int)aggIndex, expressionToString(m_aggTypes[aggIndex]).c_str());
-                    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                            message);
-                }
+                default:
+                    throwSerializableEEException(
+                            "Error in materialized view aggregation %d expression type %s",
+                            (int)aggIndex, expressionToString(m_aggTypes[aggIndex]).c_str());
             }
         }
     }

--- a/src/ee/storage/MaterializedViewTriggerForInsert.cpp
+++ b/src/ee/storage/MaterializedViewTriggerForInsert.cpp
@@ -447,8 +447,8 @@ std::size_t MaterializedViewTriggerForInsert::parseAggregation(catalog::Material
                 char message[128];
                 snprintf(message, 128, "Error in materialized view aggregation %d expression type %s",
                          (int)aggIndex, expressionToString(m_aggTypes[aggIndex]).c_str());
-                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                              message);
+                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                        message);
             }
         }
         if (usesComplexAgg || (m_aggTypes[aggIndex] == EXPRESSION_TYPE_AGGREGATE_COUNT_STAR) ) {

--- a/src/ee/storage/MaterializedViewTriggerForInsert.cpp
+++ b/src/ee/storage/MaterializedViewTriggerForInsert.cpp
@@ -443,13 +443,10 @@ std::size_t MaterializedViewTriggerForInsert::parseAggregation(catalog::Material
             case EXPRESSION_TYPE_AGGREGATE_MIN:
             case EXPRESSION_TYPE_AGGREGATE_MAX:
                 break; // legal value
-            default: {
-                char message[128];
-                snprintf(message, 128, "Error in materialized view aggregation %d expression type %s",
-                         (int)aggIndex, expressionToString(m_aggTypes[aggIndex]).c_str());
-                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                        message);
-            }
+            default:
+                throwSerializableEEException(
+                        "Error in materialized view aggregation %d expression type %s",
+                        (int)aggIndex, expressionToString(m_aggTypes[aggIndex]).c_str());
         }
         if (usesComplexAgg || (m_aggTypes[aggIndex] == EXPRESSION_TYPE_AGGREGATE_COUNT_STAR) ) {
             continue;

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1691,8 +1691,7 @@ void PersistentTable::loadTuplesForLoadTable(SerializeInputBE &serialInput, Pool
             message << "column " << i << ": " << names[i]
                     << ", type = " << getTypeName(types[i]) << std::endl;
         }
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                message.str().c_str());
+        throw SerializableEEException(message.str().c_str());
     }
 
     int tupleCount = serialInput.readInt();

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1691,8 +1691,8 @@ void PersistentTable::loadTuplesForLoadTable(SerializeInputBE &serialInput, Pool
             message << "column " << i << ": " << names[i]
                     << ", type = " << getTypeName(types[i]) << std::endl;
         }
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                      message.str().c_str());
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                message.str().c_str());
     }
 
     int tupleCount = serialInput.readInt();

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -114,30 +114,30 @@ void StreamedTable::notifyQuantumRelease() {
 }
 
 TableIterator  StreamedTable::iterator() {
-    throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                   "May not iterate a streamed table.");
 }
 
 TableIterator StreamedTable::iteratorDeletingAsWeGo() {
-    throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                   "May not iterate a streamed table.");
 }
 
 void StreamedTable::deleteAllTuples(bool freeAllocatedStrings, bool fallible)
 {
-    throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                   "May not delete all tuples of a streamed"
                                   " table.");
 }
 
 TBPtr StreamedTable::allocateNextBlock() {
-    throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                   "May not use block alloc interface with "
                                   "streamed tables.");
 }
 
 void StreamedTable::nextFreeTuple(TableTuple *) {
-    throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                   "May not use nextFreeTuple with streamed tables.");
 }
 
@@ -174,7 +174,7 @@ void StreamedTable::streamTuple(TableTuple &source, ExportTupleStream::STREAM_RO
             }
             m_migrateTxnSizeGuard.uso = m_wrapper->getUso();
             if (m_migrateTxnSizeGuard.estimatedDRLogSize >= voltdb::SECONDARY_BUFFER_SIZE) {
-                throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                                   "Migrate transaction failed, exceeding 50MB DR buffer size limit.");
             }
         }
@@ -200,7 +200,7 @@ bool StreamedTable::insertTuple(TableTuple &source)
 }
 
 void StreamedTable::loadTuplesFrom(SerializeInputBE&, Pool*) {
-    throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                   "May not update a streamed table.");
 }
 

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -114,31 +114,24 @@ void StreamedTable::notifyQuantumRelease() {
 }
 
 TableIterator  StreamedTable::iterator() {
-    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                  "May not iterate a streamed table.");
+    throw SerializableEEException("May not iterate a streamed table.");
 }
 
 TableIterator StreamedTable::iteratorDeletingAsWeGo() {
-    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                  "May not iterate a streamed table.");
+    throw SerializableEEException("May not iterate a streamed table.");
 }
 
 void StreamedTable::deleteAllTuples(bool freeAllocatedStrings, bool fallible)
 {
-    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                  "May not delete all tuples of a streamed"
-                                  " table.");
+    throw SerializableEEException("May not delete all tuples of a streamed table.");
 }
 
 TBPtr StreamedTable::allocateNextBlock() {
-    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                  "May not use block alloc interface with "
-                                  "streamed tables.");
+    throw SerializableEEException("May not use block alloc interface with streamed tables.");
 }
 
 void StreamedTable::nextFreeTuple(TableTuple *) {
-    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                  "May not use nextFreeTuple with streamed tables.");
+    throw SerializableEEException("May not use nextFreeTuple with streamed tables.");
 }
 
 void StreamedTable::streamTuple(TableTuple &source, ExportTupleStream::STREAM_ROW_TYPE type, AbstractDRTupleStream *drStream) {
@@ -174,8 +167,7 @@ void StreamedTable::streamTuple(TableTuple &source, ExportTupleStream::STREAM_RO
             }
             m_migrateTxnSizeGuard.uso = m_wrapper->getUso();
             if (m_migrateTxnSizeGuard.estimatedDRLogSize >= voltdb::SECONDARY_BUFFER_SIZE) {
-                throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                                  "Migrate transaction failed, exceeding 50MB DR buffer size limit.");
+                throw SerializableEEException("Migrate transaction failed, exceeding 50MB DR buffer size limit.");
             }
         }
     }
@@ -200,8 +192,7 @@ bool StreamedTable::insertTuple(TableTuple &source)
 }
 
 void StreamedTable::loadTuplesFrom(SerializeInputBE&, Pool*) {
-    throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                  "May not update a streamed table.");
+    throw SerializableEEException("May not update a streamed table.");
 }
 
 void StreamedTable::flushOldTuples(int64_t timeInMillis) {

--- a/src/ee/storage/table.cpp
+++ b/src/ee/storage/table.cpp
@@ -516,8 +516,7 @@ void Table::loadTuplesFrom(SerializeInputBE &serialInput,
             message << "column " << i << ": " << names[i]
                     << ", type = " << getTypeName(types[i]) << std::endl;
         }
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                message.str().c_str());
+        throw SerializableEEException(message.str().c_str());
     }
 
     loadTuplesFromNoHeader(serialInput, stringPool);

--- a/src/ee/storage/table.cpp
+++ b/src/ee/storage/table.cpp
@@ -516,8 +516,8 @@ void Table::loadTuplesFrom(SerializeInputBE &serialInput,
             message << "column " << i << ": " << names[i]
                     << ", type = " << getTypeName(types[i]) << std::endl;
         }
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                      message.str().c_str());
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+                message.str().c_str());
     }
 
     loadTuplesFromNoHeader(serialInput, stringPool);

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -284,12 +284,12 @@ class Table {
 
     // Used by delete-as-you-go iterators.  Returns an iterator to the block id of the next block.
     virtual std::vector<LargeTempTableBlockId>::iterator releaseBlock(std::vector<LargeTempTableBlockId>::iterator it) {
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                      "May only use releaseBlock with instances of LargeTempTable.");
     }
 
     virtual void freeLastScannedBlock(std::vector<TBPtr>::iterator nextBlockIterator) {
-        throw SerializableEEException(VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
+        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
                                      "May only use freeLastScannedBlock with instances of TempTable.");
     }
 

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -284,13 +284,11 @@ class Table {
 
     // Used by delete-as-you-go iterators.  Returns an iterator to the block id of the next block.
     virtual std::vector<LargeTempTableBlockId>::iterator releaseBlock(std::vector<LargeTempTableBlockId>::iterator it) {
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                     "May only use releaseBlock with instances of LargeTempTable.");
+        throw SerializableEEException("May only use releaseBlock with instances of LargeTempTable.");
     }
 
     virtual void freeLastScannedBlock(std::vector<TBPtr>::iterator nextBlockIterator) {
-        throw SerializableEEException(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_EEEXCEPTION,
-                                     "May only use freeLastScannedBlock with instances of TempTable.");
+        throw SerializableEEException("May only use freeLastScannedBlock with instances of TempTable.");
     }
 
     bool equals(voltdb::Table* other);

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -2428,7 +2428,7 @@ TEST_F(DRBinaryLogTest, MissPartitionedExceptionIsThrown) {
         flushAndApply(100);
         FAIL("Should have thrown SerializableEEException");
     } catch (SerializableEEException &e) {
-        ASSERT_EQ(VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED, e.getType());
+        ASSERT_EQ(VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_TXN_MISPARTITIONED, e.getType());
     }
 }
 


### PR DESCRIPTION
only in debug build;
Made exception types an enum class (which involved most other changes);
other minor formatting changes.

Start looking at changes in `ee/common/SerializableEEException.h` and `ee/common/SerializableEEException.cpp`.

Now, with `-Dbuild=release` build option, the following query throws the same exception:
`1> create table t(i int); insert into t values(3); select mod(i, 0) from t;`
`Command succeeded.`
`(Returned 1 rows in 0.04s)`
`VOLTDB ERROR: SQL ERROR division by zero`
`    at org.voltdb.sysprocs.AdHoc_RO_SP.run(AdHoc_RO_SP.java:46)`
With `-Dbuild=debug` build option, the exception message contains EE stack trace:
`1> create table t(i int); insert into t values(3); select mod(i, 0) from t;`
`Command succeeded.`
`(Returned 1 rows in 0.04s)`
`VOLTDB ERROR: SQL ERROR division by zero`
`STACK TRACE:	()`
`	voltdb::SerializableEEException::SerializableEEException(voltdb::VoltEEExceptionType, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)`
`	voltdb::SQLException::SQLException(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)`
`	voltdb::NValue voltdb::NValue::call<11>(std::vector<voltdb::NValue, std::allocator<voltdb::NValue> > const&)`
`	voltdb::functionexpression::GeneralFunctionExpression<11>::eval(voltdb::TableTuple const*, voltdb::TableTuple const*) const`
`	voltdb::SeqScanExecutor::p_execute(voltdb::GenericValueArray<voltdb::NValue> const&)`
`	voltdb::AbstractExecutor::execute(voltdb::GenericValueArray<voltdb::NValue> const&)`
`	voltdb::ExecutorContext::executeExecutors(std::vector<voltdb::AbstractExecutor*, std::allocator<voltdb::AbstractExecutor*> > const&, int)`
`	voltdb::ExecutorContext::executeExecutors(int)`
`	voltdb::VoltDBEngine::executePlanFragment(voltdb::ExecutorVector*, long*)`
`	voltdb::VoltDBEngine::executePlanFragment(long, long, bool)`
`	voltdb::VoltDBEngine::executePlanFragments(int, long*, long*, voltdb::ReferenceSerializeInput<(voltdb::Endianess)0>&, long, long, long, long, long, bool)`
`	Java_org_voltdb_jni_ExecutionEngine_nativeExecutePlanFragments()`
`	[0x7f40ec7b66c7]`
`    at org.voltdb.sysprocs.AdHoc_RO_SP.run(AdHoc_RO_SP.java:46)`

Unfortunately, there is very little we can do about `std::exceptions` such as `std::length_error` or `std::bad_alloc`, or any exception types defined/used from 3rd party libraries.