### PR TITLE
Catch NoSuchMethodError and NoSuchClassError

### DIFF
--- a/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
+++ b/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 
+import javassist.bytecode.annotation.NoSuchClassError;
 import org.hsqldb_voltpatches.HSQLInterface;
 import org.voltcore.logging.VoltLogger;
 import org.voltdb.ProcedurePartitionData;
@@ -150,7 +151,7 @@ public abstract class ProcedureCompiler {
         VoltProcedure procInstance;
         try {
             procInstance = (VoltProcedure) procClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodError | NoSuchClassError e) {
             throw new RuntimeException("Error instantiating procedure " + procClass.getName(), e);
         }
         Map<String, SQLStmt> stmtMap = getValidSQLStmts(compiler, procClass.getSimpleName(), procClass, procInstance, true);


### PR DESCRIPTION
As from @zeemanhe 's reply on customer's bug:
**INTERNAL:

There is an error thrown: 
VOLTDB ERROR: UNEXPECTED FAILURE:
  java.lang.NoSuchMethodError: com.i2i.fcbs.voltdb.procedure.aom.ProcAOMOperationTransaction.generateSQLStmtForProcedure(Ljava/lang/String;)Lorg/voltdb/SQLStmt;
        at com.i2i.fcbs.voltdb.procedure.aom.ProcAOMOperationTransaction.<init>(ProcAOMOperationTransaction.java:53)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at java.lang.Class.newInstance(Class.java:442)
        at org.voltdb.compiler.ProcedureCompiler.getSQLStmtMap(ProcedureCompiler.java:152)
        at org.voltdb.compiler.VoltCompiler.compileInMemoryJarfileForUpdateClasses(VoltCompiler.java:2009)
        at org.voltdb.sysprocs.UpdateApplicationBase.modifyCatalogClasses(UpdateApplicationBase.java:378)
        at org.voltdb.sysprocs.UpdateApplicationBase.prepareApplicationCatalogDiff(UpdateApplicationBase.java:138)


UAC may have a bug: NoSuchMethodError is not properly handled.**