### PR TITLE
ENG-16927 Fixed NPE caused by sub-query

### DIFF
--- a/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/Expression.java
@@ -1044,7 +1044,7 @@ public class Expression {
                 QueryExpression queryExpression = subQuery.queryExpression;
 
                 queryExpression.resolveTypes(session);
-                subQuery.prepareTable(session);
+                subQuery.prepareTable();
 
                 nodeDataTypes = queryExpression.getColumnTypes();
                 dataType      = nodeDataTypes[0];

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLogical.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionLogical.java
@@ -808,7 +808,7 @@ public class ExpressionLogical extends Expression {
 
         if (nodes[RIGHT].opType == OpTypes.TABLE) {
             nodes[RIGHT].prepareTable(session, nodes[LEFT], degree);
-            nodes[RIGHT].subQuery.prepareTable(session);
+            nodes[RIGHT].subQuery.prepareTable();
 
             if (nodes[RIGHT].isCorrelated) {
                 nodes[RIGHT].subQuery.setCorrelated();

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDQL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDQL.java
@@ -41,6 +41,7 @@ import org.hsqldb_voltpatches.QueryExpression.WithList;
 import org.hsqldb_voltpatches.lib.ArrayUtil;
 import org.hsqldb_voltpatches.lib.HsqlArrayList;
 import org.hsqldb_voltpatches.lib.HsqlList;
+import org.hsqldb_voltpatches.lib.Iterator;
 import org.hsqldb_voltpatches.lib.OrderedHashSet;
 import org.hsqldb_voltpatches.persist.HsqlDatabaseProperties;
 import org.hsqldb_voltpatches.store.BitMap;
@@ -3690,7 +3691,7 @@ public class ParserDQL extends ParserBase {
         SubQuery sq = new SubQuery(database, compileContext.subQueryDepth,
                                    queryExpression, OpTypes.TABLE_SUBQUERY);
 
-        sq.prepareTable(session);
+        sq.prepareTable();
 
         compileContext.subQueryDepth--;
 
@@ -3730,7 +3731,7 @@ public class ParserDQL extends ParserBase {
             }
         }
 */
-        sq.prepareTable(session);
+        sq.prepareTable();
 
         return sq;
     }
@@ -3750,8 +3751,14 @@ public class ParserDQL extends ParserBase {
         SubQuery sq = new SubQuery(database, compileContext.subQueryDepth,
                                    queryExpression, mode);
 
+        Iterator it = compileContext.subQueryList.iterator();
+        while (it.hasNext()) {
+            SubQuery lsq = (SubQuery)it.next();
+            if (lsq.pos == sq.pos && lsq.level == sq.level) {
+                it.remove();
+            }
+        }
         compileContext.subQueryList.add(sq);
-
         compileContext.subQueryDepth--;
 
         return sq;
@@ -3777,7 +3784,6 @@ public class ParserDQL extends ParserBase {
                                    queryExpression, view);
 
         compileContext.subQueryList.add(sq);
-
         compileContext.subQueryDepth--;
 
         return sq;
@@ -3916,7 +3922,6 @@ public class ParserDQL extends ParserBase {
                                    OpTypes.IN);
 
         compileContext.subQueryList.add(sq);
-
         compileContext.subQueryDepth--;
 
         return e;
@@ -3937,9 +3942,7 @@ public class ParserDQL extends ParserBase {
         SubQuery sq = new SubQuery(database, compileContext.subQueryDepth, e,
                                    OpTypes.TABLE);
 
-        sq.prepareTable(session);
         compileContext.subQueryList.add(sq);
-
         compileContext.subQueryDepth--;
 
         return sq;
@@ -5179,7 +5182,7 @@ public class ParserDQL extends ParserBase {
             subQueryList.clear();
 
             for (int i = 0; i < subqueries.length; i++) {
-                subqueries[i].prepareTable(session);
+                subqueries[i].prepareTable();
             }
 
             return subqueries;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDQL.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ParserDQL.java
@@ -3689,7 +3689,7 @@ public class ParserDQL extends ParserBase {
         }
 
         SubQuery sq = new SubQuery(database, compileContext.subQueryDepth,
-                                   queryExpression, OpTypes.TABLE_SUBQUERY);
+                         getPosition(), queryExpression, OpTypes.TABLE_SUBQUERY);
 
         sq.prepareTable();
 
@@ -3749,7 +3749,7 @@ public class ParserDQL extends ParserBase {
         }
 
         SubQuery sq = new SubQuery(database, compileContext.subQueryDepth,
-                                   queryExpression, mode);
+                                   getPosition(), queryExpression, mode);
 
         Iterator it = compileContext.subQueryList.iterator();
         while (it.hasNext()) {
@@ -3781,7 +3781,7 @@ public class ParserDQL extends ParserBase {
         queryExpression.resolve(session);
 
         SubQuery sq = new SubQuery(database, compileContext.subQueryDepth,
-                                   queryExpression, view);
+                                   getPosition(), queryExpression, view);
 
         compileContext.subQueryList.add(sq);
         compileContext.subQueryDepth--;
@@ -3918,8 +3918,8 @@ public class ParserDQL extends ParserBase {
         compileContext.subQueryDepth++;
 
         Expression e = XreadInValueList(degree);
-        SubQuery sq = new SubQuery(database, compileContext.subQueryDepth, e,
-                                   OpTypes.IN);
+        SubQuery sq = new SubQuery(database, compileContext.subQueryDepth,
+                                   getPosition(), e, OpTypes.IN);
 
         compileContext.subQueryList.add(sq);
         compileContext.subQueryDepth--;
@@ -3939,8 +3939,8 @@ public class ParserDQL extends ParserBase {
         e.resolveTypes(session, null);
         e.prepareTable(session, null, e.nodes[0].nodes.length);
 
-        SubQuery sq = new SubQuery(database, compileContext.subQueryDepth, e,
-                                   OpTypes.TABLE);
+        SubQuery sq = new SubQuery(database, compileContext.subQueryDepth,
+                                   getPosition(), e, OpTypes.TABLE);
 
         compileContext.subQueryList.add(sq);
         compileContext.subQueryDepth--;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/QuerySpecification.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/QuerySpecification.java
@@ -212,7 +212,7 @@ public class QuerySpecification extends QueryExpression {
         finaliseRangeVariables();
         resolveColumnReferencesForAsterisk();
         finaliseColumns();
-        resolveColumnReferences();
+        resolveColumnReferencesForGroupBy();
 
         unionColumnTypes = new Type[indexLimitVisible];
         unionColumnMap   = new int[indexLimitVisible];
@@ -225,7 +225,7 @@ public class QuerySpecification extends QueryExpression {
      * Replaces any alias column expression in the ORDER BY cluase
      * with the actual select column expression.
      */
-    private void resolveColumnReferences() {
+    private void resolveColumnReferencesForGroupBy() {
 
         if (isDistinctSelect || isGrouped) {
             acceptsSequences = false;

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/SubQuery.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/SubQuery.java
@@ -68,10 +68,11 @@ class SubQuery implements ObjectComparator {
     //
     public final static SubQuery[] emptySubqueryArray = new SubQuery[]{};
 
-    SubQuery(Database database, int level, QueryExpression queryExpression,
+    SubQuery(Database database, int level, int pos, QueryExpression queryExpression,
              int mode) {
 
         this.level           = level;
+        this.pos             = pos;
         this.queryExpression = queryExpression;
         this.database        = database;
 
@@ -98,19 +99,21 @@ class SubQuery implements ObjectComparator {
         }
     }
 
-    SubQuery(Database database, int level, QueryExpression queryExpression,
+    SubQuery(Database database, int level, int pos, QueryExpression queryExpression,
              View view) {
 
         this.level           = level;
+        this.pos             = pos;
         this.queryExpression = queryExpression;
         this.database        = database;
         this.view            = view;
     }
 
-    SubQuery(Database database, int level, Expression dataExpression,
+    SubQuery(Database database, int level, int pos, Expression dataExpression,
              int mode) {
 
         this.level              = level;
+        this.pos                = pos;
         this.database           = database;
         this.dataExpression     = dataExpression;
         dataExpression.subQuery = this;
@@ -255,7 +258,9 @@ class SubQuery implements ObjectComparator {
         SubQuery sqb = (SubQuery) b;
 
         if (sqa.parentView == null && sqb.parentView == null) {
-            return sqb.level - sqa.level;
+            int diff = sqb.level - sqa.level;
+            return diff == 0 ? sqa.pos - sqb.pos
+                             : diff;
         } else if (sqa.parentView != null && sqb.parentView != null) {
             int ia = database.schemaManager.getTableIndex(sqa.parentView);
             int ib = database.schemaManager.getTableIndex(sqb.parentView);
@@ -285,6 +290,7 @@ class SubQuery implements ObjectComparator {
         final int prime = 31;
         int result = 1;
         result = prime * result + level;
+        result = prime * result + pos;
         result = prime * result + ((queryExpression == null) ? 0 : queryExpression.hashCode());
         result = prime * result + ((database == null) ? 0 : database.hashCode());
         result = prime * result + ((view == null) ? 0 : view.hashCode());
@@ -308,6 +314,7 @@ class SubQuery implements ObjectComparator {
 
         if (other instanceof SubQuery) {
             return ((SubQuery) other).level == level
+                   && ((SubQuery) other).pos == pos
                    && ((SubQuery) other).queryExpression == queryExpression
                    && ((SubQuery) other).database == database
                    && ((SubQuery) other).view == view

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/SubQuery.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/SubQuery.java
@@ -50,6 +50,7 @@ import org.hsqldb_voltpatches.result.Result;
 class SubQuery implements ObjectComparator {
 
     int                  level;
+    int                  pos;
     private boolean      isCorrelated;
     private boolean      isExistsPredicate;
     private boolean      uniqueRows;
@@ -135,7 +136,7 @@ class SubQuery implements ObjectComparator {
         return table;
     }
 
-    public void prepareTable(Session session) {
+    public void prepareTable() {
 
         if (table != null) {
             return;

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -319,6 +319,11 @@ public class TestSubQueriesSuite extends RegressionSuite {
                             " where ID > 4) and exists (select 1 from " + tb + " where ID * T1.DEPT = 10) order by ID;",
                     new long[][] {{5, 2}});
 
+            // subquery before AND + predicate
+            validateTableOfLongs(client,
+                    "select ID from " + tb + " where (ID IN (select ID from " + tb + ") AND -100 <> ID) order by ID;",
+                    new long[][] {{1}, {2}, {3}, {4}, {5}});
+
             // not exists
             validateTableOfLongs(client,
                     "select ID, DEPT from " + tb + " T1 where not exists (select 1 from " + tb +


### PR DESCRIPTION
The root cause of this NPE is when parser is cursing back-and-forth on a sql query, one subquery might create multiple logical subqueries in `compile context` while only one of them can be correctly resolved. In this fix I added an iterator that will dedup before adding subquery into list.