### PR TITLE
ENG-16899 make hsid bindings more even for partition group

### DIFF
--- a/src/frontend/org/voltcore/messaging/ForeignHost.java
+++ b/src/frontend/org/voltcore/messaging/ForeignHost.java
@@ -19,11 +19,12 @@ package org.voltcore.messaging;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -37,21 +38,23 @@ import org.voltcore.network.PicoNetwork;
 import org.voltcore.network.QueueMonitor;
 import org.voltcore.network.VoltProtocolHandler;
 import org.voltcore.utils.CoreUtils;
-import org.voltcore.utils.DeferredSerialization;
 import org.voltcore.utils.EstTime;
 import org.voltcore.utils.RateLimitedLogger;
 import org.voltdb.OperationMode;
 import org.voltdb.VoltDB;
 
 import com.google_voltpatches.common.base.Throwables;
+import com.google_voltpatches.common.collect.ImmutableList;
+import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.primitives.Longs;
 
 public class ForeignHost {
     private static final VoltLogger hostLog = new VoltLogger("HOST");
     private static RateLimitedLogger rateLimitedLogger;
     private static long m_logRate;
 
-    final PicoNetwork m_network;
-    final FHInputHandler m_handler;
+//    final PicoNetwork m_network;
+//    final FHInputHandler m_handler;
     private final HostMessenger m_hostMessenger;
     private final Integer m_hostId;
     final InetSocketAddress m_listeningAddress;
@@ -59,8 +62,22 @@ public class ForeignHost {
     private boolean m_closing;
     boolean m_isUp;
 
+    // Each foreign host may have one or many sub-connections, depends if partition
+    // group is enabled (k-factor > 0 and hostCount > 3). Each sub-connection has
+    // a pico-network thread serves for intra-cluster traffic.
+    private ImmutableList<Subconnection> m_connections = ImmutableList.of();
+    // reference to the first object of the connection list
+    private Subconnection m_firstConn;
+
+    // Remote site id to sub-connection mapping
+    volatile ImmutableMap<Long, Subconnection> m_connByHSIds = ImmutableMap.of();
+
+    // A counter used to uniformly bind remote site ids to sub-connections (if any)
+    private final AtomicInteger m_nextConnection = new AtomicInteger(0);
+
+
     // hold onto the socket so we can kill it
-    private final Socket m_socket;
+//    private final Socket m_socket;
 
     // Set the default here for TestMessaging, which currently has no VoltDB instance
     private long m_deadHostTimeout;
@@ -72,13 +89,62 @@ public class ForeignHost {
     // great way to trigger a heartbeat timout / simulate a network partition
     private AtomicBoolean m_linkCutForTest = new AtomicBoolean(false);
 
+    // STOPNODE_NOTICE is used to prevent split-brain detection caused by POISON_PILL
     public static final int POISON_PILL = -1;
     public static final int STOPNODE_NOTICE = -2;
 
+    /*
+     *  Poison pill types
+     */
     public static final int CRASH_ALL = 0;
     public static final int CRASH_ME = 1;
     public static final int CRASH_SPECIFIED = 2;
     public static final int PRINT_STACKTRACE = 3;
+
+    /**
+     * Because the connections other than the first connection are created after cluster mesh network
+     * has established but before the whole cluster has been initialized.
+     * It's possible that some non-transactional iv2 messages to be sent through foreign host when
+     * there is only one connection, So this flag is used to prevent binding all sites to the first
+     * connection.
+     */
+    private boolean m_hasMultiConnections;
+
+    private void setLogRate(long deadHostTimeout) {
+        int logRate;
+        if (deadHostTimeout < 30 * 1000)
+            logRate = (int) (deadHostTimeout / 3);
+        else
+            logRate = 10 * 1000;
+        rateLimitedLogger = new RateLimitedLogger(logRate, hostLog, Level.WARN);
+        m_logRate = logRate;
+    }
+
+    /** Create a ForeignHost and install in VoltNetwork */
+    ForeignHost(HostMessenger host, int hostId, SocketChannel socket, int deadHostTimeout,
+            InetSocketAddress listeningAddress, PicoNetwork network)
+    throws IOException
+    {
+        m_hostMessenger = host;
+        m_handler = new FHInputHandler();
+        m_hostId = hostId;
+        m_closing = false;
+        m_isUp = true;
+        m_socket = socket.socket();
+        m_deadHostTimeout = deadHostTimeout;
+        m_listeningAddress = listeningAddress;
+        m_network = network;
+        Subconnection conn = null;
+        m_firstConn = conn;
+
+        setLogRate(deadHostTimeout);
+    }
+
+    public void enableRead(Set<Long> verbotenThreads) {
+        for (Subconnection connection : m_connections) {
+            connection.enableRead(verbotenThreads);
+        }
+    }
 
     /** ForeignHost's implementation of InputHandler */
     public class FHInputHandler extends VoltProtocolHandler {
@@ -137,176 +203,80 @@ public class ForeignHost {
         }
     }
 
-    private void setLogRate(long deadHostTimeout) {
-        int logRate;
-        if (deadHostTimeout < 30 * 1000)
-            logRate = (int) (deadHostTimeout / 3);
-        else
-            logRate = 10 * 1000;
-        rateLimitedLogger = new RateLimitedLogger(logRate, hostLog, Level.WARN);
-        m_logRate = logRate;
-    }
-
-    /** Create a ForeignHost and install in VoltNetwork */
-    ForeignHost(HostMessenger host, int hostId, SocketChannel socket, int deadHostTimeout,
-            InetSocketAddress listeningAddress, PicoNetwork network)
-    throws IOException
-    {
-        m_hostMessenger = host;
-        m_handler = new FHInputHandler();
-        m_hostId = hostId;
-        m_closing = false;
-        m_isUp = true;
-        m_socket = socket.socket();
-        m_deadHostTimeout = deadHostTimeout;
-        m_listeningAddress = listeningAddress;
-        m_network = network;
-
-        setLogRate(deadHostTimeout);
-    }
-
-    public void enableRead(Set<Long> verbotenThreads) {
-        m_network.start(m_handler, verbotenThreads);
-    }
-
-    synchronized void close()
-    {
-        m_isUp = false;
-        if (m_closing) return;
-        m_closing = true;
-        try {
-            m_network.shutdownAsync();
-
-        } catch (InterruptedException e) {
-            Throwables.propagate(e);
-        }
-    }
-
     /**
-     * Used only for test code to kill this FH
+     * Read data from the network. Runs in the context of PicoNetwork thread when
+     * data is available.
+     * @throws IOException
      */
-    void killSocket() {
-        try {
-            m_closing = true;
-            m_socket.setKeepAlive(false);
-            m_socket.setSoLinger(false, 0);
-            Thread.sleep(25);
-            m_socket.close();
-            Thread.sleep(25);
-            System.gc();
-            Thread.sleep(25);
-        }
-        catch (Exception e) {
-            // don't REALLY care if this fails
-            e.printStackTrace();
-        }
-    }
+    private void handleRead(ByteBuffer in, Connection c) throws IOException {
+        // port is locked by VoltNetwork when in valid use.
+        // assert(m_port.m_lock.tryLock() == true);
+        long recvDests[] = null;
 
-    /*
-     * Huh!? The constructor registers the ForeignHost with VoltNetwork so finalizer
-     * will never get called unless the ForeignHost is unregistered with the VN.
-     */
-    @Override
-    protected void finalize() throws Throwable
-    {
-        if (m_closing) return;
-        close();
-        super.finalize();
-    }
-
-    boolean isUp()
-    {
-        return m_isUp;
-    }
-
-    /** Send a message to the network. This public method is re-entrant. */
-    void send(final long destinations[], final VoltMessage message) {
-        if (!m_isUp) {
-            hostLog.warn("Failed to send VoltMessage because connection to host " +
-                    CoreUtils.getHostIdFromHSId(destinations[0])+ " is closed");
-            return;
-        }
-        if (destinations.length == 0) {
-            return;
-        }
-
-        // if this link is "gone silent" for partition tests, just drop the message on the floor
-        if (!m_linkCutForTest.get()) {
-            m_network.enqueue(
-                    new DeferredSerialization() {
-                        @Override
-                        public final void serialize(final ByteBuffer buf) throws IOException {
-                            buf.putInt(buf.capacity() - 4);
-                            buf.putLong(message.m_sourceHSId);
-                            buf.putInt(destinations.length);
-                            for (int ii = 0; ii < destinations.length; ii++) {
-                                buf.putLong(destinations[ii]);
-                            }
-                            message.flattenToBuffer(buf);
-                            buf.flip();
-                        }
-
-                        @Override
-                        public final void cancel() {
-                        /*
-                         * Can this be removed?
-                         */
-                        }
-
-                        @Override
-                        public String toString() {
-                            return message.getClass().getName();
-                        }
-
-                        @Override
-                        public int getSerializedSize() {
-                            final int len = 4            /* length prefix */
-                                    + 8            /* source hsid */
-                                    + 4            /* destinationCount */
-                                    + 8 * destinations.length  /* destination list */
-                                    + message.getSerializedSize();
-                            return len;
-                        }
-                    });
-        }
-
-        long current_time = EstTime.currentTimeMillis();
-        long current_delta = current_time - m_lastMessageMillis.get();
-        /*
-         * Try and give some warning when a connection is timing out.
-         * Allows you to observe the liveness of the host receiving the heartbeats
-         */
-        if (isPrimary() && current_delta > m_logRate) {
-            rateLimitedLogger.log(
-                    "Have not received a message from host "
-                        + hostnameAndIPAndPort() + " for " + (current_delta / 1000.0) + " seconds",
-                        current_time);
-        }
-        // NodeFailureFault no longer immediately trips FHInputHandler to
-        // set m_isUp to false, so use both that and m_closing to
-        // avoid repeat reports of a single node failure
-        if ((!m_closing && m_isUp) &&
-                isPrimary() &&
-                current_delta > m_deadHostTimeout)
-        {
-            if (m_deadReportsCount.getAndIncrement() == 0) {
-                hostLog.error("DEAD HOST DETECTED, hostname: " + hostnameAndIPAndPort());
-                hostLog.info("\tcurrent time: " + current_time);
-                hostLog.info("\tlast message: " + m_lastMessageMillis);
-                hostLog.info("\tdelta (millis): " + current_delta);
-                hostLog.info("\ttimeout value (millis): " + m_deadHostTimeout);
-                VoltDB.dropStackTrace("Timed out foreign host " + hostnameAndIPAndPort() + " with delta " + current_delta);
+        final long sourceHSId = in.getLong();
+        final int destCount = in.getInt();
+        if (destCount == ForeignHost.POISON_PILL) {//This is a poison pill
+            //Ignore poison pill during shutdown, in tests we receive crash messages from
+            //leader appointer during shutdown
+            if (VoltDB.instance().getMode() == OperationMode.SHUTTINGDOWN) {
+                return;
             }
-            m_hostMessenger.reportForeignHostFailed(m_hostId);
+            byte messageBytes[] = new byte[in.getInt()];
+            in.get(messageBytes);
+            String message = new String(messageBytes, "UTF-8");
+            message = String.format("Fatal error from id,hostname(%d,%s): %s",
+                    m_hostId, hostnameAndIPAndPort(), message);
+            //if poison pill with particular cause handle it.
+            int cause = in.getInt();
+            if (cause == ForeignHost.CRASH_ME) {
+                int hid = VoltDB.instance().getHostMessenger().getHostId();
+                hostLog.debug("Poison Pill with target me was sent.: " + hid);
+                //Killing myself.
+                VoltDB.instance().halt();
+            } else if (cause == ForeignHost.CRASH_ALL || cause == ForeignHost.CRASH_SPECIFIED) {
+                org.voltdb.VoltDB.crashLocalVoltDB(message, false, null);
+            } else if (cause == ForeignHost.PRINT_STACKTRACE) {
+                //collect thread dumps
+                String dumpDir = new File(VoltDB.instance().getVoltDBRootPath(), "thread_dumps").getAbsolutePath();
+                String fileName =  m_hostMessenger.getHostname() + "_host-" + m_hostId + "_" + System.currentTimeMillis()+".jstack";
+                VoltDB.dumpThreadTraceToFile(dumpDir, fileName );
+            } else {
+                //Should never come here.
+                hostLog.error("Invalid Cause in poison pill: " + cause);
+            }
+            return;
+        } else if (destCount == ForeignHost.STOPNODE_NOTICE) {
+            int targetHostId = in.getInt();
+            hostLog.info("Receive StopNode notice for host " + targetHostId);
+            m_hostMessenger.addStopNodeNotice(targetHostId);
+            return;
         }
-    }
 
-    String hostnameAndIPAndPort() {
-        return m_network.getHostnameAndIPAndPort();
-    }
+        recvDests = new long[destCount];
+        for (int i = 0; i < destCount; i++) {
+            recvDests[i] = in.getLong();
+        }
 
-    String hostname() {
-        return m_network.getHostnameOrIP();
+        final VoltMessage message =
+            m_hostMessenger.getMessageFactory().createMessageFromBuffer(in, sourceHSId);
+
+        // ENG-1608.  We sniff for SiteFailureMessage here so
+        // that a node will participate in the failure resolution protocol
+        // even if it hasn't directly witnessed a node fault.
+        if (   message instanceof SiteFailureMessage
+                && !(message instanceof SiteFailureForwardMessage))
+        {
+            SiteFailureMessage sfm = (SiteFailureMessage)message;
+            for (FaultMessage fm: sfm.asFaultMessages()) {
+                m_hostMessenger.relayForeignHostFailed(fm);
+            }
+        }
+
+        for (int i = 0; i < destCount; i++) {
+            deliverMessage( recvDests[i], message);
+        }
+
+        m_fh.updateLastMessageTime(EstTime.currentTimeMillis());
     }
 
     /** Deliver a deserialized message from the network to a local mailbox */
@@ -346,120 +316,147 @@ public class ForeignHost {
         mailbox.deliver(message);
     }
 
-    /**
-     * Read data from the network. Runs in the context of PicoNetwork thread when
-     * data is available.
-     * @throws IOException
-     */
-    private void handleRead(ByteBuffer in, Connection c) throws IOException {
-        // port is locked by VoltNetwork when in valid use.
-        // assert(m_port.m_lock.tryLock() == true);
-        long recvDests[] = null;
-
-        final long sourceHSId = in.getLong();
-        final int destCount = in.getInt();
-        if (destCount == POISON_PILL) {//This is a poison pill
-            //Ignore poison pill during shutdown, in tests we receive crash messages from
-            //leader appointer during shutdown
-            if (VoltDB.instance().getMode() == OperationMode.SHUTTINGDOWN) {
-                return;
+    synchronized void close()
+    {
+        m_isUp = false;
+        if (m_closing) return;
+        m_closing = true;
+        try {
+            for (Subconnection c : m_connections) {
+                c.close();
             }
-            byte messageBytes[] = new byte[in.getInt()];
-            in.get(messageBytes);
-            String message = new String(messageBytes, "UTF-8");
-            message = String.format("Fatal error from id,hostname(%d,%s): %s",
-                    m_hostId, hostnameAndIPAndPort(), message);
-            //if poison pill with particular cause handle it.
-            int cause = in.getInt();
-            if (cause == ForeignHost.CRASH_ME) {
-                int hid = VoltDB.instance().getHostMessenger().getHostId();
-                hostLog.debug("Poison Pill with target me was sent.: " + hid);
-                //Killing myself.
-                VoltDB.instance().halt();
-            } else if (cause == ForeignHost.CRASH_ALL || cause == ForeignHost.CRASH_SPECIFIED) {
-                org.voltdb.VoltDB.crashLocalVoltDB(message, false, null);
-            } else if (cause == ForeignHost.PRINT_STACKTRACE) {
-                //collect thread dumps
-                String dumpDir = new File(VoltDB.instance().getVoltDBRootPath(), "thread_dumps").getAbsolutePath();
-                String fileName =  m_hostMessenger.getHostname() + "_host-" + m_hostId + "_" + System.currentTimeMillis()+".jstack";
-                VoltDB.dumpThreadTraceToFile(dumpDir, fileName );
-            } else {
-                //Should never come here.
-                hostLog.error("Invalid Cause in poison pill: " + cause);
-            }
-            return;
-        } else if (destCount == STOPNODE_NOTICE) {
-            int targetHostId = in.getInt();
-            hostLog.info("Receive StopNode notice for host " + targetHostId);
-            m_hostMessenger.addStopNodeNotice(targetHostId);
-            return;
+        } catch (InterruptedException e) {
+            Throwables.propagate(e);
         }
-
-        recvDests = new long[destCount];
-        for (int i = 0; i < destCount; i++) {
-            recvDests[i] = in.getLong();
-        }
-
-        final VoltMessage message =
-            m_hostMessenger.getMessageFactory().createMessageFromBuffer(in, sourceHSId);
-
-        // ENG-1608.  We sniff for SiteFailureMessage here so
-        // that a node will participate in the failure resolution protocol
-        // even if it hasn't directly witnessed a node fault.
-        if (   message instanceof SiteFailureMessage
-                && !(message instanceof SiteFailureForwardMessage))
-        {
-            SiteFailureMessage sfm = (SiteFailureMessage)message;
-            for (FaultMessage fm: sfm.asFaultMessages()) {
-                m_hostMessenger.relayForeignHostFailed(fm);
-            }
-        }
-
-        for (int i = 0; i < destCount; i++) {
-            deliverMessage( recvDests[i], message);
-        }
-
-        //m_lastMessageMillis = System.currentTimeMillis();
-        m_lastMessageMillis.lazySet(EstTime.currentTimeMillis());
-
     }
 
-    public void sendPoisonPill(String err, int cause) {
-        // if this link is "gone silent" for partition tests, just drop the message on the floor
-        if (m_linkCutForTest.get()) {
+    /**
+     * Used only for test code to kill this FH
+     */
+    void killSocket() {
+        m_closing = true;
+        for (Subconnection c : m_connections) {
+            c.killSocket();
+        }
+    }
+
+    /*
+     * Huh!? The constructor registers the ForeignHost with VoltNetwork so finalizer
+     * will never get called unless the ForeignHost is unregistered with the VN.
+     */
+    @Override
+    protected void finalize() throws Throwable
+    {
+        if (m_closing) return;
+        close();
+        super.finalize();
+    }
+
+    boolean isUp()
+    {
+        return m_isUp;
+    }
+
+    /** Send a message to the network. This public method is re-entrant. */
+    void send(final long destinations[], final VoltMessage message) {
+        if (!m_isUp) {
+            hostLog.warn("Failed to send VoltMessage because connection to host " +
+                    CoreUtils.getHostIdFromHSId(destinations[0])+ " is closed");
+            return;
+        }
+        if (destinations.length == 0) {
             return;
         }
 
-        byte errBytes[];
-        try {
-            errBytes = err.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
-            return;
+        final HashMap<Subconnection, ArrayList<Long>> destinationsPerConn =
+                new HashMap<Subconnection, ArrayList<Long>>();
+        if (m_hasMultiConnections) {
+            for (long remoteHsId : destinations) {
+                // fast path
+                Subconnection c = m_connByHSIds.get(remoteHsId);
+                if (c == null) {
+                    // slow path, invoked when this host sends the first message for the destination
+                    c = m_connections.get(m_nextConnection.getAndIncrement() % m_connections.size());
+                    bindConnection(remoteHsId, c);
+                }
+                ArrayList<Long> bundle = destinationsPerConn.get(c);
+                if (bundle == null) {
+                    bundle = new ArrayList<Long>();
+                    destinationsPerConn.put(c, bundle);
+                }
+                bundle.add(remoteHsId);
+            }
+            for (Entry<Subconnection, ArrayList<Long>> e : destinationsPerConn.entrySet()) {
+                e.getKey().send(Longs.toArray(e.getValue()), message);
+            }
+        } else {
+            m_firstConn.send(destinations, message);
         }
-        ByteBuffer message = ByteBuffer.allocate(24 + errBytes.length);
-        message.putInt(message.capacity() - 4);
-        message.putLong(-1);
-        message.putInt(POISON_PILL);
-        message.putInt(errBytes.length);
-        message.put(errBytes);
-        message.putInt(cause);
-        message.flip();
-        m_network.enqueue(message);
+
+        detectDeadHost();
+    }
+
+    private void detectDeadHost() {
+        long current_time = EstTime.currentTimeMillis();
+        long current_delta = current_time - m_lastMessageMillis.get();
+        /*
+         * Try and give some warning when a connection is timing out.
+         * Allows you to observe the liveness of the host receiving the heartbeats
+         */
+        if (current_delta > m_logRate) {
+            rateLimitedLogger.log(
+                    "Have not received a message from host "
+                        + hostnameAndIPAndPort() + " for " + (current_delta / 1000.0) + " seconds",
+                        current_time);
+        }
+        // NodeFailureFault no longer immediately trips FHInputHandler to
+        // set m_isUp to false, so use both that and m_closing to
+        // avoid repeat reports of a single node failure
+        if ((!m_closing && m_isUp) &&
+                current_delta > m_deadHostTimeout)
+        {
+            if (m_deadReportsCount.getAndIncrement() == 0) {
+                hostLog.error("DEAD HOST DETECTED, hostname: " + hostnameAndIPAndPort());
+                hostLog.info("\tcurrent time: " + current_time);
+                hostLog.info("\tlast message: " + m_lastMessageMillis);
+                hostLog.info("\tdelta (millis): " + current_delta);
+                hostLog.info("\ttimeout value (millis): " + m_deadHostTimeout);
+                VoltDB.dropStackTrace("Timed out foreign host " + hostnameAndIPAndPort() + " with delta " + current_delta);
+            }
+            m_hostMessenger.reportForeignHostFailed(m_hostId);
+        }
+    }
+
+    // No need to have precise dead host timeout.
+    // LazySet doesn't guarantee atomic semantic, some threads may hold an older value
+    // of the timestamp for a while, eventually the value will converge. Given that
+    // heartbeat meassage is sent in every 25ms, the inconsistency window is acceptable.
+    public void updateLastMessageTime(long lastMessageMillis) {
+        m_lastMessageMillis.lazySet(lastMessageMillis);
+    }
+
+    private void bindConnection(Long hsId, Subconnection conn) {
+        ImmutableMap.Builder<Long, Subconnection> b = ImmutableMap.builder();
+        m_connByHSIds = b.putAll(m_connByHSIds)
+                         .put(hsId, conn)
+                         .build();
+    }
+
+    // Poison pill doesn't need remote hsid, remote host handles it immediately.
+    public void sendPoisonPill(String err, int cause) {
+        m_firstConn.sendPoisonPill(err, cause);
     }
 
     public FutureTask<Void> sendStopNodeNotice(int targetHostId) {
-        // if this link is "gone silent" for partition tests, just drop the message on the floor
-        if (m_linkCutForTest.get()) {
-            return null;
-        }
-        ByteBuffer message = ByteBuffer.allocate(20);
-        message.putInt(message.capacity() - 4);
-        message.putLong(-1);
-        message.putInt(STOPNODE_NOTICE);
-        message.putInt(targetHostId);
-        message.flip();
-        return m_network.enqueueAndDrain(message);
+        return m_firstConn.sendStopNodeNotice(targetHostId);
+    }
+
+    String hostnameAndIPAndPort() {
+        return m_firstConn.getHostnameAndIPAndPort();
+    }
+
+    String hostname() {
+        return m_firstConn.getHostnameOrIP();
     }
 
     public void updateDeadHostTimeout(int timeout) {
@@ -468,15 +465,11 @@ public class ForeignHost {
     }
 
     /**
+     * Test only method
      * used to immediately cut off reads from a foreign host
      * great way to trigger a heartbeat timout / simulate a network partition
      */
     void cutLink() {
         m_linkCutForTest.set(true);
-    }
-
-    public boolean isPrimary() {
-        // Secondary foreign host never time out
-        return m_deadHostTimeout != Integer.MAX_VALUE;
     }
 }

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1558,6 +1558,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     {
         assert(message != null);
         assert(destinationHSIds != null);
+        // FIXME: performance impact if sites-per-host is higher than 32
         final HashMap<ForeignHost, ArrayList<Long>> foreignHosts =
             new HashMap<ForeignHost, ArrayList<Long>>(32);
         for (long hsId : destinationHSIds) {

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -882,7 +882,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     // Called from pico network thread
     public synchronized void markPicoZombieHost(int hostId) {
         boolean removed = m_zkZombieHosts.remove(hostId);
-        if (removed) {
+        if (!removed) {
             m_picoZombieHosts.add(hostId);
         }
     }

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1397,12 +1397,6 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
     }
 
-//    private ForeignHost getPrimary(ImmutableList<ForeignHost> fhosts, int hostId) {
-//        ForeignHost fhost = fhosts.get(0);
-//        assert fhost.isPrimary();
-//        return fhost;
-//    }
-
     /*
      * Generate a slot for the mailbox and put a noop box there. Can also
      * supply a value

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -82,13 +81,9 @@ import org.voltdb.probe.MeshProber;
 
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.base.Predicate;
-import com.google_voltpatches.common.collect.ImmutableCollection;
 import com.google_voltpatches.common.collect.ImmutableList;
-import com.google_voltpatches.common.collect.ImmutableListMultimap;
 import com.google_voltpatches.common.collect.ImmutableMap;
-import com.google_voltpatches.common.collect.ImmutableMultimap;
 import com.google_voltpatches.common.collect.Maps;
-import com.google_voltpatches.common.collect.Multimaps;
 import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.net.HostAndPort;
 import com.google_voltpatches.common.primitives.Longs;
@@ -365,25 +360,17 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     private final Object m_mapLock = new Object();
 
     /*
-     * References to other hosts in the mesh. To any foreign host, there
-     * will be one primary connection and, if possible, multiple auxiliary
-     * connections.
+     * References to other hosts in the mesh.
      * Updates via COW
      */
-    volatile ImmutableListMultimap<Integer, ForeignHost> m_foreignHosts = ImmutableListMultimap.of();
+    volatile ImmutableMap<Integer, ForeignHost> m_foreignHosts = ImmutableMap.of();
 
-    /*
-     * Track dead ForeignHosts that are reported independently by zookeeper and PicoNetwork.
-     * When both have reported both lists for that hostId should be empty (and removed).
-     */
-    Map<Integer, ArrayList<ForeignHost>> m_zkZombieForeignHosts = new HashMap<> ();
-    Map<Integer, ArrayList<ForeignHost>> m_picoZombieForeignHosts = new HashMap<> ();
-
-    /*
-     * Reference to the target HSId to FH mapping
-     * Updates via COW
-     */
-    volatile ImmutableMap<Long, ForeignHost> m_fhMapping = ImmutableMap.of();
+//    /*
+//     * Track dead ForeignHosts that are reported independently by zookeeper and PicoNetwork.
+//     * When both have reported both lists for that hostId should be empty (and removed).
+//     */
+//    Map<Integer, ArrayList<ForeignHost>> m_zkZombieForeignHosts = new HashMap<> ();
+//    Map<Integer, ArrayList<ForeignHost>> m_picoZombieForeignHosts = new HashMap<> ();
 
     /*
      * References to all the local mailboxes
@@ -603,14 +590,14 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
     };
 
-    private final void addFailedHosts(Set<Integer> rip) {
+    private final void addFailedHosts(Set<Integer> failedHosts) {
         synchronized (m_mapLock) {
             ImmutableMap.Builder<Integer, String> bldr = ImmutableMap.<Integer,String>builder()
-                    .putAll(Maps.filterKeys(m_knownFailedHosts, not(in(rip))));
-            for (int hostId: rip) {
-                Iterator<ForeignHost> fhs = m_foreignHosts.get(hostId).iterator();
+                    .putAll(Maps.filterKeys(m_knownFailedHosts, not(in(failedHosts))));
+            for (int hostId: failedHosts) {
+                ForeignHost fh = m_foreignHosts.get(hostId);
 
-                String hostname = fhs.hasNext() ? fhs.next().hostnameAndIPAndPort() : "UNKNOWN";
+                String hostname = fh != null ? fh.hostnameAndIPAndPort() : "UNKNOWN";
                 bldr.put(hostId, hostname);
             }
             m_knownFailedHosts = bldr.build();
@@ -622,8 +609,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
             synchronized (m_mapLock) {
                 ImmutableMap.Builder<Integer, String> bldr = ImmutableMap.<Integer,String>builder()
                         .putAll(Maps.filterKeys(m_knownFailedHosts, not(equalTo(hostId))));
-                Iterator<ForeignHost> fhs = m_foreignHosts.get(hostId).iterator();
-                String hostname = fhs.hasNext() ? fhs.next().hostnameAndIPAndPort() : "UNKNOWN";
+                ForeignHost fhs = m_foreignHosts.get(hostId);
+                String hostname = fhs != null ? fhs.hostnameAndIPAndPort() : "UNKNOWN";
                 bldr.put(hostId, hostname);
                 m_knownFailedHosts = bldr.build();
             }
@@ -852,7 +839,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
      */
     private void putForeignHost(int hostId, ForeignHost fh) {
         synchronized (m_mapLock) {
-            m_foreignHosts = ImmutableListMultimap.<Integer, ForeignHost>builder()
+            m_foreignHosts = ImmutableMap.<Integer, ForeignHost>builder()
                     .putAll(m_foreignHosts)
                     .put(hostId, fh)
                     .build();
@@ -873,21 +860,10 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
      * Convenience method for doing the verbose COW remove from the map
      */
     private void removeForeignHost(final int hostId) {
-        ImmutableCollection<ForeignHost> fhs = m_foreignHosts.get(hostId);
+        ForeignHost fh = m_foreignHosts.get(hostId);
         synchronized (m_mapLock) {
-            m_foreignHosts = ImmutableListMultimap.<Integer, ForeignHost>builder()
-                    .putAll(Multimaps.filterKeys(m_foreignHosts, not(equalTo(hostId))))
-                    .build();
-
-            Predicate<Long> hostIdNotEqual = new Predicate<Long>() {
-                @Override
-                public boolean apply(Long intput) {
-                    return CoreUtils.getHostIdFromHSId(intput) != hostId;
-                }
-            };
-
-            m_fhMapping = ImmutableMap.<Long, ForeignHost>builder()
-                    .putAll(Maps.filterKeys(m_fhMapping, hostIdNotEqual))
+            m_foreignHosts = ImmutableMap.<Integer, ForeignHost>builder()
+                    .putAll(Maps.filterKeys(m_foreignHosts, not(equalTo(hostId))))
                     .build();
         }
         assert(Thread.holdsLock(this)); // Make sure m_zombieForeignHosts is protected
@@ -1071,14 +1047,12 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
                         m_config.internalInterface);
             hostObj.put(SocketJoiner.PORT, m_config.internalPort);
             jsArray.put(hostObj);
-            for (Entry<Integer, Collection<ForeignHost>> entry : m_foreignHosts.asMap().entrySet()) {
-                if (entry.getValue().isEmpty()) {
+            for (Entry<Integer, ForeignHost> entry : m_foreignHosts.entrySet()) {
+                if (entry.getValue() == null) {
                     continue;
                 }
                 int hsId = entry.getKey();
-                Iterator<ForeignHost> it = entry.getValue().iterator();
-                // all fhs to same host have the same address and port
-                ForeignHost fh = it.next();
+                ForeignHost fh = entry.getValue();
                 hostObj = new JSONObject();
                 hostObj.put(SocketJoiner.HOST_ID, hsId);
                 hostObj.put(SocketJoiner.ADDRESS,
@@ -1371,13 +1345,12 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         if (hostId == m_localHostId) {
             return CoreUtils.getHostnameOrAddress();
         }
-        Iterator<ForeignHost> it = m_foreignHosts.get(hostId).iterator();
-        if (it.hasNext()) {
-            ForeignHost fh = it.next();
-            return fh.hostname();
+        ForeignHost fh = m_foreignHosts.get(hostId);
+        if (fh == null) {
+            return m_knownFailedHosts.get(hostId) != null ?
+                        m_knownFailedHosts.get(hostId) : "UNKNOWN";
         }
-        return m_knownFailedHosts.get(hostId) != null ? m_knownFailedHosts.get(hostId) :
-                "UNKNOWN";
+        return fh.hostname();
     }
 
     /**
@@ -1405,8 +1378,8 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
 
         // the foreign machine case
-        ImmutableList<ForeignHost> fhosts = m_foreignHosts.get(hostId);
-        if (fhosts.isEmpty()) {
+        ForeignHost fhost = m_foreignHosts.get(hostId);
+        if (fhost == null) {
             if (!m_knownFailedHosts.containsKey(hostId)) {
                 networkLog.warn(
                         "Attempted to send a message to foreign host with id " +
@@ -1414,52 +1387,7 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
             }
             return null;
         }
-        ForeignHost fhost = null;
-        if (fhosts.size() == 1 || CoreUtils.getSiteIdFromHSId(hsId) < 0 ) {
-            // Always use primary connection to send to well-known mailboxes
-            fhost = getPrimary(fhosts, hostId);
-        } else {
-            /**
-             * Because the secondary connections are created late in the initialization, after cluster mesh network has
-             * established, but before the whole cluster has been initialized. It's possible that some non-transactional
-             * iv2 messages to be sent through foreign host when there is only one primary connection, So in
-             * case of binding all sites to the primary connection, this check has been added to prevent it.
-             */
-            if (m_hasAllSecondaryConnectionCreated) {
-                // fast path
-                // assign a foreign host for regular mailbox
-                fhost = m_fhMapping.get(hsId);
-                if (fhost == null) {
-                    // slow path
-                    // The synchronized block below is invoked on first message to the destination only.
-                    synchronized(this) {
-                        if (s_nextForeignHost.isEmpty()) {
-                            for (Integer hId : getLiveHostIds()) {
-                                s_nextForeignHost.put(hId, 1);
-                            }
-                        }
-                        // in case of multiple threads send to the same hsId at the same time
-                        fhost = m_fhMapping.get(hsId);
-                        if (fhost == null) {
-                            int perFHCounter = s_nextForeignHost.getOrDefault(hostId, 0);
-                            int index = Math.abs(perFHCounter % fhosts.size());
-                            s_nextForeignHost.put(hostId, ++perFHCounter);
-                            fhost = fhosts.get(index);
-                            if (hostLog.isDebugEnabled()) {
-                                hostLog.debug("bind " + CoreUtils.hsIdToString(hsId) +
-                                        " to " + fhost.hostnameAndIPAndPort() + " nextForeignHost=" +
-                                        perFHCounter + " hostId=" + hostId + " fhosts.size=" + fhosts.size());
-                            }
-                            bindForeignHost(hsId, fhost);
-                        }
-                    }
-                }
-            } else {
-                // otherwise use primary for a short while
-                // REPAIR_LOG_REQUEST, REPAIR_LOG_RESPONSE,DummyTaskMessage, DUMMY_TRANSACTION_RESPONSE will be sent on primary
-                fhost = getPrimary(fhosts, hostId);
-            }
-        }
+
         if (!fhost.isUp()) {
             if (!m_shuttingDown) {
                 networkLog.info("Attempted delivery of message to failed site: " + CoreUtils.hsIdToString(hsId));
@@ -1487,23 +1415,11 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
     }
 
-    private void bindForeignHost(Long hsId, ForeignHost fh) {
-        synchronized (m_mapLock) {
-            if (m_fhMapping.containsKey(hsId)) {
-                return;
-            }
-            ImmutableMap.Builder<Long, ForeignHost> b = ImmutableMap.builder();
-            m_fhMapping = b.putAll(m_fhMapping)
-                           .put(hsId, fh)
-                           .build();
-        }
-    }
-
-    private ForeignHost getPrimary(ImmutableList<ForeignHost> fhosts, int hostId) {
-        ForeignHost fhost = fhosts.get(0);
-        assert fhost.isPrimary();
-        return fhost;
-    }
+//    private ForeignHost getPrimary(ImmutableList<ForeignHost> fhosts, int hostId) {
+//        ForeignHost fhost = fhosts.get(0);
+//        assert fhost.isPrimary();
+//        return fhost;
+//    }
 
     /*
      * Generate a slot for the mailbox and put a noop box there. Can also
@@ -1767,12 +1683,9 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
      * @param hostId The id of the foreign host to kill.
      */
     public void closeForeignHostSocket(int hostId) {
-        Iterator<ForeignHost> it = m_foreignHosts.get(hostId).iterator();
-        while (it.hasNext()) {
-            ForeignHost fh = it.next();
-            if (fh.isUp()) {
-                fh.killSocket();
-            }
+        ForeignHost fh = m_foreignHosts.get(hostId);
+        if (fh != null && fh.isUp()) {
+            fh.killSocket();
         }
         reportForeignHostFailed(hostId);
     }
@@ -1786,41 +1699,30 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
     }
 
     /*
-     * Foreign hosts that share the same host id belong to the same machine, one
-     * poison pill is deadly enough
+     * Foreign hosts receives the poison pill will be dead immediately
      */
     public void sendPoisonPill(Collection<Integer> hostIds, String err, int cause) {
         for (int hostId : hostIds) {
-            Iterator<ForeignHost> it = m_foreignHosts.get(hostId).iterator();
-            // No need to overdose the poison pill
-            if (it.hasNext()) {
-                ForeignHost fh = it.next();
-                if (fh.isUp()) {
-                    fh.sendPoisonPill(err, cause);
-                }
+            ForeignHost fh = m_foreignHosts.get(hostId);
+            if (fh != null && fh.isUp()) {
+                fh.sendPoisonPill(err, cause);
             }
         }
     }
 
     public void sendPoisonPill(String err) {
         for (int hostId : m_foreignHosts.keySet()) {
-            Iterator<ForeignHost> it = m_foreignHosts.get(hostId).iterator();
-            if (it.hasNext()) {
-                ForeignHost fh = it.next();
-                if (fh.isUp()) {
-                    fh.sendPoisonPill(err, ForeignHost.CRASH_ALL);
-                }
+            ForeignHost fh = m_foreignHosts.get(hostId);
+            if (fh != null && fh.isUp()) {
+                fh.sendPoisonPill(err, ForeignHost.CRASH_ALL);
             }
         }
     }
 
     public void sendPoisonPill(int targetHostId, String err, int cause) {
-        Iterator<ForeignHost> it = m_foreignHosts.get(targetHostId).iterator();
-        if (it.hasNext()) {
-            ForeignHost fh = it.next();
-            if (fh.isUp()) {
-                fh.sendPoisonPill(err, cause);
-            }
+        ForeignHost fh = m_foreignHosts.get(targetHostId);
+        if (fh != null && fh.isUp()) {
+            fh.sendPoisonPill(err, cause);
         }
     }
 
@@ -1833,16 +1735,13 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         List<FutureTask<Void>> tasks = new ArrayList<FutureTask<Void>>();
         for (int hostId : m_foreignHosts.keySet()) {
             if (hostId == m_localHostId) {
-                continue; /* skip target host */
+                continue; /* skip local host */
             }
-            Iterator<ForeignHost> it = m_foreignHosts.get(hostId).iterator();
-            if (it.hasNext()) {
-                ForeignHost fh = it.next();
-                if (fh.isUp()) {
-                    FutureTask<Void> task = fh.sendStopNodeNotice(targetHostId);
-                    if (task != null) {
-                        tasks.add(task);
-                    }
+            ForeignHost fh = m_foreignHosts.get(hostId);
+            if (fh != null && fh.isUp()) {
+                FutureTask<Void> task = fh.sendStopNodeNotice(targetHostId);
+                if (task != null) {
+                    tasks.add(task);
                 }
             }
         }
@@ -1868,9 +1767,9 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
     }
 
-    public Map<Long, Pair<String, long[]>>
-        getIOStats(final boolean interval) throws InterruptedException, ExecutionException {
-        final ImmutableMultimap<Integer, ForeignHost> fhosts = m_foreignHosts;
+    public Map<Long, Pair<String, long[]>> getIOStats(final boolean interval)
+            throws InterruptedException, ExecutionException {
+        final ImmutableMap<Integer, ForeignHost> fhosts = m_foreignHosts;
         ArrayList<IOStatsIntf> picoNetworks = new ArrayList<IOStatsIntf>();
 
         for (ForeignHost fh : fhosts.values()) {
@@ -1886,16 +1785,14 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
      */
     public void cutLink(int hostIdA, int hostIdB) {
         if (m_localHostId == hostIdA) {
-            Iterator<ForeignHost> it = m_foreignHosts.get(hostIdB).iterator();
-            while (it.hasNext()) {
-                ForeignHost fh = it.next();
+            ForeignHost fh = m_foreignHosts.get(hostIdB);
+            if (fh != null) {
                 fh.cutLink();
             }
         }
         if (m_localHostId == hostIdB) {
-            Iterator<ForeignHost> it = m_foreignHosts.get(hostIdA).iterator();
-            while (it.hasNext()) {
-                ForeignHost fh = it.next();
+            ForeignHost fh = m_foreignHosts.get(hostIdA);
+            if (fh != null) {
                 fh.cutLink();
             }
         }
@@ -1976,9 +1873,9 @@ public class HostMessenger implements SocketJoiner.JoinHandler, InterfaceToMesse
         }
 
         for (int hostId : hostsToConnect) {
-            Iterator<ForeignHost> it = m_foreignHosts.get(hostId).iterator();
-            if (it.hasNext()) {
-                InetSocketAddress listeningAddress = it.next().m_listeningAddress;
+            ForeignHost fh = m_foreignHosts.get(hostId);
+            if (fh != null) {
+                InetSocketAddress listeningAddress = fh.m_listeningAddress;
                 for (int ii = 0; ii < m_secondaryConnections; ii++) {
                     try {
                         SocketJoiner.SocketInfo socketInfo = m_joiner.requestForConnection(listeningAddress, hostId);

--- a/src/frontend/org/voltcore/messaging/Subconnection.java
+++ b/src/frontend/org/voltcore/messaging/Subconnection.java
@@ -1,0 +1,359 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltcore.messaging;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.Set;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.voltcore.logging.VoltLogger;
+import org.voltcore.network.Connection;
+import org.voltcore.network.PicoNetwork;
+import org.voltcore.network.QueueMonitor;
+import org.voltcore.network.VoltProtocolHandler;
+import org.voltcore.utils.CoreUtils;
+import org.voltcore.utils.DeferredSerialization;
+import org.voltcore.utils.EstTime;
+import org.voltdb.OperationMode;
+import org.voltdb.VoltDB;
+
+public class Subconnection {
+    final PicoNetwork m_network;
+    // hold onto the socket so we can kill it
+    private final Socket m_socket;
+    private final Integer m_hostId;
+    private final PicoInputHandler m_handler;
+    private final HostMessenger m_hostMessenger;
+    private final ForeignHost m_fh;
+    private boolean m_isUp;
+
+    // used to immediately cut off reads from a foreign host
+    // great way to trigger a heartbeat timout / simulate a network partition
+    private AtomicBoolean m_linkCutForTest = new AtomicBoolean(false);
+
+    private static final VoltLogger hostLog = new VoltLogger("HOST");
+
+    /** Intra-cluster implementation of InputHandler */
+    public class PicoInputHandler extends VoltProtocolHandler {
+
+        @Override
+        public int getMaxRead() {
+            return Integer.MAX_VALUE;
+        }
+
+        @Override
+        public void handleMessage(ByteBuffer message, Connection c) throws IOException {
+            // if this link is "gone silent" for partition tests, just drop the message on the floor
+            if (m_linkCutForTest.get()) {
+                return;
+            }
+
+            handleRead(message, c);
+        }
+
+        @Override
+        public void stopping(Connection c)
+        {
+            m_isUp = false;
+            m_fh.connectionStopping(Subconnection.this);
+        }
+
+        @Override
+        public Runnable offBackPressure() {
+            return new Runnable() {
+                @Override
+                public void run() {}
+            };
+        }
+
+        @Override
+        public Runnable onBackPressure() {
+            return new Runnable() {
+                @Override
+                public void run() {}
+            };
+        }
+
+        @Override
+        public QueueMonitor writestreamMonitor() {
+            return null;
+        }
+    }
+
+    /**
+     * Read data from the network. Runs in the context of PicoNetwork thread when
+     * data is available.
+     * @throws IOException
+     */
+    private void handleRead(ByteBuffer in, Connection c) throws IOException {
+        // port is locked by VoltNetwork when in valid use.
+        // assert(m_port.m_lock.tryLock() == true);
+        long recvDests[] = null;
+
+        final long sourceHSId = in.getLong();
+        final int destCount = in.getInt();
+        if (destCount == ForeignHost.POISON_PILL) {//This is a poison pill
+            //Ignore poison pill during shutdown, in tests we receive crash messages from
+            //leader appointer during shutdown
+            if (VoltDB.instance().getMode() == OperationMode.SHUTTINGDOWN) {
+                return;
+            }
+            byte messageBytes[] = new byte[in.getInt()];
+            in.get(messageBytes);
+            String message = new String(messageBytes, "UTF-8");
+            message = String.format("Fatal error from id,hostname(%d,%s): %s",
+                    m_hostId, getHostnameAndIPAndPort(), message);
+            //if poison pill with particular cause handle it.
+            int cause = in.getInt();
+            if (cause == ForeignHost.CRASH_ME) {
+                int hid = VoltDB.instance().getHostMessenger().getHostId();
+                hostLog.debug("Poison Pill with target me was sent.: " + hid);
+                //Killing myself.
+                VoltDB.instance().halt();
+            } else if (cause == ForeignHost.CRASH_ALL || cause == ForeignHost.CRASH_SPECIFIED) {
+                org.voltdb.VoltDB.crashLocalVoltDB(message, false, null);
+            } else if (cause == ForeignHost.PRINT_STACKTRACE) {
+                //collect thread dumps
+                String dumpDir = new File(VoltDB.instance().getVoltDBRootPath(), "thread_dumps").getAbsolutePath();
+                String fileName =  m_hostMessenger.getHostname() + "_host-" + m_hostId + "_" + System.currentTimeMillis()+".jstack";
+                VoltDB.dumpThreadTraceToFile(dumpDir, fileName );
+            } else {
+                //Should never come here.
+                hostLog.error("Invalid Cause in poison pill: " + cause);
+            }
+            return;
+        } else if (destCount == ForeignHost.STOPNODE_NOTICE) {
+            int targetHostId = in.getInt();
+            hostLog.info("Receive StopNode notice for host " + targetHostId);
+            m_hostMessenger.addStopNodeNotice(targetHostId);
+            return;
+        }
+
+        recvDests = new long[destCount];
+        for (int i = 0; i < destCount; i++) {
+            recvDests[i] = in.getLong();
+        }
+
+        final VoltMessage message =
+            m_hostMessenger.getMessageFactory().createMessageFromBuffer(in, sourceHSId);
+
+        // ENG-1608.  We sniff for SiteFailureMessage here so
+        // that a node will participate in the failure resolution protocol
+        // even if it hasn't directly witnessed a node fault.
+        if (   message instanceof SiteFailureMessage
+                && !(message instanceof SiteFailureForwardMessage))
+        {
+            SiteFailureMessage sfm = (SiteFailureMessage)message;
+            for (FaultMessage fm: sfm.asFaultMessages()) {
+                m_hostMessenger.relayForeignHostFailed(fm);
+            }
+        }
+
+        for (int i = 0; i < destCount; i++) {
+            deliverMessage( recvDests[i], message);
+        }
+
+        m_fh.updateLastMessageTime(EstTime.currentTimeMillis());
+    }
+
+    /** Deliver a deserialized message from the network to a local mailbox */
+    private void deliverMessage(long destinationHSId, VoltMessage message) {
+        if (!m_hostMessenger.validateForeignHostId(m_hostId)) {
+            hostLog.warn(String.format("Message (%s) sent to site id: %s @ (%s) at %d from %s "
+                    + "which is a known failed host. The message will be dropped\n",
+                    message.getClass().getSimpleName(),
+                    CoreUtils.hsIdToString(destinationHSId),
+                    m_socket.getRemoteSocketAddress().toString(),
+                    m_hostMessenger.getHostId(),
+                    CoreUtils.hsIdToString(message.m_sourceHSId)));
+            return;
+        }
+
+        Mailbox mailbox = m_hostMessenger.getMailbox(destinationHSId);
+        /*
+         * At this point we are OK with messages going to sites that don't exist
+         * because we are saying that things can come and go
+         */
+        if (mailbox == null) {
+            hostLog.info(String.format("Message (%s) sent to unknown site id: %s @ (%s) at %d from %s \n",
+                    message.getClass().getSimpleName(),
+                    CoreUtils.hsIdToString(destinationHSId),
+                    m_socket.getRemoteSocketAddress().toString(),
+                    m_hostMessenger.getHostId(),
+                    CoreUtils.hsIdToString(message.m_sourceHSId)));
+            /*
+             * If it is for the wrong host, that definitely isn't cool
+             */
+            if (m_hostMessenger.getHostId() != (int)destinationHSId) {
+                VoltDB.crashLocalVoltDB("Received a message at wrong host", false, null);
+            }
+            return;
+        }
+        // deliver the message to the mailbox
+        mailbox.deliver(message);
+    }
+
+    Subconnection(int hostId, HostMessenger hm, ForeignHost fh, SocketChannel socket, PicoNetwork network) {
+        m_hostId = hostId;
+        m_socket = socket.socket();
+        m_network = network;
+        m_handler = new PicoInputHandler();
+        m_hostMessenger = hm;
+        m_fh = fh;
+        m_isUp = true;
+    }
+
+
+    public void enableRead(Set<Long> verbotenThreads) {
+        m_network.start(m_handler, verbotenThreads);
+    }
+
+    void send(final long destinations[], final VoltMessage message) {
+        if (!m_isUp) {
+            hostLog.warn("Failed to send VoltMessage because connection to host " +
+                    CoreUtils.getHostIdFromHSId(destinations[0])+ " is closed");
+            return;
+        }
+        if (destinations.length == 0) {
+            return;
+        }
+        // if this link is "gone silent" for partition tests, just drop the message on the floor
+        if (m_linkCutForTest.get()) {
+            return;
+        }
+        m_network.enqueue(
+                new DeferredSerialization() {
+                    @Override
+                    public final void serialize(final ByteBuffer buf) throws IOException {
+                        buf.putInt(buf.capacity() - 4);
+                        buf.putLong(message.m_sourceHSId);
+                        buf.putInt(destinations.length);
+                        for (int ii = 0; ii < destinations.length; ii++) {
+                            buf.putLong(destinations[ii]);
+                        }
+                        message.flattenToBuffer(buf);
+                        buf.flip();
+                    }
+
+                    @Override
+                    public final void cancel() {
+                    /*
+                     * Can this be removed?
+                     */
+                    }
+
+                    @Override
+                    public String toString() {
+                        return message.getClass().getName();
+                    }
+
+                    @Override
+                    public int getSerializedSize() {
+                        final int len = 4            /* length prefix */
+                                + 8            /* source hsid */
+                                + 4            /* destinationCount */
+                                + 8 * destinations.length  /* destination list */
+                                + message.getSerializedSize();
+                        return len;
+                    }
+                });
+    }
+
+    synchronized void close() throws InterruptedException {
+        m_isUp = false;
+        m_network.shutdownAsync();
+    }
+
+    /**
+     * Used only for test code to kill this FH
+     */
+    void killSocket() {
+        try {
+            m_socket.setKeepAlive(false);
+            m_socket.setSoLinger(false, 0);
+            Thread.sleep(25);
+            m_socket.close();
+            Thread.sleep(25);
+            System.gc();
+            Thread.sleep(25);
+        } catch (Exception e) {
+            // don't REALLY care if this fails
+            e.printStackTrace();
+        }
+    }
+
+    public void sendPoisonPill(String err, int cause) {
+     // if this link is "gone silent" for partition tests, just drop the message on the floor
+        if (m_linkCutForTest.get()) {
+            return;
+        }
+
+        byte errBytes[];
+        try {
+            errBytes = err.getBytes("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+            return;
+        }
+        ByteBuffer message = ByteBuffer.allocate(24 + errBytes.length);
+        message.putInt(message.capacity() - 4);
+        message.putLong(-1);
+        message.putInt(ForeignHost.POISON_PILL);
+        message.putInt(errBytes.length);
+        message.put(errBytes);
+        message.putInt(cause);
+        message.flip();
+        m_network.enqueue(message);
+    }
+
+    public FutureTask<Void> sendStopNodeNotice(int targetHostId) {
+        // if this link is "gone silent" for partition tests, just drop the message on the floor
+        if (m_linkCutForTest.get()) {
+            return null;
+        }
+        ByteBuffer message = ByteBuffer.allocate(20);
+        message.putInt(message.capacity() - 4);
+        message.putLong(-1);
+        message.putInt(ForeignHost.STOPNODE_NOTICE);
+        message.putInt(targetHostId);
+        message.flip();
+        return m_network.enqueueAndDrain(message);
+    }
+
+    String getHostnameAndIPAndPort() {
+        return m_network.getHostnameAndIPAndPort();
+    }
+
+    String getHostnameOrIP() {
+        return m_network.getHostnameOrIP();
+    }
+
+    PicoNetwork getPicoNetwork() {
+        return m_network;
+    }
+
+    void cutLink() {
+        m_linkCutForTest.set(true);
+    }
+
+}

--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -135,9 +135,8 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
     /**
      * Create a pico network thread
      * @param sc  SocketChannel
-     * @param isSecondary  Is this a secondary thread?
      */
-    public PicoNetwork(SocketChannel sc, boolean isSecondary) {
+    public PicoNetwork(SocketChannel sc) {
         m_sc = sc;
         InetSocketAddress remoteAddress = (InetSocketAddress)sc.socket().getRemoteSocketAddress();
         m_remoteSocketAddress = remoteAddress;
@@ -148,11 +147,7 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
             m_remoteHostname = remoteHost;
             m_remoteHostAndAddressAndPort = remoteHost + m_remoteHostAndAddressAndPort;
         }
-        if (isSecondary) {
-            m_threadName = remoteHost + "(s)";
-        } else {
-            m_threadName = remoteHost;
-        }
+        m_threadName = remoteHost;
 
         m_thread = new Thread(this, "Pico Network - " + m_threadName);
         m_thread.setDaemon(true);

--- a/src/frontend/org/voltcore/network/TLSPicoNetwork.java
+++ b/src/frontend/org/voltcore/network/TLSPicoNetwork.java
@@ -80,9 +80,8 @@ public class TLSPicoNetwork extends PicoNetwork
     private final SSLEngine m_sslEngine;
     private final CipherExecutor m_cipherExecutor;
 
-    public TLSPicoNetwork(SocketChannel sc, boolean isSecondary,
-            SSLEngine sslEngine, CipherExecutor cipherExecutor) {
-        super(sc, isSecondary);
+    public TLSPicoNetwork(SocketChannel sc, SSLEngine sslEngine, CipherExecutor cipherExecutor) {
+        super(sc);
         m_sslEngine = sslEngine;
         m_cipherExecutor = cipherExecutor;
     }

--- a/tests/frontend/org/voltcore/network/TestPicoNetwork.java
+++ b/tests/frontend/org/voltcore/network/TestPicoNetwork.java
@@ -134,7 +134,7 @@ public class TestPicoNetwork extends TestCase {
         networkChannel = ssc.accept();
         rawChannel.finishConnect();
         rawChannel.configureBlocking(true);
-        pn = new PicoNetwork(networkChannel, true);
+        pn = new PicoNetwork(networkChannel);
         handler = new MockInputHandler();
         pn.start(handler, new HashSet<Long>());
     }


### PR DESCRIPTION
Fix an issue that cause uneven site-to-network-threads binding, some pico network threads carry more traffic than others. 
Refactor a few things including 1) single ForeignHost to each remote host ID, 2) each ForeignHost may have more than one connection, 3) no difference between connections, dead host detection is performed on foreign host level. 