### PR TITLE
Fix broken tests in calcite build

### DIFF
--- a/src/frontend/org/voltdb/CatalogContext.java
+++ b/src/frontend/org/voltdb/CatalogContext.java
@@ -165,13 +165,11 @@ public class CatalogContext {
             DefaultProcedureManager defaultProcManager,
             PlannerTool plannerTool,
             HostMessenger messenger,
-            boolean hasSchemaChange)
-    {
+            boolean hasSchemaChange) {
         // check the heck out of the given params in this immutable class
         if (catalog == null) {
             throw new IllegalArgumentException("Can't create CatalogContext with null catalog.");
-        }
-        if (settings == null) {
+        } else if (settings == null) {
             throw new IllegalArgumentException("Cant't create CatalogContext with null cluster settings");
         }
 
@@ -236,8 +234,7 @@ public class CatalogContext {
             byte[] catalogBytes,
             byte[] catalogBytesHash,
             byte[] deploymentBytes,
-            HostMessenger messenger)
-    {
+            HostMessenger messenger) {
         this(catalog, settings, version, genId,
              new CatalogInfo(catalogBytes, catalogBytesHash, deploymentBytes),
              null, null, messenger, true);
@@ -280,8 +277,7 @@ public class CatalogContext {
             byte[] catalogBytesHash,
             byte[] deploymentBytes,
             HostMessenger messenger,
-            boolean hasSchemaChange)
-    {
+            boolean hasSchemaChange) {
         Catalog newCatalog = null;
         assert(catalogBytes != null);
 
@@ -353,8 +349,7 @@ public class CatalogContext {
      * @param name
      * @throws IOException
      */
-    public Runnable writeCatalogJarToFile(String path, String name, CatalogJarWriteMode mode) throws IOException
-    {
+    public Runnable writeCatalogJarToFile(String path, String name, CatalogJarWriteMode mode) throws IOException {
         File catalogFile = new VoltFile(path, name);
         File catalogTmpFile = new VoltFile(path, name + ".tmp");
 
@@ -416,8 +411,7 @@ public class CatalogContext {
     // Generate helpful status messages based on configuration present in the
     // catalog.  Used to generated these messages at startup and after an
     // @UpdateApplicationCatalog
-    SortedMap<String, String> getDebuggingInfoFromCatalog(boolean verbose)
-    {
+    SortedMap<String, String> getDebuggingInfoFromCatalog(boolean verbose) {
         SortedMap<String, String> logLines = new TreeMap<>();
 
         // topology

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -188,6 +188,7 @@ import org.voltdb.snmp.DummySnmpTrapSender;
 import org.voltdb.snmp.FaultFacility;
 import org.voltdb.snmp.FaultLevel;
 import org.voltdb.snmp.SnmpTrapSender;
+import org.voltdb.sysprocs.AdHocNTBase;
 import org.voltdb.sysprocs.VerifyCatalogAndWriteJar;
 import org.voltdb.sysprocs.saverestore.SnapshotPathType;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
@@ -880,7 +881,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             m_isRunningWithOldVerb = config.m_startAction.isLegacy();
 
             // check that this is a 64 bit VM
-            if (System.getProperty("java.vm.name").contains("64") == false) {
+            if (! System.getProperty("java.vm.name").contains("64")) {
                 hostLog.fatal("You are running on an unsupported (probably 32 bit) JVM. Exiting.");
                 System.exit(-1);
             }
@@ -992,19 +993,23 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     CatalogUtil.addExportConfigToDRConflictsTable(readDepl.deployment.getExport());
                 }
                 stageDeploymentFileForInitialize(config, readDepl.deployment);
-                stageSchemaFiles(config, readDepl.deployment.getDr() != null && DrRoleType.XDCR.equals(readDepl.deployment.getDr().getRole()));
+                stageSchemaFiles(config,
+                        readDepl.deployment.getDr() != null &&
+                                DrRoleType.XDCR.equals(readDepl.deployment.getDr().getRole()));
                 stageInitializedMarker(config);
                 hostLog.info("Initialized VoltDB root directory " + config.m_voltdbRoot.getPath());
                 consoleLog.info("Initialized VoltDB root directory " + config.m_voltdbRoot.getPath());
                 VoltDB.exit(0);
             }
             if (config.m_startAction.isLegacy()) {
-                consoleLog.warn("The \"" + config.m_startAction.m_verb + "\" command is deprecated, please use \"init\" and \"start\" for your cluster operations.");
+                consoleLog.warn("The \"" + config.m_startAction.m_verb +
+                        "\" command is deprecated, please use \"init\" and \"start\" for your cluster operations.");
             }
 
             // config UUID is part of the status tracker.
             m_statusTracker = new NodeStateTracker();
-            final File stagedCatalogLocation = new VoltFile(RealVoltDB.getStagedCatalogPath(config.m_voltdbRoot.getAbsolutePath()));
+            final File stagedCatalogLocation = new VoltFile(
+                    RealVoltDB.getStagedCatalogPath(config.m_voltdbRoot.getAbsolutePath()));
 
             if (config.m_startAction.isLegacy()) {
                 File rootFH = CatalogUtil.getVoltDbRoot(readDepl.deployment.getPaths());
@@ -1283,14 +1288,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 // IV2 mailbox stuff
                 m_cartographer = new Cartographer(m_messenger, m_configuredReplicationFactor,
                         m_catalogContext.cluster.getNetworkpartition());
-                m_partitionZeroLeader = new Supplier<Boolean>() {
-                    @Override
-                    public Boolean get() {
-                        return m_cartographer.isPartitionZeroLeader();
-                    }
-                };
+                m_partitionZeroLeader = () -> m_cartographer.isPartitionZeroLeader();
                 List<Integer> partitions = null;
-                Set<Integer> partitionGroupPeers = null;
+                final Set<Integer> partitionGroupPeers;
                 if (m_rejoining) {
                     m_configuredNumberOfPartitions = m_cartographer.getPartitionCount();
                     Set<Integer> recoverPartitions = null;
@@ -1471,7 +1471,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
              * If sync command log is on, not initializing the command log before the initiators
              * are up would cause deadlock.
              */
-            if ((m_commandLog != null) && (m_commandLog.needsInitialization())) {
+            if (m_commandLog != null && m_commandLog.needsInitialization()) {
                 consoleLog.l7dlog(Level.INFO, LogKeys.host_VoltDB_StayTunedForLogging.name(), null);
             }
             else {
@@ -1687,8 +1687,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
 
             // warn if cluster is partitionable, but partition detection is off
-            if ((m_catalogContext.cluster.getNetworkpartition() == false) &&
-                    (m_configuredReplicationFactor > 0)) {
+            if (! m_catalogContext.cluster.getNetworkpartition() && m_configuredReplicationFactor > 0) {
                 hostLog.warn("Running a redundant (k-safe) cluster with network " +
                         "partition detection disabled is not recommended for production use.");
                 // we decided not to include the stronger language below for the 3.0 version (ENG-4215)
@@ -1737,10 +1736,15 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             // take higher priority. Otherwise, the value specified via VOLTDB_OPTS will take effect.
             // If the test is started by ant and -Dlarge_mode_ratio is not set, it will take a default value "-1" which
             // we should ignore.
-            final double largeModeRatio = Double.valueOf((System.getenv("LARGE_MODE_RATIO") == null ||
-                    System.getenv("LARGE_MODE_RATIO").equals("-1")) ? System.getProperty("LARGE_MODE_RATIO", "0") : System.getenv("LARGE_MODE_RATIO"));
+            final double largeModeRatio = Double.parseDouble(
+                    System.getenv("LARGE_MODE_RATIO") == null || System.getenv("LARGE_MODE_RATIO").equals("-1") ?
+                            System.getProperty("LARGE_MODE_RATIO", "0") :
+                            System.getenv("LARGE_MODE_RATIO"));
             if (largeModeRatio > 0) {
                 hostLog.info(String.format("The large_mode_ratio property is set as %.2f", largeModeRatio));
+            }
+            if (AdHocNTBase.USING_CALCITE) {
+                hostLog.warn("Using Calcite as parser/planner. This is an experimental feature.");
             }
         }
     }

--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -99,6 +99,7 @@ import org.voltdb.parser.SQLParser;
 import org.voltdb.planner.AbstractParsedStmt;
 import org.voltdb.planner.ParsedSelectStmt;
 import org.voltdb.plannerv2.utils.DropTableUtils;
+import org.voltdb.sysprocs.AdHocNTBase;
 import org.voltdb.types.ConstraintType;
 import org.voltdb.types.ExpressionType;
 import org.voltdb.types.IndexType;
@@ -1336,10 +1337,12 @@ public class DDLCompiler {
         HashMap<String, Index> indexMap = new HashMap<>();
 
         final String name = node.attributes.get("name");
-        // Skip "CREATE TABLE" in here, since we have already added it using Calcite parser.
-        if (StreamSupport.stream(((Iterable<Table>) () -> db.getTables().iterator()).spliterator(), false)
-                .anyMatch(tbl -> tbl.getTypeName().equals(name))) {
-            return;       // Code below this point is not executed any more.
+        if (AdHocNTBase.USING_CALCITE &&    // Skip "CREATE TABLE" if we have already added it using Calcite parser.
+                StreamSupport.stream(((Iterable<Table>) () -> db.getTables().iterator()).spliterator(), false)
+                        .anyMatch(tbl -> tbl.getTypeName().equals(name))) {
+            // Code below this point is not executed any more. See VoltCompiler#compileDatabase() for
+            // how CREATE TABLE statement is processed by Calcite.
+            return;
         }
         // create a table node in the catalog
         final Table table = db.getTables().add(name);

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -86,7 +86,7 @@ public class PlannerTool {
     // take higher priority. Otherwise, the value specified via VOLTDB_OPTS will take effect.
     // If the test is started by ant and -Dlarge_mode_ratio is not set, it will take a default value "-1" which
     // we should ignore.
-    private final double m_largeModeRatio = Double.valueOf((System.getenv("LARGE_MODE_RATIO") == null ||
+    private final double m_largeModeRatio = Double.parseDouble((System.getenv("LARGE_MODE_RATIO") == null ||
             System.getenv("LARGE_MODE_RATIO").equals("-1")) ?
             System.getProperty("LARGE_MODE_RATIO", "0") :
             System.getenv("LARGE_MODE_RATIO"));
@@ -143,7 +143,6 @@ public class PlannerTool {
         m_catalogHash = catalogHash;
         m_cache = AdHocCompilerCache.getCacheForCatalogHash(catalogHash);
         m_schemaPlus = VoltSchemaPlus.from(m_database);
-
         return this;
     }
 
@@ -294,7 +293,12 @@ public class PlannerTool {
      */
     public synchronized AdHocPlannedStatement planSqlCalcite(SqlTask task)
             throws ValidationException, RelConversionException, PlannerFallbackException {
-        CompiledPlan plan = getCompiledPlanCalcite(m_schemaPlus, task.getParsedQuery());
+        CompiledPlan plan = getCompiledPlanCalcite(
+                // TODO: we need a reliable way to sync Calcite's SchemaPlus from VoltDB's Catalog,
+                // esp. since we start relying on Calcite to operate on 'CREATE TABLE' statements.
+                // See VoltCompiler#compileDatabase().
+                VoltSchemaPlus.from(m_database)/*m_schemaPlus*/,
+                task.getParsedQuery());
         plan.sql = task.getSQL();
         CorePlan core = new CorePlan(plan, m_catalogHash);
         // TODO Calcite ready: enable when we are ready

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -54,6 +54,7 @@ import org.voltdb.plannerv2.rel.logical.VoltLogicalRel;
 import org.voltdb.plannerv2.rel.physical.VoltPhysicalRel;
 import org.voltdb.plannerv2.rules.PlannerRules.Phase;
 import org.voltdb.plannerv2.utils.VoltRelUtil;
+import org.voltdb.sysprocs.AdHocNTBase;
 import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.Encoder;
 
@@ -142,7 +143,11 @@ public class PlannerTool {
         m_database = database;
         m_catalogHash = catalogHash;
         m_cache = AdHocCompilerCache.getCacheForCatalogHash(catalogHash);
-        m_schemaPlus = VoltSchemaPlus.from(m_database);
+        if (AdHocNTBase.USING_CALCITE) {
+            // Do not use Calcite to process DDLs, until we have full support of all DDLs, as well as
+            // catalog commands such as "DR TABLE foo".
+            m_schemaPlus = VoltSchemaPlus.from(m_database);
+        }
         return this;
     }
 

--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -645,15 +645,13 @@ public class VoltCompiler {
 
     private static void addBuildInfo(final InMemoryJarfile jarOutput) {
         StringBuilder buildinfo = new StringBuilder();
-        String info[] = RealVoltDB.extractBuildInfo(compilerLog);
+        String[] info = RealVoltDB.extractBuildInfo(compilerLog);
         buildinfo.append(info[0]).append('\n');
         buildinfo.append(info[1]).append('\n');
         buildinfo.append(System.getProperty("user.name")).append('\n');
         buildinfo.append(System.getProperty("user.dir")).append('\n');
-        buildinfo.append(Long.toString(System.currentTimeMillis())).append('\n');
-
-        byte buildinfoBytes[] = buildinfo.toString().getBytes(Constants.UTF8ENCODING);
-        jarOutput.put(CatalogUtil.CATALOG_BUILDINFO_FILENAME, buildinfoBytes);
+        buildinfo.append(System.currentTimeMillis()).append('\n');
+        jarOutput.put(CatalogUtil.CATALOG_BUILDINFO_FILENAME, buildinfo.toString().getBytes(Constants.UTF8ENCODING));
     }
 
     /**
@@ -1011,8 +1009,7 @@ public class VoltCompiler {
                                          Permission.getPermissionsFromAliases(Arrays.asList("SQL", "ALLPROC")));
     }
 
-    public static enum DdlProceduresToLoad
-    {
+    public static enum DdlProceduresToLoad {
         NO_DDL_PROCEDURES, ALL_DDL_PROCEDURES
     }
 
@@ -1128,7 +1125,7 @@ public class VoltCompiler {
 
             // When A/A is enabled, create an export table for every DR table to log possible conflicts
             ddlcompiler.loadAutogenExportTableSchema(db, previousDBIfAny, whichProcs, m_isXDCR);
-            /*sqlNodes.forEach(node -> {
+            sqlNodes.forEach(node -> {
                 final Pair<SchemaPlus, Pair<Statement, VoltXMLElement>> r = CreateTableUtils.addTable(node, hsql, db);
                 if (r.getSecond() != null) {
                     final Statement stmt = r.getSecond().getFirst();
@@ -1138,7 +1135,7 @@ public class VoltCompiler {
 //                  // First, need to make tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/matviewsuite-ddl.sql work.
 //                    final SchemaPlus sc = CreateIndexUtils.run(node, previousDBIfAny, db);
                 }
-            });*/
+            });
             ddlcompiler.compileToCatalog(db, m_isXDCR); // NOTE: this is the place catalog gets added for create table.
 
             // add database estimates info

--- a/src/frontend/org/voltdb/plannerv2/SqlBatchImpl.java
+++ b/src/frontend/org/voltdb/plannerv2/SqlBatchImpl.java
@@ -117,8 +117,9 @@ public class SqlBatchImpl extends SqlBatch {
                     throw new PlannerFallbackException("Not in white list, or is black listed: " + sql);
                 }
             } catch (SqlParseException e) {
-                final String errMsg = "Error: invalid SQL statement in line: " + (lineNo + e.getPos().getLineNum()) + ", column: " + e.getPos().getColumnNum() + ". " +
-                                      "Expecting one of: " + e.getExpectedTokenNames();
+                final String errMsg = String.format("Error: invalid SQL statement in line: %d, column %d. Expecting one of: %s",
+                        (lineNo + e.getPos().getLineNum()), e.getPos().getColumnNum(),
+                        e.getExpectedTokenNames());
                 log.debug(errMsg);
                 throw new PlannerFallbackException(errMsg);
                 // TODO throw a parse exception instead of fallback exception to reflect error position

--- a/src/frontend/org/voltdb/plannerv2/VoltFrameworkConfig.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltFrameworkConfig.java
@@ -89,7 +89,7 @@ public class VoltFrameworkConfig implements FrameworkConfig {
      * @param schema the converted {@code SchemaPlus} from VoltDB catalog.
      */
     public VoltFrameworkConfig(SchemaPlus schema) {
-        m_schema = Objects.requireNonNull(schema);
+        m_schema = Objects.requireNonNull(schema, "SchemaPlus is null");
         m_typeFactory = new SqlTypeFactoryImpl(getTypeSystem());
         CalciteSchema calciteSchema = CalciteSchema.from(m_schema);
         m_catalogReader = new CalciteCatalogReader(

--- a/src/frontend/org/voltdb/plannerv2/VoltSchemaPlus.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltSchemaPlus.java
@@ -55,10 +55,7 @@ public class VoltSchemaPlus {
                 false /*no caching*/, VoltFrameworkConfig.DEFAULT_SCHEMA_NAME).plus();
 
         // Get all tables from the database and add them to the SchemaPlus.
-        db.getTables().forEach(table -> {
-            schema.add(table.getTypeName(), new VoltTable(table));
-        });
-
+        db.getTables().forEach(table -> schema.add(table.getTypeName(), new VoltTable(table)));
         // Get all user-defined function from the database and add them to the SchemaPlus.
         db.getFunctions().forEach(function -> {
             try {
@@ -79,33 +76,33 @@ public class VoltSchemaPlus {
         });
 
         // add Volt extend SQL functions to the SchemaPlus
-        for (Map.Entry<Class, VoltSqlFunctions.FunctionDescriptor> function :
-                VoltSqlFunctions.VOLT_SQL_FUNCTIONS.entries()) {
-            switch(function.getValue().getType()){
-                case SCALAR:
-                    ScalarFunctionDescriptor scalarFunction = (ScalarFunctionDescriptor) function.getValue();
-                    schema.add(scalarFunction.getFunctionName().toUpperCase(),
-                            ScalarFunctionImpl.create(
-                                    function.getKey(),
-                                    scalarFunction.getFunctionName(),
-                                    scalarFunction.isExactArgumentTypes(),
-                                    scalarFunction.getFunctionId(),
-                                    scalarFunction.getArgumentTypes()));
-                    break;
-                case AGGREGATE:
-                    AggregateFunctionDescriptor aggregateFunction = (AggregateFunctionDescriptor) function.getValue();
-                    schema.add(aggregateFunction.getFunctionName().toUpperCase(),
-                            AggregateFunctionImpl.create(
-                                    function.getKey(),
-                                    aggregateFunction.getFunctionName(),
-                                    aggregateFunction.isExactArgumentTypes(),
-                                    aggregateFunction.getAggType(),
-                                    aggregateFunction.getArgumentTypes()));
-                    break;
-                default:
-                    break;
-            }
-        }
+        VoltSqlFunctions.VOLT_SQL_FUNCTIONS.entries()
+                .forEach(function -> {
+                    switch(function.getValue().getType()){
+                        case SCALAR:
+                            ScalarFunctionDescriptor scalarFunction = (ScalarFunctionDescriptor) function.getValue();
+                            schema.add(scalarFunction.getFunctionName().toUpperCase(),
+                                    ScalarFunctionImpl.create(
+                                            function.getKey(),
+                                            scalarFunction.getFunctionName(),
+                                            scalarFunction.isExactArgumentTypes(),
+                                            scalarFunction.getFunctionId(),
+                                            scalarFunction.getArgumentTypes()));
+                            break;
+                        case AGGREGATE:
+                            AggregateFunctionDescriptor aggregateFunction = (AggregateFunctionDescriptor) function.getValue();
+                            schema.add(aggregateFunction.getFunctionName().toUpperCase(),
+                                    AggregateFunctionImpl.create(
+                                            function.getKey(),
+                                            aggregateFunction.getFunctionName(),
+                                            aggregateFunction.isExactArgumentTypes(),
+                                            aggregateFunction.getAggType(),
+                                            aggregateFunction.getArgumentTypes()));
+                            break;
+                        default:
+                            break;
+                    }
+                });
 
         return schema;
     }

--- a/src/frontend/org/voltdb/plannerv2/guards/AcceptDDLsAsWeCan.java
+++ b/src/frontend/org/voltdb/plannerv2/guards/AcceptDDLsAsWeCan.java
@@ -54,7 +54,7 @@ public class AcceptDDLsAsWeCan extends CalciteCompatibilityCheck {
                 throw new PlanningErrorException("Encountered stack overflow error. " +
                         "Try reducing the number of predicate expressions in the query.");
             } else { // For all Calcite unsupported syntax, fall back to VoltDB implementation
-                throw e;
+                throw e;    // The fall back occurs in SqlBatchImpl's ctor's try-catch block calling CalciteSqlCheck.
             }
         }
     }

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
@@ -93,7 +93,7 @@ public abstract class AdHocNTBase extends UpdateApplicationBase {
      * Note that changes made to enviroment variable masks the mechanism how build.xml decides to pick planner based on
      * the Git branch name.
      */
-    static final boolean USING_CALCITE =
+    public static final boolean USING_CALCITE =
             Boolean.parseBoolean(System.getProperty("plan_with_calcite", "false")) ||
             Boolean.parseBoolean(System.getenv("plan_with_calcite"));
 


### PR DESCRIPTION
When using AdHoc to create a table and then run a SELECT query on that table, Calcite doesn't work for 2 reasons:
1. I accidentally commented out the code path for letting Calcite run `CREATE TABLE` statement that generates a new SchemaPlus.
2. @wenxuanqiu's work on SchemaPlus work to sync Catalog updates to SchemaPlus did not consider Calcite's `CREATE TABLE` work, from VoltCompiler. 
The (temporal) solution is to let PlannerTool generate a new version of SchemaPlus from PlannerTool everytime an Ad Hoc DQL is planned.

Additionally, I added a warning to `start VoltDB` process when it runs in Calcite mode.