### PR TITLE
Eng 17469 core dump on basic string create

### DIFF
--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -54,6 +54,7 @@
 namespace voltdb {
 int64_t InsertExecutor::s_modifiedTuples;
 std::string InsertExecutor::s_errorMessage{};
+std::mutex InsertExecutor::s_errorMessageUpdateLocker{};
 
 bool InsertExecutor::p_init(AbstractPlanNode* abstractNode, const ExecutorVector& executorVector) {
     VOLT_TRACE("init Insert Executor");
@@ -183,7 +184,10 @@ bool InsertExecutor::p_execute_init_internal(const TupleSchema *inputSchema,
     // https://issues.voltdb.com/browse/ENG-17091?focusedCommentId=50362&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-50362
     // count the number of successful inserts
     m_modifiedTuples = 0;
-    s_errorMessage.resize(0);   // ENG-17469: using clear() method causes problems.
+    {
+        std::lock_guard<std::mutex> g(s_errorMessageUpdateLocker);
+        s_errorMessage.clear();   // ENG-17469: using clear() method causes problems.
+    }
 
     m_tmpOutputTable = newOutputTable;
     vassert(m_tmpOutputTable);
@@ -403,7 +407,10 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
                p_execute_tuple_internal(inputTuple);
             }
          } catch (ConstraintFailureException const& e) {
-            s_errorMessage = e.what();
+            {
+               std::lock_guard<std::mutex> g(s_errorMessageUpdateLocker);
+               s_errorMessage = e.what();
+            }
             throw;
          }
          if (m_replicatedTableOperation) {
@@ -414,6 +421,7 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
          // all threads are in the same state
          char msg[4096];
          if (!s_errorMessage.empty()) {
+            std::lock_guard<std::mutex> g(s_errorMessageUpdateLocker);
             strcpy(msg, s_errorMessage.c_str());
          } else {
             snprintf(msg, sizeof msg,

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -53,7 +53,7 @@
 
 namespace voltdb {
 int64_t InsertExecutor::s_modifiedTuples;
-std::string InsertExecutor::s_errorMessage;
+std::string InsertExecutor::s_errorMessage{};
 
 bool InsertExecutor::p_init(AbstractPlanNode* abstractNode, const ExecutorVector& executorVector) {
     VOLT_TRACE("init Insert Executor");
@@ -183,7 +183,7 @@ bool InsertExecutor::p_execute_init_internal(const TupleSchema *inputSchema,
     // https://issues.voltdb.com/browse/ENG-17091?focusedCommentId=50362&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-50362
     // count the number of successful inserts
     m_modifiedTuples = 0;
-    s_errorMessage.clear();
+    s_errorMessage.resize(0);   // ENG-17469: using clear() method causes problems.
 
     m_tmpOutputTable = newOutputTable;
     vassert(m_tmpOutputTable);

--- a/src/ee/executors/insertexecutor.h
+++ b/src/ee/executors/insertexecutor.h
@@ -155,8 +155,9 @@ class InsertExecutor : public AbstractExecutor {
      */
     Table* m_targetTable = nullptr;
     int64_t m_modifiedTuples = 0;
-    static int64_t s_modifiedTuples;
+    static int64_t s_modifiedTuples;                // TODO: need to be atomic
     static std::string s_errorMessage;
+    static std::mutex s_errorMessageUpdateLocker;   // needed to lock writes to s_errorMessage
     TableTuple m_count_tuple{};
     PersistentTable* m_persistentTable = nullptr;
     TableTuple m_upsertTuple{};

--- a/src/ee/expressions/functionexpression.cpp
+++ b/src/ee/expressions/functionexpression.cpp
@@ -32,7 +32,7 @@ template<> inline NValue NValue::callUnary<FUNC_VOLT_SQL_ERROR>() const {
     if (type == VALUE_TYPE_VARCHAR) {
         if (isNull()) {
              throw SQLException(SQLException::dynamic_sql_error,
-                                "Must not ask for object length on sql null object.");
+                     "Must not ask for object length on sql null object.");
         }
         int32_t length;
         const char* buf = getObject_withoutNull(length);
@@ -69,7 +69,7 @@ template<> inline NValue NValue::call<FUNC_VOLT_SQL_ERROR>(const std::vector<NVa
         if (intValue == 0) {
             return codeArg;
         }
-        snprintf(state_format_buffer, sizeof(state_format_buffer), "%05ld", 
+        snprintf(state_format_buffer, sizeof(state_format_buffer), "%05ld",
                  static_cast<long>(intValue));
         state_format_buffer[sizeof state_format_buffer - 1] = '\0';
         sqlstatecode = state_format_buffer;


### PR DESCRIPTION
Root cause is because now that I cleared the static std::string in InsertExecutor's p_execute_init_internal() method, multiple sites would collide with each other accessing and clearing the std::string, which is not atomic. This lead to memory corruption.
Added a lock to protect write operations on this static std::string.

Note:
1. I still think that using static member variable to communicate between sites is a quick and dirty solution, the biggest problem being that we need to clean the state between txns. But an alternative solution would take some more elaborated design.
2. This fix is only to block system test failures that result in core dumps that point to the line std::string gets clear()-ed. However, we have extensive use of other static variables as means of communication for both InsertExecutor and other executors, e.g. `s_modifiedTuples`. Although they are only used by assignment/check (no increments, etc), they are still prone to concurrency bugs. The fix will come in a different PR.