### PR TITLE
ENG-16609, stop deleting empty pbd segments in the initialization of recovery

### DIFF
--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -626,7 +626,8 @@ public class PersistentBinaryDeque<M> implements BinaryDeque<M> {
                     m_extraHeaderSerializer);
 
             try {
-                if (segment.getNumEntries() == 0) {
+                // Delete preceding empty segment
+                if (segment.getNumEntries() == 0 && m_segments.isEmpty()) {
                     if (m_usageSpecificLog.isDebugEnabled()) {
                         m_usageSpecificLog.debug("Found Empty Segment with entries: " + segment.getNumEntries()
                                 + " For: " + segment.file().getName());
@@ -646,7 +647,6 @@ public class PersistentBinaryDeque<M> implements BinaryDeque<M> {
                     m_usageSpecificLog.debug(
                             "Segment " + segment.file() + " (final: " + segment.isFinal() + "), has been recovered");
                 }
-                m_segments.put(segment.segmentIndex(), segment);
             } catch (IOException e) {
                 m_usageSpecificLog.warn(
                         "Failed to retrieve entry count from segment " + segment.file() + ". Quarantining segment", e);


### PR DESCRIPTION

Delete empty segment in the middle of pbd segment chain would fail the integrity
check in next recovery.

Change-Id: I542e874bae6590a92f3c0e37a8c47fcd635ff7d7