### PR TITLE
Use C++11 TLS types to replace pthread

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.h
+++ b/src/ee/common/SynchronizedThreadLock.h
@@ -15,20 +15,14 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SYNCHRONIZEDTHREADLOCK_H_
-#define SYNCHRONIZEDTHREADLOCK_H_
+#pragma once
 
-//#include "boost/scoped_ptr.hpp"
-//#include "boost/unordered_map.hpp"
-
-#include <common/debuglog.h>
+#include <condition_variable>
 #include <map>
-#include <stack>
-#include <string>
-#include <vector>
-#include <pthread.h>
+#include <mutex>
 #include <atomic>
 
+#include "common/debuglog.h"
 #include "common/UndoQuantumReleaseInterest.h"
 
 class DRBinaryLogTest;
@@ -57,18 +51,38 @@ public:
 };
 
 class PersistentTable;
-class ExecuteWithAllSitesMemory;
-class ReplicatedMaterializedViewHandler;
-
 class SynchronizedThreadLock {
-
     friend class ExecuteWithAllSitesMemory;
     friend class ReplicatedMaterializedViewHandler;
     friend class ScopedReplicatedResourceLock;
     friend class VoltDBEngine;
     friend class ::DRBinaryLogTest;
 
+    static bool s_inSingleThreadMode;
+#ifndef  NDEBUG
+    static bool s_usingMpMemory;
+#endif
+    static bool s_holdingReplicatedTableLock;
+    static std::mutex s_sharedEngineMutex;
+    static std::condition_variable s_sharedEngineCondition;
+    static std::condition_variable s_wakeLowestEngineCondition;
+    static int32_t s_globalTxnStartCountdownLatch;
+    static int32_t s_SITES_PER_HOST;
+    static EngineLocals s_mpEngine;
+    static SharedEngineLocalsType s_enginesByPartitionId;
+
+    // For use only by friends:
+    static void lockReplicatedResource();
+    static void unlockReplicatedResource();
+
+    // These methods are like the ones above, but are only
+    // used during initialization and have fewer asserts.
+    static void lockReplicatedResourceForInit();
+    static void unlockReplicatedResourceForInit();
+
 public:
+    static const int32_t s_mpMemoryPartitionId;
+
     static void create();
     static void destroy();
     static void init(int32_t sitesPerHost, EngineLocals& newEngineLocals);
@@ -86,7 +100,7 @@ public:
      * Wrapper around calling UndoQuantum::registerUndoAction
      */
     static void addUndoAction(bool synchronized, UndoQuantum *uq, UndoReleaseAction* action,
-            PersistentTable *interest = NULL);
+            PersistentTable *interest = nullptr);
     static void addTruncateUndoAction(bool synchronized, UndoQuantum *uq, UndoReleaseAction* action,
             PersistentTable *deletedTable);
 
@@ -110,35 +124,7 @@ public:
     static void resetEngineLocalsForTest();
     static void setEngineLocalsForTest(int32_t partitionId, EngineLocals mpEngine, SharedEngineLocalsType enginesByPartitionId);
     static EngineLocals getMpEngine();
-
-private:
-
-    // For use only by friends:
-    static void lockReplicatedResource();
-    static void unlockReplicatedResource();
-
-    // These methods are like the ones above, but are only
-    // used during initialization and have fewer asserts.
-    static void lockReplicatedResourceForInit();
-    static void unlockReplicatedResourceForInit();
-
-    static bool s_inSingleThreadMode;
-#ifndef  NDEBUG
-    static bool s_usingMpMemory;
-#endif
-    static bool s_holdingReplicatedTableLock;
-    static pthread_mutex_t s_sharedEngineMutex;
-    static pthread_cond_t s_sharedEngineCondition;
-    static pthread_cond_t s_wakeLowestEngineCondition;
-    static int32_t s_globalTxnStartCountdownLatch;
-    static int32_t s_SITES_PER_HOST;
-    static EngineLocals s_mpEngine;
-    static SharedEngineLocalsType s_enginesByPartitionId;
-
-public:
-    static const int32_t s_mpMemoryPartitionId;
 };
 
 }
 
-#endif

--- a/src/ee/common/executorcontext.hpp
+++ b/src/ee/common/executorcontext.hpp
@@ -31,7 +31,6 @@
 #include <vector>
 #include <stack>
 #include <map>
-#include <memory>
 
 namespace voltdb {
 
@@ -492,19 +491,18 @@ class ExecutorContext {
 };
 
 struct EngineLocals : public PoolLocals {
-    inline EngineLocals() : PoolLocals(), context(ExecutorContext::getExecutorContext()) {}
+    inline EngineLocals() = default;
     inline explicit EngineLocals(bool dummyEntry) : PoolLocals(dummyEntry), context(NULL) {}
     inline explicit EngineLocals(ExecutorContext* ctxt) : PoolLocals(), context(ctxt) {}
-    inline EngineLocals(const EngineLocals& src) : PoolLocals(src), context(src.context)
-    {}
+    inline EngineLocals(const EngineLocals& src) : PoolLocals(src), context(src.context) {}
 
-    inline EngineLocals& operator = (EngineLocals const& rhs) {
-        PoolLocals::operator = (rhs);
+    inline EngineLocals& operator=(EngineLocals const& rhs) {
+        PoolLocals::operator=(rhs);
         context = rhs.context;
         return *this;
     }
 
-    ExecutorContext* context;
+    ExecutorContext* context = ExecutorContext::getExecutorContext();
 };
 }
 


### PR DESCRIPTION
in SynchronizedThreadLock

Broken PR #6492 into 3 smaller PRs in succession (i.e. commit dependency).
This is the 2nd PR: commit dependency on previous one #6494 
Focus on using C++11 features to replace Posix data types/function calls.