### PR TITLE
De-templatize ConditionalSynchronizedExecuteWithMpMemory ctor

### DIFF
--- a/src/ee/common/ExecuteWithMpMemory.h
+++ b/src/ee/common/ExecuteWithMpMemory.h
@@ -54,28 +54,8 @@ private:
 
 class ConditionalSynchronizedExecuteWithMpMemory {
 public:
-    template<class ExceptionTracker>
-    ConditionalSynchronizedExecuteWithMpMemory(bool needMpMemoryOnLowestThread,
-                                               bool isLowestSite,
-                                               ExceptionTracker* tracker,
-                                               const ExceptionTracker& initValue)
-    : m_usingMpMemoryOnLowestThread(needMpMemoryOnLowestThread && isLowestSite)
-    , m_okToExecute(!needMpMemoryOnLowestThread || m_usingMpMemoryOnLowestThread)
-    {
-        if (needMpMemoryOnLowestThread) {
-            if (SynchronizedThreadLock::countDownGlobalTxnStartCount(isLowestSite)) {
-                VOLT_DEBUG("Entering UseMPmemory");
-                SynchronizedThreadLock::assumeMpMemoryContext();
-                // This must be done in here to avoid a race with the non-MP path.
-                *tracker = initValue;
-            }
-        }
-    }
-
-    template<typename ExceptionTracker, typename T2>
-    ConditionalSynchronizedExecuteWithMpMemory(bool needMpMemoryOnLowestThread, bool isLowestSite,
-            ExceptionTracker* tracker, const ExceptionTracker& initValue,
-            T2& tracker2, const T2& initValue2)
+    ConditionalSynchronizedExecuteWithMpMemory(
+            bool needMpMemoryOnLowestThread, bool isLowestSite, std::function<void()> initiator)
     : m_usingMpMemoryOnLowestThread(needMpMemoryOnLowestThread && isLowestSite)
     , m_okToExecute(!needMpMemoryOnLowestThread || m_usingMpMemoryOnLowestThread) {
         if (needMpMemoryOnLowestThread) {
@@ -83,16 +63,14 @@ public:
                 VOLT_DEBUG("Entering UseMPmemory");
                 SynchronizedThreadLock::assumeMpMemoryContext();
                 // This must be done in here to avoid a race with the non-MP path.
-                *tracker = initValue;
-                tracker2 = initValue2;
+                initiator();
             }
         }
     }
-
     ~ConditionalSynchronizedExecuteWithMpMemory();
-
-    bool okToExecute() { return m_okToExecute; }
-
+    bool okToExecute() const {
+        return m_okToExecute;
+    }
 private:
     bool m_usingMpMemoryOnLowestThread;
     bool m_okToExecute;

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1682,8 +1682,9 @@ bool VoltDBEngine::loadTable(int32_t tableId, ReferenceSerializeInputBE &seriali
     //   Perhaps we cannot be ensured of data integrity for other kinds of exceptions?
 
     ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory
-            (table->isReplicatedTable(), isLowestSite(), &s_loadTableException,
-             VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
+            (table->isReplicatedTable(), isLowestSite(), []() {
+             s_loadTableException = VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE;
+             });
     if (possiblySynchronizedUseMpMemory.okToExecute()) {
         // Joined views are special. If any of the source table(s) are not empty, we cannot restore the view content
         // from a snapshot. The Java top-end has no way to know this so it still tries to tell the EE
@@ -2587,8 +2588,9 @@ bool VoltDBEngine::deleteMigratedRows(int64_t txnId, int64_t spHandle, int64_t u
                 spHandle, -1, uniqueId, false);
 
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory
-                (table->isReplicatedTable(), isLowestSite(), &s_loadTableException,
-                 VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE);
+                (table->isReplicatedTable(), isLowestSite(), []() {
+                 s_loadTableException = VoltEEExceptionType::VOLT_EE_EXCEPTION_TYPE_REPLICATED_TABLE;
+                 });
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
             bool rowsToBeDeleted;
             try {
@@ -2868,8 +2870,8 @@ void VoltDBEngine::setViewsEnabled(const std::string& viewNames, bool value) {
     do {
         VOLT_TRACE("[Partition %d] updateReplicated = %s\n", m_partitionId, updateReplicated?"true":"false");
         // Update all the partitioned table views first, then update all the replicated table views.
-        int64_t dummyExceptionTracker = 0;
-        ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(updateReplicated, m_isLowestSite, &dummyExceptionTracker, int64_t(-1));
+        ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
+                updateReplicated, m_isLowestSite, [](){});
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
             // This loop just split the viewNames by commas and process each view individually.
             for (size_t pstart = 0, pend = 0; pstart != std::string::npos; pstart = pend) {

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -93,7 +93,8 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
         vassert(targetTable->isReplicatedTable() ==
                 (m_replicatedTableOperation || SynchronizedThreadLock::isInSingleThreadMode()));
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
+                m_replicatedTableOperation, m_engine->isLowestSite(),
+                []() { s_modifiedTuples = -1l; });
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
             if (m_truncate) {
                 VOLT_TRACE("truncating table %s...", targetTable->name().c_str());

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -347,8 +347,10 @@ void InsertExecutor::p_execute_tuple(TableTuple &tuple) {
     // This should only be called from inlined insert executors because we have to change contexts every time
     ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
             m_replicatedTableOperation, m_engine->isLowestSite(),
-            &s_modifiedTuples, int64_t(-1),
-            s_errorMessage, std::string{});
+            []() {
+            s_modifiedTuples = -1l;
+            s_errorMessage.clear();
+            });
     if (possiblySynchronizedUseMpMemory.okToExecute()) {
         p_execute_tuple_internal(tuple);
         if (m_replicatedTableOperation) {
@@ -393,7 +395,8 @@ bool InsertExecutor::p_execute(const NValueArray &params) {
    const TupleSchema *inputSchema = m_inputTable->schema();
    if (p_execute_init_internal(inputSchema, m_tmpOutputTable, inputTuple)) {
       ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-            m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
+            m_replicatedTableOperation, m_engine->isLowestSite(),
+            []() { s_modifiedTuples = -1l; });
       if (possiblySynchronizedUseMpMemory.okToExecute()) {
          //
          // An insert is quite simple really. We just loop through our m_inputTable

--- a/src/ee/executors/migrateexecutor.cpp
+++ b/src/ee/executors/migrateexecutor.cpp
@@ -110,7 +110,8 @@ bool MigrateExecutor::p_execute(const NValueArray &params) {
     {
         vassert(m_replicatedTableOperation == targetTable->isReplicatedTable());
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
+                m_replicatedTableOperation, m_engine->isLowestSite(),
+                []() { s_modifiedTuples = -1l; });
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
             std::vector<TableIndex*> indexesToUpdate;
             const std::vector<TableIndex*>& allIndexes = targetTable->allIndexes();

--- a/src/ee/executors/swaptablesexecutor.cpp
+++ b/src/ee/executors/swaptablesexecutor.cpp
@@ -88,7 +88,8 @@ bool SwapTablesExecutor::p_execute(NValueArray const& params) {
     {
         vassert(m_replicatedTableOperation == theTargetTable->isReplicatedTable());
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
+                m_replicatedTableOperation, m_engine->isLowestSite(),
+                []() { s_modifiedTuples = -1l; });
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
             // count the active tuples in both tables as modified
             modified_tuples = theTargetTable->visibleTupleCount() +

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -141,7 +141,8 @@ bool UpdateExecutor::p_execute(const NValueArray &params) {
     {
         vassert(m_replicatedTableOperation == targetTable->isReplicatedTable());
         ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(
-                m_replicatedTableOperation, m_engine->isLowestSite(), &s_modifiedTuples, int64_t(-1));
+                m_replicatedTableOperation, m_engine->isLowestSite(),
+                []() { s_modifiedTuples = -1l; });
         if (possiblySynchronizedUseMpMemory.okToExecute()) {
             // determine which indices are updated by this executor
             // iterate through all target table indices and see if they contain

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -863,7 +863,7 @@ int64_t BinaryLogSink::applyTxn(BinaryLog *log, std::unordered_map<int64_t, Pers
 int64_t BinaryLogSink::applyReplicatedTxn(BinaryLog *log, std::unordered_map<int64_t, PersistentTable*> &tables,
         Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId) {
     ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory(true, engine->isLowestSite(),
-            &s_replicatedApplySuccess, false);
+            []() { s_replicatedApplySuccess = false; });
 
     long rowCount = 0;
     if (possiblySynchronizedUseMpMemory.okToExecute()) {

--- a/tests/ee/test_utils/plan_testing_baseclass.h
+++ b/tests/ee/test_utils/plan_testing_baseclass.h
@@ -253,9 +253,8 @@ public:
             throw std::logic_error(oss.str());
         }
         assert(pTable != NULL);
-        int dummyExceptionTracker;
         voltdb::ConditionalSynchronizedExecuteWithMpMemory setMpMemoryIfNeeded
-                (pTable->isReplicatedTable(), true, &dummyExceptionTracker, -1);
+                (pTable->isReplicatedTable(), true, [](){});
         for (int row = 0; row < nRows; row += 1) {
             if (row > 0 && (row % 100 == 0)) {
                 std::cout << '.';


### PR DESCRIPTION
Broken PR #6492 into 3 smaller PRs in succession (i.e. commit dependency).
This is the 3rd/last of the series. Depends on #6495 
Focus on getting rid of templatized constructor of ConditionalSynchronizedExecuteWithMPMemory and make it more flexible.