### PR TITLE
ENG-16922 make cached variables in CatalogReference volatile

### DIFF
--- a/src/catgen/in/javasrc/CatalogType.java
+++ b/src/catgen/in/javasrc/CatalogType.java
@@ -37,8 +37,8 @@ public abstract class CatalogType implements Comparable<CatalogType> {
 
     class CatalogReference<T extends CatalogType> {
 
-        T m_value = null;
-        String m_unresolvedPath = null;
+        volatile T m_value = null;
+        volatile String m_unresolvedPath = null;
         Object m_lock = new Object();
 
         public void setUnresolved(String path) {


### PR DESCRIPTION
During UAC,  the first site which acquires a lock builds the updated catalog, and other sites reference it.  Some of objects in catalog, such as CatalogMap, CatalogReference etc, are not  thread safe.  Objects updated on one site may not be visible on other sites.  System tests have caught this issue with @ NibbleDeleteSP.  Right after UAC, the sys procedure tried to build TTL procedures but couldn't find the partition column in a partition table.  The PR makes the value and path variables volatile. 