### PR TITLE
ENG 16932 - Fixed NPE when Subquery Accesses Partitioned Table

### DIFF
--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -1748,6 +1748,10 @@ public abstract class AbstractParsedStmt {
             assert(condExpr != null);
             ExpressionUtil.finalizeValueTypes(condExpr);
             condExpr = ExpressionUtil.evaluateExpression(condExpr);
+            // If the condition is a trivial CVE(TRUE) (after the evaluation) simply drop it
+            if (ConstantValueExpression.isBooleanTrue(condExpr)) {
+                condExpr = null;
+            }
         }
         return condExpr;
     }

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -27,7 +27,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.hsqldb_voltpatches.FunctionForVoltDB;
 import org.hsqldb_voltpatches.VoltXMLElement;
 import org.json_voltpatches.JSONException;
 import org.voltdb.VoltType;
@@ -1749,10 +1748,6 @@ public abstract class AbstractParsedStmt {
             assert(condExpr != null);
             ExpressionUtil.finalizeValueTypes(condExpr);
             condExpr = ExpressionUtil.evaluateExpression(condExpr);
-            // If the condition is a trivial CVE(TRUE) (after the evaluation) simply drop it
-            if (ConstantValueExpression.isBooleanTrue(condExpr)) {
-                condExpr = null;
-            }
         }
         return condExpr;
     }

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -96,7 +96,7 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
             HashMap<AbstractExpression, Set<AbstractExpression>> valueEquivalence,
             Set< Set<AbstractExpression> > eqSets) {
         if (getScanPartitioning() == null) {
-            throw new Error("Unsupported statement, subquery expressions are only supported for " +
+            throw new PlanningErrorException("Unsupported statement, subquery expressions are only supported for " +
                     "single partition procedures and AdHoc replicated tables.");
         }
         if (getScanPartitioning().getCountOfPartitionedTables() == 0 ||

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -95,7 +95,10 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
     public void promoteSinglePartitionInfo(
             HashMap<AbstractExpression, Set<AbstractExpression>> valueEquivalence,
             Set< Set<AbstractExpression> > eqSets) {
-        assert(getScanPartitioning() != null);
+        if (getScanPartitioning() == null) {
+            throw new Error("Unsupported statement, subquery expressions are only supported for " +
+                    "single partition procedures and AdHoc replicated tables.");
+        }
         if (getScanPartitioning().getCountOfPartitionedTables() == 0 ||
                 getScanPartitioning().requiresTwoFragments()) {
             return;

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -1628,6 +1628,14 @@ public class TestSubQueriesSuite extends RegressionSuite {
                         {1, 1, Long.MIN_VALUE}, {2, 1, 40}, {2, 1, 50},
                         {3, 1, Long.MIN_VALUE}, {4, 2, Long.MIN_VALUE}, {5,2, Long.MIN_VALUE}});
 
+        // ENG-16932 NPE when subquery on partitioned table
+        try {
+            client.callProcedure("@AdHoc", "select * from P1 where exists (select count(*) from P1 where ID = ID);");
+            fail();
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Unsupported statement, subquery expressions are only supported for "
+                    + "single partition procedures and AdHoc replicated tables"));
+        }
     }
 
     // Test scalar subqueries


### PR DESCRIPTION
This is only a workaround to get rid of NPE stacktrace. A real fix should include correct parsing of subquery. In the case of `SELECT ID FROM P1 WHERE EXISTS (SELECT COUNT * FROM P1);`, [previous guarding conditional block](https://github.com/VoltDB/voltdb/commit/d042c2eb141200972062b21b826323ea041667dd) cannot guard the incorrect use of partitioned table in subquery because parser fail to fetch the subquery info.