### PR TITLE
Fix error message emmited from Calcite

### DIFF
--- a/src/frontend/org/voltdb/plannerv2/utils/DropTableUtils.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/DropTableUtils.java
@@ -59,7 +59,7 @@ public class DropTableUtils {
         try {
             return VoltFastSqlParser.parse(sql);
         } catch (SqlParseException e) {
-            return null;    // TODO: when Calcite eventually support all Volt syntax, we need to rethrow in here.
+            return null;    // TODO: do not catch when Calcite eventually supports all Volt DDL syntax.
         }
     }
 


### PR DESCRIPTION
on unsupported DDL statements.

The reason is that when supporting "DROP TABLE" statements in Calcite,
it could throw SqlParseException, which gets printed.

The fix by-pass the Calcite parser for DDL in normal build (that should not use
Calcite), which was intended as a special path for processing "DROP TABLE".