### PR TITLE
Fixed error message change on DROP TABLE

### DIFF
--- a/tests/sqlcmd/baselines/simple/testcte.errbaseline
+++ b/tests/sqlcmd/baselines/simple/testcte.errbaseline
@@ -46,7 +46,7 @@ SQL error while compiling query: Error in "select * from cte" - object not found
 This should succeed.  The table cte above should be cleared.
 ------------------------------------------------------------
 This should fail.  The table cte should be gone.
-Table CTE not found
+[Ad Hoc DDL Input:1]: DDL Error: "object not found: CTE in statement [drop table cte]"
 ============================================================
 Cleaning up.
 Done.


### PR DESCRIPTION
when table does not exist.
Previous error message was issued from Calcite;
since master branch should not ever use Calcite parser/planner,
this message should revert back to original one.