### PR TITLE
ENG-17722. Change voltdbclient license to MIT.

### DIFF
--- a/LICENSE.voltdbclient
+++ b/LICENSE.voltdbclient
@@ -1,0 +1,22 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/build.xml
+++ b/build.xml
@@ -616,6 +616,7 @@ DISTRIBUTION
             <include name="README.md"/>
             <include name="README.thirdparty"/>
             <include name="LICENSE"/>
+            <include name="LICENSE.voltdbclient"/>
             <include name="bundles/**"/>
             <include name="doc/**"/>
             <include name="lib/*"/>

--- a/tools/kit_tools/upload.gradle
+++ b/tools/kit_tools/upload.gradle
@@ -94,8 +94,8 @@ uploadClientArchives {
 
                licenses {
                    license {
-                       name 'GNU Affero General Public License Version 3'
-                       url 'http://www.gnu.org/licenses/agpl.txt'
+                       name 'The MIT License'
+                       url 'https://opensource.org/licenses/mit-license.php'
                        distribution 'repo'
                    }
                }


### PR DESCRIPTION
* ENG-17722. Change voltdbclient license to MIT.

* ENG-17722. Add a LICENSE.voltdbclient with MIT client into the kit.

(Same as  pull #6516 for release-9.1.x branch)