### PR TITLE
ENG-17816 prevent ZK from being blocked

### DIFF
--- a/third_party/java/src/org/apache/zookeeper_voltpatches/ClientCnxn.java
+++ b/third_party/java/src/org/apache/zookeeper_voltpatches/ClientCnxn.java
@@ -256,7 +256,7 @@ public class ClientCnxn {
 
         Record response;
 
-        boolean finished;
+        volatile boolean finished;
 
         AsyncCallback cb;
 

--- a/third_party/java/src/org/apache/zookeeper_voltpatches/ClientCnxn.java
+++ b/third_party/java/src/org/apache/zookeeper_voltpatches/ClientCnxn.java
@@ -256,7 +256,7 @@ public class ClientCnxn {
 
         Record response;
 
-        volatile boolean finished;
+        boolean finished;
 
         AsyncCallback cb;
 


### PR DESCRIPTION
ZK client thread waits for Packet's finished status to be updated on SendThread.  Make Packet.finished volatile.  Also removed ZK sync in ZooKeeperLock since ZK is leaderless, no sync is needed. 