### PR TITLE
Eng 17700 ee check fails on voltmini

### DIFF
--- a/src/ee/common/SerializableEEException.cpp
+++ b/src/ee/common/SerializableEEException.cpp
@@ -61,7 +61,9 @@ static inline std::string const enrich(std::string const& a) noexcept {
 }
 #else   // On DEBUG build, enrich our exception message with stack trace of the place it is thrown.
 static inline std::string enrich(std::string src) {
-    return src.append("\nSTACK TRACE:").append(voltdb::StackTrace::stringStackTrace("\t"));
+    return src.append("\nSTACK TRACE:")
+        .append(voltdb::StackTrace::stringStackTrace("\t"))
+        .substr(0, 1024);
 }
 #endif
 

--- a/src/ee/common/SerializableEEException.cpp
+++ b/src/ee/common/SerializableEEException.cpp
@@ -63,7 +63,7 @@ static inline std::string const enrich(std::string const& a) noexcept {
 static inline std::string enrich(std::string src) {
     return src.append("\nSTACK TRACE:")
         .append(voltdb::StackTrace::stringStackTrace("\t"))
-        .substr(0, 4096);
+        .substr(0, 2048);
 }
 #endif
 

--- a/src/ee/common/SerializableEEException.cpp
+++ b/src/ee/common/SerializableEEException.cpp
@@ -63,7 +63,7 @@ static inline std::string const enrich(std::string const& a) noexcept {
 static inline std::string enrich(std::string src) {
     return src.append("\nSTACK TRACE:")
         .append(voltdb::StackTrace::stringStackTrace("\t"))
-        .substr(0, 1024);
+        .substr(0, 4096);
 }
 #endif
 

--- a/src/ee/common/serializeio.h
+++ b/src/ee/common/serializeio.h
@@ -518,8 +518,8 @@ protected:
     /** Reference output can't resize the buffer: Frowny-Face. */
     virtual void expand(size_t minimum_desired) {
         throwSQLException(SQLException::volt_output_buffer_overflow,
-            "Output from SQL stmt overflowed output/network buffer of 10mb (%lu bytes). "
-            "Try a \"limit\" clause or a stronger predicate.", minimum_desired);
+            "Output from SQL stmt overflowed output/network buffer of 10mb (%lu > %lu bytes). "
+            "Try a \"limit\" clause or a stronger predicate.", minimum_desired, m_capacity);
     }
 };
 

--- a/src/ee/common/serializeio.h
+++ b/src/ee/common/serializeio.h
@@ -517,9 +517,9 @@ public:
 protected:
     /** Reference output can't resize the buffer: Frowny-Face. */
     virtual void expand(size_t minimum_desired) {
-        throw SQLException(SQLException::volt_output_buffer_overflow,
-            "Output from SQL stmt overflowed output/network buffer of 10mb. "
-            "Try a \"limit\" clause or a stronger predicate.");
+        throwSQLException(SQLException::volt_output_buffer_overflow,
+            "Output from SQL stmt overflowed output/network buffer of 10mb (%lu bytes). "
+            "Try a \"limit\" clause or a stronger predicate.", minimum_desired);
     }
 };
 

--- a/src/ee/common/serializeio.h
+++ b/src/ee/common/serializeio.h
@@ -518,7 +518,7 @@ protected:
     /** Reference output can't resize the buffer: Frowny-Face. */
     virtual void expand(size_t minimum_desired) {
         throwSQLException(SQLException::volt_output_buffer_overflow,
-            "Output from SQL stmt overflowed output/network buffer of 10mb (%lu > %lu bytes). "
+            "Output from SQL stmt overflowed output/network buffer (%lu > %lu bytes). "
             "Try a \"limit\" clause or a stronger predicate.", minimum_desired, m_capacity);
     }
 };


### PR DESCRIPTION
This bug is only hit on Voltmini, and many other MacOSX enviroments.

Investigation shows that ReferenceSerializeInput and ReferenceSerializeOutput buffer size was initialized to 4096 bytes, but the error message complains overflowing 10MB network/output buffer.

The cause is in the debug build, I added stack trace to SerializableEEException message, that exceeds 4096 bytes, and causes a problem on this particular platform. The fix is to truncate stack trace to 2048 bytes. The error message looks normal (no recursion, etc.): see description of the [ticket](https://issues.voltdb.com/browse/ENG-17700).

Also updated obsolete error message complaining that buffer exceeds 10MB limit, to the actual size and capacity, since the old assumption no longer holds.