### PR TITLE
ENG-14556, terminate stream snapshot ack receiver thread if the strea…

### DIFF
--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -705,7 +705,13 @@ public class SnapshotSiteProcessor {
                                     t.close();
                                 } catch (IOException e) {
                                     snapshotSucceeded = false;
-                                    throw new RuntimeException(e);
+                                    // Don't throw timeout exception, the warning has been logged
+                                    // in another place.
+                                    if (e instanceof StreamSnapshotTimeoutException) {
+                                        continue;
+                                    } else {
+                                        throw new RuntimeException(e);
+                                    }
                                 } catch (InterruptedException e) {
                                     snapshotSucceeded = false;
                                     throw new RuntimeException(e);

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotBase.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotBase.java
@@ -71,6 +71,7 @@ public abstract class StreamSnapshotBase {
         {
             return null;
         }
+
     }
 
 }


### PR DESCRIPTION
…m snapshot write task is failed.

If the ack receiver thread is started but never receives EOS, which might caused by snapshot write task unable to
finish, the ack receiver thread is orphaned and will print out anonying warning messages every 10 minutes, this
issue has been fixed.

Change-Id: I5a752a29ffd5ab135338767e98d3fcb82ab4cbc8