### PR TITLE
ENG-17826: Validate task configuration after catalog compile

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -159,7 +159,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     public static final long SHUTDONW_SAVE_CID          = Long.MIN_VALUE + 9;
     public static final long NT_REMOTE_PROC_CID         = Long.MIN_VALUE + 10;
     public static final long MIGRATE_ROWS_DELETE_CID    = Long.MIN_VALUE + 11;
-    public static final long SCHEDULER_MANAGER_CID      = Long.MIN_VALUE + 12;
+    public static final long TASK_MANAGER_CID           = Long.MIN_VALUE + 12;
 
     // Leave CL_REPLAY_BASE_CID at the end, it uses this as a base and generates more cids
     // PerPartition cids

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -532,9 +532,14 @@ public final class InvocationDispatcher {
     }
 
     public final static Procedure getProcedureFromName(String procName, CatalogContext catalogContext) {
-        Procedure catProc = catalogContext.procedures.get(procName);
+        return getProcedureFromName(procName, catalogContext.procedures, catalogContext.m_defaultProcs);
+    }
+
+    public final static Procedure getProcedureFromName(String procName, CatalogMap<Procedure> procedures,
+            DefaultProcedureManager defaultProcs) {
+        Procedure catProc = procedures.get(procName);
         if (catProc == null) {
-            catProc = catalogContext.m_defaultProcs.checkForDefaultProcedure(procName);
+            catProc = defaultProcs.checkForDefaultProcedure(procName);
         }
 
         if (catProc == null) {

--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -70,7 +70,6 @@ import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Deployment;
 import org.voltdb.catalog.FilteredCatalogDiffEngine;
 import org.voltdb.catalog.Procedure;
-import org.voltdb.catalog.Task;
 import org.voltdb.catalog.Statement;
 import org.voltdb.catalog.Table;
 import org.voltdb.common.Constants;
@@ -83,8 +82,6 @@ import org.voltdb.planner.ParameterizationInfo;
 import org.voltdb.planner.StatementPartitioning;
 import org.voltdb.plannerv2.utils.CreateTableUtils;
 import org.voltdb.settings.ClusterSettings;
-import org.voltdb.task.TaskManager;
-import org.voltdb.task.TaskManager.TaskValidationResult;
 import org.voltdb.utils.CatalogSchemaTools;
 import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.Encoder;
@@ -1955,14 +1952,6 @@ public class VoltCompiler {
                 ancestor = ancestor.getEnclosingClass();
             }
             addClassToJar(jarOutput, ancestor);
-        }
-
-        TaskManager taskManager = VoltDB.instance().getTaskManager();
-        for (Task task : db.getTasks()) {
-            TaskValidationResult result = taskManager.validateTask(task, classLoader);
-            if (!result.isValid()) {
-                throw new VoltCompilerException(result.getErrorMessage());
-            }
         }
 
         ////////////////////////////////////////////

--- a/src/frontend/org/voltdb/compiler/statements/CreateTask.java
+++ b/src/frontend/org/voltdb/compiler/statements/CreateTask.java
@@ -21,7 +21,6 @@ import java.util.regex.Matcher;
 
 import org.hsqldb_voltpatches.Scanner;
 import org.hsqldb_voltpatches.Tokens;
-import org.voltdb.VoltDB;
 import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Task;
@@ -64,13 +63,6 @@ public class CreateTask extends StatementProcessor {
 
         Task task = tasks.add(name);
         configureTask(task, matcher, ddlStatement.newDdl);
-
-        TaskManager.TaskValidationResult result = VoltDB.instance().getTaskManager()
-                .validateTask(task, m_classLoader);
-        if (!result.isValid()) {
-            tasks.delete(name);
-            throw m_compiler.new VoltCompilerException(result.getErrorMessage());
-        }
         return true;
     }
 

--- a/src/frontend/org/voltdb/task/TaskHelper.java
+++ b/src/frontend/org/voltdb/task/TaskHelper.java
@@ -17,13 +17,17 @@
 
 package org.voltdb.task;
 
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltdb.ClientInterface;
+import org.voltdb.DefaultProcedureManager;
+import org.voltdb.InvocationDispatcher;
 import org.voltdb.ParameterConverter;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.CatalogMap;
+import org.voltdb.catalog.Database;
 import org.voltdb.catalog.ProcParameter;
 import org.voltdb.catalog.Procedure;
 
@@ -35,14 +39,32 @@ public final class TaskHelper {
     private final VoltLogger m_logger;
     private final UnaryOperator<String> m_generateLogMessage;
     private final String m_scope;
-    private final ClientInterface m_clientInterface;
+    private final Function<String, Procedure> m_procedureGetter;
+
+    private static Function<String, Procedure> createProcedureFunction(Database database) {
+        if (database == null) {
+            return null;
+        }
+        DefaultProcedureManager defaultProcedureManager = new DefaultProcedureManager(database);
+        CatalogMap<Procedure> procedures = database.getProcedures();
+        return p -> InvocationDispatcher.getProcedureFromName(p, procedures, defaultProcedureManager);
+    }
+
+    TaskHelper(VoltLogger logger, UnaryOperator<String> generateLogMessage, String scope, Database database) {
+        this(logger, generateLogMessage, scope, createProcedureFunction(database));
+    }
 
     TaskHelper(VoltLogger logger, UnaryOperator<String> generateLogMessage, String scope,
             ClientInterface clientInterface) {
+        this(logger, generateLogMessage, scope, clientInterface::getProcedureFromName);
+    }
+
+    private TaskHelper(VoltLogger logger, UnaryOperator<String> generateLogMessage, String scope,
+            Function<String, Procedure> procedureGetter) {
         m_logger = logger;
         m_generateLogMessage = generateLogMessage;
         m_scope = scope;
-        m_clientInterface = clientInterface;
+        m_procedureGetter = procedureGetter;
     }
 
     /**
@@ -141,7 +163,10 @@ public final class TaskHelper {
      */
     public void validateProcedure(TaskValidationErrors errors, boolean restrictProcedureByScope,
             String procedureName, Object[] parameters) {
-        Procedure procedure = m_clientInterface.getProcedureFromName(procedureName);
+        if (m_procedureGetter == null) {
+            return;
+        }
+        Procedure procedure = m_procedureGetter.apply(procedureName);
         if (procedure == null) {
             errors.addErrorMessage("Procedure does not exist: " + procedureName);
             return;

--- a/src/frontend/org/voltdb/task/TaskManager.java
+++ b/src/frontend/org/voltdb/task/TaskManager.java
@@ -61,6 +61,7 @@ import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.CatalogMap;
+import org.voltdb.catalog.Database;
 import org.voltdb.catalog.ProcParameter;
 import org.voltdb.catalog.Procedure;
 import org.voltdb.catalog.Task;
@@ -109,7 +110,7 @@ public final class TaskManager {
     private boolean m_started = false;
     private final Set<Integer> m_locallyLedPartitions = new HashSet<>();
     private final SimpleClientResponseAdapter m_adapter = new SimpleClientResponseAdapter(
-            ClientInterface.SCHEDULER_MANAGER_CID, getClass().getSimpleName());
+            ClientInterface.TASK_MANAGER_CID, getClass().getSimpleName());
 
     // Global configuration values
     volatile long m_minDelayNs = 0;
@@ -368,23 +369,42 @@ public final class TaskManager {
     }
 
     /**
+     * Validate that all tasks present in {@code database} have valid classes and parameters defined.
+     *
+     * @param database    {@link Database} to be validated
+     * @param classLoader {@link ClassLoader} to use to load referenced classes
+     * @return An error message or {@code null} if no errors were found
+     */
+    public static String validateTasks(Database database, ClassLoader classLoader) {
+        TaskValidationErrors errors = new TaskValidationErrors();
+        for (Task task : database.getTasks()) {
+            errors.addErrorMessage(validateTask(task, database, classLoader).getErrorMessage());
+        }
+        return errors.getErrorMessage();
+    }
+
+    /**
      * Create a factory supplier for instances of {@link ActionScheduler} as defined by the provided {@link Task}. If an
      * instance of {@link SchedulerFactory} cannot be constructed using the provided configuration the returned
      * {@link TaskValidationResult} will have an appropriate error message.
+     * <p>
+     * If {@code database} is null this method will return a {@link TaskValidationResult} or an error message. However
+     * if {@code database} is not null the returned {@link TaskValidationResult} will only ever have an error message.
      *
      * @param definition  {@link Task} defining the configuration of the schedule
+     * @param database    {@link Database} instance used to validate procedures. May be {@link null}
      * @param classLoader {@link ClassLoader} to use when loading the classes in {@code definition}
      * @return {@link TaskValidationResult} describing any problems encountered or a {@link SchedulerFactory}
      */
-    public TaskValidationResult validateTask(Task definition, ClassLoader classLoader) {
-
+    static TaskValidationResult validateTask(Task definition, Database database, ClassLoader classLoader) {
         String schedulerClassName = definition.getSchedulerclass();
         SchedulerFactory factory;
         if (!StringUtils.isBlank(schedulerClassName)) {
             // Construct scheduler from the provided class
             try {
                 Pair<String, InitializableFactory<ActionScheduler>> result = createFactory(definition,
-                        ActionScheduler.class, schedulerClassName, definition.getSchedulerparameters(), classLoader);
+                        ActionScheduler.class, schedulerClassName, definition.getSchedulerparameters(), database,
+                        classLoader);
                 String errorMessage = result.getFirst();
                 if (errorMessage != null) {
                     return new TaskValidationResult(errorMessage);
@@ -409,7 +429,7 @@ public final class TaskManager {
             try {
                 Pair<String, InitializableFactory<ActionGenerator>> result = createFactory(definition,
                         ActionGenerator.class, actionGeneratorClass, definition.getActiongeneratorparameters(),
-                        classLoader);
+                        database, classLoader);
                 String errorMessage = result.getFirst();
                 if (errorMessage != null) {
                     return new TaskValidationResult(errorMessage);
@@ -423,7 +443,7 @@ public final class TaskManager {
             try {
                 Pair<String, InitializableFactory<ActionSchedule>> result = createFactory(definition,
                         ActionSchedule.class, actionScheduleClass, definition.getScheduleparameters(),
-                        classLoader);
+                        database, classLoader);
                 String errorMessage = result.getFirst();
                 if (errorMessage != null) {
                     return new TaskValidationResult(errorMessage);
@@ -434,7 +454,8 @@ public final class TaskManager {
                         String.format("Could not load and construct class: %s", actionScheduleClass), e);
             }
 
-            factory = new CompositeSchedulerFactory(actionGeneratorFactory, actionScheduleFactory);
+            factory = database == null ? new CompositeSchedulerFactory(actionGeneratorFactory, actionScheduleFactory)
+                    : null;
         }
 
         return new TaskValidationResult(factory);
@@ -449,14 +470,15 @@ public final class TaskManager {
      * @param interfaceClass        Class of the interface which {@code className} should implement
      * @param className             Name of class the factory should construct
      * @param initializerParameters Parameters which are to be passed to constructed instance
+     * @param database              {@link Database} instance used to validate procedures. May be {@link null}
      * @param classLoader           {@link ClassLoader} to use to find the class instance of {@code className}
      * @return A {@link Pair} of an errorMessage or {@link InitializableFactory}
      * @throws NoSuchAlgorithmException
      */
     @SuppressWarnings("unchecked")
-    private <T extends Initializable> Pair<String, InitializableFactory<T>> createFactory(Task definition,
+    private static <T extends Initializable> Pair<String, InitializableFactory<T>> createFactory(Task definition,
             Class<T> interfaceClass, String className, CatalogMap<TaskParameter> initializerParameters,
-            ClassLoader classLoader) throws NoSuchAlgorithmException {
+            Database database, ClassLoader classLoader) throws NoSuchAlgorithmException {
         Class<?> initializableClass;
         try {
             initializableClass = classLoader.loadClass(className);
@@ -536,10 +558,17 @@ public final class TaskManager {
                 }
             }
 
-            String parameterErrors = validateInitializeParameters(definition, initMethod, parameters, takesHelper);
+            String parameterErrors = validateInitializeParameters(definition, initMethod, parameters, takesHelper,
+                    database);
             if (parameterErrors != null) {
-                return Pair.of("Error validating scheduler parameters: " + parameterErrors, null);
+                return Pair.of("Error validating parameters for task " + definition.getName() + ": " + parameterErrors,
+                        null);
             }
+        }
+
+        if (database != null) {
+            // Don't bother with the factory since database is only passed in for pure validation
+            return Pair.of(null, null);
         }
 
         byte[] hash = null;
@@ -584,7 +613,7 @@ public final class TaskManager {
                     future.get();
                 }
             } catch (Exception e) {
-                log.error(generateLogMessage("NONE", "Unexected exception encountered"), e);
+                log.error(generateLogMessage("NONE", "Unexpected exception encountered"), e);
             }
         }, MoreExecutors.newDirectExecutorService());
         return future;
@@ -644,7 +673,7 @@ public final class TaskManager {
                         "Applying schedule configuration: " + toString()));
             }
             TaskHandler handler = m_handlers.remove(procedureSchedule.getName());
-            TaskValidationResult result = validateTask(procedureSchedule, classLoader);
+            TaskValidationResult result = validateTask(procedureSchedule, null, classLoader);
 
             if (handler != null) {
                 // Do not restart a schedule if it has not changed
@@ -731,10 +760,11 @@ public final class TaskManager {
      * @param initMethod  initialize {@link Method} instance for the {@link Initializable}
      * @param parameters  that are going to be passed to the constructor
      * @param takesHelper If {@code true} the first parameter of the init method is a {@link ScopedHandler}
+     * @param database    {@link Database} instance used to validate procedures. May be {@link null}
      * @return error message if the parameters are not valid or {@code null} if they are
      */
-    private String validateInitializeParameters(Task definition, Method initMethod, Object[] parameters,
-            boolean takesHelper) {
+    private static String validateInitializeParameters(Task definition, Method initMethod, Object[] parameters,
+            boolean takesHelper, Database database) {
         Class<?> schedulerClass = initMethod.getDeclaringClass();
 
         for (Method m : schedulerClass.getMethods()) {
@@ -766,7 +796,7 @@ public final class TaskManager {
 
             if (takesHelper) {
                 validatorParameters[0] = new TaskHelper(log, b -> generateLogMessage(definition.getName(), b),
-                        definition.getScope(), m_clientInterface);
+                        definition.getScope(), database);
             }
 
             try {
@@ -820,7 +850,7 @@ public final class TaskManager {
      * configuration in {@link Task} is valid and all referenced classes can be constructed and initialized. If any are
      * not valid then an error message and potential exception are contained within this result describing the problem.
      */
-    public static final class TaskValidationResult {
+    static final class TaskValidationResult {
         final String m_errorMessage;
         final Exception m_exception;
         final SchedulerFactory m_factory;
@@ -1161,8 +1191,8 @@ public final class TaskManager {
             if (log.isDebugEnabled()) {
                 log.debug(generateLogMessage("Starting schedule"));
             }
-            m_scheduler = m_handler.constructScheduler(
-                    new TaskHelper(log, this::generateLogMessage, getScope(), m_clientInterface));
+            m_scheduler = m_handler
+                    .constructScheduler(new TaskHelper(log, this::generateLogMessage, getScope(), m_clientInterface));
             if (m_stats == null) {
                 m_stats = TaskStatsSource.create(m_handler.getName(), getScope(), getSiteId());
                 m_stats.register(m_statsAgent);

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -639,9 +639,7 @@ public abstract class CatalogUtil {
     }
 
     public static CatalogMap<Connector> getConnectors(CatalogContext catalogContext) {
-        final Cluster cluster = catalogContext.catalog.getClusters().get("cluster");
-        final Database db = cluster.getDatabases().get("database");
-        return db.getConnectors();
+        return catalogContext.database.getConnectors();
     }
 
     public static boolean hasEnabledConnectors(CatalogMap<Connector> connectors) {
@@ -882,8 +880,8 @@ public abstract class CatalogUtil {
             validateDeployment(catalog, deployment);
 
             // add our hacky Deployment to the catalog
-            if (catalog.getClusters().get("cluster").getDeployment().get("deployment") == null) {
-                catalog.getClusters().get("cluster").getDeployment().add("deployment");
+            if (getCluster(catalog).getDeployment().get("deployment") == null) {
+                getCluster(catalog).getDeployment().add("deployment");
             }
 
             // set the cluster info
@@ -945,9 +943,9 @@ public abstract class CatalogUtil {
     private static void setCommandLogInfo(Catalog catalog, CommandLogType commandlog) {
         int fsyncInterval = 200;
         int maxTxnsBeforeFsync = Integer.MAX_VALUE;
-        org.voltdb.catalog.CommandLog config = catalog.getClusters().get("cluster").getLogconfig().get("log");
+        org.voltdb.catalog.CommandLog config = getCluster(catalog).getLogconfig().get("log");
         if (config == null) {
-            config = catalog.getClusters().get("cluster").getLogconfig().add("log");
+            config = getCluster(catalog).getLogconfig().add("log");
         }
 
         Frequency freq = commandlog.getFrequency();
@@ -1320,7 +1318,7 @@ public abstract class CatalogUtil {
         ClusterType cluster = deployment.getCluster();
         int kFactor = cluster.getKfactor();
 
-        Cluster catCluster = catalog.getClusters().get("cluster");
+        Cluster catCluster = getCluster(catalog);
         // copy the deployment info that is currently not recorded anywhere else
         Deployment catDeploy = catCluster.getDeployment().get("deployment");
         catDeploy.setKfactor(kFactor);
@@ -1759,7 +1757,7 @@ public abstract class CatalogUtil {
      * @param exportsType A reference to the <exports> element of the deployment.xml file.
      */
     private static void setExportInfo(Catalog catalog, ExportType exportType) {
-        final Cluster cluster = catalog.getClusters().get("cluster");
+        final Cluster cluster = getCluster(catalog);
         Database db = cluster.getDatabases().get("database");
         if (DrRoleType.XDCR.value().equals(cluster.getDrrole())) {
             // add default export configuration to DR conflict table
@@ -2031,7 +2029,7 @@ public abstract class CatalogUtil {
      * @param security security element of the deployment xml
      */
     private static void setSecurityEnabled( Catalog catalog, SecurityType security) {
-        Cluster cluster = catalog.getClusters().get("cluster");
+        Cluster cluster = getCluster(catalog);
         Database database = cluster.getDatabases().get("database");
 
         cluster.setSecurityenabled(security.isEnabled());
@@ -2044,7 +2042,7 @@ public abstract class CatalogUtil {
      * @param snapshot A reference to the <snapshot> element of the deployment.xml file.
      */
     private static void setSnapshotInfo(Catalog catalog, SnapshotType snapshotSettings) {
-        Database db = catalog.getClusters().get("cluster").getDatabases().get("database");
+        Database db = getDatabase(catalog);
         SnapshotSchedule schedule = db.getSnapshotschedule().get("default");
         if (schedule == null) {
             schedule = db.getSnapshotschedule().add("default");
@@ -2296,7 +2294,7 @@ public abstract class CatalogUtil {
         // in project.xml). However, it must always be named "database", so
         // I've temporarily hardcoded it here until a more robust solution is
         // available.
-        Database db = catalog.getClusters().get("cluster").getDatabases().get("database");
+        Database db = getDatabase(catalog);
 
         SecureRandom sr = new SecureRandom();
 
@@ -2382,7 +2380,7 @@ public abstract class CatalogUtil {
     }
 
     private static void setHTTPDInfo(Catalog catalog, HttpdType httpd, SslType ssl) {
-        Cluster cluster = catalog.getClusters().get("cluster");
+        Cluster cluster = getCluster(catalog);
 
         // set the catalog info
         int defaultPort = VoltDB.DEFAULT_HTTP_PORT;
@@ -2395,7 +2393,7 @@ public abstract class CatalogUtil {
 
     private static void setDrInfo(Catalog catalog, DrType dr, ClusterType clusterType, boolean isPlaceHolderCatalog) {
         int clusterId;
-        Cluster cluster = catalog.getClusters().get("cluster");
+        Cluster cluster = getCluster(catalog);
         final Database db = cluster.getDatabases().get("database");
         assert cluster != null;
         if (dr != null) {
@@ -2703,7 +2701,7 @@ public abstract class CatalogUtil {
         Set<String> optionalTableNames = new HashSet<>();
         Catalog catalog = new Catalog();
         catalog.execute(getSerializedCatalogStringFromJar(jarfile));
-        Database db = catalog.getClusters().get("cluster").getDatabases().get("database");
+        Database db = getDatabase(catalog);
         Pair<List<Table>, Set<String>> ret;
 
         ret = getSnapshotableTables(db, true);
@@ -3296,5 +3294,13 @@ public abstract class CatalogUtil {
      */
     public static VoltTable.ColumnInfo catalogColumnToInfo(Column column) {
         return new VoltTable.ColumnInfo(column.getTypeName(), VoltType.get((byte) column.getType()));
+    }
+
+    public static Cluster getCluster(Catalog catalog) {
+        return catalog.getClusters().get("cluster");
+    }
+
+    public static Database getDatabase(Catalog catalog) {
+        return getCluster(catalog).getDatabases().get("database");
     }
 }

--- a/tests/frontend/org/voltdb/task/TestTasksEnd2End.java
+++ b/tests/frontend/org/voltdb/task/TestTasksEnd2End.java
@@ -252,6 +252,14 @@ public class TestTasksEnd2End extends LocalClustersTestBase {
         while (table.advanceRow()) {
             assertEquals("RUNNING", table.getString("STATE"));
         }
+
+        try {
+            client.callProcedure("@AdHoc", "DROP PROCEDURE " + procName);
+            fail("Should not have been able to drop: " + procName);
+        } catch (ProcCallException e) {
+            String status = e.getClientResponse().getStatusString();
+            assertTrue(status, status.contains("Procedure does not exist: " + procName));
+        }
     }
 
     @Test


### PR DESCRIPTION
Push the validation of tasks in the catalog to after the catalog compiles. It
needs to be done this way because the tasks cannot be validated until after all
procedures have been added to the catalog and can be retrieved during
validation. This also guarantees that validation occurs on all catalog update
paths.