### PR TITLE
Fixed ENG-17930

### DIFF
--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -20,8 +20,8 @@
 #include "structures/CompactingPool.h"
 #ifdef VOLT_POOL_CHECKING
 #include "common/StackTrace.h"
-#include <mutex>
 #endif
+#include <mutex>
 #include <memory>
 #include "debuglog.h"
 #include "boost/pool/pool.hpp"
@@ -63,6 +63,22 @@ struct PoolLocals {
  * instance of pools will be freed once the last ThreadLocalPool reference in the thread is destructed.
  */
 class ThreadLocalPool {
+    #ifdef VOLT_POOL_CHECKING
+        friend class SynchronizedThreadLock;
+        static StackTrace* getStackTraceFor(int32_t engineId, std::size_t sz, void* object);
+
+        int32_t m_allocatingEngine;
+        int32_t m_allocatingThread;
+    #ifdef VOLT_TRACE_ALLOCATIONS
+        using AllocTraceMap_t = std::unordered_map<void*, StackTrace*>;
+    #else
+        using AllocTraceMap_t = std::unordered_set<void*>;
+    #endif
+        using SizeBucketMap_t = std::unordered_map<std::size_t, AllocTraceMap_t>;
+        using PartitionBucketMap_t = std::unordered_map<int32_t, SizeBucketMap_t>;
+        static PartitionBucketMap_t s_allocations;
+    #endif
+    static std::mutex s_sharedMemoryMutex;
 public:
     ThreadLocalPool();
     ~ThreadLocalPool();
@@ -177,27 +193,9 @@ public:
      * relocating some other allocation.
      */
     static void freeRelocatable(Sized* string);
-
     static void resetStateForTest();
     static int32_t* getThreadPartitionIdForTest();
     static void setThreadPartitionIdForTest(int32_t* partitionId);
-private:
-    #ifdef VOLT_POOL_CHECKING
-        friend class SynchronizedThreadLock;
-        static StackTrace* getStackTraceFor(int32_t engineId, std::size_t sz, void* object);
-
-        int32_t m_allocatingEngine;
-        int32_t m_allocatingThread;
-        static std::mutex s_sharedMemoryMutex;
-    #ifdef VOLT_TRACE_ALLOCATIONS
-        using AllocTraceMap_t = std::unordered_map<void*, StackTrace*>;
-    #else
-        using AllocTraceMap_t = std::unordered_set<void*> ;
-    #endif
-        using SizeBucketMap_t = std::unordered_map<std::size_t, AllocTraceMap_t> ;
-        using PartitionBucketMap_t = std::unordered_map<int32_t, SizeBucketMap_t> ;
-        static PartitionBucketMap_t s_allocations;
-    #endif
 };
 }
 


### PR DESCRIPTION
In some unmanaged cases, multiple threads could call `ThreadLocalPool::freeExactSizedObject()` or `ThreadLocalPool::freeRelocatable()` at the same time, creating a race condition in accessing `poolMap.find(key)` when the other thread had already freed the memory from pool, therefore the crash in system test when cluster shutdown (ServerExport-kafka-migrate).
This was just my theory; but upon adding a mutex lock in those methods, the failure now changed to the one found in ENG-17818 (crash on std::set::erase on compaction path).