### PR TITLE
Initializable: Remove setScopeId

### DIFF
--- a/src/frontend/org/voltdb/task/Initializable.java
+++ b/src/frontend/org/voltdb/task/Initializable.java
@@ -57,16 +57,4 @@ public interface Initializable {
     default Collection<String> getDependencies() {
         return null;
     }
-
-    /**
-     * Set the scope and the ID for the scope in which this instance is running. This method will be invoked after
-     * {@code initialize} is invoked and prior to any other methods being invoked.
-     * <p>
-     * If {@code scope} is {@link TaskScope#PARTITIONS} {@code id} will be a partition ID. If {@code scope} is
-     * {@link TaskScope#HOSTS} {@code id} will be a host ID. Otherwise {@code id} will be {@code -1}
-     *
-     * @param scope {@link TaskScope} in which this instance is running
-     * @param id    sub ID for the scope in which this instance is running
-     */
-    default void setScopeId(TaskScope scope, int id) {}
 }

--- a/src/frontend/org/voltdb/task/TaskHelper.java
+++ b/src/frontend/org/voltdb/task/TaskHelper.java
@@ -38,7 +38,9 @@ import org.voltdb.catalog.Procedure;
 public final class TaskHelper {
     private final VoltLogger m_logger;
     private final UnaryOperator<String> m_generateLogMessage;
+    private final String m_taskName;
     private final TaskScope m_scope;
+    private final int m_scopeId;
     private final Function<String, Procedure> m_procedureGetter;
 
     private static Function<String, Procedure> createProcedureFunction(Database database) {
@@ -50,21 +52,50 @@ public final class TaskHelper {
         return p -> InvocationDispatcher.getProcedureFromName(p, procedures, defaultProcedureManager);
     }
 
-    TaskHelper(VoltLogger logger, UnaryOperator<String> generateLogMessage, TaskScope scope, Database database) {
-        this(logger, generateLogMessage, scope, createProcedureFunction(database));
+    TaskHelper(VoltLogger logger, UnaryOperator<String> generateLogMessage, String taskName, TaskScope scope,
+            Database database) {
+        this(logger, generateLogMessage, taskName, scope, -1, createProcedureFunction(database));
     }
 
-    TaskHelper(VoltLogger logger, UnaryOperator<String> generateLogMessage, TaskScope scope,
-            ClientInterface clientInterface) {
-        this(logger, generateLogMessage, scope, clientInterface::getProcedureFromName);
+    TaskHelper(VoltLogger logger, UnaryOperator<String> generateLogMessage, String taskName, TaskScope scope,
+            int scopeId, ClientInterface clientInterface) {
+        this(logger, generateLogMessage, taskName, scope, scopeId, clientInterface::getProcedureFromName);
     }
 
-    private TaskHelper(VoltLogger logger, UnaryOperator<String> generateLogMessage, TaskScope scope,
-            Function<String, Procedure> procedureGetter) {
+    private TaskHelper(VoltLogger logger, UnaryOperator<String> generateLogMessage, String taskName, TaskScope scope,
+            int scopeId, Function<String, Procedure> procedureGetter) {
         m_logger = logger;
         m_generateLogMessage = generateLogMessage;
+        m_taskName = taskName;
         m_scope = scope;
+        m_scopeId = scopeId;
         m_procedureGetter = procedureGetter;
+    }
+
+    /**
+     * @return The name of the task
+     */
+    public String getTaaskName() {
+        return m_taskName;
+    }
+
+    /**
+     * @return The scope in which the task will be executing
+     */
+    public TaskScope getTaskScepe() {
+        return m_scope;
+    }
+
+    /**
+     * Returns the ID of the scope when this helper is passed to an {@code instantiate} method otherwise {@code -1}
+     * <p>
+     * If {@code scope} is {@link TaskScope#PARTITIONS} {@code id} will be a partition ID. If {@code scope} is
+     * {@link TaskScope#HOSTS} {@code id} will be a host ID. Otherwise {@code id} will be {@code -1}
+     *
+     * @return The ID of the scope
+     */
+    public int getScopeId() {
+        return m_scopeId;
     }
 
     /**

--- a/tests/frontend/org/voltdb/task/TestTaskManager.java
+++ b/tests/frontend/org/voltdb/task/TestTaskManager.java
@@ -809,16 +809,8 @@ public class TestTaskManager {
     }
 
     public static class TestActionScheduler implements ActionScheduler {
-        private boolean setScopeIdCalled = false;
-
-        @Override
-        public void setScopeId(TaskScope scope, int id) {
-            setScopeIdCalled = true;
-        }
-
         @Override
         public DelayedAction getFirstDelayedAction() {
-            assertTrue(setScopeIdCalled);
             s_firstActionSchedulerCallCount.getAndIncrement();
             return DelayedAction.createProcedure(100, TimeUnit.MICROSECONDS, this::getNextAction, PROCEDURE_NAME);
         }


### PR DESCRIPTION
Instead of optionaly implementing a setter to get the scopeId put the taskName,
scope and scopeId into TaskHelper so that it can be accessed that way.